### PR TITLE
fix: don't auto-resume agent when it was already exited before snapshot

### DIFF
--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -982,19 +982,24 @@ struct SessionTerminalPanelSnapshot: Codable, Sendable {
     var agent: SessionRestorableAgentSnapshot?
     var tmuxStartCommand: String?
     var resumeBinding: SurfaceResumeBindingSnapshot?
+    /// Whether the agent process was actively running when this snapshot was captured.
+    /// Nil means unknown (legacy snapshots); treated as true for backwards compatibility.
+    var wasAgentRunning: Bool?
 
     init(
         workingDirectory: String? = nil,
         scrollback: String? = nil,
         agent: SessionRestorableAgentSnapshot? = nil,
         tmuxStartCommand: String? = nil,
-        resumeBinding: SurfaceResumeBindingSnapshot? = nil
+        resumeBinding: SurfaceResumeBindingSnapshot? = nil,
+        wasAgentRunning: Bool? = nil
     ) {
         self.workingDirectory = workingDirectory
         self.scrollback = scrollback
         self.agent = agent
         self.tmuxStartCommand = tmuxStartCommand
         self.resumeBinding = resumeBinding
+        self.wasAgentRunning = wasAgentRunning
     }
 }
 struct SessionBrowserPanelSnapshot: Codable, Sendable {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -463,9 +463,12 @@ extension Workspace {
             let restorableTmuxStartCommand = effectiveRestorableAgent == nil
                 ? Self.restorableTmuxStartCommand(terminalPanel.surface.debugTmuxStartCommand())
                 : nil
+            let agentWasRunning: Bool? = effectiveRestorableAgent != nil
+                ? panelShellActivityStates[panelId].map { $0 == .commandRunning }
+                : nil
             let resumeStartupInput = Self.surfaceResumeStartupInput(
                 resumeBinding,
-                autoResumeAgentSessions: AgentSessionAutoResumeSettings.isEnabled(),
+                autoResumeAgentSessions: AgentSessionAutoResumeSettings.isEnabled() && (agentWasRunning ?? true),
                 promptForApproval: false
             )
             let shouldPersistScrollback = Self.shouldPersistSessionScrollback(
@@ -499,7 +502,8 @@ extension Workspace {
                 scrollback: resolvedScrollback,
                 agent: effectiveRestorableAgent,
                 tmuxStartCommand: restorableTmuxStartCommand,
-                resumeBinding: resumeBinding
+                resumeBinding: resumeBinding,
+                wasAgentRunning: agentWasRunning
             )
             browserSnapshot = nil
             markdownSnapshot = nil
@@ -884,9 +888,13 @@ extension Workspace {
             let resumeBinding = snapshot.terminal?.resumeBinding
             let restorableAgent = snapshot.terminal?.agent
             let autoResumeAgentSessions = AgentSessionAutoResumeSettings.isEnabled()
+            // Only auto-resume if the agent was actively running when the snapshot was saved.
+            // wasAgentRunning == nil means a legacy snapshot; treat as true for backwards compatibility.
+            let agentWasRunningAtQuit = snapshot.terminal?.wasAgentRunning ?? true
+            let shouldAutoResumeAgent = autoResumeAgentSessions && agentWasRunningAtQuit
             let restoredBindingInput = Self.surfaceResumeStartupInput(
                 resumeBinding,
-                autoResumeAgentSessions: autoResumeAgentSessions,
+                autoResumeAgentSessions: shouldAutoResumeAgent,
                 allowLauncherScript: true
             )
             let effectiveResumeBinding = restoredBindingInput == nil ? nil : resumeBinding
@@ -912,7 +920,7 @@ extension Workspace {
                 tmuxStartCommand: restoredTmuxStartCommand,
                 resumeStartupInput: restoredBindingInput
             )
-            let restoredAgentResumeInput = autoResumeAgentSessions
+            let restoredAgentResumeInput = shouldAutoResumeAgent
                 ? (restoredBindingInput == nil ? restorableAgent?.resumeStartupInput() : nil)
                 : nil
             let restoredStartupInput = restoredBindingInput ?? restoredAgentResumeInput

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -463,9 +463,17 @@ extension Workspace {
             let restorableTmuxStartCommand = effectiveRestorableAgent == nil
                 ? Self.restorableTmuxStartCommand(terminalPanel.surface.debugTmuxStartCommand())
                 : nil
-            let agentWasRunning: Bool? = effectiveRestorableAgent != nil
-                ? panelShellActivityStates[panelId].map { $0 == .commandRunning }
-                : nil
+            let agentWasRunning: Bool? = {
+                guard effectiveRestorableAgent != nil else { return nil }
+                switch panelShellActivityStates[panelId] {
+                case .some(.commandRunning):
+                    return true
+                case .some(.promptIdle):
+                    return false
+                case .some(.unknown), .none:
+                    return nil
+                }
+            }()
             let resumeStartupInput = Self.surfaceResumeStartupInput(
                 resumeBinding,
                 autoResumeAgentSessions: AgentSessionAutoResumeSettings.isEnabled() && (agentWasRunning ?? true),

--- a/cmuxTests/AgentSessionAutoResumeSettingsTests.swift
+++ b/cmuxTests/AgentSessionAutoResumeSettingsTests.swift
@@ -185,6 +185,37 @@ final class AgentSessionAutoResumeSettingsTests: XCTestCase {
     }
 
     @MainActor
+    func testUnknownAgentShellStatePreservesLegacyAutoResumeBehavior() throws {
+        try withRestoredDefaults(key: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey) {
+            let defaults = UserDefaults.standard
+            defaults.removeObject(forKey: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey) // autoResumeAgentSessions = true (default)
+
+            let source = Workspace()
+            let sourcePanelId = try XCTUnwrap(source.focusedPanelId)
+            let sourceIndex = try makeRestorableAgentIndex(
+                workspaceId: source.id,
+                panelId: sourcePanelId,
+                sessionId: "codex-unknown-shell-state-session"
+            )
+            source.updatePanelShellActivityState(panelId: sourcePanelId, state: .unknown)
+            let snapshot = source.sessionSnapshot(includeScrollback: false, restorableAgentIndex: sourceIndex)
+
+            XCTAssertNil(snapshot.panels.first?.terminal?.wasAgentRunning,
+                         "unknown shell state should be persisted as nil for legacy auto-resume behavior")
+
+            let restored = Workspace()
+            restored.restoreSessionSnapshot(snapshot)
+            let restoredPanelId = try XCTUnwrap(restored.focusedPanelId)
+            let restoredPanel = try XCTUnwrap(restored.terminalPanel(for: restoredPanelId))
+            let restoredInput = restoredPanel.surface.debugInitialInputMetadata()
+
+            XCTAssertTrue(restoredInput.hasInitialInput,
+                          "unknown shell state should still auto-resume through the nil back-compat path")
+            XCTAssertGreaterThan(restoredInput.byteCount, 0)
+        }
+    }
+
+    @MainActor
     func testAgentHookBindingExitedBeforeSnapshotDoesNotAutoResumeEvenWhenTrusted() throws {
         try withRestoredDefaults(key: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey) {
             let defaults = UserDefaults.standard

--- a/cmuxTests/AgentSessionAutoResumeSettingsTests.swift
+++ b/cmuxTests/AgentSessionAutoResumeSettingsTests.swift
@@ -109,6 +109,134 @@ final class AgentSessionAutoResumeSettingsTests: XCTestCase {
         XCTAssertNil(restoredWithoutAutoResume.sessionSnapshot(includeScrollback: false).panels.first?.terminal?.agent)
     }
 
+    /// When autoResumeAgentSessions is enabled but the agent was already exited at snapshot time
+    /// (wasAgentRunning == false), cmux must NOT inject the resume command on restore.
+    /// The session ID must still be preserved for manual resume.
+    @MainActor
+    func testAgentExitedBeforeSnapshotDoesNotAutoResumeEvenWhenSettingEnabled() throws {
+        try withRestoredDefaults(key: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey) {
+            let defaults = UserDefaults.standard
+            defaults.removeObject(forKey: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey) // autoResumeAgentSessions = true (default)
+
+            let source = Workspace()
+            let sourcePanelId = try XCTUnwrap(source.focusedPanelId)
+            let sourceIndex = try makeRestorableAgentIndex(
+                workspaceId: source.id,
+                panelId: sourcePanelId,
+                sessionId: "codex-exited-before-snapshot-session"
+            )
+            // Simulate: agent was already exited (shell at promptIdle) before snapshot
+            source.updatePanelShellActivityState(panelId: sourcePanelId, state: .promptIdle)
+            let snapshot = source.sessionSnapshot(includeScrollback: false, restorableAgentIndex: sourceIndex)
+
+            XCTAssertEqual(snapshot.panels.first?.terminal?.wasAgentRunning, false,
+                           "snapshot should record wasAgentRunning=false when shell was idle at save time")
+            XCTAssertNotNil(snapshot.panels.first?.terminal?.agent,
+                            "session ID must be preserved for manual resume")
+
+            let restored = Workspace()
+            restored.restoreSessionSnapshot(snapshot)
+            let restoredPanelId = try XCTUnwrap(restored.focusedPanelId)
+            let restoredPanel = try XCTUnwrap(restored.terminalPanel(for: restoredPanelId))
+            let restoredInput = restoredPanel.surface.debugInitialInputMetadata()
+
+            XCTAssertFalse(restoredInput.hasInitialInput,
+                           "must not auto-resume when agent was already exited at snapshot time")
+            XCTAssertEqual(
+                restored.sessionSnapshot(includeScrollback: false).panels.first?.terminal?.agent?.sessionId,
+                "codex-exited-before-snapshot-session",
+                "session ID must still be available for manual resume"
+            )
+        }
+    }
+
+    /// When autoResumeAgentSessions is enabled and the agent WAS running at snapshot time
+    /// (wasAgentRunning == true), cmux MUST auto-resume as before.
+    @MainActor
+    func testAgentRunningAtSnapshotAutoResumesWhenSettingEnabled() throws {
+        try withRestoredDefaults(key: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey) {
+            let defaults = UserDefaults.standard
+            defaults.removeObject(forKey: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey) // autoResumeAgentSessions = true (default)
+
+            let source = Workspace()
+            let sourcePanelId = try XCTUnwrap(source.focusedPanelId)
+            let sourceIndex = try makeRestorableAgentIndex(
+                workspaceId: source.id,
+                panelId: sourcePanelId,
+                sessionId: "codex-running-at-snapshot-session"
+            )
+            // Simulate: agent was still running when cmux quit
+            source.updatePanelShellActivityState(panelId: sourcePanelId, state: .commandRunning)
+            let snapshot = source.sessionSnapshot(includeScrollback: false, restorableAgentIndex: sourceIndex)
+
+            XCTAssertEqual(snapshot.panels.first?.terminal?.wasAgentRunning, true,
+                           "snapshot should record wasAgentRunning=true when agent was running at save time")
+
+            let restored = Workspace()
+            restored.restoreSessionSnapshot(snapshot)
+            let restoredPanelId = try XCTUnwrap(restored.focusedPanelId)
+            let restoredPanel = try XCTUnwrap(restored.terminalPanel(for: restoredPanelId))
+            let restoredInput = restoredPanel.surface.debugInitialInputMetadata()
+
+            XCTAssertTrue(restoredInput.hasInitialInput,
+                          "must auto-resume when agent was running at snapshot time and setting is enabled")
+            XCTAssertGreaterThan(restoredInput.byteCount, 0)
+        }
+    }
+
+    @MainActor
+    func testAgentHookBindingExitedBeforeSnapshotDoesNotAutoResumeEvenWhenTrusted() throws {
+        try withRestoredDefaults(key: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey) {
+            let defaults = UserDefaults.standard
+            defaults.removeObject(forKey: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey) // autoResumeAgentSessions = true (default)
+
+            let source = Workspace()
+            let sourcePanelId = try XCTUnwrap(source.focusedPanelId)
+            let sourceIndex = try makeRestorableAgentIndex(
+                workspaceId: source.id,
+                panelId: sourcePanelId,
+                sessionId: "codex-exited-binding-session"
+            )
+            let bindingIndex = SurfaceResumeBindingIndex(bindingsByPanel: [
+                SurfaceResumeBindingIndex.PanelKey(workspaceId: source.id, panelId: sourcePanelId): SurfaceResumeBindingSnapshot(
+                    name: "Codex",
+                    kind: "codex",
+                    command: "codex resume codex-exited-binding-session",
+                    cwd: "/tmp/repo",
+                    checkpointId: "codex-exited-binding-session",
+                    source: "agent-hook",
+                    autoResume: true,
+                    updatedAt: 1_777_777_777
+                ),
+            ])
+            source.updatePanelShellActivityState(panelId: sourcePanelId, state: .promptIdle)
+            let snapshot = source.sessionSnapshot(
+                includeScrollback: false,
+                restorableAgentIndex: sourceIndex,
+                surfaceResumeBindingIndex: bindingIndex
+            )
+
+            XCTAssertEqual(snapshot.panels.first?.terminal?.wasAgentRunning, false)
+
+            let restored = Workspace()
+            restored.restoreSessionSnapshot(snapshot)
+            let restoredPanelId = try XCTUnwrap(restored.focusedPanelId)
+            let restoredPanel = try XCTUnwrap(restored.terminalPanel(for: restoredPanelId))
+            let input = restoredPanel.surface.debugInitialInputMetadata()
+
+            XCTAssertFalse(input.hasInitialInput)
+            XCTAssertEqual(input.byteCount, 0)
+            XCTAssertEqual(
+                restored.sessionSnapshot(includeScrollback: false).panels.first?.terminal?.agent?.sessionId,
+                "codex-exited-binding-session"
+            )
+            XCTAssertEqual(
+                restored.sessionSnapshot(includeScrollback: false).panels.first?.terminal?.resumeBinding?.source,
+                "agent-hook"
+            )
+        }
+    }
+
     @MainActor
     func testDisabledAutoResumeDoesNotRunAgentHookResumeBinding() throws {
         let defaults = UserDefaults.standard
@@ -325,6 +453,22 @@ final class AgentSessionAutoResumeSettingsTests: XCTestCase {
         let runningSnapshot = restored.sessionSnapshot(includeScrollback: false)
         XCTAssertNil(runningSnapshot.panels.first?.terminal?.agent)
         XCTAssertEqual(runningSnapshot.panels.first?.terminal?.resumeBinding?.kind, "tmux")
+    }
+
+    private func withRestoredDefaults<T>(
+        key: String,
+        defaults: UserDefaults = .standard,
+        body: () throws -> T
+    ) rethrows -> T {
+        let previous = defaults.object(forKey: key)
+        defer {
+            if let previous {
+                defaults.set(previous, forKey: key)
+            } else {
+                defaults.removeObject(forKey: key)
+            }
+        }
+        return try body()
     }
 
     private func makeRestorableAgentIndex(


### PR DESCRIPTION
## Problem

When `autoResumeAgentSessions` is `true` (the default), cmux resumes **every** saved agent session on reopen — even sessions the user explicitly exited before closing the terminal.

**Reproduction:**
1. Start Claude in a terminal pane
2. Type `exit` in Claude → returns to shell prompt
3. Close the window (or quit cmux)
4. Reopen cmux → Claude auto-resumes ❌

Expected: Claude should **not** auto-resume because the user already ended the session intentionally. The session ID should still be preserved for **manual** resume.

## Root Cause

cmux determines restorability by checking whether the transcript file exists on disk (for Claude) — not whether the agent was actually running when the snapshot was taken. So even after the user exits the agent, the transcript persists → cmux treats it as resumable.

The `shellActivityState` is tracked per-panel at runtime but was never persisted in the session snapshot, so there was no way for the restore path to know whether the agent was running or already gone at quit time.

## Fix

Add `wasAgentRunning: Bool?` to `SessionTerminalPanelSnapshot`. At snapshot time, set it to `shellActivityState == .commandRunning`. At restore time, skip auto-resume when `wasAgentRunning == false`.

- `nil` (legacy snapshots without the field) → treated as `true` for backwards compatibility
- Session ID is always preserved regardless, so manual resume still works

```
User scenario          wasAgentRunning   autoResumeAgentSessions   Result
─────────────────────  ───────────────   ───────────────────────   ──────
exit → close window    false             true (default)            no auto-resume ✅
cmux quit mid-session  true              true (default)            auto-resume ✅
legacy snapshot        nil               true (default)            auto-resume ✅ (compat)
any                    any               false                     no auto-resume ✅
```

## Changes

- `Sources/SessionPersistence.swift` — add `wasAgentRunning: Bool?` to `SessionTerminalPanelSnapshot`
- `Sources/Workspace.swift` — set `wasAgentRunning` at snapshot time; gate auto-resume on it at restore time
- `cmuxTests/AgentSessionAutoResumeSettingsTests.swift` — two new test cases covering both scenarios

## Verification

```
jq empty web/data/cmux.schema.json
git diff --check
```

Tests added:
- `testAgentExitedBeforeSnapshotDoesNotAutoResumeEvenWhenSettingEnabled`
- `testAgentRunningAtSnapshotAutoResumesWhenSettingEnabled`

Related: #3991 (documented `autoResumeAgentSessions` setting)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop auto-resuming agent sessions that were already exited at snapshot time. This respects the user’s exit, preserves the session ID for manual resume, and keeps unknown shell state on snapshots for legacy auto-resume.

- **Bug Fixes**
  - Persist `wasAgentRunning: Bool?` in `SessionTerminalPanelSnapshot` from `shellActivityState`; `.unknown` is stored as `nil` and treated as true for backwards compatibility.
  - Auto-resume only when `autoResumeAgentSessions` is enabled and `wasAgentRunning` is true; applies to both agents and agent-hook resume bindings.
  - Tests cover exited-before-snapshot (no auto-resume), running-at-snapshot (auto-resume), unknown-state back-compat (still auto-resumes), and trusted agent-hook binding respecting exit; added `withRestoredDefaults` helper.

<sup>Written for commit fbfb5085715324fbbc59cf975a867ff456ace22e. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4269?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Sessions now record whether an agent was running when a snapshot was taken.
  * Agent auto-resume only occurs if the agent was actively running at snapshot time.
  * Legacy snapshots remain supported (missing values treated as running for compatibility).

* **Tests**
  * New tests verify auto-resume respects snapshot-time agent state and that manual resume remains possible when auto-resume is skipped.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4269?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->