### PR TITLE
Support JSONC Dock configs

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -107903,13 +107903,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Set up cmux Dock controls for the current context.\n\nFirst, learn the feature before editing:\n1. Run `cmux docs dock` if the cmux CLI is available. If it is not, read https://cmux.com/docs/dock.\n2. Inspect the repository or current directory to understand the project type, scripts, package manager, dev servers, logs, task runners, test commands, and any existing TUI tools.\n3. If the desired Dock is ambiguous, ask the user what they want monitored or controlled before writing files.\n\nDock is cmux's right-sidebar terminal control area. A Dock config is JSON with a top-level `controls` array. Each control runs a command in its own Ghostty-backed terminal section using the user's login shell. Controls are useful for project dashboards, git/status views, dev server or build status, test watchers, log tails, queues, local services, or a custom TUI such as `cmux feed tui --opentui` when that feed is useful.\n\nChoose where to write the config:\n- In a repository or project directory, create or edit `.cmux/dock.json` so teammates can share it.\n- For a personal default outside a repo, create or edit `~/.config/cmux/dock.json`.\n- If both exist, project `.cmux/dock.json` is more specific for that project. Nested project configs apply to that directory tree; use the nearest relevant project config instead of writing unrelated controls globally.\n- If there is no repo and no clear project root, use the global config only after confirming the user wants a personal Dock.\n\nSchema:\n{\n  \"controls\": [\n    {\n      \"id\": \"short-stable-id\",\n      \"title\": \"Human label\",\n      \"command\": \"safe command to run\",\n      \"cwd\": \"optional/path\",\n      \"height\": 220,\n      \"env\": { \"NAME\": \"value\" }\n    }\n  ]\n}\n\nRules:\n- Keep ids stable, lowercase, and unique.\n- Use `cwd` for subdirectories; relative paths resolve from the config base.\n- Use `height` only when a control needs a fixed amount of vertical space.\n- Use `env` only for non-secret values needed by one control.\n- Do not put secrets, tokens, or machine-specific private paths in a shared project config.\n- Prefer commands that are safe to start repeatedly and make sense in a terminal.\n- Do not invent unavailable scripts. Read package files, Makefiles, Procfiles, README docs, config files, and existing tooling first.\n- Keep shared project Docks portable for teammates. Put personal or machine-specific controls in the global Dock.\n\nDeliverable:\n- Create or update the appropriate dock.json.\n- Preserve existing useful controls unless the user asked to replace them.\n- Validate that the JSON parses.\n- Summarize what each control does and any commands the user should review before trusting the Dock config."
+            "value": "Set up cmux Dock controls for the current context.\n\nFirst, learn the feature before editing:\n1. Run `cmux docs dock` if the cmux CLI is available. If it is not, read https://cmux.com/docs/dock.\n2. Inspect the repository or current directory to understand the project type, scripts, package manager, dev servers, logs, task runners, test commands, and any existing TUI tools.\n3. If the desired Dock is ambiguous, ask the user what they want monitored or controlled before writing files.\n\nDock is cmux's right-sidebar terminal control area. A Dock config is JSONC-compatible with a top-level `controls` array, so comments and trailing commas are allowed. Each control runs a command in its own Ghostty-backed terminal section using the user's login shell. Controls are useful for project dashboards, git/status views, dev server or build status, test watchers, log tails, queues, local services, or a custom TUI such as `cmux feed tui --opentui` when that feed is useful.\n\nChoose where to write the config:\n- In a repository or project directory, create or edit `.cmux/dock.json` so teammates can share it.\n- For a personal default outside a repo, create or edit `~/.config/cmux/dock.json`.\n- `dock.jsonc` is also supported if you want the filename to advertise comments. If `dock.json` and `dock.jsonc` both exist in the same config directory, `dock.json` wins.\n- If both project and global configs exist, project `.cmux/dock.json` or `.cmux/dock.jsonc` is more specific for that project. Nested project configs apply to that directory tree; use the nearest relevant project config instead of writing unrelated controls globally.\n- If there is no repo and no clear project root, use the global config only after confirming the user wants a personal Dock.\n\nSchema:\n{\n  \"controls\": [\n    {\n      \"id\": \"short-stable-id\",\n      \"title\": \"Human label\",\n      \"command\": \"safe command to run\",\n      \"cwd\": \"optional/path\",\n      \"height\": 220,\n      \"env\": { \"NAME\": \"value\" }\n    }\n  ]\n}\n\nRules:\n- Keep ids stable, lowercase, and unique.\n- Use `cwd` for subdirectories; relative paths resolve from the config base.\n- Use `height` only when a control needs a fixed amount of vertical space.\n- Use `env` only for non-secret values needed by one control.\n- Do not put secrets, tokens, or machine-specific private paths in a shared project config.\n- Prefer commands that are safe to start repeatedly and make sense in a terminal.\n- Do not invent unavailable scripts. Read package files, Makefiles, Procfiles, README docs, config files, and existing tooling first.\n- Keep shared project Docks portable for teammates. Put personal or machine-specific controls in the global Dock.\n\nDeliverable:\n- Create or update the appropriate Dock config file (`dock.json` or `dock.jsonc`).\n- Preserve existing useful controls unless the user asked to replace them.\n- Validate that the JSONC parses.\n- Summarize what each control does and any commands the user should review before trusting the Dock config."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "現在のコンテキストに合わせて cmux Dock コントロールを設定してください。\n\n編集する前に機能を確認してください:\n1. cmux CLI が使える場合は `cmux docs dock` を実行してください。使えない場合は https://cmux.com/docs/dock を読んでください。\n2. リポジトリまたは現在のディレクトリを調べ、プロジェクト種別、スクリプト、パッケージマネージャー、開発サーバー、ログ、タスクランナー、テストコマンド、既存の TUI ツールを把握してください。\n3. どの Dock を作るべきか曖昧な場合は、ファイルを書く前に何を監視または操作したいかユーザーに確認してください。\n\nDock は cmux の右サイドバーにあるターミナルコントロール領域です。Dock 設定はトップレベルに `controls` 配列を持つ JSON です。各コントロールはユーザーのログインシェルを使い、Ghostty ベースの独立したターミナルセクションで command を実行します。プロジェクトダッシュボード、git/status、開発サーバーやビルド状態、テストウォッチャー、ログ tail、キュー、ローカルサービス、または有用な場合の `cmux feed tui --opentui` のようなカスタム TUI に向いています。\n\n設定を書く場所を選んでください:\n- リポジトリまたはプロジェクトディレクトリでは、チームで共有できるように `.cmux/dock.json` を作成または編集してください。\n- リポジトリ外の個人用デフォルトでは、`~/.config/cmux/dock.json` を作成または編集してください。\n- 両方がある場合、そのプロジェクトでは `.cmux/dock.json` がより具体的です。ネストしたプロジェクト設定はそのディレクトリツリーに適用されます。無関係なコントロールをグローバルに書かず、最も近い適切なプロジェクト設定を使ってください。\n- リポジトリがなく、明確なプロジェクトルートもない場合は、個人用 Dock でよいかユーザーに確認してからグローバル設定を使ってください。\n\nスキーマ:\n{\n  \"controls\": [\n    {\n      \"id\": \"short-stable-id\",\n      \"title\": \"Human label\",\n      \"command\": \"safe command to run\",\n      \"cwd\": \"optional/path\",\n      \"height\": 220,\n      \"env\": { \"NAME\": \"value\" }\n    }\n  ]\n}\n\nルール:\n- id は安定した小文字の一意な値にしてください。\n- サブディレクトリで実行する場合は `cwd` を使ってください。相対パスは設定ファイルの基準ディレクトリから解決されます。\n- `height` は固定の縦幅が必要なコントロールにだけ使ってください。\n- `env` はそのコントロールだけに必要な非秘密の値にだけ使ってください。\n- 共有するプロジェクト設定にシークレット、トークン、マシン固有の非公開パスを入れないでください。\n- 繰り返し起動しても安全で、ターミナル内で意味のあるコマンドを優先してください。\n- 存在しないスクリプトを作り上げないでください。先に package ファイル、Makefile、Procfile、README、設定ファイル、既存ツールを読んでください。\n- 共有プロジェクト Dock はチームメイトが使えるよう移植性を保ってください。個人用またはマシン固有のコントロールはグローバル Dock に入れてください。\n\n成果物:\n- 適切な dock.json を作成または更新してください。\n- ユーザーが置き換えを依頼していない限り、既存の有用なコントロールは残してください。\n- JSON がパースできることを検証してください。\n- 各コントロールの役割と、信頼する前にユーザーが確認すべきコマンドを要約してください。"
+            "value": "現在のコンテキストに合わせて cmux Dock コントロールを設定してください。\n\n編集する前に機能を確認してください:\n1. cmux CLI が使える場合は `cmux docs dock` を実行してください。使えない場合は https://cmux.com/docs/dock を読んでください。\n2. リポジトリまたは現在のディレクトリを調べ、プロジェクト種別、スクリプト、パッケージマネージャー、開発サーバー、ログ、タスクランナー、テストコマンド、既存の TUI ツールを把握してください。\n3. どの Dock を作るべきか曖昧な場合は、ファイルを書く前に何を監視または操作したいかユーザーに確認してください。\n\nDock は cmux の右サイドバーにあるターミナルコントロール領域です。Dock 設定はトップレベルに `controls` 配列を持つ JSONC 互換形式なので、コメントと末尾カンマを使用できます。各コントロールはユーザーのログインシェルを使い、Ghostty ベースの独立したターミナルセクションで command を実行します。プロジェクトダッシュボード、git/status、開発サーバーやビルド状態、テストウォッチャー、ログ tail、キュー、ローカルサービス、または有用な場合の `cmux feed tui --opentui` のようなカスタム TUI に向いています。\n\n設定を書く場所を選んでください:\n- リポジトリまたはプロジェクトディレクトリでは、チームで共有できるように `.cmux/dock.json` を作成または編集してください。\n- リポジトリ外の個人用デフォルトでは、`~/.config/cmux/dock.json` を作成または編集してください。\n- ファイル名でもコメント対応を示したい場合は `dock.jsonc` もサポートされています。同じ設定ディレクトリに `dock.json` と `dock.jsonc` の両方がある場合は、`dock.json` が優先されます。\n- プロジェクト設定とグローバル設定の両方がある場合、そのプロジェクトでは `.cmux/dock.json` または `.cmux/dock.jsonc` がより具体的です。ネストしたプロジェクト設定はそのディレクトリツリーに適用されます。無関係なコントロールをグローバルに書かず、最も近い適切なプロジェクト設定を使ってください。\n- リポジトリがなく、明確なプロジェクトルートもない場合は、個人用 Dock でよいかユーザーに確認してからグローバル設定を使ってください。\n\nスキーマ:\n{\n  \"controls\": [\n    {\n      \"id\": \"short-stable-id\",\n      \"title\": \"Human label\",\n      \"command\": \"safe command to run\",\n      \"cwd\": \"optional/path\",\n      \"height\": 220,\n      \"env\": { \"NAME\": \"value\" }\n    }\n  ]\n}\n\nルール:\n- id は安定した小文字の一意な値にしてください。\n- サブディレクトリで実行する場合は `cwd` を使ってください。相対パスは設定ファイルの基準ディレクトリから解決されます。\n- `height` は固定の縦幅が必要なコントロールにだけ使ってください。\n- `env` はそのコントロールだけに必要な非秘密の値にだけ使ってください。\n- 共有するプロジェクト設定にシークレット、トークン、マシン固有の非公開パスを入れないでください。\n- 繰り返し起動しても安全で、ターミナル内で意味のあるコマンドを優先してください。\n- 存在しないスクリプトを作り上げないでください。先に package ファイル、Makefile、Procfile、README、設定ファイル、既存ツールを読んでください。\n- 共有プロジェクト Dock はチームメイトが使えるよう移植性を保ってください。個人用またはマシン固有のコントロールはグローバル Dock に入れてください。\n\n成果物:\n- 適切な Dock 設定ファイル（`dock.json` または `dock.jsonc`）を作成または更新してください。\n- ユーザーが置き換えを依頼していない限り、既存の有用なコントロールは残してください。\n- JSONC がパースできることを検証してください。\n- 各コントロールの役割と、信頼する前にユーザーが確認すべきコマンドを要約してください。"
           }
         }
       }
