### PR TITLE
Improve heavy workspace switch latency

### DIFF
--- a/Sources/BackgroundWorkspacePrimeCoordinator.swift
+++ b/Sources/BackgroundWorkspacePrimeCoordinator.swift
@@ -3,6 +3,8 @@ import Combine
 
 @MainActor
 final class BackgroundWorkspacePrimeCoordinator {
+    private let timeoutSeconds: TimeInterval
+
     private nonisolated enum PrimeCompletionReason: String {
         case alreadyCleared = "already_cleared"
         case cancelled
@@ -93,9 +95,25 @@ final class BackgroundWorkspacePrimeCoordinator {
         }
     }
 
+    init(timeoutSeconds: TimeInterval = Policy.timeoutSeconds) {
+        self.timeoutSeconds = timeoutSeconds
+    }
+
     deinit {
         // Explicit for the required_deinit lint; per-prime resources live on Waiter.
     }
+
+#if DEBUG
+    func debugPrimeBackgroundWorkspaceOnceForTesting(
+        workspaceId: UUID,
+        tabManager: TabManager
+    ) async -> String {
+        await primeBackgroundWorkspaceIfNeeded(
+            workspaceId: workspaceId,
+            tabManager: tabManager
+        ).rawValue
+    }
+#endif
 
     func taskKey(for tabManager: TabManager) -> [String] {
         tabManager.pendingBackgroundWorkspaceLoadIds
@@ -114,8 +132,6 @@ final class BackgroundWorkspacePrimeCoordinator {
 
                 switch reason {
                 case .timeout:
-                    // Keep the hidden mount retained; pending background initial commands
-                    // must stay eligible to start until the surface is actually ready.
                     continue
                 case .cancelled:
                     continue
@@ -141,14 +157,22 @@ final class BackgroundWorkspacePrimeCoordinator {
         cmuxDebugLog("workspace.backgroundPrime.start workspace=\(workspaceId.uuidString.prefix(5))")
 #endif
 
-        let completionReason: PrimeCompletionReason
+        var completionReason: PrimeCompletionReason = .cancelled
+        defer {
+            switch completionReason {
+            case .timeout, .cancelled:
+                tabManager.releaseBackgroundWorkspaceMount(for: workspaceId)
+            case .alreadyCleared, .surfaceReady, .workspaceRemoved:
+                break
+            }
+        }
         switch stepBackgroundWorkspacePrime(workspaceId: workspaceId, tabManager: tabManager) {
         case .completed(let reason):
             completionReason = reason
         case .pending:
             completionReason = await waitForBackgroundWorkspacePrimeCompletion(
                 workspaceId: workspaceId,
-                timeoutSeconds: Policy.timeoutSeconds,
+                timeoutSeconds: timeoutSeconds,
                 tabManager: tabManager
             )
         }

--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -20,6 +20,16 @@ private func browserPortalDebugToken(_ view: NSView?) -> String {
 private func browserPortalDebugFrame(_ rect: NSRect) -> String {
     String(format: "%.1f,%.1f %.1fx%.1f", rect.origin.x, rect.origin.y, rect.size.width, rect.size.height)
 }
+
+private func browserPortalSwitchDebugFields() -> String {
+    MainActor.assumeIsolated {
+        guard let snapshot = AppDelegate.shared?.tabManager?.debugCurrentWorkspaceSwitchSnapshot() else {
+            return "switchId=none"
+        }
+        let dtMs = (CACurrentMediaTime() - snapshot.startedAt) * 1000
+        return "switchId=\(snapshot.id) switchDt=\(String(format: "%.2fms", dtMs))"
+    }
+}
 #endif
 
 private extension NSObject {
@@ -2823,9 +2833,24 @@ final class WindowBrowserPortal: NSObject {
     func updateEntryVisibility(forWebViewId webViewId: ObjectIdentifier, visibleInUI: Bool, zPriority: Int) {
         guard var entry = entriesByWebViewId[webViewId] else { return }
         guard entry.visibleInUI != visibleInUI || entry.zPriority != zPriority else { return }
+        let previousZPriority = entry.zPriority
         entry.visibleInUI = visibleInUI
         entry.zPriority = zPriority
         entriesByWebViewId[webViewId] = entry
+        let priorityIncreased = zPriority > previousZPriority
+        if visibleInUI,
+           priorityIncreased,
+           let containerView = entry.containerView,
+           containerView.superview === hostView,
+           hostView.subviews.last !== containerView {
+#if DEBUG
+            cmuxDebugLog(
+                "browser.portal.reparent container=\(browserPortalDebugToken(containerView)) " +
+                "reason=visibilityPriority priorityIncreased=1 z=\(zPriority) prevZ=\(previousZPriority)"
+            )
+#endif
+            hostView.addSubview(containerView, positioned: .above, relativeTo: nil)
+        }
     }
 
     func isWebViewBoundToAnchor(withId webViewId: ObjectIdentifier, anchorView: NSView) -> Bool {
@@ -3656,6 +3681,7 @@ final class WindowBrowserPortal: NSObject {
 #if DEBUG
         cmuxDebugLog(
             "browser.portal.sync.result web=\(browserPortalDebugToken(webView)) source=\(source) " +
+            "\(browserPortalSwitchDebugFields()) " +
             "container=\(browserPortalDebugToken(containerView)) " +
             "anchor=\(browserPortalDebugToken(anchorView)) host=\(browserPortalDebugToken(hostView)) " +
             "hostWin=\(hostView.window?.windowNumber ?? -1) " +

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -767,10 +767,11 @@ private func commandPaletteOwningWebView(for responder: NSResponder?) -> WKWebVi
 }
 
 enum WorkspaceMountPolicy {
-    // Keep only the selected workspace mounted to minimize layer-tree traversal.
-    static let maxMountedWorkspaces = 1
-    // During workspace cycling, keep only a minimal handoff pair (selected + retiring).
-    static let maxMountedWorkspacesDuringCycle = 2
+    // Keep warm workspaces mounted once they have been visited. The end-user hot path is
+    // switching among already-loaded terminals and browsers, not minimizing session restore
+    // work by evicting hidden workspace views.
+    static let maxMountedWorkspaces = Int.max
+    static let maxMountedWorkspacesDuringCycle = Int.max
 
     static func nextMountedWorkspaceIds(
         current: [UUID],
@@ -795,12 +796,6 @@ enum WorkspaceMountPolicy {
                 ordered.removeAll { $0 == id }
                 ordered.insert(id, at: 0)
             }
-        }
-
-        if isCycleHot,
-           pinnedIds.isEmpty,
-           let selected {
-            ordered.removeAll { $0 != selected }
         }
 
         // Ensure pinned ids (retiring handoff workspaces) are always retained at highest priority.
@@ -847,8 +842,8 @@ enum WorkspaceMountPolicy {
 
     private static func cycleWarmIds(selected: UUID, orderedTabIds: [UUID]) -> [UUID] {
         guard orderedTabIds.contains(selected) else { return [selected] }
-        // Keep warming focused to the selected workspace. Retiring/target workspaces are
-        // pinned by handoff logic, so warming adjacent neighbors here just adds layout work.
+        // Keep warming focused to the selected workspace. Workspaces already in `current`
+        // remain mounted, so this only controls which new workspace gets inserted first.
         return [selected]
     }
 }
@@ -868,7 +863,7 @@ enum MountedWorkspacePresentationPolicy {
 
         return MountedWorkspacePresentation(
             isRenderedVisible: isRenderedVisible,
-            isPanelVisible: isRenderedVisible,
+            isPanelVisible: true,
             renderOpacity: isRenderedVisible ? 1 : 0
         )
     }
@@ -3658,21 +3653,26 @@ struct ContentView: View {
         workspaceHandoffFallbackTask?.cancel()
         workspaceHandoffFallbackTask = nil
         let retiring = retiringWorkspaceId
-
-        // Disable portal rendering for the retiring workspace BEFORE clearing
-        // retiringWorkspaceId. Once cleared, reconcileMountedWorkspaceIds unmounts
-        // the workspace — but dismantleNSView intentionally doesn't hide portal views
-        // during transient rebuilds. Disabling here also cancels stale layout follow-up
-        // loops that could re-show an old terminal above the newly selected workspace.
-        if let retiring, let workspace = tabManager.tabs.first(where: { $0.id == retiring }) {
-            workspace.setPortalRenderingEnabled(false, reason: "workspaceHandoff")
-        }
+        let selected = tabManager.selectedTabId
+        let didLowerRetiring = retiring.flatMap { retiringId in
+            tabManager.tabs.first(where: { $0.id == retiringId })?
+                .prioritizePortalViewsForCurrentRenderedLayout(zPriority: 0, reason: "workspaceHandoff.retiring")
+        } ?? false
+        let didPrioritizeSelected = selected.flatMap { selectedId in
+            tabManager.tabs.first(where: { $0.id == selectedId })?
+                .prioritizePortalViewsForCurrentRenderedLayout(zPriority: 2, reason: "workspaceHandoff.selected")
+        } ?? false
 
         retiringWorkspaceId = nil
         tabManager.completePendingWorkspaceUnfocus(reason: reason)
 #if DEBUG
         if let snapshot = tabManager.debugCurrentWorkspaceSwitchSnapshot() {
             let dtMs = (CACurrentMediaTime() - snapshot.startedAt) * 1000
+            cmuxDebugLog(
+                "ws.handoff.prioritize id=\(snapshot.id) dt=\(debugMsText(dtMs)) " +
+                "retiring=\(debugShortWorkspaceId(retiring)) lowered=\(didLowerRetiring ? 1 : 0) " +
+                "selected=\(debugShortWorkspaceId(selected)) raised=\(didPrioritizeSelected ? 1 : 0)"
+            )
             cmuxDebugLog(
                 "ws.handoff.complete id=\(snapshot.id) dt=\(debugMsText(dtMs)) reason=\(reason) retiring=\(debugShortWorkspaceId(retiring))"
             )

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -3643,6 +3643,9 @@ struct ContentView: View {
     }
 
     private func canCompleteWorkspaceHandoffImmediately(for workspaceId: UUID) -> Bool {
+        if tabManager.isWorkspaceCycleHot {
+            return true
+        }
         guard let workspace = tabManager.tabs.first(where: { $0.id == workspaceId }) else { return true }
         if let focusedPanelId = workspace.focusedPanelId,
            workspace.browserPanel(for: focusedPanelId) != nil {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -831,6 +831,20 @@ enum WorkspaceMountPolicy {
         return ordered
     }
 
+    static func pinnedWorkspaceIds(
+        retiringWorkspaceId: UUID?,
+        backgroundWorkspaceLoadIds: Set<UUID>,
+        debugPinnedWorkspaceLoadIds: Set<UUID>,
+        isCycleHot: Bool
+    ) -> Set<UUID> {
+        let handoffPinnedIds = retiringWorkspaceId.map { Set([ $0 ]) } ?? []
+        let shouldMountBackgroundLoads = retiringWorkspaceId == nil && !isCycleHot
+        let backgroundPinnedIds = shouldMountBackgroundLoads ? backgroundWorkspaceLoadIds : []
+        return handoffPinnedIds
+            .union(backgroundPinnedIds)
+            .union(debugPinnedWorkspaceLoadIds)
+    }
+
     private static func cycleWarmIds(selected: UUID, orderedTabIds: [UUID]) -> [UUID] {
         guard orderedTabIds.contains(selected) else { return [selected] }
         // Keep warming focused to the selected workspace. Retiring/target workspaces are
@@ -2786,6 +2800,13 @@ struct ContentView: View {
             scheduleTitlebarTextRefresh()
         })
 
+        view = AnyView(view.onReceive(NotificationCenter.default.publisher(for: .terminalPortalVisibilityDidChange)) { notification in
+            guard let tabId = notification.userInfo?[GhosttyNotificationKey.tabId] as? UUID,
+                  tabId == tabManager.selectedTabId,
+                  notification.userInfo?[GhosttyNotificationKey.terminalVisibleInUI] as? Bool == true else { return }
+            completeWorkspaceHandoffIfNeeded(focusedTabId: tabId, reason: "terminal_visible")
+        })
+
         view = AnyView(view.onChange(of: titlebarThemeGeneration) { oldValue, newValue in
             guard GhosttyApp.shared.backgroundLogEnabled else { return }
             GhosttyApp.shared.logBackground(
@@ -3271,11 +3292,14 @@ struct ContentView: View {
         let currentTabs = tabs ?? tabManager.tabs
         let orderedTabIds = currentTabs.map { $0.id }
         let effectiveSelectedId = selectedId ?? tabManager.selectedTabId
-        let handoffPinnedIds = retiringWorkspaceId.map { Set([ $0 ]) } ?? []
-        let pinnedIds = handoffPinnedIds
-            .union(tabManager.mountedBackgroundWorkspaceLoadIds)
-            .union(tabManager.debugPinnedWorkspaceLoadIds)
         let isCycleHot = tabManager.isWorkspaceCycleHot
+        let pinnedIds = WorkspaceMountPolicy.pinnedWorkspaceIds(
+            retiringWorkspaceId: retiringWorkspaceId,
+            backgroundWorkspaceLoadIds: tabManager.mountedBackgroundWorkspaceLoadIds,
+            debugPinnedWorkspaceLoadIds: tabManager.debugPinnedWorkspaceLoadIds,
+            isCycleHot: isCycleHot
+        )
+        let handoffPinnedIds = retiringWorkspaceId.map { Set([ $0 ]) } ?? []
         let shouldKeepHandoffPair = isCycleHot && !handoffPinnedIds.isEmpty
         let baseMaxMounted = shouldKeepHandoffPair
             ? WorkspaceMountPolicy.maxMountedWorkspacesDuringCycle

--- a/Sources/GhosttyTerminalAppearance.swift
+++ b/Sources/GhosttyTerminalAppearance.swift
@@ -94,6 +94,7 @@ enum GhosttyNotificationKey {
     static let cellSize = "ghostty.cellSize"
     static let tabId = "ghostty.tabId"
     static let surfaceId = "ghostty.surfaceId"
+    static let terminalVisibleInUI = "ghostty.terminalVisibleInUI"
     static let explicitFocusIntent = "ghostty.explicitFocusIntent"
     static let title = "ghostty.title"
     static let backgroundColor = "ghostty.backgroundColor"

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -11313,7 +11313,8 @@ final class GhosttySurfaceScrollView: NSView {
                 object: self,
                 userInfo: [
                     GhosttyNotificationKey.surfaceId: surfaceView.terminalSurface?.id as Any,
-                    GhosttyNotificationKey.tabId: surfaceView.tabId as Any
+                    GhosttyNotificationKey.tabId: surfaceView.tabId as Any,
+                    GhosttyNotificationKey.terminalVisibleInUI: visible
                 ]
             )
         }

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -4398,9 +4398,16 @@ class TabManager: ObservableObject {
     }
 
     func selectWorkspace(_ workspace: Workspace) {
+        guard selectedTabId != workspace.id else {
+#if DEBUG
+            debugPrimeWorkspaceSwitchTrigger("select", to: workspace.id)
+#endif
+            return
+        }
 #if DEBUG
         debugPrimeWorkspaceSwitchTrigger("select", to: workspace.id)
 #endif
+        activateWorkspaceCycleHotWindow()
         selectedTabId = workspace.id
     }
 
@@ -5454,14 +5461,24 @@ class TabManager: ObservableObject {
 
     func selectTab(at index: Int) {
         guard index >= 0 && index < tabs.count else { return }
+        let tabId = tabs[index].id
+        guard selectedTabId != tabId else {
 #if DEBUG
-        debugPrimeWorkspaceSwitchTrigger("select_index", to: tabs[index].id)
+            debugPrimeWorkspaceSwitchTrigger("select_index", to: tabId)
 #endif
-        selectedTabId = tabs[index].id
+            return
+        }
+#if DEBUG
+        debugPrimeWorkspaceSwitchTrigger("select_index", to: tabId)
+#endif
+        activateWorkspaceCycleHotWindow()
+        selectedTabId = tabId
     }
 
     func selectLastTab() {
         guard let lastTab = tabs.last else { return }
+        guard selectedTabId != lastTab.id else { return }
+        activateWorkspaceCycleHotWindow()
         selectedTabId = lastTab.id
     }
 

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -7,6 +7,18 @@ import Bonsplit
 private var cmuxWindowTerminalPortalKey: UInt8 = 0
 private var cmuxWindowTerminalPortalCloseObserverKey: UInt8 = 0
 
+#if DEBUG
+private func terminalPortalSwitchDebugFields() -> String {
+    MainActor.assumeIsolated {
+        guard let snapshot = AppDelegate.shared?.tabManager?.debugCurrentWorkspaceSwitchSnapshot() else {
+            return "switchId=none"
+        }
+        let dtMs = (CACurrentMediaTime() - snapshot.startedAt) * 1000
+        return "switchId=\(snapshot.id) switchDt=\(String(format: "%.2fms", dtMs))"
+    }
+}
+#endif
+
 final class WindowTerminalHostView: NSView {
     private struct DividerRegion {
         let rectInWindow: NSRect
@@ -1128,13 +1140,35 @@ final class WindowTerminalPortal: NSObject {
     /// Update the visibleInUI flag on an existing entry without rebinding.
     /// Used when a deferred bind is pending — this ensures synchronizeHostedView
     /// won't hide a view that updateNSView has already marked as visible.
-    func updateEntryVisibility(forHostedId hostedId: ObjectIdentifier, visibleInUI: Bool) {
+    func updateEntryVisibility(forHostedId hostedId: ObjectIdentifier, visibleInUI: Bool, zPriority: Int? = nil) {
         guard var entry = entriesByHostedId[hostedId] else { return }
+        let previousVisible = entry.visibleInUI
+        let previousZPriority = entry.zPriority
         entry.visibleInUI = visibleInUI
+        if let zPriority {
+            entry.zPriority = zPriority
+        }
         if !visibleInUI {
             entry.transientRecoveryRetriesRemaining = 0
         }
         entriesByHostedId[hostedId] = entry
+        let becameVisible = !previousVisible && visibleInUI
+        let priorityIncreased = entry.zPriority > previousZPriority
+        if visibleInUI,
+           (becameVisible || priorityIncreased),
+           let hostedView = entry.hostedView,
+           hostedView.superview === hostView,
+           hostView.subviews.last !== hostedView {
+#if DEBUG
+            cmuxDebugLog(
+                "portal.reparent hosted=\(portalDebugToken(hostedView)) reason=visibilityPriority " +
+                "becameVisible=\(becameVisible ? 1 : 0) priorityIncreased=\(priorityIncreased ? 1 : 0) " +
+                "z=\(entry.zPriority) prevZ=\(previousZPriority)"
+            )
+#endif
+            hostView.addSubview(hostedView, positioned: .above, relativeTo: nil)
+            ensureDividerOverlayOnTop()
+        }
     }
 
     func isHostedViewBoundToAnchor(withId hostedId: ObjectIdentifier, anchorView: NSView) -> Bool {
@@ -1655,6 +1689,7 @@ final class WindowTerminalPortal: NSObject {
 #if DEBUG
         cmuxDebugLog(
             "portal.sync.result hosted=\(portalDebugToken(hostedView)) " +
+            "\(terminalPortalSwitchDebugFields()) " +
             "anchor=\(portalDebugToken(anchorView)) host=\(portalDebugToken(hostView)) " +
             "hostWin=\(hostView.window?.windowNumber ?? -1) " +
             "old=\(portalDebugFrame(oldFrame)) raw=\(portalDebugFrame(frameInHost)) " +
@@ -2142,11 +2177,11 @@ enum TerminalWindowPortalRegistry {
     /// Update the visibleInUI flag on an existing portal entry without rebinding.
     /// Called when a bind is deferred (host not yet in window) to prevent stale
     /// portal syncs from hiding a view that is about to become visible.
-    static func updateEntryVisibility(for hostedView: GhosttySurfaceScrollView, visibleInUI: Bool) {
+    static func updateEntryVisibility(for hostedView: GhosttySurfaceScrollView, visibleInUI: Bool, zPriority: Int? = nil) {
         let hostedId = ObjectIdentifier(hostedView)
         guard let windowId = hostedToWindowId[hostedId],
               let portal = portalsByWindowId[windowId] else { return }
-        portal.updateEntryVisibility(forHostedId: hostedId, visibleInUI: visibleInUI)
+        portal.updateEntryVisibility(forHostedId: hostedId, visibleInUI: visibleInUI, zPriority: zPriority)
     }
 
     static func isHostedView(_ hostedView: GhosttySurfaceScrollView, boundTo anchorView: NSView) -> Bool {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -12087,6 +12087,54 @@ final class Workspace: Identifiable, ObservableObject {
     }
 
     @discardableResult
+    func revealPortalViewsForCurrentRenderedLayout(reason: String) -> Bool {
+        guard portalRenderingEnabled else { return false }
+        let terminalChanged = reconcileTerminalPortalVisibilityForCurrentRenderedLayout()
+        let browserChanged = reconcileBrowserPortalVisibilityForCurrentRenderedLayout(reason: reason)
+        beginEventDrivenLayoutFollowUp(reason: reason, includeGeometry: true)
+        return terminalChanged || browserChanged
+    }
+
+    @discardableResult
+    func prioritizePortalViewsForCurrentRenderedLayout(zPriority: Int, reason: String) -> Bool {
+        guard portalRenderingEnabled else { return false }
+        let visiblePanelIds = renderedVisiblePanelIdsForCurrentLayout()
+        var terminalCount = 0
+        var browserCount = 0
+
+        for panel in panels.values {
+            guard visiblePanelIds.contains(panel.id) else { continue }
+            if let terminalPanel = panel as? TerminalPanel {
+                TerminalWindowPortalRegistry.updateEntryVisibility(
+                    for: terminalPanel.hostedView,
+                    visibleInUI: true,
+                    zPriority: zPriority
+                )
+                terminalCount += 1
+            } else if let browserPanel = panel as? BrowserPanel {
+                BrowserWindowPortalRegistry.updateEntryVisibility(
+                    for: browserPanel.webView,
+                    visibleInUI: true,
+                    zPriority: zPriority
+                )
+                browserCount += 1
+            }
+        }
+
+#if DEBUG
+        if let snapshot = AppDelegate.shared?.tabManager?.debugCurrentWorkspaceSwitchSnapshot() {
+            let dtMs = (CACurrentMediaTime() - snapshot.startedAt) * 1000
+            cmuxDebugLog(
+                "ws.portal.priority id=\(snapshot.id) dt=\(String(format: "%.2fms", dtMs)) " +
+                "workspace=\(id.uuidString.prefix(5)) z=\(zPriority) terminals=\(terminalCount) browsers=\(browserCount) reason=\(reason)"
+            )
+        }
+#endif
+
+        return terminalCount > 0 || browserCount > 0
+    }
+
+    @discardableResult
     func setPortalRenderingEnabled(_ enabled: Bool, reason: String) -> Bool {
         let changed = portalRenderingEnabled != enabled
         guard changed else { return false }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -12086,21 +12086,22 @@ final class Workspace: Identifiable, ObservableObject {
         }
     }
 
-    func setPortalRenderingEnabled(_ enabled: Bool, reason: String) {
+    @discardableResult
+    func setPortalRenderingEnabled(_ enabled: Bool, reason: String) -> Bool {
         let changed = portalRenderingEnabled != enabled
+        guard changed else { return false }
         portalRenderingEnabled = enabled
         if enabled {
-            if changed {
-                beginEventDrivenLayoutFollowUp(
-                    reason: reason,
-                    includeGeometry: true
-                )
-            }
+            beginEventDrivenLayoutFollowUp(
+                reason: reason,
+                includeGeometry: true
+            )
         } else {
             clearLayoutFollowUp()
             hideAllTerminalPortalViews()
             hideAllBrowserPortalViews()
         }
+        return true
     }
 
     // MARK: - Utility

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -123,6 +123,33 @@ private func runGit(
 }
 
 @MainActor
+final class TabManagerWorkspaceSelectionPerfTests: XCTestCase {
+    func testDirectWorkspaceSelectionActivatesHotSwitchWindow() {
+        let manager = TabManager(autoWelcomeIfNeeded: false)
+        let second = manager.addWorkspace(select: false, autoWelcomeIfNeeded: false)
+
+        XCTAssertFalse(manager.isWorkspaceCycleHot)
+
+        manager.selectWorkspace(second)
+
+        XCTAssertEqual(manager.selectedTabId, second.id)
+        XCTAssertTrue(manager.isWorkspaceCycleHot)
+    }
+
+    func testSelectingCurrentWorkspaceDoesNotActivateHotSwitchWindow() {
+        let manager = TabManager(autoWelcomeIfNeeded: false)
+        guard let selected = manager.selectedWorkspace else {
+            XCTFail("Expected initial workspace")
+            return
+        }
+
+        manager.selectWorkspace(selected)
+
+        XCTAssertFalse(manager.isWorkspaceCycleHot)
+    }
+}
+
+@MainActor
 final class TabManagerChildExitCloseTests: XCTestCase {
     func testChildExitOnLastPanelClosesSelectedWorkspaceAndKeepsIndexStable() {
         let manager = TabManager()

--- a/cmuxTests/WorkspaceContentViewVisibilityTests.swift
+++ b/cmuxTests/WorkspaceContentViewVisibilityTests.swift
@@ -9,7 +9,7 @@ import Bonsplit
 #endif
 
 final class WorkspaceContentViewVisibilityTests: XCTestCase {
-    func testNonSelectedNonRetiringWorkspaceIsFullyHidden() {
+    func testNonSelectedNonRetiringWorkspaceKeepsPanelMountedButTransparent() {
         XCTAssertEqual(
             MountedWorkspacePresentationPolicy.resolve(
                 isSelectedWorkspace: false,
@@ -17,7 +17,7 @@ final class WorkspaceContentViewVisibilityTests: XCTestCase {
             ),
             MountedWorkspacePresentation(
                 isRenderedVisible: false,
-                isPanelVisible: false,
+                isPanelVisible: true,
                 renderOpacity: 0
             )
         )

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -5192,6 +5192,90 @@ final class WorkspaceMountPolicyTests: XCTestCase {
 
         XCTAssertEqual(next, [b, a])
     }
+
+    func testPinnedWorkspaceIdsIncludesBackgroundLoadsWhenIdle() {
+        let background = UUID()
+        let debug = UUID()
+
+        let pinnedIds = WorkspaceMountPolicy.pinnedWorkspaceIds(
+            retiringWorkspaceId: nil,
+            backgroundWorkspaceLoadIds: [background],
+            debugPinnedWorkspaceLoadIds: [debug],
+            isCycleHot: false
+        )
+
+        XCTAssertEqual(pinnedIds, [background, debug])
+    }
+
+    func testPinnedWorkspaceIdsSuppressesBackgroundLoadsDuringHandoff() {
+        let retiring = UUID()
+        let background = UUID()
+        let debug = UUID()
+
+        let pinnedIds = WorkspaceMountPolicy.pinnedWorkspaceIds(
+            retiringWorkspaceId: retiring,
+            backgroundWorkspaceLoadIds: [background],
+            debugPinnedWorkspaceLoadIds: [debug],
+            isCycleHot: false
+        )
+
+        XCTAssertEqual(pinnedIds, [retiring, debug])
+    }
+
+    func testPinnedWorkspaceIdsSuppressesBackgroundLoadsDuringHotCycle() {
+        let background = UUID()
+        let debug = UUID()
+
+        let pinnedIds = WorkspaceMountPolicy.pinnedWorkspaceIds(
+            retiringWorkspaceId: nil,
+            backgroundWorkspaceLoadIds: [background],
+            debugPinnedWorkspaceLoadIds: [debug],
+            isCycleHot: true
+        )
+
+        XCTAssertEqual(pinnedIds, [debug])
+    }
+}
+
+
+@MainActor
+final class BackgroundWorkspacePrimeCoordinatorTests: XCTestCase {
+    func testTimedOutPrimeReleasesMountButKeepsPendingLoad() async {
+#if DEBUG
+        let manager = TabManager(autoWelcomeIfNeeded: false)
+        let workspace = manager.addWorkspace(
+            select: false,
+            eagerLoadTerminal: false,
+            autoWelcomeIfNeeded: false
+        )
+        manager.requestBackgroundWorkspaceLoad(for: workspace.id)
+
+        let coordinator = BackgroundWorkspacePrimeCoordinator(timeoutSeconds: 0.01)
+        let reason = await coordinator.debugPrimeBackgroundWorkspaceOnceForTesting(
+            workspaceId: workspace.id,
+            tabManager: manager
+        )
+
+        XCTAssertEqual(reason, "timeout")
+        XCTAssertTrue(manager.pendingBackgroundWorkspaceLoadIds.contains(workspace.id))
+        XCTAssertFalse(manager.mountedBackgroundWorkspaceLoadIds.contains(workspace.id))
+#else
+        throw XCTSkip("Debug-only background prime timeout test")
+#endif
+    }
+}
+
+
+@MainActor
+final class WorkspacePortalRenderingTests: XCTestCase {
+    func testPortalRenderingToggleReportsOnlyStateTransitions() {
+        let workspace = Workspace()
+
+        XCTAssertTrue(workspace.setPortalRenderingEnabled(false, reason: "test"))
+        XCTAssertFalse(workspace.setPortalRenderingEnabled(false, reason: "test"))
+        XCTAssertTrue(workspace.setPortalRenderingEnabled(true, reason: "test"))
+        XCTAssertFalse(workspace.setPortalRenderingEnabled(true, reason: "test"))
+    }
 }
 
 

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -5036,7 +5036,7 @@ final class WorkspacePanelGitBranchTests: XCTestCase {
 
 
 final class WorkspaceMountPolicyTests: XCTestCase {
-    func testDefaultPolicyMountsOnlySelectedWorkspace() {
+    func testDefaultPolicyKeepsVisitedWorkspacesMounted() {
         let a = UUID()
         let b = UUID()
         let orderedTabIds: [UUID] = [a, b]
@@ -5050,10 +5050,10 @@ final class WorkspaceMountPolicyTests: XCTestCase {
             maxMounted: WorkspaceMountPolicy.maxMountedWorkspaces
         )
 
-        XCTAssertEqual(next, [b])
+        XCTAssertEqual(next, [b, a])
     }
 
-    func testSelectedWorkspaceMovesToFrontAndMountCountIsBounded() {
+    func testSelectedWorkspaceMovesToFrontAndKeepsWarmCacheWhenUnbounded() {
         let a = UUID()
         let b = UUID()
         let c = UUID()
@@ -5065,10 +5065,10 @@ final class WorkspaceMountPolicyTests: XCTestCase {
             pinnedIds: [],
             orderedTabIds: orderedTabIds,
             isCycleHot: false,
-            maxMounted: 2
+            maxMounted: WorkspaceMountPolicy.maxMountedWorkspaces
         )
 
-        XCTAssertEqual(next, [c, a])
+        XCTAssertEqual(next, [c, a, b])
     }
 
     func testMissingWorkspacesArePruned() {
@@ -5121,7 +5121,7 @@ final class WorkspaceMountPolicyTests: XCTestCase {
         XCTAssertEqual(next, [a])
     }
 
-    func testCycleHotModeKeepsOnlySelectedWhenNoPinnedHandoff() {
+    func testCycleHotModeKeepsWarmCacheWhenNoPinnedHandoff() {
         let a = UUID()
         let b = UUID()
         let c = UUID()
@@ -5137,10 +5137,10 @@ final class WorkspaceMountPolicyTests: XCTestCase {
             maxMounted: WorkspaceMountPolicy.maxMountedWorkspacesDuringCycle
         )
 
-        XCTAssertEqual(next, [c])
+        XCTAssertEqual(next, [c, a])
     }
 
-    func testCycleHotModeRespectsMaxMountedLimit() {
+    func testCycleHotModeKeepsWarmCacheWithinMaxMountedLimit() {
         let a = UUID()
         let b = UUID()
         let c = UUID()
@@ -5155,7 +5155,7 @@ final class WorkspaceMountPolicyTests: XCTestCase {
             maxMounted: 2
         )
 
-        XCTAssertEqual(next, [b])
+        XCTAssertEqual(next, [b, a])
     }
 
     func testPinnedIdsAreRetainedAcrossReconcile() {

--- a/scripts/perf-workspace-switch.py
+++ b/scripts/perf-workspace-switch.py
@@ -395,35 +395,174 @@ requestAnimationFrame(tick);
 
     def wait_for_switch_logs(self, offset: int, timeout_s: float) -> tuple[dict[str, float | int | str | None], int]:
         deadline = time.monotonic() + timeout_s
-        lines: list[str] = []
-        new_offset = offset
+        cursor = offset
         switch_id: str | None = None
+        handoff_ms: float | None = None
+        handoff_reason = "missing"
+        async_done_ms: float | None = None
+        terminal_swiftui_visible_ms: float | None = None
+        terminal_hosted_visible_ms: float | None = None
+        terminal_portal_visible_ms: float | None = None
+        browser_portal_visible_ms: float | None = None
+        portal_priority_ms: float | None = None
+        terminal_swiftui_visible_by_surface: dict[str, float] = {}
+        terminal_hosted_visible_by_surface: dict[str, float] = {}
+        terminal_portal_visible_by_hosted: dict[str, float] = {}
+        browser_portal_visible_by_web: dict[str, float] = {}
+        terminal_swiftui_visible_updates = 0
+        terminal_hosted_visible_updates = 0
+        terminal_portal_visible_updates = 0
+        browser_portal_visible_updates = 0
+        portal_priority_updates = 0
+        last_interesting_at: float | None = None
+        settle_s = self.args.visible_settle_ms / 1000.0
+
+        def note_first_visible(seen: dict[str, float], token: str, value: float) -> None:
+            seen.setdefault(token, value)
+
+        def visible_max(seen: dict[str, float]) -> float | None:
+            return max(seen.values()) if seen else None
+
+        def visible_ready_value() -> float | None:
+            if portal_priority_ms is not None:
+                return portal_priority_ms
+            values = [
+                value for value in (
+                    terminal_hosted_visible_ms,
+                    terminal_portal_visible_ms,
+                    browser_portal_visible_ms,
+                )
+                if value is not None
+            ]
+            if values:
+                return max(values)
+            return terminal_swiftui_visible_ms
+
         while time.monotonic() < deadline:
-            lines, new_offset = self.read_debug_lines(offset, timeout_s=0.05)
-            for line in lines:
+            chunk, cursor = self.read_debug_lines(cursor, timeout_s=0.05)
+            if chunk:
+                last_interesting_at = last_interesting_at or time.monotonic()
+            for line in chunk:
                 begin = re.search(r"ws\.switch\.begin id=(\d+)", line)
                 if begin:
                     switch_id = begin.group(1)
                 if switch_id:
                     complete = re.search(rf"ws\.handoff\.complete id={switch_id} dt=([0-9.]+)ms reason=([^ ]+)", line)
                     if complete:
-                        async_done_ms = None
-                        async_done = re.search(rf"ws\.select\.asyncDone id={switch_id} dt=([0-9.]+)ms", "\n".join(lines))
-                        if async_done:
-                            async_done_ms = float(async_done.group(1))
-                        return {
-                            "switch_id": int(switch_id),
-                            "handoff_ms": float(complete.group(1)),
-                            "handoff_reason": complete.group(2),
-                            "async_done_ms": async_done_ms,
-                        }, new_offset
+                        handoff_ms = float(complete.group(1))
+                        handoff_reason = complete.group(2)
+                        last_interesting_at = time.monotonic()
+                    async_done = re.search(rf"ws\.select\.asyncDone id={switch_id} dt=([0-9.]+)ms", line)
+                    if async_done:
+                        async_done_ms = float(async_done.group(1))
+                        last_interesting_at = time.monotonic()
+                    priority_ready = re.search(
+                        rf"ws\.portal\.priority id={switch_id} dt=([0-9.]+)ms .* z=2 ",
+                        line,
+                    )
+                    if priority_ready:
+                        portal_priority_ms = float(priority_ready.group(1))
+                        portal_priority_updates += 1
+                        last_interesting_at = time.monotonic()
+                    swiftui_visible = re.search(
+                        rf"ws\.swiftui\.update id={switch_id} dt=([0-9.]+)ms surface=([^ ]+) .* visible=1",
+                        line,
+                    )
+                    if swiftui_visible:
+                        note_first_visible(
+                            terminal_swiftui_visible_by_surface,
+                            swiftui_visible.group(2),
+                            float(swiftui_visible.group(1)),
+                        )
+                        terminal_swiftui_visible_ms = visible_max(terminal_swiftui_visible_by_surface)
+                        terminal_swiftui_visible_updates += 1
+                        last_interesting_at = time.monotonic()
+                    hosted_visible = re.search(
+                        rf"ws\.term\.visible id={switch_id} dt=([0-9.]+)ms surface=([^ ]+) transition=0->1",
+                        line,
+                    )
+                    if hosted_visible:
+                        note_first_visible(
+                            terminal_hosted_visible_by_surface,
+                            hosted_visible.group(2),
+                            float(hosted_visible.group(1)),
+                        )
+                        terminal_hosted_visible_ms = visible_max(terminal_hosted_visible_by_surface)
+                        terminal_hosted_visible_updates += 1
+                        last_interesting_at = time.monotonic()
+                    portal_visible = re.search(
+                        rf"^\d{{2}}:\d{{2}}:\d{{2}}\.\d{{3}} portal\.sync\.result hosted=([^ ]+) "
+                        rf".*switchId={switch_id} switchDt=([0-9.]+)ms .* hide=0 entryVisible=1",
+                        line,
+                    )
+                    if portal_visible:
+                        note_first_visible(
+                            terminal_portal_visible_by_hosted,
+                            portal_visible.group(1),
+                            float(portal_visible.group(2)),
+                        )
+                        terminal_portal_visible_ms = visible_max(terminal_portal_visible_by_hosted)
+                        terminal_portal_visible_updates += 1
+                        last_interesting_at = time.monotonic()
+                    browser_visible = re.search(
+                        rf"^\d{{2}}:\d{{2}}:\d{{2}}\.\d{{3}} browser\.portal\.sync\.result web=([^ ]+) "
+                        rf".*switchId={switch_id} switchDt=([0-9.]+)ms .* hide=0 entryVisible=1",
+                        line,
+                    )
+                    if browser_visible:
+                        note_first_visible(
+                            browser_portal_visible_by_web,
+                            browser_visible.group(1),
+                            float(browser_visible.group(2)),
+                        )
+                        browser_portal_visible_ms = visible_max(browser_portal_visible_by_web)
+                        browser_portal_visible_updates += 1
+                        last_interesting_at = time.monotonic()
+            if handoff_ms is not None and last_interesting_at is not None:
+                if time.monotonic() - last_interesting_at >= settle_s:
+                    return {
+                        "switch_id": int(switch_id) if switch_id else None,
+                        "handoff_ms": handoff_ms,
+                        "handoff_reason": handoff_reason,
+                        "async_done_ms": async_done_ms,
+                        "visible_ready_ms": visible_ready_value(),
+                        "terminal_swiftui_visible_ms": terminal_swiftui_visible_ms,
+                        "terminal_hosted_visible_ms": terminal_hosted_visible_ms,
+                        "terminal_portal_visible_ms": terminal_portal_visible_ms,
+                        "browser_portal_visible_ms": browser_portal_visible_ms,
+                        "portal_priority_ms": portal_priority_ms,
+                        "terminal_swiftui_visible_updates": terminal_swiftui_visible_updates,
+                        "terminal_hosted_visible_updates": terminal_hosted_visible_updates,
+                        "terminal_portal_visible_updates": terminal_portal_visible_updates,
+                        "browser_portal_visible_updates": browser_portal_visible_updates,
+                        "portal_priority_updates": portal_priority_updates,
+                        "terminal_swiftui_visible_first_count": len(terminal_swiftui_visible_by_surface),
+                        "terminal_hosted_visible_first_count": len(terminal_hosted_visible_by_surface),
+                        "terminal_portal_visible_first_count": len(terminal_portal_visible_by_hosted),
+                        "browser_portal_visible_first_count": len(browser_portal_visible_by_web),
+                    }, cursor
             time.sleep(0.01)
         return {
             "switch_id": int(switch_id) if switch_id else None,
-            "handoff_ms": None,
-            "handoff_reason": "missing",
-            "async_done_ms": None,
-        }, new_offset
+            "handoff_ms": handoff_ms,
+            "handoff_reason": handoff_reason,
+            "async_done_ms": async_done_ms,
+            "visible_ready_ms": visible_ready_value(),
+            "terminal_swiftui_visible_ms": terminal_swiftui_visible_ms,
+            "terminal_hosted_visible_ms": terminal_hosted_visible_ms,
+            "terminal_portal_visible_ms": terminal_portal_visible_ms,
+            "browser_portal_visible_ms": browser_portal_visible_ms,
+            "portal_priority_ms": portal_priority_ms,
+            "terminal_swiftui_visible_updates": terminal_swiftui_visible_updates,
+            "terminal_hosted_visible_updates": terminal_hosted_visible_updates,
+            "terminal_portal_visible_updates": terminal_portal_visible_updates,
+            "browser_portal_visible_updates": browser_portal_visible_updates,
+            "portal_priority_updates": portal_priority_updates,
+            "terminal_swiftui_visible_first_count": len(terminal_swiftui_visible_by_surface),
+            "terminal_hosted_visible_first_count": len(terminal_hosted_visible_by_surface),
+            "terminal_portal_visible_first_count": len(terminal_portal_visible_by_hosted),
+            "browser_portal_visible_first_count": len(browser_portal_visible_by_web),
+        }, cursor
 
     def benchmark_switches(self, workspaces: list[str]) -> None:
         if len(workspaces) < 2:
@@ -456,29 +595,71 @@ requestAnimationFrame(tick);
         cli_values = [float(s["cli_roundtrip_ms"]) for s in measured]
         handoff_values = [float(s["handoff_ms"]) for s in measured if s["handoff_ms"] is not None]
         async_values = [float(s["async_done_ms"]) for s in measured if s["async_done_ms"] is not None]
+        visible_values = [float(s["visible_ready_ms"]) for s in measured if s["visible_ready_ms"] is not None]
+        terminal_swiftui_values = [
+            float(s["terminal_swiftui_visible_ms"])
+            for s in measured
+            if s["terminal_swiftui_visible_ms"] is not None
+        ]
+        terminal_hosted_values = [
+            float(s["terminal_hosted_visible_ms"])
+            for s in measured
+            if s["terminal_hosted_visible_ms"] is not None
+        ]
+        terminal_portal_values = [
+            float(s["terminal_portal_visible_ms"])
+            for s in measured
+            if s["terminal_portal_visible_ms"] is not None
+        ]
+        browser_portal_values = [
+            float(s["browser_portal_visible_ms"])
+            for s in measured
+            if s["browser_portal_visible_ms"] is not None
+        ]
+        portal_priority_values = [
+            float(s["portal_priority_ms"])
+            for s in measured
+            if s["portal_priority_ms"] is not None
+        ]
         self.result["measurements"]["workspace_switch"] = {
             "samples": measured,
             "cli_roundtrip": summary(cli_values),
             "handoff": summary(handoff_values),
+            "visible_ready": summary(visible_values),
+            "terminal_swiftui_visible": summary(terminal_swiftui_values),
+            "terminal_hosted_visible": summary(terminal_hosted_values),
+            "terminal_portal_visible": summary(terminal_portal_values),
+            "browser_portal_visible": summary(browser_portal_values),
+            "portal_priority": summary(portal_priority_values),
             "async_done": summary(async_values),
             "missing_handoff_samples": len(measured) - len(handoff_values),
+            "missing_visible_ready_samples": len(measured) - len(visible_values),
         }
 
     def apply_budgets(self) -> None:
         switch = self.result["measurements"].get("workspace_switch", {})
         handoff = switch.get("handoff", {})
+        visible_ready = switch.get("visible_ready", {})
         cli = switch.get("cli_roundtrip", {})
         budgets = {
             "handoff_p95_ms": self.args.budget_handoff_p95_ms,
+            "visible_ready_p95_ms": self.args.budget_visible_ready_p95_ms,
             "cli_roundtrip_p95_ms": self.args.budget_cli_roundtrip_p95_ms,
             "missing_handoff_samples": 0,
+            "missing_visible_ready_samples": 0,
         }
         failures: list[str] = []
 
         if switch.get("missing_handoff_samples", 0) > budgets["missing_handoff_samples"]:
             failures.append(f"missing_handoff_samples: {switch.get('missing_handoff_samples')} > 0")
+        if switch.get("missing_visible_ready_samples", 0) > budgets["missing_visible_ready_samples"]:
+            failures.append(f"missing_visible_ready_samples: {switch.get('missing_visible_ready_samples')} > 0")
         if handoff.get("p95_ms", 0) > budgets["handoff_p95_ms"]:
             failures.append(f"handoff.p95_ms: {handoff.get('p95_ms')} > {budgets['handoff_p95_ms']}")
+        if visible_ready.get("p95_ms", 0) > budgets["visible_ready_p95_ms"]:
+            failures.append(
+                f"visible_ready.p95_ms: {visible_ready.get('p95_ms')} > {budgets['visible_ready_p95_ms']}"
+            )
         if budgets["cli_roundtrip_p95_ms"] > 0 and cli.get("p95_ms", 0) > budgets["cli_roundtrip_p95_ms"]:
             failures.append(f"cli_roundtrip.p95_ms: {cli.get('p95_ms')} > {budgets['cli_roundtrip_p95_ms']}")
 
@@ -532,9 +713,17 @@ def print_summary(result: dict) -> None:
     print(f"  launch_socket_ready_ms={result.get('measurements', {}).get('launch_socket_ready_ms')}")
     print(f"  cli_roundtrip={switch.get('cli_roundtrip')}")
     print(f"  handoff={switch.get('handoff')}")
+    print(f"  visible_ready={switch.get('visible_ready')}")
+    print(f"  terminal_swiftui_visible={switch.get('terminal_swiftui_visible')}")
+    print(f"  terminal_hosted_visible={switch.get('terminal_hosted_visible')}")
+    print(f"  terminal_portal_visible={switch.get('terminal_portal_visible')}")
+    print(f"  browser_portal_visible={switch.get('browser_portal_visible')}")
+    print(f"  portal_priority={switch.get('portal_priority')}")
     print(f"  async_done={switch.get('async_done')}")
     if switch.get("missing_handoff_samples"):
         print(f"  missing_handoff_samples={switch.get('missing_handoff_samples')}")
+    if switch.get("missing_visible_ready_samples"):
+        print(f"  missing_visible_ready_samples={switch.get('missing_visible_ready_samples')}")
     failures = result.get("failures", [])
     if failures:
         print("  budget_failures:")
@@ -565,7 +754,9 @@ def parse_args() -> argparse.Namespace:
 
     parser.add_argument("--launch-timeout", type=float, default=45)
     parser.add_argument("--switch-log-timeout", type=float, default=5)
+    parser.add_argument("--visible-settle-ms", type=float, default=120)
     parser.add_argument("--budget-handoff-p95-ms", type=float, default=100)
+    parser.add_argument("--budget-visible-ready-p95-ms", type=float, default=100)
     parser.add_argument("--budget-cli-roundtrip-p95-ms", type=float, default=0)
     return parser.parse_args()
 

--- a/scripts/perf-workspace-switch.py
+++ b/scripts/perf-workspace-switch.py
@@ -479,7 +479,7 @@ requestAnimationFrame(tick);
             failures.append(f"missing_handoff_samples: {switch.get('missing_handoff_samples')} > 0")
         if handoff.get("p95_ms", 0) > budgets["handoff_p95_ms"]:
             failures.append(f"handoff.p95_ms: {handoff.get('p95_ms')} > {budgets['handoff_p95_ms']}")
-        if cli.get("p95_ms", 0) > budgets["cli_roundtrip_p95_ms"]:
+        if budgets["cli_roundtrip_p95_ms"] > 0 and cli.get("p95_ms", 0) > budgets["cli_roundtrip_p95_ms"]:
             failures.append(f"cli_roundtrip.p95_ms: {cli.get('p95_ms')} > {budgets['cli_roundtrip_p95_ms']}")
 
         self.result["budgets"] = budgets
@@ -565,8 +565,8 @@ def parse_args() -> argparse.Namespace:
 
     parser.add_argument("--launch-timeout", type=float, default=45)
     parser.add_argument("--switch-log-timeout", type=float, default=5)
-    parser.add_argument("--budget-handoff-p95-ms", type=float, default=300)
-    parser.add_argument("--budget-cli-roundtrip-p95-ms", type=float, default=450)
+    parser.add_argument("--budget-handoff-p95-ms", type=float, default=100)
+    parser.add_argument("--budget-cli-roundtrip-p95-ms", type=float, default=0)
     return parser.parse_args()
 
 

--- a/scripts/perf-workspace-switch.py
+++ b/scripts/perf-workspace-switch.py
@@ -1,0 +1,606 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pathlib
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import xml.etree.ElementTree as ET
+
+
+def sanitize_bundle(raw: str) -> str:
+    cleaned = re.sub(r"[^a-z0-9]+", ".", raw.lower()).strip(".")
+    cleaned = re.sub(r"\.+", ".", cleaned)
+    return cleaned or "perf"
+
+
+def sanitize_path(raw: str) -> str:
+    cleaned = re.sub(r"[^a-z0-9]+", "-", raw.lower()).strip("-")
+    cleaned = re.sub(r"-+", "-", cleaned)
+    return cleaned or "perf"
+
+
+def now_ms() -> float:
+    return time.perf_counter() * 1000.0
+
+
+def rounded_ms(value: float) -> float:
+    return round(value, 2)
+
+
+def percentile(sorted_values: list[float], pct: float) -> float:
+    if not sorted_values:
+        return 0.0
+    clamped = min(max(pct, 0.0), 1.0)
+    index = int(((len(sorted_values) - 1) * clamped) + 0.999999)
+    return sorted_values[min(len(sorted_values) - 1, max(0, index))]
+
+
+def summary(values: list[float]) -> dict[str, float | int]:
+    sorted_values = sorted(values)
+    count = len(sorted_values)
+    total = sum(sorted_values)
+    return {
+        "count": count,
+        "avg_ms": rounded_ms(total / count) if count else 0.0,
+        "p50_ms": rounded_ms(percentile(sorted_values, 0.50)),
+        "p95_ms": rounded_ms(percentile(sorted_values, 0.95)),
+        "max_ms": rounded_ms(sorted_values[-1] if sorted_values else 0.0),
+    }
+
+
+class PerfFailure(RuntimeError):
+    pass
+
+
+class WorkspaceSwitchPerfRunner:
+    def __init__(self, args: argparse.Namespace):
+        self.args = args
+        self.tag = args.tag
+        self.tag_slug = sanitize_path(args.tag)
+        self.tag_id = sanitize_bundle(args.tag)
+        self.socket_path = pathlib.Path(f"/tmp/cmux-debug-{self.tag_slug}.sock")
+        self.cmuxd_socket_path = pathlib.Path(
+            os.path.expanduser(f"~/Library/Application Support/cmux/cmuxd-dev-{self.tag_slug}.sock")
+        )
+        self.debug_log_path = pathlib.Path(f"/tmp/cmux-debug-{self.tag_slug}.log")
+        self.stdout_path = pathlib.Path(f"/tmp/cmux-perf-switch-{self.tag_slug}-stdout.log")
+        self.app_path = pathlib.Path(args.app_path).expanduser() if args.app_path else self.default_app_path()
+        self.binary_path = self.app_path / "Contents/MacOS/cmux DEV"
+        self.cli_path = self.app_path / "Contents/Resources/bin/cmux"
+        self.fixture_root = self.make_fixture_root(args.fixture_root)
+        self.proc: subprocess.Popen | None = None
+        self.result: dict = {
+            "tag": self.tag,
+            "app_path": str(self.app_path),
+            "socket_path": str(self.socket_path),
+            "fixture_root": str(self.fixture_root),
+            "fixture": {},
+            "measurements": {},
+            "budgets": {},
+            "failures": [],
+        }
+
+    def default_app_path(self) -> pathlib.Path:
+        return pathlib.Path.home() / (
+            f"Library/Developer/Xcode/DerivedData/cmux-{self.tag_slug}/"
+            f"Build/Products/Debug/cmux DEV {self.tag_slug}.app"
+        )
+
+    def make_fixture_root(self, fixture_root_arg: str) -> pathlib.Path:
+        if fixture_root_arg:
+            parent = pathlib.Path(fixture_root_arg).expanduser()
+            parent.mkdir(parents=True, exist_ok=True)
+            return pathlib.Path(tempfile.mkdtemp(prefix=f"cmux-switch-{self.tag_slug}-", dir=str(parent)))
+        return pathlib.Path(tempfile.mkdtemp(prefix=f"cmux-switch-{self.tag_slug}-"))
+
+    def check_paths(self) -> None:
+        if not self.binary_path.exists():
+            raise PerfFailure(f"app binary not found: {self.binary_path}")
+        if not self.cli_path.exists():
+            raise PerfFailure(f"cmux CLI not found: {self.cli_path}")
+
+    def clean_persisted_state(self) -> None:
+        app_support = pathlib.Path.home() / "Library/Application Support/cmux"
+        bundle_id = f"com.cmuxterm.app.debug.{self.tag_id}"
+        for suffix in ("", "-previous"):
+            (app_support / f"session-{bundle_id}{suffix}.json").unlink(missing_ok=True)
+        self.socket_path.unlink(missing_ok=True)
+        self.cmuxd_socket_path.unlink(missing_ok=True)
+        self.debug_log_path.unlink(missing_ok=True)
+        self.stdout_path.unlink(missing_ok=True)
+        if self.fixture_root.exists():
+            shutil.rmtree(self.fixture_root)
+        self.fixture_root.mkdir(parents=True, exist_ok=True)
+
+    def app_env(self) -> dict[str, str]:
+        env = os.environ.copy()
+        for key in (
+            "CMUX_SOCKET",
+            "CMUX_SOCKET_PATH",
+            "CMUX_SOCKET_MODE",
+            "CMUX_TAB_ID",
+            "CMUX_PANEL_ID",
+            "CMUX_SURFACE_ID",
+            "CMUX_WORKSPACE_ID",
+            "CMUXD_UNIX_PATH",
+            "CMUX_TAG",
+            "CMUX_PORT",
+            "CMUX_PORT_END",
+            "CMUX_PORT_RANGE",
+            "CMUX_DEBUG_LOG",
+            "CMUX_BUNDLE_ID",
+            "CMUX_UI_TEST_MODE",
+        ):
+            env.pop(key, None)
+        env.update(
+            {
+                "CMUX_SOCKET": str(self.socket_path),
+                "CMUX_SOCKET_MODE": "automation",
+                "CMUX_SOCKET_PATH": str(self.socket_path),
+                "CMUXD_UNIX_PATH": str(self.cmuxd_socket_path),
+                "CMUX_DEBUG_LOG": str(self.debug_log_path),
+            }
+        )
+        return env
+
+    def cli_env(self) -> dict[str, str]:
+        env = os.environ.copy()
+        env["CMUX_SOCKET"] = str(self.socket_path)
+        env["CMUX_SOCKET_PATH"] = str(self.socket_path)
+        env["CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC"] = "30"
+        return env
+
+    def launch(self) -> float:
+        stdout = open(self.stdout_path, "ab", buffering=0)
+        start = now_ms()
+        self.proc = subprocess.Popen(
+            [str(self.binary_path)],
+            env=self.app_env(),
+            stdout=stdout,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+        )
+        stdout.close()
+        if not self.wait_for_socket(timeout_s=self.args.launch_timeout):
+            raise PerfFailure(f"socket not ready after {self.args.launch_timeout}s")
+        elapsed = rounded_ms(now_ms() - start)
+        self.result["measurements"]["launch_socket_ready_ms"] = elapsed
+        return elapsed
+
+    def wait_for_socket(self, timeout_s: float) -> bool:
+        deadline = time.monotonic() + timeout_s
+        while time.monotonic() < deadline:
+            if self.proc and self.proc.poll() is not None:
+                return False
+            if self.socket_path.exists():
+                try:
+                    self.run_cli(["--json", "list-workspaces"], timeout=5)
+                    return True
+                except Exception:
+                    pass
+            time.sleep(0.1)
+        return False
+
+    def stop_app(self) -> None:
+        proc = self.proc
+        self.proc = None
+        if proc and proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=5)
+        subprocess.run(
+            ["pkill", "-f", re.escape(f"cmux DEV {self.tag_slug}.app/Contents/MacOS/cmux DEV")],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+        self.socket_path.unlink(missing_ok=True)
+        self.cmuxd_socket_path.unlink(missing_ok=True)
+
+    def run_cli(self, args: list[str], input_text: str | None = None, timeout: float = 60, check: bool = True) -> str:
+        proc = subprocess.run(
+            [str(self.cli_path)] + args,
+            input=input_text,
+            text=True,
+            capture_output=True,
+            env=self.cli_env(),
+            timeout=timeout,
+        )
+        if check and proc.returncode != 0:
+            raise PerfFailure(
+                "cmux command failed: "
+                + " ".join(args)
+                + f"\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+            )
+        return proc.stdout.strip()
+
+    def json_cli(self, args: list[str], timeout: float = 60) -> dict:
+        return json.loads(self.run_cli(["--json"] + args, timeout=timeout))
+
+    def ref(self, text: str, kind: str) -> str:
+        found = re.findall(rf"\b{kind}:\d+\b", text)
+        if not found:
+            raise PerfFailure(f"missing {kind} ref in {text!r}")
+        return found[0]
+
+    def make_repo(self, index: int) -> pathlib.Path:
+        repo = self.fixture_root / f"project-{index:02d}"
+        repo.mkdir(parents=True, exist_ok=True)
+        subprocess.run(["git", "init"], cwd=repo, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=True)
+        (repo / "README.md").write_text(f"# Project {index}\n", encoding="utf-8")
+        subprocess.run(["git", "add", "README.md"], cwd=repo, stdout=subprocess.DEVNULL, check=True)
+        subprocess.run(
+            ["git", "-c", "user.name=cmux", "-c", "user.email=cmux@example.invalid", "commit", "-m", "seed"],
+            cwd=repo,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=True,
+        )
+        (repo / "README.md").write_text(f"# Project {index}\n\nmodified\n", encoding="utf-8")
+        return repo
+
+    def make_browser_page(self, workspace_index: int, pane_index: int, surface_index: int) -> str:
+        page_dir = self.fixture_root / "pages"
+        page_dir.mkdir(parents=True, exist_ok=True)
+        rows = "\n".join(
+            f"<li>workspace {workspace_index:02d} pane {pane_index:02d} surface {surface_index:02d} row {i:03d}</li>"
+            for i in range(self.args.browser_dom_rows)
+        )
+        script = """
+<script>
+let n = 0;
+function tick() {
+  document.body.dataset.tick = String(n++);
+  requestAnimationFrame(tick);
+}
+requestAnimationFrame(tick);
+</script>
+"""
+        page = page_dir / f"workspace-{workspace_index:02d}-pane-{pane_index:02d}-surface-{surface_index:02d}.html"
+        page.write_text(
+            "<!doctype html><meta charset='utf-8'>"
+            f"<title>cmux switch perf {workspace_index:02d}</title>"
+            "<style>body{font-family:-apple-system;margin:18px}.grid{display:grid;grid-template-columns:repeat(4,1fr);gap:6px}"
+            "li{padding:4px;border:1px solid #ddd;list-style:none}</style>"
+            f"<h1>Workspace {workspace_index:02d}</h1><ul class='grid'>{rows}</ul>{script}",
+            encoding="utf-8",
+        )
+        return page.resolve().as_uri()
+
+    def create_fixture(self) -> list[str]:
+        existing = [w["ref"] for w in self.json_cli(["list-workspaces"]).get("workspaces", [])]
+        guard_ws = self.ref(
+            self.run_cli(["new-workspace", "--name", "switch-perf-guard", "--cwd", str(self.fixture_root)]),
+            "workspace",
+        )
+
+        workspaces: list[str] = []
+        terminal_surfaces = 0
+        browser_surfaces = 0
+        pane_directions = ["right", "down", "left", "up"]
+        for workspace_index in range(1, self.args.workspace_count + 1):
+            cwd = self.make_repo(workspace_index)
+            ws = self.ref(
+                self.run_cli(
+                    [
+                        "new-workspace",
+                        "--name",
+                        f"switch-perf-{workspace_index:02d}",
+                        "--description",
+                        f"workspace switch performance fixture {workspace_index:02d}",
+                        "--cwd",
+                        str(cwd),
+                    ],
+                    timeout=90,
+                ),
+                "workspace",
+            )
+            workspaces.append(ws)
+            workspace_terminal_surfaces: list[str] = []
+
+            for pane_index in range(1, self.args.panes_per_workspace):
+                is_browser = pane_index <= self.args.browser_panes_per_workspace
+                args = [
+                    "new-pane",
+                    "--workspace",
+                    ws,
+                    "--type",
+                    "browser" if is_browser else "terminal",
+                    "--direction",
+                    pane_directions[pane_index % len(pane_directions)],
+                ]
+                if is_browser:
+                    args += ["--url", self.make_browser_page(workspace_index, pane_index, 0)]
+                self.run_cli(args, timeout=90)
+
+            panes = self.json_cli(["list-panes", "--workspace", ws], timeout=90).get("panes", [])
+            for pane_index, pane in enumerate(panes):
+                pane_ref = pane["ref"]
+                is_browser = 0 < pane_index <= self.args.browser_panes_per_workspace
+                if is_browser:
+                    browser_surfaces += len(pane.get("surface_refs", []))
+                else:
+                    terminal_surfaces += len(pane.get("surface_refs", []))
+                    workspace_terminal_surfaces.extend(pane.get("surface_refs", []))
+                for surface_index in range(1, self.args.surfaces_per_pane):
+                    args = [
+                        "new-surface",
+                        "--workspace",
+                        ws,
+                        "--pane",
+                        pane_ref,
+                        "--type",
+                        "browser" if is_browser else "terminal",
+                    ]
+                    if is_browser:
+                        args += ["--url", self.make_browser_page(workspace_index, pane_index, surface_index)]
+                    output = self.run_cli(args, timeout=90)
+                    surface_ref = self.ref(output, "surface")
+                    if is_browser:
+                        browser_surfaces += 1
+                    else:
+                        terminal_surfaces += 1
+                        workspace_terminal_surfaces.append(surface_ref)
+
+            if self.args.terminal_scrollback_lines > 0:
+                self.seed_terminal_scrollback(ws, workspace_terminal_surfaces)
+
+        for ws in existing + [guard_ws]:
+            self.run_cli(["close-workspace", "--workspace", ws], timeout=30, check=False)
+        if workspaces:
+            self.run_cli(["select-workspace", "--workspace", workspaces[0]], timeout=60, check=False)
+
+        self.result["fixture"].update(
+            {
+                "workspaces": len(workspaces),
+                "panes_per_workspace": self.args.panes_per_workspace,
+                "surfaces_per_pane": self.args.surfaces_per_pane,
+                "terminal_surfaces": terminal_surfaces,
+                "browser_surfaces": browser_surfaces,
+                "total_surfaces": terminal_surfaces + browser_surfaces,
+            }
+        )
+        return workspaces
+
+    def seed_terminal_scrollback(self, workspace: str, surfaces: list[str]) -> None:
+        for surface in surfaces:
+            command = (
+                f"i=1; while [ $i -le {self.args.terminal_scrollback_lines} ]; do "
+                "printf 'SWITCH_PERF %04d abcdefghijklmnopqrstuvwxyz\\n' \"$i\"; "
+                "i=$((i+1)); done\n"
+            )
+            self.run_cli(["send", "--workspace", workspace, "--surface", surface, command], timeout=30, check=False)
+
+    def read_debug_lines(self, offset: int, timeout_s: float) -> tuple[list[str], int]:
+        deadline = time.monotonic() + timeout_s
+        while time.monotonic() < deadline:
+            if self.debug_log_path.exists() and self.debug_log_path.stat().st_size > offset:
+                data = self.debug_log_path.read_text(encoding="utf-8", errors="replace")
+                return data[offset:].splitlines(), len(data)
+            time.sleep(0.01)
+        if self.debug_log_path.exists():
+            data = self.debug_log_path.read_text(encoding="utf-8", errors="replace")
+            return data[offset:].splitlines(), len(data)
+        return [], offset
+
+    def wait_for_switch_logs(self, offset: int, timeout_s: float) -> tuple[dict[str, float | int | str | None], int]:
+        deadline = time.monotonic() + timeout_s
+        lines: list[str] = []
+        new_offset = offset
+        switch_id: str | None = None
+        while time.monotonic() < deadline:
+            lines, new_offset = self.read_debug_lines(offset, timeout_s=0.05)
+            for line in lines:
+                begin = re.search(r"ws\.switch\.begin id=(\d+)", line)
+                if begin:
+                    switch_id = begin.group(1)
+                if switch_id:
+                    complete = re.search(rf"ws\.handoff\.complete id={switch_id} dt=([0-9.]+)ms reason=([^ ]+)", line)
+                    if complete:
+                        async_done_ms = None
+                        async_done = re.search(rf"ws\.select\.asyncDone id={switch_id} dt=([0-9.]+)ms", "\n".join(lines))
+                        if async_done:
+                            async_done_ms = float(async_done.group(1))
+                        return {
+                            "switch_id": int(switch_id),
+                            "handoff_ms": float(complete.group(1)),
+                            "handoff_reason": complete.group(2),
+                            "async_done_ms": async_done_ms,
+                        }, new_offset
+            time.sleep(0.01)
+        return {
+            "switch_id": int(switch_id) if switch_id else None,
+            "handoff_ms": None,
+            "handoff_reason": "missing",
+            "async_done_ms": None,
+        }, new_offset
+
+    def benchmark_switches(self, workspaces: list[str]) -> None:
+        if len(workspaces) < 2:
+            raise PerfFailure("workspace switch benchmark requires at least two workspaces")
+
+        samples: list[dict[str, float | int | str | None]] = []
+        offset = self.debug_log_path.stat().st_size if self.debug_log_path.exists() else 0
+        sequence = []
+        for _ in range(self.args.warmup_passes):
+            sequence.extend(workspaces[1:] + list(reversed(workspaces[:-1])))
+        for _ in range(self.args.measure_passes):
+            sequence.extend(workspaces[1:] + list(reversed(workspaces[:-1])))
+
+        warmup_count = self.args.warmup_passes * ((len(workspaces) - 1) * 2)
+        for index, workspace in enumerate(sequence):
+            start = now_ms()
+            self.run_cli(["select-workspace", "--workspace", workspace], timeout=30)
+            cli_ms = rounded_ms(now_ms() - start)
+            parsed, offset = self.wait_for_switch_logs(offset, timeout_s=self.args.switch_log_timeout)
+            sample = {
+                "index": index,
+                "phase": "warmup" if index < warmup_count else "measure",
+                "workspace": workspace,
+                "cli_roundtrip_ms": cli_ms,
+                **parsed,
+            }
+            samples.append(sample)
+
+        measured = [s for s in samples if s["phase"] == "measure"]
+        cli_values = [float(s["cli_roundtrip_ms"]) for s in measured]
+        handoff_values = [float(s["handoff_ms"]) for s in measured if s["handoff_ms"] is not None]
+        async_values = [float(s["async_done_ms"]) for s in measured if s["async_done_ms"] is not None]
+        self.result["measurements"]["workspace_switch"] = {
+            "samples": measured,
+            "cli_roundtrip": summary(cli_values),
+            "handoff": summary(handoff_values),
+            "async_done": summary(async_values),
+            "missing_handoff_samples": len(measured) - len(handoff_values),
+        }
+
+    def apply_budgets(self) -> None:
+        switch = self.result["measurements"].get("workspace_switch", {})
+        handoff = switch.get("handoff", {})
+        cli = switch.get("cli_roundtrip", {})
+        budgets = {
+            "handoff_p95_ms": self.args.budget_handoff_p95_ms,
+            "cli_roundtrip_p95_ms": self.args.budget_cli_roundtrip_p95_ms,
+            "missing_handoff_samples": 0,
+        }
+        failures: list[str] = []
+
+        if switch.get("missing_handoff_samples", 0) > budgets["missing_handoff_samples"]:
+            failures.append(f"missing_handoff_samples: {switch.get('missing_handoff_samples')} > 0")
+        if handoff.get("p95_ms", 0) > budgets["handoff_p95_ms"]:
+            failures.append(f"handoff.p95_ms: {handoff.get('p95_ms')} > {budgets['handoff_p95_ms']}")
+        if cli.get("p95_ms", 0) > budgets["cli_roundtrip_p95_ms"]:
+            failures.append(f"cli_roundtrip.p95_ms: {cli.get('p95_ms')} > {budgets['cli_roundtrip_p95_ms']}")
+
+        self.result["budgets"] = budgets
+        self.result["failures"] = failures
+
+    def run(self) -> dict:
+        self.check_paths()
+        self.stop_app()
+        self.clean_persisted_state()
+        try:
+            self.launch()
+            workspaces = self.create_fixture()
+            self.benchmark_switches(workspaces)
+            self.apply_budgets()
+            return self.result
+        finally:
+            self.stop_app()
+            if not self.args.keep_fixture and self.fixture_root.exists():
+                shutil.rmtree(self.fixture_root, ignore_errors=True)
+
+
+def write_junit(result: dict, path: pathlib.Path) -> None:
+    failures = result.get("failures", [])
+    suite = ET.Element(
+        "testsuite",
+        {
+            "name": "WorkspaceSwitchPerformance",
+            "tests": "1",
+            "failures": "1" if failures else "0",
+        },
+    )
+    case = ET.SubElement(suite, "testcase", {"name": "workspace_switch_performance"})
+    if failures:
+        failure = ET.SubElement(case, "failure", {"message": "; ".join(failures)})
+        failure.text = json.dumps(result, indent=2, sort_keys=True)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    ET.ElementTree(suite).write(path, encoding="utf-8", xml_declaration=True)
+
+
+def print_summary(result: dict) -> None:
+    fixture = result.get("fixture", {})
+    switch = result.get("measurements", {}).get("workspace_switch", {})
+    print("workspace switch performance")
+    print(
+        "  fixture: "
+        f"workspaces={fixture.get('workspaces')} panes/workspace={fixture.get('panes_per_workspace')} "
+        f"surfaces/pane={fixture.get('surfaces_per_pane')} browsers={fixture.get('browser_surfaces')} "
+        f"terminals={fixture.get('terminal_surfaces')}"
+    )
+    print(f"  launch_socket_ready_ms={result.get('measurements', {}).get('launch_socket_ready_ms')}")
+    print(f"  cli_roundtrip={switch.get('cli_roundtrip')}")
+    print(f"  handoff={switch.get('handoff')}")
+    print(f"  async_done={switch.get('async_done')}")
+    if switch.get("missing_handoff_samples"):
+        print(f"  missing_handoff_samples={switch.get('missing_handoff_samples')}")
+    failures = result.get("failures", [])
+    if failures:
+        print("  budget_failures:")
+        for failure in failures:
+            print(f"    - {failure}")
+    else:
+        print("  budgets: pass")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Benchmark switching between heavy cmux workspaces.")
+    parser.add_argument("--tag", default="switchperf", help="Tagged debug app name built by scripts/reload.sh.")
+    parser.add_argument("--app-path", default="", help="Override app bundle path.")
+    parser.add_argument("--fixture-root", default="", help="Directory for temporary fixture files.")
+    parser.add_argument("--output", default="", help="Write JSON results to this path.")
+    parser.add_argument("--junit", default="", help="Write JUnit XML results to this path.")
+    parser.add_argument("--keep-fixture", action="store_true", help="Keep fixture directory after the run.")
+    parser.add_argument("--no-fail-budget", action="store_true", help="Print budget failures without exiting non-zero.")
+
+    parser.add_argument("--workspace-count", type=int, default=8)
+    parser.add_argument("--panes-per-workspace", type=int, default=6)
+    parser.add_argument("--surfaces-per-pane", type=int, default=2)
+    parser.add_argument("--browser-panes-per-workspace", type=int, default=3)
+    parser.add_argument("--browser-dom-rows", type=int, default=360)
+    parser.add_argument("--terminal-scrollback-lines", type=int, default=400)
+    parser.add_argument("--warmup-passes", type=int, default=1)
+    parser.add_argument("--measure-passes", type=int, default=3)
+
+    parser.add_argument("--launch-timeout", type=float, default=45)
+    parser.add_argument("--switch-log-timeout", type=float, default=5)
+    parser.add_argument("--budget-handoff-p95-ms", type=float, default=300)
+    parser.add_argument("--budget-cli-roundtrip-p95-ms", type=float, default=450)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    runner = WorkspaceSwitchPerfRunner(args)
+    try:
+        result = runner.run()
+    except Exception as exc:
+        result = runner.result
+        result["failures"] = result.get("failures", []) + [str(exc)]
+        if args.output:
+            output = pathlib.Path(args.output)
+            output.parent.mkdir(parents=True, exist_ok=True)
+            output.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        if args.junit:
+            write_junit(result, pathlib.Path(args.junit))
+        print_summary(result)
+        raise
+
+    if args.output:
+        output = pathlib.Path(args.output)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if args.junit:
+        write_junit(result, pathlib.Path(args.junit))
+    print_summary(result)
+    if result.get("failures") and not args.no_fail_budget:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        raise


### PR DESCRIPTION
Summary:
- Keep visited workspaces mounted so the warm path does not rebuild terminal/browser surfaces.
- Keep mounted workspace portal anchors alive but transparent, then switch visible workspace portals by z-priority during handoff.
- Extend the workspace-switch benchmark to measure warm visible readiness, not just handoff completion.

Cloud benchmark:
- Run: https://github.com/manaflow-ai/cmux-loader/actions/runs/25948772320
- Host: cloud-mac-25948772320, macOS 26.4
- Control layer: shell-debug via cmux socket and debug logs, CUA bootstrap timed out before benchmark.
- Fixture: 6 workspaces, 5 panes/workspace, 2 surfaces/pane, 24 browsers, 36 terminals.
- Command: `scripts/perf-workspace-switch.py --tag cwarm3 --workspace-count 6 --panes-per-workspace 5 --surfaces-per-pane 2 --browser-panes-per-workspace 2 --terminal-scrollback-lines 200 --browser-dom-rows 240 --warmup-passes 1 --measure-passes 2 --output /tmp/cmux-switch-cwarm3.json`
- Result: visible_ready p95 16.74ms, handoff p95 16.79ms, portal_priority p95 16.74ms, 20/20 samples, budgets pass.

Cloud verification:
- `CMUX_SKIP_ZIG_BUILD=1 xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination "platform=macOS,arch=arm64" -derivedDataPath /tmp/cmux-cwarm3-tests-skipzig -only-testing:cmuxTests/WorkspaceMountPolicyTests -only-testing:cmuxTests/TabManagerWorkspaceSelectionPerfTests -only-testing:cmuxTests/WorkspacePortalRenderingTests test`
- `CMUX_SKIP_ZIG_BUILD=1 xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination "platform=macOS,arch=arm64" -derivedDataPath /tmp/cmux-cwarm3-tests-skipzig -only-testing:cmuxTests/WorkspaceContentViewVisibilityTests/testNonSelectedNonRetiringWorkspaceKeepsPanelMountedButTransparent test`