### PR TITLE
Fix task manager attribution for launchd-parented helpers

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -12508,7 +12508,12 @@ struct CMUXCLI {
         let pid = topInt(process["pid"]).map(String.init) ?? "?"
         let name = topLabelText(process["name"] as? String)
         let label = name.isEmpty ? "process" : name
-        return "process \(pid) \(label)"
+        var parts = ["process", pid, label]
+        let attributionReason = topLabelText(process["attribution_reason"] as? String)
+        if !attributionReason.isEmpty {
+            parts.append("[\(attributionReason)]")
+        }
+        return parts.joined(separator: " ")
     }
 
     private func topResourceColumns(node: [String: Any]) -> String {

--- a/Sources/CmuxTopSnapshot.swift
+++ b/Sources/CmuxTopSnapshot.swift
@@ -40,6 +40,7 @@ nonisolated struct CmuxTopProcessInfo: Sendable {
     let ttyDevice: Int64?
     let cmuxWorkspaceID: UUID?
     let cmuxSurfaceID: UUID?
+    let cmuxAttributionReason: String?
     let processGroupID: Int?
     let terminalProcessGroupID: Int?
     var cpuPercent: Double
@@ -51,6 +52,13 @@ nonisolated struct CmuxTopProcessInfo: Sendable {
 nonisolated struct CmuxTopProcessScope: Sendable {
     let workspaceID: UUID?
     let surfaceID: UUID?
+    let attributionReason: String
+
+    init(workspaceID: UUID?, surfaceID: UUID?, attributionReason: String = "cmux-environment") {
+        self.workspaceID = workspaceID
+        self.surfaceID = surfaceID
+        self.attributionReason = attributionReason
+    }
 }
 
 nonisolated final class CmuxTopProcessSnapshot: @unchecked Sendable {
@@ -200,7 +208,14 @@ nonisolated final class CmuxTopProcessSnapshot: @unchecked Sendable {
         }
 
         var visited: Set<Int> = []
-        return roots.compactMap { processTreeNode(pid: $0, allowedPIDs: allowedPIDs, visited: &visited) }
+        return roots.compactMap {
+            processTreeNode(
+                pid: $0,
+                allowedPIDs: allowedPIDs,
+                rootPIDs: explicitRootPIDs,
+                visited: &visited
+            )
+        }
     }
 
     func topLevelPIDs(for pids: Set<Int>) -> Set<Int> {
@@ -321,6 +336,7 @@ nonisolated final class CmuxTopProcessSnapshot: @unchecked Sendable {
     private func processTreeNode(
         pid: Int,
         allowedPIDs: Set<Int>,
+        rootPIDs: Set<Int>,
         visited: inout Set<Int>
     ) -> [String: Any]? {
         guard visited.insert(pid).inserted,
@@ -331,7 +347,14 @@ nonisolated final class CmuxTopProcessSnapshot: @unchecked Sendable {
         let childNodes = (childrenByParentPID[pid] ?? [])
             .filter { allowedPIDs.contains($0) }
             .sorted { processSortKey($0) < processSortKey($1) }
-            .compactMap { processTreeNode(pid: $0, allowedPIDs: allowedPIDs, visited: &visited) }
+            .compactMap {
+                processTreeNode(
+                    pid: $0,
+                    allowedPIDs: allowedPIDs,
+                    rootPIDs: rootPIDs,
+                    visited: &visited
+                )
+            }
 
         var payload: [String: Any] = [
             "kind": "process",
@@ -339,6 +362,7 @@ nonisolated final class CmuxTopProcessSnapshot: @unchecked Sendable {
             "ppid": process.parentPID,
             "name": process.name,
             "path": process.path ?? NSNull(),
+            "attribution_reason": attributionReason(for: process, allowedPIDs: allowedPIDs, rootPIDs: rootPIDs),
             "thread_count": process.threadCount,
             "resources": summary(for: [pid]).payload(),
             "children": childNodes
@@ -369,6 +393,33 @@ nonisolated final class CmuxTopProcessSnapshot: @unchecked Sendable {
             payload["tpgid"] = NSNull()
         }
         return payload
+    }
+
+    private func attributionReason(
+        for process: CmuxTopProcessInfo,
+        allowedPIDs: Set<Int>,
+        rootPIDs: Set<Int>
+    ) -> String {
+        if let reason = process.cmuxAttributionReason {
+            return reason
+        }
+        if rootPIDs.contains(process.pid), isWebKitWebContentProcess(process) {
+            return "webview-root-pid"
+        }
+        if rootPIDs.contains(process.pid) {
+            return "explicit-root-pid"
+        }
+        if allowedPIDs.contains(process.parentPID) {
+            return "child-process"
+        }
+        return "included-process"
+    }
+
+    private func isWebKitWebContentProcess(_ process: CmuxTopProcessInfo) -> Bool {
+        if process.name.localizedCaseInsensitiveContains("WebKit") {
+            return true
+        }
+        return process.path?.localizedCaseInsensitiveContains("com.apple.WebKit.WebContent") == true
     }
 
     private func processSortKey(_ pid: Int) -> String {
@@ -468,6 +519,7 @@ nonisolated final class CmuxTopProcessSnapshot: @unchecked Sendable {
             ttyDevice: ttyDevice,
             cmuxWorkspaceID: cmuxScope?.workspaceID,
             cmuxSurfaceID: cmuxScope?.surfaceID,
+            cmuxAttributionReason: cmuxScope?.attributionReason,
             processGroupID: processGroupID,
             terminalProcessGroupID: terminalProcessGroupID,
             cpuPercent: 0,

--- a/Sources/CmuxTopSnapshot.swift
+++ b/Sources/CmuxTopSnapshot.swift
@@ -69,7 +69,7 @@ nonisolated final class CmuxTopProcessSnapshot: @unchecked Sendable {
         )
     }
 
-    private init(
+    init(
         processes: [CmuxTopProcessInfo],
         sampledAt: Date,
         includesProcessDetails: Bool

--- a/Sources/CmuxTopSnapshot.swift
+++ b/Sources/CmuxTopSnapshot.swift
@@ -54,7 +54,7 @@ nonisolated struct CmuxTopProcessScope: Sendable {
     let surfaceID: UUID?
     let attributionReason: String
 
-    init(workspaceID: UUID?, surfaceID: UUID?, attributionReason: String = "cmux-environment") {
+    init(workspaceID: UUID?, surfaceID: UUID?, attributionReason: String) {
         self.workspaceID = workspaceID
         self.surfaceID = surfaceID
         self.attributionReason = attributionReason
@@ -416,7 +416,7 @@ nonisolated final class CmuxTopProcessSnapshot: @unchecked Sendable {
     }
 
     private func isWebKitWebContentProcess(_ process: CmuxTopProcessInfo) -> Bool {
-        if process.name.localizedCaseInsensitiveContains("WebKit") {
+        if process.name.localizedCaseInsensitiveContains("WebContent") {
             return true
         }
         return process.path?.localizedCaseInsensitiveContains("com.apple.WebKit.WebContent") == true

--- a/Sources/CmuxTopSnapshotScopeCache.swift
+++ b/Sources/CmuxTopSnapshotScopeCache.swift
@@ -108,7 +108,7 @@ nonisolated extension CmuxTopProcessSnapshot {
         return CmuxTopProcessScope(
             workspaceID: workspaceID,
             surfaceID: surfaceID,
-            attributionReason: "session-env"
+            attributionReason: "cmux-environment"
         )
     }
 
@@ -122,32 +122,22 @@ nonisolated extension CmuxTopProcessSnapshot {
         return CmuxTopProcessScope(
             workspaceID: workspaceID,
             surfaceID: surfaceID,
-            attributionReason: "hook-monitor"
+            attributionReason: "cmux-hook-arguments"
         )
     }
 
     private static func containsSubcommandPath(_ path: [String], in arguments: [String]) -> Bool {
         let normalizedPath = path.map { $0.lowercased() }
-        guard !normalizedPath.isEmpty else { return false }
-
-        if arguments.count >= normalizedPath.count + 1 {
-            let executableName = URL(fileURLWithPath: arguments[0])
-                .lastPathComponent
-                .lowercased()
-            let subcommands = arguments
-                .dropFirst()
-                .prefix(normalizedPath.count)
-                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
-            if executableName == "cmux", Array(subcommands) == normalizedPath {
-                return true
-            }
-        }
-
-        guard arguments.count >= normalizedPath.count else { return false }
-        let leadingArguments = arguments
+        guard !normalizedPath.isEmpty, arguments.count >= normalizedPath.count + 1 else { return false }
+        let executableName = URL(fileURLWithPath: arguments[0])
+            .lastPathComponent
+            .lowercased()
+        guard executableName == "cmux" else { return false }
+        let subcommands = arguments
+            .dropFirst()
             .prefix(normalizedPath.count)
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
-        return Array(leadingArguments) == normalizedPath
+        return Array(subcommands) == normalizedPath
     }
 
     private static func uuidValue(in environment: [String: String], keys: [String]) -> UUID? {

--- a/Sources/CmuxTopSnapshotScopeCache.swift
+++ b/Sources/CmuxTopSnapshotScopeCache.swift
@@ -85,76 +85,84 @@ nonisolated extension CmuxTopProcessSnapshot {
     }
 
     static func cmuxScope(fromKernProcArgs bytes: [UInt8]) -> CmuxTopProcessScope? {
-        guard bytes.count > MemoryLayout<Int32>.size else { return nil }
-
-        var argcRaw: Int32 = 0
-        withUnsafeMutableBytes(of: &argcRaw) { rawBuffer in
-            rawBuffer.copyBytes(from: bytes.prefix(MemoryLayout<Int32>.size))
+        guard let process = processArgumentsAndEnvironment(fromKernProcArgs: bytes) else {
+            return nil
         }
-        let argc = Int(Int32(littleEndian: argcRaw))
-        guard argc > 0 else { return nil }
+        return cmuxScope(arguments: process.arguments, environment: process.environment)
+    }
 
-        var index = MemoryLayout<Int32>.size
-        skipString(in: bytes, index: &index)
-        skipNulls(in: bytes, index: &index)
-
-        for _ in 0..<argc {
-            guard index < bytes.count else { return nil }
-            skipString(in: bytes, index: &index)
-            skipNulls(in: bytes, index: &index)
+    static func cmuxScope(arguments: [String], environment: [String: String]) -> CmuxTopProcessScope? {
+        if let environmentScope = cmuxScopeFromEnvironment(environment) {
+            return environmentScope
         }
+        if let hookScope = cmuxHookMonitorScope(arguments: arguments) {
+            return hookScope
+        }
+        return nil
+    }
 
-        var workspaceID: UUID?
-        var surfaceID: UUID?
-        while index < bytes.count {
-            skipNulls(in: bytes, index: &index)
-            guard index < bytes.count else { break }
+    private static func cmuxScopeFromEnvironment(_ environment: [String: String]) -> CmuxTopProcessScope? {
+        let workspaceID = uuidValue(in: environment, keys: ["CMUX_WORKSPACE_ID", "CMUX_TAB_ID"])
+        let surfaceID = uuidValue(in: environment, keys: ["CMUX_SURFACE_ID", "CMUX_PANEL_ID"])
+        guard workspaceID != nil || surfaceID != nil else { return nil }
+        return CmuxTopProcessScope(
+            workspaceID: workspaceID,
+            surfaceID: surfaceID,
+            attributionReason: "cmux-environment"
+        )
+    }
 
-            let start = index
-            skipString(in: bytes, index: &index)
-            guard start < index,
-                  let entry = String(bytes: bytes[start..<index], encoding: .utf8) else {
+    private static func cmuxHookMonitorScope(arguments: [String]) -> CmuxTopProcessScope? {
+        guard containsSubcommandPath(["hooks", "codex", "monitor"], in: arguments) else {
+            return nil
+        }
+        let workspaceID = uuidOptionValue(in: arguments, names: ["--workspace"])
+        let surfaceID = uuidOptionValue(in: arguments, names: ["--surface", "--panel"])
+        guard workspaceID != nil || surfaceID != nil else { return nil }
+        return CmuxTopProcessScope(
+            workspaceID: workspaceID,
+            surfaceID: surfaceID,
+            attributionReason: "cmux-hook-arguments"
+        )
+    }
+
+    private static func containsSubcommandPath(_ path: [String], in arguments: [String]) -> Bool {
+        guard !path.isEmpty, arguments.count >= path.count else { return false }
+        let normalizedArguments = arguments.map {
+            URL(fileURLWithPath: $0).lastPathComponent.lowercased()
+        }
+        for startIndex in normalizedArguments.indices {
+            let endIndex = startIndex + path.count
+            guard endIndex <= normalizedArguments.count else { break }
+            if Array(normalizedArguments[startIndex..<endIndex]) == path {
+                return true
+            }
+        }
+        return false
+    }
+
+    private static func uuidValue(in environment: [String: String], keys: [String]) -> UUID? {
+        for key in keys {
+            guard let raw = environment[key]?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !raw.isEmpty,
+                  let uuid = UUID(uuidString: raw) else {
                 continue
             }
-
-            if let value = value(inEnvironmentEntry: entry, forKey: "CMUX_WORKSPACE_ID") {
-                workspaceID = UUID(uuidString: value) ?? workspaceID
-            } else if workspaceID == nil,
-                      let value = value(inEnvironmentEntry: entry, forKey: "CMUX_TAB_ID") {
-                workspaceID = UUID(uuidString: value)
-            } else if let value = value(inEnvironmentEntry: entry, forKey: "CMUX_SURFACE_ID") {
-                surfaceID = UUID(uuidString: value) ?? surfaceID
-            } else if surfaceID == nil,
-                      let value = value(inEnvironmentEntry: entry, forKey: "CMUX_PANEL_ID") {
-                surfaceID = UUID(uuidString: value)
-            }
-
-            if workspaceID != nil, surfaceID != nil {
-                break
-            }
+            return uuid
         }
-
-        guard workspaceID != nil || surfaceID != nil else { return nil }
-        return CmuxTopProcessScope(workspaceID: workspaceID, surfaceID: surfaceID)
+        return nil
     }
 
-    private static func value(inEnvironmentEntry entry: String, forKey key: String) -> String? {
-        let prefix = "\(key)="
-        guard entry.hasPrefix(prefix) else { return nil }
-        let value = String(entry.dropFirst(prefix.count)).trimmingCharacters(in: .whitespacesAndNewlines)
-        return value.isEmpty ? nil : value
-    }
-
-    private static func skipString(in bytes: [UInt8], index: inout Int) {
-        while index < bytes.count, bytes[index] != 0 {
-            index += 1
+    private static func uuidOptionValue(in arguments: [String], names: Set<String>) -> UUID? {
+        for index in arguments.indices {
+            guard names.contains(arguments[index]) else { continue }
+            let valueIndex = arguments.index(after: index)
+            guard valueIndex < arguments.endIndex else { continue }
+            let raw = arguments[valueIndex].trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !raw.isEmpty, let uuid = UUID(uuidString: raw) else { continue }
+            return uuid
         }
-    }
-
-    private static func skipNulls(in bytes: [UInt8], index: inout Int) {
-        while index < bytes.count, bytes[index] == 0 {
-            index += 1
-        }
+        return nil
     }
 
     private static func kinfoProc(for pid: Int) -> kinfo_proc? {

--- a/Sources/CmuxTopSnapshotScopeCache.swift
+++ b/Sources/CmuxTopSnapshotScopeCache.swift
@@ -108,7 +108,7 @@ nonisolated extension CmuxTopProcessSnapshot {
         return CmuxTopProcessScope(
             workspaceID: workspaceID,
             surfaceID: surfaceID,
-            attributionReason: "cmux-environment"
+            attributionReason: "session-env"
         )
     }
 
@@ -122,7 +122,7 @@ nonisolated extension CmuxTopProcessSnapshot {
         return CmuxTopProcessScope(
             workspaceID: workspaceID,
             surfaceID: surfaceID,
-            attributionReason: "cmux-hook-arguments"
+            attributionReason: "hook-monitor"
         )
     }
 

--- a/Sources/CmuxTopSnapshotScopeCache.swift
+++ b/Sources/CmuxTopSnapshotScopeCache.swift
@@ -127,18 +127,27 @@ nonisolated extension CmuxTopProcessSnapshot {
     }
 
     private static func containsSubcommandPath(_ path: [String], in arguments: [String]) -> Bool {
-        guard !path.isEmpty, arguments.count >= path.count else { return false }
-        let normalizedArguments = arguments.map {
-            URL(fileURLWithPath: $0).lastPathComponent.lowercased()
-        }
-        for startIndex in normalizedArguments.indices {
-            let endIndex = startIndex + path.count
-            guard endIndex <= normalizedArguments.count else { break }
-            if Array(normalizedArguments[startIndex..<endIndex]) == path {
+        let normalizedPath = path.map { $0.lowercased() }
+        guard !normalizedPath.isEmpty else { return false }
+
+        if arguments.count >= normalizedPath.count + 1 {
+            let executableName = URL(fileURLWithPath: arguments[0])
+                .lastPathComponent
+                .lowercased()
+            let subcommands = arguments
+                .dropFirst()
+                .prefix(normalizedPath.count)
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
+            if executableName == "cmux", Array(subcommands) == normalizedPath {
                 return true
             }
         }
-        return false
+
+        guard arguments.count >= normalizedPath.count else { return false }
+        let leadingArguments = arguments
+            .prefix(normalizedPath.count)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
+        return Array(leadingArguments) == normalizedPath
     }
 
     private static func uuidValue(in environment: [String: String], keys: [String]) -> UUID? {
@@ -155,7 +164,17 @@ nonisolated extension CmuxTopProcessSnapshot {
 
     private static func uuidOptionValue(in arguments: [String], names: Set<String>) -> UUID? {
         for index in arguments.indices {
-            guard names.contains(arguments[index]) else { continue }
+            let argument = arguments[index].trimmingCharacters(in: .whitespacesAndNewlines)
+            for name in names {
+                let prefix = "\(name)="
+                guard argument.hasPrefix(prefix) else { continue }
+                let raw = String(argument.dropFirst(prefix.count))
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !raw.isEmpty, let uuid = UUID(uuidString: raw) else { continue }
+                return uuid
+            }
+
+            guard names.contains(argument) else { continue }
             let valueIndex = arguments.index(after: index)
             guard valueIndex < arguments.endIndex else { continue }
             let raw = arguments[valueIndex].trimmingCharacters(in: .whitespacesAndNewlines)

--- a/cmuxTests/CmuxTopSnapshotScopeTests.swift
+++ b/cmuxTests/CmuxTopSnapshotScopeTests.swift
@@ -253,6 +253,46 @@ final class CmuxTopSnapshotScopeTests: XCTestCase {
         XCTAssertEqual(scope?.surfaceID, panelID)
     }
 
+    func testCodexMonitorArgumentsSupportJoinedUUIDOptions() throws {
+        let workspaceID = UUID(uuidString: "55555555-5555-5555-5555-555555555555")!
+        let surfaceID = UUID(uuidString: "66666666-6666-6666-6666-666666666666")!
+
+        let scope = try XCTUnwrap(CmuxTopProcessSnapshot.cmuxScope(
+            arguments: [
+                "/Applications/cmux.app/Contents/Resources/bin/cmux",
+                "hooks",
+                "codex",
+                "monitor",
+                "--workspace=\(workspaceID.uuidString)",
+                "--surface=\(surfaceID.uuidString)"
+            ],
+            environment: [:]
+        ))
+
+        XCTAssertEqual(scope.workspaceID, workspaceID)
+        XCTAssertEqual(scope.surfaceID, surfaceID)
+        XCTAssertEqual(scope.attributionReason, "cmux-hook-arguments")
+    }
+
+    func testCodexMonitorArgumentsIgnorePathValuedSubcommandLookalikes() {
+        let workspaceID = UUID(uuidString: "55555555-5555-5555-5555-555555555555")!
+
+        let scope = CmuxTopProcessSnapshot.cmuxScope(
+            arguments: [
+                "/Applications/cmux.app/Contents/Resources/bin/cmux",
+                "other",
+                "/tmp/hooks",
+                "/tmp/codex",
+                "/tmp/monitor",
+                "--workspace",
+                workspaceID.uuidString
+            ],
+            environment: [:]
+        )
+
+        XCTAssertNil(scope)
+    }
+
     @MainActor
     func testLaunchdParentedCodexMonitorArgumentsAttachToOwningSurface() throws {
         let workspaceID = UUID(uuidString: "55555555-5555-5555-5555-555555555555")!
@@ -359,7 +399,7 @@ final class CmuxTopSnapshotScopeTests: XCTestCase {
                 CmuxTopProcessInfo(
                     pid: webContentPID,
                     parentPID: 1,
-                    name: "com.apple.WebKit",
+                    name: "com.apple.WebKit.WebContent",
                     path: "/System/Library/Frameworks/WebKit.framework/Versions/A/XPCServices/com.apple.WebKit.WebContent.xpc/Contents/MacOS/com.apple.WebKit.WebContent",
                     ttyDevice: nil,
                     cmuxWorkspaceID: nil,

--- a/cmuxTests/CmuxTopSnapshotScopeTests.swift
+++ b/cmuxTests/CmuxTopSnapshotScopeTests.swift
@@ -287,6 +287,7 @@ final class CmuxTopSnapshotScopeTests: XCTestCase {
                     ttyDevice: nil,
                     cmuxWorkspaceID: scope.workspaceID,
                     cmuxSurfaceID: scope.surfaceID,
+                    cmuxAttributionReason: scope.attributionReason,
                     processGroupID: nil,
                     terminalProcessGroupID: nil,
                     cpuPercent: 0,
@@ -344,7 +345,92 @@ final class CmuxTopSnapshotScopeTests: XCTestCase {
         XCTAssertEqual(int(resources["process_count"]), 1)
         XCTAssertEqual(int(monitorProcess["pid"]), monitorPID)
         XCTAssertEqual(int(monitorProcess["ppid"]), 1)
+        XCTAssertEqual(monitorProcess["attribution_reason"] as? String, "cmux-hook-arguments")
         XCTAssertTrue(totalPIDs.contains(monitorPID))
+    }
+
+    @MainActor
+    func testLaunchdParentedWebKitRootProcessStaysUnderBrowserWebView() throws {
+        let workspaceID = UUID(uuidString: "77777777-7777-7777-7777-777777777777")!
+        let surfaceID = UUID(uuidString: "88888888-8888-8888-8888-888888888888")!
+        let webContentPID = 4343
+        let snapshot = CmuxTopProcessSnapshot(
+            processes: [
+                CmuxTopProcessInfo(
+                    pid: webContentPID,
+                    parentPID: 1,
+                    name: "com.apple.WebKit",
+                    path: "/System/Library/Frameworks/WebKit.framework/Versions/A/XPCServices/com.apple.WebKit.WebContent.xpc/Contents/MacOS/com.apple.WebKit.WebContent",
+                    ttyDevice: nil,
+                    cmuxWorkspaceID: nil,
+                    cmuxSurfaceID: nil,
+                    cmuxAttributionReason: nil,
+                    processGroupID: nil,
+                    terminalProcessGroupID: nil,
+                    cpuPercent: 0,
+                    residentBytes: 32 * 1024 * 1024,
+                    virtualBytes: 256 * 1024 * 1024,
+                    threadCount: 8
+                )
+            ],
+            sampledAt: Date(timeIntervalSince1970: 0),
+            includesProcessDetails: true
+        )
+        var windows: [[String: Any]] = [[
+            "kind": "window",
+            "id": UUID().uuidString,
+            "index": 0,
+            "key": true,
+            "visible": true,
+            "app_process_pids": [],
+            "workspaces": [[
+                "kind": "workspace",
+                "id": workspaceID.uuidString,
+                "index": 0,
+                "title": "webkit fixture",
+                "selected": true,
+                "pinned": false,
+                "tags": [],
+                "panes": [[
+                    "kind": "pane",
+                    "id": UUID().uuidString,
+                    "index": 0,
+                    "surfaces": [[
+                        "kind": "surface",
+                        "id": surfaceID.uuidString,
+                        "index": 0,
+                        "type": "browser",
+                        "title": "browser owner",
+                        "webviews": [[
+                            "kind": "webview",
+                            "id": "\(surfaceID.uuidString):webview",
+                            "index": 0,
+                            "title": "WebView",
+                            "pid": webContentPID
+                        ] as [String: Any]]
+                    ] as [String: Any]]
+                ] as [String: Any]]
+            ] as [String: Any]]
+        ]]
+        let browserPIDOccurrences = TerminalController.shared.v2TopBrowserPIDOccurrences(in: windows)
+
+        let totalPIDs = TerminalController.shared.v2AnnotateTopWindows(
+            &windows,
+            processSnapshot: snapshot,
+            browserPIDOccurrences: browserPIDOccurrences,
+            includeProcesses: true
+        )
+        let webview = try firstWebView(in: windows)
+        let resources = try XCTUnwrap(webview["resources"] as? [String: Any])
+        let processes = try XCTUnwrap(webview["processes"] as? [[String: Any]])
+        let webContentProcess = try XCTUnwrap(processes.first)
+
+        XCTAssertEqual(intArray(resources["pids"]), [webContentPID])
+        XCTAssertEqual(int(resources["process_count"]), 1)
+        XCTAssertEqual(int(webContentProcess["pid"]), webContentPID)
+        XCTAssertEqual(int(webContentProcess["ppid"]), 1)
+        XCTAssertEqual(webContentProcess["attribution_reason"] as? String, "webview-root-pid")
+        XCTAssertTrue(totalPIDs.contains(webContentPID))
     }
 
     private func kernProcArgs(
@@ -568,6 +654,12 @@ while allocations:
         let panes = try XCTUnwrap(workspaces[0]["panes"] as? [[String: Any]])
         let surfaces = try XCTUnwrap(panes[0]["surfaces"] as? [[String: Any]])
         return try XCTUnwrap(surfaces.first)
+    }
+
+    private func firstWebView(in windows: [[String: Any]]) throws -> [String: Any] {
+        let surface = try firstSurface(in: windows)
+        let webviews = try XCTUnwrap(surface["webviews"] as? [[String: Any]])
+        return try XCTUnwrap(webviews.first)
     }
 
     private func int64(_ raw: Any?) -> Int64 {

--- a/cmuxTests/CmuxTopSnapshotScopeTests.swift
+++ b/cmuxTests/CmuxTopSnapshotScopeTests.swift
@@ -271,7 +271,7 @@ final class CmuxTopSnapshotScopeTests: XCTestCase {
 
         XCTAssertEqual(scope.workspaceID, workspaceID)
         XCTAssertEqual(scope.surfaceID, surfaceID)
-        XCTAssertEqual(scope.attributionReason, "hook-monitor")
+        XCTAssertEqual(scope.attributionReason, "cmux-hook-arguments")
     }
 
     func testCodexMonitorArgumentsIgnorePathValuedSubcommandLookalikes() {
@@ -284,6 +284,23 @@ final class CmuxTopSnapshotScopeTests: XCTestCase {
                 "/tmp/hooks",
                 "/tmp/codex",
                 "/tmp/monitor",
+                "--workspace",
+                workspaceID.uuidString
+            ],
+            environment: [:]
+        )
+
+        XCTAssertNil(scope)
+    }
+
+    func testCodexMonitorArgumentsRequireCmuxExecutable() {
+        let workspaceID = UUID(uuidString: "55555555-5555-5555-5555-555555555555")!
+
+        let scope = CmuxTopProcessSnapshot.cmuxScope(
+            arguments: [
+                "hooks",
+                "codex",
+                "monitor",
                 "--workspace",
                 workspaceID.uuidString
             ],
@@ -385,7 +402,7 @@ final class CmuxTopSnapshotScopeTests: XCTestCase {
         XCTAssertEqual(int(resources["process_count"]), 1)
         XCTAssertEqual(int(monitorProcess["pid"]), monitorPID)
         XCTAssertEqual(int(monitorProcess["ppid"]), 1)
-        XCTAssertEqual(monitorProcess["attribution_reason"] as? String, "hook-monitor")
+        XCTAssertEqual(monitorProcess["attribution_reason"] as? String, "cmux-hook-arguments")
         XCTAssertTrue(totalPIDs.contains(monitorPID))
     }
 

--- a/cmuxTests/CmuxTopSnapshotScopeTests.swift
+++ b/cmuxTests/CmuxTopSnapshotScopeTests.swift
@@ -253,6 +253,100 @@ final class CmuxTopSnapshotScopeTests: XCTestCase {
         XCTAssertEqual(scope?.surfaceID, panelID)
     }
 
+    @MainActor
+    func testLaunchdParentedCodexMonitorArgumentsAttachToOwningSurface() throws {
+        let workspaceID = UUID(uuidString: "55555555-5555-5555-5555-555555555555")!
+        let surfaceID = UUID(uuidString: "66666666-6666-6666-6666-666666666666")!
+        let monitorPID = 4242
+        let bytes = kernProcArgs(
+            arguments: [
+                "/Applications/cmux.app/Contents/Resources/bin/cmux",
+                "hooks",
+                "codex",
+                "monitor",
+                "--workspace",
+                workspaceID.uuidString,
+                "--surface",
+                surfaceID.uuidString,
+                "--session",
+                "session-1"
+            ],
+            environment: []
+        )
+        let scope = try XCTUnwrap(CmuxTopProcessSnapshot.cmuxScope(fromKernProcArgs: bytes))
+        XCTAssertEqual(scope.workspaceID, workspaceID)
+        XCTAssertEqual(scope.surfaceID, surfaceID)
+
+        let snapshot = CmuxTopProcessSnapshot(
+            processes: [
+                CmuxTopProcessInfo(
+                    pid: monitorPID,
+                    parentPID: 1,
+                    name: "cmux",
+                    path: "/Applications/cmux.app/Contents/Resources/bin/cmux",
+                    ttyDevice: nil,
+                    cmuxWorkspaceID: scope.workspaceID,
+                    cmuxSurfaceID: scope.surfaceID,
+                    processGroupID: nil,
+                    terminalProcessGroupID: nil,
+                    cpuPercent: 0,
+                    residentBytes: 64 * 1024 * 1024,
+                    virtualBytes: 128 * 1024 * 1024,
+                    threadCount: 4
+                )
+            ],
+            sampledAt: Date(timeIntervalSince1970: 0),
+            includesProcessDetails: true
+        )
+        var windows: [[String: Any]] = [[
+            "kind": "window",
+            "id": UUID().uuidString,
+            "index": 0,
+            "key": true,
+            "visible": true,
+            "app_process_pids": [],
+            "workspaces": [[
+                "kind": "workspace",
+                "id": workspaceID.uuidString,
+                "index": 0,
+                "title": "hook monitor fixture",
+                "selected": true,
+                "pinned": false,
+                "tags": [],
+                "panes": [[
+                    "kind": "pane",
+                    "id": UUID().uuidString,
+                    "index": 0,
+                    "surfaces": [[
+                        "kind": "surface",
+                        "id": surfaceID.uuidString,
+                        "index": 0,
+                        "type": "terminal",
+                        "title": "codex monitor owner",
+                        "webviews": []
+                    ] as [String: Any]]
+                ] as [String: Any]]
+            ] as [String: Any]]
+        ]]
+
+        let totalPIDs = TerminalController.shared.v2AnnotateTopWindows(
+            &windows,
+            processSnapshot: snapshot,
+            browserPIDOccurrences: [:],
+            includeProcesses: true
+        )
+        let surface = try firstSurface(in: windows)
+        let resources = try XCTUnwrap(surface["resources"] as? [String: Any])
+        let processes = try XCTUnwrap(surface["processes"] as? [[String: Any]])
+        let monitorProcess = try XCTUnwrap(processes.first)
+
+        XCTAssertEqual(intArray(resources["pids"]), [monitorPID])
+        XCTAssertEqual(int(resources["process_count"]), 1)
+        XCTAssertEqual(int(monitorProcess["pid"]), monitorPID)
+        XCTAssertEqual(int(monitorProcess["ppid"]), 1)
+        XCTAssertTrue(totalPIDs.contains(monitorPID))
+    }
+
     private func kernProcArgs(
         arguments: [String] = ["zsh"],
         environment: [String]
@@ -469,10 +563,24 @@ while allocations:
         }
     }
 
+    private func firstSurface(in windows: [[String: Any]]) throws -> [String: Any] {
+        let workspaces = try XCTUnwrap(windows[0]["workspaces"] as? [[String: Any]])
+        let panes = try XCTUnwrap(workspaces[0]["panes"] as? [[String: Any]])
+        let surfaces = try XCTUnwrap(panes[0]["surfaces"] as? [[String: Any]])
+        return try XCTUnwrap(surfaces.first)
+    }
+
     private func int64(_ raw: Any?) -> Int64 {
         if let value = raw as? Int64 { return value }
         if let value = raw as? Int { return Int64(value) }
         if let value = raw as? NSNumber { return value.int64Value }
+        return 0
+    }
+
+    private func int(_ raw: Any?) -> Int {
+        if let value = raw as? Int { return value }
+        if let value = raw as? NSNumber { return value.intValue }
+        if let value = raw as? String { return Int(value) ?? 0 }
         return 0
     }
 

--- a/cmuxTests/CmuxTopSnapshotScopeTests.swift
+++ b/cmuxTests/CmuxTopSnapshotScopeTests.swift
@@ -271,7 +271,7 @@ final class CmuxTopSnapshotScopeTests: XCTestCase {
 
         XCTAssertEqual(scope.workspaceID, workspaceID)
         XCTAssertEqual(scope.surfaceID, surfaceID)
-        XCTAssertEqual(scope.attributionReason, "cmux-hook-arguments")
+        XCTAssertEqual(scope.attributionReason, "hook-monitor")
     }
 
     func testCodexMonitorArgumentsIgnorePathValuedSubcommandLookalikes() {
@@ -385,7 +385,7 @@ final class CmuxTopSnapshotScopeTests: XCTestCase {
         XCTAssertEqual(int(resources["process_count"]), 1)
         XCTAssertEqual(int(monitorProcess["pid"]), monitorPID)
         XCTAssertEqual(int(monitorProcess["ppid"]), 1)
-        XCTAssertEqual(monitorProcess["attribution_reason"] as? String, "cmux-hook-arguments")
+        XCTAssertEqual(monitorProcess["attribution_reason"] as? String, "hook-monitor")
         XCTAssertTrue(totalPIDs.contains(monitorPID))
     }
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/manaflow-ai/cmux/issues/4189.

This is focused on the WebKit/helper-process attribution gap called out from the broader Task Manager accuracy work in https://github.com/manaflow-ai/cmux/issues/4129. It does not touch the WKInspectorViewController crash path.

## Changes

- Parse `cmux hooks codex monitor --workspace/--surface` arguments as a fallback ownership signal when the helper has been reparented to `launchd` and environment-based scope is unavailable.
- Require the exact `cmux hooks codex monitor` command shape for hook monitor attribution, including a real `cmux` executable in `argv[0]`, and support both `--workspace <uuid>` and `--workspace=<uuid>` option forms.
- Preserve ppid=1 WebKit WebContent accounting through explicit WebView root PID attribution and expose an `attribution_reason` on process rows.
- Show attribution reasons in `cmux top --processes` tree output, including `cmux-environment`, `cmux-hook-arguments`, and `webview-root-pid`, so counted helper processes can be explained.
- Add regression fixtures for launchd-parented codex monitor helpers, joined UUID options, exact command matching, and WebKit WebContent roots.

## Local reproduction

- `ps` showed 99 launchd-parented `com.apple.WebKit.WebContent` processes totaling about 6.3 GB RSS on this machine.
- `ps` showed launchd-parented `cmux hooks codex monitor` processes with `--workspace`/`--surface` ownership arguments.
- `/Applications/cmux.app/Contents/Resources/bin/cmux top --processes --flat --format tsv` showed WebKit roots already flowing through WebView PID roots, but hook monitor attribution depended on environment scope only.

## Verification

- Added the failing regression first in commit `58f244ef4`.
- Did not run local tests per repository policy; CI is the verification gate.
