### PR TITLE
Open crash diagnostics from notifications

### DIFF
--- a/Packages/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizerPrimaryPolicies.swift
+++ b/Packages/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizerPrimaryPolicies.swift
@@ -436,9 +436,7 @@ extension AgentLaunchSanitizer {
             "--agent"
         ],
         variadicOptions: [
-            "--cors",
-            "--file",
-            "-f"
+            "--cors"
         ],
         nonRestorableCommands: [
             "completion",

--- a/Packages/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizerPrimaryPolicies.swift
+++ b/Packages/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizerPrimaryPolicies.swift
@@ -75,6 +75,7 @@ extension AgentLaunchSanitizer {
         droppedOptions: [
             "--continue",
             "-c",
+            "--file",
             "--fork-session",
             "--from-pr",
             "--resume",
@@ -85,6 +86,7 @@ extension AgentLaunchSanitizer {
             "-w"
         ],
         droppedOptionPrefixes: [
+            "--file=",
             "--fork-session=",
             "--from-pr=",
             "--resume=",
@@ -150,6 +152,8 @@ extension AgentLaunchSanitizer {
         ],
         droppedOptions: [
             "--last",
+            "--image",
+            "-i",
             "--remote",
             "--remote-auth-token-env",
             "--all"
@@ -422,6 +426,8 @@ extension AgentLaunchSanitizer {
             "--hostname",
             "--mdns-domain",
             "--cors",
+            "--file",
+            "-f",
             "--model",
             "-m",
             "--session",
@@ -430,7 +436,9 @@ extension AgentLaunchSanitizer {
             "--agent"
         ],
         variadicOptions: [
-            "--cors"
+            "--cors",
+            "--file",
+            "-f"
         ],
         nonRestorableCommands: [
             "completion",
@@ -460,12 +468,16 @@ extension AgentLaunchSanitizer {
         droppedOptions: [
             "--continue",
             "-c",
+            "--file",
+            "-f",
             "--fork",
             "--session",
             "-s",
             "--prompt"
         ],
         droppedOptionPrefixes: [
+            "--file=",
+            "-f=",
             "--fork=",
             "--session=",
             "--prompt="

--- a/Packages/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchSanitizerTests.swift
+++ b/Packages/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchSanitizerTests.swift
@@ -65,8 +65,8 @@ struct AgentLaunchSanitizerTests {
         )
     }
 
-    @Test("Detects Codex fork after variadic options")
-    func detectsCodexForkAfterVariadicOptions() {
+    @Test("Detects Codex fork after startup image options")
+    func detectsCodexForkAfterStartupImageOptions() {
         #expect(
             AgentLaunchSanitizer.sanitizedLaunchArguments(
                 [
@@ -86,16 +86,14 @@ struct AgentLaunchSanitizerTests {
                 fallbackKind: "codex"
             ) == [
                 "codex",
-                "--image",
-                "/tmp/screenshot.png",
                 "--sandbox",
                 "danger-full-access",
             ]
         )
     }
 
-    @Test("Keeps Codex variadic first value named fork")
-    func keepsCodexVariadicFirstValueNamedFork() {
+    @Test("Drops Codex startup images and keeps following flags")
+    func dropsCodexStartupImagesAndKeepsFollowingFlags() {
         #expect(
             AgentLaunchSanitizer.sanitizedLaunchArguments(
                 [
@@ -110,11 +108,78 @@ struct AgentLaunchSanitizerTests {
                 fallbackKind: "codex"
             ) == [
                 "codex",
-                "--image",
-                "fork",
-                "019dad34-d218-7943-b81a-eddac5c87951",
                 "--model",
                 "gpt-5.4",
+            ]
+        )
+    }
+
+    @Test("Drops Codex restored image placeholder and prompt")
+    func dropsCodexRestoredImagePlaceholderAndPrompt() {
+        #expect(
+            AgentLaunchSanitizer.sanitizedLaunchArguments(
+                [
+                    "codex",
+                    "--yolo",
+                    "--image",
+                    "[Image #1]",
+                    "[Image #1] cmd clicking this should open the crash file in finder",
+                    "--model",
+                    "gpt-5.4",
+                ],
+                launcher: "codex",
+                fallbackKind: "codex"
+            ) == [
+                "codex",
+                "--yolo",
+                "--model",
+                "gpt-5.4",
+            ]
+        )
+    }
+
+    @Test("Drops Claude startup files")
+    func dropsClaudeStartupFiles() {
+        #expect(
+            AgentLaunchSanitizer.sanitizedLaunchArguments(
+                [
+                    "claude",
+                    "--file",
+                    "file_123:screenshot.png",
+                    "initial prompt should not replay",
+                    "--model",
+                    "sonnet",
+                ],
+                launcher: "claude",
+                fallbackKind: "claude"
+            ) == [
+                "claude",
+                "--model",
+                "sonnet",
+            ]
+        )
+    }
+
+    @Test("Drops OpenCode startup files before preserving cwd")
+    func dropsOpenCodeStartupFilesBeforePreservingCwd() {
+        #expect(
+            AgentLaunchSanitizer.sanitizedLaunchArguments(
+                [
+                    "opencode",
+                    "--file",
+                    "/tmp/screenshot.png",
+                    "--model",
+                    "anthropic/claude-sonnet-4-6",
+                    "/tmp/worktree",
+                    "initial prompt should not replay",
+                ],
+                launcher: "opencode",
+                fallbackKind: "opencode"
+            ) == [
+                "opencode",
+                "--model",
+                "anthropic/claude-sonnet-4-6",
+                "/tmp/worktree",
             ]
         )
     }

--- a/Packages/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchSanitizerTests.swift
+++ b/Packages/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchSanitizerTests.swift
@@ -184,6 +184,52 @@ struct AgentLaunchSanitizerTests {
         )
     }
 
+    @Test("Drops OpenCode startup file when it appears before cwd")
+    func dropsOpenCodeStartupFileBeforeCwd() {
+        #expect(
+            AgentLaunchSanitizer.sanitizedLaunchArguments(
+                [
+                    "opencode",
+                    "--file",
+                    "/tmp/screenshot.png",
+                    "/tmp/worktree",
+                    "initial prompt should not replay",
+                ],
+                launcher: "opencode",
+                fallbackKind: "opencode"
+            ) == [
+                "opencode",
+                "/tmp/worktree",
+            ]
+        )
+    }
+
+    @Test("Drops repeated OpenCode startup files before preserving cwd")
+    func dropsRepeatedOpenCodeStartupFilesBeforeCwd() {
+        #expect(
+            AgentLaunchSanitizer.sanitizedLaunchArguments(
+                [
+                    "opencode",
+                    "--file",
+                    "/tmp/screenshot.png",
+                    "-f",
+                    "/tmp/transcript.txt",
+                    "--model",
+                    "anthropic/claude-sonnet-4-6",
+                    "/tmp/worktree",
+                    "initial prompt should not replay",
+                ],
+                launcher: "opencode",
+                fallbackKind: "opencode"
+            ) == [
+                "opencode",
+                "--model",
+                "anthropic/claude-sonnet-4-6",
+                "/tmp/worktree",
+            ]
+        )
+    }
+
     @Test("Preserves generated Codex fork launch context")
     func preservesGeneratedCodexForkLaunchContext() {
         #expect(

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -183,13 +183,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Diagnostic file saved to ~/.local/state/cmux/crash/"
+            "value": "Diagnostic file saved. Click to reveal it in Finder."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "診断ファイルは ~/.local/state/cmux/crash/ に保存されました"
+            "value": "診断ファイルを保存しました。クリックするとFinderで表示します。"
           }
         }
       }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -13853,9 +13853,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 return nil
             }()
             if let clickAction = TerminalNotificationClickAction(userInfo: response.notification.request.content.userInfo) {
-                DispatchQueue.main.async {
-                    self.performTerminalNotificationClickAction(clickAction)
-                    if let notificationId {
+                Task { @MainActor in
+                    let didPerform = self.performTerminalNotificationClickAction(clickAction)
+                    if didPerform, let notificationId {
                         self.notificationStore?.markRead(id: notificationId)
                     }
                 }
@@ -14167,18 +14167,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     @discardableResult
+    @MainActor
     func openTerminalNotification(_ notification: TerminalNotification) -> Bool {
         if let clickAction = notification.clickAction {
-            let perform = {
-                self.performTerminalNotificationClickAction(clickAction)
-                self.notificationStore?.markRead(id: notification.id)
+            let didPerform = performTerminalNotificationClickAction(clickAction)
+            if didPerform {
+                notificationStore?.markRead(id: notification.id)
             }
-            if Thread.isMainThread {
-                perform()
-            } else {
-                DispatchQueue.main.async(execute: perform)
-            }
-            return true
+            return didPerform
         }
         return openNotification(
             tabId: notification.tabId,
@@ -14187,26 +14183,31 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         )
     }
 
-    private func performTerminalNotificationClickAction(_ action: TerminalNotificationClickAction) {
+    @discardableResult
+    private func performTerminalNotificationClickAction(_ action: TerminalNotificationClickAction) -> Bool {
         switch action {
         case .revealInFinder(let path):
-            revealInFinder(path: path)
+            return revealInFinder(path: path)
         }
     }
 
-    private func revealInFinder(path: String) {
+    @discardableResult
+    private func revealInFinder(path: String) -> Bool {
         let expandedPath = (path as NSString).expandingTildeInPath
-        guard !expandedPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        guard !expandedPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return false
+        }
         let fileURL = URL(fileURLWithPath: expandedPath)
         let fileManager = FileManager.default
         if fileManager.fileExists(atPath: fileURL.path) {
             NSWorkspace.shared.activateFileViewerSelecting([fileURL])
-            return
+            return true
         }
         let directoryURL = fileURL.deletingLastPathComponent()
         if fileManager.fileExists(atPath: directoryURL.path) {
-            NSWorkspace.shared.open(directoryURL)
+            return NSWorkspace.shared.open(directoryURL)
         }
+        return false
     }
 
     @discardableResult

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1635,7 +1635,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 body: String(
                     localized: "crashBreadcrumb.body",
                     defaultValue: "Diagnostic file saved to ~/.local/state/cmux/crash/"
-                )
+                ),
+                clickAction: .revealInFinder(path: pendingCrash.fileURL.path)
             )
             GhosttyCrashBreadcrumb.markShown(pendingCrash)
         }
@@ -7424,11 +7425,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 self?.showNotificationsPopoverFromMenuBar()
             },
             onOpenNotification: { [weak self] notification in
-                _ = self?.openNotification(
-                    tabId: notification.tabId,
-                    surfaceId: notification.surfaceId,
-                    notificationId: notification.id
-                )
+                _ = self?.openTerminalNotification(notification)
             },
             onJumpToLatestUnread: { [weak self] in
                 self?.jumpToLatestUnread()
@@ -10617,7 +10614,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // the window-context registry can lag behind model initialization, so fall back to whatever
         // tab manager currently owns the tab.
         for notification in notificationStore.notifications where !notification.isRead && notification.id != excludedNotificationId {
-            if openNotification(tabId: notification.tabId, surfaceId: notification.surfaceId, notificationId: notification.id) {
+            if openTerminalNotification(notification) {
                 return notificationStore.notifications.first(where: { $0.id == notification.id }) ?? notification
             }
         }
@@ -13843,6 +13840,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 }
                 return nil
             }()
+            if let clickAction = TerminalNotificationClickAction(userInfo: response.notification.request.content.userInfo) {
+                DispatchQueue.main.async {
+                    self.performTerminalNotificationClickAction(clickAction)
+                    if let notificationId {
+                        self.notificationStore?.markRead(id: notificationId)
+                    }
+                }
+                return
+            }
             DispatchQueue.main.async {
                 _ = self.openNotification(tabId: tabId, surfaceId: surfaceId, notificationId: notificationId)
             }
@@ -14146,6 +14152,49 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let expectedIdentifier = "cmux.main.\(context.windowId.uuidString)"
         let window: NSWindow? = context.window ?? NSApp.windows.first(where: { $0.identifier?.rawValue == expectedIdentifier })
         window?.performClose(nil)
+    }
+
+    @discardableResult
+    func openTerminalNotification(_ notification: TerminalNotification) -> Bool {
+        if let clickAction = notification.clickAction {
+            let perform = {
+                self.performTerminalNotificationClickAction(clickAction)
+                self.notificationStore?.markRead(id: notification.id)
+            }
+            if Thread.isMainThread {
+                perform()
+            } else {
+                DispatchQueue.main.async(execute: perform)
+            }
+            return true
+        }
+        return openNotification(
+            tabId: notification.tabId,
+            surfaceId: notification.surfaceId,
+            notificationId: notification.id
+        )
+    }
+
+    private func performTerminalNotificationClickAction(_ action: TerminalNotificationClickAction) {
+        switch action {
+        case .revealInFinder(let path):
+            revealInFinder(path: path)
+        }
+    }
+
+    private func revealInFinder(path: String) {
+        let expandedPath = (path as NSString).expandingTildeInPath
+        guard !expandedPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        let fileURL = URL(fileURLWithPath: expandedPath)
+        let fileManager = FileManager.default
+        if fileManager.fileExists(atPath: fileURL.path) {
+            NSWorkspace.shared.activateFileViewerSelecting([fileURL])
+            return
+        }
+        let directoryURL = fileURL.deletingLastPathComponent()
+        if fileManager.fileExists(atPath: directoryURL.path) {
+            NSWorkspace.shared.open(directoryURL)
+        }
     }
 
     @discardableResult

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1644,7 +1644,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 ),
                 body: String(
                     localized: "crashBreadcrumb.body",
-                    defaultValue: "Diagnostic file saved to ~/.local/state/cmux/crash/"
+                    defaultValue: "Diagnostic file saved. Click to reveal it in Finder."
                 ),
                 clickAction: .revealInFinder(path: pendingCrash.fileURL.path)
             )

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -10623,13 +10623,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // Prefer the latest unread that we can actually open. In early startup (especially on the VM),
         // the window-context registry can lag behind model initialization, so fall back to whatever
         // tab manager currently owns the tab.
-        for notification in notificationStore.notifications where !notification.isRead && notification.id != excludedNotificationId {
+        for notification in notificationStore.notifications
+            where Self.shouldOpenFromJumpToLatestUnread(notification, excludingNotificationId: excludedNotificationId) {
             if openTerminalNotification(notification) {
                 return notificationStore.notifications.first(where: { $0.id == notification.id }) ?? notification
             }
         }
         _ = openLatestWorkspaceUnread()
         return nil
+    }
+
+    static func shouldOpenFromJumpToLatestUnread(
+        _ notification: TerminalNotification,
+        excludingNotificationId excludedNotificationId: UUID? = nil
+    ) -> Bool {
+        guard !notification.isRead, notification.id != excludedNotificationId else { return false }
+        return notification.clickAction == nil
     }
 
     private func openLatestWorkspaceUnread() -> Bool {
@@ -14184,6 +14193,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     @discardableResult
+    @MainActor
     private func performTerminalNotificationClickAction(_ action: TerminalNotificationClickAction) -> Bool {
         switch action {
         case .revealInFinder(let path):
@@ -14192,6 +14202,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     @discardableResult
+    @MainActor
     private func revealInFinder(path: String) -> Bool {
         let expandedPath = (path as NSString).expandingTildeInPath
         guard !expandedPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {

--- a/Sources/NotificationsPage.swift
+++ b/Sources/NotificationsPage.swift
@@ -28,12 +28,10 @@ struct NotificationsPage: View {
                                     // SwiftUI action closures are not guaranteed to run on the main actor.
                                     // Ensure window focus + tab selection happens on the main thread.
                                     DispatchQueue.main.async {
-                                        _ = AppDelegate.shared?.openNotification(
-                                            tabId: notification.tabId,
-                                            surfaceId: notification.surfaceId,
-                                            notificationId: notification.id
-                                        )
-                                        selection = .tabs
+                                        _ = AppDelegate.shared?.openTerminalNotification(notification)
+                                        if notification.clickAction == nil {
+                                            selection = .tabs
+                                        }
                                     }
                                 },
                                 onClear: {

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -203,7 +203,7 @@ enum AgentResumeCommandBuilder {
         case .codex:
             let original = commandParts(launchCommand: launchCommand, fallbackExecutable: "codex")
             guard let preserved = AgentLaunchSanitizer.preservedArguments(kind: "codex", args: original.tail) else { return nil }
-            return [original.executable, "resume"] + preserved + [sessionId]
+            return [original.executable, "resume", sessionId] + preserved
         case .pi:
             return resumeWithOption(
                 kind: "pi",

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -8225,11 +8225,7 @@ class TerminalController {
             let store = TerminalNotificationStore.shared
             notification = store.notifications.first(where: { $0.id == id })
             if let notification {
-                opened = AppDelegate.shared?.openNotification(
-                    tabId: notification.tabId,
-                    surfaceId: notification.surfaceId,
-                    notificationId: notification.id
-                ) ?? false
+                opened = AppDelegate.shared?.openTerminalNotification(notification) ?? false
                 let current = store.notifications.first(where: { $0.id == notification.id }) ?? notification
                 payload = notificationPayload(current, opened: opened, includeReadState: true)
             }

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -661,6 +661,36 @@ enum NotificationAuthorizationState: Equatable {
     }
 }
 
+enum TerminalNotificationClickAction: Hashable, Sendable {
+    case revealInFinder(path: String)
+
+    private static let kindUserInfoKey = "cmuxClickAction"
+    private static let revealInFinderPathUserInfoKey = "cmuxRevealInFinderPath"
+    private static let revealInFinderKind = "revealInFinder"
+
+    var userInfo: [String: String] {
+        switch self {
+        case .revealInFinder(let path):
+            return [
+                Self.kindUserInfoKey: Self.revealInFinderKind,
+                Self.revealInFinderPathUserInfoKey: path,
+            ]
+        }
+    }
+
+    init?(userInfo: [AnyHashable: Any]) {
+        guard let kind = userInfo[Self.kindUserInfoKey] as? String else { return nil }
+        switch kind {
+        case Self.revealInFinderKind:
+            guard let path = userInfo[Self.revealInFinderPathUserInfoKey] as? String,
+                  !path.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
+            self = .revealInFinder(path: path)
+        default:
+            return nil
+        }
+    }
+}
+
 struct TerminalNotification: Identifiable, Hashable {
     let id: UUID
     let tabId: UUID
@@ -671,6 +701,7 @@ struct TerminalNotification: Identifiable, Hashable {
     let createdAt: Date
     var isRead: Bool
     var paneFlash: Bool = true
+    var clickAction: TerminalNotificationClickAction?
 }
 
 @MainActor
@@ -1082,7 +1113,8 @@ final class TerminalNotificationStore: ObservableObject {
         subtitle: String,
         body: String,
         cooldownKey: String? = nil,
-        cooldownInterval: TimeInterval? = nil
+        cooldownInterval: TimeInterval? = nil,
+        clickAction: TerminalNotificationClickAction? = nil
     ) {
         let now = Date()
         let resolvedCooldownInterval: TimeInterval?
@@ -1117,7 +1149,8 @@ final class TerminalNotificationStore: ObservableObject {
                 request: policyContext.request,
                 effects: TerminalNotificationPolicyEffects(),
                 now: now,
-                cooldownReservation: cooldownReservation
+                cooldownReservation: cooldownReservation,
+                clickAction: clickAction
             )
             return
         }
@@ -1133,7 +1166,8 @@ final class TerminalNotificationStore: ObservableObject {
                     request: policyContext.request,
                     effects: TerminalNotificationPolicyEffects(),
                     now: Date(),
-                    cooldownReservation: cooldownReservation
+                    cooldownReservation: cooldownReservation,
+                    clickAction: clickAction
                 )
                 return
             }
@@ -1148,14 +1182,16 @@ final class TerminalNotificationStore: ObservableObject {
                     request: policyContext.request,
                     envelope: envelope,
                     now: Date(),
-                    cooldownReservation: cooldownReservation
+                    cooldownReservation: cooldownReservation,
+                    clickAction: clickAction
                 )
             case .failure(let failure):
                 self.applyNotification(
                     request: policyContext.request,
                     effects: TerminalNotificationPolicyEffects(),
                     now: Date(),
-                    cooldownReservation: cooldownReservation
+                    cooldownReservation: cooldownReservation,
+                    clickAction: clickAction
                 )
                 self.reportNotificationHookFailure(failure)
             }
@@ -1242,7 +1278,8 @@ final class TerminalNotificationStore: ObservableObject {
         request: TerminalNotificationPolicyRequest,
         envelope: TerminalNotificationPolicyEnvelope,
         now: Date,
-        cooldownReservation: NotificationCooldownReservation?
+        cooldownReservation: NotificationCooldownReservation?,
+        clickAction: TerminalNotificationClickAction?
     ) {
         let payload = envelope.notification
         applyNotification(
@@ -1258,7 +1295,8 @@ final class TerminalNotificationStore: ObservableObject {
             ),
             effects: envelope.effects,
             now: now,
-            cooldownReservation: cooldownReservation
+            cooldownReservation: cooldownReservation,
+            clickAction: clickAction
         )
     }
 
@@ -1266,7 +1304,8 @@ final class TerminalNotificationStore: ObservableObject {
         request: TerminalNotificationPolicyRequest,
         effects: TerminalNotificationPolicyEffects,
         now: Date,
-        cooldownReservation: NotificationCooldownReservation?
+        cooldownReservation: NotificationCooldownReservation?,
+        clickAction: TerminalNotificationClickAction?
     ) {
         let shouldSuppressExternalDelivery = shouldSuppressExternalDelivery(
             tabId: request.tabId,
@@ -1281,7 +1320,8 @@ final class TerminalNotificationStore: ObservableObject {
             body: request.body,
             createdAt: now,
             isRead: !effects.markUnread,
-            paneFlash: effects.paneFlash
+            paneFlash: effects.paneFlash,
+            clickAction: clickAction
         )
 
         if effects.record {
@@ -1646,7 +1686,8 @@ final class TerminalNotificationStore: ObservableObject {
                 body: notification.body,
                 createdAt: notification.createdAt,
                 isRead: notification.isRead,
-                paneFlash: notification.paneFlash
+                paneFlash: notification.paneFlash,
+                clickAction: notification.clickAction
             )
         }
         if didMoveNotification {
@@ -1734,6 +1775,11 @@ final class TerminalNotificationStore: ObservableObject {
             ]
             if let surfaceId = notification.surfaceId {
                 content.userInfo["surfaceId"] = surfaceId.uuidString
+            }
+            if let clickAction = notification.clickAction {
+                for (key, value) in clickAction.userInfo {
+                    content.userInfo[key] = value
+                }
             }
 
             let request = UNNotificationRequest(

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -1709,11 +1709,7 @@ private struct NotificationsPopoverView: View {
         // SwiftUI action closures are not guaranteed to run on the main actor.
         // Ensure window focus + tab selection happens on the main thread.
         DispatchQueue.main.async {
-            _ = AppDelegate.shared?.openNotification(
-                tabId: notification.tabId,
-                surfaceId: notification.surfaceId,
-                notificationId: notification.id
-            )
+            _ = AppDelegate.shared?.openTerminalNotification(notification)
             onDismiss()
         }
     }

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -870,11 +870,7 @@ struct cmuxApp: App {
     }
 
     private func openNotificationFromMainMenu(_ notification: TerminalNotification) {
-        _ = appDelegate.openNotification(
-            tabId: notification.tabId,
-            surfaceId: notification.surfaceId,
-            notificationId: notification.id
-        )
+        _ = appDelegate.openTerminalNotification(notification)
     }
 
     private func performSplitFromMenu(direction: SplitDirection) {

--- a/cmuxTests/NotificationAndMenuBarTests.swift
+++ b/cmuxTests/NotificationAndMenuBarTests.swift
@@ -613,6 +613,37 @@ final class NotificationDockBadgeTests: XCTestCase {
         super.tearDown()
     }
 
+    func testNotificationClickActionRoundTripsAndIsStored() {
+        let store = TerminalNotificationStore.shared
+        let path = "/tmp/cmux-crash-\(UUID().uuidString).ghosttycrash"
+        let action = TerminalNotificationClickAction.revealInFinder(path: path)
+        let userInfo = Dictionary(uniqueKeysWithValues: action.userInfo.map { (AnyHashable($0.key), $0.value as Any) })
+        var delivered: TerminalNotification?
+
+        XCTAssertEqual(TerminalNotificationClickAction(userInfo: userInfo), action)
+
+        store.replaceNotificationsForTesting([])
+        store.configureNotificationDeliveryHandlerForTesting { _, notification in
+            delivered = notification
+        }
+        defer {
+            store.replaceNotificationsForTesting([])
+            store.resetNotificationDeliveryHandlerForTesting()
+        }
+
+        store.addNotification(
+            tabId: UUID(),
+            surfaceId: nil,
+            title: "Crash",
+            subtitle: "Diagnostic",
+            body: "Diagnostic file saved",
+            clickAction: action
+        )
+
+        XCTAssertEqual(store.notifications.first?.clickAction, action)
+        XCTAssertEqual(delivered?.clickAction, action)
+    }
+
     func testDockBadgeLabelEnabledAndCounted() {
         XCTAssertEqual(TerminalNotificationStore.dockBadgeLabel(unreadCount: 1, isEnabled: true), "1")
         XCTAssertEqual(TerminalNotificationStore.dockBadgeLabel(unreadCount: 42, isEnabled: true), "42")

--- a/cmuxTests/NotificationAndMenuBarTests.swift
+++ b/cmuxTests/NotificationAndMenuBarTests.swift
@@ -644,6 +644,33 @@ final class NotificationDockBadgeTests: XCTestCase {
         XCTAssertEqual(delivered?.clickAction, action)
     }
 
+    func testNotificationClickActionDoesNotMarkReadWhenRevealTargetIsMissing() throws {
+        let store = TerminalNotificationStore.shared
+        let appDelegate = AppDelegate.shared ?? AppDelegate()
+        let originalStore = appDelegate.notificationStore
+        let notification = TerminalNotification(
+            id: UUID(),
+            tabId: UUID(),
+            surfaceId: nil,
+            title: "Crash",
+            subtitle: "Diagnostic",
+            body: "Diagnostic file saved",
+            createdAt: Date(),
+            isRead: false,
+            clickAction: .revealInFinder(path: "/tmp/cmux-missing-\(UUID().uuidString)/missing.ghosttycrash")
+        )
+
+        store.replaceNotificationsForTesting([notification])
+        appDelegate.notificationStore = store
+        defer {
+            appDelegate.notificationStore = originalStore
+            store.replaceNotificationsForTesting([])
+        }
+
+        XCTAssertFalse(appDelegate.openTerminalNotification(notification))
+        XCTAssertFalse(try XCTUnwrap(store.notifications.first).isRead)
+    }
+
     func testDockBadgeLabelEnabledAndCounted() {
         XCTAssertEqual(TerminalNotificationStore.dockBadgeLabel(unreadCount: 1, isEnabled: true), "1")
         XCTAssertEqual(TerminalNotificationStore.dockBadgeLabel(unreadCount: 42, isEnabled: true), "42")

--- a/cmuxTests/NotificationAndMenuBarTests.swift
+++ b/cmuxTests/NotificationAndMenuBarTests.swift
@@ -671,6 +671,40 @@ final class NotificationDockBadgeTests: XCTestCase {
         XCTAssertFalse(try XCTUnwrap(store.notifications.first).isRead)
     }
 
+    func testJumpToLatestUnreadSkipsClickActionNotifications() {
+        let clickActionNotification = TerminalNotification(
+            id: UUID(),
+            tabId: UUID(),
+            surfaceId: nil,
+            title: "Crash",
+            subtitle: "Diagnostic",
+            body: "Diagnostic file saved",
+            createdAt: Date(),
+            isRead: false,
+            clickAction: .revealInFinder(path: "/tmp/cmux-crash.ghosttycrash")
+        )
+        let terminalNotification = TerminalNotification(
+            id: UUID(),
+            tabId: UUID(),
+            surfaceId: nil,
+            title: "Done",
+            subtitle: "",
+            body: "",
+            createdAt: Date(),
+            isRead: false
+        )
+        var readNotification = terminalNotification
+        readNotification.isRead = true
+
+        XCTAssertFalse(AppDelegate.shouldOpenFromJumpToLatestUnread(clickActionNotification))
+        XCTAssertTrue(AppDelegate.shouldOpenFromJumpToLatestUnread(terminalNotification))
+        XCTAssertFalse(AppDelegate.shouldOpenFromJumpToLatestUnread(readNotification))
+        XCTAssertFalse(AppDelegate.shouldOpenFromJumpToLatestUnread(
+            terminalNotification,
+            excludingNotificationId: terminalNotification.id
+        ))
+    }
+
     func testDockBadgeLabelEnabledAndCounted() {
         XCTAssertEqual(TerminalNotificationStore.dockBadgeLabel(unreadCount: 1, isEnabled: true), "1")
         XCTAssertEqual(TerminalNotificationStore.dockBadgeLabel(unreadCount: 42, isEnabled: true), "42")

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -1911,7 +1911,38 @@ final class SocketListenerAcceptPolicyTests: XCTestCase {
 
         XCTAssertEqual(
             snapshot.resumeCommand,
-            "cd '/Users/example/repo' && 'env' 'CODEX_HOME=/tmp/codex home' '/Users/example/.bun/bin/codex' 'resume' '--model' 'gpt-5.4' '--sandbox' 'danger-full-access' '--ask-for-approval' 'never' '--search' '--cd' '/Users/example/repo' '019dad34-d218-7943-b81a-eddac5c87951'"
+            "cd '/Users/example/repo' && 'env' 'CODEX_HOME=/tmp/codex home' '/Users/example/.bun/bin/codex' 'resume' '019dad34-d218-7943-b81a-eddac5c87951' '--model' 'gpt-5.4' '--sandbox' 'danger-full-access' '--ask-for-approval' 'never' '--search' '--cd' '/Users/example/repo'"
+        )
+    }
+
+    func testCodexResumeCommandDropsStartupImagesAndPlacesSessionBeforeFlags() {
+        let snapshot = SessionRestorableAgentSnapshot(
+            kind: .codex,
+            sessionId: "019e2bb9-5544-7201-a517-d77bb00d724f",
+            workingDirectory: "/Users/lawrence/fun/cmuxterm-hq",
+            launchCommand: AgentLaunchCommandSnapshot(
+                launcher: "codex",
+                executablePath: "/Users/lawrence/.bun/bin/codex",
+                arguments: [
+                    "/Users/lawrence/.bun/bin/codex",
+                    "resume",
+                    "--yolo",
+                    "--image",
+                    "[Image #1]",
+                    "[Image #1] cmd clicking this should open the crash file in finder",
+                    "--model",
+                    "gpt-5.4",
+                ],
+                workingDirectory: "/Users/lawrence/fun/cmuxterm-hq",
+                environment: nil,
+                capturedAt: 123,
+                source: "process"
+            )
+        )
+
+        XCTAssertEqual(
+            snapshot.resumeCommand,
+            "cd '/Users/lawrence/fun/cmuxterm-hq' && '/Users/lawrence/.bun/bin/codex' 'resume' '019e2bb9-5544-7201-a517-d77bb00d724f' '--yolo' '--model' 'gpt-5.4'"
         )
     }
 
@@ -2181,7 +2212,7 @@ final class SocketListenerAcceptPolicyTests: XCTestCase {
         )
         XCTAssertEqual(
             codexWithImage.forkCommand,
-            "cd '/Users/example/repo' && 'env' 'CODEX_HOME=/tmp/codex home' '/Users/example/.bun/bin/codex' 'fork' '019image-session' '--image' '/tmp/screenshot.png' '--model' 'gpt-5.4'"
+            "cd '/Users/example/repo' && 'env' 'CODEX_HOME=/tmp/codex home' '/Users/example/.bun/bin/codex' 'fork' '019image-session' '--model' 'gpt-5.4'"
         )
         XCTAssertEqual(
             codexFork.forkCommand,
@@ -2189,7 +2220,7 @@ final class SocketListenerAcceptPolicyTests: XCTestCase {
         )
         XCTAssertEqual(
             codexTeams.forkCommand,
-            "cd '/Users/example/repo' && 'env' 'CODEX_HOME=/tmp/codex home' '/usr/local/bin/cmux' 'codex-teams' 'fork' 'codex-teams-session' '--model' 'gpt-5.4' '--image' '/tmp/team screenshot.png' '--sandbox' 'danger-full-access'"
+            "cd '/Users/example/repo' && 'env' 'CODEX_HOME=/tmp/codex home' '/usr/local/bin/cmux' 'codex-teams' 'fork' 'codex-teams-session' '--model' 'gpt-5.4' '--sandbox' 'danger-full-access'"
         )
         XCTAssertEqual(
             directOpenCode.forkCommand,

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -3110,7 +3110,7 @@ final class SocketListenerAcceptPolicyTests: XCTestCase {
         XCTAssertEqual(snapshot.launchCommand?.arguments.first, "/usr/local/bin/codex")
         XCTAssertEqual(
             snapshot.resumeCommand,
-            "cd '/tmp/repo' && 'env' 'CODEX_HOME=/tmp/codex' '/usr/local/bin/codex' 'resume' '--model' 'gpt-5.4' '--search' 'codex-session-123'"
+            "cd '/tmp/repo' && 'env' 'CODEX_HOME=/tmp/codex' '/usr/local/bin/codex' 'resume' 'codex-session-123' '--model' 'gpt-5.4' '--search'"
         )
     }
 


### PR DESCRIPTION
Summary
- Make crash breadcrumb notifications reveal the saved .ghosttycrash file in Finder.
- Drop startup-only image/file attachment arguments from restored Codex, Claude, and OpenCode launches.
- Build Codex resume commands as `codex resume <session> ...flags` so variadic args cannot swallow the session id.

Tests
- `swift test --package-path Packages/CMUXAgentLaunch`
- `xcodebuild -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination platform=macOS,arch=arm64 -derivedDataPath /tmp/cmux-crashrestore-unit -only-testing:cmuxTests/NotificationDockBadgeTests/testNotificationClickActionRoundTripsAndIsStored test`
- `xcodebuild -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination platform=macOS,arch=arm64 -derivedDataPath /tmp/cmux-crashrestore-unit -only-testing:cmuxTests/SocketListenerAcceptPolicyTests/testCodexResumeCommandPreservesFlagsAndDropsOriginalPrompt -only-testing:cmuxTests/SocketListenerAcceptPolicyTests/testCodexResumeCommandDropsStartupImagesAndPlacesSessionBeforeFlags test`

Dogfood
- Reloaded tagged macOS build with `./scripts/reload.sh --tag crashfix`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes notification click/open behavior (including external file reveals) and adjusts agent resume/fork command construction, which could affect session restoration if argument parsing differs across agent CLIs.
> 
> **Overview**
> **Crash breadcrumb notifications are now actionable.** Crash notifications include a `clickAction` that reveals the saved `.ghosttycrash` file in Finder, and the localized body text was updated to match.
> 
> **Notification open flow is unified and extended.** A new `TerminalNotificationClickAction` is persisted into notification `userInfo`, handled on open (including from system notification callbacks), and `jumpToLatestUnread` now skips action-style notifications.
> 
> **Agent session restore is hardened.** The launch sanitizer drops startup-only attachment flags (`codex --image/-i`, `claude --file`, `opencode --file/-f`), and Codex resume command construction is reordered to `codex resume <sessionId> ...flags` to prevent variadic args from swallowing the session id; tests were updated/added accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b203c74ed93173224f11849ff1125149562bc10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notifications support interactive click actions (e.g., reveal files in Finder).

* **Improvements**
  * Terminal notification open behavior unified across the app for consistent handling.
  * Session resume command ordering refined for more reliable resume behavior.
  * CLI launch sanitization tightened to remove startup image/file options for relevant agents while preserving later flags.

* **Tests**
  * Added tests for notification click-action persistence and expanded sanitization scenarios.

* **Documentation**
  * Updated notification text to remove internal path details and instruct revealing the file in Finder.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4296?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->