### PR TITLE
Fix omnibar arrow key focus races

### DIFF
--- a/Sources/App/ShortcutRoutingSupport.swift
+++ b/Sources/App/ShortcutRoutingSupport.swift
@@ -92,6 +92,20 @@ func shouldDispatchBrowserArrowViaFirstResponderKeyDown(
     return normalizedFlags.isEmpty
 }
 
+func shouldDispatchBrowserOmnibarArrowViaFirstResponderKeyDown(
+    keyCode: UInt16,
+    firstResponderIsBrowserOmnibar: Bool,
+    firstResponderHasMarkedText: Bool = false,
+    flags: NSEvent.ModifierFlags
+) -> Bool {
+    guard firstResponderIsBrowserOmnibar else { return false }
+    guard !firstResponderHasMarkedText else { return false }
+    guard (123...126).contains(keyCode) else { return false }
+
+    let normalizedFlags = browserOmnibarNormalizedModifierFlags(flags)
+    return normalizedFlags.isEmpty
+}
+
 struct BrowserAddressBarTrackingContext {
     let trackedPanelMatchesWebView: Bool
     let omnibarResponderActive: Bool

--- a/Sources/App/ShortcutRoutingSupport.swift
+++ b/Sources/App/ShortcutRoutingSupport.swift
@@ -92,19 +92,29 @@ func shouldDispatchBrowserArrowViaFirstResponderKeyDown(
     return normalizedFlags.isEmpty
 }
 
+struct BrowserAddressBarTrackingContext {
+    let trackedPanelMatchesWebView: Bool
+    let omnibarResponderActive: Bool
+    let preferredFocusIntentIsAddressBar: Bool
+    let suppressesWebViewFocus: Bool
+    let pointerInitiatedWebFocus: Bool
+    let liveOmnibarFieldExists: Bool
+}
+
+/// Decision order:
+/// 1. Reject WebView focus from another panel.
+/// 2. Preserve if an omnibar responder is already active.
+/// 3. Require address-bar focus intent.
+/// 4. Let pointer-initiated WebView focus clear tracking.
+/// 5. Preserve if WebView focus is suppressed or a live omnibar field exists.
 func shouldPreserveBrowserAddressBarTrackingDuringWebViewFocus(
-    trackedPanelMatchesWebView: Bool,
-    omnibarResponderActive: Bool,
-    preferredFocusIntentIsAddressBar: Bool,
-    suppressesWebViewFocus: Bool,
-    pointerInitiatedWebFocus: Bool,
-    liveOmnibarFieldExists: Bool
+    _ context: BrowserAddressBarTrackingContext
 ) -> Bool {
-    guard trackedPanelMatchesWebView else { return false }
-    if omnibarResponderActive { return true }
-    guard preferredFocusIntentIsAddressBar else { return false }
-    guard !pointerInitiatedWebFocus else { return false }
-    return suppressesWebViewFocus || liveOmnibarFieldExists
+    guard context.trackedPanelMatchesWebView else { return false }
+    if context.omnibarResponderActive { return true }
+    guard context.preferredFocusIntentIsAddressBar else { return false }
+    guard !context.pointerInitiatedWebFocus else { return false }
+    return context.suppressesWebViewFocus || context.liveOmnibarFieldExists
 }
 
 func shouldDispatchCommandPaletteHorizontalArrowViaFirstResponderKeyDown(

--- a/Sources/App/ShortcutRoutingSupport.swift
+++ b/Sources/App/ShortcutRoutingSupport.swift
@@ -92,6 +92,21 @@ func shouldDispatchBrowserArrowViaFirstResponderKeyDown(
     return normalizedFlags.isEmpty
 }
 
+func shouldPreserveBrowserAddressBarTrackingDuringWebViewFocus(
+    trackedPanelMatchesWebView: Bool,
+    omnibarResponderActive: Bool,
+    preferredFocusIntentIsAddressBar: Bool,
+    suppressesWebViewFocus: Bool,
+    pointerInitiatedWebFocus: Bool,
+    liveOmnibarFieldExists: Bool
+) -> Bool {
+    guard trackedPanelMatchesWebView else { return false }
+    if omnibarResponderActive { return true }
+    guard preferredFocusIntentIsAddressBar else { return false }
+    guard !pointerInitiatedWebFocus else { return false }
+    return suppressesWebViewFocus || liveOmnibarFieldExists
+}
+
 func shouldDispatchCommandPaletteHorizontalArrowViaFirstResponderKeyDown(
     keyCode: UInt16,
     firstResponderIsCommandPaletteFieldEditor: Bool,

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -14807,12 +14807,13 @@ private extension NSWindow {
                 cmuxBrowserArrowForwardingDepth += 1
                 defer { cmuxBrowserArrowForwardingDepth = max(0, cmuxBrowserArrowForwardingDepth - 1) }
 
-                if focusedOmnibarField.currentEditor() == nil ||
-                    browserOmnibarPanelId(for: self.firstResponder) != focusedOmnibarField.panelId {
+                var currentEditorResponder = focusedOmnibarField.currentEditor() as? NSResponder
+                if currentEditorResponder == nil || self.firstResponder !== currentEditorResponder {
                     _ = self.makeFirstResponder(focusedOmnibarField)
+                    currentEditorResponder = focusedOmnibarField.currentEditor() as? NSResponder
                 }
 
-                let omnibarResponder = (focusedOmnibarField.currentEditor() as? NSResponder) ?? focusedOmnibarField
+                let omnibarResponder = currentEditorResponder ?? focusedOmnibarField
                 guard !browserResponderHasMarkedText(omnibarResponder) else {
                     return false
                 }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -12267,7 +12267,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     func focusedBrowserOmnibarField(for event: NSEvent, in window: NSWindow?) -> OmnibarNativeTextField? {
-        let panelId = focusedBrowserAddressBarPanelIdForShortcutEvent(event) ?? browserAddressBarFocusedPanelId
+        let panelId = focusedBrowserAddressBarPanelIdForShortcutEvent(event)
         return browserOmnibarField(panelId: panelId, in: window)
     }
 

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -13746,7 +13746,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                let trackedPanel = self.browserPanel(for: trackedPanelId),
                !self.shouldPreserveBrowserAddressBarTracking(
                    for: trackedPanel,
-                   trackedPanelMatchesWebView: false
+                   trackedPanelMatchesWebView: false,
+                   pointerInitiatedWebFocus: pointerInitiated,
+                   in: webView.window
                ) {
                 trackedPanel.endSuppressWebViewFocusForAddressBar()
                 self.browserAddressBarFocusedPanelId = nil

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -12366,6 +12366,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return panelId
         }
 
+        if shouldPreserveBrowserAddressBarTrackingDuringTransientShortcutResponder(
+            for: panel,
+            responder: shortcutResponder,
+            in: shortcutWindow,
+            liveOmnibarFieldExists: liveOmnibarFieldExists
+        ) {
+#if DEBUG
+            cmuxDebugLog(
+                "browser.focus.addressBar.shortcutContext panel=\(panelId.uuidString.prefix(5)) " +
+                "accepted=1 reason=transient_omnibar_focus workspace=\(workspace.id.uuidString.prefix(5)) " +
+                "event=\(NSWindow.keyDescription(event))"
+            )
+#endif
+            return panelId
+        }
+
 #if DEBUG
         let focusedPanel = workspace.focusedPanelId.map { String($0.uuidString.prefix(5)) } ?? "nil"
         cmuxDebugLog(
@@ -12376,6 +12392,42 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         )
 #endif
         return nil
+    }
+
+    private func shouldPreserveBrowserAddressBarTrackingDuringTransientShortcutResponder(
+        for panel: BrowserPanel,
+        responder: NSResponder?,
+        in window: NSWindow?,
+        liveOmnibarFieldExists: Bool
+    ) -> Bool {
+        guard browserAddressBarFocusedPanelId == panel.id else { return false }
+        guard panel.preferredFocusIntent == .addressBar else { return false }
+        guard panel.shouldSuppressWebViewFocus() ||
+            liveOmnibarFieldExists ||
+            panel.pendingAddressBarFocusRequestId != nil else {
+            return false
+        }
+
+        guard let responder else { return true }
+        if let window, responder === window {
+            return true
+        }
+        if responder is NSWindow {
+            return true
+        }
+        if browserOmnibarPanelId(for: responder) == panel.id {
+            return true
+        }
+        if cmuxOwningGhosttyView(for: responder) != nil {
+            return false
+        }
+        if responder is NSTextView || responder is NSTextField {
+            return false
+        }
+        if let window, panel.ownedFocusIntent(for: responder, in: window) != nil {
+            return false
+        }
+        return false
     }
 
     private func browserAddressBarIntentPanelId(
@@ -14857,6 +14909,31 @@ private extension NSWindow {
             }
             cmuxCommandPaletteArrowForwardingDepth += 1
             defer { cmuxCommandPaletteArrowForwardingDepth = max(0, cmuxCommandPaletteArrowForwardingDepth - 1) }
+            self.firstResponder?.keyDown(with: event)
+            return true
+        }
+
+        let firstResponderOmnibarPanelId = browserOmnibarPanelId(for: self.firstResponder)
+        if shouldDispatchBrowserOmnibarArrowViaFirstResponderKeyDown(
+            keyCode: event.keyCode,
+            firstResponderIsBrowserOmnibar: firstResponderOmnibarPanelId != nil,
+            firstResponderHasMarkedText: firstResponderHasMarkedText,
+            flags: event.modifierFlags
+        ) {
+            if cmuxBrowserArrowForwardingDepth > 0 {
+#if DEBUG
+                cmuxDebugLog("  → browser omnibar arrow reentry; using normal dispatch")
+#endif
+                return cmux_performKeyEquivalent(with: event)
+            }
+            cmuxBrowserArrowForwardingDepth += 1
+            defer { cmuxBrowserArrowForwardingDepth = max(0, cmuxBrowserArrowForwardingDepth - 1) }
+#if DEBUG
+            cmuxDebugLog(
+                "  → browser omnibar arrow routed to firstResponder.keyDown " +
+                "panel=\(firstResponderOmnibarPanelId.map { String($0.uuidString.prefix(5)) } ?? "nil")"
+            )
+#endif
             self.firstResponder?.keyDown(with: event)
             return true
         }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -12308,27 +12308,46 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let shortcutWindow = resolvedShortcutEventWindow(event) ?? NSApp.keyWindow ?? NSApp.mainWindow
         let shortcutResponder = shortcutWindow?.firstResponder
 
-        guard isBrowserOmnibarResponder(shortcutResponder) else {
+        if isBrowserOmnibarResponder(shortcutResponder) {
 #if DEBUG
-            let focusedPanel = workspace.focusedPanelId.map { String($0.uuidString.prefix(5)) } ?? "nil"
             cmuxDebugLog(
                 "browser.focus.addressBar.shortcutContext panel=\(panelId.uuidString.prefix(5)) " +
-                "accepted=0 reason=responder_not_omnibar responder=\(shortcutResponder.map { String(describing: type(of: $0)) } ?? "nil") " +
-                "pending=\(panel.pendingAddressBarFocusRequestId != nil ? 1 : 0) focusedPanel=\(focusedPanel) " +
+                "accepted=1 reason=omnibar_responder workspace=\(workspace.id.uuidString.prefix(5)) " +
                 "event=\(NSWindow.keyDescription(event))"
             )
 #endif
-            return nil
+            return panelId
+        }
+
+        let liveOmnibarFieldExists = browserOmnibarField(panelId: panelId, in: shortcutWindow) != nil
+        if shouldPreserveBrowserAddressBarTrackingDuringWebViewFocus(
+            trackedPanelMatchesWebView: true,
+            omnibarResponderActive: false,
+            preferredFocusIntentIsAddressBar: panel.preferredFocusIntent == .addressBar,
+            suppressesWebViewFocus: panel.shouldSuppressWebViewFocus(),
+            pointerInitiatedWebFocus: false,
+            liveOmnibarFieldExists: liveOmnibarFieldExists
+        ) {
+#if DEBUG
+            cmuxDebugLog(
+                "browser.focus.addressBar.shortcutContext panel=\(panelId.uuidString.prefix(5)) " +
+                "accepted=1 reason=tracked_omnibar_field workspace=\(workspace.id.uuidString.prefix(5)) " +
+                "event=\(NSWindow.keyDescription(event))"
+            )
+#endif
+            return panelId
         }
 
 #if DEBUG
+        let focusedPanel = workspace.focusedPanelId.map { String($0.uuidString.prefix(5)) } ?? "nil"
         cmuxDebugLog(
             "browser.focus.addressBar.shortcutContext panel=\(panelId.uuidString.prefix(5)) " +
-            "accepted=1 reason=omnibar_responder workspace=\(workspace.id.uuidString.prefix(5)) " +
+            "accepted=0 reason=responder_not_omnibar responder=\(shortcutResponder.map { String(describing: type(of: $0)) } ?? "nil") " +
+            "pending=\(panel.pendingAddressBarFocusRequestId != nil ? 1 : 0) focusedPanel=\(focusedPanel) " +
             "event=\(NSWindow.keyDescription(event))"
         )
 #endif
-        return panelId
+        return nil
     }
 
     private func browserOmnibarOwnerView(for responder: NSResponder?) -> NSView? {
@@ -12357,12 +12376,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return true
     }
 
-    private func shouldPreserveBrowserAddressBarTracking(for panel: BrowserPanel) -> Bool {
+    private func shouldPreserveBrowserAddressBarTracking(
+        for panel: BrowserPanel,
+        pointerInitiatedWebFocus: Bool = false,
+        in window: NSWindow? = nil
+    ) -> Bool {
         guard browserAddressBarFocusedPanelId == panel.id else { return false }
-        if isBrowserOmnibarResponder(panel.webView.window?.firstResponder) {
-            return true
-        }
-        return panel.preferredFocusIntent == .addressBar && panel.shouldSuppressWebViewFocus()
+        let resolvedWindow = window ?? panel.webView.window
+        return shouldPreserveBrowserAddressBarTrackingDuringWebViewFocus(
+            trackedPanelMatchesWebView: true,
+            omnibarResponderActive: isBrowserOmnibarResponder(resolvedWindow?.firstResponder),
+            preferredFocusIntentIsAddressBar: panel.preferredFocusIntent == .addressBar,
+            suppressesWebViewFocus: panel.shouldSuppressWebViewFocus(),
+            pointerInitiatedWebFocus: pointerInitiatedWebFocus,
+            liveOmnibarFieldExists: browserOmnibarField(panelId: panel.id, in: resolvedWindow) != nil
+        )
     }
 
     @discardableResult
@@ -13707,6 +13735,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             guard let self else { return }
             guard let webView = notification.object as? CmuxWebView,
                   let panel = self.browserPanelOwning(webView) else { return }
+            let pointerInitiated = notification.userInfo?["pointerInitiated"] as? Bool ?? false
 
             if let trackedPanelId = self.browserAddressBarFocusedPanelId,
                trackedPanelId != panel.id,
@@ -13723,11 +13752,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 #endif
             }
 
-            guard !self.shouldPreserveBrowserAddressBarTracking(for: panel) else {
+            guard !self.shouldPreserveBrowserAddressBarTracking(
+                for: panel,
+                pointerInitiatedWebFocus: pointerInitiated,
+                in: webView.window
+            ) else {
 #if DEBUG
                 cmuxDebugLog(
                     "addressBar CLEAR panelId=\(panel.id.uuidString.prefix(8)) " +
-                    "reason=skip_preserve_omnibar_handoff"
+                    "reason=skip_preserve_omnibar_handoff pointer=\(pointerInitiated ? 1 : 0)"
                 )
 #endif
                 return

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -12272,7 +12272,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     func focusedBrowserAddressBarPanelIdForShortcutEvent(_ event: NSEvent) -> UUID? {
-        guard let panelId = browserAddressBarFocusedPanelId else { return nil }
+        let shortcutWindow = resolvedShortcutEventWindow(event) ?? NSApp.keyWindow ?? NSApp.mainWindow
+        let shortcutResponder = shortcutWindow?.firstResponder
+        let responderPanelId = isBrowserOmnibarResponder(shortcutResponder)
+            ? browserOmnibarPanelId(for: shortcutResponder)
+            : nil
+        guard let panelId = responderPanelId ?? browserAddressBarFocusedPanelId else { return nil }
 
         guard let context = preferredMainWindowContextForShortcutRouting(event: event) else {
 #if DEBUG
@@ -12305,18 +12310,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return nil
         }
 
-        let shortcutWindow = resolvedShortcutEventWindow(event) ?? NSApp.keyWindow ?? NSApp.mainWindow
-        let shortcutResponder = shortcutWindow?.firstResponder
-
-        if isBrowserOmnibarResponder(shortcutResponder) {
+        if let responderPanelId {
 #if DEBUG
             cmuxDebugLog(
-                "browser.focus.addressBar.shortcutContext panel=\(panelId.uuidString.prefix(5)) " +
+                "browser.focus.addressBar.shortcutContext panel=\(responderPanelId.uuidString.prefix(5)) " +
                 "accepted=1 reason=omnibar_responder workspace=\(workspace.id.uuidString.prefix(5)) " +
                 "event=\(NSWindow.keyDescription(event))"
             )
 #endif
-            return panelId
+            return responderPanelId
         }
 
         let liveOmnibarFieldExists = browserOmnibarField(panelId: panelId, in: shortcutWindow) != nil

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -12320,14 +12320,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
 
         let liveOmnibarFieldExists = browserOmnibarField(panelId: panelId, in: shortcutWindow) != nil
-        if shouldPreserveBrowserAddressBarTrackingDuringWebViewFocus(
+        let trackingContext = BrowserAddressBarTrackingContext(
             trackedPanelMatchesWebView: true,
             omnibarResponderActive: false,
             preferredFocusIntentIsAddressBar: panel.preferredFocusIntent == .addressBar,
             suppressesWebViewFocus: panel.shouldSuppressWebViewFocus(),
             pointerInitiatedWebFocus: false,
             liveOmnibarFieldExists: liveOmnibarFieldExists
-        ) {
+        )
+        if shouldPreserveBrowserAddressBarTrackingDuringWebViewFocus(trackingContext) {
 #if DEBUG
             cmuxDebugLog(
                 "browser.focus.addressBar.shortcutContext panel=\(panelId.uuidString.prefix(5)) " +
@@ -12378,19 +12379,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     private func shouldPreserveBrowserAddressBarTracking(
         for panel: BrowserPanel,
+        trackedPanelMatchesWebView: Bool,
         pointerInitiatedWebFocus: Bool = false,
         in window: NSWindow? = nil
     ) -> Bool {
         guard browserAddressBarFocusedPanelId == panel.id else { return false }
         let resolvedWindow = window ?? panel.webView.window
-        return shouldPreserveBrowserAddressBarTrackingDuringWebViewFocus(
-            trackedPanelMatchesWebView: true,
+        let trackingContext = BrowserAddressBarTrackingContext(
+            trackedPanelMatchesWebView: trackedPanelMatchesWebView,
             omnibarResponderActive: isBrowserOmnibarResponder(resolvedWindow?.firstResponder),
             preferredFocusIntentIsAddressBar: panel.preferredFocusIntent == .addressBar,
             suppressesWebViewFocus: panel.shouldSuppressWebViewFocus(),
             pointerInitiatedWebFocus: pointerInitiatedWebFocus,
             liveOmnibarFieldExists: browserOmnibarField(panelId: panel.id, in: resolvedWindow) != nil
         )
+        return shouldPreserveBrowserAddressBarTrackingDuringWebViewFocus(trackingContext)
     }
 
     @discardableResult
@@ -13735,12 +13738,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             guard let self else { return }
             guard let webView = notification.object as? CmuxWebView,
                   let panel = self.browserPanelOwning(webView) else { return }
-            let pointerInitiated = notification.userInfo?["pointerInitiated"] as? Bool ?? false
+            let pointerInitiatedKey = BrowserFirstResponderNotificationUserInfoKey.pointerInitiated
+            let pointerInitiated = notification.userInfo?[pointerInitiatedKey] as? Bool ?? false
 
             if let trackedPanelId = self.browserAddressBarFocusedPanelId,
                trackedPanelId != panel.id,
                let trackedPanel = self.browserPanel(for: trackedPanelId),
-               !self.shouldPreserveBrowserAddressBarTracking(for: trackedPanel) {
+               !self.shouldPreserveBrowserAddressBarTracking(
+                   for: trackedPanel,
+                   trackedPanelMatchesWebView: false
+               ) {
                 trackedPanel.endSuppressWebViewFocusForAddressBar()
                 self.browserAddressBarFocusedPanelId = nil
                 self.stopBrowserOmnibarSelectionRepeat()
@@ -13754,6 +13761,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
             guard !self.shouldPreserveBrowserAddressBarTracking(
                 for: panel,
+                trackedPanelMatchesWebView: panel.webView === webView,
                 pointerInitiatedWebFocus: pointerInitiated,
                 in: webView.window
             ) else {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -695,6 +695,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private var browserAddressBarFocusedPanelId: UUID?
     private var browserOmnibarRepeatStartWorkItem: DispatchWorkItem?
     private var browserOmnibarRepeatTickWorkItem: DispatchWorkItem?
+    private var browserOmnibarRepeatPanelId: UUID?
     private var browserOmnibarRepeatKeyCode: UInt16?
     private var browserOmnibarRepeatDelta: Int = 0
     private var browserAddressBarFocusObserver: NSObjectProtocol?
@@ -11317,7 +11318,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             stopBrowserOmnibarSelectionRepeat()
         }
 
-        let hasFocusedAddressBarInShortcutContext = focusedBrowserAddressBarPanelIdForShortcutEvent(event) != nil
+        let focusedAddressBarPanelIdInShortcutContext = focusedBrowserAddressBarPanelIdForShortcutEvent(event)
+        let hasFocusedAddressBarInShortcutContext = focusedAddressBarPanelIdInShortcutContext != nil
 
         if shouldRouteConfiguredPaletteSelection, activeConfiguredShortcutChordPrefixForCurrentEvent == nil, armConfiguredShortcutChordIfNeeded(event: event, actions: [.commandPaletteNext, .commandPalettePrevious]) {
             return true
@@ -11429,9 +11431,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             hasFocusedAddressBar: hasFocusedAddressBarInShortcutContext,
             flags: flags,
             chars: chars
-        ) {
-            dispatchBrowserOmnibarSelectionMove(delta: delta)
-            startBrowserOmnibarSelectionRepeatIfNeeded(keyCode: event.keyCode, delta: delta)
+        ),
+           let focusedAddressBarPanelIdInShortcutContext {
+            dispatchBrowserOmnibarSelectionMove(panelId: focusedAddressBarPanelIdInShortcutContext, delta: delta)
+            startBrowserOmnibarSelectionRepeatIfNeeded(
+                panelId: focusedAddressBarPanelIdInShortcutContext,
+                keyCode: event.keyCode,
+                delta: delta
+            )
             return true
         }
 
@@ -11439,8 +11446,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             hasFocusedAddressBar: hasFocusedAddressBarInShortcutContext,
             flags: event.modifierFlags,
             keyCode: event.keyCode
-        ) {
-            dispatchBrowserOmnibarSelectionMove(delta: delta)
+        ),
+           let focusedAddressBarPanelIdInShortcutContext {
+            dispatchBrowserOmnibarSelectionMove(panelId: focusedAddressBarPanelIdInShortcutContext, delta: delta)
             return true
         }
 
@@ -12262,6 +12270,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         browserOmnibarField(panelId: browserAddressBarFocusedPanelId, in: window)
     }
 
+    func focusedBrowserOmnibarField(for event: NSEvent, in window: NSWindow?) -> OmnibarNativeTextField? {
+        let panelId = focusedBrowserAddressBarPanelIdForShortcutEvent(event) ?? browserAddressBarFocusedPanelId
+        return browserOmnibarField(panelId: panelId, in: window)
+    }
+
     func clearBrowserAddressBarFocus(panelId: UUID, reason: String) {
         guard browserAddressBarFocusedPanelId == panelId else { return }
         browserAddressBarFocusedPanelId = nil
@@ -12277,17 +12290,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let responderPanelId = isBrowserOmnibarResponder(shortcutResponder)
             ? browserOmnibarPanelId(for: shortcutResponder)
             : nil
-        guard let panelId = responderPanelId ?? browserAddressBarFocusedPanelId else { return nil }
 
         guard let context = preferredMainWindowContextForShortcutRouting(event: event) else {
 #if DEBUG
+            let candidatePanelId = responderPanelId ?? browserAddressBarFocusedPanelId
+            guard let candidatePanelId else { return nil }
             cmuxDebugLog(
-                "browser.focus.addressBar.shortcutContext panel=\(panelId.uuidString.prefix(5)) " +
+                "browser.focus.addressBar.shortcutContext panel=\(candidatePanelId.uuidString.prefix(5)) " +
                 "accepted=0 reason=no_context event=\(NSWindow.keyDescription(event))"
             )
 #endif
             return nil
         }
+
+        let intentPanelId = browserAddressBarIntentPanelId(in: context, window: shortcutWindow)
+        guard let panelId = responderPanelId ?? browserAddressBarFocusedPanelId ?? intentPanelId else { return nil }
 
         guard let workspace = context.tabManager.selectedWorkspace else {
 #if DEBUG
@@ -12321,6 +12338,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return responderPanelId
         }
 
+        if intentPanelId == panelId, browserAddressBarFocusedPanelId == nil {
+#if DEBUG
+            cmuxDebugLog(
+                "browser.focus.addressBar.shortcutContext panel=\(panelId.uuidString.prefix(5)) " +
+                "accepted=1 reason=addressbar_intent workspace=\(workspace.id.uuidString.prefix(5)) " +
+                "event=\(NSWindow.keyDescription(event))"
+            )
+#endif
+            return panelId
+        }
+
         let liveOmnibarFieldExists = browserOmnibarField(panelId: panelId, in: shortcutWindow) != nil
         let trackingContext = BrowserAddressBarTrackingContext(
             trackedPanelMatchesWebView: true,
@@ -12351,6 +12379,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         )
 #endif
         return nil
+    }
+
+    private func browserAddressBarIntentPanelId(
+        in context: MainWindowContext,
+        window: NSWindow?
+    ) -> UUID? {
+        guard let workspace = context.tabManager.selectedWorkspace,
+              let focusedPanelId = workspace.focusedPanelId,
+              let panel = workspace.browserPanel(for: focusedPanelId),
+              panel.preferredFocusIntent == .addressBar,
+              let field = browserOmnibarField(panelId: panel.id, in: window) else {
+            return nil
+        }
+
+        guard panel.shouldSuppressWebViewFocus() || field.currentEditor() != nil else {
+            return nil
+        }
+        return panel.id
     }
 
     private func browserOmnibarOwnerView(for responder: NSResponder?) -> NSView? {
@@ -12436,9 +12482,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         )
     }
 
-    private func dispatchBrowserOmnibarSelectionMove(delta: Int) {
+    private func dispatchBrowserOmnibarSelectionMove(panelId: UUID, delta: Int) {
         guard delta != 0 else { return }
-        guard let panelId = browserAddressBarFocusedPanelId else { return }
 #if DEBUG
         cmuxDebugLog(
             "browser.focus.omnibar.selectionMove panel=\(panelId.uuidString.prefix(5)) " +
@@ -12452,23 +12497,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         )
     }
 
-    private func startBrowserOmnibarSelectionRepeatIfNeeded(keyCode: UInt16, delta: Int) {
+    private func startBrowserOmnibarSelectionRepeatIfNeeded(panelId: UUID, keyCode: UInt16, delta: Int) {
         guard delta != 0 else { return }
-        guard browserAddressBarFocusedPanelId != nil else {
-#if DEBUG
-            cmuxDebugLog(
-                "browser.focus.omnibar.repeat.start key=\(keyCode) delta=\(delta) " +
-                "result=skip_no_focused_address_bar"
-            )
-#endif
-            return
-        }
 
-        if browserOmnibarRepeatKeyCode == keyCode, browserOmnibarRepeatDelta == delta {
+        if browserOmnibarRepeatPanelId == panelId,
+           browserOmnibarRepeatKeyCode == keyCode,
+           browserOmnibarRepeatDelta == delta {
 #if DEBUG
-            let panelToken = browserAddressBarFocusedPanelId.map { String($0.uuidString.prefix(5)) } ?? "nil"
             cmuxDebugLog(
-                "browser.focus.omnibar.repeat.start panel=\(panelToken) " +
+                "browser.focus.omnibar.repeat.start panel=\(panelId.uuidString.prefix(5)) " +
                 "key=\(keyCode) delta=\(delta) result=reuse"
             )
 #endif
@@ -12476,12 +12513,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
 
         stopBrowserOmnibarSelectionRepeat()
+        browserOmnibarRepeatPanelId = panelId
         browserOmnibarRepeatKeyCode = keyCode
         browserOmnibarRepeatDelta = delta
 #if DEBUG
-        let panelToken = browserAddressBarFocusedPanelId.map { String($0.uuidString.prefix(5)) } ?? "nil"
         cmuxDebugLog(
-            "browser.focus.omnibar.repeat.start panel=\(panelToken) " +
+            "browser.focus.omnibar.repeat.start panel=\(panelId.uuidString.prefix(5)) " +
             "key=\(keyCode) delta=\(delta) result=armed"
         )
 #endif
@@ -12495,7 +12532,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     private func scheduleBrowserOmnibarSelectionRepeatTick() {
         browserOmnibarRepeatStartWorkItem = nil
-        guard browserAddressBarFocusedPanelId != nil else {
+        guard let panelId = browserOmnibarRepeatPanelId else {
 #if DEBUG
             cmuxDebugLog("browser.focus.omnibar.repeat.tick result=stop_no_focused_address_bar")
 #endif
@@ -12505,13 +12542,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         guard browserOmnibarRepeatKeyCode != nil else { return }
 
 #if DEBUG
-        let panelToken = browserAddressBarFocusedPanelId.map { String($0.uuidString.prefix(5)) } ?? "nil"
         cmuxDebugLog(
-            "browser.focus.omnibar.repeat.tick panel=\(panelToken) " +
+            "browser.focus.omnibar.repeat.tick panel=\(panelId.uuidString.prefix(5)) " +
             "delta=\(browserOmnibarRepeatDelta)"
         )
 #endif
-        dispatchBrowserOmnibarSelectionMove(delta: browserOmnibarRepeatDelta)
+        dispatchBrowserOmnibarSelectionMove(panelId: panelId, delta: browserOmnibarRepeatDelta)
 
         let tick = DispatchWorkItem { [weak self] in
             self?.scheduleBrowserOmnibarSelectionRepeatTick()
@@ -12522,6 +12558,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     private func stopBrowserOmnibarSelectionRepeat() {
 #if DEBUG
+        let previousPanelId = browserOmnibarRepeatPanelId
         let previousKeyCode = browserOmnibarRepeatKeyCode
         let previousDelta = browserOmnibarRepeatDelta
 #endif
@@ -12529,12 +12566,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         browserOmnibarRepeatTickWorkItem?.cancel()
         browserOmnibarRepeatStartWorkItem = nil
         browserOmnibarRepeatTickWorkItem = nil
+        browserOmnibarRepeatPanelId = nil
         browserOmnibarRepeatKeyCode = nil
         browserOmnibarRepeatDelta = 0
 #if DEBUG
         if previousKeyCode != nil || previousDelta != 0 {
             cmuxDebugLog(
-                "browser.focus.omnibar.repeat.stop key=\(previousKeyCode.map(String.init) ?? "nil") " +
+                "browser.focus.omnibar.repeat.stop panel=\(previousPanelId.map { String($0.uuidString.prefix(5)) } ?? "nil") " +
+                "key=\(previousKeyCode.map(String.init) ?? "nil") " +
                 "delta=\(previousDelta)"
             )
         }
@@ -13750,7 +13789,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                    for: trackedPanel,
                    trackedPanelMatchesWebView: false,
                    pointerInitiatedWebFocus: pointerInitiated,
-                   in: webView.window
+                   in: trackedPanel.webView.window
                ) {
                 trackedPanel.endSuppressWebViewFocusForAddressBar()
                 self.browserAddressBarFocusedPanelId = nil
@@ -14840,7 +14879,7 @@ private extension NSWindow {
             firstResponderHasMarkedText: firstResponderHasMarkedText,
             flags: event.modifierFlags
         ) {
-            if let focusedOmnibarField = AppDelegate.shared?.focusedBrowserOmnibarField(in: self),
+            if let focusedOmnibarField = AppDelegate.shared?.focusedBrowserOmnibarField(for: event, in: self),
                browserOmnibarPanelId(for: self.firstResponder) == nil,
                focusedOmnibarField.window === self {
                 if cmuxBrowserArrowForwardingDepth > 0 {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -12266,10 +12266,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         browserAddressBarFocusedPanelId
     }
 
-    func focusedBrowserOmnibarField(in window: NSWindow?) -> OmnibarNativeTextField? {
-        browserOmnibarField(panelId: browserAddressBarFocusedPanelId, in: window)
-    }
-
     func focusedBrowserOmnibarField(for event: NSEvent, in window: NSWindow?) -> OmnibarNativeTextField? {
         let panelId = focusedBrowserAddressBarPanelIdForShortcutEvent(event) ?? browserAddressBarFocusedPanelId
         return browserOmnibarField(panelId: panelId, in: window)
@@ -12350,8 +12346,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
 
         let liveOmnibarFieldExists = browserOmnibarField(panelId: panelId, in: shortcutWindow) != nil
+        let trackedPanelMatchesShortcutResponder = browserPanel(panel, ownsShortcutResponder: shortcutResponder, in: shortcutWindow)
         let trackingContext = BrowserAddressBarTrackingContext(
-            trackedPanelMatchesWebView: true,
+            trackedPanelMatchesWebView: trackedPanelMatchesShortcutResponder,
             omnibarResponderActive: false,
             preferredFocusIntentIsAddressBar: panel.preferredFocusIntent == .addressBar,
             suppressesWebViewFocus: panel.shouldSuppressWebViewFocus(),
@@ -12397,6 +12394,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return nil
         }
         return panel.id
+    }
+
+    private func browserPanel(
+        _ panel: BrowserPanel,
+        ownsShortcutResponder responder: NSResponder?,
+        in window: NSWindow?
+    ) -> Bool {
+        guard let responder, let window else { return false }
+        if browserOmnibarPanelId(for: responder) == panel.id {
+            return true
+        }
+        if case .browser(.webView)? = panel.ownedFocusIntent(for: responder, in: window) {
+            return true
+        }
+        return false
     }
 
     private func browserOmnibarOwnerView(for responder: NSResponder?) -> NSView? {
@@ -13776,57 +13788,63 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             object: nil,
             queue: .main
         ) { [weak self] notification in
-            guard let self else { return }
-            guard let webView = notification.object as? CmuxWebView,
-                  let panel = self.browserPanelOwning(webView) else { return }
-            let pointerInitiatedKey = BrowserFirstResponderNotificationUserInfoKey.pointerInitiated
-            let pointerInitiated = notification.userInfo?[pointerInitiatedKey] as? Bool ?? false
+            MainActor.assumeIsolated {
+                self?.handleBrowserWebViewFirstResponderNotification(notification)
+            }
+        }
+    }
 
-            if let trackedPanelId = self.browserAddressBarFocusedPanelId,
-               trackedPanelId != panel.id,
-               let trackedPanel = self.browserPanel(for: trackedPanelId),
-               !self.shouldPreserveBrowserAddressBarTracking(
-                   for: trackedPanel,
-                   trackedPanelMatchesWebView: false,
-                   pointerInitiatedWebFocus: pointerInitiated,
-                   in: trackedPanel.webView.window
-               ) {
-                trackedPanel.endSuppressWebViewFocusForAddressBar()
-                self.browserAddressBarFocusedPanelId = nil
-                self.stopBrowserOmnibarSelectionRepeat()
-#if DEBUG
-                cmuxDebugLog(
-                    "addressBar CLEAR panelId=\(trackedPanelId.uuidString.prefix(8)) " +
-                    "reason=stale_other_panel_webViewFirstResponder"
-                )
-#endif
-            }
+    @MainActor
+    private func handleBrowserWebViewFirstResponderNotification(_ notification: Notification) {
+        guard let webView = notification.object as? CmuxWebView,
+              let panel = browserPanelOwning(webView) else { return }
+        let pointerInitiatedKey = BrowserFirstResponderNotificationUserInfoKey.pointerInitiated
+        let pointerInitiated = notification.userInfo?[pointerInitiatedKey] as? Bool ?? false
 
-            guard !self.shouldPreserveBrowserAddressBarTracking(
-                for: panel,
-                trackedPanelMatchesWebView: panel.webView === webView,
-                pointerInitiatedWebFocus: pointerInitiated,
-                in: webView.window
-            ) else {
+        if let trackedPanelId = browserAddressBarFocusedPanelId,
+           trackedPanelId != panel.id,
+           let trackedPanel = browserPanel(for: trackedPanelId),
+           !shouldPreserveBrowserAddressBarTracking(
+               for: trackedPanel,
+               trackedPanelMatchesWebView: false,
+               pointerInitiatedWebFocus: pointerInitiated,
+               in: trackedPanel.webView.window
+           ) {
+            trackedPanel.endSuppressWebViewFocusForAddressBar()
+            browserAddressBarFocusedPanelId = nil
+            stopBrowserOmnibarSelectionRepeat()
 #if DEBUG
-                cmuxDebugLog(
-                    "addressBar CLEAR panelId=\(panel.id.uuidString.prefix(8)) " +
-                    "reason=skip_preserve_omnibar_handoff pointer=\(pointerInitiated ? 1 : 0)"
-                )
+            cmuxDebugLog(
+                "addressBar CLEAR panelId=\(trackedPanelId.uuidString.prefix(8)) " +
+                "reason=stale_other_panel_webViewFirstResponder"
+            )
 #endif
-                return
-            }
-            panel.endSuppressWebViewFocusForAddressBar()
-            if self.browserAddressBarFocusedPanelId == panel.id {
-                self.browserAddressBarFocusedPanelId = nil
-                self.stopBrowserOmnibarSelectionRepeat()
+        }
+
+        guard !shouldPreserveBrowserAddressBarTracking(
+            for: panel,
+            trackedPanelMatchesWebView: panel.webView === webView,
+            pointerInitiatedWebFocus: pointerInitiated,
+            in: webView.window
+        ) else {
 #if DEBUG
-                cmuxDebugLog(
-                    "addressBar CLEAR panelId=\(panel.id.uuidString.prefix(8)) " +
-                    "reason=webViewFirstResponder"
-                )
+            cmuxDebugLog(
+                "addressBar CLEAR panelId=\(panel.id.uuidString.prefix(8)) " +
+                "reason=skip_preserve_omnibar_handoff pointer=\(pointerInitiated ? 1 : 0)"
+            )
 #endif
-            }
+            return
+        }
+        panel.endSuppressWebViewFocusForAddressBar()
+        if browserAddressBarFocusedPanelId == panel.id {
+            browserAddressBarFocusedPanelId = nil
+            stopBrowserOmnibarSelectionRepeat()
+#if DEBUG
+            cmuxDebugLog(
+                "addressBar CLEAR panelId=\(panel.id.uuidString.prefix(8)) " +
+                "reason=webViewFirstResponder"
+            )
+#endif
         }
     }
 
@@ -14891,13 +14909,28 @@ private extension NSWindow {
                 cmuxBrowserArrowForwardingDepth += 1
                 defer { cmuxBrowserArrowForwardingDepth = max(0, cmuxBrowserArrowForwardingDepth - 1) }
 
-                var currentEditorResponder = focusedOmnibarField.currentEditor() as? NSResponder
+                var currentEditorResponder: NSResponder? = focusedOmnibarField.currentEditor()
                 if currentEditorResponder == nil || self.firstResponder !== currentEditorResponder {
-                    _ = self.makeFirstResponder(focusedOmnibarField)
-                    currentEditorResponder = focusedOmnibarField.currentEditor() as? NSResponder
+                    guard self.makeFirstResponder(focusedOmnibarField) else {
+#if DEBUG
+                        cmuxDebugLog("  → browser arrow omnibar restore rejected")
+#endif
+                        return false
+                    }
+                    currentEditorResponder = focusedOmnibarField.currentEditor()
                 }
 
-                let omnibarResponder = currentEditorResponder ?? focusedOmnibarField
+                let omnibarResponder: NSResponder
+                if let currentEditorResponder, self.firstResponder === currentEditorResponder {
+                    omnibarResponder = currentEditorResponder
+                } else if self.firstResponder === focusedOmnibarField {
+                    omnibarResponder = focusedOmnibarField
+                } else {
+#if DEBUG
+                    cmuxDebugLog("  → browser arrow omnibar restore did not become first responder")
+#endif
+                    return false
+                }
                 guard !browserResponderHasMarkedText(omnibarResponder) else {
                     return false
                 }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -12258,6 +12258,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         browserAddressBarFocusedPanelId
     }
 
+    func focusedBrowserOmnibarField(in window: NSWindow?) -> OmnibarNativeTextField? {
+        browserOmnibarField(panelId: browserAddressBarFocusedPanelId, in: window)
+    }
+
     func clearBrowserAddressBarFocus(panelId: UUID, reason: String) {
         guard browserAddressBarFocusedPanelId == panelId else { return }
         browserAddressBarFocusedPanelId = nil
@@ -14791,6 +14795,34 @@ private extension NSWindow {
             firstResponderHasMarkedText: firstResponderHasMarkedText,
             flags: event.modifierFlags
         ) {
+            if let focusedOmnibarField = AppDelegate.shared?.focusedBrowserOmnibarField(in: self),
+               browserOmnibarPanelId(for: self.firstResponder) == nil,
+               focusedOmnibarField.window === self {
+                if cmuxBrowserArrowForwardingDepth > 0 {
+#if DEBUG
+                    cmuxDebugLog("  → browser arrow omnibar restore reentry; using normal dispatch")
+#endif
+                    return cmux_performKeyEquivalent(with: event)
+                }
+                cmuxBrowserArrowForwardingDepth += 1
+                defer { cmuxBrowserArrowForwardingDepth = max(0, cmuxBrowserArrowForwardingDepth - 1) }
+
+                if focusedOmnibarField.currentEditor() == nil ||
+                    browserOmnibarPanelId(for: self.firstResponder) != focusedOmnibarField.panelId {
+                    _ = self.makeFirstResponder(focusedOmnibarField)
+                }
+
+                let omnibarResponder = (focusedOmnibarField.currentEditor() as? NSResponder) ?? focusedOmnibarField
+                guard !browserResponderHasMarkedText(omnibarResponder) else {
+                    return false
+                }
+#if DEBUG
+                cmuxDebugLog("  → browser arrow restored focused omnibar before keyDown")
+#endif
+                omnibarResponder.keyDown(with: event)
+                return true
+            }
+
             // Match the Return/Enter forwarding guard: AppKit/WebKit can re-enter
             // performKeyEquivalent while the synthesized keyDown is in flight.
             if cmuxBrowserArrowForwardingDepth > 0 {
@@ -14926,6 +14958,10 @@ private extension NSWindow {
         in window: NSWindow,
         event: NSEvent?
     ) -> CmuxWebView? {
+        if browserOmnibarPanelId(for: responder) != nil {
+            return nil
+        }
+
         // Browser find runs in the portal slot alongside the hosted WKWebView.
         // Treat its native field editor chain as browser chrome, not as web content,
         // so Cmd+F can move first responder into the find field while web focus is suppressed.

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -14931,11 +14931,12 @@ private extension NSWindow {
 #endif
                     return false
                 }
-                guard !browserResponderHasMarkedText(omnibarResponder) else {
-                    return false
-                }
 #if DEBUG
-                cmuxDebugLog("  → browser arrow restored focused omnibar before keyDown")
+                if browserResponderHasMarkedText(omnibarResponder) {
+                    cmuxDebugLog("  → browser arrow restored focused omnibar with marked text before keyDown")
+                } else {
+                    cmuxDebugLog("  → browser arrow restored focused omnibar before keyDown")
+                }
 #endif
                 omnibarResponder.keyDown(with: event)
                 return true

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -7,6 +7,94 @@ import ObjectiveC
 private var cmuxBrowserPanelNeedsRenderingStateReattachKey: UInt8 = 0
 let browserOmnibarTextFieldIdentifier = NSUserInterfaceItemIdentifier("cmux.browserOmnibarTextField")
 
+private final class WeakOmnibarNativeTextField {
+    weak var field: OmnibarNativeTextField?
+
+    init(_ field: OmnibarNativeTextField) {
+        self.field = field
+    }
+}
+
+final class BrowserOmnibarNativeFieldRegistry {
+    static let shared = BrowserOmnibarNativeFieldRegistry()
+
+    private var fields: [UUID: [WeakOmnibarNativeTextField]] = [:]
+
+    func register(_ field: OmnibarNativeTextField, panelId: UUID) {
+        var entries = fields[panelId] ?? []
+        entries.removeAll { entry in
+            guard let existing = entry.field else { return true }
+            return existing === field
+        }
+        entries.append(WeakOmnibarNativeTextField(field))
+        fields[panelId] = entries
+    }
+
+    func unregister(_ field: OmnibarNativeTextField, panelId: UUID) {
+        guard var entries = fields[panelId] else { return }
+        entries.removeAll { entry in
+            guard let existing = entry.field else { return true }
+            return existing === field
+        }
+        if entries.isEmpty {
+            fields.removeValue(forKey: panelId)
+        } else {
+            fields[panelId] = entries
+        }
+    }
+
+    func field(for panelId: UUID?, in window: NSWindow? = nil) -> OmnibarNativeTextField? {
+        guard let panelId else { return nil }
+        pruneDeadEntries(for: panelId)
+        guard let entries = fields[panelId] else { return nil }
+        let liveFields = entries.reversed().compactMap(\.field)
+        if let window, let windowField = liveFields.first(where: { $0.window === window }) {
+            return windowField
+        }
+        return liveFields.first
+    }
+
+    func fieldOwningEditor(_ editor: NSTextView, in window: NSWindow? = nil) -> OmnibarNativeTextField? {
+        for panelId in Array(fields.keys) {
+            pruneDeadEntries(for: panelId)
+        }
+
+        let liveFields = fields.values.flatMap { entries in
+            entries.reversed().compactMap(\.field)
+        }
+        if let window,
+           let windowField = liveFields.first(where: { $0.window === window && $0.currentEditor() === editor }) {
+            return windowField
+        }
+        if let registeredField = liveFields.first(where: { $0.currentEditor() === editor }) {
+            return registeredField
+        }
+
+        guard let root = window?.contentView?.superview ?? window?.contentView else {
+            return nil
+        }
+        var stack: [NSView] = [root]
+        while let view = stack.popLast() {
+            if let field = view as? OmnibarNativeTextField,
+               field.currentEditor() === editor {
+                return field
+            }
+            stack.append(contentsOf: view.subviews)
+        }
+        return nil
+    }
+
+    private func pruneDeadEntries(for panelId: UUID) {
+        guard var entries = fields[panelId] else { return }
+        entries.removeAll { $0.field == nil }
+        if entries.isEmpty {
+            fields.removeValue(forKey: panelId)
+        } else {
+            fields[panelId] = entries
+        }
+    }
+}
+
 private func browserPanelViewObjectID(_ object: AnyObject?) -> String {
     guard let object else { return "nil" }
     return String(describing: Unmanaged.passUnretained(object).toOpaque())
@@ -3967,6 +4055,7 @@ struct OmnibarTextFieldRepresentable: NSViewRepresentable {
     func makeNSView(context: Context) -> OmnibarNativeTextField {
         let field = OmnibarNativeTextField(frame: .zero)
         field.panelId = panelId
+        BrowserOmnibarNativeFieldRegistry.shared.register(field, panelId: panelId)
         field.identifier = browserOmnibarTextFieldIdentifier
         field.font = .systemFont(ofSize: 12)
         field.placeholderString = placeholder
@@ -3990,7 +4079,11 @@ struct OmnibarTextFieldRepresentable: NSViewRepresentable {
     func updateNSView(_ nsView: OmnibarNativeTextField, context: Context) {
         context.coordinator.parent = self
         context.coordinator.parentField = nsView
+        if let previousPanelId = nsView.panelId, previousPanelId != panelId {
+            BrowserOmnibarNativeFieldRegistry.shared.unregister(nsView, panelId: previousPanelId)
+        }
         nsView.panelId = panelId
+        BrowserOmnibarNativeFieldRegistry.shared.register(nsView, panelId: panelId)
         nsView.placeholderString = placeholder
         context.coordinator.queueSelectAllRequest(selectAllRequestId)
 
@@ -4116,6 +4209,9 @@ struct OmnibarTextFieldRepresentable: NSViewRepresentable {
     }
 
     static func dismantleNSView(_ nsView: OmnibarNativeTextField, coordinator: Coordinator) {
+        if let panelId = nsView.panelId {
+            BrowserOmnibarNativeFieldRegistry.shared.unregister(nsView, panelId: panelId)
+        }
         nsView.onPointerDown = nil
         nsView.onHandleKeyEvent = nil
         nsView.delegate = nil
@@ -4126,6 +4222,24 @@ struct OmnibarTextFieldRepresentable: NSViewRepresentable {
 
 func browserOmnibarPanelId(for responder: NSResponder?) -> UUID? {
     browserOmnibarField(for: responder)?.panelId
+}
+
+func browserOmnibarField(panelId: UUID?, in window: NSWindow?) -> OmnibarNativeTextField? {
+    if let registeredField = BrowserOmnibarNativeFieldRegistry.shared.field(for: panelId, in: window) {
+        return registeredField
+    }
+    guard let panelId, let root = window?.contentView?.superview ?? window?.contentView else {
+        return nil
+    }
+
+    var stack: [NSView] = [root]
+    while let view = stack.popLast() {
+        if let field = view as? OmnibarNativeTextField, field.panelId == panelId {
+            return field
+        }
+        stack.append(contentsOf: view.subviews)
+    }
+    return nil
 }
 
 @discardableResult
@@ -4145,11 +4259,16 @@ private func browserOmnibarField(for responder: NSResponder?) -> OmnibarNativeTe
         return field
     }
 
-    if let editor = responder as? NSTextView,
-       editor.isFieldEditor,
-       let field = cmuxFieldEditorOwnerView(editor) as? OmnibarNativeTextField,
-       field.currentEditor() === editor {
-        return field
+    if let editor = responder as? NSTextView, editor.isFieldEditor {
+        if let field = BrowserOmnibarNativeFieldRegistry.shared.fieldOwningEditor(editor, in: editor.window) {
+            return field
+        }
+
+        if let field = cmuxFieldEditorOwnerView(editor) as? OmnibarNativeTextField,
+           field.currentEditor() === editor {
+            return field
+        }
+
     }
 
     return nil

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -906,7 +906,7 @@ struct BrowserPanelView: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: .browserMoveOmnibarSelection)) { notification in
             guard let panelId = notification.object as? UUID, panelId == panel.id else { return }
-            guard addressBarFocused, !omnibarState.suggestions.isEmpty else { return }
+            guard canHandleOmnibarSelectionNavigation(), !omnibarState.suggestions.isEmpty else { return }
             guard let delta = notification.userInfo?["delta"] as? Int, delta != 0 else { return }
 #if DEBUG
             logBrowserFocusState(event: "addressBarFocus.moveSelection", detail: "delta=\(delta)")
@@ -1300,7 +1300,7 @@ struct BrowserPanelView: View {
                     setAddressBarFocused(false, reason: "omnibar.fieldLostFocus")
                 },
                 onMoveSelection: { delta in
-                    guard addressBarFocused, !omnibarState.suggestions.isEmpty else { return }
+                    guard canHandleOmnibarSelectionNavigation(), !omnibarState.suggestions.isEmpty else { return }
                     let effects = omnibarReduce(state: &omnibarState, event: .moveSelection(delta: delta))
                     applyOmnibarEffects(effects)
                     refreshInlineCompletion()
@@ -1479,6 +1479,21 @@ struct BrowserPanelView: View {
 #endif
         }
         cmuxWebView.allowsFirstResponderAcquisition = next
+    }
+
+    private func canHandleOmnibarSelectionNavigation() -> Bool {
+        if addressBarFocused {
+            return true
+        }
+        if AppDelegate.shared?.focusedBrowserAddressBarPanelId() == panel.id {
+            return true
+        }
+        let fieldWindow = panel.webView.window ?? NSApp.keyWindow ?? NSApp.mainWindow
+        if let field = browserOmnibarField(panelId: panel.id, in: fieldWindow),
+           field.currentEditor() != nil {
+            return true
+        }
+        return false
     }
 
     private func setAddressBarFocused(_ focused: Bool, reason: String) {

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -19,6 +19,12 @@ private final class WeakOmnibarNativeTextField {
 final class BrowserOmnibarNativeFieldRegistry {
     static let shared = BrowserOmnibarNativeFieldRegistry()
 
+    // Ownership invariant: OmnibarNativeTextField.panelId is the single source
+    // of truth for field-to-panel ownership, and a live omnibar field owns its
+    // current field editor. AppKit's field-editor responder chain is the normal
+    // lookup path, but it can keep a stale nextResponder during browser
+    // focus/layout transitions. This weak registry is only a live-field lookup
+    // cache for those stale-responder windows; it does not create ownership.
     private var fields: [UUID: [WeakOmnibarNativeTextField]] = [:]
 
     func register(_ field: OmnibarNativeTextField, panelId: UUID) {
@@ -4235,6 +4241,8 @@ func browserOmnibarField(panelId: UUID?, in window: NSWindow?) -> OmnibarNativeT
         return nil
     }
 
+    // Fallback for SwiftUI/AppKit reconnect windows where the live native field
+    // has been attached but registration has not yet observed it.
     var stack: [NSView] = [root]
     while let view = stack.popLast() {
         if let field = view as? OmnibarNativeTextField, field.panelId == panelId {

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -6869,7 +6869,16 @@ struct WebViewRepresentable: NSViewRepresentable {
             return
         }
         if isPanelFocused && responderChainContains(window.firstResponder, target: webView) {
-            panel.noteWebViewFocused()
+            if panel.shouldSuppressWebViewFocus() {
+#if DEBUG
+                cmuxDebugLog(
+                    "browser.focus.content.apply panel=\(panel.id.uuidString.prefix(5)) " +
+                    "action=skip_webview_intent reason=suppressed_first_responder_chain"
+                )
+#endif
+            } else {
+                panel.noteWebViewFocused()
+            }
         }
         if shouldFocusWebView {
             if panel.shouldSuppressWebViewFocus() {

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -15,6 +15,7 @@ private final class WeakOmnibarNativeTextField {
     }
 }
 
+@MainActor
 final class BrowserOmnibarNativeFieldRegistry {
     static let shared = BrowserOmnibarNativeFieldRegistry()
 
@@ -4220,10 +4221,12 @@ struct OmnibarTextFieldRepresentable: NSViewRepresentable {
     }
 }
 
+@MainActor
 func browserOmnibarPanelId(for responder: NSResponder?) -> UUID? {
     browserOmnibarField(for: responder)?.panelId
 }
 
+@MainActor
 func browserOmnibarField(panelId: UUID?, in window: NSWindow?) -> OmnibarNativeTextField? {
     if let registeredField = BrowserOmnibarNativeFieldRegistry.shared.field(for: panelId, in: window) {
         return registeredField
@@ -4243,6 +4246,7 @@ func browserOmnibarField(panelId: UUID?, in window: NSWindow?) -> OmnibarNativeT
 }
 
 @discardableResult
+@MainActor
 func browserPrepareOmnibarForProgrammaticBlur(panelId: UUID, responder: NSResponder?) -> Bool {
     guard let field = browserOmnibarField(for: responder),
           field.panelId == panelId else {
@@ -4252,6 +4256,7 @@ func browserPrepareOmnibarForProgrammaticBlur(panelId: UUID, responder: NSRespon
     return true
 }
 
+@MainActor
 private func browserOmnibarField(for responder: NSResponder?) -> OmnibarNativeTextField? {
     guard let responder else { return nil }
 

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -55,10 +55,10 @@ final class BrowserOmnibarNativeFieldRegistry {
         pruneDeadEntries(for: panelId)
         guard let entries = fields[panelId] else { return nil }
         let liveFields = entries.reversed().compactMap(\.field)
-        if let window, let windowField = liveFields.first(where: { $0.window === window }) {
-            return windowField
+        if let window {
+            return liveFields.first(where: { $0.window === window })
         }
-        return liveFields.first
+        return liveFields.first(where: { $0.window != nil }) ?? liveFields.first
     }
 
     func fieldOwningEditor(_ editor: NSTextView, in window: NSWindow? = nil) -> OmnibarNativeTextField? {

--- a/Sources/Panels/CmuxWebView.swift
+++ b/Sources/Panels/CmuxWebView.swift
@@ -427,10 +427,11 @@ final class CmuxWebView: WKWebView {
         }
         let result = super.becomeFirstResponder()
         if result {
+            let pointerInitiatedKey = BrowserFirstResponderNotificationUserInfoKey.pointerInitiated
             NotificationCenter.default.post(
                 name: .browserDidBecomeFirstResponderWebView,
                 object: self,
-                userInfo: ["pointerInitiated": pointerFocusAllowanceDepth > 0]
+                userInfo: [pointerInitiatedKey: pointerFocusAllowanceDepth > 0]
             )
         }
 #if DEBUG

--- a/Sources/Panels/CmuxWebView.swift
+++ b/Sources/Panels/CmuxWebView.swift
@@ -427,7 +427,11 @@ final class CmuxWebView: WKWebView {
         }
         let result = super.becomeFirstResponder()
         if result {
-            NotificationCenter.default.post(name: .browserDidBecomeFirstResponderWebView, object: self)
+            NotificationCenter.default.post(
+                name: .browserDidBecomeFirstResponderWebView,
+                object: self,
+                userInfo: ["pointerInitiated": pointerFocusAllowanceDepth > 0]
+            )
         }
 #if DEBUG
         let eventType = NSApp.currentEvent.map { String(describing: $0.type) } ?? "nil"

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -7605,3 +7605,7 @@ extension Notification.Name {
     static let browserPortalRegistryDidChange = Notification.Name("cmux.browserPortalRegistryDidChange")
     static let workspaceOrderDidChange = Notification.Name("cmux.workspaceOrderDidChange")
 }
+
+enum BrowserFirstResponderNotificationUserInfoKey {
+    static let pointerInitiated = "pointerInitiated"
+}

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -3219,6 +3219,79 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         XCTAssertEqual(observedDelta, 1)
     }
 
+    func testOmnibarArrowSelectionSurvivesTransientWindowFirstResponder() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let windowId = appDelegate.createMainWindow()
+        defer { closeWindow(withId: windowId) }
+
+        guard let window = window(withId: windowId),
+              let contentView = window.contentView,
+              let manager = appDelegate.tabManagerFor(windowId: windowId),
+              let workspace = manager.selectedWorkspace,
+              let browserPanelId = manager.openBrowser(inWorkspace: workspace.id),
+              let browserPanel = workspace.browserPanel(for: browserPanelId) else {
+            XCTFail("Expected focused browser panel")
+            return
+        }
+
+        let field = OmnibarNativeTextField(frame: NSRect(x: 8, y: 8, width: 240, height: 24))
+        field.identifier = browserOmnibarTextFieldIdentifier
+        field.panelId = browserPanelId
+        field.stringValue = "example"
+        contentView.addSubview(field)
+        BrowserOmnibarNativeFieldRegistry.shared.register(field, panelId: browserPanelId)
+        defer {
+            NotificationCenter.default.post(name: .browserDidBlurAddressBar, object: browserPanelId)
+            BrowserOmnibarNativeFieldRegistry.shared.unregister(field, panelId: browserPanelId)
+            field.removeFromSuperview()
+        }
+
+        _ = browserPanel.requestAddressBarFocus()
+        NotificationCenter.default.post(name: .browserDidFocusAddressBar, object: browserPanelId)
+        _ = window.makeFirstResponder(nil)
+        XCTAssertTrue(window.firstResponder === window)
+
+        let moveExpectation = expectation(
+            description: "Expected omnibar move-selection notification while first responder is transiently the window"
+        )
+        var observedPanelId: UUID?
+        var observedDelta: Int?
+        let moveToken = NotificationCenter.default.addObserver(
+            forName: .browserMoveOmnibarSelection,
+            object: nil,
+            queue: nil
+        ) { notification in
+            observedPanelId = notification.object as? UUID
+            observedDelta = notification.userInfo?["delta"] as? Int
+            moveExpectation.fulfill()
+        }
+        defer { NotificationCenter.default.removeObserver(moveToken) }
+
+        guard let downArrowEvent = makeKeyDownEvent(
+            key: String(UnicodeScalar(NSDownArrowFunctionKey)!),
+            modifiers: [],
+            keyCode: 125,
+            windowNumber: window.windowNumber
+        ) else {
+            XCTFail("Failed to construct Down Arrow event")
+            return
+        }
+
+#if DEBUG
+        XCTAssertTrue(appDelegate.debugHandleCustomShortcut(event: downArrowEvent))
+#else
+        XCTFail("debugHandleCustomShortcut is only available in DEBUG")
+#endif
+
+        wait(for: [moveExpectation], timeout: 1.0)
+        XCTAssertEqual(observedPanelId, browserPanelId)
+        XCTAssertEqual(observedDelta, 1)
+    }
+
     func testCmdPhysicalWWithDvorakCharactersDoesNotTriggerClosePanelShortcut() {
         guard let appDelegate = AppDelegate.shared else {
             XCTFail("Expected AppDelegate.shared")

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -3148,6 +3148,77 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         XCTAssertEqual(appDelegate.fileExplorerState?.mode, initialMode)
     }
 
+    func testOmnibarArrowSelectionUsesResponderResolvedPanelWhenTrackedFocusWasCleared() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let windowId = appDelegate.createMainWindow()
+        defer { closeWindow(withId: windowId) }
+
+        guard let window = window(withId: windowId),
+              let contentView = window.contentView,
+              let manager = appDelegate.tabManagerFor(windowId: windowId),
+              let workspace = manager.selectedWorkspace,
+              let browserPanelId = manager.openBrowser(inWorkspace: workspace.id) else {
+            XCTFail("Expected focused browser panel")
+            return
+        }
+
+        let field = OmnibarNativeTextField(frame: NSRect(x: 8, y: 8, width: 240, height: 24))
+        field.identifier = browserOmnibarTextFieldIdentifier
+        field.panelId = browserPanelId
+        field.stringValue = "example"
+        contentView.addSubview(field)
+        BrowserOmnibarNativeFieldRegistry.shared.register(field, panelId: browserPanelId)
+        defer {
+            BrowserOmnibarNativeFieldRegistry.shared.unregister(field, panelId: browserPanelId)
+            field.removeFromSuperview()
+        }
+
+        XCTAssertTrue(window.makeFirstResponder(field))
+        XCTAssertNotNil(field.currentEditor())
+
+        NotificationCenter.default.post(name: .browserDidBlurAddressBar, object: browserPanelId)
+
+        let moveExpectation = expectation(
+            description: "Expected omnibar move-selection notification for responder-resolved panel"
+        )
+        var observedPanelId: UUID?
+        var observedDelta: Int?
+        let moveToken = NotificationCenter.default.addObserver(
+            forName: .browserMoveOmnibarSelection,
+            object: nil,
+            queue: nil
+        ) { notification in
+            observedPanelId = notification.object as? UUID
+            observedDelta = notification.userInfo?["delta"] as? Int
+            moveExpectation.fulfill()
+        }
+        defer { NotificationCenter.default.removeObserver(moveToken) }
+
+        guard let downArrowEvent = makeKeyDownEvent(
+            key: String(UnicodeScalar(NSDownArrowFunctionKey)!),
+            modifiers: [],
+            keyCode: 125,
+            windowNumber: window.windowNumber
+        ) else {
+            XCTFail("Failed to construct Down Arrow event")
+            return
+        }
+
+#if DEBUG
+        XCTAssertTrue(appDelegate.debugHandleCustomShortcut(event: downArrowEvent))
+#else
+        XCTFail("debugHandleCustomShortcut is only available in DEBUG")
+#endif
+
+        wait(for: [moveExpectation], timeout: 1.0)
+        XCTAssertEqual(observedPanelId, browserPanelId)
+        XCTAssertEqual(observedDelta, 1)
+    }
+
     func testCmdPhysicalWWithDvorakCharactersDoesNotTriggerClosePanelShortcut() {
         guard let appDelegate = AppDelegate.shared else {
             XCTFail("Expected AppDelegate.shared")

--- a/cmuxTests/BrowserConfigTests.swift
+++ b/cmuxTests/BrowserConfigTests.swift
@@ -826,6 +826,62 @@ final class CmuxWebViewKeyEquivalentTests: XCTestCase {
     }
 
     @MainActor
+    func testWindowArrowForwardingRoutesFocusedOmnibarFieldEditorThroughKeyDown() {
+        _ = NSApplication.shared
+        AppDelegate.installWindowResponderSwizzlesForTesting()
+
+        let panelId = UUID()
+        let window = FieldEditorProbeWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 640, height: 420),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        let container = NSView(frame: window.contentRect(forFrameRect: window.frame))
+        window.contentView = container
+
+        let field = OmnibarNativeTextField(frame: NSRect(x: 12, y: 380, width: 360, height: 24))
+        field.panelId = panelId
+        field.stringValue = "abcdef"
+        container.addSubview(field)
+
+        window.makeKeyAndOrderFront(nil)
+        defer {
+            NotificationCenter.default.post(name: .browserDidBlurAddressBar, object: panelId)
+            AppDelegate.clearWindowFirstResponderGuardTesting()
+            field.removeFromSuperview()
+            window.contentView = nil
+            window.orderOut(nil)
+        }
+
+        XCTAssertTrue(window.makeFirstResponder(field))
+        guard field.currentEditor() === window.testFieldEditor else {
+            XCTFail("Expected the omnibar to use the probe field editor")
+            return
+        }
+
+        NotificationCenter.default.post(name: .browserDidFocusAddressBar, object: panelId)
+        window.testFieldEditor.resetKeyDownKeyCodes()
+
+        guard let leftArrowEvent = makeKeyDownEvent(
+            key: String(UnicodeScalar(NSLeftArrowFunctionKey)!),
+            modifiers: [],
+            keyCode: 123,
+            windowNumber: window.windowNumber
+        ) else {
+            XCTFail("Failed to construct Left Arrow event")
+            return
+        }
+
+        XCTAssertTrue(window.performKeyEquivalent(with: leftArrowEvent))
+        XCTAssertEqual(
+            window.testFieldEditor.keyDownKeyCodes,
+            [123],
+            "A live omnibar field editor must receive plain arrows through keyDown so NSTextView can move the caret"
+        )
+    }
+
+    @MainActor
     func testWindowArrowForwardingRestoresFocusedOmnibarBeforeBrowserFirstResponder() {
         _ = NSApplication.shared
         AppDelegate.installWindowResponderSwizzlesForTesting()

--- a/cmuxTests/BrowserConfigTests.swift
+++ b/cmuxTests/BrowserConfigTests.swift
@@ -118,12 +118,14 @@ final class BrowserAddressBarTrackingPolicyTests: XCTestCase {
     func testNonPointerWebViewFocusPreservesTrackedAddressBarWithLiveOmnibarField() {
         XCTAssertTrue(
             shouldPreserveBrowserAddressBarTrackingDuringWebViewFocus(
-                trackedPanelMatchesWebView: true,
-                omnibarResponderActive: false,
-                preferredFocusIntentIsAddressBar: true,
-                suppressesWebViewFocus: false,
-                pointerInitiatedWebFocus: false,
-                liveOmnibarFieldExists: true
+                BrowserAddressBarTrackingContext(
+                    trackedPanelMatchesWebView: true,
+                    omnibarResponderActive: false,
+                    preferredFocusIntentIsAddressBar: true,
+                    suppressesWebViewFocus: false,
+                    pointerInitiatedWebFocus: false,
+                    liveOmnibarFieldExists: true
+                )
             )
         )
     }
@@ -131,12 +133,14 @@ final class BrowserAddressBarTrackingPolicyTests: XCTestCase {
     func testPointerWebViewFocusCanClearTrackedAddressBar() {
         XCTAssertFalse(
             shouldPreserveBrowserAddressBarTrackingDuringWebViewFocus(
-                trackedPanelMatchesWebView: true,
-                omnibarResponderActive: false,
-                preferredFocusIntentIsAddressBar: true,
-                suppressesWebViewFocus: true,
-                pointerInitiatedWebFocus: true,
-                liveOmnibarFieldExists: true
+                BrowserAddressBarTrackingContext(
+                    trackedPanelMatchesWebView: true,
+                    omnibarResponderActive: false,
+                    preferredFocusIntentIsAddressBar: true,
+                    suppressesWebViewFocus: true,
+                    pointerInitiatedWebFocus: true,
+                    liveOmnibarFieldExists: true
+                )
             )
         )
     }
@@ -144,14 +148,91 @@ final class BrowserAddressBarTrackingPolicyTests: XCTestCase {
     func testOtherPanelWebViewFocusDoesNotPreserveAddressBarTracking() {
         XCTAssertFalse(
             shouldPreserveBrowserAddressBarTrackingDuringWebViewFocus(
-                trackedPanelMatchesWebView: false,
-                omnibarResponderActive: true,
-                preferredFocusIntentIsAddressBar: true,
-                suppressesWebViewFocus: true,
-                pointerInitiatedWebFocus: false,
-                liveOmnibarFieldExists: true
+                BrowserAddressBarTrackingContext(
+                    trackedPanelMatchesWebView: false,
+                    omnibarResponderActive: true,
+                    preferredFocusIntentIsAddressBar: true,
+                    suppressesWebViewFocus: true,
+                    pointerInitiatedWebFocus: false,
+                    liveOmnibarFieldExists: true
+                )
             )
         )
+    }
+}
+
+final class BrowserOmnibarNativeFieldRegistryTests: XCTestCase {
+    @MainActor
+    func testSpecificWindowLookupDoesNotReturnFieldFromAnotherWindow() {
+        let panelId = UUID()
+        let registry = BrowserOmnibarNativeFieldRegistry.shared
+        let firstWindow = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 200),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        let secondWindow = NSWindow(
+            contentRect: NSRect(x: 20, y: 20, width: 320, height: 200),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        let firstContainer = NSView(frame: firstWindow.contentRect(forFrameRect: firstWindow.frame))
+        let secondContainer = NSView(frame: secondWindow.contentRect(forFrameRect: secondWindow.frame))
+        firstWindow.contentView = firstContainer
+        secondWindow.contentView = secondContainer
+
+        let field = OmnibarNativeTextField(frame: NSRect(x: 0, y: 0, width: 120, height: 24))
+        field.panelId = panelId
+        firstContainer.addSubview(field)
+        registry.register(field, panelId: panelId)
+
+        defer {
+            registry.unregister(field, panelId: panelId)
+            field.removeFromSuperview()
+            firstWindow.contentView = nil
+            secondWindow.contentView = nil
+            firstWindow.orderOut(nil)
+            secondWindow.orderOut(nil)
+        }
+
+        XCTAssertTrue(registry.field(for: panelId, in: firstWindow) === field)
+        XCTAssertNil(registry.field(for: panelId, in: secondWindow))
+    }
+
+    @MainActor
+    func testNilWindowLookupPrefersAttachedFieldBeforeDetachedField() {
+        let panelId = UUID()
+        let registry = BrowserOmnibarNativeFieldRegistry.shared
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 200),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        let container = NSView(frame: window.contentRect(forFrameRect: window.frame))
+        window.contentView = container
+
+        let attachedField = OmnibarNativeTextField(frame: NSRect(x: 0, y: 0, width: 120, height: 24))
+        attachedField.panelId = panelId
+        container.addSubview(attachedField)
+
+        let detachedField = OmnibarNativeTextField(frame: NSRect(x: 0, y: 0, width: 120, height: 24))
+        detachedField.panelId = panelId
+
+        registry.register(attachedField, panelId: panelId)
+        registry.register(detachedField, panelId: panelId)
+
+        defer {
+            registry.unregister(attachedField, panelId: panelId)
+            registry.unregister(detachedField, panelId: panelId)
+            attachedField.removeFromSuperview()
+            window.contentView = nil
+            window.orderOut(nil)
+        }
+
+        XCTAssertTrue(registry.field(for: panelId) === attachedField)
     }
 }
 

--- a/cmuxTests/BrowserConfigTests.swift
+++ b/cmuxTests/BrowserConfigTests.swift
@@ -114,6 +114,47 @@ private final class BrowserMarkedTextProbeTextView: NSTextView {
     }
 }
 
+final class BrowserAddressBarTrackingPolicyTests: XCTestCase {
+    func testNonPointerWebViewFocusPreservesTrackedAddressBarWithLiveOmnibarField() {
+        XCTAssertTrue(
+            shouldPreserveBrowserAddressBarTrackingDuringWebViewFocus(
+                trackedPanelMatchesWebView: true,
+                omnibarResponderActive: false,
+                preferredFocusIntentIsAddressBar: true,
+                suppressesWebViewFocus: false,
+                pointerInitiatedWebFocus: false,
+                liveOmnibarFieldExists: true
+            )
+        )
+    }
+
+    func testPointerWebViewFocusCanClearTrackedAddressBar() {
+        XCTAssertFalse(
+            shouldPreserveBrowserAddressBarTrackingDuringWebViewFocus(
+                trackedPanelMatchesWebView: true,
+                omnibarResponderActive: false,
+                preferredFocusIntentIsAddressBar: true,
+                suppressesWebViewFocus: true,
+                pointerInitiatedWebFocus: true,
+                liveOmnibarFieldExists: true
+            )
+        )
+    }
+
+    func testOtherPanelWebViewFocusDoesNotPreserveAddressBarTracking() {
+        XCTAssertFalse(
+            shouldPreserveBrowserAddressBarTrackingDuringWebViewFocus(
+                trackedPanelMatchesWebView: false,
+                omnibarResponderActive: true,
+                preferredFocusIntentIsAddressBar: true,
+                suppressesWebViewFocus: true,
+                pointerInitiatedWebFocus: false,
+                liveOmnibarFieldExists: true
+            )
+        )
+    }
+}
+
 final class CmuxWebViewKeyEquivalentTests: XCTestCase {
     private final class ActionSpy: NSObject {
         private(set) var invoked: Bool = false

--- a/cmuxTests/BrowserConfigTests.swift
+++ b/cmuxTests/BrowserConfigTests.swift
@@ -287,6 +287,7 @@ final class CmuxWebViewKeyEquivalentTests: XCTestCase {
     private final class FieldEditorProbeTextView: NSTextView {
         private(set) var delegateReadCount = 0
         private(set) var keyDownKeyCodes: [UInt16] = []
+        var reportsMarkedText = false
 
         override var delegate: NSTextViewDelegate? {
             get {
@@ -305,6 +306,10 @@ final class CmuxWebViewKeyEquivalentTests: XCTestCase {
 
         override func keyDown(with event: NSEvent) {
             keyDownKeyCodes.append(event.keyCode)
+        }
+
+        override func hasMarkedText() -> Bool {
+            reportsMarkedText
         }
 
         func resetKeyDownKeyCodes() {
@@ -882,6 +887,70 @@ final class CmuxWebViewKeyEquivalentTests: XCTestCase {
             [123],
             "When the omnibar is still logically focused, transient WebView first-responder state must not steal plain arrows from the omnibar field editor"
         )
+    }
+
+    @MainActor
+    func testWindowArrowForwardingConsumesMarkedTextOmnibarRestore() {
+        _ = NSApplication.shared
+        AppDelegate.installWindowResponderSwizzlesForTesting()
+
+        let panelId = UUID()
+        let window = FieldEditorProbeWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 640, height: 420),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        let container = NSView(frame: window.contentRect(forFrameRect: window.frame))
+        window.contentView = container
+
+        let field = OmnibarNativeTextField(frame: NSRect(x: 12, y: 380, width: 360, height: 24))
+        field.panelId = panelId
+        field.stringValue = "abcdef"
+        container.addSubview(field)
+
+        let webView = CmuxWebView(frame: NSRect(x: 0, y: 0, width: 640, height: 360), configuration: WKWebViewConfiguration())
+        webView.allowsFirstResponderAcquisition = true
+        container.addSubview(webView)
+
+        window.makeKeyAndOrderFront(nil)
+        defer {
+            NotificationCenter.default.post(name: .browserDidBlurAddressBar, object: panelId)
+            AppDelegate.clearWindowFirstResponderGuardTesting()
+            field.removeFromSuperview()
+            webView.removeFromSuperview()
+            window.contentView = nil
+            window.orderOut(nil)
+        }
+
+        XCTAssertTrue(window.makeFirstResponder(field))
+        guard field.currentEditor() === window.testFieldEditor else {
+            XCTFail("Expected the omnibar to use the probe field editor")
+            return
+        }
+
+        NotificationCenter.default.post(name: .browserDidFocusAddressBar, object: panelId)
+        window.testFieldEditor.resetKeyDownKeyCodes()
+        window.testFieldEditor.reportsMarkedText = true
+
+        XCTAssertTrue(window.makeFirstResponder(webView))
+        XCTAssertTrue(window.firstResponder === webView)
+
+        guard let leftArrowEvent = makeKeyDownEvent(
+            key: String(UnicodeScalar(NSLeftArrowFunctionKey)!),
+            modifiers: [],
+            keyCode: 123,
+            windowNumber: window.windowNumber
+        ) else {
+            XCTFail("Failed to construct Left Arrow event")
+            return
+        }
+
+        XCTAssertTrue(
+            window.performKeyEquivalent(with: leftArrowEvent),
+            "After restoring the omnibar, the arrow must be delivered once instead of returning unhandled after mutating first responder"
+        )
+        XCTAssertEqual(window.testFieldEditor.keyDownKeyCodes, [123])
     }
 
     @MainActor

--- a/cmuxTests/BrowserConfigTests.swift
+++ b/cmuxTests/BrowserConfigTests.swift
@@ -164,6 +164,7 @@ final class CmuxWebViewKeyEquivalentTests: XCTestCase {
 
     private final class FieldEditorProbeTextView: NSTextView {
         private(set) var delegateReadCount = 0
+        private(set) var keyDownKeyCodes: [UInt16] = []
 
         override var delegate: NSTextViewDelegate? {
             get {
@@ -178,6 +179,22 @@ final class CmuxWebViewKeyEquivalentTests: XCTestCase {
         override var isFieldEditor: Bool {
             get { true }
             set {}
+        }
+
+        override func keyDown(with event: NSEvent) {
+            keyDownKeyCodes.append(event.keyCode)
+        }
+
+        func resetKeyDownKeyCodes() {
+            keyDownKeyCodes.removeAll()
+        }
+    }
+
+    private final class FieldEditorProbeWindow: NSWindow {
+        let testFieldEditor = FieldEditorProbeTextView(frame: NSRect(x: 0, y: 0, width: 240, height: 24))
+
+        override func fieldEditor(_ createFlag: Bool, for object: Any?) -> NSText? {
+            testFieldEditor
         }
     }
     func testCmdNRoutesToMainMenuWhenWebViewIsFirstResponder() {
@@ -678,6 +695,70 @@ final class CmuxWebViewKeyEquivalentTests: XCTestCase {
             fieldEditor.delegateReadCount,
             0,
             "Field-editor webview ownership should come from tracked associations, not NSTextView.delegate"
+        )
+    }
+
+    @MainActor
+    func testWindowArrowForwardingRestoresFocusedOmnibarBeforeBrowserFirstResponder() {
+        _ = NSApplication.shared
+        AppDelegate.installWindowResponderSwizzlesForTesting()
+
+        let panelId = UUID()
+        let window = FieldEditorProbeWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 640, height: 420),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        let container = NSView(frame: window.contentRect(forFrameRect: window.frame))
+        window.contentView = container
+
+        let field = OmnibarNativeTextField(frame: NSRect(x: 12, y: 380, width: 360, height: 24))
+        field.panelId = panelId
+        field.stringValue = "abcdef"
+        container.addSubview(field)
+
+        let webView = CmuxWebView(frame: NSRect(x: 0, y: 0, width: 640, height: 360), configuration: WKWebViewConfiguration())
+        webView.allowsFirstResponderAcquisition = true
+        container.addSubview(webView)
+
+        window.makeKeyAndOrderFront(nil)
+        defer {
+            NotificationCenter.default.post(name: .browserDidBlurAddressBar, object: panelId)
+            AppDelegate.clearWindowFirstResponderGuardTesting()
+            field.removeFromSuperview()
+            webView.removeFromSuperview()
+            window.contentView = nil
+            window.orderOut(nil)
+        }
+
+        XCTAssertTrue(window.makeFirstResponder(field))
+        guard field.currentEditor() === window.testFieldEditor else {
+            XCTFail("Expected the omnibar to use the probe field editor")
+            return
+        }
+
+        NotificationCenter.default.post(name: .browserDidFocusAddressBar, object: panelId)
+        window.testFieldEditor.resetKeyDownKeyCodes()
+
+        XCTAssertTrue(window.makeFirstResponder(webView))
+        XCTAssertTrue(window.firstResponder === webView)
+
+        guard let leftArrowEvent = makeKeyDownEvent(
+            key: String(UnicodeScalar(NSLeftArrowFunctionKey)!),
+            modifiers: [],
+            keyCode: 123,
+            windowNumber: window.windowNumber
+        ) else {
+            XCTFail("Failed to construct Left Arrow event")
+            return
+        }
+
+        XCTAssertTrue(window.performKeyEquivalent(with: leftArrowEvent))
+        XCTAssertEqual(
+            window.testFieldEditor.keyDownKeyCodes,
+            [123],
+            "When the omnibar is still logically focused, transient WebView first-responder state must not steal plain arrows from the omnibar field editor"
         )
     }
 

--- a/cmuxTests/OmnibarAndToolsTests.swift
+++ b/cmuxTests/OmnibarAndToolsTests.swift
@@ -713,6 +713,57 @@ private final class OmnibarInlineDeletionHarness {
 }
 
 
+@MainActor
+final class BrowserOmnibarFieldEditorResolutionTests: XCTestCase {
+    func testPanelIdResolutionUsesLiveOmnibarFieldWhenFieldEditorResponderChainIsStale() {
+        _ = NSApplication.shared
+
+        let panelId = UUID()
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 420, height: 80),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        let contentView = NSView(frame: window.contentRect(forFrameRect: window.frame))
+        window.contentView = contentView
+
+        let staleWebView = CmuxWebView(frame: NSRect(x: 0, y: 0, width: 420, height: 80), configuration: WKWebViewConfiguration())
+        contentView.addSubview(staleWebView)
+
+        let field = OmnibarNativeTextField(frame: NSRect(x: 8, y: 28, width: 300, height: 24))
+        field.panelId = panelId
+        contentView.addSubview(field)
+
+        window.makeKeyAndOrderFront(nil)
+        defer {
+            field.removeFromSuperview()
+            staleWebView.removeFromSuperview()
+            window.contentView = nil
+            window.orderOut(nil)
+        }
+
+        XCTAssertTrue(window.makeFirstResponder(field))
+        guard let editor = field.currentEditor() as? NSTextView else {
+            XCTFail("Expected omnibar field editor after focusing text field")
+            return
+        }
+
+        let originalNextResponder = editor.nextResponder
+        editor.nextResponder = staleWebView
+        defer {
+            editor.nextResponder = originalNextResponder
+        }
+
+        XCTAssertEqual(
+            browserOmnibarPanelId(for: editor),
+            panelId,
+            "A live omnibar field editor must resolve to its owning omnibar field even when AppKit leaves a stale browser responder chain behind"
+        )
+    }
+}
+
+
 final class OmnibarRemoteSuggestionMergeTests: XCTestCase {
     func testMergeRemoteSuggestionsInsertsBelowSearchAndDedupes() {
         let now = Date()


### PR DESCRIPTION
## Summary
- adds regression coverage for stale omnibar field-editor ownership and transient WebView first-responder arrow routing
- restores live omnibar field fallback lookup for stale/nil window ownership cases
- prevents browser arrow forwarding from treating the omnibar field editor as web content, and restores the logically focused omnibar before dispatching arrows

Fixes #4141

## Testing
- Not run locally, per repo policy; CI is the validation path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches AppKit first-responder tracking and keyboard event routing for the browser omnibar, which is easy to regress and can affect typing/navigation behavior across windows and panels.
> 
> **Overview**
> Fixes browser omnibar arrow-key race conditions by **resolving the focused panel from the current omnibar responder/intent (not just stale tracked state)** and by making omnibar selection repeat state panel-specific.
> 
> Adds a `BrowserOmnibarNativeFieldRegistry` and `browserOmnibarField(panelId:in:)` fallback lookup to reliably find the live omnibar field/field-editor even when AppKit leaves stale responder chains, and updates arrow-key forwarding to route plain arrows through `keyDown` for omnibar responders (including restoring omnibar focus before forwarding).
> 
> Refactors address-bar tracking preservation into `shouldPreserveBrowserAddressBarTrackingDuringWebViewFocus` with pointer-initiated WebView focus signals (propagated via `.browserDidBecomeFirstResponderWebView` userInfo), and adds regression tests covering stale field-editor ownership, transient first-responder states, and arrow routing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dd9e94f19348b67f2a47d4387d7649041a203c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Registry and lookup support for live omnibar fields and improved omnibar focus resolution
  * First-responder notifications now include pointer-initiated info for focus transitions

* **Bug Fixes**
  * Improved preservation/clearing of address-bar tracking across webview focus changes (pointer-initiated, suppression, live omnibar)
  * More reliable arrow-key routing that restores and forwards keys to the omnibar when appropriate

* **Tests**
  * Added tests for tracking policy, omnibar lookup/resolution, and key-event routing

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4183)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->