### PR TITLE
fix: honor right-click-action from ghostty config

### DIFF
--- a/Sources/GhosttyConfig.swift
+++ b/Sources/GhosttyConfig.swift
@@ -45,6 +45,10 @@ struct GhosttyConfig {
     // Palette colors (0-15)
     var palette: [Int: NSColor] = [:]
 
+    // Mouse behavior — mirrors Ghostty's `right-click-action` config key.
+    // Valid values: "context-menu" (default), "paste", "copy", "copy-or-paste", "ignore".
+    var rightClickAction: String = "context-menu"
+
     var unfocusedSplitOverlayOpacity: Double {
         let clamped = min(1.0, max(0.15, unfocusedSplitOpacity))
         return min(1.0, max(0.0, 1.0 - clamped))
@@ -445,6 +449,8 @@ struct GhosttyConfig {
                     if let opacity = Double(value) {
                         sidebarTintOpacity = min(max(opacity, 0), 1)
                     }
+                case "right-click-action":
+                    rightClickAction = value
                 default:
                     break
                 }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -9029,6 +9029,15 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             return nil
         }
 
+        // Honor Ghostty's `right-click-action` config. When the user has
+        // chosen anything other than the default context menu, return nil
+        // so AppKit doesn't show cmux's NSMenu and the click flows through
+        // rightMouseDown/Up to Ghostty's mouse handler, which performs the
+        // configured action (paste / copy / copy-or-paste / ignore).
+        if GhosttyConfig.load().rightClickAction != "context-menu" {
+            return nil
+        }
+
         window?.makeFirstResponder(self)
         let point = convert(event.locationInWindow, from: nil)
         ghostty_surface_mouse_pos(surface, point.x, bounds.height - point.y, modsFromEvent(event))

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -275,6 +275,29 @@ final class GhosttyConfigTests: XCTestCase {
         XCTAssertEqual(config.backgroundBlur, .macosGlassClear)
     }
 
+    func testRightClickActionDefaultsToContextMenu() {
+        let config = GhosttyConfig()
+        XCTAssertEqual(config.rightClickAction, "context-menu")
+    }
+
+    func testParseRightClickActionReadsPaste() {
+        var config = GhosttyConfig()
+        config.parse("right-click-action = paste")
+        XCTAssertEqual(config.rightClickAction, "paste")
+    }
+
+    func testParseRightClickActionReadsCopyOrPaste() {
+        var config = GhosttyConfig()
+        config.parse("right-click-action = copy-or-paste")
+        XCTAssertEqual(config.rightClickAction, "copy-or-paste")
+    }
+
+    func testParseRightClickActionIgnoresUnknownKey() {
+        var config = GhosttyConfig()
+        config.parse("right-clicl-action = paste")
+        XCTAssertEqual(config.rightClickAction, "context-menu")
+    }
+
     func testLoadThemeResolvesBuiltinAliasFromGhosttyResourcesDir() throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-ghostty-themes-\(UUID().uuidString)")


### PR DESCRIPTION
## Summary

cmux reads `~/.config/ghostty/config` (per the README), but the
`right-click-action` setting was silently dropped. Right-clicking a
terminal surface always showed cmux's native `NSMenu`, so the
configured action (`paste`, `copy`, `copy-or-paste`, `ignore`) never
ran.

This PR honors the setting:

1. **`Sources/GhosttyConfig.swift`** — adds a `rightClickAction: String`
   field defaulting to `"context-menu"` and a `case` in `parse(...)` so
   the value is captured (previously fell into `default: break`).
2. **`Sources/GhosttyTerminalView.swift`** — at the top of
   `menu(for:)`, returns `nil` when the configured action is anything
   other than `"context-menu"`. AppKit then doesn't show cmux's
   `NSMenu`, and the click flows through `rightMouseDown` /
   `rightMouseUp` to Ghostty's mouse handler, which performs the
   configured action.

Fixes #4177.

## Commit structure

Per `CLAUDE.md`'s regression-test policy, this PR uses a two-commit
structure so CI proves the test catches the bug:

1. `test(GhosttyConfig): add failing test for right-click-action parsing`
   — adds 4 assertions next to the existing `parse(...)` tests in
   `cmuxTests/GhosttyConfigTests.swift`. CI on this commit alone should
   go red (no `rightClickAction` field exists yet).
2. `fix(GhosttyConfig): honor right-click-action from ghostty config`
   — the actual change. CI should go green.

## Test plan

- [x] `xcodebuild ... -derivedDataPath /tmp/cmux-rca-fix build`
      succeeds locally.
- [x] `./scripts/reload.sh --tag rca-fix` builds the tagged Debug app.
- [x] Manual repro from #4177 verified: with
      `right-click-action = paste` in `~/.config/ghostty/config`,
      right-click in a terminal pane pastes the clipboard with no
      context menu shown. Removing the line restores the previous
      `NSMenu` behavior.
- [ ] CI: tests on commit 1 fail, tests on commit 2 pass.

## Notes / open questions

- The new tests live in `GhosttyConfigTests` next to the existing
  `testParseBackgroundOpacityReadsConfigValue` /
  `testParseBackgroundBlurReadsMacOSGlassClear` parser tests. Same
  shape: construct a `GhosttyConfig`, call `parse(...)`, assert the
  field was set. This exercises observable parser behavior (per the
  test-quality policy in `CLAUDE.md`), not source-text shape.
- The handler change in `GhosttyTerminalView.menu(for:)` doesn't ship
  a unit test — exercising that path requires running AppKit and
  invoking `menu(for:)` with a real `NSEvent`. Per the
  test-quality policy ("If no meaningful behavioral or artifact-level
  test is practical, skip the fake regression test and state that
  explicitly"), I left it untested at the unit layer; the manual
  repro above covers it.
- This intentionally only handles `right-click-action`. Whether to
  also wire `mouse-shift-capture` or other Ghostty mouse keys is a
  scope decision for the maintainer — happy to extend in a follow-up
  if desired.
- `middle-click-action` already works (per CHANGELOG 0.62.0); this
  PR doesn't touch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honor the `right-click-action` from Ghostty config so right-click performs the configured behavior (paste/copy/copy-or-paste/ignore) instead of always showing the cmux context menu. Fixes #4177.

- **Bug Fixes**
  - Parse `right-click-action` in `GhosttyConfig` with default `"context-menu"`.
  - In `GhosttyTerminalView.menu(for:)`, return `nil` when the action isn’t `"context-menu"` so the event reaches Ghostty’s mouse handler.
  - Added unit tests for default and parsing cases.

<sup>Written for commit 9e2e1fe97e78737f40d63df53a0e7ba4c821cd9e. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4216?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added right-click action configuration, enabling users to customize terminal behavior when right-clicking. The feature supports multiple action types for different use cases, with a default action provided.

* **Tests**
  * Added comprehensive test coverage for right-click action configuration, including parsing validation, default value verification, and handling of custom and invalid actions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4216)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->