### PR TITLE
Bridge terminal shell activity to tab loading indicator for renamed tabs

### DIFF
--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -8698,6 +8698,18 @@ final class Workspace: Identifiable, ObservableObject {
                 shellState: state
             )
         }
+
+        // Bridge terminal shell activity to the tab-level loading indicator so
+        // renamed terminal tabs still show a spinner when a command is running.
+        if panels[panelId] is TerminalPanel,
+           let tabId = surfaceIdFromPanelId(panelId),
+           let existing = bonsplitController.tab(tabId) {
+            let isLoading = state == .commandRunning
+            if existing.isLoading != isLoading {
+                bonsplitController.updateTab(tabId, isLoading: isLoading)
+            }
+        }
+
 #if DEBUG
         cmuxDebugLog(
             "surface.shellState workspace=\(id.uuidString.prefix(5)) " +
@@ -13824,7 +13836,7 @@ extension Workspace: BonsplitDelegate {
                 icon: panel.displayIcon,
                 iconImageData: browserPanel?.faviconPNGData,
                 kind: surfaceKind(for: panel),
-                isLoading: browserPanel?.isLoading ?? false,
+                isLoading: browserPanel?.isLoading ?? (panelShellActivityStates[panelId] == .commandRunning),
                 isPinned: pinnedPanelIds.contains(panelId),
                 directory: panelDirectories[panelId],
                 ttyName: surfaceTTYNames[panelId],


### PR DESCRIPTION
## Summary

When a terminal tab is renamed, the custom title completely overrides the dynamic title from the shell. This means terminal-based agents like Codex or Claude Code can no longer show a "loading" spinner in the tab name, because the dynamic title updates are suppressed.

This change bridges the existing `PanelShellActivityState` (already tracked for close-confirmation logic) to Bonsplit's native `isLoading` tab indicator. Terminal tabs now show the loading spinner independently of the title, so renamed tabs keep their custom name while still indicating when a command is running.

## Changes

- In `updatePanelShellActivityState`, when the panel is a `TerminalPanel`, we now forward `isLoading: true` to `bonsplitController.updateTab` whenever `state == .commandRunning`, and `isLoading: false` otherwise.
- Only sends updates when the current tab's `isLoading` value actually differs, avoiding no-op Bonsplit mutations.
- Browser tabs are unaffected; they continue to drive `isLoading` from `WKWebView.isLoading`.

## Testing

- Built and tested locally with a tagged debug app (`terminal-loading-spinner`).
- Verified that:
  1. Default tab names still show the loading indicator during long-running commands.
  2. After renaming a tab, the custom title persists and the loading indicator still appears when a command is running.
  3. Browser tabs continue to show loading indicators during page navigations.

## Demo Video

Video URL or attachment:

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed terminal tabs now show a loading spinner while commands run, without losing the custom title. We bridge shell `commandRunning` to tab `isLoading` (including on tab init) and skip no-op updates; browser tabs still use `WKWebView.isLoading`.

<sup>Written for commit efb7d5c183dc4279e917797a7edd5dfe0706d819. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal tabs now sync their loading spinner with actual shell activity so the loader appears only while commands are running.
  * When closing or detaching tabs, the staged tab preserves its loading state based on recent shell activity if the usual browser-derived state is unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4175)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->