### PR TITLE
Keep compact sidebar row height stable on notifications

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -787,9 +787,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private var didSetupTerminalCmdClickUITest = false
     private var didSetupGotoSplitUITest = false
     private var didSetupBonsplitTabDragUITest = false
+    private var didSetupSidebarRowHeightNotificationUITest = false
+    private var didDeliverSidebarRowHeightNotificationUITest = false
+    private var sidebarRowHeightNotificationUITestRequestName: String?
+    private var sidebarRowHeightNotificationUITestStateName: String?
     private var terminalCmdClickUITestPoller: DispatchSourceTimer?
     private var bonsplitTabDragUITestRecorder: DispatchSourceTimer?
     private var gotoSplitUITestRecorder: DispatchSourceTimer?
+    private var sidebarRowHeightNotificationUITestSource: DispatchSourceFileSystemObject?
     private var gotoSplitUITestObservers: [NSObjectProtocol] = []
     private var didSetupMultiWindowNotificationsUITest = false
     private var didSetupDisplayResolutionUITestDiagnostics = false
@@ -1611,6 +1616,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         setupTerminalCmdClickUITestIfNeeded()
         setupGotoSplitUITestIfNeeded()
         setupBonsplitTabDragUITestIfNeeded()
+        setupSidebarRowHeightNotificationUITestIfNeeded()
         setupMultiWindowNotificationsUITestIfNeeded()
         setupDisplayResolutionUITestDiagnosticsIfNeeded()
         setupPortalStatsUITestDiagnosticsIfNeeded()
