### PR TITLE
Fix conditional light theme foreground rendering

### DIFF
--- a/Sources/GhosttyApp+SurfaceConfigurationReload.swift
+++ b/Sources/GhosttyApp+SurfaceConfigurationReload.swift
@@ -2,7 +2,8 @@ extension GhosttyApp {
     func reloadSurfaceConfiguration(
         _ surface: ghostty_surface_t,
         soft: Bool = false,
-        source: String = "unspecified"
+        source: String = "unspecified",
+        preferredColorScheme: GhosttyConfig.ColorSchemePreference? = nil
     ) {
         if soft, let config {
             ghostty_surface_update_config(surface, config)
@@ -11,7 +12,11 @@ extension GhosttyApp {
         }
 
         guard let newConfig = ghostty_config_new() else { return }
-        _ = loadDefaultConfigFilesWithLegacyFallback(newConfig)
+        let reloadColorScheme = preferredColorScheme ?? GhosttyConfig.currentColorSchemePreference()
+        _ = loadDefaultConfigFilesWithLegacyFallback(
+            newConfig,
+            preferredColorScheme: reloadColorScheme
+        )
         // Ghostty Surface.updateConfig derives its own surface state from the
         // passed config. The C API does not retain this temporary pointer.
         ghostty_surface_update_config(surface, newConfig)

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1845,6 +1845,7 @@ class GhosttyApp {
     private var defaultBackgroundUpdateScope: GhosttyDefaultBackgroundUpdateScope = .unscoped
     private var defaultBackgroundScopeSource: String = "initialize"
     private var lastAppearanceColorScheme: GhosttyConfig.ColorSchemePreference?
+    private var synchronizedRuntimeColorScheme: ghostty_color_scheme_e?
     private lazy var defaultBackgroundNotificationDispatcher: GhosttyDefaultBackgroundNotificationDispatcher =
         // Theme chrome should track terminal theme changes in the same frame.
         // Keep coalescing semantics, but flush in the next main turn instead of waiting ~1 frame.
@@ -2953,7 +2954,7 @@ class GhosttyApp {
         previousColorScheme != currentColorScheme
     }
 
-    static func ghosttyRuntimeColorScheme(
+    nonisolated static func ghosttyRuntimeColorScheme(
         for colorScheme: GhosttyConfig.ColorSchemePreference
     ) -> ghostty_color_scheme_e {
         switch colorScheme {
@@ -3179,7 +3180,9 @@ class GhosttyApp {
     ) {
         guard let app else { return }
         let scheme = Self.ghosttyRuntimeColorScheme(for: colorScheme)
+        guard synchronizedRuntimeColorScheme != scheme else { return }
         ghostty_app_set_color_scheme(app, scheme)
+        synchronizedRuntimeColorScheme = scheme
         if backgroundLogEnabled {
             let schemeLabel = colorScheme == .dark ? "dark" : "light"
             logBackground("app color scheme source=\(source) scheme=\(schemeLabel)")

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -2980,9 +2980,21 @@ class GhosttyApp {
         previousColorScheme != currentColorScheme
     }
 
-    struct AppearanceSynchronizationPlan {
-        let runtimeColorScheme: ghostty_color_scheme_e?
-        let shouldReloadConfiguration: Bool
+    enum AppearanceSynchronizationPlan {
+        case unchanged
+        case reload(
+            colorScheme: GhosttyConfig.ColorSchemePreference,
+            runtimeColorScheme: ghostty_color_scheme_e
+        )
+
+        var shouldReloadConfiguration: Bool {
+            switch self {
+            case .unchanged:
+                return false
+            case .reload:
+                return true
+            }
+        }
     }
 
     static func appearanceSynchronizationPlan(
@@ -2993,15 +3005,12 @@ class GhosttyApp {
             previousColorScheme: previousColorScheme,
             currentColorScheme: currentColorScheme
         ) else {
-            return AppearanceSynchronizationPlan(
-                runtimeColorScheme: nil,
-                shouldReloadConfiguration: false
-            )
+            return .unchanged
         }
 
-        return AppearanceSynchronizationPlan(
-            runtimeColorScheme: ghosttyRuntimeColorScheme(for: currentColorScheme),
-            shouldReloadConfiguration: true
+        return .reload(
+            colorScheme: currentColorScheme,
+            runtimeColorScheme: ghosttyRuntimeColorScheme(for: currentColorScheme)
         )
     }
 
@@ -3221,19 +3230,17 @@ class GhosttyApp {
                 "appearance sync source=\(source) previous=\(previousLabel) current=\(currentLabel) reload=\(plan.shouldReloadConfiguration)"
             )
         }
-        guard plan.shouldReloadConfiguration else { return }
-        if let runtimeColorScheme = plan.runtimeColorScheme {
-            synchronizeGhosttyRuntimeColorScheme(
-                runtimeColorScheme,
-                colorScheme: currentColorScheme,
-                source: source
-            )
-        }
-        lastAppearanceColorScheme = currentColorScheme
+        guard case let .reload(colorScheme, runtimeColorScheme) = plan else { return }
+        synchronizeGhosttyRuntimeColorScheme(
+            runtimeColorScheme,
+            colorScheme: colorScheme,
+            source: source
+        )
+        lastAppearanceColorScheme = colorScheme
         reloadConfiguration(
             source: "appearanceSync:\(source)",
             reloadSettingsFromFile: false,
-            preferredColorScheme: currentColorScheme
+            preferredColorScheme: colorScheme
         )
     }
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -2955,6 +2955,31 @@ class GhosttyApp {
         previousColorScheme != currentColorScheme
     }
 
+    struct AppearanceSynchronizationPlan {
+        let runtimeColorScheme: ghostty_color_scheme_e?
+        let shouldReloadConfiguration: Bool
+    }
+
+    static func appearanceSynchronizationPlan(
+        previousColorScheme: GhosttyConfig.ColorSchemePreference?,
+        currentColorScheme: GhosttyConfig.ColorSchemePreference
+    ) -> AppearanceSynchronizationPlan {
+        guard shouldReloadConfigurationForAppearanceChange(
+            previousColorScheme: previousColorScheme,
+            currentColorScheme: currentColorScheme
+        ) else {
+            return AppearanceSynchronizationPlan(
+                runtimeColorScheme: nil,
+                shouldReloadConfiguration: false
+            )
+        }
+
+        return AppearanceSynchronizationPlan(
+            runtimeColorScheme: ghosttyRuntimeColorScheme(for: currentColorScheme),
+            shouldReloadConfiguration: true
+        )
+    }
+
     static func ghosttyRuntimeColorScheme(
         for colorScheme: GhosttyConfig.ColorSchemePreference
     ) -> ghostty_color_scheme_e {
@@ -3147,7 +3172,7 @@ class GhosttyApp {
         let currentColorScheme = GhosttyConfig.currentColorSchemePreference(
             appAppearance: appearance ?? NSApp?.effectiveAppearance
         )
-        let shouldReload = Self.shouldReloadConfigurationForAppearanceChange(
+        let plan = Self.appearanceSynchronizationPlan(
             previousColorScheme: lastAppearanceColorScheme,
             currentColorScheme: currentColorScheme
         )
@@ -3163,12 +3188,19 @@ class GhosttyApp {
             }
             let currentLabel: String = currentColorScheme == .dark ? "dark" : "light"
             logBackground(
-                "appearance sync source=\(source) previous=\(previousLabel) current=\(currentLabel) reload=\(shouldReload)"
+                "appearance sync source=\(source) previous=\(previousLabel) current=\(currentLabel) reload=\(plan.shouldReloadConfiguration)"
             )
         }
-        guard shouldReload else { return }
-        synchronizeGhosttyRuntimeColorScheme(currentColorScheme, source: source)
+        guard plan.runtimeColorScheme != nil || plan.shouldReloadConfiguration else { return }
+        if let runtimeColorScheme = plan.runtimeColorScheme {
+            synchronizeGhosttyRuntimeColorScheme(
+                runtimeColorScheme,
+                colorScheme: currentColorScheme,
+                source: source
+            )
+        }
         lastAppearanceColorScheme = currentColorScheme
+        guard plan.shouldReloadConfiguration else { return }
         reloadConfiguration(
             source: "appearanceSync:\(source)",
             reloadSettingsFromFile: false
@@ -3179,9 +3211,20 @@ class GhosttyApp {
         _ colorScheme: GhosttyConfig.ColorSchemePreference,
         source: String
     ) {
+        synchronizeGhosttyRuntimeColorScheme(
+            Self.ghosttyRuntimeColorScheme(for: colorScheme),
+            colorScheme: colorScheme,
+            source: source
+        )
+    }
+
+    private func synchronizeGhosttyRuntimeColorScheme(
+        _ runtimeColorScheme: ghostty_color_scheme_e,
+        colorScheme: GhosttyConfig.ColorSchemePreference,
+        source: String
+    ) {
         guard let app else { return }
-        let scheme = Self.ghosttyRuntimeColorScheme(for: colorScheme)
-        ghostty_app_set_color_scheme(app, scheme)
+        ghostty_app_set_color_scheme(app, runtimeColorScheme)
         if backgroundLogEnabled {
             let schemeLabel = colorScheme == .dark ? "dark" : "light"
             logBackground("app color scheme source=\(source) scheme=\(schemeLabel)")

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -2953,6 +2953,17 @@ class GhosttyApp {
         previousColorScheme != currentColorScheme
     }
 
+    static func ghosttyRuntimeColorScheme(
+        for colorScheme: GhosttyConfig.ColorSchemePreference
+    ) -> ghostty_color_scheme_e {
+        switch colorScheme {
+        case .light:
+            return GHOSTTY_COLOR_SCHEME_LIGHT
+        case .dark:
+            return GHOSTTY_COLOR_SCHEME_DARK
+        }
+    }
+
     static func shouldCaptureScrollLagEvent(
         samples: Int,
         averageMs: Double,
@@ -3134,6 +3145,7 @@ class GhosttyApp {
         let currentColorScheme = GhosttyConfig.currentColorSchemePreference(
             appAppearance: appearance ?? NSApp?.effectiveAppearance
         )
+        synchronizeGhosttyRuntimeColorScheme(currentColorScheme, source: source)
         let shouldReload = Self.shouldReloadConfigurationForAppearanceChange(
             previousColorScheme: lastAppearanceColorScheme,
             currentColorScheme: currentColorScheme
@@ -3159,6 +3171,19 @@ class GhosttyApp {
             source: "appearanceSync:\(source)",
             reloadSettingsFromFile: false
         )
+    }
+
+    private func synchronizeGhosttyRuntimeColorScheme(
+        _ colorScheme: GhosttyConfig.ColorSchemePreference,
+        source: String
+    ) {
+        guard let app else { return }
+        let scheme = Self.ghosttyRuntimeColorScheme(for: colorScheme)
+        ghostty_app_set_color_scheme(app, scheme)
+        if backgroundLogEnabled {
+            let schemeLabel = colorScheme == .dark ? "dark" : "light"
+            logBackground("app color scheme source=\(source) scheme=\(schemeLabel)")
+        }
     }
 
     func openConfigurationInTextEdit() {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1982,9 +1982,14 @@ class GhosttyApp {
             return
         }
 
+        let initialColorScheme = GhosttyConfig.currentColorSchemePreference()
+
         // Load default config (includes user config). If this fails hard (e.g. due to
         // invalid user config), ghostty_app_new may return nil; we fall back below.
-        let primaryRenderingModeChanged = loadDefaultConfigFilesWithLegacyFallback(primaryConfig)
+        let primaryRenderingModeChanged = loadDefaultConfigFilesWithLegacyFallback(
+            primaryConfig,
+            preferredColorScheme: initialColorScheme
+        )
         updateDefaultBackground(
             from: primaryConfig,
             source: "initialize.primaryConfig",
@@ -2149,7 +2154,6 @@ class GhosttyApp {
         }
 
         // Notify observers that a usable config is available (initial load).
-        let initialColorScheme = GhosttyConfig.currentColorSchemePreference()
         synchronizeGhosttyRuntimeColorScheme(initialColorScheme, source: "initialize")
         lastAppearanceColorScheme = initialColorScheme
         GhosttyConfig.invalidateLoadCache()
@@ -2203,8 +2207,10 @@ class GhosttyApp {
         }
     }
 
-    private func loadCmuxDefaultAppearanceConfig(_ config: ghostty_config_t) {
-        let preferredColorScheme = GhosttyConfig.currentColorSchemePreference()
+    private func loadCmuxDefaultAppearanceConfig(
+        _ config: ghostty_config_t,
+        preferredColorScheme: GhosttyConfig.ColorSchemePreference
+    ) {
         if let url = GhosttyConfig.cmuxDefaultThemeConfigURL(preferredColorScheme: preferredColorScheme) {
             url.path.withCString { path in
                 ghostty_config_load_file(config, path)
@@ -2222,14 +2228,20 @@ class GhosttyApp {
 
     private func loadStartupPreviewProfile(
         _ profile: GhosttyStartupAppearancePreviewProfile,
-        into config: ghostty_config_t
+        into config: ghostty_config_t,
+        preferredColorScheme: GhosttyConfig.ColorSchemePreference
     ) {
         if profile == .freshInstall {
-            loadCmuxDefaultAppearanceConfig(config)
+            loadCmuxDefaultAppearanceConfig(
+                config,
+                preferredColorScheme: preferredColorScheme
+            )
             return
         }
 
-        guard let contents = profile.previewConfigContents() else { return }
+        guard let contents = profile.previewConfigContents(
+            preferredColorScheme: preferredColorScheme
+        ) else { return }
         loadInlineGhosttyConfig(
             contents,
             into: config,
@@ -2238,7 +2250,10 @@ class GhosttyApp {
         )
     }
 
-    func loadDefaultConfigFilesWithLegacyFallback(_ config: ghostty_config_t) -> Bool {
+    func loadDefaultConfigFilesWithLegacyFallback(
+        _ config: ghostty_config_t,
+        preferredColorScheme: GhosttyConfig.ColorSchemePreference = GhosttyConfig.currentColorSchemePreference()
+    ) -> Bool {
         #if DEBUG
         let startupPreviewProfile = GhosttyStartupAppearancePreviewState.profile
         if startupPreviewProfile.loadsRealUserConfig {
@@ -2247,10 +2262,17 @@ class GhosttyApp {
             loadCmuxAppSupportGhosttyConfigIfNeeded(config)
             ghostty_config_load_recursive_files(config)
             if Self.shouldApplyManagedDefaultAppearance() {
-                loadCmuxDefaultAppearanceConfig(config)
+                loadCmuxDefaultAppearanceConfig(
+                    config,
+                    preferredColorScheme: preferredColorScheme
+                )
             }
         } else {
-            loadStartupPreviewProfile(startupPreviewProfile, into: config)
+            loadStartupPreviewProfile(
+                startupPreviewProfile,
+                into: config,
+                preferredColorScheme: preferredColorScheme
+            )
         }
         #else
         ghostty_config_load_default_files(config)
@@ -2258,7 +2280,10 @@ class GhosttyApp {
         loadCmuxAppSupportGhosttyConfigIfNeeded(config)
         ghostty_config_load_recursive_files(config)
         if Self.shouldApplyManagedDefaultAppearance() {
-            loadCmuxDefaultAppearanceConfig(config)
+            loadCmuxDefaultAppearanceConfig(
+                config,
+                preferredColorScheme: preferredColorScheme
+            )
         }
         #endif
         loadCJKFontFallbackIfNeeded(config)
@@ -3106,7 +3131,8 @@ class GhosttyApp {
     func reloadConfiguration(
         soft: Bool = false,
         source: String = "unspecified",
-        reloadSettingsFromFile: Bool = true
+        reloadSettingsFromFile: Bool = true,
+        preferredColorScheme: GhosttyConfig.ColorSchemePreference? = nil
     ) {
         if reloadSettingsFromFile {
             KeyboardShortcutSettings.settingsFileStore.reload()
@@ -3120,6 +3146,7 @@ class GhosttyApp {
                 AppDelegate.shared?.reloadCmuxConfigStores(source: source)
             }
         }
+        let reloadColorScheme = preferredColorScheme ?? GhosttyConfig.currentColorSchemePreference()
         guard let app else {
             logThemeAction("reload skipped source=\(source) soft=\(soft) reason=no_app")
             return
@@ -3128,7 +3155,7 @@ class GhosttyApp {
         resetDefaultBackgroundUpdateScope(source: "reloadConfiguration(source=\(source))")
         if soft, let config {
             ghostty_app_update_config(app, config)
-            lastAppearanceColorScheme = GhosttyConfig.currentColorSchemePreference()
+            lastAppearanceColorScheme = reloadColorScheme
             GhosttyConfig.invalidateLoadCache()
             NotificationCenter.default.post(name: .ghosttyConfigDidReload, object: nil)
             scheduleSurfaceRefreshAfterConfigurationReload(source: source)
@@ -3140,7 +3167,10 @@ class GhosttyApp {
             logThemeAction("reload skipped source=\(source) soft=\(soft) reason=config_alloc_failed")
             return
         }
-        let renderingModeChanged = loadDefaultConfigFilesWithLegacyFallback(newConfig)
+        let renderingModeChanged = loadDefaultConfigFilesWithLegacyFallback(
+            newConfig,
+            preferredColorScheme: reloadColorScheme
+        )
         ghostty_app_update_config(app, newConfig)
         updateDefaultBackground(
             from: newConfig,
@@ -3155,7 +3185,7 @@ class GhosttyApp {
             ghostty_config_free(oldConfig)
         }
         config = newConfig
-        lastAppearanceColorScheme = GhosttyConfig.currentColorSchemePreference()
+        lastAppearanceColorScheme = reloadColorScheme
         GhosttyConfig.invalidateLoadCache()
         NotificationCenter.default.post(name: .ghosttyConfigDidReload, object: nil)
         scheduleSurfaceRefreshAfterConfigurationReload(source: source)
@@ -3191,7 +3221,7 @@ class GhosttyApp {
                 "appearance sync source=\(source) previous=\(previousLabel) current=\(currentLabel) reload=\(plan.shouldReloadConfiguration)"
             )
         }
-        guard plan.runtimeColorScheme != nil || plan.shouldReloadConfiguration else { return }
+        guard plan.shouldReloadConfiguration else { return }
         if let runtimeColorScheme = plan.runtimeColorScheme {
             synchronizeGhosttyRuntimeColorScheme(
                 runtimeColorScheme,
@@ -3200,10 +3230,10 @@ class GhosttyApp {
             )
         }
         lastAppearanceColorScheme = currentColorScheme
-        guard plan.shouldReloadConfiguration else { return }
         reloadConfiguration(
             source: "appearanceSync:\(source)",
-            reloadSettingsFromFile: false
+            reloadSettingsFromFile: false,
+            preferredColorScheme: currentColorScheme
         )
     }
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1845,7 +1845,6 @@ class GhosttyApp {
     private var defaultBackgroundUpdateScope: GhosttyDefaultBackgroundUpdateScope = .unscoped
     private var defaultBackgroundScopeSource: String = "initialize"
     private var lastAppearanceColorScheme: GhosttyConfig.ColorSchemePreference?
-    private var synchronizedRuntimeColorScheme: ghostty_color_scheme_e?
     private lazy var defaultBackgroundNotificationDispatcher: GhosttyDefaultBackgroundNotificationDispatcher =
         // Theme chrome should track terminal theme changes in the same frame.
         // Keep coalescing semantics, but flush in the next main turn instead of waiting ~1 frame.
@@ -2150,7 +2149,9 @@ class GhosttyApp {
         }
 
         // Notify observers that a usable config is available (initial load).
-        lastAppearanceColorScheme = GhosttyConfig.currentColorSchemePreference()
+        let initialColorScheme = GhosttyConfig.currentColorSchemePreference()
+        synchronizeGhosttyRuntimeColorScheme(initialColorScheme, source: "initialize")
+        lastAppearanceColorScheme = initialColorScheme
         GhosttyConfig.invalidateLoadCache()
         NotificationCenter.default.post(name: .ghosttyConfigDidReload, object: nil)
 
@@ -2954,7 +2955,7 @@ class GhosttyApp {
         previousColorScheme != currentColorScheme
     }
 
-    nonisolated static func ghosttyRuntimeColorScheme(
+    static func ghosttyRuntimeColorScheme(
         for colorScheme: GhosttyConfig.ColorSchemePreference
     ) -> ghostty_color_scheme_e {
         switch colorScheme {
@@ -3146,7 +3147,6 @@ class GhosttyApp {
         let currentColorScheme = GhosttyConfig.currentColorSchemePreference(
             appAppearance: appearance ?? NSApp?.effectiveAppearance
         )
-        synchronizeGhosttyRuntimeColorScheme(currentColorScheme, source: source)
         let shouldReload = Self.shouldReloadConfigurationForAppearanceChange(
             previousColorScheme: lastAppearanceColorScheme,
             currentColorScheme: currentColorScheme
@@ -3167,6 +3167,7 @@ class GhosttyApp {
             )
         }
         guard shouldReload else { return }
+        synchronizeGhosttyRuntimeColorScheme(currentColorScheme, source: source)
         lastAppearanceColorScheme = currentColorScheme
         reloadConfiguration(
             source: "appearanceSync:\(source)",
@@ -3180,9 +3181,7 @@ class GhosttyApp {
     ) {
         guard let app else { return }
         let scheme = Self.ghosttyRuntimeColorScheme(for: colorScheme)
-        guard synchronizedRuntimeColorScheme != scheme else { return }
         ghostty_app_set_color_scheme(app, scheme)
-        synchronizedRuntimeColorScheme = scheme
         if backgroundLogEnabled {
             let schemeLabel = colorScheme == .dark ? "dark" : "light"
             logBackground("app color scheme source=\(source) scheme=\(schemeLabel)")

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -480,8 +480,12 @@ final class GhosttyConfigTests: XCTestCase {
             currentColorScheme: .light
         )
 
-        XCTAssertNil(plan.runtimeColorScheme)
-        XCTAssertFalse(plan.shouldReloadConfiguration)
+        switch plan {
+        case .unchanged:
+            XCTAssertFalse(plan.shouldReloadConfiguration)
+        case .reload:
+            XCTFail("Unchanged appearance should not produce a reload plan")
+        }
     }
 
     func testAppearanceSynchronizationPlanUpdatesGhosttyRuntimeWhenReloading() {
@@ -489,7 +493,7 @@ final class GhosttyConfigTests: XCTestCase {
             (
                 previous: GhosttyConfig.ColorSchemePreference?,
                 current: GhosttyConfig.ColorSchemePreference,
-                runtime: ghostty_color_scheme_e?
+                runtime: ghostty_color_scheme_e
             )
         ] = [
             (nil, .dark, GHOSTTY_COLOR_SCHEME_DARK),
@@ -503,8 +507,14 @@ final class GhosttyConfigTests: XCTestCase {
                 currentColorScheme: testCase.current
             )
 
-            XCTAssertEqual(plan.runtimeColorScheme, testCase.runtime)
-            XCTAssertTrue(plan.shouldReloadConfiguration)
+            switch plan {
+            case .unchanged:
+                XCTFail("Changed appearance should produce a reload plan")
+            case let .reload(colorScheme, runtimeColorScheme):
+                XCTAssertEqual(colorScheme, testCase.current)
+                XCTAssertEqual(runtimeColorScheme, testCase.runtime)
+                XCTAssertTrue(plan.shouldReloadConfiguration)
+            }
         }
     }
 

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -474,6 +474,40 @@ final class GhosttyConfigTests: XCTestCase {
         XCTAssertFalse(GhosttyApp.shouldReloadConfigurationForAppearanceChange(previousColorScheme: .dark, currentColorScheme: .dark))
     }
 
+    func testAppearanceSynchronizationPlanSkipsRuntimeUpdateWhenColorSchemeIsUnchanged() {
+        let plan = GhosttyApp.appearanceSynchronizationPlan(
+            previousColorScheme: .light,
+            currentColorScheme: .light
+        )
+
+        XCTAssertNil(plan.runtimeColorScheme)
+        XCTAssertFalse(plan.shouldReloadConfiguration)
+    }
+
+    func testAppearanceSynchronizationPlanUpdatesGhosttyRuntimeWhenReloading() {
+        let cases: [
+            (
+                previous: GhosttyConfig.ColorSchemePreference?,
+                current: GhosttyConfig.ColorSchemePreference,
+                runtime: ghostty_color_scheme_e?
+            )
+        ] = [
+            (nil, .dark, GHOSTTY_COLOR_SCHEME_DARK),
+            (.dark, .light, GHOSTTY_COLOR_SCHEME_LIGHT),
+            (.light, .dark, GHOSTTY_COLOR_SCHEME_DARK),
+        ]
+
+        for testCase in cases {
+            let plan = GhosttyApp.appearanceSynchronizationPlan(
+                previousColorScheme: testCase.previous,
+                currentColorScheme: testCase.current
+            )
+
+            XCTAssertEqual(plan.runtimeColorScheme, testCase.runtime)
+            XCTAssertTrue(plan.shouldReloadConfiguration)
+        }
+    }
+
     func testScrollLagCaptureRequiresSustainedLag() {
         let cases: [(samples: Int, averageMs: Double, maxMs: Double, expected: Bool)] = [
             (4, 18, 85, false),


### PR DESCRIPTION
## Summary
- Fixes #4267.
- Synchronizes Ghostty's app-level runtime color scheme before appearance-driven configuration replay so conditional light/dark themes resolve foreground and palette colors against the active appearance.
- Keeps stable-appearance notifications on the no-op path, with unit coverage for the appearance synchronization plan.

## Testing
- `git diff --check`
- CI only for tests/builds per repo policy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the appearance-change reload path and config loading to explicitly pass/synchronize color scheme, which can affect how themes resolve and when configs are reloaded across app/surface scopes.
> 
> **Overview**
> Fixes conditional light/dark theme resolution by **synchronizing Ghostty’s runtime color scheme before replaying configuration on appearance changes**.
> 
> Threads an explicit `preferredColorScheme` through config loading/reload paths (app + surface) so managed/default appearance configs and startup previews load against the intended scheme, and adds an `AppearanceSynchronizationPlan` (with tests) to ensure the no-op path avoids unnecessary work while reloads carry both the config and runtime scheme updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dce9581178f428a6241dd643cd943888f61634fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->