### PR TITLE
fix(cli): install Gemini feed hook with BeforeTool

### DIFF
--- a/CLI/CMUXCLI+AgentHookDefinitions.swift
+++ b/CLI/CMUXCLI+AgentHookDefinitions.swift
@@ -240,7 +240,7 @@ extension CMUXCLI {
                 .init(agentEvent: "AfterAgent", cmuxSubcommand: "stop"),
                 .init(agentEvent: "SessionEnd", cmuxSubcommand: "session-end"),
             ],
-            feedHookEvents: ["PreToolUse"]
+            feedHookEvents: ["BeforeTool"]
         ),
         AgentHookDef(
             name: "kiro", displayName: "Kiro", statusKey: "kiro",

--- a/CLI/CMUXCLI+AgentHookDefinitions.swift
+++ b/CLI/CMUXCLI+AgentHookDefinitions.swift
@@ -157,7 +157,7 @@ extension CMUXCLI {
                 .init(agentEvent: "AfterAgent", cmuxSubcommand: "stop"),
                 .init(agentEvent: "SessionEnd", cmuxSubcommand: "session-end"),
             ],
-            feedHookEvents: ["PreToolUse"]
+            feedHookEvents: ["BeforeTool"]
         ),
         AgentHookDef(
             name: "rovodev", displayName: "Rovo Dev", statusKey: "rovodev",

--- a/CLI/CMUXCLI+AgentHookDefinitions.swift
+++ b/CLI/CMUXCLI+AgentHookDefinitions.swift
@@ -263,10 +263,6 @@ extension CMUXCLI {
     }
 
     private static func isLegacyCmuxOwnedHookCommand(_ command: String, for def: AgentHookDef) -> Bool {
-        // Legacy cmux codex-hook and feed-hook commands only existed for Codex hooks.
-        guard def.name == "codex" else {
-            return false
-        }
         let tokens = legacyCmuxCommandTokens(from: command, for: def)
         guard !tokens.isEmpty,
               URL(fileURLWithPath: String(tokens[0])).lastPathComponent == "cmux"
@@ -274,6 +270,20 @@ extension CMUXCLI {
             return false
         }
 
+        if def.name == "gemini" {
+            return tokens.count >= 7
+                && tokens[1] == "hooks"
+                && tokens[2] == "feed"
+                && tokens[3] == "--source"
+                && tokens[4] == "gemini"
+                && tokens[5] == "--event"
+                && tokens[6] == "PreToolUse"
+        }
+
+        // Legacy cmux codex-hook and feed-hook commands only existed for Codex hooks.
+        guard def.name == "codex" else {
+            return false
+        }
         if tokens.count >= 2, tokens[1] == "codex-hook" {
             return true
         }

--- a/CLI/FeedEventClassifier.swift
+++ b/CLI/FeedEventClassifier.swift
@@ -223,6 +223,7 @@ struct FeedEventClassifier {
     /// event, so it carries ``FeedEventSemantic/toolStartMaybeApproval``.
     private static let genericFeedEventSemantics: [String: FeedEventSemantic] = [
         "PreToolUse": .toolStartMaybeApproval,
+        "BeforeTool": .toolStartMaybeApproval,
         "beforeShellExecution": .toolStartMaybeApproval,
         "PermissionRequest": .approvalRequest,
         "PostToolUse": .toolEnd,

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -23085,7 +23085,7 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
         }
 
         switch event {
-        case "PreToolUse", "beforeShellExecution":
+        case "PreToolUse", "BeforeTool", "beforeShellExecution":
             if source == "codex" { return ("PreToolUse", false) }
             switch toolName {
             case "ExitPlanMode":

--- a/cmuxTests/RovoDevHookConfigTests.swift
+++ b/cmuxTests/RovoDevHookConfigTests.swift
@@ -8,12 +8,15 @@ import XCTest
 #endif
 
 final class RovoDevHookConfigTests: XCTestCase {
-    func testGeminiFeedHookUsesCurrentBeforeToolEventName() throws {
+    func testGeminiFeedHookOwnershipCoversCurrentAndLegacyEventNames() throws {
         let def = try XCTUnwrap(CMUXCLI.agentDef(named: "gemini"))
+        let currentCommand = CMUXCLI.feedHookCommandString(for: def, agentEvent: "BeforeTool")
+        let legacyCommand = CMUXCLI.feedHookCommandString(for: def, agentEvent: "PreToolUse")
 
-        XCTAssertEqual(def.feedHookEvents, ["BeforeTool"])
-        XCTAssertTrue(CMUXCLI.feedHookCommandString(for: def, agentEvent: "BeforeTool").contains("--event BeforeTool"))
-        XCTAssertFalse(def.feedHookEvents.contains("PreToolUse"))
+        XCTAssertTrue(currentCommand.contains("--event BeforeTool"))
+        XCTAssertTrue(CMUXCLI.isCmuxOwnedHookCommand(currentCommand, for: def))
+        XCTAssertTrue(CMUXCLI.isCmuxOwnedHookCommand(legacyCommand, for: def))
+        XCTAssertFalse(CMUXCLI.isCmuxOwnedHookCommand(legacyCommand, for: def, includeLegacy: false))
     }
 
     func testInstallAddsRootBlockAndUninstallRestoresOriginalConfig() {

--- a/cmuxTests/RovoDevHookConfigTests.swift
+++ b/cmuxTests/RovoDevHookConfigTests.swift
@@ -13,6 +13,7 @@ final class RovoDevHookConfigTests: XCTestCase {
         let currentCommand = CMUXCLI.feedHookCommandString(for: def, agentEvent: "BeforeTool")
         let legacyCommand = CMUXCLI.feedHookCommandString(for: def, agentEvent: "PreToolUse")
 
+        XCTAssertTrue(def.feedHookEvents.contains("BeforeTool"))
         XCTAssertTrue(currentCommand.contains("--event BeforeTool"))
         XCTAssertTrue(CMUXCLI.isCmuxOwnedHookCommand(currentCommand, for: def))
         XCTAssertTrue(CMUXCLI.isCmuxOwnedHookCommand(legacyCommand, for: def))

--- a/cmuxTests/RovoDevHookConfigTests.swift
+++ b/cmuxTests/RovoDevHookConfigTests.swift
@@ -8,6 +8,14 @@ import XCTest
 #endif
 
 final class RovoDevHookConfigTests: XCTestCase {
+    func testGeminiFeedHookUsesCurrentBeforeToolEventName() throws {
+        let def = try XCTUnwrap(CMUXCLI.agentDef(named: "gemini"))
+
+        XCTAssertEqual(def.feedHookEvents, ["BeforeTool"])
+        XCTAssertTrue(CMUXCLI.feedHookCommandString(for: def, agentEvent: "BeforeTool").contains("--event BeforeTool"))
+        XCTAssertFalse(def.feedHookEvents.contains("PreToolUse"))
+    }
+
     func testInstallAddsRootBlockAndUninstallRestoresOriginalConfig() {
         let existing = """
         sessions:


### PR DESCRIPTION
## Summary
- Update the Gemini feed hook install event from `PreToolUse` to `BeforeTool`, matching the current Gemini CLI hook schema.
- Treat `BeforeTool` like the existing pre-tool feed event in the generated CLI classifier.
- Add a regression test that keeps Gemini from installing `PreToolUse`.

Fixes #4215.

## Testing
- `swiftc <stub> CLI/CMUXCLI+AgentHookDefinitions.swift <assertion main> && ./check`
- `rg -n 'case "PreToolUse", "BeforeTool", "beforeShellExecution"' CLI/cmux.swift`\n\n## Note\n- `xcodebuild test -only-testing:cmuxTests/RovoDevHookConfigTests` could not complete in this local checkout: first run missed the `vendor/bonsplit` submodule; after initializing it, package resolution/build stayed silent for several minutes and was stopped locally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Gemini feed hook from `PreToolUse` to `BeforeTool` to match the current CLI schema and preserve pre-tool behavior. Update the classifier to accept `BeforeTool`, remove legacy `PreToolUse` installs, and add tests for both event names and ownership checks (fixes #4215).

<sup>Written for commit c87db80a1d0a2805ee8d0d70028c774756105f2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Updated Gemini agent integration event handling to use current event naming conventions
  * Enhanced event classification for tool operations to properly recognize and process events
<!-- end of auto-generated comment: release notes by coderabbit.ai -->