### PR TITLE
Preserve Codex plugin config during hook setup

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -20635,7 +20635,7 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
 
     @discardableResult
     private static func removeCmuxCodexHookTrustBlock(from lines: inout [String]) -> CodexHookTrustBlockRemovalResult {
-        var ranges: [ClosedRange<Int>] = []
+        var removedBlock = false
         var index = 0
         while index < lines.count {
             guard lines[index] == cmuxCodexHookTrustBegin else {
@@ -20646,14 +20646,32 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
             guard let endIndex = lines[index...].firstIndex(of: cmuxCodexHookTrustEnd) else {
                 return .malformed
             }
-            ranges.append(index...endIndex)
-            index = endIndex + 1
+            let preservedLines = codexHookTrustBlockUnownedLines(
+                from: lines[(index + 1)..<endIndex]
+            )
+            lines.replaceSubrange(index...endIndex, with: preservedLines)
+            removedBlock = true
+            index += preservedLines.count
         }
 
-        for range in ranges.reversed() {
-            lines.removeSubrange(range)
+        return removedBlock ? .removed : .notFound
+    }
+
+    private static func codexHookTrustBlockUnownedLines(from lines: ArraySlice<String>) -> [String] {
+        var preserved: [String] = []
+        var index = lines.startIndex
+        while index < lines.endIndex {
+            if codexHookTrustTableEscapedKey(from: lines[index]) != nil {
+                index += 1
+                while index < lines.endIndex, !tomlLineIsAnyTableHeader(lines[index]) {
+                    index += 1
+                }
+                continue
+            }
+            preserved.append(lines[index])
+            index += 1
         }
-        return ranges.isEmpty ? .notFound : .removed
+        return preserved
     }
 
     private static func stripMalformedCmuxCodexHookTrustMarker(from lines: inout [String]) {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -20017,6 +20017,7 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
             hooksFilePath: filePath,
             def: def
         )
+        let codexLegacyHookTrustHashes = Self.codexLegacyHookTrustHashes(def: def)
 
         let newData = try JSONSerialization.data(withJSONObject: existing, options: [.prettyPrinted, .sortedKeys])
         let newString = String(data: newData, encoding: .utf8) ?? "{}"
@@ -20068,13 +20069,15 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                 let trustClean = Self.codexConfigTomlRemovingHookTrust(
                     in: existingContent,
                     entries: codexHookTrustEntries,
-                    removingEscapedKeyPrefixes: codexHookTrustEscapedKeyPrefixes
+                    removingEscapedKeyPrefixes: codexHookTrustEscapedKeyPrefixes,
+                    removingTrustedHashes: codexLegacyHookTrustHashes
                 )
                 let featureContent = Self.codexConfigTomlInstallingHooksFeature(in: trustClean)
                 let trustInstall = Self.codexConfigTomlInstallingHookTrust(
                     in: featureContent,
                     entries: codexHookTrustEntries,
-                    removingEscapedKeyPrefixes: codexHookTrustEscapedKeyPrefixes
+                    removingEscapedKeyPrefixes: codexHookTrustEscapedKeyPrefixes,
+                    removingTrustedHashes: codexLegacyHookTrustHashes
                 )
                 let newContent = trustInstall.content
                 if newContent != existingContent {
@@ -20359,11 +20362,12 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
     private static func codexConfigTomlRemovingHookTrust(
         in existingContent: String,
         entries: [CodexHookTrustEntry],
-        removingEscapedKeyPrefixes escapedKeyPrefixes: Set<String>
+        removingEscapedKeyPrefixes escapedKeyPrefixes: Set<String>,
+        removingTrustedHashes additionalTrustedHashes: Set<String> = []
     ) -> String {
         var lines = tomlLines(from: existingContent)
         let escapedKeys = Set(entries.map { tomlBasicStringContent($0.key) })
-        let trustedHashes = Set(entries.map(\.trustedHash))
+        let trustedHashes = Set(entries.map(\.trustedHash)).union(additionalTrustedHashes)
         let removalResult = removeCmuxCodexHookTrustBlock(
             from: &lines,
             removingEscapedKeys: escapedKeys,
@@ -20380,11 +20384,12 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
     private static func codexConfigTomlInstallingHookTrust(
         in existingContent: String,
         entries: [CodexHookTrustEntry],
-        removingEscapedKeyPrefixes escapedKeyPrefixes: Set<String> = []
+        removingEscapedKeyPrefixes escapedKeyPrefixes: Set<String> = [],
+        removingTrustedHashes additionalTrustedHashes: Set<String> = []
     ) -> CodexHookTrustInstallResult {
         var lines = tomlLines(from: existingContent)
         let escapedKeys = Set(entries.map { tomlBasicStringContent($0.key) })
-        let trustedHashes = Set(entries.map(\.trustedHash))
+        let trustedHashes = Set(entries.map(\.trustedHash)).union(additionalTrustedHashes)
         let removalResult = removeCmuxCodexHookTrustBlock(
             from: &lines,
             removingEscapedKeys: escapedKeys,

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -20065,12 +20065,12 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                 } else {
                     existingContent = ""
                 }
-                let trustClean = Self.codexConfigTomlInstallingHookTrust(
+                let trustClean = Self.codexConfigTomlRemovingHookTrust(
                     in: existingContent,
-                    entries: [],
+                    entries: codexHookTrustEntries,
                     removingEscapedKeyPrefixes: codexHookTrustEscapedKeyPrefixes
                 )
-                let featureContent = Self.codexConfigTomlInstallingHooksFeature(in: trustClean.content)
+                let featureContent = Self.codexConfigTomlInstallingHooksFeature(in: trustClean)
                 let trustInstall = Self.codexConfigTomlInstallingHookTrust(
                     in: featureContent,
                     entries: codexHookTrustEntries,
@@ -20331,11 +20331,13 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
     ) -> String {
         var lines = tomlLines(from: existingContent)
         let escapedKeys = Set(entries.map { tomlBasicStringContent($0.key) })
+        let trustedHashes = Set(entries.map(\.trustedHash))
         removeCmuxCodexHooksFeatureBlock(from: &lines)
         if removeCmuxCodexHookTrustBlock(
             from: &lines,
             removingEscapedKeys: escapedKeys,
-            removingEscapedKeyPrefixes: escapedKeyPrefixes
+            removingEscapedKeyPrefixes: escapedKeyPrefixes,
+            removingTrustedHashes: trustedHashes
         ) == .malformed {
             stripMalformedCmuxCodexHookTrustMarker(from: &lines)
         }
@@ -20346,6 +20348,27 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
         return tomlContent(from: lines)
     }
 
+    private static func codexConfigTomlRemovingHookTrust(
+        in existingContent: String,
+        entries: [CodexHookTrustEntry],
+        removingEscapedKeyPrefixes escapedKeyPrefixes: Set<String>
+    ) -> String {
+        var lines = tomlLines(from: existingContent)
+        let escapedKeys = Set(entries.map { tomlBasicStringContent($0.key) })
+        let trustedHashes = Set(entries.map(\.trustedHash))
+        let removalResult = removeCmuxCodexHookTrustBlock(
+            from: &lines,
+            removingEscapedKeys: escapedKeys,
+            removingEscapedKeyPrefixes: escapedKeyPrefixes,
+            removingTrustedHashes: trustedHashes
+        )
+        if removalResult == .malformed {
+            stripMalformedCmuxCodexHookTrustMarker(from: &lines)
+        }
+        removeCodexHookTrustTables(withEscapedKeys: escapedKeys, from: &lines)
+        return tomlContent(from: lines)
+    }
+
     private static func codexConfigTomlInstallingHookTrust(
         in existingContent: String,
         entries: [CodexHookTrustEntry],
@@ -20353,10 +20376,12 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
     ) -> CodexHookTrustInstallResult {
         var lines = tomlLines(from: existingContent)
         let escapedKeys = Set(entries.map { tomlBasicStringContent($0.key) })
+        let trustedHashes = Set(entries.map(\.trustedHash))
         let removalResult = removeCmuxCodexHookTrustBlock(
             from: &lines,
             removingEscapedKeys: escapedKeys,
-            removingEscapedKeyPrefixes: escapedKeyPrefixes
+            removingEscapedKeyPrefixes: escapedKeyPrefixes,
+            removingTrustedHashes: trustedHashes
         )
         if removalResult == .malformed {
             stripMalformedCmuxCodexHookTrustMarker(from: &lines)
@@ -20681,7 +20706,8 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
     private static func removeCmuxCodexHookTrustBlock(
         from lines: inout [String],
         removingEscapedKeys escapedKeys: Set<String> = [],
-        removingEscapedKeyPrefixes escapedKeyPrefixes: Set<String> = []
+        removingEscapedKeyPrefixes escapedKeyPrefixes: Set<String> = [],
+        removingTrustedHashes trustedHashes: Set<String> = []
     ) -> CodexHookTrustBlockRemovalResult {
         var replacements: [(range: ClosedRange<Int>, lines: [String])] = []
         var index = 0
@@ -20697,7 +20723,8 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
             let preservedLines = codexHookTrustBlockUnownedLines(
                 from: lines[(index + 1)..<endIndex],
                 removingEscapedKeys: escapedKeys,
-                removingEscapedKeyPrefixes: escapedKeyPrefixes
+                removingEscapedKeyPrefixes: escapedKeyPrefixes,
+                removingTrustedHashes: trustedHashes
             )
             replacements.append((index...endIndex, preservedLines))
             index = endIndex + 1
@@ -20712,7 +20739,8 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
     private static func codexHookTrustBlockUnownedLines(
         from lines: ArraySlice<String>,
         removingEscapedKeys escapedKeys: Set<String>,
-        removingEscapedKeyPrefixes escapedKeyPrefixes: Set<String>
+        removingEscapedKeyPrefixes escapedKeyPrefixes: Set<String>,
+        removingTrustedHashes trustedHashes: Set<String>
     ) -> [String] {
         var preserved: [String] = []
         var index = lines.startIndex
@@ -20725,8 +20753,10 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                 }
                 if !codexHookTrustEscapedKeyIsRemoved(
                     escapedKey,
+                    trustedHash: codexHookTrustTrustedHash(from: lines[tableStart..<index]),
                     removingEscapedKeys: escapedKeys,
-                    removingEscapedKeyPrefixes: escapedKeyPrefixes
+                    removingEscapedKeyPrefixes: escapedKeyPrefixes,
+                    removingTrustedHashes: trustedHashes
                 ) {
                     preserved.append(contentsOf: lines[tableStart..<index])
                 }
@@ -20752,10 +20782,32 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
 
     private static func codexHookTrustEscapedKeyIsRemoved(
         _ escapedKey: String,
+        trustedHash: String?,
         removingEscapedKeys escapedKeys: Set<String>,
-        removingEscapedKeyPrefixes escapedKeyPrefixes: Set<String>
+        removingEscapedKeyPrefixes escapedKeyPrefixes: Set<String>,
+        removingTrustedHashes trustedHashes: Set<String>
     ) -> Bool {
-        escapedKeys.contains(escapedKey) || escapedKeyPrefixes.contains { escapedKey.hasPrefix($0) }
+        if escapedKeys.contains(escapedKey) {
+            return true
+        }
+        guard let trustedHash, trustedHashes.contains(trustedHash) else {
+            return false
+        }
+        return escapedKeyPrefixes.contains { escapedKey.hasPrefix($0) }
+    }
+
+    private static func codexHookTrustTrustedHash(from lines: ArraySlice<String>) -> String? {
+        for line in lines {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard let equalsIndex = trimmed.firstIndex(of: "=") else { continue }
+            let key = String(trimmed[..<equalsIndex]).trimmingCharacters(in: .whitespaces)
+            guard key == "trusted_hash" else { continue }
+            let valueStart = trimmed.index(after: equalsIndex)
+            let value = String(trimmed[valueStart...]).trimmingCharacters(in: .whitespaces)
+            guard value.hasPrefix("\""), value.hasSuffix("\""), value.count >= 2 else { continue }
+            return String(value.dropFirst().dropLast())
+        }
+        return nil
     }
 
     private static func stripMalformedCmuxCodexHookTrustMarker(from lines: inout [String]) {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -20748,7 +20748,7 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
             if let escapedKey = codexHookTrustTableEscapedKey(from: lines[index]) {
                 let tableStart = index
                 index += 1
-                while index < lines.endIndex, !tomlLineIsAnyTableHeader(lines[index]) {
+                while index < lines.endIndex, !tomlLineIsCodexHookTrustBlockTableBoundary(lines[index]) {
                     index += 1
                 }
                 if !codexHookTrustEscapedKeyIsRemoved(
@@ -20772,7 +20772,7 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
             }
             let tableStart = index
             index += 1
-            while index < lines.endIndex, !tomlLineIsAnyTableHeader(lines[index]) {
+            while index < lines.endIndex, !tomlLineIsCodexHookTrustBlockTableBoundary(lines[index]) {
                 index += 1
             }
             preserved.append(contentsOf: lines[tableStart..<index])
@@ -20823,9 +20823,20 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                 index += 1
                 continue
             }
-            let endIndex = tomlTableEndIndex(in: lines, after: index)
+            let endIndex = codexHookTrustTableEndIndex(in: lines, after: index)
             lines.removeSubrange(index..<endIndex)
         }
+    }
+
+    private static func codexHookTrustTableEndIndex(in lines: [String], after tableStart: Int) -> Int {
+        var index = tableStart + 1
+        while index < lines.count {
+            if tomlLineIsCodexHookTrustBlockTableBoundary(lines[index]) {
+                return index
+            }
+            index += 1
+        }
+        return lines.count
     }
 
     private static func codexHookTrustTableEscapedKey(from line: String) -> String? {
@@ -20835,6 +20846,10 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
             return nil
         }
         return String(line[keyRange])
+    }
+
+    private static func tomlLineIsCodexHookTrustBlockTableBoundary(_ line: String) -> Bool {
+        codexHookTrustTableEscapedKey(from: line) != nil || tomlLineIsAnyTableHeader(line)
     }
 
     private static func tomlLineIsCodexHooksFeatureBegin(_ line: String) -> Bool {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -20635,7 +20635,7 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
 
     @discardableResult
     private static func removeCmuxCodexHookTrustBlock(from lines: inout [String]) -> CodexHookTrustBlockRemovalResult {
-        var removedBlock = false
+        var replacements: [(range: ClosedRange<Int>, lines: [String])] = []
         var index = 0
         while index < lines.count {
             guard lines[index] == cmuxCodexHookTrustBegin else {
@@ -20649,12 +20649,14 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
             let preservedLines = codexHookTrustBlockUnownedLines(
                 from: lines[(index + 1)..<endIndex]
             )
-            lines.replaceSubrange(index...endIndex, with: preservedLines)
-            removedBlock = true
-            index += preservedLines.count
+            replacements.append((index...endIndex, preservedLines))
+            index = endIndex + 1
         }
 
-        return removedBlock ? .removed : .notFound
+        for replacement in replacements.reversed() {
+            lines.replaceSubrange(replacement.range, with: replacement.lines)
+        }
+        return replacements.isEmpty ? .notFound : .removed
     }
 
     private static func codexHookTrustBlockUnownedLines(from lines: ArraySlice<String>) -> [String] {
@@ -20668,8 +20670,17 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                 }
                 continue
             }
-            preserved.append(lines[index])
+
+            guard tomlLineIsAnyTableHeader(lines[index]) else {
+                index += 1
+                continue
+            }
+            let tableStart = index
             index += 1
+            while index < lines.endIndex, !tomlLineIsAnyTableHeader(lines[index]) {
+                index += 1
+            }
+            preserved.append(contentsOf: lines[tableStart..<index])
         }
         return preserved
     }
@@ -20693,13 +20704,16 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
     }
 
     private static func codexHookTrustTableEscapedKey(from line: String) -> String? {
-        let trimmed = line.trimmingCharacters(in: .whitespaces)
-        let prefix = "[hooks.state.\""
-        let suffix = "\"]"
-        guard trimmed.hasPrefix(prefix), trimmed.hasSuffix(suffix) else {
+        let pattern = #"^\s*\[\s*hooks\s*\.\s*state\s*\.\s*"((?:[^"\\\n]|\\.)*)"\s*\]\s*(#.*)?$"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else {
             return nil
         }
-        return String(trimmed.dropFirst(prefix.count).dropLast(suffix.count))
+        let range = NSRange(line.startIndex..<line.endIndex, in: line)
+        guard let match = regex.firstMatch(in: line, range: range),
+              let keyRange = Range(match.range(at: 1), in: line) else {
+            return nil
+        }
+        return String(line[keyRange])
     }
 
     private static func tomlLineIsCodexHooksFeatureBegin(_ line: String) -> Bool {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -20675,6 +20675,9 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
             }
 
             guard tomlLineIsAnyTableHeader(lines[index]) else {
+                // Marker drift can capture user config lines; only cmux-owned
+                // hook trust tables are safe to discard.
+                preserved.append(lines[index])
                 index += 1
                 continue
             }

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -20217,6 +20217,9 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
         "# cmux-codex-hook-trust-f5cc24da-7a09-4b20-a756-89e7786f6738 begin"
     private static let cmuxCodexHookTrustEnd =
         "# cmux-codex-hook-trust-f5cc24da-7a09-4b20-a756-89e7786f6738 end"
+    private static let codexHookTrustTableHeaderRegex = try! NSRegularExpression(
+        pattern: #"^\s*\[\s*hooks\s*\.\s*state\s*\.\s*"((?:[^"\\\n]|\\.)*)"\s*\]\s*(#.*)?$"#
+    )
 
     struct CodexHookTrustEntry: Equatable {
         let key: String
@@ -20704,12 +20707,8 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
     }
 
     private static func codexHookTrustTableEscapedKey(from line: String) -> String? {
-        let pattern = #"^\s*\[\s*hooks\s*\.\s*state\s*\.\s*"((?:[^"\\\n]|\\.)*)"\s*\]\s*(#.*)?$"#
-        guard let regex = try? NSRegularExpression(pattern: pattern) else {
-            return nil
-        }
         let range = NSRange(line.startIndex..<line.endIndex, in: line)
-        guard let match = regex.firstMatch(in: line, range: range),
+        guard let match = codexHookTrustTableHeaderRegex.firstMatch(in: line, range: range),
               let keyRange = Range(match.range(at: 1), in: line) else {
             return nil
         }

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -20125,6 +20125,11 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
         }
 
         var hooks = json["hooks"] as? [String: Any] ?? [:]
+        let codexHookTrustEntriesToRemove = Self.codexHookTrustEntries(
+            hooks: hooks,
+            hooksFilePath: filePath,
+            def: def
+        )
         var removed = 0
 
         let isCmuxOwnedCommand: (String) -> Bool = { cmd in
@@ -20176,7 +20181,10 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                 } catch {
                     throw CLIError(message: "\(configPath) exists but could not be read. Fix permissions or remove it before uninstalling \(def.displayName) hooks. \(String(describing: error))")
                 }
-                let newContent = Self.codexConfigTomlUninstallingHooksFeature(from: content)
+                let newContent = Self.codexConfigTomlUninstallingHooksFeature(
+                    from: content,
+                    removingHookTrustEntries: codexHookTrustEntriesToRemove
+                )
                 if newContent != content {
                     try newContent.write(toFile: configPath, atomically: true, encoding: .utf8)
                     print("Removed Codex hooks feature from \(configPath)")
@@ -20240,9 +20248,6 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
     static func codexConfigTomlInstallingHooksFeature(in existingContent: String) -> String {
         var lines = tomlLines(from: existingContent)
         removeCmuxCodexHooksFeatureBlock(from: &lines)
-        if removeCmuxCodexHookTrustBlock(from: &lines) == .malformed {
-            stripMalformedCmuxCodexHookTrustMarker(from: &lines)
-        }
         lines.removeAll { tomlLineDefinesKey("codex_hooks", line: $0) }
         lines.removeAll { tomlLineDefinesDottedFeaturesKey("codex_hooks", line: $0) }
 
@@ -20304,12 +20309,17 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
         return lines
     }
 
-    static func codexConfigTomlUninstallingHooksFeature(from existingContent: String) -> String {
+    static func codexConfigTomlUninstallingHooksFeature(
+        from existingContent: String,
+        removingHookTrustEntries entries: [CodexHookTrustEntry] = []
+    ) -> String {
         var lines = tomlLines(from: existingContent)
+        let escapedKeys = Set(entries.map { tomlBasicStringContent($0.key) })
         removeCmuxCodexHooksFeatureBlock(from: &lines)
-        if removeCmuxCodexHookTrustBlock(from: &lines) == .malformed {
+        if removeCmuxCodexHookTrustBlock(from: &lines, removingEscapedKeys: escapedKeys) == .malformed {
             stripMalformedCmuxCodexHookTrustMarker(from: &lines)
         }
+        removeCodexHookTrustTables(withEscapedKeys: escapedKeys, from: &lines)
         lines.removeAll { tomlLineDefinesKey("codex_hooks", line: $0) }
         lines.removeAll { tomlLineDefinesDottedFeaturesKey("codex_hooks", line: $0) }
         removeEmptyFeaturesTable(from: &lines)
@@ -20321,17 +20331,15 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
         entries: [CodexHookTrustEntry]
     ) -> CodexHookTrustInstallResult {
         var lines = tomlLines(from: existingContent)
-        let removalResult = removeCmuxCodexHookTrustBlock(from: &lines)
+        let escapedKeys = Set(entries.map { tomlBasicStringContent($0.key) })
+        let removalResult = removeCmuxCodexHookTrustBlock(from: &lines, removingEscapedKeys: escapedKeys)
         if removalResult == .malformed {
             stripMalformedCmuxCodexHookTrustMarker(from: &lines)
         }
         guard !entries.isEmpty else {
             return CodexHookTrustInstallResult(content: tomlContent(from: lines), installedTrust: false)
         }
-        removeCodexHookTrustTables(
-            withEscapedKeys: Set(entries.map { tomlBasicStringContent($0.key) }),
-            from: &lines
-        )
+        removeCodexHookTrustTables(withEscapedKeys: escapedKeys, from: &lines)
 
         if !lines.isEmpty, lines.last?.isEmpty == false {
             lines.append("")
@@ -20637,7 +20645,10 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
     }
 
     @discardableResult
-    private static func removeCmuxCodexHookTrustBlock(from lines: inout [String]) -> CodexHookTrustBlockRemovalResult {
+    private static func removeCmuxCodexHookTrustBlock(
+        from lines: inout [String],
+        removingEscapedKeys escapedKeys: Set<String> = []
+    ) -> CodexHookTrustBlockRemovalResult {
         var replacements: [(range: ClosedRange<Int>, lines: [String])] = []
         var index = 0
         while index < lines.count {
@@ -20650,7 +20661,8 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                 return .malformed
             }
             let preservedLines = codexHookTrustBlockUnownedLines(
-                from: lines[(index + 1)..<endIndex]
+                from: lines[(index + 1)..<endIndex],
+                removingEscapedKeys: escapedKeys
             )
             replacements.append((index...endIndex, preservedLines))
             index = endIndex + 1
@@ -20662,14 +20674,21 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
         return replacements.isEmpty ? .notFound : .removed
     }
 
-    private static func codexHookTrustBlockUnownedLines(from lines: ArraySlice<String>) -> [String] {
+    private static func codexHookTrustBlockUnownedLines(
+        from lines: ArraySlice<String>,
+        removingEscapedKeys escapedKeys: Set<String>
+    ) -> [String] {
         var preserved: [String] = []
         var index = lines.startIndex
         while index < lines.endIndex {
-            if codexHookTrustTableEscapedKey(from: lines[index]) != nil {
+            if let escapedKey = codexHookTrustTableEscapedKey(from: lines[index]) {
+                let tableStart = index
                 index += 1
                 while index < lines.endIndex, !tomlLineIsAnyTableHeader(lines[index]) {
                     index += 1
+                }
+                if !escapedKeys.contains(escapedKey) {
+                    preserved.append(contentsOf: lines[tableStart..<index])
                 }
                 continue
             }

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -20013,6 +20013,10 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
             hooksFilePath: filePath,
             def: def
         )
+        let codexHookTrustEscapedKeyPrefixes = Self.codexHookTrustEscapedKeyPrefixes(
+            hooksFilePath: filePath,
+            def: def
+        )
 
         let newData = try JSONSerialization.data(withJSONObject: existing, options: [.prettyPrinted, .sortedKeys])
         let newString = String(data: newData, encoding: .utf8) ?? "{}"
@@ -20061,10 +20065,16 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                 } else {
                     existingContent = ""
                 }
-                let featureContent = Self.codexConfigTomlInstallingHooksFeature(in: existingContent)
+                let trustClean = Self.codexConfigTomlInstallingHookTrust(
+                    in: existingContent,
+                    entries: [],
+                    removingEscapedKeyPrefixes: codexHookTrustEscapedKeyPrefixes
+                )
+                let featureContent = Self.codexConfigTomlInstallingHooksFeature(in: trustClean.content)
                 let trustInstall = Self.codexConfigTomlInstallingHookTrust(
                     in: featureContent,
-                    entries: codexHookTrustEntries
+                    entries: codexHookTrustEntries,
+                    removingEscapedKeyPrefixes: codexHookTrustEscapedKeyPrefixes
                 )
                 let newContent = trustInstall.content
                 if newContent != existingContent {
@@ -20130,6 +20140,10 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
             hooksFilePath: filePath,
             def: def
         )
+        let codexHookTrustEscapedKeyPrefixesToRemove = Self.codexHookTrustEscapedKeyPrefixes(
+            hooksFilePath: filePath,
+            def: def
+        )
         var removed = 0
 
         let isCmuxOwnedCommand: (String) -> Bool = { cmd in
@@ -20183,7 +20197,8 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                 }
                 let newContent = Self.codexConfigTomlUninstallingHooksFeature(
                     from: content,
-                    removingHookTrustEntries: codexHookTrustEntriesToRemove
+                    removingHookTrustEntries: codexHookTrustEntriesToRemove,
+                    removingEscapedKeyPrefixes: codexHookTrustEscapedKeyPrefixesToRemove
                 )
                 if newContent != content {
                     try newContent.write(toFile: configPath, atomically: true, encoding: .utf8)
@@ -20311,12 +20326,17 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
 
     static func codexConfigTomlUninstallingHooksFeature(
         from existingContent: String,
-        removingHookTrustEntries entries: [CodexHookTrustEntry] = []
+        removingHookTrustEntries entries: [CodexHookTrustEntry] = [],
+        removingEscapedKeyPrefixes escapedKeyPrefixes: Set<String> = []
     ) -> String {
         var lines = tomlLines(from: existingContent)
         let escapedKeys = Set(entries.map { tomlBasicStringContent($0.key) })
         removeCmuxCodexHooksFeatureBlock(from: &lines)
-        if removeCmuxCodexHookTrustBlock(from: &lines, removingEscapedKeys: escapedKeys) == .malformed {
+        if removeCmuxCodexHookTrustBlock(
+            from: &lines,
+            removingEscapedKeys: escapedKeys,
+            removingEscapedKeyPrefixes: escapedKeyPrefixes
+        ) == .malformed {
             stripMalformedCmuxCodexHookTrustMarker(from: &lines)
         }
         removeCodexHookTrustTables(withEscapedKeys: escapedKeys, from: &lines)
@@ -20328,11 +20348,16 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
 
     private static func codexConfigTomlInstallingHookTrust(
         in existingContent: String,
-        entries: [CodexHookTrustEntry]
+        entries: [CodexHookTrustEntry],
+        removingEscapedKeyPrefixes escapedKeyPrefixes: Set<String> = []
     ) -> CodexHookTrustInstallResult {
         var lines = tomlLines(from: existingContent)
         let escapedKeys = Set(entries.map { tomlBasicStringContent($0.key) })
-        let removalResult = removeCmuxCodexHookTrustBlock(from: &lines, removingEscapedKeys: escapedKeys)
+        let removalResult = removeCmuxCodexHookTrustBlock(
+            from: &lines,
+            removingEscapedKeys: escapedKeys,
+            removingEscapedKeyPrefixes: escapedKeyPrefixes
+        )
         if removalResult == .malformed {
             stripMalformedCmuxCodexHookTrustMarker(from: &lines)
         }
@@ -20394,6 +20419,14 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
         }
 
         return entries
+    }
+
+    private static func codexHookTrustEscapedKeyPrefixes(
+        hooksFilePath: String,
+        def: AgentHookDef
+    ) -> Set<String> {
+        guard def.name == "codex" else { return [] }
+        return [tomlBasicStringContent("\(codexNormalizedHookSourcePath(hooksFilePath)):")]
     }
 
     private static func codexNormalizedHookSourcePath(_ path: String) -> String {
@@ -20647,7 +20680,8 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
     @discardableResult
     private static func removeCmuxCodexHookTrustBlock(
         from lines: inout [String],
-        removingEscapedKeys escapedKeys: Set<String> = []
+        removingEscapedKeys escapedKeys: Set<String> = [],
+        removingEscapedKeyPrefixes escapedKeyPrefixes: Set<String> = []
     ) -> CodexHookTrustBlockRemovalResult {
         var replacements: [(range: ClosedRange<Int>, lines: [String])] = []
         var index = 0
@@ -20662,7 +20696,8 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
             }
             let preservedLines = codexHookTrustBlockUnownedLines(
                 from: lines[(index + 1)..<endIndex],
-                removingEscapedKeys: escapedKeys
+                removingEscapedKeys: escapedKeys,
+                removingEscapedKeyPrefixes: escapedKeyPrefixes
             )
             replacements.append((index...endIndex, preservedLines))
             index = endIndex + 1
@@ -20676,7 +20711,8 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
 
     private static func codexHookTrustBlockUnownedLines(
         from lines: ArraySlice<String>,
-        removingEscapedKeys escapedKeys: Set<String>
+        removingEscapedKeys escapedKeys: Set<String>,
+        removingEscapedKeyPrefixes escapedKeyPrefixes: Set<String>
     ) -> [String] {
         var preserved: [String] = []
         var index = lines.startIndex
@@ -20687,7 +20723,11 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                 while index < lines.endIndex, !tomlLineIsAnyTableHeader(lines[index]) {
                     index += 1
                 }
-                if !escapedKeys.contains(escapedKey) {
+                if !codexHookTrustEscapedKeyIsRemoved(
+                    escapedKey,
+                    removingEscapedKeys: escapedKeys,
+                    removingEscapedKeyPrefixes: escapedKeyPrefixes
+                ) {
                     preserved.append(contentsOf: lines[tableStart..<index])
                 }
                 continue
@@ -20708,6 +20748,14 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
             preserved.append(contentsOf: lines[tableStart..<index])
         }
         return preserved
+    }
+
+    private static func codexHookTrustEscapedKeyIsRemoved(
+        _ escapedKey: String,
+        removingEscapedKeys escapedKeys: Set<String>,
+        removingEscapedKeyPrefixes escapedKeyPrefixes: Set<String>
+    ) -> Bool {
+        escapedKeys.contains(escapedKey) || escapedKeyPrefixes.contains { escapedKey.hasPrefix($0) }
     }
 
     private static func stripMalformedCmuxCodexHookTrustMarker(from lines: inout [String]) {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -20141,11 +20141,11 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
             def: def,
             includeLegacyOwnedCommands: true
         )
-        let codexDefaultHookTrustHashesToRemove = Set(Self.codexHookTrustEntries(
+        let codexStaleHookTrustHashesToRemove = Set(Self.codexHookTrustEntries(
             hooks: buildHooksDict(for: def),
             hooksFilePath: filePath,
             def: def
-        ).map(\.trustedHash))
+        ).map(\.trustedHash)).union(Self.codexLegacyHookTrustHashes(def: def))
         let codexHookTrustEscapedKeyPrefixesToRemove = Self.codexHookTrustEscapedKeyPrefixes(
             hooksFilePath: filePath,
             def: def
@@ -20205,7 +20205,7 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                     from: content,
                     removingHookTrustEntries: codexHookTrustEntriesToRemove,
                     removingEscapedKeyPrefixes: codexHookTrustEscapedKeyPrefixesToRemove,
-                    removingTrustedHashes: codexDefaultHookTrustHashesToRemove
+                    removingTrustedHashes: codexStaleHookTrustHashesToRemove
                 )
                 if newContent != content {
                     try newContent.write(toFile: configPath, atomically: true, encoding: .utf8)
@@ -20461,6 +20461,54 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
     ) -> Set<String> {
         guard def.name == "codex" else { return [] }
         return [tomlBasicStringContent("\(codexNormalizedHookSourcePath(hooksFilePath)):")]
+    }
+
+    private static func codexLegacyHookTrustHashes(def: AgentHookDef) -> Set<String> {
+        guard def.name == "codex" else { return [] }
+        let hookTimeoutMs: Int
+        if case .nested(let timeoutMs) = def.format {
+            hookTimeoutMs = timeoutMs
+        } else {
+            hookTimeoutMs = 600
+        }
+
+        var hashes = Set<String>()
+        func insertHashes(eventLabel: String, command: String, timeouts: [Int]) {
+            let commands = [
+                command,
+                "[ -n \"$CMUX_SURFACE_ID\" ] && [ \"$\(def.disableEnvVar)\" != \"1\" ] && command -v cmux >/dev/null 2>&1 && \(command) || echo '{}'",
+            ]
+            for command in commands {
+                for timeout in timeouts {
+                    hashes.insert(codexCommandHookHash(
+                        eventLabel: eventLabel,
+                        matcher: nil,
+                        command: command,
+                        timeoutMs: timeout,
+                        statusMessage: nil
+                    ))
+                }
+            }
+        }
+
+        for event in def.events {
+            guard let eventLabel = codexHookEventLabel(event.agentEvent) else { continue }
+            insertHashes(
+                eventLabel: eventLabel,
+                command: "cmux codex-hook \(event.cmuxSubcommand)",
+                timeouts: [hookTimeoutMs, 600]
+            )
+        }
+
+        for agentEvent in def.feedHookEvents {
+            guard let eventLabel = codexHookEventLabel(agentEvent) else { continue }
+            insertHashes(
+                eventLabel: eventLabel,
+                command: "cmux feed-hook --source \(def.name) --event \(agentEvent)",
+                timeouts: [120_000, 600]
+            )
+        }
+        return hashes
     }
 
     private static func codexNormalizedHookSourcePath(_ path: String) -> String {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -20139,11 +20139,12 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
             hooks: hooks,
             hooksFilePath: filePath,
             def: def
-        ) + Self.codexHookTrustEntries(
+        )
+        let codexDefaultHookTrustHashesToRemove = Set(Self.codexHookTrustEntries(
             hooks: buildHooksDict(for: def),
             hooksFilePath: filePath,
             def: def
-        )
+        ).map(\.trustedHash))
         let codexHookTrustEscapedKeyPrefixesToRemove = Self.codexHookTrustEscapedKeyPrefixes(
             hooksFilePath: filePath,
             def: def
@@ -20202,7 +20203,8 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                 let newContent = Self.codexConfigTomlUninstallingHooksFeature(
                     from: content,
                     removingHookTrustEntries: codexHookTrustEntriesToRemove,
-                    removingEscapedKeyPrefixes: codexHookTrustEscapedKeyPrefixesToRemove
+                    removingEscapedKeyPrefixes: codexHookTrustEscapedKeyPrefixesToRemove,
+                    removingTrustedHashes: codexDefaultHookTrustHashesToRemove
                 )
                 if newContent != content {
                     try newContent.write(toFile: configPath, atomically: true, encoding: .utf8)
@@ -20331,11 +20333,12 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
     static func codexConfigTomlUninstallingHooksFeature(
         from existingContent: String,
         removingHookTrustEntries entries: [CodexHookTrustEntry] = [],
-        removingEscapedKeyPrefixes escapedKeyPrefixes: Set<String> = []
+        removingEscapedKeyPrefixes escapedKeyPrefixes: Set<String> = [],
+        removingTrustedHashes additionalTrustedHashes: Set<String> = []
     ) -> String {
         var lines = tomlLines(from: existingContent)
         let escapedKeys = Set(entries.map { tomlBasicStringContent($0.key) })
-        let trustedHashes = Set(entries.map(\.trustedHash))
+        let trustedHashes = Set(entries.map(\.trustedHash)).union(additionalTrustedHashes)
         removeCmuxCodexHooksFeatureBlock(from: &lines)
         if removeCmuxCodexHookTrustBlock(
             from: &lines,

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -20138,7 +20138,8 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
         let codexHookTrustEntriesToRemove = Self.codexHookTrustEntries(
             hooks: hooks,
             hooksFilePath: filePath,
-            def: def
+            def: def,
+            includeLegacyOwnedCommands: true
         )
         let codexDefaultHookTrustHashesToRemove = Set(Self.codexHookTrustEntries(
             hooks: buildHooksDict(for: def),
@@ -20413,11 +20414,12 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
     static func codexHookTrustEntries(
         hooks: [String: Any],
         hooksFilePath: String,
-        def: AgentHookDef
+        def: AgentHookDef,
+        includeLegacyOwnedCommands: Bool = false
     ) -> [CodexHookTrustEntry] {
         guard def.name == "codex" else { return [] }
         let isOwnedCommand: (String) -> Bool = { command in
-            isCmuxOwnedHookCommand(command, for: def, includeLegacy: false)
+            isCmuxOwnedHookCommand(command, for: def, includeLegacy: includeLegacyOwnedCommands)
         }
         var entries: [CodexHookTrustEntry] = []
         let keySource = codexNormalizedHookSourcePath(hooksFilePath)

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -20139,6 +20139,10 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
             hooks: hooks,
             hooksFilePath: filePath,
             def: def
+        ) + Self.codexHookTrustEntries(
+            hooks: buildHooksDict(for: def),
+            hooksFilePath: filePath,
+            def: def
         )
         let codexHookTrustEscapedKeyPrefixesToRemove = Self.codexHookTrustEscapedKeyPrefixes(
             hooksFilePath: filePath,

--- a/tests/test_codex_feed_hooks.py
+++ b/tests/test_codex_feed_hooks.py
@@ -1582,6 +1582,77 @@ def test_uninstall_preserves_third_party_hook_trust_inside_cmux_marker(
         raise AssertionError(f"third-party hook trust was removed: {config_toml!r}")
 
 
+def test_uninstall_retry_removes_stale_cmux_hook_trust_after_hooks_are_cleaned(
+    cli_path: str, root: Path
+) -> None:
+    codex_home = root / "codex-home-uninstall-retry-stale-trust"
+    codex_home.mkdir()
+    env = os.environ.copy()
+    env["CODEX_HOME"] = str(codex_home)
+
+    result = subprocess.run(
+        [cli_path, "hooks", "codex", "install", "--yes"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+        timeout=20,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"hooks codex install failed exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+
+    hooks_path = codex_home / "hooks.json"
+    hooks = json.loads(hooks_path.read_text(encoding="utf-8"))
+    expected_trust = expected_cmux_codex_hook_trust(hooks, hooks_path)
+    if not expected_trust:
+        raise AssertionError(f"expected cmux Codex trust entries, got {expected_trust!r}")
+
+    config_path = codex_home / "config.toml"
+    trust_end = "# cmux-codex-hook-trust-f5cc24da-7a09-4b20-a756-89e7786f6738 end"
+    same_file_user_key = f"{hooks_path.resolve()}:pre_tool_use:8:0"
+    third_party_key = "/tmp/third-party/hooks.json:pre_tool_use:0:0"
+    config_toml = config_path.read_text(encoding="utf-8")
+    config_path.write_text(
+        config_toml.replace(
+            trust_end,
+            f'[hooks.state."{same_file_user_key}"]\n'
+            'trusted_hash = "sha256:same-file-user"\n'
+            f'[hooks.state."{third_party_key}"]\n'
+            'trusted_hash = "sha256:third-party"\n'
+            f"{trust_end}",
+        ),
+        encoding="utf-8",
+    )
+    hooks_path.write_text('{"hooks": {}}\n', encoding="utf-8")
+
+    result = subprocess.run(
+        [cli_path, "hooks", "codex", "uninstall", "--yes"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+        timeout=20,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"hooks codex uninstall retry failed exit={result.returncode}\n"
+            f"stdout={result.stdout}\nstderr={result.stderr}"
+        )
+
+    config_toml = config_path.read_text(encoding="utf-8")
+    if "cmux-codex-hook-trust-f5cc24da-7a09-4b20-a756-89e7786f6738" in config_toml:
+        raise AssertionError(f"cmux hook trust marker was preserved: {config_toml!r}")
+    for key, trusted_hash in expected_trust.items():
+        if key in config_toml or trusted_hash in config_toml:
+            raise AssertionError(f"stale cmux hook trust was preserved: {config_toml!r}")
+    if 'trusted_hash = "sha256:same-file-user"' not in config_toml:
+        raise AssertionError(f"same-file user hook trust was removed: {config_toml!r}")
+    if 'trusted_hash = "sha256:third-party"' not in config_toml:
+        raise AssertionError(f"third-party hook trust was removed: {config_toml!r}")
+
+
 def test_uninstall_codex_hooks_removes_legacy_managed_block(cli_path: str, root: Path) -> None:
     codex_home = root / "codex-home-legacy-uninstall"
     codex_home.mkdir()
@@ -1841,6 +1912,7 @@ def main() -> int:
             test_install_preserves_plugin_tables_inside_stale_cmux_hook_trust_marker(cli_path, root)
             test_install_enables_hooks_when_stale_trust_marker_captures_dotted_feature(cli_path, root)
             test_uninstall_preserves_third_party_hook_trust_inside_cmux_marker(cli_path, root)
+            test_uninstall_retry_removes_stale_cmux_hook_trust_after_hooks_are_cleaned(cli_path, root)
             test_uninstall_codex_hooks_removes_legacy_managed_block(cli_path, root)
             test_install_surfaces_invalid_codex_config_encoding(cli_path, root)
             test_uninstall_surfaces_invalid_codex_config_encoding(cli_path, root)

--- a/tests/test_codex_feed_hooks.py
+++ b/tests/test_codex_feed_hooks.py
@@ -1724,6 +1724,71 @@ def test_uninstall_retry_preserves_user_hook_trust_at_default_cmux_key(
             raise AssertionError(f"stale cmux hook trust was preserved: {config_toml!r}")
 
 
+def test_uninstall_removes_legacy_codex_hook_trust(cli_path: str, root: Path) -> None:
+    codex_home = root / "codex-home-uninstall-legacy-trust"
+    codex_home.mkdir()
+    hooks_path = codex_home / "hooks.json"
+    config_path = codex_home / "config.toml"
+    legacy_command = "cmux feed-hook --source codex --event PreToolUse"
+    legacy_key = f"{hooks_path.resolve()}:pre_tool_use:0:0"
+    legacy_hash = codex_command_hook_hash(
+        event_label="pre_tool_use",
+        matcher=None,
+        command=legacy_command,
+        timeout=120_000,
+        status_message=None,
+    )
+    hooks_path.write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": legacy_command,
+                                    "timeout": 120_000,
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    config_path.write_text(
+        f'[hooks.state."{legacy_key}"]\n'
+        f'trusted_hash = "{legacy_hash}"\n',
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env["CODEX_HOME"] = str(codex_home)
+
+    result = subprocess.run(
+        [cli_path, "hooks", "codex", "uninstall", "--yes"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+        timeout=20,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"hooks codex uninstall failed exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+
+    hooks = json.loads(hooks_path.read_text(encoding="utf-8"))
+    if legacy_command in json.dumps(hooks):
+        raise AssertionError(f"legacy cmux hook command was preserved: {hooks!r}")
+    config_toml = config_path.read_text(encoding="utf-8")
+    if legacy_key in config_toml or legacy_hash in config_toml:
+        raise AssertionError(f"legacy cmux hook trust was preserved: {config_toml!r}")
+
+
 def test_uninstall_codex_hooks_removes_legacy_managed_block(cli_path: str, root: Path) -> None:
     codex_home = root / "codex-home-legacy-uninstall"
     codex_home.mkdir()
@@ -1985,6 +2050,7 @@ def main() -> int:
             test_uninstall_preserves_third_party_hook_trust_inside_cmux_marker(cli_path, root)
             test_uninstall_retry_removes_stale_cmux_hook_trust_after_hooks_are_cleaned(cli_path, root)
             test_uninstall_retry_preserves_user_hook_trust_at_default_cmux_key(cli_path, root)
+            test_uninstall_removes_legacy_codex_hook_trust(cli_path, root)
             test_uninstall_codex_hooks_removes_legacy_managed_block(cli_path, root)
             test_install_surfaces_invalid_codex_config_encoding(cli_path, root)
             test_uninstall_surfaces_invalid_codex_config_encoding(cli_path, root)

--- a/tests/test_codex_feed_hooks.py
+++ b/tests/test_codex_feed_hooks.py
@@ -1612,6 +1612,14 @@ def test_uninstall_retry_removes_stale_cmux_hook_trust_after_hooks_are_cleaned(
     config_path = codex_home / "config.toml"
     trust_end = "# cmux-codex-hook-trust-f5cc24da-7a09-4b20-a756-89e7786f6738 end"
     same_file_user_key = f"{hooks_path.resolve()}:pre_tool_use:8:0"
+    legacy_key = f"{hooks_path.resolve()}:pre_tool_use:9:0"
+    legacy_hash = codex_command_hook_hash(
+        event_label="pre_tool_use",
+        matcher=None,
+        command="cmux feed-hook --source codex --event PreToolUse",
+        timeout=120_000,
+        status_message=None,
+    )
     third_party_key = "/tmp/third-party/hooks.json:pre_tool_use:0:0"
     config_toml = config_path.read_text(encoding="utf-8")
     config_path.write_text(
@@ -1619,6 +1627,8 @@ def test_uninstall_retry_removes_stale_cmux_hook_trust_after_hooks_are_cleaned(
             trust_end,
             f'[hooks.state."{same_file_user_key}"]\n'
             'trusted_hash = "sha256:same-file-user"\n'
+            f'[hooks.state."{legacy_key}"]\n'
+            f'trusted_hash = "{legacy_hash}"\n'
             f'[hooks.state."{third_party_key}"]\n'
             'trusted_hash = "sha256:third-party"\n'
             f"{trust_end}",
@@ -1647,6 +1657,8 @@ def test_uninstall_retry_removes_stale_cmux_hook_trust_after_hooks_are_cleaned(
     for key, trusted_hash in expected_trust.items():
         if key in config_toml or trusted_hash in config_toml:
             raise AssertionError(f"stale cmux hook trust was preserved: {config_toml!r}")
+    if legacy_key in config_toml or legacy_hash in config_toml:
+        raise AssertionError(f"legacy cmux hook trust was preserved: {config_toml!r}")
     if 'trusted_hash = "sha256:same-file-user"' not in config_toml:
         raise AssertionError(f"same-file user hook trust was removed: {config_toml!r}")
     if 'trusted_hash = "sha256:third-party"' not in config_toml:

--- a/tests/test_codex_feed_hooks.py
+++ b/tests/test_codex_feed_hooks.py
@@ -1389,6 +1389,7 @@ def test_install_preserves_plugin_tables_inside_stale_cmux_hook_trust_marker(
         status_message=None,
     )
     same_file_user_key = f"{hooks_path.resolve()}:pre_tool_use:8:0"
+    escaped_user_key = "/tmp/third-party\\t/hooks.json:pre_tool_use:0:0"
     third_party_key = "/tmp/third-party/hooks.json:pre_tool_use:0:0"
     config_path = codex_home / "config.toml"
     config_path.write_text(
@@ -1398,6 +1399,9 @@ def test_install_preserves_plugin_tables_inside_stale_cmux_hook_trust_marker(
         "preserve_loose_config = true\n"
         f'[ hooks . state . "{stale_key}" ] # stale cmux trust\n'
         'trusted_hash = "sha256:stale"\n'
+        "\n"
+        f'[hooks.state."{escaped_user_key}"]\n'
+        'trusted_hash = "sha256:escaped-user"\n'
         "\n"
         f'[hooks.state."{stale_old_cmux_key}"]\n'
         f'trusted_hash = "{stale_old_cmux_hash}"\n'
@@ -1443,6 +1447,8 @@ def test_install_preserves_plugin_tables_inside_stale_cmux_hook_trust_marker(
         raise AssertionError(f"third-party hook trust was removed: {config_toml!r}")
     if 'trusted_hash = "sha256:same-file-user"' not in config_toml:
         raise AssertionError(f"same-file user hook trust was removed: {config_toml!r}")
+    if 'trusted_hash = "sha256:escaped-user"' not in config_toml:
+        raise AssertionError(f"escaped-key user hook trust was removed: {config_toml!r}")
     if 'trusted_hash = "sha256:stale"' in config_toml:
         raise AssertionError(f"stale cmux hook trust was preserved: {config_toml!r}")
     if stale_old_cmux_key in config_toml:

--- a/tests/test_codex_feed_hooks.py
+++ b/tests/test_codex_feed_hooks.py
@@ -1380,6 +1380,7 @@ def test_install_preserves_plugin_tables_inside_stale_cmux_hook_trust_marker(
     codex_home.mkdir()
     hooks_path = codex_home / "hooks.json"
     stale_key = f"{hooks_path.resolve()}:pre_tool_use:0:0"
+    third_party_key = "/tmp/third-party/hooks.json:pre_tool_use:0:0"
     config_path = codex_home / "config.toml"
     config_path.write_text(
         "[features]\n"
@@ -1388,6 +1389,9 @@ def test_install_preserves_plugin_tables_inside_stale_cmux_hook_trust_marker(
         "preserve_loose_config = true\n"
         f'[ hooks . state . "{stale_key}" ] # stale cmux trust\n'
         'trusted_hash = "sha256:stale"\n'
+        "\n"
+        f'[hooks.state."{third_party_key}"]\n'
+        'trusted_hash = "sha256:third-party"\n'
         "\n"
         '[plugins."documents@openai-primary-runtime"]\n'
         "enabled = true\n"
@@ -1420,6 +1424,8 @@ def test_install_preserves_plugin_tables_inside_stale_cmux_hook_trust_marker(
         raise AssertionError(f"browser plugin table was removed: {config_toml!r}")
     if "preserve_loose_config = true" not in config_toml:
         raise AssertionError(f"loose config line was removed: {config_toml!r}")
+    if 'trusted_hash = "sha256:third-party"' not in config_toml:
+        raise AssertionError(f"third-party hook trust was removed: {config_toml!r}")
     if 'trusted_hash = "sha256:stale"' in config_toml:
         raise AssertionError(f"stale cmux hook trust was preserved: {config_toml!r}")
     trust_begin = "# cmux-codex-hook-trust-f5cc24da-7a09-4b20-a756-89e7786f6738 begin"
@@ -1446,6 +1452,63 @@ def test_install_preserves_plugin_tables_inside_stale_cmux_hook_trust_marker(
             raise AssertionError(
                 f"missing fresh trusted hash for {key}: expected {trusted_hash!r}, got state {state!r}"
             )
+
+
+def test_uninstall_preserves_third_party_hook_trust_inside_cmux_marker(
+    cli_path: str, root: Path
+) -> None:
+    codex_home = root / "codex-home-uninstall-stale-third-party-trust"
+    codex_home.mkdir()
+    env = os.environ.copy()
+    env["CODEX_HOME"] = str(codex_home)
+
+    result = subprocess.run(
+        [cli_path, "hooks", "codex", "install", "--yes"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+        timeout=20,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"hooks codex install failed exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+
+    config_path = codex_home / "config.toml"
+    trust_end = "# cmux-codex-hook-trust-f5cc24da-7a09-4b20-a756-89e7786f6738 end"
+    third_party_key = "/tmp/third-party/hooks.json:pre_tool_use:0:0"
+    config_toml = config_path.read_text(encoding="utf-8")
+    config_path.write_text(
+        config_toml.replace(
+            trust_end,
+            f'[hooks.state."{third_party_key}"]\n'
+            'trusted_hash = "sha256:third-party"\n'
+            f"{trust_end}",
+        ),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [cli_path, "hooks", "codex", "uninstall", "--yes"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+        timeout=20,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"hooks codex uninstall failed exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+
+    config_toml = config_path.read_text(encoding="utf-8")
+    if "cmux-codex-hook-trust-f5cc24da-7a09-4b20-a756-89e7786f6738" in config_toml:
+        raise AssertionError(f"cmux hook trust marker was preserved: {config_toml!r}")
+    if str((codex_home / "hooks.json").resolve()) in config_toml:
+        raise AssertionError(f"cmux hook trust was preserved: {config_toml!r}")
+    if 'trusted_hash = "sha256:third-party"' not in config_toml:
+        raise AssertionError(f"third-party hook trust was removed: {config_toml!r}")
 
 
 def test_uninstall_codex_hooks_removes_legacy_managed_block(cli_path: str, root: Path) -> None:
@@ -1705,6 +1768,7 @@ def main() -> int:
             test_uninstall_preserves_unowned_hook_trust_when_cmux_marker_is_unclosed(cli_path, root)
             test_install_recovers_hook_trust_when_cmux_marker_is_unclosed(cli_path, root)
             test_install_preserves_plugin_tables_inside_stale_cmux_hook_trust_marker(cli_path, root)
+            test_uninstall_preserves_third_party_hook_trust_inside_cmux_marker(cli_path, root)
             test_uninstall_codex_hooks_removes_legacy_managed_block(cli_path, root)
             test_install_surfaces_invalid_codex_config_encoding(cli_path, root)
             test_uninstall_surfaces_invalid_codex_config_encoding(cli_path, root)

--- a/tests/test_codex_feed_hooks.py
+++ b/tests/test_codex_feed_hooks.py
@@ -1388,6 +1388,14 @@ def test_install_preserves_plugin_tables_inside_stale_cmux_hook_trust_marker(
         timeout=120_000,
         status_message=None,
     )
+    stale_legacy_key = f"{hooks_path.resolve()}:pre_tool_use:10:0"
+    stale_legacy_hash = codex_command_hook_hash(
+        event_label="pre_tool_use",
+        matcher=None,
+        command="cmux feed-hook --source codex --event PreToolUse",
+        timeout=120_000,
+        status_message=None,
+    )
     same_file_user_key = f"{hooks_path.resolve()}:pre_tool_use:8:0"
     escaped_user_key = "/tmp/third-party\\t/hooks.json:pre_tool_use:0:0"
     third_party_key = "/tmp/third-party/hooks.json:pre_tool_use:0:0"
@@ -1405,6 +1413,9 @@ def test_install_preserves_plugin_tables_inside_stale_cmux_hook_trust_marker(
         "\n"
         f'[hooks.state."{stale_old_cmux_key}"]\n'
         f'trusted_hash = "{stale_old_cmux_hash}"\n'
+        "\n"
+        f'[hooks.state."{stale_legacy_key}"]\n'
+        f'trusted_hash = "{stale_legacy_hash}"\n'
         "\n"
         f'[hooks.state."{same_file_user_key}"]\n'
         'trusted_hash = "sha256:same-file-user"\n'
@@ -1453,6 +1464,8 @@ def test_install_preserves_plugin_tables_inside_stale_cmux_hook_trust_marker(
         raise AssertionError(f"stale cmux hook trust was preserved: {config_toml!r}")
     if stale_old_cmux_key in config_toml:
         raise AssertionError(f"old cmux hook trust was preserved: {config_toml!r}")
+    if stale_legacy_key in config_toml or stale_legacy_hash in config_toml:
+        raise AssertionError(f"legacy cmux hook trust was preserved: {config_toml!r}")
     trust_begin = "# cmux-codex-hook-trust-f5cc24da-7a09-4b20-a756-89e7786f6738 begin"
     trust_end = "# cmux-codex-hook-trust-f5cc24da-7a09-4b20-a756-89e7786f6738 end"
     if config_toml.count(trust_begin) != 1:

--- a/tests/test_codex_feed_hooks.py
+++ b/tests/test_codex_feed_hooks.py
@@ -1385,6 +1385,7 @@ def test_install_preserves_plugin_tables_inside_stale_cmux_hook_trust_marker(
         "[features]\n"
         "hooks = true\n"
         "# cmux-codex-hook-trust-f5cc24da-7a09-4b20-a756-89e7786f6738 begin\n"
+        "preserve_loose_config = true\n"
         f'[ hooks . state . "{stale_key}" ] # stale cmux trust\n'
         'trusted_hash = "sha256:stale"\n'
         "\n"
@@ -1417,6 +1418,8 @@ def test_install_preserves_plugin_tables_inside_stale_cmux_hook_trust_marker(
         raise AssertionError(f"documents plugin table was removed: {config_toml!r}")
     if '[plugins."browser@openai-bundled"]' not in config_toml:
         raise AssertionError(f"browser plugin table was removed: {config_toml!r}")
+    if "preserve_loose_config = true" not in config_toml:
+        raise AssertionError(f"loose config line was removed: {config_toml!r}")
     if 'trusted_hash = "sha256:stale"' in config_toml:
         raise AssertionError(f"stale cmux hook trust was preserved: {config_toml!r}")
     trust_begin = "# cmux-codex-hook-trust-f5cc24da-7a09-4b20-a756-89e7786f6738 begin"

--- a/tests/test_codex_feed_hooks.py
+++ b/tests/test_codex_feed_hooks.py
@@ -1380,6 +1380,7 @@ def test_install_preserves_plugin_tables_inside_stale_cmux_hook_trust_marker(
     codex_home.mkdir()
     hooks_path = codex_home / "hooks.json"
     stale_key = f"{hooks_path.resolve()}:pre_tool_use:0:0"
+    stale_old_cmux_key = f"{hooks_path.resolve()}:pre_tool_use:9:0"
     third_party_key = "/tmp/third-party/hooks.json:pre_tool_use:0:0"
     config_path = codex_home / "config.toml"
     config_path.write_text(
@@ -1389,6 +1390,9 @@ def test_install_preserves_plugin_tables_inside_stale_cmux_hook_trust_marker(
         "preserve_loose_config = true\n"
         f'[ hooks . state . "{stale_key}" ] # stale cmux trust\n'
         'trusted_hash = "sha256:stale"\n'
+        "\n"
+        f'[hooks.state."{stale_old_cmux_key}"]\n'
+        'trusted_hash = "sha256:old-cmux"\n'
         "\n"
         f'[hooks.state."{third_party_key}"]\n'
         'trusted_hash = "sha256:third-party"\n'
@@ -1428,6 +1432,8 @@ def test_install_preserves_plugin_tables_inside_stale_cmux_hook_trust_marker(
         raise AssertionError(f"third-party hook trust was removed: {config_toml!r}")
     if 'trusted_hash = "sha256:stale"' in config_toml:
         raise AssertionError(f"stale cmux hook trust was preserved: {config_toml!r}")
+    if 'trusted_hash = "sha256:old-cmux"' in config_toml:
+        raise AssertionError(f"old cmux hook trust was preserved: {config_toml!r}")
     trust_begin = "# cmux-codex-hook-trust-f5cc24da-7a09-4b20-a756-89e7786f6738 begin"
     trust_end = "# cmux-codex-hook-trust-f5cc24da-7a09-4b20-a756-89e7786f6738 end"
     if config_toml.count(trust_begin) != 1:
@@ -1452,6 +1458,45 @@ def test_install_preserves_plugin_tables_inside_stale_cmux_hook_trust_marker(
             raise AssertionError(
                 f"missing fresh trusted hash for {key}: expected {trusted_hash!r}, got state {state!r}"
             )
+
+
+def test_install_enables_hooks_when_stale_trust_marker_captures_dotted_feature(
+    cli_path: str, root: Path
+) -> None:
+    codex_home = root / "codex-home-stale-trust-with-dotted-feature"
+    codex_home.mkdir()
+    hooks_path = codex_home / "hooks.json"
+    stale_key = f"{hooks_path.resolve()}:pre_tool_use:0:0"
+    config_path = codex_home / "config.toml"
+    config_path.write_text(
+        "# cmux-codex-hook-trust-f5cc24da-7a09-4b20-a756-89e7786f6738 begin\n"
+        f'[hooks.state."{stale_key}"]\n'
+        'trusted_hash = "sha256:stale"\n'
+        "features.experimental = true\n"
+        "# cmux-codex-hook-trust-f5cc24da-7a09-4b20-a756-89e7786f6738 end\n",
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env["CODEX_HOME"] = str(codex_home)
+
+    result = subprocess.run(
+        [cli_path, "hooks", "codex", "install", "--yes"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+        timeout=20,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"hooks codex install failed exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+
+    config_toml = config_path.read_text(encoding="utf-8")
+    if "hooks = true" not in config_toml and "features.hooks = true" not in config_toml:
+        raise AssertionError(f"install did not enable Codex hooks: {config_toml!r}")
+    if 'trusted_hash = "sha256:stale"' in config_toml:
+        raise AssertionError(f"stale cmux hook trust was preserved: {config_toml!r}")
 
 
 def test_uninstall_preserves_third_party_hook_trust_inside_cmux_marker(
@@ -1768,6 +1813,7 @@ def main() -> int:
             test_uninstall_preserves_unowned_hook_trust_when_cmux_marker_is_unclosed(cli_path, root)
             test_install_recovers_hook_trust_when_cmux_marker_is_unclosed(cli_path, root)
             test_install_preserves_plugin_tables_inside_stale_cmux_hook_trust_marker(cli_path, root)
+            test_install_enables_hooks_when_stale_trust_marker_captures_dotted_feature(cli_path, root)
             test_uninstall_preserves_third_party_hook_trust_inside_cmux_marker(cli_path, root)
             test_uninstall_codex_hooks_removes_legacy_managed_block(cli_path, root)
             test_install_surfaces_invalid_codex_config_encoding(cli_path, root)

--- a/tests/test_codex_feed_hooks.py
+++ b/tests/test_codex_feed_hooks.py
@@ -1381,6 +1381,14 @@ def test_install_preserves_plugin_tables_inside_stale_cmux_hook_trust_marker(
     hooks_path = codex_home / "hooks.json"
     stale_key = f"{hooks_path.resolve()}:pre_tool_use:0:0"
     stale_old_cmux_key = f"{hooks_path.resolve()}:pre_tool_use:9:0"
+    stale_old_cmux_hash = codex_command_hook_hash(
+        event_label="pre_tool_use",
+        matcher=None,
+        command=cmux_codex_feed_command("PreToolUse"),
+        timeout=120_000,
+        status_message=None,
+    )
+    same_file_user_key = f"{hooks_path.resolve()}:pre_tool_use:8:0"
     third_party_key = "/tmp/third-party/hooks.json:pre_tool_use:0:0"
     config_path = codex_home / "config.toml"
     config_path.write_text(
@@ -1392,7 +1400,10 @@ def test_install_preserves_plugin_tables_inside_stale_cmux_hook_trust_marker(
         'trusted_hash = "sha256:stale"\n'
         "\n"
         f'[hooks.state."{stale_old_cmux_key}"]\n'
-        'trusted_hash = "sha256:old-cmux"\n'
+        f'trusted_hash = "{stale_old_cmux_hash}"\n'
+        "\n"
+        f'[hooks.state."{same_file_user_key}"]\n'
+        'trusted_hash = "sha256:same-file-user"\n'
         "\n"
         f'[hooks.state."{third_party_key}"]\n'
         'trusted_hash = "sha256:third-party"\n'
@@ -1430,9 +1441,11 @@ def test_install_preserves_plugin_tables_inside_stale_cmux_hook_trust_marker(
         raise AssertionError(f"loose config line was removed: {config_toml!r}")
     if 'trusted_hash = "sha256:third-party"' not in config_toml:
         raise AssertionError(f"third-party hook trust was removed: {config_toml!r}")
+    if 'trusted_hash = "sha256:same-file-user"' not in config_toml:
+        raise AssertionError(f"same-file user hook trust was removed: {config_toml!r}")
     if 'trusted_hash = "sha256:stale"' in config_toml:
         raise AssertionError(f"stale cmux hook trust was preserved: {config_toml!r}")
-    if 'trusted_hash = "sha256:old-cmux"' in config_toml:
+    if stale_old_cmux_key in config_toml:
         raise AssertionError(f"old cmux hook trust was preserved: {config_toml!r}")
     trust_begin = "# cmux-codex-hook-trust-f5cc24da-7a09-4b20-a756-89e7786f6738 begin"
     trust_end = "# cmux-codex-hook-trust-f5cc24da-7a09-4b20-a756-89e7786f6738 end"
@@ -1522,11 +1535,14 @@ def test_uninstall_preserves_third_party_hook_trust_inside_cmux_marker(
 
     config_path = codex_home / "config.toml"
     trust_end = "# cmux-codex-hook-trust-f5cc24da-7a09-4b20-a756-89e7786f6738 end"
+    same_file_user_key = f"{(codex_home / 'hooks.json').resolve()}:pre_tool_use:8:0"
     third_party_key = "/tmp/third-party/hooks.json:pre_tool_use:0:0"
     config_toml = config_path.read_text(encoding="utf-8")
     config_path.write_text(
         config_toml.replace(
             trust_end,
+            f'[hooks.state."{same_file_user_key}"]\n'
+            'trusted_hash = "sha256:same-file-user"\n'
             f'[hooks.state."{third_party_key}"]\n'
             'trusted_hash = "sha256:third-party"\n'
             f"{trust_end}",
@@ -1550,8 +1566,12 @@ def test_uninstall_preserves_third_party_hook_trust_inside_cmux_marker(
     config_toml = config_path.read_text(encoding="utf-8")
     if "cmux-codex-hook-trust-f5cc24da-7a09-4b20-a756-89e7786f6738" in config_toml:
         raise AssertionError(f"cmux hook trust marker was preserved: {config_toml!r}")
-    if str((codex_home / "hooks.json").resolve()) in config_toml:
-        raise AssertionError(f"cmux hook trust was preserved: {config_toml!r}")
+    state = codex_hook_trust_state(config_toml)
+    for key in state:
+        if key.startswith(f"{(codex_home / 'hooks.json').resolve()}:") and key != same_file_user_key:
+            raise AssertionError(f"cmux hook trust was preserved: {config_toml!r}")
+    if 'trusted_hash = "sha256:same-file-user"' not in config_toml:
+        raise AssertionError(f"same-file user hook trust was removed: {config_toml!r}")
     if 'trusted_hash = "sha256:third-party"' not in config_toml:
         raise AssertionError(f"third-party hook trust was removed: {config_toml!r}")
 

--- a/tests/test_codex_feed_hooks.py
+++ b/tests/test_codex_feed_hooks.py
@@ -1373,6 +1373,68 @@ def test_install_recovers_hook_trust_when_cmux_marker_is_unclosed(
             )
 
 
+def test_install_preserves_plugin_tables_inside_stale_cmux_hook_trust_marker(
+    cli_path: str, root: Path
+) -> None:
+    codex_home = root / "codex-home-stale-trust-with-plugins"
+    codex_home.mkdir()
+    hooks_path = codex_home / "hooks.json"
+    stale_key = f"{hooks_path.resolve()}:pre_tool_use:0:0"
+    config_path = codex_home / "config.toml"
+    config_path.write_text(
+        "[features]\n"
+        "hooks = true\n"
+        "# cmux-codex-hook-trust-f5cc24da-7a09-4b20-a756-89e7786f6738 begin\n"
+        f'[hooks.state."{stale_key}"]\n'
+        'trusted_hash = "sha256:stale"\n'
+        "\n"
+        '[plugins."documents@openai-primary-runtime"]\n'
+        "enabled = true\n"
+        "\n"
+        '[plugins."browser@openai-bundled"]\n'
+        "enabled = true\n"
+        "# cmux-codex-hook-trust-f5cc24da-7a09-4b20-a756-89e7786f6738 end\n",
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env["CODEX_HOME"] = str(codex_home)
+
+    result = subprocess.run(
+        [cli_path, "hooks", "codex", "install", "--yes"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+        timeout=20,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"hooks codex install failed exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+
+    config_toml = config_path.read_text(encoding="utf-8")
+    if '[plugins."documents@openai-primary-runtime"]' not in config_toml:
+        raise AssertionError(f"documents plugin table was removed: {config_toml!r}")
+    if '[plugins."browser@openai-bundled"]' not in config_toml:
+        raise AssertionError(f"browser plugin table was removed: {config_toml!r}")
+    if 'trusted_hash = "sha256:stale"' in config_toml:
+        raise AssertionError(f"stale cmux hook trust was preserved: {config_toml!r}")
+    trust_begin = "# cmux-codex-hook-trust-f5cc24da-7a09-4b20-a756-89e7786f6738 begin"
+    if config_toml.count(trust_begin) != 1:
+        raise AssertionError(f"install did not write one fresh cmux hook trust marker: {config_toml!r}")
+    if config_toml.index('[plugins."browser@openai-bundled"]') > config_toml.index(trust_begin):
+        raise AssertionError(f"plugin tables should stay outside the fresh cmux trust block: {config_toml!r}")
+
+    hooks = json.loads(hooks_path.read_text(encoding="utf-8"))
+    state = codex_hook_trust_state(config_toml)
+    expected_trust = expected_cmux_codex_hook_trust(hooks, hooks_path)
+    for key, trusted_hash in expected_trust.items():
+        if state.get(key, {}).get("trusted_hash") != trusted_hash:
+            raise AssertionError(
+                f"missing fresh trusted hash for {key}: expected {trusted_hash!r}, got state {state!r}"
+            )
+
+
 def test_uninstall_codex_hooks_removes_legacy_managed_block(cli_path: str, root: Path) -> None:
     codex_home = root / "codex-home-legacy-uninstall"
     codex_home.mkdir()
@@ -1629,6 +1691,7 @@ def main() -> int:
             test_uninstall_removes_cmux_owned_codex_hooks_feature(cli_path, root)
             test_uninstall_preserves_unowned_hook_trust_when_cmux_marker_is_unclosed(cli_path, root)
             test_install_recovers_hook_trust_when_cmux_marker_is_unclosed(cli_path, root)
+            test_install_preserves_plugin_tables_inside_stale_cmux_hook_trust_marker(cli_path, root)
             test_uninstall_codex_hooks_removes_legacy_managed_block(cli_path, root)
             test_install_surfaces_invalid_codex_config_encoding(cli_path, root)
             test_uninstall_surfaces_invalid_codex_config_encoding(cli_path, root)

--- a/tests/test_codex_feed_hooks.py
+++ b/tests/test_codex_feed_hooks.py
@@ -1653,6 +1653,77 @@ def test_uninstall_retry_removes_stale_cmux_hook_trust_after_hooks_are_cleaned(
         raise AssertionError(f"third-party hook trust was removed: {config_toml!r}")
 
 
+def test_uninstall_retry_preserves_user_hook_trust_at_default_cmux_key(
+    cli_path: str, root: Path
+) -> None:
+    codex_home = root / "codex-home-uninstall-retry-user-default-key"
+    codex_home.mkdir()
+    hooks_path = codex_home / "hooks.json"
+    config_path = codex_home / "config.toml"
+    user_key = f"{hooks_path.resolve()}:pre_tool_use:0:0"
+    user_hooks = {
+        "hooks": {
+            "PreToolUse": [
+                {
+                    "hooks": [
+                        {"type": "command", "command": "printf user", "timeout": 1000}
+                    ]
+                }
+            ]
+        }
+    }
+    hooks_path.write_text(json.dumps(user_hooks, indent=2) + "\n", encoding="utf-8")
+    config_path.write_text(
+        f'[hooks.state."{user_key}"]\n'
+        'trusted_hash = "sha256:user-default-index"\n',
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env["CODEX_HOME"] = str(codex_home)
+
+    result = subprocess.run(
+        [cli_path, "hooks", "codex", "install", "--yes"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+        timeout=20,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"hooks codex install failed exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+
+    installed_hooks = json.loads(hooks_path.read_text(encoding="utf-8"))
+    expected_trust = expected_cmux_codex_hook_trust(installed_hooks, hooks_path)
+    if not expected_trust:
+        raise AssertionError(f"expected cmux Codex trust entries, got {expected_trust!r}")
+    hooks_path.write_text(json.dumps(user_hooks, indent=2) + "\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [cli_path, "hooks", "codex", "uninstall", "--yes"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+        timeout=20,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"hooks codex uninstall retry failed exit={result.returncode}\n"
+            f"stdout={result.stdout}\nstderr={result.stderr}"
+        )
+
+    config_toml = config_path.read_text(encoding="utf-8")
+    if 'trusted_hash = "sha256:user-default-index"' not in config_toml:
+        raise AssertionError(f"user hook trust at default cmux key was removed: {config_toml!r}")
+    for key, trusted_hash in expected_trust.items():
+        if trusted_hash in config_toml:
+            raise AssertionError(f"stale cmux hook trust was preserved: {config_toml!r}")
+        if key != user_key and key in config_toml:
+            raise AssertionError(f"stale cmux hook trust was preserved: {config_toml!r}")
+
+
 def test_uninstall_codex_hooks_removes_legacy_managed_block(cli_path: str, root: Path) -> None:
     codex_home = root / "codex-home-legacy-uninstall"
     codex_home.mkdir()
@@ -1913,6 +1984,7 @@ def main() -> int:
             test_install_enables_hooks_when_stale_trust_marker_captures_dotted_feature(cli_path, root)
             test_uninstall_preserves_third_party_hook_trust_inside_cmux_marker(cli_path, root)
             test_uninstall_retry_removes_stale_cmux_hook_trust_after_hooks_are_cleaned(cli_path, root)
+            test_uninstall_retry_preserves_user_hook_trust_at_default_cmux_key(cli_path, root)
             test_uninstall_codex_hooks_removes_legacy_managed_block(cli_path, root)
             test_install_surfaces_invalid_codex_config_encoding(cli_path, root)
             test_uninstall_surfaces_invalid_codex_config_encoding(cli_path, root)

--- a/tests/test_codex_feed_hooks.py
+++ b/tests/test_codex_feed_hooks.py
@@ -1385,7 +1385,7 @@ def test_install_preserves_plugin_tables_inside_stale_cmux_hook_trust_marker(
         "[features]\n"
         "hooks = true\n"
         "# cmux-codex-hook-trust-f5cc24da-7a09-4b20-a756-89e7786f6738 begin\n"
-        f'[hooks.state."{stale_key}"]\n'
+        f'[ hooks . state . "{stale_key}" ] # stale cmux trust\n'
         'trusted_hash = "sha256:stale"\n'
         "\n"
         '[plugins."documents@openai-primary-runtime"]\n'
@@ -1420,10 +1420,20 @@ def test_install_preserves_plugin_tables_inside_stale_cmux_hook_trust_marker(
     if 'trusted_hash = "sha256:stale"' in config_toml:
         raise AssertionError(f"stale cmux hook trust was preserved: {config_toml!r}")
     trust_begin = "# cmux-codex-hook-trust-f5cc24da-7a09-4b20-a756-89e7786f6738 begin"
+    trust_end = "# cmux-codex-hook-trust-f5cc24da-7a09-4b20-a756-89e7786f6738 end"
     if config_toml.count(trust_begin) != 1:
         raise AssertionError(f"install did not write one fresh cmux hook trust marker: {config_toml!r}")
-    if config_toml.index('[plugins."browser@openai-bundled"]') > config_toml.index(trust_begin):
-        raise AssertionError(f"plugin tables should stay outside the fresh cmux trust block: {config_toml!r}")
+    if config_toml.count(trust_end) != 1:
+        raise AssertionError(f"install did not close the fresh cmux trust block: {config_toml!r}")
+    trust_begin_index = config_toml.index(trust_begin)
+    trust_end_index = config_toml.index(trust_end)
+    for plugin_header in (
+        '[plugins."documents@openai-primary-runtime"]',
+        '[plugins."browser@openai-bundled"]',
+    ):
+        plugin_index = config_toml.index(plugin_header)
+        if trust_begin_index < plugin_index < trust_end_index:
+            raise AssertionError(f"plugin table remained inside fresh cmux trust block: {config_toml!r}")
 
     hooks = json.loads(hooks_path.read_text(encoding="utf-8"))
     state = codex_hook_trust_state(config_toml)


### PR DESCRIPTION
## Summary
- Preserve unrelated TOML tables that drift inside the cmux Codex hook-trust marker.
- Add a regression for Codex plugin tables being removed during hook setup.

## Testing
- RED: new regression failed before the fix with `documents plugin table was removed`.
- `./scripts/reload.sh --tag hookplug`
- `PYTHONPATH=tests CMUX_CLI_BIN=... python3 - <<'PY' ... test_install_preserves_plugin_tables_inside_stale_cmux_hook_trust_marker ... PY`
- `TMPDIR=/tmp CMUX_CLI_BIN=... python3 tests/test_codex_feed_hooks.py`

## Issues
- User-reported: `cmux hooks setup` proposed deleting Codex plugin tables from `~/.codex/config.toml`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Codex hook install/uninstall logic that rewrites user `config.toml`, so mistakes could delete or mis-handle user/plugin configuration despite added regressions. Scope is contained to Codex hook trust parsing/removal paths.
> 
> **Overview**
> Fixes Codex hook install/uninstall to **stop deleting unrelated `config.toml` content** when stale cmux hook-trust markers have drifted to include other tables/lines.
> 
> Install now pre-cleans existing hook-trust by removing only cmux-owned trust entries (including legacy hashes) using key-prefix + `trusted_hash` matching, then writes a single fresh trust block; uninstall similarly removes cmux-owned/legacy trust while preserving third-party and user trust.
> 
> Updates TOML parsing to treat any table header as a boundary (regex-based `[hooks.state."…"]` detection) and adds regressions covering plugin-table preservation, dotted-feature capture, uninstall retry cleanup, and legacy trust removal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 087b31e712b87ea3ae94d858a4bb6b5bb61a51bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Codex hook install/uninstall so `cmux hooks setup` stops deleting plugin tables or unrelated config. Install now also prunes legacy Codex trust while preserving user and third‑party trust; uninstall still removes legacy trust and commands.

- **Bug Fixes**
  - Pre-clean trust markers before placing hooks; use hook‑trust headers as boundaries; preserve `[plugins.*]` and loose lines; handle whitespace/comments; cache the header regex.
  - Install: remove only cmux-owned trust via exact keys and `"<hooks.json path>:"` prefixes when `trusted_hash` matches known cmux or legacy hashes; keep third‑party and same‑file user trust; enable hooks even if dotted `features.*` lines were captured.
  - Uninstall/retry: delete cmux-owned trust and legacy Codex trust/commands; preserve user trust at the default `:0:0` key and third‑party trust.

<sup>Written for commit 087b31e712b87ea3ae94d858a4bb6b5bb61a51bd. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4270?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Installer now removes stale Codex hook trusted-hash entries while preserving intervening plugin tables and loose config lines, generating a single fresh trust block and relocating plugin tables outside it.
* **Refactor**
  * Improved trust-marker handling to more reliably preserve non-hook content and apply safe in-place updates.
* **Tests**
  * Added regression tests for install-preserve behavior and for uninstall behavior that keeps third-party trust entries while removing managed markers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4270?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->