@@ -108114,6 +108114,108 @@
           "stringUnit": {
             "state": "translated",
             "value": "DockコントロールのIDは空にできません。"
+          }
+        }
+      }
+    },
+    "dock.error.jsoncParseFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't parse Dock config as JSONC: %@."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dock設定をJSONCとして解析できませんでした: %@。"
+          }
+        }
+      }
+    },
+    "dock.error.jsoncParseFailed.recovery": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check comments and trailing commas in your Dock config file, then reload Dock."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dock設定ファイルのコメントと末尾カンマを確認してから、Dockを再読み込みしてください。"
+          }
+        }
+      }
+    },
+    "dock.error.jsoncParseFailed.reason.encoding": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "an unsupported text encoding"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サポートされていないテキストエンコーディング"
+          }
+        }
+      }
+    },
+    "dock.error.jsoncParseFailed.reason.syntax": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "invalid syntax"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無効なJSONC構文"
+          }
+        }
+      }
+    },
+    "dock.error.jsoncParseFailed.reason.trailingComma": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "an invalid trailing comma"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無効な末尾カンマ"
+          }
+        }
+      }
+    },
+    "dock.error.jsoncParseFailed.reason.unterminatedBlockComment": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "an unterminated block comment"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "閉じられていないブロックコメント"
           }
         }
       }

