### PR TITLE
Fix notification popover teardown crash

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -10562,8 +10562,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     @discardableResult
-    func dismissNotificationsPopoverIfShown() -> Bool {
-        titlebarAccessoryController.dismissNotificationsPopoverIfShown()
+    func dismissNotificationsPopoverIfShown(animated: Bool = true) -> Bool {
+        titlebarAccessoryController.dismissNotificationsPopoverIfShown(animated: animated)
     }
 
     func isNotificationsPopoverShown() -> Bool {

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -1581,8 +1581,9 @@ final class TitlebarControlsAccessoryViewController: NSTitlebarAccessoryViewCont
         )
     }
 
-    func dismissNotificationsPopover() {
+    func dismissNotificationsPopover(animated: Bool = true) {
         if notificationsPopover.isShown {
+            notificationsPopover.animates = animated
             notificationsPopover.performClose(nil)
         }
     }
@@ -1994,7 +1995,7 @@ final class UpdateTitlebarAccessoryController {
         for index in matchingIndices {
             let accessory = window.titlebarAccessoryViewControllers[index]
             if let controls = accessory as? TitlebarControlsAccessoryViewController {
-                controls.dismissNotificationsPopover()
+                controls.dismissNotificationsPopover(animated: false)
             }
             window.removeTitlebarAccessoryViewController(at: index)
         }
@@ -2066,7 +2067,7 @@ final class UpdateTitlebarAccessoryController {
                 return
             }
             for controller in controllers where controller !== target {
-                controller.dismissNotificationsPopover()
+                controller.dismissNotificationsPopover(animated: animated)
             }
             target.toggleNotificationsPopover(animated: animated, externalAnchor: anchorView)
             return
@@ -2077,7 +2078,7 @@ final class UpdateTitlebarAccessoryController {
         let target = preferredNotificationsController(from: controllers, preferShownPopover: true)
         for controller in controllers {
             if controller !== target {
-                controller.dismissNotificationsPopover()
+                controller.dismissNotificationsPopover(animated: animated)
             }
         }
         target?.toggleNotificationsPopover(animated: animated)
@@ -2139,15 +2140,16 @@ final class UpdateTitlebarAccessoryController {
     }
 
     @discardableResult
-    func dismissNotificationsPopoverIfShown() -> Bool {
+    func dismissNotificationsPopoverIfShown(animated: Bool = true) -> Bool {
         let controllers = controlsControllers.allObjects
         var dismissed = false
         if let popover = detachedNotificationsPopover, popover.isShown {
+            popover.animates = animated
             popover.performClose(nil)
             dismissed = true
         }
         for controller in controllers where controller.popoverIsShownForTesting {
-            controller.dismissNotificationsPopover()
+            controller.dismissNotificationsPopover(animated: animated)
             dismissed = true
         }
         return dismissed
@@ -2160,7 +2162,7 @@ final class UpdateTitlebarAccessoryController {
         let target = preferredNotificationsController(from: controllers, preferShownPopover: false)
         for controller in controllers {
             if controller !== target {
-                controller.dismissNotificationsPopover()
+                controller.dismissNotificationsPopover(animated: animated)
             }
         }
         guard let target else { return }

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -127,7 +127,7 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         AppDelegate.shared?.shortcutLayoutCharacterProvider = KeyboardLayout.character(forKeyCode:modifierFlags:)
         AppDelegate.shared?.debugCloseMainWindowConfirmationHandler = nil
         AppDelegate.shared?.debugCreateMainWindowSourceIsNativeFullScreenOverride = nil
-        AppDelegate.shared?.dismissNotificationsPopoverIfShown()
+        AppDelegate.shared?.dismissNotificationsPopoverIfShown(animated: false)
         RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
         for action in KeyboardShortcutSettings.Action.allCases {
             if actionsWithPersistedShortcut.contains(action),
@@ -973,6 +973,33 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
 #else
         XCTFail("debugHandleCustomShortcut is only available in DEBUG")
 #endif
+    }
+
+    func testNotificationsPopoverDismissCanSkipAnimationsForTestTeardown() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let windowId = appDelegate.createMainWindow()
+        defer { closeWindow(withId: windowId) }
+
+        guard let window = window(withId: windowId) else {
+            XCTFail("Expected test window")
+            return
+        }
+
+        appDelegate.attachUpdateAccessory(to: window)
+        window.makeKeyAndOrderFront(nil)
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+
+        appDelegate.toggleNotificationsPopover(animated: false)
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+        XCTAssertTrue(appDelegate.isNotificationsPopoverShown())
+
+        XCTAssertTrue(appDelegate.dismissNotificationsPopoverIfShown(animated: false))
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+        XCTAssertFalse(appDelegate.isNotificationsPopoverShown())
     }
 
     func testCmdNResolvesEventWindowWhenObjectKeyLookupIsMismatched() {


### PR DESCRIPTION
Summary:
- Recent crash review found one current-main actionable crash: `cmux DEV-2026-05-14-192725.ips`, `EXC_BAD_ACCESS` in AppKit `_NSWindowTransformAnimation dealloc` while `AppDelegateShortcutRoutingTests.tearDown()` dismissed the notifications popover.
- Adds a regression test for non-animated notification popover teardown.
- Plumbs `animated` through notification popover dismissal and uses non-animated dismissal for teardown and accessory removal paths.

Tests:
- Red commit `1921883d0`: on cloud macOS 26.4, the new test failed to compile because `dismissNotificationsPopoverIfShown(animated:)` did not exist yet.
- Green commit `94af2ac03`: same cloud targeted test passed with exit 0.
- `git diff --check origin/main...HEAD`
- `./scripts/reload.sh --tag popfix`

Cloud proof:
- Run: https://github.com/manaflow-ai/cmux-loader/actions/runs/25918449540
- Host: `cloud-mac-25918449540`
- Control layer: `cua-ssh` became usable after the targeted xcodebuild lane finished.
- CUA state artifact: `/tmp/cloud-mac-25918449540-finder-state/state.txt`
- Screenshot checked: `/tmp/cloud-mac-25918449540-finder-state/screenshot.jpe`
- Full-screen Terminal recording was blocked by Computer Use safety for `com.apple.Terminal`, so the reproduction proof is the cloud red/green targeted xcodebuild result.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: limited to notification popover dismissal behavior (plumbing an `animated` flag) and test updates, with no changes to notification data or routing logic.
> 
> **Overview**
> Prevents a teardown-time AppKit crash by **plumbing an `animated` flag through notification popover dismissal** and using non-animated closes in sensitive paths.
> 
> `AppDelegate.dismissNotificationsPopoverIfShown` and `UpdateTitlebarAccessory` dismissal helpers now accept `animated` and set `NSPopover.animates` before `performClose`, including when removing the titlebar accessory. Tests update teardown to dismiss without animation and add a regression test that opens and dismisses the popover with `animated: false`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94af2ac031ff0801cbfc7d34bf4af343104a38b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a macOS crash during teardown by allowing non-animated dismissal of the notifications popover and using it in tests and accessory removal. Prevents EXC_BAD_ACCESS in AppKit when closing the popover during teardown.

- **Bug Fixes**
  - Added an `animated` flag to popover dismissal and threaded it through AppDelegate and titlebar accessory controllers (sets `popover.animates` accordingly).
  - Use `animated: false` during test teardown and when removing accessory controllers to avoid teardown animations that triggered the crash.
  - Added a regression test that opens the popover, dismisses it without animation, and verifies it closes cleanly.

<sup>Written for commit 94af2ac031ff0801cbfc7d34bf4af343104a38b2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated notification popover dismissal functionality to provide configurable animation behavior.

* **Tests**
  * Added test coverage for popover dismissal animation options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4204)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->