### PR TITLE
Fix browser deep-link popups (slack://, discord://, etc.)

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -11984,6 +11984,74 @@
         }
       }
     },
+    "browser.externalOpenPrompt.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A web page in cmux wants to open a link in another app. You can stay in the browser instead."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux のウェブページが別のアプリでリンクを開こうとしています。代わりにブラウザに留まることもできます。"
+          }
+        }
+      }
+    },
+    "browser.externalOpenPrompt.openApp": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open App"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリを開く"
+          }
+        }
+      }
+    },
+    "browser.externalOpenPrompt.stayInBrowser": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stay in Browser"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ブラウザに留まる"
+          }
+        }
+      }
+    },
+    "browser.externalOpenPrompt.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open External App?"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "外部アプリを開きますか？"
+          }
+        }
+      }
+    },
     "browser.error.insecure.message": {
       "extractionState": "manual",
       "localizations": {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -11933,6 +11933,74 @@
         }
       }
     },
+    "browser.externalOpenFailure.appName": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This app"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このアプリ"
+          }
+        }
+      }
+    },
+    "browser.externalOpenFailure.copyLink": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy Link"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リンクをコピー"
+          }
+        }
+      }
+    },
+    "browser.externalOpenFailure.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ might not be installed, or macOS could not open this link. Install the app, or copy the link and open it elsewhere."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ がインストールされていないか、macOS がこのリンクを開けませんでした。アプリをインストールするか、リンクをコピーして別の場所で開いてください。"
+          }
+        }
+      }
+    },
+    "browser.externalOpenFailure.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cannot Open Link"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リンクを開けません"
+          }
+        }
+      }
+    },
     "browser.error.insecure.message": {
       "extractionState": "manual",
       "localizations": {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -11933,23 +11933,6 @@
         }
       }
     },
-    "browser.externalOpenFailure.appName": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This app"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "このアプリ"
-          }
-        }
-      }
-    },
     "browser.externalOpenFailure.copyLink": {
       "extractionState": "manual",
       "localizations": {
@@ -11973,13 +11956,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ might not be installed, or macOS could not open this link. Install the app, or copy the link and open it elsewhere."
+            "value": "cmux could not open this link. You can copy it and open it in another app."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ がインストールされていないか、macOS がこのリンクを開けませんでした。アプリをインストールするか、リンクをコピーして別の場所で開いてください。"
+            "value": "cmux はこのリンクを開けませんでした。リンクをコピーして別のアプリで開けます。"
           }
         }
       }

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1305,9 +1305,12 @@ private func browserPresentExternalNavigationFailure(for url: URL, in webView: W
         localized: "browser.externalOpenFailure.title",
         defaultValue: "Cannot Open Link"
     )
