### PR TITLE
Strip RequestTTY from background SSH option calls

### DIFF
--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -4796,9 +4796,13 @@ final class WorkspaceRemoteSessionController {
     }
 
     private func backgroundSSHOptions(_ options: [String]) -> [String] {
+        // Options that must not propagate to background SSH calls (probe,
+        // daemon bootstrap, scp). RequestTTY=force breaks the platform probe
+        // because PTY allocation interferes with stdout parsing on resume.
         let batchSSHControlOptionKeys: Set<String> = [
             "controlmaster",
             "controlpersist",
+            "requesttty",
         ]
         return normalizedSSHOptions(options).filter { option in
             guard let key = sshOptionKey(option) else { return false }


### PR DESCRIPTION
## Summary

- `backgroundSSHOptions` was leaking `RequestTTY=*` into background ssh invocations (platform probe, daemon bootstrap, scp), causing PTY allocation to interleave control bytes into stdout and break the probe parser.
- Added `requesttty` to `batchSSHControlOptionKeys` alongside the existing `controlmaster` / `controlpersist` filter.
- Interactive SSH sessions still honor `RequestTTY` because they use the full `sshOptions` list, not `backgroundSSHOptions`.

## Repro

1. Run `cmux ssh <host> --name foo --ssh-option RequestTTY=force -- '<some command requiring a PTY>'` so the workspace's saved `sshOptions` contains `RequestTTY=force`. (This is the only practical way to get a PTY for non-shell remote commands.)
2. Quit cmux.
3. Relaunch cmux → workspace tries to auto-reconnect → fails with:
   ```
   SSH error (<host>): Remote daemon bootstrap failed: failed to query remote platform: __CMUX_REMOTE_HOME__=...
   __CMUX_REMOTE_OS__=Linux
   __CMUX_REMOTE_ARCH__=x86_64
   __CMUX_REMOTE_EXISTS__=yes (retry 1 in 4s)
   ```
4. With this patch applied, the same workspace resumes cleanly.

## Why this works

`probeRemoteBootstrapStateLocked` runs `sh -c <script>` via `sshExec` and parses the resulting stdout for the `__CMUX_REMOTE_*` markers. With `RequestTTY=force` in the options, ssh allocates a PTY for the probe; bytes flow through line discipline rather than a pipe, the parser's `hasPrefix` checks fail to match the marker lines (likely due to control-byte interleaving or session-init banner injection from PAM in the PTY path), and the bootstrap reports the failure with the very stdout it just discarded.

## Test plan

- [x] Local Debug build with the patch — workspace created via `cmux ssh --ssh-option RequestTTY=force` resumes cleanly after Cmd+Q + relaunch. Verified saved `sshOptions` in `~/Library/Application Support/cmux/session-com.cmuxterm.app.debug.<tag>.json` still contains `RequestTTY=force`, confirming the fix is taking effect at probe time rather than at config save time.
- [ ] Cmux maintainers: any other `backgroundSSHOptions` consumers I should sanity-check against (`installRemoteRelayMetadataLocked`, `scpExec`, etc. all share the same path so the filter applies cleanly)?

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop passing `RequestTTY=*` to background SSH calls to prevent PTY allocation from corrupting probe output. This fixes workspace resume failures caused by mis-parsed platform probes.

- **Bug Fixes**
  - Added `requesttty` to `batchSSHControlOptionKeys` so `backgroundSSHOptions` strips it for probe, daemon bootstrap, and `scp`.
  - Interactive SSH still honors `RequestTTY` via the full `sshOptions`.

<sup>Written for commit 7d554b4bada043977d8e1da497c512b220d70338. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of remote session operations by refining SSH configuration handling to prevent interference with background session management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4195)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->