--- a/Sources/DockConfigParser.swift
+++ b/Sources/DockConfigParser.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+nonisolated struct DockConfigFile: Codable, Sendable {
+    let controls: [DockControlDefinition]
+}
+
+nonisolated enum DockConfigFileLocator {
+    static func existingConfigURL(in directory: URL) -> URL? {
+        let jsonURL = directory.appendingPathComponent("dock.json", isDirectory: false)
+        if FileManager.default.fileExists(atPath: jsonURL.path) {
+            return jsonURL
+        }
+        let jsoncURL = directory.appendingPathComponent("dock.jsonc", isDirectory: false)
+        if FileManager.default.fileExists(atPath: jsoncURL.path) {
+            return jsoncURL
+        }
+        return nil
+    }
+}
+
+nonisolated enum DockConfigParser {
+    /// Decodes Dock controls from a JSONC configuration payload.
+    static func decodeControls(data: Data) throws -> [DockControlDefinition] {
+        let sanitized: Data
+        do {
+            sanitized = try JSONCParser.preprocess(data: data)
+        } catch {
+            let reason = parseFailureReason(for: error)
+            throw NSError(
+                domain: "cmux.dock",
+                code: 2,
+                userInfo: [
+                    NSLocalizedDescriptionKey: String(
+                        localized: "dock.error.jsoncParseFailed",
+                        defaultValue: "Couldn't parse Dock config as JSONC: \(reason)."
+                    ),
+                    NSLocalizedRecoverySuggestionErrorKey: String(
+                        localized: "dock.error.jsoncParseFailed.recovery",
+                        defaultValue: "Check comments and trailing commas in your Dock config file, then reload Dock."
+                    ),
+                    NSUnderlyingErrorKey: error,
+                ]
+            )
+        }
+        return try JSONDecoder().decode(DockConfigFile.self, from: sanitized).controls
+    }
+
+    private static func parseFailureReason(for error: Error) -> String {
+        switch error {
+        case JSONCParser.JSONCError.unterminatedBlockComment:
+            return String(
+                localized: "dock.error.jsoncParseFailed.reason.unterminatedBlockComment",
+                defaultValue: "an unterminated block comment"
+            )
+        case JSONCParser.JSONCError.invalidTrailingComma:
+            return String(
+                localized: "dock.error.jsoncParseFailed.reason.trailingComma",
+                defaultValue: "an invalid trailing comma"
+            )
+        case JSONCParser.JSONCError.invalidTextEncoding:
+            return String(
+                localized: "dock.error.jsoncParseFailed.reason.encoding",
+                defaultValue: "an unsupported text encoding"
+            )
+        default:
+            return String(
+                localized: "dock.error.jsoncParseFailed.reason.syntax",
+                defaultValue: "invalid syntax"
+            )
+        }
+    }
+}

