### PR TITLE
Open markdown files with shared viewer path

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -6726,10 +6726,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
 
 #if DEBUG
-        cmuxDebugLog("file.preview.externalOpen source=\(debugSource) path=\(filePath)")
+        cmuxDebugLog("file.externalOpen source=\(debugSource) path=\(filePath)")
 #endif
-        _ = workspace.openOrFocusFilePreviewSurface(inPane: paneId, filePath: filePath)
-        return true
+        return !workspace.openFileSurfaces(
+            inPane: paneId,
+            filePaths: [filePath],
+            focus: true,
+            reuseExisting: true
+        ).isEmpty
     }
 
     @discardableResult

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2455,7 +2455,12 @@ struct ContentView: View {
         }
 
         sidebarSelectionState.selection = .tabs
-        _ = workspace.openOrFocusFilePreviewSurface(inPane: paneId, filePath: filePath)
+        _ = workspace.openFileSurfaces(
+            inPane: paneId,
+            filePaths: [filePath],
+            focus: true,
+            reuseExisting: true
+        )
     }
 
     private func syncFileExplorerDirectory() {

--- a/Sources/RightSidebarToolPanel.swift
+++ b/Sources/RightSidebarToolPanel.swift
@@ -91,7 +91,12 @@ final class RightSidebarToolPanel: Panel, ObservableObject {
               let paneId = workspace.bonsplitController.focusedPaneId ?? workspace.bonsplitController.allPaneIds.first else {
             return
         }
-        _ = workspace.openOrFocusFilePreviewSurface(inPane: paneId, filePath: filePath)
+        _ = workspace.openFileSurfaces(
+            inPane: paneId,
+            filePaths: [filePath],
+            focus: true,
+            reuseExisting: true
+        )
     }
 
     var isFocusedInWorkspace: Bool {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -13150,14 +13150,14 @@ final class Workspace: Identifiable, ObservableObject {
     ) -> Bool {
         switch destination {
         case .insert(let paneId, let index):
-            return openDroppedFileSurfaces(
+            return !openFileSurfaces(
                 inPane: paneId,
                 filePaths: [entry.filePath],
                 focus: true,
                 targetIndex: index
-            )
+            ).isEmpty
         case .split(let paneId, let orientation, let insertFirst):
-            return splitPaneWithDroppedFile(
+            return splitPaneWithFileSurface(
                 targetPane: paneId,
                 orientation: orientation,
                 insertFirst: insertFirst,
@@ -13179,16 +13179,16 @@ final class Workspace: Identifiable, ObservableObject {
 
         switch request.destination {
         case .insert(let paneId, let index):
-            return openDroppedFileSurfaces(
+            return !openFileSurfaces(
                 inPane: paneId,
                 filePaths: entries.map(\.filePath),
                 focus: true,
                 targetIndex: index
-            )
+            ).isEmpty
 
         case .split(let sourcePaneId, let orientation, let insertFirst):
             guard let first = entries.first,
-                  let firstPanel = splitPaneWithDroppedFile(
+                  let firstPanel = splitPaneWithFileSurface(
                     targetPane: sourcePaneId,
                     orientation: orientation,
                     insertFirst: insertFirst,
@@ -13198,59 +13198,17 @@ final class Workspace: Identifiable, ObservableObject {
             }
 
             let targetPane = paneId(forPanelId: firstPanel.id) ?? sourcePaneId
-            var openedAny = true
-            let openedRest = openDroppedFileSurfaces(
+            _ = openFileSurfaces(
                 inPane: targetPane,
                 filePaths: entries.dropFirst().map(\.filePath),
                 focus: true
             )
-            openedAny = openedAny || openedRest
-            return openedAny
+            return true
         }
     }
 
     @discardableResult
-    private func openDroppedFileSurfaces(
-        inPane paneId: PaneID,
-        filePaths: [String],
-        focus: Bool? = nil,
-        targetIndex: Int? = nil
-    ) -> Bool {
-        let shouldFocusNewTabs = focus ?? (bonsplitController.focusedPaneId == paneId)
-        var nextIndex = targetIndex
-        var openedAny = false
-
-        for filePath in filePaths {
-            let opened: Bool
-            if MarkdownPanelFileLinkResolver.isMarkdownPathLike(filePath) {
-                opened = newMarkdownSurface(
-                    inPane: paneId,
-                    filePath: filePath,
-                    focus: shouldFocusNewTabs,
-                    targetIndex: nextIndex
-                ) != nil
-            } else {
-                opened = newFilePreviewSurface(
-                    inPane: paneId,
-                    filePath: filePath,
-                    focus: shouldFocusNewTabs,
-                    targetIndex: nextIndex
-                ) != nil
-            }
-
-            if opened {
-                openedAny = true
-                if let index = nextIndex {
-                    nextIndex = index + 1
-                }
-            }
-        }
-
-        return openedAny
-    }
-
-    @discardableResult
-    private func splitPaneWithDroppedFile(
+    private func splitPaneWithFileSurface(
         targetPane paneId: PaneID,
         orientation: SplitOrientation,
         insertFirst: Bool,

--- a/cmuxTests/MarkdownPanelTests.swift
+++ b/cmuxTests/MarkdownPanelTests.swift
@@ -131,8 +131,10 @@ final class MarkdownPanelTests: XCTestCase {
 
         let markdownPanels = workspace.panels.values.compactMap { $0 as? MarkdownPanel }
         XCTAssertEqual(markdownPanels.count, 1)
-        XCTAssertEqual(markdownPanels.first?.filePath, fileURL.path)
-        XCTAssertEqual(markdownPanels.first?.displayMode, .preview)
+        let originalMarkdownPanel = try XCTUnwrap(markdownPanels.first)
+        let originalMarkdownPanelID = ObjectIdentifier(originalMarkdownPanel)
+        XCTAssertEqual(originalMarkdownPanel.filePath, fileURL.path)
+        XCTAssertEqual(originalMarkdownPanel.displayMode, .preview)
         XCTAssertTrue(workspace.panels.values.compactMap { $0 as? FilePreviewPanel }.isEmpty)
 
         XCTAssertTrue(
@@ -141,7 +143,9 @@ final class MarkdownPanelTests: XCTestCase {
                 debugSource: "unit-test-reopen"
             )
         )
-        XCTAssertEqual(workspace.panels.values.compactMap { $0 as? MarkdownPanel }.count, 1)
+        let reopenedMarkdownPanels = workspace.panels.values.compactMap { $0 as? MarkdownPanel }
+        XCTAssertEqual(reopenedMarkdownPanels.count, 1)
+        XCTAssertTrue(reopenedMarkdownPanels.contains { ObjectIdentifier($0) == originalMarkdownPanelID })
     }
 
     func testOpenMarkdownPanelReloadsWhenFileChangesOnDisk() async throws {

--- a/cmuxTests/MarkdownPanelTests.swift
+++ b/cmuxTests/MarkdownPanelTests.swift
@@ -83,6 +83,64 @@ final class MarkdownPanelTests: XCTestCase {
         XCTAssertEqual(payload["display_mode"] as? String, MarkdownPanelDisplayMode.preview.rawValue)
     }
 
+    func testExternalFileOpenRoutesMarkdownFilesToPreviewMarkdownPanel() throws {
+        let fileManager = FileManager.default
+        let directoryURL = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-markdown-external-open-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        defer {
+            try? fileManager.removeItem(at: directoryURL)
+        }
+
+        let fileURL = directoryURL.appendingPathComponent("README.md")
+        try "# Title\n\nBody.\n".write(to: fileURL, atomically: true, encoding: .utf8)
+
+        let previousShared = AppDelegate.shared
+        let appDelegate = AppDelegate()
+        defer {
+            AppDelegate.shared = previousShared
+        }
+
+        let manager = TabManager()
+        let workspace = manager.addWorkspace(
+            workingDirectory: directoryURL.path,
+            select: true,
+            eagerLoadTerminal: false
+        )
+        defer {
+            for panel in workspace.panels.values {
+                panel.close()
+            }
+        }
+
+#if DEBUG
+        appDelegate.registerMainWindowContextForTesting(tabManager: manager)
+#else
+        XCTFail("registerMainWindowContextForTesting is only available in DEBUG")
+#endif
+
+        XCTAssertTrue(
+            appDelegate.openFilePreviewInPreferredMainWindow(
+                filePath: fileURL.path,
+                debugSource: "unit-test"
+            )
+        )
+
+        let markdownPanels = workspace.panels.values.compactMap { $0 as? MarkdownPanel }
+        XCTAssertEqual(markdownPanels.count, 1)
+        XCTAssertEqual(markdownPanels.first?.filePath, fileURL.path)
+        XCTAssertEqual(markdownPanels.first?.displayMode, .preview)
+        XCTAssertTrue(workspace.panels.values.compactMap { $0 as? FilePreviewPanel }.isEmpty)
+
+        XCTAssertTrue(
+            appDelegate.openFilePreviewInPreferredMainWindow(
+                filePath: fileURL.path,
+                debugSource: "unit-test-reopen"
+            )
+        )
+        XCTAssertEqual(workspace.panels.values.compactMap { $0 as? MarkdownPanel }.count, 1)
+    }
+
     func testOpenMarkdownPanelReloadsWhenFileChangesOnDisk() async throws {
         let fileManager = FileManager.default
         let directoryURL = fileManager.temporaryDirectory

--- a/cmuxTests/MarkdownPanelTests.swift
+++ b/cmuxTests/MarkdownPanelTests.swift
@@ -108,15 +108,18 @@ final class MarkdownPanelTests: XCTestCase {
             eagerLoadTerminal: false
         )
         defer {
+            TerminalController.shared.setActiveTabManager(nil)
             for panel in workspace.panels.values {
                 panel.close()
             }
         }
+        TerminalController.shared.setActiveTabManager(manager)
 
 #if DEBUG
         appDelegate.registerMainWindowContextForTesting(tabManager: manager)
 #else
         XCTFail("registerMainWindowContextForTesting is only available in DEBUG")
+        return
 #endif
 
         XCTAssertTrue(


### PR DESCRIPTION
Summary:
- Route external file opens and file explorer opens through Workspace.openFileSurfaces so markdown files create MarkdownPanel surfaces.
- Reuse the same file-surface helper for dropped-file insertions and remove the duplicate dropped-file opener.

Tests:
- xcodebuildmcp macos test --scheme cmux-unit with MarkdownPanelTests/testFileOpenRoutesMarkdownFilesToPreviewMarkdownPanel and MarkdownPanelTests/testExternalFileOpenRoutesMarkdownFilesToPreviewMarkdownPanel
- ./scripts/reload.sh --tag mdopen

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core file-opening paths (external open, sidebar open, drag-and-drop) to a unified helper that can reuse existing tabs and route `.md` files to `MarkdownPanel`, so regressions could affect tab creation/focus and drop behavior.
> 
> **Overview**
> **Unifies file opening behavior across the app.** External file opens (`AppDelegate`), sidebar opens (`ContentView`/`RightSidebarToolPanel`), and drag-and-drop inserts (`Workspace`) now route through `Workspace.openFileSurfaces(..., reuseExisting: true)` so markdown paths open as preview `MarkdownPanel`s and reopening focuses the existing surface instead of creating duplicates.
> 
> **Simplifies drop handling.** Removes the bespoke `openDroppedFileSurfaces` helper and renames `splitPaneWithDroppedFile` to `splitPaneWithFileSurface`, relying on the shared open/split logic and returning success based on whether any panels were opened.
> 
> **Adds coverage for the new external-open path.** Introduces `MarkdownPanelTests.testExternalFileOpenRoutesMarkdownFilesToPreviewMarkdownPanel` to verify `.md` external opens create a preview markdown surface and repeated opens reuse the same panel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2607bd1b3ff657d659c65847efecf33005130e70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route all markdown file opens through the shared `openFileSurfaces` path so they always open as a preview `MarkdownPanel` and reuse existing tabs. This unifies external, file explorer, and drag-and-drop behavior and removes duplicate code.

- **Bug Fixes**
  - External and file explorer opens now route to preview `MarkdownPanel` and reuse an existing tab.
  - Drag-and-drop uses the same opener for consistent behavior.

- **Refactors**
  - Consolidated to `openFileSurfaces`; removed `openDroppedFileSurfaces`; renamed `splitPaneWithDroppedFile` to `splitPaneWithFileSurface`.
  - Updated `AppDelegate`, `ContentView`, and `RightSidebarToolPanel` to call `openFileSurfaces(focus: true, reuseExisting: true)`.
  - Hardened the external-open test to assert preview mode, reuse of the same `MarkdownPanel` instance, and no `FilePreviewPanel`.

<sup>Written for commit 2607bd1b3ff657d659c65847efecf33005130e70. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4285?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * External file opens and sidebar previews now reuse and focus existing preview panels consistently.
  * Drag-and-drop and split-pane behavior for dropped files is streamlined for more predictable preview placement.

* **Tests**
  * Added coverage to verify external markdown files open in preview panels and that reopening reuses the same panel.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4285?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->