### PR TITLE
Restore Claude session after /clear by capturing rotated session id

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -755,9 +755,13 @@ private final class ClaudeHookSessionStore {
         surfaceId: String
     ) throws -> [String] {
         let keep = normalizeSessionId(keepSessionId)
-        let normalizedWorkspace = normalizeOptional(workspaceId)
-        let normalizedSurface = normalizeOptional(surfaceId)
-        guard !keep.isEmpty, normalizedWorkspace != nil || normalizedSurface != nil else {
+        // Require both workspace and surface: pruning is a panel-scoped
+        // operation, and proceeding with only one would silently widen the
+        // sweep (e.g. an empty surfaceId would prune every session in the
+        // workspace).
+        guard !keep.isEmpty,
+              let workspace = normalizeOptional(workspaceId),
+              let surface = normalizeOptional(surfaceId) else {
             return []
         }
         return try withLockedState { state in
@@ -766,13 +770,9 @@ private final class ClaudeHookSessionStore {
             // checks. Compute the set, then remove in a separate pass.
             var removed: [String] = []
             for (sid, record) in state.sessions {
-                guard sid != keep else { continue }
-                let recordWorkspace = normalizeOptional(record.workspaceId)
-                let recordSurface = normalizeOptional(record.surfaceId)
-                if let normalizedSurface, recordSurface != normalizedSurface {
-                    continue
-                }
-                if let normalizedWorkspace, recordWorkspace != normalizedWorkspace {
+                guard sid != keep,
+                      normalizeOptional(record.workspaceId) == workspace,
+                      normalizeOptional(record.surfaceId) == surface else {
                     continue
                 }
                 removed.append(sid)
@@ -783,10 +783,9 @@ private final class ClaudeHookSessionStore {
             // If the active-session pointer still targets a removed record,
             // clear it so later Stop/SessionEnd events cannot revive state
             // that no longer has a matching session record.
-            if let normalizedWorkspace,
-               let active = state.activeSessionsByWorkspace[normalizedWorkspace],
+            if let active = state.activeSessionsByWorkspace[workspace],
                removed.contains(active.sessionId) {
-                state.activeSessionsByWorkspace.removeValue(forKey: normalizedWorkspace)
+                state.activeSessionsByWorkspace.removeValue(forKey: workspace)
             }
             return removed
         }

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -761,6 +761,9 @@ private final class ClaudeHookSessionStore {
             return []
         }
         return try withLockedState { state in
+            // Collect victims first; mutating `state.sessions` while iterating
+            // it is undefined behavior in Swift and can trap under runtime
+            // checks. Compute the set, then remove in a separate pass.
             var removed: [String] = []
             for (sid, record) in state.sessions {
                 guard sid != keep else { continue }
@@ -772,8 +775,10 @@ private final class ClaudeHookSessionStore {
                 if let normalizedWorkspace, recordWorkspace != normalizedWorkspace {
                     continue
                 }
-                state.sessions.removeValue(forKey: sid)
                 removed.append(sid)
+            }
+            for sid in removed {
+                state.sessions.removeValue(forKey: sid)
             }
             // If the active-session pointer still targets a removed record,
             // clear it so later Stop/SessionEnd events cannot revive state

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -741,6 +741,51 @@ private final class ClaudeHookSessionStore {
         }
         return value
     }
+
+    /// Remove any Claude hook records bound to the same panel (workspaceId +
+    /// surfaceId) other than `keepSessionId`. Used after a `/clear` rotation
+    /// so the pre-clear session does not shadow the rotated one when session
+    /// autosave loads the index.
+    ///
+    /// Returns the session IDs that were removed (for telemetry / tests).
+    @discardableResult
+    func removePanelSiblings(
+        keepSessionId: String,
+        workspaceId: String,
+        surfaceId: String
+    ) throws -> [String] {
+        let keep = normalizeSessionId(keepSessionId)
+        let normalizedWorkspace = normalizeOptional(workspaceId)
+        let normalizedSurface = normalizeOptional(surfaceId)
+        guard !keep.isEmpty, normalizedWorkspace != nil || normalizedSurface != nil else {
+            return []
+        }
+        return try withLockedState { state in
+            var removed: [String] = []
+            for (sid, record) in state.sessions {
+                guard sid != keep else { continue }
+                let recordWorkspace = normalizeOptional(record.workspaceId)
+                let recordSurface = normalizeOptional(record.surfaceId)
+                if let normalizedSurface, recordSurface != normalizedSurface {
+                    continue
+                }
+                if let normalizedWorkspace, recordWorkspace != normalizedWorkspace {
+                    continue
+                }
+                state.sessions.removeValue(forKey: sid)
+                removed.append(sid)
+            }
+            // If the active-session pointer still targets a removed record,
+            // clear it so later Stop/SessionEnd events cannot revive state
+            // that no longer has a matching session record.
+            if let normalizedWorkspace,
+               let active = state.activeSessionsByWorkspace[normalizedWorkspace],
+               removed.contains(active.sessionId) {
+                state.activeSessionsByWorkspace.removeValue(forKey: normalizedWorkspace)
+            }
+            return removed
+        }
+    }
 }
 
 private let codexHookWrapperProcessNames: Set<String> = [
@@ -16690,6 +16735,14 @@ struct CMUXCLI {
                 // Non-clear SessionStart can arrive late from startup/resume/compact
                 // after /clear, so only /clear or replacement of a stopped owner
                 // establishes a new active boundary.
+                //
+                // When it is a new active boundary (/clear or a stopped-session
+                // replacement), mark the record restorable immediately so
+                // session autosave can pick up the rotated sessionId before the
+                // first post-rotation turn writes a transcript. Otherwise the
+                // snapshot keeps pointing at the pre-clear session, which is
+                // exactly the one the user just abandoned, and
+                // `restore-session` resumes the wrong Claude transcript.
                 try? sessionStore.upsert(
                     sessionId: sessionId,
                     workspaceId: workspaceId,
@@ -16698,10 +16751,25 @@ struct CMUXCLI {
                     transcriptPath: parsedInput.transcriptPath,
                     pid: claudePid,
                     launchCommand: launchCommand,
-                    isRestorable: false,
+                    isRestorable: shouldPromoteActiveSession ? true : false,
                     markActive: shouldPromoteActiveSession,
                     turnId: parsedInput.turnId
                 )
+                if isClearSessionStart {
+                    // `/clear` abandons the previous session on the same panel.
+                    // Without pruning, both records linger with matching
+                    // (workspace, surface) and the older one can win on
+                    // autosave when updatedAt ordering flukes (e.g., a late
+                    // pre-clear Notification Stamp). Consume siblings on this
+                    // panel so only the rotated session remains restorable.
+                    pruneClaudeSessionSiblings(
+                        store: sessionStore,
+                        keepSessionId: sessionId,
+                        workspaceId: workspaceId,
+                        surfaceId: surfaceId,
+                        telemetry: telemetry
+                    )
+                }
             }
             // Register PID for stale-session detection and OSC suppression.
             // Startup/resume SessionStart remains non-visible; /clear is a
@@ -17198,6 +17266,41 @@ struct CMUXCLI {
             return false
         }
         return source.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "clear"
+    }
+
+    private func pruneClaudeSessionSiblings(
+        store: ClaudeHookSessionStore,
+        keepSessionId: String,
+        workspaceId: String,
+        surfaceId: String,
+        telemetry: CLISocketSentryTelemetry
+    ) {
+        do {
+            let removed = try store.removePanelSiblings(
+                keepSessionId: keepSessionId,
+                workspaceId: workspaceId,
+                surfaceId: surfaceId
+            )
+            if !removed.isEmpty {
+                telemetry.breadcrumb(
+                    "claude-hook.clear.pruned-siblings",
+                    data: [
+                        "removed_count": removed.count,
+                        "workspace_id": workspaceId,
+                        "surface_id": surfaceId,
+                    ]
+                )
+            }
+        } catch {
+            telemetry.breadcrumb(
+                "claude-hook.clear.prune-siblings.error",
+                data: [
+                    "error": String(describing: error),
+                    "workspace_id": workspaceId,
+                    "surface_id": surfaceId,
+                ]
+            )
+        }
     }
 
     private func socketPanelOption(_ surfaceId: String?) -> String {

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -73,6 +73,124 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         )
     }
 
+    func testClaudeClearSessionStartMarksRotatedSessionRestorable() throws {
+        // Regression test: on `/clear`, Claude does not kill its process and
+        // does not emit `SessionEnd` for the pre-clear session. Without the
+        // fix, the rotated session is written to the hook store with
+        // `isRestorable=false`, so session autosave keeps pointing at the
+        // abandoned pre-clear session id and `restore-session` resumes the
+        // wrong Claude transcript. The rotated session must be immediately
+        // restorable so autosave can capture it before the first post-clear
+        // turn writes a transcript.
+        let context = try makeClaudeHookContext(name: "claude-clear-restorable")
+        defer { context.cleanup() }
+
+        let rotatedSessionId = "rotated-session"
+        let result = runClaudeHook(
+            context: context,
+            arguments: ["hooks", "claude", "session-start"],
+            standardInput: #"{"session_id":"\#(rotatedSessionId)","source":"clear","cwd":"\#(context.root.path)","hook_event_name":"SessionStart"}"#
+        )
+
+        XCTAssertFalse(result.timedOut, result.stderr)
+        XCTAssertEqual(result.status, 0, result.stderr)
+
+        let record = try readClaudeHookSession(rotatedSessionId, context: context)
+        XCTAssertEqual(
+            record["isRestorable"] as? Bool,
+            true,
+            "Clear SessionStart must be immediately restorable; otherwise autosave falls back to the pre-clear session id."
+        )
+    }
+
+    func testClaudeClearSessionStartPrunesPreClearSiblingOnSamePanel() throws {
+        // Regression test: `/clear` produces a new sessionId on the same panel.
+        // Without pruning, the pre-clear record lingers in the hook store, and
+        // because its transcript still exists on disk it stays restorable.
+        // Session autosave can then pick it over the rotated session if its
+        // `updatedAt` is fresher (e.g., a late pre-clear Stop/Notification
+        // hook). Pruning pre-clear siblings ensures the rotated session is
+        // the sole candidate for this panel.
+        let context = try makeClaudeHookContext(name: "claude-clear-prune")
+        defer { context.cleanup() }
+
+        let preClearSessionId = "pre-clear-session"
+        let rotatedSessionId = "post-clear-session"
+
+        let preClear = runClaudeHook(
+            context: context,
+            arguments: ["hooks", "claude", "session-start"],
+            standardInput: #"{"session_id":"\#(preClearSessionId)","source":"startup","cwd":"\#(context.root.path)","hook_event_name":"SessionStart"}"#
+        )
+        XCTAssertFalse(preClear.timedOut, preClear.stderr)
+        XCTAssertEqual(preClear.status, 0, preClear.stderr)
+
+        let rotated = runClaudeHook(
+            context: context,
+            arguments: ["hooks", "claude", "session-start"],
+            standardInput: #"{"session_id":"\#(rotatedSessionId)","source":"clear","cwd":"\#(context.root.path)","hook_event_name":"SessionStart"}"#
+        )
+        XCTAssertFalse(rotated.timedOut, rotated.stderr)
+        XCTAssertEqual(rotated.status, 0, rotated.stderr)
+
+        let stateURL = context.root.appendingPathComponent("claude-hook-sessions.json")
+        let savedState = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(contentsOf: stateURL)) as? [String: Any])
+        let savedSessions = try XCTUnwrap(savedState["sessions"] as? [String: Any])
+        XCTAssertNil(
+            savedSessions[preClearSessionId],
+            "Expected the pre-clear sibling on the same panel to be pruned, saw keys \(Array(savedSessions.keys))"
+        )
+        XCTAssertNotNil(
+            savedSessions[rotatedSessionId],
+            "Expected the rotated session to remain in the hook store"
+        )
+    }
+
+    func testClaudeClearSessionStartKeepsSiblingsOnDifferentPanels() throws {
+        // Pruning must be scoped to the panel the clear event targets.
+        // A sibling session bound to a *different* panel (e.g., another
+        // Claude tab in the same cmux window) must not be touched.
+        let context = try makeClaudeHookContext(name: "claude-clear-prune-scoped")
+        defer { context.cleanup() }
+
+        let otherPanelSessionId = "other-panel-session"
+        let otherSurfaceId = "33333333-3333-3333-3333-333333333333"
+        let now = Date().timeIntervalSince1970
+        let seeded: [String: Any] = [
+            "version": 1,
+            "sessions": [
+                otherPanelSessionId: [
+                    "sessionId": otherPanelSessionId,
+                    "workspaceId": context.workspaceId,
+                    "surfaceId": otherSurfaceId,
+                    "cwd": context.root.path,
+                    "startedAt": now,
+                    "updatedAt": now,
+                ],
+            ],
+        ]
+        let stateURL = context.root.appendingPathComponent("claude-hook-sessions.json")
+        try JSONSerialization.data(withJSONObject: seeded, options: [.prettyPrinted])
+            .write(to: stateURL, options: .atomic)
+
+        let rotatedSessionId = "rotated-session"
+        let rotated = runClaudeHook(
+            context: context,
+            arguments: ["hooks", "claude", "session-start"],
+            standardInput: #"{"session_id":"\#(rotatedSessionId)","source":"clear","cwd":"\#(context.root.path)","hook_event_name":"SessionStart"}"#
+        )
+        XCTAssertFalse(rotated.timedOut, rotated.stderr)
+        XCTAssertEqual(rotated.status, 0, rotated.stderr)
+
+        let savedState = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(contentsOf: stateURL)) as? [String: Any])
+        let savedSessions = try XCTUnwrap(savedState["sessions"] as? [String: Any])
+        XCTAssertNotNil(
+            savedSessions[otherPanelSessionId],
+            "Expected siblings on a different panel to survive a clear-rotation prune"
+        )
+        XCTAssertNotNil(savedSessions[rotatedSessionId])
+    }
+
     func testClaudeStopFromPreviousSessionDoesNotClobberClearRunningStatus() throws {
         let context = try makeClaudeHookContext(name: "claude-clear-stale-stop")
         defer { context.cleanup() }

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -191,6 +191,165 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         XCTAssertNotNil(savedSessions[rotatedSessionId])
     }
 
+    func testClaudeClearSessionStartPrunesAllPreClearSiblingsOnSamePanel() throws {
+        // Hook stores in the wild can accumulate more than one stale record
+        // per panel — the bug this fix targets has been latent long enough
+        // that a single prune pass must sweep every sibling, not just the
+        // most recent one. Seed three pre-clear records bound to the panel
+        // and assert the rotation removes all of them.
+        let context = try makeClaudeHookContext(name: "claude-clear-prune-many")
+        defer { context.cleanup() }
+
+        let staleIds = ["stale-1", "stale-2", "stale-3"]
+        let now = Date().timeIntervalSince1970
+        var seededSessions: [String: Any] = [:]
+        for (offset, sid) in staleIds.enumerated() {
+            seededSessions[sid] = [
+                "sessionId": sid,
+                "workspaceId": context.workspaceId,
+                "surfaceId": context.surfaceId,
+                "cwd": context.root.path,
+                "startedAt": now - TimeInterval(60 * (offset + 1)),
+                "updatedAt": now - TimeInterval(60 * (offset + 1)),
+            ] as [String: Any]
+        }
+        let seeded: [String: Any] = ["version": 1, "sessions": seededSessions]
+        let stateURL = context.root.appendingPathComponent("claude-hook-sessions.json")
+        try JSONSerialization.data(withJSONObject: seeded, options: [.prettyPrinted])
+            .write(to: stateURL, options: .atomic)
+
+        let rotatedSessionId = "rotated-session"
+        let rotated = runClaudeHook(
+            context: context,
+            arguments: ["hooks", "claude", "session-start"],
+            standardInput: #"{"session_id":"\#(rotatedSessionId)","source":"clear","cwd":"\#(context.root.path)","hook_event_name":"SessionStart"}"#
+        )
+        XCTAssertFalse(rotated.timedOut, rotated.stderr)
+        XCTAssertEqual(rotated.status, 0, rotated.stderr)
+
+        let savedState = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(contentsOf: stateURL)) as? [String: Any])
+        let savedSessions = try XCTUnwrap(savedState["sessions"] as? [String: Any])
+        for staleId in staleIds {
+            XCTAssertNil(
+                savedSessions[staleId],
+                "Expected stale record \(staleId) to be pruned, remaining keys: \(Array(savedSessions.keys))"
+            )
+        }
+        XCTAssertNotNil(savedSessions[rotatedSessionId])
+    }
+
+    func testClaudeReplacementOfStoppedSessionMarksNewSessionRestorable() throws {
+        // The same `shouldPromoteActiveSession` boundary that flips
+        // `isRestorable=true` for `/clear` also covers the
+        // "user opens a fresh session after the previous one stopped" case.
+        // Without this, opening a new Claude session on the same workspace
+        // after Stop would resume the stopped session on cmux relaunch
+        // before the new session writes its first turn.
+        //
+        // The exact flow that triggers this is:
+        //   1. session-start old (no source)
+        //   2. prompt-submit old turn-1  → marks old active
+        //   3. stop old turn-1            → upserts old with
+        //                                   allowsNewSessionReplacement=true
+        //   4. session-start new source=startup → must mark new restorable
+        //      because the active owner allows replacement.
+        let context = try makeClaudeHookContext(name: "claude-replacement-restorable")
+        defer { context.cleanup() }
+
+        let oldStart = runClaudeHook(
+            context: context,
+            arguments: ["hooks", "claude", "session-start"],
+            standardInput: #"{"session_id":"old-session","cwd":"\#(context.root.path)","hook_event_name":"SessionStart"}"#
+        )
+        XCTAssertFalse(oldStart.timedOut, oldStart.stderr)
+        XCTAssertEqual(oldStart.status, 0, oldStart.stderr)
+
+        let oldPrompt = runClaudeHook(
+            context: context,
+            arguments: ["hooks", "claude", "prompt-submit"],
+            standardInput: #"{"session_id":"old-session","turn_id":"turn-1","cwd":"\#(context.root.path)","hook_event_name":"PromptSubmit"}"#
+        )
+        XCTAssertFalse(oldPrompt.timedOut, oldPrompt.stderr)
+        XCTAssertEqual(oldPrompt.status, 0, oldPrompt.stderr)
+
+        let oldStop = runClaudeHook(
+            context: context,
+            arguments: ["hooks", "claude", "stop"],
+            standardInput: #"{"session_id":"old-session","turn_id":"turn-1","cwd":"\#(context.root.path)","hook_event_name":"Stop","last_assistant_message":"old turn finished"}"#
+        )
+        XCTAssertFalse(oldStop.timedOut, oldStop.stderr)
+        XCTAssertEqual(oldStop.status, 0, oldStop.stderr)
+
+        let newStart = runClaudeHook(
+            context: context,
+            arguments: ["hooks", "claude", "session-start"],
+            standardInput: #"{"session_id":"new-session","source":"startup","cwd":"\#(context.root.path)","hook_event_name":"SessionStart"}"#
+        )
+        XCTAssertFalse(newStart.timedOut, newStart.stderr)
+        XCTAssertEqual(newStart.status, 0, newStart.stderr)
+
+        let newRecord = try readClaudeHookSession("new-session", context: context)
+        XCTAssertEqual(
+            newRecord["isRestorable"] as? Bool,
+            true,
+            "Replacement of a stopped owner is a new active boundary; the new session must be immediately restorable so autosave does not roll back to the stopped one."
+        )
+    }
+
+    func testClaudeReplacementOfStoppedSessionDoesNotPruneStoppedRecord() throws {
+        // Pruning is intentionally scoped to `/clear` only. The
+        // replacement-of-stopped-owner path is a softer boundary: the user
+        // didn't abandon the previous session, it just wound down. We still
+        // promote the new session to active+restorable so autosave catches
+        // it, but the stopped record stays in the store so its lookup data
+        // (subtitle, body, transcriptPath) remains available to the
+        // sidebar/feed. This test pins that asymmetry: only the clear path
+        // prunes siblings.
+        let context = try makeClaudeHookContext(name: "claude-replacement-keeps-old")
+        defer { context.cleanup() }
+
+        let oldStart = runClaudeHook(
+            context: context,
+            arguments: ["hooks", "claude", "session-start"],
+            standardInput: #"{"session_id":"old-session","cwd":"\#(context.root.path)","hook_event_name":"SessionStart"}"#
+        )
+        XCTAssertFalse(oldStart.timedOut, oldStart.stderr)
+        XCTAssertEqual(oldStart.status, 0, oldStart.stderr)
+
+        let oldPrompt = runClaudeHook(
+            context: context,
+            arguments: ["hooks", "claude", "prompt-submit"],
+            standardInput: #"{"session_id":"old-session","turn_id":"turn-1","cwd":"\#(context.root.path)","hook_event_name":"PromptSubmit"}"#
+        )
+        XCTAssertFalse(oldPrompt.timedOut, oldPrompt.stderr)
+        XCTAssertEqual(oldPrompt.status, 0, oldPrompt.stderr)
+
+        let oldStop = runClaudeHook(
+            context: context,
+            arguments: ["hooks", "claude", "stop"],
+            standardInput: #"{"session_id":"old-session","turn_id":"turn-1","cwd":"\#(context.root.path)","hook_event_name":"Stop","last_assistant_message":"old turn finished"}"#
+        )
+        XCTAssertFalse(oldStop.timedOut, oldStop.stderr)
+        XCTAssertEqual(oldStop.status, 0, oldStop.stderr)
+
+        let newStart = runClaudeHook(
+            context: context,
+            arguments: ["hooks", "claude", "session-start"],
+            standardInput: #"{"session_id":"new-session","source":"startup","cwd":"\#(context.root.path)","hook_event_name":"SessionStart"}"#
+        )
+        XCTAssertFalse(newStart.timedOut, newStart.stderr)
+        XCTAssertEqual(newStart.status, 0, newStart.stderr)
+
+        let stateURL = context.root.appendingPathComponent("claude-hook-sessions.json")
+        let savedState = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(contentsOf: stateURL)) as? [String: Any])
+        let savedSessions = try XCTUnwrap(savedState["sessions"] as? [String: Any])
+        XCTAssertNotNil(
+            savedSessions["old-session"],
+            "Replacement-of-stopped-owner must not prune the stopped record; the sidebar still uses its lookup data. Pruning is /clear-only."
+        )
+        XCTAssertNotNil(savedSessions["new-session"])
+    }
+
     func testClaudeStopFromPreviousSessionDoesNotClobberClearRunningStatus() throws {
         let context = try makeClaudeHookContext(name: "claude-clear-stale-stop")
         defer { context.cleanup() }


### PR DESCRIPTION
## Summary

Fix a gap in cmux's Claude session restore: a Claude session that has been `/clear`-ed cannot be restored after a cmux relaunch. The wrong (pre-clear) session resumes — so the user's recent post-clear context is silently lost.

## Repro

1. Open a Claude pane in cmux (or any tool that uses the bundled Claude wrapper).
2. Have a non-trivial conversation in session **A**. Wait for autosave to capture the snapshot (`session-com.cmuxterm.app.json` → panel → `terminal.agent.sessionId = A`).
3. Run `/clear` inside Claude. Claude rotates to session **B** but does **not** kill its process and does **not** emit `SessionEnd` for **A** — only `SessionStart(source=clear, session_id=B)`.
4. Quit cmux **before** typing the first post-clear turn (so the on-disk transcript for **B** has not been written yet).
5. Relaunch cmux → `cmux restore-session`.
6. Observed: cmux runs `claude --resume A` — the very session the user just abandoned.
7. Expected: cmux runs `claude --resume B`, or at minimum does not silently roll back to **A**.

## Root cause

In `runClaudeHook` → `case "session-start"` (`CLI/cmux.swift`), the rotated record is upserted with `isRestorable=false`:

```swift
try? sessionStore.upsert(
    sessionId: sessionId,
    ...
    isRestorable: false,                 // ← also for /clear and replacement
    markActive: shouldPromoteActiveSession,
    turnId: parsedInput.turnId
)
```

`RestorableAgentSessionIndex.load()` (the input to autosave) then filters out the rotated record because `isRestorable == false` *and* its transcript file does not yet exist on disk. The pre-clear record (whose transcript still exists) survives the filter and wins on `updatedAt`. Autosave bakes the abandoned `sessionId` into the session snapshot, and `restore-session` resumes that.

In addition, even after the user types and the rotated record becomes restorable, the stale pre-clear record lingers in `~/.cmuxterm/claude-hook-sessions.json` until the 7-day prune. A late pre-clear `Stop` / `Notification` refresh on the old record can bump its `updatedAt` past the rotated one and re-introduce the same wrong-resume.

## Fix

Two targeted changes in `runClaudeHook` `case "session-start"`:

1. **Mark the rotated record restorable immediately** when SessionStart establishes a new active boundary (`/clear` or replacement of a stopped owner — i.e. `shouldPromoteActiveSession == true`). Autosave now captures the rotated id before any transcript exists, so killing cmux mid-rotation no longer rolls back to the pre-clear session.
2. **Prune pre-clear sibling records** scoped to the same `(workspace, surface)` of the rotation. The abandoned record can no longer out-rank the rotated one through ordering flukes, and the hook store stops accumulating per-panel cruft.

The new active-session pointer (`activeSessionsByWorkspace[ws] = rotated`) is preserved across the prune, so the existing "stale Stop from old session must not clobber clear status" guard (`testClaudeStopFromPreviousSessionDoesNotClobberClearRunningStatus`) still holds.

Pruning runs from a separate `withLockedState` after the upsert completes — sequential, not nested — so the existing `flock` discipline is unchanged.

## Test plan

Three new integration tests in `cmuxTests/CLINotifyProcessIntegrationRegressionTests`:

- `testClaudeClearSessionStartMarksRotatedSessionRestorable` — proves the rotated record is `isRestorable=true` immediately after the clear hook, before any transcript exists.
- `testClaudeClearSessionStartPrunesPreClearSiblingOnSamePanel` — proves the pre-clear record is removed from `state.sessions` after the rotation, leaving the rotated record as the sole candidate.
- `testClaudeClearSessionStartKeepsSiblingsOnDifferentPanels` — proves pruning is scoped: a session bound to a different `surfaceId` survives the rotation untouched.

Existing regression tests still pass:

- `testClaudeClearSessionStartMarksWorkspaceRunning`
- `testClaudeSessionStartRecordIsNotRestorableUntilPrompt` — non-`/clear` `source=startup` continues to write `isRestorable=false`, because `shouldPromoteActiveSession` is false in that path.
- `testClaudeStopFromPreviousSessionDoesNotClobberClearRunningStatus` — late stale Stop on the pre-clear session is still rejected by `isCurrent` (active pointer = rotated, not pre-clear).
- `testClaudePromptSubmitFromNewSessionCanReplaceStoppedSession`
- `testClaudeSessionEndChecksConsumedWorkspaceBeforeClearingVisibleState`
- `testClaudeSessionEndDoesNotConsumeSameSessionStaleTurn`

Local: `xcodebuild -scheme cmux-unit … test -only-testing:cmuxTests/CLINotifyProcessIntegrationRegressionTests/<each>` → all 9 pass.

## Out of scope

- Behavior on `compact` and `resume` SessionStart sources is unchanged (those keep the existing `isRestorable=false` until the first prompt).
- The pre-existing 7-day `pruneExpired` cutoff is unchanged.
- No changes to the Claude wrapper script (`Resources/bin/claude`) or to the hooks JSON it injects.

## Author note

I'm a happy cmux dogfooder — opening this draft so a maintainer can sanity-check the boundary semantics around `shouldPromoteActiveSession`. If `replacement-of-stopped-owner` should NOT be marked restorable until first prompt (to keep that path symmetric with startup/resume), I'm happy to narrow the change to `isClearSessionStart` only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes wrong resume after `/clear` by immediately marking the rotated Claude session restorable and pruning only same-panel siblings so autosave restores the right session. Tightens pruning to require both `workspaceId` and `surfaceId`, and keeps replacement-of-stopped sessions immediately restorable.

- **Bug Fixes**
  - `SessionStart` that promotes a new active boundary (`/clear` or replacement of a stopped owner) now sets `isRestorable=true` so autosave captures the rotated `sessionId` before a transcript exists.
  - On `/clear`, exhaustively prunes same-panel siblings in the hook store (scoped by `(workspaceId, surfaceId)`), with a strict guard that requires both IDs to avoid widening the sweep; replacement-of-stopped-owner does not prune.
  - Tests cover immediate restorability, same-panel pruning (including multi-sibling), cross-panel safety, replacement marking as restorable, and non-pruning on replacement.

- **Refactors**
  - In `removePanelSiblings`, collect-then-remove to avoid mutating during iteration; no behavior change.

<sup>Written for commit 94db2d92e00e90d8f821eaa934911ad5593254b1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improve session handling during panel clear/rotation: pre-clear sibling sessions on the same panel are pruned, and rotated/replacement sessions are persisted as restorable so autosave/restoration selects the correct session.
* **Tests**
  * Add regression tests covering session-start, prompt-submit, stop, clear flows, sibling-pruning behavior, and restorable-session marking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4179)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->