### PR TITLE
Search terminal scrollback globally

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		3865A0013865A0013865A001 /* SearchIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3865B0013865B0013865B001 /* SearchIndex.swift */; };
 		3865A0023865A0023865A002 /* GlobalSearchCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3865B0023865B0023865B002 /* GlobalSearchCoordinator.swift */; };
 		3865A0033865A0033865A003 /* MenubarSearchPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3865B0033865B0033865B003 /* MenubarSearchPopover.swift */; };
+		3865A0093865A0093865A009 /* GlobalSearchKeyboardFocusBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3865B0093865B0093865B009 /* GlobalSearchKeyboardFocusBridge.swift */; };
 		3865A0043865A0043865A004 /* SearchIndexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3865B0043865B0043865B004 /* SearchIndexTests.swift */; };
 		3865A0053865A0053865A005 /* GlobalSearchShortcutSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3865B0053865B0053865B005 /* GlobalSearchShortcutSettingsTests.swift */; };
 		3865A0063865A0063865A006 /* AppDelegate+GlobalSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3865B0063865B0063865B006 /* AppDelegate+GlobalSearch.swift */; };
@@ -551,6 +552,7 @@
 		3865B0063865B0063865B006 /* AppDelegate+GlobalSearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Search/AppDelegate+GlobalSearch.swift"; sourceTree = "<group>"; };
 		3865B0073865B0073865B007 /* GlobalSearchDocuments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Search/GlobalSearchDocuments.swift; sourceTree = "<group>"; };
 		3865B0083865B0083865B008 /* GlobalSearchPanelCaptureManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Search/GlobalSearchPanelCaptureManager.swift; sourceTree = "<group>"; };
+		3865B0093865B0093865B009 /* GlobalSearchKeyboardFocusBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Search/GlobalSearchKeyboardFocusBridge.swift; sourceTree = "<group>"; };
 		312DE7503B4658DD173121B8 /* AuthManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AuthManager.swift; sourceTree = "<group>"; };
 		FEED0000000000000000F001 /* FeedCoordinator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FeedCoordinator.swift; sourceTree = "<group>"; };
 		FEED0000000000000000F004 /* FeedPanelView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FeedPanelView.swift; sourceTree = "<group>"; };
@@ -1295,6 +1297,7 @@
 				3865B0083865B0083865B008 /* GlobalSearchPanelCaptureManager.swift */,
 				3865B0023865B0023865B002 /* GlobalSearchCoordinator.swift */,
 				3865B0033865B0033865B003 /* MenubarSearchPopover.swift */,
+				3865B0093865B0093865B009 /* GlobalSearchKeyboardFocusBridge.swift */,
 				A5001410 /* Panel.swift */,
 				A5001411 /* TerminalPanel.swift */,
 				A5001412 /* BrowserPanel.swift */,
@@ -1976,6 +1979,7 @@
 				3865A0083865A0083865A008 /* GlobalSearchPanelCaptureManager.swift in Sources */,
 				3865A0023865A0023865A002 /* GlobalSearchCoordinator.swift in Sources */,
 				3865A0033865A0033865A003 /* MenubarSearchPopover.swift in Sources */,
