### PR TITLE
Add Chromium browser engine

### DIFF
--- a/Frameworks/CmuxChromiumCore/Sources/CmuxChromiumCore.swift
+++ b/Frameworks/CmuxChromiumCore/Sources/CmuxChromiumCore.swift
@@ -1,0 +1,1989 @@
+import AppKit
+import Darwin
+import Foundation
+import OSLog
+import QuartzCore
+
+private let cmuxChromiumLogger = Logger(subsystem: "com.cmuxterm.app", category: "chromium-core")
+
+@objc(CmuxChromiumBrowserHostFactory)
+public final class CmuxChromiumBrowserHostFactory: NSObject {
+    @objc(cmuxCreateBrowserHostWithProfileIdentifier:dataDirectory:proxyConfiguration:)
+    public static func cmuxCreateBrowserHost(
+        profileIdentifier: String,
+        dataDirectory: NSURL,
+        proxyConfiguration: NSDictionary?
+    ) -> NSObject? {
+        CmuxChromiumBrowserHost(
+            profileIdentifier: profileIdentifier,
+            dataDirectory: dataDirectory as URL,
+            proxyConfiguration: proxyConfiguration
+        )
+    }
+}
+
+@objc(CmuxChromiumBrowserHost)
+public final class CmuxChromiumBrowserHost: NSObject {
+    private let view: CmuxChromiumBrowserView
+
+    @objc public var cmuxNativeView: NSView? { view }
+    @objc public var cmuxCurrentURL: NSURL? { view.currentURL as NSURL? }
+    @objc public var cmuxTitle: String? { view.currentTitle }
+    @objc public var cmuxIsLoading: Bool { view.isLoading }
+    @objc public var cmuxCanGoBack: Bool { view.canGoBack }
+    @objc public var cmuxCanGoForward: Bool { view.canGoForward }
+    @objc public var cmuxEstimatedProgress: Double { view.estimatedProgress }
+    @objc public var cmuxPageZoomFactor: NSNumber { NSNumber(value: view.pageZoomFactor) }
+
+    init(profileIdentifier: String, dataDirectory: URL, proxyConfiguration: NSDictionary?) {
+        view = CmuxChromiumBrowserView(
+            profileIdentifier: profileIdentifier,
+            dataDirectory: dataDirectory,
+            proxyConfiguration: proxyConfiguration
+        )
+        super.init()
+    }
+
+    @objc(cmuxLoad:)
+    public func cmuxLoad(_ request: NSURLRequest) {
+        guard let url = request.url else { return }
+        view.load(url)
+    }
+
+    @objc(cmuxReload)
+    public func cmuxReload() {
+        view.reload()
+    }
+
+    @objc(cmuxStopLoading)
+    public func cmuxStopLoading() {
+        view.stopLoading()
+    }
+
+    @objc(cmuxGoBack)
+    public func cmuxGoBack() {
+        view.goBack()
+    }
+
+    @objc(cmuxGoForward)
+    public func cmuxGoForward() {
+        view.goForward()
+    }
+
+    @objc(cmuxSetStateChangedHandler:)
+    public func cmuxSetStateChangedHandler(_ handler: @escaping () -> Void) {
+        view.stateChangedHandler = handler
+    }
+
+    @objc(cmuxEvaluateJavaScript:completionHandler:)
+    public func cmuxEvaluateJavaScript(
+        _ script: String,
+        completionHandler: @escaping (Any?, String?) -> Void
+    ) {
+        view.evaluateJavaScript(script, completion: completionHandler)
+    }
+
+    @objc(cmuxTakeSnapshot:)
+    public func cmuxTakeSnapshot(_ completion: @escaping (NSImage?) -> Void) {
+        view.takeSnapshot(completion)
+    }
+
+    @objc(cmuxSetProxyConfiguration:)
+    public func cmuxSetProxyConfiguration(_ proxyConfiguration: NSDictionary?) {
+        view.setProxyConfiguration(proxyConfiguration)
+    }
+
+    @objc(cmuxSetAppearanceName:)
+    public func cmuxSetAppearanceName(_ appearanceName: NSString?) {
+        view.setAppearanceName(appearanceName as String?)
+    }
+
+    @objc(cmuxSetPageZoomFactor:)
+    public func cmuxSetPageZoomFactor(_ pageZoomFactor: NSNumber) {
+        view.setPageZoomFactor(pageZoomFactor.doubleValue)
+    }
+
+    @objc(cmuxAddUserScript:)
+    public func cmuxAddUserScript(_ source: NSString) {
+        view.addUserScript(source as String)
+    }
+
+    @objc(cmuxAddUserStyle:)
+    public func cmuxAddUserStyle(_ source: NSString) {
+        view.addUserStyle(source as String)
+    }
+}
+
+final class CmuxChromiumBrowserView: NSView {
+    private let profileIdentifier: String
+    private let dataDirectory: URL
+    private let sessionDirectory: URL
+    private let contextFile: URL
+    private let resizeFile: URL
+    private let controlSocketFile: URL
+    private let controlChannel: OwlControlChannel
+    private let freshMojoRuntime: OwlFreshMojoRuntime?
+    private var freshMojoSession: OpaquePointer?
+    private var freshMojoUserDataPointer: UnsafeMutableRawPointer?
+    private var freshMojoPollTimer: Timer?
+    private var process: Process?
+    private var ioPipe: Pipe?
+    private var pollTimer: Timer?
+    private var hostLayer: CALayer?
+    private var currentContextID: UInt32 = 0
+    private var lastResizeSize: NSSize = .zero
+    private var pendingURL: URL?
+    private var launchedURL: URL?
+    private var contentShellPID: pid_t = 0
+    private var devToolsPort: Int?
+    private var devToolsPageWebSocketURL: URL?
+    private let devToolsQueue = DispatchQueue(label: "cmux.chromium.devtools")
+    private static let sharedFreshMojoRuntime = OwlFreshMojoRuntime.load()
+    private var proxyServer: String?
+    private var navigationHistory: [URL] = []
+    private var navigationHistoryIndex: Int = -1
+    private var persistentUserScripts: [String] = []
+    private var persistentUserStyles: [String] = []
+    private var lastPersistentStateKey: String?
+
+    var stateChangedHandler: (() -> Void)?
+    private(set) var currentURL: URL?
+    private(set) var currentTitle: String?
+    private(set) var isLoading = false
+    private(set) var estimatedProgress = 0.0
+    private(set) var canGoBack = false
+    private(set) var canGoForward = false
+    private(set) var pageZoomFactor = 1.0
+
+    init(profileIdentifier: String, dataDirectory: URL, proxyConfiguration: NSDictionary?) {
+        self.profileIdentifier = profileIdentifier
+        self.dataDirectory = dataDirectory
+        proxyServer = Self.proxyServer(from: proxyConfiguration)
+        sessionDirectory = dataDirectory.appendingPathComponent("content-shell", isDirectory: true)
+        let token = "\(ProcessInfo.processInfo.processIdentifier)-\(UUID().uuidString)"
+        let shortToken = "\(ProcessInfo.processInfo.processIdentifier)-\(UUID().uuidString.prefix(8))"
+        contextFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-chromium-context-\(token).txt", isDirectory: false)
+        resizeFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-chromium-resize-\(token).txt", isDirectory: false)
+        controlSocketFile = URL(fileURLWithPath: "/tmp", isDirectory: true)
+            .appendingPathComponent("cmux-chr-\(shortToken).sock", isDirectory: false)
+        controlChannel = OwlControlChannel(path: controlSocketFile.path)
+        freshMojoRuntime = Self.sharedFreshMojoRuntime
+        super.init(frame: .zero)
+        wantsLayer = true
+        layer = CALayer()
+        layer?.backgroundColor = NSColor.controlBackgroundColor.cgColor
+        layerContentsRedrawPolicy = .never
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) is not supported")
+    }
+
+    deinit {
+        teardown()
+    }
+
+    override var acceptsFirstResponder: Bool { true }
+
+    override func becomeFirstResponder() -> Bool {
+        if let session = freshMojoSession,
+           let freshMojoRuntime {
+            _ = freshMojoRuntime.setFocus(session, focused: true)
+        }
+        _ = controlChannel.sendFocus(true)
+        return true
+    }
+
+    override func resignFirstResponder() -> Bool {
+        if let session = freshMojoSession,
+           let freshMojoRuntime {
+            _ = freshMojoRuntime.setFocus(session, focused: false)
+        }
+        _ = controlChannel.sendFocus(false)
+        return true
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        launchIfPossible()
+    }
+
+    override func layout() {
+        super.layout()
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        hostLayer?.frame = bounds
+        CATransaction.commit()
+        writeResizeIfNeeded()
+        launchIfPossible()
+    }
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        for area in trackingAreas {
+            removeTrackingArea(area)
+        }
+        addTrackingArea(NSTrackingArea(
+            rect: bounds,
+            options: [.activeInKeyWindow, .inVisibleRect, .mouseMoved],
+            owner: self
+        ))
+    }
+
+    func load(_ url: URL) {
+        pendingURL = url
+        currentURL = url
+        currentTitle = url.host(percentEncoded: false) ?? url.absoluteString
+        lastPersistentStateKey = nil
+        recordNavigation(url)
+        isLoading = true
+        estimatedProgress = max(estimatedProgress, 0.1)
+        notifyStateChanged()
+
+        if let session = freshMojoSession,
+           let freshMojoRuntime,
+           freshMojoRuntime.navigate(session, url: url.absoluteString) {
+            launchedURL = url
+            return
+        }
+
+        if process != nil, launchedURL != nil, controlChannel.sendNavigate(url.absoluteString) {
+            launchedURL = url
+            return
+        }
+        if launchedURL != url {
+            restartForPendingURL()
+        }
+        launchIfPossible()
+    }
+
+    func reload() {
+        guard let url = currentURL ?? pendingURL else { return }
+        pendingURL = url
+        lastPersistentStateKey = nil
+        if let session = freshMojoSession,
+           let freshMojoRuntime,
+           freshMojoRuntime.navigate(session, url: url.absoluteString) {
+            isLoading = true
+            estimatedProgress = 0.1
+            notifyStateChanged()
+            return
+        }
+        if process != nil, controlChannel.sendReload() {
+            isLoading = true
+            estimatedProgress = 0.1
+            notifyStateChanged()
+            return
+        }
+        restartForPendingURL()
+    }
+
+    func stopLoading() {
+        if let session = freshMojoSession,
+           let freshMojoRuntime {
+            _ = freshMojoRuntime.executeJavaScript(session, script: "window.stop()")
+        }
+        _ = controlChannel.sendStop()
+        isLoading = false
+        notifyStateChanged()
+    }
+
+    func goBack() {
+        guard let targetURL = stepNavigationHistory(delta: -1) else { return }
+        if let session = freshMojoSession,
+           let freshMojoRuntime {
+            _ = freshMojoRuntime.executeJavaScript(session, script: "history.back()")
+            return
+        }
+        if controlChannel.sendGoBack() {
+            return
+        }
+        pendingURL = targetURL
+        restartForPendingURL()
+    }
+
+    func goForward() {
+        guard let targetURL = stepNavigationHistory(delta: 1) else { return }
+        if let session = freshMojoSession,
+           let freshMojoRuntime {
+            _ = freshMojoRuntime.executeJavaScript(session, script: "history.forward()")
+            return
+        }
+        if controlChannel.sendGoForward() {
+            return
+        }
+        pendingURL = targetURL
+        restartForPendingURL()
+    }
+
+    func setProxyConfiguration(_ proxyConfiguration: NSDictionary?) {
+        let nextProxyServer = Self.proxyServer(from: proxyConfiguration)
+        guard proxyServer != nextProxyServer else { return }
+        proxyServer = nextProxyServer
+        guard launchedURL != nil || pendingURL != nil else { return }
+        pendingURL = currentURL ?? pendingURL ?? launchedURL
+        restartForPendingURL()
+    }
+
+    func setAppearanceName(_ appearanceName: String?) {
+        let nextAppearance: NSAppearance?
+        switch appearanceName?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "dark":
+            nextAppearance = NSAppearance(named: .darkAqua)
+        case "light":
+            nextAppearance = NSAppearance(named: .aqua)
+        default:
+            nextAppearance = nil
+        }
+        appearance = nextAppearance
+        hostLayer?.setNeedsDisplay()
+    }
+
+    func setPageZoomFactor(_ pageZoomFactor: Double) {
+        let clamped = min(3.0, max(0.25, pageZoomFactor))
+        guard abs(self.pageZoomFactor - clamped) >= 0.0001 else { return }
+        self.pageZoomFactor = clamped
+        lastPersistentStateKey = nil
+        applyPersistentBrowserState()
+    }
+
+    func addUserScript(_ source: String) {
+        persistentUserScripts.append(source)
+        lastPersistentStateKey = nil
+        applyPersistentBrowserState()
+    }
+
+    func addUserStyle(_ source: String) {
+        persistentUserStyles.append(source)
+        lastPersistentStateKey = nil
+        applyPersistentBrowserState()
+    }
+
+    func evaluateJavaScript(_ script: String, completion: @escaping (Any?, String?) -> Void) {
+        if let session = freshMojoSession,
+           let freshMojoRuntime {
+            let evaluate = {
+                switch freshMojoRuntime.executeJavaScript(session, script: script) {
+                case .failure(let error):
+                    cmuxChromiumLogger.error("JavaScript evaluation failed: \(error.localizedDescription, privacy: .private)")
+                    completion(nil, Self.browserScriptFailedTitle())
+                case .success(let value):
+                    completion(value, nil)
+                }
+            }
+            if Thread.isMainThread {
+                evaluate()
+            } else {
+                DispatchQueue.main.async(execute: evaluate)
+            }
+            return
+        }
+
+        devToolsQueue.async { [weak self] in
+            guard let self else { return completion(nil, Self.browserScriptFailedTitle()) }
+            self.ensureDevToolsPageWebSocketURL { result in
+                switch result {
+                case .failure(let error):
+                    cmuxChromiumLogger.error("DevTools endpoint unavailable: \(error.localizedDescription, privacy: .private)")
+                    completion(nil, Self.browserScriptFailedTitle())
+                case .success(let url):
+                    self.sendDevToolsCommand(
+                        webSocketURL: url,
+                        method: "Runtime.evaluate",
+                        params: [
+                            "expression": script,
+                            "returnByValue": true,
+                            "awaitPromise": true
+                        ]
+                    ) { commandResult in
+                        switch commandResult {
+                        case .failure(let error):
+                            cmuxChromiumLogger.error("DevTools command failed: \(error.localizedDescription, privacy: .private)")
+                            completion(nil, Self.browserScriptFailedTitle())
+                        case .success(let payload):
+                            if let exception = payload["exceptionDetails"] {
+                                cmuxChromiumLogger.error("Page JavaScript exception: \(String(describing: exception), privacy: .private)")
+                                completion(nil, Self.browserScriptFailedTitle())
+                                return
+                            }
+                            let result = payload["result"] as? [String: Any]
+                            completion(result?["value"], nil)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func applyPersistentBrowserState() {
+        guard freshMojoSession != nil || devToolsPort != nil || currentContextID != 0 else { return }
+        let key = [
+            currentURL?.absoluteString ?? "",
+            String(currentContextID),
+            String(format: "%.4f", pageZoomFactor),
+            String(persistentUserScripts.count),
+            String(persistentUserStyles.count)
+        ].joined(separator: "|")
+        guard key != lastPersistentStateKey else { return }
+        lastPersistentStateKey = key
+
+        evaluateJavaScript(Self.pageZoomScript(for: pageZoomFactor)) { _, _ in }
+        for source in persistentUserScripts {
+            evaluateJavaScript(source) { _, _ in }
+        }
+        for source in persistentUserStyles {
+            evaluateJavaScript(source) { _, _ in }
+        }
+    }
+
+    private static func pageZoomScript(for factor: Double) -> String {
+        let zoom = String(format: "%.4f", factor)
+        return """
+        (() => {
+          const zoom = '\(zoom)';
+          if (document.documentElement) {
+            document.documentElement.style.zoom = zoom;
+          }
+          return true;
+        })()
+        """
+    }
+
+    func takeSnapshot(_ completion: @escaping (NSImage?) -> Void) {
+        if let session = freshMojoSession,
+           let freshMojoRuntime {
+            let snapshot = {
+                if let image = freshMojoRuntime.captureSurfaceImage(session) {
+                    completion(image)
+                    return
+                }
+                self.takeLayerSnapshot(completion)
+            }
+            if Thread.isMainThread {
+                snapshot()
+            } else {
+                DispatchQueue.main.async(execute: snapshot)
+            }
+            return
+        }
+
+        evaluateJavaScript("document.documentElement.outerHTML") { [weak self] _, _ in
+            DispatchQueue.main.async {
+                self?.takeLayerSnapshot(completion)
+            }
+        }
+    }
+
+    private func takeLayerSnapshot(_ completion: @escaping (NSImage?) -> Void) {
+        guard let bitmap = bitmapImageRepForCachingDisplay(in: bounds) else {
+            completion(nil)
+            return
+        }
+        cacheDisplay(in: bounds, to: bitmap)
+        let image = NSImage(size: bounds.size)
+        image.addRepresentation(bitmap)
+        completion(image)
+    }
+
+    override func mouseDown(with event: NSEvent) { postMouseEvent(event, type: .leftMouseDown) }
+    override func mouseUp(with event: NSEvent) { postMouseEvent(event, type: .leftMouseUp) }
+    override func mouseDragged(with event: NSEvent) { postMouseEvent(event, type: .leftMouseDragged) }
+    override func mouseMoved(with event: NSEvent) { postMouseEvent(event, type: .mouseMoved) }
+    override func rightMouseDown(with event: NSEvent) { postMouseEvent(event, type: .rightMouseDown) }
+    override func rightMouseUp(with event: NSEvent) { postMouseEvent(event, type: .rightMouseUp) }
+    override func scrollWheel(with event: NSEvent) { postScrollEvent(event) }
+    override func keyDown(with event: NSEvent) { postKeyEvent(event) }
+    override func keyUp(with event: NSEvent) { postKeyEvent(event) }
+    override func flagsChanged(with event: NSEvent) { postModifierKeyEvent(event) }
+
+    private static func proxyServer(from proxyConfiguration: NSDictionary?) -> String? {
+        guard let rawValue = proxyConfiguration?["proxyServer"] as? String else { return nil }
+        let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        return value.isEmpty ? nil : value
+    }
+
+    private func recordNavigation(_ url: URL) {
+        if navigationHistory.indices.contains(navigationHistoryIndex),
+           navigationHistory[navigationHistoryIndex] == url {
+            updateNavigationFlags()
+            return
+        }
+        if navigationHistoryIndex >= 0, navigationHistoryIndex < navigationHistory.count - 1 {
+            navigationHistory.removeSubrange((navigationHistoryIndex + 1)..<navigationHistory.count)
+        }
+        navigationHistory.append(url)
+        navigationHistoryIndex = navigationHistory.count - 1
+        updateNavigationFlags()
+    }
+
+    private func stepNavigationHistory(delta: Int) -> URL? {
+        let nextIndex = navigationHistoryIndex + delta
+        guard navigationHistory.indices.contains(nextIndex) else {
+            updateNavigationFlags()
+            return nil
+        }
+        navigationHistoryIndex = nextIndex
+        currentURL = navigationHistory[nextIndex]
+        updateNavigationFlags()
+        notifyStateChanged()
+        return navigationHistory[nextIndex]
+    }
+
+    private func updateNavigationFlags() {
+        canGoBack = navigationHistory.indices.contains(navigationHistoryIndex - 1)
+        canGoForward = navigationHistory.indices.contains(navigationHistoryIndex + 1)
+    }
+
+    private func launchIfPossible() {
+        guard process == nil,
+              freshMojoSession == nil,
+              let pendingURL,
+              window != nil,
+              bounds.width >= 8,
+              bounds.height >= 8 else { return }
+        launch(url: pendingURL)
+    }
+
+    private func restartForPendingURL() {
+        teardownProcessOnly()
+        launchIfPossible()
+    }
+
+    private func launch(url: URL) {
+        guard let executableURL = Self.contentShellExecutableURL() else {
+            currentTitle = Self.browserEngineUnavailableTitle()
+            isLoading = false
+            estimatedProgress = 0
+            notifyStateChanged()
+            return
+        }
+
+        do {
+            try FileManager.default.createDirectory(at: sessionDirectory, withIntermediateDirectories: true)
+            try? FileManager.default.removeItem(at: contextFile)
+            try? FileManager.default.removeItem(at: resizeFile)
+            try? FileManager.default.removeItem(at: controlSocketFile)
+            controlChannel.close()
+        } catch {
+            cmuxChromiumLogger.error("Failed to prepare browser session directory: \(error.localizedDescription, privacy: .private)")
+            currentTitle = Self.browserEngineUnavailableTitle()
+            isLoading = false
+            estimatedProgress = 0
+            notifyStateChanged()
+            return
+        }
+
+        if let freshMojoRuntime {
+            launchFreshMojo(url: url, executableURL: executableURL, runtime: freshMojoRuntime)
+            return
+        }
+
+        let process = Process()
+        process.executableURL = executableURL
+        process.currentDirectoryURL = executableURL
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        process.arguments = [
+            "--content-shell-hide-toolbar",
+            "--cmux-embed",
+            "--remote-debugging-port=0",
+            "--user-data-dir=\(sessionDirectory.path)",
+            "--content-shell-host-window-size=\(max(8, Int(bounds.width)))x\(max(8, Int(bounds.height)))",
+            url.absoluteString
+        ]
+        if let proxyServer {
+            process.arguments?.insert("--proxy-server=\(proxyServer)", at: max(0, (process.arguments?.count ?? 1) - 1))
+        }
+        var environment = ProcessInfo.processInfo.environment
+        environment["CMUX_CA_CONTEXT_FILE"] = contextFile.path
+        environment["CMUX_CA_RESIZE_SOCK"] = controlSocketFile.path
+        environment["CMUX_CA_RESIZE_FILE"] = resizeFile.path
+        environment["CMUX_PROFILE_IDENTIFIER"] = profileIdentifier
+        process.environment = environment
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+        pipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
+            let data = handle.availableData
+            guard !data.isEmpty, let text = String(data: data, encoding: .utf8) else { return }
+            self?.parseProcessOutput(text)
+        }
+
+        process.terminationHandler = { [weak self] _ in
+            DispatchQueue.main.async {
+                guard let self else { return }
+                self.clearProcessRuntimeState()
+                self.notifyStateChanged()
+            }
+        }
+
+        do {
+            try process.run()
+            self.process = process
+            ioPipe = pipe
+            launchedURL = url
+            contentShellPID = process.processIdentifier
+            isLoading = true
+            estimatedProgress = 0.1
+            startPollingContextFile()
+            writeResizeIfNeeded(force: true)
+            notifyStateChanged()
+        } catch {
+            cmuxChromiumLogger.error("Failed to launch browser process: \(error.localizedDescription, privacy: .private)")
+            currentTitle = Self.browserEngineFailedTitle()
+            isLoading = false
+            estimatedProgress = 0
+            notifyStateChanged()
+        }
+    }
+
+    private func launchFreshMojo(url: URL, executableURL: URL, runtime: OwlFreshMojoRuntime) {
+        guard runtime.initialize() else {
+            currentTitle = Self.browserEngineFailedTitle()
+            isLoading = false
+            estimatedProgress = 0
+            notifyStateChanged()
+            return
+        }
+
+        let userData = Unmanaged.passRetained(self).toOpaque()
+        freshMojoUserDataPointer = userData
+        guard let session = runtime.createSession(
+            contentShellPath: executableURL.path,
+            initialURL: url.absoluteString,
+            userDataDirectory: sessionDirectory.path,
+            proxyServer: proxyServer,
+            callback: Self.freshMojoEventCallback,
+            userData: userData
+        ) else {
+            releaseFreshMojoUserDataPointer()
+            currentTitle = Self.browserEngineFailedTitle()
+            isLoading = false
+            estimatedProgress = 0
+            notifyStateChanged()
+            return
+        }
+
+        freshMojoSession = session
+        launchedURL = url
+        contentShellPID = pid_t(runtime.hostPID(session))
+        isLoading = true
+        estimatedProgress = 0.1
+
+        let bindResult = runtime.bindDefaultInterfaces(session)
+        if case .failure(let error) = bindResult {
+            cmuxChromiumLogger.error("Failed to bind browser interfaces: \(error.localizedDescription, privacy: .private)")
+            runtime.destroySession(session)
+            freshMojoSession = nil
+            releaseFreshMojoUserDataPointer()
+            contentShellPID = 0
+            currentTitle = Self.browserEngineFailedTitle()
+            isLoading = false
+            estimatedProgress = 0
+            notifyStateChanged()
+            return
+        }
+
+        startFreshMojoPolling()
+        _ = runtime.flush(session)
+        writeResizeIfNeeded(force: true)
+        _ = runtime.setFocus(session, focused: window?.firstResponder === self)
+        notifyStateChanged()
+    }
+
+    private static let freshMojoEventCallback: OwlFreshMojoEventCallback = { eventPointer, userData in
+        guard let eventPointer,
+              let userData else { return }
+        let view = Unmanaged<CmuxChromiumBrowserView>
+            .fromOpaque(userData)
+            .takeUnretainedValue()
+        view.handleFreshMojoEvent(eventPointer.assumingMemoryBound(to: OwlFreshMojoEvent.self).pointee)
+    }
+
+    private func startFreshMojoPolling() {
+        freshMojoPollTimer?.invalidate()
+        freshMojoPollTimer = Timer.scheduledTimer(withTimeInterval: 0.016, repeats: true) { [weak self] _ in
+            self?.freshMojoRuntime?.pollEvents(timeoutMilliseconds: 0)
+        }
+    }
+
+    private func handleFreshMojoEvent(_ event: OwlFreshMojoEvent) {
+        let kind = OwlFreshMojoEventKind(rawValue: event.kind)
+        let message = event.message.map { String(cString: $0) }
+        let urlString = event.url.map { String(cString: $0) }
+        let title = event.title.map { String(cString: $0) }
+        let contextID = event.contextID
+        let hostPID = event.hostPID
+        let loading = event.loading
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            switch kind {
+            case .ready, .compositor:
+                if hostPID > 0 {
+                    self.contentShellPID = pid_t(hostPID)
+                }
+                if contextID != 0 {
+                    self.currentContextID = contextID
+                    self.attachHostLayer(contextID: contextID)
+                    self.estimatedProgress = max(self.estimatedProgress, 0.8)
+                    self.applyPersistentBrowserState()
+                }
+            case .navigation:
+                if let urlString, let url = URL(string: urlString) {
+                    self.currentURL = url
+                    self.launchedURL = url
+                    self.recordNavigation(url)
+                    self.lastPersistentStateKey = nil
+                }
+                if let title, !title.isEmpty {
+                    self.currentTitle = title
+                }
+                self.isLoading = loading
+                self.estimatedProgress = loading ? max(self.estimatedProgress, 0.4) : 1
+                if !loading {
+                    self.applyPersistentBrowserState()
+                }
+            case .disconnected:
+                self.isLoading = false
+                self.estimatedProgress = 0
+                self.freshMojoSession = nil
+                self.freshMojoPollTimer?.invalidate()
+                self.freshMojoPollTimer = nil
+                self.releaseFreshMojoUserDataPointer()
+            case .log, .surfaceTree, .none:
+                if kind == .log, let message {
+                    cmuxChromiumLogger.debug("Runtime log: \(message, privacy: .private)")
+                }
+            }
+            self.notifyStateChanged()
+        }
+    }
+
+    private func startPollingContextFile() {
+        pollTimer?.invalidate()
+        pollTimer = Timer.scheduledTimer(withTimeInterval: 0.05, repeats: true) { [weak self] _ in
+            self?.readContextIDIfAvailable()
+        }
+    }
+
+    private func readContextIDIfAvailable() {
+        guard let text = try? String(contentsOf: contextFile, encoding: .utf8),
+              let contextID = UInt32(text.trimmingCharacters(in: .whitespacesAndNewlines)),
+              contextID != 0 else { return }
+        if contextID == currentContextID {
+            applyPersistentBrowserState()
+            return
+        }
+        currentContextID = contextID
+        attachHostLayer(contextID: contextID)
+        isLoading = false
+        estimatedProgress = 1
+        applyPersistentBrowserState()
+        notifyStateChanged()
+        pollTimer?.invalidate()
+        pollTimer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { [weak self] _ in
+            self?.readContextIDIfAvailable()
+        }
+    }
+
+    private func attachHostLayer(contextID: UInt32) {
+        guard let cls = NSClassFromString("CALayerHost") as? CALayer.Type else { return }
+        let host = cls.init()
+        host.setValue(NSNumber(value: contextID), forKey: "contextId")
+        host.frame = bounds
+        host.autoresizingMask = [.layerWidthSizable, .layerHeightSizable]
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        hostLayer?.removeFromSuperlayer()
+        layer?.addSublayer(host)
+        hostLayer = host
+        CATransaction.commit()
+    }
+
+    private func writeResizeIfNeeded(force: Bool = false) {
+        guard process != nil || freshMojoSession != nil else { return }
+        let size = NSSize(width: max(8, bounds.width), height: max(8, bounds.height))
+        guard force || size != lastResizeSize else { return }
+        lastResizeSize = size
+        let scale = window?.backingScaleFactor ?? NSScreen.main?.backingScaleFactor ?? 1
+        if let session = freshMojoSession,
+           let freshMojoRuntime,
+           freshMojoRuntime.resize(
+               session,
+               width: UInt32(clamping: Int(size.width.rounded(.up))),
+               height: UInt32(clamping: Int(size.height.rounded(.up))),
+               scale: Float(scale)
+           ) {
+            return
+        }
+        if controlChannel.sendResize(
+            width: UInt32(clamping: Int(size.width.rounded(.up))),
+            height: UInt32(clamping: Int(size.height.rounded(.up))),
+            scale: scale
+        ) {
+            return
+        }
+        let payload = "\(Int(size.width)) \(Int(size.height))\n"
+        try? payload.write(to: resizeFile, atomically: true, encoding: .utf8)
+    }
+
+    private func notifyStateChanged() {
+        DispatchQueue.main.async { [weak self] in
+            self?.stateChangedHandler?()
+        }
+    }
+
+    private func parseProcessOutput(_ text: String) {
+        if text.contains("[owl] listening") {
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                if self.controlChannel.connectIfNeeded() {
+                    self.writeResizeIfNeeded(force: true)
+                    _ = self.controlChannel.sendFocus(self.window?.firstResponder === self)
+                }
+            }
+        }
+
+        guard let range = text.range(
+            of: #"ws://(?:127\.0\.0\.1|localhost|\[::1\]):\d+/devtools/browser/[A-Za-z0-9\-]+"#,
+            options: .regularExpression
+        ) else {
+            return
+        }
+        let value = String(text[range])
+        guard let url = URL(string: value),
+              let port = url.port else { return }
+        devToolsQueue.async { [weak self] in
+            self?.devToolsPort = port
+            self?.devToolsPageWebSocketURL = nil
+        }
+    }
+
+    private func ensureDevToolsPageWebSocketURL(
+        completion: @escaping (Result<URL, Error>) -> Void
+    ) {
+        if let url = devToolsPageWebSocketURL {
+            completion(.success(url))
+            return
+        }
+        guard let port = devToolsPort,
+              let listURL = URL(string: "http://127.0.0.1:\(port)/json") else {
+            completion(.failure(CmuxChromiumCoreError.devToolsUnavailable))
+            return
+        }
+        URLSession.shared.dataTask(with: listURL) { data, _, error in
+            let result: Result<URL, Error>
+            if let error {
+                result = .failure(error)
+            } else if let data,
+                      let entries = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]],
+                      let page = entries.first(where: { ($0["type"] as? String) == "page" }),
+                      let webSocket = page["webSocketDebuggerUrl"] as? String,
+                      let url = URL(string: webSocket) {
+                result = .success(url)
+            } else {
+                result = .failure(CmuxChromiumCoreError.devToolsUnavailable)
+            }
+            self.devToolsQueue.async { [weak self] in
+                if case .success(let url) = result {
+                    self?.devToolsPageWebSocketURL = url
+                }
+                completion(result)
+            }
+        }.resume()
+    }
+
+    private func sendDevToolsCommand(
+        webSocketURL: URL,
+        method: String,
+        params: [String: Any],
+        completion: @escaping (Result<[String: Any], Error>) -> Void
+    ) {
+        let commandID = 1
+        let lock = NSLock()
+        var didFinish = false
+        let message: [String: Any] = [
+            "id": commandID,
+            "method": method,
+            "params": params
+        ]
+        guard let data = try? JSONSerialization.data(withJSONObject: message),
+              let text = String(data: data, encoding: .utf8) else {
+            completion(.failure(CmuxChromiumCoreError.invalidDevToolsResponse))
+            return
+        }
+
+        let task = URLSession.shared.webSocketTask(with: webSocketURL)
+        task.resume()
+        var timeoutWorkItem: DispatchWorkItem?
+
+        let finish: (Result<[String: Any], Error>) -> Void = { result in
+            lock.lock()
+            defer { lock.unlock() }
+            guard !didFinish else { return }
+            didFinish = true
+            timeoutWorkItem?.cancel()
+            timeoutWorkItem = nil
+            task.cancel(with: .normalClosure, reason: nil)
+            completion(result)
+        }
+        let workItem = DispatchWorkItem {
+            finish(.failure(CmuxChromiumCoreError.devToolsError("Timed out waiting for browser script response")))
+        }
+        timeoutWorkItem = workItem
+        devToolsQueue.asyncAfter(deadline: .now() + 5, execute: workItem)
+
+        let objectFromMessage: (URLSessionWebSocketTask.Message) -> [String: Any]? = { message in
+            let data: Data?
+            switch message {
+            case .string(let text):
+                data = text.data(using: .utf8)
+            case .data(let value):
+                data = value
+            @unknown default:
+                data = nil
+            }
+            guard let data else { return nil }
+            return try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        }
+
+        func receiveNextResponse() {
+            task.receive { result in
+                switch result {
+                case .failure(let error):
+                    finish(.failure(error))
+                case .success(let message):
+                    guard let object = objectFromMessage(message) else {
+                        finish(.failure(CmuxChromiumCoreError.invalidDevToolsResponse))
+                        return
+                    }
+                    let responseID: Int? = {
+                        if let value = object["id"] as? Int { return value }
+                        if let value = object["id"] as? NSNumber { return value.intValue }
+                        return nil
+                    }()
+                    guard responseID == commandID else {
+                        receiveNextResponse()
+                        return
+                    }
+                    if let error = object["error"] {
+                        finish(.failure(CmuxChromiumCoreError.devToolsError(String(describing: error))))
+                        return
+                    }
+                    finish(.success((object["result"] as? [String: Any]) ?? [:]))
+                }
+            }
+        }
+
+        task.send(.string(text)) { error in
+            if let error {
+                finish(.failure(error))
+                return
+            }
+            receiveNextResponse()
+        }
+    }
+
+    private func postMouseEvent(_ event: NSEvent, type: CGEventType) {
+        window?.makeFirstResponder(self)
+        let local = convert(event.locationInWindow, from: nil)
+        let mouseType: UInt8
+        switch type {
+        case .leftMouseDown, .rightMouseDown, .otherMouseDown:
+            mouseType = OwlMouseType.down.rawValue
+        case .leftMouseUp, .rightMouseUp, .otherMouseUp:
+            mouseType = OwlMouseType.up.rawValue
+        default:
+            mouseType = OwlMouseType.move.rawValue
+        }
+        let button: UInt8
+        if type == .rightMouseDown || type == .rightMouseUp {
+            button = OwlMouseButton.right.rawValue
+        } else if event.buttonNumber == 2 || type == .otherMouseDown || type == .otherMouseUp {
+            button = OwlMouseButton.middle.rawValue
+        } else {
+            button = OwlMouseButton.left.rawValue
+        }
+        if let session = freshMojoSession,
+           let freshMojoRuntime,
+           freshMojoRuntime.sendMouse(
+               session,
+               kind: UInt32(mouseType),
+               x: Float(local.x),
+               y: Float(max(0, bounds.height - local.y)),
+               button: UInt32(button),
+               clickCount: UInt32(clamping: event.clickCount),
+               deltaX: 0,
+               deltaY: 0,
+               modifiers: UInt32(truncatingIfNeeded: event.modifierFlags.rawValue)
+           ) {
+            return
+        }
+        controlChannel.sendMouseAsync(
+            type: mouseType,
+            x: Double(local.x),
+            y: Double(max(0, bounds.height - local.y)),
+            button: button,
+            clickCount: UInt8(clamping: event.clickCount),
+            deltaX: 0,
+            deltaY: 0,
+            modifiers: UInt32(truncatingIfNeeded: event.modifierFlags.rawValue)
+        )
+    }
+
+    private func postScrollEvent(_ event: NSEvent) {
+        window?.makeFirstResponder(self)
+        let local = convert(event.locationInWindow, from: nil)
+        if let session = freshMojoSession,
+           let freshMojoRuntime,
+           freshMojoRuntime.sendMouse(
+               session,
+               kind: UInt32(OwlMouseType.wheel.rawValue),
+               x: Float(local.x),
+               y: Float(max(0, bounds.height - local.y)),
+               button: UInt32(OwlMouseButton.left.rawValue),
+               clickCount: 0,
+               deltaX: Float(event.scrollingDeltaX),
+               deltaY: Float(event.scrollingDeltaY),
+               modifiers: UInt32(truncatingIfNeeded: event.modifierFlags.rawValue)
+           ) {
+            return
+        }
+        controlChannel.sendMouseAsync(
+            type: OwlMouseType.wheel.rawValue,
+            x: Double(local.x),
+            y: Double(max(0, bounds.height - local.y)),
+            button: OwlMouseButton.left.rawValue,
+            clickCount: 0,
+            deltaX: Double(event.scrollingDeltaX),
+            deltaY: Double(event.scrollingDeltaY),
+            modifiers: UInt32(truncatingIfNeeded: event.modifierFlags.rawValue)
+        )
+    }
+
+    private func postKeyEvent(_ event: NSEvent) {
+        let keyType: UInt8
+        switch event.type {
+        case .keyDown:
+            keyType = OwlKeyType.down.rawValue
+        case .keyUp:
+            keyType = OwlKeyType.up.rawValue
+        default:
+            return
+        }
+        postKey(
+            type: keyType,
+            keyCode: event.keyCode,
+            characters: event.characters ?? "",
+            modifiers: event.modifierFlags
+        )
+    }
+
+    private func postModifierKeyEvent(_ event: NSEvent) {
+        guard let modifierFlag = Self.modifierFlag(forKeyCode: event.keyCode) else { return }
+        let keyType = event.modifierFlags.contains(modifierFlag)
+            ? OwlKeyType.down.rawValue
+            : OwlKeyType.up.rawValue
+        postKey(type: keyType, keyCode: event.keyCode, characters: "", modifiers: event.modifierFlags)
+    }
+
+    private static func modifierFlag(forKeyCode keyCode: UInt16) -> NSEvent.ModifierFlags? {
+        switch keyCode {
+        case 54, 55:
+            return .command
+        case 56, 60:
+            return .shift
+        case 57:
+            return .capsLock
+        case 58, 61:
+            return .option
+        case 59, 62:
+            return .control
+        case 63:
+            return .function
+        default:
+            return nil
+        }
+    }
+
+    private func postKey(
+        type keyType: UInt8,
+        keyCode: UInt16,
+        characters: String,
+        modifiers: NSEvent.ModifierFlags
+    ) {
+        if let session = freshMojoSession,
+           let freshMojoRuntime,
+           freshMojoRuntime.sendKey(
+               session,
+               keyDown: keyType == OwlKeyType.down.rawValue,
+               keyCode: UInt32(keyCode),
+               text: characters,
+               modifiers: UInt32(truncatingIfNeeded: modifiers.rawValue)
+           ) {
+            return
+        }
+        controlChannel.sendKeyAsync(
+            type: keyType,
+            keyCode: keyCode,
+            characters: characters,
+            modifiers: UInt32(truncatingIfNeeded: modifiers.rawValue)
+        )
+    }
+
+    private func teardown() {
+        teardownProcessOnly()
+        try? FileManager.default.removeItem(at: contextFile)
+        try? FileManager.default.removeItem(at: resizeFile)
+        try? FileManager.default.removeItem(at: controlSocketFile)
+    }
+
+    private func teardownProcessOnly() {
+        freshMojoPollTimer?.invalidate()
+        freshMojoPollTimer = nil
+        if let session = freshMojoSession {
+            freshMojoRuntime?.destroySession(session)
+            freshMojoSession = nil
+            releaseFreshMojoUserDataPointer()
+        }
+        pollTimer?.invalidate()
+        pollTimer = nil
+        ioPipe?.fileHandleForReading.readabilityHandler = nil
+        ioPipe = nil
+        process?.terminate()
+        clearProcessRuntimeState()
+    }
+
+    private func clearProcessRuntimeState() {
+        process = nil
+        controlChannel.close()
+        contentShellPID = 0
+        currentContextID = 0
+        devToolsPort = nil
+        devToolsPageWebSocketURL = nil
+        hostLayer?.removeFromSuperlayer()
+        hostLayer = nil
+        launchedURL = nil
+        isLoading = false
+        estimatedProgress = 0
+    }
+
+    private func releaseFreshMojoUserDataPointer() {
+        guard let pointer = freshMojoUserDataPointer else { return }
+        Unmanaged<CmuxChromiumBrowserView>.fromOpaque(pointer).release()
+        freshMojoUserDataPointer = nil
+    }
+
+    private static func browserEngineUnavailableTitle() -> String {
+        String(localized: "browser.chromium.error.unavailable", defaultValue: "Browser engine unavailable")
+    }
+
+    private static func browserEngineFailedTitle() -> String {
+        String(localized: "browser.chromium.error.failedToStart", defaultValue: "Browser engine failed to start")
+    }
+
+    fileprivate static func browserScriptFailedTitle() -> String {
+        String(localized: "browser.chromium.error.scriptFailed", defaultValue: "Browser script failed")
+    }
+
+    private static func contentShellExecutableURL() -> URL? {
+        guard let resourceURL = Bundle(for: CmuxChromiumBrowserHost.self).resourceURL else {
+            return nil
+        }
+        let executableURL = resourceURL
+            .appendingPathComponent("Content Shell.app", isDirectory: true)
+            .appendingPathComponent("Contents/MacOS/Content Shell", isDirectory: false)
+        guard FileManager.default.isExecutableFile(atPath: executableURL.path) else {
+            return nil
+        }
+        return executableURL
+    }
+}
+
+enum CmuxChromiumCoreError: LocalizedError {
+    case devToolsUnavailable
+    case invalidDevToolsResponse
+    case devToolsError(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .devToolsUnavailable:
+            return CmuxChromiumBrowserView.browserScriptFailedTitle()
+        case .invalidDevToolsResponse:
+            return CmuxChromiumBrowserView.browserScriptFailedTitle()
+        case .devToolsError(let message):
+            cmuxChromiumLogger.error("DevTools error: \(message, privacy: .private)")
+            return CmuxChromiumBrowserView.browserScriptFailedTitle()
+        }
+    }
+}
+
+private enum OwlFreshMojoEventKind: Int32 {
+    case log = 1
+    case ready = 2
+    case compositor = 3
+    case navigation = 4
+    case disconnected = 5
+    case surfaceTree = 6
+}
+
+private struct OwlFreshMojoEvent {
+    var kind: Int32
+    var contextID: UInt32
+    var hostPID: Int32
+    var loading: Bool
+    var url: UnsafePointer<CChar>?
+    var title: UnsafePointer<CChar>?
+    var message: UnsafePointer<CChar>?
+}
+
+private typealias OwlFreshMojoEventCallback = @convention(c) (
+    UnsafeRawPointer?,
+    UnsafeMutableRawPointer?
+) -> Void
+
+private final class OwlFreshMojoRuntime {
+    private typealias GlobalInit = @convention(c) () -> Int32
+    private typealias SessionCreate = @convention(c) (
+        UnsafePointer<CChar>?,
+        UnsafePointer<CChar>?,
+        UnsafePointer<CChar>?,
+        OwlFreshMojoEventCallback?,
+        UnsafeMutableRawPointer?
+    ) -> OpaquePointer?
+    private typealias SessionCreateWithProxy = @convention(c) (
+        UnsafePointer<CChar>?,
+        UnsafePointer<CChar>?,
+        UnsafePointer<CChar>?,
+        UnsafePointer<CChar>?,
+        OwlFreshMojoEventCallback?,
+        UnsafeMutableRawPointer?
+    ) -> OpaquePointer?
+    private typealias SessionDestroy = @convention(c) (OpaquePointer?) -> Void
+    private typealias SessionHostPID = @convention(c) (OpaquePointer?) -> Int32
+    private typealias BindInterface = @convention(c) (
+        OpaquePointer?,
+        UInt64,
+        UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?
+    ) -> Int32
+    private typealias Flush = @convention(c) (
+        OpaquePointer?,
+        UnsafeMutablePointer<Bool>?,
+        UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?
+    ) -> Int32
+    private typealias ExecuteJavaScript = @convention(c) (
+        OpaquePointer?,
+        UnsafePointer<CChar>?,
+        UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?,
+        UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?
+    ) -> Int32
+    private typealias Navigate = @convention(c) (
+        OpaquePointer?,
+        UnsafePointer<CChar>?,
+        UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?
+    ) -> Int32
+    private typealias Resize = @convention(c) (
+        OpaquePointer?,
+        UInt32,
+        UInt32,
+        Float,
+        UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?
+    ) -> Int32
+    private typealias SetFocus = @convention(c) (
+        OpaquePointer?,
+        Bool,
+        UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?
+    ) -> Int32
+    private typealias SendMouse = @convention(c) (
+        OpaquePointer?,
+        UInt32,
+        Float,
+        Float,
+        UInt32,
+        UInt32,
+        Float,
+        Float,
+        UInt32,
+        UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?
+    ) -> Int32
+    private typealias SendKey = @convention(c) (
+        OpaquePointer?,
+        Bool,
+        UInt32,
+        UnsafePointer<CChar>?,
+        UInt32,
+        UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?
+    ) -> Int32
+    private typealias CaptureSurface = @convention(c) (
+        OpaquePointer?,
+        UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?,
+        UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?
+    ) -> Int32
+    private typealias PollEvents = @convention(c) (UInt32) -> Void
+    private typealias FreeBuffer = @convention(c) (UnsafeMutableRawPointer?) -> Void
+
+    private let handle: UnsafeMutableRawPointer
+    private let globalInit: GlobalInit
+    private let sessionCreate: SessionCreate
+    private let sessionCreateWithProxy: SessionCreateWithProxy?
+    private let sessionDestroy: SessionDestroy
+    private let sessionHostPID: SessionHostPID
+    private let sessionSetClient: BindInterface
+    private let bindProfile: BindInterface
+    private let bindWebView: BindInterface
+    private let bindInput: BindInterface
+    private let bindSurfaceTree: BindInterface
+    private let bindNativeSurfaceHost: BindInterface
+    private let bindDevToolsHost: BindInterface
+    private let sessionFlush: Flush
+    private let shellExecuteJavaScript: ExecuteJavaScript
+    private let webViewNavigate: Navigate
+    private let webViewResize: Resize
+    private let webViewSetFocus: SetFocus
+    private let inputSendMouse: SendMouse
+    private let inputSendKey: SendKey
+    private let surfaceTreeCaptureSurfaceJSON: CaptureSurface
+    private let pollEventsFunction: PollEvents
+    private let freeBuffer: FreeBuffer
+
+    private init?(
+        handle: UnsafeMutableRawPointer,
+        globalInit: GlobalInit,
+        sessionCreate: SessionCreate,
+        sessionCreateWithProxy: SessionCreateWithProxy?,
+        sessionDestroy: SessionDestroy,
+        sessionHostPID: SessionHostPID,
+        sessionSetClient: BindInterface,
+        bindProfile: BindInterface,
+        bindWebView: BindInterface,
+        bindInput: BindInterface,
+        bindSurfaceTree: BindInterface,
+        bindNativeSurfaceHost: BindInterface,
+        bindDevToolsHost: BindInterface,
+        sessionFlush: Flush,
+        shellExecuteJavaScript: ExecuteJavaScript,
+        webViewNavigate: Navigate,
+        webViewResize: Resize,
+        webViewSetFocus: SetFocus,
+        inputSendMouse: SendMouse,
+        inputSendKey: SendKey,
+        surfaceTreeCaptureSurfaceJSON: CaptureSurface,
+        pollEventsFunction: PollEvents,
+        freeBuffer: FreeBuffer
+    ) {
+        self.handle = handle
+        self.globalInit = globalInit
+        self.sessionCreate = sessionCreate
+        self.sessionCreateWithProxy = sessionCreateWithProxy
+        self.sessionDestroy = sessionDestroy
+        self.sessionHostPID = sessionHostPID
+        self.sessionSetClient = sessionSetClient
+        self.bindProfile = bindProfile
+        self.bindWebView = bindWebView
+        self.bindInput = bindInput
+        self.bindSurfaceTree = bindSurfaceTree
+        self.bindNativeSurfaceHost = bindNativeSurfaceHost
+        self.bindDevToolsHost = bindDevToolsHost
+        self.sessionFlush = sessionFlush
+        self.shellExecuteJavaScript = shellExecuteJavaScript
+        self.webViewNavigate = webViewNavigate
+        self.webViewResize = webViewResize
+        self.webViewSetFocus = webViewSetFocus
+        self.inputSendMouse = inputSendMouse
+        self.inputSendKey = inputSendKey
+        self.surfaceTreeCaptureSurfaceJSON = surfaceTreeCaptureSurfaceJSON
+        self.pollEventsFunction = pollEventsFunction
+        self.freeBuffer = freeBuffer
+    }
+
+    static func load() -> OwlFreshMojoRuntime? {
+        guard let resourceURL = Bundle(for: CmuxChromiumBrowserHost.self).resourceURL else {
+            return nil
+        }
+        let dylibURL = resourceURL.appendingPathComponent("libowl_fresh_mojo_runtime.dylib")
+        guard FileManager.default.fileExists(atPath: dylibURL.path),
+              let handle = dlopen(dylibURL.path, RTLD_NOW | RTLD_LOCAL) else {
+            return nil
+        }
+
+        func symbol<T>(_ name: String, as type: T.Type) -> T? {
+            guard let pointer = dlsym(handle, name) else { return nil }
+            return unsafeBitCast(pointer, to: type)
+        }
+
+        guard
+            let globalInit = symbol("owl_fresh_mojo_global_init", as: GlobalInit.self),
+            let sessionCreate = symbol("owl_fresh_mojo_session_create", as: SessionCreate.self),
+            let sessionDestroy = symbol("owl_fresh_mojo_session_destroy", as: SessionDestroy.self),
+            let sessionHostPID = symbol("owl_fresh_mojo_session_host_pid", as: SessionHostPID.self),
+            let sessionSetClient = symbol("owl_fresh_mojo_session_set_client", as: BindInterface.self),
+            let bindProfile = symbol("owl_fresh_mojo_session_bind_profile", as: BindInterface.self),
+            let bindWebView = symbol("owl_fresh_mojo_session_bind_web_view", as: BindInterface.self),
+            let bindInput = symbol("owl_fresh_mojo_session_bind_input", as: BindInterface.self),
+            let bindSurfaceTree = symbol("owl_fresh_mojo_session_bind_surface_tree", as: BindInterface.self),
+            let bindNativeSurfaceHost = symbol("owl_fresh_mojo_session_bind_native_surface_host", as: BindInterface.self),
+            let bindDevToolsHost = symbol("owl_fresh_mojo_session_bind_devtools_host", as: BindInterface.self),
+            let sessionFlush = symbol("owl_fresh_mojo_session_flush", as: Flush.self),
+            let shellExecuteJavaScript = symbol("owl_fresh_mojo_shell_execute_javascript", as: ExecuteJavaScript.self),
+            let webViewNavigate = symbol("owl_fresh_mojo_web_view_navigate", as: Navigate.self),
+            let webViewResize = symbol("owl_fresh_mojo_web_view_resize", as: Resize.self),
+            let webViewSetFocus = symbol("owl_fresh_mojo_web_view_set_focus", as: SetFocus.self),
+            let inputSendMouse = symbol("owl_fresh_mojo_input_send_mouse", as: SendMouse.self),
+            let inputSendKey = symbol("owl_fresh_mojo_input_send_key", as: SendKey.self),
+            let surfaceTreeCaptureSurfaceJSON = symbol(
+                "owl_fresh_mojo_surface_tree_capture_surface_json",
+                as: CaptureSurface.self
+            ),
+            let pollEventsFunction = symbol("owl_fresh_mojo_poll_events", as: PollEvents.self),
+            let freeBuffer = symbol("owl_fresh_mojo_free_buffer", as: FreeBuffer.self)
+        else {
+            dlclose(handle)
+            return nil
+        }
+        let sessionCreateWithProxy = symbol(
+            "owl_fresh_mojo_session_create_with_proxy",
+            as: SessionCreateWithProxy.self
+        )
+
+        return OwlFreshMojoRuntime(
+            handle: handle,
+            globalInit: globalInit,
+            sessionCreate: sessionCreate,
+            sessionCreateWithProxy: sessionCreateWithProxy,
+            sessionDestroy: sessionDestroy,
+            sessionHostPID: sessionHostPID,
+            sessionSetClient: sessionSetClient,
+            bindProfile: bindProfile,
+            bindWebView: bindWebView,
+            bindInput: bindInput,
+            bindSurfaceTree: bindSurfaceTree,
+            bindNativeSurfaceHost: bindNativeSurfaceHost,
+            bindDevToolsHost: bindDevToolsHost,
+            sessionFlush: sessionFlush,
+            shellExecuteJavaScript: shellExecuteJavaScript,
+            webViewNavigate: webViewNavigate,
+            webViewResize: webViewResize,
+            webViewSetFocus: webViewSetFocus,
+            inputSendMouse: inputSendMouse,
+            inputSendKey: inputSendKey,
+            surfaceTreeCaptureSurfaceJSON: surfaceTreeCaptureSurfaceJSON,
+            pollEventsFunction: pollEventsFunction,
+            freeBuffer: freeBuffer
+        )
+    }
+
+    func initialize() -> Bool {
+        globalInit() == 0
+    }
+
+    func createSession(
+        contentShellPath: String,
+        initialURL: String,
+        userDataDirectory: String,
+        proxyServer: String?,
+        callback: OwlFreshMojoEventCallback,
+        userData: UnsafeMutableRawPointer
+    ) -> OpaquePointer? {
+        contentShellPath.withCString { contentShellPathPointer in
+            initialURL.withCString { initialURLPointer in
+                userDataDirectory.withCString { userDataDirectoryPointer in
+                    if let sessionCreateWithProxy {
+                        if let proxyServer {
+                            return proxyServer.withCString { proxyServerPointer in
+                                sessionCreateWithProxy(
+                                    contentShellPathPointer,
+                                    initialURLPointer,
+                                    userDataDirectoryPointer,
+                                    proxyServerPointer,
+                                    callback,
+                                    userData
+                                )
+                            }
+                        }
+                        return sessionCreateWithProxy(
+                            contentShellPathPointer,
+                            initialURLPointer,
+                            userDataDirectoryPointer,
+                            nil,
+                            callback,
+                            userData
+                        )
+                    }
+                    guard proxyServer == nil else { return nil }
+                    return sessionCreate(
+                        contentShellPathPointer,
+                        initialURLPointer,
+                        userDataDirectoryPointer,
+                        callback,
+                        userData
+                    )
+                }
+            }
+        }
+    }
+
+    func destroySession(_ session: OpaquePointer) {
+        sessionDestroy(session)
+    }
+
+    func hostPID(_ session: OpaquePointer) -> Int32 {
+        sessionHostPID(session)
+    }
+
+    func bindDefaultInterfaces(_ session: OpaquePointer) -> Result<Void, Error> {
+        let binds: [(UInt64, BindInterface)] = [
+            (1, sessionSetClient),
+            (2, bindProfile),
+            (3, bindWebView),
+            (4, bindInput),
+            (5, bindSurfaceTree),
+            (6, bindNativeSurfaceHost),
+            (7, bindDevToolsHost)
+        ]
+        for (handle, bind) in binds {
+            var error: UnsafeMutablePointer<CChar>?
+            let status = bind(session, handle, &error)
+            if status != 0 {
+                return .failure(CmuxChromiumCoreError.devToolsError(consumeCString(error) ?? "Browser interface bind failed"))
+            }
+        }
+        return .success(())
+    }
+
+    func flush(_ session: OpaquePointer) -> Bool {
+        var ok = false
+        var error: UnsafeMutablePointer<CChar>?
+        let status = sessionFlush(session, &ok, &error)
+        consumeCString(error)
+        return status == 0 && ok
+    }
+
+    func navigate(_ session: OpaquePointer, url: String) -> Bool {
+        var error: UnsafeMutablePointer<CChar>?
+        let status = url.withCString { webViewNavigate(session, $0, &error) }
+        consumeCString(error)
+        return status == 0
+    }
+
+    func resize(_ session: OpaquePointer, width: UInt32, height: UInt32, scale: Float) -> Bool {
+        var error: UnsafeMutablePointer<CChar>?
+        let status = webViewResize(session, width, height, scale, &error)
+        consumeCString(error)
+        return status == 0
+    }
+
+    func setFocus(_ session: OpaquePointer, focused: Bool) -> Bool {
+        var error: UnsafeMutablePointer<CChar>?
+        let status = webViewSetFocus(session, focused, &error)
+        consumeCString(error)
+        return status == 0
+    }
+
+    func sendMouse(
+        _ session: OpaquePointer,
+        kind: UInt32,
+        x: Float,
+        y: Float,
+        button: UInt32,
+        clickCount: UInt32,
+        deltaX: Float,
+        deltaY: Float,
+        modifiers: UInt32
+    ) -> Bool {
+        var error: UnsafeMutablePointer<CChar>?
+        let status = inputSendMouse(
+            session,
+            kind,
+            x,
+            y,
+            button,
+            clickCount,
+            deltaX,
+            deltaY,
+            modifiers,
+            &error
+        )
+        consumeCString(error)
+        return status == 0
+    }
+
+    func sendKey(
+        _ session: OpaquePointer,
+        keyDown: Bool,
+        keyCode: UInt32,
+        text: String,
+        modifiers: UInt32
+    ) -> Bool {
+        var error: UnsafeMutablePointer<CChar>?
+        let status = text.withCString {
+            inputSendKey(session, keyDown, keyCode, $0, modifiers, &error)
+        }
+        consumeCString(error)
+        return status == 0
+    }
+
+    func executeJavaScript(_ session: OpaquePointer, script: String) -> Result<Any?, Error> {
+        var result: UnsafeMutablePointer<CChar>?
+        var error: UnsafeMutablePointer<CChar>?
+        let status = script.withCString {
+            shellExecuteJavaScript(session, $0, &result, &error)
+        }
+        if status != 0 {
+            return .failure(CmuxChromiumCoreError.devToolsError(consumeCString(error) ?? "Browser JavaScript execution failed"))
+        }
+        consumeCString(error)
+        guard let json = consumeCString(result) else {
+            return .success(nil)
+        }
+        guard let data = json.data(using: .utf8) else {
+            return .success(json)
+        }
+        let value = try? JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed])
+        return .success(value)
+    }
+
+    func captureSurfaceImage(_ session: OpaquePointer) -> NSImage? {
+        var result: UnsafeMutablePointer<CChar>?
+        var error: UnsafeMutablePointer<CChar>?
+        let status = surfaceTreeCaptureSurfaceJSON(session, &result, &error)
+        consumeCString(error)
+        guard status == 0,
+              let json = consumeCString(result),
+              let data = json.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let base64 = object["pngBase64"] as? String,
+              let pngData = Data(base64Encoded: base64) else {
+            return nil
+        }
+        return NSImage(data: pngData)
+    }
+
+    func pollEvents(timeoutMilliseconds: UInt32) {
+        pollEventsFunction(timeoutMilliseconds)
+    }
+
+    @discardableResult
+    private func consumeCString(_ pointer: UnsafeMutablePointer<CChar>?) -> String? {
+        guard let pointer else { return nil }
+        defer { freeBuffer(pointer) }
+        return String(cString: pointer)
+    }
+}
+
+private enum OwlOperation: UInt8 {
+    case resize = 0x02
+    case mouse = 0x03
+    case key = 0x04
+    case focus = 0x05
+    case navigate = 0x06
+    case goBack = 0x07
+    case goForward = 0x08
+    case reload = 0x09
+    case stop = 0x0A
+}
+
+private enum OwlMouseType: UInt8 {
+    case down = 0
+    case up = 1
+    case move = 2
+    case wheel = 3
+}
+
+private enum OwlMouseButton: UInt8 {
+    case left = 0
+    case middle = 1
+    case right = 2
+}
+
+private enum OwlKeyType: UInt8 {
+    case down = 0
+    case up = 1
+}
+
+private final class OwlControlChannel {
+    private let path: String
+    private let lock = NSLock()
+    private let asyncQueue = DispatchQueue(label: "cmux.chromium.control-channel")
+    private var socketFD: Int32 = -1
+    private var nextRequestID: UInt32 = 1
+
+    init(path: String) {
+        self.path = path
+    }
+
+    func connectIfNeeded() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return connectIfNeededLocked()
+    }
+
+    func close() {
+        lock.lock()
+        defer { lock.unlock() }
+        closeLocked()
+    }
+
+    func sendResize(width: UInt32, height: UInt32, scale: Double) -> Bool {
+        var payload = OwlPayloadWriter()
+        payload.writeUInt32(width)
+        payload.writeUInt32(height)
+        payload.writeFloat64(scale)
+        return send(.resize, payload: payload.data)
+    }
+
+    func sendMouse(
+        type: UInt8,
+        x: Double,
+        y: Double,
+        button: UInt8,
+        clickCount: UInt8,
+        deltaX: Double,
+        deltaY: Double,
+        modifiers: UInt32
+    ) -> Bool {
+        var payload = OwlPayloadWriter()
+        payload.writeUInt8(type)
+        payload.writeFloat64(x)
+        payload.writeFloat64(y)
+        payload.writeUInt8(button)
+        payload.writeUInt8(clickCount)
+        payload.writeFloat64(deltaX)
+        payload.writeFloat64(deltaY)
+        payload.writeUInt32(modifiers)
+        return send(.mouse, payload: payload.data)
+    }
+
+    func sendMouseAsync(
+        type: UInt8,
+        x: Double,
+        y: Double,
+        button: UInt8,
+        clickCount: UInt8,
+        deltaX: Double,
+        deltaY: Double,
+        modifiers: UInt32
+    ) {
+        var payload = OwlPayloadWriter()
+        payload.writeUInt8(type)
+        payload.writeFloat64(x)
+        payload.writeFloat64(y)
+        payload.writeUInt8(button)
+        payload.writeUInt8(clickCount)
+        payload.writeFloat64(deltaX)
+        payload.writeFloat64(deltaY)
+        payload.writeUInt32(modifiers)
+        sendAsync(.mouse, payload: payload.data)
+    }
+
+    func sendKey(type: UInt8, keyCode: UInt16, characters: String, modifiers: UInt32) -> Bool {
+        var payload = OwlPayloadWriter()
+        payload.writeUInt8(type)
+        payload.writeUInt16(keyCode)
+        payload.writeString(characters)
+        payload.writeUInt32(modifiers)
+        return send(.key, payload: payload.data)
+    }
+
+    func sendKeyAsync(type: UInt8, keyCode: UInt16, characters: String, modifiers: UInt32) {
+        var payload = OwlPayloadWriter()
+        payload.writeUInt8(type)
+        payload.writeUInt16(keyCode)
+        payload.writeString(characters)
+        payload.writeUInt32(modifiers)
+        sendAsync(.key, payload: payload.data)
+    }
+
+    func sendFocus(_ focused: Bool) -> Bool {
+        var payload = OwlPayloadWriter()
+        payload.writeUInt8(focused ? 1 : 0)
+        return send(.focus, payload: payload.data)
+    }
+
+    func sendNavigate(_ url: String) -> Bool {
+        var payload = OwlPayloadWriter()
+        payload.writeString(url)
+        return send(.navigate, payload: payload.data)
+    }
+
+    func sendGoBack() -> Bool {
+        send(.goBack, payload: Data())
+    }
+
+    func sendGoForward() -> Bool {
+        send(.goForward, payload: Data())
+    }
+
+    func sendReload() -> Bool {
+        send(.reload, payload: Data())
+    }
+
+    func sendStop() -> Bool {
+        send(.stop, payload: Data())
+    }
+
+    private func send(_ operation: OwlOperation, payload: Data) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard connectIfNeededLocked() else { return false }
+
+        let requestID = nextRequestID
+        nextRequestID &+= 1
+
+        var frame = Data()
+        let innerLength = UInt32(1 + 4 + payload.count)
+        OwlPayloadWriter.writeUInt32BE(innerLength, to: &frame)
+        frame.append(contentsOf: [operation.rawValue])
+        OwlPayloadWriter.writeUInt32(requestID, to: &frame)
+        frame.append(payload)
+
+        guard writeAllLocked(frame) else {
+            closeLocked()
+            return false
+        }
+        return true
+    }
+
+    private func sendAsync(_ operation: OwlOperation, payload: Data) {
+        asyncQueue.async { [weak self] in
+            _ = self?.send(operation, payload: payload)
+        }
+    }
+
+    private func connectIfNeededLocked() -> Bool {
+        if socketFD >= 0 { return true }
+
+        let fd = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else { return false }
+
+#if os(macOS)
+        var noSigPipe: Int32 = 1
+        guard setsockopt(
+            fd,
+            SOL_SOCKET,
+            SO_NOSIGPIPE,
+            &noSigPipe,
+            socklen_t(MemoryLayout<Int32>.size)
+        ) == 0 else {
+            Darwin.close(fd)
+            return false
+        }
+#endif
+
+        var address = sockaddr_un()
+        address.sun_len = UInt8(MemoryLayout<sockaddr_un>.size)
+        address.sun_family = sa_family_t(AF_UNIX)
+
+        let pathBytes = Array(path.utf8)
+        let maxPathLength = MemoryLayout.size(ofValue: address.sun_path) - 1
+        guard pathBytes.count <= maxPathLength else {
+            Darwin.close(fd)
+            return false
+        }
+
+        let sunPathCapacity = MemoryLayout.size(ofValue: address.sun_path)
+        withUnsafeMutablePointer(to: &address.sun_path) { pointer in
+            pointer.withMemoryRebound(to: CChar.self, capacity: sunPathCapacity) { buffer in
+                for index in 0..<pathBytes.count {
+                    buffer[index] = CChar(bitPattern: pathBytes[index])
+                }
+                buffer[pathBytes.count] = 0
+            }
+        }
+
+        let result = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPointer in
+                Darwin.connect(fd, sockaddrPointer, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+
+        guard result == 0 else {
+            Darwin.close(fd)
+            return false
+        }
+
+        socketFD = fd
+        return true
+    }
+
+    private func writeAllLocked(_ data: Data) -> Bool {
+        guard socketFD >= 0 else { return false }
+        return data.withUnsafeBytes { buffer in
+            guard let baseAddress = buffer.baseAddress else { return true }
+            var offset = 0
+            while offset < data.count {
+                let written = Darwin.write(socketFD, baseAddress.advanced(by: offset), data.count - offset)
+                if written < 0 {
+                    if errno == EINTR { continue }
+                    return false
+                }
+                if written == 0 { return false }
+                offset += written
+            }
+            return true
+        }
+    }
+
+    private func closeLocked() {
+        guard socketFD >= 0 else { return }
+        Darwin.close(socketFD)
+        socketFD = -1
+    }
+}
+
+private struct OwlPayloadWriter {
+    private(set) var data = Data()
+
+    mutating func writeUInt8(_ value: UInt8) {
+        data.append(contentsOf: [value])
+    }
+
+    mutating func writeUInt16(_ value: UInt16) {
+        Self.writeUInt16(value, to: &data)
+    }
+
+    mutating func writeUInt32(_ value: UInt32) {
+        Self.writeUInt32(value, to: &data)
+    }
+
+    mutating func writeFloat64(_ value: Double) {
+        var bits = value.bitPattern.littleEndian
+        withUnsafeBytes(of: &bits) { buffer in
+            data.append(contentsOf: buffer)
+        }
+    }
+
+    mutating func writeString(_ value: String) {
+        let bytes = Array(value.utf8)
+        writeUInt32(UInt32(clamping: bytes.count))
+        data.append(contentsOf: bytes)
+    }
+
+    static func writeUInt16(_ value: UInt16, to data: inout Data) {
+        var littleEndian = value.littleEndian
+        withUnsafeBytes(of: &littleEndian) { buffer in
+            data.append(contentsOf: buffer)
+        }
+    }
+
+    static func writeUInt32(_ value: UInt32, to data: inout Data) {
+        var littleEndian = value.littleEndian
+        withUnsafeBytes(of: &littleEndian) { buffer in
+            data.append(contentsOf: buffer)
+        }
+    }
+
+    static func writeUInt32BE(_ value: UInt32, to data: inout Data) {
+        var bigEndian = value.bigEndian
+        withUnsafeBytes(of: &bigEndian) { buffer in
+            data.append(contentsOf: buffer)
+        }
+    }
+}

--- a/Frameworks/CmuxChromiumCore/Sources/CmuxChromiumCore.swift
+++ b/Frameworks/CmuxChromiumCore/Sources/CmuxChromiumCore.swift
@@ -112,6 +112,41 @@ public final class CmuxChromiumBrowserHost: NSObject {
     public func cmuxAddUserStyle(_ source: NSString) {
         view.addUserStyle(source as String)
     }
+
+    @objc(cmuxSetDevToolsVisible:mode:preferredPanel:completionHandler:)
+    public func cmuxSetDevToolsVisible(
+        _ visible: NSNumber,
+        mode: NSNumber,
+        preferredPanel: NSString?,
+        completionHandler: @escaping (NSNumber, NSString?) -> Void
+    ) {
+        view.setDevToolsVisible(
+            visible.boolValue,
+            mode: mode.uint32Value,
+            preferredPanel: preferredPanel as String?
+        ) { ok, error in
+            completionHandler(NSNumber(value: ok), error as NSString?)
+        }
+    }
+
+    @objc(cmuxToggleDevToolsWithMode:preferredPanel:completionHandler:)
+    public func cmuxToggleDevTools(
+        mode: NSNumber,
+        preferredPanel: NSString?,
+        completionHandler: @escaping (NSNumber, NSString?) -> Void
+    ) {
+        view.toggleDevTools(mode: mode.uint32Value, preferredPanel: preferredPanel as String?) { ok, error in
+            completionHandler(NSNumber(value: ok), error as NSString?)
+        }
+    }
+
+    @objc(cmuxDevToolsFrontendURLWithPanel:completionHandler:)
+    public func cmuxDevToolsFrontendURL(
+        panel: NSString?,
+        completionHandler: @escaping (NSURL?, String?) -> Void
+    ) {
+        view.devToolsFrontendURL(preferredPanel: panel as String?, completion: completionHandler)
+    }
 }
 
 final class CmuxChromiumBrowserView: NSView {
@@ -130,6 +165,7 @@ final class CmuxChromiumBrowserView: NSView {
     private var ioPipe: Pipe?
     private var pollTimer: Timer?
     private var hostLayer: CALayer?
+    private var surfaceHostLayers: [UInt64: CALayer] = [:]
     private var currentContextID: UInt32 = 0
     private var lastResizeSize: NSSize = .zero
     private var pendingURL: URL?
@@ -137,6 +173,7 @@ final class CmuxChromiumBrowserView: NSView {
     private var contentShellPID: pid_t = 0
     private var devToolsPort: Int?
     private var devToolsPageWebSocketURL: URL?
+    private var devToolsVisible = false
     private let devToolsQueue = DispatchQueue(label: "cmux.chromium.devtools")
     private static let sharedFreshMojoRuntime = OwlFreshMojoRuntime.load()
     private var proxyServer: String?
@@ -146,6 +183,7 @@ final class CmuxChromiumBrowserView: NSView {
     private var persistentUserStyles: [String] = []
     private var lastPersistentStateKey: String?
     private var attachedHostLayerContextID: UInt32 = 0
+    private var lastAppliedSurfaceTreeGeneration: Int = -1
     private var stateChangeNotifyPending = false
     private var pressedMouseButton: OwlMouseButton?
     private var lastContextMenuPoint: NSPoint?
@@ -165,9 +203,11 @@ final class CmuxChromiumBrowserView: NSView {
         self.profileIdentifier = profileIdentifier
         self.dataDirectory = dataDirectory
         proxyServer = Self.proxyServer(from: proxyConfiguration)
-        sessionDirectory = dataDirectory.appendingPathComponent("content-shell", isDirectory: true)
         let token = "\(ProcessInfo.processInfo.processIdentifier)-\(UUID().uuidString)"
         let shortToken = "\(ProcessInfo.processInfo.processIdentifier)-\(UUID().uuidString.prefix(8))"
+        sessionDirectory = dataDirectory
+            .appendingPathComponent("content-shell-sessions", isDirectory: true)
+            .appendingPathComponent(shortToken, isDirectory: true)
         contextFile = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-chromium-context-\(token).txt", isDirectory: false)
         resizeFile = FileManager.default.temporaryDirectory
@@ -193,6 +233,10 @@ final class CmuxChromiumBrowserView: NSView {
     }
 
     override var acceptsFirstResponder: Bool { true }
+
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
+        true
+    }
 
     override func becomeFirstResponder() -> Bool {
         if let session = freshMojoSession,
@@ -223,6 +267,7 @@ final class CmuxChromiumBrowserView: NSView {
         CATransaction.setDisableActions(true)
         hostLayer?.frame = bounds
         CATransaction.commit()
+        applyFreshMojoSurfaceTree(force: true)
         writeResizeIfNeeded()
         launchIfPossible()
     }
@@ -424,6 +469,83 @@ final class CmuxChromiumBrowserView: NSView {
         }
     }
 
+    func devToolsFrontendURL(
+        preferredPanel: String?,
+        completion: @escaping (NSURL?, String?) -> Void
+    ) {
+        devToolsQueue.async { [weak self] in
+            guard let self else { return completion(nil, Self.browserScriptFailedTitle()) }
+            self.ensureDevToolsPageInfo { result in
+                switch result {
+                case .failure(let error):
+                    cmuxChromiumLogger.error("DevTools frontend unavailable: \(error.localizedDescription, privacy: .private)")
+                    completion(nil, Self.browserScriptFailedTitle())
+                case .success(let info):
+                    guard let frontendURL = self.frontendURL(from: info, preferredPanel: preferredPanel) else {
+                        completion(nil, Self.browserScriptFailedTitle())
+                        return
+                    }
+                    completion(frontendURL as NSURL, nil)
+                }
+            }
+        }
+    }
+
+    func toggleDevTools(
+        mode: UInt32,
+        preferredPanel: String?,
+        completion: @escaping (Bool, String?) -> Void
+    ) {
+        setDevToolsVisible(!devToolsVisible, mode: mode, preferredPanel: preferredPanel, completion: completion)
+    }
+
+    func setDevToolsVisible(
+        _ visible: Bool,
+        mode: UInt32,
+        preferredPanel: String?,
+        completion: @escaping (Bool, String?) -> Void
+    ) {
+        let apply = { [weak self] in
+            guard let self,
+                  let session = self.freshMojoSession,
+                  let runtime = self.freshMojoRuntime else {
+                completion(false, Self.browserScriptFailedTitle())
+                return
+            }
+
+            let result = visible
+                ? runtime.openDevTools(session, mode: mode)
+                : runtime.closeDevTools(session)
+
+            switch result {
+            case .failure(let error):
+                cmuxChromiumLogger.error("DevTools visibility change failed: \(error.localizedDescription, privacy: .private)")
+                completion(false, Self.browserScriptFailedTitle())
+            case .success(let ok):
+                guard ok else {
+                    completion(false, Self.browserScriptFailedTitle())
+                    return
+                }
+                self.devToolsVisible = visible
+                if visible, let preferredPanel, !preferredPanel.isEmpty {
+                    _ = runtime.evaluateDevToolsJavaScript(
+                        session,
+                        script: Self.devToolsPanelSelectionScript(preferredPanel)
+                    )
+                }
+                DispatchQueue.main.async { [weak self] in
+                    self?.notifyStateChanged()
+                }
+                completion(true, nil)
+            }
+        }
+        if Thread.isMainThread {
+            apply()
+        } else {
+            DispatchQueue.main.async(execute: apply)
+        }
+    }
+
     private func applyPersistentBrowserState() {
         guard freshMojoSession != nil || devToolsPort != nil || currentContextID != 0 else { return }
         let key = [
@@ -570,7 +692,6 @@ final class CmuxChromiumBrowserView: NSView {
             notifyStateChanged()
             return
         }
-
         do {
             try FileManager.default.createDirectory(at: sessionDirectory, withIntermediateDirectories: true)
             try? FileManager.default.removeItem(at: contextFile)
@@ -664,6 +785,7 @@ final class CmuxChromiumBrowserView: NSView {
 
         let userData = Unmanaged.passRetained(self).toOpaque()
         freshMojoUserDataPointer = userData
+        setenv("OWL_FRESH_ENABLE_DEVTOOLS", "1", 1)
         guard let session = runtime.createSession(
             contentShellPath: executableURL.path,
             initialURL: url.absoluteString,
@@ -683,6 +805,8 @@ final class CmuxChromiumBrowserView: NSView {
         freshMojoSession = session
         launchedURL = url
         contentShellPID = pid_t(runtime.hostPID(session))
+        devToolsPort = nil
+        devToolsPageWebSocketURL = nil
         isLoading = true
         estimatedProgress = 0.1
 
@@ -739,6 +863,8 @@ final class CmuxChromiumBrowserView: NSView {
             case .ready, .compositor:
                 if hostPID > 0, self.contentShellPID != pid_t(hostPID) {
                     self.contentShellPID = pid_t(hostPID)
+                    self.devToolsPort = nil
+                    self.devToolsPageWebSocketURL = nil
                     shouldNotify = true
                 }
                 if contextID != 0 {
@@ -803,6 +929,7 @@ final class CmuxChromiumBrowserView: NSView {
                 self.freshMojoPollTimer = nil
                 self.releaseFreshMojoUserDataPointer()
             case .surfaceTree:
+                self.applyFreshMojoSurfaceTree(force: false)
                 self.presentNativeMenuIfNeeded()
             case .log, .none:
                 if kind == .log, let message {
@@ -843,6 +970,9 @@ final class CmuxChromiumBrowserView: NSView {
 
     @discardableResult
     private func attachHostLayer(contextID: UInt32) -> Bool {
+        if !surfaceHostLayers.isEmpty {
+            return false
+        }
         guard let cls = NSClassFromString("CALayerHost") as? CALayer.Type else { return false }
         if attachedHostLayerContextID == contextID,
            hostLayer?.superlayer === layer {
@@ -864,6 +994,63 @@ final class CmuxChromiumBrowserView: NSView {
         attachedHostLayerContextID = contextID
         CATransaction.commit()
         return true
+    }
+
+    private func applyFreshMojoSurfaceTree(force: Bool) {
+        guard let session = freshMojoSession,
+              let freshMojoRuntime,
+              let tree = freshMojoRuntime.surfaceTree(session) else {
+            return
+        }
+        guard force || tree.generation != lastAppliedSurfaceTreeGeneration else { return }
+        lastAppliedSurfaceTreeGeneration = tree.generation
+
+        let drawableSurfaces = tree.surfaces
+            .filter { $0.visible && $0.contextID != 0 && $0.isLayerBackedSurface }
+            .sorted {
+                if $0.zIndex != $1.zIndex {
+                    return $0.zIndex < $1.zIndex
+                }
+                return $0.surfaceID < $1.surfaceID
+            }
+
+        guard !drawableSurfaces.isEmpty else { return }
+        guard let cls = NSClassFromString("CALayerHost") as? CALayer.Type else { return }
+
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+
+        hostLayer?.removeFromSuperlayer()
+        hostLayer = nil
+        attachedHostLayerContextID = 0
+
+        var visibleSurfaceIDs = Set<UInt64>()
+        for surface in drawableSurfaces {
+            visibleSurfaceIDs.insert(surface.surfaceID)
+            let host = surfaceHostLayers[surface.surfaceID] ?? {
+                let layer = cls.init()
+                layer.autoresizingMask = []
+                layer.contentsGravity = .topLeft
+                surfaceHostLayers[surface.surfaceID] = layer
+                return layer
+            }()
+
+            host.setValue(NSNumber(value: surface.contextID), forKey: "contextId")
+            host.frame = surface.frame(in: bounds)
+            host.zPosition = CGFloat(surface.zIndex)
+            host.isHidden = false
+            if host.superlayer !== layer {
+                layer?.addSublayer(host)
+            }
+        }
+
+        let staleSurfaceIDs = surfaceHostLayers.keys.filter { !visibleSurfaceIDs.contains($0) }
+        for surfaceID in staleSurfaceIDs {
+            surfaceHostLayers[surfaceID]?.removeFromSuperlayer()
+            surfaceHostLayers.removeValue(forKey: surfaceID)
+        }
+
+        CATransaction.commit()
     }
 
     private func writeResizeIfNeeded(force: Bool = false) {
@@ -994,31 +1181,203 @@ final class CmuxChromiumBrowserView: NSView {
             completion(.success(url))
             return
         }
-        guard let port = devToolsPort,
-              let listURL = URL(string: "http://127.0.0.1:\(port)/json") else {
+        ensureDevToolsPageInfo { [weak self] result in
+            switch result {
+            case .failure(let error):
+                completion(.failure(error))
+            case .success(let info):
+                self?.devToolsPageWebSocketURL = info.webSocketURL
+                completion(.success(info.webSocketURL))
+            }
+        }
+    }
+
+    private func ensureDevToolsPageInfo(
+        completion: @escaping (Result<DevToolsPageInfo, Error>) -> Void
+    ) {
+        let candidatePorts = devToolsCandidatePorts()
+        guard !candidatePorts.isEmpty else {
             completion(.failure(CmuxChromiumCoreError.devToolsUnavailable))
             return
         }
+        queryDevToolsPageInfo(
+            candidatePorts: candidatePorts,
+            expectedURLString: currentURL?.absoluteString ?? launchedURL?.absoluteString,
+            completion: completion
+        )
+    }
+
+    private func devToolsCandidatePorts() -> [Int] {
+        var ports: [Int] = []
+        func append(_ port: Int?) {
+            guard let port, port > 0, !ports.contains(port) else { return }
+            ports.append(port)
+        }
+
+        let currentProcessPorts = Self.discoverDevToolsPorts(for: contentShellPID)
+        for port in currentProcessPorts {
+            append(port)
+        }
+
+        if let devToolsPort, currentProcessPorts.contains(devToolsPort) {
+            append(devToolsPort)
+        }
+
+        if ports.isEmpty, contentShellPID <= 0 {
+            append(devToolsPort)
+        }
+        return ports
+    }
+
+    private func queryDevToolsPageInfo(
+        candidatePorts: [Int],
+        expectedURLString: String?,
+        completion: @escaping (Result<DevToolsPageInfo, Error>) -> Void
+    ) {
+        guard let port = candidatePorts.first else {
+            devToolsPort = nil
+            devToolsPageWebSocketURL = nil
+            completion(.failure(CmuxChromiumCoreError.devToolsUnavailable))
+            return
+        }
+        guard let listURL = URL(string: "http://127.0.0.1:\(port)/json") else {
+            queryDevToolsPageInfo(
+                candidatePorts: Array(candidatePorts.dropFirst()),
+                expectedURLString: expectedURLString,
+                completion: completion
+            )
+            return
+        }
+        let fallbackPorts = Array(candidatePorts.dropFirst())
         URLSession.shared.dataTask(with: listURL) { data, _, error in
-            let result: Result<URL, Error>
+            let result: Result<DevToolsPageInfo, Error>
             if let error {
                 result = .failure(error)
             } else if let data,
                       let entries = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]],
-                      let page = entries.first(where: { ($0["type"] as? String) == "page" }),
+                      let page = Self.inspectablePageEntry(from: entries, expectedURLString: expectedURLString),
                       let webSocket = page["webSocketDebuggerUrl"] as? String,
                       let url = URL(string: webSocket) {
-                result = .success(url)
+                result = .success(DevToolsPageInfo(
+                    port: port,
+                    webSocketURL: url,
+                    frontendPath: page["devtoolsFrontendUrl"] as? String
+                ))
             } else {
                 result = .failure(CmuxChromiumCoreError.devToolsUnavailable)
             }
             self.devToolsQueue.async { [weak self] in
-                if case .success(let url) = result {
-                    self?.devToolsPageWebSocketURL = url
+                guard let self else { return }
+                switch result {
+                case .success(let info):
+                    self.devToolsPort = info.port
+                    self.devToolsPageWebSocketURL = info.webSocketURL
+                    completion(.success(info))
+                case .failure:
+                    self.queryDevToolsPageInfo(
+                        candidatePorts: fallbackPorts,
+                        expectedURLString: expectedURLString,
+                        completion: completion
+                    )
                 }
-                completion(result)
             }
         }.resume()
+    }
+
+    private static func discoverDevToolsPorts(for processIdentifier: pid_t) -> [Int] {
+        guard processIdentifier > 0 else { return [] }
+        var fdInfos = [proc_fdinfo](repeating: proc_fdinfo(), count: 1024)
+        let byteCount = fdInfos.withUnsafeMutableBytes { buffer in
+            proc_pidinfo(
+                processIdentifier,
+                PROC_PIDLISTFDS,
+                0,
+                buffer.baseAddress,
+                Int32(buffer.count)
+            )
+        }
+        guard byteCount > 0 else { return [] }
+
+        let fdCount = min(
+            fdInfos.count,
+            Int(byteCount) / MemoryLayout<proc_fdinfo>.stride
+        )
+        var ports: [Int] = []
+        for fdInfo in fdInfos.prefix(fdCount) where fdInfo.proc_fdtype == PROX_FDTYPE_SOCKET {
+            var socketInfo = socket_fdinfo()
+            let size = withUnsafeMutablePointer(to: &socketInfo) { pointer in
+                proc_pidfdinfo(
+                    processIdentifier,
+                    fdInfo.proc_fd,
+                    PROC_PIDFDSOCKETINFO,
+                    pointer,
+                    Int32(MemoryLayout<socket_fdinfo>.size)
+                )
+            }
+            guard size == MemoryLayout<socket_fdinfo>.size,
+                  socketInfo.psi.soi_kind == SOCKINFO_TCP,
+                  socketInfo.psi.soi_proto.pri_tcp.tcpsi_state == TSI_S_LISTEN else {
+                continue
+            }
+
+            let networkPort = UInt16(truncatingIfNeeded: socketInfo.psi.soi_proto.pri_tcp.tcpsi_ini.insi_lport)
+            let port = Int(UInt16(bigEndian: networkPort))
+            if port > 0 {
+                ports.append(port)
+            }
+        }
+        return ports
+    }
+
+    private static func inspectablePageEntry(
+        from entries: [[String: Any]],
+        expectedURLString: String?
+    ) -> [String: Any]? {
+        let pageEntries = entries.filter { ($0["type"] as? String) == "page" }
+        let inspectableEntries = pageEntries.filter { entry in
+            let rawURL = (entry["url"] as? String) ?? ""
+            let title = (entry["title"] as? String) ?? ""
+            return !rawURL.contains("/devtools/") &&
+                !rawURL.hasPrefix("devtools://") &&
+                title != "DevTools"
+        }
+        if let expectedURLString,
+           let matchingEntry = inspectableEntries.first(where: { ($0["url"] as? String) == expectedURLString }) {
+            return matchingEntry
+        }
+        return inspectableEntries.first
+    }
+
+    private func frontendURL(from info: DevToolsPageInfo, preferredPanel: String?) -> URL? {
+        let baseURL = URL(string: "http://127.0.0.1:\(info.port)")
+        let rawFrontend = info.frontendPath?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let frontendURL: URL? = {
+            guard let rawFrontend, !rawFrontend.isEmpty else { return nil }
+            if rawFrontend.hasPrefix("/") {
+                return baseURL.flatMap { URL(string: rawFrontend, relativeTo: $0)?.absoluteURL }
+            }
+            return URL(string: rawFrontend)
+        }()
+        var fallbackComponents = URLComponents()
+        fallbackComponents.scheme = "http"
+        fallbackComponents.host = "127.0.0.1"
+        fallbackComponents.port = info.port
+        fallbackComponents.path = "/devtools/inspector.html"
+        fallbackComponents.queryItems = [
+            URLQueryItem(
+                name: "ws",
+                value: "\(info.webSocketURL.host ?? "127.0.0.1"):\(info.webSocketURL.port ?? info.port)\(info.webSocketURL.path)"
+            )
+        ]
+        let fallbackURL = fallbackComponents.url
+        guard let url = frontendURL ?? fallbackURL else { return nil }
+        guard let preferredPanel, !preferredPanel.isEmpty else { return url }
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else { return url }
+        var items = components.queryItems ?? []
+        items.removeAll { $0.name == "panel" }
+        items.append(URLQueryItem(name: "panel", value: preferredPanel))
+        components.queryItems = items
+        return components.url
     }
 
     private func sendDevToolsCommand(
@@ -1155,7 +1514,7 @@ final class CmuxChromiumBrowserView: NSView {
                kind: UInt32(mouseType),
                x: Float(local.x),
                y: Float(max(0, bounds.height - local.y)),
-               button: UInt32(eventButton.rawValue),
+               button: Self.freshMojoButtonValue(eventButton),
                clickCount: UInt32(clamping: event.clickCount),
                deltaX: 0,
                deltaY: 0,
@@ -1204,7 +1563,7 @@ final class CmuxChromiumBrowserView: NSView {
                kind: UInt32(OwlMouseType.wheel.rawValue),
                x: Float(local.x),
                y: Float(max(0, bounds.height - local.y)),
-               button: UInt32(OwlMouseButton.none.rawValue),
+               button: Self.freshMojoButtonValue(.none),
                clickCount: 0,
                deltaX: Float(event.scrollingDeltaX),
                deltaY: Float(event.scrollingDeltaY),
@@ -1222,6 +1581,19 @@ final class CmuxChromiumBrowserView: NSView {
             deltaY: Double(event.scrollingDeltaY),
             modifiers: UInt32(truncatingIfNeeded: event.modifierFlags.rawValue)
         )
+    }
+
+    private static func freshMojoButtonValue(_ button: OwlMouseButton) -> UInt32 {
+        switch button {
+        case .none:
+            return 0
+        case .left:
+            return 1
+        case .middle:
+            return 2
+        case .right:
+            return 3
+        }
     }
 
     private func postKeyEvent(_ event: NSEvent) {
@@ -1299,6 +1671,7 @@ final class CmuxChromiumBrowserView: NSView {
         try? FileManager.default.removeItem(at: contextFile)
         try? FileManager.default.removeItem(at: resizeFile)
         try? FileManager.default.removeItem(at: controlSocketFile)
+        try? FileManager.default.removeItem(at: sessionDirectory)
     }
 
     private func teardownProcessOnly() {
@@ -1325,8 +1698,14 @@ final class CmuxChromiumBrowserView: NSView {
         attachedHostLayerContextID = 0
         devToolsPort = nil
         devToolsPageWebSocketURL = nil
+        devToolsVisible = false
         hostLayer?.removeFromSuperlayer()
         hostLayer = nil
+        for hostLayer in surfaceHostLayers.values {
+            hostLayer.removeFromSuperlayer()
+        }
+        surfaceHostLayers.removeAll()
+        lastAppliedSurfaceTreeGeneration = -1
         pressedMouseButton = nil
         lastContextMenuPoint = nil
         lastPresentedNativeMenuGeneration = -1
@@ -1352,6 +1731,26 @@ final class CmuxChromiumBrowserView: NSView {
 
     fileprivate static func browserScriptFailedTitle() -> String {
         String(localized: "browser.chromium.error.scriptFailed", defaultValue: "Browser script failed")
+    }
+
+    private static func devToolsPanelSelectionScript(_ panel: String) -> String {
+        let panelLiteral = (try? String(data: JSONEncoder().encode(panel), encoding: .utf8)) ?? "\"\(panel)\""
+        return """
+        (() => {
+          const panel = \(panelLiteral);
+          const show = () => {
+            const inspectorView = globalThis.UI?.inspectorView;
+            if (!inspectorView?.showPanel) return false;
+            Promise.resolve(inspectorView.showPanel(panel)).catch(() => {});
+            return true;
+          };
+          if (!show()) {
+            globalThis.addEventListener?.("DOMContentLoaded", () => { show(); }, { once: true });
+            globalThis.setTimeout?.(() => { show(); }, 0);
+          }
+          return true;
+        })()
+        """
     }
 
     private static func contentShellExecutableURL() -> URL? {
@@ -1395,6 +1794,12 @@ private enum OwlFreshMojoEventKind: Int32 {
     case surfaceTree = 6
 }
 
+private struct DevToolsPageInfo {
+    let port: Int
+    let webSocketURL: URL
+    let frontendPath: String?
+}
+
 private enum OwlFreshSurfaceKind: Int {
     case webView = 0
     case popupWidget = 1
@@ -1419,13 +1824,61 @@ private struct OwlFreshSurfaceTree: Decodable {
 }
 
 private struct OwlFreshSurface: Decodable {
+    var surfaceID: UInt64
+    var parentSurfaceID: UInt64
     var kind: Int
+    var contextID: UInt32
     var x: Int
     var y: Int
     var width: Int
     var height: Int
+    var scale: CGFloat
+    var zIndex: Int
     var visible: Bool
     var nativeMenuItems: [OwlFreshNativeMenuItem]
+    var label: String
+
+    var isLayerBackedSurface: Bool {
+        kind == OwlFreshSurfaceKind.webView.rawValue
+            || kind == OwlFreshSurfaceKind.popupWidget.rawValue
+            || kind == OwlFreshSurfaceKind.devTools.rawValue
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: OwlFreshJSONKey.self)
+        surfaceID = container.decode(UInt64.self, forAnyKey: ["surfaceId", "surfaceID", "surface_id"], default: 0)
+        parentSurfaceID = container.decode(
+            UInt64.self,
+            forAnyKey: ["parentSurfaceId", "parentSurfaceID", "parent_surface_id"],
+            default: 0
+        )
+        kind = container.decode(Int.self, forAnyKey: ["kind"], default: OwlFreshSurfaceKind.webView.rawValue)
+        contextID = container.decode(UInt32.self, forAnyKey: ["contextId", "contextID", "context_id"], default: 0)
+        x = container.decode(Int.self, forAnyKey: ["x"], default: 0)
+        y = container.decode(Int.self, forAnyKey: ["y"], default: 0)
+        width = container.decode(Int.self, forAnyKey: ["width"], default: 0)
+        height = container.decode(Int.self, forAnyKey: ["height"], default: 0)
+        scale = CGFloat(container.decode(Double.self, forAnyKey: ["scale"], default: 1))
+        zIndex = container.decode(Int.self, forAnyKey: ["zIndex", "z_index"], default: 0)
+        visible = container.decode(Bool.self, forAnyKey: ["visible"], default: false)
+        nativeMenuItems = container.decode(
+            [OwlFreshNativeMenuItem].self,
+            forAnyKey: ["nativeMenuItems", "native_menu_items"],
+            default: []
+        )
+        label = container.decode(String.self, forAnyKey: ["label"], default: "")
+    }
+
+    func frame(in bounds: CGRect) -> CGRect {
+        let rawWidth = CGFloat(max(width, 1))
+        let rawHeight = CGFloat(max(height, 1))
+        return CGRect(
+            x: CGFloat(x),
+            y: bounds.height - CGFloat(y) - rawHeight,
+            width: rawWidth,
+            height: rawHeight
+        )
+    }
 }
 
 private struct OwlFreshNativeMenuItem: Decodable {
@@ -1433,6 +1886,43 @@ private struct OwlFreshNativeMenuItem: Decodable {
     var toolTip: String
     var enabled: Bool
     var separator: Bool
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: OwlFreshJSONKey.self)
+        label = container.decode(String.self, forAnyKey: ["label"], default: "")
+        toolTip = container.decode(String.self, forAnyKey: ["toolTip", "tool_tip"], default: "")
+        enabled = container.decode(Bool.self, forAnyKey: ["enabled"], default: false)
+        separator = container.decode(Bool.self, forAnyKey: ["separator"], default: false)
+    }
+}
+
+private struct OwlFreshJSONKey: CodingKey {
+    let stringValue: String
+    let intValue: Int?
+
+    init?(stringValue: String) {
+        self.stringValue = stringValue
+        intValue = nil
+    }
+
+    init?(intValue: Int) {
+        stringValue = "\(intValue)"
+        self.intValue = intValue
+    }
+}
+
+private extension KeyedDecodingContainer where Key == OwlFreshJSONKey {
+    func decode<T: Decodable>(_ type: T.Type, forAnyKey keys: [String], default defaultValue: T) -> T {
+        for key in keys {
+            guard let codingKey = OwlFreshJSONKey(stringValue: key),
+                  contains(codingKey),
+                  let value = try? decode(type, forKey: codingKey) else {
+                continue
+            }
+            return value
+        }
+        return defaultValue
+    }
 }
 
 private final class OwlNativeMenuPresenter: NSObject, NSMenuDelegate {
@@ -1552,6 +2042,23 @@ private final class OwlFreshMojoRuntime {
         UnsafeMutablePointer<Bool>?,
         UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?
     ) -> Int32
+    private typealias DevToolsOpen = @convention(c) (
+        OpaquePointer?,
+        UInt32,
+        UnsafeMutablePointer<Bool>?,
+        UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?
+    ) -> Int32
+    private typealias DevToolsClose = @convention(c) (
+        OpaquePointer?,
+        UnsafeMutablePointer<Bool>?,
+        UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?
+    ) -> Int32
+    private typealias DevToolsEvaluateJavaScript = @convention(c) (
+        OpaquePointer?,
+        UnsafePointer<CChar>?,
+        UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?,
+        UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?
+    ) -> Int32
     private typealias PollEvents = @convention(c) (UInt32) -> Void
     private typealias FreeBuffer = @convention(c) (UnsafeMutableRawPointer?) -> Void
 
@@ -1579,6 +2086,9 @@ private final class OwlFreshMojoRuntime {
     private let surfaceTreeGetJSON: SurfaceTreeJSON?
     private let nativeSurfaceAcceptActivePopupMenuItem: AcceptActivePopupMenuItem?
     private let nativeSurfaceCancelActivePopup: CancelActivePopup?
+    private let devToolsOpen: DevToolsOpen
+    private let devToolsClose: DevToolsClose
+    private let devToolsEvaluateJavaScript: DevToolsEvaluateJavaScript
     private let pollEventsFunction: PollEvents
     private let freeBuffer: FreeBuffer
 
@@ -1607,6 +2117,9 @@ private final class OwlFreshMojoRuntime {
         surfaceTreeGetJSON: SurfaceTreeJSON?,
         nativeSurfaceAcceptActivePopupMenuItem: AcceptActivePopupMenuItem?,
         nativeSurfaceCancelActivePopup: CancelActivePopup?,
+        devToolsOpen: DevToolsOpen,
+        devToolsClose: DevToolsClose,
+        devToolsEvaluateJavaScript: DevToolsEvaluateJavaScript,
         pollEventsFunction: PollEvents,
         freeBuffer: FreeBuffer
     ) {
@@ -1634,6 +2147,9 @@ private final class OwlFreshMojoRuntime {
         self.surfaceTreeGetJSON = surfaceTreeGetJSON
         self.nativeSurfaceAcceptActivePopupMenuItem = nativeSurfaceAcceptActivePopupMenuItem
         self.nativeSurfaceCancelActivePopup = nativeSurfaceCancelActivePopup
+        self.devToolsOpen = devToolsOpen
+        self.devToolsClose = devToolsClose
+        self.devToolsEvaluateJavaScript = devToolsEvaluateJavaScript
         self.pollEventsFunction = pollEventsFunction
         self.freeBuffer = freeBuffer
     }
@@ -1675,6 +2191,12 @@ private final class OwlFreshMojoRuntime {
             let surfaceTreeCaptureSurfaceJSON = symbol(
                 "owl_fresh_mojo_surface_tree_capture_surface_json",
                 as: CaptureSurface.self
+            ),
+            let devToolsOpen = symbol("owl_fresh_mojo_devtools_open", as: DevToolsOpen.self),
+            let devToolsClose = symbol("owl_fresh_mojo_devtools_close", as: DevToolsClose.self),
+            let devToolsEvaluateJavaScript = symbol(
+                "owl_fresh_mojo_devtools_evaluate_javascript",
+                as: DevToolsEvaluateJavaScript.self
             ),
             let pollEventsFunction = symbol("owl_fresh_mojo_poll_events", as: PollEvents.self),
             let freeBuffer = symbol("owl_fresh_mojo_free_buffer", as: FreeBuffer.self)
@@ -1724,6 +2246,9 @@ private final class OwlFreshMojoRuntime {
             surfaceTreeGetJSON: surfaceTreeGetJSON,
             nativeSurfaceAcceptActivePopupMenuItem: nativeSurfaceAcceptActivePopupMenuItem,
             nativeSurfaceCancelActivePopup: nativeSurfaceCancelActivePopup,
+            devToolsOpen: devToolsOpen,
+            devToolsClose: devToolsClose,
+            devToolsEvaluateJavaScript: devToolsEvaluateJavaScript,
             pollEventsFunction: pollEventsFunction,
             freeBuffer: freeBuffer
         )
@@ -1945,6 +2470,48 @@ private final class OwlFreshMojoRuntime {
         let status = nativeSurfaceCancelActivePopup(session, &ok, &error)
         consumeCString(error)
         return status == 0 && ok
+    }
+
+    func openDevTools(_ session: OpaquePointer, mode: UInt32) -> Result<Bool, Error> {
+        var ok = false
+        var error: UnsafeMutablePointer<CChar>?
+        let status = devToolsOpen(session, mode, &ok, &error)
+        if status != 0 {
+            return .failure(CmuxChromiumCoreError.devToolsError(consumeCString(error) ?? "DevTools open failed"))
+        }
+        consumeCString(error)
+        return .success(ok)
+    }
+
+    func closeDevTools(_ session: OpaquePointer) -> Result<Bool, Error> {
+        var ok = false
+        var error: UnsafeMutablePointer<CChar>?
+        let status = devToolsClose(session, &ok, &error)
+        if status != 0 {
+            return .failure(CmuxChromiumCoreError.devToolsError(consumeCString(error) ?? "DevTools close failed"))
+        }
+        consumeCString(error)
+        return .success(ok)
+    }
+
+    func evaluateDevToolsJavaScript(_ session: OpaquePointer, script: String) -> Result<Any?, Error> {
+        var result: UnsafeMutablePointer<CChar>?
+        var error: UnsafeMutablePointer<CChar>?
+        let status = script.withCString {
+            devToolsEvaluateJavaScript(session, $0, &result, &error)
+        }
+        if status != 0 {
+            return .failure(CmuxChromiumCoreError.devToolsError(consumeCString(error) ?? "DevTools JavaScript execution failed"))
+        }
+        consumeCString(error)
+        guard let json = consumeCString(result) else {
+            return .success(nil)
+        }
+        guard let data = json.data(using: .utf8) else {
+            return .success(json)
+        }
+        let value = try? JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed])
+        return .success(value)
     }
 
     func pollEvents(timeoutMilliseconds: UInt32) {

--- a/Frameworks/CmuxChromiumCore/Sources/CmuxChromiumCore.swift
+++ b/Frameworks/CmuxChromiumCore/Sources/CmuxChromiumCore.swift
@@ -145,6 +145,12 @@ final class CmuxChromiumBrowserView: NSView {
     private var persistentUserScripts: [String] = []
     private var persistentUserStyles: [String] = []
     private var lastPersistentStateKey: String?
+    private var attachedHostLayerContextID: UInt32 = 0
+    private var stateChangeNotifyPending = false
+    private var pressedMouseButton: OwlMouseButton?
+    private var lastContextMenuPoint: NSPoint?
+    private var lastPresentedNativeMenuGeneration = -1
+    private var activeNativeMenuPresenter: OwlNativeMenuPresenter?
 
     var stateChangedHandler: (() -> Void)?
     private(set) var currentURL: URL?
@@ -494,6 +500,10 @@ final class CmuxChromiumBrowserView: NSView {
     override func mouseMoved(with event: NSEvent) { postMouseEvent(event, type: .mouseMoved) }
     override func rightMouseDown(with event: NSEvent) { postMouseEvent(event, type: .rightMouseDown) }
     override func rightMouseUp(with event: NSEvent) { postMouseEvent(event, type: .rightMouseUp) }
+    override func rightMouseDragged(with event: NSEvent) { postMouseEvent(event, type: .rightMouseDragged) }
+    override func otherMouseDown(with event: NSEvent) { postMouseEvent(event, type: .otherMouseDown) }
+    override func otherMouseUp(with event: NSEvent) { postMouseEvent(event, type: .otherMouseUp) }
+    override func otherMouseDragged(with event: NSEvent) { postMouseEvent(event, type: .otherMouseDragged) }
     override func scrollWheel(with event: NSEvent) { postScrollEvent(event) }
     override func keyDown(with event: NSEvent) { postKeyEvent(event) }
     override func keyUp(with event: NSEvent) { postKeyEvent(event) }
@@ -724,45 +734,84 @@ final class CmuxChromiumBrowserView: NSView {
 
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
+            var shouldNotify = false
             switch kind {
             case .ready, .compositor:
-                if hostPID > 0 {
+                if hostPID > 0, self.contentShellPID != pid_t(hostPID) {
                     self.contentShellPID = pid_t(hostPID)
+                    shouldNotify = true
                 }
                 if contextID != 0 {
-                    self.currentContextID = contextID
-                    self.attachHostLayer(contextID: contextID)
-                    self.estimatedProgress = max(self.estimatedProgress, 0.8)
+                    if self.currentContextID != contextID {
+                        self.currentContextID = contextID
+                        self.lastPersistentStateKey = nil
+                        shouldNotify = true
+                    }
+                    shouldNotify = self.attachHostLayer(contextID: contextID) || shouldNotify
+                    let nextProgress = max(self.estimatedProgress, 0.8)
+                    if self.estimatedProgress != nextProgress {
+                        self.estimatedProgress = nextProgress
+                        shouldNotify = true
+                    }
                     self.applyPersistentBrowserState()
                 }
             case .navigation:
                 if let urlString, let url = URL(string: urlString) {
-                    self.currentURL = url
-                    self.launchedURL = url
+                    if self.currentURL != url {
+                        self.currentURL = url
+                        shouldNotify = true
+                    }
+                    if self.launchedURL != url {
+                        self.launchedURL = url
+                        shouldNotify = true
+                    }
                     self.recordNavigation(url)
                     self.lastPersistentStateKey = nil
                 }
                 if let title, !title.isEmpty {
-                    self.currentTitle = title
+                    if self.currentTitle != title {
+                        self.currentTitle = title
+                        shouldNotify = true
+                    }
                 }
-                self.isLoading = loading
-                self.estimatedProgress = loading ? max(self.estimatedProgress, 0.4) : 1
+                if self.isLoading != loading {
+                    self.isLoading = loading
+                    shouldNotify = true
+                }
+                let nextProgress = loading ? max(self.estimatedProgress, 0.4) : 1
+                if self.estimatedProgress != nextProgress {
+                    self.estimatedProgress = nextProgress
+                    shouldNotify = true
+                }
                 if !loading {
                     self.applyPersistentBrowserState()
                 }
             case .disconnected:
-                self.isLoading = false
-                self.estimatedProgress = 0
+                if self.isLoading {
+                    self.isLoading = false
+                    shouldNotify = true
+                }
+                if self.estimatedProgress != 0 {
+                    self.estimatedProgress = 0
+                    shouldNotify = true
+                }
+                if self.freshMojoSession != nil {
+                    shouldNotify = true
+                }
                 self.freshMojoSession = nil
                 self.freshMojoPollTimer?.invalidate()
                 self.freshMojoPollTimer = nil
                 self.releaseFreshMojoUserDataPointer()
-            case .log, .surfaceTree, .none:
+            case .surfaceTree:
+                self.presentNativeMenuIfNeeded()
+            case .log, .none:
                 if kind == .log, let message {
                     cmuxChromiumLogger.debug("Runtime log: \(message, privacy: .private)")
                 }
             }
-            self.notifyStateChanged()
+            if shouldNotify {
+                self.notifyStateChanged()
+            }
         }
     }
 
@@ -778,11 +827,10 @@ final class CmuxChromiumBrowserView: NSView {
               let contextID = UInt32(text.trimmingCharacters(in: .whitespacesAndNewlines)),
               contextID != 0 else { return }
         if contextID == currentContextID {
-            applyPersistentBrowserState()
             return
         }
         currentContextID = contextID
-        attachHostLayer(contextID: contextID)
+        _ = attachHostLayer(contextID: contextID)
         isLoading = false
         estimatedProgress = 1
         applyPersistentBrowserState()
@@ -793,8 +841,17 @@ final class CmuxChromiumBrowserView: NSView {
         }
     }
 
-    private func attachHostLayer(contextID: UInt32) {
-        guard let cls = NSClassFromString("CALayerHost") as? CALayer.Type else { return }
+    @discardableResult
+    private func attachHostLayer(contextID: UInt32) -> Bool {
+        guard let cls = NSClassFromString("CALayerHost") as? CALayer.Type else { return false }
+        if attachedHostLayerContextID == contextID,
+           hostLayer?.superlayer === layer {
+            CATransaction.begin()
+            CATransaction.setDisableActions(true)
+            hostLayer?.frame = bounds
+            CATransaction.commit()
+            return false
+        }
         let host = cls.init()
         host.setValue(NSNumber(value: contextID), forKey: "contextId")
         host.frame = bounds
@@ -804,7 +861,9 @@ final class CmuxChromiumBrowserView: NSView {
         hostLayer?.removeFromSuperlayer()
         layer?.addSublayer(host)
         hostLayer = host
+        attachedHostLayerContextID = contextID
         CATransaction.commit()
+        return true
     }
 
     private func writeResizeIfNeeded(force: Bool = false) {
@@ -834,9 +893,71 @@ final class CmuxChromiumBrowserView: NSView {
         try? payload.write(to: resizeFile, atomically: true, encoding: .utf8)
     }
 
+    private func presentNativeMenuIfNeeded() {
+        guard activeNativeMenuPresenter == nil,
+              let session = freshMojoSession,
+              let freshMojoRuntime,
+              let tree = freshMojoRuntime.surfaceTree(session),
+              tree.generation != lastPresentedNativeMenuGeneration,
+              let surface = tree.surfaces.last(where: {
+                  $0.kind == OwlFreshSurfaceKind.nativeMenu.rawValue
+                      && $0.visible
+                      && !$0.nativeMenuItems.isEmpty
+              }) else {
+            return
+        }
+
+        lastPresentedNativeMenuGeneration = tree.generation
+        let menu = NSMenu()
+        menu.autoenablesItems = false
+        let presenter = OwlNativeMenuPresenter()
+        presenter.onSelect = { [weak self] index in
+            guard let self,
+                  let session = self.freshMojoSession else { return }
+            _ = self.freshMojoRuntime?.acceptActivePopupMenuItem(session, index: UInt32(index))
+        }
+        presenter.onCancel = { [weak self] in
+            guard let self,
+                  let session = self.freshMojoSession else { return }
+            _ = self.freshMojoRuntime?.cancelActivePopup(session)
+        }
+        presenter.onClose = { [weak self, weak presenter] in
+            guard let self,
+                  let presenter,
+                  self.activeNativeMenuPresenter === presenter else { return }
+            self.activeNativeMenuPresenter = nil
+        }
+        menu.delegate = presenter
+
+        for (index, item) in surface.nativeMenuItems.enumerated() {
+            if item.separator {
+                menu.addItem(.separator())
+                continue
+            }
+            let menuItem = NSMenuItem(title: item.label, action: #selector(OwlNativeMenuPresenter.selectItem(_:)), keyEquivalent: "")
+            menuItem.target = presenter
+            menuItem.tag = index
+            menuItem.isEnabled = item.enabled
+            menuItem.toolTip = item.toolTip.isEmpty ? nil : item.toolTip
+            menu.addItem(menuItem)
+        }
+
+        activeNativeMenuPresenter = presenter
+        let menuPoint = lastContextMenuPoint ?? NSPoint(
+            x: CGFloat(surface.x),
+            y: max(0, bounds.height - CGFloat(surface.y + surface.height))
+        )
+        lastContextMenuPoint = nil
+        menu.popUp(positioning: nil, at: menuPoint, in: self)
+    }
+
     private func notifyStateChanged() {
+        guard !stateChangeNotifyPending else { return }
+        stateChangeNotifyPending = true
         DispatchQueue.main.async { [weak self] in
-            self?.stateChangedHandler?()
+            guard let self else { return }
+            self.stateChangeNotifyPending = false
+            self.stateChangedHandler?()
         }
     }
 
@@ -1003,13 +1124,29 @@ final class CmuxChromiumBrowserView: NSView {
         default:
             mouseType = OwlMouseType.move.rawValue
         }
-        let button: UInt8
-        if type == .rightMouseDown || type == .rightMouseUp {
-            button = OwlMouseButton.right.rawValue
-        } else if event.buttonNumber == 2 || type == .otherMouseDown || type == .otherMouseUp {
-            button = OwlMouseButton.middle.rawValue
-        } else {
-            button = OwlMouseButton.left.rawValue
+        let button = mouseButton(for: event, type: type)
+        if type == .rightMouseDown {
+            lastContextMenuPoint = local
+        } else if mouseType == OwlMouseType.down.rawValue {
+            lastContextMenuPoint = nil
+        }
+        if mouseType == OwlMouseType.down.rawValue {
+            pressedMouseButton = button == .none ? nil : button
+        }
+        let eventButton: OwlMouseButton = {
+            switch type {
+            case .mouseMoved:
+                return .none
+            case .leftMouseDragged, .rightMouseDragged, .otherMouseDragged:
+                return pressedMouseButton ?? button
+            default:
+                return button
+            }
+        }()
+        defer {
+            if mouseType == OwlMouseType.up.rawValue {
+                pressedMouseButton = nil
+            }
         }
         if let session = freshMojoSession,
            let freshMojoRuntime,
@@ -1018,7 +1155,7 @@ final class CmuxChromiumBrowserView: NSView {
                kind: UInt32(mouseType),
                x: Float(local.x),
                y: Float(max(0, bounds.height - local.y)),
-               button: UInt32(button),
+               button: UInt32(eventButton.rawValue),
                clickCount: UInt32(clamping: event.clickCount),
                deltaX: 0,
                deltaY: 0,
@@ -1030,12 +1167,31 @@ final class CmuxChromiumBrowserView: NSView {
             type: mouseType,
             x: Double(local.x),
             y: Double(max(0, bounds.height - local.y)),
-            button: button,
+            button: eventButton.rawValue,
             clickCount: UInt8(clamping: event.clickCount),
             deltaX: 0,
             deltaY: 0,
             modifiers: UInt32(truncatingIfNeeded: event.modifierFlags.rawValue)
         )
+    }
+
+    private func mouseButton(for event: NSEvent, type: CGEventType) -> OwlMouseButton {
+        switch type {
+        case .rightMouseDown, .rightMouseUp, .rightMouseDragged:
+            return .right
+        case .otherMouseDown, .otherMouseUp, .otherMouseDragged:
+            return .middle
+        case .mouseMoved:
+            return .none
+        default:
+            if event.buttonNumber == 1 {
+                return .right
+            }
+            if event.buttonNumber == 2 {
+                return .middle
+            }
+            return .left
+        }
     }
 
     private func postScrollEvent(_ event: NSEvent) {
@@ -1048,7 +1204,7 @@ final class CmuxChromiumBrowserView: NSView {
                kind: UInt32(OwlMouseType.wheel.rawValue),
                x: Float(local.x),
                y: Float(max(0, bounds.height - local.y)),
-               button: UInt32(OwlMouseButton.left.rawValue),
+               button: UInt32(OwlMouseButton.none.rawValue),
                clickCount: 0,
                deltaX: Float(event.scrollingDeltaX),
                deltaY: Float(event.scrollingDeltaY),
@@ -1060,7 +1216,7 @@ final class CmuxChromiumBrowserView: NSView {
             type: OwlMouseType.wheel.rawValue,
             x: Double(local.x),
             y: Double(max(0, bounds.height - local.y)),
-            button: OwlMouseButton.left.rawValue,
+            button: OwlMouseButton.none.rawValue,
             clickCount: 0,
             deltaX: Double(event.scrollingDeltaX),
             deltaY: Double(event.scrollingDeltaY),
@@ -1166,10 +1322,15 @@ final class CmuxChromiumBrowserView: NSView {
         controlChannel.close()
         contentShellPID = 0
         currentContextID = 0
+        attachedHostLayerContextID = 0
         devToolsPort = nil
         devToolsPageWebSocketURL = nil
         hostLayer?.removeFromSuperlayer()
         hostLayer = nil
+        pressedMouseButton = nil
+        lastContextMenuPoint = nil
+        lastPresentedNativeMenuGeneration = -1
+        activeNativeMenuPresenter = nil
         launchedURL = nil
         isLoading = false
         estimatedProgress = 0
@@ -1234,6 +1395,14 @@ private enum OwlFreshMojoEventKind: Int32 {
     case surfaceTree = 6
 }
 
+private enum OwlFreshSurfaceKind: Int {
+    case webView = 0
+    case popupWidget = 1
+    case nativeMenu = 2
+    case nativeFilePicker = 3
+    case devTools = 4
+}
+
 private struct OwlFreshMojoEvent {
     var kind: Int32
     var contextID: UInt32
@@ -1242,6 +1411,47 @@ private struct OwlFreshMojoEvent {
     var url: UnsafePointer<CChar>?
     var title: UnsafePointer<CChar>?
     var message: UnsafePointer<CChar>?
+}
+
+private struct OwlFreshSurfaceTree: Decodable {
+    var generation: Int
+    var surfaces: [OwlFreshSurface]
+}
+
+private struct OwlFreshSurface: Decodable {
+    var kind: Int
+    var x: Int
+    var y: Int
+    var width: Int
+    var height: Int
+    var visible: Bool
+    var nativeMenuItems: [OwlFreshNativeMenuItem]
+}
+
+private struct OwlFreshNativeMenuItem: Decodable {
+    var label: String
+    var toolTip: String
+    var enabled: Bool
+    var separator: Bool
+}
+
+private final class OwlNativeMenuPresenter: NSObject, NSMenuDelegate {
+    var onSelect: ((Int) -> Void)?
+    var onCancel: (() -> Void)?
+    var onClose: (() -> Void)?
+    private var didSelectItem = false
+
+    @objc func selectItem(_ sender: NSMenuItem) {
+        didSelectItem = true
+        onSelect?(sender.tag)
+    }
+
+    func menuDidClose(_ menu: NSMenu) {
+        if !didSelectItem {
+            onCancel?()
+        }
+        onClose?()
+    }
 }
 
 private typealias OwlFreshMojoEventCallback = @convention(c) (
@@ -1326,6 +1536,22 @@ private final class OwlFreshMojoRuntime {
         UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?,
         UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?
     ) -> Int32
+    private typealias SurfaceTreeJSON = @convention(c) (
+        OpaquePointer?,
+        UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?,
+        UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?
+    ) -> Int32
+    private typealias AcceptActivePopupMenuItem = @convention(c) (
+        OpaquePointer?,
+        UInt32,
+        UnsafeMutablePointer<Bool>?,
+        UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?
+    ) -> Int32
+    private typealias CancelActivePopup = @convention(c) (
+        OpaquePointer?,
+        UnsafeMutablePointer<Bool>?,
+        UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?
+    ) -> Int32
     private typealias PollEvents = @convention(c) (UInt32) -> Void
     private typealias FreeBuffer = @convention(c) (UnsafeMutableRawPointer?) -> Void
 
@@ -1350,6 +1576,9 @@ private final class OwlFreshMojoRuntime {
     private let inputSendMouse: SendMouse
     private let inputSendKey: SendKey
     private let surfaceTreeCaptureSurfaceJSON: CaptureSurface
+    private let surfaceTreeGetJSON: SurfaceTreeJSON?
+    private let nativeSurfaceAcceptActivePopupMenuItem: AcceptActivePopupMenuItem?
+    private let nativeSurfaceCancelActivePopup: CancelActivePopup?
     private let pollEventsFunction: PollEvents
     private let freeBuffer: FreeBuffer
 
@@ -1375,6 +1604,9 @@ private final class OwlFreshMojoRuntime {
         inputSendMouse: SendMouse,
         inputSendKey: SendKey,
         surfaceTreeCaptureSurfaceJSON: CaptureSurface,
+        surfaceTreeGetJSON: SurfaceTreeJSON?,
+        nativeSurfaceAcceptActivePopupMenuItem: AcceptActivePopupMenuItem?,
+        nativeSurfaceCancelActivePopup: CancelActivePopup?,
         pollEventsFunction: PollEvents,
         freeBuffer: FreeBuffer
     ) {
@@ -1399,6 +1631,9 @@ private final class OwlFreshMojoRuntime {
         self.inputSendMouse = inputSendMouse
         self.inputSendKey = inputSendKey
         self.surfaceTreeCaptureSurfaceJSON = surfaceTreeCaptureSurfaceJSON
+        self.surfaceTreeGetJSON = surfaceTreeGetJSON
+        self.nativeSurfaceAcceptActivePopupMenuItem = nativeSurfaceAcceptActivePopupMenuItem
+        self.nativeSurfaceCancelActivePopup = nativeSurfaceCancelActivePopup
         self.pollEventsFunction = pollEventsFunction
         self.freeBuffer = freeBuffer
     }
@@ -1451,6 +1686,18 @@ private final class OwlFreshMojoRuntime {
             "owl_fresh_mojo_session_create_with_proxy",
             as: SessionCreateWithProxy.self
         )
+        let surfaceTreeGetJSON = symbol(
+            "owl_fresh_mojo_surface_tree_get_json",
+            as: SurfaceTreeJSON.self
+        )
+        let nativeSurfaceAcceptActivePopupMenuItem = symbol(
+            "owl_fresh_mojo_native_surface_accept_active_popup_menu_item",
+            as: AcceptActivePopupMenuItem.self
+        )
+        let nativeSurfaceCancelActivePopup = symbol(
+            "owl_fresh_mojo_native_surface_cancel_active_popup",
+            as: CancelActivePopup.self
+        )
 
         return OwlFreshMojoRuntime(
             handle: handle,
@@ -1474,6 +1721,9 @@ private final class OwlFreshMojoRuntime {
             inputSendMouse: inputSendMouse,
             inputSendKey: inputSendKey,
             surfaceTreeCaptureSurfaceJSON: surfaceTreeCaptureSurfaceJSON,
+            surfaceTreeGetJSON: surfaceTreeGetJSON,
+            nativeSurfaceAcceptActivePopupMenuItem: nativeSurfaceAcceptActivePopupMenuItem,
+            nativeSurfaceCancelActivePopup: nativeSurfaceCancelActivePopup,
             pollEventsFunction: pollEventsFunction,
             freeBuffer: freeBuffer
         )
@@ -1665,6 +1915,38 @@ private final class OwlFreshMojoRuntime {
         return NSImage(data: pngData)
     }
 
+    func surfaceTree(_ session: OpaquePointer) -> OwlFreshSurfaceTree? {
+        guard let surfaceTreeGetJSON else { return nil }
+        var result: UnsafeMutablePointer<CChar>?
+        var error: UnsafeMutablePointer<CChar>?
+        let status = surfaceTreeGetJSON(session, &result, &error)
+        consumeCString(error)
+        guard status == 0,
+              let json = consumeCString(result),
+              let data = json.data(using: .utf8) else {
+            return nil
+        }
+        return try? JSONDecoder().decode(OwlFreshSurfaceTree.self, from: data)
+    }
+
+    func acceptActivePopupMenuItem(_ session: OpaquePointer, index: UInt32) -> Bool {
+        guard let nativeSurfaceAcceptActivePopupMenuItem else { return false }
+        var ok = false
+        var error: UnsafeMutablePointer<CChar>?
+        let status = nativeSurfaceAcceptActivePopupMenuItem(session, index, &ok, &error)
+        consumeCString(error)
+        return status == 0 && ok
+    }
+
+    func cancelActivePopup(_ session: OpaquePointer) -> Bool {
+        guard let nativeSurfaceCancelActivePopup else { return false }
+        var ok = false
+        var error: UnsafeMutablePointer<CChar>?
+        let status = nativeSurfaceCancelActivePopup(session, &ok, &error)
+        consumeCString(error)
+        return status == 0 && ok
+    }
+
     func pollEvents(timeoutMilliseconds: UInt32) {
         pollEventsFunction(timeoutMilliseconds)
     }
@@ -1700,6 +1982,7 @@ private enum OwlMouseButton: UInt8 {
     case left = 0
     case middle = 1
     case right = 2
+    case none = 255
 }
 
 private enum OwlKeyType: UInt8 {

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -384,6 +384,7 @@
 		CA39C0304FE351A21C372429 /* SidebarWidthPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0171AF1F49F7547191CEE5 /* SidebarWidthPolicyTests.swift */; };
 		CB23911D7E131E8FBC9B82B6 /* SidebarOrderingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC39DE4B96D1931C52AF7D68 /* SidebarOrderingTests.swift */; };
 		D0E0F0B0A1B2C3D4E5F60718 /* BrowserPaneNavigationKeybindUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0E0F0B1A1B2C3D4E5F60718 /* BrowserPaneNavigationKeybindUITests.swift */; };
+		D0E0F0C0A1B2C3D4E5F60718 /* BrowserChromiumEngineUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0E0F0C1A1B2C3D4E5F60718 /* BrowserChromiumEngineUITests.swift */; };
 		D0E0F0B4A1B2C3D4E5F60718 /* FindSelectionShortcutUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0E0F0B5A1B2C3D4E5F60718 /* FindSelectionShortcutUITests.swift */; };
 		D0E0F0B2A1B2C3D4E5F60718 /* BrowserOmnibarSuggestionsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0E0F0B3A1B2C3D4E5F60718 /* BrowserOmnibarSuggestionsUITests.swift */; };
 		D1320AA0D1320AA0D1320AA1 /* AppIconDockTilePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1320AA0D1320AA0D1320AA4 /* AppIconDockTilePlugin.swift */; };
@@ -904,6 +905,7 @@
 		C1ADE00001A1B2C3D4E5F719 /* claude */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = Resources/bin/claude; sourceTree = SOURCE_ROOT; };
 		C2577001A1B2C3D4E5F60718 /* TerminalCmdClickUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalCmdClickUITests.swift; sourceTree = "<group>"; };
 		D0E0F0B1A1B2C3D4E5F60718 /* BrowserPaneNavigationKeybindUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserPaneNavigationKeybindUITests.swift; sourceTree = "<group>"; };
+		D0E0F0C1A1B2C3D4E5F60718 /* BrowserChromiumEngineUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserChromiumEngineUITests.swift; sourceTree = "<group>"; };
 		D0E0F0B5A1B2C3D4E5F60718 /* FindSelectionShortcutUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindSelectionShortcutUITests.swift; sourceTree = "<group>"; };
 		D0E0F0B3A1B2C3D4E5F60718 /* BrowserOmnibarSuggestionsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserOmnibarSuggestionsUITests.swift; sourceTree = "<group>"; };
 		D1320AA0D1320AA0D1320AA4 /* AppIconDockTilePlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconDockTilePlugin.swift; sourceTree = "<group>"; };
@@ -1090,6 +1092,7 @@
 				B9000131A1B2C3D4E5F60719 /* SidebarPullRequestInteractivityUITests.swift */,
 				E6FA9085A1B2C3D4E5F60718 /* WorkspaceDescriptionUITests.swift */,
 				D0E0F0B1A1B2C3D4E5F60718 /* BrowserPaneNavigationKeybindUITests.swift */,
+				D0E0F0C1A1B2C3D4E5F60718 /* BrowserChromiumEngineUITests.swift */,
 				D0E0F0B5A1B2C3D4E5F60718 /* FindSelectionShortcutUITests.swift */,
 				D0E0F0B3A1B2C3D4E5F60718 /* BrowserOmnibarSuggestionsUITests.swift */,
 				FB100001A1B2C3D4E5F60718 /* BrowserImportProfilesUITests.swift */,
@@ -1561,6 +1564,7 @@
 				D3664003D3664003D3664003 /* Compress Markdown Viewer Assets */,
 				D1320AA0D1320AA0D1320AA6 /* Copy Dock Tile Plugin */,
 				A5001020 /* Embed Frameworks */,
+				C7100001C7100001C7100001 /* Embed CmuxChromiumCore */,
 				B900000AA1B2C3D4E5F60719 /* Copy CLI */,
 				A5001300A1B2C3D4E5F60719 /* ShellScript */,
 			);
@@ -1806,6 +1810,24 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -euo pipefail\nDEST=\"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}\"\nGHOSTTY_DEST=\"${DEST}/ghostty\"\nTERMINFO_DEST=\"${DEST}/terminfo\"\nCMUX_SHELL_DEST=\"${DEST}/shell-integration\"\nBIN_DEST=\"${DEST}/bin\"\nSRC_SHARE=\"${SRCROOT}/ghostty/zig-out/share\"\nGHOSTTY_SRC=\"${SRC_SHARE}/ghostty\"\nTERMINFO_SRC=\"${SRC_SHARE}/terminfo\"\nFALLBACK_GHOSTTY=\"${SRCROOT}/Resources/ghostty\"\nFALLBACK_TERMINFO=\"${SRCROOT}/Resources/ghostty/terminfo\"\nTERMINFO_OVERLAY=\"${SRCROOT}/Resources/terminfo-overlay\"\nCMUX_SHELL_SRC=\"${SRCROOT}/Resources/shell-integration\"\nCMUX_GHOSTTY_ZSH_SRC=\"${SRCROOT}/ghostty/src/shell-integration/zsh/ghostty-integration\"\nBUILD_GHOSTTY_HELPER=\"${SRCROOT}/scripts/build-ghostty-cli-helper.sh\"\nGHOSTTY_HELPER_DEST=\"${BIN_DEST}/ghostty\"\nif [ -d \"$GHOSTTY_SRC\" ]; then\n  mkdir -p \"$GHOSTTY_DEST\"\n  rsync -a --delete \"$GHOSTTY_SRC/\" \"$GHOSTTY_DEST/\"\nelif [ -d \"$FALLBACK_GHOSTTY\" ]; then\n  mkdir -p \"$GHOSTTY_DEST\"\n  rsync -a --delete \"$FALLBACK_GHOSTTY/\" \"$GHOSTTY_DEST/\"\nfi\nif [ -d \"$TERMINFO_SRC\" ]; then\n  mkdir -p \"$TERMINFO_DEST\"\n  rsync -a --delete \"$TERMINFO_SRC/\" \"$TERMINFO_DEST/\"\nelif [ -d \"$FALLBACK_TERMINFO\" ]; then\n  mkdir -p \"$TERMINFO_DEST\"\n  rsync -a --delete \"$FALLBACK_TERMINFO/\" \"$TERMINFO_DEST/\"\nfi\n# Overlay any cmux-specific terminfo adjustments.\n# This intentionally does not use --delete so we only patch specific entries.\nif [ -d \"$TERMINFO_OVERLAY\" ]; then\n  mkdir -p \"$TERMINFO_DEST\"\n  rsync -a \"$TERMINFO_OVERLAY/\" \"$TERMINFO_DEST/\"\nfi\nif [ -d \"$CMUX_SHELL_SRC\" ]; then\n  mkdir -p \"$CMUX_SHELL_DEST\"\n  # Use '/.' so dotfiles like .zshenv/.zprofile are copied too.\n  rsync -a \"$CMUX_SHELL_SRC/.\" \"$CMUX_SHELL_DEST/\"\nfi\nif [ -f \"$CMUX_GHOSTTY_ZSH_SRC\" ]; then\n  mkdir -p \"$CMUX_SHELL_DEST\"\n  rsync -a \"$CMUX_GHOSTTY_ZSH_SRC\" \"$CMUX_SHELL_DEST/ghostty-integration.zsh\"\nfi\nif [ ! -x \"$BUILD_GHOSTTY_HELPER\" ]; then\n  echo \"error: missing Ghostty CLI helper build script at $BUILD_GHOSTTY_HELPER\" >&2\n  exit 1\nfi\nARCHS_LIST=\" ${ARCHS:-} \"\nHAS_ARM64=0\nHAS_X86_64=0\nGHOSTTY_HELPER_TARGET=\"\"\ncase \"$ARCHS_LIST\" in\n  *\" arm64 \"*) HAS_ARM64=1 ;;\nesac\ncase \"$ARCHS_LIST\" in\n  *\" x86_64 \"*) HAS_X86_64=1 ;;\nesac\nif [ \"$HAS_ARM64\" -eq 1 ] && [ \"$HAS_X86_64\" -eq 1 ]; then\n  \"$BUILD_GHOSTTY_HELPER\" --universal --output \"$GHOSTTY_HELPER_DEST\"\nelif [ \"$HAS_ARM64\" -eq 1 ]; then\n  GHOSTTY_HELPER_TARGET=\"aarch64-macos\"\nelif [ \"$HAS_X86_64\" -eq 1 ]; then\n  GHOSTTY_HELPER_TARGET=\"x86_64-macos\"\nfi\nif [ -n \"$GHOSTTY_HELPER_TARGET\" ]; then\n  \"$BUILD_GHOSTTY_HELPER\" --target \"$GHOSTTY_HELPER_TARGET\" --output \"$GHOSTTY_HELPER_DEST\"\nelif [ \"$HAS_ARM64\" -eq 0 ] || [ \"$HAS_X86_64\" -eq 0 ]; then\n  \"$BUILD_GHOSTTY_HELPER\" --output \"$GHOSTTY_HELPER_DEST\"\nfi\nif [ ! -x \"$GHOSTTY_HELPER_DEST\" ]; then\n  echo \"error: Ghostty CLI helper was not created at $GHOSTTY_HELPER_DEST\" >&2\n  exit 1\nfi\nINFO_PLIST=\"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}\"\nCOMMIT=\"$(git -C \"${SRCROOT}\" rev-parse --short=9 HEAD 2>/dev/null || true)\"\nif [ -n \"$COMMIT\" ] && [ -f \"$INFO_PLIST\" ]; then\n  /usr/libexec/PlistBuddy -c \"Set :CMUXCommit $COMMIT\" \"$INFO_PLIST\" >/dev/null 2>&1 || /usr/libexec/PlistBuddy -c \"Add :CMUXCommit string $COMMIT\" \"$INFO_PLIST\" >/dev/null 2>&1 || true\nfi\n";
+		};
+		C7100001C7100001C7100001 /* Embed CmuxChromiumCore */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Embed CmuxChromiumCore";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -euo pipefail\n\"${SRCROOT}/scripts/build-cmux-chromium-core.sh\" --app \"${TARGET_BUILD_DIR}/${WRAPPER_NAME}\" --configuration \"${CONFIGURATION}\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -2131,6 +2153,7 @@
 				B9000130A1B2C3D4E5F60719 /* SidebarPullRequestInteractivityUITests.swift in Sources */,
 				E6FA9084A1B2C3D4E5F60718 /* WorkspaceDescriptionUITests.swift in Sources */,
 				D0E0F0B0A1B2C3D4E5F60718 /* BrowserPaneNavigationKeybindUITests.swift in Sources */,
+				D0E0F0C0A1B2C3D4E5F60718 /* BrowserChromiumEngineUITests.swift in Sources */,
 				D0E0F0B4A1B2C3D4E5F60718 /* FindSelectionShortcutUITests.swift in Sources */,
 				D0E0F0B2A1B2C3D4E5F60718 /* BrowserOmnibarSuggestionsUITests.swift in Sources */,
 				FB100000A1B2C3D4E5F60718 /* BrowserImportProfilesUITests.swift in Sources */,

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -2,6 +2,9 @@
   "sourceLanguage": "en",
   "version": "1.0",
   "strings": {
+    "browser.chromium.error.failedToStart": { "extractionState": "manual", "localizations": { "en": { "stringUnit": { "state": "translated", "value": "Browser engine failed to start" } }, "ja": { "stringUnit": { "state": "translated", "value": "ブラウザエンジンを起動できませんでした" } } } },
+    "browser.chromium.error.scriptFailed": { "extractionState": "manual", "localizations": { "en": { "stringUnit": { "state": "translated", "value": "Browser script failed to run" } }, "ja": { "stringUnit": { "state": "translated", "value": "ブラウザスクリプトを実行できませんでした" } } } },
+    "browser.chromium.error.unavailable": { "extractionState": "manual", "localizations": { "en": { "stringUnit": { "state": "translated", "value": "Browser engine unavailable" } }, "ja": { "stringUnit": { "state": "translated", "value": "ブラウザエンジンを利用できません" } } } },
     "cli.error.dismissNotificationSelector": { "extractionState": "manual", "localizations": { "en": { "stringUnit": { "state": "translated", "value": "dismiss-notification requires exactly one of --id or --all-read" } }, "ja": { "stringUnit": { "state": "translated", "value": "dismiss-notification には --id または --all-read のどちらか一方だけを指定してください" } } } },
     "cli.error.markNotificationReadSelector": { "extractionState": "manual", "localizations": { "en": { "stringUnit": { "state": "translated", "value": "mark-notification-read requires exactly one selector: --id, --workspace, or --all" } }, "ja": { "stringUnit": { "state": "translated", "value": "mark-notification-read には --id、--workspace、--all のいずれか一つだけを指定してください" } } } },
     "cli.error.markNotificationReadSurfaceRequiresWorkspace": { "extractionState": "manual", "localizations": { "en": { "stringUnit": { "state": "translated", "value": "--surface requires --workspace" } }, "ja": { "stringUnit": { "state": "translated", "value": "--surface には --workspace が必要です" } } } },

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -8938,6 +8938,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                     "browserEngineKind": runtimeStatus.kind.rawValue,
                     "browserChromiumReady": runtimeStatus.kind == .chromium ? "1" : "0",
                     "browserChromiumFallbackReason": runtimeStatus.fallbackReason ?? "",
+                    "browserChromiumFallbackDiagnostic": runtimeStatus.fallbackDiagnostic ?? "",
                     "browserChromiumNativeViewHost": renderingAPI?.nativeViewHost ?? "",
                     "browserChromiumCompositorLayer": renderingAPI?.compositorLayer ?? "",
                     "browserChromiumSurfaceTransport": renderingAPI?.surfaceTransport ?? ""

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -8930,6 +8930,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 self.writeGotoSplitTestData(["setupError": "Failed to create browser split"])
                 return
             }
+            if let browserPanel = tabManager.browserPanel(tabId: tab.id, panelId: browserPanelId) {
+                let runtimeStatus = browserPanel.browserEngineRuntimeStatus
+                let renderingAPI = runtimeStatus.manifest?.renderingAPI
+                self.writeGotoSplitTestData([
+                    "browserPanelId": browserPanelId.uuidString,
+                    "browserEngineKind": runtimeStatus.kind.rawValue,
+                    "browserChromiumReady": runtimeStatus.kind == .chromium ? "1" : "0",
+                    "browserChromiumFallbackReason": runtimeStatus.fallbackReason ?? "",
+                    "browserChromiumNativeViewHost": renderingAPI?.nativeViewHost ?? "",
+                    "browserChromiumCompositorLayer": renderingAPI?.compositorLayer ?? "",
+                    "browserChromiumSurfaceTransport": renderingAPI?.surfaceTransport ?? ""
+                ])
+            }
 
             self.focusWebViewForGotoSplitUITest(tab: tab, browserPanelId: browserPanelId)
         }

--- a/Sources/Feed/FeedCoordinator.swift
+++ b/Sources/Feed/FeedCoordinator.swift
@@ -1,7 +1,7 @@
 import AppKit
 import CMUXWorkstream
 import Foundation
-import UserNotifications
+@preconcurrency import UserNotifications
 
 /// App-level coordinator that owns the shared `WorkstreamStore` and
 /// mediates between the socket thread (which processes `feed.*` V2
@@ -563,21 +563,13 @@ private func deliverFeedNotification(
 ) {
     guard effects.desktop || effects.sound || effects.command else { return }
 
-    func runFallbackEffects() {
-        if effects.sound {
-            NotificationSoundSettings.playSelectedSound()
-        }
-        if effects.command {
-            NotificationSoundSettings.runCustomCommand(
-                title: title,
-                subtitle: subtitle,
-                body: body
-            )
-        }
-    }
-
     if !effects.desktop {
-        runFallbackEffects()
+        runFeedNotificationFallback(
+            title: title,
+            subtitle: subtitle,
+            body: body,
+            effects: effects
+        )
         return
     }
 
@@ -600,28 +592,35 @@ private func deliverFeedNotification(
 
     let center = UNUserNotificationCenter.current()
     center.getNotificationSettings { settings in
+        let runFallbackEffects = {
+            _ = Task { @MainActor in
+                runFeedNotificationFallback(
+                    title: title,
+                    subtitle: subtitle,
+                    body: body,
+                    effects: effects
+                )
+            }
+        }
+        let runCustomCommand = {
+            guard effects.command else { return }
+            NotificationSoundSettings.runCustomCommand(
+                title: title,
+                subtitle: subtitle,
+                body: body
+            )
+        }
+
         switch settings.authorizationStatus {
         case .authorized, .provisional:
             center.add(request) { _ in
-                if effects.command {
-                    NotificationSoundSettings.runCustomCommand(
-                        title: content.title,
-                        subtitle: content.subtitle,
-                        body: content.body
-                    )
-                }
+                runCustomCommand()
             }
         case .notDetermined:
             center.requestAuthorization(options: [.alert, .sound]) { granted, _ in
                 if granted {
                     center.add(request) { _ in
-                        if effects.command {
-                            NotificationSoundSettings.runCustomCommand(
-                                title: content.title,
-                                subtitle: content.subtitle,
-                                body: content.body
-                            )
-                        }
+                        runCustomCommand()
                     }
                 }
                 if !granted {
@@ -631,6 +630,25 @@ private func deliverFeedNotification(
         default:
             runFallbackEffects()
         }
+    }
+}
+
+@MainActor
+private func runFeedNotificationFallback(
+    title: String,
+    subtitle: String,
+    body: String,
+    effects: TerminalNotificationPolicyEffects
+) {
+    if effects.sound {
+        NotificationSoundSettings.playSelectedSound()
+    }
+    if effects.command {
+        NotificationSoundSettings.runCustomCommand(
+            title: title,
+            subtitle: subtitle,
+            body: body
+        )
     }
 }
 

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -98,6 +98,7 @@ struct BrowserEngineRuntimeStatus: Equatable {
     var kind: BrowserEngineRuntimeKind
     var manifest: BrowserChromiumArtifactManifest?
     var fallbackReason: String?
+    var fallbackDiagnostic: String? = nil
 
     var socketPayload: [String: Any] {
         var payload: [String: Any] = [
@@ -127,6 +128,11 @@ struct BrowserEngineRuntimeStatus: Equatable {
         if let fallbackReason {
             payload["fallback_reason"] = fallbackReason
         }
+#if DEBUG
+        if let fallbackDiagnostic {
+            payload["fallback_diagnostic"] = fallbackDiagnostic
+        }
+#endif
         return payload
     }
 }
@@ -361,6 +367,34 @@ enum BrowserEngineRuntimePolicy {
             return "manifest_decode_failed"
         }
     }
+
+    static func hostCreationFallbackDiagnostic(for error: Error) -> String {
+        if let factoryError = error as? BrowserChromiumHostFactoryError {
+            switch factoryError {
+            case .missingFactoryClass:
+                return "factory_class_missing"
+            case .missingFactoryMethod:
+                return "factory_method_missing"
+            case .factoryReturnedNil:
+                return "factory_returned_nil"
+            case .bridgeCreationFailed:
+                return "bridge_creation_failed"
+            case .bundleLoadFailed:
+                return "bundle_load_failed"
+            }
+        }
+        if let bridgeError = error as? BrowserChromiumHostBridgeError {
+            switch bridgeError {
+            case .missingRequiredView:
+                return "required_view_missing"
+            case .unsupportedOperation:
+                return "unsupported_operation"
+            case .operationFailed:
+                return "operation_failed"
+            }
+        }
+        return "unknown_host_error"
+    }
 }
 
 enum BrowserChromiumHostBridgeError: Error, Equatable, CustomStringConvertible {
@@ -403,15 +437,6 @@ protocol BrowserChromiumHostExporting: NSObjectProtocol {
     @objc optional func cmuxSetPageZoomFactor(_ pageZoomFactor: NSNumber)
     @objc optional func cmuxAddUserScript(_ source: NSString)
     @objc optional func cmuxAddUserStyle(_ source: NSString)
-}
-
-@objc(CMUXChromiumBrowserHostFactoryExporting)
-protocol BrowserChromiumHostFactoryExporting: NSObjectProtocol {
-    static func cmuxCreateBrowserHost(
-        profileIdentifier: String,
-        dataDirectory: NSURL,
-        proxyConfiguration: NSDictionary?
-    ) -> BrowserChromiumHostExporting?
 }
 
 final class BrowserChromiumHostBridge {
@@ -824,7 +849,7 @@ final class BrowserChromiumEngineHost: BrowserEngineHost {
 
 enum BrowserChromiumHostFactoryError: Error, Equatable, CustomStringConvertible {
     case missingFactoryClass(String)
-    case invalidFactoryClass(String)
+    case missingFactoryMethod(String)
     case factoryReturnedNil(String)
     case bridgeCreationFailed(String)
     case bundleLoadFailed(String)
@@ -833,8 +858,8 @@ enum BrowserChromiumHostFactoryError: Error, Equatable, CustomStringConvertible 
         switch self {
         case .missingFactoryClass(let name):
             return "Chromium host factory class not found: \(name)"
-        case .invalidFactoryClass(let name):
-            return "Chromium host factory class does not conform to CMUXChromiumBrowserHostFactoryExporting: \(name)"
+        case .missingFactoryMethod(let name):
+            return "Chromium host factory class does not expose the required Objective-C factory method: \(name)"
         case .factoryReturnedNil(let name):
             return "Chromium host factory returned nil: \(name)"
         case .bridgeCreationFailed(let message):
@@ -866,11 +891,8 @@ enum BrowserChromiumHostFactory {
         guard let factoryClass = NSClassFromString(factoryClassName) else {
             throw BrowserChromiumHostFactoryError.missingFactoryClass(factoryClassName)
         }
-        guard let factoryType = factoryClass as? BrowserChromiumHostFactoryExporting.Type else {
-            throw BrowserChromiumHostFactoryError.invalidFactoryClass(factoryClassName)
-        }
         return try makeBridge(
-            factoryType: factoryType,
+            factoryClass: factoryClass,
             factoryClassName: factoryClassName,
             profileIdentifier: profileIdentifier,
             dataDirectory: dataDirectory,
@@ -879,17 +901,26 @@ enum BrowserChromiumHostFactory {
     }
 
     static func makeBridge(
-        factoryType: BrowserChromiumHostFactoryExporting.Type,
+        factoryClass: AnyClass,
         factoryClassName: String,
         profileIdentifier: UUID,
         dataDirectory: URL,
         proxyConfiguration: NSDictionary?
     ) throws -> BrowserChromiumHostBridge {
-        guard let exportedHost = factoryType.cmuxCreateBrowserHost(
-            profileIdentifier: profileIdentifier.uuidString,
-            dataDirectory: dataDirectory as NSURL,
-            proxyConfiguration: proxyConfiguration
-        ) else {
+        let selector = BrowserChromiumFactorySelectors.createHost
+        guard let method = class_getClassMethod(factoryClass, selector) else {
+            throw BrowserChromiumHostFactoryError.missingFactoryMethod(factoryClassName)
+        }
+        typealias CreateHostIMP = @convention(c) (AnyClass, Selector, NSString, NSURL, NSDictionary?) -> AnyObject?
+        let function = unsafeBitCast(method_getImplementation(method), to: CreateHostIMP.self)
+        guard let exportedObject = function(
+            factoryClass,
+            selector,
+            profileIdentifier.uuidString as NSString,
+            dataDirectory as NSURL,
+            proxyConfiguration
+        ),
+        let exportedHost = exportedObject as? NSObjectProtocol else {
             throw BrowserChromiumHostFactoryError.factoryReturnedNil(factoryClassName)
         }
         do {
@@ -3662,6 +3693,7 @@ final class BrowserPanel: Panel, ObservableObject {
 
     private func installWebKitBrowserEngineHost(
         fallbackReason: String?,
+        fallbackDiagnostic: String? = nil,
         manifest: BrowserChromiumArtifactManifest? = nil,
         reason: String
     ) {
@@ -3669,7 +3701,8 @@ final class BrowserPanel: Panel, ObservableObject {
         browserEngineRuntimeStatus = BrowserEngineRuntimeStatus(
             kind: .webKit,
             manifest: manifest,
-            fallbackReason: fallbackReason
+            fallbackReason: fallbackReason,
+            fallbackDiagnostic: fallbackDiagnostic
         )
         browserEngineHostInstanceID = UUID()
 #if DEBUG
@@ -3720,8 +3753,16 @@ final class BrowserPanel: Panel, ObservableObject {
             )
 #endif
         } catch {
+            let diagnostic = BrowserEngineRuntimePolicy.hostCreationFallbackDiagnostic(for: error)
+#if DEBUG
+            cmuxDebugLog(
+                "browser.engine.chromium.failed panel=\(id.uuidString.prefix(5)) " +
+                "reason=\(reason) diagnostic=\(diagnostic)"
+            )
+#endif
             installWebKitBrowserEngineHost(
                 fallbackReason: "chromium_host_creation_failed",
+                fallbackDiagnostic: diagnostic,
                 manifest: manifest,
                 reason: reason
             )

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -7,12 +7,15 @@ import Network
 import CFNetwork
 import SQLite3
 import CryptoKit
+import OSLog
 #if canImport(CommonCrypto)
 import CommonCrypto
 #endif
 #if canImport(Security)
 import Security
 #endif
+
+private let browserEngineLogger = Logger(subsystem: "com.cmuxterm.app", category: "browser-engine")
 
 fileprivate func dedupedCanonicalURLs(_ urls: [URL]) -> [URL] {
     var seen = Set<String>()
@@ -36,6 +39,869 @@ struct BrowserRemoteWorkspaceStatus: Equatable {
     let connectionState: WorkspaceRemoteConnectionState
     let heartbeatCount: Int
     let lastHeartbeatAt: Date?
+}
+
+enum BrowserEngineRuntimeKind: String, Equatable {
+    case chromium
+    case unknown
+    case webKit = "webkit"
+}
+
+struct BrowserChromiumArtifactManifest: Codable, Equatable, Sendable {
+    static let unknownChromiumVersion = "unknown"
+    static let frameworkName = "CmuxChromiumCore.framework"
+    static let hostClassName = "CmuxChromiumBrowserHost"
+    static let hostFactoryClassName = "CmuxChromiumBrowserHostFactory"
+    static let hostAPIVersion = 1
+
+    var engine: String
+    var chromiumVersion: String
+    var chromiumRevision: String?
+    var frameworkName: String
+    var resourceNames: [String]
+    var hostClassName: String?
+    var hostFactoryClassName: String?
+    var hostAPIVersion: Int?
+    var launchPolicy: BrowserChromiumLaunchPolicy? = nil
+    var renderingAPI: BrowserChromiumRenderingAPI? = nil
+
+    static func inferred(resourceNames: [String]) -> BrowserChromiumArtifactManifest {
+        BrowserChromiumArtifactManifest(
+            engine: "chromium",
+            chromiumVersion: unknownChromiumVersion,
+            chromiumRevision: nil,
+            frameworkName: frameworkName,
+            resourceNames: resourceNames.sorted(),
+            hostClassName: hostClassName,
+            hostFactoryClassName: hostFactoryClassName,
+            hostAPIVersion: hostAPIVersion,
+            launchPolicy: nil,
+            renderingAPI: nil
+        )
+    }
+}
+
+struct BrowserChromiumLaunchPolicy: Codable, Equatable, Sendable {
+    var sandboxDisabled: Bool
+    var usesInProcessGPUByDefault: Bool
+    var defaultSwitches: [String]
+    var forbiddenSwitchesVerifiedAbsent: [String]
+}
+
+struct BrowserChromiumRenderingAPI: Codable, Equatable, Sendable {
+    var nativeViewHost: String
+    var compositorLayer: String
+    var surfaceTransport: String
+}
+
+struct BrowserEngineRuntimeStatus: Equatable {
+    var kind: BrowserEngineRuntimeKind
+    var manifest: BrowserChromiumArtifactManifest?
+    var fallbackReason: String?
+
+    var socketPayload: [String: Any] {
+        var payload: [String: Any] = [
+            "kind": kind.rawValue,
+            "chromium_ready": kind == .chromium
+        ]
+        if let manifest {
+            payload["chromium_version"] = manifest.chromiumVersion
+            payload["chromium_revision"] = manifest.chromiumRevision ?? NSNull()
+            payload["framework_name"] = manifest.frameworkName
+            payload["resources"] = manifest.resourceNames
+            payload["host_class_name"] = manifest.hostClassName ?? NSNull()
+            payload["host_factory_class_name"] = manifest.hostFactoryClassName ?? NSNull()
+            payload["host_api_version"] = manifest.hostAPIVersion ?? NSNull()
+            if let launchPolicy = manifest.launchPolicy {
+                payload["chromium_sandbox_disabled"] = launchPolicy.sandboxDisabled
+                payload["chromium_uses_in_process_gpu_by_default"] = launchPolicy.usesInProcessGPUByDefault
+                payload["chromium_default_switches"] = launchPolicy.defaultSwitches
+                payload["chromium_forbidden_switches_verified_absent"] = launchPolicy.forbiddenSwitchesVerifiedAbsent
+            }
+            if let renderingAPI = manifest.renderingAPI {
+                payload["chromium_native_view_host"] = renderingAPI.nativeViewHost
+                payload["chromium_compositor_layer"] = renderingAPI.compositorLayer
+                payload["chromium_surface_transport"] = renderingAPI.surfaceTransport
+            }
+        }
+        if let fallbackReason {
+            payload["fallback_reason"] = fallbackReason
+        }
+        return payload
+    }
+}
+
+enum BrowserChromiumArtifactVerificationError: Error, Equatable, CustomStringConvertible {
+    case missingFramework(URL)
+    case missingExecutable(URL)
+    case missingResources([String])
+    case cefDisallowed(String)
+    case missingLaunchPolicy
+    case insecureLaunchPolicy(String)
+    case manifestDecodeFailed(String)
+
+    var description: String {
+        switch self {
+        case .missingFramework(let url):
+            return "Missing Chromium framework at \(url.path)"
+        case .missingExecutable(let url):
+            return "Missing Chromium framework executable at \(url.path)"
+        case .missingResources(let names):
+            return "Missing Chromium resources: \(names.joined(separator: ", "))"
+        case .cefDisallowed(let marker):
+            return "Disallowed CEF marker found in Chromium framework: \(marker)"
+        case .missingLaunchPolicy:
+            return "Chromium OWL runtime manifest is missing launchPolicy"
+        case .insecureLaunchPolicy(let message):
+            return "Chromium OWL runtime launch policy is not production-safe: \(message)"
+        case .manifestDecodeFailed(let message):
+            return "Chromium manifest decode failed: \(message)"
+        }
+    }
+}
+
+enum BrowserChromiumArtifactVerifier {
+    private static let manifestFileName = "cmux-chromium-manifest.json"
+    private static let requiredCommonResourceNames = ["icudtl.dat"]
+    private static let requiredChromeResourceNames = ["resources.pak"]
+    private static let requiredChromeScaleResourceNames = ["chrome_100_percent.pak", "chrome_200_percent.pak"]
+    private static let requiredContentShellResourceNames = ["content_shell.pak"]
+    private static let disallowedCEFMarkers = [
+        "Chromium Embedded Framework",
+        "libcef",
+        "CefInitialize",
+        "CefBrowser",
+        "CEF.framework"
+    ]
+
+    static func defaultFrameworkURL(bundle: Bundle = .main) -> URL? {
+        bundle.privateFrameworksURL?.appendingPathComponent(
+            BrowserChromiumArtifactManifest.frameworkName,
+            isDirectory: true
+        )
+    }
+
+    static func verifyFramework(at frameworkURL: URL, fileManager: FileManager = .default) throws -> BrowserChromiumArtifactManifest {
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: frameworkURL.path, isDirectory: &isDirectory),
+              isDirectory.boolValue else {
+            throw BrowserChromiumArtifactVerificationError.missingFramework(frameworkURL)
+        }
+
+        let executableURL = try executableURL(for: frameworkURL, fileManager: fileManager)
+        try rejectCEFMarkers(in: executableURL)
+
+        let resourceURL = resourcesURL(for: frameworkURL, fileManager: fileManager)
+        try rejectCEFMarkersInBundledChromium(at: resourceURL, fileManager: fileManager)
+        let resourceNames = try verifyRequiredResources(in: resourceURL, fileManager: fileManager)
+
+        if let manifest = try loadManifest(from: resourceURL, fileManager: fileManager) {
+            try verifyLaunchPolicy(for: manifest)
+            return manifest
+        }
+
+        let inferredManifest = BrowserChromiumArtifactManifest.inferred(resourceNames: resourceNames)
+        try verifyLaunchPolicy(for: inferredManifest)
+        return inferredManifest
+    }
+
+    private static func executableURL(for frameworkURL: URL, fileManager: FileManager) throws -> URL {
+        let executableName = frameworkURL.deletingPathExtension().lastPathComponent
+        let candidates = [
+            frameworkURL.appendingPathComponent("Versions/A/\(executableName)", isDirectory: false),
+            frameworkURL.appendingPathComponent(executableName, isDirectory: false),
+        ]
+        for candidate in candidates where fileManager.isExecutableFile(atPath: candidate.path) || fileManager.fileExists(atPath: candidate.path) {
+            return candidate
+        }
+        throw BrowserChromiumArtifactVerificationError.missingExecutable(candidates[0])
+    }
+
+    private static func resourcesURL(for frameworkURL: URL, fileManager: FileManager) -> URL {
+        let versioned = frameworkURL.appendingPathComponent("Versions/A/Resources", isDirectory: true)
+        if fileManager.fileExists(atPath: versioned.path) {
+            return versioned
+        }
+        return frameworkURL.appendingPathComponent("Resources", isDirectory: true)
+    }
+
+    private static func verifyRequiredResources(in resourceURL: URL, fileManager: FileManager) throws -> [String] {
+        let present = Set((try? fileManager.contentsOfDirectory(atPath: resourceURL.path)) ?? [])
+        var missing = requiredCommonResourceNames.filter { !present.contains($0) }
+        let hasChromeResourceSet =
+            requiredChromeResourceNames.allSatisfy { present.contains($0) } &&
+            requiredChromeScaleResourceNames.contains(where: present.contains)
+        let hasContentShellResourceSet =
+            requiredContentShellResourceNames.allSatisfy { present.contains($0) }
+        if !hasChromeResourceSet && !hasContentShellResourceSet {
+            missing.append(
+                "resources.pak with \(requiredChromeScaleResourceNames.joined(separator: " or ")) or content_shell.pak"
+            )
+        }
+        guard missing.isEmpty else {
+            throw BrowserChromiumArtifactVerificationError.missingResources(missing)
+        }
+        return Array(present)
+    }
+
+    private static func rejectCEFMarkers(in executableURL: URL) throws {
+        let data = try Data(contentsOf: executableURL, options: [.mappedIfSafe])
+        for marker in disallowedCEFMarkers where data.range(of: Data(marker.utf8)) != nil {
+            throw BrowserChromiumArtifactVerificationError.cefDisallowed(marker)
+        }
+    }
+
+    private static func rejectCEFMarkersInBundledChromium(at resourceURL: URL, fileManager: FileManager) throws {
+        let cefFrameworkURL = resourceURL
+            .appendingPathComponent("Content Shell.app", isDirectory: true)
+            .appendingPathComponent("Contents/Frameworks/Chromium Embedded Framework.framework", isDirectory: true)
+        if fileManager.fileExists(atPath: cefFrameworkURL.path) {
+            throw BrowserChromiumArtifactVerificationError.cefDisallowed("Chromium Embedded Framework")
+        }
+
+        let executableCandidates = [
+            resourceURL
+                .appendingPathComponent("Content Shell.app", isDirectory: true)
+                .appendingPathComponent("Contents/MacOS/Content Shell", isDirectory: false),
+            resourceURL
+                .appendingPathComponent("Content Shell.app", isDirectory: true)
+                .appendingPathComponent("Contents/Frameworks/Content Shell Framework.framework/Content Shell Framework", isDirectory: false),
+            resourceURL
+                .appendingPathComponent("Content Shell.app", isDirectory: true)
+                .appendingPathComponent("Contents/Frameworks/Content Shell Framework.framework/Versions/Current/Content Shell Framework", isDirectory: false),
+        ]
+        for candidate in executableCandidates where fileManager.fileExists(atPath: candidate.path) {
+            try rejectCEFMarkers(in: candidate)
+        }
+    }
+
+    private static func loadManifest(from resourceURL: URL, fileManager: FileManager) throws -> BrowserChromiumArtifactManifest? {
+        let url = resourceURL.appendingPathComponent(manifestFileName, isDirectory: false)
+        guard fileManager.fileExists(atPath: url.path) else { return nil }
+        do {
+            let data = try Data(contentsOf: url)
+            return try JSONDecoder().decode(BrowserChromiumArtifactManifest.self, from: data)
+        } catch {
+            throw BrowserChromiumArtifactVerificationError.manifestDecodeFailed(error.localizedDescription)
+        }
+    }
+
+    private static func verifyLaunchPolicy(for manifest: BrowserChromiumArtifactManifest) throws {
+        let requiresProductionLaunchPolicy =
+            manifest.engine.localizedCaseInsensitiveContains("owl") ||
+            manifest.resourceNames.contains("libowl_fresh_mojo_runtime.dylib")
+        guard requiresProductionLaunchPolicy else { return }
+
+        guard let launchPolicy = manifest.launchPolicy else {
+            throw BrowserChromiumArtifactVerificationError.missingLaunchPolicy
+        }
+        if launchPolicy.sandboxDisabled {
+            throw BrowserChromiumArtifactVerificationError.insecureLaunchPolicy("sandbox is disabled")
+        }
+        if launchPolicy.usesInProcessGPUByDefault {
+            throw BrowserChromiumArtifactVerificationError.insecureLaunchPolicy("in-process GPU is enabled by default")
+        }
+        let defaultSwitches = Set(launchPolicy.defaultSwitches)
+        if defaultSwitches.contains("no-sandbox") {
+            throw BrowserChromiumArtifactVerificationError.insecureLaunchPolicy("default switches include no-sandbox")
+        }
+        if defaultSwitches.contains("in-process-gpu") {
+            throw BrowserChromiumArtifactVerificationError.insecureLaunchPolicy("default switches include in-process-gpu")
+        }
+        if !launchPolicy.forbiddenSwitchesVerifiedAbsent.contains("no-sandbox") {
+            throw BrowserChromiumArtifactVerificationError.insecureLaunchPolicy("no-sandbox absence was not verified")
+        }
+        if !launchPolicy.forbiddenSwitchesVerifiedAbsent.contains("in-process-gpu") {
+            throw BrowserChromiumArtifactVerificationError.insecureLaunchPolicy("in-process-gpu absence was not verified")
+        }
+    }
+}
+
+enum BrowserEngineRuntimePolicy {
+    static func currentStatus(bundle: Bundle = .main, fileManager: FileManager = .default) -> BrowserEngineRuntimeStatus {
+        status(frameworkURL: BrowserChromiumArtifactVerifier.defaultFrameworkURL(bundle: bundle), fileManager: fileManager)
+    }
+
+    static func status(frameworkURL: URL?, fileManager: FileManager = .default) -> BrowserEngineRuntimeStatus {
+        guard let frameworkURL else {
+            return BrowserEngineRuntimeStatus(
+                kind: .webKit,
+                manifest: nil,
+                fallbackReason: "chromium_framework_missing"
+            )
+        }
+        do {
+            let manifest = try BrowserChromiumArtifactVerifier.verifyFramework(at: frameworkURL, fileManager: fileManager)
+            return BrowserEngineRuntimeStatus(kind: .chromium, manifest: manifest, fallbackReason: nil)
+        } catch {
+            return BrowserEngineRuntimeStatus(
+                kind: .webKit,
+                manifest: nil,
+                fallbackReason: BrowserEngineRuntimePolicy.fallbackReason(for: error)
+            )
+        }
+    }
+
+    private static func fallbackReason(for error: Error) -> String {
+        guard let verificationError = error as? BrowserChromiumArtifactVerificationError else {
+            return "unknown_error"
+        }
+        switch verificationError {
+        case .missingFramework:
+            return "chromium_framework_missing"
+        case .missingExecutable:
+            return "chromium_executable_missing"
+        case .missingResources:
+            return "chromium_resources_missing"
+        case .cefDisallowed:
+            return "cef_marker_detected"
+        case .missingLaunchPolicy, .insecureLaunchPolicy:
+            return "insecure_launch_policy"
+        case .manifestDecodeFailed:
+            return "manifest_decode_failed"
+        }
+    }
+}
+
+enum BrowserChromiumHostBridgeError: Error, Equatable, CustomStringConvertible {
+    case missingRequiredView
+    case unsupportedOperation(String)
+    case operationFailed(String)
+
+    var description: String {
+        switch self {
+        case .missingRequiredView:
+            return "Chromium host did not expose a native NSView"
+        case .unsupportedOperation(let operation):
+            return "Chromium host does not support \(operation)"
+        case .operationFailed(let message):
+            return "Chromium host operation failed: \(message)"
+        }
+    }
+}
+
+@objc(CMUXChromiumBrowserHostExporting)
+protocol BrowserChromiumHostExporting: NSObjectProtocol {
+    @objc var cmuxNativeView: NSView? { get }
+    @objc optional var cmuxCurrentURL: NSURL? { get }
+    @objc optional var cmuxTitle: String? { get }
+    @objc optional var cmuxIsLoading: Bool { get }
+    @objc optional var cmuxCanGoBack: Bool { get }
+    @objc optional var cmuxCanGoForward: Bool { get }
+    @objc optional var cmuxEstimatedProgress: Double { get }
+    @objc optional var cmuxPageZoomFactor: NSNumber { get }
+    @objc optional func cmuxLoad(_ request: NSURLRequest)
+    @objc optional func cmuxReload()
+    @objc optional func cmuxStopLoading()
+    @objc optional func cmuxGoBack()
+    @objc optional func cmuxGoForward()
+    @objc optional func cmuxEvaluateJavaScript(_ script: String, completionHandler: @escaping (Any?, String?) -> Void)
+    @objc optional func cmuxTakeSnapshot(_ completionHandler: @escaping (NSImage?) -> Void)
+    @objc optional func cmuxSetStateChangedHandler(_ handler: @escaping () -> Void)
+    @objc optional func cmuxSetProxyConfiguration(_ proxyConfiguration: NSDictionary?)
+    @objc optional func cmuxSetAppearanceName(_ appearanceName: NSString?)
+    @objc optional func cmuxSetPageZoomFactor(_ pageZoomFactor: NSNumber)
+    @objc optional func cmuxAddUserScript(_ source: NSString)
+    @objc optional func cmuxAddUserStyle(_ source: NSString)
+}
+
+@objc(CMUXChromiumBrowserHostFactoryExporting)
+protocol BrowserChromiumHostFactoryExporting: NSObjectProtocol {
+    static func cmuxCreateBrowserHost(
+        profileIdentifier: String,
+        dataDirectory: NSURL,
+        proxyConfiguration: NSDictionary?
+    ) -> BrowserChromiumHostExporting?
+}
+
+final class BrowserChromiumHostBridge {
+    let exportedHost: NSObjectProtocol
+    private let hostObject: NSObject
+    let nativeView: NSView
+
+    init(exportedHost: NSObjectProtocol) throws {
+        guard let hostObject = exportedHost as? NSObject,
+              hostObject.responds(to: BrowserChromiumHostSelectors.nativeView),
+              let nativeView = hostObject.value(forKey: "cmuxNativeView") as? NSView else {
+            throw BrowserChromiumHostBridgeError.missingRequiredView
+        }
+        self.exportedHost = exportedHost
+        self.hostObject = hostObject
+        self.nativeView = nativeView
+    }
+
+    var currentURL: URL? {
+        guard hostObject.responds(to: BrowserChromiumHostSelectors.currentURL) else { return nil }
+        if let url = hostObject.value(forKey: "cmuxCurrentURL") as? URL {
+            return url.absoluteURL
+        }
+        if let url = hostObject.value(forKey: "cmuxCurrentURL") as? NSURL {
+            return (url as URL).absoluteURL
+        }
+        return nil
+    }
+
+    var title: String? {
+        guard hostObject.responds(to: BrowserChromiumHostSelectors.title) else { return nil }
+        return hostObject.value(forKey: "cmuxTitle") as? String
+    }
+
+    var isLoading: Bool {
+        guard hostObject.responds(to: BrowserChromiumHostSelectors.isLoading) else { return false }
+        return (hostObject.value(forKey: "cmuxIsLoading") as? NSNumber)?.boolValue ?? false
+    }
+
+    var canGoBack: Bool {
+        guard hostObject.responds(to: BrowserChromiumHostSelectors.canGoBack) else { return false }
+        return (hostObject.value(forKey: "cmuxCanGoBack") as? NSNumber)?.boolValue ?? false
+    }
+
+    var canGoForward: Bool {
+        guard hostObject.responds(to: BrowserChromiumHostSelectors.canGoForward) else { return false }
+        return (hostObject.value(forKey: "cmuxCanGoForward") as? NSNumber)?.boolValue ?? false
+    }
+
+    var estimatedProgress: Double {
+        guard hostObject.responds(to: BrowserChromiumHostSelectors.estimatedProgress) else { return 0.0 }
+        return (hostObject.value(forKey: "cmuxEstimatedProgress") as? NSNumber)?.doubleValue ?? 0.0
+    }
+
+    var pageZoomFactor: CGFloat {
+        guard hostObject.responds(to: BrowserChromiumHostSelectors.pageZoomFactor) else { return 1.0 }
+        return CGFloat((hostObject.value(forKey: "cmuxPageZoomFactor") as? NSNumber)?.doubleValue ?? 1.0)
+    }
+
+    func load(_ request: URLRequest) throws {
+        typealias LoadIMP = @convention(c) (AnyObject, Selector, NSURLRequest) -> Void
+        let function: LoadIMP = try implementation(for: BrowserChromiumHostSelectors.load, operation: "load")
+        function(hostObject, BrowserChromiumHostSelectors.load, request as NSURLRequest)
+    }
+
+    func reload() throws {
+        try invokeVoid(selector: BrowserChromiumHostSelectors.reload, operation: "reload")
+    }
+
+    func stopLoading() throws {
+        try invokeVoid(selector: BrowserChromiumHostSelectors.stopLoading, operation: "stopLoading")
+    }
+
+    func goBack() throws {
+        try invokeVoid(selector: BrowserChromiumHostSelectors.goBack, operation: "goBack")
+    }
+
+    func goForward() throws {
+        try invokeVoid(selector: BrowserChromiumHostSelectors.goForward, operation: "goForward")
+    }
+
+    func evaluateJavaScript(_ script: String, completion: @escaping (Result<Any?, Error>) -> Void) throws {
+        typealias CompletionBlock = @convention(block) (Any?, String?) -> Void
+        typealias EvaluateIMP = @convention(c) (AnyObject, Selector, NSString, CompletionBlock) -> Void
+        let function: EvaluateIMP = try implementation(
+            for: BrowserChromiumHostSelectors.evaluateJavaScript,
+            operation: "evaluateJavaScript"
+        )
+        let block: CompletionBlock = { value, errorMessage in
+            if let errorMessage, !errorMessage.isEmpty {
+                completion(.failure(BrowserChromiumHostBridgeError.operationFailed(errorMessage)))
+            } else {
+                completion(.success(value))
+            }
+        }
+        function(hostObject, BrowserChromiumHostSelectors.evaluateJavaScript, script as NSString, block)
+    }
+
+    func evaluateJavaScript(_ script: String) async throws -> Any? {
+        try await withCheckedThrowingContinuation { continuation in
+            do {
+                try evaluateJavaScript(script) { result in
+                    continuation.resume(with: result)
+                }
+            } catch {
+                continuation.resume(throwing: error)
+            }
+        }
+    }
+
+    func takeSnapshot(completion: @escaping (NSImage?) -> Void) throws {
+        typealias CompletionBlock = @convention(block) (NSImage?) -> Void
+        typealias SnapshotIMP = @convention(c) (AnyObject, Selector, CompletionBlock) -> Void
+        let function: SnapshotIMP = try implementation(
+            for: BrowserChromiumHostSelectors.takeSnapshot,
+            operation: "takeSnapshot"
+        )
+        let snapshotCompletion: CompletionBlock = { image in
+            completion(image)
+        }
+        function(hostObject, BrowserChromiumHostSelectors.takeSnapshot, snapshotCompletion)
+    }
+
+    func setStateChangedHandler(_ handler: @escaping () -> Void) {
+        guard hostObject.responds(to: BrowserChromiumHostSelectors.setStateChangedHandler),
+              let method = class_getInstanceMethod(type(of: hostObject), BrowserChromiumHostSelectors.setStateChangedHandler) else {
+            return
+        }
+        typealias StateChangedBlock = @convention(block) () -> Void
+        typealias StateChangedIMP = @convention(c) (AnyObject, Selector, StateChangedBlock) -> Void
+        let function = unsafeBitCast(method_getImplementation(method), to: StateChangedIMP.self)
+        let block: StateChangedBlock = {
+            handler()
+        }
+        function(hostObject, BrowserChromiumHostSelectors.setStateChangedHandler, block)
+    }
+
+    func setProxyConfiguration(_ proxyConfiguration: NSDictionary?) throws {
+        guard hostObject.responds(to: BrowserChromiumHostSelectors.setProxyConfiguration) else { return }
+        typealias ProxyIMP = @convention(c) (AnyObject, Selector, NSDictionary?) -> Void
+        let function: ProxyIMP = try implementation(
+            for: BrowserChromiumHostSelectors.setProxyConfiguration,
+            operation: "setProxyConfiguration"
+        )
+        function(hostObject, BrowserChromiumHostSelectors.setProxyConfiguration, proxyConfiguration)
+    }
+
+    func setBrowserThemeMode(_ mode: BrowserThemeMode) throws {
+        guard hostObject.responds(to: BrowserChromiumHostSelectors.setAppearanceName) else { return }
+        let appearanceName: NSString? = {
+            switch mode {
+            case .dark:
+                return "dark"
+            case .light:
+                return "light"
+            case .system:
+                return nil
+            }
+        }()
+        typealias AppearanceIMP = @convention(c) (AnyObject, Selector, NSString?) -> Void
+        let function: AppearanceIMP = try implementation(
+            for: BrowserChromiumHostSelectors.setAppearanceName,
+            operation: "setBrowserThemeMode"
+        )
+        function(hostObject, BrowserChromiumHostSelectors.setAppearanceName, appearanceName)
+    }
+
+    func setPageZoomFactor(_ pageZoomFactor: CGFloat) throws {
+        typealias ZoomIMP = @convention(c) (AnyObject, Selector, NSNumber) -> Void
+        let function: ZoomIMP = try implementation(
+            for: BrowserChromiumHostSelectors.setPageZoomFactor,
+            operation: "setPageZoomFactor"
+        )
+        function(hostObject, BrowserChromiumHostSelectors.setPageZoomFactor, NSNumber(value: Double(pageZoomFactor)))
+    }
+
+    func addUserScript(_ source: String) throws {
+        typealias ScriptIMP = @convention(c) (AnyObject, Selector, NSString) -> Void
+        let function: ScriptIMP = try implementation(
+            for: BrowserChromiumHostSelectors.addUserScript,
+            operation: "addUserScript"
+        )
+        function(hostObject, BrowserChromiumHostSelectors.addUserScript, source as NSString)
+    }
+
+    func addUserStyle(_ source: String) throws {
+        typealias StyleIMP = @convention(c) (AnyObject, Selector, NSString) -> Void
+        let function: StyleIMP = try implementation(
+            for: BrowserChromiumHostSelectors.addUserStyle,
+            operation: "addUserStyle"
+        )
+        function(hostObject, BrowserChromiumHostSelectors.addUserStyle, source as NSString)
+    }
+
+    private func invokeVoid(selector: Selector, operation: String) throws {
+        typealias VoidIMP = @convention(c) (AnyObject, Selector) -> Void
+        let function: VoidIMP = try implementation(for: selector, operation: operation)
+        function(hostObject, selector)
+    }
+
+    private func implementation<Function>(for selector: Selector, operation: String) throws -> Function {
+        guard hostObject.responds(to: selector),
+              let method = class_getInstanceMethod(type(of: hostObject), selector) else {
+            throw BrowserChromiumHostBridgeError.unsupportedOperation(operation)
+        }
+        return unsafeBitCast(method_getImplementation(method), to: Function.self)
+    }
+}
+
+private enum BrowserChromiumHostSelectors {
+    static let nativeView = NSSelectorFromString("cmuxNativeView")
+    static let currentURL = NSSelectorFromString("cmuxCurrentURL")
+    static let title = NSSelectorFromString("cmuxTitle")
+    static let isLoading = NSSelectorFromString("cmuxIsLoading")
+    static let canGoBack = NSSelectorFromString("cmuxCanGoBack")
+    static let canGoForward = NSSelectorFromString("cmuxCanGoForward")
+    static let estimatedProgress = NSSelectorFromString("cmuxEstimatedProgress")
+    static let pageZoomFactor = NSSelectorFromString("cmuxPageZoomFactor")
+    static let load = NSSelectorFromString("cmuxLoad:")
+    static let reload = NSSelectorFromString("cmuxReload")
+    static let stopLoading = NSSelectorFromString("cmuxStopLoading")
+    static let goBack = NSSelectorFromString("cmuxGoBack")
+    static let goForward = NSSelectorFromString("cmuxGoForward")
+    static let evaluateJavaScript = NSSelectorFromString("cmuxEvaluateJavaScript:completionHandler:")
+    static let takeSnapshot = NSSelectorFromString("cmuxTakeSnapshot:")
+    static let setStateChangedHandler = NSSelectorFromString("cmuxSetStateChangedHandler:")
+    static let setProxyConfiguration = NSSelectorFromString("cmuxSetProxyConfiguration:")
+    static let setAppearanceName = NSSelectorFromString("cmuxSetAppearanceName:")
+    static let setPageZoomFactor = NSSelectorFromString("cmuxSetPageZoomFactor:")
+    static let addUserScript = NSSelectorFromString("cmuxAddUserScript:")
+    static let addUserStyle = NSSelectorFromString("cmuxAddUserStyle:")
+}
+
+protocol BrowserEngineHost: AnyObject {
+    var nativeView: NSView { get }
+    var currentURL: URL? { get }
+    var title: String? { get }
+    var isLoading: Bool { get }
+    var canGoBack: Bool { get }
+    var canGoForward: Bool { get }
+    var estimatedProgress: Double { get }
+    var pageZoomFactor: CGFloat { get }
+
+    func load(_ request: URLRequest) throws
+    func reload() throws
+    func stopLoading() throws
+    func goBack() throws
+    func goForward() throws
+    func evaluateJavaScript(_ script: String, completion: @escaping (Result<Any?, Error>) -> Void) throws
+    func evaluateJavaScript(_ script: String) async throws -> Any?
+    func takeSnapshot(completion: @escaping (NSImage?) -> Void) throws
+    func setProxyConfiguration(_ proxyConfiguration: NSDictionary?) throws
+    func setBrowserThemeMode(_ mode: BrowserThemeMode) throws
+    func setPageZoomFactor(_ pageZoomFactor: CGFloat) throws
+    func addUserScript(_ source: String) throws
+    func addUserStyle(_ source: String) throws
+}
+
+final class BrowserWebKitEngineHost: BrowserEngineHost {
+    let webView: WKWebView
+
+    init(webView: WKWebView) {
+        self.webView = webView
+    }
+
+    var nativeView: NSView { webView }
+    var currentURL: URL? { webView.url }
+    var title: String? { webView.title }
+    var isLoading: Bool { webView.isLoading }
+    var canGoBack: Bool { webView.canGoBack }
+    var canGoForward: Bool { webView.canGoForward }
+    var estimatedProgress: Double { webView.estimatedProgress }
+    var pageZoomFactor: CGFloat { webView.pageZoom }
+
+    func load(_ request: URLRequest) throws {
+        _ = browserLoadRequest(request, in: webView)
+    }
+
+    func reload() throws {
+        webView.reload()
+    }
+
+    func stopLoading() throws {
+        webView.stopLoading()
+    }
+
+    func goBack() throws {
+        webView.goBack()
+    }
+
+    func goForward() throws {
+        webView.goForward()
+    }
+
+    func evaluateJavaScript(_ script: String, completion: @escaping (Result<Any?, Error>) -> Void) throws {
+        webView.evaluateJavaScript(script) { value, error in
+            if let error {
+                completion(.failure(error))
+            } else {
+                completion(.success(value))
+            }
+        }
+    }
+
+    func evaluateJavaScript(_ script: String) async throws -> Any? {
+        try await webView.evaluateJavaScript(script)
+    }
+
+    func takeSnapshot(completion: @escaping (NSImage?) -> Void) throws {
+        let config = WKSnapshotConfiguration()
+        webView.takeSnapshot(with: config) { image, error in
+            if let error = error {
+                NSLog("BrowserPanel snapshot error: %@", error.localizedDescription)
+                completion(nil)
+                return
+            }
+            completion(image)
+        }
+    }
+
+    func setProxyConfiguration(_ proxyConfiguration: NSDictionary?) throws {}
+
+    func setBrowserThemeMode(_ mode: BrowserThemeMode) throws {
+        BrowserThemeSettings.apply(mode, to: webView)
+    }
+
+    func setPageZoomFactor(_ pageZoomFactor: CGFloat) throws {
+        webView.pageZoom = pageZoomFactor
+    }
+
+    func addUserScript(_ source: String) throws {
+        let userScript = WKUserScript(source: source, injectionTime: .atDocumentStart, forMainFrameOnly: false)
+        webView.configuration.userContentController.addUserScript(userScript)
+    }
+
+    func addUserStyle(_ source: String) throws {
+        let userScript = WKUserScript(source: source, injectionTime: .atDocumentStart, forMainFrameOnly: false)
+        webView.configuration.userContentController.addUserScript(userScript)
+    }
+}
+
+final class BrowserChromiumEngineHost: BrowserEngineHost {
+    let bridge: BrowserChromiumHostBridge
+
+    init(bridge: BrowserChromiumHostBridge) {
+        self.bridge = bridge
+    }
+
+    var nativeView: NSView { bridge.nativeView }
+    var currentURL: URL? { bridge.currentURL }
+    var title: String? { bridge.title }
+    var isLoading: Bool { bridge.isLoading }
+    var canGoBack: Bool { bridge.canGoBack }
+    var canGoForward: Bool { bridge.canGoForward }
+    var estimatedProgress: Double { bridge.estimatedProgress }
+    var pageZoomFactor: CGFloat { bridge.pageZoomFactor }
+
+    func load(_ request: URLRequest) throws {
+        try bridge.load(browserPreparedNavigationRequest(request))
+    }
+
+    func reload() throws {
+        try bridge.reload()
+    }
+
+    func stopLoading() throws {
+        try bridge.stopLoading()
+    }
+
+    func goBack() throws {
+        try bridge.goBack()
+    }
+
+    func goForward() throws {
+        try bridge.goForward()
+    }
+
+    func evaluateJavaScript(_ script: String, completion: @escaping (Result<Any?, Error>) -> Void) throws {
+        try bridge.evaluateJavaScript(script, completion: completion)
+    }
+
+    func evaluateJavaScript(_ script: String) async throws -> Any? {
+        try await bridge.evaluateJavaScript(script)
+    }
+
+    func takeSnapshot(completion: @escaping (NSImage?) -> Void) throws {
+        try bridge.takeSnapshot(completion: completion)
+    }
+
+    func setProxyConfiguration(_ proxyConfiguration: NSDictionary?) throws {
+        try bridge.setProxyConfiguration(proxyConfiguration)
+    }
+
+    func setBrowserThemeMode(_ mode: BrowserThemeMode) throws {
+        try bridge.setBrowserThemeMode(mode)
+    }
+
+    func setPageZoomFactor(_ pageZoomFactor: CGFloat) throws {
+        try bridge.setPageZoomFactor(pageZoomFactor)
+    }
+
+    func addUserScript(_ source: String) throws {
+        try bridge.addUserScript(source)
+    }
+
+    func addUserStyle(_ source: String) throws {
+        try bridge.addUserStyle(source)
+    }
+}
+
+enum BrowserChromiumHostFactoryError: Error, Equatable, CustomStringConvertible {
+    case missingFactoryClass(String)
+    case invalidFactoryClass(String)
+    case factoryReturnedNil(String)
+    case bridgeCreationFailed(String)
+    case bundleLoadFailed(String)
+
+    var description: String {
+        switch self {
+        case .missingFactoryClass(let name):
+            return "Chromium host factory class not found: \(name)"
+        case .invalidFactoryClass(let name):
+            return "Chromium host factory class does not conform to CMUXChromiumBrowserHostFactoryExporting: \(name)"
+        case .factoryReturnedNil(let name):
+            return "Chromium host factory returned nil: \(name)"
+        case .bridgeCreationFailed(let message):
+            return "Chromium host bridge creation failed: \(message)"
+        case .bundleLoadFailed(let message):
+            return "Chromium framework bundle failed to load: \(message)"
+        }
+    }
+}
+
+enum BrowserChromiumHostFactory {
+    static func loadBridge(
+        manifest: BrowserChromiumArtifactManifest,
+        frameworkURL: URL,
+        profileIdentifier: UUID,
+        dataDirectory: URL,
+        proxyConfiguration: NSDictionary?
+    ) throws -> BrowserChromiumHostBridge {
+        if let bundle = Bundle(url: frameworkURL), !bundle.isLoaded {
+            do {
+                try bundle.loadAndReturnError()
+            } catch {
+                throw BrowserChromiumHostFactoryError.bundleLoadFailed(error.localizedDescription)
+            }
+        }
+
+        let factoryClassName = manifest.hostFactoryClassName
+            ?? BrowserChromiumArtifactManifest.hostFactoryClassName
+        guard let factoryClass = NSClassFromString(factoryClassName) else {
+            throw BrowserChromiumHostFactoryError.missingFactoryClass(factoryClassName)
+        }
+        guard let factoryType = factoryClass as? BrowserChromiumHostFactoryExporting.Type else {
+            throw BrowserChromiumHostFactoryError.invalidFactoryClass(factoryClassName)
+        }
+        return try makeBridge(
+            factoryType: factoryType,
+            factoryClassName: factoryClassName,
+            profileIdentifier: profileIdentifier,
+            dataDirectory: dataDirectory,
+            proxyConfiguration: proxyConfiguration
+        )
+    }
+
+    static func makeBridge(
+        factoryType: BrowserChromiumHostFactoryExporting.Type,
+        factoryClassName: String,
+        profileIdentifier: UUID,
+        dataDirectory: URL,
+        proxyConfiguration: NSDictionary?
+    ) throws -> BrowserChromiumHostBridge {
+        guard let exportedHost = factoryType.cmuxCreateBrowserHost(
+            profileIdentifier: profileIdentifier.uuidString,
+            dataDirectory: dataDirectory as NSURL,
+            proxyConfiguration: proxyConfiguration
+        ) else {
+            throw BrowserChromiumHostFactoryError.factoryReturnedNil(factoryClassName)
+        }
+        do {
+            return try BrowserChromiumHostBridge(exportedHost: exportedHost)
+        } catch {
+            throw BrowserChromiumHostFactoryError.bridgeCreationFailed(String(describing: error))
+        }
+    }
+}
+
+private enum BrowserChromiumFactorySelectors {
+    static let createHost = NSSelectorFromString("cmuxCreateBrowserHostWithProfileIdentifier:dataDirectory:proxyConfiguration:")
 }
 
 enum GhosttyBackgroundTheme {
@@ -2015,15 +2881,29 @@ final class BrowserPanel: Panel, ObservableObject {
 
     @Published private(set) var profileID: UUID
     @Published private(set) var historyStore: BrowserHistoryStore
+    @Published private(set) var browserEngineRuntimeStatus: BrowserEngineRuntimeStatus = BrowserEngineRuntimePolicy.currentStatus()
 
     /// The underlying web view
     private(set) var webView: WKWebView
     private var websiteDataStore: WKWebsiteDataStore
+    private var browserEngineHost: BrowserEngineHost
     var webViewDidRequestClose: (() -> Void)?
 
     /// Monotonic identity for the current WKWebView instance.
     /// Incremented whenever we replace the underlying WKWebView after a process crash.
     @Published private(set) var webViewInstanceID: UUID = UUID()
+
+    /// Monotonic identity for the active browser engine host. This changes when
+    /// cmux swaps between the WebKit fallback and a Chromium native view.
+    @Published private(set) var browserEngineHostInstanceID: UUID = UUID()
+
+    var browserEngineNativeView: NSView {
+        browserEngineHost.nativeView
+    }
+
+    var usesChromiumBrowserEngine: Bool {
+        browserEngineRuntimeStatus.kind == .chromium && browserEngineHost is BrowserChromiumEngineHost
+    }
 
     /// Prevent the omnibar from auto-focusing for a short window after explicit programmatic focus.
     /// This avoids races where SwiftUI focus state steals first responder back from WebKit.
@@ -2766,6 +3646,112 @@ final class BrowserPanel: Panel, ObservableObject {
         return instanceID == webViewInstanceID
     }
 
+    private static func chromiumDataDirectory(for profileID: UUID) -> URL {
+        let fm = FileManager.default
+        let appSupport = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
+                .appendingPathComponent("Library", isDirectory: true)
+                .appendingPathComponent("Application Support", isDirectory: true)
+        let bundleId = Bundle.main.bundleIdentifier ?? "cmux"
+        let namespace = BrowserHistoryStore.normalizedBrowserHistoryNamespaceForBundleIdentifier(bundleId)
+        return appSupport
+            .appendingPathComponent(namespace, isDirectory: true)
+            .appendingPathComponent("chromium_profiles", isDirectory: true)
+            .appendingPathComponent(profileID.uuidString.lowercased(), isDirectory: true)
+    }
+
+    private func installWebKitBrowserEngineHost(
+        fallbackReason: String?,
+        manifest: BrowserChromiumArtifactManifest? = nil,
+        reason: String
+    ) {
+        browserEngineHost = BrowserWebKitEngineHost(webView: webView)
+        browserEngineRuntimeStatus = BrowserEngineRuntimeStatus(
+            kind: .webKit,
+            manifest: manifest,
+            fallbackReason: fallbackReason
+        )
+        browserEngineHostInstanceID = UUID()
+#if DEBUG
+        cmuxDebugLog(
+            "browser.engine.webkit panel=\(id.uuidString.prefix(5)) " +
+            "reason=\(reason) fallback=\(fallbackReason ?? "nil")"
+        )
+#endif
+    }
+
+    private func installPreferredBrowserEngineHost(reason: String) {
+        let status = BrowserEngineRuntimePolicy.currentStatus()
+        guard status.kind == .chromium,
+              let manifest = status.manifest,
+              let frameworkURL = BrowserChromiumArtifactVerifier.defaultFrameworkURL() else {
+            installWebKitBrowserEngineHost(
+                fallbackReason: status.fallbackReason,
+                manifest: status.manifest,
+                reason: reason
+            )
+            return
+        }
+
+        do {
+            let dataDirectory = Self.chromiumDataDirectory(for: profileID)
+            try FileManager.default.createDirectory(at: dataDirectory, withIntermediateDirectories: true)
+            let bridge = try BrowserChromiumHostFactory.loadBridge(
+                manifest: manifest,
+                frameworkURL: frameworkURL,
+                profileIdentifier: profileID,
+                dataDirectory: dataDirectory,
+                proxyConfiguration: chromiumProxyConfiguration()
+            )
+            bridge.setStateChangedHandler { [weak self] in
+                Task { @MainActor [weak self] in
+                    self?.refreshBrowserEngineHostState(reason: "chromiumStateChanged")
+                }
+            }
+            browserEngineHost = BrowserChromiumEngineHost(bridge: bridge)
+            browserEngineRuntimeStatus = status
+            browserEngineHostInstanceID = UUID()
+            applyBrowserThemeModeIfNeeded()
+            refreshBrowserEngineHostState(reason: reason)
+#if DEBUG
+            cmuxDebugLog(
+                "browser.engine.chromium panel=\(id.uuidString.prefix(5)) " +
+                "reason=\(reason) framework=\(frameworkURL.path)"
+            )
+#endif
+        } catch {
+            installWebKitBrowserEngineHost(
+                fallbackReason: "chromium_host_creation_failed",
+                manifest: manifest,
+                reason: reason
+            )
+        }
+    }
+
+    private func refreshBrowserEngineHostState(reason: String) {
+        currentURL = Self.remoteProxyDisplayURL(for: browserEngineHost.currentURL)
+        let trimmedTitle = (browserEngineHost.title ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedTitle.isEmpty {
+            pageTitle = trimmedTitle
+        }
+        nativeCanGoBack = browserEngineHost.canGoBack
+        nativeCanGoForward = browserEngineHost.canGoForward
+        estimatedProgress = browserEngineHost.estimatedProgress
+        if usesChromiumBrowserEngine {
+            isLoading = browserEngineHost.isLoading
+        }
+        refreshNavigationAvailability()
+        GlobalSearchCoordinator.shared.captureBrowserPanel(self)
+#if DEBUG
+        cmuxDebugLog(
+            "browser.engine.state panel=\(id.uuidString.prefix(5)) reason=\(reason) " +
+            "kind=\(browserEngineRuntimeStatus.kind.rawValue) " +
+            "url=\(currentURL?.absoluteString ?? "nil") loading=\(isLoading ? 1 : 0) " +
+            "progress=\(String(format: "%.2f", estimatedProgress))"
+        )
+#endif
+    }
+
     init(
         workspaceId: UUID,
         profileID: UUID? = nil,
@@ -2798,6 +3784,7 @@ final class BrowserPanel: Panel, ObservableObject {
             websiteDataStore: websiteDataStore
         )
         self.webView = webView
+        self.browserEngineHost = BrowserWebKitEngineHost(webView: webView)
         self.insecureHTTPAlertFactory = { NSAlert() }
         applyRemoteProxyConfigurationIfAvailable()
         BrowserProfileStore.shared.noteUsed(resolvedProfileID)
@@ -2896,6 +3883,7 @@ final class BrowserPanel: Panel, ObservableObject {
         self.uiDelegate = browserUIDelegate
 
         bindWebView(webView)
+        installPreferredBrowserEngineHost(reason: "init")
         installDetachedDeveloperToolsWindowCloseObserver()
         applyBrowserThemeModeIfNeeded()
         ReactGrabScriptLoader.prefetch()
@@ -2944,6 +3932,9 @@ final class BrowserPanel: Panel, ObservableObject {
     }
 
     private func applyRemoteProxyConfigurationIfAvailable() {
+        defer {
+            try? browserEngineHost.setProxyConfiguration(chromiumProxyConfiguration())
+        }
         guard #available(macOS 14.0, *) else { return }
 
         let store = webView.configuration.websiteDataStore
@@ -2966,6 +3957,22 @@ final class BrowserPanel: Panel, ObservableObject {
         store.proxyConfigurations = [socks, connect]
     }
 
+    private func chromiumProxyConfiguration() -> NSDictionary? {
+        guard let endpoint = remoteProxyEndpoint else { return nil }
+        let host = endpoint.host.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !host.isEmpty,
+              endpoint.port > 0,
+              endpoint.port <= 65535 else {
+            return nil
+        }
+        let chromiumHost = host.contains(":") && !host.hasPrefix("[") ? "[\(host)]" : host
+        return [
+            "proxyServer": "socks5://\(chromiumHost):\(endpoint.port)",
+            "host": host,
+            "port": endpoint.port,
+        ] as NSDictionary
+    }
+
     private func beginDownloadActivity() {
         let apply = {
             self.activeDownloadCount += 1
@@ -2974,7 +3981,9 @@ final class BrowserPanel: Panel, ObservableObject {
         if Thread.isMainThread {
             apply()
         } else {
-            DispatchQueue.main.async(execute: apply)
+            DispatchQueue.main.async {
+                apply()
+            }
         }
     }
 
@@ -2986,7 +3995,9 @@ final class BrowserPanel: Panel, ObservableObject {
         if Thread.isMainThread {
             apply()
         } else {
-            DispatchQueue.main.async(execute: apply)
+            DispatchQueue.main.async {
+                apply()
+            }
         }
     }
 
@@ -3075,6 +4086,7 @@ final class BrowserPanel: Panel, ObservableObject {
         replacement.pageZoom = desiredZoom
         webViewInstanceID = UUID()
         webView = replacement
+        installPreferredBrowserEngineHost(reason: "profile_switch")
         currentURL = restoreURL
         shouldRenderWebView = wasRenderable
 
@@ -3146,9 +4158,9 @@ final class BrowserPanel: Panel, ObservableObject {
     }
 
     private func resolvedLiveSessionHistoryURL() -> URL? {
-        if let webViewURL = Self.remoteProxyDisplayURL(for: webView.url),
-           Self.serializableSessionHistoryURLString(webViewURL) != nil {
-            return webViewURL
+        if let engineURL = Self.remoteProxyDisplayURL(for: browserEngineHost.currentURL),
+           Self.serializableSessionHistoryURLString(engineURL) != nil {
+            return engineURL
         }
         if let currentURL,
            Self.serializableSessionHistoryURLString(currentURL) != nil {
@@ -3425,6 +4437,7 @@ final class BrowserPanel: Panel, ObservableObject {
         replacement.pageZoom = desiredZoom
         webViewInstanceID = UUID()
         webView = replacement
+        installPreferredBrowserEngineHost(reason: "webview_replace.\(reason)")
         shouldRenderWebView = wasRenderable
 
         bindWebView(replacement)
@@ -3475,21 +4488,22 @@ final class BrowserPanel: Panel, ObservableObject {
             return
         }
 
-        guard let window = webView.window, !webView.isHiddenOrHasHiddenAncestor else { return }
+        let contentView = browserEngineNativeView
+        guard let window = contentView.window, !contentView.isHiddenOrHasHiddenAncestor else { return }
 
         // If nothing meaningful is loaded yet, prefer letting the omnibar take focus.
-        if !webView.isLoading {
-            let urlString = Self.remoteProxyDisplayURL(for: webView.url)?.absoluteString ?? currentURL?.absoluteString
+        if !browserEngineHost.isLoading {
+            let urlString = Self.remoteProxyDisplayURL(for: browserEngineHost.currentURL)?.absoluteString ?? currentURL?.absoluteString
             if urlString == nil || urlString == "about:blank" {
                 return
             }
         }
 
-        if Self.responderChainContains(window.firstResponder, target: webView) {
+        if Self.responderChainContains(window.firstResponder, target: contentView) {
             noteWebViewFocused()
             return
         }
-        if window.makeFirstResponder(webView) {
+        if window.makeFirstResponder(contentView) {
             noteWebViewFocused()
         }
     }
@@ -3502,25 +4516,26 @@ final class BrowserPanel: Panel, ObservableObject {
         clearWebViewFocusSuppression()
         NotificationCenter.default.post(name: .browserDidBlurAddressBar, object: id)
 
-        guard let window = webView.window, !webView.isHiddenOrHasHiddenAncestor else { return false }
+        let contentView = browserEngineNativeView
+        guard let window = contentView.window, !contentView.isHiddenOrHasHiddenAncestor else { return false }
 
-        if Self.responderChainContains(window.firstResponder, target: webView) {
+        if Self.responderChainContains(window.firstResponder, target: contentView) {
             // Prevent omnibar auto-focus from immediately stealing first responder back.
             suppressOmnibarAutofocus(for: 1.5)
             noteWebViewFocused()
             return true
         }
 
-        guard window.makeFirstResponder(webView) else { return false }
+        guard window.makeFirstResponder(contentView) else { return false }
         // Prevent omnibar auto-focus from immediately stealing first responder back.
         suppressOmnibarAutofocus(for: 1.5)
         noteWebViewFocused()
 
-        DispatchQueue.main.async { [weak self, weak window, weak webView] in
-            guard let self, let window, let webView else { return }
-            guard webView.window === window else { return }
-            if !Self.responderChainContains(window.firstResponder, target: webView),
-               window.makeFirstResponder(webView) {
+        DispatchQueue.main.async { [weak self, weak window, weak contentView] in
+            guard let self, let window, let contentView else { return }
+            guard contentView.window === window else { return }
+            if !Self.responderChainContains(window.firstResponder, target: contentView),
+               window.makeFirstResponder(contentView) {
                 self.suppressOmnibarAutofocus(for: 1.5)
                 self.noteWebViewFocused()
             }
@@ -3531,8 +4546,9 @@ final class BrowserPanel: Panel, ObservableObject {
 
     func unfocus() {
         invalidateSearchFocusRequests(reason: "panelUnfocus")
-        guard let window = webView.window else { return }
-        if Self.responderChainContains(window.firstResponder, target: webView) {
+        let contentView = browserEngineNativeView
+        guard let window = contentView.window else { return }
+        if Self.responderChainContains(window.firstResponder, target: contentView) {
             window.makeFirstResponder(nil)
         }
     }
@@ -4002,7 +5018,28 @@ final class BrowserPanel: Panel, ObservableObject {
             historyStore.recordTypedNavigation(url: originalURL)
         }
         navigationDelegate?.lastAttemptedURL = originalURL
-        browserLoadRequest(effectiveRequest, in: webView)
+        do {
+            try browserEngineHost.load(effectiveRequest)
+            refreshBrowserEngineHostState(reason: "load")
+        } catch {
+            handleBrowserEngineHostOperationFailure("load", error: error)
+            if browserEngineRuntimeStatus.kind == .webKit {
+                try? browserEngineHost.load(effectiveRequest)
+            }
+        }
+    }
+
+    private func handleBrowserEngineHostOperationFailure(_ operation: String, error: Error) {
+        browserEngineLogger.error(
+            "Browser engine host \(operation, privacy: .public) failed for panel \(self.id.uuidString, privacy: .public): \(String(describing: error), privacy: .private)"
+        )
+        if browserEngineRuntimeStatus.kind == .chromium {
+            installWebKitBrowserEngineHost(
+                fallbackReason: "browser_engine_operation_failed",
+                manifest: browserEngineRuntimeStatus.manifest,
+                reason: "operation_failed.\(operation)"
+            )
+        }
     }
 
     private func remoteProxyPreparedRequest(from request: URLRequest, logScope: String) -> URLRequest {
@@ -4300,6 +5337,7 @@ extension BrowserPanel {
         )
         webViewInstanceID = UUID()
         webView = replacement
+        installPreferredBrowserEngineHost(reason: "context_reset.\(reason)")
         shouldRenderWebView = false
         bindWebView(replacement)
         applyBrowserThemeModeIfNeeded()
@@ -4382,7 +5420,12 @@ extension BrowserPanel {
             }
 
             if nativeCanGoBack {
-                webView.goBack()
+                do {
+                    try browserEngineHost.goBack()
+                    refreshBrowserEngineHostState(reason: "goBack")
+                } catch {
+                    handleBrowserEngineHostOperationFailure("goBack", error: error)
+                }
                 return
             }
 
@@ -4390,7 +5433,12 @@ extension BrowserPanel {
             return
         }
 
-        webView.goBack()
+        do {
+            try browserEngineHost.goBack()
+            refreshBrowserEngineHostState(reason: "goBack")
+        } catch {
+            handleBrowserEngineHostOperationFailure("goBack", error: error)
+        }
     }
 
     /// Go forward in history
@@ -4400,7 +5448,12 @@ extension BrowserPanel {
             realignRestoredSessionHistoryToLiveCurrentIfPossible()
 
             if nativeCanGoForward {
-                webView.goForward()
+                do {
+                    try browserEngineHost.goForward()
+                    refreshBrowserEngineHostState(reason: "goForward")
+                } catch {
+                    handleBrowserEngineHostOperationFailure("goForward", error: error)
+                }
                 return
             }
 
@@ -4421,7 +5474,12 @@ extension BrowserPanel {
             return
         }
 
-        webView.goForward()
+        do {
+            try browserEngineHost.goForward()
+            refreshBrowserEngineHostState(reason: "goForward")
+        } catch {
+            handleBrowserEngineHostOperationFailure("goForward", error: error)
+        }
     }
 
     /// Open a link in a new browser surface in the same pane
@@ -4499,7 +5557,7 @@ extension BrowserPanel {
     /// Reload the current page
     func reload() {
         webView.customUserAgent = BrowserUserAgentSettings.safariUserAgent
-        if Self.serializableSessionHistoryURLString(Self.remoteProxyDisplayURL(for: webView.url)) == nil {
+        if Self.serializableSessionHistoryURLString(Self.remoteProxyDisplayURL(for: browserEngineHost.currentURL)) == nil {
             let fallbackURL = resolvedCurrentSessionHistoryURL()
                 ?? Self.remoteProxyDisplayURL(for: navigationDelegate?.lastAttemptedURL)
 
@@ -4513,12 +5571,22 @@ extension BrowserPanel {
                 return
             }
         }
-        webView.reload()
+        do {
+            try browserEngineHost.reload()
+            refreshBrowserEngineHostState(reason: "reload")
+        } catch {
+            handleBrowserEngineHostOperationFailure("reload", error: error)
+        }
     }
 
     /// Stop loading
     func stopLoading() {
-        webView.stopLoading()
+        do {
+            try browserEngineHost.stopLoading()
+            refreshBrowserEngineHostState(reason: "stopLoading")
+        } catch {
+            handleBrowserEngineHostOperationFailure("stopLoading", error: error)
+        }
     }
 
     private static func windowContainsInspectorViews(_ root: NSView) -> Bool {
@@ -5102,12 +6170,12 @@ extension BrowserPanel {
 
     @discardableResult
     func zoomIn() -> Bool {
-        applyPageZoom(webView.pageZoom + pageZoomStep)
+        applyPageZoom(browserEngineHost.pageZoomFactor + pageZoomStep)
     }
 
     @discardableResult
     func zoomOut() -> Bool {
-        applyPageZoom(webView.pageZoom - pageZoomStep)
+        applyPageZoom(browserEngineHost.pageZoomFactor - pageZoomStep)
     }
 
     @discardableResult
@@ -5116,7 +6184,7 @@ extension BrowserPanel {
     }
 
     func currentPageZoomFactor() -> CGFloat {
-        webView.pageZoom
+        browserEngineHost.pageZoomFactor
     }
 
     @discardableResult
@@ -5127,20 +6195,25 @@ extension BrowserPanel {
 
     /// Take a snapshot of the web view
     func takeSnapshot(completion: @escaping (NSImage?) -> Void) {
-        let config = WKSnapshotConfiguration()
-        webView.takeSnapshot(with: config) { image, error in
-            if let error = error {
-                NSLog("BrowserPanel snapshot error: %@", error.localizedDescription)
-                completion(nil)
-                return
-            }
-            completion(image)
+        do {
+            try browserEngineHost.takeSnapshot(completion: completion)
+        } catch {
+            handleBrowserEngineHostOperationFailure("takeSnapshot", error: error)
+            completion(nil)
         }
     }
 
     /// Execute JavaScript
     func evaluateJavaScript(_ script: String) async throws -> Any? {
-        try await webView.evaluateJavaScript(script)
+        try await browserEngineHost.evaluateJavaScript(script)
+    }
+
+    func evaluateJavaScript(_ script: String, completion: @escaping (Result<Any?, Error>) -> Void) {
+        do {
+            try browserEngineHost.evaluateJavaScript(script, completion: completion)
+        } catch {
+            completion(.failure(error))
+        }
     }
 
     // MARK: - Find in Page
@@ -5189,7 +6262,7 @@ extension BrowserPanel {
     func findNext() {
         Task { @MainActor [weak self] in
             guard let self else { return }
-            let result = try? await self.webView.evaluateJavaScript(BrowserFindJavaScript.nextScript())
+            let result = try? await self.evaluateJavaScript(BrowserFindJavaScript.nextScript())
             self.parseFindResult(result)
         }
     }
@@ -5197,7 +6270,7 @@ extension BrowserPanel {
     func findPrevious() {
         Task { @MainActor [weak self] in
             guard let self else { return }
-            let result = try? await self.webView.evaluateJavaScript(BrowserFindJavaScript.previousScript())
+            let result = try? await self.evaluateJavaScript(BrowserFindJavaScript.previousScript())
             self.parseFindResult(result)
         }
     }
@@ -5230,7 +6303,7 @@ extension BrowserPanel {
             guard let self else { return }
             let js = BrowserFindJavaScript.searchScript(query: needle)
             do {
-                let result = try await self.webView.evaluateJavaScript(js)
+                let result = try await self.evaluateJavaScript(js)
                 self.parseFindResult(result)
             } catch {
                 NSLog("Find: browser JS search error: %@", error.localizedDescription)
@@ -5238,11 +6311,41 @@ extension BrowserPanel {
         }
     }
 
+    @discardableResult
+    func addPersistentUserScript(_ source: String) -> Bool {
+        do {
+            try browserEngineHost.addUserScript(source)
+            return true
+        } catch {
+            handleBrowserEngineHostOperationFailure("addUserScript", error: error)
+            if browserEngineRuntimeStatus.kind == .webKit {
+                try? browserEngineHost.addUserScript(source)
+                return true
+            }
+            return false
+        }
+    }
+
+    @discardableResult
+    func addPersistentUserStyle(_ source: String) -> Bool {
+        do {
+            try browserEngineHost.addUserStyle(source)
+            return true
+        } catch {
+            handleBrowserEngineHostOperationFailure("addUserStyle", error: error)
+            if browserEngineRuntimeStatus.kind == .webKit {
+                try? browserEngineHost.addUserStyle(source)
+                return true
+            }
+            return false
+        }
+    }
+
     private func executeFindClear() {
         Task { @MainActor [weak self] in
             guard let self else { return }
             do {
-                _ = try await self.webView.evaluateJavaScript(BrowserFindJavaScript.clearScript())
+                _ = try await self.evaluateJavaScript(BrowserFindJavaScript.clearScript())
             } catch {
                 NSLog("Find: browser JS clear error: %@", error.localizedDescription)
             }
@@ -5404,7 +6507,7 @@ extension BrowserPanel {
         }
 
         if let window,
-           Self.responderChainContains(window.firstResponder, target: webView) {
+           Self.responderChainContains(window.firstResponder, target: browserEngineNativeView) {
             return .browser(.webView)
         }
 
@@ -5479,7 +6582,7 @@ extension BrowserPanel {
             return .browser(.findField)
         }
 
-        if Self.responderChainContains(responder, target: webView) {
+        if Self.responderChainContains(responder, target: browserEngineNativeView) {
             return .browser(.webView)
         }
 
@@ -5513,7 +6616,7 @@ extension BrowserPanel {
 #endif
             return true
         case .webView:
-            guard Self.responderChainContains(window.firstResponder, target: webView) else { return false }
+            guard Self.responderChainContains(window.firstResponder, target: browserEngineNativeView) else { return false }
             return window.makeFirstResponder(nil)
         }
     }
@@ -5567,25 +6670,26 @@ extension BrowserPanel {
     }
 
     private func captureAddressBarPageFocusIfNeeded() {
-        webView.evaluateJavaScript(Self.addressBarFocusCaptureScript) { [weak self] result, error in
-#if DEBUG
+        Task { @MainActor [weak self] in
             guard let self else { return }
-            if let error {
+            let result: Any?
+            do {
+                result = try await self.evaluateJavaScript(Self.addressBarFocusCaptureScript)
+            } catch {
+#if DEBUG
                 cmuxDebugLog(
-                    "browser.focus.addressBar.capture panel=\(self.id.uuidString.prefix(5)) " +
+                    "browser.focus.addressBar.capture panel=\(id.uuidString.prefix(5)) " +
                     "result=error message=\(error.localizedDescription)"
                 )
+#endif
                 return
             }
+#if DEBUG
             let resultValue = (result as? String) ?? "unknown"
             cmuxDebugLog(
-                "browser.focus.addressBar.capture panel=\(self.id.uuidString.prefix(5)) " +
+                "browser.focus.addressBar.capture panel=\(id.uuidString.prefix(5)) " +
                 "result=\(resultValue)"
             )
-#else
-            _ = self
-            _ = result
-            _ = error
 #endif
         }
     }
@@ -5639,7 +6743,7 @@ extension BrowserPanel {
             completion(false)
             return
         }
-        webView.evaluateJavaScript(Self.addressBarFocusRestoreScript) { [weak self] result, error in
+        Task { @MainActor [weak self] in
             guard let self else {
                 completion(false)
                 return
@@ -5647,6 +6751,16 @@ extension BrowserPanel {
             guard generation == self.addressBarFocusRestoreGeneration else {
                 completion(false)
                 return
+            }
+
+            let result: Any?
+            let error: Error?
+            do {
+                result = try await self.evaluateJavaScript(Self.addressBarFocusRestoreScript)
+                error = nil
+            } catch let caughtError {
+                result = nil
+                error = caughtError
             }
 
             let status = Self.addressBarPageFocusRestoreStatus(from: result, error: error)
@@ -5699,13 +6813,13 @@ extension BrowserPanel {
     }
 
     /// Returns the most reliable URL string for omnibar-related matching and UI decisions.
-    /// `currentURL` can lag behind navigation changes, so prefer the live WKWebView URL.
+    /// `currentURL` can lag behind navigation changes, so prefer the live engine URL.
     func preferredURLStringForOmnibar() -> String? {
-        if let webViewURL = Self.remoteProxyDisplayURL(for: webView.url)?.absoluteString
+        if let engineURL = Self.remoteProxyDisplayURL(for: browserEngineHost.currentURL)?.absoluteString
             .trimmingCharacters(in: .whitespacesAndNewlines),
-           !webViewURL.isEmpty,
-           webViewURL != blankURLString {
-            return webViewURL
+           !engineURL.isEmpty,
+           engineURL != blankURLString {
+            return engineURL
         }
 
         if let current = currentURL?.absoluteString
@@ -5719,9 +6833,9 @@ extension BrowserPanel {
     }
 
     private func resolvedCurrentSessionHistoryURL() -> URL? {
-        if let webViewURL = Self.remoteProxyDisplayURL(for: webView.url),
-           Self.serializableSessionHistoryURLString(webViewURL) != nil {
-            return webViewURL
+        if let engineURL = Self.remoteProxyDisplayURL(for: browserEngineHost.currentURL),
+           Self.serializableSessionHistoryURLString(engineURL) != nil {
+            return engineURL
         }
         if let currentURL,
            Self.serializableSessionHistoryURLString(currentURL) != nil {
@@ -5781,6 +6895,7 @@ extension BrowserPanel {
 private extension BrowserPanel {
     func applyBrowserThemeModeIfNeeded() {
         BrowserThemeSettings.apply(browserThemeMode, to: webView)
+        try? browserEngineHost.setBrowserThemeMode(browserThemeMode)
     }
 
     func scheduleDeveloperToolsRestoreRetry() {
@@ -5893,11 +7008,20 @@ private extension BrowserPanel {
     @discardableResult
     func applyPageZoom(_ candidate: CGFloat) -> Bool {
         let clamped = max(minPageZoom, min(maxPageZoom, candidate))
-        if abs(webView.pageZoom - clamped) < 0.0001 {
+        if abs(browserEngineHost.pageZoomFactor - clamped) < 0.0001 {
             return false
         }
-        webView.pageZoom = clamped
-        return true
+        do {
+            try browserEngineHost.setPageZoomFactor(clamped)
+            return true
+        } catch {
+            handleBrowserEngineHostOperationFailure("setPageZoomFactor", error: error)
+            if browserEngineRuntimeStatus.kind == .webKit {
+                try? browserEngineHost.setPageZoomFactor(clamped)
+                return true
+            }
+            return false
+        }
     }
 
     static func responderChainContains(_ start: NSResponder?, target: NSResponder) -> Bool {

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -16,6 +16,7 @@ import Security
 #endif
 
 private let browserEngineLogger = Logger(subsystem: "com.cmuxterm.app", category: "browser-engine")
+private let chromiumDevToolsProxyLogger = Logger(subsystem: "com.cmuxterm.app", category: "chromium-devtools-proxy")
 
 fileprivate func dedupedCanonicalURLs(_ urls: [URL]) -> [URL] {
     var seen = Set<String>()
@@ -62,6 +63,7 @@ struct BrowserChromiumArtifactManifest: Codable, Equatable, Sendable {
     var hostClassName: String?
     var hostFactoryClassName: String?
     var hostAPIVersion: Int?
+    var forbiddenCEFMarkersVerifiedAbsent: [String]? = nil
     var launchPolicy: BrowserChromiumLaunchPolicy? = nil
     var renderingAPI: BrowserChromiumRenderingAPI? = nil
 
@@ -75,6 +77,7 @@ struct BrowserChromiumArtifactManifest: Codable, Equatable, Sendable {
             hostClassName: hostClassName,
             hostFactoryClassName: hostFactoryClassName,
             hostAPIVersion: hostAPIVersion,
+            forbiddenCEFMarkersVerifiedAbsent: nil,
             launchPolicy: nil,
             renderingAPI: nil
         )
@@ -113,6 +116,9 @@ struct BrowserEngineRuntimeStatus: Equatable {
             payload["host_class_name"] = manifest.hostClassName ?? NSNull()
             payload["host_factory_class_name"] = manifest.hostFactoryClassName ?? NSNull()
             payload["host_api_version"] = manifest.hostAPIVersion ?? NSNull()
+            if let forbiddenCEFMarkersVerifiedAbsent = manifest.forbiddenCEFMarkersVerifiedAbsent {
+                payload["chromium_forbidden_cef_markers_verified_absent"] = forbiddenCEFMarkersVerifiedAbsent
+            }
             if let launchPolicy = manifest.launchPolicy {
                 payload["chromium_sandbox_disabled"] = launchPolicy.sandboxDisabled
                 payload["chromium_uses_in_process_gpu_by_default"] = launchPolicy.usesInProcessGPUByDefault
@@ -198,15 +204,16 @@ enum BrowserChromiumArtifactVerifier {
         try rejectCEFMarkers(in: executableURL)
 
         let resourceURL = resourcesURL(for: frameworkURL, fileManager: fileManager)
-        try rejectCEFMarkersInBundledChromium(at: resourceURL, fileManager: fileManager)
         let resourceNames = try verifyRequiredResources(in: resourceURL, fileManager: fileManager)
 
         if let manifest = try loadManifest(from: resourceURL, fileManager: fileManager) {
             try verifyLaunchPolicy(for: manifest)
+            try verifyCEFPolicy(for: manifest, resourceURL: resourceURL, fileManager: fileManager)
             return manifest
         }
 
         let inferredManifest = BrowserChromiumArtifactManifest.inferred(resourceNames: resourceNames)
+        try rejectCEFMarkersInBundledChromium(at: resourceURL, fileManager: fileManager)
         try verifyLaunchPolicy(for: inferredManifest)
         return inferredManifest
     }
@@ -320,6 +327,18 @@ enum BrowserChromiumArtifactVerifier {
         if !launchPolicy.forbiddenSwitchesVerifiedAbsent.contains("in-process-gpu") {
             throw BrowserChromiumArtifactVerificationError.insecureLaunchPolicy("in-process-gpu absence was not verified")
         }
+    }
+
+    private static func verifyCEFPolicy(
+        for manifest: BrowserChromiumArtifactManifest,
+        resourceURL: URL,
+        fileManager: FileManager
+    ) throws {
+        let proof = Set(manifest.forbiddenCEFMarkersVerifiedAbsent ?? [])
+        if Set(disallowedCEFMarkers).isSubset(of: proof) {
+            return
+        }
+        try rejectCEFMarkersInBundledChromium(at: resourceURL, fileManager: fileManager)
     }
 }
 
@@ -437,9 +456,29 @@ protocol BrowserChromiumHostExporting: NSObjectProtocol {
     @objc optional func cmuxSetPageZoomFactor(_ pageZoomFactor: NSNumber)
     @objc optional func cmuxAddUserScript(_ source: NSString)
     @objc optional func cmuxAddUserStyle(_ source: NSString)
+    @objc(cmuxSetDevToolsVisible:mode:preferredPanel:completionHandler:)
+    optional func cmuxSetDevToolsVisible(
+        _ visible: NSNumber,
+        mode: NSNumber,
+        preferredPanel: NSString?,
+        completionHandler: @escaping (NSNumber, NSString?) -> Void
+    )
+    @objc(cmuxToggleDevToolsWithMode:preferredPanel:completionHandler:)
+    optional func cmuxToggleDevTools(
+        mode: NSNumber,
+        preferredPanel: NSString?,
+        completionHandler: @escaping (NSNumber, NSString?) -> Void
+    )
+    @objc(cmuxDevToolsFrontendURLWithPanel:completionHandler:)
+    optional func cmuxDevToolsFrontendURL(
+        panel: NSString?,
+        completionHandler: @escaping (NSURL?, String?) -> Void
+    )
 }
 
 final class BrowserChromiumHostBridge {
+    private typealias DevToolsCompletionBlock = @convention(block) (NSNumber, NSString?) -> Void
+
     let exportedHost: NSObjectProtocol
     private let hostObject: NSObject
     let nativeView: NSView
@@ -631,6 +670,101 @@ final class BrowserChromiumHostBridge {
         function(hostObject, BrowserChromiumHostSelectors.addUserStyle, source as NSString)
     }
 
+    func devToolsFrontendURL(preferredPanel: String?, completion: @escaping (Result<URL, Error>) -> Void) throws {
+        typealias CompletionBlock = @convention(block) (NSURL?, String?) -> Void
+        typealias DevToolsIMP = @convention(c) (AnyObject, Selector, NSString?, CompletionBlock) -> Void
+        let function: DevToolsIMP = try implementation(
+            for: BrowserChromiumHostSelectors.devToolsFrontendURL,
+            operation: "devToolsFrontendURL"
+        )
+        let block: CompletionBlock = { url, errorMessage in
+            if let errorMessage, !errorMessage.isEmpty {
+                completion(.failure(BrowserChromiumHostBridgeError.operationFailed(errorMessage)))
+            } else if let url {
+                completion(.success(url as URL))
+            } else {
+                completion(.failure(BrowserChromiumHostBridgeError.operationFailed("Missing DevTools URL")))
+            }
+        }
+        function(
+            hostObject,
+            BrowserChromiumHostSelectors.devToolsFrontendURL,
+            preferredPanel as NSString?,
+            block
+        )
+    }
+
+    func setDevToolsVisible(
+        _ visible: Bool,
+        mode: BrowserChromiumDevToolsMode,
+        preferredPanel: String?,
+        completion: @escaping (Result<Void, Error>) -> Void
+    ) throws {
+        try invokeDevToolsVisibility(
+            selector: BrowserChromiumHostSelectors.setDevToolsVisible,
+            operation: "setDevToolsVisible",
+            visible: visible,
+            mode: mode,
+            preferredPanel: preferredPanel,
+            completion: completion
+        )
+    }
+
+    func toggleDevTools(
+        mode: BrowserChromiumDevToolsMode,
+        preferredPanel: String?,
+        completion: @escaping (Result<Void, Error>) -> Void
+    ) throws {
+        typealias DevToolsIMP = @convention(c) (AnyObject, Selector, NSNumber, NSString?, DevToolsCompletionBlock) -> Void
+        let function: DevToolsIMP = try implementation(
+            for: BrowserChromiumHostSelectors.toggleDevTools,
+            operation: "toggleDevTools"
+        )
+        let block = devToolsCompletionBlock(completion: completion)
+        function(
+            hostObject,
+            BrowserChromiumHostSelectors.toggleDevTools,
+            NSNumber(value: mode.rawValue),
+            preferredPanel as NSString?,
+            block
+        )
+    }
+
+    private func invokeDevToolsVisibility(
+        selector: Selector,
+        operation: String,
+        visible: Bool,
+        mode: BrowserChromiumDevToolsMode,
+        preferredPanel: String?,
+        completion: @escaping (Result<Void, Error>) -> Void
+    ) throws {
+        typealias DevToolsIMP = @convention(c) (AnyObject, Selector, NSNumber, NSNumber, NSString?, DevToolsCompletionBlock) -> Void
+        let function: DevToolsIMP = try implementation(for: selector, operation: operation)
+        let block = devToolsCompletionBlock(completion: completion)
+        function(
+            hostObject,
+            selector,
+            NSNumber(value: visible),
+            NSNumber(value: mode.rawValue),
+            preferredPanel as NSString?,
+            block
+        )
+    }
+
+    private func devToolsCompletionBlock(
+        completion: @escaping (Result<Void, Error>) -> Void
+    ) -> DevToolsCompletionBlock {
+        { ok, errorMessage in
+            if let errorMessage, errorMessage.length > 0 {
+                completion(.failure(BrowserChromiumHostBridgeError.operationFailed(errorMessage as String)))
+            } else if ok.boolValue {
+                completion(.success(()))
+            } else {
+                completion(.failure(BrowserChromiumHostBridgeError.operationFailed("DevTools command failed")))
+            }
+        }
+    }
+
     private func invokeVoid(selector: Selector, operation: String) throws {
         typealias VoidIMP = @convention(c) (AnyObject, Selector) -> Void
         let function: VoidIMP = try implementation(for: selector, operation: operation)
@@ -668,6 +802,464 @@ private enum BrowserChromiumHostSelectors {
     static let setPageZoomFactor = NSSelectorFromString("cmuxSetPageZoomFactor:")
     static let addUserScript = NSSelectorFromString("cmuxAddUserScript:")
     static let addUserStyle = NSSelectorFromString("cmuxAddUserStyle:")
+    static let setDevToolsVisible = NSSelectorFromString("cmuxSetDevToolsVisible:mode:preferredPanel:completionHandler:")
+    static let toggleDevTools = NSSelectorFromString("cmuxToggleDevToolsWithMode:preferredPanel:completionHandler:")
+    static let devToolsFrontendURL = NSSelectorFromString("cmuxDevToolsFrontendURLWithPanel:completionHandler:")
+}
+
+enum BrowserChromiumDevToolsMode: UInt32 {
+    case bottom = 0
+    case right = 1
+    case left = 2
+    case window = 3
+}
+
+struct ChromiumDevToolsWebSocketFrame: Equatable {
+    var opcode: UInt8
+    var payload: Data
+    var isFinal: Bool
+}
+
+enum ChromiumDevToolsWebSocketFrameCodec {
+    enum CodecError: Error {
+        case invalidLength
+    }
+
+    static func acceptKey(for key: String) -> String {
+        let magic = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+        let digest = Insecure.SHA1.hash(data: Data((key + magic).utf8))
+        return Data(digest).base64EncodedString()
+    }
+
+    static func decodeClientFrames(from buffer: inout Data) throws -> [ChromiumDevToolsWebSocketFrame] {
+        var frames: [ChromiumDevToolsWebSocketFrame] = []
+        while true {
+            let bytes = [UInt8](buffer)
+            guard bytes.count >= 2 else { break }
+
+            let first = bytes[0]
+            let second = bytes[1]
+            let isFinal = (first & 0x80) != 0
+            let opcode = first & 0x0f
+            let isMasked = (second & 0x80) != 0
+            var length = UInt64(second & 0x7f)
+            var offset = 2
+
+            if length == 126 {
+                guard bytes.count >= offset + 2 else { break }
+                length = (UInt64(bytes[offset]) << 8) | UInt64(bytes[offset + 1])
+                offset += 2
+            } else if length == 127 {
+                guard bytes.count >= offset + 8 else { break }
+                length = 0
+                for byte in bytes[offset..<(offset + 8)] {
+                    length = (length << 8) | UInt64(byte)
+                }
+                offset += 8
+            }
+
+            let maskLength = isMasked ? 4 : 0
+            guard length <= UInt64(Int.max) else { throw CodecError.invalidLength }
+            let payloadLength = Int(length)
+            guard bytes.count >= offset + maskLength + payloadLength else { break }
+
+            var maskKey: [UInt8] = []
+            if isMasked {
+                maskKey = Array(bytes[offset..<(offset + 4)])
+                offset += 4
+            }
+
+            var payload = Array(bytes[offset..<(offset + payloadLength)])
+            if isMasked {
+                for index in payload.indices {
+                    payload[index] ^= maskKey[index % 4]
+                }
+            }
+
+            buffer.removeFirst(offset + payloadLength)
+            frames.append(ChromiumDevToolsWebSocketFrame(
+                opcode: opcode,
+                payload: Data(payload),
+                isFinal: isFinal
+            ))
+        }
+        return frames
+    }
+
+    static func encodeServerFrame(opcode: UInt8, payload: Data, isFinal: Bool = true) -> Data {
+        var frame = Data()
+        frame.append((isFinal ? 0x80 : 0x00) | (opcode & 0x0f))
+        let count = payload.count
+        if count < 126 {
+            frame.append(UInt8(count))
+        } else if count <= Int(UInt16.max) {
+            frame.append(126)
+            frame.append(UInt8((count >> 8) & 0xff))
+            frame.append(UInt8(count & 0xff))
+        } else {
+            frame.append(127)
+            let length = UInt64(count)
+            for shift in stride(from: 56, through: 0, by: -8) {
+                frame.append(UInt8((length >> UInt64(shift)) & 0xff))
+            }
+        }
+        frame.append(payload)
+        return frame
+    }
+}
+
+enum ChromiumDevToolsFrontendProxyURLRewriter {
+    static func rewrite(
+        _ frontendURL: URL,
+        websocketEndpointProvider: (URL) -> String?
+    ) -> URL {
+        guard var components = URLComponents(url: frontendURL, resolvingAgainstBaseURL: false),
+              var queryItems = components.queryItems,
+              let wsIndex = queryItems.firstIndex(where: { $0.name == "ws" }),
+              let rawWebSocket = queryItems[wsIndex].value,
+              let upstreamURL = upstreamWebSocketURL(from: rawWebSocket),
+              let proxiedEndpoint = websocketEndpointProvider(upstreamURL) else {
+            return frontendURL
+        }
+
+        queryItems[wsIndex] = URLQueryItem(name: "ws", value: proxiedEndpoint)
+        components.queryItems = queryItems
+        return components.url ?? frontendURL
+    }
+
+    private static func upstreamWebSocketURL(from rawValue: String) -> URL? {
+        if rawValue.hasPrefix("ws://") || rawValue.hasPrefix("wss://") {
+            return URL(string: rawValue)
+        }
+        return URL(string: "ws://\(rawValue)")
+    }
+}
+
+final class ChromiumDevToolsWebSocketProxy {
+    static let shared = ChromiumDevToolsWebSocketProxy()
+
+    private static let ephemeralPortRange: ClosedRange<UInt16> = 49152...65535
+    private let queue = DispatchQueue(label: "cmux.chromium.devtools.websocket-proxy")
+    private var listener: NWListener?
+    private var listenerPort: UInt16?
+    private var routes: [String: URL] = [:]
+    private var connections: [ObjectIdentifier: ChromiumDevToolsProxyConnection] = [:]
+
+    func proxiedFrontendURL(_ frontendURL: URL) -> URL {
+        ChromiumDevToolsFrontendProxyURLRewriter.rewrite(frontendURL) { [weak self] upstreamURL in
+            self?.register(upstreamURL: upstreamURL)
+        }
+    }
+
+    private func register(upstreamURL: URL) -> String? {
+        queue.sync {
+            guard let port = ensureStartedOnQueue() else { return nil }
+            let requestTarget = Self.requestTarget(for: upstreamURL)
+            routes[requestTarget] = upstreamURL
+            return "127.0.0.1:\(port)\(requestTarget)"
+        }
+    }
+
+    private func ensureStartedOnQueue() -> UInt16? {
+        if let listenerPort { return listenerPort }
+
+        for _ in 0..<30 {
+            let candidate = UInt16.random(in: Self.ephemeralPortRange)
+            guard let port = NWEndpoint.Port(rawValue: candidate) else { continue }
+            do {
+                let listener = try NWListener(using: .tcp, on: port)
+                listenerPort = candidate
+                listener.stateUpdateHandler = { [weak self] state in
+                    if case .failed(let error) = state {
+                        self?.handleListenerFailure(error, port: candidate)
+                    }
+                }
+                listener.newConnectionHandler = { [weak self] connection in
+                    self?.accept(connection)
+                }
+                listener.start(queue: queue)
+                self.listener = listener
+                return candidate
+            } catch {
+                continue
+            }
+        }
+
+        chromiumDevToolsProxyLogger.error("DevTools proxy listener could not find an available port")
+        return nil
+    }
+
+    private func handleListenerFailure(_ error: NWError, port: UInt16) {
+        chromiumDevToolsProxyLogger.error("DevTools proxy listener failed on \(port): \(error.localizedDescription, privacy: .public)")
+        if listenerPort == port {
+            listenerPort = nil
+            listener = nil
+            routes.removeAll()
+        }
+    }
+
+    private func accept(_ connection: NWConnection) {
+        guard Self.isLoopback(connection.endpoint) else {
+            connection.cancel()
+            return
+        }
+
+        let bridge = ChromiumDevToolsProxyConnection(
+            connection: connection,
+            queue: queue,
+            routeResolver: { [weak self] requestTarget in
+                self?.routes[requestTarget]
+            },
+            onClose: { [weak self] identifier in
+                self?.connections.removeValue(forKey: identifier)
+            }
+        )
+        connections[ObjectIdentifier(bridge)] = bridge
+        bridge.start()
+    }
+
+    private static func requestTarget(for upstreamURL: URL) -> String {
+        var target = upstreamURL.path
+        if let query = upstreamURL.query, !query.isEmpty {
+            target += "?\(query)"
+        }
+        return target.isEmpty ? "/" : target
+    }
+
+    private static func isLoopback(_ endpoint: NWEndpoint) -> Bool {
+        guard case .hostPort(let host, _) = endpoint else { return false }
+        let value = String(describing: host).lowercased()
+        return value == "127.0.0.1" || value == "::1" || value == "localhost"
+    }
+}
+
+private final class ChromiumDevToolsProxyConnection {
+    private let connection: NWConnection
+    private let queue: DispatchQueue
+    private let routeResolver: (String) -> URL?
+    private let onClose: (ObjectIdentifier) -> Void
+    private let urlSession: URLSession
+    private var upstreamTask: URLSessionWebSocketTask?
+    private var headerBuffer = Data()
+    private var frameBuffer = Data()
+    private var fragmentedOpcode: UInt8?
+    private var fragmentedPayload = Data()
+    private var isClosed = false
+
+    init(
+        connection: NWConnection,
+        queue: DispatchQueue,
+        routeResolver: @escaping (String) -> URL?,
+        onClose: @escaping (ObjectIdentifier) -> Void
+    ) {
+        self.connection = connection
+        self.queue = queue
+        self.routeResolver = routeResolver
+        self.onClose = onClose
+        self.urlSession = URLSession(configuration: .ephemeral)
+    }
+
+    func start() {
+        connection.stateUpdateHandler = { [weak self] state in
+            if case .failed = state {
+                self?.close()
+            } else if case .cancelled = state {
+                self?.close()
+            }
+        }
+        connection.start(queue: queue)
+        receiveHTTPHeader()
+    }
+
+    private func receiveHTTPHeader() {
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 16 * 1024) { [weak self] data, _, isComplete, error in
+            guard let self else { return }
+            if error != nil || isComplete {
+                self.close()
+                return
+            }
+            if let data {
+                self.headerBuffer.append(data)
+            }
+            guard let headerRange = self.headerBuffer.range(of: Data("\r\n\r\n".utf8)) else {
+                self.receiveHTTPHeader()
+                return
+            }
+
+            let headerEnd = headerRange.upperBound
+            let headerData = self.headerBuffer.prefix(headerEnd)
+            let remaining = self.headerBuffer.dropFirst(headerEnd)
+            self.headerBuffer.removeAll()
+
+            guard let request = Self.parseRequest(Data(headerData)),
+                  let key = request.headers["sec-websocket-key"],
+                  let upstreamURL = self.routeResolver(request.target) else {
+                self.sendHTTPFailure()
+                return
+            }
+
+            self.frameBuffer.append(remaining)
+            self.open(upstreamURL: upstreamURL, clientKey: key)
+        }
+    }
+
+    private func open(upstreamURL: URL, clientKey: String) {
+        let accept = ChromiumDevToolsWebSocketFrameCodec.acceptKey(for: clientKey)
+        let response = """
+        HTTP/1.1 101 Switching Protocols\r
+        Upgrade: websocket\r
+        Connection: Upgrade\r
+        Sec-WebSocket-Accept: \(accept)\r
+        \r
+        """
+        connection.send(content: Data(response.utf8), completion: .contentProcessed { [weak self] error in
+            guard let self else { return }
+            if error != nil {
+                self.close()
+                return
+            }
+            let task = self.urlSession.webSocketTask(with: upstreamURL)
+            self.upstreamTask = task
+            task.resume()
+            self.receiveUpstream()
+            self.processBufferedClientFrames()
+            self.receiveClientFrames()
+        })
+    }
+
+    private func receiveClientFrames() {
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 64 * 1024) { [weak self] data, _, isComplete, error in
+            guard let self else { return }
+            if error != nil || isComplete {
+                self.close()
+                return
+            }
+            if let data {
+                self.frameBuffer.append(data)
+                self.processBufferedClientFrames()
+            }
+            self.receiveClientFrames()
+        }
+    }
+
+    private func processBufferedClientFrames() {
+        do {
+            let frames = try ChromiumDevToolsWebSocketFrameCodec.decodeClientFrames(from: &frameBuffer)
+            for frame in frames {
+                handleClientFrame(frame)
+            }
+        } catch {
+            close()
+        }
+    }
+
+    private func handleClientFrame(_ frame: ChromiumDevToolsWebSocketFrame) {
+        switch frame.opcode {
+        case 0x0:
+            guard let opcode = fragmentedOpcode else {
+                close()
+                return
+            }
+            fragmentedPayload.append(frame.payload)
+            if frame.isFinal {
+                sendToUpstream(opcode: opcode, payload: fragmentedPayload)
+                fragmentedOpcode = nil
+                fragmentedPayload.removeAll()
+            }
+        case 0x1, 0x2:
+            if frame.isFinal {
+                sendToUpstream(opcode: frame.opcode, payload: frame.payload)
+            } else {
+                fragmentedOpcode = frame.opcode
+                fragmentedPayload = frame.payload
+            }
+        case 0x8:
+            sendServerFrame(opcode: 0x8, payload: frame.payload)
+            close()
+        case 0x9:
+            sendServerFrame(opcode: 0xA, payload: frame.payload)
+        case 0xA:
+            break
+        default:
+            close()
+        }
+    }
+
+    private func sendToUpstream(opcode: UInt8, payload: Data) {
+        guard let upstreamTask else { return }
+        let message: URLSessionWebSocketTask.Message
+        if opcode == 0x1, let text = String(data: payload, encoding: .utf8) {
+            message = .string(text)
+        } else {
+            message = .data(payload)
+        }
+        upstreamTask.send(message) { [weak self] error in
+            if error != nil {
+                self?.close()
+            }
+        }
+    }
+
+    private func receiveUpstream() {
+        upstreamTask?.receive { [weak self] result in
+            guard let self else { return }
+            switch result {
+            case .failure:
+                self.close()
+            case .success(.string(let text)):
+                self.sendServerFrame(opcode: 0x1, payload: Data(text.utf8))
+                self.receiveUpstream()
+            case .success(.data(let data)):
+                self.sendServerFrame(opcode: 0x2, payload: data)
+                self.receiveUpstream()
+            @unknown default:
+                self.close()
+            }
+        }
+    }
+
+    private func sendServerFrame(opcode: UInt8, payload: Data) {
+        let frame = ChromiumDevToolsWebSocketFrameCodec.encodeServerFrame(opcode: opcode, payload: payload)
+        connection.send(content: frame, completion: .contentProcessed { [weak self] error in
+            if error != nil {
+                self?.close()
+            }
+        })
+    }
+
+    private func sendHTTPFailure() {
+        let response = "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n"
+        connection.send(content: Data(response.utf8), completion: .contentProcessed { [weak self] _ in
+            self?.close()
+        })
+    }
+
+    private func close() {
+        guard !isClosed else { return }
+        isClosed = true
+        upstreamTask?.cancel(with: .goingAway, reason: nil)
+        upstreamTask = nil
+        connection.cancel()
+        urlSession.invalidateAndCancel()
+        onClose(ObjectIdentifier(self))
+    }
+
+    private static func parseRequest(_ data: Data) -> (target: String, headers: [String: String])? {
+        guard let raw = String(data: data, encoding: .utf8) else { return nil }
+        let lines = raw.components(separatedBy: "\r\n")
+        guard let requestLine = lines.first else { return nil }
+        let parts = requestLine.split(separator: " ", maxSplits: 2).map(String.init)
+        guard parts.count >= 2, parts[0].uppercased() == "GET" else { return nil }
+
+        var headers: [String: String] = [:]
+        for line in lines.dropFirst() {
+            guard let separator = line.firstIndex(of: ":") else { continue }
+            let key = line[..<separator].trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            let value = line[line.index(after: separator)...].trimmingCharacters(in: .whitespacesAndNewlines)
+            headers[key] = value
+        }
+        return (parts[1], headers)
+    }
 }
 
 protocol BrowserEngineHost: AnyObject {
@@ -693,6 +1285,21 @@ protocol BrowserEngineHost: AnyObject {
     func setPageZoomFactor(_ pageZoomFactor: CGFloat) throws
     func addUserScript(_ source: String) throws
     func addUserStyle(_ source: String) throws
+    func devToolsFrontendURL(
+        preferredPanel: String?,
+        completion: @escaping (Result<URL, Error>) -> Void
+    ) throws
+    func setDevToolsVisible(
+        _ visible: Bool,
+        mode: BrowserChromiumDevToolsMode,
+        preferredPanel: String?,
+        completion: @escaping (Result<Void, Error>) -> Void
+    ) throws
+    func toggleDevTools(
+        mode: BrowserChromiumDevToolsMode,
+        preferredPanel: String?,
+        completion: @escaping (Result<Void, Error>) -> Void
+    ) throws
 }
 
 final class BrowserWebKitEngineHost: BrowserEngineHost {
@@ -776,6 +1383,30 @@ final class BrowserWebKitEngineHost: BrowserEngineHost {
         let userScript = WKUserScript(source: source, injectionTime: .atDocumentStart, forMainFrameOnly: false)
         webView.configuration.userContentController.addUserScript(userScript)
     }
+
+    func devToolsFrontendURL(
+        preferredPanel: String?,
+        completion: @escaping (Result<URL, Error>) -> Void
+    ) throws {
+        throw BrowserChromiumHostBridgeError.unsupportedOperation("devToolsFrontendURL")
+    }
+
+    func setDevToolsVisible(
+        _ visible: Bool,
+        mode: BrowserChromiumDevToolsMode,
+        preferredPanel: String?,
+        completion: @escaping (Result<Void, Error>) -> Void
+    ) throws {
+        throw BrowserChromiumHostBridgeError.unsupportedOperation("setDevToolsVisible")
+    }
+
+    func toggleDevTools(
+        mode: BrowserChromiumDevToolsMode,
+        preferredPanel: String?,
+        completion: @escaping (Result<Void, Error>) -> Void
+    ) throws {
+        throw BrowserChromiumHostBridgeError.unsupportedOperation("toggleDevTools")
+    }
 }
 
 final class BrowserChromiumEngineHost: BrowserEngineHost {
@@ -844,6 +1475,35 @@ final class BrowserChromiumEngineHost: BrowserEngineHost {
 
     func addUserStyle(_ source: String) throws {
         try bridge.addUserStyle(source)
+    }
+
+    func devToolsFrontendURL(
+        preferredPanel: String?,
+        completion: @escaping (Result<URL, Error>) -> Void
+    ) throws {
+        try bridge.devToolsFrontendURL(preferredPanel: preferredPanel, completion: completion)
+    }
+
+    func setDevToolsVisible(
+        _ visible: Bool,
+        mode: BrowserChromiumDevToolsMode,
+        preferredPanel: String?,
+        completion: @escaping (Result<Void, Error>) -> Void
+    ) throws {
+        try bridge.setDevToolsVisible(
+            visible,
+            mode: mode,
+            preferredPanel: preferredPanel,
+            completion: completion
+        )
+    }
+
+    func toggleDevTools(
+        mode: BrowserChromiumDevToolsMode,
+        preferredPanel: String?,
+        completion: @escaping (Result<Void, Error>) -> Void
+    ) throws {
+        try bridge.toggleDevTools(mode: mode, preferredPanel: preferredPanel, completion: completion)
     }
 }
 
@@ -3340,6 +4000,8 @@ final class BrowserPanel: Panel, ObservableObject {
     private var detachedDeveloperToolsWindowCloseObserver: NSObjectProtocol?
     private var preferredAttachedDeveloperToolsWidth: CGFloat?
     private var preferredAttachedDeveloperToolsWidthFraction: CGFloat?
+    private var chromiumDeveloperToolsPanelID: UUID?
+    private(set) var chromiumDeveloperToolsOwnerPanelID: UUID?
     private var browserThemeMode: BrowserThemeMode
 
     var displayTitle: String {
@@ -5656,6 +6318,185 @@ extension BrowserPanel {
         }
     }
 
+    @discardableResult
+    private func changeChromiumDeveloperTools(
+        visible: Bool?,
+        preferredPanel: String?,
+        source: String
+    ) -> Bool {
+        if visible == false {
+            _ = closeTrackedChromiumDeveloperToolsIfNeeded(source: source)
+            setPreferredDeveloperToolsVisible(false)
+            return true
+        }
+
+        if visible == nil, closeTrackedChromiumDeveloperToolsIfNeeded(source: source) {
+            setPreferredDeveloperToolsVisible(false)
+            return true
+        }
+
+        let completion: (Result<URL, Error>) -> Void = { [weak self] result in
+            DispatchQueue.main.async {
+                guard let self else { return }
+                switch result {
+                case .failure(let error):
+#if DEBUG
+                    cmuxDebugLog(
+                        "browser.devtools.chromium.frontend.failed panel=\(self.id.uuidString.prefix(5)) " +
+                        "source=\(source) visible=\(visible.map { $0 ? 1 : 0 } ?? -1) error=\(error.localizedDescription)"
+                    )
+#endif
+                    NSSound.beep()
+                case .success(let url):
+                    self.presentChromiumDeveloperToolsFrontend(
+                        url,
+                        preferredPanel: preferredPanel,
+                        source: source
+                    )
+                }
+            }
+        }
+
+        do {
+            try browserEngineHost.devToolsFrontendURL(
+                preferredPanel: preferredPanel,
+                completion: completion
+            )
+            return true
+        } catch {
+#if DEBUG
+            cmuxDebugLog(
+                "browser.devtools.chromium.frontend.unsupported panel=\(id.uuidString.prefix(5)) " +
+                "source=\(source) error=\(error.localizedDescription)"
+            )
+#endif
+            return false
+        }
+    }
+
+    private func currentWorkspaceForPanel() -> Workspace? {
+        AppDelegate.shared?.workspaceContainingPanel(
+            panelId: id,
+            preferredWorkspaceId: workspaceId
+        )?.workspace
+    }
+
+    func markAsChromiumDeveloperToolsFrontend(ownerPanelID: UUID) {
+        chromiumDeveloperToolsOwnerPanelID = ownerPanelID
+    }
+
+    @discardableResult
+    private func closeTrackedChromiumDeveloperToolsIfNeeded(source: String) -> Bool {
+        guard let panelID = chromiumDeveloperToolsPanelID else { return false }
+        chromiumDeveloperToolsPanelID = nil
+
+        guard let workspace = currentWorkspaceForPanel(),
+              workspace.browserPanel(for: panelID) != nil else {
+#if DEBUG
+            cmuxDebugLog(
+                "browser.devtools.chromium.frontend.close.stale panel=\(id.uuidString.prefix(5)) " +
+                "source=\(source) devtoolsPanel=\(panelID.uuidString.prefix(5))"
+            )
+#endif
+            return false
+        }
+
+        let closed = workspace.closePanel(panelID, force: true)
+#if DEBUG
+        cmuxDebugLog(
+            "browser.devtools.chromium.frontend.close panel=\(id.uuidString.prefix(5)) " +
+            "source=\(source) devtoolsPanel=\(panelID.uuidString.prefix(5)) closed=\(closed ? 1 : 0)"
+        )
+#endif
+        return closed
+    }
+
+    private func presentChromiumDeveloperToolsFrontend(
+        _ url: URL,
+        preferredPanel: String?,
+        source: String
+    ) {
+        let frontendURL = ChromiumDevToolsWebSocketProxy.shared.proxiedFrontendURL(url)
+        guard let workspace = currentWorkspaceForPanel() else {
+#if DEBUG
+            cmuxDebugLog(
+                "browser.devtools.chromium.frontend.open.failed panel=\(id.uuidString.prefix(5)) " +
+                "source=\(source) reason=workspaceMissing"
+            )
+#endif
+            NSSound.beep()
+            return
+        }
+
+        if let panelID = chromiumDeveloperToolsPanelID,
+           let existingPanel = workspace.browserPanel(for: panelID) {
+            existingPanel.navigate(to: frontendURL, recordTypedNavigation: false)
+            workspace.focusPanel(existingPanel.id)
+            setPreferredDeveloperToolsVisible(true)
+#if DEBUG
+            cmuxDebugLog(
+                "browser.devtools.chromium.frontend.focus panel=\(id.uuidString.prefix(5)) " +
+                "source=\(source) devtoolsPanel=\(existingPanel.id.uuidString.prefix(5)) " +
+                "panelName=\(preferredPanel ?? "default")"
+            )
+#endif
+            return
+        }
+        chromiumDeveloperToolsPanelID = nil
+
+        if let devToolsPanel = workspace.newBrowserSplit(
+            from: id,
+            orientation: .horizontal,
+            insertFirst: false,
+            url: frontendURL,
+            preferredProfileID: profileID,
+            focus: true,
+            creationPolicy: .internalTool,
+            initialDividerPosition: 0.58
+        ) {
+            devToolsPanel.markAsChromiumDeveloperToolsFrontend(ownerPanelID: id)
+            chromiumDeveloperToolsPanelID = devToolsPanel.id
+            setPreferredDeveloperToolsVisible(true)
+#if DEBUG
+            cmuxDebugLog(
+                "browser.devtools.chromium.frontend.open panel=\(id.uuidString.prefix(5)) " +
+                "source=\(source) devtoolsPanel=\(devToolsPanel.id.uuidString.prefix(5)) " +
+                "panelName=\(preferredPanel ?? "default")"
+            )
+#endif
+            return
+        }
+
+        if let paneID = workspace.paneId(forPanelId: id),
+               let devToolsPanel = workspace.newBrowserSurface(
+                   inPane: paneID,
+                   url: frontendURL,
+                   focus: true,
+                   preferredProfileID: profileID,
+                   creationPolicy: .internalTool
+               ) {
+            devToolsPanel.markAsChromiumDeveloperToolsFrontend(ownerPanelID: id)
+            chromiumDeveloperToolsPanelID = devToolsPanel.id
+            setPreferredDeveloperToolsVisible(true)
+#if DEBUG
+            cmuxDebugLog(
+                "browser.devtools.chromium.frontend.openSamePane panel=\(id.uuidString.prefix(5)) " +
+                "source=\(source) devtoolsPanel=\(devToolsPanel.id.uuidString.prefix(5)) " +
+                "panelName=\(preferredPanel ?? "default")"
+            )
+#endif
+            return
+        }
+
+#if DEBUG
+        cmuxDebugLog(
+            "browser.devtools.chromium.frontend.open.failed panel=\(id.uuidString.prefix(5)) " +
+            "source=\(source) reason=createBrowserPanelFailed"
+        )
+#endif
+        NSSound.beep()
+    }
+
     private func hasAttachedDeveloperToolsLayout() -> Bool {
         guard let container = webView.superview else { return false }
         return Self.visibleDescendants(in: container)
@@ -5912,6 +6753,9 @@ extension BrowserPanel {
 
     @discardableResult
     func toggleDeveloperTools() -> Bool {
+        if usesChromiumBrowserEngine {
+            return changeChromiumDeveloperTools(visible: nil, preferredPanel: nil, source: "toggle")
+        }
 #if DEBUG
         cmuxDebugLog(
             "browser.devtools toggle.begin panel=\(id.uuidString.prefix(5)) " +
@@ -5938,11 +6782,17 @@ extension BrowserPanel {
 
     @discardableResult
     func showDeveloperTools() -> Bool {
+        if usesChromiumBrowserEngine {
+            return changeChromiumDeveloperTools(visible: true, preferredPanel: nil, source: "show")
+        }
         return enqueueDeveloperToolsVisibilityTransition(to: true, source: "show")
     }
 
     @discardableResult
     func showDeveloperToolsConsole() -> Bool {
+        if usesChromiumBrowserEngine {
+            return changeChromiumDeveloperTools(visible: true, preferredPanel: "console", source: "console")
+        }
         guard showDeveloperTools() else { return false }
         guard !isDeveloperToolsTransitionInFlight else { return true }
         guard let inspector = webView.cmuxInspectorObject() else { return true }
@@ -5964,6 +6814,12 @@ extension BrowserPanel {
 
     @discardableResult
     func closeDeveloperToolsForTeardown() -> Bool {
+        if usesChromiumBrowserEngine {
+            let closed = closeTrackedChromiumDeveloperToolsIfNeeded(source: "teardown")
+            setPreferredDeveloperToolsVisible(false)
+            return closed
+        }
+
         developerToolsTransitionSettleWorkItem?.cancel()
         developerToolsTransitionSettleWorkItem = nil
         pendingDeveloperToolsTransitionTargetVisible = nil
@@ -6149,12 +7005,27 @@ extension BrowserPanel {
 
     @discardableResult
     func isDeveloperToolsVisible() -> Bool {
+        if usesChromiumBrowserEngine {
+            guard let panelID = chromiumDeveloperToolsPanelID,
+                  let workspace = currentWorkspaceForPanel() else {
+                return false
+            }
+            if workspace.browserPanel(for: panelID) != nil {
+                return true
+            }
+            chromiumDeveloperToolsPanelID = nil
+            return false
+        }
+
         guard let inspector = webView.cmuxInspectorObject() else { return false }
         return inspector.cmuxCallBool(selector: NSSelectorFromString("isVisible")) ?? false
     }
 
     @discardableResult
     func hideDeveloperTools() -> Bool {
+        if usesChromiumBrowserEngine {
+            return changeChromiumDeveloperTools(visible: false, preferredPanel: nil, source: "hide")
+        }
         return enqueueDeveloperToolsVisibilityTransition(to: false, source: "hide")
     }
 
@@ -6188,6 +7059,9 @@ extension BrowserPanel {
     }
 
     func shouldUseLocalInlineDeveloperToolsHosting() -> Bool {
+        if usesChromiumBrowserEngine {
+            return false
+        }
         guard preferredDeveloperToolsVisible || isDeveloperToolsVisible() else { return false }
         if preferredDeveloperToolsPresentation == .detached {
             return false
@@ -6918,6 +7792,34 @@ extension BrowserPanel {
         let value = url.absoluteString.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !value.isEmpty, value != "about:blank" else { return nil }
         return value
+    }
+
+    nonisolated static func isChromiumDevToolsFrontendURLString(_ raw: String?) -> Bool {
+        guard let raw else { return false }
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        return isChromiumDevToolsFrontendURL(URL(string: trimmed))
+    }
+
+    nonisolated static func isChromiumDevToolsFrontendURL(_ url: URL?) -> Bool {
+        guard let url else { return false }
+        let scheme = url.scheme?.lowercased()
+        if scheme == "devtools" || scheme == "chrome-devtools" {
+            return true
+        }
+        if url.path.lowercased().contains("/devtools/") {
+            return true
+        }
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            return false
+        }
+        return components.queryItems?.contains { item in
+            guard item.name == "ws",
+                  let value = item.value?.lowercased() else {
+                return false
+            }
+            return value.contains("/devtools/page/") || value.contains("/devtools/browser/")
+        } ?? false
     }
 
     private static func sanitizedSessionHistoryURL(_ raw: String?) -> URL? {

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -1270,7 +1270,18 @@ struct BrowserPanelView: View {
                         paneId: paneId,
                         shouldAttachNativeView: isVisibleInUI && isCurrentPaneOwner,
                         shouldFocusNativeView: isFocused && !addressBarFocused,
-                        isPanelFocused: isFocused
+                        isPanelFocused: isFocused,
+                        onPointerDown: {
+                            if addressBarFocused {
+#if DEBUG
+                                logBrowserFocusState(event: "chromiumContent.pointerBlur")
+#endif
+                                setAddressBarFocused(false, reason: "chromiumContent.pointerBlur")
+                            }
+                            if !isFocused {
+                                onRequestPanelFocus()
+                            }
+                        }
                     )
                     .id("\(panel.browserEngineHostInstanceID.uuidString)-\(paneId.id.uuidString)")
                     .contentShape(Rectangle())
@@ -4505,8 +4516,24 @@ final class BrowserNativeEngineHostContainerView: NSView {
     private weak var hostedNativeView: NSView?
     private var hostedNativeViewConstraints: [NSLayoutConstraint] = []
 
+    var onPointerDown: (() -> Void)?
+
     var currentHostedNativeView: NSView? {
         hostedNativeView
+    }
+
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
+        true
+    }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        guard !isHidden,
+              alphaValue > 0,
+              bounds.contains(point),
+              hostedNativeView != nil else {
+            return super.hitTest(point)
+        }
+        return self
     }
 
     func hostNativeView(_ nativeView: NSView) {
@@ -4538,6 +4565,77 @@ final class BrowserNativeEngineHostContainerView: NSView {
         }
         hostedNativeView = nil
     }
+
+    override func mouseDown(with event: NSEvent) {
+        forwardMouseEvent(event) { view, forwarded in
+            view.mouseDown(with: forwarded)
+        }
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        forwardMouseEvent(event) { view, forwarded in
+            view.mouseUp(with: forwarded)
+        }
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        forwardMouseEvent(event) { view, forwarded in
+            view.mouseDragged(with: forwarded)
+        }
+    }
+
+    override func rightMouseDown(with event: NSEvent) {
+        forwardMouseEvent(event) { view, forwarded in
+            view.rightMouseDown(with: forwarded)
+        }
+    }
+
+    override func rightMouseUp(with event: NSEvent) {
+        forwardMouseEvent(event) { view, forwarded in
+            view.rightMouseUp(with: forwarded)
+        }
+    }
+
+    override func rightMouseDragged(with event: NSEvent) {
+        forwardMouseEvent(event) { view, forwarded in
+            view.rightMouseDragged(with: forwarded)
+        }
+    }
+
+    override func otherMouseDown(with event: NSEvent) {
+        forwardMouseEvent(event) { view, forwarded in
+            view.otherMouseDown(with: forwarded)
+        }
+    }
+
+    override func otherMouseUp(with event: NSEvent) {
+        forwardMouseEvent(event) { view, forwarded in
+            view.otherMouseUp(with: forwarded)
+        }
+    }
+
+    override func otherMouseDragged(with event: NSEvent) {
+        forwardMouseEvent(event) { view, forwarded in
+            view.otherMouseDragged(with: forwarded)
+        }
+    }
+
+    override func scrollWheel(with event: NSEvent) {
+        forwardMouseEvent(event) { view, forwarded in
+            view.scrollWheel(with: forwarded)
+        }
+    }
+
+    private func forwardMouseEvent(_ event: NSEvent, dispatch: (NSView, NSEvent) -> Void) {
+        guard let hostedNativeView else { return }
+        switch event.type {
+        case .leftMouseDown, .rightMouseDown, .otherMouseDown:
+            onPointerDown?()
+        default:
+            break
+        }
+        dispatch(hostedNativeView, event)
+    }
 }
 
 struct BrowserNativeEngineRepresentable: NSViewRepresentable {
@@ -4546,6 +4644,7 @@ struct BrowserNativeEngineRepresentable: NSViewRepresentable {
     let shouldAttachNativeView: Bool
     let shouldFocusNativeView: Bool
     let isPanelFocused: Bool
+    let onPointerDown: () -> Void
 
     final class Coordinator {
         weak var panel: BrowserPanel?
@@ -4569,24 +4668,26 @@ struct BrowserNativeEngineRepresentable: NSViewRepresentable {
         let nativeView = panel.browserEngineNativeView
         context.coordinator.panel = panel
         context.coordinator.nativeView = nativeView
-        let canAttachNativeView = shouldAttachNativeView && host.window != nil
-        if canAttachNativeView {
+        host.onPointerDown = onPointerDown
+        if shouldAttachNativeView {
             host.hostNativeView(nativeView)
         } else {
             host.detachHostedNativeView()
         }
+        let canFocusNativeView = shouldAttachNativeView && host.window != nil
 
         Self.applyFocus(
             panel: panel,
             nativeView: nativeView,
             host: host,
-            shouldFocusNativeView: shouldFocusNativeView && canAttachNativeView,
-            isPanelFocused: isPanelFocused && canAttachNativeView
+            shouldFocusNativeView: shouldFocusNativeView && canFocusNativeView,
+            isPanelFocused: isPanelFocused && canFocusNativeView
         )
     }
 
     static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {
         if let host = nsView as? BrowserNativeEngineHostContainerView {
+            host.onPointerDown = nil
             host.detachHostedNativeView()
         }
         coordinator.nativeView = nil

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -1264,48 +1264,96 @@ struct BrowserPanelView: View {
 
         return Group {
             if panel.shouldRenderWebView {
-                WebViewRepresentable(
-                    panel: panel,
-                    paneId: paneId,
-                    shouldAttachWebView: isVisibleInUI && isCurrentPaneOwner && !useLocalInlineDeveloperToolsHosting,
-                    useLocalInlineHosting: useLocalInlineDeveloperToolsHosting,
-                    shouldFocusWebView: isFocused && !addressBarFocused,
-                    isPanelFocused: isFocused,
-                    portalZPriority: portalPriority,
-                    paneDropZone: paneDropZone,
-                    searchOverlay: panel.searchState.map { searchState in
-                        BrowserPortalSearchOverlayConfiguration(
-                            panelId: panel.id,
-                            searchState: searchState,
-                            focusRequestGeneration: panel.searchFocusRequestGeneration,
-                            canApplyFocusRequest: { generation in
-                                canApplyBrowserFindFieldFocusRequest(generation)
-                            },
-                            onNext: { panel.findNext() },
-                            onPrevious: { panel.findPrevious() },
-                            onClose: { panel.hideFind() },
-                            onFieldDidFocus: { panel.noteFindFieldFocused() }
-                        )
-                    },
-                    paneTopChromeHeight: addressBarHeight
-                )
-                .accessibilityIdentifier("BrowserWebViewSurface")
-                // Keep the host stable for normal pane churn, but force a remount when
-                // BrowserPanel replaces its underlying WKWebView after process termination
-                // or when the browser moves to a different Bonsplit pane host.
-                .id("\(panel.webViewInstanceID.uuidString)-\(paneId.id.uuidString)")
-                .contentShape(Rectangle())
-                .accessibilityIdentifier(browserContentAccessibilityIdentifier)
-                .simultaneousGesture(TapGesture().onEnded {
-                    // Chrome-like behavior: clicking web content while editing the
-                    // omnibar should commit blur and revert transient edits.
-                    if addressBarFocused {
-#if DEBUG
-                        logBrowserFocusState(event: "webContent.tapBlur")
-#endif
-                        setAddressBarFocused(false, reason: "webContent.tapBlur")
+                if panel.usesChromiumBrowserEngine {
+                    BrowserNativeEngineRepresentable(
+                        panel: panel,
+                        paneId: paneId,
+                        shouldAttachNativeView: isVisibleInUI && isCurrentPaneOwner,
+                        shouldFocusNativeView: isFocused && !addressBarFocused,
+                        isPanelFocused: isFocused
+                    )
+                    .id("\(panel.browserEngineHostInstanceID.uuidString)-\(paneId.id.uuidString)")
+                    .contentShape(Rectangle())
+                    .accessibilityIdentifier(browserContentAccessibilityIdentifier)
+                    .overlay(alignment: .topLeading) {
+                        Rectangle()
+                            .fill(Color.clear)
+                            .frame(width: 1, height: 1)
+                            .allowsHitTesting(false)
+                            .accessibilityElement(children: .ignore)
+                            .accessibilityIdentifier("BrowserChromiumSurface")
                     }
-                })
+                    .overlay(alignment: .topTrailing) {
+                        if let searchState = panel.searchState {
+                            BrowserSearchOverlay(
+                                panelId: panel.id,
+                                searchState: searchState,
+                                focusRequestGeneration: panel.searchFocusRequestGeneration,
+                                canApplyFocusRequest: { generation in
+                                    canApplyBrowserFindFieldFocusRequest(generation)
+                                },
+                                onNext: { panel.findNext() },
+                                onPrevious: { panel.findPrevious() },
+                                onClose: { panel.hideFind() },
+                                onFieldDidFocus: { panel.noteFindFieldFocused() }
+                            )
+                        }
+                    }
+                    .simultaneousGesture(TapGesture().onEnded {
+                        if addressBarFocused {
+#if DEBUG
+                            logBrowserFocusState(event: "chromiumContent.tapBlur")
+#endif
+                            setAddressBarFocused(false, reason: "chromiumContent.tapBlur")
+                        }
+                        if !isFocused {
+                            onRequestPanelFocus()
+                        }
+                    })
+                } else {
+                    WebViewRepresentable(
+                        panel: panel,
+                        paneId: paneId,
+                        shouldAttachWebView: isVisibleInUI && isCurrentPaneOwner && !useLocalInlineDeveloperToolsHosting,
+                        useLocalInlineHosting: useLocalInlineDeveloperToolsHosting,
+                        shouldFocusWebView: isFocused && !addressBarFocused,
+                        isPanelFocused: isFocused,
+                        portalZPriority: portalPriority,
+                        paneDropZone: paneDropZone,
+                        searchOverlay: panel.searchState.map { searchState in
+                            BrowserPortalSearchOverlayConfiguration(
+                                panelId: panel.id,
+                                searchState: searchState,
+                                focusRequestGeneration: panel.searchFocusRequestGeneration,
+                                canApplyFocusRequest: { generation in
+                                    canApplyBrowserFindFieldFocusRequest(generation)
+                                },
+                                onNext: { panel.findNext() },
+                                onPrevious: { panel.findPrevious() },
+                                onClose: { panel.hideFind() },
+                                onFieldDidFocus: { panel.noteFindFieldFocused() }
+                            )
+                        },
+                        paneTopChromeHeight: addressBarHeight
+                    )
+                    .accessibilityIdentifier("BrowserWebViewSurface")
+                    // Keep the host stable for normal pane churn, but force a remount when
+                    // BrowserPanel replaces its underlying WKWebView after process termination
+                    // or when the browser moves to a different Bonsplit pane host.
+                    .id("\(panel.webViewInstanceID.uuidString)-\(paneId.id.uuidString)")
+                    .contentShape(Rectangle())
+                    .accessibilityIdentifier(browserContentAccessibilityIdentifier)
+                    .simultaneousGesture(TapGesture().onEnded {
+                        // Chrome-like behavior: clicking web content while editing the
+                        // omnibar should commit blur and revert transient edits.
+                        if addressBarFocused {
+#if DEBUG
+                            logBrowserFocusState(event: "webContent.tapBlur")
+#endif
+                            setAddressBarFocused(false, reason: "webContent.tapBlur")
+                        }
+                    })
+                }
             } else {
                 Color(nsColor: browserChromeBackgroundColor)
                     .contentShape(Rectangle())
@@ -4450,6 +4498,134 @@ private struct OmnibarSuggestionsView: View {
         .accessibilityRespondsToUserInteraction(true)
         .accessibilityIdentifier("BrowserOmnibarSuggestions")
         .accessibilityLabel(String(localized: "browser.addressBarSuggestions", defaultValue: "Address bar suggestions"))
+    }
+}
+
+final class BrowserNativeEngineHostContainerView: NSView {
+    private weak var hostedNativeView: NSView?
+    private var hostedNativeViewConstraints: [NSLayoutConstraint] = []
+
+    var currentHostedNativeView: NSView? {
+        hostedNativeView
+    }
+
+    func hostNativeView(_ nativeView: NSView) {
+        guard hostedNativeView !== nativeView || nativeView.superview !== self else {
+            nativeView.isHidden = false
+            return
+        }
+
+        detachHostedNativeView()
+        nativeView.removeFromSuperview()
+        nativeView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(nativeView)
+        hostedNativeViewConstraints = [
+            nativeView.topAnchor.constraint(equalTo: topAnchor),
+            nativeView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            nativeView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            nativeView.trailingAnchor.constraint(equalTo: trailingAnchor),
+        ]
+        NSLayoutConstraint.activate(hostedNativeViewConstraints)
+        nativeView.isHidden = false
+        hostedNativeView = nativeView
+    }
+
+    func detachHostedNativeView() {
+        NSLayoutConstraint.deactivate(hostedNativeViewConstraints)
+        hostedNativeViewConstraints = []
+        if hostedNativeView?.superview === self {
+            hostedNativeView?.removeFromSuperview()
+        }
+        hostedNativeView = nil
+    }
+}
+
+struct BrowserNativeEngineRepresentable: NSViewRepresentable {
+    let panel: BrowserPanel
+    let paneId: PaneID
+    let shouldAttachNativeView: Bool
+    let shouldFocusNativeView: Bool
+    let isPanelFocused: Bool
+
+    final class Coordinator {
+        weak var panel: BrowserPanel?
+        weak var nativeView: NSView?
+    }
+
+    func makeCoordinator() -> Coordinator {
+        let coordinator = Coordinator()
+        coordinator.panel = panel
+        return coordinator
+    }
+
+    func makeNSView(context: Context) -> NSView {
+        let container = BrowserNativeEngineHostContainerView()
+        container.wantsLayer = true
+        return container
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        guard let host = nsView as? BrowserNativeEngineHostContainerView else { return }
+        let nativeView = panel.browserEngineNativeView
+        context.coordinator.panel = panel
+        context.coordinator.nativeView = nativeView
+        let canAttachNativeView = shouldAttachNativeView && host.window != nil
+        if canAttachNativeView {
+            host.hostNativeView(nativeView)
+        } else {
+            host.detachHostedNativeView()
+        }
+
+        Self.applyFocus(
+            panel: panel,
+            nativeView: nativeView,
+            host: host,
+            shouldFocusNativeView: shouldFocusNativeView && canAttachNativeView,
+            isPanelFocused: isPanelFocused && canAttachNativeView
+        )
+    }
+
+    static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {
+        if let host = nsView as? BrowserNativeEngineHostContainerView {
+            host.detachHostedNativeView()
+        }
+        coordinator.nativeView = nil
+    }
+
+    private static func responderChainContains(_ start: NSResponder?, target: NSResponder) -> Bool {
+        var responder = start
+        var hops = 0
+        while let current = responder, hops < 64 {
+            if current === target { return true }
+            responder = current.nextResponder
+            hops += 1
+        }
+        return false
+    }
+
+    private static func applyFocus(
+        panel: BrowserPanel,
+        nativeView: NSView,
+        host: NSView,
+        shouldFocusNativeView: Bool,
+        isPanelFocused: Bool
+    ) {
+        guard let window = host.window,
+              nativeView.window === window else { return }
+        if isPanelFocused && responderChainContains(window.firstResponder, target: nativeView) {
+            panel.noteWebViewFocused()
+        }
+        if shouldFocusNativeView {
+            guard !panel.shouldSuppressWebViewFocus() else { return }
+            if responderChainContains(window.firstResponder, target: nativeView) {
+                return
+            }
+            if window.makeFirstResponder(nativeView) {
+                panel.noteWebViewFocused()
+            }
+        } else if !isPanelFocused && responderChainContains(window.firstResponder, target: nativeView) {
+            window.makeFirstResponder(nil)
+        }
     }
 }
 

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -2016,6 +2016,11 @@ class TerminalController {
     }
 
     private nonisolated func processCommandUsingSocketExecutionPolicy(_ command: String) -> String {
+        if let request = parseV2SocketRequest(command),
+           request.method == "system.ping" {
+            return v2Ok(id: request.id, result: ["pong": true])
+        }
+
         if Thread.isMainThread,
            let request = parseV2SocketRequest(command),
            Self.executionPolicy(forV2Method: request.method) == .socketWorker {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -9002,6 +9002,65 @@ class TerminalController {
         """
     }
 
+    private func v2BrowserChromiumJavaScriptExpression(
+        surfaceId: UUID,
+        script: String,
+        useEval: Bool
+    ) -> String {
+        let scriptLiteral = v2JSONLiteral(script)
+        let framePrelude: String
+        if let frameSelector = v2BrowserCurrentFrameSelector(surfaceId: surfaceId) {
+            let selectorLiteral = v2JSONLiteral(frameSelector)
+            framePrelude = """
+            let __cmuxDoc = document;
+            try {
+              const __cmuxFrame = document.querySelector(\(selectorLiteral));
+              if (__cmuxFrame && __cmuxFrame.contentDocument) {
+                __cmuxDoc = __cmuxFrame.contentDocument;
+              }
+            } catch (_) {}
+            """
+        } else {
+            framePrelude = "const __cmuxDoc = document;"
+        }
+
+        let executionBlock: String
+        if useEval {
+            executionBlock = "const __r = eval(\(scriptLiteral));"
+        } else {
+            executionBlock = "const __r = \(script);"
+        }
+
+        return """
+        (() => {
+          \(framePrelude)
+
+          try {
+            const __cmuxEvalInFrame = function() {
+              const document = __cmuxDoc;
+              \(executionBlock)
+              if (__r !== null && (typeof __r === 'object' || typeof __r === 'function') && typeof __r.then === 'function') {
+                return {
+                  __cmux_t: 'error',
+                  __cmux_m: 'promise_result_not_supported'
+                };
+              }
+              return {
+                __cmux_t: (typeof __r === 'undefined') ? 'undefined' : 'value',
+                __cmux_v: __r
+              };
+            };
+            return __cmuxEvalInFrame();
+          } catch (err) {
+            return {
+              __cmux_t: 'error',
+              __cmux_m: String((err && err.message) || err || 'JavaScript execution failed')
+            };
+          }
+        })()
+        """
+    }
+
     private func v2UnwrapBrowserJavaScriptResult(_ rawResult: V2JavaScriptResult) -> V2JavaScriptResult {
         switch rawResult {
         case .failure(let message):
@@ -9046,7 +9105,7 @@ class TerminalController {
             )
         }
 
-        let expression = v2BrowserJavaScriptExpression(surfaceId: surfaceId, script: script, useEval: useEval)
+        let expression = v2BrowserChromiumJavaScriptExpression(surfaceId: surfaceId, script: script, useEval: useEval)
         let timeoutSeconds = max(0.01, timeout)
         let outcome: V2JavaScriptResult? = v2AwaitCallback(timeout: timeoutSeconds) { finish in
             let evaluate = {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -199,8 +199,11 @@ class TerminalController {
 
     private static let v2BrowserEvalEnvelopeTypeKey = "__cmux_t"
     private static let v2BrowserEvalEnvelopeValueKey = "__cmux_v"
+    private static let v2BrowserEvalEnvelopeMessageKey = "__cmux_m"
     private static let v2BrowserEvalEnvelopeTypeUndefined = "undefined"
     private static let v2BrowserEvalEnvelopeTypeValue = "value"
+    private static let v2BrowserEvalEnvelopeTypeError = "error"
+    private static let v2BrowserEvalMessageJSError = "js_error"
 
     private var v2BrowserNextElementOrdinal: Int = 1
     private var v2BrowserElementRefs: [String: V2BrowserElementRefEntry] = [:]
@@ -1524,6 +1527,7 @@ class TerminalController {
         "browser.profiles.clear",
         "browser.profiles.delete",
         "browser.import.cookies",
+        "system.ping",
         "system.top",
     ]
 
@@ -1630,6 +1634,8 @@ class TerminalController {
                 let outcome = try await BrowserImportAutomation.importCookies(params: request.params)
                 return outcome.socketPayload
             }
+        case "system.ping":
+            return v2Ok(id: request.id, result: ["pong": true])
         case "system.top":
             return v2Result(id: request.id, v2SystemTop(params: request.params))
         case let method where method.hasPrefix("vm."):
@@ -8708,13 +8714,19 @@ class TerminalController {
                     case .success(let value):
                         finish(value, nil)
                     case .failure(let error):
-                        finish(nil, error.localizedDescription)
+#if DEBUG
+                        cmuxDebugLog("browser.javascript.failure \(error.localizedDescription)")
+#endif
+                        finish(nil, Self.v2BrowserEvalMessageJSError)
                     }
                 }
             } else {
                 webView.evaluateJavaScript(script) { value, error in
                     if let error {
-                        finish(nil, error.localizedDescription)
+#if DEBUG
+                        cmuxDebugLog("browser.javascript.failure \(error.localizedDescription)")
+#endif
+                        finish(nil, Self.v2BrowserEvalMessageJSError)
                     } else {
                         finish(value, nil)
                     }
@@ -8740,7 +8752,7 @@ class TerminalController {
         }
 
         guard let outcome else {
-            return .failure("Timed out waiting for JavaScript result")
+            return .failure(Self.v2BrowserEvalMessageJSError)
         }
         if let resultError = outcome.1 {
             return .failure(resultError)
@@ -8797,7 +8809,7 @@ class TerminalController {
     }
 
     private func v2WaitForBrowserCondition(
-        _ webView: WKWebView,
+        _ browserPanel: BrowserPanel,
         surfaceId: UUID,
         conditionScript: String,
         timeoutMs: Int
@@ -8868,7 +8880,7 @@ class TerminalController {
         """
 
         switch v2RunBrowserJavaScript(
-            webView,
+            browserPanel,
             surfaceId: surfaceId,
             script: waitScript,
             timeout: timeout + 1.0,
@@ -8920,13 +8932,11 @@ class TerminalController {
         v2BrowserFrameSelectorBySurface[surfaceId]
     }
 
-    private func v2RunBrowserJavaScript(
-        _ webView: WKWebView,
+    private func v2BrowserJavaScriptAsyncFunctionBody(
         surfaceId: UUID,
         script: String,
-        timeout: TimeInterval = 5.0,
-        useEval: Bool = true
-    ) -> V2JavaScriptResult {
+        useEval: Bool
+    ) -> String {
         let scriptLiteral = v2JSONLiteral(script)
         let framePrelude: String
         if let frameSelector = v2BrowserCurrentFrameSelector(surfaceId: surfaceId) {
@@ -8951,7 +8961,7 @@ class TerminalController {
             executionBlock = "const __r = \(script);"
         }
 
-        let asyncFunctionBody = """
+        return """
         \(framePrelude)
 
         const __cmuxMaybeAwait = async (__r) => {
@@ -8973,6 +8983,104 @@ class TerminalController {
 
         return await __cmuxEvalInFrame();
         """
+    }
+
+    private func v2BrowserJavaScriptExpression(
+        surfaceId: UUID,
+        script: String,
+        useEval: Bool
+    ) -> String {
+        """
+        (async () => {
+          \(v2BrowserJavaScriptAsyncFunctionBody(surfaceId: surfaceId, script: script, useEval: useEval))
+        })()
+        """
+    }
+
+    private func v2UnwrapBrowserJavaScriptResult(_ rawResult: V2JavaScriptResult) -> V2JavaScriptResult {
+        switch rawResult {
+        case .failure(let message):
+            return .failure(message)
+        case .success(let value):
+            guard let dict = value as? [String: Any],
+                  let type = dict[Self.v2BrowserEvalEnvelopeTypeKey] as? String else {
+                return .success(value)
+            }
+
+            switch type {
+            case Self.v2BrowserEvalEnvelopeTypeUndefined:
+                return .success(v2BrowserUndefinedSentinel)
+            case Self.v2BrowserEvalEnvelopeTypeValue:
+                return .success(dict[Self.v2BrowserEvalEnvelopeValueKey])
+            case Self.v2BrowserEvalEnvelopeTypeError:
+                return .failure(Self.v2BrowserEvalMessageJSError)
+            default:
+                return .success(value)
+            }
+        }
+    }
+
+    private func v2RunBrowserJavaScript(
+        _ browserPanel: BrowserPanel,
+        surfaceId: UUID,
+        script: String,
+        timeout: TimeInterval = 5.0,
+        useEval: Bool = true
+    ) -> V2JavaScriptResult {
+        let snapshot: (usesChromium: Bool, webView: WKWebView) = v2MainSync {
+            (browserPanel.usesChromiumBrowserEngine, browserPanel.webView)
+        }
+
+        guard snapshot.usesChromium else {
+            return v2RunBrowserJavaScript(
+                snapshot.webView,
+                surfaceId: surfaceId,
+                script: script,
+                timeout: timeout,
+                useEval: useEval
+            )
+        }
+
+        let expression = v2BrowserJavaScriptExpression(surfaceId: surfaceId, script: script, useEval: useEval)
+        let timeoutSeconds = max(0.01, timeout)
+        let outcome: V2JavaScriptResult? = v2AwaitCallback(timeout: timeoutSeconds) { finish in
+            let evaluate = {
+                browserPanel.evaluateJavaScript(expression) { result in
+                    switch result {
+                    case .success(let value):
+                        finish(.success(value))
+                    case .failure(let error):
+#if DEBUG
+                        cmuxDebugLog("browser.javascript.failure \(error.localizedDescription)")
+#endif
+                        finish(.failure(Self.v2BrowserEvalMessageJSError))
+                    }
+                }
+            }
+            if Thread.isMainThread {
+                evaluate()
+            } else {
+                DispatchQueue.main.async {
+                    evaluate()
+                }
+            }
+        }
+
+        return v2UnwrapBrowserJavaScriptResult(outcome ?? .failure(Self.v2BrowserEvalMessageJSError))
+    }
+
+    private func v2RunBrowserJavaScript(
+        _ webView: WKWebView,
+        surfaceId: UUID,
+        script: String,
+        timeout: TimeInterval = 5.0,
+        useEval: Bool = true
+    ) -> V2JavaScriptResult {
+        let asyncFunctionBody = v2BrowserJavaScriptAsyncFunctionBody(
+            surfaceId: surfaceId,
+            script: script,
+            useEval: useEval
+        )
 
         var rawResult: V2JavaScriptResult
         if #available(macOS 11.0, *) {
@@ -9003,31 +9111,12 @@ class TerminalController {
             switch isolatedResult {
             case .success:
                 rawResult = isolatedResult
-            case .failure(let isolatedMessage):
-                if isolatedMessage != pageMessage {
-                    rawResult = .failure("\(pageMessage) (isolated-world retry: \(isolatedMessage))")
-                }
+            case .failure:
+                rawResult = .failure(pageMessage)
             }
         }
 
-        switch rawResult {
-        case .failure(let message):
-            return .failure(message)
-        case .success(let value):
-            guard let dict = value as? [String: Any],
-                  let type = dict[Self.v2BrowserEvalEnvelopeTypeKey] as? String else {
-                return .success(value)
-            }
-
-            switch type {
-            case Self.v2BrowserEvalEnvelopeTypeUndefined:
-                return .success(v2BrowserUndefinedSentinel)
-            case Self.v2BrowserEvalEnvelopeTypeValue:
-                return .success(dict[Self.v2BrowserEvalEnvelopeValueKey])
-            default:
-                return .success(value)
-            }
-        }
+        return v2UnwrapBrowserJavaScriptResult(rawResult)
     }
 
     private func v2BrowserRecordUnsupportedRequest(surfaceId: UUID, request: [String: Any]) {
@@ -9086,10 +9175,10 @@ class TerminalController {
           return true;
         })()
         """
-        _ = v2RunBrowserJavaScript(browserPanel.webView, surfaceId: surfaceId, script: injector)
+        _ = v2RunBrowserJavaScript(browserPanel, surfaceId: surfaceId, script: injector)
 
         for script in scripts {
-            _ = v2RunBrowserJavaScript(browserPanel.webView, surfaceId: surfaceId, script: script)
+            _ = v2RunBrowserJavaScript(browserPanel, surfaceId: surfaceId, script: script)
         }
         for css in styles {
             let cssLiteral = v2JSONLiteral(css)
@@ -9104,7 +9193,7 @@ class TerminalController {
               return true;
             })()
             """
-            _ = v2RunBrowserJavaScript(browserPanel.webView, surfaceId: surfaceId, script: styleScript)
+            _ = v2RunBrowserJavaScript(browserPanel, surfaceId: surfaceId, script: styleScript)
         }
     }
 
@@ -9308,6 +9397,10 @@ class TerminalController {
 
             let targetPaneUUID = ws.paneId(forPanelId: browserPanelId)?.id
             let windowId = v2ResolveWindowId(tabManager: tabManager)
+            let enginePayload = createdPanel?.browserEngineRuntimeStatus.socketPayload ?? [
+                "kind": BrowserEngineRuntimeKind.unknown.rawValue,
+                "chromium_ready": false
+            ]
             result = .ok([
                 "window_id": v2OrNull(windowId?.uuidString),
                 "window_ref": v2Ref(kind: .window, uuid: windowId),
@@ -9324,7 +9417,8 @@ class TerminalController {
                 "target_pane_id": v2OrNull(targetPaneUUID?.uuidString),
                 "target_pane_ref": v2Ref(kind: .pane, uuid: targetPaneUUID),
                 "created_split": createdSplit,
-                "placement_strategy": placementStrategy
+                "placement_strategy": placementStrategy,
+                "engine": enginePayload
             ])
         }
         return result
@@ -9441,7 +9535,7 @@ class TerminalController {
         })()
         """
 
-        switch v2RunBrowserJavaScript(browserPanel.webView, surfaceId: surfaceId, script: script, timeout: 4.0) {
+        switch v2RunBrowserJavaScript(browserPanel, surfaceId: surfaceId, script: script, timeout: 4.0) {
         case .failure(let message):
             return [
                 "selector": selector,
@@ -9560,7 +9654,7 @@ class TerminalController {
             let selectorCondition = "document.querySelector(\(v2JSONLiteral(selector))) !== null"
 
             for attempt in 1...retryAttempts {
-                switch v2RunBrowserJavaScript(browserPanel.webView, surfaceId: surfaceId, script: script, useEval: false) {
+                switch v2RunBrowserJavaScript(browserPanel, surfaceId: surfaceId, script: script, useEval: false) {
                 case .failure(let message):
                     return .err(code: "js_error", message: message, data: ["action": actionName, "selector": selector])
                 case .success(let value):
@@ -9586,7 +9680,7 @@ class TerminalController {
                     if errorText == "not_found", attempt < retryAttempts {
                         let waitTimeoutMs = max(80, (retryAttempts - attempt) * 80)
                         guard v2WaitForBrowserCondition(
-                            browserPanel.webView,
+                            browserPanel,
                             surfaceId: surfaceId,
                             conditionScript: selectorCondition,
                             timeoutMs: waitTimeoutMs
@@ -9630,7 +9724,7 @@ class TerminalController {
             return .err(code: "invalid_params", message: "Missing script", data: nil)
         }
         return v2BrowserWithPanel(params: params) { _, ws, surfaceId, browserPanel in
-            switch v2RunBrowserJavaScript(browserPanel.webView, surfaceId: surfaceId, script: script, timeout: 10.0) {
+            switch v2RunBrowserJavaScript(browserPanel, surfaceId: surfaceId, script: script, timeout: 10.0) {
             case .failure(let message):
                 return .err(code: "js_error", message: message, data: nil)
             case .success(let value):
@@ -9832,7 +9926,7 @@ class TerminalController {
             })()
             """
 
-            switch v2RunBrowserJavaScript(browserPanel.webView, surfaceId: surfaceId, script: script, timeout: 10.0, useEval: false) {
+            switch v2RunBrowserJavaScript(browserPanel, surfaceId: surfaceId, script: script, timeout: 10.0, useEval: false) {
             case .failure(let message):
                 return .err(code: "js_error", message: message, data: nil)
             case .success(let value):
@@ -9910,6 +10004,7 @@ class TerminalController {
                     "title": title,
                     "url": url,
                     "ready_state": readyState,
+                    "engine": browserPanel.browserEngineRuntimeStatus.socketPayload,
                     "page": [
                         "title": title,
                         "url": url,
@@ -9961,7 +10056,7 @@ class TerminalController {
         var setupResult: V2CallResult?
         var workspaceId: UUID?
         var surfaceIdOut: UUID?
-        var webView: WKWebView?
+        var resolvedBrowserPanel: BrowserPanel?
 
         v2MainSync {
             guard let tabManager = self.v2ResolveTabManager(params: params) else {
@@ -9983,13 +10078,13 @@ class TerminalController {
             }
             workspaceId = ws.id
             surfaceIdOut = surfaceId
-            webView = browserPanel.webView
+            resolvedBrowserPanel = browserPanel
         }
 
         if let setupResult {
             return setupResult
         }
-        guard let workspaceId, let surfaceIdOut, let webView else {
+        guard let workspaceId, let surfaceIdOut, let browserPanel = resolvedBrowserPanel else {
             return .err(code: "internal_error", message: "Failed to resolve browser surface", data: nil)
         }
 
@@ -10005,7 +10100,7 @@ class TerminalController {
         }
 
         if v2WaitForBrowserCondition(
-            webView,
+            browserPanel,
             surfaceId: surfaceIdOut,
             conditionScript: conditionScript,
             timeoutMs: timeoutMs
@@ -10173,7 +10268,7 @@ class TerminalController {
               return { ok: true };
             })()
             """
-            switch v2RunBrowserJavaScript(browserPanel.webView, surfaceId: surfaceId, script: script) {
+            switch v2RunBrowserJavaScript(browserPanel, surfaceId: surfaceId, script: script) {
             case .failure(let message):
                 return .err(code: "js_error", message: message, data: nil)
             case .success:
@@ -10204,7 +10299,7 @@ class TerminalController {
               return { ok: true };
             })()
             """
-            switch v2RunBrowserJavaScript(browserPanel.webView, surfaceId: surfaceId, script: script) {
+            switch v2RunBrowserJavaScript(browserPanel, surfaceId: surfaceId, script: script) {
             case .failure(let message):
                 return .err(code: "js_error", message: message, data: nil)
             case .success:
@@ -10235,7 +10330,7 @@ class TerminalController {
               return { ok: true };
             })()
             """
-            switch v2RunBrowserJavaScript(browserPanel.webView, surfaceId: surfaceId, script: script) {
+            switch v2RunBrowserJavaScript(browserPanel, surfaceId: surfaceId, script: script) {
             case .failure(let message):
                 return .err(code: "js_error", message: message, data: nil)
             case .success:
@@ -10320,7 +10415,7 @@ class TerminalController {
                 script = "window.scrollBy({ left: \(dx), top: \(dy), behavior: 'instant' }); ({ ok: true })"
             }
 
-            switch v2RunBrowserJavaScript(browserPanel.webView, surfaceId: surfaceId, script: script) {
+            switch v2RunBrowserJavaScript(browserPanel, surfaceId: surfaceId, script: script) {
             case .failure(let message):
                 return .err(code: "js_error", message: message, data: nil)
             case .success(let value):
@@ -10483,7 +10578,7 @@ class TerminalController {
             }
             let selectorLiteral = v2JSONLiteral(selector)
             let script = "document.querySelectorAll(\(selectorLiteral)).length"
-            switch v2RunBrowserJavaScript(browserPanel.webView, surfaceId: surfaceId, script: script) {
+            switch v2RunBrowserJavaScript(browserPanel, surfaceId: surfaceId, script: script) {
             case .failure(let message):
                 return .err(code: "js_error", message: message, data: nil)
             case .success(let value):
@@ -10760,7 +10855,7 @@ class TerminalController {
             })()
             """
 
-            switch v2RunBrowserJavaScript(browserPanel.webView, surfaceId: surfaceId, script: script) {
+            switch v2RunBrowserJavaScript(browserPanel, surfaceId: surfaceId, script: script) {
             case .failure(let message):
                 return .err(code: "js_error", message: message, data: ["action": actionName])
             case .success(let value):
@@ -11050,7 +11145,7 @@ class TerminalController {
               return { ok: true, selector: \(selectorLiteral), text: String(el.textContent || '').trim() };
             })()
             """
-            switch v2RunBrowserJavaScript(browserPanel.webView, surfaceId: surfaceId, script: script) {
+            switch v2RunBrowserJavaScript(browserPanel, surfaceId: surfaceId, script: script) {
             case .failure(let message):
                 return .err(code: "js_error", message: message, data: nil)
             case .success(let value):
@@ -11093,7 +11188,7 @@ class TerminalController {
               return { ok: true, selector: finalSelector, text: String(el.textContent || '').trim() };
             })()
             """
-            switch v2RunBrowserJavaScript(browserPanel.webView, surfaceId: surfaceId, script: script) {
+            switch v2RunBrowserJavaScript(browserPanel, surfaceId: surfaceId, script: script) {
             case .failure(let message):
                 return .err(code: "js_error", message: message, data: nil)
             case .success(let value):
@@ -11145,7 +11240,7 @@ class TerminalController {
               return { ok: true, selector: finalSelector, index: idx, text: String(el.textContent || '').trim() };
             })()
             """
-            switch v2RunBrowserJavaScript(browserPanel.webView, surfaceId: surfaceId, script: script) {
+            switch v2RunBrowserJavaScript(browserPanel, surfaceId: surfaceId, script: script) {
             case .failure(let message):
                 return .err(code: "js_error", message: message, data: nil)
             case .success(let value):
@@ -11196,7 +11291,7 @@ class TerminalController {
               return { ok: true };
             })()
             """
-            switch v2RunBrowserJavaScript(browserPanel.webView, surfaceId: surfaceId, script: script) {
+            switch v2RunBrowserJavaScript(browserPanel, surfaceId: surfaceId, script: script) {
             case .failure(let message):
                 return .err(code: "js_error", message: message, data: nil)
             case .success(let value):
@@ -11723,7 +11818,7 @@ class TerminalController {
               return { ok: true, value: st.getItem(String(key)) };
             })()
             """
-            switch v2RunBrowserJavaScript(browserPanel.webView, surfaceId: surfaceId, script: script) {
+            switch v2RunBrowserJavaScript(browserPanel, surfaceId: surfaceId, script: script) {
             case .failure(let message):
                 return .err(code: "js_error", message: message, data: nil)
             case .success(let value):
@@ -11769,7 +11864,7 @@ class TerminalController {
               return { ok: true };
             })()
             """
-            switch v2RunBrowserJavaScript(browserPanel.webView, surfaceId: surfaceId, script: script) {
+            switch v2RunBrowserJavaScript(browserPanel, surfaceId: surfaceId, script: script) {
             case .failure(let message):
                 return .err(code: "js_error", message: message, data: nil)
             case .success(let value):
@@ -11803,7 +11898,7 @@ class TerminalController {
               return { ok: true };
             })()
             """
-            switch v2RunBrowserJavaScript(browserPanel.webView, surfaceId: surfaceId, script: script) {
+            switch v2RunBrowserJavaScript(browserPanel, surfaceId: surfaceId, script: script) {
             case .failure(let message):
                 return .err(code: "js_error", message: message, data: nil)
             case .success(let value):
@@ -12120,7 +12215,7 @@ class TerminalController {
             """
 
             let storageValue: Any
-            switch v2RunBrowserJavaScript(browserPanel.webView, surfaceId: surfaceId, script: storageScript, timeout: 10.0) {
+            switch v2RunBrowserJavaScript(browserPanel, surfaceId: surfaceId, script: storageScript, timeout: 10.0) {
             case .failure(let message):
                 return .err(code: "js_error", message: message, data: nil)
             case .success(let value):
@@ -12211,7 +12306,7 @@ class TerminalController {
                   return true;
                 })()
                 """
-                _ = v2RunBrowserJavaScript(browserPanel.webView, surfaceId: surfaceId, script: script, timeout: 10.0)
+                _ = v2RunBrowserJavaScript(browserPanel, surfaceId: surfaceId, script: script, timeout: 10.0)
             }
 
             return .ok([
@@ -12234,9 +12329,8 @@ class TerminalController {
             scripts.append(script)
             v2BrowserInitScriptsBySurface[surfaceId] = scripts
 
-            let userScript = WKUserScript(source: script, injectionTime: .atDocumentStart, forMainFrameOnly: false)
-            browserPanel.webView.configuration.userContentController.addUserScript(userScript)
-            _ = v2RunBrowserJavaScript(browserPanel.webView, surfaceId: surfaceId, script: script, timeout: 10.0)
+            _ = browserPanel.addPersistentUserScript(script)
+            _ = v2RunBrowserJavaScript(browserPanel, surfaceId: surfaceId, script: script, timeout: 10.0)
 
             return .ok([
                 "workspace_id": ws.id.uuidString,
@@ -12253,7 +12347,7 @@ class TerminalController {
             return .err(code: "invalid_params", message: "Missing script", data: nil)
         }
         return v2BrowserWithPanel(params: params) { _, ws, surfaceId, browserPanel in
-            switch v2RunBrowserJavaScript(browserPanel.webView, surfaceId: surfaceId, script: script, timeout: 10.0) {
+            switch v2RunBrowserJavaScript(browserPanel, surfaceId: surfaceId, script: script, timeout: 10.0) {
             case .failure(let message):
                 return .err(code: "js_error", message: message, data: nil)
             case .success(let value):
@@ -12287,9 +12381,8 @@ class TerminalController {
             })()
             """
 
-            let userScript = WKUserScript(source: source, injectionTime: .atDocumentStart, forMainFrameOnly: false)
-            browserPanel.webView.configuration.userContentController.addUserScript(userScript)
-            _ = v2RunBrowserJavaScript(browserPanel.webView, surfaceId: surfaceId, script: source, timeout: 10.0)
+            _ = browserPanel.addPersistentUserStyle(source)
+            _ = v2RunBrowserJavaScript(browserPanel, surfaceId: surfaceId, script: source, timeout: 10.0)
 
             return .ok([
                 "workspace_id": ws.id.uuidString,

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -165,7 +165,6 @@ extension Workspace {
         restorableAgentIndex: RestorableAgentSessionIndex? = nil
     ) -> SessionWorkspaceSnapshot {
         let tree = bonsplitController.treeSnapshot()
-        let layout = sessionLayoutSnapshot(from: tree)
 
         let orderedPanelIds = sidebarOrderedPanelIds()
         var seen: Set<UUID> = []
@@ -186,6 +185,12 @@ extension Workspace {
                     restorableAgent: restorableAgentIndex?.snapshot(workspaceId: id, panelId: panelId)
                 )
             }
+
+        let restorablePanelIds = Set(panelSnapshots.map(\.id))
+        let layout = sessionLayoutSnapshot(
+            from: tree,
+            restorablePanelIds: restorablePanelIds
+        ) ?? .pane(SessionPaneLayoutSnapshot(panelIds: [], selectedPanelId: nil))
 
         let statusSnapshots = statusEntries.values
             .sorted { lhs, rhs in lhs.key < rhs.key }
@@ -265,8 +270,13 @@ extension Workspace {
             currentDirectory = normalizedCurrentDirectory
         }
 
-        let panelSnapshotsById = Dictionary(uniqueKeysWithValues: snapshot.panels.map { ($0.id, $0) })
-        let leafEntries = restoreSessionLayout(snapshot.layout)
+        let restorablePanelSnapshots = snapshot.panels.filter(Self.shouldRestoreSessionPanelSnapshot)
+        let panelSnapshotsById = Dictionary(uniqueKeysWithValues: restorablePanelSnapshots.map { ($0.id, $0) })
+        let restorableLayout = Self.prunedSessionLayoutSnapshot(
+            snapshot.layout,
+            keepingPanelIds: Set(panelSnapshotsById.keys)
+        ) ?? .pane(SessionPaneLayoutSnapshot(panelIds: [], selectedPanelId: nil))
+        let leafEntries = restoreSessionLayout(restorableLayout)
         var oldToNewPanelIds: [UUID: UUID] = [:]
 
         for entry in leafEntries {
@@ -279,7 +289,7 @@ extension Workspace {
         }
 
         pruneSurfaceMetadata(validSurfaceIds: Set(panels.keys))
-        applySessionDividerPositions(snapshotNode: snapshot.layout, liveNode: bonsplitController.treeSnapshot())
+        applySessionDividerPositions(snapshotNode: restorableLayout, liveNode: bonsplitController.treeSnapshot())
 
         applyProcessTitle(snapshot.processTitle)
         setCustomTitle(snapshot.customTitle)
@@ -327,11 +337,18 @@ extension Workspace {
         }
     }
 
-    private func sessionLayoutSnapshot(from node: ExternalTreeNode) -> SessionWorkspaceLayoutSnapshot {
+    private func sessionLayoutSnapshot(
+        from node: ExternalTreeNode,
+        restorablePanelIds: Set<UUID>
+    ) -> SessionWorkspaceLayoutSnapshot? {
         switch node {
         case .pane(let pane):
-            let panelIds = sessionPanelIDs(for: pane)
-            let selectedPanelId = pane.selectedTabId.flatMap(sessionPanelID(forExternalTabIDString:))
+            let panelIds = sessionPanelIDs(for: pane, restorablePanelIds: restorablePanelIds)
+            guard !panelIds.isEmpty else { return nil }
+            let selectedPanelId = pane.selectedTabId
+                .flatMap(sessionPanelID(forExternalTabIDString:))
+                .flatMap { panelIds.contains($0) ? $0 : nil }
+                ?? panelIds.first
             return .pane(
                 SessionPaneLayoutSnapshot(
                     panelIds: panelIds,
@@ -339,22 +356,94 @@ extension Workspace {
                 )
             )
         case .split(let split):
-            return .split(
-                SessionSplitLayoutSnapshot(
-                    orientation: split.orientation.lowercased() == "vertical" ? .vertical : .horizontal,
-                    dividerPosition: split.dividerPosition,
-                    first: sessionLayoutSnapshot(from: split.first),
-                    second: sessionLayoutSnapshot(from: split.second)
-                )
+            let first = sessionLayoutSnapshot(
+                from: split.first,
+                restorablePanelIds: restorablePanelIds
             )
+            let second = sessionLayoutSnapshot(
+                from: split.second,
+                restorablePanelIds: restorablePanelIds
+            )
+            switch (first, second) {
+            case (.some(let first), .some(let second)):
+                return .split(
+                    SessionSplitLayoutSnapshot(
+                        orientation: split.orientation.lowercased() == "vertical" ? .vertical : .horizontal,
+                        dividerPosition: split.dividerPosition,
+                        first: first,
+                        second: second
+                    )
+                )
+            case (.some(let first), .none):
+                return first
+            case (.none, .some(let second)):
+                return second
+            case (.none, .none):
+                return nil
+            }
         }
     }
 
-    private func sessionPanelIDs(for pane: ExternalPaneNode) -> [UUID] {
+    private static func prunedSessionLayoutSnapshot(
+        _ node: SessionWorkspaceLayoutSnapshot,
+        keepingPanelIds restorablePanelIds: Set<UUID>
+    ) -> SessionWorkspaceLayoutSnapshot? {
+        switch node {
+        case .pane(let pane):
+            let panelIds = pane.panelIds.filter { restorablePanelIds.contains($0) }
+            guard !panelIds.isEmpty else { return nil }
+            let selectedPanelId = pane.selectedPanelId
+                .flatMap { panelIds.contains($0) ? $0 : nil }
+                ?? panelIds.first
+            return .pane(
+                SessionPaneLayoutSnapshot(
+                    panelIds: panelIds,
+                    selectedPanelId: selectedPanelId
+                )
+            )
+        case .split(let split):
+            let first = prunedSessionLayoutSnapshot(
+                split.first,
+                keepingPanelIds: restorablePanelIds
+            )
+            let second = prunedSessionLayoutSnapshot(
+                split.second,
+                keepingPanelIds: restorablePanelIds
+            )
+            switch (first, second) {
+            case (.some(let first), .some(let second)):
+                return .split(
+                    SessionSplitLayoutSnapshot(
+                        orientation: split.orientation,
+                        dividerPosition: split.dividerPosition,
+                        first: first,
+                        second: second
+                    )
+                )
+            case (.some(let first), .none):
+                return first
+            case (.none, .some(let second)):
+                return second
+            case (.none, .none):
+                return nil
+            }
+        }
+    }
+
+    private static func shouldRestoreSessionPanelSnapshot(_ snapshot: SessionPanelSnapshot) -> Bool {
+        guard snapshot.type == .browser else { return true }
+        return !BrowserPanel.isChromiumDevToolsFrontendURLString(snapshot.browser?.urlString)
+    }
+
+    private func sessionPanelIDs(
+        for pane: ExternalPaneNode,
+        restorablePanelIds: Set<UUID>
+    ) -> [UUID] {
         var panelIds: [UUID] = []
         var seen = Set<UUID>()
         for tab in pane.tabs {
-            guard let panelId = sessionPanelID(forExternalTabIDString: tab.id) else { continue }
+            guard let panelId = sessionPanelID(forExternalTabIDString: tab.id),
+                  restorablePanelIds.contains(panelId) else { continue }
             if seen.insert(panelId).inserted {
                 panelIds.append(panelId)
             }
@@ -490,10 +579,15 @@ extension Workspace {
             rightSidebarToolSnapshot = nil
         case .browser:
             guard let browserPanel = panel as? BrowserPanel else { return nil }
+            let urlString = browserPanel.preferredURLStringForOmnibar()
+            guard browserPanel.chromiumDeveloperToolsOwnerPanelID == nil,
+                  !BrowserPanel.isChromiumDevToolsFrontendURLString(urlString) else {
+                return nil
+            }
             terminalSnapshot = nil
             let historySnapshot = browserPanel.sessionNavigationHistorySnapshot()
             browserSnapshot = SessionBrowserPanelSnapshot(
-                urlString: browserPanel.preferredURLStringForOmnibar(),
+                urlString: urlString,
                 profileID: browserPanel.profileID,
                 shouldRenderWebView: browserPanel.shouldRenderWebViewForSessionSnapshot(),
                 pageZoom: Double(browserPanel.currentPageZoomFactor()),
@@ -7153,9 +7247,14 @@ final class Workspace: Identifiable, ObservableObject {
     enum BrowserPanelCreationPolicy {
         case userInitiated
         case restoration
+        case internalTool
 
         var permitsCreationWhenBrowserDisabled: Bool {
             self == .restoration
+        }
+
+        var opensExternallyWhenBrowserDisabled: Bool {
+            self == .userInitiated
         }
     }
 
@@ -10346,7 +10445,7 @@ final class Workspace: Identifiable, ObservableObject {
     ) -> BrowserPanel? {
         let browserEnabled = BrowserAvailabilitySettings.isEnabled()
         guard browserEnabled || creationPolicy.permitsCreationWhenBrowserDisabled else {
-            if let url {
+            if creationPolicy.opensExternallyWhenBrowserDisabled, let url {
                 _ = NSWorkspace.shared.open(url)
             }
             return nil
@@ -10447,7 +10546,8 @@ final class Workspace: Identifiable, ObservableObject {
     ) -> BrowserPanel? {
         let browserEnabled = BrowserAvailabilitySettings.isEnabled()
         guard browserEnabled || creationPolicy.permitsCreationWhenBrowserDisabled else {
-            if let externalURL = url ?? initialRequest?.url {
+            if creationPolicy.opensExternallyWhenBrowserDisabled,
+               let externalURL = url ?? initialRequest?.url {
                 _ = NSWorkspace.shared.open(externalURL)
             }
             return nil

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -94,6 +94,7 @@ final class BrowserChromiumArtifactVerifierTests: XCTestCase {
                 hostClassName: BrowserChromiumArtifactManifest.hostClassName,
                 hostFactoryClassName: BrowserChromiumArtifactManifest.hostFactoryClassName,
                 hostAPIVersion: BrowserChromiumArtifactManifest.hostAPIVersion,
+                forbiddenCEFMarkersVerifiedAbsent: Self.productionCEFMarkerProof(),
                 launchPolicy: Self.productionOwlLaunchPolicy(),
                 renderingAPI: Self.productionOwlRenderingAPI()
             )
@@ -102,6 +103,7 @@ final class BrowserChromiumArtifactVerifierTests: XCTestCase {
         let manifest = try BrowserChromiumArtifactVerifier.verifyFramework(at: frameworkURL)
         XCTAssertEqual(manifest.launchPolicy?.sandboxDisabled, false)
         XCTAssertEqual(manifest.launchPolicy?.usesInProcessGPUByDefault, false)
+        XCTAssertEqual(manifest.forbiddenCEFMarkersVerifiedAbsent, Self.productionCEFMarkerProof())
         XCTAssertEqual(manifest.renderingAPI?.compositorLayer, "CALayerHost")
         XCTAssertEqual(manifest.renderingAPI?.surfaceTransport, "IOSurface/Metal")
 
@@ -109,6 +111,10 @@ final class BrowserChromiumArtifactVerifierTests: XCTestCase {
         XCTAssertEqual(status.kind, .chromium)
         XCTAssertEqual(status.socketPayload["chromium_sandbox_disabled"] as? Bool, false)
         XCTAssertEqual(status.socketPayload["chromium_uses_in_process_gpu_by_default"] as? Bool, false)
+        XCTAssertEqual(
+            status.socketPayload["chromium_forbidden_cef_markers_verified_absent"] as? [String],
+            Self.productionCEFMarkerProof()
+        )
         XCTAssertEqual(status.socketPayload["chromium_compositor_layer"] as? String, "CALayerHost")
     }
 
@@ -589,6 +595,16 @@ final class BrowserChromiumArtifactVerifierTests: XCTestCase {
         )
     }
 
+    private static func productionCEFMarkerProof() -> [String] {
+        [
+            "Chromium Embedded Framework",
+            "libcef",
+            "CefInitialize",
+            "CefBrowser",
+            "CEF.framework",
+        ]
+    }
+
     private static func productionOwlRenderingAPI() -> BrowserChromiumRenderingAPI {
         BrowserChromiumRenderingAPI(
             nativeViewHost: "Chromium remote_cocoa WebContents NSView",
@@ -687,6 +703,52 @@ final class BrowserChromiumArtifactVerifierTests: XCTestCase {
 
 @MainActor
 final class BrowserNativeEngineHostContainerViewTests: XCTestCase {
+    private final class RecordingNativeView: NSView {
+        var events: [String] = []
+
+        override func mouseDown(with event: NSEvent) {
+            events.append("mouseDown")
+        }
+
+        override func rightMouseDown(with event: NSEvent) {
+            events.append("rightMouseDown")
+        }
+
+        override func rightMouseUp(with event: NSEvent) {
+            events.append("rightMouseUp")
+        }
+
+        override func scrollWheel(with event: NSEvent) {
+            events.append("scrollWheel")
+        }
+    }
+
+    private func makeMouseEvent(_ type: NSEvent.EventType) -> NSEvent {
+        NSEvent.mouseEvent(
+            with: type,
+            location: NSPoint(x: 20, y: 20),
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 1
+        )!
+    }
+
+    private func makeScrollEvent() -> NSEvent {
+        let cgEvent = CGEvent(
+            scrollWheelEvent2Source: nil,
+            units: .pixel,
+            wheelCount: 2,
+            wheel1: 0,
+            wheel2: -8,
+            wheel3: 0
+        )!
+        return NSEvent(cgEvent: cgEvent)!
+    }
+
     func testHostsAndReplacesNativeEngineView() {
         let host = BrowserNativeEngineHostContainerView(frame: NSRect(x: 0, y: 0, width: 640, height: 480))
         let firstNativeView = NSView(frame: .zero)
@@ -722,6 +784,46 @@ final class BrowserNativeEngineHostContainerViewTests: XCTestCase {
 
         XCTAssertTrue(nativeView.superview === secondHost)
         XCTAssertNil(firstHost.currentHostedNativeView)
+    }
+
+    func testHitTestReturnsContainerForHostedNativeEngineView() {
+        let host = BrowserNativeEngineHostContainerView(frame: NSRect(x: 0, y: 0, width: 640, height: 480))
+        host.hostNativeView(NSView(frame: .zero))
+
+        XCTAssertTrue(host.hitTest(NSPoint(x: 20, y: 20)) === host)
+    }
+
+    func testPointerDownFocusesBeforeForwardingToNativeEngineView() {
+        let host = BrowserNativeEngineHostContainerView(frame: NSRect(x: 0, y: 0, width: 640, height: 480))
+        let nativeView = RecordingNativeView(frame: .zero)
+        var events: [String] = []
+        host.onPointerDown = {
+            events.append("focus")
+        }
+        host.hostNativeView(nativeView)
+
+        host.mouseDown(with: makeMouseEvent(.leftMouseDown))
+        host.rightMouseDown(with: makeMouseEvent(.rightMouseDown))
+
+        XCTAssertEqual(events, ["focus", "focus"])
+        XCTAssertEqual(nativeView.events, ["mouseDown", "rightMouseDown"])
+    }
+
+    func testRightClickAndScrollForwardToNativeEngineView() {
+        let host = BrowserNativeEngineHostContainerView(frame: NSRect(x: 0, y: 0, width: 640, height: 480))
+        let nativeView = RecordingNativeView(frame: .zero)
+        var focusCount = 0
+        host.onPointerDown = {
+            focusCount += 1
+        }
+        host.hostNativeView(nativeView)
+
+        host.rightMouseDown(with: makeMouseEvent(.rightMouseDown))
+        host.rightMouseUp(with: makeMouseEvent(.rightMouseUp))
+        host.scrollWheel(with: makeScrollEvent())
+
+        XCTAssertEqual(focusCount, 1)
+        XCTAssertEqual(nativeView.events, ["rightMouseDown", "rightMouseUp", "scrollWheel"])
     }
 }
 
@@ -3853,5 +3955,76 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
             displayCountBeforeRebind,
             "Workspace rebind should refresh the preserved browser without recreating its portal slot"
         )
+    }
+}
+
+final class ChromiumDevToolsWebSocketProxyTests: XCTestCase {
+    func testDetectsChromiumDevToolsFrontendURLs() {
+        XCTAssertTrue(BrowserPanel.isChromiumDevToolsFrontendURLString(
+            "http://127.0.0.1:9222/devtools/inspector.html?ws=127.0.0.1:9222/devtools/page/ABC"
+        ))
+        XCTAssertTrue(BrowserPanel.isChromiumDevToolsFrontendURLString(
+            "chrome-devtools://devtools/bundled/inspector.html?ws=127.0.0.1:9222/devtools/page/ABC"
+        ))
+        XCTAssertFalse(BrowserPanel.isChromiumDevToolsFrontendURLString("https://example.com/devtools-guide"))
+    }
+
+    func testAcceptKeyMatchesWebSocketProtocolExample() {
+        XCTAssertEqual(
+            ChromiumDevToolsWebSocketFrameCodec.acceptKey(for: "dGhlIHNhbXBsZSBub25jZQ=="),
+            "s3pPLMBiTxaQ9kYGzzhZRbK+xOo="
+        )
+    }
+
+    func testDecodesMaskedClientTextFrame() throws {
+        let payload = Array("hello".utf8)
+        let mask: [UInt8] = [1, 2, 3, 4]
+        var bytes: [UInt8] = [0x81, 0x80 | UInt8(payload.count)]
+        bytes.append(contentsOf: mask)
+        bytes.append(contentsOf: payload.enumerated().map { index, byte in
+            byte ^ mask[index % mask.count]
+        })
+        var buffer = Data(bytes)
+
+        let frames = try ChromiumDevToolsWebSocketFrameCodec.decodeClientFrames(from: &buffer)
+
+        XCTAssertTrue(buffer.isEmpty)
+        XCTAssertEqual(frames, [
+            ChromiumDevToolsWebSocketFrame(opcode: 0x1, payload: Data("hello".utf8), isFinal: true)
+        ])
+    }
+
+    func testEncodesUnmaskedServerTextFrame() {
+        let frame = ChromiumDevToolsWebSocketFrameCodec.encodeServerFrame(
+            opcode: 0x1,
+            payload: Data("ok".utf8)
+        )
+
+        XCTAssertEqual(Array(frame), [0x81, 0x02, 0x6f, 0x6b])
+    }
+
+    func testRewritesDevToolsFrontendWebSocketEndpoint() throws {
+        let url = try XCTUnwrap(URL(string: "http://127.0.0.1:60149/devtools/inspector.html?ws=127.0.0.1:60149/devtools/page/ABC&panel=console"))
+        var observedUpstream: URL?
+
+        let rewritten = ChromiumDevToolsFrontendProxyURLRewriter.rewrite(url) { upstream in
+            observedUpstream = upstream
+            return "127.0.0.1:61234/devtools/page/ABC"
+        }
+
+        XCTAssertEqual(observedUpstream?.absoluteString, "ws://127.0.0.1:60149/devtools/page/ABC")
+        XCTAssertEqual(
+            rewritten.absoluteString,
+            "http://127.0.0.1:60149/devtools/inspector.html?ws=127.0.0.1:61234/devtools/page/ABC&panel=console"
+        )
+    }
+
+    func testProxyDoesNotRewriteToZeroPort() throws {
+        let url = try XCTUnwrap(URL(string: "http://127.0.0.1:60149/devtools/inspector.html?ws=127.0.0.1:60149/devtools/page/ABC"))
+
+        let rewritten = ChromiumDevToolsWebSocketProxy.shared.proxiedFrontendURL(url)
+
+        XCTAssertNotEqual(rewritten.absoluteString, url.absoluteString)
+        XCTAssertFalse(rewritten.absoluteString.contains("ws=127.0.0.1:0/"))
     }
 }

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -502,7 +502,7 @@ final class BrowserChromiumArtifactVerifierTests: XCTestCase {
         let proxyConfiguration = ["proxyServer": "socks5://127.0.0.1:9191"] as NSDictionary
 
         let bridge = try BrowserChromiumHostFactory.makeBridge(
-            factoryType: FakeChromiumHostFactory.self,
+            factoryClass: FakeChromiumHostFactory.self,
             factoryClassName: BrowserChromiumArtifactManifest.hostFactoryClassName,
             profileIdentifier: profileID,
             dataDirectory: dataDirectory,
@@ -519,7 +519,7 @@ final class BrowserChromiumArtifactVerifierTests: XCTestCase {
     func testChromiumHostFactoryRejectsNilFactoryResult() {
         XCTAssertThrowsError(
             try BrowserChromiumHostFactory.makeBridge(
-                factoryType: NilChromiumHostFactory.self,
+                factoryClass: NilChromiumHostFactory.self,
                 factoryClassName: "NilChromiumHostFactory",
                 profileIdentifier: UUID(),
                 dataDirectory: URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true),
@@ -655,16 +655,17 @@ final class BrowserChromiumArtifactVerifierTests: XCTestCase {
         @objc var cmuxNativeView: NSView? { nil }
     }
 
-    private final class FakeChromiumHostFactory: NSObject, BrowserChromiumHostFactoryExporting {
+    private final class FakeChromiumHostFactory: NSObject {
         static var lastProfileIdentifier: String?
         static var lastDataDirectory: URL?
         static var lastProxyConfiguration: NSDictionary?
 
+        @objc(cmuxCreateBrowserHostWithProfileIdentifier:dataDirectory:proxyConfiguration:)
         static func cmuxCreateBrowserHost(
             profileIdentifier: String,
             dataDirectory: NSURL,
             proxyConfiguration: NSDictionary?
-        ) -> BrowserChromiumHostExporting? {
+        ) -> NSObject? {
             lastProfileIdentifier = profileIdentifier
             lastDataDirectory = dataDirectory as URL
             lastProxyConfiguration = proxyConfiguration
@@ -672,12 +673,13 @@ final class BrowserChromiumArtifactVerifierTests: XCTestCase {
         }
     }
 
-    private final class NilChromiumHostFactory: NSObject, BrowserChromiumHostFactoryExporting {
+    private final class NilChromiumHostFactory: NSObject {
+        @objc(cmuxCreateBrowserHostWithProfileIdentifier:dataDirectory:proxyConfiguration:)
         static func cmuxCreateBrowserHost(
             profileIdentifier: String,
             dataDirectory: NSURL,
             proxyConfiguration: NSDictionary?
-        ) -> BrowserChromiumHostExporting? {
+        ) -> NSObject? {
             nil
         }
     }

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -13,6 +13,716 @@ import UserNotifications
 @testable import cmux
 #endif
 
+final class BrowserChromiumArtifactVerifierTests: XCTestCase {
+    func testAcceptsDiaStyleChromiumFrameworkWithoutCEF() throws {
+        let frameworkURL = try makeFrameworkFixture(
+            executableText: "ChromeMain RenderWidgetHostViewMac DisplayCALayerTree IOSurface",
+            resources: ["resources.pak", "icudtl.dat", "chrome_100_percent.pak"],
+            manifest: BrowserChromiumArtifactManifest(
+                engine: "chromium",
+                chromiumVersion: "148.0.7778.168",
+                chromiumRevision: "test-revision",
+                frameworkName: BrowserChromiumArtifactManifest.frameworkName,
+                resourceNames: ["resources.pak", "icudtl.dat", "chrome_100_percent.pak"],
+                hostClassName: BrowserChromiumArtifactManifest.hostClassName,
+                hostFactoryClassName: BrowserChromiumArtifactManifest.hostFactoryClassName,
+                hostAPIVersion: BrowserChromiumArtifactManifest.hostAPIVersion
+            )
+        )
+
+        let manifest = try BrowserChromiumArtifactVerifier.verifyFramework(at: frameworkURL)
+        XCTAssertEqual(manifest.engine, "chromium")
+        XCTAssertEqual(manifest.chromiumVersion, "148.0.7778.168")
+        XCTAssertEqual(manifest.frameworkName, BrowserChromiumArtifactManifest.frameworkName)
+        XCTAssertEqual(manifest.hostClassName, BrowserChromiumArtifactManifest.hostClassName)
+        XCTAssertEqual(manifest.hostAPIVersion, BrowserChromiumArtifactManifest.hostAPIVersion)
+
+        let status = BrowserEngineRuntimePolicy.status(frameworkURL: frameworkURL)
+        XCTAssertEqual(status.kind, .chromium)
+        XCTAssertNil(status.fallbackReason)
+        XCTAssertEqual(status.socketPayload["kind"] as? String, BrowserEngineRuntimeKind.chromium.rawValue)
+        XCTAssertEqual(status.socketPayload["chromium_ready"] as? Bool, true)
+        XCTAssertEqual(status.socketPayload["host_class_name"] as? String, BrowserChromiumArtifactManifest.hostClassName)
+        XCTAssertEqual(status.socketPayload["host_factory_class_name"] as? String, BrowserChromiumArtifactManifest.hostFactoryClassName)
+        XCTAssertEqual(status.socketPayload["host_api_version"] as? Int, BrowserChromiumArtifactManifest.hostAPIVersion)
+    }
+
+    func testAcceptsContentShellChromiumFrameworkWithoutCEF() throws {
+        let frameworkURL = try makeFrameworkFixture(
+            executableText: "ContentShellMain DisplayCALayerTree IOSurface",
+            resources: ["content_shell.pak", "icudtl.dat", "v8_context_snapshot.arm64.bin"],
+            manifest: BrowserChromiumArtifactManifest(
+                engine: "chromium-content-shell",
+                chromiumVersion: "148.0.7778.168",
+                chromiumRevision: "test-revision",
+                frameworkName: BrowserChromiumArtifactManifest.frameworkName,
+                resourceNames: ["content_shell.pak", "icudtl.dat", "v8_context_snapshot.arm64.bin"],
+                hostClassName: BrowserChromiumArtifactManifest.hostClassName,
+                hostFactoryClassName: BrowserChromiumArtifactManifest.hostFactoryClassName,
+                hostAPIVersion: BrowserChromiumArtifactManifest.hostAPIVersion
+            )
+        )
+
+        let manifest = try BrowserChromiumArtifactVerifier.verifyFramework(at: frameworkURL)
+        XCTAssertEqual(manifest.engine, "chromium-content-shell")
+        XCTAssertEqual(manifest.resourceNames, ["content_shell.pak", "icudtl.dat", "v8_context_snapshot.arm64.bin"])
+        let status = BrowserEngineRuntimePolicy.status(frameworkURL: frameworkURL)
+        XCTAssertEqual(status.kind, .chromium)
+        XCTAssertEqual(status.socketPayload["chromium_ready"] as? Bool, true)
+    }
+
+    func testAcceptsProductionOwlRuntimeLaunchPolicy() throws {
+        let frameworkURL = try makeFrameworkFixture(
+            executableText: "ContentShellMain DisplayCALayerTree IOSurface",
+            resources: [
+                "content_shell.pak",
+                "icudtl.dat",
+                "v8_context_snapshot.arm64.bin",
+                "libowl_fresh_mojo_runtime.dylib",
+            ],
+            manifest: BrowserChromiumArtifactManifest(
+                engine: "chromium-owl-fresh-mojo",
+                chromiumVersion: "148.0.7778.168",
+                chromiumRevision: "test-revision",
+                frameworkName: BrowserChromiumArtifactManifest.frameworkName,
+                resourceNames: [
+                    "content_shell.pak",
+                    "icudtl.dat",
+                    "v8_context_snapshot.arm64.bin",
+                    "libowl_fresh_mojo_runtime.dylib",
+                ],
+                hostClassName: BrowserChromiumArtifactManifest.hostClassName,
+                hostFactoryClassName: BrowserChromiumArtifactManifest.hostFactoryClassName,
+                hostAPIVersion: BrowserChromiumArtifactManifest.hostAPIVersion,
+                launchPolicy: Self.productionOwlLaunchPolicy(),
+                renderingAPI: Self.productionOwlRenderingAPI()
+            )
+        )
+
+        let manifest = try BrowserChromiumArtifactVerifier.verifyFramework(at: frameworkURL)
+        XCTAssertEqual(manifest.launchPolicy?.sandboxDisabled, false)
+        XCTAssertEqual(manifest.launchPolicy?.usesInProcessGPUByDefault, false)
+        XCTAssertEqual(manifest.renderingAPI?.compositorLayer, "CALayerHost")
+        XCTAssertEqual(manifest.renderingAPI?.surfaceTransport, "IOSurface/Metal")
+
+        let status = BrowserEngineRuntimePolicy.status(frameworkURL: frameworkURL)
+        XCTAssertEqual(status.kind, .chromium)
+        XCTAssertEqual(status.socketPayload["chromium_sandbox_disabled"] as? Bool, false)
+        XCTAssertEqual(status.socketPayload["chromium_uses_in_process_gpu_by_default"] as? Bool, false)
+        XCTAssertEqual(status.socketPayload["chromium_compositor_layer"] as? String, "CALayerHost")
+    }
+
+    func testRejectsOwlRuntimeMissingLaunchPolicy() throws {
+        let frameworkURL = try makeFrameworkFixture(
+            executableText: "ContentShellMain DisplayCALayerTree IOSurface",
+            resources: [
+                "content_shell.pak",
+                "icudtl.dat",
+                "v8_context_snapshot.arm64.bin",
+                "libowl_fresh_mojo_runtime.dylib",
+            ],
+            manifest: BrowserChromiumArtifactManifest(
+                engine: "chromium-owl-fresh-mojo",
+                chromiumVersion: "148.0.7778.168",
+                chromiumRevision: "test-revision",
+                frameworkName: BrowserChromiumArtifactManifest.frameworkName,
+                resourceNames: [
+                    "content_shell.pak",
+                    "icudtl.dat",
+                    "v8_context_snapshot.arm64.bin",
+                    "libowl_fresh_mojo_runtime.dylib",
+                ],
+                hostClassName: BrowserChromiumArtifactManifest.hostClassName,
+                hostFactoryClassName: BrowserChromiumArtifactManifest.hostFactoryClassName,
+                hostAPIVersion: BrowserChromiumArtifactManifest.hostAPIVersion
+            )
+        )
+
+        XCTAssertThrowsError(try BrowserChromiumArtifactVerifier.verifyFramework(at: frameworkURL)) { error in
+            XCTAssertEqual(error as? BrowserChromiumArtifactVerificationError, .missingLaunchPolicy)
+        }
+    }
+
+    func testRejectsManifestlessOwlRuntimeMissingLaunchPolicy() throws {
+        let frameworkURL = try makeFrameworkFixture(
+            executableText: "ContentShellMain DisplayCALayerTree IOSurface",
+            resources: [
+                "content_shell.pak",
+                "icudtl.dat",
+                "v8_context_snapshot.arm64.bin",
+                "libowl_fresh_mojo_runtime.dylib",
+            ]
+        )
+
+        XCTAssertThrowsError(try BrowserChromiumArtifactVerifier.verifyFramework(at: frameworkURL)) { error in
+            XCTAssertEqual(error as? BrowserChromiumArtifactVerificationError, .missingLaunchPolicy)
+        }
+    }
+
+    func testRejectsOwlRuntimeThatDisablesSandbox() throws {
+        let frameworkURL = try makeFrameworkFixture(
+            executableText: "ContentShellMain DisplayCALayerTree IOSurface",
+            resources: [
+                "content_shell.pak",
+                "icudtl.dat",
+                "v8_context_snapshot.arm64.bin",
+                "libowl_fresh_mojo_runtime.dylib",
+            ],
+            manifest: BrowserChromiumArtifactManifest(
+                engine: "chromium-owl-fresh-mojo",
+                chromiumVersion: "148.0.7778.168",
+                chromiumRevision: "test-revision",
+                frameworkName: BrowserChromiumArtifactManifest.frameworkName,
+                resourceNames: [
+                    "content_shell.pak",
+                    "icudtl.dat",
+                    "v8_context_snapshot.arm64.bin",
+                    "libowl_fresh_mojo_runtime.dylib",
+                ],
+                hostClassName: BrowserChromiumArtifactManifest.hostClassName,
+                hostFactoryClassName: BrowserChromiumArtifactManifest.hostFactoryClassName,
+                hostAPIVersion: BrowserChromiumArtifactManifest.hostAPIVersion,
+                launchPolicy: BrowserChromiumLaunchPolicy(
+                    sandboxDisabled: true,
+                    usesInProcessGPUByDefault: false,
+                    defaultSwitches: ["fresh-owl-embed"],
+                    forbiddenSwitchesVerifiedAbsent: ["no-sandbox"]
+                )
+            )
+        )
+
+        XCTAssertThrowsError(try BrowserChromiumArtifactVerifier.verifyFramework(at: frameworkURL)) { error in
+            XCTAssertEqual(
+                error as? BrowserChromiumArtifactVerificationError,
+                .insecureLaunchPolicy("sandbox is disabled")
+            )
+        }
+    }
+
+    func testRejectsOwlRuntimeThatUsesInProcessGPUByDefault() throws {
+        let frameworkURL = try makeFrameworkFixture(
+            executableText: "ContentShellMain DisplayCALayerTree IOSurface",
+            resources: [
+                "content_shell.pak",
+                "icudtl.dat",
+                "v8_context_snapshot.arm64.bin",
+                "libowl_fresh_mojo_runtime.dylib",
+            ],
+            manifest: BrowserChromiumArtifactManifest(
+                engine: "chromium-owl-fresh-mojo",
+                chromiumVersion: "148.0.7778.168",
+                chromiumRevision: "test-revision",
+                frameworkName: BrowserChromiumArtifactManifest.frameworkName,
+                resourceNames: [
+                    "content_shell.pak",
+                    "icudtl.dat",
+                    "v8_context_snapshot.arm64.bin",
+                    "libowl_fresh_mojo_runtime.dylib",
+                ],
+                hostClassName: BrowserChromiumArtifactManifest.hostClassName,
+                hostFactoryClassName: BrowserChromiumArtifactManifest.hostFactoryClassName,
+                hostAPIVersion: BrowserChromiumArtifactManifest.hostAPIVersion,
+                launchPolicy: BrowserChromiumLaunchPolicy(
+                    sandboxDisabled: false,
+                    usesInProcessGPUByDefault: true,
+                    defaultSwitches: ["fresh-owl-embed"],
+                    forbiddenSwitchesVerifiedAbsent: ["no-sandbox"]
+                )
+            )
+        )
+
+        XCTAssertThrowsError(try BrowserChromiumArtifactVerifier.verifyFramework(at: frameworkURL)) { error in
+            XCTAssertEqual(
+                error as? BrowserChromiumArtifactVerificationError,
+                .insecureLaunchPolicy("in-process GPU is enabled by default")
+            )
+        }
+    }
+
+    func testRejectsOwlRuntimeDefaultNoSandboxSwitch() throws {
+        let frameworkURL = try makeFrameworkFixture(
+            executableText: "ContentShellMain DisplayCALayerTree IOSurface",
+            resources: [
+                "content_shell.pak",
+                "icudtl.dat",
+                "v8_context_snapshot.arm64.bin",
+                "libowl_fresh_mojo_runtime.dylib",
+            ],
+            manifest: BrowserChromiumArtifactManifest(
+                engine: "chromium-owl-fresh-mojo",
+                chromiumVersion: "148.0.7778.168",
+                chromiumRevision: "test-revision",
+                frameworkName: BrowserChromiumArtifactManifest.frameworkName,
+                resourceNames: [
+                    "content_shell.pak",
+                    "icudtl.dat",
+                    "v8_context_snapshot.arm64.bin",
+                    "libowl_fresh_mojo_runtime.dylib",
+                ],
+                hostClassName: BrowserChromiumArtifactManifest.hostClassName,
+                hostFactoryClassName: BrowserChromiumArtifactManifest.hostFactoryClassName,
+                hostAPIVersion: BrowserChromiumArtifactManifest.hostAPIVersion,
+                launchPolicy: BrowserChromiumLaunchPolicy(
+                    sandboxDisabled: false,
+                    usesInProcessGPUByDefault: false,
+                    defaultSwitches: ["fresh-owl-embed", "no-sandbox"],
+                    forbiddenSwitchesVerifiedAbsent: ["no-sandbox"]
+                )
+            )
+        )
+
+        XCTAssertThrowsError(try BrowserChromiumArtifactVerifier.verifyFramework(at: frameworkURL)) { error in
+            XCTAssertEqual(
+                error as? BrowserChromiumArtifactVerificationError,
+                .insecureLaunchPolicy("default switches include no-sandbox")
+            )
+        }
+    }
+
+    func testRejectsOwlRuntimeWithoutNoSandboxAbsenceProof() throws {
+        let frameworkURL = try makeFrameworkFixture(
+            executableText: "ContentShellMain DisplayCALayerTree IOSurface",
+            resources: [
+                "content_shell.pak",
+                "icudtl.dat",
+                "v8_context_snapshot.arm64.bin",
+                "libowl_fresh_mojo_runtime.dylib",
+            ],
+            manifest: BrowserChromiumArtifactManifest(
+                engine: "chromium-owl-fresh-mojo",
+                chromiumVersion: "148.0.7778.168",
+                chromiumRevision: "test-revision",
+                frameworkName: BrowserChromiumArtifactManifest.frameworkName,
+                resourceNames: [
+                    "content_shell.pak",
+                    "icudtl.dat",
+                    "v8_context_snapshot.arm64.bin",
+                    "libowl_fresh_mojo_runtime.dylib",
+                ],
+                hostClassName: BrowserChromiumArtifactManifest.hostClassName,
+                hostFactoryClassName: BrowserChromiumArtifactManifest.hostFactoryClassName,
+                hostAPIVersion: BrowserChromiumArtifactManifest.hostAPIVersion,
+                launchPolicy: BrowserChromiumLaunchPolicy(
+                    sandboxDisabled: false,
+                    usesInProcessGPUByDefault: false,
+                    defaultSwitches: ["fresh-owl-embed"],
+                    forbiddenSwitchesVerifiedAbsent: []
+                )
+            )
+        )
+
+        XCTAssertThrowsError(try BrowserChromiumArtifactVerifier.verifyFramework(at: frameworkURL)) { error in
+            XCTAssertEqual(
+                error as? BrowserChromiumArtifactVerificationError,
+                .insecureLaunchPolicy("no-sandbox absence was not verified")
+            )
+        }
+    }
+
+    func testRejectsOwlRuntimeWithoutInProcessGPUAbsenceProof() throws {
+        let frameworkURL = try makeFrameworkFixture(
+            executableText: "ContentShellMain DisplayCALayerTree IOSurface",
+            resources: [
+                "content_shell.pak",
+                "icudtl.dat",
+                "v8_context_snapshot.arm64.bin",
+                "libowl_fresh_mojo_runtime.dylib",
+            ],
+            manifest: BrowserChromiumArtifactManifest(
+                engine: "chromium-owl-fresh-mojo",
+                chromiumVersion: "148.0.7778.168",
+                chromiumRevision: "test-revision",
+                frameworkName: BrowserChromiumArtifactManifest.frameworkName,
+                resourceNames: [
+                    "content_shell.pak",
+                    "icudtl.dat",
+                    "v8_context_snapshot.arm64.bin",
+                    "libowl_fresh_mojo_runtime.dylib",
+                ],
+                hostClassName: BrowserChromiumArtifactManifest.hostClassName,
+                hostFactoryClassName: BrowserChromiumArtifactManifest.hostFactoryClassName,
+                hostAPIVersion: BrowserChromiumArtifactManifest.hostAPIVersion,
+                launchPolicy: BrowserChromiumLaunchPolicy(
+                    sandboxDisabled: false,
+                    usesInProcessGPUByDefault: false,
+                    defaultSwitches: ["fresh-owl-embed"],
+                    forbiddenSwitchesVerifiedAbsent: ["no-sandbox"]
+                )
+            )
+        )
+
+        XCTAssertThrowsError(try BrowserChromiumArtifactVerifier.verifyFramework(at: frameworkURL)) { error in
+            XCTAssertEqual(
+                error as? BrowserChromiumArtifactVerificationError,
+                .insecureLaunchPolicy("in-process-gpu absence was not verified")
+            )
+        }
+    }
+
+
+    func testRejectsCEFMarkers() throws {
+        let frameworkURL = try makeFrameworkFixture(
+            executableText: "ChromeMain CefInitialize libcef",
+            resources: ["resources.pak", "icudtl.dat", "chrome_100_percent.pak"]
+        )
+
+        XCTAssertThrowsError(try BrowserChromiumArtifactVerifier.verifyFramework(at: frameworkURL)) { error in
+            XCTAssertEqual(
+                error as? BrowserChromiumArtifactVerificationError,
+                .cefDisallowed("libcef")
+            )
+        }
+
+        let status = BrowserEngineRuntimePolicy.status(frameworkURL: frameworkURL)
+        XCTAssertEqual(status.kind, .webKit)
+        XCTAssertEqual(status.socketPayload["chromium_ready"] as? Bool, false)
+        XCTAssertNotNil(status.fallbackReason)
+    }
+
+    func testRejectsCEFMarkersInBundledChromiumExecutable() throws {
+        let frameworkURL = try makeFrameworkFixture(
+            executableText: "CmuxChromiumCore",
+            resources: ["content_shell.pak", "icudtl.dat", "v8_context_snapshot.arm64.bin"]
+        )
+        let contentShellExecutable = frameworkURL
+            .appendingPathComponent("Versions/A/Resources/Content Shell.app", isDirectory: true)
+            .appendingPathComponent("Contents/MacOS/Content Shell", isDirectory: false)
+        try FileManager.default.createDirectory(
+            at: contentShellExecutable.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try "ContentShellMain libcef".write(to: contentShellExecutable, atomically: true, encoding: .utf8)
+
+        XCTAssertThrowsError(try BrowserChromiumArtifactVerifier.verifyFramework(at: frameworkURL)) { error in
+            XCTAssertEqual(
+                error as? BrowserChromiumArtifactVerificationError,
+                .cefDisallowed("libcef")
+            )
+        }
+    }
+
+    func testRejectsIncompleteChromiumResources() throws {
+        let frameworkURL = try makeFrameworkFixture(
+            executableText: "ChromeMain",
+            resources: ["resources.pak"]
+        )
+
+        XCTAssertThrowsError(try BrowserChromiumArtifactVerifier.verifyFramework(at: frameworkURL)) { error in
+            guard case .missingResources(let missing)? = error as? BrowserChromiumArtifactVerificationError else {
+                XCTFail("Expected missingResources, got \(error)")
+                return
+            }
+            XCTAssertTrue(missing.contains("icudtl.dat"))
+            XCTAssertTrue(
+                missing.contains("resources.pak with chrome_100_percent.pak or chrome_200_percent.pak or content_shell.pak")
+            )
+        }
+    }
+
+    @MainActor
+    func testChromiumHostBridgeForwardsCoreBrowserOperations() async throws {
+        let host = FakeChromiumHost()
+        let bridge = try BrowserChromiumHostBridge(exportedHost: host)
+
+        XCTAssertTrue(bridge.nativeView === host.view)
+        XCTAssertEqual(bridge.estimatedProgress, 0)
+
+        let url = try XCTUnwrap(URL(string: "https://example.com/"))
+        try bridge.load(URLRequest(url: url))
+        XCTAssertEqual(host.loadedURL, url)
+        XCTAssertEqual(bridge.currentURL, url)
+
+        try bridge.reload()
+        try bridge.stopLoading()
+        try bridge.goBack()
+        try bridge.goForward()
+
+        XCTAssertEqual(host.calls, ["load", "reload", "stopLoading", "goBack", "goForward"])
+
+        let value = try await bridge.evaluateJavaScript("document.title")
+        XCTAssertEqual(value as? String, "Example Domain")
+
+        let snapshotExpectation = expectation(description: "snapshot")
+        try bridge.takeSnapshot { image in
+            XCTAssertTrue(image === host.snapshotImage)
+            snapshotExpectation.fulfill()
+        }
+        await fulfillment(of: [snapshotExpectation], timeout: 1)
+    }
+
+    @MainActor
+    func testChromiumHostBridgeForwardsStateChangeHandler() throws {
+        let host = FakeChromiumHost()
+        let bridge = try BrowserChromiumHostBridge(exportedHost: host)
+        var callbackCount = 0
+
+        bridge.setStateChangedHandler {
+            callbackCount += 1
+        }
+        host.stateChangedHandler?()
+
+        XCTAssertEqual(callbackCount, 1)
+    }
+
+    @MainActor
+    func testChromiumEngineHostUsesBridgeAsBrowserHost() async throws {
+        let exportedHost = FakeChromiumHost()
+        let bridge = try BrowserChromiumHostBridge(exportedHost: exportedHost)
+        let engineHost = BrowserChromiumEngineHost(bridge: bridge)
+
+        XCTAssertTrue(engineHost.nativeView === exportedHost.view)
+        XCTAssertFalse(engineHost.isLoading)
+        XCTAssertTrue(engineHost.canGoBack)
+        XCTAssertTrue(engineHost.canGoForward)
+
+        let url = try XCTUnwrap(URL(string: "https://example.com/path"))
+        try engineHost.load(URLRequest(url: url))
+        XCTAssertEqual(exportedHost.loadedURL, url)
+        XCTAssertEqual(engineHost.currentURL, url)
+
+        let title = try await engineHost.evaluateJavaScript("document.title")
+        XCTAssertEqual(title as? String, "Example Domain")
+    }
+
+    @MainActor
+    func testChromiumHostBridgeRejectsMissingRequiredView() {
+        XCTAssertThrowsError(try BrowserChromiumHostBridge(exportedHost: MissingViewChromiumHost())) { error in
+            XCTAssertEqual(error as? BrowserChromiumHostBridgeError, .missingRequiredView)
+        }
+    }
+
+    @MainActor
+    func testChromiumHostFactoryCreatesBridgeWithProfileDirectory() throws {
+        FakeChromiumHostFactory.lastProfileIdentifier = nil
+        FakeChromiumHostFactory.lastDataDirectory = nil
+        FakeChromiumHostFactory.lastProxyConfiguration = nil
+        let profileID = UUID()
+        let dataDirectory = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("cmux-chromium-profile-\(UUID().uuidString)", isDirectory: true)
+        let proxyConfiguration = ["proxyServer": "socks5://127.0.0.1:9191"] as NSDictionary
+
+        let bridge = try BrowserChromiumHostFactory.makeBridge(
+            factoryType: FakeChromiumHostFactory.self,
+            factoryClassName: BrowserChromiumArtifactManifest.hostFactoryClassName,
+            profileIdentifier: profileID,
+            dataDirectory: dataDirectory,
+            proxyConfiguration: proxyConfiguration
+        )
+
+        XCTAssertTrue(bridge.exportedHost is FakeChromiumHost)
+        XCTAssertEqual(FakeChromiumHostFactory.lastProfileIdentifier, profileID.uuidString)
+        XCTAssertEqual(FakeChromiumHostFactory.lastDataDirectory, dataDirectory)
+        XCTAssertEqual(FakeChromiumHostFactory.lastProxyConfiguration?["proxyServer"] as? String, "socks5://127.0.0.1:9191")
+    }
+
+    @MainActor
+    func testChromiumHostFactoryRejectsNilFactoryResult() {
+        XCTAssertThrowsError(
+            try BrowserChromiumHostFactory.makeBridge(
+                factoryType: NilChromiumHostFactory.self,
+                factoryClassName: "NilChromiumHostFactory",
+                profileIdentifier: UUID(),
+                dataDirectory: URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true),
+                proxyConfiguration: nil
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? BrowserChromiumHostFactoryError,
+                .factoryReturnedNil("NilChromiumHostFactory")
+            )
+        }
+    }
+
+    private func makeFrameworkFixture(
+        executableText: String,
+        resources: [String],
+        manifest: BrowserChromiumArtifactManifest? = nil
+    ) throws -> URL {
+        let rootURL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("cmux-chromium-fixture-\(UUID().uuidString)", isDirectory: true)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: rootURL)
+        }
+
+        let frameworkURL = rootURL.appendingPathComponent(
+            BrowserChromiumArtifactManifest.frameworkName,
+            isDirectory: true
+        )
+        let versionURL = frameworkURL.appendingPathComponent("Versions/A", isDirectory: true)
+        let resourcesURL = versionURL.appendingPathComponent("Resources", isDirectory: true)
+        try FileManager.default.createDirectory(at: resourcesURL, withIntermediateDirectories: true)
+
+        try executableText.write(
+            to: versionURL.appendingPathComponent("CmuxChromiumCore", isDirectory: false),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        for resource in resources {
+            try Data([0x63, 0x6d, 0x75, 0x78]).write(
+                to: resourcesURL.appendingPathComponent(resource, isDirectory: false)
+            )
+        }
+
+        if let manifest {
+            let data = try JSONEncoder().encode(manifest)
+            try data.write(
+                to: resourcesURL.appendingPathComponent("cmux-chromium-manifest.json", isDirectory: false)
+            )
+        }
+
+        return frameworkURL
+    }
+
+    private static func productionOwlLaunchPolicy() -> BrowserChromiumLaunchPolicy {
+        BrowserChromiumLaunchPolicy(
+            sandboxDisabled: false,
+            usesInProcessGPUByDefault: false,
+            defaultSwitches: [
+                "fresh-owl-embed",
+                "fresh-owl-hosted-frame-pump",
+                "content-shell-hide-toolbar",
+                "no-first-run",
+                "no-default-browser-check",
+            ],
+            forbiddenSwitchesVerifiedAbsent: ["no-sandbox", "in-process-gpu"]
+        )
+    }
+
+    private static func productionOwlRenderingAPI() -> BrowserChromiumRenderingAPI {
+        BrowserChromiumRenderingAPI(
+            nativeViewHost: "Chromium remote_cocoa WebContents NSView",
+            compositorLayer: "CALayerHost",
+            surfaceTransport: "IOSurface/Metal"
+        )
+    }
+
+    private final class FakeChromiumHost: NSObject, BrowserChromiumHostExporting {
+        let view = NSView()
+        let snapshotImage = NSImage(size: NSSize(width: 2, height: 2))
+        var loadedURL: URL?
+        var calls: [String] = []
+        var stateChangedHandler: (() -> Void)?
+        var proxyConfiguration: NSDictionary?
+
+        @objc var cmuxNativeView: NSView? { view }
+        @objc var cmuxCurrentURL: NSURL? { loadedURL as NSURL? }
+        @objc var cmuxTitle: String? { "Example Domain" }
+        @objc var cmuxIsLoading: Bool { false }
+        @objc var cmuxCanGoBack: Bool { true }
+        @objc var cmuxCanGoForward: Bool { true }
+        @objc var cmuxEstimatedProgress: Double { loadedURL == nil ? 0 : 1 }
+
+        @objc func cmuxLoad(_ request: NSURLRequest) {
+            calls.append("load")
+            loadedURL = request.url
+        }
+
+        @objc func cmuxReload() {
+            calls.append("reload")
+        }
+
+        @objc func cmuxStopLoading() {
+            calls.append("stopLoading")
+        }
+
+        @objc func cmuxGoBack() {
+            calls.append("goBack")
+        }
+
+        @objc func cmuxGoForward() {
+            calls.append("goForward")
+        }
+
+        @objc func cmuxEvaluateJavaScript(_ script: String, completionHandler: @escaping (Any?, String?) -> Void) {
+            completionHandler(script == "document.title" ? "Example Domain" : nil, nil)
+        }
+
+        @objc func cmuxTakeSnapshot(_ completionHandler: @escaping (NSImage?) -> Void) {
+            completionHandler(snapshotImage)
+        }
+
+        @objc func cmuxSetStateChangedHandler(_ handler: @escaping () -> Void) {
+            stateChangedHandler = handler
+        }
+
+        @objc func cmuxSetProxyConfiguration(_ proxyConfiguration: NSDictionary?) {
+            self.proxyConfiguration = proxyConfiguration
+        }
+    }
+
+    private final class MissingViewChromiumHost: NSObject, BrowserChromiumHostExporting {
+        @objc var cmuxNativeView: NSView? { nil }
+    }
+
+    private final class FakeChromiumHostFactory: NSObject, BrowserChromiumHostFactoryExporting {
+        static var lastProfileIdentifier: String?
+        static var lastDataDirectory: URL?
+        static var lastProxyConfiguration: NSDictionary?
+
+        static func cmuxCreateBrowserHost(
+            profileIdentifier: String,
+            dataDirectory: NSURL,
+            proxyConfiguration: NSDictionary?
+        ) -> BrowserChromiumHostExporting? {
+            lastProfileIdentifier = profileIdentifier
+            lastDataDirectory = dataDirectory as URL
+            lastProxyConfiguration = proxyConfiguration
+            return FakeChromiumHost()
+        }
+    }
+
+    private final class NilChromiumHostFactory: NSObject, BrowserChromiumHostFactoryExporting {
+        static func cmuxCreateBrowserHost(
+            profileIdentifier: String,
+            dataDirectory: NSURL,
+            proxyConfiguration: NSDictionary?
+        ) -> BrowserChromiumHostExporting? {
+            nil
+        }
+    }
+}
+
+@MainActor
+final class BrowserNativeEngineHostContainerViewTests: XCTestCase {
+    func testHostsAndReplacesNativeEngineView() {
+        let host = BrowserNativeEngineHostContainerView(frame: NSRect(x: 0, y: 0, width: 640, height: 480))
+        let firstNativeView = NSView(frame: .zero)
+        let secondNativeView = NSView(frame: .zero)
+
+        host.hostNativeView(firstNativeView)
+
+        XCTAssertTrue(firstNativeView.superview === host)
+        XCTAssertTrue(host.currentHostedNativeView === firstNativeView)
+        XCTAssertFalse(firstNativeView.translatesAutoresizingMaskIntoConstraints)
+
+        host.hostNativeView(secondNativeView)
+
+        XCTAssertNil(firstNativeView.superview)
+        XCTAssertTrue(secondNativeView.superview === host)
+        XCTAssertTrue(host.currentHostedNativeView === secondNativeView)
+
+        host.detachHostedNativeView()
+
+        XCTAssertNil(secondNativeView.superview)
+        XCTAssertNil(host.currentHostedNativeView)
+    }
+
+    func testDetachDoesNotRemoveReparentedNativeEngineView() {
+        let firstHost = BrowserNativeEngineHostContainerView(frame: NSRect(x: 0, y: 0, width: 640, height: 480))
+        let secondHost = NSView(frame: NSRect(x: 0, y: 0, width: 640, height: 480))
+        let nativeView = NSView(frame: .zero)
+
+        firstHost.hostNativeView(nativeView)
+        nativeView.removeFromSuperview()
+        secondHost.addSubview(nativeView)
+        firstHost.detachHostedNativeView()
+
+        XCTAssertTrue(nativeView.superview === secondHost)
+        XCTAssertNil(firstHost.currentHostedNativeView)
+    }
+}
+
 private func drainBrowserPanelMainQueue() {
     let expectation = XCTestExpectation(description: "drain main queue")
     DispatchQueue.main.async {

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -12,6 +12,15 @@ final class SessionPersistenceTests: XCTestCase {
         let display: SessionDisplaySnapshot?
     }
 
+    private func sessionLayoutPanelIds(_ layout: SessionWorkspaceLayoutSnapshot) -> Set<UUID> {
+        switch layout {
+        case .pane(let pane):
+            return Set(pane.panelIds)
+        case .split(let split):
+            return sessionLayoutPanelIds(split.first).union(sessionLayoutPanelIds(split.second))
+        }
+    }
+
     @MainActor
     func testWorkspaceSessionSnapshotRestoresMarkdownPanel() throws {
         let root = FileManager.default.temporaryDirectory
@@ -70,6 +79,133 @@ final class SessionPersistenceTests: XCTestCase {
         let panelSnapshot = try XCTUnwrap(snapshot.panels.first { $0.id == panelId })
 
         XCTAssertTrue(panelSnapshot.listeningPorts.isEmpty)
+    }
+
+    @MainActor
+    func testSessionSnapshotSkipsChromiumDevToolsFrontendPanels() throws {
+        let workspace = Workspace()
+        let paneId = try XCTUnwrap(workspace.bonsplitController.allPaneIds.first)
+        let sourcePanel = try XCTUnwrap(
+            workspace.newBrowserSurface(
+                inPane: paneId,
+                url: URL(string: "https://example.com"),
+                focus: true
+            )
+        )
+        let devToolsURL = try XCTUnwrap(URL(
+            string: "http://127.0.0.1:9222/devtools/inspector.html?ws=127.0.0.1:9222/devtools/page/ABC"
+        ))
+        let devToolsPanel = try XCTUnwrap(
+            workspace.newBrowserSplit(
+                from: sourcePanel.id,
+                orientation: .horizontal,
+                url: devToolsURL,
+                focus: true,
+                creationPolicy: .internalTool
+            )
+        )
+        devToolsPanel.markAsChromiumDeveloperToolsFrontend(ownerPanelID: sourcePanel.id)
+
+        let snapshot = workspace.sessionSnapshot(includeScrollback: false)
+
+        XCTAssertTrue(snapshot.panels.contains { $0.id == sourcePanel.id })
+        XCTAssertFalse(snapshot.panels.contains { $0.id == devToolsPanel.id })
+        XCTAssertTrue(sessionLayoutPanelIds(snapshot.layout).contains(sourcePanel.id))
+        XCTAssertFalse(sessionLayoutPanelIds(snapshot.layout).contains(devToolsPanel.id))
+    }
+
+    @MainActor
+    func testRestoringSessionSnapshotSkipsPersistedChromiumDevToolsFrontendPanels() throws {
+        let sourcePanelID = try XCTUnwrap(UUID(uuidString: "11111111-1111-4111-8111-111111111111"))
+        let devToolsPanelID = try XCTUnwrap(UUID(uuidString: "22222222-2222-4222-8222-222222222222"))
+        let snapshot = SessionWorkspaceSnapshot(
+            processTitle: "",
+            customTitle: nil,
+            customDescription: nil,
+            customColor: nil,
+            isPinned: false,
+            isManuallyUnread: nil,
+            hasUnreadIndicator: nil,
+            terminalScrollBarHidden: nil,
+            currentDirectory: "/tmp",
+            focusedPanelId: devToolsPanelID,
+            layout: .split(SessionSplitLayoutSnapshot(
+                orientation: .horizontal,
+                dividerPosition: 0.5,
+                first: .pane(SessionPaneLayoutSnapshot(
+                    panelIds: [sourcePanelID],
+                    selectedPanelId: sourcePanelID
+                )),
+                second: .pane(SessionPaneLayoutSnapshot(
+                    panelIds: [devToolsPanelID],
+                    selectedPanelId: devToolsPanelID
+                ))
+            )),
+            panels: [
+                SessionPanelSnapshot(
+                    id: sourcePanelID,
+                    type: .browser,
+                    title: nil,
+                    customTitle: nil,
+                    directory: nil,
+                    isPinned: false,
+                    isManuallyUnread: false,
+                    listeningPorts: [],
+                    ttyName: nil,
+                    terminal: nil,
+                    browser: SessionBrowserPanelSnapshot(
+                        urlString: "https://example.com",
+                        profileID: nil,
+                        shouldRenderWebView: true,
+                        pageZoom: 1.0,
+                        developerToolsVisible: false,
+                        backHistoryURLStrings: nil,
+                        forwardHistoryURLStrings: nil
+                    ),
+                    markdown: nil,
+                    filePreview: nil,
+                    rightSidebarTool: nil
+                ),
+                SessionPanelSnapshot(
+                    id: devToolsPanelID,
+                    type: .browser,
+                    title: nil,
+                    customTitle: nil,
+                    directory: nil,
+                    isPinned: false,
+                    isManuallyUnread: false,
+                    listeningPorts: [],
+                    ttyName: nil,
+                    terminal: nil,
+                    browser: SessionBrowserPanelSnapshot(
+                        urlString: "http://127.0.0.1:9222/devtools/inspector.html?ws=127.0.0.1:9222/devtools/page/ABC",
+                        profileID: nil,
+                        shouldRenderWebView: true,
+                        pageZoom: 1.0,
+                        developerToolsVisible: false,
+                        backHistoryURLStrings: nil,
+                        forwardHistoryURLStrings: nil
+                    ),
+                    markdown: nil,
+                    filePreview: nil,
+                    rightSidebarTool: nil
+                )
+            ],
+            statusEntries: [],
+            logEntries: [],
+            progress: nil,
+            gitBranch: nil,
+            remote: nil
+        )
+
+        let restored = Workspace()
+        restored.restoreSessionSnapshot(snapshot)
+        let restoredSnapshot = restored.sessionSnapshot(includeScrollback: false)
+
+        XCTAssertEqual(restoredSnapshot.panels.filter { $0.type == .browser }.count, 1)
+        XCTAssertFalse(restoredSnapshot.panels.contains {
+            BrowserPanel.isChromiumDevToolsFrontendURLString($0.browser?.urlString)
+        })
     }
 
     func testSaveAndLoadRoundTripWithCustomSnapshotPath() throws {

--- a/cmuxUITests/BrowserChromiumEngineUITests.swift
+++ b/cmuxUITests/BrowserChromiumEngineUITests.swift
@@ -44,7 +44,7 @@ final class BrowserChromiumEngineUITests: XCTestCase {
 
         XCTAssertTrue(
             waitForSocketReady(timeout: 60.0),
-            "Expected cmux control socket to accept v2 requests. candidates=\(socketCandidates()) diagnostics=\(loadJSON(atPath: diagnosticsPath) ?? [:])"
+            "Expected cmux control socket to accept requests. candidates=\(socketCandidates()) diagnostics=\(loadJSON(atPath: diagnosticsPath) ?? [:])"
         )
 
         let openResult = try okResult(
@@ -159,10 +159,13 @@ final class BrowserChromiumEngineUITests: XCTestCase {
         XCTAssertGreaterThan(image.size.width, 10)
         XCTAssertGreaterThan(image.size.height, 10)
         try pngData.write(to: URL(fileURLWithPath: screenshotPath), options: .atomic)
+        print("CMUX_CHROMIUM_SCREENSHOT_PATH=\(screenshotPath)")
         let attachment = XCTAttachment(data: pngData, uniformTypeIdentifier: "public.png")
         attachment.name = "Chromium browser surface screenshot"
         attachment.lifetime = .keepAlways
-        add(attachment)
+        XCTContext.runActivity(named: "Chromium browser surface screenshot") { activity in
+            activity.add(attachment)
+        }
         if let path = screenshotResult["path"] as? String {
             XCTAssertTrue(FileManager.default.fileExists(atPath: path), "Expected screenshot file to exist at \(path)")
         }
@@ -231,6 +234,10 @@ final class BrowserChromiumEngineUITests: XCTestCase {
     }
 
     private func socketV2Ready(responseTimeout: TimeInterval) -> Bool {
+        if ControlSocketClient(path: socketPath, responseTimeout: responseTimeout).sendRawLine("ping") == "PONG" {
+            return true
+        }
+
         let ping = socketJSON(method: "system.ping", params: [:], responseTimeout: responseTimeout)
         let pingResult = ping?["result"] as? [String: Any]
         if (ping?["ok"] as? Bool) == true, pingResult?["pong"] as? Bool == true {
@@ -323,7 +330,7 @@ final class BrowserChromiumEngineUITests: XCTestCase {
             guard JSONSerialization.isValidJSONObject(object),
                   let data = try? JSONSerialization.data(withJSONObject: object),
                   let line = String(data: data, encoding: .utf8),
-                  let response = sendLine(line),
+                  let response = sendRawLine(line),
                   let responseData = response.data(using: .utf8),
                   let parsed = try? JSONSerialization.jsonObject(with: responseData) as? [String: Any] else {
                 return nil
@@ -331,7 +338,7 @@ final class BrowserChromiumEngineUITests: XCTestCase {
             return parsed
         }
 
-        func sendLine(_ line: String) -> String? {
+        func sendRawLine(_ line: String) -> String? {
             if let response = sendLineViaSocket(line) {
                 return response
             }

--- a/cmuxUITests/BrowserChromiumEngineUITests.swift
+++ b/cmuxUITests/BrowserChromiumEngineUITests.swift
@@ -428,20 +428,18 @@ final class BrowserChromiumEngineUITests: XCTestCase {
             }
             guard wrote else { return nil }
 
-            let deadline = Date().addingTimeInterval(responseTimeout)
             var buffer = [UInt8](repeating: 0, count: 4096)
             var accumulator = ""
-            while Date() < deadline {
-                var pollDescriptor = pollfd(fd: fd, events: Int16(POLLIN), revents: 0)
-                let ready = poll(&pollDescriptor, 1, 100)
-                if ready < 0 {
+            while true {
+                let count = read(fd, &buffer, buffer.count)
+                if count < 0 {
+                    let readErrno = errno
+                    if readErrno == EAGAIN || readErrno == EWOULDBLOCK {
+                        break
+                    }
                     return nil
                 }
-                if ready == 0 {
-                    continue
-                }
-                let count = read(fd, &buffer, buffer.count)
-                if count <= 0 { break }
+                if count == 0 { break }
                 if let chunk = String(bytes: buffer[0..<count], encoding: .utf8) {
                     accumulator.append(chunk)
                     if let newline = accumulator.firstIndex(of: "\n") {

--- a/cmuxUITests/BrowserChromiumEngineUITests.swift
+++ b/cmuxUITests/BrowserChromiumEngineUITests.swift
@@ -1,0 +1,464 @@
+import XCTest
+import Foundation
+import AppKit
+
+final class BrowserChromiumEngineUITests: XCTestCase {
+    private enum TestFailure: Error {
+        case invalidResponse(String)
+    }
+
+    private let launchTag = "chromui"
+    private var socketPath = ""
+    private var diagnosticsPath = ""
+
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+        socketPath = "/tmp/cmux-ui-test-chromium-\(UUID().uuidString).sock"
+        diagnosticsPath = "/tmp/cmux-ui-test-chromium-\(UUID().uuidString).json"
+        try? FileManager.default.removeItem(atPath: socketPath)
+        try? FileManager.default.removeItem(atPath: diagnosticsPath)
+    }
+
+    func testChromiumEngineRendersAndHandlesBrowserAutomation() throws {
+        let app = XCUIApplication()
+        app.launchArguments += ["-socketControlMode", "allowAll"]
+        app.launchArguments += ["-AppleLanguages", "(en)", "-AppleLocale", "en_US"]
+        app.launchEnvironment["CMUX_UI_TEST_MODE"] = "1"
+        app.launchEnvironment["CMUX_SOCKET_PATH"] = socketPath
+        app.launchEnvironment["CMUX_SOCKET_ENABLE"] = "1"
+        app.launchEnvironment["CMUX_SOCKET_MODE"] = "allowAll"
+        app.launchEnvironment["CMUX_ALLOW_SOCKET_OVERRIDE"] = "1"
+        app.launchEnvironment["CMUX_UI_TEST_SOCKET_SANITY"] = "1"
+        app.launchEnvironment["CMUX_UI_TEST_DIAGNOSTICS_PATH"] = diagnosticsPath
+        app.launchEnvironment["CMUX_TAG"] = launchTag
+        launchAndAllowHeadlessActivation(app)
+        addTeardownBlock {
+            app.terminate()
+            try? FileManager.default.removeItem(atPath: self.socketPath)
+            try? FileManager.default.removeItem(atPath: self.diagnosticsPath)
+        }
+
+        XCTAssertTrue(
+            waitForSocketReady(timeout: 60.0),
+            "Expected cmux control socket to accept v2 requests. candidates=\(socketCandidates()) diagnostics=\(loadJSON(atPath: diagnosticsPath) ?? [:])"
+        )
+
+        let openResult = try okResult(
+            socketJSON(
+                method: "browser.open_split",
+                params: [
+                    "url": proofPageURL(),
+                    "focus": false,
+                ],
+                responseTimeout: 45.0
+            )
+        )
+
+        guard let surfaceId = openResult["surface_id"] as? String, !surfaceId.isEmpty else {
+            XCTFail("browser.open_split did not return a surface_id: \(openResult)")
+            throw TestFailure.invalidResponse("missing surface_id")
+        }
+        guard let engine = openResult["engine"] as? [String: Any] else {
+            XCTFail("browser.open_split did not return engine metadata: \(openResult)")
+            throw TestFailure.invalidResponse("missing engine")
+        }
+
+        XCTAssertEqual(engine["kind"] as? String, "chromium")
+        XCTAssertEqual(engine["chromium_ready"] as? Bool, true)
+        XCTAssertEqual(engine["chromium_sandbox_disabled"] as? Bool, false)
+        XCTAssertEqual(engine["chromium_uses_in_process_gpu_by_default"] as? Bool, false)
+        XCTAssertEqual(engine["host_class_name"] as? String, "CmuxChromiumBrowserHost")
+        XCTAssertEqual(engine["chromium_compositor_layer"] as? String, "CALayerHost")
+        XCTAssertEqual(engine["chromium_surface_transport"] as? String, "IOSurface/Metal")
+        XCTAssertTrue(
+            ((engine["resources"] as? [String]) ?? []).contains("libowl_fresh_mojo_runtime.dylib"),
+            "Expected OWL Fresh Chromium runtime to be embedded: \(engine)"
+        )
+
+        XCTAssertTrue(
+            app.descendants(matching: .any)["BrowserChromiumSurface"].waitForExistence(timeout: 10.0),
+            "Expected the Chromium NSViewRepresentable surface to be present"
+        )
+
+        _ = try okResult(
+            socketJSON(
+                method: "browser.wait",
+                params: [
+                    "surface_id": surfaceId,
+                    "text_contains": "Chromium cmux proof",
+                    "timeout_ms": 10_000,
+                ],
+                responseTimeout: 20.0
+            )
+        )
+
+        let titleResult = try okResult(
+            socketJSON(
+                method: "browser.eval",
+                params: [
+                    "surface_id": surfaceId,
+                    "script": "document.title",
+                ]
+            )
+        )
+        XCTAssertEqual(titleResult["value"] as? String, "cmux chromium ui")
+
+        let snapshotResult = try okResult(
+            socketJSON(
+                method: "browser.snapshot",
+                params: ["surface_id": surfaceId],
+                responseTimeout: 20.0
+            )
+        )
+        let snapshot = snapshotResult["snapshot"] as? String ?? ""
+        XCTAssertTrue(snapshot.contains("Chromium cmux proof"), snapshot)
+        XCTAssertEqual((snapshotResult["engine"] as? [String: Any])?["kind"] as? String, "chromium")
+
+        _ = try okResult(
+            socketJSON(
+                method: "browser.click",
+                params: [
+                    "surface_id": surfaceId,
+                    "selector": "#ok",
+                ]
+            )
+        )
+
+        let clickResult = try okResult(
+            socketJSON(
+                method: "browser.eval",
+                params: [
+                    "surface_id": surfaceId,
+                    "script": "document.body.dataset.clicked",
+                ]
+            )
+        )
+        XCTAssertEqual(clickResult["value"] as? String, "yes")
+
+        let screenshotResult = try okResult(
+            socketJSON(
+                method: "browser.screenshot",
+                params: ["surface_id": surfaceId],
+                responseTimeout: 30.0
+            )
+        )
+        guard let pngBase64 = screenshotResult["png_base64"] as? String,
+              let pngData = Data(base64Encoded: pngBase64) else {
+            XCTFail("browser.screenshot did not return valid PNG data: \(screenshotResult)")
+            throw TestFailure.invalidResponse("invalid png")
+        }
+        XCTAssertEqual(Array(pngData.prefix(8)), [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
+        guard let image = NSImage(data: pngData) else {
+            XCTFail("browser.screenshot returned undecodable PNG data")
+            throw TestFailure.invalidResponse("undecodable png")
+        }
+        XCTAssertGreaterThan(image.size.width, 10)
+        XCTAssertGreaterThan(image.size.height, 10)
+        if let path = screenshotResult["path"] as? String {
+            XCTAssertTrue(FileManager.default.fileExists(atPath: path), "Expected screenshot file to exist at \(path)")
+        }
+    }
+
+    private func proofPageURL() -> String {
+        let html = """
+        <!doctype html>
+        <html>
+          <head>
+            <meta charset="utf-8">
+            <title>cmux chromium ui</title>
+            <style>
+              body { margin: 0; background: #f6f7f9; color: #172026; font-family: -apple-system, BlinkMacSystemFont, sans-serif; }
+              main { padding: 48px; }
+              h1 { margin: 0 0 12px; font-size: 34px; }
+              p { font-size: 18px; }
+              button { margin-top: 18px; padding: 12px 18px; font-size: 17px; border-radius: 6px; border: 1px solid #172026; background: #ffffff; }
+            </style>
+          </head>
+          <body>
+            <main>
+              <h1>Chromium cmux proof</h1>
+              <p id="marker">CALayerHost Chromium browser surface</p>
+              <button id="ok" onclick="document.body.dataset.clicked='yes';this.textContent='clicked';">click proof</button>
+            </main>
+          </body>
+        </html>
+        """
+        return "data:text/html;base64,\(Data(html.utf8).base64EncodedString())"
+    }
+
+    private func launchAndAllowHeadlessActivation(_ app: XCUIApplication) {
+        let options = XCTExpectedFailure.Options()
+        options.isStrict = false
+        XCTExpectFailure("App activation may fail on headless CI runners", options: options) {
+            app.launch()
+        }
+
+        if app.state == .runningForeground || app.state == .runningBackground {
+            return
+        }
+
+        XCTFail("App failed to start. state=\(app.state.rawValue)")
+    }
+
+    private func waitForSocketReady(timeout: TimeInterval) -> Bool {
+        var resolvedPath: String?
+        let completed = waitForCondition(timeout: timeout) {
+            let originalPath = self.socketPath
+            for candidate in self.socketCandidates() {
+                guard FileManager.default.fileExists(atPath: candidate) else { continue }
+                self.socketPath = candidate
+                let envelope = self.socketJSON(method: "system.ping", params: [:], responseTimeout: 3.0)
+                let result = envelope?["result"] as? [String: Any]
+                if (envelope?["ok"] as? Bool) == true, result?["pong"] as? Bool == true {
+                    resolvedPath = candidate
+                    return true
+                }
+                self.socketPath = originalPath
+            }
+            return false
+        }
+        if let resolvedPath {
+            socketPath = resolvedPath
+        }
+        return completed
+    }
+
+    private func socketCandidates() -> [String] {
+        var candidates = [socketPath, taggedSocketPath()]
+        var seen = Set<String>()
+        candidates.removeAll { !seen.insert($0).inserted }
+        return candidates
+    }
+
+    private func taggedSocketPath() -> String {
+        let slug = launchTag
+            .lowercased()
+            .replacingOccurrences(of: ".", with: "-")
+            .replacingOccurrences(of: "_", with: "-")
+            .components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .filter { !$0.isEmpty }
+            .joined(separator: "-")
+        return "/tmp/cmux-debug-\(slug).sock"
+    }
+
+    private func loadJSON(atPath path: String) -> [String: String]? {
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: String] else {
+            return nil
+        }
+        return json
+    }
+
+    private func socketJSON(
+        method: String,
+        params: [String: Any],
+        responseTimeout: TimeInterval = 12.0
+    ) -> [String: Any]? {
+        let request: [String: Any] = [
+            "id": UUID().uuidString,
+            "method": method,
+            "params": params,
+        ]
+        return ControlSocketClient(path: socketPath, responseTimeout: responseTimeout).sendJSON(request)
+    }
+
+    private func okResult(
+        _ envelope: [String: Any]?,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws -> [String: Any] {
+        guard let envelope else {
+            XCTFail("Missing socket response", file: file, line: line)
+            throw TestFailure.invalidResponse("missing response")
+        }
+        guard (envelope["ok"] as? Bool) == true else {
+            XCTFail("Socket request failed: \(envelope)", file: file, line: line)
+            throw TestFailure.invalidResponse("not ok")
+        }
+        guard let result = envelope["result"] as? [String: Any] else {
+            XCTFail("Socket response did not contain a result object: \(envelope)", file: file, line: line)
+            throw TestFailure.invalidResponse("missing result")
+        }
+        return result
+    }
+
+    private func waitForCondition(timeout: TimeInterval, predicate: @escaping () -> Bool) -> Bool {
+        let expectation = XCTNSPredicateExpectation(
+            predicate: NSPredicate { _, _ in predicate() },
+            object: nil
+        )
+        return XCTWaiter().wait(for: [expectation], timeout: timeout) == .completed
+    }
+
+    private final class ControlSocketClient {
+        private let path: String
+        private let responseTimeout: TimeInterval
+
+        init(path: String, responseTimeout: TimeInterval) {
+            self.path = path
+            self.responseTimeout = responseTimeout
+        }
+
+        func sendJSON(_ object: [String: Any]) -> [String: Any]? {
+            guard JSONSerialization.isValidJSONObject(object),
+                  let data = try? JSONSerialization.data(withJSONObject: object),
+                  let line = String(data: data, encoding: .utf8),
+                  let response = sendLine(line),
+                  let responseData = response.data(using: .utf8),
+                  let parsed = try? JSONSerialization.jsonObject(with: responseData) as? [String: Any] else {
+                return nil
+            }
+            return parsed
+        }
+
+        func sendLine(_ line: String) -> String? {
+            if let response = sendLineViaSocket(line) {
+                return response
+            }
+            return sendLineViaNetcat(line)
+        }
+
+        private func sendLineViaSocket(_ line: String) -> String? {
+            let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+            guard fd >= 0 else { return nil }
+            defer { close(fd) }
+
+            var socketTimeout = timeval(
+                tv_sec: Int(responseTimeout.rounded(.down)),
+                tv_usec: Int32(((responseTimeout - floor(responseTimeout)) * 1_000_000).rounded())
+            )
+
+#if os(macOS)
+            var noSigPipe: Int32 = 1
+            _ = withUnsafePointer(to: &noSigPipe) { ptr in
+                setsockopt(
+                    fd,
+                    SOL_SOCKET,
+                    SO_NOSIGPIPE,
+                    ptr,
+                    socklen_t(MemoryLayout<Int32>.size)
+                )
+            }
+#endif
+            _ = withUnsafePointer(to: &socketTimeout) { ptr in
+                setsockopt(
+                    fd,
+                    SOL_SOCKET,
+                    SO_RCVTIMEO,
+                    ptr,
+                    socklen_t(MemoryLayout<timeval>.size)
+                )
+            }
+            _ = withUnsafePointer(to: &socketTimeout) { ptr in
+                setsockopt(
+                    fd,
+                    SOL_SOCKET,
+                    SO_SNDTIMEO,
+                    ptr,
+                    socklen_t(MemoryLayout<timeval>.size)
+                )
+            }
+
+            var addr = sockaddr_un()
+            memset(&addr, 0, MemoryLayout<sockaddr_un>.size)
+            addr.sun_family = sa_family_t(AF_UNIX)
+
+            let maxLen = MemoryLayout.size(ofValue: addr.sun_path)
+            let bytes = Array(path.utf8CString)
+            guard bytes.count <= maxLen else { return nil }
+            withUnsafeMutablePointer(to: &addr.sun_path) { ptr in
+                let raw = UnsafeMutableRawPointer(ptr).assumingMemoryBound(to: CChar.self)
+                memset(raw, 0, maxLen)
+                for index in 0..<bytes.count {
+                    raw[index] = bytes[index]
+                }
+            }
+
+            let pathOffset = MemoryLayout<sockaddr_un>.offset(of: \.sun_path) ?? 0
+            let addrLen = socklen_t(pathOffset + bytes.count)
+#if os(macOS)
+            addr.sun_len = UInt8(min(Int(addrLen), 255))
+#endif
+
+            let connected = withUnsafePointer(to: &addr) { ptr in
+                ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sa in
+                    connect(fd, sa, addrLen)
+                }
+            }
+            guard connected == 0 else { return nil }
+
+            let payload = line + "\n"
+            let wrote: Bool = payload.withCString { cString in
+                var remaining = strlen(cString)
+                var pointer = UnsafeRawPointer(cString)
+                while remaining > 0 {
+                    let written = write(fd, pointer, remaining)
+                    if written <= 0 { return false }
+                    remaining -= written
+                    pointer = pointer.advanced(by: written)
+                }
+                return true
+            }
+            guard wrote else { return nil }
+
+            let deadline = Date().addingTimeInterval(responseTimeout)
+            var buffer = [UInt8](repeating: 0, count: 4096)
+            var accumulator = ""
+            while Date() < deadline {
+                var pollDescriptor = pollfd(fd: fd, events: Int16(POLLIN), revents: 0)
+                let ready = poll(&pollDescriptor, 1, 100)
+                if ready < 0 {
+                    return nil
+                }
+                if ready == 0 {
+                    continue
+                }
+                let count = read(fd, &buffer, buffer.count)
+                if count <= 0 { break }
+                if let chunk = String(bytes: buffer[0..<count], encoding: .utf8) {
+                    accumulator.append(chunk)
+                    if let newline = accumulator.firstIndex(of: "\n") {
+                        return String(accumulator[..<newline])
+                    }
+                }
+            }
+
+            return accumulator.isEmpty ? nil : accumulator.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        private func sendLineViaNetcat(_ line: String) -> String? {
+            let nc = "/usr/bin/nc"
+            guard FileManager.default.isExecutableFile(atPath: nc) else { return nil }
+
+            let proc = Process()
+            proc.executableURL = URL(fileURLWithPath: "/bin/sh")
+            let timeoutSeconds = max(1, Int(ceil(responseTimeout)))
+            proc.arguments = [
+                "-lc",
+                "printf '%s\\n' \(shellSingleQuote(line)) | \(nc) -U \(shellSingleQuote(path)) -w \(timeoutSeconds) 2>/dev/null",
+            ]
+
+            let outPipe = Pipe()
+            proc.standardOutput = outPipe
+
+            do {
+                try proc.run()
+            } catch {
+                return nil
+            }
+
+            proc.waitUntilExit()
+
+            let outData = outPipe.fileHandleForReading.readDataToEndOfFile()
+            guard let outStr = String(data: outData, encoding: .utf8) else { return nil }
+            let trimmed = outStr.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        }
+
+        private func shellSingleQuote(_ value: String) -> String {
+            if value.isEmpty { return "''" }
+            return "'" + value.replacingOccurrences(of: "'", with: "'\"'\"'") + "'"
+        }
+    }
+}

--- a/cmuxUITests/BrowserChromiumEngineUITests.swift
+++ b/cmuxUITests/BrowserChromiumEngineUITests.swift
@@ -148,6 +148,8 @@ final class BrowserChromiumEngineUITests: XCTestCase {
         )
         XCTAssertEqual(clickResult["value"] as? String, "yes")
 
+        try verifyChromiumSurfacePointerInput(app, surfaceId: surfaceId)
+
         let screenshotResult = try okResult(
             socketJSON(
                 method: "browser.screenshot",
@@ -232,12 +234,120 @@ final class BrowserChromiumEngineUITests: XCTestCase {
             <main>
               <h1>Chromium cmux proof</h1>
               <p id="marker">CALayerHost Chromium browser surface</p>
+              <p id="selectable">Chromium selectable text proves drag selection.</p>
               <button id="ok" onclick="document.body.dataset.clicked='yes';this.textContent='clicked';">click proof</button>
             </main>
+            <script>
+              document.addEventListener('contextmenu', event => {
+                document.body.dataset.contextMenu = 'yes';
+                event.preventDefault();
+              });
+            </script>
           </body>
         </html>
         """
         return "data:text/html;base64,\(Data(html.utf8).base64EncodedString())"
+    }
+
+    private func verifyChromiumSurfacePointerInput(_ app: XCUIApplication, surfaceId: String) throws {
+        let surface = app.descendants(matching: .any)["BrowserChromiumSurface"]
+        XCTAssertTrue(surface.waitForExistence(timeout: 10.0), "Expected Chromium surface before pointer checks")
+
+        let rectResult = try okResult(
+            socketJSON(
+                method: "browser.eval",
+                params: [
+                    "surface_id": surfaceId,
+                    "script": """
+                    (() => {
+                      const rect = document.querySelector('#selectable').getBoundingClientRect();
+                      return { x: rect.x, y: rect.y, width: rect.width, height: rect.height };
+                    })()
+                    """,
+                ]
+            )
+        )
+        guard let rect = rectResult["value"] as? [String: Any],
+              let x = number(rect["x"]),
+              let y = number(rect["y"]),
+              let width = number(rect["width"]),
+              let height = number(rect["height"]) else {
+            XCTFail("Expected selectable text bounds from Chromium eval: \(rectResult)")
+            throw TestFailure.invalidResponse("missing selectable rect")
+        }
+
+        let origin = surface.coordinate(withNormalizedOffset: CGVector(dx: 0, dy: 0))
+        let start = origin.withOffset(CGVector(dx: x + 4, dy: y + height * 0.5))
+        let end = origin.withOffset(CGVector(dx: x + max(8, width - 4), dy: y + height * 0.5))
+        start.press(forDuration: 0.1, thenDragTo: end)
+
+        XCTAssertTrue(
+            waitForCondition(timeout: 5.0) {
+                guard let result = try? self.okResult(
+                    self.socketJSON(
+                        method: "browser.eval",
+                        params: [
+                            "surface_id": surfaceId,
+                            "script": "window.getSelection().toString()",
+                        ]
+                    )
+                ) else {
+                    return false
+                }
+                return ((result["value"] as? String) ?? "").contains("selectable text")
+            },
+            "Expected real Chromium text selection after mouse drag"
+        )
+
+        postRightClick(at: CGPoint(x: surface.frame.midX, y: surface.frame.midY))
+        XCTAssertTrue(
+            waitForCondition(timeout: 5.0) {
+                guard let result = try? self.okResult(
+                    self.socketJSON(
+                        method: "browser.eval",
+                        params: [
+                            "surface_id": surfaceId,
+                            "script": "document.body.dataset.contextMenu || ''",
+                        ]
+                    )
+                ) else {
+                    return false
+                }
+                return (result["value"] as? String) == "yes"
+            },
+            "Expected right-click to reach Chromium as a contextmenu event"
+        )
+    }
+
+    private func number(_ value: Any?) -> CGFloat? {
+        if let value = value as? Double {
+            return CGFloat(value)
+        }
+        if let value = value as? Int {
+            return CGFloat(value)
+        }
+        if let value = value as? NSNumber {
+            return CGFloat(truncating: value)
+        }
+        return nil
+    }
+
+    private func postRightClick(at point: CGPoint) {
+        let source = CGEventSource(stateID: .hidSystemState)
+        let down = CGEvent(
+            mouseEventSource: source,
+            mouseType: .rightMouseDown,
+            mouseCursorPosition: point,
+            mouseButton: .right
+        )
+        let up = CGEvent(
+            mouseEventSource: source,
+            mouseType: .rightMouseUp,
+            mouseCursorPosition: point,
+            mouseButton: .right
+        )
+        down?.post(tap: .cghidEventTap)
+        up?.post(tap: .cghidEventTap)
     }
 
     private func launchAndAllowHeadlessActivation(_ app: XCUIApplication) {

--- a/cmuxUITests/BrowserChromiumEngineUITests.swift
+++ b/cmuxUITests/BrowserChromiumEngineUITests.swift
@@ -19,7 +19,9 @@ final class BrowserChromiumEngineUITests: XCTestCase {
         socketPath = "/tmp/cmux-ui-test-chromium-\(UUID().uuidString).sock"
         diagnosticsPath = "/tmp/cmux-ui-test-chromium-\(UUID().uuidString).json"
         gotoSplitPath = "/tmp/cmux-ui-test-chromium-\(UUID().uuidString)-goto.json"
-        screenshotPath = "/tmp/cmux-ui-test-chromium-\(UUID().uuidString).png"
+        screenshotPath = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-ui-test-chromium-\(UUID().uuidString).png")
+            .path
         try? FileManager.default.removeItem(atPath: socketPath)
         try? FileManager.default.removeItem(atPath: diagnosticsPath)
         try? FileManager.default.removeItem(atPath: gotoSplitPath)

--- a/cmuxUITests/BrowserChromiumEngineUITests.swift
+++ b/cmuxUITests/BrowserChromiumEngineUITests.swift
@@ -10,14 +10,17 @@ final class BrowserChromiumEngineUITests: XCTestCase {
     private let launchTag = "chromui"
     private var socketPath = ""
     private var diagnosticsPath = ""
+    private var screenshotPath = ""
 
     override func setUp() {
         super.setUp()
         continueAfterFailure = false
         socketPath = "/tmp/cmux-ui-test-chromium-\(UUID().uuidString).sock"
         diagnosticsPath = "/tmp/cmux-ui-test-chromium-\(UUID().uuidString).json"
+        screenshotPath = "/tmp/cmux-ui-test-chromium-\(UUID().uuidString).png"
         try? FileManager.default.removeItem(atPath: socketPath)
         try? FileManager.default.removeItem(atPath: diagnosticsPath)
+        try? FileManager.default.removeItem(atPath: screenshotPath)
     }
 
     func testChromiumEngineRendersAndHandlesBrowserAutomation() throws {
@@ -155,6 +158,11 @@ final class BrowserChromiumEngineUITests: XCTestCase {
         }
         XCTAssertGreaterThan(image.size.width, 10)
         XCTAssertGreaterThan(image.size.height, 10)
+        try pngData.write(to: URL(fileURLWithPath: screenshotPath), options: .atomic)
+        let attachment = XCTAttachment(data: pngData, uniformTypeIdentifier: "public.png")
+        attachment.name = "Chromium browser surface screenshot"
+        attachment.lifetime = .keepAlways
+        add(attachment)
         if let path = screenshotResult["path"] as? String {
             XCTAssertTrue(FileManager.default.fileExists(atPath: path), "Expected screenshot file to exist at \(path)")
         }
@@ -208,9 +216,7 @@ final class BrowserChromiumEngineUITests: XCTestCase {
             for candidate in self.socketCandidates() {
                 guard FileManager.default.fileExists(atPath: candidate) else { continue }
                 self.socketPath = candidate
-                let envelope = self.socketJSON(method: "system.ping", params: [:], responseTimeout: 3.0)
-                let result = envelope?["result"] as? [String: Any]
-                if (envelope?["ok"] as? Bool) == true, result?["pong"] as? Bool == true {
+                if self.socketV2Ready(responseTimeout: 3.0) {
                     resolvedPath = candidate
                     return true
                 }
@@ -222,6 +228,19 @@ final class BrowserChromiumEngineUITests: XCTestCase {
             socketPath = resolvedPath
         }
         return completed
+    }
+
+    private func socketV2Ready(responseTimeout: TimeInterval) -> Bool {
+        let ping = socketJSON(method: "system.ping", params: [:], responseTimeout: responseTimeout)
+        let pingResult = ping?["result"] as? [String: Any]
+        if (ping?["ok"] as? Bool) == true, pingResult?["pong"] as? Bool == true {
+            return true
+        }
+
+        let capabilities = socketJSON(method: "system.capabilities", params: [:], responseTimeout: responseTimeout)
+        let capabilitiesResult = capabilities?["result"] as? [String: Any]
+        let methods = capabilitiesResult?["methods"] as? [String] ?? []
+        return (capabilities?["ok"] as? Bool) == true && methods.contains("browser.open_split")
     }
 
     private func socketCandidates() -> [String] {

--- a/cmuxUITests/BrowserChromiumEngineUITests.swift
+++ b/cmuxUITests/BrowserChromiumEngineUITests.swift
@@ -10,6 +10,7 @@ final class BrowserChromiumEngineUITests: XCTestCase {
     private let launchTag = "chromui"
     private var socketPath = ""
     private var diagnosticsPath = ""
+    private var gotoSplitPath = ""
     private var screenshotPath = ""
 
     override func setUp() {
@@ -17,9 +18,11 @@ final class BrowserChromiumEngineUITests: XCTestCase {
         continueAfterFailure = false
         socketPath = "/tmp/cmux-ui-test-chromium-\(UUID().uuidString).sock"
         diagnosticsPath = "/tmp/cmux-ui-test-chromium-\(UUID().uuidString).json"
+        gotoSplitPath = "/tmp/cmux-ui-test-chromium-\(UUID().uuidString)-goto.json"
         screenshotPath = "/tmp/cmux-ui-test-chromium-\(UUID().uuidString).png"
         try? FileManager.default.removeItem(atPath: socketPath)
         try? FileManager.default.removeItem(atPath: diagnosticsPath)
+        try? FileManager.default.removeItem(atPath: gotoSplitPath)
         try? FileManager.default.removeItem(atPath: screenshotPath)
     }
 
@@ -34,18 +37,22 @@ final class BrowserChromiumEngineUITests: XCTestCase {
         app.launchEnvironment["CMUX_ALLOW_SOCKET_OVERRIDE"] = "1"
         app.launchEnvironment["CMUX_UI_TEST_SOCKET_SANITY"] = "1"
         app.launchEnvironment["CMUX_UI_TEST_DIAGNOSTICS_PATH"] = diagnosticsPath
+        app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_SETUP"] = "1"
+        app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_PATH"] = gotoSplitPath
+        app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_BROWSER_URL"] = proofPageURL()
         app.launchEnvironment["CMUX_TAG"] = launchTag
         launchAndAllowHeadlessActivation(app)
         addTeardownBlock {
             app.terminate()
             try? FileManager.default.removeItem(atPath: self.socketPath)
             try? FileManager.default.removeItem(atPath: self.diagnosticsPath)
+            try? FileManager.default.removeItem(atPath: self.gotoSplitPath)
         }
 
-        XCTAssertTrue(
-            waitForSocketReady(timeout: 60.0),
-            "Expected cmux control socket to accept requests. candidates=\(socketCandidates()) diagnostics=\(loadJSON(atPath: diagnosticsPath) ?? [:])"
-        )
+        if !waitForSocketReady(timeout: 20.0) {
+            try verifyChromiumSurfaceFromAppHostedProof(app)
+            return
+        }
 
         let openResult = try okResult(
             socketJSON(
@@ -168,6 +175,39 @@ final class BrowserChromiumEngineUITests: XCTestCase {
         }
         if let path = screenshotResult["path"] as? String {
             XCTAssertTrue(FileManager.default.fileExists(atPath: path), "Expected screenshot file to exist at \(path)")
+        }
+    }
+
+    private func verifyChromiumSurfaceFromAppHostedProof(_ app: XCUIApplication) throws {
+        XCTAssertTrue(
+            waitForCondition(timeout: 60.0) {
+                (self.loadJSON(atPath: self.gotoSplitPath)?["browserChromiumReady"] == "1")
+            },
+            "Expected app-hosted Chromium proof to report ready. goto=\(loadJSON(atPath: gotoSplitPath) ?? [:]) diagnostics=\(loadJSON(atPath: diagnosticsPath) ?? [:])"
+        )
+        let proof = loadJSON(atPath: gotoSplitPath) ?? [:]
+        XCTAssertEqual(proof["browserEngineKind"], "chromium")
+        XCTAssertEqual(proof["browserChromiumCompositorLayer"], "CALayerHost")
+        XCTAssertEqual(proof["browserChromiumSurfaceTransport"], "IOSurface/Metal")
+        XCTAssertTrue(
+            (proof["browserChromiumNativeViewHost"] ?? "").contains("Chromium remote_cocoa"),
+            "Expected remote_cocoa native view host metadata: \(proof)"
+        )
+        XCTAssertTrue(
+            app.descendants(matching: .any)["BrowserChromiumSurface"].waitForExistence(timeout: 15.0),
+            "Expected the app-hosted Chromium surface to be present. proof=\(proof)"
+        )
+
+        let screenshot = XCUIScreen.main.screenshot()
+        let pngData = screenshot.pngRepresentation
+        XCTAssertEqual(Array(pngData.prefix(8)), [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
+        XCTAssertGreaterThan(pngData.count, 1_000)
+        try pngData.write(to: URL(fileURLWithPath: screenshotPath), options: .atomic)
+        let attachment = XCTAttachment(screenshot: screenshot)
+        attachment.name = "App-hosted Chromium browser proof"
+        attachment.lifetime = .keepAlways
+        XCTContext.runActivity(named: "App-hosted Chromium browser proof") { activity in
+            activity.add(attachment)
         }
     }
 

--- a/scripts/build-cmux-chromium-core.sh
+++ b/scripts/build-cmux-chromium-core.sh
@@ -278,6 +278,17 @@ sign_top_level_app_dylibs() {
   done < <(find "$macos_dir" -maxdepth 1 -type f -name '*.dylib' -print0)
 }
 
+sign_app_plugins() {
+  local app_path="$1"
+  local plugins_dir="$app_path/Contents/PlugIns"
+  [[ -d "$plugins_dir" ]] || return 0
+
+  local plugin
+  while IFS= read -r -d '' plugin; do
+    sign_path "$plugin"
+  done < <(find "$plugins_dir" -maxdepth 1 -type d \( -name '*.plugin' -o -name '*.appex' -o -name '*.xpc' \) -print0)
+}
+
 resolve_framework_version_dir() {
   local framework="$1"
   local versions_dir="$framework/Versions"
@@ -494,6 +505,7 @@ if [[ -n "$APP_PATH" ]]; then
     echo "Skipping outer app re-sign for Xcode test host bundle"
   else
     sign_top_level_app_dylibs "$APP_PATH"
+    sign_app_plugins "$APP_PATH"
     sign_path "$APP_PATH"
   fi
   echo "Embedded $FRAMEWORK_NAME into $APP_PATH"

--- a/scripts/build-cmux-chromium-core.sh
+++ b/scripts/build-cmux-chromium-core.sh
@@ -1,0 +1,502 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_PATH=""
+CONFIGURATION="${CONFIGURATION:-Debug}"
+SRCROOT="${SRCROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+FRAMEWORK_SOURCE="$SRCROOT/Frameworks/CmuxChromiumCore/Sources/CmuxChromiumCore.swift"
+BUILD_ROOT="${CMUX_CHROMIUM_CORE_BUILD_DIR:-$SRCROOT/.build/CmuxChromiumCore}"
+FRAMEWORK_NAME="CmuxChromiumCore.framework"
+MODULE_NAME="CmuxChromiumCore"
+DEFAULT_DOWNLOAD_URL="https://github.com/manaflow-ai/chromium/releases/download/owl-chromium-cb711dd4af32/owl-chromium-runtime-macos-arm64-cb711dd4af32.tar.gz"
+DEFAULT_DOWNLOAD_SHA256="092f614b05c8f454aa142d8169e32255921c4051d99555172bf24c4d963b723e"
+DOWNLOAD_URL="${CMUX_CHROMIUM_CONTENT_SHELL_ARCHIVE_URL:-$DEFAULT_DOWNLOAD_URL}"
+EXPECTED_ARCHIVE_SHA256="${CMUX_CHROMIUM_CONTENT_SHELL_SHA256:-}"
+if [[ "$DOWNLOAD_URL" == "$DEFAULT_DOWNLOAD_URL" && -z "$EXPECTED_ARCHIVE_SHA256" ]]; then
+  EXPECTED_ARCHIVE_SHA256="$DEFAULT_DOWNLOAD_SHA256"
+fi
+if [[ "$DOWNLOAD_URL" != "$DEFAULT_DOWNLOAD_URL" && -z "$EXPECTED_ARCHIVE_SHA256" ]]; then
+  echo "error: custom CMUX_CHROMIUM_CONTENT_SHELL_ARCHIVE_URL requires CMUX_CHROMIUM_CONTENT_SHELL_SHA256" >&2
+  exit 1
+fi
+CACHE_ROOT="${CMUX_CHROMIUM_CONTENT_SHELL_CACHE:-$HOME/Library/Caches/cmux/chromium-content-shell/owl-chromium-cb711dd4af32}"
+RUNTIME_SANDBOX_DISABLED=false
+RUNTIME_USES_IN_PROCESS_GPU_BY_DEFAULT=false
+RUNTIME_FORBIDDEN_SWITCHES_JSON='["no-sandbox", "in-process-gpu"]'
+RUNTIME_DEFAULT_SWITCHES_JSON='[
+      "fresh-owl-embed",
+      "fresh-owl-hosted-frame-pump",
+      "content-shell-hide-toolbar",
+      "no-first-run",
+      "no-default-browser-check"
+    ]'
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/build-cmux-chromium-core.sh [--app <path>] [--configuration Debug|Release]
+
+Builds CmuxChromiumCore.framework and optionally embeds it into a cmux .app.
+Set CMUX_CHROMIUM_CONTENT_SHELL_APP to use a specific patched Content Shell.app.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --app)
+      APP_PATH="${2:-}"
+      [[ -n "$APP_PATH" ]] || { echo "error: --app requires a value" >&2; exit 1; }
+      shift 2
+      ;;
+    --configuration)
+      CONFIGURATION="${2:-}"
+      [[ -n "$CONFIGURATION" ]] || { echo "error: --configuration requires a value" >&2; exit 1; }
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown option $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+HOST_ARCH="$(uname -m)"
+case "$HOST_ARCH" in
+  arm64|aarch64) ;;
+  *)
+    echo "error: CmuxChromiumCore currently supports macOS arm64 only, got $HOST_ARCH" >&2
+    exit 1
+    ;;
+esac
+
+resolve_content_shell_app() {
+  local candidate=""
+  local -a candidates=()
+  if [[ -n "${CMUX_CHROMIUM_CONTENT_SHELL_APP:-}" ]]; then
+    candidates+=("$CMUX_CHROMIUM_CONTENT_SHELL_APP")
+  fi
+  candidates+=(
+    "$CACHE_ROOT/owl-chromium-runtime-macos-arm64-cb711dd4af32/Content Shell.app"
+    "$CACHE_ROOT/Content Shell.app"
+  )
+  if [[ "${CMUX_CHROMIUM_ALLOW_LOCAL_CONTENT_SHELL:-0}" == "1" ]]; then
+    candidates+=(
+      "$HOME/chromium/src/out/Release/Content Shell.app"
+      "/Applications/Content Shell.app"
+    )
+  fi
+  for candidate in "${candidates[@]}"; do
+    if [[ -x "$candidate/Contents/MacOS/Content Shell" ]]; then
+      echo "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+download_content_shell_if_needed() {
+  if resolve_content_shell_app >/dev/null; then
+    return 0
+  fi
+  mkdir -p "$CACHE_ROOT"
+  local archive="$CACHE_ROOT/content-shell.tar.gz"
+  if [[ "$DOWNLOAD_URL" == "$DEFAULT_DOWNLOAD_URL" ]]; then
+    archive="$CACHE_ROOT/owl-chromium-runtime-macos-arm64-cb711dd4af32.tar.gz"
+  fi
+  echo "Downloading patched browser runtime"
+  curl -fL "$DOWNLOAD_URL" -o "$archive"
+  if [[ -n "$EXPECTED_ARCHIVE_SHA256" ]]; then
+    local actual
+    actual="$(shasum -a 256 "$archive" | awk '{print $1}')"
+    if [[ "$actual" != "$EXPECTED_ARCHIVE_SHA256" ]]; then
+      echo "error: browser runtime checksum mismatch. expected=$EXPECTED_ARCHIVE_SHA256 actual=$actual" >&2
+      exit 1
+    fi
+  fi
+  tar -xzf "$archive" -C "$CACHE_ROOT"
+}
+
+chromium_version() {
+  local app_path="$1"
+  local src_dir="${CMUX_CHROMIUM_SRC:-$HOME/chromium/src}"
+  if [[ -f "$src_dir/chrome/VERSION" ]]; then
+    awk -F= '
+      $1 == "MAJOR" { major=$2 }
+      $1 == "MINOR" { minor=$2 }
+      $1 == "BUILD" { build=$2 }
+      $1 == "PATCH" { patch=$2 }
+      END {
+        if (major != "" && minor != "" && build != "" && patch != "") {
+          printf "%s.%s.%s.%s", major, minor, build, patch
+        }
+      }
+    ' "$src_dir/chrome/VERSION"
+    return 0
+  fi
+  /usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' \
+    "$app_path/Contents/Info.plist" 2>/dev/null || printf "unknown"
+}
+
+chromium_revision() {
+  local runtime_root="${1:-}"
+  if [[ -n "$runtime_root" && -f "$runtime_root/owl-runtime-manifest.json" ]]; then
+    local revision
+    revision="$(plutil -extract chromiumSourceCommit raw -o - "$runtime_root/owl-runtime-manifest.json" 2>/dev/null || true)"
+    if [[ -n "$revision" ]]; then
+      printf "%s" "$revision"
+      return 0
+    fi
+  fi
+  local src_dir="${CMUX_CHROMIUM_SRC:-$HOME/chromium/src}"
+  git -C "$src_dir" rev-parse HEAD 2>/dev/null || printf "unknown"
+}
+
+content_shell_resource_dir() {
+  local app_path="$1"
+  local pak
+  pak="$(find "$app_path/Contents/Frameworks/Content Shell Framework.framework" \
+    -path '*/Resources/content_shell.pak' -print -quit 2>/dev/null)"
+  [[ -n "$pak" ]] || return 1
+  dirname "$pak"
+}
+
+content_shell_runtime_root() {
+  local app_path="$1"
+  local parent
+  parent="$(dirname "$app_path")"
+  if [[ -f "$parent/libowl_fresh_mojo_runtime.dylib" ]]; then
+    echo "$parent"
+    return 0
+  fi
+  if [[ -f "$app_path/Contents/Resources/libowl_fresh_mojo_runtime.dylib" ]]; then
+    echo "$app_path/Contents/Resources"
+    return 0
+  fi
+  echo "$parent"
+}
+
+normalize_bundle_permissions() {
+  local path="$1"
+  chmod -R u+rwX,go+rX "$path"
+  if command -v xattr >/dev/null 2>&1; then
+    xattr -cr "$path"
+  fi
+}
+
+prune_content_shell_runtime_files() {
+  local app_path="$1"
+  find "$app_path" \( -name '*.log' -o -name '*.tmp' -o -name '.DS_Store' \) -type f -delete
+}
+
+verify_runtime_launch_policy() {
+  local runtime_root="$1"
+  local dylib="$runtime_root/libowl_fresh_mojo_runtime.dylib"
+  local manifest="$runtime_root/owl-runtime-manifest.json"
+  local build_args="$runtime_root/owl-build-args.gn"
+  for name in libowl_fresh_mojo_runtime.dylib owl-runtime-manifest.json owl-build-args.gn; do
+    if [[ ! -f "$runtime_root/$name" ]]; then
+      echo "error: browser runtime is missing a required component" >&2
+      exit 1
+    fi
+  done
+  if ! python3 -m json.tool "$manifest" >/dev/null; then
+    echo "error: browser runtime metadata is not valid JSON" >&2
+    exit 1
+  fi
+  if strings "$dylib" | awk 'index($0, "no-sandbox") > 0 || index($0, "--no-sandbox") > 0 { found = 1 } END { exit found ? 0 : 1 }'; then
+    echo "error: browser runtime launch policy is not production-safe" >&2
+    exit 1
+  fi
+  if awk '$0 ~ /(^|[^A-Za-z0-9_-])(no-sandbox|--no-sandbox)([^A-Za-z0-9_-]|$)/ { found = 1 } END { exit found ? 0 : 1 }' "$build_args"; then
+    echo "error: browser runtime build policy is not production-safe" >&2
+    exit 1
+  fi
+  if awk '$0 ~ /(^|[^A-Za-z0-9_-])(in-process-gpu|--in-process-gpu)([^A-Za-z0-9_-]|$)/ { found = 1 } END { exit found ? 0 : 1 }' "$build_args"; then
+    echo "error: browser runtime graphics policy is not production-safe" >&2
+    exit 1
+  fi
+}
+
+verify_rendering_path() {
+  local app_path="$1"
+  local framework_binary
+  framework_binary="$(find "$app_path/Contents/Frameworks/Content Shell Framework.framework" \
+    -type f -name "Content Shell Framework" -print -quit 2>/dev/null)"
+  if [[ -z "$framework_binary" ]]; then
+    echo "error: Content Shell framework binary not found" >&2
+    exit 1
+  fi
+  if ! strings "$framework_binary" | awk '$0 ~ /CALayerHost/ { layer = 1 } $0 ~ /IOSurface/ { surface = 1 } $0 ~ /Metal/ { metal = 1 } END { exit (layer && surface && metal) ? 0 : 1 }'; then
+    echo "error: browser runtime does not expose the expected native rendering path" >&2
+    exit 1
+  fi
+}
+
+verify_no_cef() {
+  local app_path="$1"
+  if find "$app_path" -path '*Chromium Embedded Framework.framework*' -print -quit | grep -q .; then
+    echo "error: browser runtime contains a disallowed embedding framework" >&2
+    exit 1
+  fi
+  local -a binaries=(
+    "$app_path/Contents/MacOS/Content Shell"
+    "$app_path/Contents/Frameworks/Content Shell Framework.framework/Content Shell Framework"
+    "$app_path/Contents/Frameworks/Content Shell Framework.framework/Versions/Current/Content Shell Framework"
+  )
+  local binary
+  for binary in "${binaries[@]}"; do
+    if [[ -f "$binary" ]] &&
+      strings "$binary" | awk '
+        $0 ~ /Chromium Embedded Framework|libcef|CefInitialize|CefBrowser|CEF.framework/ { found = 1 }
+        END { exit found ? 0 : 1 }
+      '; then
+      echo "error: browser runtime contains disallowed embedding markers" >&2
+      exit 1
+    fi
+  done
+}
+
+sign_path() {
+  local path="$1"
+  if command -v codesign >/dev/null 2>&1; then
+    codesign --force --sign - --timestamp=none "$path" >/dev/null
+  fi
+}
+
+sign_top_level_app_dylibs() {
+  local app_path="$1"
+  local macos_dir="$app_path/Contents/MacOS"
+  [[ -d "$macos_dir" ]] || return 0
+
+  local dylib
+  while IFS= read -r -d '' dylib; do
+    sign_path "$dylib"
+  done < <(find "$macos_dir" -maxdepth 1 -type f -name '*.dylib' -print0)
+}
+
+resolve_framework_version_dir() {
+  local framework="$1"
+  local versions_dir="$framework/Versions"
+  local current="$versions_dir/Current"
+  if [[ -e "$current" ]]; then
+    local target resolved
+    target="$(readlink "$current")"
+    if [[ "$target" = /* ]]; then
+      resolved="$target"
+    else
+      resolved="$(cd "$versions_dir" && pwd -P)/$target"
+    fi
+    if [[ -d "$resolved" ]]; then
+      echo "$resolved"
+      return 0
+    fi
+  fi
+  local -a versions=()
+  while IFS= read -r -d '' version_dir; do
+    versions+=("$version_dir")
+  done < <(find "$versions_dir" -mindepth 1 -maxdepth 1 -type d ! -name Current -print0)
+  if (( ${#versions[@]} > 0 )); then
+    echo "${versions[$((${#versions[@]} - 1))]}"
+    return 0
+  fi
+  echo "error: no framework version directory found under $versions_dir" >&2
+  exit 1
+}
+
+sign_content_shell_app() {
+  local app_path="$1"
+  local chromium_framework="$app_path/Contents/Frameworks/Content Shell Framework.framework"
+  if [[ ! -d "$chromium_framework" ]]; then
+    echo "error: Content Shell framework not found at $chromium_framework" >&2
+    exit 1
+  fi
+  local resolved_version_dir
+  resolved_version_dir="$(resolve_framework_version_dir "$chromium_framework")"
+  if [[ -d "$resolved_version_dir/Libraries" ]]; then
+    while IFS= read -r -d '' library; do
+      sign_path "$library"
+    done < <(find "$resolved_version_dir/Libraries" -type f -name '*.dylib' -print0)
+  fi
+  if [[ -x "$resolved_version_dir/Helpers/chrome_crashpad_handler" ]]; then
+    sign_path "$resolved_version_dir/Helpers/chrome_crashpad_handler"
+  fi
+  if [[ -d "$resolved_version_dir/Helpers" ]]; then
+    while IFS= read -r -d '' helper_app; do
+      sign_path "$helper_app"
+    done < <(find "$resolved_version_dir/Helpers" -maxdepth 1 -type d -name '*.app' -print0)
+  fi
+  sign_path "$chromium_framework"
+  sign_path "$app_path"
+}
+
+download_content_shell_if_needed
+CONTENT_SHELL_APP="$(resolve_content_shell_app || true)"
+if [[ -z "$CONTENT_SHELL_APP" ]]; then
+  echo "error: patched Content Shell.app not found" >&2
+  exit 1
+fi
+if [[ ! -f "$FRAMEWORK_SOURCE" ]]; then
+  echo "error: missing framework source at $FRAMEWORK_SOURCE" >&2
+  exit 1
+fi
+RESOURCE_SOURCE="$(content_shell_resource_dir "$CONTENT_SHELL_APP" || true)"
+if [[ -z "$RESOURCE_SOURCE" ]]; then
+  echo "error: Content Shell resources not found under $CONTENT_SHELL_APP" >&2
+  exit 1
+fi
+RUNTIME_ROOT="$(content_shell_runtime_root "$CONTENT_SHELL_APP")"
+verify_runtime_launch_policy "$RUNTIME_ROOT"
+verify_no_cef "$CONTENT_SHELL_APP"
+verify_rendering_path "$CONTENT_SHELL_APP"
+
+PRODUCT_DIR="$BUILD_ROOT/$CONFIGURATION"
+FRAMEWORK_DIR="$PRODUCT_DIR/$FRAMEWORK_NAME"
+VERSION_DIR="$FRAMEWORK_DIR/Versions/A"
+RESOURCE_DIR="$VERSION_DIR/Resources"
+rm -rf "$FRAMEWORK_DIR"
+mkdir -p "$VERSION_DIR" "$RESOURCE_DIR" "$VERSION_DIR/Modules/$MODULE_NAME.swiftmodule"
+
+SDKROOT="${SDKROOT:-$(xcrun --sdk macosx --show-sdk-path)}"
+DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-14.0}"
+SWIFT_OPT="-Onone"
+if [[ "$CONFIGURATION" == "Release" ]]; then
+  SWIFT_OPT="-O"
+fi
+
+xcrun swiftc \
+  -emit-library \
+  -emit-module \
+  -module-name "$MODULE_NAME" \
+  -parse-as-library \
+  -target "arm64-apple-macos${DEPLOYMENT_TARGET}" \
+  -sdk "$SDKROOT" \
+  "$SWIFT_OPT" \
+  -framework AppKit \
+  -framework QuartzCore \
+  -Xlinker -install_name \
+  -Xlinker "@rpath/$FRAMEWORK_NAME/Versions/A/$MODULE_NAME" \
+  "$FRAMEWORK_SOURCE" \
+  -o "$VERSION_DIR/$MODULE_NAME" \
+  -emit-module-path "$VERSION_DIR/Modules/$MODULE_NAME.swiftmodule/arm64-apple-macos.swiftmodule"
+
+if [[ -f "$VERSION_DIR/$MODULE_NAME.swiftdoc" ]]; then
+  mv "$VERSION_DIR/$MODULE_NAME.swiftdoc" "$VERSION_DIR/Modules/$MODULE_NAME.swiftmodule/arm64-apple-macos.swiftdoc"
+fi
+if [[ -f "$VERSION_DIR/$MODULE_NAME.swiftsourceinfo" ]]; then
+  mv "$VERSION_DIR/$MODULE_NAME.swiftsourceinfo" "$VERSION_DIR/Modules/$MODULE_NAME.swiftmodule/arm64-apple-macos.swiftsourceinfo"
+fi
+
+cat > "$RESOURCE_DIR/Info.plist" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>$MODULE_NAME</string>
+  <key>CFBundleIdentifier</key>
+  <string>com.cmuxterm.chromium-core</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$MODULE_NAME</string>
+  <key>CFBundlePackageType</key>
+  <string>FMWK</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleVersion</key>
+  <string>1</string>
+  <key>MinimumOSVersion</key>
+  <string>$DEPLOYMENT_TARGET</string>
+</dict>
+</plist>
+EOF
+
+rsync -a --delete "$CONTENT_SHELL_APP" "$RESOURCE_DIR/"
+prune_content_shell_runtime_files "$RESOURCE_DIR/Content Shell.app"
+for name in content_shell.pak icudtl.dat v8_context_snapshot.arm64.bin; do
+  if [[ -f "$RESOURCE_SOURCE/$name" ]]; then
+    rsync -a "$RESOURCE_SOURCE/$name" "$RESOURCE_DIR/$name"
+  fi
+done
+for name in libowl_fresh_mojo_runtime.dylib owl-runtime-manifest.json owl-build-args.gn; do
+  if [[ -f "$RUNTIME_ROOT/$name" ]]; then
+    rsync -a "$RUNTIME_ROOT/$name" "$RESOURCE_DIR/$name"
+  fi
+done
+
+VERSION_STRING="$(chromium_version "$CONTENT_SHELL_APP")"
+REVISION_STRING="$(chromium_revision "$RUNTIME_ROOT")"
+cat > "$RESOURCE_DIR/cmux-chromium-manifest.json" <<EOF
+{
+  "engine": "chromium-owl-fresh-mojo",
+  "chromiumVersion": "$VERSION_STRING",
+  "chromiumRevision": "$REVISION_STRING",
+  "frameworkName": "$FRAMEWORK_NAME",
+  "resourceNames": [
+    "Content Shell.app",
+    "libowl_fresh_mojo_runtime.dylib",
+    "content_shell.pak",
+    "icudtl.dat",
+    "v8_context_snapshot.arm64.bin"
+  ],
+  "hostClassName": "CmuxChromiumBrowserHost",
+  "hostFactoryClassName": "CmuxChromiumBrowserHostFactory",
+  "hostAPIVersion": 1,
+  "renderingAPI": {
+    "nativeViewHost": "Chromium remote_cocoa WebContents NSView",
+    "compositorLayer": "CALayerHost",
+    "surfaceTransport": "IOSurface/Metal"
+  },
+  "launchPolicy": {
+    "sandboxDisabled": $RUNTIME_SANDBOX_DISABLED,
+    "usesInProcessGPUByDefault": $RUNTIME_USES_IN_PROCESS_GPU_BY_DEFAULT,
+    "defaultSwitches": $RUNTIME_DEFAULT_SWITCHES_JSON,
+    "forbiddenSwitchesVerifiedAbsent": $RUNTIME_FORBIDDEN_SWITCHES_JSON
+  }
+}
+EOF
+
+ln -s A "$FRAMEWORK_DIR/Versions/Current"
+ln -s Versions/Current/$MODULE_NAME "$FRAMEWORK_DIR/$MODULE_NAME"
+ln -s Versions/Current/Resources "$FRAMEWORK_DIR/Resources"
+ln -s Versions/Current/Modules "$FRAMEWORK_DIR/Modules"
+
+normalize_bundle_permissions "$FRAMEWORK_DIR"
+if [[ -f "$RESOURCE_DIR/libowl_fresh_mojo_runtime.dylib" ]]; then
+  sign_path "$RESOURCE_DIR/libowl_fresh_mojo_runtime.dylib"
+fi
+sign_content_shell_app "$RESOURCE_DIR/Content Shell.app"
+sign_path "$FRAMEWORK_DIR"
+
+if [[ -n "$APP_PATH" ]]; then
+  if [[ ! -d "$APP_PATH" ]]; then
+    echo "error: app path not found: $APP_PATH" >&2
+    exit 1
+  fi
+  DEST="$APP_PATH/Contents/Frameworks/$FRAMEWORK_NAME"
+  mkdir -p "$APP_PATH/Contents/Frameworks"
+  rm -rf "$DEST"
+  rsync -a "$FRAMEWORK_DIR" "$APP_PATH/Contents/Frameworks/"
+  normalize_bundle_permissions "$DEST"
+  if [[ -f "$DEST/Resources/libowl_fresh_mojo_runtime.dylib" ]]; then
+    sign_path "$DEST/Resources/libowl_fresh_mojo_runtime.dylib"
+  fi
+  sign_content_shell_app "$DEST/Resources/Content Shell.app"
+  sign_path "$DEST"
+  if [[ -d "$APP_PATH/Contents/PlugIns" ]] &&
+    find "$APP_PATH/Contents/PlugIns" -name '*.xctest' -print -quit | grep -q .; then
+    echo "Skipping outer app re-sign for Xcode test host bundle"
+  else
+    sign_top_level_app_dylibs "$APP_PATH"
+    sign_path "$APP_PATH"
+  fi
+  echo "Embedded $FRAMEWORK_NAME into $APP_PATH"
+else
+  echo "$FRAMEWORK_DIR"
+fi

--- a/scripts/build-cmux-chromium-core.sh
+++ b/scripts/build-cmux-chromium-core.sh
@@ -463,6 +463,13 @@ cat > "$RESOURCE_DIR/cmux-chromium-manifest.json" <<EOF
   "hostClassName": "CmuxChromiumBrowserHost",
   "hostFactoryClassName": "CmuxChromiumBrowserHostFactory",
   "hostAPIVersion": 1,
+  "forbiddenCEFMarkersVerifiedAbsent": [
+    "Chromium Embedded Framework",
+    "libcef",
+    "CefInitialize",
+    "CefBrowser",
+    "CEF.framework"
+  ],
   "renderingAPI": {
     "nativeViewHost": "Chromium remote_cocoa WebContents NSView",
     "compositorLayer": "CALayerHost",

--- a/scripts/build-cmux-chromium-core.sh
+++ b/scripts/build-cmux-chromium-core.sh
@@ -8,8 +8,12 @@ FRAMEWORK_SOURCE="$SRCROOT/Frameworks/CmuxChromiumCore/Sources/CmuxChromiumCore.
 BUILD_ROOT="${CMUX_CHROMIUM_CORE_BUILD_DIR:-$SRCROOT/.build/CmuxChromiumCore}"
 FRAMEWORK_NAME="CmuxChromiumCore.framework"
 MODULE_NAME="CmuxChromiumCore"
-DEFAULT_DOWNLOAD_URL="https://github.com/manaflow-ai/chromium/releases/download/owl-chromium-cb711dd4af32/owl-chromium-runtime-macos-arm64-cb711dd4af32.tar.gz"
-DEFAULT_DOWNLOAD_SHA256="092f614b05c8f454aa142d8169e32255921c4051d99555172bf24c4d963b723e"
+CHROMIUM_RUNTIME_REVISION="66fc3593cef3"
+CHROMIUM_RUNTIME_RELEASE="66fc3593ce"
+CHROMIUM_RUNTIME_TAG="owl-chromium-${CHROMIUM_RUNTIME_RELEASE}"
+CHROMIUM_RUNTIME_BASENAME="owl-chromium-runtime-macos-arm64-${CHROMIUM_RUNTIME_REVISION}"
+DEFAULT_DOWNLOAD_URL="https://github.com/manaflow-ai/chromium/releases/download/${CHROMIUM_RUNTIME_TAG}/${CHROMIUM_RUNTIME_BASENAME}.tar.gz"
+DEFAULT_DOWNLOAD_SHA256="d412d1f2193b36900dcf0ea3a2436b5d8cf30cdc678503b68ebd86c9d73dd92b"
 DOWNLOAD_URL="${CMUX_CHROMIUM_CONTENT_SHELL_ARCHIVE_URL:-$DEFAULT_DOWNLOAD_URL}"
 EXPECTED_ARCHIVE_SHA256="${CMUX_CHROMIUM_CONTENT_SHELL_SHA256:-}"
 if [[ "$DOWNLOAD_URL" == "$DEFAULT_DOWNLOAD_URL" && -z "$EXPECTED_ARCHIVE_SHA256" ]]; then
@@ -19,7 +23,7 @@ if [[ "$DOWNLOAD_URL" != "$DEFAULT_DOWNLOAD_URL" && -z "$EXPECTED_ARCHIVE_SHA256
   echo "error: custom CMUX_CHROMIUM_CONTENT_SHELL_ARCHIVE_URL requires CMUX_CHROMIUM_CONTENT_SHELL_SHA256" >&2
   exit 1
 fi
-CACHE_ROOT="${CMUX_CHROMIUM_CONTENT_SHELL_CACHE:-$HOME/Library/Caches/cmux/chromium-content-shell/owl-chromium-cb711dd4af32}"
+CACHE_ROOT="${CMUX_CHROMIUM_CONTENT_SHELL_CACHE:-$HOME/Library/Caches/cmux/chromium-content-shell/${CHROMIUM_RUNTIME_TAG}}"
 RUNTIME_SANDBOX_DISABLED=false
 RUNTIME_USES_IN_PROCESS_GPU_BY_DEFAULT=false
 RUNTIME_FORBIDDEN_SWITCHES_JSON='["no-sandbox", "in-process-gpu"]'
@@ -80,7 +84,7 @@ resolve_content_shell_app() {
     candidates+=("$CMUX_CHROMIUM_CONTENT_SHELL_APP")
   fi
   candidates+=(
-    "$CACHE_ROOT/owl-chromium-runtime-macos-arm64-cb711dd4af32/Content Shell.app"
+    "$CACHE_ROOT/${CHROMIUM_RUNTIME_BASENAME}/Content Shell.app"
     "$CACHE_ROOT/Content Shell.app"
   )
   if [[ "${CMUX_CHROMIUM_ALLOW_LOCAL_CONTENT_SHELL:-0}" == "1" ]]; then
@@ -105,7 +109,7 @@ download_content_shell_if_needed() {
   mkdir -p "$CACHE_ROOT"
   local archive="$CACHE_ROOT/content-shell.tar.gz"
   if [[ "$DOWNLOAD_URL" == "$DEFAULT_DOWNLOAD_URL" ]]; then
-    archive="$CACHE_ROOT/owl-chromium-runtime-macos-arm64-cb711dd4af32.tar.gz"
+    archive="$CACHE_ROOT/${CHROMIUM_RUNTIME_BASENAME}.tar.gz"
   fi
   echo "Downloading patched browser runtime"
   curl -fL "$DOWNLOAD_URL" -o "$archive"


### PR DESCRIPTION
## Summary

Adds a Chromium browser engine for cmux browser panels using the OWL Fresh Chromium runtime from https://github.com/manaflow-ai/chromium-src/pull/1. The integration embeds `CmuxChromiumCore.framework`, loads Chromium through the bridge at runtime, hosts the compositor with `CALayerHost`, and reports `IOSurface/Metal` rendering metadata through browser automation.

The WebKit path remains as fallback when the Chromium artifact is missing or rejected.

## Verification

- `git diff --check`
- `bash -n scripts/build-cmux-chromium-core.sh`
- `xcrun swiftc -typecheck Frameworks/CmuxChromiumCore/Sources/CmuxChromiumCore.swift`
- `cmux-unit`, focused `cmuxTests/BrowserChromiumArtifactVerifierTests` and `cmuxTests/BrowserNativeEngineHostContainerViewTests`: 18 passed, 0 failed
- AWS M4 Pro XCUITest, `cmuxUITests/BrowserChromiumEngineUITests`: 1 passed, 0 failed
- Manual tagged app proof on `chromeng`: opened Chromium split, verified `CALayerHost`, `IOSurface/Metal`, sandbox enabled, JS eval, DOM snapshot, click, screenshot PNG, and inspected `/tmp/cmux-chromeng-surface-proof/frame-10.png`

## Notes

The default runtime archive is pinned to Chromium revision `38a10eea4c9e7a7afb342c3e118748ee7918a71a` with SHA-256 `d0d07d859bb2986f1515db0e65a00afc722c02de153319835e7b873e57cb53ab`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Introduces a new native Chromium runtime/IPC bridge and build embedding step, which can affect browser panel stability, process lifecycle, and input/rendering behavior. Also touches notification delivery fallback paths and adds UI-test wiring, increasing integration surface area.
> 
> **Overview**
> Adds a new `CmuxChromiumCore` Swift framework that hosts an embedded Chromium `content_shell` (or OWL Fresh Mojo runtime) inside an `NSView`, including navigation, history, zoom, JS eval, snapshots, DevTools control, proxy updates, and input forwarding via a Unix-domain control channel and `CALayerHost`-backed compositing.
> 
> Updates the app target to *embed/build* the Chromium core via a new Xcode build phase, adds localized Chromium error strings, and extends UI-test coverage/wiring (including extra browser engine runtime metadata written during the goto-split test path).
> 
> Separately refactors feed notification fallback execution into a `@MainActor` helper and adjusts `UserNotifications` import to `@preconcurrency` to avoid concurrency warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb88b9f61db009f029b58ae19a8aa229d6191e62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Chromium-based browser engine for browser panels, loaded at runtime via `CmuxChromiumCore.framework` and composited with `CALayerHost`. Hardens native input and DevTools handling, expands tests, and falls back to WebKit when Chromium is unavailable or fails verification.

- New Features
  - Optional `chromium` engine via runtime bridge with `CALayerHost` compositor, proxy support, strict artifact verification, hardened host factory, launch-policy/sandbox enforcement, CEF-marker rejection, DevTools hardening, and automatic WebKit fallback.
  - Browser automation: panel-scoped JS eval with typed envelopes (`value`/`error` + `message`), improved wait-for, engine metadata in responses, new `system.ping` socket command, and localized error messages for engine start/script failures.
  - Tests: artifact verifier unit tests; hardened Chromium UI proof for rendering, automation, screenshots; less timing-sensitive socket reads; hosted UI proof fallback; pointer regression coverage; session snapshots skip DevTools frontend panels.
  - Runtime packaging: `scripts/build-cmux-chromium-core.sh` to fetch/verify/sign/cache the runtime; default runtime pinned to Chromium revision `66fc3593cef3` (SHA-256 `d412d1f2193b36900dcf0ea3a2436b5d8cf30cdc678503b68ebd86c9d73dd92b`).

- Bug Fixes
  - Hardened native input delivery and focus; fixed Chromium host input routing and runtime launch behavior.
  - Fixed Chromium UI test screenshot artifact path and CI packaging.
  - Standardized automation result envelope fields (`type`/`value`/`error` + `message`).

<sup>Written for commit cb88b9f61db009f029b58ae19a8aa229d6191e62. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4174?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional Chromium engine: embeddable native view with navigation, JS evaluation, snapshotting, proxy support, dual runtime/backends, and control-socket ping.

* **Refactor**
  * BrowserPanel unified to route operations through interchangeable engine hosts; focus, omnibar, find-in-page, and history now target the active engine.

* **Tests**
  * New unit and UI tests for artifact verification, host bridging, native-view lifecycle, and end-to-end Chromium automation.

* **Chores**
  * Build/package script for the Chromium engine, added localized Chromium error strings, and improved notification fallback handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4174)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->