### PR TITLE
Cmd-click reload duplicates browser tab

### DIFF
--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -5019,6 +5019,52 @@ extension BrowserPanel {
 #endif
     }
 
+    /// Duplicate the current browser surface using the workspace's tab placement rules.
+    @discardableResult
+    func duplicateTabToRight(focus: Bool = true) -> BrowserPanel? {
+#if DEBUG
+        cmuxDebugLog(
+            "browser.duplicate.begin panel=\(id.uuidString.prefix(5)) " +
+            "workspace=\(workspaceId.uuidString.prefix(5))"
+        )
+#endif
+        guard let app = AppDelegate.shared else {
+#if DEBUG
+            cmuxDebugLog("browser.duplicate.abort panel=\(id.uuidString.prefix(5)) reason=missingAppDelegate")
+#endif
+            return nil
+        }
+        guard let workspace = app.workspaceContainingPanel(
+            panelId: id,
+            preferredWorkspaceId: workspaceId
+        )?.workspace else {
+#if DEBUG
+            cmuxDebugLog("browser.duplicate.abort panel=\(id.uuidString.prefix(5)) reason=workspaceMissing")
+#endif
+            return nil
+        }
+
+        guard let newPanel = workspace.duplicateBrowserToRight(panelId: id, focus: focus) else {
+#if DEBUG
+            cmuxDebugLog("browser.duplicate.abort panel=\(id.uuidString.prefix(5)) reason=newPanelFailed")
+#endif
+            return nil
+        }
+#if DEBUG
+        cmuxDebugLog(
+            "browser.duplicate.done panel=\(id.uuidString.prefix(5)) " +
+            "newPanel=\(newPanel.id.uuidString.prefix(5)) workspace=\(workspace.id.uuidString.prefix(5))"
+        )
+#endif
+        return newPanel
+    }
+
+    var currentURLForTabDuplication: URL? {
+        resolvedCurrentSessionHistoryURL()
+            ?? Self.remoteProxyDisplayURL(for: webView.url)
+            ?? currentURL
+    }
+
     /// Reload the current page
     func reload() {
         webView.customUserAgent = BrowserUserAgentSettings.safariUserAgent

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -5019,46 +5019,6 @@ extension BrowserPanel {
 #endif
     }
 
-    /// Duplicate the current browser surface using the workspace's tab placement rules.
-    @discardableResult
-    func duplicateTabToRight(focus: Bool = true) -> BrowserPanel? {
-#if DEBUG
-        cmuxDebugLog(
-            "browser.duplicate.begin panel=\(id.uuidString.prefix(5)) " +
-            "workspace=\(workspaceId.uuidString.prefix(5))"
-        )
-#endif
-        guard let app = AppDelegate.shared else {
-#if DEBUG
-            cmuxDebugLog("browser.duplicate.abort panel=\(id.uuidString.prefix(5)) reason=missingAppDelegate")
-#endif
-            return nil
-        }
-        guard let workspace = app.workspaceContainingPanel(
-            panelId: id,
-            preferredWorkspaceId: workspaceId
-        )?.workspace else {
-#if DEBUG
-            cmuxDebugLog("browser.duplicate.abort panel=\(id.uuidString.prefix(5)) reason=workspaceMissing")
-#endif
-            return nil
-        }
-
-        guard let newPanel = workspace.duplicateBrowserToRight(panelId: id, focus: focus) else {
-#if DEBUG
-            cmuxDebugLog("browser.duplicate.abort panel=\(id.uuidString.prefix(5)) reason=newPanelFailed")
-#endif
-            return nil
-        }
-#if DEBUG
-        cmuxDebugLog(
-            "browser.duplicate.done panel=\(id.uuidString.prefix(5)) " +
-            "newPanel=\(newPanel.id.uuidString.prefix(5)) workspace=\(workspace.id.uuidString.prefix(5))"
-        )
-#endif
-        return newPanel
-    }
-
     var currentURLForTabDuplication: URL? {
         resolvedCurrentSessionHistoryURL()
             ?? Self.remoteProxyDisplayURL(for: webView.url)

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -598,6 +598,41 @@ struct BrowserPanelView: View {
         return currentPaneId.id == paneId.id
     }
 
+    private var currentEventIsCommandPointerActivation: Bool {
+        guard let event = NSApp.currentEvent else { return false }
+        switch event.type {
+        case .leftMouseDown, .leftMouseUp:
+            break
+        default:
+            return false
+        }
+        let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        return flags.contains(.command)
+    }
+
+    private func handleReloadOrStopButtonAction() {
+        if panel.isLoading {
+#if DEBUG
+            cmuxDebugLog("browser.stop panel=\(panel.id.uuidString.prefix(5))")
+#endif
+            panel.stopLoading()
+            return
+        }
+
+        if currentEventIsCommandPointerActivation {
+#if DEBUG
+            cmuxDebugLog("browser.reload.commandClickDuplicate panel=\(panel.id.uuidString.prefix(5))")
+#endif
+            _ = panel.duplicateTabToRight()
+            return
+        }
+
+#if DEBUG
+        cmuxDebugLog("browser.reload panel=\(panel.id.uuidString.prefix(5))")
+#endif
+        panel.reload()
+    }
+
     var body: some View {
         // Layering contract: browser find UI is mounted in the portal-hosted AppKit
         // container. Rendering it here can hide it behind the portal-hosted WKWebView.
@@ -973,19 +1008,7 @@ struct BrowserPanelView: View {
             .opacity(panel.canGoForward ? 1.0 : 0.4)
             .safeHelp(String(localized: "browser.goForward", defaultValue: "Go Forward"))
 
-            Button(action: {
-                if panel.isLoading {
-                    #if DEBUG
-                    cmuxDebugLog("browser.stop panel=\(panel.id.uuidString.prefix(5))")
-                    #endif
-                    panel.stopLoading()
-                } else {
-                    #if DEBUG
-                    cmuxDebugLog("browser.reload panel=\(panel.id.uuidString.prefix(5))")
-                    #endif
-                    panel.reload()
-                }
-            }) {
+            Button(action: handleReloadOrStopButtonAction) {
                 Image(systemName: panel.isLoading ? "xmark" : "arrow.clockwise")
                     .font(.system(size: 12, weight: .medium))
                     .frame(width: addressBarButtonHitSize, height: addressBarButtonHitSize, alignment: .center)

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -601,7 +601,7 @@ struct BrowserPanelView: View {
     private var currentEventIsCommandPointerActivation: Bool {
         guard let event = NSApp.currentEvent else { return false }
         switch event.type {
-        case .leftMouseDown, .leftMouseUp:
+        case .leftMouseUp:
             break
         default:
             return false
@@ -623,7 +623,24 @@ struct BrowserPanelView: View {
 #if DEBUG
             cmuxDebugLog("browser.reload.commandClickDuplicate panel=\(panel.id.uuidString.prefix(5))")
 #endif
-            _ = panel.duplicateTabToRight()
+            guard let workspace = owningWorkspace else {
+#if DEBUG
+                cmuxDebugLog("browser.reload.commandClickDuplicate.abort panel=\(panel.id.uuidString.prefix(5)) reason=workspaceMissing")
+#endif
+                return
+            }
+            guard let newPanel = workspace.duplicateBrowserToRight(panelId: panel.id) else {
+#if DEBUG
+                cmuxDebugLog("browser.reload.commandClickDuplicate.abort panel=\(panel.id.uuidString.prefix(5)) reason=newPanelFailed")
+#endif
+                return
+            }
+#if DEBUG
+            cmuxDebugLog(
+                "browser.reload.commandClickDuplicate.done panel=\(panel.id.uuidString.prefix(5)) " +
+                "newPanel=\(newPanel.id.uuidString.prefix(5))"
+            )
+#endif
             return
         }
 

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -5803,30 +5803,22 @@ class TerminalController {
                 finish()
 
             case "duplicate", "duplicate_tab":
-                guard let anchorTabId = workspace.surfaceIdFromPanelId(surfaceId),
-                      let paneId = workspace.paneId(forPanelId: surfaceId),
-                      let browserPanel = workspace.browserPanel(for: surfaceId) else {
+                guard let browserPanel = workspace.browserPanel(for: surfaceId) else {
                     result = .err(code: "invalid_state", message: "Duplicate is only available for browser tabs", data: nil)
                     return
                 }
                 guard BrowserAvailabilitySettings.isEnabled() else {
                     result = v2BrowserDisabledExternalOpenResult(
-                        url: browserPanel.currentURL,
+                        url: browserPanel.currentURLForTabDuplication,
                         tabManager: tabManager
                     )
                     return
                 }
 
-                let targetIndex = insertionIndexToRight(anchorTabId: anchorTabId, inPane: paneId)
-                guard let newPanel = workspace.newBrowserSurface(
-                    inPane: paneId,
-                    url: browserPanel.currentURL,
-                    focus: focus
-                ) else {
+                guard let newPanel = workspace.duplicateBrowserToRight(panelId: surfaceId, focus: focus) else {
                     result = .err(code: "internal_error", message: "Failed to duplicate tab", data: nil)
                     return
                 }
-                _ = workspace.reorderSurface(panelId: newPanel.id, toIndex: targetIndex, focus: focus)
                 finish([
                     "created_surface_id": newPanel.id.uuidString,
                     "created_surface_ref": v2Ref(kind: .surface, uuid: newPanel.id),

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -13011,17 +13011,20 @@ final class Workspace: Identifiable, ObservableObject {
         _ = reorderSurface(panelId: newPanel.id, toIndex: targetIndex)
     }
 
-    private func duplicateBrowserToRight(anchorTabId: TabID, inPane paneId: PaneID) {
-        guard let panelId = panelIdFromSurfaceId(anchorTabId),
-              let browser = browserPanel(for: panelId) else { return }
+    @discardableResult
+    func duplicateBrowserToRight(panelId: UUID, focus: Bool = true) -> BrowserPanel? {
+        guard let anchorTabId = surfaceIdFromPanelId(panelId),
+              let paneId = paneId(forPanelId: panelId),
+              let browser = browserPanel(for: panelId) else { return nil }
         let targetIndex = insertionIndexToRight(of: anchorTabId, inPane: paneId)
         guard let newPanel = newBrowserSurface(
             inPane: paneId,
-            url: browser.currentURL,
-            focus: true,
+            url: browser.currentURLForTabDuplication,
+            focus: focus,
             preferredProfileID: browser.profileID
-        ) else { return }
-        _ = reorderSurface(panelId: newPanel.id, toIndex: targetIndex)
+        ) else { return nil }
+        _ = reorderSurface(panelId: newPanel.id, toIndex: targetIndex, focus: focus)
+        return newPanel
     }
 
     private func promptRenamePanel(tabId: TabID) {
@@ -14691,7 +14694,8 @@ extension Workspace: BonsplitDelegate {
                   let browser = browserPanel(for: panelId) else { return }
             browser.reload()
         case .duplicate:
-            duplicateBrowserToRight(anchorTabId: tab.id, inPane: pane)
+            guard let panelId = panelIdFromSurfaceId(tab.id) else { return }
+            _ = duplicateBrowserToRight(panelId: panelId)
         case .togglePin:
             guard let panelId = panelIdFromSurfaceId(tab.id) else { return }
             let shouldPin = !pinnedPanelIds.contains(panelId)


### PR DESCRIPTION
## Summary
- make Cmd-click on the browser reload button duplicate the current browser tab instead of reloading
- route browser duplication through the shared workspace duplicate-to-right path for toolbar, tab context, and socket actions
- preserve plain reload and stop behavior

Closes #4280

## Testing
- Not run locally per repo policy; CI will validate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes browser toolbar interaction and centralizes tab-duplication routing, which could affect tab placement/focus and URL restoration behavior across UI and socket actions.
> 
> **Overview**
> Cmd-clicking the browser reload button now **duplicates the current browser tab to the right** (while normal click still reloads and loading state still stops).
> 
> Browser tab duplication is routed through a shared `Workspace.duplicateBrowserToRight(panelId:focus:)` helper used by the toolbar, tab context actions, and `TerminalController` socket actions, and duplication now chooses a best-effort URL via `BrowserPanel.currentURLForTabDuplication` (session history/proxy display/current URL fallback).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cebc2c0f41e10922368b35a9e551613bff42617f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cmd-click on the browser reload button now duplicates the current tab to the right using workspace rules. Plain click still reloads; clicking while loading still stops.

- **New Features**
  - Cmd-click reload duplicates the tab to the right.
  - Uses workspace placement/focus rules for consistency.
  - Picks the best URL to duplicate (session history, proxy display URL, or current URL).

- **Refactors**
  - Centralized duplication via `Workspace.duplicateBrowserToRight(panelId:focus:)` and return the new panel.
  - `TerminalController` duplicate now routes through the same path; removed manual insert/reorder.
  - Standardized URL selection with `BrowserPanel.currentURLForTabDuplication`.
  - Added a shared reload/stop handler and Command-click detection in `BrowserPanelView`.

<sup>Written for commit cebc2c0f41e10922368b35a9e551613bff42617f. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4284?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Duplicate the current browser tab to the right, using a best-effort URL selection so duplicates open at the most relevant page.
  * Command-clicking the reload/stop toolbar button duplicates the tab (when applicable); regular reload and stop behaviors remain unchanged.

* **Refactor**
  * Tab-duplication and toolbar behaviour consolidated for more reliable and consistent interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4284?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->