### PR TITLE
browser: expose webview lifecycle state in top

### DIFF
--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -4572,6 +4572,7 @@ extension BrowserPanel {
 
     func resetForWorkspaceContextChange(reason: String) {
         guard needsWorkspaceContextReset else {
+            resetWebViewLifecycleMetadata()
 #if DEBUG
             cmuxDebugLog(
                 "browser.contextReset.skip panel=\(id.uuidString.prefix(5)) " +

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -2069,6 +2069,13 @@ private enum BrowserInsecureHTTPNavigationIntent {
     case newTab
 }
 
+enum BrowserWebViewLifecycleState: String {
+    case newTab = "new_tab"
+    case liveVisible = "live_visible"
+    case liveHidden = "live_hidden"
+    case closing
+}
+
 /// Observable state for browser find-in-page. Mirrors `TerminalSurface.SearchState`.
 @MainActor
 final class BrowserSearchState: ObservableObject {
@@ -2487,8 +2494,22 @@ final class BrowserPanel: Panel, ObservableObject {
 
     /// Whether the browser panel should render its WKWebView in the content area.
     /// New browser tabs stay in an empty "new tab" state until first navigation.
-    @Published private(set) var shouldRenderWebView: Bool = false
+    @Published private(set) var shouldRenderWebView: Bool = false {
+        didSet {
+            if oldValue != shouldRenderWebView {
+                refreshWebViewLifecycleState()
+            }
+        }
+    }
     private var restoredSessionShouldRenderWebView: Bool?
+
+    @Published private(set) var webViewLifecycleState: BrowserWebViewLifecycleState = .newTab
+    private(set) var webViewLastVisibleAt: Date?
+    private(set) var webViewLastHiddenAt: Date?
+    private(set) var webViewLastVisibilityChangeAt: Date?
+    private(set) var webViewLastVisibilityChangeReason: String?
+    private var isWebViewVisibleInUI: Bool = false
+    private var isClosingWebViewLifecycle: Bool = false
 
     /// True when the browser is showing the internal empty new-tab page (no WKWebView attached yet).
     var isShowingNewTabPage: Bool {
@@ -2675,6 +2696,77 @@ final class BrowserPanel: Panel, ObservableObject {
 
     var currentBrowserThemeMode: BrowserThemeMode {
         browserThemeMode
+    }
+
+    func noteWebViewVisibility(
+        _ visible: Bool,
+        reason: String,
+        now: Date = Date(),
+        recordIfUnchanged: Bool = false
+    ) {
+        let changed = isWebViewVisibleInUI != visible
+        guard changed || recordIfUnchanged || webViewLastVisibilityChangeReason == nil else {
+            refreshWebViewLifecycleState()
+            return
+        }
+
+        isWebViewVisibleInUI = visible
+        if visible {
+            webViewLastVisibleAt = now
+        } else {
+            webViewLastHiddenAt = now
+        }
+        webViewLastVisibilityChangeAt = now
+        webViewLastVisibilityChangeReason = reason
+        refreshWebViewLifecycleState()
+    }
+
+    func webViewLifecycleTopPayload(now: Date = Date()) -> [String: Any] {
+        return [
+            "state": webViewLifecycleState.rawValue,
+            "visible_in_ui": isWebViewVisibleInUI,
+            "should_render": shouldRenderWebView,
+            "last_visible_at": Self.webViewLifecycleTimestamp(webViewLastVisibleAt),
+            "last_hidden_at": Self.webViewLifecycleTimestamp(webViewLastHiddenAt),
+            "last_visibility_change_at": Self.webViewLifecycleTimestamp(webViewLastVisibilityChangeAt),
+            "last_visibility_change_reason": webViewLastVisibilityChangeReason.map { $0 as Any } ?? NSNull(),
+            "hidden_duration_ms": Self.webViewHiddenDurationMilliseconds(
+                hiddenAt: webViewLastHiddenAt,
+                visible: isWebViewVisibleInUI,
+                now: now
+            )
+        ]
+    }
+
+    private func refreshWebViewLifecycleState() {
+        let nextState: BrowserWebViewLifecycleState
+        if isClosingWebViewLifecycle {
+            nextState = .closing
+        } else if !shouldRenderWebView {
+            nextState = .newTab
+        } else if isWebViewVisibleInUI {
+            nextState = .liveVisible
+        } else {
+            nextState = .liveHidden
+        }
+        guard webViewLifecycleState != nextState else { return }
+        webViewLifecycleState = nextState
+    }
+
+    private static func webViewLifecycleTimestamp(_ date: Date?) -> Any {
+        guard let date else { return NSNull() }
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.string(from: date)
+    }
+
+    private static func webViewHiddenDurationMilliseconds(
+        hiddenAt: Date?,
+        visible: Bool,
+        now: Date
+    ) -> Any {
+        guard !visible, let hiddenAt else { return NSNull() }
+        return max(0, Int((now.timeIntervalSince(hiddenAt) * 1000.0).rounded()))
     }
 
     /// Popups inherit this panel's exact WebKit storage and process context.
@@ -3769,6 +3861,8 @@ final class BrowserPanel: Panel, ObservableObject {
     }
 
     func close() {
+        isClosingWebViewLifecycle = true
+        refreshWebViewLifecycleState()
         GlobalSearchCoordinator.shared.purgePanel(id: id)
         closeDeveloperToolsForTeardown()
 
@@ -6210,6 +6304,11 @@ private extension BrowserPanel {
 
 extension BrowserPanel {
     func hideBrowserPortalView(source: String) {
+        noteWebViewVisibility(
+            false,
+            reason: "portal.\(source)",
+            recordIfUnchanged: true
+        )
         BrowserWindowPortalRegistry.hide(
             webView: webView,
             source: source

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -2706,7 +2706,8 @@ final class BrowserPanel: Panel, ObservableObject {
     ) {
         let changed = isWebViewVisibleInUI != visible
         let isFirstVisibilityRecord = webViewLastVisibilityChangeReason == nil
-        guard changed || recordIfUnchanged || isFirstVisibilityRecord else {
+        let shouldRecordVisibleHeartbeat = visible && recordIfUnchanged
+        guard changed || shouldRecordVisibleHeartbeat || isFirstVisibilityRecord else {
             refreshWebViewLifecycleState()
             return
         }
@@ -2719,8 +2720,10 @@ final class BrowserPanel: Panel, ObservableObject {
                 webViewLastHiddenAt = now
             }
             webViewLastVisibilityChangeAt = now
+            webViewLastVisibilityChangeReason = reason
+        } else if shouldRecordVisibleHeartbeat {
+            webViewLastVisibleAt = now
         }
-        webViewLastVisibilityChangeReason = reason
         refreshWebViewLifecycleState()
     }
 
@@ -3414,9 +3417,11 @@ final class BrowserPanel: Panel, ObservableObject {
         )
         replacement.pageZoom = desiredZoom
         webViewInstanceID = UUID()
+        resetWebViewLifecycleMetadata()
         webView = replacement
         currentURL = restoreURL
         shouldRenderWebView = wasRenderable
+        refreshWebViewLifecycleState()
 
         bindWebView(replacement)
         applyBrowserThemeModeIfNeeded()
@@ -3764,8 +3769,10 @@ final class BrowserPanel: Panel, ObservableObject {
         )
         replacement.pageZoom = desiredZoom
         webViewInstanceID = UUID()
+        resetWebViewLifecycleMetadata()
         webView = replacement
         shouldRenderWebView = wasRenderable
+        refreshWebViewLifecycleState()
 
         bindWebView(replacement)
         applyBrowserThemeModeIfNeeded()

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -2779,13 +2779,15 @@ final class BrowserPanel: Panel, ObservableObject {
         return max(0, Int((now.timeIntervalSince(hiddenAt) * 1000.0).rounded()))
     }
 
-    private func resetWebViewLifecycleMetadata() {
+    private func resetWebViewLifecycleMetadata(resetVisibility: Bool = true) {
         webViewLifecycleState = .newTab
-        webViewLastVisibleAt = nil
-        webViewLastHiddenAt = nil
-        webViewLastVisibilityChangeAt = nil
-        webViewLastVisibilityChangeReason = nil
-        isWebViewVisibleInUI = false
+        if resetVisibility {
+            webViewLastVisibleAt = nil
+            webViewLastHiddenAt = nil
+            webViewLastVisibilityChangeAt = nil
+            webViewLastVisibilityChangeReason = nil
+            isWebViewVisibleInUI = false
+        }
         isClosingWebViewLifecycle = false
     }
 
@@ -3417,7 +3419,7 @@ final class BrowserPanel: Panel, ObservableObject {
         )
         replacement.pageZoom = desiredZoom
         webViewInstanceID = UUID()
-        resetWebViewLifecycleMetadata()
+        resetWebViewLifecycleMetadata(resetVisibility: false)
         webView = replacement
         currentURL = restoreURL
         shouldRenderWebView = wasRenderable
@@ -3769,7 +3771,7 @@ final class BrowserPanel: Panel, ObservableObject {
         )
         replacement.pageZoom = desiredZoom
         webViewInstanceID = UUID()
-        resetWebViewLifecycleMetadata()
+        resetWebViewLifecycleMetadata(resetVisibility: false)
         webView = replacement
         shouldRenderWebView = wasRenderable
         refreshWebViewLifecycleState()

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -2069,7 +2069,7 @@ private enum BrowserInsecureHTTPNavigationIntent {
     case newTab
 }
 
-enum BrowserWebViewLifecycleState: String {
+nonisolated enum BrowserWebViewLifecycleState: String {
     case newTab = "new_tab"
     case liveVisible = "live_visible"
     case liveHidden = "live_hidden"
@@ -2705,18 +2705,21 @@ final class BrowserPanel: Panel, ObservableObject {
         recordIfUnchanged: Bool = false
     ) {
         let changed = isWebViewVisibleInUI != visible
-        guard changed || recordIfUnchanged || webViewLastVisibilityChangeReason == nil else {
+        let isFirstVisibilityRecord = webViewLastVisibilityChangeReason == nil
+        guard changed || recordIfUnchanged || isFirstVisibilityRecord else {
             refreshWebViewLifecycleState()
             return
         }
 
-        isWebViewVisibleInUI = visible
-        if visible {
-            webViewLastVisibleAt = now
-        } else {
-            webViewLastHiddenAt = now
+        if changed || isFirstVisibilityRecord {
+            isWebViewVisibleInUI = visible
+            if visible {
+                webViewLastVisibleAt = now
+            } else {
+                webViewLastHiddenAt = now
+            }
+            webViewLastVisibilityChangeAt = now
         }
-        webViewLastVisibilityChangeAt = now
         webViewLastVisibilityChangeReason = reason
         refreshWebViewLifecycleState()
     }
@@ -2753,11 +2756,15 @@ final class BrowserPanel: Panel, ObservableObject {
         webViewLifecycleState = nextState
     }
 
-    private static func webViewLifecycleTimestamp(_ date: Date?) -> Any {
-        guard let date else { return NSNull() }
+    private static let webViewLifecycleTimestampFormatter: ISO8601DateFormatter = {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        return formatter.string(from: date)
+        return formatter
+    }()
+
+    private static func webViewLifecycleTimestamp(_ date: Date?) -> Any {
+        guard let date else { return NSNull() }
+        return webViewLifecycleTimestampFormatter.string(from: date)
     }
 
     private static func webViewHiddenDurationMilliseconds(
@@ -2767,6 +2774,16 @@ final class BrowserPanel: Panel, ObservableObject {
     ) -> Any {
         guard !visible, let hiddenAt else { return NSNull() }
         return max(0, Int((now.timeIntervalSince(hiddenAt) * 1000.0).rounded()))
+    }
+
+    private func resetWebViewLifecycleMetadata() {
+        webViewLifecycleState = .newTab
+        webViewLastVisibleAt = nil
+        webViewLastHiddenAt = nil
+        webViewLastVisibilityChangeAt = nil
+        webViewLastVisibilityChangeReason = nil
+        isWebViewVisibleInUI = false
+        isClosingWebViewLifecycle = false
     }
 
     /// Popups inherit this panel's exact WebKit storage and process context.
@@ -4604,6 +4621,7 @@ extension BrowserPanel {
         restoredSessionShouldRenderWebView = nil
         faviconPNGData = nil
         lastFaviconURLString = nil
+        resetWebViewLifecycleMetadata()
         activePortalHostLease = nil
         pendingDistinctPortalHostReplacementPaneId = nil
         lockedPortalHost = nil
@@ -4626,6 +4644,7 @@ extension BrowserPanel {
         webViewInstanceID = UUID()
         webView = replacement
         shouldRenderWebView = false
+        refreshWebViewLifecycleState()
         bindWebView(replacement)
         applyBrowserThemeModeIfNeeded()
         refreshNavigationAvailability()

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -778,9 +778,10 @@ struct BrowserPanelView: View {
             }
         }
         .onChange(of: isVisibleInUI) { visibleInUI in
+            let effectiveVisibility = visibleInUI && isCurrentPaneOwner
             panel.noteWebViewVisibility(
-                visibleInUI && isCurrentPaneOwner,
-                reason: visibleInUI ? "view.visible" : "view.hidden"
+                effectiveVisibility,
+                reason: effectiveVisibility ? "view.visible" : "view.hidden"
             )
             if visibleInUI {
                 panel.cancelPendingDeveloperToolsVisibilityLossCheck()
@@ -6701,11 +6702,6 @@ struct WebViewRepresentable: NSViewRepresentable {
         let previousZPriority = coordinator.desiredPortalZPriority
         coordinator.desiredPortalVisibleInUI = shouldAttachWebView && isCurrentPaneOwner
         coordinator.desiredPortalZPriority = portalZPriority
-        let lifecycleVisibleInUI = coordinator.desiredPortalVisibleInUI
-        let lifecycleReason = lifecycleVisibleInUI ? "portal.update.visible" : "portal.update.hidden"
-        DispatchQueue.main.async { [weak panel] in
-            panel?.noteWebViewVisibility(lifecycleVisibleInUI, reason: lifecycleReason)
-        }
         coordinator.attachGeneration += 1
         let generation = coordinator.attachGeneration
         let activePaneDropContext = coordinator.desiredPortalVisibleInUI ? paneDropContext : nil
@@ -6739,6 +6735,11 @@ struct WebViewRepresentable: NSViewRepresentable {
                 bounds: host.bounds,
                 reason: "update"
             )
+        if portalHostAccepted || didReleasePortalHost {
+            let lifecycleVisibleInUI = portalHostAccepted && coordinator.desiredPortalVisibleInUI
+            let lifecycleReason = lifecycleVisibleInUI ? "portal.update.visible" : "portal.update.hidden"
+            panel.noteWebViewVisibility(lifecycleVisibleInUI, reason: lifecycleReason)
+        }
 #if DEBUG
         if !isCurrentPaneOwner && (shouldAttachWebView || host.window != nil) {
             cmuxDebugLog(

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -714,6 +714,10 @@ struct BrowserPanelView: View {
             if browserProfilePopoverVerticalPaddingRaw != resolvedProfilePopoverVerticalPadding {
                 browserProfilePopoverVerticalPaddingRaw = resolvedProfilePopoverVerticalPadding
             }
+            panel.noteWebViewVisibility(
+                isVisibleInUI && isCurrentPaneOwner,
+                reason: "view.onAppear"
+            )
             panel.refreshAppearanceDrivenColors()
             panel.setBrowserThemeMode(browserThemeMode)
             applyPendingAddressBarFocusRequestIfNeeded()
@@ -774,6 +778,10 @@ struct BrowserPanelView: View {
             }
         }
         .onChange(of: isVisibleInUI) { visibleInUI in
+            panel.noteWebViewVisibility(
+                visibleInUI && isCurrentPaneOwner,
+                reason: visibleInUI ? "view.visible" : "view.hidden"
+            )
             if visibleInUI {
                 panel.cancelPendingDeveloperToolsVisibilityLossCheck()
                 return
@@ -6693,6 +6701,10 @@ struct WebViewRepresentable: NSViewRepresentable {
         let previousZPriority = coordinator.desiredPortalZPriority
         coordinator.desiredPortalVisibleInUI = shouldAttachWebView && isCurrentPaneOwner
         coordinator.desiredPortalZPriority = portalZPriority
+        panel.noteWebViewVisibility(
+            coordinator.desiredPortalVisibleInUI,
+            reason: coordinator.desiredPortalVisibleInUI ? "portal.update.visible" : "portal.update.hidden"
+        )
         coordinator.attachGeneration += 1
         let generation = coordinator.attachGeneration
         let activePaneDropContext = coordinator.desiredPortalVisibleInUI ? paneDropContext : nil

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -6701,10 +6701,11 @@ struct WebViewRepresentable: NSViewRepresentable {
         let previousZPriority = coordinator.desiredPortalZPriority
         coordinator.desiredPortalVisibleInUI = shouldAttachWebView && isCurrentPaneOwner
         coordinator.desiredPortalZPriority = portalZPriority
-        panel.noteWebViewVisibility(
-            coordinator.desiredPortalVisibleInUI,
-            reason: coordinator.desiredPortalVisibleInUI ? "portal.update.visible" : "portal.update.hidden"
-        )
+        let lifecycleVisibleInUI = coordinator.desiredPortalVisibleInUI
+        let lifecycleReason = lifecycleVisibleInUI ? "portal.update.visible" : "portal.update.hidden"
+        DispatchQueue.main.async { [weak panel] in
+            panel?.noteWebViewVisibility(lifecycleVisibleInUI, reason: lifecycleReason)
+        }
         coordinator.attachGeneration += 1
         let generation = coordinator.attachGeneration
         let activePaneDropContext = coordinator.desiredPortalVisibleInUI ? paneDropContext : nil

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -3610,8 +3610,10 @@ class TerminalController {
             if panel.panelType == .browser, let browserPanel = panel as? BrowserPanel {
                 let webContentPID = CmuxWebContentProcessIdentifier.pid(for: browserPanel.webView)
                 let url = browserPanel.currentURL?.absoluteString ?? ""
+                let webViewLifecycle = browserPanel.webViewLifecycleTopPayload()
                 item["url"] = url
                 item["browser_web_content_pid"] = v2OrNull(webContentPID)
+                item["browser_webview_lifecycle_state"] = browserPanel.webViewLifecycleState.rawValue
                 item["webviews"] = [
                     [
                         "kind": "webview",
@@ -3622,7 +3624,8 @@ class TerminalController {
                         "surface_ref": v2Ref(kind: .surface, uuid: panel.id),
                         "title": browserPanel.displayTitle,
                         "url": url,
-                        "pid": v2OrNull(webContentPID)
+                        "pid": v2OrNull(webContentPID),
+                        "lifecycle": webViewLifecycle
                     ] as [String: Any]
                 ]
             } else {

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -1218,7 +1218,7 @@ final class BrowserPanelWebViewLifecycleTests: XCTestCase {
         XCTAssertEqual(payload["state"] as? String, "live_hidden")
         XCTAssertEqual(payload["visible_in_ui"] as? Bool, false)
         XCTAssertEqual(payload["should_render"] as? Bool, true)
-        XCTAssertEqual(payload["last_visibility_change_reason"] as? String, "test.hidden.duplicate")
+        XCTAssertEqual(payload["last_visibility_change_reason"] as? String, "test.hidden")
         XCTAssertEqual(payload["hidden_duration_ms"] as? Int, 11250)
 
         panel.close()

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -1172,6 +1172,54 @@ final class BrowserPanelPopupContextTests: XCTestCase {
     }
 }
 
+@MainActor
+final class BrowserPanelWebViewLifecycleTests: XCTestCase {
+    func testLifecycleStartsAsNewTabUntilRenderable() {
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            initialURL: URL(string: "https://example.test/")!,
+            renderInitialNavigation: false,
+            isRemoteWorkspace: false
+        )
+        defer { panel.close() }
+
+        XCTAssertEqual(panel.webViewLifecycleState, .newTab)
+
+        panel.noteWebViewVisibility(true, reason: "test.visible")
+
+        XCTAssertEqual(panel.webViewLifecycleState, .newTab)
+    }
+
+    func testLifecycleTracksVisibleHiddenAndClosingStates() {
+        let hiddenAt = Date(timeIntervalSince1970: 100)
+        let now = hiddenAt.addingTimeInterval(1.25)
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            initialURL: URL(string: "https://example.test/")!,
+            isRemoteWorkspace: false
+        )
+        defer { panel.close() }
+
+        XCTAssertEqual(panel.webViewLifecycleState, .liveHidden)
+
+        panel.noteWebViewVisibility(true, reason: "test.visible", now: hiddenAt)
+        XCTAssertEqual(panel.webViewLifecycleState, .liveVisible)
+
+        panel.noteWebViewVisibility(false, reason: "test.hidden", now: hiddenAt)
+        XCTAssertEqual(panel.webViewLifecycleState, .liveHidden)
+
+        let payload = panel.webViewLifecycleTopPayload(now: now)
+        XCTAssertEqual(payload["state"] as? String, "live_hidden")
+        XCTAssertEqual(payload["visible_in_ui"] as? Bool, false)
+        XCTAssertEqual(payload["should_render"] as? Bool, true)
+        XCTAssertEqual(payload["last_visibility_change_reason"] as? String, "test.hidden")
+        XCTAssertEqual(payload["hidden_duration_ms"] as? Int, 1250)
+
+        panel.close()
+        XCTAssertEqual(panel.webViewLifecycleState, .closing)
+    }
+}
+
 final class BrowserNewTabNavigationSeedTests: XCTestCase {
     func testPreservesOriginalRequestHeadersMethodBodyAndBypassHost() throws {
         let url = try XCTUnwrap(URL(string: "https://www.linkedin.com/redir/redirect?url=https%3A%2F%2Fexample.com"))

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -1192,13 +1192,13 @@ final class BrowserPanelWebViewLifecycleTests: XCTestCase {
 
     func testLifecycleTracksVisibleHiddenAndClosingStates() {
         let hiddenAt = Date(timeIntervalSince1970: 100)
-        let now = hiddenAt.addingTimeInterval(1.25)
+        let duplicateHiddenAt = hiddenAt.addingTimeInterval(10)
+        let now = hiddenAt.addingTimeInterval(11.25)
         let panel = BrowserPanel(
             workspaceId: UUID(),
             initialURL: URL(string: "https://example.test/")!,
             isRemoteWorkspace: false
         )
-        defer { panel.close() }
 
         XCTAssertEqual(panel.webViewLifecycleState, .liveHidden)
 
@@ -1207,13 +1207,19 @@ final class BrowserPanelWebViewLifecycleTests: XCTestCase {
 
         panel.noteWebViewVisibility(false, reason: "test.hidden", now: hiddenAt)
         XCTAssertEqual(panel.webViewLifecycleState, .liveHidden)
+        panel.noteWebViewVisibility(
+            false,
+            reason: "test.hidden.duplicate",
+            now: duplicateHiddenAt,
+            recordIfUnchanged: true
+        )
 
         let payload = panel.webViewLifecycleTopPayload(now: now)
         XCTAssertEqual(payload["state"] as? String, "live_hidden")
         XCTAssertEqual(payload["visible_in_ui"] as? Bool, false)
         XCTAssertEqual(payload["should_render"] as? Bool, true)
-        XCTAssertEqual(payload["last_visibility_change_reason"] as? String, "test.hidden")
-        XCTAssertEqual(payload["hidden_duration_ms"] as? Int, 1250)
+        XCTAssertEqual(payload["last_visibility_change_reason"] as? String, "test.hidden.duplicate")
+        XCTAssertEqual(payload["hidden_duration_ms"] as? Int, 11250)
 
         panel.close()
         XCTAssertEqual(panel.webViewLifecycleState, .closing)


### PR DESCRIPTION
## Summary
- Track browser WKWebView lifecycle state as new_tab, live_visible, live_hidden, or closing.
- Record browser portal/view visibility timestamps and reasons without resetting hidden duration on duplicate hide events.
- Include lifecycle data in cmux top browser webview payloads for memory diagnostics.
- Reset lifecycle metadata when a browser panel is reused for a fresh workspace context.
- Add focused BrowserPanel lifecycle unit coverage.

## Why
Hidden browser tabs/workspaces currently keep their WKWebView and WebContent process alive, but cmux top does not distinguish visible webviews from hidden retained ones. This PR adds the observability needed before adding discard/reclaim policy in follow-up PRs.

## Review follow-up
- Addressed duplicate hide events resetting hidden_duration_ms.
- Deferred portal update lifecycle recording out of NSViewRepresentable render/update.
- Reset lifecycle metadata during workspace context reset.
- Removed test double-close.

## Validation
- `git diff --check`
- `swiftc -parse Sources/Panels/BrowserPanel.swift Sources/Panels/BrowserPanelView.swift Sources/TerminalController.swift cmuxTests/GhosttyConfigTests.swift`

Not run: `./scripts/test-unit.sh -only-testing:cmuxTests/BrowserPanelWebViewLifecycleTests` because this machine has only Command Line Tools selected and no Xcode.app install; xcodebuild exits with: tool xcodebuild requires Xcode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Browser panel now persists WebView lifecycle states (new, visible, hidden, closing) with timestamped visibility transitions and computed hidden duration.
  * Lifecycle state and payload are included in workspace/browser surface telemetry.

* **Behavior**
  * Panel view and portal interactions now report UI visibility changes; hiding the portal records a visibility transition.

* **Tests**
  * Added tests verifying lifecycle transitions, payload contents, and closing behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4243?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->