### PR TITLE
Ignore foreign crash breadcrumb files

### DIFF
--- a/Sources/GhosttyCrashBreadcrumb.swift
+++ b/Sources/GhosttyCrashBreadcrumb.swift
@@ -15,7 +15,7 @@ nonisolated enum GhosttyCrashBreadcrumb {
             .appendingPathComponent(".local/state/cmux/crash", isDirectory: true)
     }
 
-    @Sendable
+    @concurrent
     nonisolated static func pendingCrashFromDefaultStorage() async -> PendingCrash? {
         await Task.detached(priority: .utility) {
             pendingCrash()

--- a/Sources/GhosttyCrashBreadcrumb.swift
+++ b/Sources/GhosttyCrashBreadcrumb.swift
@@ -10,7 +10,7 @@ nonisolated enum GhosttyCrashBreadcrumb {
     static let lastShownCrashDefaultsKey = "ghosttyCrashBreadcrumb.lastShownCrashAt"
     static let notificationTabId = UUID(uuidString: "00000000-0000-0000-0000-000000003873")!
 
-    static var defaultCrashDirectoryURL: URL {
+    nonisolated static var defaultCrashDirectoryURL: URL {
         FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".local/state/cmux/crash", isDirectory: true)
     }
@@ -22,7 +22,7 @@ nonisolated enum GhosttyCrashBreadcrumb {
         }.value
     }
 
-    static func pendingCrash(
+    nonisolated static func pendingCrash(
         in crashDirectoryURL: URL = defaultCrashDirectoryURL,
         defaults: UserDefaults = .standard,
         fileManager: FileManager = .default,
@@ -44,11 +44,11 @@ nonisolated enum GhosttyCrashBreadcrumb {
         return latest
     }
 
-    static func markShown(_ pendingCrash: PendingCrash, defaults: UserDefaults = .standard) {
+    nonisolated static func markShown(_ pendingCrash: PendingCrash, defaults: UserDefaults = .standard) {
         defaults.set(pendingCrash.modifiedAt, forKey: lastShownCrashDefaultsKey)
     }
 
-    static func markCleanExit(defaults: UserDefaults = .standard, date: Date = Date()) {
+    nonisolated static func markCleanExit(defaults: UserDefaults = .standard, date: Date = Date()) {
         defaults.set(date, forKey: lastCleanExitDefaultsKey)
     }
 
@@ -80,78 +80,8 @@ nonisolated enum GhosttyCrashBreadcrumb {
 
     private static func crashReportMatchesCurrentExecutable(_ url: URL, currentExecutableURL: URL?) -> Bool {
         guard let currentExecutableURL else { return true }
-        guard let reportedExecutablePaths = reportedExecutablePaths(in: url) else { return true }
-        let currentExecutablePath = normalizedPath(currentExecutableURL.path)
+        guard let reportedExecutablePaths = GhosttyCrashReportMetadata.reportedExecutablePaths(in: url) else { return true }
+        let currentExecutablePath = GhosttyCrashReportMetadata.normalizedPath(currentExecutableURL.path)
         return reportedExecutablePaths.contains(currentExecutablePath)
-    }
-
-    private static func reportedExecutablePaths(in url: URL) -> Set<String>? {
-        guard let data = try? Data(contentsOf: url, options: .mappedIfSafe),
-              let event = sentryEvent(from: data),
-              let debugMeta = event["debug_meta"] as? [String: Any],
-              let images = debugMeta["images"] as? [[String: Any]]
-        else {
-            return nil
-        }
-
-        let paths = images.compactMap { image -> String? in
-            guard let codeFile = image["code_file"] as? String else { return nil }
-            let trimmedPath = codeFile.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !trimmedPath.isEmpty else { return nil }
-            return normalizedPath(trimmedPath)
-        }
-        return paths.isEmpty ? nil : Set(paths)
-    }
-
-    private static func sentryEvent(from data: Data) -> [String: Any]? {
-        guard let envelopeHeaderRange = lineRange(after: data.startIndex, in: data) else {
-            return nil
-        }
-        let itemHeaderStart = data.index(after: envelopeHeaderRange.upperBound)
-        guard let itemHeaderRange = lineRange(after: itemHeaderStart, in: data),
-              let itemHeader = jsonObject(in: itemHeaderRange, from: data),
-              itemHeader["type"] as? String == "event"
-        else {
-            return nil
-        }
-
-        let payloadStart = data.index(after: itemHeaderRange.upperBound)
-        if let length = itemHeader["length"] as? Int {
-            guard length >= 0,
-                  let payloadEnd = data.index(payloadStart, offsetBy: length, limitedBy: data.endIndex)
-            else {
-                return nil
-            }
-            return jsonObject(in: payloadStart..<payloadEnd, from: data)
-        }
-
-        guard let payloadRange = lineRange(after: payloadStart, in: data) else {
-            return nil
-        }
-        return jsonObject(in: payloadRange, from: data)
-    }
-
-    private static func lineRange(after startIndex: Data.Index, in data: Data) -> Range<Data.Index>? {
-        guard startIndex < data.endIndex,
-              let newlineIndex = data[startIndex...].firstIndex(of: 0x0A)
-        else {
-            return nil
-        }
-        return startIndex..<newlineIndex
-    }
-
-    private static func jsonObject(in range: Range<Data.Index>, from data: Data) -> [String: Any]? {
-        guard range.lowerBound <= range.upperBound else { return nil }
-        guard let object = try? JSONSerialization.jsonObject(with: data.subdata(in: range)) else {
-            return nil
-        }
-        return object as? [String: Any]
-    }
-
-    private static func normalizedPath(_ path: String) -> String {
-        URL(fileURLWithPath: path)
-            .standardizedFileURL
-            .resolvingSymlinksInPath()
-            .path
     }
 }

--- a/Sources/GhosttyCrashBreadcrumb.swift
+++ b/Sources/GhosttyCrashBreadcrumb.swift
@@ -25,9 +25,14 @@ nonisolated enum GhosttyCrashBreadcrumb {
     static func pendingCrash(
         in crashDirectoryURL: URL = defaultCrashDirectoryURL,
         defaults: UserDefaults = .standard,
-        fileManager: FileManager = .default
+        fileManager: FileManager = .default,
+        currentExecutableURL: URL? = Bundle.main.executableURL
     ) -> PendingCrash? {
-        guard let latest = latestCrashFile(in: crashDirectoryURL, fileManager: fileManager) else {
+        guard let latest = latestCrashFile(
+            in: crashDirectoryURL,
+            fileManager: fileManager,
+            currentExecutableURL: currentExecutableURL
+        ) else {
             return nil
         }
 
@@ -49,7 +54,8 @@ nonisolated enum GhosttyCrashBreadcrumb {
 
     private static func latestCrashFile(
         in crashDirectoryURL: URL,
-        fileManager: FileManager
+        fileManager: FileManager,
+        currentExecutableURL: URL?
     ) -> PendingCrash? {
         guard let urls = try? fileManager.contentsOfDirectory(
             at: crashDirectoryURL,
@@ -61,6 +67,7 @@ nonisolated enum GhosttyCrashBreadcrumb {
 
         return urls
             .filter { $0.pathExtension == "ghosttycrash" }
+            .filter { crashReportMatchesCurrentExecutable($0, currentExecutableURL: currentExecutableURL) }
             .compactMap { url -> PendingCrash? in
                 guard let values = try? url.resourceValues(forKeys: [.contentModificationDateKey]),
                       let modifiedAt = values.contentModificationDate else {
@@ -69,5 +76,82 @@ nonisolated enum GhosttyCrashBreadcrumb {
                 return PendingCrash(fileURL: url, modifiedAt: modifiedAt)
             }
             .max { lhs, rhs in lhs.modifiedAt < rhs.modifiedAt }
+    }
+
+    private static func crashReportMatchesCurrentExecutable(_ url: URL, currentExecutableURL: URL?) -> Bool {
+        guard let currentExecutableURL else { return true }
+        guard let reportedExecutablePaths = reportedExecutablePaths(in: url) else { return true }
+        let currentExecutablePath = normalizedPath(currentExecutableURL.path)
+        return reportedExecutablePaths.contains(currentExecutablePath)
+    }
+
+    private static func reportedExecutablePaths(in url: URL) -> Set<String>? {
+        guard let data = try? Data(contentsOf: url, options: .mappedIfSafe),
+              let event = sentryEvent(from: data),
+              let debugMeta = event["debug_meta"] as? [String: Any],
+              let images = debugMeta["images"] as? [[String: Any]]
+        else {
+            return nil
+        }
+
+        let paths = images.compactMap { image -> String? in
+            guard let codeFile = image["code_file"] as? String else { return nil }
+            let trimmedPath = codeFile.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmedPath.isEmpty else { return nil }
+            return normalizedPath(trimmedPath)
+        }
+        return paths.isEmpty ? nil : Set(paths)
+    }
+
+    private static func sentryEvent(from data: Data) -> [String: Any]? {
+        guard let envelopeHeaderRange = lineRange(after: data.startIndex, in: data) else {
+            return nil
+        }
+        let itemHeaderStart = data.index(after: envelopeHeaderRange.upperBound)
+        guard let itemHeaderRange = lineRange(after: itemHeaderStart, in: data),
+              let itemHeader = jsonObject(in: itemHeaderRange, from: data),
+              itemHeader["type"] as? String == "event"
+        else {
+            return nil
+        }
+
+        let payloadStart = data.index(after: itemHeaderRange.upperBound)
+        if let length = itemHeader["length"] as? Int {
+            guard length >= 0,
+                  let payloadEnd = data.index(payloadStart, offsetBy: length, limitedBy: data.endIndex)
+            else {
+                return nil
+            }
+            return jsonObject(in: payloadStart..<payloadEnd, from: data)
+        }
+
+        guard let payloadRange = lineRange(after: payloadStart, in: data) else {
+            return nil
+        }
+        return jsonObject(in: payloadRange, from: data)
+    }
+
+    private static func lineRange(after startIndex: Data.Index, in data: Data) -> Range<Data.Index>? {
+        guard startIndex < data.endIndex,
+              let newlineIndex = data[startIndex...].firstIndex(of: 0x0A)
+        else {
+            return nil
+        }
+        return startIndex..<newlineIndex
+    }
+
+    private static func jsonObject(in range: Range<Data.Index>, from data: Data) -> [String: Any]? {
+        guard range.lowerBound <= range.upperBound else { return nil }
+        guard let object = try? JSONSerialization.jsonObject(with: data.subdata(in: range)) else {
+            return nil
+        }
+        return object as? [String: Any]
+    }
+
+    private static func normalizedPath(_ path: String) -> String {
+        URL(fileURLWithPath: path)
+            .standardizedFileURL
+            .resolvingSymlinksInPath()
+            .path
     }
 }

--- a/Sources/GhosttyCrashBreadcrumb.swift
+++ b/Sources/GhosttyCrashBreadcrumb.swift
@@ -15,7 +15,7 @@ nonisolated enum GhosttyCrashBreadcrumb {
             .appendingPathComponent(".local/state/cmux/crash", isDirectory: true)
     }
 
-    @concurrent
+    @Sendable
     nonisolated static func pendingCrashFromDefaultStorage() async -> PendingCrash? {
         await Task.detached(priority: .utility) {
             pendingCrash()

--- a/Sources/GhosttyCrashReportMetadata.swift
+++ b/Sources/GhosttyCrashReportMetadata.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+nonisolated enum GhosttyCrashReportMetadata {
+    static func reportedExecutablePaths(in url: URL) -> Set<String>? {
+        guard let data = try? Data(contentsOf: url, options: .mappedIfSafe),
+              let event = sentryEvent(from: data),
+              let debugMeta = event["debug_meta"] as? [String: Any],
+              let images = debugMeta["images"] as? [[String: Any]]
+        else {
+            return nil
+        }
+
+        let paths = images.compactMap { image -> String? in
+            guard let codeFile = image["code_file"] as? String else { return nil }
+            let trimmedPath = codeFile.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmedPath.isEmpty else { return nil }
+            return normalizedPath(trimmedPath)
+        }
+        return paths.isEmpty ? nil : Set(paths)
+    }
+
+    static func normalizedPath(_ path: String) -> String {
+        URL(fileURLWithPath: path)
+            .standardizedFileURL
+            .resolvingSymlinksInPath()
+            .path
+    }
+
+    private static func sentryEvent(from data: Data) -> [String: Any]? {
+        guard let envelopeHeaderRange = lineRange(after: data.startIndex, in: data) else {
+            return nil
+        }
+        let itemHeaderStart = data.index(after: envelopeHeaderRange.upperBound)
+        guard let itemHeaderRange = lineRange(after: itemHeaderStart, in: data),
+              let itemHeader = jsonObject(in: itemHeaderRange, from: data),
+              itemHeader["type"] as? String == "event"
+        else {
+            return nil
+        }
+
+        let payloadStart = data.index(after: itemHeaderRange.upperBound)
+        if let length = itemHeader["length"] as? Int {
+            guard length >= 0,
+                  let payloadEnd = data.index(payloadStart, offsetBy: length, limitedBy: data.endIndex)
+            else {
+                return nil
+            }
+            return jsonObject(in: payloadStart..<payloadEnd, from: data)
+        }
+
+        guard let payloadRange = lineRange(after: payloadStart, in: data) else {
+            return nil
+        }
+        return jsonObject(in: payloadRange, from: data)
+    }
+
+    private static func lineRange(after startIndex: Data.Index, in data: Data) -> Range<Data.Index>? {
+        guard startIndex < data.endIndex,
+              let newlineIndex = data[startIndex...].firstIndex(of: 0x0A)
+        else {
+            return nil
+        }
+        return startIndex..<newlineIndex
+    }
+
+    private static func jsonObject(in range: Range<Data.Index>, from data: Data) -> [String: Any]? {
+        guard range.lowerBound <= range.upperBound else { return nil }
+        guard let object = try? JSONSerialization.jsonObject(with: data.subdata(in: range)) else {
+            return nil
+        }
+        return object as? [String: Any]
+    }
+}

--- a/Sources/GhosttyCrashReportMetadata.swift
+++ b/Sources/GhosttyCrashReportMetadata.swift
@@ -30,28 +30,42 @@ nonisolated enum GhosttyCrashReportMetadata {
         guard let envelopeHeaderRange = lineRange(after: data.startIndex, in: data) else {
             return nil
         }
-        let itemHeaderStart = data.index(after: envelopeHeaderRange.upperBound)
-        guard let itemHeaderRange = lineRange(after: itemHeaderStart, in: data),
-              let itemHeader = jsonObject(in: itemHeaderRange, from: data),
-              itemHeader["type"] as? String == "event"
-        else {
-            return nil
-        }
 
-        let payloadStart = data.index(after: itemHeaderRange.upperBound)
-        if let length = itemHeader["length"] as? Int {
-            guard length >= 0,
-                  let payloadEnd = data.index(payloadStart, offsetBy: length, limitedBy: data.endIndex)
+        var itemHeaderStart = data.index(after: envelopeHeaderRange.upperBound)
+        while itemHeaderStart < data.endIndex {
+            guard let itemHeaderRange = lineRange(after: itemHeaderStart, in: data),
+                  let itemHeader = jsonObject(in: itemHeaderRange, from: data)
             else {
                 return nil
             }
-            return jsonObject(in: payloadStart..<payloadEnd, from: data)
+
+            let payloadStart = data.index(after: itemHeaderRange.upperBound)
+            let payloadRange: Range<Data.Index>
+            if let length = itemHeader["length"] as? Int {
+                guard length >= 0,
+                      let payloadEnd = data.index(payloadStart, offsetBy: length, limitedBy: data.endIndex)
+                else {
+                    return nil
+                }
+                payloadRange = payloadStart..<payloadEnd
+                itemHeaderStart = payloadEnd
+                if itemHeaderStart < data.endIndex, data[itemHeaderStart] == 0x0A {
+                    itemHeaderStart = data.index(after: itemHeaderStart)
+                }
+            } else {
+                guard let lineRange = lineRange(after: payloadStart, in: data) else {
+                    return nil
+                }
+                payloadRange = lineRange
+                itemHeaderStart = data.index(after: lineRange.upperBound)
+            }
+
+            if itemHeader["type"] as? String == "event" {
+                return jsonObject(in: payloadRange, from: data)
+            }
         }
 
-        guard let payloadRange = lineRange(after: payloadStart, in: data) else {
-            return nil
-        }
-        return jsonObject(in: payloadRange, from: data)
+        return nil
     }
 
     private static func lineRange(after startIndex: Data.Index, in data: Data) -> Range<Data.Index>? {

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -314,6 +314,7 @@
 		A5001670 /* SessionRestoredTerminalCommandStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001671 /* SessionRestoredTerminalCommandStore.swift */; };
 		A5001621 /* AppleScriptSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001620 /* AppleScriptSupport.swift */; };
 		C3873001C3873001C3873001 /* GhosttyCrashBreadcrumb.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3873002C3873002C3873002 /* GhosttyCrashBreadcrumb.swift */; };
+		C3873003C3873003C3873003 /* GhosttyCrashReportMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3873004C3873004C3873004 /* GhosttyCrashReportMetadata.swift */; };
 		A5001623 /* cmux.sdef in Resources */ = {isa = PBXBuildFile; fileRef = A5001622 /* cmux.sdef */; };
 		A5001640 /* RemoteRelayZshBootstrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001641 /* RemoteRelayZshBootstrap.swift */; };
 		A5001660 /* RestorableAgentSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001661 /* RestorableAgentSession.swift */; };
@@ -732,6 +733,7 @@
 		C7A505000000000000000001 /* TerminalControllerTopSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalControllerTopSupport.swift; sourceTree = "<group>"; };
 		A5001090 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C3873002C3873002C3873002 /* GhosttyCrashBreadcrumb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyCrashBreadcrumb.swift; sourceTree = "<group>"; };
+		C3873004C3873004C3873004 /* GhosttyCrashReportMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyCrashReportMetadata.swift; sourceTree = "<group>"; };
 		C3677002000000000000002 /* CmuxSSHURLRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxSSHURLRequest.swift; sourceTree = "<group>"; };
 		C3677004000000000000002 /* AppDelegate+CmuxSSHURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+CmuxSSHURL.swift"; sourceTree = "<group>"; };
 		E3309A02 /* AppDelegate+EqualizeSplitsShortcut.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+EqualizeSplitsShortcut.swift"; sourceTree = "<group>"; };
@@ -1297,6 +1299,7 @@
 				A5001090 /* AppDelegate.swift */,
 				3865B0063865B0063865B006 /* AppDelegate+GlobalSearch.swift */,
 				C3873002C3873002C3873002 /* GhosttyCrashBreadcrumb.swift */,
+				C3873004C3873004C3873004 /* GhosttyCrashReportMetadata.swift */,
 				C3677002000000000000002 /* CmuxSSHURLRequest.swift */,
 				C3677004000000000000002 /* AppDelegate+CmuxSSHURL.swift */,
 				E3309A02 /* AppDelegate+EqualizeSplitsShortcut.swift */,
@@ -2010,6 +2013,7 @@
 				A5001601 /* SentryHelper.swift in Sources */,
 				A5001621 /* AppleScriptSupport.swift in Sources */,
 				C3873001C3873001C3873001 /* GhosttyCrashBreadcrumb.swift in Sources */,
+				C3873003C3873003C3873003 /* GhosttyCrashReportMetadata.swift in Sources */,
 				A5001093 /* AppDelegate.swift in Sources */,
 				C3677002000000000000001 /* CmuxSSHURLRequest.swift in Sources */,
 				C3677004000000000000001 /* AppDelegate+CmuxSSHURL.swift in Sources */,

--- a/cmuxTests/NotificationAndMenuBarTests.swift
+++ b/cmuxTests/NotificationAndMenuBarTests.swift
@@ -470,6 +470,33 @@ final class GhosttyCrashBreadcrumbTests: XCTestCase {
         XCTAssertEqual(pending?.modifiedAt, currentCrashDate)
     }
 
+    func testPendingCrashIgnoresForeignCrashWhenEventIsNotFirstEnvelopeItem() throws {
+        let currentCrashDate = Date(timeIntervalSince1970: 200)
+        let foreignCrashDate = Date(timeIntervalSince1970: 300)
+        let currentExecutablePath = try XCTUnwrap(Bundle.main.executableURL?.path)
+        let currentCrashURL = try writeCrashEnvelope(
+            named: "current-before-foreign-leading-item.ghosttycrash",
+            executablePath: currentExecutablePath,
+            modifiedAt: currentCrashDate
+        )
+        _ = try writeCrashEnvelope(
+            named: "foreign-leading-item.ghosttycrash",
+            executablePath: "/private/tmp/cmux-tbinput-unit/Build/Products/Debug/cmux DEV.app/Contents/MacOS/cmux DEV",
+            modifiedAt: foreignCrashDate,
+            leadingItems: [
+                (type: "attachment", payload: Data(#"{"filename":"metadata.txt"}"#.utf8)),
+            ]
+        )
+
+        let pending = GhosttyCrashBreadcrumb.pendingCrash(
+            in: crashDirectoryURL,
+            defaults: defaults
+        )
+
+        XCTAssertEqual(pending?.fileURL.resolvingSymlinksInPath(), currentCrashURL.resolvingSymlinksInPath())
+        XCTAssertEqual(pending?.modifiedAt, currentCrashDate)
+    }
+
     func testPendingCrashReturnsNilForOnlyDifferentExecutableCrash() throws {
         _ = try writeCrashEnvelope(
             named: "foreign-only.ghosttycrash",
@@ -517,7 +544,12 @@ final class GhosttyCrashBreadcrumbTests: XCTestCase {
         return url
     }
 
-    private func writeCrashEnvelope(named name: String, executablePath: String, modifiedAt: Date) throws -> URL {
+    private func writeCrashEnvelope(
+        named name: String,
+        executablePath: String,
+        modifiedAt: Date,
+        leadingItems: [(type: String, payload: Data)] = []
+    ) throws -> URL {
         let url = crashDirectoryURL.appendingPathComponent(name)
         let event = [
             "debug_meta": [
@@ -532,6 +564,13 @@ final class GhosttyCrashBreadcrumbTests: XCTestCase {
         let eventHeader = #"{"type":"event","length":\#(eventData.count)}"#
         var envelope = Data(#"{"event_id":"00000000-0000-0000-0000-000000000000"}"#.utf8)
         envelope.append(0x0A)
+        for item in leadingItems {
+            let itemHeader = #"{"type":"\#(item.type)","length":\#(item.payload.count)}"#
+            envelope.append(Data(itemHeader.utf8))
+            envelope.append(0x0A)
+            envelope.append(item.payload)
+            envelope.append(0x0A)
+        }
         envelope.append(Data(eventHeader.utf8))
         envelope.append(0x0A)
         envelope.append(eventData)

--- a/cmuxTests/NotificationAndMenuBarTests.swift
+++ b/cmuxTests/NotificationAndMenuBarTests.swift
@@ -426,6 +426,26 @@ final class GhosttyCrashBreadcrumbTests: XCTestCase {
         XCTAssertEqual(pending?.modifiedAt, crashDate)
     }
 
+    func testPendingCrashDetectedFromMatchingEnvelopeWhenNewerThanCleanExit() throws {
+        let cleanExit = Date(timeIntervalSince1970: 100)
+        let crashDate = Date(timeIntervalSince1970: 200)
+        defaults.set(cleanExit, forKey: GhosttyCrashBreadcrumb.lastCleanExitDefaultsKey)
+        let currentExecutablePath = try XCTUnwrap(Bundle.main.executableURL?.path)
+        let crashURL = try writeCrashEnvelope(
+            named: "matching-newer.ghosttycrash",
+            executablePath: currentExecutablePath,
+            modifiedAt: crashDate
+        )
+
+        let pending = GhosttyCrashBreadcrumb.pendingCrash(
+            in: crashDirectoryURL,
+            defaults: defaults
+        )
+
+        XCTAssertEqual(pending?.fileURL.resolvingSymlinksInPath(), crashURL.resolvingSymlinksInPath())
+        XCTAssertEqual(pending?.modifiedAt, crashDate)
+    }
+
     func testPendingCrashIgnoresNewerCrashFromDifferentExecutable() throws {
         let currentCrashDate = Date(timeIntervalSince1970: 200)
         let foreignCrashDate = Date(timeIntervalSince1970: 300)

--- a/cmuxTests/NotificationAndMenuBarTests.swift
+++ b/cmuxTests/NotificationAndMenuBarTests.swift
@@ -426,6 +426,30 @@ final class GhosttyCrashBreadcrumbTests: XCTestCase {
         XCTAssertEqual(pending?.modifiedAt, crashDate)
     }
 
+    func testPendingCrashIgnoresNewerCrashFromDifferentExecutable() throws {
+        let currentCrashDate = Date(timeIntervalSince1970: 200)
+        let foreignCrashDate = Date(timeIntervalSince1970: 300)
+        let currentExecutablePath = try XCTUnwrap(Bundle.main.executableURL?.path)
+        let currentCrashURL = try writeCrashEnvelope(
+            named: "current.ghosttycrash",
+            executablePath: currentExecutablePath,
+            modifiedAt: currentCrashDate
+        )
+        _ = try writeCrashEnvelope(
+            named: "foreign.ghosttycrash",
+            executablePath: "/private/tmp/cmux-tbinput-unit/Build/Products/Debug/cmux DEV.app/Contents/MacOS/cmux DEV",
+            modifiedAt: foreignCrashDate
+        )
+
+        let pending = GhosttyCrashBreadcrumb.pendingCrash(
+            in: crashDirectoryURL,
+            defaults: defaults
+        )
+
+        XCTAssertEqual(pending?.fileURL, currentCrashURL)
+        XCTAssertEqual(pending?.modifiedAt, currentCrashDate)
+    }
+
     func testDefaultCrashDirectoryUsesCmuxStatePath() throws {
         XCTAssertTrue(
             GhosttyCrashBreadcrumb.defaultCrashDirectoryURL.path.hasSuffix("/.local/state/cmux/crash"),
@@ -453,6 +477,33 @@ final class GhosttyCrashBreadcrumbTests: XCTestCase {
     private func writeCrashFile(named name: String, modifiedAt: Date) throws -> URL {
         let url = crashDirectoryURL.appendingPathComponent(name)
         try Data("MDMP".utf8).write(to: url)
+        try FileManager.default.setAttributes(
+            [.modificationDate: modifiedAt],
+            ofItemAtPath: url.path
+        )
+        return url
+    }
+
+    private func writeCrashEnvelope(named name: String, executablePath: String, modifiedAt: Date) throws -> URL {
+        let url = crashDirectoryURL.appendingPathComponent(name)
+        let event = [
+            "debug_meta": [
+                "images": [
+                    [
+                        "code_file": executablePath,
+                    ],
+                ],
+            ],
+        ]
+        let eventData = try JSONSerialization.data(withJSONObject: event)
+        let eventHeader = #"{"type":"event","length":\#(eventData.count)}"#
+        var envelope = Data(#"{"event_id":"00000000-0000-0000-0000-000000000000"}"#.utf8)
+        envelope.append(0x0A)
+        envelope.append(Data(eventHeader.utf8))
+        envelope.append(0x0A)
+        envelope.append(eventData)
+        envelope.append(0x0A)
+        try envelope.write(to: url)
         try FileManager.default.setAttributes(
             [.modificationDate: modifiedAt],
             ofItemAtPath: url.path

--- a/cmuxTests/NotificationAndMenuBarTests.swift
+++ b/cmuxTests/NotificationAndMenuBarTests.swift
@@ -422,7 +422,7 @@ final class GhosttyCrashBreadcrumbTests: XCTestCase {
             defaults: defaults
         )
 
-        XCTAssertEqual(pending?.fileURL, crashURL)
+        XCTAssertEqual(pending?.fileURL.resolvingSymlinksInPath(), crashURL.resolvingSymlinksInPath())
         XCTAssertEqual(pending?.modifiedAt, crashDate)
     }
 
@@ -446,8 +446,21 @@ final class GhosttyCrashBreadcrumbTests: XCTestCase {
             defaults: defaults
         )
 
-        XCTAssertEqual(pending?.fileURL, currentCrashURL)
+        XCTAssertEqual(pending?.fileURL.resolvingSymlinksInPath(), currentCrashURL.resolvingSymlinksInPath())
         XCTAssertEqual(pending?.modifiedAt, currentCrashDate)
+    }
+
+    func testPendingCrashReturnsNilForOnlyDifferentExecutableCrash() throws {
+        _ = try writeCrashEnvelope(
+            named: "foreign-only.ghosttycrash",
+            executablePath: "/private/tmp/cmux-tbinput-unit/Build/Products/Debug/cmux DEV.app/Contents/MacOS/cmux DEV",
+            modifiedAt: Date(timeIntervalSince1970: 300)
+        )
+
+        XCTAssertNil(GhosttyCrashBreadcrumb.pendingCrash(
+            in: crashDirectoryURL,
+            defaults: defaults
+        ))
     }
 
     func testDefaultCrashDirectoryUsesCmuxStatePath() throws {
@@ -464,7 +477,7 @@ final class GhosttyCrashBreadcrumbTests: XCTestCase {
             in: crashDirectoryURL,
             defaults: defaults
         ))
-        XCTAssertEqual(pending.fileURL, crashURL)
+        XCTAssertEqual(pending.fileURL.resolvingSymlinksInPath(), crashURL.resolvingSymlinksInPath())
 
         GhosttyCrashBreadcrumb.markShown(pending, defaults: defaults)
 


### PR DESCRIPTION
Summary
- Filter Ghostty crash breadcrumb files by the current app executable path.
- Keep legacy or malformed crash reports visible when executable metadata cannot be read.
- Added regression coverage for newer crash reports from other cmux builds.

Red failure
- Commit fa0aeae9d: `xcodebuildmcp macos test --project-path cmux.xcodeproj --scheme cmux-unit --configuration Debug --derived-data-path /tmp/cmux-crashbt-red --json '{"extraArgs":["-only-testing:cmuxTests/GhosttyCrashBreadcrumbTests/testPendingCrashIgnoresNewerCrashFromDifferentExecutable"]}' --output json` failed because `foreign.ghosttycrash` was selected over `current.ghosttycrash`.\n\nGreen pass\n- `xcodebuildmcp macos test --project-path cmux.xcodeproj --scheme cmux-unit --configuration Debug --derived-data-path /tmp/cmux-crashbt-green --json '{"extraArgs":["-only-testing:cmuxTests/GhosttyCrashBreadcrumbTests"]}' --output json` passed, 5 tests.\n- `./scripts/reload.sh --tag crashbt` passed.\n\nCrash evidence\n- Latest local diagnostic: `/Users/lawrence/.local/state/cmux/crash/28c81e8c-fb23-4263-14ce-38028eda1dfd.ghosttycrash`, timestamp 2026-05-16T07:23:45Z, executable `/private/tmp/cmux-tbinput-unit/Build/Products/Debug/cmux DEV.app/Contents/MacOS/cmux DEV`, XCTest-injected.\n- Latest real installed app diagnostic found: `/Users/lawrence/.local/state/cmux/crash/2d78ed00-d05d-44a3-a56e-bcd6efc9be2c.ghosttycrash`, timestamp 2026-05-15T12:33:10Z, executable `/Applications/cmux.app/Contents/MacOS/cmux`.\n\nDogfood\n- Tagged build: crashbt.\n- `reload.sh` printed dev web origin `http://localhost:9930`, but cmux helper terminal creation failed: `surface-health` reported the helper terminal `in_window: false`, `read-screen` returned `Terminal surface not found`, and `cmux top` showed no process for the helper surface. I cleaned up the empty helper pane, so the matching visible web dev server is not running.\n

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes crash-breadcrumb selection logic by parsing and filtering crash reports by the running executable path, which could unintentionally hide valid crash prompts if metadata parsing or path normalization is wrong.
> 
> **Overview**
> **Crash breadcrumb detection now ignores reports from other builds.** `GhosttyCrashBreadcrumb.pendingCrash` filters `.ghosttycrash` files by matching the crash report’s recorded executable path against `Bundle.main.executableURL` (with symlink-resolved normalization), while falling back to legacy behavior when metadata is unavailable.
> 
> This adds `GhosttyCrashReportMetadata` to parse Sentry envelope crash files and extract `debug_meta.images[].code_file`, updates the Xcode project to include it, and expands unit tests to cover matching vs foreign executables, non-leading envelope items, and symlink-safe URL comparisons.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f55fa6a19a5d09ccc8a6f324082fe856cb769ef3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Filters Ghostty crash breadcrumbs to only show crashes from the current app executable. Hardened Sentry envelope parsing scans all items and tolerates malformed files to avoid surfacing crashes from other builds.

- **Bug Fixes**
  - Only select `.ghosttycrash` files whose Sentry envelope `debug_meta.images[].code_file` matches `Bundle.main.executableURL` (normalized, symlinks resolved).
  - Parse Sentry envelopes by scanning all items to find the `event`; support length-bound and newline-delimited payloads; tolerate malformed files.
  - Fall back to legacy behavior when executable metadata or the current executable path is unavailable; tests cover matching vs foreign envelopes, non-leading event items, and nil when only foreign crashes exist.
  - Mark `GhosttyCrashBreadcrumb` APIs as `nonisolated` and allow `currentExecutableURL` injection to keep concurrency warnings clean.

<sup>Written for commit f55fa6a19a5d09ccc8a6f324082fe856cb769ef3. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4271?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added parsing of stored crash-report metadata to extract executable paths.

* **Bug Fixes**
  * Crash detection now filters reports to only those matching the running executable, selecting the newest matching report and ignoring foreign-executable reports to reduce false positives and incorrect picks.

* **Tests**
  * Expanded tests for executable-aware crash selection and symlink-resolved path comparisons; added cases for newer vs. foreign crashes and empty-match scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4271?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->