### PR TITLE
Open cmd-click markdown links in cmux

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1292,16 +1292,18 @@ func resolveTerminalOpenURLTarget(_ rawValue: String) -> TerminalOpenURLTarget? 
     if let parsed = URL(string: trimmed),
        let scheme = parsed.scheme?.lowercased() {
         if scheme == "http" || scheme == "https" {
-            guard BrowserInsecureHTTPSettings.normalizeHost(parsed.host ?? "") != nil else {
+            let webCandidate = cmuxTrimTerminalPathTrailingPunctuation(trimmed)
+            let webURL = URL(string: webCandidate) ?? parsed
+            guard BrowserInsecureHTTPSettings.normalizeHost(webURL.host ?? "") != nil else {
                 #if DEBUG
-                cmuxDebugLog("link.resolve result=external(invalidHost) url=\(parsed)")
+                cmuxDebugLog("link.resolve result=external(invalidHost) url=\(webURL)")
                 #endif
-                return .external(parsed)
+                return .external(webURL)
             }
             #if DEBUG
-            cmuxDebugLog("link.resolve result=embeddedBrowser url=\(parsed)")
+            cmuxDebugLog("link.resolve result=embeddedBrowser url=\(webURL)")
             #endif
-            return .embeddedBrowser(parsed)
+            return .embeddedBrowser(webURL)
         }
         #if DEBUG
         cmuxDebugLog("link.resolve result=external(scheme=\(scheme)) url=\(parsed)")
@@ -1309,7 +1311,8 @@ func resolveTerminalOpenURLTarget(_ rawValue: String) -> TerminalOpenURLTarget? 
         return .external(parsed)
     }
 
-    if let webURL = resolveBrowserNavigableURL(trimmed) {
+    let webCandidate = cmuxTrimTerminalPathTrailingPunctuation(trimmed)
+    if let webURL = resolveBrowserNavigableURL(webCandidate) {
         guard BrowserInsecureHTTPSettings.normalizeHost(webURL.host ?? "") != nil else {
             #if DEBUG
             cmuxDebugLog("link.resolve result=external(bareHost-invalidHost) url=\(webURL)")
@@ -4049,13 +4052,15 @@ class GhosttyApp {
             if target.url.isFileURL,
                fileURLHost == nil || fileURLHost?.isEmpty == true || fileURLHost == "localhost" {
                 let fileURL = target.url
+                let resolvedFilePath = cmuxResolveQuicklookPath(fileURL.path, cwd: nil) ?? fileURL.path
+                let resolvedFileURL = URL(fileURLWithPath: resolvedFilePath)
                 let routed: Bool = performOnMain {
                     // Remote-surface guard runs before shouldRoute so we never
                     // stat a local path on the main thread for a remote workspace.
                     guard let termSurface = surfaceView.terminalSurface,
                           let workspace = termSurface.owningWorkspace(),
                           !workspace.isRemoteTerminalSurface(termSurface.id),
-                          CommandClickFileOpenRouter.shouldRouteInCmux(path: fileURL.path) else {
+                          CommandClickFileOpenRouter.shouldRouteInCmux(path: resolvedFilePath) else {
                         return false
                     }
                     // Defer the split creation. Ghostty's Surface.openUrl holds
@@ -4090,26 +4095,26 @@ class GhosttyApp {
                         )?.workspace ?? workspace
                         // Re-apply the sync remote-surface gate; panel may have moved.
                         guard !resolvedWorkspace.isRemoteTerminalSurface(surfaceId) else {
-                            NSWorkspace.shared.open(fileURL)
+                            NSWorkspace.shared.open(resolvedFileURL)
                             return
                         }
                         // TOCTOU re-check: file may have been removed/renamed
                         // since the synchronous gate. Fall through if so.
-                        guard CommandClickFileOpenRouter.shouldRouteInCmux(path: fileURL.path) else {
-                            NSWorkspace.shared.open(fileURL)
+                        guard CommandClickFileOpenRouter.shouldRouteInCmux(path: resolvedFilePath) else {
+                            NSWorkspace.shared.open(resolvedFileURL)
                             return
                         }
                         if CommandClickFileOpenRouter.openInCmux(
                             workspace: resolvedWorkspace,
                             sourcePanelId: surfaceId,
-                            filePath: fileURL.path
+                            filePath: resolvedFilePath
                         ) {
                             return
                         }
                         // Split creation failed (source pane gone between
                         // commit and dispatch). Surface via system opener so
                         // the click is not silently lost.
-                        NSWorkspace.shared.open(fileURL)
+                        NSWorkspace.shared.open(resolvedFileURL)
                     }
                     return true
                 }

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -4711,7 +4711,7 @@ enum TelemetrySettings {
 
 enum CmdClickMarkdownRouteSettings {
     static let key = "openMarkdownInCmuxViewer"
-    static let defaultValue = false
+    static let defaultValue = true
 
     static func isEnabled(defaults: UserDefaults = .standard) -> Bool {
         defaults.object(forKey: key) == nil ? defaultValue : defaults.bool(forKey: key)

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -4293,6 +4293,18 @@ final class TerminalOpenURLTargetResolutionTests: XCTestCase {
         }
     }
 
+    func testTrimsTrailingSentencePunctuationFromWebURLs() throws {
+        let target = try XCTUnwrap(resolveTerminalOpenURLTarget("https://docs.x.ai/build/overview."))
+        switch target {
+        case let .embeddedBrowser(url):
+            XCTAssertEqual(url.scheme, "https")
+            XCTAssertEqual(url.host, "docs.x.ai")
+            XCTAssertEqual(url.path, "/build/overview")
+        default:
+            XCTFail("Expected web URL with trailing sentence punctuation to route to embedded browser")
+        }
+    }
+
     func testResolvesBareDomainAsEmbeddedBrowser() throws {
         let target = try XCTUnwrap(resolveTerminalOpenURLTarget("example.com/docs"))
         switch target {
@@ -4411,6 +4423,20 @@ final class TerminalCmdClickPathPunctuationTrimmingTests: XCTestCase {
         XCTAssertEqual(
             cmuxResolveQuicklookPathForTesting(
                 "\(strippedPath).",
+                cwd: "/tmp",
+                existingPaths: [strippedPath]
+            ),
+            strippedPath
+        )
+    }
+
+    func testResolveQuicklookExpandsTildeBeforeTryingPunctuationTrimmedMarkdownPath() {
+        let rawPath = "~/.grok/docs/user-guide/10-hooks.md."
+        let strippedPath = ("~/.grok/docs/user-guide/10-hooks.md" as NSString).expandingTildeInPath
+
+        XCTAssertEqual(
+            cmuxResolveQuicklookPathForTesting(
+                rawPath,
                 cwd: "/tmp",
                 existingPaths: [strippedPath]
             ),

--- a/cmuxTests/WindowAndDragTests.swift
+++ b/cmuxTests/WindowAndDragTests.swift
@@ -2619,6 +2619,18 @@ final class FilePreviewPanelTextSavingTests: XCTestCase {
         XCTAssertFalse(CmdClickSupportedFileRouteSettings.shouldRoute(path: fileURL.path, defaults: defaults))
     }
 
+    func testCmdClickMarkdownRoutingDefaultsToCmuxViewerForReadableMarkdown() throws {
+        let suiteName = "cmux.markdown-preview-routing-default.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let fileURL = try temporaryTextFile(contents: "# preview me", encoding: .utf8, pathExtension: "md")
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        XCTAssertTrue(CmdClickMarkdownRouteSettings.isEnabled(defaults: defaults))
+        XCTAssertTrue(CmdClickMarkdownRouteSettings.shouldRoute(path: fileURL.path, defaults: defaults))
+    }
+
     func testCmdClickFilePreviewRoutingReusesRightSidePane() throws {
         let sourceURL = try temporaryTextFile(contents: "source", encoding: .utf8)
         let firstURL = try temporaryTextFile(contents: "first", encoding: .utf8)


### PR DESCRIPTION
## Summary
- Trim sentence punctuation from terminal web links before routing.
- Resolve terminal markdown file paths with the same punctuation-tolerant path lookup used by quick look.
- Default cmd-click markdown files to the cmux viewer.

## Testing
- Red: `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/cmux-mdlink-red -only-testing:cmuxTests/TerminalOpenURLTargetResolutionTests/testTrimsTrailingSentencePunctuationFromWebURLs test` failed on `d1df4f327` before the fix.
- Pass: `CMUX_TAG=mdlink xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/cmux-mdlink-fix -only-testing:cmuxTests/TerminalOpenURLTargetResolutionTests/testTrimsTrailingSentencePunctuationFromWebURLs test`
- Pass: `CMUX_TAG=mdlink CMUX_SOCKET_PATH=/tmp/cmux-debug-mdlink.sock CMUX_ALLOW_SOCKET_OVERRIDE=1 xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/cmux-mdlink-fix -only-testing:cmuxTests/FilePreviewPanelTextSavingTests/testCmdClickMarkdownRoutingDefaultsToCmuxViewerForReadableMarkdown test`

## Task
User request: cmd-clicking terminal markdown links should open in cmux markdown, including URL/file tokens followed by sentence punctuation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default cmd-click routing behavior (markdown now opens in the cmux viewer) and adjusts URL/file path normalization, which could alter how some links are interpreted or opened.
> 
> **Overview**
> Cmd-click URL resolution now **trims trailing sentence punctuation** before deciding whether to open HTTP(S) links in the embedded browser, improving handling of links like `https://.../page.`.
> 
> Cmd-click file handling now **resolves the clicked file path via `cmuxResolveQuicklookPath`** before routing into cmux (and before falling back to `NSWorkspace`), making punctuation/tilde-tolerant markdown paths open more reliably.
> 
> Markdown routing is now **enabled by default** via `CmdClickMarkdownRouteSettings.defaultValue = true`, with new unit/UI tests covering punctuation trimming, tilde expansion, and the new default behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3e2e33fd26aa28a15af42ac931d25e981515b6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cmd-clicking markdown links in the terminal now opens in the cmux markdown viewer. Matches the request to handle URL/file tokens that end with sentence punctuation so links resolve correctly.

- New Features
  - Trim trailing sentence punctuation from web URLs and file tokens before routing.
  - Resolve markdown file paths with the quicklook-style, punctuation-tolerant lookup (including tilde expansion).
  - Default cmd-click on markdown files to open in the cmux viewer.
  - Added tests for URL trimming and markdown routing defaults.

<sup>Written for commit a3e2e33fd26aa28a15af42ac931d25e981515b6e. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4230?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