@@ -10111,6 +10117,204 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     private func loadGotoSplitTestData(at path: String) -> [String: String] {
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: String] else {
+            return [:]
+        }
+        return object
+    }
+
+    private func setupSidebarRowHeightNotificationUITestIfNeeded() {
+        guard !didSetupSidebarRowHeightNotificationUITest else { return }
+        didSetupSidebarRowHeightNotificationUITest = true
+
+        let env = ProcessInfo.processInfo.environment
+        guard sidebarRowHeightUITestFlag("CMUX_UI_TEST_SIDEBAR_ROW_HEIGHT_NOTIFICATION_SETUP", env: env) else { return }
+        let triggerPath = sidebarRowHeightUITestString(
+            "CMUX_UI_TEST_SIDEBAR_ROW_HEIGHT_NOTIFICATION_TRIGGER_PATH",
+            env: env
+        )
+        let statePath = sidebarRowHeightUITestString(
+            "CMUX_UI_TEST_SIDEBAR_ROW_HEIGHT_NOTIFICATION_STATE_PATH",
+            env: env
+        )
+        if let requestName = sidebarRowHeightUITestString(
+            "CMUX_UI_TEST_SIDEBAR_ROW_HEIGHT_NOTIFICATION_REQUEST_NAME",
+            env: env
+        ),
+           let stateName = sidebarRowHeightUITestString(
+               "CMUX_UI_TEST_SIDEBAR_ROW_HEIGHT_NOTIFICATION_STATE_NAME",
+               env: env
+           ) {
+            sidebarRowHeightNotificationUITestRequestName = requestName
+            sidebarRowHeightNotificationUITestStateName = stateName
+            DistributedNotificationCenter.default().addObserver(
+                self,
+                selector: #selector(handleSidebarRowHeightNotificationUITestRequest(_:)),
+                name: Notification.Name(requestName),
+                object: nil,
+                suspensionBehavior: .deliverImmediately
+            )
+            writeSidebarRowHeightNotificationUITestState(["ready": "1", "transport": "distributed"], at: statePath)
+            return
+        }
+        guard let triggerPath, let statePath else {
+            return
+        }
+
+        FileManager.default.createFile(atPath: triggerPath, contents: Data(), attributes: nil)
+        let fd = open(triggerPath, O_EVTONLY)
+        guard fd >= 0 else {
+            writeSidebarRowHeightNotificationUITestState(["ready": "0", "error": "open_failed"], at: statePath)
+            return
+        }
+
+        let source = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: fd,
+            eventMask: [.write, .extend, .attrib],
+            queue: .main
+        )
+        source.setEventHandler { [weak self] in
+            self?.deliverSidebarRowHeightNotificationUITestIfNeeded(statePath: statePath)
+        }
+        source.setCancelHandler {
+            close(fd)
+        }
+        sidebarRowHeightNotificationUITestSource = source
+        source.resume()
+        writeSidebarRowHeightNotificationUITestState(["ready": "1"], at: statePath)
+    }
+
+    private func sidebarRowHeightUITestString(_ key: String, env: [String: String]) -> String? {
+        if let value = env[key], !value.isEmpty {
+            return value
+        }
+        if let value = sidebarRowHeightUITestArgumentValue(key) {
+            return value
+        }
+        if let value = UserDefaults.standard.string(forKey: key), !value.isEmpty {
+            return value
+        }
+        return nil
+    }
+
+    private func sidebarRowHeightUITestFlag(_ key: String, env: [String: String]) -> Bool {
+        if env[key] == "1" {
+            return true
+        }
+        if sidebarRowHeightUITestArgumentValue(key) == "1" {
+            return true
+        }
+        return UserDefaults.standard.string(forKey: key) == "1"
+            || UserDefaults.standard.bool(forKey: key)
+    }
+
+    private func sidebarRowHeightUITestArgumentValue(_ key: String) -> String? {
+        let arguments = CommandLine.arguments
+        guard let index = arguments.firstIndex(of: "-\(key)") else {
+            return nil
+        }
+        let valueIndex = arguments.index(after: index)
+        guard valueIndex < arguments.endIndex else {
+            return nil
+        }
+        let value = arguments[valueIndex]
+        return value.isEmpty ? nil : value
+    }
+
+    @objc private func handleSidebarRowHeightNotificationUITestRequest(_ notification: Notification) {
+        deliverSidebarRowHeightNotificationUITestIfNeeded(statePath: nil)
+    }
+
+    private func deliverSidebarRowHeightNotificationUITestIfNeeded(statePath: String?) {
+        guard !didDeliverSidebarRowHeightNotificationUITest else { return }
+        let targetContext = sidebarRowHeightNotificationUITestTargetContext()
+        let targetTabManager = targetContext?.tabManager ?? tabManager
+        let targetMode = sidebarRowHeightUITestString(
+            "CMUX_UI_TEST_SIDEBAR_ROW_HEIGHT_NOTIFICATION_TARGET",
+            env: ProcessInfo.processInfo.environment
+        )
+        guard let targetTabManager,
+              let notificationStore,
+              let tabId = sidebarRowHeightNotificationUITestTabId(targetMode: targetMode, tabManager: targetTabManager) else {
+            writeSidebarRowHeightNotificationUITestState(["notified": "0", "error": "workspace_missing"], at: statePath)
+            return
+        }
+
+        let previousFocusOverride = AppFocusState.overrideIsFocused
+        AppFocusState.overrideIsFocused = false
+        notificationStore.addNotification(
+            tabId: tabId,
+            surfaceId: nil,
+            title: "sidebar-height-ui-test",
+            subtitle: "ui-test",
+            body: "compact row height"
+        )
+        notificationStore.markUnread(forTabId: tabId)
+        AppFocusState.overrideIsFocused = previousFocusOverride
+        didDeliverSidebarRowHeightNotificationUITest = true
+        if let requestName = sidebarRowHeightNotificationUITestRequestName {
+            DistributedNotificationCenter.default().removeObserver(
+                self,
+                name: Notification.Name(requestName),
+                object: nil
+            )
+            sidebarRowHeightNotificationUITestRequestName = nil
+        }
+        sidebarRowHeightNotificationUITestSource?.cancel()
+        sidebarRowHeightNotificationUITestSource = nil
+        writeSidebarRowHeightNotificationUITestState([
+            "notified": "1",
+            "tabId": tabId.uuidString,
+            "windowId": targetContext?.windowId.uuidString ?? "",
+        ], at: statePath)
+    }
+
+    private func sidebarRowHeightNotificationUITestTabId(targetMode: String?, tabManager: TabManager) -> UUID? {
+        switch targetMode {
+        case "first":
+            return tabManager.tabs.first?.id
+        default:
+            return tabManager.selectedTabId ?? tabManager.tabs.first?.id
+        }
+    }
+
+    private func sidebarRowHeightNotificationUITestTargetContext() -> MainWindowContext? {
+        if let context = contextForMainWindow(NSApp.keyWindow),
+           !context.tabManager.tabs.isEmpty {
+            return context
+        }
+        if let context = contextForMainWindow(NSApp.mainWindow),
+           !context.tabManager.tabs.isEmpty {
+            return context
+        }
+        if let context = mainWindowContexts.values.first(where: { context in
+            resolvedWindow(for: context) != nil && !context.tabManager.tabs.isEmpty
+        }) {
+            return context
+        }
+        return mainWindowContexts.values.first { !$0.tabManager.tabs.isEmpty }
+    }
+
+    private func writeSidebarRowHeightNotificationUITestState(_ updates: [String: String], at path: String?) {
+        if let stateName = sidebarRowHeightNotificationUITestStateName {
+            DistributedNotificationCenter.default().postNotificationName(
+                Notification.Name(stateName),
+                object: nil,
+                userInfo: updates,
+                deliverImmediately: true
+            )
+        }
+        guard let path, !path.isEmpty else { return }
+        var payload = loadSidebarRowHeightNotificationUITestState(at: path)
+        for (key, value) in updates {
+            payload[key] = value
+        }
+        guard let data = try? JSONSerialization.data(withJSONObject: payload) else { return }
+        try? data.write(to: URL(fileURLWithPath: path), options: .atomic)
+    }
+
+    private func loadSidebarRowHeightNotificationUITestState(at path: String) -> [String: String] {
         guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
               let object = try? JSONSerialization.jsonObject(with: data) as? [String: String] else {
             return [:]

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -12233,6 +12233,11 @@ enum SidebarTrailingAccessoryWidthPolicy {
     static let closeButtonWidth: CGFloat = 16
 }
 
+enum SidebarWorkspaceTitleRowMetrics {
+    static let badgeSize: CGFloat = 16
+    static let minimumHeight: CGFloat = badgeSize
+}
+
 #if DEBUG
 private enum SidebarWorkspaceRowHeightUITestProbe {
     static func publish(workspaceId: UUID, index: Int, count: Int, height: CGFloat, unreadCount: Int, isSelected: Bool) {
@@ -12807,7 +12812,10 @@ private struct TabItemView: View, Equatable {
                             .font(.system(size: 9, weight: .semibold))
                             .foregroundColor(.white)
                     }
-                    .frame(width: 16, height: 16)
+                    .frame(
+                        width: SidebarWorkspaceTitleRowMetrics.badgeSize,
+                        height: SidebarWorkspaceTitleRowMetrics.badgeSize
+                    )
                 }
 
                 if workspaceSnapshot.isPinned {
@@ -12826,6 +12834,7 @@ private struct TabItemView: View, Equatable {
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .layoutPriority(1)
             }
+            .frame(minHeight: SidebarWorkspaceTitleRowMetrics.minimumHeight, alignment: .center)
 
             if let description = workspaceSnapshot.customDescription {
                 SidebarWorkspaceDescriptionText(
@@ -13068,7 +13077,9 @@ private struct TabItemView: View, Equatable {
                 unreadCount: unreadCount,
                 isSelected: isActive
             ) { height in
-                rowHeight = height
+                if abs(rowHeight - height) > 0.5 {
+                    rowHeight = height
+                }
             }
         }
         .contentShape(Rectangle())

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -12233,6 +12233,132 @@ enum SidebarTrailingAccessoryWidthPolicy {
     static let closeButtonWidth: CGFloat = 16
 }
 
+#if DEBUG
+private enum SidebarWorkspaceRowHeightUITestProbe {
+    static func publish(workspaceId: UUID, index: Int, count: Int, height: CGFloat, unreadCount: Int, isSelected: Bool) {
+        let env = ProcessInfo.processInfo.environment
+        guard flag("CMUX_UI_TEST_SIDEBAR_ROW_HEIGHT_PROBE", env: env) else {
+            return
+        }
+        let path = string("CMUX_UI_TEST_SIDEBAR_ROW_HEIGHT_PROBE_PATH", env: env) ?? ""
+        let notificationName = string("CMUX_UI_TEST_SIDEBAR_ROW_HEIGHT_PROBE_NAME", env: env) ?? ""
+        guard !path.isEmpty || !notificationName.isEmpty else { return }
+        var payload: [String: Any] = [
+            "workspaceId": workspaceId.uuidString,
+            "index": index + 1,
+            "count": count,
+            "height": Double(height),
+            "unreadCount": unreadCount,
+            "isSelected": isSelected,
+            "publishedAt": Date().timeIntervalSince1970,
+        ]
+        if !notificationName.isEmpty {
+            DistributedNotificationCenter.default().postNotificationName(
+                Notification.Name(notificationName),
+                object: nil,
+                userInfo: payload,
+                deliverImmediately: true
+            )
+        }
+        guard !path.isEmpty else { return }
+        if let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
+           let existing = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            var events = existing["events"] as? [[String: Any]] ?? []
+            events.append(payload)
+            payload["events"] = Array(events.suffix(20))
+        } else {
+            payload["events"] = [payload]
+        }
+        guard let data = try? JSONSerialization.data(withJSONObject: payload) else { return }
+        try? data.write(to: URL(fileURLWithPath: path), options: .atomic)
+    }
+
+    private static func string(_ key: String, env: [String: String]) -> String? {
+        if let value = env[key], !value.isEmpty {
+            return value
+        }
+        if let value = argumentValue(key) {
+            return value
+        }
+        if let value = UserDefaults.standard.string(forKey: key), !value.isEmpty {
+            return value
+        }
+        return nil
+    }
+
+    private static func flag(_ key: String, env: [String: String]) -> Bool {
+        if env[key] == "1" {
+            return true
+        }
+        if argumentValue(key) == "1" {
+            return true
+        }
+        return UserDefaults.standard.string(forKey: key) == "1"
+            || UserDefaults.standard.bool(forKey: key)
+    }
+
+    private static func argumentValue(_ key: String) -> String? {
+        let arguments = CommandLine.arguments
+        guard let index = arguments.firstIndex(of: "-\(key)") else {
+            return nil
+        }
+        let valueIndex = arguments.index(after: index)
+        guard valueIndex < arguments.endIndex else {
+            return nil
+        }
+        let value = arguments[valueIndex]
+        return value.isEmpty ? nil : value
+    }
+}
+#endif
+
+private struct SidebarWorkspaceRowHeightMeasurement: View {
+    let workspaceId: UUID
+    let index: Int
+    let count: Int
+    let unreadCount: Int
+    let isSelected: Bool
+    let onHeightChange: (CGFloat) -> Void
+
+    var body: some View {
+        GeometryReader { proxy in
+            Color.clear
+                .onAppear {
+                    publish(height: proxy.size.height, unreadCount: unreadCount)
+                }
+                .onChange(of: proxy.size.height) { _, newHeight in
+                    publish(height: newHeight, unreadCount: unreadCount)
+                }
+#if DEBUG
+                .onChange(of: unreadCount) { _, newUnreadCount in
+                    publish(height: proxy.size.height, unreadCount: newUnreadCount)
+                }
+                .onChange(of: isSelected) { _, _ in
+                    publish(height: proxy.size.height, unreadCount: unreadCount)
+                }
+                .onChange(of: count) { _, _ in
+                    publish(height: proxy.size.height, unreadCount: unreadCount)
+                }
+#endif
+        }
+    }
+
+    private func publish(height rawHeight: CGFloat, unreadCount: Int) {
+        let height = max(rawHeight, 1)
+        onHeightChange(height)
+#if DEBUG
+        SidebarWorkspaceRowHeightUITestProbe.publish(
+            workspaceId: workspaceId,
+            index: index,
+            count: count,
+            height: height,
+            unreadCount: unreadCount,
+            isSelected: isSelected
+        )
+#endif
+    }
+}
+
 // PERF: TabItemView is Equatable so SwiftUI skips body re-evaluation when
 // the parent rebuilds with unchanged values. Without this, every TabManager
 // or NotificationStore publish causes ALL tab items to re-evaluate (~18% of
@@ -12428,6 +12554,57 @@ private struct TabItemView: View, Equatable {
     private var titleFontWeight: Font.Weight {
         .semibold
     }
+
+    private var titleFontSize: CGFloat {
+#if DEBUG
+        if let value = sidebarRowHeightUITestPositiveCGFloat("CMUX_UI_TEST_SIDEBAR_ROW_HEIGHT_TITLE_FONT_SIZE") {
+            return value
+        }
+#endif
+        return 12.5
+    }
+
+    private var titleHeightOverride: CGFloat? {
+#if DEBUG
+        return sidebarRowHeightUITestPositiveCGFloat("CMUX_UI_TEST_SIDEBAR_ROW_HEIGHT_TITLE_HEIGHT")
+#else
+        return nil
+#endif
+    }
+
+#if DEBUG
+    private func sidebarRowHeightUITestPositiveCGFloat(_ key: String) -> CGFloat? {
+        if let raw = ProcessInfo.processInfo.environment[key],
+           let value = Double(raw),
+           value > 0 {
+            return CGFloat(value)
+        }
+        if let raw = sidebarRowHeightUITestArgumentValue(key),
+           let value = Double(raw),
+           value > 0 {
+            return CGFloat(value)
+        }
+        if let raw = UserDefaults.standard.string(forKey: key),
+           let value = Double(raw),
+           value > 0 {
+            return CGFloat(value)
+        }
+        return nil
+    }
+
+    private func sidebarRowHeightUITestArgumentValue(_ key: String) -> String? {
+        let arguments = CommandLine.arguments
+        guard let index = arguments.firstIndex(of: "-\(key)") else {
+            return nil
+        }
+        let valueIndex = arguments.index(after: index)
+        guard valueIndex < arguments.endIndex else {
+            return nil
+        }
+        let value = arguments[valueIndex]
+        return value.isEmpty ? nil : value
+    }
+#endif
 
     private var showsLeadingRail: Bool {
         explicitRailColor != nil
@@ -12641,10 +12818,11 @@ private struct TabItemView: View, Equatable {
                 }
 
                 Text(workspaceSnapshot.title)
-                    .font(.system(size: 12.5, weight: titleFontWeight))
+                    .font(.system(size: titleFontSize, weight: titleFontWeight))
                     .foregroundColor(activePrimaryTextColor)
                     .lineLimit(1)
                     .truncationMode(.tail)
+                    .frame(height: titleHeightOverride, alignment: .center)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .layoutPriority(1)
             }
@@ -12883,14 +13061,14 @@ private struct TabItemView: View, Equatable {
         .shortcutHintVisibilityAnimation(value: showsWorkspaceShortcutHint)
         .padding(.horizontal, 6)
         .background {
-            GeometryReader { proxy in
-                Color.clear
-                    .onAppear {
-                        rowHeight = max(proxy.size.height, 1)
-                    }
-                    .onChange(of: proxy.size.height) { newHeight in
-                        rowHeight = max(newHeight, 1)
-                    }
+            SidebarWorkspaceRowHeightMeasurement(
+                workspaceId: tab.id,
+                index: index,
+                count: accessibilityWorkspaceCount,
+                unreadCount: unreadCount,
+                isSelected: isActive
+            ) { height in
+                rowHeight = height
             }
         }
         .contentShape(Rectangle())

--- a/cmuxUITests/WorkspaceSidebarScrollUITests.swift
+++ b/cmuxUITests/WorkspaceSidebarScrollUITests.swift
@@ -1,12 +1,61 @@
+import Foundation
 import XCTest
 
 final class WorkspaceSidebarScrollUITests: XCTestCase {
     private let topTitlebarWorkspaceClearance: CGFloat = 32
+    private let rowHeightTolerance: CGFloat = 0.25
     private let maxSidebarOverflowWorkspaceCount = 80
+    private var notificationTriggerPath = ""
+    private var notificationStatePath = ""
+    private var rowHeightProbePath = ""
+    private var notificationRequestName = ""
+    private var notificationStateName = ""
+    private var rowHeightProbeNotificationName = ""
+    private var temporaryDirectoryPath = ""
+    private var appLogPath = ""
+    private var launchTag = ""
+    private var appProcess: Process?
+    private var sidebarHeightProbeApp: XCUIApplication?
+    private let sidebarHeightObservationLock = NSLock()
+    private var observedNotificationState: [String: String] = [:]
+    private var observedSidebarHeightProbeEvents: [SidebarHeightProbe] = []
 
     override func setUp() {
         super.setUp()
         continueAfterFailure = false
+        let token = UUID().uuidString
+        let temporaryDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-ui-test-sidebar-height-\(token)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
+        temporaryDirectoryPath = temporaryDirectory.path
+        notificationTriggerPath = temporaryDirectory.appendingPathComponent("trigger").path
+        notificationStatePath = temporaryDirectory.appendingPathComponent("state.json").path
+        rowHeightProbePath = temporaryDirectory.appendingPathComponent("row.json").path
+        appLogPath = temporaryDirectory.appendingPathComponent("app.log").path
+        notificationRequestName = "dev.cmux.ui.sidebarRowHeight.request.\(token)"
+        notificationStateName = "dev.cmux.ui.sidebarRowHeight.state.\(token)"
+        rowHeightProbeNotificationName = "dev.cmux.ui.sidebarRowHeight.probe.\(token)"
+        launchTag = "ui-sidebar-\(UUID().uuidString.prefix(8))"
+        observedNotificationState = [:]
+        observedSidebarHeightProbeEvents = []
+        installSidebarHeightNotificationObservers()
+        try? FileManager.default.removeItem(atPath: notificationTriggerPath)
+        try? FileManager.default.removeItem(atPath: notificationStatePath)
+        try? FileManager.default.removeItem(atPath: rowHeightProbePath)
+    }
+
+    override func tearDown() {
+        sidebarHeightProbeApp?.terminate()
+        sidebarHeightProbeApp = nil
+        terminateAppProcess()
+        removeSidebarHeightNotificationObservers()
+        try? FileManager.default.removeItem(atPath: notificationTriggerPath)
+        try? FileManager.default.removeItem(atPath: notificationStatePath)
+        try? FileManager.default.removeItem(atPath: rowHeightProbePath)
+        if !temporaryDirectoryPath.isEmpty {
+            try? FileManager.default.removeItem(atPath: temporaryDirectoryPath)
+        }
+        super.tearDown()
     }
 
     func testWorkspaceSelectionKeepsSidebarRowVisible() {
@@ -110,11 +159,128 @@ final class WorkspaceSidebarScrollUITests: XCTestCase {
         )
     }
 
+    func testCompactWorkspaceRowHeightStaysStableWhenNotificationAppears() throws {
+        try launchSidebarHeightProbeApp()
+        XCTAssertTrue(
+            waitForNotificationStateValue(key: "ready", value: "1", timeout: 20.0),
+            "Expected the sidebar row height notification test trigger to become ready. \(sidebarHeightProbeDiagnostics())"
+        )
+
+        guard let baselineProbe = waitForSidebarHeightProbe(
+            timeout: 4.0,
+            matching: { $0.index == 1 && $0.count == 1 && $0.isSelected && $0.unreadCount == 0 }
+        ) else {
+            XCTFail("Expected first row baseline height probe data. \(sidebarHeightProbeDiagnostics())")
+            return
+        }
+        XCTAssertGreaterThan(baselineProbe.height, 10, "Expected the baseline row probe to measure a laid-out row")
+
+        try triggerSidebarHeightNotification()
+        XCTAssertTrue(
+            waitForNotificationStateValue(key: "notified", value: "1", timeout: 4.0),
+            "Expected the sidebar row height notification trigger to deliver"
+        )
+        let notificationProbes = waitForSidebarHeightProbeEvents(
+            timeout: 8.0,
+            matching: { $0.index == 1 && $0.count == 1 && $0.isSelected && $0.unreadCount > 0 }
+        )
+        guard !notificationProbes.isEmpty else {
+            XCTFail("Expected first row height probe data after notification. \(sidebarHeightProbeDiagnostics())")
+            return
+        }
+        print(
+            "Sidebar row height baseline=\(baselineProbe.height) notificationHeights=\(notificationProbes.map(\.height))"
+        )
+        for notificationProbe in notificationProbes {
+            XCTAssertGreaterThan(notificationProbe.height, 10, "Expected the notification row probe to measure a laid-out row")
+            XCTAssertEqual(
+                notificationProbe.height,
+                baselineProbe.height,
+                accuracy: rowHeightTolerance,
+                "Compact sidebar workspace row layout must not grow when the unread notification badge appears"
+            )
+        }
+    }
+
     private func configureLaunch(_ app: XCUIApplication) {
-        app.launchArguments += ["-newWorkspacePlacement", "end"]
-        app.launchArguments += ["-AppleLanguages", "(en)", "-AppleLocale", "en_US"]
-        app.launchEnvironment["CMUX_UI_TEST_MODE"] = "1"
-        app.launchEnvironment["CMUX_TAG"] = "ui-sidebar-scroll"
+        app.launchArguments += baseLaunchArguments
+        baseLaunchEnvironment.forEach { key, value in
+            app.launchEnvironment[key] = value
+        }
+    }
+
+    private var baseLaunchArguments: [String] {
+        ["-newWorkspacePlacement", "end", "-AppleLanguages", "(en)", "-AppleLocale", "en_US"]
+    }
+
+    private var baseLaunchEnvironment: [String: String] {
+        [
+            "CMUX_UI_TEST_MODE": "1",
+            "CMUX_TAG": launchTag,
+        ]
+    }
+
+    private var compactSidebarLaunchArguments: [String] {
+        [
+            "-sidebarHideAllDetails", "true",
+            "-sidebarShowWorkspaceDescription", "false",
+            "-sidebarShowNotificationMessage", "false",
+            "-sidebarShowBranchDirectory", "false",
+            "-sidebarShowPullRequest", "false",
+            "-sidebarShowSSH", "false",
+            "-sidebarShowPorts", "false",
+            "-sidebarShowLog", "false",
+            "-sidebarShowProgress", "false",
+            "-sidebarShowStatusPills", "false",
+        ]
+    }
+
+    private func configureSidebarHeightProbeLaunch(_ app: XCUIApplication) {
+        configureLaunch(app)
+        app.launchArguments += compactSidebarLaunchArguments + sidebarHeightNotificationLaunchArguments
+        sidebarHeightNotificationLaunchEnvironment.forEach { key, value in
+            app.launchEnvironment[key] = value
+        }
+    }
+
+    private var sidebarHeightNotificationLaunchEnvironment: [String: String] {
+        var environment = [
+            "CMUX_UI_TEST_SIDEBAR_ROW_HEIGHT_NOTIFICATION_SETUP": "1",
+            "CMUX_UI_TEST_SIDEBAR_ROW_HEIGHT_NOTIFICATION_TRIGGER_PATH": notificationTriggerPath,
+            "CMUX_UI_TEST_SIDEBAR_ROW_HEIGHT_NOTIFICATION_STATE_PATH": notificationStatePath,
+            "CMUX_UI_TEST_SIDEBAR_ROW_HEIGHT_NOTIFICATION_TARGET": "first",
+            "CMUX_UI_TEST_SIDEBAR_ROW_HEIGHT_PROBE": "1",
+            "CMUX_UI_TEST_SIDEBAR_ROW_HEIGHT_PROBE_PATH": rowHeightProbePath,
+            "CMUX_UI_TEST_SIDEBAR_ROW_HEIGHT_PROBE_NAME": rowHeightProbeNotificationName,
+            "CMUX_UI_TEST_SIDEBAR_ROW_HEIGHT_TITLE_FONT_SIZE": "1",
+            "CMUX_UI_TEST_SIDEBAR_ROW_HEIGHT_TITLE_HEIGHT": "1",
+        ]
+        if usesXCTestManagedSidebarHeightLaunch {
+            environment["CMUX_UI_TEST_SIDEBAR_ROW_HEIGHT_NOTIFICATION_REQUEST_NAME"] = notificationRequestName
+            environment["CMUX_UI_TEST_SIDEBAR_ROW_HEIGHT_NOTIFICATION_STATE_NAME"] = notificationStateName
+        }
+        return environment
+    }
+
+    private var sidebarHeightNotificationLaunchArguments: [String] {
+        var arguments = [
+            "-CMUX_UI_TEST_SIDEBAR_ROW_HEIGHT_NOTIFICATION_SETUP", "1",
+            "-CMUX_UI_TEST_SIDEBAR_ROW_HEIGHT_NOTIFICATION_TRIGGER_PATH", notificationTriggerPath,
+            "-CMUX_UI_TEST_SIDEBAR_ROW_HEIGHT_NOTIFICATION_STATE_PATH", notificationStatePath,
+            "-CMUX_UI_TEST_SIDEBAR_ROW_HEIGHT_NOTIFICATION_TARGET", "first",
+            "-CMUX_UI_TEST_SIDEBAR_ROW_HEIGHT_PROBE", "1",
+            "-CMUX_UI_TEST_SIDEBAR_ROW_HEIGHT_PROBE_PATH", rowHeightProbePath,
+            "-CMUX_UI_TEST_SIDEBAR_ROW_HEIGHT_PROBE_NAME", rowHeightProbeNotificationName,
+            "-CMUX_UI_TEST_SIDEBAR_ROW_HEIGHT_TITLE_FONT_SIZE", "1",
+            "-CMUX_UI_TEST_SIDEBAR_ROW_HEIGHT_TITLE_HEIGHT", "1",
+        ]
+        if usesXCTestManagedSidebarHeightLaunch {
+            arguments += [
+                "-CMUX_UI_TEST_SIDEBAR_ROW_HEIGHT_NOTIFICATION_REQUEST_NAME", notificationRequestName,
+                "-CMUX_UI_TEST_SIDEBAR_ROW_HEIGHT_NOTIFICATION_STATE_NAME", notificationStateName,
+            ]
+        }
+        return arguments
     }
 
     private func waitForWorkspaceRowHittable(
@@ -257,6 +423,329 @@ final class WorkspaceSidebarScrollUITests: XCTestCase {
             },
             "App failed to launch. state=\(app.state.rawValue)"
         )
+    }
+
+    private var usesXCTestManagedSidebarHeightLaunch: Bool {
+        let environment = ProcessInfo.processInfo.environment
+        if environment["GITHUB_ACTIONS"] == "true" || environment["CI"] == "true" {
+            return true
+        }
+        return NSHomeDirectory().contains("/Users/runner/")
+    }
+
+    private func launchSidebarHeightProbeApp() throws {
+        if usesXCTestManagedSidebarHeightLaunch {
+            let app = XCUIApplication()
+            configureSidebarHeightProbeLaunch(app)
+            launchAndEnsureRunning(app)
+            sidebarHeightProbeApp = app
+            return
+        }
+        try launchAppProcessForSidebarHeightProbe()
+    }
+
+    private func launchAppProcessForSidebarHeightProbe() throws {
+        let binaryPath = try resolveAppBinaryPath()
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: binaryPath)
+        process.arguments = baseLaunchArguments + compactSidebarLaunchArguments + sidebarHeightNotificationLaunchArguments
+
+        var environment = ProcessInfo.processInfo.environment
+        for (key, value) in baseLaunchEnvironment {
+            environment[key] = value
+        }
+        for (key, value) in sidebarHeightNotificationLaunchEnvironment {
+            environment[key] = value
+        }
+        process.environment = environment
+
+        FileManager.default.createFile(atPath: appLogPath, contents: nil)
+        let logHandle = FileHandle(forWritingAtPath: appLogPath)
+        process.standardOutput = logHandle
+        process.standardError = logHandle
+
+        try process.run()
+        appProcess = process
+    }
+
+    private func resolveAppBinaryPath() throws -> String {
+        let testBundle = Bundle(for: Self.self)
+        let productsDir = testBundle.bundleURL
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let binaryPath = productsDir
+            .appendingPathComponent("cmux DEV.app")
+            .appendingPathComponent("Contents/MacOS/cmux DEV")
+            .path
+        if FileManager.default.fileExists(atPath: binaryPath) {
+            return binaryPath
+        }
+        throw NSError(domain: "WorkspaceSidebarScrollUITests", code: 1, userInfo: [
+            NSLocalizedDescriptionKey: "App binary not found at \(binaryPath). testBundle=\(testBundle.bundleURL.path)"
+        ])
+    }
+
+    private func terminateAppProcess() {
+        guard let process = appProcess else { return }
+        defer { appProcess = nil }
+        guard process.isRunning else { return }
+        process.terminate()
+        let deadline = Date().addingTimeInterval(5.0)
+        while process.isRunning && Date() < deadline {
+            RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+        }
+        if process.isRunning {
+            process.interrupt()
+        }
+    }
+
+    private func triggerSidebarHeightNotification() throws {
+        if usesXCTestManagedSidebarHeightLaunch {
+            DistributedNotificationCenter.default().postNotificationName(
+                Notification.Name(notificationRequestName),
+                object: nil,
+                userInfo: [:],
+                deliverImmediately: true
+            )
+        }
+        try? "notify\n".write(
+            to: URL(fileURLWithPath: notificationTriggerPath),
+            atomically: false,
+            encoding: .utf8
+        )
+    }
+
+    private func waitForNotificationStateValue(key: String, value: String, timeout: TimeInterval) -> Bool {
+        pollUntil(timeout: timeout) {
+            self.observedNotificationStateValue(key: key) == value
+                || self.readStringState(at: self.notificationStatePath)?[key] == value
+        }
+    }
+
+    private func waitForSidebarHeightProbe(
+        timeout: TimeInterval,
+        matching predicate: @escaping (SidebarHeightProbe) -> Bool
+    ) -> SidebarHeightProbe? {
+        var match: SidebarHeightProbe?
+        _ = pollUntil(timeout: timeout) {
+            if let probe = self.readSidebarHeightProbeEvents().last(where: predicate) {
+                match = probe
+                return true
+            }
+            return false
+        }
+        return match
+    }
+
+    private func waitForSidebarHeightProbeEvents(
+        timeout: TimeInterval,
+        matching predicate: @escaping (SidebarHeightProbe) -> Bool
+    ) -> [SidebarHeightProbe] {
+        var matches: [SidebarHeightProbe] = []
+        _ = pollUntil(timeout: timeout) {
+            matches = self.readSidebarHeightProbeEvents().filter(predicate)
+            return !matches.isEmpty
+        }
+        return matches
+    }
+
+    private func readSidebarHeightProbeEvents() -> [SidebarHeightProbe] {
+        let observedEvents = observedSidebarHeightProbeEventsSnapshot()
+        guard let payload = readJSONDictionary(at: rowHeightProbePath) else { return observedEvents }
+        guard let events = payload["events"] as? [[String: Any]] else {
+            return observedEvents + (sidebarHeightProbe(from: payload).map { [$0] } ?? [])
+        }
+        return observedEvents + events.compactMap(sidebarHeightProbe(from:))
+    }
+
+    private func sidebarHeightProbe(from payload: [String: Any]) -> SidebarHeightProbe? {
+        guard let unreadCount = intValue(payload["unreadCount"]),
+              let height = doubleValue(payload["height"]),
+              let index = intValue(payload["index"]),
+              let count = intValue(payload["count"]),
+              let isSelected = boolValue(payload["isSelected"]) else {
+            return nil
+        }
+        return SidebarHeightProbe(
+            height: CGFloat(height),
+            unreadCount: unreadCount,
+            workspaceId: payload["workspaceId"] as? String,
+            index: index,
+            count: count,
+            isSelected: isSelected
+        )
+    }
+
+    private func intValue(_ value: Any?) -> Int? {
+        if let value = value as? Int {
+            return value
+        }
+        if let value = value as? NSNumber {
+            return value.intValue
+        }
+        if let value = value as? String {
+            return Int(value)
+        }
+        return nil
+    }
+
+    private func doubleValue(_ value: Any?) -> Double? {
+        if let value = value as? Double {
+            return value
+        }
+        if let value = value as? NSNumber {
+            return value.doubleValue
+        }
+        if let value = value as? String {
+            return Double(value)
+        }
+        return nil
+    }
+
+    private func boolValue(_ value: Any?) -> Bool? {
+        if let value = value as? Bool {
+            return value
+        }
+        if let value = value as? NSNumber {
+            return value.boolValue
+        }
+        if let value = value as? String {
+            return value == "1" || value.lowercased() == "true"
+        }
+        return nil
+    }
+
+    private func sidebarHeightProbeDiagnostics() -> String {
+        let state = readJSONDictionary(at: notificationStatePath) ?? [:]
+        let probe = readJSONDictionary(at: rowHeightProbePath) ?? [:]
+        let fileManager = FileManager.default
+        let xctestAppState = sidebarHeightProbeApp.map { String($0.state.rawValue) } ?? "none"
+        return "state=\(state) observedState=\(observedNotificationStateSnapshot()) "
+            + "probe=\(probe) observedProbeEvents=\(observedSidebarHeightProbeEventsSnapshot().count) "
+            + "statePath=\(notificationStatePath) stateExists=\(fileManager.fileExists(atPath: notificationStatePath)) "
+            + "probePath=\(rowHeightProbePath) probeExists=\(fileManager.fileExists(atPath: rowHeightProbePath)) "
+            + "appRunning=\(appProcess?.isRunning == true) xctestAppState=\(xctestAppState) "
+            + "appLog=\(appLogTail()) "
+            + "requestName=\(notificationRequestName)"
+    }
+
+    private func appLogTail() -> String {
+        guard !appLogPath.isEmpty,
+              let log = try? String(contentsOfFile: appLogPath, encoding: .utf8),
+              !log.isEmpty else {
+            return "<empty>"
+        }
+        return String(log.suffix(1200))
+    }
+
+    private func installSidebarHeightNotificationObservers() {
+        DistributedNotificationCenter.default().addObserver(
+            self,
+            selector: #selector(handleSidebarHeightStateNotification(_:)),
+            name: Notification.Name(notificationStateName),
+            object: nil,
+            suspensionBehavior: .deliverImmediately
+        )
+        DistributedNotificationCenter.default().addObserver(
+            self,
+            selector: #selector(handleSidebarHeightProbeNotification(_:)),
+            name: Notification.Name(rowHeightProbeNotificationName),
+            object: nil,
+            suspensionBehavior: .deliverImmediately
+        )
+    }
+
+    private func removeSidebarHeightNotificationObservers() {
+        if !notificationStateName.isEmpty {
+            DistributedNotificationCenter.default().removeObserver(
+                self,
+                name: Notification.Name(notificationStateName),
+                object: nil
+            )
+        }
+        if !rowHeightProbeNotificationName.isEmpty {
+            DistributedNotificationCenter.default().removeObserver(
+                self,
+                name: Notification.Name(rowHeightProbeNotificationName),
+                object: nil
+            )
+        }
+    }
+
+    @objc private func handleSidebarHeightStateNotification(_ notification: Notification) {
+        let payload = stringKeyedPayload(from: notification)
+        let updates = payload.reduce(into: [String: String]()) { result, entry in
+            guard let value = entry.value as? String else { return }
+            result[entry.key] = value
+        }
+        guard !updates.isEmpty else { return }
+        sidebarHeightObservationLock.lock()
+        for (key, value) in updates {
+            observedNotificationState[key] = value
+        }
+        sidebarHeightObservationLock.unlock()
+    }
+
+    @objc private func handleSidebarHeightProbeNotification(_ notification: Notification) {
+        guard let probe = sidebarHeightProbe(from: stringKeyedPayload(from: notification)) else { return }
+        sidebarHeightObservationLock.lock()
+        observedSidebarHeightProbeEvents.append(probe)
+        sidebarHeightObservationLock.unlock()
+    }
+
+    private func stringKeyedPayload(from notification: Notification) -> [String: Any] {
+        (notification.userInfo ?? [:]).reduce(into: [String: Any]()) { result, entry in
+            result[String(describing: entry.key)] = entry.value
+        }
+    }
+
+    private func observedNotificationStateValue(key: String) -> String? {
+        sidebarHeightObservationLock.lock()
+        let value = observedNotificationState[key]
+        sidebarHeightObservationLock.unlock()
+        return value
+    }
+
+    private func observedNotificationStateSnapshot() -> [String: String] {
+        sidebarHeightObservationLock.lock()
+        let snapshot = observedNotificationState
+        sidebarHeightObservationLock.unlock()
+        return snapshot
+    }
+
+    private func observedSidebarHeightProbeEventsSnapshot() -> [SidebarHeightProbe] {
+        sidebarHeightObservationLock.lock()
+        let snapshot = observedSidebarHeightProbeEvents
+        sidebarHeightObservationLock.unlock()
+        return snapshot
+    }
+
+    private func readStringState(at path: String) -> [String: String]? {
+        guard let payload = readJSONDictionary(at: path) else { return nil }
+        return payload.reduce(into: [String: String]()) { result, entry in
+            if let value = entry.value as? String {
+                result[entry.key] = value
+            }
+        }
+    }
+
+    private func readJSONDictionary(at path: String) -> [String: Any]? {
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
+              let payload = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        return payload
+    }
+
+    private struct SidebarHeightProbe {
+        let height: CGFloat
+        let unreadCount: Int
+        let workspaceId: String?
+        let index: Int
+        let count: Int
+        let isSelected: Bool
     }
 
     private func pollUntil(


### PR DESCRIPTION
Summary:
- Adds a regression XCUITest for compact sidebar workspace row height when an unread notification badge appears.
- Keeps the compact workspace title row at badge height so rows do not grow when notifications arrive, whether sidebar details are shown or hidden.

Verification:
- Red test commit: https://github.com/manaflow-ai/cmux/commit/a7b1337645b85338387f2049ab5bd63131e44855
- Fix commit: https://github.com/manaflow-ai/cmux/commit/adb635773b95c46d33896fc9551125e06d80a05f
- AWS M4 red XCUITest failed as intended: `Sidebar row height baseline=17.0 notificationHeights=[32.0, 32.0]`, result bundle `/tmp/cmux-e2e-sideht-red7.xcresult`.
- AWS M4 green XCUITest passed: `Sidebar row height baseline=32.0 notificationHeights=[32.0]`, result bundle `/tmp/cmux-e2e-sideht-green7.xcresult`.
- Hosted green E2E passed: https://github.com/manaflow-ai/cmux/actions/runs/26048482655
- Local app build passed with warning budget respected: `xcodebuild ... -derivedDataPath /tmp/cmux-sideht-warning-build build` and `python3 scripts/swift_warning_budget.py --log /tmp/cmux-sideht-build-output.txt`.
- PR checks are green, including CircleCI macOS debug/release/unit tests, workflow guard, web typecheck, remote daemon tests, activation session, Greptile, and CodeRabbit.

Video proof:
- Before-proof cloud Mac was provisioned at https://github.com/manaflow-ai/cmux-loader/actions/runs/25955825133, but no validated video was recorded before the host expired.
- Hosted E2E recording did not produce `/tmp/test-recording.mp4`, so no MP4 artifact is available.