-    alert.informativeText = String(
-        localized: "browser.externalOpenFailure.message",
-        defaultValue: "\(appName) might not be installed, or macOS could not open this link. Install the app, or copy the link and open it elsewhere."
+    alert.informativeText = String.localizedStringWithFormat(
+        String(
+            localized: "browser.externalOpenFailure.message",
+            defaultValue: "%@ might not be installed, or macOS could not open this link. Install the app, or copy the link and open it elsewhere."
+        ),
+        appName
     )
     alert.addButton(withTitle: String(localized: "common.ok", defaultValue: "OK"))
     alert.addButton(withTitle: String(

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1244,8 +1244,13 @@ func browserShouldOpenURLExternally(_ url: URL) -> Bool {
     return !browserEmbeddedNavigationSchemes.contains(scheme)
 }
 
+enum BrowserExternalNavigationAction: Equatable {
+    case browserFallback(URL)
+    case promptToOpenApp(URL)
+}
+
 func browserShouldRouteExternalNavigation(_ url: URL, targetFrameIsMainFrame _: Bool?) -> Bool {
-    return browserShouldOpenURLExternally(url)
+    return browserExternalNavigationAction(for: url) != nil
 }
 
 func browserIntentFallbackURL(for url: URL) -> URL? {
@@ -1273,9 +1278,52 @@ func browserIntentFallbackURL(for url: URL) -> URL? {
     return nil
 }
 
+func browserExternalNavigationAction(for url: URL) -> BrowserExternalNavigationAction? {
+    if let fallbackURL = browserIntentFallbackURL(for: url) {
+        return .browserFallback(fallbackURL)
+    }
+    guard browserShouldOpenURLExternally(url) else { return nil }
+    return .promptToOpenApp(url)
+}
+
 private func browserCopyExternalNavigationURL(_ url: URL) {
     NSPasteboard.general.clearContents()
     NSPasteboard.general.setString(url.absoluteString, forType: .string)
+}
+
+private func browserPresentExternalNavigationPrompt(
+    for url: URL,
+    in webView: WKWebView,
+    completion: @escaping (Bool) -> Void
+) {
+    let alert = NSAlert()
+    alert.alertStyle = .informational
+    alert.messageText = String(
+        localized: "browser.externalOpenPrompt.title",
+        defaultValue: "Open External App?"
+    )
+    alert.informativeText = String(
+        localized: "browser.externalOpenPrompt.message",
+        defaultValue: "A web page in cmux wants to open a link in another app. You can stay in the browser instead."
+    )
+    alert.addButton(withTitle: String(
+        localized: "browser.externalOpenPrompt.openApp",
+        defaultValue: "Open App"
+    ))
+    alert.addButton(withTitle: String(
+        localized: "browser.externalOpenPrompt.stayInBrowser",
+        defaultValue: "Stay in Browser"
+    ))
+
+    let handleResponse: (NSApplication.ModalResponse) -> Void = { response in
+        completion(response == .alertFirstButtonReturn)
+    }
+
+    if let window = webView.window {
+        alert.beginSheetModal(for: window, completionHandler: handleResponse)
+        return
+    }
+    handleResponse(alert.runModal())
 }
 
 private func browserPresentExternalNavigationFailure(for url: URL, in webView: WKWebView) {
@@ -1309,24 +1357,11 @@ private func browserPresentExternalNavigationFailure(for url: URL, in webView: W
 }
 
 @discardableResult
-func browserHandleExternalNavigation(
+private func browserOpenExternalNavigationURL(
     _ url: URL,
     source: String,
-    webView: WKWebView,
-    loadFallbackRequest: (URLRequest) -> Void
+    webView: WKWebView
 ) -> Bool {
-    if let fallbackURL = browserIntentFallbackURL(for: url) {
-        let request = URLRequest(url: fallbackURL)
-        loadFallbackRequest(request)
-#if DEBUG
-        cmuxDebugLog(
-            "browser.navigation.external source=\(source) opened=1 fallback=1 " +
-            "fallbackURL=\(browserNavigationDebugURL(fallbackURL)) url=\(browserNavigationDebugURL(url))"
-        )
-#endif
-        return true
-    }
-
     let opened = NSWorkspace.shared.open(url)
     if !opened {
         browserPresentExternalNavigationFailure(for: url, in: webView)
@@ -1337,7 +1372,45 @@ func browserHandleExternalNavigation(
         "url=\(browserNavigationDebugURL(url))"
     )
 #endif
-    return true
+    return opened
+}
+
+@discardableResult
+func browserHandleExternalNavigation(
+    _ url: URL,
+    source: String,
+    webView: WKWebView,
+    loadFallbackRequest: (URLRequest) -> Void
+) -> Bool {
+    guard let action = browserExternalNavigationAction(for: url) else { return false }
+
+    switch action {
+    case let .browserFallback(fallbackURL):
+        let request = URLRequest(url: fallbackURL)
+        loadFallbackRequest(request)
+#if DEBUG
+        cmuxDebugLog(
+            "browser.navigation.external source=\(source) opened=1 fallback=1 " +
+            "fallbackURL=\(browserNavigationDebugURL(fallbackURL)) url=\(browserNavigationDebugURL(url))"
+        )
+#endif
+        return true
+
+    case let .promptToOpenApp(externalURL):
+        browserPresentExternalNavigationPrompt(for: externalURL, in: webView) { shouldOpenApp in
+            guard shouldOpenApp else {
+#if DEBUG
+                cmuxDebugLog(
+                    "browser.navigation.external source=\(source) opened=0 prompt=1 allowed=0 " +
+                    "url=\(browserNavigationDebugURL(externalURL))"
+                )
+#endif
+                return
+            }
+            browserOpenExternalNavigationURL(externalURL, source: source, webView: webView)
+        }
+        return true
+    }
 }
 
 enum BrowserUserAgentSettings {

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1020,12 +1020,125 @@ func browserShouldOpenURLExternally(_ url: URL) -> Bool {
     return !browserEmbeddedNavigationSchemes.contains(scheme)
 }
 
-func browserShouldRouteExternalNavigation(_ url: URL, targetFrameIsMainFrame: Bool?) -> Bool {
-    targetFrameIsMainFrame != false && browserShouldOpenURLExternally(url)
+func browserShouldRouteExternalNavigation(_ url: URL, targetFrameIsMainFrame _: Bool?) -> Bool {
+    return browserShouldOpenURLExternally(url)
 }
 
 func browserIntentFallbackURL(for url: URL) -> URL? {
-    nil
+    guard url.scheme?.lowercased() == "intent" else { return nil }
+    guard let intentMarker = url.absoluteString.range(of: "#Intent;") else { return nil }
+
+    let fallbackPrefix = "S.browser_fallback_url="
+    let intentBody = url.absoluteString[intentMarker.upperBound...]
+    for component in intentBody.split(separator: ";", omittingEmptySubsequences: false) {
+        if component == "end" { break }
+        guard component.hasPrefix(fallbackPrefix) else { continue }
+
+        let rawFallbackURL = String(component.dropFirst(fallbackPrefix.count))
+        guard !rawFallbackURL.isEmpty else { return nil }
+
+        let decodedFallbackURL = rawFallbackURL.removingPercentEncoding ?? rawFallbackURL
+        guard let fallbackURL = URL(string: decodedFallbackURL),
+              let fallbackScheme = fallbackURL.scheme?.lowercased(),
+              fallbackScheme == "http" || fallbackScheme == "https" else {
+            return nil
+        }
+        return fallbackURL
+    }
+
+    return nil
+}
+
+private func browserExternalApplicationName(for url: URL) -> String {
+    switch url.scheme?.lowercased() {
+    case "discord":
+        return "Discord"
+    case "msteams":
+        return "Microsoft Teams"
+    case "slack":
+        return "Slack"
+    case "vscode":
+        return "Visual Studio Code"
+    case "zoommtg", "zoomus":
+        return "Zoom"
+    case let scheme? where !scheme.isEmpty:
+        return "\(scheme)://"
+    default:
+        return String(localized: "browser.externalOpenFailure.appName", defaultValue: "This app")
+    }
+}
+
+private func browserCopyExternalNavigationURL(_ url: URL) {
+    NSPasteboard.general.clearContents()
+    NSPasteboard.general.setString(url.absoluteString, forType: .string)
+}
+
+private func browserPresentExternalNavigationFailure(for url: URL, in webView: WKWebView) {
+    let appName = browserExternalApplicationName(for: url)
+    let alert = NSAlert()
+    alert.alertStyle = .warning
+    alert.messageText = String(
+        localized: "browser.externalOpenFailure.title",
+        defaultValue: "Cannot Open Link"
+    )
+    alert.informativeText = String(
+        localized: "browser.externalOpenFailure.message",
+        defaultValue: "\(appName) might not be installed, or macOS could not open this link. Install the app, or copy the link and open it elsewhere."
+    )
+    alert.addButton(withTitle: String(localized: "common.ok", defaultValue: "OK"))
+    alert.addButton(withTitle: String(
+        localized: "browser.externalOpenFailure.copyLink",
+        defaultValue: "Copy Link"
+    ))
+
+    let handleResponse: (NSApplication.ModalResponse) -> Void = { response in
+        if response == .alertSecondButtonReturn {
+            browserCopyExternalNavigationURL(url)
+        }
+    }
+
+    if let window = webView.window {
+        alert.beginSheetModal(for: window, completionHandler: handleResponse)
+        return
+    }
+    handleResponse(alert.runModal())
+}
+
+@discardableResult
+func browserHandleExternalNavigation(
+    _ url: URL,
+    source: String,
+    webView: WKWebView,
+    loadFallbackRequest: ((URLRequest) -> Void)? = nil
+) -> Bool {
+    if let fallbackURL = browserIntentFallbackURL(for: url) {
+        let request = URLRequest(url: fallbackURL)
+        if let loadFallbackRequest {
+            loadFallbackRequest(request)
+        } else {
+            browserLoadRequest(request, in: webView)
+        }
+#if DEBUG
+        cmuxDebugLog(
+            "browser.navigation.external source=\(source) opened=1 fallback=1 " +
+            "fallbackURL=\(browserNavigationDebugURL(fallbackURL)) url=\(browserNavigationDebugURL(url))"
+        )
+#endif
+        return true
+    }
+
+    let opened = NSWorkspace.shared.open(url)
+    if !opened {
+        NSLog("BrowserPanel external navigation failed to open URL: %@", url.absoluteString)
+        browserPresentExternalNavigationFailure(for: url, in: webView)
+    }
+#if DEBUG
+    cmuxDebugLog(
+        "browser.navigation.external source=\(source) opened=\(opened ? 1 : 0) " +
+        "url=\(browserNavigationDebugURL(url))"
+    )
+#endif
+    return true
 }
 
 enum BrowserUserAgentSettings {
@@ -6674,15 +6787,11 @@ private class BrowserNavigationDelegate: NSObject, WKNavigationDelegate {
         // WebKit cannot open app-specific deeplinks (discord://, slack://, zoommtg://, etc.).
         // Hand these off to macOS so the owning app can handle them.
         if let url = navigationAction.request.url,
-           navigationAction.targetFrame?.isMainFrame != false,
-           browserShouldOpenURLExternally(url) {
-            let opened = NSWorkspace.shared.open(url)
-            if !opened {
-                NSLog("BrowserPanel external navigation failed to open URL: %@", url.absoluteString)
-            }
-            #if DEBUG
-            cmuxDebugLog("browser.navigation.external source=navDelegate opened=\(opened ? 1 : 0) url=\(url.absoluteString)")
-            #endif
+           browserShouldRouteExternalNavigation(
+               url,
+               targetFrameIsMainFrame: navigationAction.targetFrame?.isMainFrame
+           ) {
+            browserHandleExternalNavigation(url, source: "navDelegate", webView: webView)
             decisionHandler(.cancel)
             return
         }
@@ -6863,14 +6972,11 @@ private class BrowserUIDelegate: NSObject, WKUIDelegate {
 #endif
         // External URL schemes → hand off to macOS, don't create a popup
         if let url = navigationAction.request.url,
-           browserShouldOpenURLExternally(url) {
-            let opened = NSWorkspace.shared.open(url)
-            if !opened {
-                NSLog("BrowserPanel external navigation failed to open URL: %@", url.absoluteString)
-            }
-            #if DEBUG
-            cmuxDebugLog("browser.navigation.external source=uiDelegate opened=\(opened ? 1 : 0) url=\(browserNavigationDebugURL(url))")
-            #endif
+           browserShouldRouteExternalNavigation(
+               url,
+               targetFrameIsMainFrame: navigationAction.targetFrame?.isMainFrame
+           ) {
+            browserHandleExternalNavigation(url, source: "uiDelegate", webView: webView)
             return nil
         }
 

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1020,6 +1020,14 @@ func browserShouldOpenURLExternally(_ url: URL) -> Bool {
     return !browserEmbeddedNavigationSchemes.contains(scheme)
 }
 
+func browserShouldRouteExternalNavigation(_ url: URL, targetFrameIsMainFrame: Bool?) -> Bool {
+    targetFrameIsMainFrame != false && browserShouldOpenURLExternally(url)
+}
+
+func browserIntentFallbackURL(for url: URL) -> URL? {
+    nil
+}
+
 enum BrowserUserAgentSettings {
     // Force a Safari UA. Some WebKit builds return a minimal UA without Version/Safari tokens,
     // and some installs may have legacy Chrome UA overrides. Both can cause Google to serve

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1273,44 +1273,21 @@ func browserIntentFallbackURL(for url: URL) -> URL? {
     return nil
 }
 
-private func browserExternalApplicationName(for url: URL) -> String {
-    switch url.scheme?.lowercased() {
-    case "discord":
-        return "Discord"
-    case "msteams":
-        return "Microsoft Teams"
-    case "slack":
-        return "Slack"
-    case "vscode":
-        return "Visual Studio Code"
-    case "zoommtg", "zoomus":
-        return "Zoom"
-    case let scheme? where !scheme.isEmpty:
-        return "\(scheme)://"
-    default:
-        return String(localized: "browser.externalOpenFailure.appName", defaultValue: "This app")
-    }
-}
-
 private func browserCopyExternalNavigationURL(_ url: URL) {
     NSPasteboard.general.clearContents()
     NSPasteboard.general.setString(url.absoluteString, forType: .string)
 }
 
 private func browserPresentExternalNavigationFailure(for url: URL, in webView: WKWebView) {
-    let appName = browserExternalApplicationName(for: url)
     let alert = NSAlert()
     alert.alertStyle = .warning
     alert.messageText = String(
         localized: "browser.externalOpenFailure.title",
         defaultValue: "Cannot Open Link"
     )
-    alert.informativeText = String.localizedStringWithFormat(
-        String(
-            localized: "browser.externalOpenFailure.message",
-            defaultValue: "%@ might not be installed, or macOS could not open this link. Install the app, or copy the link and open it elsewhere."
-        ),
-        appName
+    alert.informativeText = String(
+        localized: "browser.externalOpenFailure.message",
+        defaultValue: "cmux could not open this link. You can copy it and open it in another app."
     )
     alert.addButton(withTitle: String(localized: "common.ok", defaultValue: "OK"))
     alert.addButton(withTitle: String(
@@ -1336,15 +1313,11 @@ func browserHandleExternalNavigation(
     _ url: URL,
     source: String,
     webView: WKWebView,
-    loadFallbackRequest: ((URLRequest) -> Void)? = nil
+    loadFallbackRequest: (URLRequest) -> Void
 ) -> Bool {
     if let fallbackURL = browserIntentFallbackURL(for: url) {
         let request = URLRequest(url: fallbackURL)
-        if let loadFallbackRequest {
-            loadFallbackRequest(request)
-        } else {
-            browserLoadRequest(request, in: webView)
-        }
+        loadFallbackRequest(request)
 #if DEBUG
         cmuxDebugLog(
             "browser.navigation.external source=\(source) opened=1 fallback=1 " +
@@ -7024,7 +6997,14 @@ private class BrowserNavigationDelegate: NSObject, WKNavigationDelegate {
                url,
                targetFrameIsMainFrame: navigationAction.targetFrame?.isMainFrame
            ) {
-            browserHandleExternalNavigation(url, source: "navDelegate", webView: webView)
+            browserHandleExternalNavigation(
+                url,
+                source: "navDelegate",
+                webView: webView,
+                loadFallbackRequest: { [requestNavigation] request in
+                    requestNavigation?(request, .currentTab)
+                }
+            )
             decisionHandler(.cancel)
             return
         }
@@ -7209,7 +7189,14 @@ private class BrowserUIDelegate: NSObject, WKUIDelegate {
                url,
                targetFrameIsMainFrame: navigationAction.targetFrame?.isMainFrame
            ) {
-            browserHandleExternalNavigation(url, source: "uiDelegate", webView: webView)
+            browserHandleExternalNavigation(
+                url,
+                source: "uiDelegate",
+                webView: webView,
+                loadFallbackRequest: { [requestNavigation] request in
+                    requestNavigation?(request, .currentTab)
+                }
+            )
             return nil
         }
 

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1249,7 +1249,7 @@ enum BrowserExternalNavigationAction: Equatable {
     case promptToOpenApp(URL)
 }
 
-func browserShouldRouteExternalNavigation(_ url: URL, targetFrameIsMainFrame _: Bool?) -> Bool {
+func browserShouldRouteExternalNavigation(_ url: URL) -> Bool {
     return browserExternalNavigationAction(for: url) != nil
 }
 
@@ -7066,10 +7066,7 @@ private class BrowserNavigationDelegate: NSObject, WKNavigationDelegate {
         // WebKit cannot open app-specific deeplinks (discord://, slack://, zoommtg://, etc.).
         // Hand these off to macOS so the owning app can handle them.
         if let url = navigationAction.request.url,
-           browserShouldRouteExternalNavigation(
-               url,
-               targetFrameIsMainFrame: navigationAction.targetFrame?.isMainFrame
-           ) {
+           browserShouldRouteExternalNavigation(url) {
             browserHandleExternalNavigation(
                 url,
                 source: "navDelegate",
@@ -7258,10 +7255,7 @@ private class BrowserUIDelegate: NSObject, WKUIDelegate {
 #endif
         // External URL schemes → hand off to macOS, don't create a popup
         if let url = navigationAction.request.url,
-           browserShouldRouteExternalNavigation(
-               url,
-               targetFrameIsMainFrame: navigationAction.targetFrame?.isMainFrame
-           ) {
+           browserShouldRouteExternalNavigation(url) {
             browserHandleExternalNavigation(
                 url,
                 source: "uiDelegate",

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1356,7 +1356,6 @@ func browserHandleExternalNavigation(
 
     let opened = NSWorkspace.shared.open(url)
     if !opened {
-        NSLog("BrowserPanel external navigation failed to open URL: %@", url.absoluteString)
         browserPresentExternalNavigationFailure(for: url, in: webView)
     }
 #if DEBUG

--- a/Sources/Panels/BrowserPopupWindowController.swift
+++ b/Sources/Panels/BrowserPopupWindowController.swift
@@ -438,10 +438,7 @@ private class PopupUIDelegate: NSObject, WKUIDelegate {
         windowFeatures: WKWindowFeatures
     ) -> WKWebView? {
         if let url = navigationAction.request.url,
-           browserShouldRouteExternalNavigation(
-               url,
-               targetFrameIsMainFrame: navigationAction.targetFrame?.isMainFrame
-           ) {
+           browserShouldRouteExternalNavigation(url) {
             browserHandleExternalNavigation(
                 url,
                 source: "popupUIDelegate",
@@ -596,10 +593,7 @@ private class PopupNavigationDelegate: NSObject, WKNavigationDelegate {
         }
 
         // External URL schemes → hand off to macOS
-        if browserShouldRouteExternalNavigation(
-            url,
-            targetFrameIsMainFrame: navigationAction.targetFrame?.isMainFrame
-        ) {
+        if browserShouldRouteExternalNavigation(url) {
             browserHandleExternalNavigation(
                 url,
                 source: "popupNavDelegate",

--- a/Sources/Panels/BrowserPopupWindowController.swift
+++ b/Sources/Panels/BrowserPopupWindowController.swift
@@ -424,8 +424,11 @@ private class PopupUIDelegate: NSObject, WKUIDelegate {
         windowFeatures: WKWindowFeatures
     ) -> WKWebView? {
         if let url = navigationAction.request.url,
-           browserShouldOpenURLExternally(url) {
-            NSWorkspace.shared.open(url)
+           browserShouldRouteExternalNavigation(
+               url,
+               targetFrameIsMainFrame: navigationAction.targetFrame?.isMainFrame
+           ) {
+            browserHandleExternalNavigation(url, source: "popupUIDelegate", webView: webView)
             return nil
         }
 
@@ -566,24 +569,24 @@ private class PopupNavigationDelegate: NSObject, WKNavigationDelegate {
         decidePolicyFor navigationAction: WKNavigationAction,
         decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
     ) {
-        // Only guard main-frame navigations
-        guard navigationAction.targetFrame?.isMainFrame != false else {
-            decisionHandler(.allow)
-            return
-        }
-
         guard let url = navigationAction.request.url else {
             decisionHandler(.allow)
             return
         }
 
         // External URL schemes → hand off to macOS
-        if browserShouldOpenURLExternally(url) {
-            NSWorkspace.shared.open(url)
-            #if DEBUG
-            cmuxDebugLog("popup.nav.external url=\(url.absoluteString)")
-            #endif
+        if browserShouldRouteExternalNavigation(
+            url,
+            targetFrameIsMainFrame: navigationAction.targetFrame?.isMainFrame
+        ) {
+            browserHandleExternalNavigation(url, source: "popupNavDelegate", webView: webView)
             decisionHandler(.cancel)
+            return
+        }
+
+        // Only guard main-frame navigations
+        guard navigationAction.targetFrame?.isMainFrame != false else {
+            decisionHandler(.allow)
             return
         }
 

--- a/Sources/Panels/BrowserPopupWindowController.swift
+++ b/Sources/Panels/BrowserPopupWindowController.swift
@@ -353,6 +353,20 @@ final class BrowserPopupWindowController: NSObject, NSWindowDelegate {
         }
     }
 
+    fileprivate func requestNavigation(_ request: URLRequest, in webView: WKWebView) {
+        guard let url = request.url else { return }
+
+        if browserShouldBlockInsecureHTTPURL(url) {
+            presentInsecureHTTPAlert(for: url, in: webView) { [weak webView] policy in
+                guard policy == .allow, let webView else { return }
+                browserLoadRequest(request, in: webView)
+            }
+            return
+        }
+
+        browserLoadRequest(request, in: webView)
+    }
+
     // MARK: - Insecure HTTP prompt (parity with main browser)
 
     /// Shows the same 3-button insecure HTTP alert as the main browser.
@@ -428,7 +442,14 @@ private class PopupUIDelegate: NSObject, WKUIDelegate {
                url,
                targetFrameIsMainFrame: navigationAction.targetFrame?.isMainFrame
            ) {
-            browserHandleExternalNavigation(url, source: "popupUIDelegate", webView: webView)
+            browserHandleExternalNavigation(
+                url,
+                source: "popupUIDelegate",
+                webView: webView,
+                loadFallbackRequest: { [weak controller] request in
+                    controller?.requestNavigation(request, in: webView)
+                }
+            )
             return nil
         }
 
@@ -579,7 +600,14 @@ private class PopupNavigationDelegate: NSObject, WKNavigationDelegate {
             url,
             targetFrameIsMainFrame: navigationAction.targetFrame?.isMainFrame
         ) {
-            browserHandleExternalNavigation(url, source: "popupNavDelegate", webView: webView)
+            browserHandleExternalNavigation(
+                url,
+                source: "popupNavDelegate",
+                webView: webView,
+                loadFallbackRequest: { [weak controller] request in
+                    controller?.requestNavigation(request, in: webView)
+                }
+            )
             decisionHandler(.cancel)
             return
         }

--- a/cmuxTests/BrowserConfigTests.swift
+++ b/cmuxTests/BrowserConfigTests.swift
@@ -3650,6 +3650,7 @@ final class BrowserExternalNavigationSchemeTests: XCTestCase {
         let vscode = try XCTUnwrap(URL(string: "vscode://file/Users/example/project/README.md"))
 
         XCTAssertTrue(browserShouldRouteExternalNavigation(vscode, targetFrameIsMainFrame: false))
+        XCTAssertEqual(browserExternalNavigationAction(for: vscode), .promptToOpenApp(vscode))
     }
 
     func testEmbeddedSubframeNavigationStaysInWebView() throws {
@@ -3660,8 +3661,10 @@ final class BrowserExternalNavigationSchemeTests: XCTestCase {
 
     func testIntentBrowserFallbackURLExtraction() throws {
         let intent = try XCTUnwrap(URL(string: "intent://join/abc#Intent;scheme=zoommtg;package=us.zoom.videomeetings;S.browser_fallback_url=https%3A%2F%2Fzoom.us%2Fjoin%2Fabc;end"))
+        let fallback = try XCTUnwrap(URL(string: "https://zoom.us/join/abc"))
 
-        XCTAssertEqual(browserIntentFallbackURL(for: intent)?.absoluteString, "https://zoom.us/join/abc")
+        XCTAssertEqual(browserIntentFallbackURL(for: intent), fallback)
+        XCTAssertEqual(browserExternalNavigationAction(for: intent), .browserFallback(fallback))
     }
 
     func testIntentBrowserFallbackURLRejectsExternalSchemes() throws {

--- a/cmuxTests/BrowserConfigTests.swift
+++ b/cmuxTests/BrowserConfigTests.swift
@@ -3645,6 +3645,30 @@ final class BrowserExternalNavigationSchemeTests: XCTestCase {
         XCTAssertFalse(browserShouldOpenURLExternally(javascript))
         XCTAssertFalse(browserShouldOpenURLExternally(webkitInternal))
     }
+
+    func testCustomAppSchemesRouteExternallyFromSubframes() throws {
+        let vscode = try XCTUnwrap(URL(string: "vscode://file/Users/example/project/README.md"))
+
+        XCTAssertTrue(browserShouldRouteExternalNavigation(vscode, targetFrameIsMainFrame: false))
+    }
+
+    func testEmbeddedSubframeNavigationStaysInWebView() throws {
+        let https = try XCTUnwrap(URL(string: "https://example.com/iframe"))
+
+        XCTAssertFalse(browserShouldRouteExternalNavigation(https, targetFrameIsMainFrame: false))
+    }
+
+    func testIntentBrowserFallbackURLExtraction() throws {
+        let intent = try XCTUnwrap(URL(string: "intent://join/abc#Intent;scheme=zoommtg;package=us.zoom.videomeetings;S.browser_fallback_url=https%3A%2F%2Fzoom.us%2Fjoin%2Fabc;end"))
+
+        XCTAssertEqual(browserIntentFallbackURL(for: intent)?.absoluteString, "https://zoom.us/join/abc")
+    }
+
+    func testIntentBrowserFallbackURLRejectsExternalSchemes() throws {
+        let intent = try XCTUnwrap(URL(string: "intent://open#Intent;S.browser_fallback_url=slack%3A%2F%2Fopen;end"))
+
+        XCTAssertNil(browserIntentFallbackURL(for: intent))
+    }
 }
 
 

--- a/cmuxTests/BrowserConfigTests.swift
+++ b/cmuxTests/BrowserConfigTests.swift
@@ -3649,14 +3649,14 @@ final class BrowserExternalNavigationSchemeTests: XCTestCase {
     func testCustomAppSchemesRouteExternallyFromSubframes() throws {
         let vscode = try XCTUnwrap(URL(string: "vscode://file/Users/example/project/README.md"))
 
-        XCTAssertTrue(browserShouldRouteExternalNavigation(vscode, targetFrameIsMainFrame: false))
+        XCTAssertTrue(browserShouldRouteExternalNavigation(vscode))
         XCTAssertEqual(browserExternalNavigationAction(for: vscode), .promptToOpenApp(vscode))
     }
 
     func testEmbeddedSubframeNavigationStaysInWebView() throws {
         let https = try XCTUnwrap(URL(string: "https://example.com/iframe"))
 
-        XCTAssertFalse(browserShouldRouteExternalNavigation(https, targetFrameIsMainFrame: false))
+        XCTAssertFalse(browserShouldRouteExternalNavigation(https))
     }
 
     func testIntentBrowserFallbackURLExtraction() throws {


### PR DESCRIPTION
Fixes #4224.

## Summary
- Route browser external-scheme navigations regardless of main-frame vs subframe target so hidden-iframe app deep links reach LaunchServices.
- Share external deep-link handling across the main browser pane and popup delegates, including debug `browser.navigation.external ... opened=` logs.
- Parse safe HTTPS `intent://` browser fallback URLs and load them in the web view.
- Show a localized sheet with a copy-link action when macOS reports that an external URL could not be opened.

## Reproduction
- Used the running local cmux production app in workspace `cmux78: #4224 browser deep-link popups`.
- Created a throwaway browser pane with a data URL containing a button that inserts a hidden iframe with `vscode://file/Users/austinwang/manaflow/term/cmux78/README.md`.
- Clicking the button changed the page status to `iframe fired` and inserted the iframe, but Visual Studio Code did not launch.
- Running `/usr/bin/open` with the same `vscode://` URL launched Visual Studio Code, confirming the scheme handler worked and the failure was in cmux/WebKit routing.

## Testing
- Added regression coverage first in commit `test: cover browser external deep links`; it fails before the fix because subframe external routing stays false and intent fallback extraction returns nil.
- Did not run local tests per repo instructions; CI should exercise the unit tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes browser navigation routing for external schemes and `intent://` URLs across main and popup WebViews, which can affect link-opening behavior and user flows. Adds new prompts/sheets and clipboard copy behavior that should be validated across navigation paths.
> 
> **Overview**
> Fixes external deep-link handling so non-HTTP(S) URLs (e.g., `slack://`, `discord://`) are **routed out to macOS even when triggered from subframes and popups**, using a shared `browserHandleExternalNavigation` path.
> 
> Adds **user-facing UX** around external navigation: a localized *“Open external app?”* prompt before handing off to `NSWorkspace`, plus a localized failure sheet with *Copy Link* (copies to pasteboard) when macOS can’t open the URL.
> 
> Introduces parsing of `intent://` URLs to extract a **safe HTTPS `S.browser_fallback_url`** and load it in the WebView instead of launching an app, and adds regression tests covering subframe routing and intent fallback extraction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f87b55b469f0357eac5ade0ae262c843dadf323c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes deep-link handling so app URLs like slack://, discord://, vscode://, and zoommtg:// open from pages, subframes, and popups (#4224). Adds an “Open App?” prompt, safe `intent://` HTTPS fallbacks, a localized failure dialog with Copy Link, and masks URLs in debug logs.

- **Bug Fixes**
  - Route external schemes from any frame in both main and popup views; cancel WebKit and open via macOS.
  - Ask before opening external app links (Open App / Stay in Browser), with localized text.
  - Extract HTTPS-only `S.browser_fallback_url` from `intent://` and load it via browser navigation.
  - On open failure, show a localized warning with Copy Link; mask external deep-link URLs in debug logs.

<sup>Written for commit f87b55b469f0357eac5ade0ae262c843dadf323c. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4226?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved external link handling with intelligent fallback support to enhance app compatibility
  * New error notifications with user-friendly messaging when external applications fail to open, including a quick link copy option
  * Enhanced multilingual support for external navigation error messages

* **Tests**
  * Added comprehensive test coverage for external navigation routing and error handling scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4226?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->