--- a/Sources/DockEmptyView.swift
+++ b/Sources/DockEmptyView.swift
@@ -101,12 +101,13 @@ struct DockEmptyView: View {
             2. Inspect the repository or current directory to understand the project type, scripts, package manager, dev servers, logs, task runners, test commands, and any existing TUI tools.
             3. If the desired Dock is ambiguous, ask the user what they want monitored or controlled before writing files.
 
-            Dock is cmux's right-sidebar terminal control area. A Dock config is JSON with a top-level `controls` array. Each control runs a command in its own Ghostty-backed terminal section using the user's login shell. Controls are useful for project dashboards, git/status views, dev server or build status, test watchers, log tails, queues, local services, or a custom TUI such as `cmux feed tui --opentui` when that feed is useful.
+            Dock is cmux's right-sidebar terminal control area. A Dock config is JSONC-compatible with a top-level `controls` array, so comments and trailing commas are allowed. Each control runs a command in its own Ghostty-backed terminal section using the user's login shell. Controls are useful for project dashboards, git/status views, dev server or build status, test watchers, log tails, queues, local services, or a custom TUI such as `cmux feed tui --opentui` when that feed is useful.
 
             Choose where to write the config:
             - In a repository or project directory, create or edit `.cmux/dock.json` so teammates can share it.
             - For a personal default outside a repo, create or edit `~/.config/cmux/dock.json`.
-            - If both exist, project `.cmux/dock.json` is more specific for that project. Nested project configs apply to that directory tree; use the nearest relevant project config instead of writing unrelated controls globally.
+            - `dock.jsonc` is also supported if you want the filename to advertise comments. If `dock.json` and `dock.jsonc` both exist in the same config directory, `dock.json` wins.
+            - If both project and global configs exist, project `.cmux/dock.json` or `.cmux/dock.jsonc` is more specific for that project. Nested project configs apply to that directory tree; use the nearest relevant project config instead of writing unrelated controls globally.
             - If there is no repo and no clear project root, use the global config only after confirming the user wants a personal Dock.
 
             Schema:
@@ -134,9 +135,9 @@ struct DockEmptyView: View {
             - Keep shared project Docks portable for teammates. Put personal or machine-specific controls in the global Dock.
 
             Deliverable:
-            - Create or update the appropriate dock.json.
+            - Create or update the appropriate Dock config file (`dock.json` or `dock.jsonc`).
             - Preserve existing useful controls unless the user asked to replace them.
-            - Validate that the JSON parses.
+            - Validate that the JSONC parses.
             - Summarize what each control does and any commands the user should review before trusting the Dock config.
             """
         )

--- a/Sources/DockPanelView.swift
+++ b/Sources/DockPanelView.swift
@@ -2,7 +2,7 @@ import AppKit
 import Bonsplit
 import SwiftUI
 
-struct DockControlDefinition: Codable, Equatable, Identifiable {
+nonisolated struct DockControlDefinition: Codable, Equatable, Identifiable, Sendable {
     let id: String
     let title: String
     let command: String
@@ -77,10 +77,6 @@ struct DockControlDefinition: Codable, Equatable, Identifiable {
             try container.encode(env, forKey: .env)
         }
     }
-}
-
-private struct DockConfigFile: Codable {
-    let controls: [DockControlDefinition]
 }
 
 private struct DockConfigResolution {
@@ -397,8 +393,7 @@ final class DockControlsStore: ObservableObject {
             )
         }
 
-        let globalURL = globalConfigURL()
-        if FileManager.default.fileExists(atPath: globalURL.path) {
+        if let globalURL = globalConfigURL() {
             return try loadConfig(
                 from: globalURL,
                 baseDirectory: FileManager.default.homeDirectoryForCurrentUser.path,
@@ -420,9 +415,9 @@ final class DockControlsStore: ObservableObject {
         isProjectSource: Bool
     ) throws -> DockConfigResolution {
         let data = try Data(contentsOf: url)
-        let file = try JSONDecoder().decode(DockConfigFile.self, from: data)
+        let controls = try DockConfigParser.decodeControls(data: data)
         var seen = Set<String>()
-        for control in file.controls {
+        for control in controls {
             guard seen.insert(control.id).inserted else {
                 throw NSError(
                     domain: "cmux.dock",
@@ -437,7 +432,7 @@ final class DockControlsStore: ObservableObject {
             }
         }
         return DockConfigResolution(
-            controls: file.controls,
+            controls: controls,
             sourceURL: url,
             baseDirectory: baseDirectory,
             isProjectSource: isProjectSource
@@ -458,10 +453,8 @@ final class DockControlsStore: ObservableObject {
         var candidate = URL(fileURLWithPath: rootDirectory, isDirectory: true)
         let homePath = FileManager.default.homeDirectoryForCurrentUser.path
         while true {
-            let configURL = candidate
-                .appendingPathComponent(".cmux", isDirectory: true)
-                .appendingPathComponent("dock.json", isDirectory: false)
-            if FileManager.default.fileExists(atPath: configURL.path) {
+            let configDirectory = candidate.appendingPathComponent(".cmux", isDirectory: true)
+            if let configURL = DockConfigFileLocator.existingConfigURL(in: configDirectory) {
                 return configURL
             }
             let parent = candidate.deletingLastPathComponent()
@@ -477,7 +470,20 @@ final class DockControlsStore: ObservableObject {
         return cmuxDirectory.deletingLastPathComponent().path
     }
 
-    private static func globalConfigURL() -> URL {
+    private static func globalConfigURL() -> URL? {
+        if ProcessInfo.processInfo.environment["CMUX_UI_TEST_MODE"] == "1",
+           let testPath = ProcessInfo.processInfo.environment["CMUX_UI_TEST_DOCK_CONFIG_PATH"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+           !testPath.isEmpty {
+            let testURL = URL(fileURLWithPath: testPath)
+            return FileManager.default.fileExists(atPath: testURL.path) ? testURL : nil
+        }
+        let configDirectory = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".config/cmux", isDirectory: true)
+        return DockConfigFileLocator.existingConfigURL(in: configDirectory)
+    }
+
+    private static func defaultGlobalConfigURL() -> URL {
         if ProcessInfo.processInfo.environment["CMUX_UI_TEST_MODE"] == "1",
            let testPath = ProcessInfo.processInfo.environment["CMUX_UI_TEST_DOCK_CONFIG_PATH"]?
             .trimmingCharacters(in: .whitespacesAndNewlines),
@@ -494,7 +500,7 @@ final class DockControlsStore: ObservableObject {
                 .appendingPathComponent(".cmux", isDirectory: true)
                 .appendingPathComponent("dock.json", isDirectory: false)
         }
-        return globalConfigURL()
+        return defaultGlobalConfigURL()
     }
 
     private static func existingDirectory(_ rawPath: String) -> String? {

--- a/Sources/DockPanelView.swift
+++ b/Sources/DockPanelView.swift
@@ -236,6 +236,7 @@ final class DockControlsStore: ObservableObject {
     @Published private(set) var controls: [DockControlRuntime] = []
     @Published private(set) var sourceLabel = ""
     @Published private(set) var errorMessage: String?
+    @Published private(set) var errorRecoverySuggestion: String?
     @Published private(set) var trustRequest: DockTrustRequest?
 
     private var lastRootDirectory: String?
@@ -271,6 +272,7 @@ final class DockControlsStore: ObservableObject {
         lastWorkspaceId = workspaceId
         hasLoadedConfiguration = true
         errorMessage = nil
+        errorRecoverySuggestion = nil
         trustRequest = nil
         activeConfigURL = nil
 
@@ -301,6 +303,7 @@ final class DockControlsStore: ObservableObject {
             replaceControls(with: [])
             sourceLabel = String(localized: "dock.source.error", defaultValue: "Dock")
             errorMessage = error.localizedDescription
+            errorRecoverySuggestion = (error as NSError).localizedRecoverySuggestion
         }
     }
 
@@ -331,6 +334,7 @@ final class DockControlsStore: ObservableObject {
             NSWorkspace.shared.open(target)
         } catch {
             errorMessage = error.localizedDescription
+            errorRecoverySuggestion = (error as NSError).localizedRecoverySuggestion
         }
     }
 
@@ -496,11 +500,12 @@ final class DockControlsStore: ObservableObject {
 
     private static func preferredEditableConfigURL(rootDirectory: String?) throws -> URL {
         if let rootDirectory = rootDirectory.flatMap(existingDirectory) {
-            return URL(fileURLWithPath: rootDirectory, isDirectory: true)
+            let configDirectory = URL(fileURLWithPath: rootDirectory, isDirectory: true)
                 .appendingPathComponent(".cmux", isDirectory: true)
-                .appendingPathComponent("dock.json", isDirectory: false)
+            return DockConfigFileLocator.existingConfigURL(in: configDirectory)
+                ?? configDirectory.appendingPathComponent("dock.json", isDirectory: false)
         }
-        return defaultGlobalConfigURL()
+        return globalConfigURL() ?? defaultGlobalConfigURL()
     }
 
     private static func existingDirectory(_ rawPath: String) -> String? {
@@ -625,7 +630,7 @@ struct DockPanelView: View {
                 store.trustAndReload()
             }
         } else if let error = store.errorMessage {
-            DockErrorView(message: error)
+            DockErrorView(message: error, recoverySuggestion: store.errorRecoverySuggestion)
         } else if store.controls.isEmpty {
             DockEmptyView()
         } else {
@@ -849,6 +854,7 @@ private struct DockTrustView: View {
 
 private struct DockErrorView: View {
     let message: String
+    let recoverySuggestion: String?
 
     var body: some View {
         VStack(spacing: 8) {
@@ -861,6 +867,12 @@ private struct DockErrorView: View {
                 .font(.system(size: 12))
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
+            if let recoverySuggestion, !recoverySuggestion.isEmpty {
+                Text(recoverySuggestion)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+            }
         }
         .padding(20)
         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Sources/JSONCParser.swift
+++ b/Sources/JSONCParser.swift
@@ -199,7 +199,7 @@ enum JSONCParser {
         return result
     }
 
-    private enum JSONCError: LocalizedError {
+    nonisolated enum JSONCError: LocalizedError {
         case invalidTextEncoding
         case invalidTrailingComma
         case unterminatedBlockComment

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		C0DEF0A30000000000000001 /* SidebarPortDisplayText.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEF0A30000000000000002 /* SidebarPortDisplayText.swift */; };
 		C0DEF0B10000000000000001 /* JSONCParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEF0B10000000000000002 /* JSONCParser.swift */; };
 		C0DEF0B10000000000000003 /* JSONCParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEF0B10000000000000002 /* JSONCParser.swift */; };
+		D0C0D0C0D0C0D0C0D0C0D005 /* DockConfigParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C0D0C0D0C0D0C0D0C0D006 /* DockConfigParser.swift */; };
 		C0DEF0B30000000000000001 /* KeyboardShortcutSettingsFileStoreMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEF0B30000000000000002 /* KeyboardShortcutSettingsFileStoreMigrationTests.swift */; };
 		E3337001E3337001E3337001 /* KeyboardShortcutSettingsFileStoreStartupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3337002E3337002E3337002 /* KeyboardShortcutSettingsFileStoreStartupTests.swift */; };
 		C34670010000000000000001 /* AppDelegateRenameShortcutContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C34670010000000000000002 /* AppDelegateRenameShortcutContextTests.swift */; };
@@ -649,6 +650,7 @@
 		D7AB34400000000000000002 /* WorkspaceSurfaceConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSurfaceConfig.swift; sourceTree = "<group>"; };
 		D0C0D0C0D0C0D0C0D0C0D002 /* DockPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockPanelView.swift; sourceTree = "<group>"; };
 		D0C0D0C0D0C0D0C0D0C0D004 /* DockEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockEmptyView.swift; sourceTree = "<group>"; };
+		D0C0D0C0D0C0D0C0D0C0D006 /* DockConfigParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockConfigParser.swift; sourceTree = "<group>"; };
 		C0DE32470000000000000002 /* ContentViewIdentifierCopyCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentViewIdentifierCopyCommands.swift; sourceTree = "<group>"; };
 		9960CC3992F3C44489E7627C /* WorkspaceRuntimeSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/WorkspaceRuntimeSettings.swift; sourceTree = "<group>"; };
 		243632BA1DBBA36FD46E0610 /* SidebarAppearanceSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarAppearanceSupport.swift; sourceTree = "<group>"; };
@@ -1402,6 +1404,7 @@
 				FE0030A3 /* RightSidebarToolPanel.swift */,
 				D0C0D0C0D0C0D0C0D0C0D002 /* DockPanelView.swift */,
 				D0C0D0C0D0C0D0C0D0C0D004 /* DockEmptyView.swift */,
+				D0C0D0C0D0C0D0C0D0C0D006 /* DockConfigParser.swift */,
 				105D8421DF4E2E09D255D785 /* Auth */,
 				590E4F5F342E5B27010ECC8D /* Cloud */,
 				FEED0000000000000000F003 /* Feed */,
@@ -2118,6 +2121,7 @@
 				FE0031A3 /* RightSidebarToolPanel.swift in Sources */,
 				D0C0D0C0D0C0D0C0D0C0D001 /* DockPanelView.swift in Sources */,
 				D0C0D0C0D0C0D0C0D0C0D003 /* DockEmptyView.swift in Sources */,
+				D0C0D0C0D0C0D0C0D0C0D005 /* DockConfigParser.swift in Sources */,
 				FEED0000000000000000F002 /* FeedCoordinator.swift in Sources */,
 				FEED0000000000000000F005 /* FeedPanelView.swift in Sources */,
 				FEED0000000000000000F013 /* FeedPermissionActionPolicy.swift in Sources */,

--- a/cmuxTests/CmuxConfigTests.swift
+++ b/cmuxTests/CmuxConfigTests.swift
@@ -7,6 +7,128 @@ import XCTest
 @testable import cmux
 #endif
 
+final class DockConfigParserTests: XCTestCase {
+
+    private func decodeControls(_ source: String) throws -> [DockControlDefinition] {
+        try DockConfigParser.decodeControls(data: Data(source.utf8))
+    }
+
+    func testParsesLineCommentedControlAndTrailingComma() throws {
+        let controls = try decodeControls("""
+        {
+          "controls": [
+            {
+              "id": "git",
+              "title": "Git",
+              "command": "lazygit",
+            },
+            // {
+            //   "id": "logs",
+            //   "title": "Logs",
+            //   "command": "tail -f ./logs/development.log"
+            // }
+          ]
+        }
+        """)
+
+        XCTAssertEqual(controls.map(\.id), ["git"])
+        XCTAssertEqual(controls.first?.command, "lazygit")
+    }
+
+    func testParsesBlockCommentedControlAndPreservesCommentSyntaxInStrings() throws {
+        let controls = try decodeControls("""
+        {
+          "controls": [
+            /*
+            {
+              "id": "disabled",
+              "title": "Disabled",
+              "command": "echo disabled"
+            },
+            */
+            {
+              "id": "server",
+              "title": "Server",
+              "command": "echo http://localhost:3000 && echo not-a-comment"
+            }
+          ]
+        }
+        """)
+
+        XCTAssertEqual(controls.map(\.id), ["server"])
+        XCTAssertEqual(controls.first?.command, "echo http://localhost:3000 && echo not-a-comment")
+    }
+
+    func testPreservesCommentMarkersInStringValues() throws {
+        let controls = try decodeControls("""
+        {
+          "controls": [
+            {
+              "id": "test",
+              "title": "Test",
+              "command": "echo line // not a comment && echo block /* also not a comment */"
+            }
+          ]
+        }
+        """)
+
+        XCTAssertEqual(controls.count, 1)
+        XCTAssertEqual(
+            controls.first?.command,
+            "echo line // not a comment && echo block /* also not a comment */"
+        )
+    }
+
+    func testPrefersDockJSONOverDockJSONCInSameDirectory() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "dock-config-locator-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let jsonURL = root.appendingPathComponent("dock.json")
+        let jsoncURL = root.appendingPathComponent("dock.jsonc")
+        try "{}".write(to: jsoncURL, atomically: true, encoding: .utf8)
+        try "{}".write(to: jsonURL, atomically: true, encoding: .utf8)
+
+        XCTAssertEqual(DockConfigFileLocator.existingConfigURL(in: root), jsonURL)
+    }
+
+    func testFindsDockJSONCWhenDockJSONIsAbsent() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "dock-config-locator-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let jsoncURL = root.appendingPathComponent("dock.jsonc")
+        try "{}".write(to: jsoncURL, atomically: true, encoding: .utf8)
+
+        XCTAssertEqual(DockConfigFileLocator.existingConfigURL(in: root), jsoncURL)
+    }
+
+    func testReportsJSONCPreprocessingErrors() {
+        XCTAssertThrowsError(try decodeControls("""
+        {
+          "controls": [
+            /*
+            { "id": "git", "command": "lazygit" }
+          ]
+        }
+        """)) { error in
+            XCTAssertEqual(error.localizedDescription, "Couldn't parse Dock config as JSONC: an unterminated block comment.")
+            let nsError = error as NSError
+            XCTAssertEqual(
+                nsError.localizedRecoverySuggestion,
+                "Check comments and trailing commas in your Dock config file, then reload Dock."
+            )
+            XCTAssertNotNil(nsError.userInfo[NSUnderlyingErrorKey])
+        }
+    }
+}
+
 // MARK: - JSON Decoding
 
 final class CmuxConfigDecodingTests: XCTestCase {

--- a/docs/dock.md
+++ b/docs/dock.md
@@ -8,9 +8,9 @@ Each command starts inside the terminal's non-interactive login shell. That keep
 
 ## Configuration
 
-Dock is configured with JSON:
+Dock is configured with JSONC-compatible files, so comments and trailing commas are allowed. The default filename remains `dock.json` for backward compatibility:
 
-```json
+```jsonc
 {
   "controls": [
     {
@@ -48,30 +48,31 @@ Fields:
 - `height`: optional requested terminal height in points. Controls without a height share remaining space.
 - `env`: optional non-secret environment variables passed only to that control.
 
-The order of `controls` is the order shown in Dock. Reorder entries in the file to reorder Dock controls. Remove an entry from the file to remove it from Dock.
+The order of `controls` is the order shown in Dock. Reorder entries in the file to reorder Dock controls. Remove an entry from the file to remove it from Dock. Because Dock config is JSONC, you can also temporarily disable controls with `//` or `/* ... */` comments.
 
 ## Config Precedence
 
-cmux looks for Dock config in this order:
+cmux walks from the current project directory up through parent directories. In each `.cmux` directory it checks `dock.json` first, then `dock.jsonc`. The nearest config wins, so a nested `.cmux/dock.jsonc` takes precedence over a parent `.cmux/dock.json`.
 
-1. `.cmux/dock.json` in the current project or a parent directory
-2. `~/.config/cmux/dock.json`
+If no project config exists, cmux checks `~/.config/cmux/dock.json` first, then `~/.config/cmux/dock.jsonc`.
 
-Use `.cmux/dock.json` for repo-specific controls that should be shared with teammates. Commit it to the repo when the commands are safe and portable.
+If both `dock.json` and `dock.jsonc` exist in the same config directory, `dock.json` wins. New configs created by cmux still use `dock.json`.
 
-Use `~/.config/cmux/dock.json` for personal defaults, machines without a repo, or controls that are specific to your local setup.
+Use `.cmux/dock.json` for repo-specific controls that should be shared with teammates. Commit it to the repo when the commands are safe and portable. Use `.cmux/dock.jsonc` only if you want the filename itself to advertise comments.
 
-Nested project configs apply to their directory tree. If a nested project has its own `.cmux/dock.json`, use that nearest config for work inside the nested project. Do not put unrelated project controls into the global config just because a repo is absent.
+Use `~/.config/cmux/dock.json` for personal defaults, machines without a repo, or controls that are specific to your local setup. Use `~/.config/cmux/dock.jsonc` only if you want the filename itself to advertise comments.
 
-If neither file exists, Dock opens empty and offers a prompt to create a starter config. cmux does not add Dock controls automatically.
+Nested project configs apply to their directory tree. If a nested project has its own `.cmux/dock.json` or `.cmux/dock.jsonc`, use that nearest config for work inside the nested project. Do not put unrelated project controls into the global config just because a repo is absent.
 
-Relative `cwd` values resolve from the config base. For `.cmux/dock.json`, that base is the project directory containing `.cmux`. For the global config, that base is the home directory.
+If no Dock config file exists, Dock opens empty and offers a prompt to create a starter config. cmux does not add Dock controls automatically.
+
+Relative `cwd` values resolve from the config base. For `.cmux/dock.json` or `.cmux/dock.jsonc`, that base is the project directory containing `.cmux`. For the global config, that base is the home directory.
 
 ## Trust
 
 Project Dock configs can start commands. The first time cmux sees a project Dock config, it shows a trust gate before launching controls. Changing the config changes the trust fingerprint and asks again.
 
-Global Dock config at `~/.config/cmux/dock.json` is treated as personal config and starts without a project trust gate.
+Global Dock config at `~/.config/cmux/dock.json` or `~/.config/cmux/dock.jsonc` is treated as personal config and starts without a project trust gate.
 
 Do not put secrets, tokens, or machine-specific private paths in a shared project Dock config. Read secrets from the user's shell, local env files, or existing dev tooling.
 
@@ -83,7 +84,7 @@ When asking a coding agent to create a Dock config, tell it to run:
 cmux docs dock
 ```
 
-The agent should inspect the project first, choose project config or global config deliberately, ask the user when the desired controls are unclear, validate the JSON, and summarize each command before the user trusts the config.
+The agent should inspect the project first, choose project config or global config deliberately, ask the user when the desired controls are unclear, validate the JSONC, and summarize each command before the user trusts the config.
 
 ## Naming
 


### PR DESCRIPTION
## Summary
- Parse Dock config files with the shared JSONC parser before decoding controls.
- Keep Dock parsing in a dedicated `DockConfigParser` source file and surface stable, user-facing parse errors with recovery guidance.
- Add focused coverage for comments, trailing commas, comment-like text inside strings, and JSONC parse failures.
- Update Dock docs and the empty-state setup prompt to describe JSONC support.

## Validation
- `git diff --check`
- `python3 -m json.tool Resources/Localizable.xcstrings`
- `CMUX_SKIP_ZIG_BUILD=1 ./scripts/reload.sh --tag dock-jsonc`

Tests were not run locally per repository policy; the new behavior is covered by `DockConfigParserTests` for CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dock configuration now supports JSONC (comments and trailing commas); both dock.json and dock.jsonc are recognized, with dock.json preferred when both exist.

* **Documentation**
  * Updated docs and in-app guidance/agent prompts to describe JSONC, filename behavior, control ordering, and validation guidance.

* **Bug Fixes / UX**
  * Improved localized parse error messages with specific failure reasons and recovery suggestions for JSONC parse failures.

* **Tests**
  * Added tests covering JSONC preprocessing, error reporting, and config file selection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4263?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->