### PR TITLE
Markdown viewer: fix entities, add callouts, line numbers, perf

### DIFF
--- a/Resources/markdown-viewer/shell.html
+++ b/Resources/markdown-viewer/shell.html
@@ -338,7 +338,9 @@ html { scroll-behavior: smooth; }
     }
     return hash;
   }
-  var lastRenderedHash = 0;
+  // Sentinel must not collide with any valid fnv1aHash() output. fnv1aHash
+  // ends with `>>> 0`, which produces 0..2^32-1; null sits outside that range.
+  var lastRenderedHash = null;
 
   function escapeHtml(s) {
     // Let WebKit's HTML serializer do escaping rather than trying
@@ -899,7 +901,18 @@ html { scroll-behavior: smooth; }
   // Fast pre-check: most markdown files produce HTML with no dangerous
   // elements or attributes. This regex tests for patterns the full
   // TreeWalker sanitizer would act on — if none match, skip the walk.
-  var sanitizationPattern = /<(?:script|iframe|object|embed|link(?:\s)|meta|base|form|button|textarea|select|option|svg|math)\b|<input\b(?![^>]*type\s*=\s*["']?checkbox)|(?:\son[a-z]+=|\bstyle\s*=|\bsrcdoc\s*=|\bautofocus\b|\bformaction\s*=|\bxlink:href\s*=)|(?:href|src)\s*=\s*["']?\s*(?:javascript|vbscript|data):/i;
+  //
+  // Notes on each alternation:
+  //   <link\b ...                  word-boundary, not <link(?:\s) — catches
+  //                                <link> with no following whitespace.
+  //   \son[a-z]+\s*=               whitespace before `=` is tolerated by
+  //                                browsers, so `onload =` must still match.
+  //   (?:href|src) ... &           any character reference inside an href/src
+  //                                value (e.g. `&#106;avascript:`) forces the
+  //                                full sanitizer; entity decoding happens at
+  //                                attribute-parse time, so the slow path
+  //                                gets the resolved value via attr.value.
+  var sanitizationPattern = /<(?:script|iframe|object|embed|link\b|meta|base|form|button|textarea|select|option|svg|math)\b|<input\b(?![^>]*type\s*=\s*["']?checkbox)|(?:\son[a-z]+\s*=|\bstyle\s*=|\bsrcdoc\s*=|\bautofocus\b|\bformaction\s*=|\bxlink:href\s*=)|(?:href|src)\s*=\s*["']?\s*(?:javascript|vbscript|data):|(?:href|src)\s*=\s*["'][^"']*&/i;
   function needsSanitization(html) {
     return sanitizationPattern.test(html || '');
   }
@@ -1064,7 +1077,11 @@ html { scroll-behavior: smooth; }
           highlighted = escapeHtml(raw);
         }
         var langClass = langName ? ' language-' + langName : '';
-        var lineCount = (raw.match(/\n/g) || []).length + 1;
+        // Strip exactly one trailing newline before counting lines so code
+        // blocks that end in "\n" (the common case from marked) don't render
+        // a phantom empty line number in the gutter.
+        var rawForLineCount = raw.replace(/\r?\n$/, '');
+        var lineCount = (rawForLineCount.match(/\n/g) || []).length + 1;
         var gutter = '';
         for (var ln = 1; ln <= lineCount; ln++) {
           gutter += '<span class="cmux-line-num">' + ln + '</span>';
@@ -1082,16 +1099,14 @@ html { scroll-behavior: smooth; }
         }
         var type = calloutMatch[1].toLowerCase();
         var body = quote.replace(calloutMatch[0], '<p>').replace(/^<p>\s*(?:<br\s*\/?>)?\s*/, '<p>');
-        var icons = {
-          note: '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"/></svg>',
-          tip: '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 1.5c-2.363 0-4 1.69-4 3.75 0 .984.424 1.625.984 2.304l.214.253c.223.264.47.556.673.848.284.411.537.896.621 1.49a.75.75 0 0 1-1.484.211c-.04-.282-.163-.547-.37-.847a8.456 8.456 0 0 0-.542-.68c-.084-.1-.173-.205-.268-.32C3.201 7.75 2.5 6.766 2.5 5.25 2.5 2.31 4.863.5 8 .5s5.5 1.81 5.5 4.75c0 1.516-.701 2.5-1.328 3.259a10.8 10.8 0 0 0-.268.32c-.207.245-.383.453-.542.68-.207.3-.33.565-.37.847a.751.751 0 0 1-1.485-.212c.084-.593.337-1.078.621-1.489.203-.292.45-.584.673-.848.075-.088.147-.173.213-.253.561-.679.985-1.32.985-2.304 0-2.06-1.637-3.75-4-3.75ZM5.75 12h4.5a.75.75 0 0 1 0 1.5h-4.5a.75.75 0 0 1 0-1.5ZM6 15.25a.75.75 0 0 1 .75-.75h2.5a.75.75 0 0 1 0 1.5h-2.5a.75.75 0 0 1-.75-.75Z"/></svg>',
-          important: '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M0 1.75C0 .784.784 0 1.75 0h12.5C15.216 0 16 .784 16 1.75v9.5A1.75 1.75 0 0 1 14.25 13H8.06l-2.573 2.573A1.458 1.458 0 0 1 3 14.543V13H1.75A1.75 1.75 0 0 1 0 11.25Zm1.75-.25a.25.25 0 0 0-.25.25v9.5c0 .138.112.25.25.25h2a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h6.5a.25.25 0 0 0 .25-.25v-9.5a.25.25 0 0 0-.25-.25Zm7 2.25v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 9a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"/></svg>',
-          warning: '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M6.457 1.047c.659-1.234 2.427-1.234 3.086 0l6.082 11.378A1.75 1.75 0 0 1 14.082 15H1.918a1.75 1.75 0 0 1-1.543-2.575Zm1.763.707a.25.25 0 0 0-.44 0L1.698 13.132a.25.25 0 0 0 .22.368h12.164a.25.25 0 0 0 .22-.368Zm.53 3.996v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 11a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"/></svg>',
-          caution: '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"/></svg>'
-        };
         var title = type.charAt(0).toUpperCase() + type.slice(1);
+        // Emit a data-attribute placeholder; the icon <svg> is injected
+        // after sanitization by injectCalloutIcons() so the sanitizer
+        // (which strips all <svg> elements as a hardening measure) cannot
+        // remove our own trusted icons. `type` comes from the allow-listed
+        // capture group above, so the attribute value is safe.
         return '<div class="cmux-callout cmux-callout-' + type + '">'
-          + '<div class="cmux-callout-title">' + (icons[type] || '') + ' ' + title + '</div>'
+          + '<div class="cmux-callout-title" data-cmux-callout-type="' + type + '">' + title + '</div>'
           + '<div class="cmux-callout-body">' + body + '</div>'
           + '</div>\n';
       }
@@ -1359,7 +1374,31 @@ html { scroll-behavior: smooth; }
     });
   }
 
