### PR TITLE
fix: render local .html files with full styling in cmux browser

### DIFF
--- a/Sources/CommandClickFileOpenRouter.swift
+++ b/Sources/CommandClickFileOpenRouter.swift
@@ -1,6 +1,17 @@
 import Foundation
 
 enum CommandClickFileOpenRouter {
+    /// File extensions that should be rendered by the embedded browser
+    /// rather than the file-preview viewer. Without this, opening a local
+    /// `.html` file (cmd-click in terminal, file-explorer reveal, etc.)
+    /// drops into the text-mode preview and shows the raw HTML source.
+    static let browserRenderedExtensions: Set<String> = ["html", "htm", "xhtml"]
+
+    static func shouldRenderInBrowser(path: String) -> Bool {
+        let ext = (path as NSString).pathExtension.lowercased()
+        return browserRenderedExtensions.contains(ext)
+    }
+
     nonisolated static func shouldRouteInCmux(path: String) -> Bool {
         CmdClickMarkdownRouteSettings.shouldRoute(path: path)
             || CmdClickSupportedFileRouteSettings.shouldRoute(path: path)
@@ -12,6 +23,29 @@ enum CommandClickFileOpenRouter {
         sourcePanelId: UUID,
         filePath: String
     ) -> Bool {
+        // HTML-like documents are intended to be rendered, not read as
+        // source. Route them into the embedded browser when the supported-
+        // file routing toggle is on; fall back to the rest of the pipeline
+        // (markdown viewer / file preview) otherwise.
+        if shouldRenderInBrowser(path: filePath),
+           CmdClickSupportedFileRouteSettings.isEnabled(),
+           CmdClickSupportedFileRouteSettings.isReadableRegularFile(path: filePath) {
+            let fileURL = URL(fileURLWithPath: filePath)
+            if let targetPane = workspace.preferredRightSideTargetPane(fromPanelId: sourcePanelId),
+               workspace.newBrowserSurface(inPane: targetPane, url: fileURL, focus: true) != nil {
+                return true
+            }
+            if workspace.newBrowserSplit(
+                from: sourcePanelId,
+                orientation: .horizontal,
+                url: fileURL
+            ) != nil {
+                return true
+            }
+            // Browser creation failed (e.g. browser disabled). Fall through
+            // to the regular preview pipeline below so the click is not lost.
+        }
+
         if CmdClickMarkdownRouteSettings.shouldRoute(path: filePath),
            workspace.openOrFocusMarkdownSplit(from: sourcePanelId, filePath: filePath) != nil {
             return true

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1017,12 +1017,17 @@ func browserReadAccessURL(forLocalFileURL fileURL: URL, fileManager: FileManager
     // Prefer a broader root (e.g. user home) so sibling assets referenced
     // via `../assets/style.css` resolve. Only widen access to a root that
     // actually contains the target file.
-    let standardizedTarget = fileURL.standardizedFileURL.path
+    //
+    // Resolve symlinks on both the target and each root before comparing so
+    // a symlink inside `$HOME` that points outside cannot trick us into
+    // granting home-wide read access to a file that is, in canonical terms,
+    // not under `$HOME`.
+    let canonicalTarget = fileURL.resolvingSymlinksInPath().standardizedFileURL.path
     for root in browserReadAccessRootCandidates(fileManager: fileManager) {
-        let rootPath = root.path
-        guard !rootPath.isEmpty, rootPath != "/" else { continue }
-        let prefix = rootPath.hasSuffix("/") ? rootPath : rootPath + "/"
-        if standardizedTarget == rootPath || standardizedTarget.hasPrefix(prefix) {
+        let canonicalRoot = root.resolvingSymlinksInPath().standardizedFileURL.path
+        guard !canonicalRoot.isEmpty, canonicalRoot != "/" else { continue }
+        let prefix = canonicalRoot.hasSuffix("/") ? canonicalRoot : canonicalRoot + "/"
+        if canonicalTarget == canonicalRoot || canonicalTarget.hasPrefix(prefix) {
             return root
         }
     }

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -981,12 +981,50 @@ struct BrowserPopupBrowserContext {
     let processPool: WKProcessPool
 }
 
+/// Roots that are reasonable to grant a `WKWebView` read access to when
+/// loading a local `file://` URL.
+///
+/// We start from the user's home directory because most authored HTML the
+/// user navigates to (project checkouts, generated reports, static-site
+/// previews) keeps its CSS/images in a sibling directory of the page itself
+/// (e.g. `<link href="../../assets/style.css">`). Granting access only to
+/// the page's parent directory — as `loadFileURL` does by default — leaves
+/// those resources blocked by WebKit's sandbox, so the page renders with
+/// User Agent default styling only and looks unstyled. Granting access to
+/// the user home keeps siblings reachable while still excluding system
+/// directories outside `$HOME`.
+///
+/// For files outside the user's home (e.g. `/tmp`, `/Volumes/...`) we fall
+/// back to the file's parent directory, matching the previous behavior.
+func browserReadAccessRootCandidates(fileManager: FileManager = .default) -> [URL] {
+    var roots: [URL] = []
+    let home = fileManager.homeDirectoryForCurrentUser.standardizedFileURL
+    if !home.path.isEmpty, home.path.hasPrefix("/") {
+        roots.append(home)
+    }
+    return roots
+}
+
 func browserReadAccessURL(forLocalFileURL fileURL: URL, fileManager: FileManager = .default) -> URL? {
     guard fileURL.isFileURL, fileURL.path.hasPrefix("/") else { return nil }
     let path = fileURL.path
     var isDirectory: ObjCBool = false
-    if fileManager.fileExists(atPath: path, isDirectory: &isDirectory), isDirectory.boolValue {
+    let exists = fileManager.fileExists(atPath: path, isDirectory: &isDirectory)
+    if exists, isDirectory.boolValue {
         return fileURL
+    }
+
+    // Prefer a broader root (e.g. user home) so sibling assets referenced
+    // via `../assets/style.css` resolve. Only widen access to a root that
+    // actually contains the target file.
+    let standardizedTarget = fileURL.standardizedFileURL.path
+    for root in browserReadAccessRootCandidates(fileManager: fileManager) {
+        let rootPath = root.path
+        guard !rootPath.isEmpty, rootPath != "/" else { continue }
+        let prefix = rootPath.hasSuffix("/") ? rootPath : rootPath + "/"
+        if standardizedTarget == rootPath || standardizedTarget.hasPrefix(prefix) {
+            return root
+        }
     }
 
     let parent = fileURL.deletingLastPathComponent()

--- a/cmuxTests/BrowserConfigTests.swift
+++ b/cmuxTests/BrowserConfigTests.swift
@@ -3649,9 +3649,18 @@ final class BrowserReadAccessURLTests: XCTestCase {
         try "<html></html>".write(to: file, atomically: true, encoding: .utf8)
 
         // Skip on machines where the system temp dir happens to live under
-        // the user's home (rare, e.g. some CI sandboxes).
-        let home = FileManager.default.homeDirectoryForCurrentUser.standardizedFileURL.path
-        try XCTSkipIf(tempRoot.path.hasPrefix(home + "/") || tempRoot.path == home)
+        // the user's home (rare, e.g. some CI sandboxes). Compare canonical
+        // (symlink-resolved) path components instead of doing a fragile
+        // string prefix match.
+        let homeURL = FileManager.default.homeDirectoryForCurrentUser
+            .resolvingSymlinksInPath()
+            .standardizedFileURL
+        let canonicalTempRoot = tempRoot.resolvingSymlinksInPath().standardizedFileURL
+        let homeComponents = homeURL.pathComponents
+        let tempComponents = canonicalTempRoot.pathComponents
+        let tempIsUnderHome = tempComponents.count >= homeComponents.count
+            && Array(tempComponents.prefix(homeComponents.count)) == homeComponents
+        try XCTSkipIf(tempIsUnderHome)
 
         let readAccessURL = try XCTUnwrap(browserReadAccessURL(forLocalFileURL: file))
         XCTAssertEqual(readAccessURL.standardizedFileURL, dir.standardizedFileURL)

--- a/cmuxTests/BrowserConfigTests.swift
+++ b/cmuxTests/BrowserConfigTests.swift
@@ -3610,6 +3610,69 @@ final class BrowserReadAccessURLTests: XCTestCase {
         let hostOnly = try XCTUnwrap(URL(string: "file://example.html"))
         XCTAssertNil(browserReadAccessURL(forLocalFileURL: hostOnly))
     }
+
+    func testWidensReadAccessToUserHomeForFilesUnderHome() throws {
+        // Files under the user's home directory should grant read access at
+        // the home root so sibling-directory assets (e.g. `../assets/style.css`
+        // referenced from a deeply nested generated report) resolve. Without
+        // this, WKWebView's sandbox blocks anything outside the page's
+        // immediate parent and the page renders unstyled.
+        let fm = FileManager.default
+        let home = fm.homeDirectoryForCurrentUser.standardizedFileURL
+        let containerName = "BrowserReadAccessURLTests-\(UUID().uuidString)"
+        let container = home.appendingPathComponent(containerName, isDirectory: true)
+        let nested = container
+            .appendingPathComponent("reports", isDirectory: true)
+            .appendingPathComponent("2026-05-15", isDirectory: true)
+        let file = nested.appendingPathComponent("kr-stocks.html")
+        try fm.createDirectory(at: nested, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: container) }
+        try "<html></html>".write(to: file, atomically: true, encoding: .utf8)
+
+        let readAccessURL = try XCTUnwrap(browserReadAccessURL(forLocalFileURL: file))
+        XCTAssertEqual(readAccessURL.standardizedFileURL, home)
+    }
+
+    func testFallsBackToParentDirectoryForFilesOutsideHome() throws {
+        // /tmp is outside the user home; behavior should match the previous
+        // parent-directory fallback so we don't accidentally widen access on
+        // shared paths.
+        let tempRoot = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .standardizedFileURL
+        let dir = tempRoot.appendingPathComponent(
+            "BrowserReadAccessURLTests-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        let file = dir.appendingPathComponent("sample.html")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try "<html></html>".write(to: file, atomically: true, encoding: .utf8)
+
+        // Skip on machines where the system temp dir happens to live under
+        // the user's home (rare, e.g. some CI sandboxes).
+        let home = FileManager.default.homeDirectoryForCurrentUser.standardizedFileURL.path
+        try XCTSkipIf(tempRoot.path.hasPrefix(home + "/") || tempRoot.path == home)
+
+        let readAccessURL = try XCTUnwrap(browserReadAccessURL(forLocalFileURL: file))
+        XCTAssertEqual(readAccessURL.standardizedFileURL, dir.standardizedFileURL)
+    }
+}
+
+final class CommandClickFileOpenRouterBrowserRenderTests: XCTestCase {
+    func testHTMLExtensionsRouteToBrowser() {
+        XCTAssertTrue(CommandClickFileOpenRouter.shouldRenderInBrowser(path: "/tmp/index.html"))
+        XCTAssertTrue(CommandClickFileOpenRouter.shouldRenderInBrowser(path: "/tmp/INDEX.HTML"))
+        XCTAssertTrue(CommandClickFileOpenRouter.shouldRenderInBrowser(path: "/tmp/page.htm"))
+        XCTAssertTrue(CommandClickFileOpenRouter.shouldRenderInBrowser(path: "/tmp/page.xhtml"))
+    }
+
+    func testNonHTMLExtensionsDoNotRouteToBrowser() {
+        XCTAssertFalse(CommandClickFileOpenRouter.shouldRenderInBrowser(path: "/tmp/readme.md"))
+        XCTAssertFalse(CommandClickFileOpenRouter.shouldRenderInBrowser(path: "/tmp/main.swift"))
+        XCTAssertFalse(CommandClickFileOpenRouter.shouldRenderInBrowser(path: "/tmp/style.css"))
+        XCTAssertFalse(CommandClickFileOpenRouter.shouldRenderInBrowser(path: "/tmp/data.json"))
+        XCTAssertFalse(CommandClickFileOpenRouter.shouldRenderInBrowser(path: "/tmp/no-extension"))
+    }
 }
 
 


### PR DESCRIPTION
## Summary

Local `.html` files (e.g. `file:///Users/me/reports/2026-05-15/page.html`) currently fail to render correctly in cmux's embedded browser in two ways:

1. **Cmd-clicking an `.html` link in the terminal** opens the file in the file-preview viewer's *text* mode, so the user sees raw HTML source instead of the rendered page. `FilePreviewKindResolver.textExtensions` includes `htm` / `html`, and the cmd-click router unconditionally hands HTML over to that pipeline.

2. **Navigating directly to a `file://` URL in a browser tab** loads the document, but external resources (CSS, images, scripts) referenced via `../assets/style.css`-style relative paths are silently blocked by WebKit's sandbox. The result is a page with only User-Agent default styling — text and font-size are visible, but the layout, colors, and images are gone. The cause is `browserReadAccessURL`, which only grants read access to the page's *immediate parent directory*. Generated reports, static-site previews, and project-local docs commonly keep their assets in a sibling directory (e.g. `reports/2026-05-15/page.html` → `../../assets/style.css`), so anything more than one level up is blocked.

This PR fixes both.

## Repro

Create a folder layout like:

```
/Users/me/site/
├── assets/style.css        ← shared stylesheet
└── reports/2026-05-15/
    └── page.html           ← <link rel="stylesheet" href="../../assets/style.css">
```

Before this PR:

- `file:///Users/me/site/reports/2026-05-15/page.html` typed in a browser tab → renders unstyled (only UA defaults apply).
- `cmd-click` on the same path in a terminal → opens the file-preview viewer in text mode, showing the raw `<html>...</html>` source.

After this PR, both produce the styled page in the embedded browser.

## Changes

### `Sources/CommandClickFileOpenRouter.swift`

Recognizes `html` / `htm` / `xhtml` and routes them into the embedded browser via `newBrowserSurface` / `newBrowserSplit` *before* falling through to the markdown / file-preview pipelines. Gated on `CmdClickSupportedFileRouteSettings.isEnabled()` and `isReadableRegularFile`, mirroring the existing supported-file route. Falls back to the original pipeline if browser creation fails (e.g. browser disabled in settings) so the click is never silently dropped.

### `Sources/Panels/BrowserPanel.swift`

`browserReadAccessURL` now widens the allowed read-access root to the user's home directory when the target file lives under `$HOME`, so sibling-directory assets resolve. Files outside `$HOME` (e.g. `/tmp`, `/Volumes/...`) keep the previous parent-directory behavior — we don't want to widen sandbox scope on shared paths. The change is captured in a new helper, `browserReadAccessRootCandidates`, so the policy is auditable in one place.

### `cmuxTests/BrowserConfigTests.swift`

- New `BrowserReadAccessURLTests` cases:
  - `testWidensReadAccessToUserHomeForFilesUnderHome` — verifies a deeply nested HTML under `$HOME` returns home as the read-access root.
  - `testFallsBackToParentDirectoryForFilesOutsideHome` — verifies `/tmp` files keep the previous parent-only fallback (skipped on the rare CI/sandbox config where `NSTemporaryDirectory()` is itself under `$HOME`).
- New `CommandClickFileOpenRouterBrowserRenderTests`:
  - `testHTMLExtensionsRouteToBrowser` — `.html`, `.htm`, `.xhtml`, and uppercase variants.
  - `testNonHTMLExtensionsDoNotRouteToBrowser` — `.md`, `.swift`, `.css`, `.json`, no-extension files.

## Build / test status

I do **not** currently have `zig` installed locally, so I could not produce a full Debug build via `./scripts/reload.sh --tag …` from this machine. I verified the Swift sources parse cleanly (`swiftc -parse`) and that the test additions compile against the existing types. Happy to follow up with a screen recording / additional iteration once a maintainer kicks CI, or I can install zig and reload locally if preferred.

If a reviewer wants to reproduce locally:

```bash
git fetch origin pull/<this-pr>/head:fix-local-html-render
git checkout fix-local-html-render
./scripts/reload.sh --tag fix-html
# then in the launched build, navigate a browser tab to a file:// URL
# whose <link href> points into a sibling-of-parent directory under $HOME.
```

## Notes / open questions

- The home-directory widening is intentionally scoped to `$HOME` only. Granting `/` would make every `file://` page able to read every other file the user owns; granting only the parent directory is too tight (the bug). `$HOME` matches what users typically intend by "open this local report in cmux's browser" while still excluding `/etc`, `/Library`, `/private`, etc. Open to alternatives — e.g. recognizing the workspace root, or making the widening opt-in via a setting.
- The HTML routing branch sits on top of the existing `CmdClickSupportedFileRouteSettings` toggle, so a user who has explicitly disabled in-cmux file routing will still get the old `NSWorkspace.shared.open(url)` behavior. That seemed safer than introducing a separate toggle for HTML.
- I considered removing `htm` / `html` from `FilePreviewKindResolver.textExtensions` directly. I left it in place so that `.html` files opened from contexts that *don't* go through `CommandClickFileOpenRouter` (e.g. an explicit "open in text editor" path) still degrade to text mode rather than failing. If maintainers prefer the stricter approach, I can flip that bit and update the related tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes local `.html` rendering in the cmux browser so pages open with full styling, including relative assets under `$HOME`. Cmd-click on `.html` now renders instead of raw source, with read-access checks hardened against symlink tricks.

- **Bug Fixes**
  - Route `.html`/`.htm`/`.xhtml` cmd-clicks to the embedded browser. Gated by `CmdClickSupportedFileRouteSettings`; falls back to file preview if the browser is disabled.
  - Widen `WKWebView` read access to the user’s home when the target is under `$HOME` so sibling assets resolve; keep parent-directory scope for files outside `$HOME`. Resolve symlinks on both target and root candidates before containment checks to prevent bypass.
  - Add tests for HTML routing, home read-access widening, and canonical containment; update temp-dir test to use symlink-resolved path components.

<sup>Written for commit 5a62ddc64d4125ed84633eba89121c77c98a3fa1. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4197?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Command-click can open HTML/HTM/XHTML files in the embedded browser, preferring a side browser view.
* **Improved Behavior**
  * Browser file access now more reliably allows loading related local assets for files under the user home directory, falling back to prior behavior for other locations.
* **Tests**
  * Added tests covering browser routing for HTML extensions and read-access behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4197)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->