+				3865A0093865A0093865A009 /* GlobalSearchKeyboardFocusBridge.swift in Sources */,
 				3865A0063865A0063865A006 /* AppDelegate+GlobalSearch.swift in Sources */,
 				A5001400 /* Panel.swift in Sources */,
 				A5001401 /* TerminalPanel.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Command palette navigation shortcuts, including ⌃ P, are also customizable and
 | Shortcut | Action |
 |----------|--------|
 | ⌘ F | Find |
-| ⌘ ⇧ F | Find in directory |
+| ⌘ ⇧ F | Search all panels |
 | ⌘ G / ⌥ ⌘ G | Find next / previous |
 | ⌥ ⌘ ⇧ F | Hide find bar |
 | ⌘ E | Use selection for find |

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -112256,8 +112256,8 @@
     "globalSearch.palette.placeholder": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "Search all windows, panels, browser tabs..." } },
-        "ja": { "stringUnit": { "state": "translated", "value": "すべてのウィンドウ、パネル、ブラウザタブを検索..." } }
+        "en": { "stringUnit": { "state": "translated", "value": "Search all terminals, panels, browser tabs..." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "すべてのターミナル、パネル、ブラウザタブを検索..." } }
       }
     },
     "globalSearch.empty.prompt": {
@@ -112272,6 +112272,13 @@
       "localizations": {
         "en": { "stringUnit": { "state": "translated", "value": "No results" } },
         "ja": { "stringUnit": { "state": "translated", "value": "結果がありません" } }
+      }
+    },
+    "globalSearch.empty.searching": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Searching..." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "検索中..." } }
       }
     },
     "globalSearch.empty.noOpenPanels": {
@@ -112295,11 +112302,32 @@
         "ja": { "stringUnit": { "state": "translated", "value": "Markdown" } }
       }
     },
+    "globalSearch.kind.terminal": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Terminal" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "ターミナル" } }
+      }
+    },
     "globalSearch.kind.title": {
       "extractionState": "manual",
       "localizations": {
         "en": { "stringUnit": { "state": "translated", "value": "Title" } },
         "ja": { "stringUnit": { "state": "translated", "value": "タイトル" } }
+      }
+    },
+    "globalSearch.terminal.lineLocation": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Line %lld" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "%lld 行目" } }
+      }
+    },
+    "globalSearch.terminal.lineRangeLocation": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Lines %lld-%lld" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "%lld-%lld 行目" } }
       }
     },
     "globalSearch.untitled": {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -9931,6 +9931,23 @@
         }
       }
     },
+    "command.openSearchPane.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Search as Pane"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "検索をペインで開く"
+          }
+        }
+      }
+    },
     "command.openVaultPane.title": {
       "extractionState": "manual",
       "localizations": {
@@ -105905,6 +105922,23 @@
         }
       }
     },
+    "shortcut.switchRightSidebarToSearch.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show Sidebar Search"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サイドバーのグローバル検索を表示"
+          }
+        }
+      }
+    },
     "shortcut.switchRightSidebarToSessions.label": {
       "extractionState": "manual",
       "localizations": {
@@ -106595,6 +106629,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "検索"
+          }
+        }
+      }
+    },
+    "rightSidebar.mode.search": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "グローバル検索"
           }
         }
       }
@@ -112365,7 +112416,7 @@
     "rightSidebar.remote.error.usage.hide": { "extractionState": "manual", "localizations": { "en": { "stringUnit": { "state": "translated", "value": "ERROR: Usage: right_sidebar hide [--workspace=<workspace-id>] [--window=<window-id>]" } }, "ja": { "stringUnit": { "state": "translated", "value": "ERROR: 使用法: right_sidebar hide [--workspace=<workspace-id>] [--window=<window-id>]" } } } },
     "rightSidebar.remote.error.usage.focus": { "extractionState": "manual", "localizations": { "en": { "stringUnit": { "state": "translated", "value": "ERROR: Usage: right_sidebar focus [--workspace=<workspace-id>] [--window=<window-id>]" } }, "ja": { "stringUnit": { "state": "translated", "value": "ERROR: 使用法: right_sidebar focus [--workspace=<workspace-id>] [--window=<window-id>]" } } } },
     "rightSidebar.remote.error.usage.mode": { "extractionState": "manual", "localizations": { "en": { "stringUnit": { "state": "translated", "value": "ERROR: Usage: right_sidebar mode [--workspace=<workspace-id>] [--window=<window-id>]" } }, "ja": { "stringUnit": { "state": "translated", "value": "ERROR: 使用法: right_sidebar mode [--workspace=<workspace-id>] [--window=<window-id>]" } } } },
-    "rightSidebar.remote.error.usage.set": { "extractionState": "manual", "localizations": { "en": { "stringUnit": { "state": "translated", "value": "ERROR: Usage: right_sidebar set <files|find|vault|sessions|feed|dock> [--no-focus] [--workspace=<workspace-id>] [--window=<window-id>]" } }, "ja": { "stringUnit": { "state": "translated", "value": "ERROR: 使用法: right_sidebar set <files|find|vault|sessions|feed|dock> [--no-focus] [--workspace=<workspace-id>] [--window=<window-id>]" } } } },
+    "rightSidebar.remote.error.usage.set": { "extractionState": "manual", "localizations": { "en": { "stringUnit": { "state": "translated", "value": "ERROR: Usage: right_sidebar set <files|find|search|vault|sessions|feed|dock> [--no-focus] [--workspace=<workspace-id>] [--window=<window-id>]" } }, "ja": { "stringUnit": { "state": "translated", "value": "ERROR: 使用法: right_sidebar set <files|find|search|vault|sessions|feed|dock> [--no-focus] [--workspace=<workspace-id>] [--window=<window-id>]" } } } },
     "rightSidebar.remote.error.unknownMode": { "extractionState": "manual", "localizations": { "en": { "stringUnit": { "state": "translated", "value": "ERROR: Unknown right sidebar mode '%@'" } }, "ja": { "stringUnit": { "state": "translated", "value": "ERROR: 不明な右サイドバーモード '%@'" } } } },
     "rightSidebar.remote.error.noFocusOnlySet": { "extractionState": "manual", "localizations": { "en": { "stringUnit": { "state": "translated", "value": "ERROR: --no-focus is only valid with right_sidebar set" } }, "ja": { "stringUnit": { "state": "translated", "value": "ERROR: --no-focus は right_sidebar set でのみ使えます" } } } },
     "rightSidebar.remote.error.unknownCommand": { "extractionState": "manual", "localizations": { "en": { "stringUnit": { "state": "translated", "value": "ERROR: Unknown right sidebar command '%@'" } }, "ja": { "stringUnit": { "state": "translated", "value": "ERROR: 不明な右サイドバーコマンド '%@'" } } } },

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -43960,6 +43960,23 @@
         }
       }
     },
+    "menu.find.searchAllPanels": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search All…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべて検索…"
+          }
+        }
+      }
+    },
     "menu.find.findPrevious": {
       "extractionState": "manual",
       "localizations": {
@@ -112288,20 +112305,6 @@
       "localizations": {
         "en": { "stringUnit": { "state": "translated", "value": "Process" } },
         "ja": { "stringUnit": { "state": "translated", "value": "プロセス" } }
-      }
-    },
-    "shortcut.globalSearch.label": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "Global Search" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "グローバル検索" } }
-      }
-    },
-    "statusMenu.searchAllWindows": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "Search All Windows..." } },
-        "ja": { "stringUnit": { "state": "translated", "value": "すべてのウィンドウを検索..." } }
       }
     },
     "globalSearch.palette.placeholder": {

--- a/Sources/App/MainWindowVisibilityController.swift
+++ b/Sources/App/MainWindowVisibilityController.swift
@@ -13,6 +13,7 @@ final class MainWindowVisibilityController {
         case fileSearchFocus
         case findShortcut
         case focusMainWindow
+        case globalSearchFocus
         case globalHotkey
         case menuBar
         case notification

--- a/Sources/App/MenuBarExtraController.swift
+++ b/Sources/App/MenuBarExtraController.swift
@@ -7,7 +7,6 @@ final class MenuBarExtraController: NSObject, NSMenuDelegate {
     private let statusItem: NSStatusItem
     private let menu = NSMenu(title: "cmux")
     private let notificationStore: TerminalNotificationStore
-    private let onShowGlobalSearch: (NSStatusBarButton, (() -> Void)?) -> Void
     private let onShowMainWindow: () -> Void
     private let onShowNotifications: () -> Void
     private let onOpenNotification: (TerminalNotification) -> Void
@@ -21,7 +20,6 @@ final class MenuBarExtraController: NSObject, NSMenuDelegate {
 
     private let stateHintItem = NSMenuItem(title: String(localized: "statusMenu.noUnread", defaultValue: "No unread notifications"), action: nil, keyEquivalent: "")
     private let buildHintItem = NSMenuItem(title: "", action: nil, keyEquivalent: "")
-    private let globalSearchItem = NSMenuItem(title: String(localized: "statusMenu.searchAllWindows", defaultValue: "Search All Windows..."), action: nil, keyEquivalent: "")
     private let showMainWindowItem = NSMenuItem(title: String(localized: "statusMenu.showCmux", defaultValue: "Show cmux"), action: nil, keyEquivalent: "")
     private let taskManagerItem = NSMenuItem(title: String(localized: "statusMenu.taskManager", defaultValue: "Task Manager..."), action: nil, keyEquivalent: "")
     private let notificationListSeparator = NSMenuItem.separator()
@@ -37,7 +35,6 @@ final class MenuBarExtraController: NSObject, NSMenuDelegate {
     private var notificationItems: [NSMenuItem] = []
     init(
         notificationStore: TerminalNotificationStore,
-        onShowGlobalSearch: @escaping (NSStatusBarButton, (() -> Void)?) -> Void,
         onShowMainWindow: @escaping () -> Void,
         onShowNotifications: @escaping () -> Void,
         onOpenNotification: @escaping (TerminalNotification) -> Void,
@@ -48,7 +45,6 @@ final class MenuBarExtraController: NSObject, NSMenuDelegate {
         onQuitApp: @escaping () -> Void
     ) {
         self.notificationStore = notificationStore
-        self.onShowGlobalSearch = onShowGlobalSearch
         self.onShowMainWindow = onShowMainWindow
         self.onShowNotifications = onShowNotifications
         self.onOpenNotification = onOpenNotification
@@ -94,10 +90,6 @@ final class MenuBarExtraController: NSObject, NSMenuDelegate {
         }
 
         menu.addItem(.separator())
-
-        globalSearchItem.target = self
-        globalSearchItem.action = #selector(globalSearchAction)
-        menu.addItem(globalSearchItem)
 
         showMainWindowItem.target = self
         showMainWindowItem.action = #selector(showMainWindowAction)
@@ -176,7 +168,6 @@ final class MenuBarExtraController: NSObject, NSMenuDelegate {
         stateHintItem.title = snapshot.stateHintTitle
         showMainWindowItem.isHidden = !MenuBarOnlySettings.shouldShowMainWindowMenuItem()
 
-        applyShortcut(KeyboardShortcutSettings.menuShortcut(for: .globalSearch), to: globalSearchItem)
         applyShortcut(KeyboardShortcutSettings.menuShortcut(for: .showNotifications), to: showNotificationsItem)
         applyShortcut(KeyboardShortcutSettings.menuShortcut(for: .jumpToUnread), to: jumpToUnreadItem)
 
@@ -242,29 +233,12 @@ final class MenuBarExtraController: NSObject, NSMenuDelegate {
     }
 
     @objc private func statusItemButtonAction(_ sender: NSStatusBarButton) {
-        guard let event = NSApp.currentEvent else {
-            onShowGlobalSearch(sender, nil)
-            return
-        }
-
-        let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-        if event.type == .rightMouseUp || flags.contains(.control) {
-            refreshUI()
-            menu.popUp(positioning: nil, at: NSPoint(x: 0, y: sender.bounds.height), in: sender)
-        } else {
-            onShowGlobalSearch(sender, nil)
-        }
+        popUpMenu(from: sender)
     }
 
-    @discardableResult
-    func toggleGlobalSearchPalette(onDismiss: (() -> Void)? = nil) -> Bool {
-        guard let button = statusItem.button else { return false }
-        onShowGlobalSearch(button, onDismiss)
-        return true
-    }
-
-    @objc private func globalSearchAction() {
-        toggleGlobalSearchPalette()
+    private func popUpMenu(from sender: NSStatusBarButton) {
+        refreshUI()
+        menu.popUp(positioning: nil, at: NSPoint(x: 0, y: sender.bounds.height), in: sender)
     }
 
     @objc private func showMainWindowAction() {

--- a/Sources/App/ShortcutRoutingSupport.swift
+++ b/Sources/App/ShortcutRoutingSupport.swift
@@ -407,6 +407,7 @@ func shouldRouteCommandEquivalentDirectlyToMainMenu(_ event: NSEvent) -> Bool {
 
 private enum BrowserFindCommandEquivalent: CaseIterable {
     case find
+    case searchAllPanels
     case findInDirectory
     case findNext
     case findPrevious
@@ -416,6 +417,7 @@ private enum BrowserFindCommandEquivalent: CaseIterable {
     var action: KeyboardShortcutSettings.Action {
         switch self {
         case .find: return .find
+        case .searchAllPanels: return .searchAllPanels
         case .findInDirectory: return .findInDirectory
         case .findNext: return .findNext
         case .findPrevious: return .findPrevious
@@ -428,7 +430,7 @@ private enum BrowserFindCommandEquivalent: CaseIterable {
         switch self {
         case .find, .findNext, .findPrevious, .hideFind:
             return true
-        case .findInDirectory, .useSelection:
+        case .searchAllPanels, .findInDirectory, .useSelection:
             return false
         }
     }
@@ -475,6 +477,10 @@ func shouldRouteBrowserFindCommandEquivalentThroughWebContentFirst(
     }
 
     if case .find = shortcut {
+        return false
+    }
+
+    if case .searchAllPanels = shortcut {
         return false
     }
 

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -6069,6 +6069,45 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     @discardableResult
+    func focusGlobalSearchInActiveMainWindow(preferredWindow: NSWindow? = nil) -> Bool {
+        let context = preferredRegisteredMainWindowContext(preferredWindow: preferredWindow)
+
+        guard let context else {
+#if DEBUG
+            dlog(
+                "global.search.focus.app.abort reason=noContext preferred={\(debugWindowToken(preferredWindow))} " +
+                "\(debugShortcutRouteSnapshot())"
+            )
+#endif
+            return false
+        }
+        let window = context.window ?? windowForMainWindowId(context.windowId)
+#if DEBUG
+        let beforeResponder = window?.firstResponder.map { String(describing: type(of: $0)) } ?? "nil"
+        dlog(
+            "global.search.focus.app.begin preferred={\(debugWindowToken(preferredWindow))} " +
+            "context={\(debugContextToken(context))} targetWin={\(debugWindowToken(window))} " +
+            "fr=\(beforeResponder)"
+        )
+#endif
+        if let window {
+            mainWindowVisibilityController.focusForInWindowCommand(window, reason: .globalSearchFocus)
+        }
+        let result = context.keyboardFocusCoordinator.focusRightSidebar(
+            mode: .search,
+            focusFirstItem: true
+        )
+#if DEBUG
+        let afterResponder = window?.firstResponder.map { String(describing: type(of: $0)) } ?? "nil"
+        dlog(
+            "global.search.focus.app.end result=\(result ? 1 : 0) " +
+            "targetWin={\(debugWindowToken(window))} fr=\(afterResponder)"
+        )
+#endif
+        return result
+    }
+
+    @discardableResult
     func performFindShortcutInActiveMainWindow(preferredWindow: NSWindow? = nil) -> Bool {
         let context = preferredRegisteredMainWindowContext(preferredWindow: preferredWindow)
 
@@ -7448,6 +7487,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     func toggleGlobalSearchPaletteFromGlobalHotkey() {
+        if focusGlobalSearchInActiveMainWindow(preferredWindow: NSApp.keyWindow ?? NSApp.mainWindow) {
+            return
+        }
+
         if menuBarExtraController == nil,
            MenuBarExtraSettings.shouldInstallMenuBarExtra() {
             setupMenuBarExtra()

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -704,7 +704,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private lazy var titlebarAccessoryController = UpdateTitlebarAccessoryController(viewModel: updateViewModel)
     private let windowDecorationsController = WindowDecorationsController()
     private var menuBarExtraController: MenuBarExtraController?
-    private var transientGlobalSearchMenuBarExtraController: MenuBarExtraController?
     private var lastMenuBarExtraShouldInstall: Bool?
     private lazy var mainWindowVisibilityController = MainWindowVisibilityController(
         dependencies: .init(
@@ -7444,7 +7443,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     private func setupMenuBarExtra() {
         guard menuBarExtraController == nil else { return }
-        removeTransientGlobalSearchMenuBarExtraController()
         menuBarExtraController = makeMenuBarExtraController()
     }
 
@@ -7452,9 +7450,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let store = TerminalNotificationStore.shared
         return MenuBarExtraController(
             notificationStore: store,
-            onShowGlobalSearch: { button, onDismiss in
-                GlobalSearchCoordinator.shared.togglePalette(anchor: button, onDismiss: onDismiss)
-            },
             onShowMainWindow: { [weak self] in
                 self?.showMainWindowFromMenuBar()
             },
@@ -7486,72 +7481,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         )
     }
 
-    func toggleGlobalSearchPaletteFromGlobalHotkey() {
-        if focusGlobalSearchInActiveMainWindow(preferredWindow: NSApp.keyWindow ?? NSApp.mainWindow) {
-            return
-        }
-
-        if menuBarExtraController == nil,
-           MenuBarExtraSettings.shouldInstallMenuBarExtra() {
-            setupMenuBarExtra()
-        }
-
-        if let menuBarExtraController,
-           menuBarExtraController.toggleGlobalSearchPalette() {
-            return
-        }
-
-        if toggleGlobalSearchPaletteFromTransientMenuBarExtra() {
-            return
-        }
-
-        NSSound.beep()
-    }
-
-    private func toggleGlobalSearchPaletteFromTransientMenuBarExtra() -> Bool {
-        if let controller = transientGlobalSearchMenuBarExtraController {
-            if controller.toggleGlobalSearchPalette(
-                onDismiss: transientGlobalSearchDismissalHandler(for: controller)
-            ) {
-                return true
-            }
-            controller.removeFromMenuBar()
-            transientGlobalSearchMenuBarExtraController = nil
-        }
-
-        let controller = makeMenuBarExtraController()
-        transientGlobalSearchMenuBarExtraController = controller
-
-        let onDismiss = transientGlobalSearchDismissalHandler(for: controller)
-
-        guard controller.toggleGlobalSearchPalette(onDismiss: onDismiss) else {
-            controller.removeFromMenuBar()
-            transientGlobalSearchMenuBarExtraController = nil
-            return false
-        }
-
-        return true
-    }
-
-    private func removeTransientGlobalSearchMenuBarExtraController() {
-        transientGlobalSearchMenuBarExtraController?.removeFromMenuBar()
-        transientGlobalSearchMenuBarExtraController = nil
-    }
-
-    private func transientGlobalSearchDismissalHandler(
-        for controller: MenuBarExtraController
-    ) -> () -> Void {
-        return { [weak self, weak controller] in
-            guard let self,
-                  let controller,
-                  self.transientGlobalSearchMenuBarExtraController === controller else {
-                return
-            }
-            controller.removeFromMenuBar()
-            self.transientGlobalSearchMenuBarExtraController = nil
-        }
-    }
-
     private func installMenuBarVisibilityObserver() {
         guard menuBarVisibilityObserver == nil else { return }
         menuBarVisibilityObserver = NotificationCenter.default.addObserver(
@@ -7576,7 +7505,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     private func syncMenuBarExtraVisibility(defaults: UserDefaults = .standard) {
         let shouldInstall = MenuBarExtraSettings.shouldInstallMenuBarExtra(defaults: defaults)
-        let previousShouldInstall = lastMenuBarExtraShouldInstall
         lastMenuBarExtraShouldInstall = shouldInstall
 
         if shouldInstall {
@@ -7584,12 +7512,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return
         }
 
-        let hadPersistentController = menuBarExtraController != nil
         menuBarExtraController?.removeFromMenuBar()
         menuBarExtraController = nil
-        if previousShouldInstall == true || hadPersistentController {
-            removeTransientGlobalSearchMenuBarExtraController()
-        }
     }
 
     @MainActor
@@ -10830,7 +10754,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             // here would swallow the first stroke and leave the second one
             // orphaned, breaking that keystroke for the focused terminal/browser
             // input.
-            guard action != .showHideAllWindows && action != .globalSearch else { return false }
+            guard action != .showHideAllWindows else { return false }
             return KeyboardShortcutSettings.shortcut(for: action).hasChord
         }
     }
@@ -12044,6 +11968,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return shortcutEventBrowserPanel(event)?.resetZoom() ?? false
         }
 
+        if matchConfiguredShortcut(event: event, action: .searchAllPanels) {
+            return focusGlobalSearchInActiveMainWindow(preferredWindow: resolvedShortcutEventWindow(event))
+        }
+
         if matchConfiguredShortcut(event: event, action: .findInDirectory) {
             return focusFileSearchInActiveMainWindow(preferredWindow: resolvedShortcutEventWindow(event))
         }
@@ -12799,6 +12727,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             let shortcutWindow = resolvedShortcutEventWindow(event)
             cmuxRememberFindSelectionBeforePanelFocusMove(tabManager: tabManager, window: shortcutWindow ?? NSApp.keyWindow); return performFindShortcutInActiveMainWindow(preferredWindow: shortcutWindow)
         }
+        if matchConfiguredShortcut(event: event, action: .searchAllPanels) {
+            return focusGlobalSearchInActiveMainWindow(preferredWindow: resolvedShortcutEventWindow(event))
+        }
         if matchConfiguredShortcut(event: event, action: .findInDirectory) {
             return focusFileSearchInActiveMainWindow(preferredWindow: resolvedShortcutEventWindow(event))
         }
@@ -13231,7 +13162,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     private func isMenuBackedShortcutAction(_ action: KeyboardShortcutSettings.Action) -> Bool {
-        action != .showHideAllWindows && action != .globalSearch
+        action != .showHideAllWindows && action != .searchAllPanels
     }
 
     private func numberedShortcutDigit(event: NSEvent, stroke: ShortcutStroke) -> Int? {

--- a/Sources/ContentView+RightSidebarCommandPalette.swift
+++ b/Sources/ContentView+RightSidebarCommandPalette.swift
@@ -116,6 +116,8 @@ extension ContentView {
             return "palette.showRightSidebarFiles"
         case .find:
             return "palette.showRightSidebarFind"
+        case .search:
+            return "palette.showRightSidebarSearch"
         case .sessions:
             return "palette.showRightSidebarSessions"
         case .feed:
@@ -141,6 +143,8 @@ extension ContentView {
             return "palette.openFilesPane"
         case .find:
             return "palette.openFindPane"
+        case .search:
+            return "palette.openSearchPane"
         case .sessions:
             return "palette.openVaultPane"
         case .feed, .dock:
@@ -154,6 +158,8 @@ extension ContentView {
             return String(localized: "command.openFilesPane.title", defaultValue: "Open Files as Pane")
         case .find:
             return String(localized: "command.openFindPane.title", defaultValue: "Open Find as Pane")
+        case .search:
+            return String(localized: "command.openSearchPane.title", defaultValue: "Open Search as Pane")
         case .sessions:
             return String(localized: "command.openVaultPane.title", defaultValue: "Open Vault as Pane")
         case .feed, .dock:

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -6148,6 +6148,9 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
         guard let pending else { return }
         scrollbar = pending
+        if let panelID = terminalSurface?.id {
+            GlobalSearchCoordinator.shared.captureTerminalPanel(id: panelID)
+        }
         NotificationCenter.default.post(
             name: .ghosttyDidUpdateScrollbar,
             object: self,

--- a/Sources/KeyboardShortcutContext.swift
+++ b/Sources/KeyboardShortcutContext.swift
@@ -49,7 +49,7 @@ extension KeyboardShortcutSettings.Action {
 
     var shortcutContext: ShortcutContext {
         switch self {
-        case .switchRightSidebarToFiles, .switchRightSidebarToFind, .switchRightSidebarToSessions, .switchRightSidebarToFeed, .switchRightSidebarToDock:
+        case .switchRightSidebarToFiles, .switchRightSidebarToFind, .switchRightSidebarToSearch, .switchRightSidebarToSessions, .switchRightSidebarToFeed, .switchRightSidebarToDock:
             return .rightSidebarFocus
         case .renameTab, .renameWorkspace:
             return .nonBrowserPanel

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -84,6 +84,7 @@ enum KeyboardShortcutSettings {
         case focusRightSidebar
         case switchRightSidebarToFiles
         case switchRightSidebarToFind
+        case switchRightSidebarToSearch
         case switchRightSidebarToSessions
         case switchRightSidebarToFeed
         case switchRightSidebarToDock
@@ -168,6 +169,7 @@ enum KeyboardShortcutSettings {
             case .focusRightSidebar: return String(localized: "shortcut.focusRightSidebar.label", defaultValue: "Toggle Right Sidebar Focus")
             case .switchRightSidebarToFiles: return String(localized: "shortcut.switchRightSidebarToFiles.label", defaultValue: "Show Sidebar Files")
             case .switchRightSidebarToFind: return String(localized: "shortcut.switchRightSidebarToFind.label", defaultValue: "Show Sidebar Find")
+            case .switchRightSidebarToSearch: return String(localized: "shortcut.switchRightSidebarToSearch.label", defaultValue: "Show Sidebar Search")
             case .switchRightSidebarToSessions: return String(localized: "shortcut.switchRightSidebarToSessions.label", defaultValue: "Show Sidebar Vault")
             case .switchRightSidebarToFeed: return String(localized: "shortcut.switchRightSidebarToFeed.label", defaultValue: "Show Sidebar Feed")
             case .switchRightSidebarToDock: return String(localized: "shortcut.switchRightSidebarToDock.label", defaultValue: "Show Sidebar Dock")
@@ -225,6 +227,7 @@ enum KeyboardShortcutSettings {
             switch self {
             case .switchRightSidebarToFiles,
                  .switchRightSidebarToFind,
+                 .switchRightSidebarToSearch,
                  .switchRightSidebarToSessions,
                  .switchRightSidebarToFeed,
                  .switchRightSidebarToDock:
@@ -286,6 +289,8 @@ enum KeyboardShortcutSettings {
                 return StoredShortcut(key: "1", command: false, shift: false, option: false, control: true)
             case .switchRightSidebarToFind:
                 return StoredShortcut(key: "2", command: false, shift: false, option: false, control: true)
+            case .switchRightSidebarToSearch:
+                return StoredShortcut(key: "6", command: false, shift: false, option: false, control: true)
             case .switchRightSidebarToSessions:
                 return StoredShortcut(key: "3", command: false, shift: false, option: false, control: true)
             case .switchRightSidebarToFeed:

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -5,6 +5,8 @@ import SwiftUI
 
 /// Stores customizable keyboard shortcuts (definitions + persistence).
 enum KeyboardShortcutSettings {
+    static let legacyGlobalSearchDefaultsKey = "shortcut.globalSearch"
+
     static let didChangeNotification = Notification.Name("cmux.keyboardShortcutSettingsDidChange")
     static let actionUserInfoKey = "action"
     static let settingsFileDisplayPath = "~/.config/cmux/cmux.json"
@@ -29,6 +31,7 @@ enum KeyboardShortcutSettings {
         let colocatedSidebarActions = [
             .focusRightSidebar,
             .toggleRightSidebar,
+            .searchAllPanels,
             .findInDirectory,
         ].filter(actions.contains)
         let actionSet = Set(colocatedSidebarActions)
@@ -62,7 +65,7 @@ enum KeyboardShortcutSettings {
         case openSettings
         case reloadConfiguration
         case showHideAllWindows
-        case globalSearch
+        case searchAllPanels
         case newWindow
         case closeWindow
         case toggleFullScreen
@@ -148,7 +151,7 @@ enum KeyboardShortcutSettings {
             case .openSettings: return String(localized: "menu.app.settings", defaultValue: "Settings…")
             case .reloadConfiguration: return String(localized: "menu.app.reloadConfiguration", defaultValue: "Reload Configuration")
             case .showHideAllWindows: return String(localized: "settings.globalHotkey.shortcut", defaultValue: "Show/Hide All Windows")
-            case .globalSearch: return String(localized: "shortcut.globalSearch.label", defaultValue: "Global Search")
+            case .searchAllPanels: return String(localized: "menu.find.searchAllPanels", defaultValue: "Search All…")
             case .newWindow: return String(localized: "shortcut.newWindow.label", defaultValue: "New Window")
             case .closeWindow: return String(localized: "shortcut.closeWindow.label", defaultValue: "Close Window")
             case .toggleFullScreen: return String(localized: "command.toggleFullScreen.title", defaultValue: "Toggle Full Screen")
@@ -249,8 +252,8 @@ enum KeyboardShortcutSettings {
                 // does not collide with the standard cancel keystroke that
                 // NSAlert/NSOpenPanel use.
                 return StoredShortcut(key: ".", command: true, shift: false, option: true, control: true)
-            case .globalSearch:
-                return StoredShortcut(key: "f", command: true, shift: false, option: true, control: false)
+            case .searchAllPanels:
+                return StoredShortcut(key: "f", command: true, shift: true, option: false, control: false)
             case .newWindow:
                 return StoredShortcut(key: "n", command: true, shift: true, option: false, control: false)
             case .closeWindow:
@@ -369,7 +372,7 @@ enum KeyboardShortcutSettings {
             case .find:
                 return StoredShortcut(key: "f", command: true, shift: false, option: false, control: false)
             case .findInDirectory:
-                return StoredShortcut(key: "f", command: true, shift: true, option: false, control: false)
+                return .unbound
             case .findNext:
                 return StoredShortcut(key: "g", command: true, shift: false, option: false, control: false)
             case .findPrevious:
@@ -457,7 +460,7 @@ enum KeyboardShortcutSettings {
                 return normalized
             }
 
-            return usesNumberedDigitMatching || self == .showHideAllWindows || self == .globalSearch ? nil : shortcut
+            return usesNumberedDigitMatching || self == .showHideAllWindows ? nil : shortcut
         }
 
         func resolvedRecordedShortcutIgnoringConflicts(_ shortcut: StoredShortcut, checkingSystemWideConflicts: Bool = true) -> RecordedShortcutResolution {
@@ -466,7 +469,7 @@ enum KeyboardShortcutSettings {
             }
 
             switch self {
-            case .showHideAllWindows, .globalSearch:
+            case .showHideAllWindows:
                 return KeyboardShortcutSettings.normalizedSystemWideHotkeyShortcutResult(
                     shortcut,
                     for: self,
@@ -730,7 +733,7 @@ enum KeyboardShortcutSettings {
         case let .accepted(normalizedShortcut):
             return normalizedShortcut
         case .rejected:
-            if action.usesNumberedDigitMatching || action == .showHideAllWindows || action == .globalSearch {
+            if action.usesNumberedDigitMatching || action == .showHideAllWindows {
                 return nil
             }
             return shortcut
@@ -801,6 +804,9 @@ enum KeyboardShortcutSettings {
 
     static func resetShortcut(for action: Action) {
         UserDefaults.standard.removeObject(forKey: action.defaultsKey)
+        if action == .searchAllPanels {
+            UserDefaults.standard.removeObject(forKey: legacyGlobalSearchDefaultsKey)
+        }
         postDidChangeNotification(action: action)
     }
 
@@ -810,6 +816,7 @@ enum KeyboardShortcutSettings {
         for action in Action.allCases {
             UserDefaults.standard.removeObject(forKey: action.defaultsKey)
         }
+        UserDefaults.standard.removeObject(forKey: legacyGlobalSearchDefaultsKey)
         postDidChangeNotification()
     }
 
@@ -956,11 +963,9 @@ final class SystemWideHotkeyController {
     private static let hotKeySignature: OSType = 0x434D484B // "CMHK"
     private static let hotKeyIDs: [KeyboardShortcutSettings.Action: UInt32] = [
         .showHideAllWindows: 1,
-        .globalSearch: 2,
     ]
     private static let systemWideActions: [KeyboardShortcutSettings.Action] = [
         .showHideAllWindows,
-        .globalSearch,
     ]
 
     private var hotKeyRefs: [KeyboardShortcutSettings.Action: EventHotKeyRef] = [:]
@@ -1106,8 +1111,6 @@ final class SystemWideHotkeyController {
         switch action {
         case .showHideAllWindows:
             return SystemWideHotkeySettings.isEnabled()
-        case .globalSearch:
-            return true
         default:
             assertionFailure("Unhandled system-wide hotkey action: \(action.rawValue)")
             return false
@@ -1197,8 +1200,6 @@ final class SystemWideHotkeyController {
         switch action {
         case .showHideAllWindows:
             AppDelegate.shared?.toggleApplicationVisibilityFromGlobalHotkey()
-        case .globalSearch:
-            AppDelegate.shared?.toggleGlobalSearchPaletteFromGlobalHotkey()
         default:
             assertionFailure("Unhandled system-wide hotkey action: \(action.rawValue)")
             break

--- a/Sources/KeyboardShortcutSettingsFileStore.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore.swift
@@ -795,8 +795,12 @@ final class CmuxSettingsFileStore {
             bindings[key] = rawValue
         }
 
+        let hasSearchAllPanelsBinding = bindings["searchAllPanels"] != nil
         for (rawAction, rawBinding) in bindings {
-            guard let action = KeyboardShortcutSettings.Action(rawValue: rawAction) else {
+            if rawAction == "globalSearch", hasSearchAllPanelsBinding {
+                continue
+            }
+            guard let action = shortcutAction(for: rawAction) else {
                 NSLog("[CmuxSettingsFileStore] ignoring unknown shortcut action '%@' in %@", rawAction, sourcePath)
                 continue
             }
@@ -810,6 +814,13 @@ final class CmuxSettingsFileStore {
             }
             snapshot.shortcuts[action] = shortcut
         }
+    }
+
+    private func shortcutAction(for rawAction: String) -> KeyboardShortcutSettings.Action? {
+        if rawAction == "globalSearch" {
+            return .searchAllPanels
+        }
+        return KeyboardShortcutSettings.Action(rawValue: rawAction)
     }
 
     private func parseShortcutBindingValue(

--- a/Sources/KeyboardShortcutSettingsLookup.swift
+++ b/Sources/KeyboardShortcutSettingsLookup.swift
@@ -6,16 +6,17 @@ extension KeyboardShortcutSettings {
         shortcutLookupObserver?(action)
         #endif
 
-        if let managedShortcut = settingsFileStore.override(for: action) {
-            return managedShortcut.isUnbound ? nil : managedShortcut
+        if let explicitShortcut = explicitShortcutOverride(for: action) {
+            return explicitShortcut.isUnbound ? nil : explicitShortcut
         }
 
-        guard let data = UserDefaults.standard.data(forKey: action.defaultsKey),
-              let shortcut = try? JSONDecoder().decode(StoredShortcut.self, from: data) else {
-            let defaultShortcut = action.defaultShortcut
-            return defaultShortcut.isUnbound ? nil : defaultShortcut
+        if action == .searchAllPanels,
+           shouldSuppressSearchAllPanelsDefaultForExplicitFindInDirectory() {
+            return nil
         }
-        return shortcut.isUnbound ? nil : shortcut
+
+        let defaultShortcut = action.defaultShortcut
+        return defaultShortcut.isUnbound ? nil : defaultShortcut
     }
 
     static func shortcut(for action: Action) -> StoredShortcut {
@@ -42,4 +43,38 @@ extension KeyboardShortcutSettings {
         return String(localized: "settings.shortcuts.managedByFile", defaultValue: "Managed in cmux.json")
     }
 
+    private static func explicitShortcutOverride(for action: Action) -> StoredShortcut? {
+        if let managedShortcut = settingsFileStore.override(for: action) {
+            return managedShortcut
+        }
+
+        if let shortcut = userDefaultsShortcut(forKey: action.defaultsKey) {
+            return shortcut
+        }
+
+        if action == .searchAllPanels,
+           let shortcut = userDefaultsShortcut(forKey: legacyGlobalSearchDefaultsKey) {
+            return shortcut
+        }
+
+        return nil
+    }
+
+    private static func userDefaultsShortcut(forKey key: String) -> StoredShortcut? {
+        guard let data = UserDefaults.standard.data(forKey: key),
+              let shortcut = try? JSONDecoder().decode(StoredShortcut.self, from: data) else {
+            return nil
+        }
+        return shortcut
+    }
+
+    private static func shouldSuppressSearchAllPanelsDefaultForExplicitFindInDirectory() -> Bool {
+        guard explicitShortcutOverride(for: .searchAllPanels) == nil,
+              let findShortcut = explicitShortcutOverride(for: .findInDirectory),
+              !findShortcut.isUnbound else {
+            return false
+        }
+
+        return findShortcut.configIdentifier == Action.searchAllPanels.defaultShortcut.configIdentifier
+    }
 }

--- a/Sources/MainWindowFocusController.swift
+++ b/Sources/MainWindowFocusController.swift
@@ -53,6 +53,7 @@ final class MainWindowFocusController {
     private weak var rightSidebarHost: RightSidebarKeyboardFocusView?
     private weak var fileExplorerHost: FileExplorerContainerView?
     private weak var fileSearchHost: FileExplorerContainerView?
+    private weak var globalSearchHost: GlobalSearchKeyboardFocusView?
     private weak var feedHost: FeedKeyboardFocusView?
     private weak var dockHost: DockKeyboardFocusView?
 
@@ -109,10 +110,15 @@ final class MainWindowFocusController {
             fileExplorerHost = host
         case .find:
             fileSearchHost = host
-        case .sessions, .feed, .dock:
+        case .search, .sessions, .feed, .dock:
             break
         }
         focusRegisteredRightSidebarEndpointIfNeeded(mode: mode)
+    }
+
+    func registerGlobalSearchHost(_ host: GlobalSearchKeyboardFocusView) {
+        globalSearchHost = host
+        focusRegisteredRightSidebarEndpointIfNeeded(mode: .search)
     }
 
     func registerFeedHost(_ host: FeedKeyboardFocusView) {
@@ -179,6 +185,9 @@ final class MainWindowFocusController {
         }
         if fileExplorerHost?.ownsKeyboardFocus(responder) == true ||
             fileSearchHost?.ownsKeyboardFocus(responder) == true {
+            return true
+        }
+        if globalSearchHost?.ownsKeyboardFocus(responder) == true {
             return true
         }
         if feedHost?.ownsKeyboardFocus(responder) == true {
@@ -631,7 +640,7 @@ final class MainWindowFocusController {
         switch mode {
         case .files:
             return .outline
-        case .find:
+        case .find, .search:
             return .searchField
         case .sessions:
             return .host
@@ -651,6 +660,8 @@ final class MainWindowFocusController {
             return fileExplorerHost?.focusOutline() == true
         case .find:
             return fileSearchHost?.focusSearchField() == true
+        case .search:
+            return globalSearchHost?.focusSearchFieldFromCoordinator() == true
         case .sessions:
             return false
         case .feed:
@@ -726,6 +737,9 @@ final class MainWindowFocusController {
         }
         if fileSearchHost?.ownsKeyboardFocus(responder) == true {
             return .find
+        }
+        if globalSearchHost?.ownsKeyboardFocus(responder) == true {
+            return .search
         }
         if feedHost?.ownsKeyboardFocus(responder) == true || responder is FeedKeyboardFocusResponder {
             return .feed

--- a/Sources/RightSidebarMode+Availability.swift
+++ b/Sources/RightSidebarMode+Availability.swift
@@ -7,6 +7,8 @@ extension RightSidebarMode {
             return .files
         case "find":
             return .find
+        case "search", "global-search", "global_search":
+            return .search
         case "vault", "sessions":
             return .sessions
         case "feed":
@@ -32,7 +34,7 @@ extension RightSidebarMode {
 
     func isAvailable(dockEnabled: Bool) -> Bool {
         switch self {
-        case .files, .find, .sessions, .feed:
+        case .files, .find, .search, .sessions, .feed:
             return true
         case .dock:
             return dockEnabled

--- a/Sources/RightSidebarPanelView.swift
+++ b/Sources/RightSidebarPanelView.swift
@@ -12,6 +12,7 @@ private func rightSidebarDebugResponder(_ responder: NSResponder?) -> String {
 nonisolated enum RightSidebarMode: String, CaseIterable, Codable, Sendable {
     case files
     case find
+    case search
     case sessions
     case feed
     case dock
@@ -20,6 +21,7 @@ nonisolated enum RightSidebarMode: String, CaseIterable, Codable, Sendable {
         switch self {
         case .files: return String(localized: "rightSidebar.mode.files", defaultValue: "Files")
         case .find: return String(localized: "rightSidebar.mode.find", defaultValue: "Find")
+        case .search: return String(localized: "rightSidebar.mode.search", defaultValue: "Search")
         case .sessions: return String(localized: "rightSidebar.mode.sessions", defaultValue: "Vault")
         case .feed: return String(localized: "rightSidebar.mode.feed", defaultValue: "Feed")
         case .dock: return String(localized: "rightSidebar.mode.dock", defaultValue: "Dock")
@@ -30,6 +32,7 @@ nonisolated enum RightSidebarMode: String, CaseIterable, Codable, Sendable {
         switch self {
         case .files: return "folder"
         case .find: return "magnifyingglass"
+        case .search: return "magnifyingglass.circle"
         case .sessions: return "books.vertical"
         case .feed: return "dot.radiowaves.left.and.right"
         case .dock: return "dock.rectangle"
@@ -40,6 +43,7 @@ nonisolated enum RightSidebarMode: String, CaseIterable, Codable, Sendable {
         switch self {
         case .files: return .switchRightSidebarToFiles
         case .find: return .switchRightSidebarToFind
+        case .search: return .switchRightSidebarToSearch
         case .sessions: return .switchRightSidebarToSessions
         case .feed: return .switchRightSidebarToFeed
         case .dock: return .switchRightSidebarToDock
@@ -48,7 +52,7 @@ nonisolated enum RightSidebarMode: String, CaseIterable, Codable, Sendable {
 }
 
 extension RightSidebarMode {
-    static let paneModes: [RightSidebarMode] = [.files, .find, .sessions]
+    static let paneModes: [RightSidebarMode] = [.files, .find, .search, .sessions]
 
     var canOpenAsPane: Bool {
         Self.paneModes.contains(self)
@@ -63,6 +67,9 @@ extension RightSidebarMode {
         }
         if KeyboardShortcutSettings.shortcut(for: .switchRightSidebarToFind).matches(event: event) {
             return .find
+        }
+        if KeyboardShortcutSettings.shortcut(for: .switchRightSidebarToSearch).matches(event: event) {
+            return .search
         }
         if KeyboardShortcutSettings.shortcut(for: .switchRightSidebarToSessions).matches(event: event) {
             return .sessions
@@ -238,7 +245,8 @@ struct RightSidebarPanelView: View {
                         isSelected: fileExplorerState.mode == mode,
                         badgeCount: mode == .feed ? feedPendingCount : 0,
                         shortcutHint: KeyboardShortcutSettings.shortcut(for: mode.shortcutAction),
-                        showsShortcutHint: showsModeShortcutHints
+                        showsShortcutHint: showsModeShortcutHints,
+                        showsLabel: availableModes.count <= 4
                     ) {
                         if AppDelegate.shared?.focusRightSidebarInActiveMainWindow(
                             mode: mode,
@@ -379,6 +387,8 @@ struct RightSidebarPanelView: View {
                 onOpenFilePreview: onOpenFilePreview,
                 presentation: .find
             )
+        case .search:
+            GlobalSearchSurfaceView(coordinator: .shared, placement: .rightSidebar)
         case .sessions:
             SessionIndexView(store: sessionIndexStore, onResume: onResumeSession)
                 .onAppear {
@@ -518,6 +528,7 @@ private struct ModeBarButton: View {
     var badgeCount: Int = 0
     let shortcutHint: StoredShortcut
     let showsShortcutHint: Bool
+    let showsLabel: Bool
     let action: () -> Void
 
     @State private var isHovered: Bool = false
@@ -527,10 +538,12 @@ private struct ModeBarButton: View {
             HStack(spacing: 4) {
                 Image(systemName: mode.symbolName)
                     .font(.system(size: 11, weight: .medium))
-                Text(mode.label)
-                    .font(.system(size: 11, weight: .medium))
-                    .lineLimit(1)
-                    .truncationMode(.tail)
+                if showsLabel {
+                    Text(mode.label)
+                        .font(.system(size: 11, weight: .medium))
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                }
                 if badgeCount > 0 {
                     pendingChip
                 }

--- a/Sources/RightSidebarRemoteCommand.swift
+++ b/Sources/RightSidebarRemoteCommand.swift
@@ -126,7 +126,7 @@ extension RightSidebarRemoteRequest {
             return .success(.init(command: .getState, target: target))
         case "set":
             guard positional.count == 2 else {
-                return .failure(.init(message: String(localized: "rightSidebar.remote.error.usage.set", defaultValue: "ERROR: Usage: right_sidebar set <files|find|vault|sessions|feed|dock> [--no-focus] [--workspace=<workspace-id>] [--window=<window-id>]")))
+                return .failure(.init(message: String(localized: "rightSidebar.remote.error.usage.set", defaultValue: "ERROR: Usage: right_sidebar set <files|find|search|vault|sessions|feed|dock> [--no-focus] [--workspace=<workspace-id>] [--window=<window-id>]")))
             }
             guard let mode = RightSidebarMode.from(cliArgument: positional[1]) else {
                 return .failure(.init(message: String(localized: "rightSidebar.remote.error.unknownMode", defaultValue: "ERROR: Unknown right sidebar mode '\(positional[1])'")))

--- a/Sources/RightSidebarToolPanel.swift
+++ b/Sources/RightSidebarToolPanel.swift
@@ -13,6 +13,7 @@ final class RightSidebarToolPanel: Panel, ObservableObject {
     private weak var workspace: Workspace?
     private weak var fileExplorerContainerView: FileExplorerContainerView?
     private weak var sessionIndexFocusAnchorView: RightSidebarToolFocusAnchorView?
+    private weak var globalSearchFocusAnchorView: GlobalSearchKeyboardFocusView?
     private var fileExplorerStoreStorage: FileExplorerStore?
     private var fileExplorerStateStorage: FileExplorerState?
     private var sessionIndexStoreStorage: SessionIndexStore?
@@ -73,6 +74,10 @@ final class RightSidebarToolPanel: Panel, ObservableObject {
         sessionIndexFocusAnchorView = anchor
     }
 
+    fileprivate func attachGlobalSearchFocusAnchor(_ anchor: GlobalSearchKeyboardFocusView?) {
+        globalSearchFocusAnchorView = anchor
+    }
+
     func syncWorkspaceRoot(from workspace: Workspace) {
         switch mode {
         case .files, .find:
@@ -81,7 +86,7 @@ final class RightSidebarToolPanel: Panel, ObservableObject {
         case .sessions:
             guard let store = sessionIndexStoreStorage else { return }
             syncSessionIndexRoot(from: workspace, store: store)
-        case .feed, .dock:
+        case .search, .feed, .dock:
             break
         }
     }
@@ -101,6 +106,7 @@ final class RightSidebarToolPanel: Panel, ObservableObject {
     func close() {
         fileExplorerContainerView = nil
         sessionIndexFocusAnchorView = nil
+        globalSearchFocusAnchorView = nil
         fileExplorerStoreStorage?.applyWorkspaceRoot(.none)
         sessionIndexStoreStorage?.setCurrentDirectoryIfChanged(nil)
         workspaceObservationCancellable = nil
@@ -112,6 +118,8 @@ final class RightSidebarToolPanel: Panel, ObservableObject {
             _ = fileExplorerContainerView?.focusOutline()
         case .find:
             _ = fileExplorerContainerView?.focusSearchField()
+        case .search:
+            _ = globalSearchFocusAnchorView?.focusSearchFieldFromCoordinator()
         case .sessions:
             guard let anchor = sessionIndexFocusAnchorView,
                   let window = anchor.window else { return }
@@ -134,6 +142,9 @@ final class RightSidebarToolPanel: Panel, ObservableObject {
         switch mode {
         case .files, .find:
             guard fileExplorerContainerView?.ownsKeyboardFocus(responder) == true else { return nil }
+            return .panel
+        case .search:
+            guard globalSearchFocusAnchorView?.ownsKeyboardFocus(responder) == true else { return nil }
             return .panel
         case .sessions:
             guard sessionIndexFocusAnchorView?.ownsKeyboardFocus(responder) == true else { return nil }
@@ -256,6 +267,12 @@ struct RightSidebarToolPanelView: View {
                 placement: .pane,
                 onFocus: requestPanelFocusIfNeeded,
                 onContainerChange: panel.attachFileExplorerContainer
+            )
+        case .search:
+            GlobalSearchSurfaceView(
+                coordinator: .shared,
+                placement: .pane,
+                onFocusAnchorChange: panel.attachGlobalSearchFocusAnchor
             )
         case .sessions:
             SessionIndexView(

--- a/Sources/Search/AppDelegate+GlobalSearch.swift
+++ b/Sources/Search/AppDelegate+GlobalSearch.swift
@@ -187,6 +187,8 @@ extension AppDelegate {
                 applyBrowserInlineSearch(query: query, hit: hit, to: browserPanel)
             } else if let markdownPanel = workspace.markdownPanel(for: panelID) {
                 applyMarkdownInlineSearch(query: query, hit: hit, to: markdownPanel)
+            } else if let terminalPanel = workspace.terminalPanel(for: panelID) {
+                applyTerminalInlineSearch(query: query, hit: hit, to: terminalPanel)
             }
         }
     }
@@ -204,6 +206,19 @@ extension AppDelegate {
         guard let needle = GlobalSearchInlineSearch.needle(for: query, hit: hit) else { return }
         panel.applySearchNeedle(needle)
     }
+
+    private func applyTerminalInlineSearch(query: String, hit: SearchIndexHit, to panel: TerminalPanel) {
+        guard hit.kind == .terminal,
+              let needle = GlobalSearchInlineSearch.needle(for: query, hit: hit) else {
+            return
+        }
+        if let searchState = panel.searchState {
+            searchState.needle = needle
+        } else {
+            panel.searchState = TerminalSurface.SearchState(needle: needle)
+        }
+        NotificationCenter.default.post(name: .ghosttySearchFocus, object: panel.surface)
+    }
 }
 
 enum GlobalSearchInlineSearch {
@@ -215,13 +230,30 @@ enum GlobalSearchInlineSearch {
         let tokens = SearchIndex.queryTokens(for: query)
         guard !tokens.isEmpty else { return nil }
 
-        let hitText = [
+        let hitParts = [
             hit.snippet,
             hit.title,
             hit.location,
             hit.anchor
-        ].joined(separator: "\n").lowercased()
+        ]
+        let hitText = hitParts.joined(separator: "\n").lowercased()
 
-        return tokens.first { hitText.contains($0) } ?? tokens[0]
+        if let exactToken = tokens.first(where: { hitText.contains($0) }) {
+            return exactToken
+        }
+
+        return hitParts
+            .compactMap { fuzzyMatchedNeedle(for: query, in: $0) }
+            .first
+            ?? tokens[0]
+    }
+
+    private static func fuzzyMatchedNeedle(for query: String, in candidate: String) -> String? {
+        let source = candidate.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let range = SearchIndex.fuzzyMatchedRange(query: query, in: source) else { return nil }
+        let matched = String(source[range])
+            .trimmingCharacters(in: CharacterSet.whitespacesAndNewlines.union(CharacterSet(charactersIn: ".")))
+        guard !matched.isEmpty else { return nil }
+        return matched
     }
 }

--- a/Sources/Search/GlobalSearchCoordinator.swift
+++ b/Sources/Search/GlobalSearchCoordinator.swift
@@ -95,6 +95,10 @@ final class GlobalSearchCoordinator {
         captureManager.captureMarkdownPanel(panel)
     }
 
+    func captureTerminalPanel(id panelID: UUID) {
+        captureManager.captureTerminalPanel(id: panelID)
+    }
+
     func purgePanel(id panelID: UUID) {
         captureManager.cancelCaptures(forPanelID: panelID)
         panelPurgeTasks[panelID]?.cancel()

--- a/Sources/Search/GlobalSearchCoordinator.swift
+++ b/Sources/Search/GlobalSearchCoordinator.swift
@@ -18,7 +18,6 @@ final class GlobalSearchCoordinator {
             self?.cancelPanelPurge(forPanelID: panelID)
         }
     )
-    private lazy var popover = MenubarSearchPopover(coordinator: self)
 
     private init() {}
 
@@ -42,18 +41,6 @@ final class GlobalSearchCoordinator {
         }
     }
 
-    func togglePalette(anchor: NSStatusBarButton, onDismiss: (() -> Void)? = nil) {
-        popover.toggle(relativeTo: anchor, onDismiss: onDismiss)
-    }
-
-    func dismissPalette() {
-        popover.dismiss()
-    }
-
-    func isPaletteVisible() -> Bool {
-        popover.isShown
-    }
-
     func search(query: String) async -> [SearchIndexHit] {
         guard let index = await ensureIndex() else { return [] }
         do {
@@ -75,7 +62,6 @@ final class GlobalSearchCoordinator {
     }
 
     func activate(_ hit: SearchIndexHit, query: String) {
-        popover.dismiss()
         AppDelegate.shared?.openGlobalSearchHit(hit, query: query)
     }
 

--- a/Sources/Search/GlobalSearchDocuments.swift
+++ b/Sources/Search/GlobalSearchDocuments.swift
@@ -2,6 +2,8 @@ import Foundation
 
 enum GlobalSearchIndexingLimits {
     static let maxIndexedTextCharacters = 400_000
+    static let maxIndexedTerminalScrollbackLines = 4_000
+    static let terminalLineChunkSize = 4
 }
 
 @MainActor
@@ -34,7 +36,9 @@ enum GlobalSearchDocuments {
             kind = .browser
         case .markdown:
             kind = .markdown
-        case .terminal, .filePreview, .rightSidebarTool:
+        case .terminal:
+            kind = .terminal
+        case .filePreview, .rightSidebarTool:
             kind = .title
         }
 
@@ -91,10 +95,150 @@ enum GlobalSearchDocuments {
         )
     }
 
-    static func cappedText(_ text: String) -> String {
+    static func terminalDocuments(
+        scrollback: String,
+        context: GlobalSearchPanelContext
+    ) -> [SearchIndexDocument] {
+        let lines = normalizedTerminalScrollbackLines(scrollback)
+        guard !lines.isEmpty else { return [] }
+
+        var documents: [SearchIndexDocument] = []
+        var chunkLines: [(lineNumber: Int, text: String)] = []
+
+        func flushChunk() {
+            guard !chunkLines.isEmpty else { return }
+            let startLineNumber = chunkLines[0].lineNumber
+            let endLineNumber = chunkLines[chunkLines.count - 1].lineNumber
+            let chunkText = chunkLines
+                .map { $0.text }
+                .joined(separator: "\n")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            defer { chunkLines.removeAll(keepingCapacity: true) }
+            guard !chunkText.isEmpty else { return }
+
+            let lineLabel: String
+            if startLineNumber == endLineNumber {
+                lineLabel = String(
+                    localized: "globalSearch.terminal.lineLocation",
+                    defaultValue: "Line \(startLineNumber)"
+                )
+            } else {
+                lineLabel = String(
+                    localized: "globalSearch.terminal.lineRangeLocation",
+                    defaultValue: "Lines \(startLineNumber)-\(endLineNumber)"
+                )
+            }
+            let location = [
+                context.location,
+                context.panelTitle,
+                lineLabel
+            ].filter { !$0.isEmpty }.joined(separator: " > ")
+
+            documents.append(
+                SearchIndexDocument(
+                    id: SearchIndexDocument.terminalLineChunkStableID(
+                        panelID: context.panelID,
+                        startLineNumber: startLineNumber
+                    ),
+                    windowID: context.windowID,
+                    workspaceID: context.workspaceID,
+                    panelID: context.panelID,
+                    kind: .terminal,
+                    title: context.panelTitle,
+                    location: location,
+                    anchor: "line:\(startLineNumber)",
+                    text: chunkText
+                )
+            )
+        }
+
+        for (offset, line) in lines.enumerated() {
+            chunkLines.append((lineNumber: offset + 1, text: line))
+            if chunkLines.count >= GlobalSearchIndexingLimits.terminalLineChunkSize {
+                flushChunk()
+            }
+        }
+        flushChunk()
+
+        return documents
+    }
+
+    nonisolated static func normalizedTerminalScrollbackLines(_ scrollback: String) -> [String] {
+        let normalized = strippedTerminalControlSequences(scrollback)
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+        let cappedScrollback = cappedTailText(normalized)
+        return cappedScrollback
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map(String.init)
+    }
+
+    nonisolated private static func strippedTerminalControlSequences(_ text: String) -> String {
+        var output = String.UnicodeScalarView()
+        let scalars = text.unicodeScalars
+        var index = scalars.startIndex
+
+        func scalar(after scalarIndex: String.UnicodeScalarView.Index) -> String.UnicodeScalarView.Index {
+            scalars.index(after: scalarIndex)
+        }
+
+        func skipUntilStringTerminator(from startIndex: String.UnicodeScalarView.Index) -> String.UnicodeScalarView.Index {
+            var cursor = startIndex
+            while cursor < scalars.endIndex {
+                if scalars[cursor].value == 0x07 {
+                    return scalar(after: cursor)
+                }
+                if scalars[cursor].value == 0x1B {
+                    let next = scalar(after: cursor)
+                    if next < scalars.endIndex, scalars[next] == "\\" {
+                        return scalar(after: next)
+                    }
+                }
+                cursor = scalar(after: cursor)
+            }
+            return cursor
+        }
+
+        while index < scalars.endIndex {
+            guard scalars[index].value == 0x1B else {
+                output.append(scalars[index])
+                index = scalar(after: index)
+                continue
+            }
+
+            let next = scalar(after: index)
+            guard next < scalars.endIndex else { break }
+
+            switch scalars[next] {
+            case "[":
+                index = scalar(after: next)
+                while index < scalars.endIndex {
+                    let value = scalars[index].value
+                    index = scalar(after: index)
+                    if (0x40...0x7E).contains(value) {
+                        break
+                    }
+                }
+            case "]", "P", "^", "_":
+                index = skipUntilStringTerminator(from: scalar(after: next))
+            default:
+                index = scalar(after: next)
+            }
+        }
+
+        return String(output)
+    }
+
+    nonisolated static func cappedText(_ text: String) -> String {
         guard text.count > GlobalSearchIndexingLimits.maxIndexedTextCharacters else { return text }
         let endIndex = text.index(text.startIndex, offsetBy: GlobalSearchIndexingLimits.maxIndexedTextCharacters)
         return String(text[..<endIndex])
+    }
+
+    nonisolated static func cappedTailText(_ text: String) -> String {
+        guard text.count > GlobalSearchIndexingLimits.maxIndexedTextCharacters else { return text }
+        let startIndex = text.index(text.endIndex, offsetBy: -GlobalSearchIndexingLimits.maxIndexedTextCharacters)
+        return String(text[startIndex...])
     }
 
     static func firstNonEmpty(_ values: String?...) -> String? {

--- a/Sources/Search/GlobalSearchDocuments.swift
+++ b/Sources/Search/GlobalSearchDocuments.swift
@@ -19,12 +19,30 @@ struct GlobalSearchPanelContext {
     var location: String {
         "\(windowTitle) > \(workspaceTitle)"
     }
+
+    var terminalDocumentContext: GlobalSearchTerminalDocumentContext {
+        GlobalSearchTerminalDocumentContext(
+            windowID: windowID,
+            workspaceID: workspaceID,
+            panelID: panelID,
+            panelTitle: panelTitle,
+            location: location
+        )
+    }
 }
 
 struct BrowserPagePayload: Decodable {
     let title: String
     let url: String
     let text: String
+}
+
+struct GlobalSearchTerminalDocumentContext: Sendable {
+    let windowID: UUID
+    let workspaceID: UUID
+    let panelID: UUID
+    let panelTitle: String
+    let location: String
 }
 
 @MainActor
@@ -95,9 +113,9 @@ enum GlobalSearchDocuments {
         )
     }
 
-    static func terminalDocuments(
+    nonisolated static func terminalDocuments(
         scrollback: String,
-        context: GlobalSearchPanelContext
+        context: GlobalSearchTerminalDocumentContext
     ) -> [SearchIndexDocument] {
         let lines = normalizedTerminalScrollbackLines(scrollback)
         guard !lines.isEmpty else { return [] }
@@ -167,7 +185,13 @@ enum GlobalSearchDocuments {
         let normalized = strippedTerminalControlSequences(scrollback)
             .replacingOccurrences(of: "\r\n", with: "\n")
             .replacingOccurrences(of: "\r", with: "\n")
-        let cappedScrollback = cappedTailText(normalized)
+        let lines = normalized
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map(String.init)
+        let lineCapped = lines.count > GlobalSearchIndexingLimits.maxIndexedTerminalScrollbackLines
+            ? Array(lines.suffix(GlobalSearchIndexingLimits.maxIndexedTerminalScrollbackLines))
+            : lines
+        let cappedScrollback = cappedTailText(lineCapped.joined(separator: "\n"))
         return cappedScrollback
             .split(separator: "\n", omittingEmptySubsequences: false)
             .map(String.init)

--- a/Sources/Search/GlobalSearchDocuments.swift
+++ b/Sources/Search/GlobalSearchDocuments.swift
@@ -191,10 +191,31 @@ enum GlobalSearchDocuments {
         let lineCapped = lines.count > GlobalSearchIndexingLimits.maxIndexedTerminalScrollbackLines
             ? Array(lines.suffix(GlobalSearchIndexingLimits.maxIndexedTerminalScrollbackLines))
             : lines
-        let cappedScrollback = cappedTailText(lineCapped.joined(separator: "\n"))
-        return cappedScrollback
-            .split(separator: "\n", omittingEmptySubsequences: false)
-            .map(String.init)
+        return characterCappedTailLines(lineCapped)
+    }
+
+    nonisolated private static func characterCappedTailLines(_ lines: [String]) -> [String] {
+        var retainedReversed: [String] = []
+        var remainingCharacters = GlobalSearchIndexingLimits.maxIndexedTextCharacters
+
+        for line in lines.reversed() {
+            let separatorCharacters = retainedReversed.isEmpty ? 0 : 1
+            guard remainingCharacters > separatorCharacters else { break }
+
+            let lineBudget = remainingCharacters - separatorCharacters
+            if line.count <= lineBudget {
+                retainedReversed.append(line)
+                remainingCharacters = lineBudget - line.count
+            } else if retainedReversed.isEmpty {
+                let startIndex = line.index(line.endIndex, offsetBy: -lineBudget)
+                retainedReversed.append(String(line[startIndex...]))
+                remainingCharacters = 0
+            } else {
+                break
+            }
+        }
+
+        return retainedReversed.reversed()
     }
 
     nonisolated private static func strippedTerminalControlSequences(_ text: String) -> String {

--- a/Sources/Search/GlobalSearchKeyboardFocusBridge.swift
+++ b/Sources/Search/GlobalSearchKeyboardFocusBridge.swift
@@ -1,0 +1,142 @@
+import AppKit
+import SwiftUI
+
+struct GlobalSearchKeyboardFocusAnchor: NSViewRepresentable {
+    final class Coordinator {
+        var placement: GlobalSearchSurfacePlacement
+        var onViewChange: (GlobalSearchKeyboardFocusView?) -> Void
+        var onFocusSearchField: () -> Bool
+        var ownsSearchFieldFocus: () -> Bool
+        weak var attachedView: GlobalSearchKeyboardFocusView?
+
+        init(
+            placement: GlobalSearchSurfacePlacement,
+            onViewChange: @escaping (GlobalSearchKeyboardFocusView?) -> Void,
+            onFocusSearchField: @escaping () -> Bool,
+            ownsSearchFieldFocus: @escaping () -> Bool
+        ) {
+            self.placement = placement
+            self.onViewChange = onViewChange
+            self.onFocusSearchField = onFocusSearchField
+            self.ownsSearchFieldFocus = ownsSearchFieldFocus
+        }
+
+        func attach(_ view: GlobalSearchKeyboardFocusView) {
+            view.placement = placement
+            view.onFocusSearchField = onFocusSearchField
+            view.ownsSearchFieldFocus = ownsSearchFieldFocus
+            guard attachedView !== view else { return }
+            attachedView = view
+            onViewChange(view)
+        }
+
+        func detach(_ view: GlobalSearchKeyboardFocusView) {
+            guard attachedView === view else { return }
+            attachedView = nil
+            onViewChange(nil)
+        }
+    }
+
+    let placement: GlobalSearchSurfacePlacement
+    var onViewChange: (GlobalSearchKeyboardFocusView?) -> Void
+    var onFocusSearchField: () -> Bool
+    var ownsSearchFieldFocus: () -> Bool
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(
+            placement: placement,
+            onViewChange: onViewChange,
+            onFocusSearchField: onFocusSearchField,
+            ownsSearchFieldFocus: ownsSearchFieldFocus
+        )
+    }
+
+    func makeNSView(context: Context) -> GlobalSearchKeyboardFocusView {
+        let view = GlobalSearchKeyboardFocusView()
+        context.coordinator.attach(view)
+        return view
+    }
+
+    func updateNSView(_ nsView: GlobalSearchKeyboardFocusView, context: Context) {
+        context.coordinator.placement = placement
+        context.coordinator.onViewChange = onViewChange
+        context.coordinator.onFocusSearchField = onFocusSearchField
+        context.coordinator.ownsSearchFieldFocus = ownsSearchFieldFocus
+        context.coordinator.attach(nsView)
+        nsView.registerWithKeyboardFocusCoordinatorIfNeeded()
+    }
+
+    static func dismantleNSView(_ nsView: GlobalSearchKeyboardFocusView, coordinator: Coordinator) {
+        coordinator.detach(nsView)
+    }
+}
+
+final class GlobalSearchKeyboardFocusView: NSView {
+    var placement: GlobalSearchSurfacePlacement = .rightSidebar
+    var onFocusSearchField: (() -> Bool)?
+    var ownsSearchFieldFocus: (() -> Bool)?
+
+    override var acceptsFirstResponder: Bool { true }
+    override var canBecomeKeyView: Bool { true }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        registerWithKeyboardFocusCoordinatorIfNeeded()
+    }
+
+    override func layout() {
+        super.layout()
+        registerWithKeyboardFocusCoordinatorIfNeeded()
+    }
+
+    func registerWithKeyboardFocusCoordinatorIfNeeded() {
+        guard placement == .rightSidebar, let window else { return }
+        AppDelegate.shared?.keyboardFocusCoordinator(for: window)?.registerGlobalSearchHost(self)
+    }
+
+    func focusSearchFieldFromCoordinator() -> Bool {
+        if onFocusSearchField?() == true {
+            return true
+        }
+        guard let window else { return false }
+        return window.makeFirstResponder(self)
+    }
+
+    func ownsKeyboardFocus(_ responder: NSResponder) -> Bool {
+        if responder === self { return true }
+        if ownsSearchFieldFocus?() == true, Self.isTextFieldEditor(responder) {
+            return true
+        }
+        guard let responderView = Self.view(for: responder) else { return false }
+        guard let root = focusRootView else { return false }
+        return responderView === root || responderView.isDescendant(of: root)
+    }
+
+    private static func isTextFieldEditor(_ responder: NSResponder) -> Bool {
+        guard let textView = responder as? NSTextView else { return false }
+        return textView.isFieldEditor
+    }
+
+    private static func view(for responder: NSResponder) -> NSView? {
+        if let textView = responder as? NSTextView,
+           textView.isFieldEditor,
+           let delegateResponder = textView.delegate as? NSResponder,
+           delegateResponder !== textView,
+           let delegateView = view(for: delegateResponder) {
+            return delegateView
+        }
+
+        var current: NSResponder? = responder
+        while let candidate = current {
+            if let view = candidate as? NSView {
+                return view
+            }
+            current = candidate.nextResponder
+        }
+        return nil
+    }
+
+    private var focusRootView: NSView? {
+        superview
+    }
+}

--- a/Sources/Search/GlobalSearchKeyboardFocusBridge.swift
+++ b/Sources/Search/GlobalSearchKeyboardFocusBridge.swift
@@ -75,6 +75,7 @@ final class GlobalSearchKeyboardFocusView: NSView {
     var placement: GlobalSearchSurfacePlacement = .rightSidebar
     var onFocusSearchField: (() -> Bool)?
     var ownsSearchFieldFocus: (() -> Bool)?
+    private weak var registeredWindow: NSWindow?
 
     override var acceptsFirstResponder: Bool { true }
     override var canBecomeKeyView: Bool { true }
@@ -90,7 +91,12 @@ final class GlobalSearchKeyboardFocusView: NSView {
     }
 
     func registerWithKeyboardFocusCoordinatorIfNeeded() {
-        guard placement == .rightSidebar, let window else { return }
+        guard placement == .rightSidebar, let window else {
+            registeredWindow = nil
+            return
+        }
+        guard registeredWindow !== window else { return }
+        registeredWindow = window
         AppDelegate.shared?.keyboardFocusCoordinator(for: window)?.registerGlobalSearchHost(self)
     }
 

--- a/Sources/Search/GlobalSearchPanelCaptureManager.swift
+++ b/Sources/Search/GlobalSearchPanelCaptureManager.swift
@@ -38,6 +38,8 @@ final class GlobalSearchPanelCaptureManager {
             }
         } else if let browserPanel = context.panel as? BrowserPanel {
             captureBrowserPanel(browserPanel)
+        } else if let terminalPanel = context.panel as? TerminalPanel {
+            await indexTerminalPanel(terminalPanel, context: context, index: index)
         }
     }
 
@@ -279,6 +281,51 @@ final class GlobalSearchPanelCaptureManager {
             return try JSONDecoder().decode(BrowserPagePayload.self, from: data)
         } catch {
             return nil
+        }
+    }
+
+    private func indexTerminalPanel(
+        _ panel: TerminalPanel,
+        context: GlobalSearchPanelContext,
+        index: SearchIndex
+    ) async {
+        guard !Task.isCancelled else { return }
+        guard let scrollback = TerminalController.shared.readTerminalTextForSnapshot(
+            terminalPanel: panel,
+            includeScrollback: true,
+            lineLimit: GlobalSearchIndexingLimits.maxIndexedTerminalScrollbackLines
+        ) else {
+            await purgeTerminalDocuments(forPanelID: context.panelID, index: index)
+            return
+        }
+
+        let documents = GlobalSearchDocuments.terminalDocuments(
+            scrollback: scrollback,
+            context: context
+        )
+
+        do {
+            guard !Task.isCancelled else { return }
+            try await index.replacePanelDocuments(
+                panelID: context.panelID,
+                kind: .terminal,
+                with: documents
+            )
+        } catch {
+            guard !Task.isCancelled else { return }
+#if DEBUG
+            cmuxDebugLog("globalSearch.terminal.upsert failed panel=\(context.panelID.uuidString.prefix(5)) error=\(error.localizedDescription)")
+#endif
+        }
+    }
+
+    private func purgeTerminalDocuments(forPanelID panelID: UUID, index: SearchIndex) async {
+        do {
+            try await index.deletePanelDocuments(panelID: panelID, kind: .terminal)
+        } catch {
+#if DEBUG
+            cmuxDebugLog("globalSearch.terminal.purge failed panel=\(panelID.uuidString.prefix(5)) error=\(error.localizedDescription)")
+#endif
         }
     }
 }

--- a/Sources/Search/GlobalSearchPanelCaptureManager.swift
+++ b/Sources/Search/GlobalSearchPanelCaptureManager.swift
@@ -299,10 +299,13 @@ final class GlobalSearchPanelCaptureManager {
             return
         }
 
-        let documents = GlobalSearchDocuments.terminalDocuments(
-            scrollback: scrollback,
-            context: context
-        )
+        let terminalContext = context.terminalDocumentContext
+        let documents = await Task.detached(priority: .utility) {
+            GlobalSearchDocuments.terminalDocuments(
+                scrollback: scrollback,
+                context: terminalContext
+            )
+        }.value
 
         do {
             guard !Task.isCancelled else { return }

--- a/Sources/Search/GlobalSearchPanelCaptureManager.swift
+++ b/Sources/Search/GlobalSearchPanelCaptureManager.swift
@@ -350,7 +350,8 @@ final class GlobalSearchPanelCaptureManager {
         guard let scrollback = TerminalController.shared.readTerminalTextForSnapshot(
             terminalPanel: panel,
             includeScrollback: true,
-            lineLimit: GlobalSearchIndexingLimits.maxIndexedTerminalScrollbackLines
+            lineLimit: GlobalSearchIndexingLimits.maxIndexedTerminalScrollbackLines,
+            allowVTExport: false
         ) else {
             await purgeTerminalDocuments(forPanelID: context.panelID, index: index)
             return

--- a/Sources/Search/GlobalSearchPanelCaptureManager.swift
+++ b/Sources/Search/GlobalSearchPanelCaptureManager.swift
@@ -4,6 +4,7 @@ import Foundation
 final class GlobalSearchPanelCaptureManager {
     private let browserCaptureDebounceMilliseconds = 250
     private let markdownCaptureDebounceMilliseconds = 250
+    private let terminalCaptureDebounceMilliseconds = 300
     private let indexProvider: () async -> SearchIndex?
     private let cancelPanelPurge: (UUID) -> Void
 
@@ -13,6 +14,9 @@ final class GlobalSearchPanelCaptureManager {
     private var markdownCaptureTimers: [UUID: DispatchSourceTimer] = [:]
     private var markdownCaptureTasks: [UUID: Task<Void, Never>] = [:]
     private var markdownCaptureTaskIDs: [UUID: UUID] = [:]
+    private var terminalCaptureTimers: [UUID: DispatchSourceTimer] = [:]
+    private var terminalCaptureTasks: [UUID: Task<Void, Never>] = [:]
+    private var terminalCaptureTaskIDs: [UUID: UUID] = [:]
 
     init(
         indexProvider: @escaping () async -> SearchIndex?,
@@ -161,9 +165,54 @@ final class GlobalSearchPanelCaptureManager {
         timer.resume()
     }
 
+    func captureTerminalPanel(id panelID: UUID) {
+        let taskID = UUID()
+        cancelPanelPurge(panelID)
+        cancelTerminalCapture(forPanelID: panelID)
+        terminalCaptureTaskIDs[panelID] = taskID
+
+        let timer = makeDebounceTimer(milliseconds: terminalCaptureDebounceMilliseconds) { [weak self] in
+            Task { @MainActor [weak self] in
+                guard let self,
+                      self.terminalCaptureTaskIDs[panelID] == taskID else {
+                    return
+                }
+                self.terminalCaptureTimers[panelID]?.cancel()
+                self.terminalCaptureTimers[panelID] = nil
+
+                let task = Task { @MainActor [weak self] in
+                    guard let self else { return }
+                    defer {
+                        if self.terminalCaptureTaskIDs[panelID] == taskID {
+                            self.terminalCaptureTasks[panelID] = nil
+                            self.terminalCaptureTaskIDs[panelID] = nil
+                        }
+                    }
+
+                    guard !Task.isCancelled,
+                          self.terminalCaptureTaskIDs[panelID] == taskID,
+                          let context = AppDelegate.shared?.globalSearchContext(
+                              forPanelID: panelID,
+                              preferredWorkspaceID: nil
+                          ),
+                          let terminalPanel = context.panel as? TerminalPanel,
+                          let index = await self.indexProvider() else {
+                        return
+                    }
+
+                    await self.indexTerminalPanel(terminalPanel, context: context, index: index)
+                }
+                self.terminalCaptureTasks[panelID] = task
+            }
+        }
+        terminalCaptureTimers[panelID] = timer
+        timer.resume()
+    }
+
     func cancelCaptures(forPanelID panelID: UUID) {
         cancelBrowserCapture(forPanelID: panelID)
         cancelMarkdownCapture(forPanelID: panelID)
+        cancelTerminalCapture(forPanelID: panelID)
     }
 
     private func cancelBrowserCapture(forPanelID panelID: UUID) {
@@ -180,6 +229,14 @@ final class GlobalSearchPanelCaptureManager {
         markdownCaptureTasks[panelID]?.cancel()
         markdownCaptureTasks[panelID] = nil
         markdownCaptureTaskIDs[panelID] = nil
+    }
+
+    private func cancelTerminalCapture(forPanelID panelID: UUID) {
+        terminalCaptureTimers[panelID]?.cancel()
+        terminalCaptureTimers[panelID] = nil
+        terminalCaptureTasks[panelID]?.cancel()
+        terminalCaptureTasks[panelID] = nil
+        terminalCaptureTaskIDs[panelID] = nil
     }
 
     private func makeDebounceTimer(

--- a/Sources/Search/MenubarSearchPopover.swift
+++ b/Sources/Search/MenubarSearchPopover.swift
@@ -77,7 +77,7 @@ private struct GlobalSearchPaletteView: View {
                 TextField(
                     String(
                         localized: "globalSearch.palette.placeholder",
-                        defaultValue: "Search all windows, panels, browser tabs..."
+                        defaultValue: "Search all terminals, panels, browser tabs..."
                     ),
                     text: $query
                 )
@@ -92,7 +92,9 @@ private struct GlobalSearchPaletteView: View {
 
             if results.isEmpty {
                 GlobalSearchEmptyStateView(
-                    title: query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                    title: isSearching
+                        ? String(localized: "globalSearch.empty.searching", defaultValue: "Searching...")
+                        : query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                         ? String(localized: "globalSearch.empty.noOpenPanels", defaultValue: "No open panels")
                         : String(localized: "globalSearch.empty.noResults", defaultValue: "No results")
                 )
@@ -360,6 +362,8 @@ private struct GlobalSearchResultRow: Identifiable, Equatable {
             return "globe"
         case .markdown:
             return "doc.richtext"
+        case .terminal:
+            return "terminal"
         case .title:
             return "rectangle.stack"
         }

--- a/Sources/Search/MenubarSearchPopover.swift
+++ b/Sources/Search/MenubarSearchPopover.swift
@@ -18,7 +18,7 @@ final class MenubarSearchPopover: NSObject, NSPopoverDelegate {
         popover.contentSize = NSSize(width: 720, height: 460)
         popover.delegate = self
         popover.contentViewController = NSHostingController(
-            rootView: GlobalSearchPaletteView(coordinator: coordinator)
+            rootView: GlobalSearchSurfaceView(coordinator: coordinator, placement: .popover)
         )
     }
 
@@ -51,8 +51,79 @@ final class MenubarSearchPopover: NSObject, NSPopoverDelegate {
     }
 }
 
-private struct GlobalSearchPaletteView: View {
+enum GlobalSearchSurfacePlacement {
+    case popover
+    case rightSidebar
+    case pane
+
+    var fixedSize: CGSize? {
+        switch self {
+        case .popover:
+            return CGSize(width: 720, height: 460)
+        case .rightSidebar, .pane:
+            return nil
+        }
+    }
+
+    var headerHeight: CGFloat {
+        switch self {
+        case .popover:
+            return 56
+        case .rightSidebar, .pane:
+            return 44
+        }
+    }
+
+    var horizontalPadding: CGFloat {
+        switch self {
+        case .popover:
+            return 18
+        case .rightSidebar, .pane:
+            return 12
+        }
+    }
+
+    var searchFontSize: CGFloat {
+        switch self {
+        case .popover:
+            return 18
+        case .rightSidebar, .pane:
+            return 14
+        }
+    }
+
+    var rowHorizontalPadding: CGFloat {
+        switch self {
+        case .popover:
+            return 14
+        case .rightSidebar, .pane:
+            return 10
+        }
+    }
+
+    var rowVerticalPadding: CGFloat {
+        switch self {
+        case .popover:
+            return 8
+        case .rightSidebar, .pane:
+            return 7
+        }
+    }
+
+    var focusesSearchFieldOnAppear: Bool {
+        switch self {
+        case .popover, .pane:
+            return true
+        case .rightSidebar:
+            return false
+        }
+    }
+}
+
+struct GlobalSearchSurfaceView: View {
     let coordinator: GlobalSearchCoordinator
+    let placement: GlobalSearchSurfacePlacement
+    var onFocusAnchorChange: (GlobalSearchKeyboardFocusView?) -> Void = { _ in }
 
     @State private var query = ""
     @State private var results: [GlobalSearchResultRow] = []
@@ -63,6 +134,7 @@ private struct GlobalSearchPaletteView: View {
     @State private var searchTask: Task<Void, Never>?
     @State private var refreshTask: Task<Void, Never>?
     @State private var keyMonitor: Any?
+    @State private var focusAnchorBox = GlobalSearchFocusAnchorBox()
     @FocusState private var searchFieldFocused: Bool
 
     private let searchDebounceMilliseconds = 80
@@ -82,11 +154,12 @@ private struct GlobalSearchPaletteView: View {
                     text: $query
                 )
                 .textFieldStyle(.plain)
-                .font(.system(size: 18, weight: .regular))
+                .font(.system(size: placement.searchFontSize, weight: .regular))
                 .focused($searchFieldFocused)
+                .accessibilityIdentifier("GlobalSearch.searchField")
             }
-            .padding(.horizontal, 18)
-            .frame(height: 56)
+            .padding(.horizontal, placement.horizontalPadding)
+            .frame(height: placement.headerHeight)
 
             Divider()
 
@@ -106,6 +179,7 @@ private struct GlobalSearchPaletteView: View {
                             GlobalSearchResultRowView(
                                 row: row,
                                 isSelected: selectedIndex == row.index,
+                                placement: placement,
                                 action: {
                                     selectedIndex = row.index
                                     openSelectedResult()
@@ -122,10 +196,20 @@ private struct GlobalSearchPaletteView: View {
                 }
             }
         }
-        .frame(width: 720, height: 460)
-        .background(.regularMaterial)
+        .modifier(GlobalSearchSurfaceFrameModifier(placement: placement))
+        .background(surfaceBackground)
+        .background(
+            GlobalSearchKeyboardFocusAnchor(
+                placement: placement,
+                onViewChange: attachFocusAnchor,
+                onFocusSearchField: focusSearchFieldFromCoordinator
+            )
+            .frame(width: 0, height: 0)
+        )
         .onAppear {
-            searchFieldFocused = true
+            if placement.focusesSearchFieldOnAppear {
+                searchFieldFocused = true
+            }
             installKeyMonitorIfNeeded()
             resetResultsForPopoverOpen()
             refreshTask?.cancel()
@@ -137,6 +221,7 @@ private struct GlobalSearchPaletteView: View {
         }
         .onDisappear {
             removeKeyMonitor()
+            attachFocusAnchor(nil)
             refreshTask?.cancel()
             refreshTask = nil
             cancelSearchWork()
@@ -144,6 +229,27 @@ private struct GlobalSearchPaletteView: View {
         .onChange(of: query) { _, newValue in
             scheduleSearch(newValue)
         }
+    }
+
+    @ViewBuilder
+    private var surfaceBackground: some View {
+        switch placement {
+        case .popover:
+            Rectangle()
+                .fill(.regularMaterial)
+        case .rightSidebar, .pane:
+            Color(nsColor: .controlBackgroundColor)
+        }
+    }
+
+    private func attachFocusAnchor(_ anchor: GlobalSearchKeyboardFocusView?) {
+        focusAnchorBox.view = anchor
+        onFocusAnchorChange(anchor)
+    }
+
+    private func focusSearchFieldFromCoordinator() -> Bool {
+        searchFieldFocused = true
+        return true
     }
 
     private func scheduleSearch(_ nextQuery: String) {
@@ -235,7 +341,7 @@ private struct GlobalSearchPaletteView: View {
     }
 
     private func handleKeyEvent(_ event: GlobalSearchKeyEvent) -> Bool {
-        guard coordinator.isPaletteVisible() else { return false }
+        guard keyHandlingIsActive(for: event) else { return false }
 
         let flags = event.modifierFlags
         if flags.contains(.command),
@@ -250,6 +356,7 @@ private struct GlobalSearchPaletteView: View {
 
         switch event.keyCode {
         case 53:
+            guard placement == .popover else { return false }
             coordinator.dismissPalette()
             return true
         case 126:
@@ -268,6 +375,21 @@ private struct GlobalSearchPaletteView: View {
                 return !isTextEditingCommand(event) && !isSystemCommand(event)
             }
             return false
+        }
+    }
+
+    private func keyHandlingIsActive(for event: GlobalSearchKeyEvent) -> Bool {
+        switch placement {
+        case .popover:
+            return coordinator.isPaletteVisible()
+        case .rightSidebar, .pane:
+            guard let focusAnchorView = focusAnchorBox.view,
+                  let window = focusAnchorView.window,
+                  event.windowNumber == 0 || event.windowNumber == window.windowNumber,
+                  let responder = window.firstResponder else {
+                return false
+            }
+            return focusAnchorView.ownsKeyboardFocus(responder)
         }
     }
 
@@ -301,14 +423,32 @@ private struct GlobalSearchPaletteView: View {
     }
 }
 
+private final class GlobalSearchFocusAnchorBox {
+    weak var view: GlobalSearchKeyboardFocusView?
+}
+
+private struct GlobalSearchSurfaceFrameModifier: ViewModifier {
+    let placement: GlobalSearchSurfacePlacement
+
+    func body(content: Content) -> some View {
+        if let fixedSize = placement.fixedSize {
+            content.frame(width: fixedSize.width, height: fixedSize.height)
+        } else {
+            content.frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+}
+
 private struct GlobalSearchKeyEvent: Sendable {
     let keyCode: UInt16
     let charactersIgnoringModifiers: String?
+    let windowNumber: Int
     private let modifierFlagsRawValue: UInt
 
     init(_ event: NSEvent) {
         keyCode = event.keyCode
         charactersIgnoringModifiers = event.charactersIgnoringModifiers
+        windowNumber = event.windowNumber
         modifierFlagsRawValue = event.modifierFlags
             .intersection(.deviceIndependentFlagsMask)
             .rawValue
@@ -316,6 +456,131 @@ private struct GlobalSearchKeyEvent: Sendable {
 
     var modifierFlags: NSEvent.ModifierFlags {
         NSEvent.ModifierFlags(rawValue: modifierFlagsRawValue)
+    }
+}
+
+private struct GlobalSearchKeyboardFocusAnchor: NSViewRepresentable {
+    final class Coordinator {
+        var placement: GlobalSearchSurfacePlacement
+        var onViewChange: (GlobalSearchKeyboardFocusView?) -> Void
+        var onFocusSearchField: () -> Bool
+        weak var attachedView: GlobalSearchKeyboardFocusView?
+
+        init(
+            placement: GlobalSearchSurfacePlacement,
+            onViewChange: @escaping (GlobalSearchKeyboardFocusView?) -> Void,
+            onFocusSearchField: @escaping () -> Bool
+        ) {
+            self.placement = placement
+            self.onViewChange = onViewChange
+            self.onFocusSearchField = onFocusSearchField
+        }
+
+        func attach(_ view: GlobalSearchKeyboardFocusView) {
+            view.placement = placement
+            view.onFocusSearchField = onFocusSearchField
+            guard attachedView !== view else { return }
+            attachedView = view
+            onViewChange(view)
+        }
+
+        func detach(_ view: GlobalSearchKeyboardFocusView) {
+            guard attachedView === view else { return }
+            attachedView = nil
+            onViewChange(nil)
+        }
+    }
+
+    let placement: GlobalSearchSurfacePlacement
+    var onViewChange: (GlobalSearchKeyboardFocusView?) -> Void
+    var onFocusSearchField: () -> Bool
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(
+            placement: placement,
+            onViewChange: onViewChange,
+            onFocusSearchField: onFocusSearchField
+        )
+    }
+
+    func makeNSView(context: Context) -> GlobalSearchKeyboardFocusView {
+        let view = GlobalSearchKeyboardFocusView()
+        context.coordinator.attach(view)
+        return view
+    }
+
+    func updateNSView(_ nsView: GlobalSearchKeyboardFocusView, context: Context) {
+        context.coordinator.placement = placement
+        context.coordinator.onViewChange = onViewChange
+        context.coordinator.onFocusSearchField = onFocusSearchField
+        context.coordinator.attach(nsView)
+        nsView.registerWithKeyboardFocusCoordinatorIfNeeded()
+    }
+
+    static func dismantleNSView(_ nsView: GlobalSearchKeyboardFocusView, coordinator: Coordinator) {
+        coordinator.detach(nsView)
+    }
+}
+
+final class GlobalSearchKeyboardFocusView: NSView {
+    var placement: GlobalSearchSurfacePlacement = .popover
+    var onFocusSearchField: (() -> Bool)?
+
+    override var acceptsFirstResponder: Bool { true }
+    override var canBecomeKeyView: Bool { true }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        registerWithKeyboardFocusCoordinatorIfNeeded()
+    }
+
+    override func layout() {
+        super.layout()
+        registerWithKeyboardFocusCoordinatorIfNeeded()
+    }
+
+    func registerWithKeyboardFocusCoordinatorIfNeeded() {
+        guard placement == .rightSidebar, let window else { return }
+        AppDelegate.shared?.keyboardFocusCoordinator(for: window)?.registerGlobalSearchHost(self)
+    }
+
+    func focusSearchFieldFromCoordinator() -> Bool {
+        if onFocusSearchField?() == true {
+            return true
+        }
+        guard let window else { return false }
+        return window.makeFirstResponder(self)
+    }
+
+    func ownsKeyboardFocus(_ responder: NSResponder) -> Bool {
+        if responder === self { return true }
+        guard let responderView = Self.view(for: responder) else { return false }
+        guard let root = focusRootView else { return false }
+        return responderView === root || responderView.isDescendant(of: root)
+    }
+
+    private static func view(for responder: NSResponder) -> NSView? {
+        if let view = responder as? NSView {
+            return view
+        }
+        if let textView = responder as? NSTextView,
+           let delegateView = textView.delegate as? NSView {
+            return delegateView
+        }
+        return nil
+    }
+
+    private var focusRootView: NSView? {
+        guard let superview else { return nil }
+        var current: NSView? = superview
+        while let view = current {
+            let typeName = String(describing: type(of: view))
+            if typeName.contains("NSHosting") || typeName.contains("ViewHost") {
+                return view
+            }
+            current = view.superview
+        }
+        return superview
     }
 }
 
@@ -373,6 +638,7 @@ private struct GlobalSearchResultRow: Identifiable, Equatable {
 private struct GlobalSearchResultRowView: View {
     let row: GlobalSearchResultRow
     let isSelected: Bool
+    let placement: GlobalSearchSurfacePlacement
     let action: () -> Void
 
     var body: some View {
@@ -414,12 +680,13 @@ private struct GlobalSearchResultRowView: View {
                         .frame(minWidth: 30, alignment: .trailing)
                 }
             }
-            .padding(.horizontal, 14)
-            .padding(.vertical, 8)
+            .padding(.horizontal, placement.rowHorizontalPadding)
+            .padding(.vertical, placement.rowVerticalPadding)
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(isSelected ? Color.accentColor.opacity(0.16) : Color.clear)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .accessibilityIdentifier("GlobalSearch.resultRow.\(row.index)")
     }
 }

--- a/Sources/Search/MenubarSearchPopover.swift
+++ b/Sources/Search/MenubarSearchPopover.swift
@@ -139,7 +139,8 @@ struct GlobalSearchSurfaceView: View {
             GlobalSearchKeyboardFocusAnchor(
                 placement: placement,
                 onViewChange: attachFocusAnchor,
-                onFocusSearchField: focusSearchFieldFromCoordinator
+                onFocusSearchField: focusSearchFieldFromCoordinator,
+                ownsSearchFieldFocus: { searchFieldFocused }
             )
             .frame(width: 0, height: 0)
         )
@@ -182,6 +183,7 @@ struct GlobalSearchSurfaceView: View {
     }
 
     private func focusSearchFieldFromCoordinator() -> Bool {
+        guard focusAnchorBox.view?.window != nil else { return false }
         searchFieldFocused = true
         return true
     }
@@ -386,131 +388,6 @@ private struct GlobalSearchKeyEvent: Sendable {
 
     var modifierFlags: NSEvent.ModifierFlags {
         NSEvent.ModifierFlags(rawValue: modifierFlagsRawValue)
-    }
-}
-
-private struct GlobalSearchKeyboardFocusAnchor: NSViewRepresentable {
-    final class Coordinator {
-        var placement: GlobalSearchSurfacePlacement
-        var onViewChange: (GlobalSearchKeyboardFocusView?) -> Void
-        var onFocusSearchField: () -> Bool
-        weak var attachedView: GlobalSearchKeyboardFocusView?
-
-        init(
-            placement: GlobalSearchSurfacePlacement,
-            onViewChange: @escaping (GlobalSearchKeyboardFocusView?) -> Void,
-            onFocusSearchField: @escaping () -> Bool
-        ) {
-            self.placement = placement
-            self.onViewChange = onViewChange
-            self.onFocusSearchField = onFocusSearchField
-        }
-
-        func attach(_ view: GlobalSearchKeyboardFocusView) {
-            view.placement = placement
-            view.onFocusSearchField = onFocusSearchField
-            guard attachedView !== view else { return }
-            attachedView = view
-            onViewChange(view)
-        }
-
-        func detach(_ view: GlobalSearchKeyboardFocusView) {
-            guard attachedView === view else { return }
-            attachedView = nil
-            onViewChange(nil)
-        }
-    }
-
-    let placement: GlobalSearchSurfacePlacement
-    var onViewChange: (GlobalSearchKeyboardFocusView?) -> Void
-    var onFocusSearchField: () -> Bool
-
-    func makeCoordinator() -> Coordinator {
-        Coordinator(
-            placement: placement,
-            onViewChange: onViewChange,
-            onFocusSearchField: onFocusSearchField
-        )
-    }
-
-    func makeNSView(context: Context) -> GlobalSearchKeyboardFocusView {
-        let view = GlobalSearchKeyboardFocusView()
-        context.coordinator.attach(view)
-        return view
-    }
-
-    func updateNSView(_ nsView: GlobalSearchKeyboardFocusView, context: Context) {
-        context.coordinator.placement = placement
-        context.coordinator.onViewChange = onViewChange
-        context.coordinator.onFocusSearchField = onFocusSearchField
-        context.coordinator.attach(nsView)
-        nsView.registerWithKeyboardFocusCoordinatorIfNeeded()
-    }
-
-    static func dismantleNSView(_ nsView: GlobalSearchKeyboardFocusView, coordinator: Coordinator) {
-        coordinator.detach(nsView)
-    }
-}
-
-final class GlobalSearchKeyboardFocusView: NSView {
-    var placement: GlobalSearchSurfacePlacement = .rightSidebar
-    var onFocusSearchField: (() -> Bool)?
-
-    override var acceptsFirstResponder: Bool { true }
-    override var canBecomeKeyView: Bool { true }
-
-    override func viewDidMoveToWindow() {
-        super.viewDidMoveToWindow()
-        registerWithKeyboardFocusCoordinatorIfNeeded()
-    }
-
-    override func layout() {
-        super.layout()
-        registerWithKeyboardFocusCoordinatorIfNeeded()
-    }
-
-    func registerWithKeyboardFocusCoordinatorIfNeeded() {
-        guard placement == .rightSidebar, let window else { return }
-        AppDelegate.shared?.keyboardFocusCoordinator(for: window)?.registerGlobalSearchHost(self)
-    }
-
-    func focusSearchFieldFromCoordinator() -> Bool {
-        if onFocusSearchField?() == true {
-            return true
-        }
-        guard let window else { return false }
-        return window.makeFirstResponder(self)
-    }
-
-    func ownsKeyboardFocus(_ responder: NSResponder) -> Bool {
-        if responder === self { return true }
-        guard let responderView = Self.view(for: responder) else { return false }
-        guard let root = focusRootView else { return false }
-        return responderView === root || responderView.isDescendant(of: root)
-    }
-
-    private static func view(for responder: NSResponder) -> NSView? {
-        if let view = responder as? NSView {
-            return view
-        }
-        if let textView = responder as? NSTextView,
-           let delegateView = textView.delegate as? NSView {
-            return delegateView
-        }
-        return nil
-    }
-
-    private var focusRootView: NSView? {
-        guard let superview else { return nil }
-        var current: NSView? = superview
-        while let view = current {
-            let typeName = String(describing: type(of: view))
-            if typeName.contains("NSHosting") || typeName.contains("ViewHost") {
-                return view
-            }
-            current = view.superview
-        }
-        return superview
     }
 }
 

--- a/Sources/Search/MenubarSearchPopover.swift
+++ b/Sources/Search/MenubarSearchPopover.swift
@@ -1,65 +1,12 @@
 import AppKit
 import SwiftUI
 
-@MainActor
-final class MenubarSearchPopover: NSObject, NSPopoverDelegate {
-    private unowned let coordinator: GlobalSearchCoordinator
-    private let popover = NSPopover()
-
-    var isShown: Bool {
-        popover.isShown
-    }
-
-    init(coordinator: GlobalSearchCoordinator) {
-        self.coordinator = coordinator
-        super.init()
-        popover.behavior = .transient
-        popover.animates = true
-        popover.contentSize = NSSize(width: 720, height: 460)
-        popover.delegate = self
-        popover.contentViewController = NSHostingController(
-            rootView: GlobalSearchSurfaceView(coordinator: coordinator, placement: .popover)
-        )
-    }
-
-    private var dismissalHandler: (() -> Void)?
-
-    func toggle(relativeTo button: NSStatusBarButton, onDismiss: (() -> Void)? = nil) {
-        if popover.isShown {
-            dismiss()
-        } else {
-            show(relativeTo: button, onDismiss: onDismiss)
-        }
-    }
-
-    func show(relativeTo button: NSStatusBarButton, onDismiss: (() -> Void)? = nil) {
-        if popover.isShown {
-            popover.performClose(nil)
-        }
-        dismissalHandler = onDismiss
-        popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
-    }
-
-    func dismiss() {
-        popover.performClose(nil)
-    }
-
-    func popoverDidClose(_ notification: Notification) {
-        let handler = dismissalHandler
-        dismissalHandler = nil
-        handler?()
-    }
-}
-
 enum GlobalSearchSurfacePlacement {
-    case popover
     case rightSidebar
     case pane
 
     var fixedSize: CGSize? {
         switch self {
-        case .popover:
-            return CGSize(width: 720, height: 460)
         case .rightSidebar, .pane:
             return nil
         }
@@ -67,8 +14,6 @@ enum GlobalSearchSurfacePlacement {
 
     var headerHeight: CGFloat {
         switch self {
-        case .popover:
-            return 56
         case .rightSidebar, .pane:
             return 44
         }
@@ -76,8 +21,6 @@ enum GlobalSearchSurfacePlacement {
 
     var horizontalPadding: CGFloat {
         switch self {
-        case .popover:
-            return 18
         case .rightSidebar, .pane:
             return 12
         }
@@ -85,8 +28,6 @@ enum GlobalSearchSurfacePlacement {
 
     var searchFontSize: CGFloat {
         switch self {
-        case .popover:
-            return 18
         case .rightSidebar, .pane:
             return 14
         }
@@ -94,8 +35,6 @@ enum GlobalSearchSurfacePlacement {
 
     var rowHorizontalPadding: CGFloat {
         switch self {
-        case .popover:
-            return 14
         case .rightSidebar, .pane:
             return 10
         }
@@ -103,8 +42,6 @@ enum GlobalSearchSurfacePlacement {
 
     var rowVerticalPadding: CGFloat {
         switch self {
-        case .popover:
-            return 8
         case .rightSidebar, .pane:
             return 7
         }
@@ -112,7 +49,7 @@ enum GlobalSearchSurfacePlacement {
 
     var focusesSearchFieldOnAppear: Bool {
         switch self {
-        case .popover, .pane:
+        case .pane:
             return true
         case .rightSidebar:
             return false
@@ -234,9 +171,6 @@ struct GlobalSearchSurfaceView: View {
     @ViewBuilder
     private var surfaceBackground: some View {
         switch placement {
-        case .popover:
-            Rectangle()
-                .fill(.regularMaterial)
         case .rightSidebar, .pane:
             Color(nsColor: .controlBackgroundColor)
         }
@@ -356,9 +290,7 @@ struct GlobalSearchSurfaceView: View {
 
         switch event.keyCode {
         case 53:
-            guard placement == .popover else { return false }
-            coordinator.dismissPalette()
-            return true
+            return false
         case 126:
             selectedIndex = max(0, selectedIndex - 1)
             return true
@@ -380,8 +312,6 @@ struct GlobalSearchSurfaceView: View {
 
     private func keyHandlingIsActive(for event: GlobalSearchKeyEvent) -> Bool {
         switch placement {
-        case .popover:
-            return coordinator.isPaletteVisible()
         case .rightSidebar, .pane:
             guard let focusAnchorView = focusAnchorBox.view,
                   let window = focusAnchorView.window,
@@ -523,7 +453,7 @@ private struct GlobalSearchKeyboardFocusAnchor: NSViewRepresentable {
 }
 
 final class GlobalSearchKeyboardFocusView: NSView {
-    var placement: GlobalSearchSurfacePlacement = .popover
+    var placement: GlobalSearchSurfacePlacement = .rightSidebar
     var onFocusSearchField: (() -> Bool)?
 
     override var acceptsFirstResponder: Bool { true }

--- a/Sources/Search/SearchIndex.swift
+++ b/Sources/Search/SearchIndex.swift
@@ -4,6 +4,7 @@ import SQLite3
 enum GlobalSearchKind: String, Codable, Sendable {
     case browser
     case markdown
+    case terminal
     case title
 
     var localizedLabel: String {
@@ -12,6 +13,8 @@ enum GlobalSearchKind: String, Codable, Sendable {
             return String(localized: "globalSearch.kind.browser", defaultValue: "Browser")
         case .markdown:
             return String(localized: "globalSearch.kind.markdown", defaultValue: "Markdown")
+        case .terminal:
+            return String(localized: "globalSearch.kind.terminal", defaultValue: "Terminal")
         case .title:
             return String(localized: "globalSearch.kind.title", defaultValue: "Title")
         }
@@ -64,6 +67,10 @@ struct SearchIndexDocument: Sendable, Equatable {
             kind.rawValue,
             subtype
         ].joined(separator: ":")
+    }
+
+    static func terminalLineChunkStableID(panelID: UUID, startLineNumber: Int) -> String {
+        panelStableID(panelID: panelID, kind: .terminal, subtype: "line:\(startLineNumber)")
     }
 }
 
@@ -188,6 +195,32 @@ actor SearchIndex {
         }
     }
 
+    func deletePanelDocuments(panelID: UUID, kind: GlobalSearchKind) throws {
+        try withStatement("DELETE FROM chunks WHERE panel_id = ?1 AND kind = ?2") { statement in
+            try bind(panelID.uuidString, at: 1, in: statement)
+            try bind(kind.rawValue, at: 2, in: statement)
+            try stepDone(statement)
+        }
+    }
+
+    func replacePanelDocuments(
+        panelID: UUID,
+        kind: GlobalSearchKind,
+        with documents: [SearchIndexDocument]
+    ) throws {
+        try execute("BEGIN IMMEDIATE TRANSACTION")
+        do {
+            try deletePanelDocuments(panelID: panelID, kind: kind)
+            for document in documents {
+                try upsert(document)
+            }
+            try execute("COMMIT")
+        } catch {
+            try? execute("ROLLBACK")
+            throw error
+        }
+    }
+
     func deleteDocument(id: String) throws {
         try withStatement("DELETE FROM chunks WHERE id = ?1") { statement in
             try bind(id, at: 1, in: statement)
@@ -202,7 +235,6 @@ actor SearchIndex {
     func search(_ rawQuery: String, limit: Int = 20) throws -> [SearchIndexHit] {
         let trimmed = rawQuery.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty, limit > 0 else { return [] }
-        guard let matchQuery = Self.matchQuery(for: trimmed) else { return [] }
 
         let sql = """
             SELECT
@@ -224,29 +256,43 @@ actor SearchIndex {
             LIMIT ?2
             """
 
-        return try withStatement(sql) { statement in
-            try bind(matchQuery, at: 1, in: statement)
-            let limitBindResult = sqlite3_bind_int64(statement, 2, sqlite3_int64(limit))
-            guard limitBindResult == SQLITE_OK else {
-                throw SearchIndexError.bindFailed(
-                    Self.sqliteMessage(database) ?? "bind failed with code \(limitBindResult)"
-                )
-            }
+        let ftsHits: [SearchIndexHit]
+        if let matchQuery = Self.matchQuery(for: trimmed) {
+            ftsHits = try withStatement(sql) { statement in
+                try bind(matchQuery, at: 1, in: statement)
+                let limitBindResult = sqlite3_bind_int64(statement, 2, sqlite3_int64(limit))
+                guard limitBindResult == SQLITE_OK else {
+                    throw SearchIndexError.bindFailed(
+                        Self.sqliteMessage(database) ?? "bind failed with code \(limitBindResult)"
+                    )
+                }
 
-            var hits: [SearchIndexHit] = []
-            while true {
-                let stepResult = sqlite3_step(statement)
-                switch stepResult {
-                case SQLITE_ROW:
-                    guard let hit = Self.hit(from: statement) else { continue }
-                    hits.append(hit)
-                case SQLITE_DONE:
-                    return hits
-                default:
-                    throw SearchIndexError.stepFailed(Self.sqliteMessage(database) ?? "step failed with code \(stepResult)")
+                var hits: [SearchIndexHit] = []
+                while true {
+                    let stepResult = sqlite3_step(statement)
+                    switch stepResult {
+                    case SQLITE_ROW:
+                        guard let hit = Self.hit(from: statement) else { continue }
+                        hits.append(hit)
+                    case SQLITE_DONE:
+                        return hits
+                    default:
+                        throw SearchIndexError.stepFailed(Self.sqliteMessage(database) ?? "step failed with code \(stepResult)")
+                    }
                 }
             }
+        } else {
+            ftsHits = []
         }
+
+        guard ftsHits.count < limit else { return ftsHits }
+        let excludedIDs = Set(ftsHits.map(\.id))
+        let fuzzyHits = try fuzzySearch(
+            trimmed,
+            excludingIDs: excludedIDs,
+            limit: limit - ftsHits.count
+        )
+        return Array((ftsHits + fuzzyHits).prefix(limit))
     }
 
     #if DEBUG
@@ -438,6 +484,119 @@ actor SearchIndex {
         )
     }
 
+    private struct StoredSearchDocument {
+        let id: String
+        let windowID: UUID
+        let workspaceID: UUID
+        let panelID: UUID?
+        let kind: GlobalSearchKind
+        let title: String
+        let location: String
+        let anchor: String
+        let timestamp: Date
+        let text: String
+    }
+
+    private func fuzzySearch(
+        _ rawQuery: String,
+        excludingIDs excludedIDs: Set<String>,
+        limit: Int
+    ) throws -> [SearchIndexHit] {
+        guard limit > 0 else { return [] }
+        let fuzzyQuery = Self.normalizedFuzzyQuery(rawQuery)
+        guard !fuzzyQuery.isEmpty else { return [] }
+
+        let sql = """
+            SELECT
+                id,
+                window_id,
+                workspace_id,
+                panel_id,
+                kind,
+                title,
+                location,
+                anchor,
+                ts,
+                text
+            FROM chunks
+            ORDER BY ts DESC
+            """
+
+        let matches: [SearchIndexHit] = try withStatement(sql) { statement in
+            var hits: [SearchIndexHit] = []
+            while true {
+                let stepResult = sqlite3_step(statement)
+                switch stepResult {
+                case SQLITE_ROW:
+                    guard let document = Self.storedDocument(from: statement),
+                          !excludedIDs.contains(document.id) else {
+                        continue
+                    }
+                    let searchable = [
+                        document.title,
+                        document.location,
+                        document.text
+                    ].joined(separator: "\n")
+                    guard let score = Self.fuzzyScore(query: fuzzyQuery, candidate: searchable) else {
+                        continue
+                    }
+                    hits.append(
+                        SearchIndexHit(
+                            id: document.id,
+                            windowID: document.windowID,
+                            workspaceID: document.workspaceID,
+                            panelID: document.panelID,
+                            kind: document.kind,
+                            title: document.title,
+                            location: document.location,
+                            anchor: document.anchor,
+                            snippet: Self.fuzzySnippet(query: rawQuery, text: document.text, fallback: document.title),
+                            rank: 10_000 + score,
+                            timestamp: document.timestamp
+                        )
+                    )
+                case SQLITE_DONE:
+                    return hits
+                default:
+                    throw SearchIndexError.stepFailed(Self.sqliteMessage(database) ?? "step failed with code \(stepResult)")
+                }
+            }
+        }
+
+        return matches
+            .sorted {
+                if $0.rank != $1.rank { return $0.rank < $1.rank }
+                return $0.timestamp > $1.timestamp
+            }
+            .prefix(limit)
+            .map { $0 }
+    }
+
+    private static func storedDocument(from statement: OpaquePointer) -> StoredSearchDocument? {
+        guard let id = sqliteText(statement, 0),
+              let windowIDString = sqliteText(statement, 1),
+              let workspaceIDString = sqliteText(statement, 2),
+              let kindRawValue = sqliteText(statement, 4),
+              let windowID = UUID(uuidString: windowIDString),
+              let workspaceID = UUID(uuidString: workspaceIDString),
+              let kind = GlobalSearchKind(rawValue: kindRawValue) else {
+            return nil
+        }
+
+        return StoredSearchDocument(
+            id: id,
+            windowID: windowID,
+            workspaceID: workspaceID,
+            panelID: sqliteText(statement, 3).flatMap(UUID.init(uuidString:)),
+            kind: kind,
+            title: sqliteText(statement, 5) ?? "",
+            location: sqliteText(statement, 6) ?? "",
+            anchor: sqliteText(statement, 7) ?? "",
+            timestamp: Date(timeIntervalSince1970: sqlite3_column_double(statement, 8)),
+            text: sqliteText(statement, 9) ?? ""
+        )
+    }
+
     static func queryTokens(for rawQuery: String) -> [String] {
         let tokens = rawQuery
             .components(separatedBy: CharacterSet.alphanumerics.inverted)
@@ -446,6 +605,142 @@ actor SearchIndex {
             .map { $0.lowercased() }
 
         return tokens
+    }
+
+    static func normalizedFuzzyQuery(_ rawQuery: String) -> String {
+        rawQuery
+            .lowercased()
+            .unicodeScalars
+            .filter { !CharacterSet.whitespacesAndNewlines.contains($0) }
+            .map(String.init)
+            .joined()
+    }
+
+    static func fuzzyScore(query: String, candidate: String) -> Double? {
+        fuzzyMatch(query: query, candidate: candidate)?.score
+    }
+
+    static func fuzzyMatchedRange(query: String, in candidate: String) -> Range<String.Index>? {
+        let fuzzyQuery = normalizedFuzzyQuery(query)
+        guard let match = fuzzyMatch(query: fuzzyQuery, candidate: candidate),
+              let first = match.positions.first,
+              let last = match.positions.last else {
+            return nil
+        }
+
+        let scalars = candidate.unicodeScalars
+        guard let startScalar = scalars.index(scalars.startIndex, offsetBy: first, limitedBy: scalars.endIndex),
+              let lastScalar = scalars.index(scalars.startIndex, offsetBy: last, limitedBy: scalars.endIndex) else {
+            return nil
+        }
+        let endScalar = scalars.index(after: lastScalar)
+        let start = String.Index(startScalar, within: candidate) ?? candidate.startIndex
+        let end = String.Index(endScalar, within: candidate) ?? candidate.endIndex
+        return start..<end
+    }
+
+    private struct FuzzyMatch {
+        let score: Double
+        let positions: [Int]
+    }
+
+    private static func fuzzyMatch(query: String, candidate: String) -> FuzzyMatch? {
+        let queryScalars = Array(query.lowercased().unicodeScalars)
+        let candidateScalars = Array(candidate.lowercased().unicodeScalars)
+        guard !queryScalars.isEmpty, !candidateScalars.isEmpty else { return nil }
+
+        var bestPositions = Array<[Int]?>(repeating: nil, count: queryScalars.count)
+
+        for (candidateIndex, candidateScalar) in candidateScalars.enumerated() {
+            for queryIndex in stride(from: queryScalars.count - 1, through: 0, by: -1) {
+                guard queryScalars[queryIndex] == candidateScalar else { continue }
+
+                let positions: [Int]
+                if queryIndex == 0 {
+                    positions = [candidateIndex]
+                } else {
+                    guard let previousPositions = bestPositions[queryIndex - 1] else {
+                        continue
+                    }
+                    positions = previousPositions + [candidateIndex]
+                }
+
+                if isBetterFuzzyPrefix(positions, than: bestPositions[queryIndex]) {
+                    bestPositions[queryIndex] = positions
+                }
+            }
+        }
+
+        let lastQueryIndex = queryScalars.count - 1
+        guard let positions = bestPositions[lastQueryIndex] else {
+            return nil
+        }
+
+        var score = Double(positions.last ?? 0) * 0.001
+        score += Double((positions.last ?? 0) - (positions.first ?? 0)) * 2
+        for index in positions.indices.dropFirst() {
+            let gap = positions[index] - positions[index - 1] - 1
+            if gap == 0 {
+                score -= 1
+            }
+        }
+        return FuzzyMatch(
+            score: score,
+            positions: positions
+        )
+    }
+
+    private static func isBetterFuzzyPrefix(_ candidate: [Int], than current: [Int]?) -> Bool {
+        guard let current,
+              let candidateFirst = candidate.first,
+              let candidateLast = candidate.last,
+              let currentFirst = current.first,
+              let currentLast = current.last else {
+            return true
+        }
+
+        let candidateSpan = candidateLast - candidateFirst
+        let currentSpan = currentLast - currentFirst
+        if candidateSpan != currentSpan {
+            return candidateSpan < currentSpan
+        }
+        return candidateFirst > currentFirst
+    }
+
+    private static func fuzzySnippet(query: String, text: String, fallback: String) -> String {
+        let source = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        let fallbackSource = fallback.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !source.isEmpty else { return fallbackSource }
+
+        let lowercasedSource = source.lowercased()
+        if let token = queryTokens(for: query).first(where: { lowercasedSource.contains($0) }),
+           let range = lowercasedSource.range(of: token) {
+            return snippet(from: source, around: range.lowerBound)
+        }
+
+        let fuzzyQuery = normalizedFuzzyQuery(query)
+        if !fuzzyQuery.isEmpty,
+           let range = fuzzyMatchedRange(query: fuzzyQuery, in: source) {
+            return snippet(from: source, around: range.lowerBound)
+        }
+
+        return snippet(from: source, around: source.startIndex)
+    }
+
+    private static func snippet(from text: String, around index: String.Index, radius: Int = 90) -> String {
+        let lineStart = text[..<index].lastIndex(of: "\n").map { text.index(after: $0) } ?? text.startIndex
+        let start = text.distance(from: lineStart, to: index) <= radius
+            ? lineStart
+            : (text.index(index, offsetBy: -radius, limitedBy: text.startIndex) ?? text.startIndex)
+        let end = text.index(index, offsetBy: radius, limitedBy: text.endIndex) ?? text.endIndex
+        var snippet = String(text[start..<end])
+        if start > text.startIndex {
+            snippet = "..." + snippet
+        }
+        if end < text.endIndex {
+            snippet += "..."
+        }
+        return snippet
     }
 
     private static func matchQuery(for rawQuery: String) -> String? {

--- a/Sources/Search/SearchIndex.swift
+++ b/Sources/Search/SearchIndex.swift
@@ -326,6 +326,7 @@ actor SearchIndex {
             """, database: database)
         try execute("CREATE INDEX IF NOT EXISTS chunks_panel_idx ON chunks(panel_id)", database: database)
         try execute("CREATE INDEX IF NOT EXISTS chunks_workspace_idx ON chunks(workspace_id)", database: database)
+        try execute("CREATE INDEX IF NOT EXISTS chunks_ts_desc_idx ON chunks(ts DESC)", database: database)
         try execute("""
             CREATE VIRTUAL TABLE IF NOT EXISTS chunks_fts USING fts5(
                 title,

--- a/Sources/Search/SearchIndex.swift
+++ b/Sources/Search/SearchIndex.swift
@@ -671,25 +671,30 @@ actor SearchIndex {
         let positions: [Int]
     }
 
+    private struct FoldedCandidateScalar {
+        let scalar: UnicodeScalar
+        let originalOffset: Int
+    }
+
     private static func fuzzyMatch(query: String, candidate: String) -> FuzzyMatch? {
         let queryScalars = Array(query.lowercased().unicodeScalars)
-        let candidateScalars = Array(candidate.lowercased().unicodeScalars)
+        let candidateScalars = foldedCandidateScalars(candidate)
         guard !queryScalars.isEmpty, !candidateScalars.isEmpty else { return nil }
 
         var bestPositions = Array<[Int]?>(repeating: nil, count: queryScalars.count)
 
-        for (candidateIndex, candidateScalar) in candidateScalars.enumerated() {
+        for candidateScalar in candidateScalars {
             for queryIndex in stride(from: queryScalars.count - 1, through: 0, by: -1) {
-                guard queryScalars[queryIndex] == candidateScalar else { continue }
+                guard queryScalars[queryIndex] == candidateScalar.scalar else { continue }
 
                 let positions: [Int]
                 if queryIndex == 0 {
-                    positions = [candidateIndex]
+                    positions = [candidateScalar.originalOffset]
                 } else {
                     guard let previousPositions = bestPositions[queryIndex - 1] else {
                         continue
                     }
-                    positions = previousPositions + [candidateIndex]
+                    positions = previousPositions + [candidateScalar.originalOffset]
                 }
 
                 if isBetterFuzzyPrefix(positions, than: bestPositions[queryIndex]) {
@@ -717,6 +722,19 @@ actor SearchIndex {
         )
     }
 
+    private static func foldedCandidateScalars(_ candidate: String) -> [FoldedCandidateScalar] {
+        var folded: [FoldedCandidateScalar] = []
+        for (offset, scalar) in candidate.unicodeScalars.enumerated() {
+            let lowercaseScalars = String(scalar).lowercased().unicodeScalars
+            folded.append(
+                contentsOf: lowercaseScalars.map {
+                    FoldedCandidateScalar(scalar: $0, originalOffset: offset)
+                }
+            )
+        }
+        return folded
+    }
+
     private static func isBetterFuzzyPrefix(_ candidate: [Int], than current: [Int]?) -> Bool {
         guard let current,
               let candidateFirst = candidate.first,
@@ -741,7 +759,7 @@ actor SearchIndex {
 
         let lowercasedSource = source.lowercased()
         if let token = queryTokens(for: query).first(where: { lowercasedSource.contains($0) }),
-           let range = lowercasedSource.range(of: token) {
+           let range = source.range(of: token, options: [.caseInsensitive, .diacriticInsensitive]) {
             return snippet(from: source, around: range.lowerBound)
         }
 

--- a/Sources/Search/SearchIndex.swift
+++ b/Sources/Search/SearchIndex.swift
@@ -113,8 +113,16 @@ enum SearchIndexError: LocalizedError {
 
 actor SearchIndex {
     private static let schemaVersion = 1
+    private static let minFuzzyCandidateRows = 100
+    private static let maxFuzzyCandidateRows = 500
+    private static let fuzzyCandidateMultiplier = 25
+    private static let maxFuzzySearchableCharacters = 40_000
 
     private var database: OpaquePointer?
+
+    nonisolated static var fuzzyCandidateRowLimitForTesting: Int {
+        maxFuzzyCandidateRows
+    }
 
     nonisolated static func open(databaseURL: URL = .cmuxSearchDatabaseURL) async throws -> SearchIndex {
         // Actor initializers run on the caller executor, so open SQLite off the MainActor.
@@ -260,12 +268,7 @@ actor SearchIndex {
         if let matchQuery = Self.matchQuery(for: trimmed) {
             ftsHits = try withStatement(sql) { statement in
                 try bind(matchQuery, at: 1, in: statement)
-                let limitBindResult = sqlite3_bind_int64(statement, 2, sqlite3_int64(limit))
-                guard limitBindResult == SQLITE_OK else {
-                    throw SearchIndexError.bindFailed(
-                        Self.sqliteMessage(database) ?? "bind failed with code \(limitBindResult)"
-                    )
-                }
+                try bind(limit, at: 2, in: statement)
 
                 var hits: [SearchIndexHit] = []
                 while true {
@@ -436,6 +439,13 @@ actor SearchIndex {
         }
     }
 
+    private func bind(_ value: Int, at index: Int32, in statement: OpaquePointer) throws {
+        let result = sqlite3_bind_int64(statement, index, sqlite3_int64(value))
+        guard result == SQLITE_OK else {
+            throw SearchIndexError.bindFailed(Self.sqliteMessage(database) ?? "bind failed with code \(result)")
+        }
+    }
+
     private func bindNull(at index: Int32, in statement: OpaquePointer) throws {
         let result = sqlite3_bind_null(statement, index)
         guard result == SQLITE_OK else {
@@ -505,6 +515,7 @@ actor SearchIndex {
         guard limit > 0 else { return [] }
         let fuzzyQuery = Self.normalizedFuzzyQuery(rawQuery)
         guard !fuzzyQuery.isEmpty else { return [] }
+        let candidateLimit = Self.fuzzyCandidateLimit(for: limit)
 
         let sql = """
             SELECT
@@ -520,9 +531,11 @@ actor SearchIndex {
                 text
             FROM chunks
             ORDER BY ts DESC
+            LIMIT ?1
             """
 
         let matches: [SearchIndexHit] = try withStatement(sql) { statement in
+            try bind(candidateLimit, at: 1, in: statement)
             var hits: [SearchIndexHit] = []
             while true {
                 let stepResult = sqlite3_step(statement)
@@ -537,6 +550,9 @@ actor SearchIndex {
                         document.location,
                         document.text
                     ].joined(separator: "\n")
+                    guard searchable.count <= Self.maxFuzzySearchableCharacters else {
+                        continue
+                    }
                     guard let score = Self.fuzzyScore(query: fuzzyQuery, candidate: searchable) else {
                         continue
                     }
@@ -570,6 +586,17 @@ actor SearchIndex {
             }
             .prefix(limit)
             .map { $0 }
+    }
+
+    private static func fuzzyCandidateLimit(for resultLimit: Int) -> Int {
+        guard resultLimit > 0 else { return 0 }
+        let expanded: Int
+        if resultLimit >= maxFuzzyCandidateRows / fuzzyCandidateMultiplier {
+            expanded = maxFuzzyCandidateRows
+        } else {
+            expanded = max(resultLimit * fuzzyCandidateMultiplier, minFuzzyCandidateRows)
+        }
+        return min(maxFuzzyCandidateRows, max(resultLimit, expanded))
     }
 
     private static func storedDocument(from statement: OpaquePointer) -> StoredSearchDocument? {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -7209,9 +7209,11 @@ class TerminalController {
     func readTerminalTextForSnapshot(
         terminalPanel: TerminalPanel,
         includeScrollback: Bool = false,
-        lineLimit: Int? = nil
+        lineLimit: Int? = nil,
+        allowVTExport: Bool = true
     ) -> String? {
         if includeScrollback,
+           allowVTExport,
            let vtOutput = readTerminalTextFromVTExportForSnapshot(
                terminalPanel: terminalPanel,
                lineLimit: lineLimit

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -4844,7 +4844,7 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
                 14
             ),
             (
-                .findInDirectory,
+                .searchAllPanels,
                 [.command, .shift],
                 "f",
                 3
@@ -4884,11 +4884,120 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         }
     }
 
+    func testCommandShiftFOpensRightSidebarGlobalSearch() {
+        let previousAppDelegate = AppDelegate.shared
+        let appDelegate = AppDelegate()
+        defer { AppDelegate.shared = previousAppDelegate }
+        let windowId = UUID()
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 360, height: 240),
+            styleMask: [.titled, .closable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.identifier = NSUserInterfaceItemIdentifier("cmux.main.\(windowId.uuidString)")
+        defer {
+            window.orderOut(nil)
+            window.close()
+        }
+
+        let tabManager = TabManager()
+        let fileExplorerState = FileExplorerState()
+        fileExplorerState.setVisible(false)
+        fileExplorerState.mode = .files
+
+        appDelegate.registerMainWindow(
+            window,
+            windowId: windowId,
+            tabManager: tabManager,
+            sidebarState: SidebarState(isVisible: true),
+            sidebarSelectionState: SidebarSelectionState(),
+            fileExplorerState: fileExplorerState
+        )
+
+        window.makeKeyAndOrderFront(nil)
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+
+        guard let event = makeKeyDownEvent(
+            key: "f",
+            modifiers: [.command, .shift],
+            keyCode: 3,
+            windowNumber: window.windowNumber
+        ) else {
+            XCTFail("Failed to construct Cmd+Shift+F shortcut event")
+            return
+        }
+
+        #if DEBUG
+        XCTAssertTrue(appDelegate.debugHandleCustomShortcut(event: event))
+        XCTAssertTrue(fileExplorerState.isVisible)
+        XCTAssertEqual(fileExplorerState.mode, .search)
+        #else
+        XCTFail("debugHandleCustomShortcut is only available in DEBUG")
+        #endif
+    }
+
+    func testExplicitLegacyFindInDirectoryCommandShiftFWinsOverSearchAllPanelsDefault() {
+        let previousAppDelegate = AppDelegate.shared
+        let appDelegate = AppDelegate()
+        defer { AppDelegate.shared = previousAppDelegate }
+        let windowId = UUID()
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 360, height: 240),
+            styleMask: [.titled, .closable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.identifier = NSUserInterfaceItemIdentifier("cmux.main.\(windowId.uuidString)")
+        defer {
+            window.orderOut(nil)
+            window.close()
+        }
+
+        let tabManager = TabManager()
+        let fileExplorerState = FileExplorerState()
+        fileExplorerState.setVisible(false)
+        fileExplorerState.mode = .files
+
+        appDelegate.registerMainWindow(
+            window,
+            windowId: windowId,
+            tabManager: tabManager,
+            sidebarState: SidebarState(isVisible: true),
+            sidebarSelectionState: SidebarSelectionState(),
+            fileExplorerState: fileExplorerState
+        )
+
+        window.makeKeyAndOrderFront(nil)
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+
+        guard let event = makeKeyDownEvent(
+            key: "f",
+            modifiers: [.command, .shift],
+            keyCode: 3,
+            windowNumber: window.windowNumber
+        ) else {
+            XCTFail("Failed to construct Cmd+Shift+F shortcut event")
+            return
+        }
+
+        let legacyFindShortcut = StoredShortcut(key: "f", command: true, shift: true, option: false, control: false)
+        withTemporaryShortcut(action: .findInDirectory, shortcut: legacyFindShortcut) {
+            #if DEBUG
+            XCTAssertTrue(appDelegate.debugHandleCustomShortcut(event: event))
+            XCTAssertTrue(fileExplorerState.isVisible)
+            XCTAssertEqual(fileExplorerState.mode, .find)
+            #else
+            XCTFail("debugHandleCustomShortcut is only available in DEBUG")
+            #endif
+        }
+    }
+
     func testBrowserFindCommandPreflightConsultsConfiguredFindFamilyShortcuts() {
         #if DEBUG
         let cases: [(action: KeyboardShortcutSettings.Action, modifiers: NSEvent.ModifierFlags, key: String, keyCode: UInt16)] = [
             (.find, [.command], "f", 3),
-            (.findInDirectory, [.command, .shift], "f", 3),
+            (.searchAllPanels, [.command, .shift], "f", 3),
             (.findNext, [.command], "g", 5),
             (.findPrevious, [.command, .option], "g", 5),
             (.hideFind, [.command, .option, .shift], "f", 3),
@@ -5398,38 +5507,6 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         XCTAssertEqual(menuProbe.callCount, 0, "Cmd+D must not keep splitting after splitRight is remapped")
     }
 
-    func testCurrentGlobalSearchShortcutIsNotSuppressedAsStaleMenuShortcut() {
-        guard let appDelegate = AppDelegate.shared else {
-            XCTFail("Expected AppDelegate.shared")
-            return
-        }
-
-        guard let event = makeKeyDownEvent(
-            key: "d",
-            modifiers: [.command],
-            keyCode: 2,
-            windowNumber: 0
-        ) else {
-            XCTFail("Failed to construct Cmd+D event")
-            return
-        }
-
-        let remappedGlobalSearch = StoredShortcut(
-            key: "d",
-            command: true,
-            shift: false,
-            option: false,
-            control: false
-        )
-
-        withTemporaryShortcut(action: .globalSearch, shortcut: remappedGlobalSearch) {
-            XCTAssertFalse(
-                appDelegate.shouldSuppressStaleCmuxMenuShortcut(event: event),
-                "Current globalSearch remaps must not be treated as stale menu shortcuts"
-            )
-        }
-    }
-
     func testApplicationSendEventSuppressesRemappedCmdDStaleMenuShortcut() {
         let previousMainMenu = NSApp.mainMenu
         let probeWindow = NSWindow(
@@ -5486,6 +5563,65 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         }
 
         XCTAssertEqual(menuProbe.callCount, 0, "App-level Cmd+D dispatch must not fire a stale split menu item after remap")
+    }
+
+    func testRemappedSearchAllPanelsDefaultIsNotSuppressedAsStaleMenuShortcut() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let probeWindow = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 240),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        let focusableView = FocusableTestView(frame: NSRect(x: 0, y: 0, width: 200, height: 120))
+
+        defer {
+            probeWindow.orderOut(nil)
+        }
+
+        probeWindow.contentView = focusableView
+        probeWindow.makeKeyAndOrderFront(nil)
+        probeWindow.displayIfNeeded()
+        XCTAssertTrue(probeWindow.makeFirstResponder(focusableView), "Expected probe view to own first responder")
+
+        guard let event = makeKeyDownEvent(
+            key: "f",
+            modifiers: [.command, .shift],
+            keyCode: 3,
+            windowNumber: probeWindow.windowNumber
+        ) else {
+            XCTFail("Failed to construct Cmd+Shift+F event")
+            return
+        }
+
+        let cases: [(name: String, shortcut: StoredShortcut)] = [
+            (
+                "remapped",
+                StoredShortcut(key: "g", command: true, shift: true, option: false, control: false)
+            ),
+            ("unbound", .unbound),
+        ]
+
+        for testCase in cases {
+            withTemporaryShortcut(action: .searchAllPanels, shortcut: testCase.shortcut) {
+                #if DEBUG
+                XCTAssertFalse(
+                    appDelegate.debugHandleCustomShortcut(event: event),
+                    "\(testCase.name) searchAllPanels should not handle its old default shortcut"
+                )
+                #else
+                XCTFail("debugHandleCustomShortcut is only available in DEBUG")
+                #endif
+                XCTAssertFalse(
+                    appDelegate.shouldSuppressStaleCmuxMenuShortcut(event: event),
+                    "\(testCase.name) searchAllPanels has no menu item, so its old default must stay available to responders"
+                )
+            }
+        }
     }
 
     func testApplicationSendEventRoutesCmdDMenuEquivalentToActiveShortcutRecorder() {

--- a/cmuxTests/FileExplorerStateModePersistenceTests.swift
+++ b/cmuxTests/FileExplorerStateModePersistenceTests.swift
@@ -48,6 +48,8 @@ final class FileExplorerStateModePersistenceTests: XCTestCase {
     func testCLIArgumentNormalizerMapsVaultAndSessionsToSessions() {
         XCTAssertEqual(RightSidebarMode.from(cliArgument: "files"), .files)
         XCTAssertEqual(RightSidebarMode.from(cliArgument: "find"), .find)
+        XCTAssertEqual(RightSidebarMode.from(cliArgument: "search"), .search)
+        XCTAssertEqual(RightSidebarMode.from(cliArgument: "global-search"), .search)
         XCTAssertEqual(RightSidebarMode.from(cliArgument: "vault"), .sessions)
         XCTAssertEqual(RightSidebarMode.from(cliArgument: "sessions"), .sessions)
         XCTAssertEqual(RightSidebarMode.from(cliArgument: "feed"), .feed)

--- a/cmuxTests/GlobalSearchShortcutSettingsTests.swift
+++ b/cmuxTests/GlobalSearchShortcutSettingsTests.swift
@@ -12,10 +12,11 @@ final class GlobalSearchShortcutSettingsTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
+        UserDefaults.standard.removeObject(forKey: KeyboardShortcutSettings.legacyGlobalSearchDefaultsKey)
         originalSettingsFileStore = KeyboardShortcutSettings.settingsFileStore
         KeyboardShortcutSettings.settingsFileStore = KeyboardShortcutSettingsFileStore(
             primaryPath: FileManager.default.temporaryDirectory
-                .appendingPathComponent("cmux-global-search-shortcuts-\(UUID().uuidString).json")
+                .appendingPathComponent("cmux-search-all-panels-shortcuts-\(UUID().uuidString).json")
                 .path,
             fallbackPath: nil,
             additionalFallbackPaths: [],
@@ -26,50 +27,60 @@ final class GlobalSearchShortcutSettingsTests: XCTestCase {
 
     override func tearDown() {
         KeyboardShortcutSettings.settingsFileStore = originalSettingsFileStore
+        UserDefaults.standard.removeObject(forKey: KeyboardShortcutSettings.legacyGlobalSearchDefaultsKey)
         KeyboardShortcutSettings.resetAll()
         super.tearDown()
     }
 
-    func testGlobalSearchDefaultShortcutIsRemappableAndSystemWideSafe() {
-        let defaultShortcut = KeyboardShortcutSettings.shortcut(for: .globalSearch)
+    func testSearchAllPanelsDefaultShortcutIsRightSidebarCommandShiftF() {
+        let defaultShortcut = KeyboardShortcutSettings.shortcut(for: .searchAllPanels)
 
         XCTAssertEqual(
             defaultShortcut,
-            StoredShortcut(key: "f", command: true, shift: false, option: true, control: false)
+            StoredShortcut(key: "f", command: true, shift: true, option: false, control: false)
         )
-        XCTAssertTrue(KeyboardShortcutSettings.publicShortcutActions.contains(.globalSearch))
-        XCTAssertTrue(KeyboardShortcutSettings.settingsVisibleActions.contains(.globalSearch))
-        XCTAssertEqual(KeyboardShortcutSettings.shortcut(for: .sendFeedback), .unbound)
+        XCTAssertTrue(KeyboardShortcutSettings.publicShortcutActions.contains(.searchAllPanels))
+        XCTAssertTrue(KeyboardShortcutSettings.settingsVisibleActions.contains(.searchAllPanels))
+        XCTAssertFalse(KeyboardShortcutSettings.Action.allCases.map(\.rawValue).contains("globalSearch"))
         XCTAssertEqual(
-            KeyboardShortcutSettings.Action.globalSearch.normalizedRecordedShortcutResult(defaultShortcut),
+            KeyboardShortcutSettings.Action.searchAllPanels.normalizedRecordedShortcutResult(defaultShortcut),
             .accepted(defaultShortcut)
         )
     }
 
-    func testGlobalSearchRejectsBareSystemWideShortcut() {
-        let bareShortcut = StoredShortcut(key: "f", command: false, shift: false, option: false, control: false)
+    func testSearchAllPanelsDefaultDoesNotShadowExplicitLegacyFindInDirectoryShortcut() {
+        let legacyFindShortcut = StoredShortcut(key: "f", command: true, shift: true, option: false, control: false)
+        KeyboardShortcutSettings.setShortcut(legacyFindShortcut, for: .findInDirectory)
 
-        XCTAssertEqual(
-            KeyboardShortcutSettings.Action.globalSearch.normalizedRecordedShortcutResult(bareShortcut),
-            .rejected(.systemWideHotkeyRequiresModifier)
-        )
+        XCTAssertEqual(KeyboardShortcutSettings.shortcut(for: .findInDirectory), legacyFindShortcut)
+        XCTAssertEqual(KeyboardShortcutSettings.shortcut(for: .searchAllPanels), .unbound)
+
+        KeyboardShortcutSettings.setShortcut(legacyFindShortcut, for: .searchAllPanels)
+
+        XCTAssertEqual(KeyboardShortcutSettings.shortcut(for: .searchAllPanels), legacyFindShortcut)
     }
 
-    func testGlobalSearchRejectsConfiguredShowHideHotkeyConflict() {
-        let reservedShortcut = StoredShortcut(key: "g", command: true, shift: false, option: true, control: true)
+    func testLegacyGlobalSearchUserDefaultsShortcutMigratesToSearchAllPanels() throws {
+        let legacyShortcut = StoredShortcut(key: "k", command: true, shift: true, option: false, control: true)
+        let legacyData = try JSONEncoder().encode(legacyShortcut)
+        UserDefaults.standard.set(legacyData, forKey: KeyboardShortcutSettings.legacyGlobalSearchDefaultsKey)
 
-        KeyboardShortcutSettings.setShortcut(.unbound, for: .globalSearch)
-        SystemWideHotkeySettings.setShortcut(reservedShortcut)
+        XCTAssertEqual(KeyboardShortcutSettings.shortcut(for: .searchAllPanels), legacyShortcut)
 
-        XCTAssertEqual(
-            KeyboardShortcutSettings.Action.globalSearch.normalizedRecordedShortcutResult(reservedShortcut),
-            .rejected(.reservedBySystem)
-        )
+        let newShortcut = StoredShortcut(key: "j", command: true, shift: true, option: false, control: true)
+        KeyboardShortcutSettings.setShortcut(newShortcut, for: .searchAllPanels)
+
+        XCTAssertEqual(KeyboardShortcutSettings.shortcut(for: .searchAllPanels), newShortcut)
+
+        KeyboardShortcutSettings.resetShortcut(for: .searchAllPanels)
+
+        XCTAssertNil(UserDefaults.standard.object(forKey: KeyboardShortcutSettings.legacyGlobalSearchDefaultsKey))
+        XCTAssertEqual(KeyboardShortcutSettings.shortcut(for: .searchAllPanels), KeyboardShortcutSettings.Action.searchAllPanels.defaultShortcut)
     }
 
-    func testSettingsFileStoreParsesGlobalSearchShortcut() throws {
+    func testSettingsFileStoreParsesSearchAllPanelsShortcut() throws {
         let directoryURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent("cmux-global-search-settings-\(UUID().uuidString)", isDirectory: true)
+            .appendingPathComponent("cmux-search-all-panels-settings-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: directoryURL) }
 
@@ -77,7 +88,7 @@ final class GlobalSearchShortcutSettingsTests: XCTestCase {
         try """
         {
           "shortcuts": {
-            "globalSearch": "cmd+ctrl+g"
+            "searchAllPanels": "cmd+ctrl+g"
           }
         }
         """.write(to: settingsFileURL, atomically: true, encoding: .utf8)
@@ -89,14 +100,14 @@ final class GlobalSearchShortcutSettingsTests: XCTestCase {
         )
 
         XCTAssertEqual(
-            store.override(for: .globalSearch),
+            store.override(for: .searchAllPanels),
             StoredShortcut(key: "g", command: true, shift: false, option: false, control: true)
         )
     }
 
-    func testSettingsFileStoreRejectsGlobalSearchChordBinding() throws {
+    func testSettingsFileStoreParsesLegacyGlobalSearchShortcutAsSearchAllPanels() throws {
         let directoryURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent("cmux-global-search-invalid-settings-\(UUID().uuidString)", isDirectory: true)
+            .appendingPathComponent("cmux-legacy-global-search-settings-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: directoryURL) }
 
@@ -104,7 +115,7 @@ final class GlobalSearchShortcutSettingsTests: XCTestCase {
         try """
         {
           "shortcuts": {
-            "globalSearch": ["cmd+k", "f"]
+            "globalSearch": "cmd+ctrl+h"
           }
         }
         """.write(to: settingsFileURL, atomically: true, encoding: .utf8)
@@ -115,6 +126,9 @@ final class GlobalSearchShortcutSettingsTests: XCTestCase {
             startWatching: false
         )
 
-        XCTAssertNil(store.override(for: .globalSearch))
+        XCTAssertEqual(
+            store.override(for: .searchAllPanels),
+            StoredShortcut(key: "h", command: true, shift: false, option: false, control: true)
+        )
     }
 }

--- a/cmuxTests/RightSidebarCommandPaletteTests.swift
+++ b/cmuxTests/RightSidebarCommandPaletteTests.swift
@@ -35,7 +35,8 @@ final class RightSidebarCommandPaletteTests: XCTestCase {
                 XCTAssertTrue(contribution.enablement(context))
             }
 
-            XCTAssertEqual(contributions.count, 4)
+            XCTAssertEqual(contributions.count, 5)
+            XCTAssertNotNil(contributionsByID[ContentView.commandPaletteRightSidebarModeCommandID(.search)])
             XCTAssertNotNil(contributionsByID[ContentView.commandPaletteRightSidebarModeCommandID(.feed)])
             XCTAssertNil(contributionsByID[ContentView.commandPaletteRightSidebarModeCommandID(.dock)])
         }
@@ -55,6 +56,17 @@ final class RightSidebarCommandPaletteTests: XCTestCase {
                 )
             }
         }
+    }
+
+    func testCommandPaletteIncludesSearchPaneCommand() {
+        let descriptors = ContentView.commandPaletteRightSidebarToolPaneCommandDescriptors()
+        let searchDescriptor = descriptors.first { $0.mode == .search }
+
+        XCTAssertEqual(searchDescriptor?.commandId, "palette.openSearchPane")
+        XCTAssertEqual(
+            searchDescriptor?.title,
+            String(localized: "command.openSearchPane.title", defaultValue: "Open Search as Pane")
+        )
     }
 
     func testCommandPaletteUnreadDeferActionUsesConfigurableShortcutAction() {

--- a/cmuxTests/RightSidebarCommandPaletteTests.swift
+++ b/cmuxTests/RightSidebarCommandPaletteTests.swift
@@ -76,6 +76,14 @@ final class RightSidebarCommandPaletteTests: XCTestCase {
         )
     }
 
+    func testCommandPaletteDoesNotExposeSearchAllCommand() {
+        XCTAssertNil(ContentView.commandPaletteShortcutAction(forCommandID: "palette.searchAllPanels"))
+        XCTAssertEqual(
+            ContentView.commandPaletteShortcutAction(forCommandID: "palette.findInDirectory"),
+            .findInDirectory
+        )
+    }
+
     private func withSavedBetaFeatureDefaults(_ body: () throws -> Void) rethrows {
         let defaults = UserDefaults.standard
         let previousDock = defaults.object(forKey: RightSidebarBetaFeatureSettings.dockEnabledKey)

--- a/cmuxTests/SearchIndexTests.swift
+++ b/cmuxTests/SearchIndexTests.swift
@@ -58,6 +58,113 @@ final class SearchIndexTests: XCTestCase {
         XCTAssertEqual(markdownHits.first?.panelID, markdownPanelID)
     }
 
+    func testSearchFindsTerminalScrollbackChunks() async throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.directoryURL) }
+
+        let index = try SearchIndex(databaseURL: fixture.databaseURL)
+        let windowID = UUID()
+        let workspaceID = UUID()
+        let terminalPanelID = UUID()
+        let documentID = SearchIndexDocument.terminalLineChunkStableID(
+            panelID: terminalPanelID,
+            startLineNumber: 42
+        )
+
+        try await index.upsert(
+            SearchIndexDocument(
+                id: documentID,
+                windowID: windowID,
+                workspaceID: workspaceID,
+                panelID: terminalPanelID,
+                kind: .terminal,
+                title: "Build",
+                location: "Window > Workspace > Build > Line 42",
+                anchor: "line:42",
+                text: "swift build failed with orchardtoken in terminal scrollback",
+                timestamp: Date(timeIntervalSince1970: 300)
+            )
+        )
+
+        let hits = try await index.search("orchardtoken", limit: 10)
+        XCTAssertEqual(hits.map(\.id), [documentID])
+        XCTAssertEqual(hits.first?.kind, .terminal)
+        XCTAssertEqual(hits.first?.panelID, terminalPanelID)
+        XCTAssertEqual(hits.first?.anchor, "line:42")
+    }
+
+    func testSearchUsesFuzzySubsequenceFallback() async throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.directoryURL) }
+
+        let index = try SearchIndex(databaseURL: fixture.databaseURL)
+        let terminalPanelID = UUID()
+        let documentID = SearchIndexDocument.terminalLineChunkStableID(
+            panelID: terminalPanelID,
+            startLineNumber: 9
+        )
+
+        try await index.upsert(
+            SearchIndexDocument(
+                id: documentID,
+                windowID: UUID(),
+                workspaceID: UUID(),
+                panelID: terminalPanelID,
+                kind: .terminal,
+                title: "Deploy",
+                location: "Window > Deploy > Line 9",
+                anchor: "line:9",
+                text: "deployment configuration loaded from scrollback"
+            )
+        )
+
+        let hits = try await index.search("dplcfg", limit: 10)
+        XCTAssertEqual(hits.map(\.id), [documentID])
+        XCTAssertEqual(hits.first?.kind, .terminal)
+    }
+
+    func testSearchCentersFuzzySnippetOnTightMatch() async throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.directoryURL) }
+
+        let index = try SearchIndex(databaseURL: fixture.databaseURL)
+        let documentID = SearchIndexDocument.terminalLineChunkStableID(
+            panelID: UUID(),
+            startLineNumber: 1
+        )
+
+        try await index.upsert(
+            SearchIndexDocument(
+                id: documentID,
+                windowID: UUID(),
+                workspaceID: UUID(),
+                panelID: UUID(),
+                kind: .terminal,
+                title: "Terminal",
+                location: "Window > Terminal > Line 1",
+                anchor: "line:1",
+                text: [
+                    "The default interactive shell is now zsh.",
+                    "For more details, please visit support.",
+                    "SCROLLBACK_FUZZY_NEEDLE_7391 finished from terminal one"
+                ].joined(separator: "\n")
+            )
+        )
+
+        let hits = try await index.search("sbn7391", limit: 10)
+        XCTAssertEqual(hits.map(\.id), [documentID])
+        XCTAssertTrue(hits[0].snippet.contains("SCROLLBACK_FUZZY_NEEDLE_7391"))
+        XCTAssertTrue(hits[0].snippet.hasPrefix("...SCROLLBACK_FUZZY_NEEDLE_7391"), hits[0].snippet)
+    }
+
+    func testTerminalScrollbackNormalizationSplitsCarriageReturnsAndDropsControlSequences() {
+        let lines = GlobalSearchDocuments.normalizedTerminalScrollbackLines(
+            "\u{1B}]10;rgb:00/00/00\u{1B}\\first\rsecond\r\n\u{1B}[31mthird"
+        )
+
+        XCTAssertEqual(lines, ["first", "second", "third"])
+    }
+
     func testUpsertReplacesExistingDocumentText() async throws {
         let fixture = try makeFixture()
         defer { try? FileManager.default.removeItem(at: fixture.directoryURL) }
@@ -224,6 +331,27 @@ final class SearchIndexTests: XCTestCase {
         )
     }
 
+    func testInlineNeedleUsesFuzzyMatchedSnippetSpan() {
+        let hit = SearchIndexHit(
+            id: "terminal-doc",
+            windowID: UUID(),
+            workspaceID: UUID(),
+            panelID: UUID(),
+            kind: .terminal,
+            title: "Build",
+            location: "Window > Workspace > Build > Lines 1-4",
+            anchor: "line:1",
+            snippet: "SCROLLBACK_FUZZY_NEEDLE_7391 finished",
+            rank: 10_000,
+            timestamp: Date(timeIntervalSince1970: 0)
+        )
+
+        XCTAssertEqual(
+            GlobalSearchInlineSearch.needle(for: "sfn7391", hit: hit),
+            "SCROLLBACK_FUZZY_NEEDLE_7391"
+        )
+    }
+
     func testDeletePanelRemovesIndexedDocuments() async throws {
         let fixture = try makeFixture()
         defer { try? FileManager.default.removeItem(at: fixture.directoryURL) }
@@ -300,6 +428,79 @@ final class SearchIndexTests: XCTestCase {
         XCTAssertEqual(staleDocumentHits, [])
 
         let titleHits = try await index.search("stabletitlekeyword", limit: 10)
+        XCTAssertEqual(titleHits.map(\.id), [titleID])
+    }
+
+    func testReplacePanelTerminalDocumentsKeepsTitleDocument() async throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.directoryURL) }
+
+        let index = try SearchIndex(databaseURL: fixture.databaseURL)
+        let windowID = UUID()
+        let workspaceID = UUID()
+        let panelID = UUID()
+        let titleID = SearchIndexDocument.panelStableID(panelID: panelID, kind: .title)
+        let staleTerminalID = SearchIndexDocument.terminalLineChunkStableID(
+            panelID: panelID,
+            startLineNumber: 1
+        )
+        let freshTerminalID = SearchIndexDocument.terminalLineChunkStableID(
+            panelID: panelID,
+            startLineNumber: 5
+        )
+
+        try await index.upsert(
+            SearchIndexDocument(
+                id: titleID,
+                windowID: windowID,
+                workspaceID: workspaceID,
+                panelID: panelID,
+                kind: .title,
+                title: "Terminal Title",
+                location: "Window > Workspace",
+                anchor: "title",
+                text: "persistenttitlekeyword"
+            )
+        )
+        try await index.upsert(
+            SearchIndexDocument(
+                id: staleTerminalID,
+                windowID: windowID,
+                workspaceID: workspaceID,
+                panelID: panelID,
+                kind: .terminal,
+                title: "Terminal Title",
+                location: "Window > Workspace > Line 1",
+                anchor: "line:1",
+                text: "stalebufferkeyword"
+            )
+        )
+
+        try await index.replacePanelDocuments(
+            panelID: panelID,
+            kind: .terminal,
+            with: [
+                SearchIndexDocument(
+                    id: freshTerminalID,
+                    windowID: windowID,
+                    workspaceID: workspaceID,
+                    panelID: panelID,
+                    kind: .terminal,
+                    title: "Terminal Title",
+                    location: "Window > Workspace > Line 5",
+                    anchor: "line:5",
+                    text: "freshbufferkeyword"
+                )
+            ]
+        )
+
+        let staleHits = try await index.search("stalebufferkeyword", limit: 10)
+        XCTAssertEqual(staleHits, [])
+
+        let freshHits = try await index.search("freshbufferkeyword", limit: 10)
+        XCTAssertEqual(freshHits.map(\.id), [freshTerminalID])
+
+        let titleHits = try await index.search("persistenttitlekeyword", limit: 10)
         XCTAssertEqual(titleHits.map(\.id), [titleID])
     }
 

--- a/cmuxTests/SearchIndexTests.swift
+++ b/cmuxTests/SearchIndexTests.swift
@@ -219,6 +219,46 @@ final class SearchIndexTests: XCTestCase {
         XCTAssertEqual(lines.last, "line-\(maxLines + 2)")
     }
 
+    func testTerminalScrollbackNormalizationPreservesLineBoundariesWhenCharacterCapped() {
+        let maxLines = GlobalSearchIndexingLimits.maxIndexedTerminalScrollbackLines
+        let wideSuffix = String(repeating: "x", count: 120)
+        let scrollback = (1...maxLines)
+            .map { "line-\($0)-\(wideSuffix)" }
+            .joined(separator: "\n")
+
+        let lines = GlobalSearchDocuments.normalizedTerminalScrollbackLines(scrollback)
+        let joined = lines.joined(separator: "\n")
+
+        XCTAssertLessThan(lines.count, maxLines)
+        XCTAssertLessThanOrEqual(joined.count, GlobalSearchIndexingLimits.maxIndexedTextCharacters)
+        XCTAssertTrue(lines.first?.hasPrefix("line-") == true, lines.first ?? "")
+        XCTAssertEqual(lines.last, "line-\(maxLines)-\(wideSuffix)")
+    }
+
+    func testSearchSnippetUsesOriginalStringIndicesForCaseInsensitiveTokenMatch() async throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.directoryURL) }
+
+        let index = try SearchIndex(databaseURL: fixture.databaseURL)
+        try await index.upsert(
+            SearchIndexDocument(
+                id: "expanded-lowercase-prefix",
+                windowID: UUID(),
+                workspaceID: UUID(),
+                panelID: UUID(),
+                kind: .terminal,
+                title: "Terminal",
+                location: "Window > Terminal > Line 1",
+                anchor: "line:1",
+                text: "\(String(repeating: "İ", count: 8)) needle after expanded lowercase prefix"
+            )
+        )
+
+        let hits = try await index.search("needle", limit: 10)
+        XCTAssertEqual(hits.map(\.id), ["expanded-lowercase-prefix"])
+        XCTAssertTrue(hits[0].snippet.contains("needle"), hits[0].snippet)
+    }
+
     func testUpsertReplacesExistingDocumentText() async throws {
         let fixture = try makeFixture()
         defer { try? FileManager.default.removeItem(at: fixture.directoryURL) }

--- a/cmuxTests/SearchIndexTests.swift
+++ b/cmuxTests/SearchIndexTests.swift
@@ -123,6 +123,47 @@ final class SearchIndexTests: XCTestCase {
         XCTAssertEqual(hits.first?.kind, .terminal)
     }
 
+    func testFuzzySearchOnlyScoresRecentBoundedCandidateSet() async throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.directoryURL) }
+
+        let index = try SearchIndex(databaseURL: fixture.databaseURL)
+        for offset in 0..<SearchIndex.fuzzyCandidateRowLimitForTesting {
+            try await index.upsert(
+                SearchIndexDocument(
+                    id: "recent-\(offset)",
+                    windowID: UUID(),
+                    workspaceID: UUID(),
+                    panelID: UUID(),
+                    kind: .terminal,
+                    title: "Recent \(offset)",
+                    location: "Window > Terminal > Line \(offset)",
+                    anchor: "line:\(offset)",
+                    text: "recent terminal row without the fuzzy candidate",
+                    timestamp: Date(timeIntervalSince1970: Double(offset + 1))
+                )
+            )
+        }
+
+        try await index.upsert(
+            SearchIndexDocument(
+                id: "old-fuzzy-doc",
+                windowID: UUID(),
+                workspaceID: UUID(),
+                panelID: UUID(),
+                kind: .terminal,
+                title: "Old Terminal",
+                location: "Window > Terminal > Line 1",
+                anchor: "line:1",
+                text: "supercalifragilistic old terminal scrollback candidate",
+                timestamp: Date(timeIntervalSince1970: 0)
+            )
+        )
+
+        let hits = try await index.search("sprcfg", limit: 10)
+        XCTAssertTrue(hits.isEmpty)
+    }
+
     func testSearchCentersFuzzySnippetOnTightMatch() async throws {
         let fixture = try makeFixture()
         defer { try? FileManager.default.removeItem(at: fixture.directoryURL) }
@@ -163,6 +204,19 @@ final class SearchIndexTests: XCTestCase {
         )
 
         XCTAssertEqual(lines, ["first", "second", "third"])
+    }
+
+    func testTerminalScrollbackNormalizationCapsToTailLineBudget() {
+        let maxLines = GlobalSearchIndexingLimits.maxIndexedTerminalScrollbackLines
+        let scrollback = (1...(maxLines + 2))
+            .map { "line-\($0)" }
+            .joined(separator: "\n")
+
+        let lines = GlobalSearchDocuments.normalizedTerminalScrollbackLines(scrollback)
+
+        XCTAssertEqual(lines.count, maxLines)
+        XCTAssertEqual(lines.first, "line-3")
+        XCTAssertEqual(lines.last, "line-\(maxLines + 2)")
     }
 
     func testUpsertReplacesExistingDocumentText() async throws {

--- a/cmuxTests/ShortcutAndCommandPaletteTests.swift
+++ b/cmuxTests/ShortcutAndCommandPaletteTests.swift
@@ -1056,6 +1056,7 @@ final class RightSidebarModeShortcutHintTests: XCTestCase {
         .focusRightSidebar,
         .switchRightSidebarToFiles,
         .switchRightSidebarToFind,
+        .switchRightSidebarToSearch,
         .switchRightSidebarToSessions,
         .switchRightSidebarToFeed,
         .switchRightSidebarToDock,
@@ -1107,6 +1108,7 @@ final class RightSidebarModeShortcutHintTests: XCTestCase {
     func testModeShortcutActionsMatchModeSwitchingActions() {
         XCTAssertEqual(RightSidebarMode.files.shortcutAction, .switchRightSidebarToFiles)
         XCTAssertEqual(RightSidebarMode.find.shortcutAction, .switchRightSidebarToFind)
+        XCTAssertEqual(RightSidebarMode.search.shortcutAction, .switchRightSidebarToSearch)
         XCTAssertEqual(RightSidebarMode.sessions.shortcutAction, .switchRightSidebarToSessions)
         XCTAssertEqual(RightSidebarMode.feed.shortcutAction, .switchRightSidebarToFeed)
         XCTAssertEqual(RightSidebarMode.dock.shortcutAction, .switchRightSidebarToDock)
@@ -1132,6 +1134,10 @@ final class RightSidebarModeShortcutHintTests: XCTestCase {
         XCTAssertEqual(
             RightSidebarMode.modeShortcut(for: makeKeyDownEvent(key: "5", modifiers: [.control], keyCode: 23)),
             .dock
+        )
+        XCTAssertEqual(
+            RightSidebarMode.modeShortcut(for: makeKeyDownEvent(key: "6", modifiers: [.control], keyCode: 22)),
+            .search
         )
     }
 
@@ -1189,6 +1195,10 @@ final class RightSidebarModeShortcutHintTests: XCTestCase {
         XCTAssertEqual(
             RightSidebarMode.modeShortcut(for: makeKeyDownEvent(key: "5", modifiers: [.control], keyCode: 23)),
             .dock
+        )
+        XCTAssertEqual(
+            RightSidebarMode.modeShortcut(for: makeKeyDownEvent(key: "6", modifiers: [.control], keyCode: 22)),
+            .search
         )
     }
 

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -366,6 +366,7 @@ final class WorkspaceRenameShortcutDefaultsTests: XCTestCase {
         let modeSwitchActions: [(KeyboardShortcutSettings.Action, String)] = [
             (.switchRightSidebarToFiles, "1"),
             (.switchRightSidebarToFind, "2"),
+            (.switchRightSidebarToSearch, "6"),
             (.switchRightSidebarToSessions, "3"),
             (.switchRightSidebarToFeed, "4"),
             (.switchRightSidebarToDock, "5"),
@@ -775,6 +776,7 @@ final class KeyboardShortcutSettingsFileStoreTests: XCTestCase {
                 "focusRightSidebar": "cmd+opt+shift+e",
                 "switchRightSidebarToFiles": "ctrl+4",
                 "switchRightSidebarToFind": "ctrl+5",
+                "switchRightSidebarToSearch": "ctrl+9",
                 "switchRightSidebarToSessions": "ctrl+6",
                 "switchRightSidebarToFeed": "ctrl+7",
                 "switchRightSidebarToDock": "ctrl+8"
@@ -801,6 +803,10 @@ final class KeyboardShortcutSettingsFileStoreTests: XCTestCase {
         XCTAssertEqual(
             store.override(for: .switchRightSidebarToFind),
             StoredShortcut(key: "5", command: false, shift: false, option: false, control: true)
+        )
+        XCTAssertEqual(
+            store.override(for: .switchRightSidebarToSearch),
+            StoredShortcut(key: "9", command: false, shift: false, option: false, control: true)
         )
         XCTAssertEqual(
             store.override(for: .switchRightSidebarToSessions),

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -354,12 +354,14 @@ final class WorkspaceRenameShortcutDefaultsTests: XCTestCase {
         XCTAssertFalse(focusRightSidebar.option)
         XCTAssertFalse(focusRightSidebar.control)
 
-        let findInDirectory = KeyboardShortcutSettings.Action.findInDirectory.defaultShortcut
-        XCTAssertEqual(findInDirectory.key, "f")
-        XCTAssertTrue(findInDirectory.command)
-        XCTAssertTrue(findInDirectory.shift)
-        XCTAssertFalse(findInDirectory.option)
-        XCTAssertFalse(findInDirectory.control)
+        let searchAllPanels = KeyboardShortcutSettings.Action.searchAllPanels.defaultShortcut
+        XCTAssertEqual(searchAllPanels.key, "f")
+        XCTAssertTrue(searchAllPanels.command)
+        XCTAssertTrue(searchAllPanels.shift)
+        XCTAssertFalse(searchAllPanels.option)
+        XCTAssertFalse(searchAllPanels.control)
+
+        XCTAssertEqual(KeyboardShortcutSettings.Action.findInDirectory.defaultShortcut, .unbound)
     }
 
     func testRightSidebarModeSwitchesHavePrivateControlDigitDefaults() {
@@ -389,6 +391,7 @@ final class WorkspaceRenameShortcutDefaultsTests: XCTestCase {
 
         XCTAssertTrue(visibleActions.contains(.toggleRightSidebar))
         XCTAssertTrue(visibleActions.contains(.focusRightSidebar))
+        XCTAssertTrue(visibleActions.contains(.searchAllPanels))
         XCTAssertTrue(visibleActions.contains(.findInDirectory))
         XCTAssertTrue(visibleActions.contains(.markOldestUnreadAndJumpNext))
         XCTAssertFalse(visibleActions.contains(.showHideAllWindows))
@@ -411,6 +414,7 @@ final class WorkspaceRenameShortcutDefaultsTests: XCTestCase {
         let expectedActions: [KeyboardShortcutSettings.Action] = [
             .focusRightSidebar,
             .toggleRightSidebar,
+            .searchAllPanels,
             .findInDirectory,
         ]
 

--- a/web/data/cmux-shortcuts.ts
+++ b/web/data/cmux-shortcuts.ts
@@ -31,12 +31,6 @@ export const shortcutCategories: ShortcutCategory[] = [
         description: { en: "Show/hide all cmux windows", ja: "すべてのcmuxウインドウを表示/非表示" },
         note: { en: "system-wide hotkey", ja: "システム全体のホットキー" },
       },
-      {
-        id: "globalSearch",
-        combos: [["⌥", "⌘", "F"]],
-        description: { en: "Global search", ja: "グローバル検索" },
-        note: { en: "system-wide hotkey", ja: "システム全体のホットキー" },
-      },
       { id: "commandPalette", combos: [["⌘", "⇧", "P"]], description: { en: "Command palette", ja: "コマンドパレット" } },
       {
         id: "commandPaletteNext",
@@ -173,7 +167,7 @@ export const shortcutCategories: ShortcutCategory[] = [
     titleKey: "find",
     shortcuts: [
       { id: "find", combos: [["⌘", "F"]], description: { en: "Find", ja: "検索" } },
-      { id: "findInDirectory", combos: [["⌘", "⇧", "F"]], description: { en: "Find in directory", ja: "ディレクトリ内を検索" } },
+      { id: "searchAllPanels", combos: [["⌘", "⇧", "F"]], description: { en: "Search all panels", ja: "すべてのパネルを検索" } },
       { id: "findNext", combos: [["⌘", "G"]], description: { en: "Find next", ja: "次を検索" } },
       { id: "findPrevious", combos: [["⌥", "⌘", "G"]], description: { en: "Find previous", ja: "前を検索" } },
       { id: "hideFind", combos: [["⌥", "⌘", "⇧", "F"]], description: { en: "Hide find bar", ja: "検索バーを隠す" } },

--- a/web/data/cmux.schema.json
+++ b/web/data/cmux.schema.json
@@ -790,6 +790,7 @@
               "focusRightSidebar",
               "switchRightSidebarToFiles",
               "switchRightSidebarToFind",
+              "switchRightSidebarToSearch",
               "switchRightSidebarToSessions",
               "switchRightSidebarToFeed",
               "switchRightSidebarToDock",

--- a/web/data/cmux.schema.json
+++ b/web/data/cmux.schema.json
@@ -770,6 +770,7 @@
               "openSettings",
               "reloadConfiguration",
               "showHideAllWindows",
+              "searchAllPanels",
               "globalSearch",
               "newWindow",
               "closeWindow",


### PR DESCRIPTION
Summary:
- Index terminal scrollback chunks in global search alongside browser, markdown, and title documents.
- Add fzf-style fuzzy fallback ranking and matched-line snippets for all global search documents.
- Activate terminal hits by focusing the panel and opening terminal find with the literal matched token.
- Normalize terminal scrollback before indexing by stripping terminal control sequences and splitting CR, CRLF, and LF line endings.

Verification:
- `jq empty Resources/Localizable.xcstrings`
- `git diff --check`
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/cmux-scrollsearch-test '-only-testing:cmuxTests/SearchIndexTests' test`
- `./scripts/reload.sh --tag scrlbk`
- Cloud tagged reload on `cloud-mac-25864318825` with `./scripts/reload.sh --tag scrlbk --launch`

Proof:
- Baseline cloud run: https://github.com/manaflow-ai/cmux-loader/actions/runs/25862242107
- Final cloud run: https://github.com/manaflow-ai/cmux-loader/actions/runs/25864318825
- Final recording: `/tmp/scrlbk-feature-demo-v4/recording.mov`
- Search-result frame: `/tmp/scrlbk-feature-demo-v4/frame-search-result.png`
- Activation frame: `/tmp/scrlbk-feature-demo-v4/frame-final.png`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches search indexing/ranking, window focus routing, and keyboard shortcut migration, which could cause regressions in search results relevance or focus/shortcut behavior across panels. Changes are localized to search/shortcut subsystems with added test coverage, but affect core navigation UX.
> 
> **Overview**
> **Global search now includes terminal scrollback** by capturing terminal panels, normalizing scrollback (strip control sequences + normalize line endings), chunking it into indexed documents, and activating hits by focusing the terminal panel and opening terminal find with the matched needle.
> 
> **Search indexing/ranking is enhanced** with a fuzzy subsequence fallback when FTS doesn’t return enough results, plus better snippet/needle selection; `SearchIndex` adds terminal document IDs, per-kind panel replacement/deletion helpers, and a new timestamp index.
> 
> **UI/shortcut routing shifts global search into the right sidebar**: adds `RightSidebarMode.search`, embeds `GlobalSearchSurfaceView` in the sidebar and tool pane with a keyboard-focus bridge, introduces the `searchAllPanels` action defaulting to `⌘⇧F`, migrates legacy `globalSearch` bindings (UserDefaults + `cmux.json`), and updates menu/CLI/help strings while removing the menubar popover-based palette and related hotkey plumbing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78c4f0918ccba5ace4c6325d181d08f77e80bd62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add global search over terminal scrollback and a right‑sidebar Search pane. ⌘⇧F now runs “Search All…” and focuses the Search pane and field in the active window.

- **New Features**
  - Right‑sidebar Search pane (`.search`): default Ctrl+6; ⌘⇧F runs `searchAllPanels`; Command Palette “Open Search as Pane”; CLI `right_sidebar set search`. Legacy `globalSearch` bindings migrate to `searchAllPanels`; “Find in directory” is unbound by default, and the ⌘⇧F default is suppressed if `findInDirectory` is explicitly bound.
  - Index terminal scrollback as `terminal` documents (4‑line chunks, up to 4,000 lines), stripping control sequences and normalizing line endings. The index stays fresh with debounced captures on scrollback changes and when the scrollbar attaches. Activating a terminal hit focuses the panel and opens terminal find with the matched token.
  - Fuzzy subsequence fallback when FTS has no hits; centered snippets for all kinds; `SearchIndex` adds `replacePanelDocuments` and `deletePanelDocuments`. Menu shows “Search All…”. README and web schema/shortcuts updated.

- **Bug Fixes**
  - Fixed ⌘⇧F routing so Search triggers in the active main window with reliable focus on the Search field. Fixed terminal search edge cases (chunk‑boundary matches, correct inline needle application, stale‑capture prevention), and avoided pasteboard‑based terminal captures.

<sup>Written for commit 78c4f0918ccba5ace4c6325d181d08f77e80bd62. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4171?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global search now indexes terminal content and shows terminal results with a terminal icon.
  * Added a dedicated Search mode in the right sidebar and a command to open Search as a pane.

* **Improvements**
  * Search placeholder updated to "Search all terminals…"; empty state shows "Searching…".
  * New shortcuts: Search All Panels (⌘⇧F) and switch right sidebar to Search (default Ctrl+6).

* **Tests**
  * Added coverage for terminal indexing, fuzzy matching, and command-palette/shortcut behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4171)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->