+  // Octicon SVGs for GitHub-style callouts. Kept out of the rendered HTML
+  // pipeline and injected post-sanitization so the sanitizer's blanket
+  // <svg> strip does not remove our own trusted icons. Markup is constant
+  // and never blended with user-supplied content.
+  var calloutIcons = {
+    note: '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"/></svg>',
+    tip: '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 1.5c-2.363 0-4 1.69-4 3.75 0 .984.424 1.625.984 2.304l.214.253c.223.264.47.556.673.848.284.411.537.896.621 1.49a.75.75 0 0 1-1.484.211c-.04-.282-.163-.547-.37-.847a8.456 8.456 0 0 0-.542-.68c-.084-.1-.173-.205-.268-.32C3.201 7.75 2.5 6.766 2.5 5.25 2.5 2.31 4.863.5 8 .5s5.5 1.81 5.5 4.75c0 1.516-.701 2.5-1.328 3.259a10.8 10.8 0 0 0-.268.32c-.207.245-.383.453-.542.68-.207.3-.33.565-.37.847a.751.751 0 0 1-1.485-.212c.084-.593.337-1.078.621-1.489.203-.292.45-.584.673-.848.075-.088.147-.173.213-.253.561-.679.985-1.32.985-2.304 0-2.06-1.637-3.75-4-3.75ZM5.75 12h4.5a.75.75 0 0 1 0 1.5h-4.5a.75.75 0 0 1 0-1.5ZM6 15.25a.75.75 0 0 1 .75-.75h2.5a.75.75 0 0 1 0 1.5h-2.5a.75.75 0 0 1-.75-.75Z"/></svg>',
+    important: '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M0 1.75C0 .784.784 0 1.75 0h12.5C15.216 0 16 .784 16 1.75v9.5A1.75 1.75 0 0 1 14.25 13H8.06l-2.573 2.573A1.458 1.458 0 0 1 3 14.543V13H1.75A1.75 1.75 0 0 1 0 11.25Zm1.75-.25a.25.25 0 0 0-.25.25v9.5c0 .138.112.25.25.25h2a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h6.5a.25.25 0 0 0 .25-.25v-9.5a.25.25 0 0 0-.25-.25Zm7 2.25v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 9a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"/></svg>',
+    warning: '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M6.457 1.047c.659-1.234 2.427-1.234 3.086 0l6.082 11.378A1.75 1.75 0 0 1 14.082 15H1.918a1.75 1.75 0 0 1-1.543-2.575Zm1.763.707a.25.25 0 0 0-.44 0L1.698 13.132a.25.25 0 0 0 .22.368h12.164a.25.25 0 0 0 .22-.368Zm.53 3.996v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 11a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"/></svg>',
+    caution: '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"/></svg>'
+  };
+
+  function injectCalloutIcons() {
+    contentEl.querySelectorAll('.cmux-callout-title[data-cmux-callout-type]').forEach(function(titleEl) {
+      if (titleEl.querySelector('svg')) { return; }
+      var type = String(titleEl.getAttribute('data-cmux-callout-type') || '').toLowerCase();
+      var icon = calloutIcons[type];
+      if (icon) {
+        titleEl.insertAdjacentHTML('afterbegin', icon + ' ');
+      }
+    });
+  }
+
   function postProcessSpecialBlocks() {
+    injectCalloutIcons();
     if (contentEl.querySelector('.cmux-mermaid:not([data-rendered])')) {
       loadLib('mermaid', renderMermaidBlocks);
     }
@@ -1556,7 +1595,7 @@ html { scroll-behavior: smooth; }
   }
   window.__cmuxRenderMarkdown = function(md) {
     if (renderTimer) { clearTimeout(renderTimer); }
-    if (lastRenderedHash === 0) {
+    if (lastRenderedHash === null) {
       doRender(md);
       return;
     }
@@ -1662,8 +1701,12 @@ html { scroll-behavior: smooth; }
 
   // Fix Cmd+A / Ctrl+A to select the entire document content rather
   // than just the focused paragraph (WebKit default behavior).
+  //
+  // Match on ev.code === 'KeyA' (physical key position) rather than
+  // ev.key === 'a' so the shortcut works regardless of keyboard layout
+  // and modifier-induced case changes.
   document.addEventListener('keydown', function(ev) {
-    if ((ev.metaKey || ev.ctrlKey) && !ev.shiftKey && !ev.altKey && ev.key === 'a') {
+    if ((ev.metaKey || ev.ctrlKey) && !ev.shiftKey && !ev.altKey && ev.code === 'KeyA') {
       ev.preventDefault();
       var range = document.createRange();
       range.selectNodeContents(contentEl);

--- a/Resources/markdown-viewer/shell.html
+++ b/Resources/markdown-viewer/shell.html
@@ -50,6 +50,33 @@ body {
   padding: 0; /* hljs class already pads */
   overflow: auto;
 }
+/* Line number gutter for fenced code blocks. */
+pre.cmux-code-with-lines {
+  display: flex;
+  flex-direction: row;
+}
+pre.cmux-code-with-lines code.hljs {
+  flex: 1;
+  min-width: 0;
+}
+.cmux-line-gutter {
+  display: flex;
+  flex-direction: column;
+  padding: 16px 0;
+  padding-right: 12px;
+  padding-left: 12px;
+  border-right: 1px solid var(--borderColor-muted);
+  text-align: right;
+  -webkit-user-select: none;
+  user-select: none;
+  flex-shrink: 0;
+}
+.cmux-line-num {
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--fgColor-muted);
+  opacity: 0.55;
+}
 .cmux-code-block {
   position: relative;
   margin: 0 0 16px 0;
@@ -216,6 +243,39 @@ body {
   margin: 0.6em 0;
   text-align: left;
 }
+/* GitHub-style callout/admonition blocks. */
+.cmux-callout {
+  padding: 12px 16px;
+  margin: 0 0 16px 0;
+  border-left: 4px solid;
+  border-radius: 6px;
+  background: var(--bgColor-muted);
+}
+.cmux-callout-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  font-size: 14px;
+  margin-bottom: 6px;
+}
+.cmux-callout-title svg {
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+}
+.cmux-callout-body > :first-child { margin-top: 0; }
+.cmux-callout-body > :last-child { margin-bottom: 0; }
+.cmux-callout-note   { border-left-color: #539bf5; }
+.cmux-callout-tip    { border-left-color: #3fb950; }
+.cmux-callout-important { border-left-color: #a371f7; }
+.cmux-callout-warning { border-left-color: #d29922; }
+.cmux-callout-caution { border-left-color: #f85149; }
+.cmux-callout-note .cmux-callout-title   { color: #539bf5; }
+.cmux-callout-tip .cmux-callout-title    { color: #3fb950; }
+.cmux-callout-important .cmux-callout-title { color: #a371f7; }
+.cmux-callout-warning .cmux-callout-title { color: #d29922; }
+.cmux-callout-caution .cmux-callout-title { color: #f85149; }
 /* Custom selection color that reads on both themes. */
 ::selection { background: rgba(56, 139, 253, 0.4); }
 /* Smooth-anchor scroll for heading links. */
@@ -951,8 +1011,9 @@ html { scroll-behavior: smooth; }
     pedantic: false,
     renderer: {
       codespan(code) {
-        var raw = code || '';
-        return '<code>' + escapeHtml(raw) + '</code>';
+        // marked v13 passes code already HTML-escaped; don't double-escape.
+        // Markdown-file links are detected later in markMarkdownFileLinks().
+        return '<code>' + (code || '') + '</code>';
       },
       code(code, infostring, escaped) {
         var raw = code || '';
@@ -983,11 +1044,36 @@ html { scroll-behavior: smooth; }
           highlighted = escapeHtml(raw);
         }
         var langClass = langName ? ' language-' + langName : '';
-        return '<pre><code class="hljs' + langClass + '">' + highlighted + '</code></pre>\n';
+        var lineCount = (raw.match(/\n/g) || []).length + 1;
+        var gutter = '';
+        for (var ln = 1; ln <= lineCount; ln++) {
+          gutter += '<span class="cmux-line-num">' + ln + '</span>';
+        }
+        return '<pre class="cmux-code-with-lines"><span class="cmux-line-gutter" aria-hidden="true">' + gutter + '</span><code class="hljs' + langClass + '">' + highlighted + '</code></pre>\n';
       },
       heading(text, level, raw) {
         var slug = uniqueHeadingSlug(raw);
         return '<h' + level + ' id="' + slug + '">' + text + '</h' + level + '>\n';
+      },
+      blockquote(quote) {
+        var calloutMatch = (quote || '').match(/^<p>\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]/i);
+        if (!calloutMatch) {
+          return '<blockquote>\n' + quote + '</blockquote>\n';
+        }
+        var type = calloutMatch[1].toLowerCase();
+        var body = quote.replace(calloutMatch[0], '<p>').replace(/^<p>\s*(?:<br\s*\/?>)?\s*/, '<p>');
+        var icons = {
+          note: '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"/></svg>',
+          tip: '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 1.5c-2.363 0-4 1.69-4 3.75 0 .984.424 1.625.984 2.304l.214.253c.223.264.47.556.673.848.284.411.537.896.621 1.49a.75.75 0 0 1-1.484.211c-.04-.282-.163-.547-.37-.847a8.456 8.456 0 0 0-.542-.68c-.084-.1-.173-.205-.268-.32C3.201 7.75 2.5 6.766 2.5 5.25 2.5 2.31 4.863.5 8 .5s5.5 1.81 5.5 4.75c0 1.516-.701 2.5-1.328 3.259a10.8 10.8 0 0 0-.268.32c-.207.245-.383.453-.542.68-.207.3-.33.565-.37.847a.751.751 0 0 1-1.485-.212c.084-.593.337-1.078.621-1.489.203-.292.45-.584.673-.848.075-.088.147-.173.213-.253.561-.679.985-1.32.985-2.304 0-2.06-1.637-3.75-4-3.75ZM5.75 12h4.5a.75.75 0 0 1 0 1.5h-4.5a.75.75 0 0 1 0-1.5ZM6 15.25a.75.75 0 0 1 .75-.75h2.5a.75.75 0 0 1 0 1.5h-2.5a.75.75 0 0 1-.75-.75Z"/></svg>',
+          important: '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M0 1.75C0 .784.784 0 1.75 0h12.5C15.216 0 16 .784 16 1.75v9.5A1.75 1.75 0 0 1 14.25 13H8.06l-2.573 2.573A1.458 1.458 0 0 1 3 14.543V13H1.75A1.75 1.75 0 0 1 0 11.25Zm1.75-.25a.25.25 0 0 0-.25.25v9.5c0 .138.112.25.25.25h2a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h6.5a.25.25 0 0 0 .25-.25v-9.5a.25.25 0 0 0-.25-.25Zm7 2.25v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 9a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"/></svg>',
+          warning: '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M6.457 1.047c.659-1.234 2.427-1.234 3.086 0l6.082 11.378A1.75 1.75 0 0 1 14.082 15H1.918a1.75 1.75 0 0 1-1.543-2.575Zm1.763.707a.25.25 0 0 0-.44 0L1.698 13.132a.25.25 0 0 0 .22.368h12.164a.25.25 0 0 0 .22-.368Zm.53 3.996v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 11a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"/></svg>',
+          caution: '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"/></svg>'
+        };
+        var title = type.charAt(0).toUpperCase() + type.slice(1);
+        return '<div class="cmux-callout cmux-callout-' + type + '">'
+          + '<div class="cmux-callout-title">' + (icons[type] || '') + ' ' + title + '</div>'
+          + '<div class="cmux-callout-body">' + body + '</div>'
+          + '</div>\n';
       }
     }
   });
@@ -1535,6 +1621,19 @@ html { scroll-behavior: smooth; }
     darkMql.addListener(window.__cmuxApplyTheme);
   }
   window.__cmuxApplyTheme();
+
+  // Fix Cmd+A / Ctrl+A to select the entire document content rather
+  // than just the focused paragraph (WebKit default behavior).
+  document.addEventListener('keydown', function(ev) {
+    if ((ev.metaKey || ev.ctrlKey) && !ev.shiftKey && !ev.altKey && ev.key === 'a') {
+      ev.preventDefault();
+      var range = document.createRange();
+      range.selectNodeContents(contentEl);
+      var sel = window.getSelection();
+      sel.removeAllRanges();
+      sel.addRange(range);
+    }
+  });
 })();
 </script>
 </body>

--- a/Resources/markdown-viewer/shell.html
+++ b/Resources/markdown-viewer/shell.html
@@ -334,7 +334,9 @@ html { scroll-behavior: smooth; }
     var hash = 0x811c9dc5;
     for (var i = 0, len = str.length; i < len; i++) {
       hash ^= str.charCodeAt(i);
-      hash = (hash * 0x01000193) >>> 0;
+      // Math.imul gives C-like 32-bit integer multiply; plain `*` would lose
+      // precision once the product exceeds 2^53, corrupting the hash.
+      hash = Math.imul(hash, 0x01000193) >>> 0;
     }
     return hash;
   }
@@ -920,7 +922,13 @@ html { scroll-behavior: smooth; }
   //                                remote images" privacy gate is bypassed.
   //                                Local (relative/file) images stay on the fast
   //                                path; rewriteLocalImageSources handles them.
-  var sanitizationPattern = /<(?:script|iframe|object|embed|link\b|meta|base|form|button|textarea|select|option|svg|math)\b|<input\b(?![^>]*type\s*=\s*["']?checkbox)|<img\b[^>]*\ssrc\s*=\s*["']?\s*https?:|(?:\son[a-z]+\s*=|\bstyle\s*=|\bsrcdoc\s*=|\bautofocus\b|\bformaction\s*=|\bxlink:href\s*=)|(?:href|src)\s*=\s*["']?\s*(?:javascript|vbscript|data):|(?:href|src)\s*=\s*["'][^"']*&/i;
+  //
+  // INVARIANT: this pattern must be a superset of everything
+  // sanitizeRenderedHTML() would act on. The tag list mirrors blockedTags
+  // (incl. style + media tags audio/video/picture/source/track), and the
+  // entity-reference branch matches quoted AND unquoted href/src values so
+  // forms like `href=&#106;avascript:` cannot skip the slow path.
+  var sanitizationPattern = /<(?:script|iframe|object|embed|link\b|meta|base|style|audio|video|picture|source|track|form|button|textarea|select|option|svg|math)\b|<input\b(?![^>]*type\s*=\s*["']?checkbox)|<img\b[^>]*\ssrc\s*=\s*["']?\s*https?:|(?:\son[a-z]+\s*=|\bstyle\s*=|\bsrcdoc\s*=|\bautofocus\b|\bformaction\s*=|\bxlink:href\s*=)|(?:href|src)\s*=\s*["']?\s*(?:javascript|vbscript|data):|(?:href|src)\s*=\s*(?:"[^"]*&|'[^']*&|[^"'\s>]*&)/i;
   function needsSanitization(html) {
     return sanitizationPattern.test(html || '');
   }
@@ -1619,6 +1627,11 @@ html { scroll-behavior: smooth; }
     var restoreImageSources = options.restoreImageSources !== false;
     var clone = contentEl.cloneNode(true);
     clone.querySelectorAll('.cmux-code-copy-button').forEach(function(el) {
+      el.remove();
+    });
+    // Line-number gutters are viewer chrome, not content — drop them so
+    // exported HTML and copied plain text don't carry "1 2 3 …" line numbers.
+    clone.querySelectorAll('.cmux-line-gutter').forEach(function(el) {
       el.remove();
     });
     clone.querySelectorAll('.cmux-remote-image-placeholder').forEach(function(el) {

--- a/Resources/markdown-viewer/shell.html
+++ b/Resources/markdown-viewer/shell.html
@@ -912,7 +912,15 @@ html { scroll-behavior: smooth; }
   //                                full sanitizer; entity decoding happens at
   //                                attribute-parse time, so the slow path
   //                                gets the resolved value via attr.value.
-  var sanitizationPattern = /<(?:script|iframe|object|embed|link\b|meta|base|form|button|textarea|select|option|svg|math)\b|<input\b(?![^>]*type\s*=\s*["']?checkbox)|(?:\son[a-z]+\s*=|\bstyle\s*=|\bsrcdoc\s*=|\bautofocus\b|\bformaction\s*=|\bxlink:href\s*=)|(?:href|src)\s*=\s*["']?\s*(?:javascript|vbscript|data):|(?:href|src)\s*=\s*["'][^"']*&/i;
+  //   <img ... src=...http(s):     remote images must reach sanitizeRenderedHTML
+  //                                (which runs on an inert <template>) so their
+  //                                live src is stripped into data-cmux-remote-src
+  //                                before insertion — otherwise the browser
+  //                                auto-fetches them and the "don't auto-load
+  //                                remote images" privacy gate is bypassed.
+  //                                Local (relative/file) images stay on the fast
+  //                                path; rewriteLocalImageSources handles them.
+  var sanitizationPattern = /<(?:script|iframe|object|embed|link\b|meta|base|form|button|textarea|select|option|svg|math)\b|<input\b(?![^>]*type\s*=\s*["']?checkbox)|<img\b[^>]*\ssrc\s*=\s*["']?\s*https?:|(?:\son[a-z]+\s*=|\bstyle\s*=|\bsrcdoc\s*=|\bautofocus\b|\bformaction\s*=|\bxlink:href\s*=)|(?:href|src)\s*=\s*["']?\s*(?:javascript|vbscript|data):|(?:href|src)\s*=\s*["'][^"']*&/i;
   function needsSanitization(html) {
     return sanitizationPattern.test(html || '');
   }

--- a/Resources/markdown-viewer/shell.html
+++ b/Resources/markdown-viewer/shell.html
@@ -928,7 +928,7 @@ html { scroll-behavior: smooth; }
   // (incl. style + media tags audio/video/picture/source/track), and the
   // entity-reference branch matches quoted AND unquoted href/src values so
   // forms like `href=&#106;avascript:` cannot skip the slow path.
-  var sanitizationPattern = /<(?:script|iframe|object|embed|link\b|meta|base|style|audio|video|picture|source|track|form|button|textarea|select|option|svg|math)\b|<input\b(?![^>]*type\s*=\s*["']?checkbox)|<img\b[^>]*\ssrc\s*=\s*["']?\s*https?:|(?:\son[a-z]+\s*=|\bstyle\s*=|\bsrcdoc\s*=|\bautofocus\b|\bformaction\s*=|\bxlink:href\s*=)|(?:href|src)\s*=\s*["']?\s*(?:javascript|vbscript|data):|(?:href|src)\s*=\s*(?:"[^"]*&|'[^']*&|[^"'\s>]*&)/i;
+  var sanitizationPattern = /<(?:script|iframe|object|embed|link\b|meta|base|style|audio|video|picture|source|track|form|button|textarea|select|option|svg|math)\b|<input\b(?![^>]*type\s*=\s*["']?checkbox)|<img\b[^>]*\ssrc\s*=\s*["']?\s*https?:|(?:\son[a-z]+\s*=|\bstyle\s*=|\bsrcset\s*=|\bbackground\s*=|\bsrcdoc\s*=|\bautofocus\b|\bformaction\s*=|\bxlink:href\s*=)|(?:href|src)\s*=\s*["']?\s*(?:javascript|vbscript|data):|(?:href|src)\s*=\s*(?:"[^"]*&|'[^']*&|[^"'\s>]*&)/i;
   function needsSanitization(html) {
     return sanitizationPattern.test(html || '');
   }

--- a/Resources/markdown-viewer/shell.html
+++ b/Resources/markdown-viewer/shell.html
@@ -328,6 +328,18 @@ html { scroll-behavior: smooth; }
     return value;
   }
 
+  // FNV-1a hash for fast content-change detection. Uses 32-bit arithmetic
+  // (safe in JS) to avoid the O(n) innerHTML string comparison on re-render.
+  function fnv1aHash(str) {
+    var hash = 0x811c9dc5;
+    for (var i = 0, len = str.length; i < len; i++) {
+      hash ^= str.charCodeAt(i);
+      hash = (hash * 0x01000193) >>> 0;
+    }
+    return hash;
+  }
+  var lastRenderedHash = 0;
+
   function escapeHtml(s) {
     // Let WebKit's HTML serializer do escaping rather than trying
     // to keep a hand-written entity table correct.
@@ -882,6 +894,14 @@ html { scroll-behavior: smooth; }
     } catch (e) {
       return false;
     }
+  }
+
+  // Fast pre-check: most markdown files produce HTML with no dangerous
+  // elements or attributes. This regex tests for patterns the full
+  // TreeWalker sanitizer would act on — if none match, skip the walk.
+  var sanitizationPattern = /<(?:script|iframe|object|embed|link(?:\s)|meta|base|form|button|textarea|select|option|svg|math)\b|<input\b(?![^>]*type\s*=\s*["']?checkbox)|(?:\son[a-z]+=|\bstyle\s*=|\bsrcdoc\s*=|\bautofocus\b|\bformaction\s*=|\bxlink:href\s*=)|(?:href|src)\s*=\s*["']?\s*(?:javascript|vbscript|data):/i;
+  function needsSanitization(html) {
+    return sanitizationPattern.test(html || '');
   }
 
   function sanitizeRenderedHTML(html) {
@@ -1503,15 +1523,22 @@ html { scroll-behavior: smooth; }
     openMarkdownCandidate(rawPath);
   }, true);
 
-  window.__cmuxRenderMarkdown = function(md) {
+  // Debounce rapid re-renders (e.g. atomic write-rename fires watcher
+  // twice in quick succession). 80ms is fast enough to feel instant but
+  // collapses bursts from editors like vim, emacs, and VS Code.
+  var renderTimer = null;
+  function doRender(md) {
     try {
       headingSlugCounts = Object.create(null);
       var documentParts = extractFrontmatter(md || '');
+      var parsed = marked.parse(documentParts.body || '');
       var html = renderFrontmatter(documentParts.frontmatter)
-        + sanitizeRenderedHTML(marked.parse(documentParts.body || ''));
-      var didReplaceContent = contentEl.innerHTML !== html;
+        + (needsSanitization(parsed) ? sanitizeRenderedHTML(parsed) : parsed);
+      var hash = fnv1aHash(html);
+      var didReplaceContent = hash !== lastRenderedHash;
       var scrollState = didReplaceContent ? captureMarkdownScrollState() : null;
       if (didReplaceContent) {
+        lastRenderedHash = hash;
         contentEl.innerHTML = html;
       }
       rewriteLocalImageSources();
@@ -1526,6 +1553,17 @@ html { scroll-behavior: smooth; }
         + 'markdown render error: ' + escapeHtml(String((e && e.message) || e))
         + '</div><pre><code>' + escapeHtml(md || '') + '</code></pre>';
     }
+  }
+  window.__cmuxRenderMarkdown = function(md) {
+    if (renderTimer) { clearTimeout(renderTimer); }
+    if (lastRenderedHash === 0) {
+      doRender(md);
+      return;
+    }
+    renderTimer = setTimeout(function() {
+      renderTimer = null;
+      doRender(md);
+    }, 80);
   };
 
   function cleanRenderedContentClone(options) {

--- a/Resources/markdown-viewer/shell.html
+++ b/Resources/markdown-viewer/shell.html
@@ -900,35 +900,63 @@ html { scroll-behavior: smooth; }
     }
   }
 
-  // Fast pre-check: most markdown files produce HTML with no dangerous
-  // elements or attributes. This regex tests for patterns the full
-  // TreeWalker sanitizer would act on — if none match, skip the walk.
-  //
-  // Notes on each alternation:
-  //   <link\b ...                  word-boundary, not <link(?:\s) — catches
-  //                                <link> with no following whitespace.
-  //   \son[a-z]+\s*=               whitespace before `=` is tolerated by
-  //                                browsers, so `onload =` must still match.
-  //   (?:href|src) ... &           any character reference inside an href/src
-  //                                value (e.g. `&#106;avascript:`) forces the
-  //                                full sanitizer; entity decoding happens at
-  //                                attribute-parse time, so the slow path
-  //                                gets the resolved value via attr.value.
-  //   <img ... src=...http(s):     remote images must reach sanitizeRenderedHTML
-  //                                (which runs on an inert <template>) so their
-  //                                live src is stripped into data-cmux-remote-src
-  //                                before insertion — otherwise the browser
-  //                                auto-fetches them and the "don't auto-load
-  //                                remote images" privacy gate is bypassed.
-  //                                Local (relative/file) images stay on the fast
-  //                                path; rewriteLocalImageSources handles them.
-  //
-  // INVARIANT: this pattern must be a superset of everything
-  // sanitizeRenderedHTML() would act on. The tag list mirrors blockedTags
-  // (incl. style + media tags audio/video/picture/source/track), and the
-  // entity-reference branch matches quoted AND unquoted href/src values so
-  // forms like `href=&#106;avascript:` cannot skip the slow path.
-  var sanitizationPattern = /<(?:script|iframe|object|embed|link\b|meta|base|style|audio|video|picture|source|track|form|button|textarea|select|option|svg|math)\b|<input\b(?![^>]*type\s*=\s*["']?checkbox)|<img\b[^>]*\ssrc\s*=\s*["']?\s*https?:|(?:\son[a-z]+\s*=|\bstyle\s*=|\bsrcset\s*=|\bbackground\s*=|\bsrcdoc\s*=|\bautofocus\b|\bformaction\s*=|\bxlink:href\s*=)|(?:href|src)\s*=\s*["']?\s*(?:javascript|vbscript|data):|(?:href|src)\s*=\s*(?:"[^"]*&|'[^']*&|[^"'\s>]*&)/i;
+  // Single source of truth for sanitization. Both the full TreeWalker
+  // sanitizer (sanitizeRenderedHTML) and the fast pre-check (needsSanitization)
+  // are derived from these lists, so the fast-path can never drift out of sync
+  // with what the sanitizer actually strips. Add a tag or attribute here once
+  // and both paths update together.
+  var SANITIZER_BLOCKED_TAGS = {
+    script: true, iframe: true, object: true, embed: true, link: true,
+    meta: true, base: true, style: true, audio: true, video: true,
+    picture: true, source: true, track: true, form: true, button: true,
+    textarea: true, select: true, option: true, svg: true, math: true
+  };
+  // Attributes the sanitizer strips outright. Any on* event handler is also
+  // stripped (handled by prefix, not listed here). `input` (checkbox-only) and
+  // remote <img> src are special-cased in both the sanitizer and the pattern.
+  var SANITIZER_BLOCKED_ATTRS = [
+    'style', 'background', 'srcset', 'srcdoc', 'autofocus', 'formaction', 'xlink:href'
+  ];
+  // Valueless-capable (boolean) attributes match on a word boundary in the
+  // fast-path regex rather than requiring `=` (e.g. bare `<button autofocus>`).
+  var SANITIZER_BOOLEAN_ATTRS = { autofocus: true };
+
+  function reEscapeForPattern(s) {
+    return String(s).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  }
+
+  // Build the fast pre-check regex from the same lists the sanitizer uses.
+  // Most markdown produces HTML with nothing dangerous; when none of these
+  // alternations match we skip the TreeWalker walk entirely.
+  //   - tag list           mirrors SANITIZER_BLOCKED_TAGS
+  //   - <input ...checkbox  input is allowed only as a checkbox
+  //   - <img ...src=http(s) remote images must reach sanitizeRenderedHTML
+  //                         (which runs on an inert <template>) so the live src
+  //                         is stripped before the browser auto-fetches it —
+  //                         the "don't auto-load remote images" privacy gate.
+  //                         Local/relative images stay on the fast path.
+  //   - on* / blocked attrs mirror SANITIZER_BLOCKED_ATTRS
+  //   - javascript:/...     active-protocol href/src
+  //   - href/src ... &      any character reference (quoted or unquoted) in an
+  //                         href/src value, so entity-encoded payloads like
+  //                         `href=&#106;avascript:` can't skip the slow path.
+  function buildSanitizationPattern() {
+    var tags = Object.keys(SANITIZER_BLOCKED_TAGS).map(reEscapeForPattern).join('|');
+    var attrs = SANITIZER_BLOCKED_ATTRS.map(function(a) {
+      var esc = reEscapeForPattern(a);
+      return SANITIZER_BOOLEAN_ATTRS[a] ? '\\b' + esc + '\\b' : '\\b' + esc + '\\s*=';
+    }).join('|');
+    return new RegExp(
+      '<(?:' + tags + ')\\b' +
+      '|<input\\b(?![^>]*type\\s*=\\s*["\']?checkbox)' +
+      '|<img\\b[^>]*\\ssrc\\s*=\\s*["\']?\\s*https?:' +
+      '|(?:\\son[a-z]+\\s*=|' + attrs + ')' +
+      '|(?:href|src)\\s*=\\s*["\']?\\s*(?:javascript|vbscript|data):' +
+      '|(?:href|src)\\s*=\\s*(?:"[^"]*&|\'[^\']*&|[^"\'\\s>]*&)',
+      'i'
+    );
+  }
+  var sanitizationPattern = buildSanitizationPattern();
   function needsSanitization(html) {
     return sanitizationPattern.test(html || '');
   }
@@ -937,28 +965,9 @@ html { scroll-behavior: smooth; }
     var template = document.createElement('template');
     template.innerHTML = String(html || '');
 
-    var blockedTags = {
-      script: true,
-      iframe: true,
-      object: true,
-      embed: true,
-      link: true,
-      style: true,
-      meta: true,
-      base: true,
-      audio: true,
-      form: true,
-      button: true,
-      picture: true,
-      source: true,
-      textarea: true,
-      track: true,
-      video: true,
-      select: true,
-      option: true,
-      svg: true,
-      math: true
-    };
+    // Reuse the shared block list so the sanitizer and the fast-path regex
+    // (buildSanitizationPattern) can never disagree about which tags to strip.
+    var blockedTags = SANITIZER_BLOCKED_TAGS;
 
     var walker = document.createTreeWalker(template.content, NodeFilter.SHOW_ELEMENT);
     var elements = [];
@@ -995,16 +1004,7 @@ html { scroll-behavior: smooth; }
           el.removeAttribute(attr.name);
           return;
         }
-        if (
-          name.indexOf('on') === 0 ||
-          name === 'style' ||
-          name === 'background' ||
-          name === 'srcset' ||
-          name === 'srcdoc' ||
-          name === 'autofocus' ||
-          name === 'formaction' ||
-          name === 'xlink:href'
-        ) {
+        if (name.indexOf('on') === 0 || SANITIZER_BLOCKED_ATTRS.indexOf(name) !== -1) {
           el.removeAttribute(attr.name);
           return;
         }

--- a/Resources/markdown-viewer/shell.html
+++ b/Resources/markdown-viewer/shell.html
@@ -50,6 +50,33 @@ body {
   padding: 0; /* hljs class already pads */
   overflow: auto;
 }
+/* Line number gutter for fenced code blocks. */
+pre.cmux-code-with-lines {
+  display: flex;
+  flex-direction: row;
+}
+pre.cmux-code-with-lines code.hljs {
+  flex: 1;
+  min-width: 0;
+}
+.cmux-line-gutter {
+  display: flex;
+  flex-direction: column;
+  padding: 16px 0;
+  padding-right: 12px;
+  padding-left: 12px;
+  border-right: 1px solid var(--borderColor-muted);
+  text-align: right;
+  -webkit-user-select: none;
+  user-select: none;
+  flex-shrink: 0;
+}
+.cmux-line-num {
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--fgColor-muted);
+  opacity: 0.55;
+}
 .cmux-code-block {
   position: relative;
   margin: 0 0 16px 0;
@@ -225,6 +252,39 @@ body {
   margin: 0.6em 0;
   text-align: left;
 }
+/* GitHub-style callout/admonition blocks. */
+.cmux-callout {
+  padding: 12px 16px;
+  margin: 0 0 16px 0;
+  border-left: 4px solid;
+  border-radius: 6px;
+  background: var(--bgColor-muted);
+}
+.cmux-callout-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  font-size: 14px;
+  margin-bottom: 6px;
+}
+.cmux-callout-title svg {
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+}
+.cmux-callout-body > :first-child { margin-top: 0; }
+.cmux-callout-body > :last-child { margin-bottom: 0; }
+.cmux-callout-note   { border-left-color: #539bf5; }
+.cmux-callout-tip    { border-left-color: #3fb950; }
+.cmux-callout-important { border-left-color: #a371f7; }
+.cmux-callout-warning { border-left-color: #d29922; }
+.cmux-callout-caution { border-left-color: #f85149; }
+.cmux-callout-note .cmux-callout-title   { color: #539bf5; }
+.cmux-callout-tip .cmux-callout-title    { color: #3fb950; }
+.cmux-callout-important .cmux-callout-title { color: #a371f7; }
+.cmux-callout-warning .cmux-callout-title { color: #d29922; }
+.cmux-callout-caution .cmux-callout-title { color: #f85149; }
 /* Custom selection color that reads on both themes. */
 ::selection { background: rgba(56, 139, 253, 0.4); }
 /* Smooth-anchor scroll for heading links. */
@@ -1012,8 +1072,9 @@ html { scroll-behavior: smooth; }
     pedantic: false,
     renderer: {
       codespan(code) {
-        var raw = code || '';
-        return '<code>' + escapeHtml(raw) + '</code>';
+        // marked v13 passes code already HTML-escaped; don't double-escape.
+        // Markdown-file links are detected later in markMarkdownFileLinks().
+        return '<code>' + (code || '') + '</code>';
       },
       code(code, infostring, escaped) {
         var raw = code || '';
@@ -1044,7 +1105,12 @@ html { scroll-behavior: smooth; }
           highlighted = escapeHtml(raw);
         }
         var langClass = langName ? ' language-' + langName : '';
-        return '<pre><code class="hljs' + langClass + '">' + highlighted + '</code></pre>\n';
+        var lineCount = (raw.match(/\n/g) || []).length + 1;
+        var gutter = '';
+        for (var ln = 1; ln <= lineCount; ln++) {
+          gutter += '<span class="cmux-line-num">' + ln + '</span>';
+        }
+        return '<pre class="cmux-code-with-lines"><span class="cmux-line-gutter" aria-hidden="true">' + gutter + '</span><code class="hljs' + langClass + '">' + highlighted + '</code></pre>\n';
       },
       heading(text, level, raw) {
         var slug = uniqueHeadingSlug(raw);
@@ -1056,6 +1122,26 @@ html { scroll-behavior: smooth; }
           html += ' title="' + escapeAttribute(decodeHTML(title)) + '"';
         }
         return html + '>' + sanitizeLinkLabelHTML(text) + '</a>';
+      },
+      blockquote(quote) {
+        var calloutMatch = (quote || '').match(/^<p>\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]/i);
+        if (!calloutMatch) {
+          return '<blockquote>\n' + quote + '</blockquote>\n';
+        }
+        var type = calloutMatch[1].toLowerCase();
+        var body = quote.replace(calloutMatch[0], '<p>').replace(/^<p>\s*(?:<br\s*\/?>)?\s*/, '<p>');
+        var icons = {
+          note: '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"/></svg>',
+          tip: '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 1.5c-2.363 0-4 1.69-4 3.75 0 .984.424 1.625.984 2.304l.214.253c.223.264.47.556.673.848.284.411.537.896.621 1.49a.75.75 0 0 1-1.484.211c-.04-.282-.163-.547-.37-.847a8.456 8.456 0 0 0-.542-.68c-.084-.1-.173-.205-.268-.32C3.201 7.75 2.5 6.766 2.5 5.25 2.5 2.31 4.863.5 8 .5s5.5 1.81 5.5 4.75c0 1.516-.701 2.5-1.328 3.259a10.8 10.8 0 0 0-.268.32c-.207.245-.383.453-.542.68-.207.3-.33.565-.37.847a.751.751 0 0 1-1.485-.212c.084-.593.337-1.078.621-1.489.203-.292.45-.584.673-.848.075-.088.147-.173.213-.253.561-.679.985-1.32.985-2.304 0-2.06-1.637-3.75-4-3.75ZM5.75 12h4.5a.75.75 0 0 1 0 1.5h-4.5a.75.75 0 0 1 0-1.5ZM6 15.25a.75.75 0 0 1 .75-.75h2.5a.75.75 0 0 1 0 1.5h-2.5a.75.75 0 0 1-.75-.75Z"/></svg>',
+          important: '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M0 1.75C0 .784.784 0 1.75 0h12.5C15.216 0 16 .784 16 1.75v9.5A1.75 1.75 0 0 1 14.25 13H8.06l-2.573 2.573A1.458 1.458 0 0 1 3 14.543V13H1.75A1.75 1.75 0 0 1 0 11.25Zm1.75-.25a.25.25 0 0 0-.25.25v9.5c0 .138.112.25.25.25h2a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h6.5a.25.25 0 0 0 .25-.25v-9.5a.25.25 0 0 0-.25-.25Zm7 2.25v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 9a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"/></svg>',
+          warning: '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M6.457 1.047c.659-1.234 2.427-1.234 3.086 0l6.082 11.378A1.75 1.75 0 0 1 14.082 15H1.918a1.75 1.75 0 0 1-1.543-2.575Zm1.763.707a.25.25 0 0 0-.44 0L1.698 13.132a.25.25 0 0 0 .22.368h12.164a.25.25 0 0 0 .22-.368Zm.53 3.996v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 11a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"/></svg>',
+          caution: '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"/></svg>'
+        };
+        var title = type.charAt(0).toUpperCase() + type.slice(1);
+        return '<div class="cmux-callout cmux-callout-' + type + '">'
+          + '<div class="cmux-callout-title">' + (icons[type] || '') + ' ' + title + '</div>'
+          + '<div class="cmux-callout-body">' + body + '</div>'
+          + '</div>\n';
       }
     }
   });
@@ -1824,6 +1910,19 @@ html { scroll-behavior: smooth; }
   CmuxViewerNavigation.installManualInputReset({
     target: document,
     getScroller: markdownScroller
+  });
+
+  // Fix Cmd+A / Ctrl+A to select the entire document content rather
+  // than just the focused paragraph (WebKit default behavior).
+  document.addEventListener('keydown', function(ev) {
+    if ((ev.metaKey || ev.ctrlKey) && !ev.shiftKey && !ev.altKey && ev.key === 'a') {
+      ev.preventDefault();
+      var range = document.createRange();
+      range.selectNodeContents(contentEl);
+      var sel = window.getSelection();
+      sel.removeAllRanges();
+      sel.addRange(range);
+    }
   });
 })();
 </script>

--- a/Resources/markdown-viewer/shell.html
+++ b/Resources/markdown-viewer/shell.html
@@ -989,7 +989,7 @@ html { scroll-behavior: smooth; }
   // (incl. style + media tags audio/video/picture/source/track), and the
   // entity-reference branch matches quoted AND unquoted href/src values so
   // forms like `href=&#106;avascript:` cannot skip the slow path.
-  var sanitizationPattern = /<(?:script|iframe|object|embed|link\b|meta|base|style|audio|video|picture|source|track|form|button|textarea|select|option|svg|math)\b|<input\b(?![^>]*type\s*=\s*["']?checkbox)|<img\b[^>]*\ssrc\s*=\s*["']?\s*https?:|(?:\son[a-z]+\s*=|\bstyle\s*=|\bsrcdoc\s*=|\bautofocus\b|\bformaction\s*=|\bxlink:href\s*=)|(?:href|src)\s*=\s*["']?\s*(?:javascript|vbscript|data):|(?:href|src)\s*=\s*(?:"[^"]*&|'[^']*&|[^"'\s>]*&)/i;
+  var sanitizationPattern = /<(?:script|iframe|object|embed|link\b|meta|base|style|audio|video|picture|source|track|form|button|textarea|select|option|svg|math)\b|<input\b(?![^>]*type\s*=\s*["']?checkbox)|<img\b[^>]*\ssrc\s*=\s*["']?\s*https?:|(?:\son[a-z]+\s*=|\bstyle\s*=|\bsrcset\s*=|\bbackground\s*=|\bsrcdoc\s*=|\bautofocus\b|\bformaction\s*=|\bxlink:href\s*=)|(?:href|src)\s*=\s*["']?\s*(?:javascript|vbscript|data):|(?:href|src)\s*=\s*(?:"[^"]*&|'[^']*&|[^"'\s>]*&)/i;
   function needsSanitization(html) {
     return sanitizationPattern.test(html || '');
   }

--- a/Resources/markdown-viewer/shell.html
+++ b/Resources/markdown-viewer/shell.html
@@ -346,7 +346,9 @@ html { scroll-behavior: smooth; }
     var hash = 0x811c9dc5;
     for (var i = 0, len = str.length; i < len; i++) {
       hash ^= str.charCodeAt(i);
-      hash = (hash * 0x01000193) >>> 0;
+      // Math.imul gives C-like 32-bit integer multiply; plain `*` would lose
+      // precision once the product exceeds 2^53, corrupting the hash.
+      hash = Math.imul(hash, 0x01000193) >>> 0;
     }
     return hash;
   }
@@ -981,7 +983,13 @@ html { scroll-behavior: smooth; }
   //                                remote images" privacy gate is bypassed.
   //                                Local (relative/file) images stay on the fast
   //                                path; rewriteLocalImageSources handles them.
-  var sanitizationPattern = /<(?:script|iframe|object|embed|link\b|meta|base|form|button|textarea|select|option|svg|math)\b|<input\b(?![^>]*type\s*=\s*["']?checkbox)|<img\b[^>]*\ssrc\s*=\s*["']?\s*https?:|(?:\son[a-z]+\s*=|\bstyle\s*=|\bsrcdoc\s*=|\bautofocus\b|\bformaction\s*=|\bxlink:href\s*=)|(?:href|src)\s*=\s*["']?\s*(?:javascript|vbscript|data):|(?:href|src)\s*=\s*["'][^"']*&/i;
+  //
+  // INVARIANT: this pattern must be a superset of everything
+  // sanitizeRenderedHTML() would act on. The tag list mirrors blockedTags
+  // (incl. style + media tags audio/video/picture/source/track), and the
+  // entity-reference branch matches quoted AND unquoted href/src values so
+  // forms like `href=&#106;avascript:` cannot skip the slow path.
+  var sanitizationPattern = /<(?:script|iframe|object|embed|link\b|meta|base|style|audio|video|picture|source|track|form|button|textarea|select|option|svg|math)\b|<input\b(?![^>]*type\s*=\s*["']?checkbox)|<img\b[^>]*\ssrc\s*=\s*["']?\s*https?:|(?:\son[a-z]+\s*=|\bstyle\s*=|\bsrcdoc\s*=|\bautofocus\b|\bformaction\s*=|\bxlink:href\s*=)|(?:href|src)\s*=\s*["']?\s*(?:javascript|vbscript|data):|(?:href|src)\s*=\s*(?:"[^"]*&|'[^']*&|[^"'\s>]*&)/i;
   function needsSanitization(html) {
     return sanitizationPattern.test(html || '');
   }
@@ -1899,6 +1907,11 @@ html { scroll-behavior: smooth; }
     var restoreImageSources = options.restoreImageSources !== false;
     var clone = contentEl.cloneNode(true);
     clone.querySelectorAll('.cmux-code-copy-button').forEach(function(el) {
+      el.remove();
+    });
+    // Line-number gutters are viewer chrome, not content — drop them so
+    // exported HTML and copied plain text don't carry "1 2 3 …" line numbers.
+    clone.querySelectorAll('.cmux-line-gutter').forEach(function(el) {
       el.remove();
     });
     clone.querySelectorAll('.cmux-remote-image-placeholder').forEach(function(el) {

--- a/Resources/markdown-viewer/shell.html
+++ b/Resources/markdown-viewer/shell.html
@@ -350,7 +350,9 @@ html { scroll-behavior: smooth; }
     }
     return hash;
   }
-  var lastRenderedHash = 0;
+  // Sentinel must not collide with any valid fnv1aHash() output. fnv1aHash
+  // ends with `>>> 0`, which produces 0..2^32-1; null sits outside that range.
+  var lastRenderedHash = null;
 
   function escapeHtml(s) {
     // Let WebKit's HTML serializer do escaping rather than trying
@@ -960,7 +962,18 @@ html { scroll-behavior: smooth; }
   // Fast pre-check: most markdown files produce HTML with no dangerous
   // elements or attributes. This regex tests for patterns the full
   // TreeWalker sanitizer would act on — if none match, skip the walk.
-  var sanitizationPattern = /<(?:script|iframe|object|embed|link(?:\s)|meta|base|form|button|textarea|select|option|svg|math)\b|<input\b(?![^>]*type\s*=\s*["']?checkbox)|(?:\son[a-z]+=|\bstyle\s*=|\bsrcdoc\s*=|\bautofocus\b|\bformaction\s*=|\bxlink:href\s*=)|(?:href|src)\s*=\s*["']?\s*(?:javascript|vbscript|data):/i;
+  //
+  // Notes on each alternation:
+  //   <link\b ...                  word-boundary, not <link(?:\s) — catches
+  //                                <link> with no following whitespace.
+  //   \son[a-z]+\s*=               whitespace before `=` is tolerated by
+  //                                browsers, so `onload =` must still match.
+  //   (?:href|src) ... &           any character reference inside an href/src
+  //                                value (e.g. `&#106;avascript:`) forces the
+  //                                full sanitizer; entity decoding happens at
+  //                                attribute-parse time, so the slow path
+  //                                gets the resolved value via attr.value.
+  var sanitizationPattern = /<(?:script|iframe|object|embed|link\b|meta|base|form|button|textarea|select|option|svg|math)\b|<input\b(?![^>]*type\s*=\s*["']?checkbox)|(?:\son[a-z]+\s*=|\bstyle\s*=|\bsrcdoc\s*=|\bautofocus\b|\bformaction\s*=|\bxlink:href\s*=)|(?:href|src)\s*=\s*["']?\s*(?:javascript|vbscript|data):|(?:href|src)\s*=\s*["'][^"']*&/i;
   function needsSanitization(html) {
     return sanitizationPattern.test(html || '');
   }
@@ -1125,7 +1138,11 @@ html { scroll-behavior: smooth; }
           highlighted = escapeHtml(raw);
         }
         var langClass = langName ? ' language-' + langName : '';
-        var lineCount = (raw.match(/\n/g) || []).length + 1;
+        // Strip exactly one trailing newline before counting lines so code
+        // blocks that end in "\n" (the common case from marked) don't render
+        // a phantom empty line number in the gutter.
+        var rawForLineCount = raw.replace(/\r?\n$/, '');
+        var lineCount = (rawForLineCount.match(/\n/g) || []).length + 1;
         var gutter = '';
         for (var ln = 1; ln <= lineCount; ln++) {
           gutter += '<span class="cmux-line-num">' + ln + '</span>';
@@ -1150,16 +1167,14 @@ html { scroll-behavior: smooth; }
         }
         var type = calloutMatch[1].toLowerCase();
         var body = quote.replace(calloutMatch[0], '<p>').replace(/^<p>\s*(?:<br\s*\/?>)?\s*/, '<p>');
-        var icons = {
-          note: '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"/></svg>',
-          tip: '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 1.5c-2.363 0-4 1.69-4 3.75 0 .984.424 1.625.984 2.304l.214.253c.223.264.47.556.673.848.284.411.537.896.621 1.49a.75.75 0 0 1-1.484.211c-.04-.282-.163-.547-.37-.847a8.456 8.456 0 0 0-.542-.68c-.084-.1-.173-.205-.268-.32C3.201 7.75 2.5 6.766 2.5 5.25 2.5 2.31 4.863.5 8 .5s5.5 1.81 5.5 4.75c0 1.516-.701 2.5-1.328 3.259a10.8 10.8 0 0 0-.268.32c-.207.245-.383.453-.542.68-.207.3-.33.565-.37.847a.751.751 0 0 1-1.485-.212c.084-.593.337-1.078.621-1.489.203-.292.45-.584.673-.848.075-.088.147-.173.213-.253.561-.679.985-1.32.985-2.304 0-2.06-1.637-3.75-4-3.75ZM5.75 12h4.5a.75.75 0 0 1 0 1.5h-4.5a.75.75 0 0 1 0-1.5ZM6 15.25a.75.75 0 0 1 .75-.75h2.5a.75.75 0 0 1 0 1.5h-2.5a.75.75 0 0 1-.75-.75Z"/></svg>',
-          important: '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M0 1.75C0 .784.784 0 1.75 0h12.5C15.216 0 16 .784 16 1.75v9.5A1.75 1.75 0 0 1 14.25 13H8.06l-2.573 2.573A1.458 1.458 0 0 1 3 14.543V13H1.75A1.75 1.75 0 0 1 0 11.25Zm1.75-.25a.25.25 0 0 0-.25.25v9.5c0 .138.112.25.25.25h2a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h6.5a.25.25 0 0 0 .25-.25v-9.5a.25.25 0 0 0-.25-.25Zm7 2.25v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 9a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"/></svg>',
-          warning: '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M6.457 1.047c.659-1.234 2.427-1.234 3.086 0l6.082 11.378A1.75 1.75 0 0 1 14.082 15H1.918a1.75 1.75 0 0 1-1.543-2.575Zm1.763.707a.25.25 0 0 0-.44 0L1.698 13.132a.25.25 0 0 0 .22.368h12.164a.25.25 0 0 0 .22-.368Zm.53 3.996v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 11a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"/></svg>',
-          caution: '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"/></svg>'
-        };
         var title = type.charAt(0).toUpperCase() + type.slice(1);
+        // Emit a data-attribute placeholder; the icon <svg> is injected
+        // after sanitization by injectCalloutIcons() so the sanitizer
+        // (which strips all <svg> elements as a hardening measure) cannot
+        // remove our own trusted icons. `type` comes from the allow-listed
+        // capture group above, so the attribute value is safe.
         return '<div class="cmux-callout cmux-callout-' + type + '">'
-          + '<div class="cmux-callout-title">' + (icons[type] || '') + ' ' + title + '</div>'
+          + '<div class="cmux-callout-title" data-cmux-callout-type="' + type + '">' + title + '</div>'
           + '<div class="cmux-callout-body">' + body + '</div>'
           + '</div>\n';
       }
@@ -1639,7 +1654,31 @@ html { scroll-behavior: smooth; }
     });
   }
 
+  // Octicon SVGs for GitHub-style callouts. Kept out of the rendered HTML
+  // pipeline and injected post-sanitization so the sanitizer's blanket
+  // <svg> strip does not remove our own trusted icons. Markup is constant
+  // and never blended with user-supplied content.
+  var calloutIcons = {
+    note: '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"/></svg>',
+    tip: '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 1.5c-2.363 0-4 1.69-4 3.75 0 .984.424 1.625.984 2.304l.214.253c.223.264.47.556.673.848.284.411.537.896.621 1.49a.75.75 0 0 1-1.484.211c-.04-.282-.163-.547-.37-.847a8.456 8.456 0 0 0-.542-.68c-.084-.1-.173-.205-.268-.32C3.201 7.75 2.5 6.766 2.5 5.25 2.5 2.31 4.863.5 8 .5s5.5 1.81 5.5 4.75c0 1.516-.701 2.5-1.328 3.259a10.8 10.8 0 0 0-.268.32c-.207.245-.383.453-.542.68-.207.3-.33.565-.37.847a.751.751 0 0 1-1.485-.212c.084-.593.337-1.078.621-1.489.203-.292.45-.584.673-.848.075-.088.147-.173.213-.253.561-.679.985-1.32.985-2.304 0-2.06-1.637-3.75-4-3.75ZM5.75 12h4.5a.75.75 0 0 1 0 1.5h-4.5a.75.75 0 0 1 0-1.5ZM6 15.25a.75.75 0 0 1 .75-.75h2.5a.75.75 0 0 1 0 1.5h-2.5a.75.75 0 0 1-.75-.75Z"/></svg>',
+    important: '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M0 1.75C0 .784.784 0 1.75 0h12.5C15.216 0 16 .784 16 1.75v9.5A1.75 1.75 0 0 1 14.25 13H8.06l-2.573 2.573A1.458 1.458 0 0 1 3 14.543V13H1.75A1.75 1.75 0 0 1 0 11.25Zm1.75-.25a.25.25 0 0 0-.25.25v9.5c0 .138.112.25.25.25h2a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h6.5a.25.25 0 0 0 .25-.25v-9.5a.25.25 0 0 0-.25-.25Zm7 2.25v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 9a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"/></svg>',
+    warning: '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M6.457 1.047c.659-1.234 2.427-1.234 3.086 0l6.082 11.378A1.75 1.75 0 0 1 14.082 15H1.918a1.75 1.75 0 0 1-1.543-2.575Zm1.763.707a.25.25 0 0 0-.44 0L1.698 13.132a.25.25 0 0 0 .22.368h12.164a.25.25 0 0 0 .22-.368Zm.53 3.996v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 11a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"/></svg>',
+    caution: '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"/></svg>'
+  };
+
+  function injectCalloutIcons() {
+    contentEl.querySelectorAll('.cmux-callout-title[data-cmux-callout-type]').forEach(function(titleEl) {
+      if (titleEl.querySelector('svg')) { return; }
+      var type = String(titleEl.getAttribute('data-cmux-callout-type') || '').toLowerCase();
+      var icon = calloutIcons[type];
+      if (icon) {
+        titleEl.insertAdjacentHTML('afterbegin', icon + ' ');
+      }
+    });
+  }
+
   function postProcessSpecialBlocks() {
+    injectCalloutIcons();
     if (contentEl.querySelector('.cmux-mermaid:not([data-rendered])')) {
       loadLib('mermaid', renderMermaidBlocks);
     }
@@ -1836,7 +1875,7 @@ html { scroll-behavior: smooth; }
   }
   window.__cmuxRenderMarkdown = function(md) {
     if (renderTimer) { clearTimeout(renderTimer); }
-    if (lastRenderedHash === 0) {
+    if (lastRenderedHash === null) {
       doRender(md);
       return;
     }
@@ -1952,8 +1991,12 @@ html { scroll-behavior: smooth; }
 
   // Fix Cmd+A / Ctrl+A to select the entire document content rather
   // than just the focused paragraph (WebKit default behavior).
+  //
+  // Match on ev.code === 'KeyA' (physical key position) rather than
+  // ev.key === 'a' so the shortcut works regardless of keyboard layout
+  // and modifier-induced case changes.
   document.addEventListener('keydown', function(ev) {
-    if ((ev.metaKey || ev.ctrlKey) && !ev.shiftKey && !ev.altKey && ev.key === 'a') {
+    if ((ev.metaKey || ev.ctrlKey) && !ev.shiftKey && !ev.altKey && ev.code === 'KeyA') {
       ev.preventDefault();
       var range = document.createRange();
       range.selectNodeContents(contentEl);

--- a/Resources/markdown-viewer/shell.html
+++ b/Resources/markdown-viewer/shell.html
@@ -973,7 +973,15 @@ html { scroll-behavior: smooth; }
   //                                full sanitizer; entity decoding happens at
   //                                attribute-parse time, so the slow path
   //                                gets the resolved value via attr.value.
-  var sanitizationPattern = /<(?:script|iframe|object|embed|link\b|meta|base|form|button|textarea|select|option|svg|math)\b|<input\b(?![^>]*type\s*=\s*["']?checkbox)|(?:\son[a-z]+\s*=|\bstyle\s*=|\bsrcdoc\s*=|\bautofocus\b|\bformaction\s*=|\bxlink:href\s*=)|(?:href|src)\s*=\s*["']?\s*(?:javascript|vbscript|data):|(?:href|src)\s*=\s*["'][^"']*&/i;
+  //   <img ... src=...http(s):     remote images must reach sanitizeRenderedHTML
+  //                                (which runs on an inert <template>) so their
+  //                                live src is stripped into data-cmux-remote-src
+  //                                before insertion — otherwise the browser
+  //                                auto-fetches them and the "don't auto-load
+  //                                remote images" privacy gate is bypassed.
+  //                                Local (relative/file) images stay on the fast
+  //                                path; rewriteLocalImageSources handles them.
+  var sanitizationPattern = /<(?:script|iframe|object|embed|link\b|meta|base|form|button|textarea|select|option|svg|math)\b|<input\b(?![^>]*type\s*=\s*["']?checkbox)|<img\b[^>]*\ssrc\s*=\s*["']?\s*https?:|(?:\son[a-z]+\s*=|\bstyle\s*=|\bsrcdoc\s*=|\bautofocus\b|\bformaction\s*=|\bxlink:href\s*=)|(?:href|src)\s*=\s*["']?\s*(?:javascript|vbscript|data):|(?:href|src)\s*=\s*["'][^"']*&/i;
   function needsSanitization(html) {
     return sanitizationPattern.test(html || '');
   }

--- a/Resources/markdown-viewer/shell.html
+++ b/Resources/markdown-viewer/shell.html
@@ -961,35 +961,63 @@ html { scroll-behavior: smooth; }
     }
   }
 
-  // Fast pre-check: most markdown files produce HTML with no dangerous
-  // elements or attributes. This regex tests for patterns the full
-  // TreeWalker sanitizer would act on — if none match, skip the walk.
-  //
-  // Notes on each alternation:
-  //   <link\b ...                  word-boundary, not <link(?:\s) — catches
-  //                                <link> with no following whitespace.
-  //   \son[a-z]+\s*=               whitespace before `=` is tolerated by
-  //                                browsers, so `onload =` must still match.
-  //   (?:href|src) ... &           any character reference inside an href/src
-  //                                value (e.g. `&#106;avascript:`) forces the
-  //                                full sanitizer; entity decoding happens at
-  //                                attribute-parse time, so the slow path
-  //                                gets the resolved value via attr.value.
-  //   <img ... src=...http(s):     remote images must reach sanitizeRenderedHTML
-  //                                (which runs on an inert <template>) so their
-  //                                live src is stripped into data-cmux-remote-src
-  //                                before insertion — otherwise the browser
-  //                                auto-fetches them and the "don't auto-load
-  //                                remote images" privacy gate is bypassed.
-  //                                Local (relative/file) images stay on the fast
-  //                                path; rewriteLocalImageSources handles them.
-  //
-  // INVARIANT: this pattern must be a superset of everything
-  // sanitizeRenderedHTML() would act on. The tag list mirrors blockedTags
-  // (incl. style + media tags audio/video/picture/source/track), and the
-  // entity-reference branch matches quoted AND unquoted href/src values so
-  // forms like `href=&#106;avascript:` cannot skip the slow path.
-  var sanitizationPattern = /<(?:script|iframe|object|embed|link\b|meta|base|style|audio|video|picture|source|track|form|button|textarea|select|option|svg|math)\b|<input\b(?![^>]*type\s*=\s*["']?checkbox)|<img\b[^>]*\ssrc\s*=\s*["']?\s*https?:|(?:\son[a-z]+\s*=|\bstyle\s*=|\bsrcset\s*=|\bbackground\s*=|\bsrcdoc\s*=|\bautofocus\b|\bformaction\s*=|\bxlink:href\s*=)|(?:href|src)\s*=\s*["']?\s*(?:javascript|vbscript|data):|(?:href|src)\s*=\s*(?:"[^"]*&|'[^']*&|[^"'\s>]*&)/i;
+  // Single source of truth for sanitization. Both the full TreeWalker
+  // sanitizer (sanitizeRenderedHTML) and the fast pre-check (needsSanitization)
+  // are derived from these lists, so the fast-path can never drift out of sync
+  // with what the sanitizer actually strips. Add a tag or attribute here once
+  // and both paths update together.
+  var SANITIZER_BLOCKED_TAGS = {
+    script: true, iframe: true, object: true, embed: true, link: true,
+    meta: true, base: true, style: true, audio: true, video: true,
+    picture: true, source: true, track: true, form: true, button: true,
+    textarea: true, select: true, option: true, svg: true, math: true
+  };
+  // Attributes the sanitizer strips outright. Any on* event handler is also
+  // stripped (handled by prefix, not listed here). `input` (checkbox-only) and
+  // remote <img> src are special-cased in both the sanitizer and the pattern.
+  var SANITIZER_BLOCKED_ATTRS = [
+    'style', 'background', 'srcset', 'srcdoc', 'autofocus', 'formaction', 'xlink:href'
+  ];
+  // Valueless-capable (boolean) attributes match on a word boundary in the
+  // fast-path regex rather than requiring `=` (e.g. bare `<button autofocus>`).
+  var SANITIZER_BOOLEAN_ATTRS = { autofocus: true };
+
+  function reEscapeForPattern(s) {
+    return String(s).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  }
+
+  // Build the fast pre-check regex from the same lists the sanitizer uses.
+  // Most markdown produces HTML with nothing dangerous; when none of these
+  // alternations match we skip the TreeWalker walk entirely.
+  //   - tag list           mirrors SANITIZER_BLOCKED_TAGS
+  //   - <input ...checkbox  input is allowed only as a checkbox
+  //   - <img ...src=http(s) remote images must reach sanitizeRenderedHTML
+  //                         (which runs on an inert <template>) so the live src
+  //                         is stripped before the browser auto-fetches it —
+  //                         the "don't auto-load remote images" privacy gate.
+  //                         Local/relative images stay on the fast path.
+  //   - on* / blocked attrs mirror SANITIZER_BLOCKED_ATTRS
+  //   - javascript:/...     active-protocol href/src
+  //   - href/src ... &      any character reference (quoted or unquoted) in an
+  //                         href/src value, so entity-encoded payloads like
+  //                         `href=&#106;avascript:` can't skip the slow path.
+  function buildSanitizationPattern() {
+    var tags = Object.keys(SANITIZER_BLOCKED_TAGS).map(reEscapeForPattern).join('|');
+    var attrs = SANITIZER_BLOCKED_ATTRS.map(function(a) {
+      var esc = reEscapeForPattern(a);
+      return SANITIZER_BOOLEAN_ATTRS[a] ? '\\b' + esc + '\\b' : '\\b' + esc + '\\s*=';
+    }).join('|');
+    return new RegExp(
+      '<(?:' + tags + ')\\b' +
+      '|<input\\b(?![^>]*type\\s*=\\s*["\']?checkbox)' +
+      '|<img\\b[^>]*\\ssrc\\s*=\\s*["\']?\\s*https?:' +
+      '|(?:\\son[a-z]+\\s*=|' + attrs + ')' +
+      '|(?:href|src)\\s*=\\s*["\']?\\s*(?:javascript|vbscript|data):' +
+      '|(?:href|src)\\s*=\\s*(?:"[^"]*&|\'[^\']*&|[^"\'\\s>]*&)',
+      'i'
+    );
+  }
+  var sanitizationPattern = buildSanitizationPattern();
   function needsSanitization(html) {
     return sanitizationPattern.test(html || '');
   }
@@ -998,28 +1026,9 @@ html { scroll-behavior: smooth; }
     var template = document.createElement('template');
     template.innerHTML = String(html || '');
 
-    var blockedTags = {
-      script: true,
-      iframe: true,
-      object: true,
-      embed: true,
-      link: true,
-      style: true,
-      meta: true,
-      base: true,
-      audio: true,
-      form: true,
-      button: true,
-      picture: true,
-      source: true,
-      textarea: true,
-      track: true,
-      video: true,
-      select: true,
-      option: true,
-      svg: true,
-      math: true
-    };
+    // Reuse the shared block list so the sanitizer and the fast-path regex
+    // (buildSanitizationPattern) can never disagree about which tags to strip.
+    var blockedTags = SANITIZER_BLOCKED_TAGS;
 
     var walker = document.createTreeWalker(template.content, NodeFilter.SHOW_ELEMENT);
     var elements = [];
@@ -1056,16 +1065,7 @@ html { scroll-behavior: smooth; }
           el.removeAttribute(attr.name);
           return;
         }
-        if (
-          name.indexOf('on') === 0 ||
-          name === 'style' ||
-          name === 'background' ||
-          name === 'srcset' ||
-          name === 'srcdoc' ||
-          name === 'autofocus' ||
-          name === 'formaction' ||
-          name === 'xlink:href'
-        ) {
+        if (name.indexOf('on') === 0 || SANITIZER_BLOCKED_ATTRS.indexOf(name) !== -1) {
           el.removeAttribute(attr.name);
           return;
         }

--- a/Resources/markdown-viewer/shell.html
+++ b/Resources/markdown-viewer/shell.html
@@ -340,6 +340,18 @@ html { scroll-behavior: smooth; }
     return value;
   }
 
+  // FNV-1a hash for fast content-change detection. Uses 32-bit arithmetic
+  // (safe in JS) to avoid the O(n) innerHTML string comparison on re-render.
+  function fnv1aHash(str) {
+    var hash = 0x811c9dc5;
+    for (var i = 0, len = str.length; i < len; i++) {
+      hash ^= str.charCodeAt(i);
+      hash = (hash * 0x01000193) >>> 0;
+    }
+    return hash;
+  }
+  var lastRenderedHash = 0;
+
   function escapeHtml(s) {
     // Let WebKit's HTML serializer do escaping rather than trying
     // to keep a hand-written entity table correct.
@@ -943,6 +955,14 @@ html { scroll-behavior: smooth; }
     } catch (e) {
       return false;
     }
+  }
+
+  // Fast pre-check: most markdown files produce HTML with no dangerous
+  // elements or attributes. This regex tests for patterns the full
+  // TreeWalker sanitizer would act on — if none match, skip the walk.
+  var sanitizationPattern = /<(?:script|iframe|object|embed|link(?:\s)|meta|base|form|button|textarea|select|option|svg|math)\b|<input\b(?![^>]*type\s*=\s*["']?checkbox)|(?:\son[a-z]+=|\bstyle\s*=|\bsrcdoc\s*=|\bautofocus\b|\bformaction\s*=|\bxlink:href\s*=)|(?:href|src)\s*=\s*["']?\s*(?:javascript|vbscript|data):/i;
+  function needsSanitization(html) {
+    return sanitizationPattern.test(html || '');
   }
 
   function sanitizeRenderedHTML(html) {
@@ -1783,15 +1803,22 @@ html { scroll-behavior: smooth; }
     openMarkdownCandidate(rawPath);
   }, true);
 
-  window.__cmuxRenderMarkdown = function(md) {
+  // Debounce rapid re-renders (e.g. atomic write-rename fires watcher
+  // twice in quick succession). 80ms is fast enough to feel instant but
+  // collapses bursts from editors like vim, emacs, and VS Code.
+  var renderTimer = null;
+  function doRender(md) {
     try {
       headingSlugCounts = Object.create(null);
       var documentParts = extractFrontmatter(md || '');
+      var parsed = marked.parse(documentParts.body || '');
       var html = renderFrontmatter(documentParts.frontmatter)
-        + sanitizeRenderedHTML(marked.parse(documentParts.body || ''));
-      var didReplaceContent = contentEl.innerHTML !== html;
+        + (needsSanitization(parsed) ? sanitizeRenderedHTML(parsed) : parsed);
+      var hash = fnv1aHash(html);
+      var didReplaceContent = hash !== lastRenderedHash;
       var scrollState = didReplaceContent ? captureMarkdownScrollState() : null;
       if (didReplaceContent) {
+        lastRenderedHash = hash;
         contentEl.innerHTML = html;
       }
       rewriteLocalImageSources();
@@ -1806,6 +1833,17 @@ html { scroll-behavior: smooth; }
         + 'markdown render error: ' + escapeHtml(String((e && e.message) || e))
         + '</div><pre><code>' + escapeHtml(md || '') + '</code></pre>';
     }
+  }
+  window.__cmuxRenderMarkdown = function(md) {
+    if (renderTimer) { clearTimeout(renderTimer); }
+    if (lastRenderedHash === 0) {
+      doRender(md);
+      return;
+    }
+    renderTimer = setTimeout(function() {
+      renderTimer = null;
+      doRender(md);
+    }, 80);
   };
 
   function cleanRenderedContentClone(options) {


### PR DESCRIPTION
## Summary

- **Fix #4144**: stop double-escaping HTML entities in inline code spans (marked v13 already escapes codespan output)
- **Fix #2591**: Cmd+A / Ctrl+A now selects the entire document instead of one paragraph
- **Callouts**: GitHub-style `> [!NOTE]`, `> [!TIP]`, `> [!IMPORTANT]`, `> [!WARNING]`, `> [!CAUTION]` with colored borders and Octicon SVG icons
- **Line numbers**: fenced code blocks get a non-selectable line number gutter
- **Perf**: FNV-1a hash replaces O(n) innerHTML string diff; regex fast-path skips sanitizer TreeWalker for clean markdown; 80ms debounce collapses rapid file-watcher events

All changes are in `Resources/markdown-viewer/shell.html` — no Swift changes.

## Test plan

- [ ] Open a markdown file with `` `<div>` `` and `` `A & B` `` — entities should render as literal characters, not `&lt;div&gt;`
- [ ] Add `> [!NOTE]`, `> [!WARNING]`, etc. blockquotes — should render with colored left border and icon
- [ ] Fenced code blocks should show line numbers in a left gutter; numbers should not be included when copying code
- [ ] Cmd+A should select the full document content, not just one paragraph
- [ ] Rapidly save a file multiple times — viewer should not flicker or double-render

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgraded the Markdown viewer with GitHub-style callouts and code-block line numbers, fixed inline-code entities and select-all, and sped up renders with a hash diff, a sanitizer fast-path generated from shared config, and an 80ms debounce. Remote-image privacy is preserved (including `srcset`/`background` and http(s) `img[src]`), callout icons are injected post-sanitization, gutters no longer show phantom lines, and line numbers are excluded from exported HTML and copied text.

- **New Features**
  - Callouts: `> [!NOTE]`, `> [!TIP]`, `> [!IMPORTANT]`, `> [!WARNING]`, `> [!CAUTION]` with icons and colored borders.
  - Code line numbers: fenced blocks get a non-selectable gutter so copying grabs only code.

- **Bug Fixes**
  - Rendering and copy/export: stop double-escaping HTML entities in inline code (`marked v13` already escapes); strip one trailing newline to remove phantom last line; exclude line-number gutters from exported HTML and copied text.
  - Security and sanitization: fast-path is built from shared blocklists (strict superset), covers style/media tags, `srcset`/`background`, remote http(s) `img[src]`, and quoted/unquoted entity-encoded protocols; callout icons added after sanitization; remote-image privacy gate remains.
  - Input and diffing: Cmd/Ctrl+A selects the entire document across keyboard layouts; FNV‑1a hash uses `Math.imul` for correct 32‑bit diffing.

<sup>Written for commit 820935414cf0168158ee2a1a7dcd72b80f2aa72f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Code blocks now show per-line gutters (line numbers) and GitHub-style callouts/admonitions (NOTE, TIP, IMPORTANT, WARNING, CAUTION).
* **Bug Fixes**
  * Fixed select-all (Cmd+A / Ctrl+A) behavior inside the markdown viewer.
  * Inline code rendering corrected to avoid double-escaping.
* **Refactor**
  * Rendering is debounced and uses fast pre-check sanitization to reduce unnecessary re-renders; scroll restored only when content truly changes.
* **Other**
  * Exported/copied outputs no longer include line-number gutter elements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4185?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->