### PR TITLE
Blank markdown shell before first render

### DIFF
--- a/Resources/markdown-viewer/shell.html
+++ b/Resources/markdown-viewer/shell.html
@@ -182,16 +182,10 @@ body {
 ::selection { background: rgba(56, 139, 253, 0.4); }
 /* Smooth-anchor scroll for heading links. */
 html { scroll-behavior: smooth; }
-/* Loading shimmer while the first render is in flight. */
-#content:empty::before {
-  content: "";
-  display: block;
-  height: 1px;
-}
 </style>
 </head>
 <body>
-<article id="content" class="markdown-body"><p style="color:#f85149">Loading markdown shell…</p></article>
+<article id="content" class="markdown-body"></article>
 <script>
 {{markedJS}}
 </script>


### PR DESCRIPTION
Summary:
- Remove the visible markdown shell loading text.
- Leave the markdown viewer content empty until the first render or a boot error.

Verification:
- ./scripts/reload.sh --tag mdblank
- Attempted cmux-unit MarkdownPanelTests targeted run, but XcodeBuildMCP timed out and removed its temp result bundle before a pass/fail result was available.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI change limited to the markdown viewer HTML shell; it only affects initial rendering state and removes a placeholder message/CSS without touching rendering logic or data handling.
> 
> **Overview**
> The markdown viewer `shell.html` now renders with an *empty* `#content` container instead of showing a visible “Loading…” placeholder on boot.
> 
> It also removes the associated CSS that styled the empty-state/shimmer, so the viewer stays blank until the first successful render (or an existing boot error is shown).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a72307bd0b3dfa7c7bda98d51bbc8b8b1e8922d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the markdown viewer’s visible loading placeholder and shimmer. The viewer now stays empty until the first render or a boot error, reducing flicker and visual noise.

<sup>Written for commit 0a72307bd0b3dfa7c7bda98d51bbc8b8b1e8922d. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4294?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed the loading placeholder message and CSS shimmer animation from the markdown viewer, which now displays an initially empty content area for a cleaner visual presentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4294?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->