### PR TITLE
feat: persist workspace sessions by directory

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -3740,14 +3740,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return false
         }
 
-        if synchronously {
-            _ = sessionPersistenceQueue.sync(execute: writePrimarySnapshotBlock)
-        } else {
-            sessionPersistenceQueue.async {
-                if writePrimarySnapshotBlock(), let snapshot {
-                    SessionPersistenceStore.saveWorkspaceSnapshots(from: snapshot)
-                }
+        let writeAllSnapshotsBlock = {
+            if writePrimarySnapshotBlock(), let snapshot {
+                SessionPersistenceStore.saveWorkspaceSnapshots(from: snapshot)
             }
+        }
+
+        if synchronously {
+            sessionPersistenceQueue.sync(execute: writeAllSnapshotsBlock)
+        } else {
+            sessionPersistenceQueue.async(execute: writeAllSnapshotsBlock)
         }
     }
 

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -3716,6 +3716,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         quantized.forEach { hasher.combine($0) }
     }
 
+    private func persistWorkspaceSessionSnapshots(
+        from snapshot: AppSessionSnapshot,
+        synchronously: Bool
+    ) {
+        let writeBlock = {
+            SessionPersistenceStore.saveWorkspaceSnapshots(from: snapshot)
+        }
+        if synchronously {
+            sessionPersistenceQueue.sync(execute: writeBlock)
+        } else {
+            sessionPersistenceQueue.async(execute: writeBlock)
+        }
+    }
+
     private func persistSessionSnapshot(
         _ snapshot: AppSessionSnapshot?,
         removeWhenEmpty: Bool,
@@ -3781,19 +3795,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let windows: [SessionWindowSnapshot] = contexts
             .prefix(SessionPersistencePolicy.maxWindowsPerSnapshot)
             .map { context in
-                let window = context.window ?? windowForMainWindowId(context.windowId)
-                return SessionWindowSnapshot(
-                    frame: window.map { SessionRectSnapshot($0.frame) },
-                    display: displaySnapshot(for: window),
-                    tabManager: context.tabManager.sessionSnapshot(
-                        includeScrollback: includeScrollback,
-                        restorableAgentIndex: restorableAgentIndex
-                    ),
-                    sidebar: SessionSidebarSnapshot(
-                        isVisible: context.sidebarState.isVisible,
-                        selection: SessionSidebarSelection(selection: context.sidebarSelectionState.selection),
-                        width: SessionPersistencePolicy.sanitizedSidebarWidth(Double(context.sidebarState.persistedWidth))
-                    )
+                sessionWindowSnapshot(
+                    for: context,
+                    includeScrollback: includeScrollback,
+                    restorableAgentIndex: restorableAgentIndex
                 )
             }
 
@@ -3802,6 +3807,27 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             version: SessionSnapshotSchema.currentVersion,
             createdAt: Date().timeIntervalSince1970,
             windows: windows
+        )
+    }
+
+    private func sessionWindowSnapshot(
+        for context: MainWindowContext,
+        includeScrollback: Bool,
+        restorableAgentIndex: RestorableAgentSessionIndex?
+    ) -> SessionWindowSnapshot {
+        let window = context.window ?? windowForMainWindowId(context.windowId)
+        return SessionWindowSnapshot(
+            frame: window.map { SessionRectSnapshot($0.frame) },
+            display: displaySnapshot(for: window),
+            tabManager: context.tabManager.sessionSnapshot(
+                includeScrollback: includeScrollback,
+                restorableAgentIndex: restorableAgentIndex
+            ),
+            sidebar: SessionSidebarSnapshot(
+                isVisible: context.sidebarState.isVisible,
+                selection: SessionSidebarSelection(selection: context.sidebarSelectionState.selection),
+                width: SessionPersistencePolicy.sanitizedSidebarWidth(Double(context.sidebarState.persistedWidth))
+            )
         )
     }
 
@@ -14107,6 +14133,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             persistWindowGeometry(from: window)
         }
 
+        let shouldPersistOnUnregister = Self.shouldPersistSnapshotOnWindowUnregister(isTerminatingApp: isTerminatingApp)
+        let closingWorkspaceSnapshot = shouldPersistOnUnregister
+            ? contextForMainTerminalWindow(window, reindex: false).map { context in
+                AppSessionSnapshot(
+                    version: SessionSnapshotSchema.currentVersion,
+                    createdAt: Date().timeIntervalSince1970,
+                    windows: [
+                        sessionWindowSnapshot(
+                            for: context,
+                            includeScrollback: false,
+                            restorableAgentIndex: RestorableAgentSessionIndex.load()
+                        ),
+                    ]
+                )
+            }
+            : nil
         guard let removed = unregisterMainWindowContext(for: window) else { return }
         publishCmuxWindowLifecycle(name: "window.closed", windowId: removed.windowId, origin: "appkit_close")
         commandPaletteVisibilityByWindowId.removeValue(forKey: removed.windowId)
@@ -14140,7 +14182,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // During app termination we already persisted a full snapshot (with scrollback)
         // in applicationShouldTerminate/applicationWillTerminate. Saving again here would
         // overwrite it as windows tear down one-by-one, dropping closed windows and replay.
-        if Self.shouldPersistSnapshotOnWindowUnregister(isTerminatingApp: isTerminatingApp) {
+        if shouldPersistOnUnregister {
+            if let closingWorkspaceSnapshot {
+                persistWorkspaceSessionSnapshots(from: closingWorkspaceSnapshot, synchronously: false)
+            }
             _ = saveSessionSnapshot(includeScrollback: false, removeWhenEmpty: false)
         }
     }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -3741,7 +3741,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
 
         if synchronously {
-            writeBlock()
+            sessionPersistenceQueue.sync(execute: writeBlock)
         } else {
             sessionPersistenceQueue.async(execute: writeBlock)
         }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -3734,6 +3734,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             }
             if let snapshot {
                 _ = SessionPersistenceStore.save(snapshot)
+                SessionPersistenceStore.saveWorkspaceSnapshots(from: snapshot)
             } else if removeWhenEmpty {
                 SessionPersistenceStore.removeSnapshot()
             }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -3724,7 +3724,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     ) {
         guard snapshot != nil || removeWhenEmpty || persistedGeometryData != nil else { return }
 
-        let writePrimarySnapshotBlock = { () -> Bool in
+        let writePrimarySnapshotBlock = { () -> SessionSnapshotWriteResult in
             Self.removeLegacyPersistedWindowGeometry()
             if let persistedGeometryData {
                 UserDefaults.standard.set(
@@ -3733,17 +3733,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 )
             }
             if let snapshot {
-                return SessionPersistenceStore.save(snapshot)
+                return SessionPersistenceStore.saveResult(snapshot)
             } else if removeWhenEmpty {
                 SessionPersistenceStore.removeSnapshot()
             }
-            return false
+            return .unchanged
         }
 
         let writeAllSnapshotsBlock = {
-            if writePrimarySnapshotBlock(), let snapshot {
-                SessionPersistenceStore.saveWorkspaceSnapshots(from: snapshot)
+            guard let snapshot else {
+                _ = writePrimarySnapshotBlock()
+                return
             }
+            guard writePrimarySnapshotBlock() != .failed else { return }
+            SessionPersistenceStore.saveWorkspaceSnapshots(from: snapshot)
         }
 
         if synchronously {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -3724,7 +3724,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     ) {
         guard snapshot != nil || removeWhenEmpty || persistedGeometryData != nil else { return }
 
-        let writeBlock = {
+        let writePrimarySnapshotBlock = { () -> Bool in
             Self.removeLegacyPersistedWindowGeometry()
             if let persistedGeometryData {
                 UserDefaults.standard.set(
@@ -3733,17 +3733,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 )
             }
             if let snapshot {
-                _ = SessionPersistenceStore.save(snapshot)
-                SessionPersistenceStore.saveWorkspaceSnapshots(from: snapshot)
+                return SessionPersistenceStore.save(snapshot)
             } else if removeWhenEmpty {
                 SessionPersistenceStore.removeSnapshot()
             }
+            return false
         }
 
         if synchronously {
-            sessionPersistenceQueue.sync(execute: writeBlock)
+            _ = sessionPersistenceQueue.sync(execute: writePrimarySnapshotBlock)
         } else {
-            sessionPersistenceQueue.async(execute: writeBlock)
+            sessionPersistenceQueue.async {
+                if writePrimarySnapshotBlock(), let snapshot {
+                    SessionPersistenceStore.saveWorkspaceSnapshots(from: snapshot)
+                }
+            }
         }
     }
 

--- a/Sources/CmuxConfigExecutor.swift
+++ b/Sources/CmuxConfigExecutor.swift
@@ -498,7 +498,10 @@ struct CmuxConfigExecutor {
         }
 
         let resolvedCwd = CmuxConfigStore.resolveCwd(wsDef.cwd, relativeTo: baseCwd)
-        let newWorkspace = tabManager.addWorkspace(workingDirectory: resolvedCwd)
+        let newWorkspace = tabManager.addWorkspace(
+            workingDirectory: resolvedCwd,
+            restoreWorkspaceSession: false
+        )
         newWorkspace.setCustomTitle(workspaceName)
         if let color = wsDef.color {
             newWorkspace.setCustomColor(color)

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -1,4 +1,5 @@
 import CoreGraphics
+import CryptoKit
 import Foundation
 import Bonsplit
 
@@ -376,6 +377,13 @@ struct AppSessionSnapshot: Codable, Sendable {
     var windows: [SessionWindowSnapshot]
 }
 
+struct WorkspaceSessionSnapshotEnvelope: Codable, Sendable {
+    var version: Int
+    var createdAt: TimeInterval
+    var workingDirectory: String
+    var workspace: SessionWorkspaceSnapshot
+}
+
 enum SessionPersistenceStore {
     static func load(fileURL: URL? = nil) -> AppSessionSnapshot? {
         guard let fileURL = fileURL ?? defaultSnapshotFileURL() else { return nil }
@@ -436,6 +444,178 @@ enum SessionPersistenceStore {
             return
         }
         _ = save(snapshot, fileURL: fileURL)
+    }
+
+    static func loadWorkspaceSnapshot(
+        workingDirectory: String,
+        bundleIdentifier: String? = Bundle.main.bundleIdentifier,
+        appSupportDirectory: URL? = nil,
+        fileManager: FileManager = .default
+    ) -> SessionWorkspaceSnapshot? {
+        guard let fileURL = workspaceSnapshotFileURL(
+            workingDirectory: workingDirectory,
+            bundleIdentifier: bundleIdentifier,
+            appSupportDirectory: appSupportDirectory,
+            fileManager: fileManager
+        ) else {
+            return nil
+        }
+        guard let data = try? Data(contentsOf: fileURL) else { return nil }
+        let decoder = JSONDecoder()
+        guard let envelope = try? decoder.decode(WorkspaceSessionSnapshotEnvelope.self, from: data) else {
+            return nil
+        }
+        guard envelope.version == SessionSnapshotSchema.currentVersion else { return nil }
+        guard let canonicalRequested = canonicalWorkspaceDirectoryPath(
+            workingDirectory,
+            fileManager: fileManager
+        ) else {
+            return nil
+        }
+        guard envelope.workingDirectory == canonicalRequested else { return nil }
+        return envelope.workspace
+    }
+
+    @discardableResult
+    static func saveWorkspaceSnapshot(
+        _ snapshot: SessionWorkspaceSnapshot,
+        workingDirectory: String,
+        bundleIdentifier: String? = Bundle.main.bundleIdentifier,
+        appSupportDirectory: URL? = nil,
+        fileManager: FileManager = .default
+    ) -> Bool {
+        guard let canonicalDirectory = canonicalWorkspaceDirectoryPath(
+            workingDirectory,
+            fileManager: fileManager
+        ) else {
+            return false
+        }
+        guard let fileURL = workspaceSnapshotFileURL(
+            workingDirectory: canonicalDirectory,
+            bundleIdentifier: bundleIdentifier,
+            appSupportDirectory: appSupportDirectory,
+            fileManager: fileManager
+        ) else {
+            return false
+        }
+        var canonicalSnapshot = snapshot
+        canonicalSnapshot.currentDirectory = canonicalDirectory
+        let envelope = WorkspaceSessionSnapshotEnvelope(
+            version: SessionSnapshotSchema.currentVersion,
+            createdAt: Date().timeIntervalSince1970,
+            workingDirectory: canonicalDirectory,
+            workspace: canonicalSnapshot
+        )
+        let directory = fileURL.deletingLastPathComponent()
+        do {
+            try fileManager.createDirectory(at: directory, withIntermediateDirectories: true, attributes: nil)
+            let data = try encodedWorkspaceSnapshotData(envelope)
+            if let existingData = try? Data(contentsOf: fileURL), existingData == data {
+                return true
+            }
+            try data.write(to: fileURL, options: .atomic)
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    static func saveWorkspaceSnapshots(
+        from snapshot: AppSessionSnapshot,
+        bundleIdentifier: String? = Bundle.main.bundleIdentifier,
+        appSupportDirectory: URL? = nil,
+        fileManager: FileManager = .default
+    ) {
+        for window in snapshot.windows {
+            for workspace in window.tabManager.workspaces {
+                _ = saveWorkspaceSnapshot(
+                    workspace,
+                    workingDirectory: workspace.currentDirectory,
+                    bundleIdentifier: bundleIdentifier,
+                    appSupportDirectory: appSupportDirectory,
+                    fileManager: fileManager
+                )
+            }
+        }
+    }
+
+    private static func encodedWorkspaceSnapshotData(_ envelope: WorkspaceSessionSnapshotEnvelope) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return try encoder.encode(envelope)
+    }
+
+    private static func workspaceSnapshotFileURL(
+        workingDirectory: String,
+        bundleIdentifier: String?,
+        appSupportDirectory: URL?,
+        fileManager: FileManager
+    ) -> URL? {
+        guard let canonicalDirectory = canonicalWorkspaceDirectoryPath(
+            workingDirectory,
+            fileManager: fileManager
+        ) else {
+            return nil
+        }
+        guard let root = workspaceSnapshotsRootURL(
+            bundleIdentifier: bundleIdentifier,
+            appSupportDirectory: appSupportDirectory
+        ) else {
+            return nil
+        }
+        let digest = workspaceDirectoryDigest(canonicalDirectory)
+        return root
+            .appendingPathComponent(digest, isDirectory: true)
+            .appendingPathComponent("session.json", isDirectory: false)
+    }
+
+    private static func workspaceSnapshotsRootURL(
+        bundleIdentifier: String?,
+        appSupportDirectory: URL?
+    ) -> URL? {
+        let resolvedAppSupport: URL
+        if let appSupportDirectory {
+            resolvedAppSupport = appSupportDirectory
+        } else if let discovered = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first {
+            resolvedAppSupport = discovered
+        } else {
+            return nil
+        }
+        let bundleId = (bundleIdentifier?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false)
+            ? bundleIdentifier!
+            : "com.cmuxterm.app"
+        let safeBundleId = bundleId.replacingOccurrences(
+            of: "[^A-Za-z0-9._-]",
+            with: "_",
+            options: .regularExpression
+        )
+        return resolvedAppSupport
+            .appendingPathComponent("cmux", isDirectory: true)
+            .appendingPathComponent("workspace-sessions", isDirectory: true)
+            .appendingPathComponent(safeBundleId, isDirectory: true)
+    }
+
+    private static func canonicalWorkspaceDirectoryPath(
+        _ workingDirectory: String,
+        fileManager: FileManager
+    ) -> String? {
+        let trimmed = workingDirectory.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let expanded = (trimmed as NSString).expandingTildeInPath
+        let url = URL(fileURLWithPath: expanded, isDirectory: true)
+            .standardizedFileURL
+            .resolvingSymlinksInPath()
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory), isDirectory.boolValue else {
+            return nil
+        }
+        return url.path
+    }
+
+    private static func workspaceDirectoryDigest(_ path: String) -> String {
+        SHA256.hash(data: Data(path.utf8))
+            .map { String(format: "%02x", $0) }
+            .joined()
     }
 
     static func defaultSnapshotFileURL(

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -377,7 +377,7 @@ struct AppSessionSnapshot: Codable, Sendable {
     var windows: [SessionWindowSnapshot]
 }
 
-struct WorkspaceSessionSnapshotEnvelope: Codable, Sendable {
+nonisolated struct WorkspaceSessionSnapshotEnvelope: Codable, Sendable {
     var version: Int
     var createdAt: TimeInterval
     var workingDirectory: String
@@ -500,17 +500,29 @@ enum SessionPersistenceStore {
         }
         var canonicalSnapshot = snapshot
         canonicalSnapshot.currentDirectory = canonicalDirectory
-        let envelope = WorkspaceSessionSnapshotEnvelope(
-            version: SessionSnapshotSchema.currentVersion,
-            createdAt: Date().timeIntervalSince1970,
-            workingDirectory: canonicalDirectory,
-            workspace: canonicalSnapshot
-        )
         let directory = fileURL.deletingLastPathComponent()
         do {
             try fileManager.createDirectory(at: directory, withIntermediateDirectories: true, attributes: nil)
+            let existingData = try? Data(contentsOf: fileURL)
+            let existingEnvelope = existingData.flatMap { data -> WorkspaceSessionSnapshotEnvelope? in
+                try? JSONDecoder().decode(WorkspaceSessionSnapshotEnvelope.self, from: data)
+            }
+            let createdAt: TimeInterval
+            if existingEnvelope?.version == SessionSnapshotSchema.currentVersion,
+               existingEnvelope?.workingDirectory == canonicalDirectory,
+               let existingCreatedAt = existingEnvelope?.createdAt {
+                createdAt = existingCreatedAt
+            } else {
+                createdAt = Date().timeIntervalSince1970
+            }
+            let envelope = WorkspaceSessionSnapshotEnvelope(
+                version: SessionSnapshotSchema.currentVersion,
+                createdAt: createdAt,
+                workingDirectory: canonicalDirectory,
+                workspace: canonicalSnapshot
+            )
             let data = try encodedWorkspaceSnapshotData(envelope)
-            if let existingData = try? Data(contentsOf: fileURL), existingData == data {
+            if existingData == data {
                 return true
             }
             try data.write(to: fileURL, options: .atomic)

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -349,6 +349,7 @@ struct SessionWorkspaceSnapshot: Codable, Sendable {
     var hasUnreadIndicator: Bool? = nil
     var terminalScrollBarHidden: Bool?
     var currentDirectory: String
+    var workspaceSessionRootDirectory: String? = nil
     var focusedPanelId: UUID?
     var layout: SessionWorkspaceLayoutSnapshot
     var panels: [SessionPanelSnapshot]
@@ -377,14 +378,14 @@ struct AppSessionSnapshot: Codable, Sendable {
     var windows: [SessionWindowSnapshot]
 }
 
-nonisolated struct WorkspaceSessionSnapshotEnvelope: Codable, Sendable {
+struct WorkspaceSessionSnapshotEnvelope: Codable, Sendable {
     var version: Int
     var createdAt: TimeInterval
     var workingDirectory: String
     var workspace: SessionWorkspaceSnapshot
 }
 
-nonisolated enum SessionSnapshotWriteResult: Equatable, Sendable {
+enum SessionSnapshotWriteResult: Equatable, Sendable {
     case written
     case unchanged
     case failed
@@ -518,7 +519,7 @@ enum SessionPersistenceStore {
             return false
         }
         var canonicalSnapshot = snapshot
-        canonicalSnapshot.currentDirectory = canonicalDirectory
+        canonicalSnapshot.workspaceSessionRootDirectory = canonicalDirectory
         let directory = fileURL.deletingLastPathComponent()
         do {
             try fileManager.createDirectory(at: directory, withIntermediateDirectories: true, attributes: nil)
@@ -559,9 +560,10 @@ enum SessionPersistenceStore {
     ) {
         for window in snapshot.windows {
             for workspace in window.tabManager.workspaces {
+                let keyDirectory = workspace.workspaceSessionRootDirectory ?? workspace.currentDirectory
                 _ = saveWorkspaceSnapshot(
                     workspace,
-                    workingDirectory: workspace.currentDirectory,
+                    workingDirectory: keyDirectory,
                     bundleIdentifier: bundleIdentifier,
                     appSupportDirectory: appSupportDirectory,
                     fileManager: fileManager

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -384,6 +384,21 @@ nonisolated struct WorkspaceSessionSnapshotEnvelope: Codable, Sendable {
     var workspace: SessionWorkspaceSnapshot
 }
 
+nonisolated enum SessionSnapshotWriteResult: Equatable, Sendable {
+    case written
+    case unchanged
+    case failed
+
+    var succeeded: Bool {
+        switch self {
+        case .written, .unchanged:
+            true
+        case .failed:
+            false
+        }
+    }
+}
+
 enum SessionPersistenceStore {
     static func load(fileURL: URL? = nil) -> AppSessionSnapshot? {
         guard let fileURL = fileURL ?? defaultSnapshotFileURL() else { return nil }
@@ -397,18 +412,22 @@ enum SessionPersistenceStore {
 
     @discardableResult
     static func save(_ snapshot: AppSessionSnapshot, fileURL: URL? = nil) -> Bool {
-        guard let fileURL = fileURL ?? defaultSnapshotFileURL() else { return false }
+        saveResult(snapshot, fileURL: fileURL).succeeded
+    }
+
+    static func saveResult(_ snapshot: AppSessionSnapshot, fileURL: URL? = nil) -> SessionSnapshotWriteResult {
+        guard let fileURL = fileURL ?? defaultSnapshotFileURL() else { return .failed }
         let directory = fileURL.deletingLastPathComponent()
         do {
             try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true, attributes: nil)
             let data = try encodedSnapshotData(snapshot)
             if let existingData = try? Data(contentsOf: fileURL), existingData == data {
-                return true
+                return .unchanged
             }
             try data.write(to: fileURL, options: .atomic)
-            return true
+            return .written
         } catch {
-            return false
+            return .failed
         }
     }
 

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -1055,10 +1055,6 @@ class TabManager: ObservableObject {
         label: "com.cmux.initial-workspace-git-probe",
         qos: .utility
     )
-    private let workspaceSessionRestoreQueue = DispatchQueue(
-        label: "com.cmux.workspace-session-restore",
-        qos: .utility
-    )
     private var workspaceGitProbeStateByKey: [WorkspaceGitProbeKey: WorkspaceGitProbeState] = [:]
     private var workspaceGitProbeTimersByKey: [WorkspaceGitProbeKey: [DispatchSourceTimer]] = [:]
     private var workspaceGitTrackedDirectoryByKey: [WorkspaceGitProbeKey: String] = [:]
@@ -2280,37 +2276,45 @@ class TabManager: ObservableObject {
         expectedPanelIds: Set<UUID>,
         explicitTitle: String?
     ) {
-        workspaceSessionRestoreQueue.async { [workingDirectory, bundleIdentifier, appSupportDirectory] in
-            let restoredSnapshot = SessionPersistenceStore.loadWorkspaceSnapshot(
-                workingDirectory: workingDirectory,
-                bundleIdentifier: bundleIdentifier,
-                appSupportDirectory: appSupportDirectory
-            )
-            DispatchQueue.main.async { [weak self] in
-                guard let self else { return }
-                guard let workspace = self.tabs.first(where: { $0.id == workspaceId }) else { return }
-                guard workspace.customTitle == expectedCustomTitle,
-                      workspace.currentDirectory == expectedCurrentDirectory,
-                      Set(workspace.panels.keys) == expectedPanelIds else {
-                    return
+        Task { [weak self, workingDirectory, bundleIdentifier, appSupportDirectory] in
+            let restoredSnapshot = await Task.detached(priority: .utility) {
+                SessionPersistenceStore.loadWorkspaceSnapshot(
+                    workingDirectory: workingDirectory,
+                    bundleIdentifier: bundleIdentifier,
+                    appSupportDirectory: appSupportDirectory
+                )
+            }.value
+            guard let self else { return }
+            guard let workspace = tabs.first(where: { $0.id == workspaceId }) else { return }
+            guard workspace.customTitle == expectedCustomTitle,
+                  workspace.currentDirectory == expectedCurrentDirectory,
+                  Set(workspace.panels.keys) == expectedPanelIds else {
+                return
+            }
+            if let restoredSnapshot {
+                workspace.restoreSessionSnapshot(restoredSnapshot)
+                clearWorkspaceGitProbes(workspaceId: workspace.id)
+                for terminalPanel in workspace.panels.values.compactMap({ $0 as? TerminalPanel }) {
+                    scheduleInitialWorkspaceGitMetadataRefreshIfPossible(
+                        workspaceId: workspace.id,
+                        panelId: terminalPanel.id,
+                        reason: "workspace-session-restore"
+                    )
                 }
-                if let restoredSnapshot {
-                    workspace.restoreSessionSnapshot(restoredSnapshot)
-                    if let explicitTitle {
-                        workspace.setCustomTitle(explicitTitle)
-                    }
-                    return
+                if let explicitTitle {
+                    workspace.setCustomTitle(explicitTitle)
                 }
-                guard autoWelcomeIfNeeded,
-                      select,
-                      !UserDefaults.standard.bool(forKey: WelcomeSettings.shownKey) else {
-                    return
-                }
-                if let appDelegate = AppDelegate.shared {
-                    appDelegate.sendWelcomeCommandWhenReady(to: workspace, markShownOnSend: true)
-                } else {
-                    sendWelcomeWhenReady(to: workspace)
-                }
+                return
+            }
+            guard autoWelcomeIfNeeded,
+                  select,
+                  !UserDefaults.standard.bool(forKey: WelcomeSettings.shownKey) else {
+                return
+            }
+            if let appDelegate = AppDelegate.shared {
+                appDelegate.sendWelcomeCommandWhenReady(to: workspace, markShownOnSend: true)
+            } else {
+                sendWelcomeWhenReady(to: workspace)
             }
         }
     }

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -2264,7 +2264,7 @@ class TabManager: ObservableObject {
         }
     }
 
-    private func scheduleWorkspaceSessionRestore(
+    @MainActor private func scheduleWorkspaceSessionRestore(
         workingDirectory: String,
         workspaceId: UUID,
         bundleIdentifier: String?,

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -1055,6 +1055,10 @@ class TabManager: ObservableObject {
         label: "com.cmux.initial-workspace-git-probe",
         qos: .utility
     )
+    private let workspaceSessionRestoreQueue = DispatchQueue(
+        label: "com.cmux.workspace-session-restore",
+        qos: .utility
+    )
     private var workspaceGitProbeStateByKey: [WorkspaceGitProbeKey: WorkspaceGitProbeState] = [:]
     private var workspaceGitProbeTimersByKey: [WorkspaceGitProbeKey: [DispatchSourceTimer]] = [:]
     private var workspaceGitTrackedDirectoryByKey: [WorkspaceGitProbeKey: String] = [:]
@@ -2165,20 +2169,11 @@ class TabManager: ObservableObject {
             sentryBreadcrumb("workspace.create", data: ["tabCount": nextTabCount])
             let explicitWorkingDirectory = normalizedWorkingDirectory(overrideWorkingDirectory)
             let workingDirectory = explicitWorkingDirectory ?? snapshot.preferredWorkingDirectory
-            let restoredWorkspaceSnapshot: SessionWorkspaceSnapshot?
-            if restoreWorkspaceSession,
-               let explicitWorkingDirectory,
-               initialTerminalCommand == nil,
-               initialTerminalInput == nil,
-               initialTerminalEnvironment.isEmpty {
-                restoredWorkspaceSnapshot = SessionPersistenceStore.loadWorkspaceSnapshot(
-                    workingDirectory: explicitWorkingDirectory,
-                    bundleIdentifier: workspaceSessionBundleIdentifier,
-                    appSupportDirectory: workspaceSessionAppSupportDirectory
-                )
-            } else {
-                restoredWorkspaceSnapshot = nil
-            }
+            let workspaceSessionRestoreRequested = restoreWorkspaceSession
+                && explicitWorkingDirectory != nil
+                && initialTerminalCommand == nil
+                && initialTerminalInput == nil
+                && initialTerminalEnvironment.isEmpty
             let inheritedConfig = workspaceCreationConfigTemplate(
                 inheritedTerminalFontPoints: snapshot.inheritedTerminalFontPoints
             )
@@ -2197,9 +2192,6 @@ class TabManager: ObservableObject {
                 initialTerminalInput: initialTerminalInput,
                 initialTerminalEnvironment: initialTerminalEnvironment
             )
-            if let restoredWorkspaceSnapshot {
-                newWorkspace.restoreSessionSnapshot(restoredWorkspaceSnapshot)
-            }
             applyCreationChromeInheritance(
                 to: newWorkspace,
                 from: sourceWorkspace ?? capturedTabs.first
@@ -2252,7 +2244,20 @@ class TabManager: ObservableObject {
                 "selectedTabId": select ? newWorkspace.id.uuidString : (snapshot.selectedTabId?.uuidString ?? "")
             ])
 #endif
-            if autoWelcomeIfNeeded && restoredWorkspaceSnapshot == nil && select && !UserDefaults.standard.bool(forKey: WelcomeSettings.shownKey) {
+            if workspaceSessionRestoreRequested, let explicitWorkingDirectory {
+                scheduleWorkspaceSessionRestore(
+                    workingDirectory: explicitWorkingDirectory,
+                    workspaceId: newWorkspace.id,
+                    bundleIdentifier: workspaceSessionBundleIdentifier,
+                    appSupportDirectory: workspaceSessionAppSupportDirectory,
+                    autoWelcomeIfNeeded: autoWelcomeIfNeeded,
+                    select: select,
+                    expectedCustomTitle: newWorkspace.customTitle,
+                    expectedCurrentDirectory: newWorkspace.currentDirectory,
+                    expectedPanelIds: Set(newWorkspace.panels.keys),
+                    explicitTitle: title
+                )
+            } else if autoWelcomeIfNeeded && select && !UserDefaults.standard.bool(forKey: WelcomeSettings.shownKey) {
                 if let appDelegate = AppDelegate.shared {
                     appDelegate.sendWelcomeCommandWhenReady(to: newWorkspace, markShownOnSend: true)
                 } else {
@@ -2260,6 +2265,53 @@ class TabManager: ObservableObject {
                 }
             }
             return newWorkspace
+        }
+    }
+
+    private func scheduleWorkspaceSessionRestore(
+        workingDirectory: String,
+        workspaceId: UUID,
+        bundleIdentifier: String?,
+        appSupportDirectory: URL?,
+        autoWelcomeIfNeeded: Bool,
+        select: Bool,
+        expectedCustomTitle: String?,
+        expectedCurrentDirectory: String,
+        expectedPanelIds: Set<UUID>,
+        explicitTitle: String?
+    ) {
+        workspaceSessionRestoreQueue.async { [workingDirectory, bundleIdentifier, appSupportDirectory] in
+            let restoredSnapshot = SessionPersistenceStore.loadWorkspaceSnapshot(
+                workingDirectory: workingDirectory,
+                bundleIdentifier: bundleIdentifier,
+                appSupportDirectory: appSupportDirectory
+            )
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                guard let workspace = self.tabs.first(where: { $0.id == workspaceId }) else { return }
+                guard workspace.customTitle == expectedCustomTitle,
+                      workspace.currentDirectory == expectedCurrentDirectory,
+                      Set(workspace.panels.keys) == expectedPanelIds else {
+                    return
+                }
+                if let restoredSnapshot {
+                    workspace.restoreSessionSnapshot(restoredSnapshot)
+                    if let explicitTitle {
+                        workspace.setCustomTitle(explicitTitle)
+                    }
+                    return
+                }
+                guard autoWelcomeIfNeeded,
+                      select,
+                      !UserDefaults.standard.bool(forKey: WelcomeSettings.shownKey) else {
+                    return
+                }
+                if let appDelegate = AppDelegate.shared {
+                    appDelegate.sendWelcomeCommandWhenReady(to: workspace, markShownOnSend: true)
+                } else {
+                    sendWelcomeWhenReady(to: workspace)
+                }
+            }
         }
     }
 

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -2304,6 +2304,9 @@ class TabManager: ObservableObject {
                 if let explicitTitle {
                     workspace.setCustomTitle(explicitTitle)
                 }
+                if selectedTabId == workspace.id {
+                    updateWindowTitle(for: workspace)
+                }
                 return
             }
             guard autoWelcomeIfNeeded,

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -1104,13 +1104,19 @@ class TabManager: ObservableObject {
         initialWorkspaceTitle: String? = nil,
         initialWorkingDirectory: String? = nil,
         initialTerminalInput: String? = nil,
-        autoWelcomeIfNeeded: Bool = true
+        autoWelcomeIfNeeded: Bool = true,
+        workspaceSessionAppSupportDirectory: URL? = nil,
+        workspaceSessionBundleIdentifier: String? = Bundle.main.bundleIdentifier,
+        restoreWorkspaceSession: Bool = true
     ) {
         addWorkspace(
             title: initialWorkspaceTitle,
             workingDirectory: initialWorkingDirectory,
             initialTerminalInput: initialTerminalInput,
-            autoWelcomeIfNeeded: autoWelcomeIfNeeded
+            autoWelcomeIfNeeded: autoWelcomeIfNeeded,
+            workspaceSessionAppSupportDirectory: workspaceSessionAppSupportDirectory,
+            workspaceSessionBundleIdentifier: workspaceSessionBundleIdentifier,
+            restoreWorkspaceSession: restoreWorkspaceSession
         )
         observers.append(NotificationCenter.default.addObserver(
             forName: .ghosttyDidSetTitle,
@@ -2126,7 +2132,10 @@ class TabManager: ObservableObject {
         select: Bool = true,
         eagerLoadTerminal: Bool = false,
         placementOverride: NewWorkspacePlacement? = nil,
-        autoWelcomeIfNeeded: Bool = true
+        autoWelcomeIfNeeded: Bool = true,
+        workspaceSessionAppSupportDirectory: URL? = nil,
+        workspaceSessionBundleIdentifier: String? = Bundle.main.bundleIdentifier,
+        restoreWorkspaceSession: Bool = true
     ) -> Workspace {
         let sourceWorkspace = selectedWorkspace
         let capturedTabs = tabs
@@ -2156,6 +2165,20 @@ class TabManager: ObservableObject {
             sentryBreadcrumb("workspace.create", data: ["tabCount": nextTabCount])
             let explicitWorkingDirectory = normalizedWorkingDirectory(overrideWorkingDirectory)
             let workingDirectory = explicitWorkingDirectory ?? snapshot.preferredWorkingDirectory
+            let restoredWorkspaceSnapshot: SessionWorkspaceSnapshot?
+            if restoreWorkspaceSession,
+               let explicitWorkingDirectory,
+               initialTerminalCommand == nil,
+               initialTerminalInput == nil,
+               initialTerminalEnvironment.isEmpty {
+                restoredWorkspaceSnapshot = SessionPersistenceStore.loadWorkspaceSnapshot(
+                    workingDirectory: explicitWorkingDirectory,
+                    bundleIdentifier: workspaceSessionBundleIdentifier,
+                    appSupportDirectory: workspaceSessionAppSupportDirectory
+                )
+            } else {
+                restoredWorkspaceSnapshot = nil
+            }
             let inheritedConfig = workspaceCreationConfigTemplate(
                 inheritedTerminalFontPoints: snapshot.inheritedTerminalFontPoints
             )
@@ -2174,6 +2197,9 @@ class TabManager: ObservableObject {
                 initialTerminalInput: initialTerminalInput,
                 initialTerminalEnvironment: initialTerminalEnvironment
             )
+            if let restoredWorkspaceSnapshot {
+                newWorkspace.restoreSessionSnapshot(restoredWorkspaceSnapshot)
+            }
             applyCreationChromeInheritance(
                 to: newWorkspace,
                 from: sourceWorkspace ?? capturedTabs.first
@@ -2226,7 +2252,7 @@ class TabManager: ObservableObject {
                 "selectedTabId": select ? newWorkspace.id.uuidString : (snapshot.selectedTabId?.uuidString ?? "")
             ])
 #endif
-            if autoWelcomeIfNeeded && select && !UserDefaults.standard.bool(forKey: WelcomeSettings.shownKey) {
+            if autoWelcomeIfNeeded && restoredWorkspaceSnapshot == nil && select && !UserDefaults.standard.bool(forKey: WelcomeSettings.shownKey) {
                 if let appDelegate = AppDelegate.shared {
                     appDelegate.sendWelcomeCommandWhenReady(to: newWorkspace, markShownOnSend: true)
                 } else {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -4390,7 +4390,8 @@ class TerminalController {
                 initialTerminalCommand: layoutNode == nil ? initialCommand : nil,
                 initialTerminalEnvironment: layoutNode == nil ? initialEnv : [:],
                 select: shouldFocus,
-                eagerLoadTerminal: !shouldFocus
+                eagerLoadTerminal: !shouldFocus,
+                restoreWorkspaceSession: layoutNode == nil
             )
             ws.setCustomDescription(description)
             if let layoutNode {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -229,6 +229,7 @@ extension Workspace {
             hasUnreadIndicator: hasWorkspaceUnreadIndicator,
             terminalScrollBarHidden: terminalScrollBarHidden ? true : nil,
             currentDirectory: currentDirectory,
+            workspaceSessionRootDirectory: workspaceSessionRootDirectory,
             focusedPanelId: focusedPanelId,
             layout: layout,
             panels: panelSnapshots,
@@ -263,6 +264,10 @@ extension Workspace {
         let normalizedCurrentDirectory = snapshot.currentDirectory.trimmingCharacters(in: .whitespacesAndNewlines)
         if !normalizedCurrentDirectory.isEmpty {
             currentDirectory = normalizedCurrentDirectory
+        }
+        let normalizedSessionRootDirectory = snapshot.workspaceSessionRootDirectory?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if !normalizedSessionRootDirectory.isEmpty {
+            workspaceSessionRootDirectory = normalizedSessionRootDirectory
         }
 
         let panelSnapshotsById = Dictionary(uniqueKeysWithValues: snapshot.panels.map { ($0.id, $0) })
@@ -7172,6 +7177,7 @@ final class Workspace: Identifiable, ObservableObject {
     @Published var customColor: String?  // hex string, e.g. "#C0392B"
     @Published private(set) var terminalScrollBarHidden: Bool = false
     @Published var currentDirectory: String
+    var workspaceSessionRootDirectory: String?
     @Published private(set) var surfaceTabBarDirectory: String?
     private(set) var preferredBrowserProfileID: UUID?
 
@@ -7782,6 +7788,7 @@ final class Workspace: Identifiable, ObservableObject {
         self.currentDirectory = hasWorkingDirectory
             ? trimmedWorkingDirectory
             : FileManager.default.homeDirectoryForCurrentUser.path
+        self.workspaceSessionRootDirectory = hasWorkingDirectory ? trimmedWorkingDirectory : nil
         self.surfaceTabBarDirectory = initialDirectory
 
         // Configure bonsplit with keepAllAlive to preserve terminal state

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -265,9 +265,12 @@ extension Workspace {
         if !normalizedCurrentDirectory.isEmpty {
             currentDirectory = normalizedCurrentDirectory
         }
-        let normalizedSessionRootDirectory = snapshot.workspaceSessionRootDirectory?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        if !normalizedSessionRootDirectory.isEmpty {
+        let normalizedSessionRootDirectory = snapshot.workspaceSessionRootDirectory?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if let normalizedSessionRootDirectory, !normalizedSessionRootDirectory.isEmpty {
             workspaceSessionRootDirectory = normalizedSessionRootDirectory
+        } else {
+            workspaceSessionRootDirectory = nil
         }
 
         let panelSnapshotsById = Dictionary(uniqueKeysWithValues: snapshot.panels.map { ($0.id, $0) })

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -247,6 +247,57 @@ final class SessionPersistenceTests: XCTestCase {
         XCTAssertEqual(loaded.currentDirectory, workspaceDirectory.path)
     }
 
+    func testWorkspaceSessionSaveSkipsRewritingIdenticalSnapshotData() throws {
+        let appSupport = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-workspace-session-support-\(UUID().uuidString)", isDirectory: true)
+        let workspaceDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-workspace-session-repo-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: appSupport, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: workspaceDirectory, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: appSupport)
+            try? FileManager.default.removeItem(at: workspaceDirectory)
+        }
+
+        var workspace = makeSnapshot(version: SessionSnapshotSchema.currentVersion)
+            .windows[0]
+            .tabManager
+            .workspaces[0]
+        workspace.currentDirectory = workspaceDirectory.path
+        workspace.customTitle = "Stable Workspace"
+
+        XCTAssertTrue(
+            SessionPersistenceStore.saveWorkspaceSnapshot(
+                workspace,
+                workingDirectory: workspaceDirectory.path,
+                bundleIdentifier: "dev.cmux.tests",
+                appSupportDirectory: appSupport
+            )
+        )
+        let snapshotPath = try XCTUnwrap(
+            FileManager.default.subpathsOfDirectory(atPath: appSupport.path)
+                .first { $0.hasSuffix("session.json") }
+        )
+        let snapshotURL = appSupport.appendingPathComponent(snapshotPath, isDirectory: false)
+        let firstFileNumber = try fileNumber(for: snapshotURL)
+
+        XCTAssertTrue(
+            SessionPersistenceStore.saveWorkspaceSnapshot(
+                workspace,
+                workingDirectory: workspaceDirectory.path,
+                bundleIdentifier: "dev.cmux.tests",
+                appSupportDirectory: appSupport
+            )
+        )
+        let secondFileNumber = try fileNumber(for: snapshotURL)
+
+        XCTAssertEqual(
+            secondFileNumber,
+            firstFileNumber,
+            "Saving identical workspace session data should not replace the snapshot file"
+        )
+    }
+
     func testSaveSkipsRewritingIdenticalSnapshotData() throws {
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-session-tests-\(UUID().uuidString)", isDirectory: true)

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -222,7 +222,7 @@ final class SessionPersistenceTests: XCTestCase {
         )
     }
 
-    func testWorkspaceSessionSaveCanonicalizesSnapshotWorkingDirectoryToKey() throws {
+    func testWorkspaceSessionSavePreservesLiveDirectoryWhileCanonicalizingKey() throws {
         let appSupport = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-workspace-session-support-\(UUID().uuidString)", isDirectory: true)
         let workspaceDirectory = FileManager.default.temporaryDirectory
@@ -258,7 +258,44 @@ final class SessionPersistenceTests: XCTestCase {
             )
         )
         XCTAssertEqual(loaded.customTitle, "Canonicalized Workspace")
-        XCTAssertEqual(loaded.currentDirectory, workspaceDirectory.path)
+        XCTAssertEqual(loaded.currentDirectory, "/tmp")
+        XCTAssertEqual(loaded.workspaceSessionRootDirectory, workspaceDirectory.path)
+    }
+
+    func testWorkspaceSessionBatchSaveUsesStableRootDirectoryKey() throws {
+        let appSupport = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-workspace-session-support-\(UUID().uuidString)", isDirectory: true)
+        let workspaceDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-workspace-session-repo-\(UUID().uuidString)", isDirectory: true)
+        let liveDirectory = workspaceDirectory.appendingPathComponent("src", isDirectory: true)
+        try FileManager.default.createDirectory(at: appSupport, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: liveDirectory, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: appSupport)
+            try? FileManager.default.removeItem(at: workspaceDirectory)
+        }
+
+        var snapshot = makeSnapshot(version: SessionSnapshotSchema.currentVersion)
+        snapshot.windows[0].tabManager.workspaces[0].currentDirectory = liveDirectory.path
+        snapshot.windows[0].tabManager.workspaces[0].workspaceSessionRootDirectory = workspaceDirectory.path
+        snapshot.windows[0].tabManager.workspaces[0].customTitle = "Stable Root Workspace"
+
+        SessionPersistenceStore.saveWorkspaceSnapshots(
+            from: snapshot,
+            bundleIdentifier: "dev.cmux.tests",
+            appSupportDirectory: appSupport
+        )
+
+        let loaded = try XCTUnwrap(
+            SessionPersistenceStore.loadWorkspaceSnapshot(
+                workingDirectory: workspaceDirectory.path,
+                bundleIdentifier: "dev.cmux.tests",
+                appSupportDirectory: appSupport
+            )
+        )
+        XCTAssertEqual(loaded.customTitle, "Stable Root Workspace")
+        XCTAssertEqual(loaded.currentDirectory, liveDirectory.path)
+        XCTAssertEqual(loaded.workspaceSessionRootDirectory, workspaceDirectory.path)
     }
 
     func testWorkspaceSessionSaveSkipsRewritingIdenticalSnapshotData() throws {

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -98,6 +98,20 @@ final class SessionPersistenceTests: XCTestCase {
         XCTAssertEqual(visibleFrame.y, 25, accuracy: 0.001)
     }
 
+    func testSaveResultDistinguishesUnchangedFromFailedWrites() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-session-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let snapshotURL = tempDir.appendingPathComponent("session.json", isDirectory: false)
+        let snapshot = makeSnapshot(version: SessionSnapshotSchema.currentVersion)
+
+        XCTAssertEqual(SessionPersistenceStore.saveResult(snapshot, fileURL: snapshotURL), .written)
+        XCTAssertEqual(SessionPersistenceStore.saveResult(snapshot, fileURL: snapshotURL), .unchanged)
+        XCTAssertTrue(SessionPersistenceStore.save(snapshot, fileURL: snapshotURL))
+    }
+
     func testLoadReopenSessionSnapshotRequiresPreviousSnapshotFile() throws {
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-session-tests-\(UUID().uuidString)", isDirectory: true)

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -163,6 +163,90 @@ final class SessionPersistenceTests: XCTestCase {
         )
     }
 
+    func testWorkspaceSessionSnapshotRoundTripsByWorkingDirectory() throws {
+        let appSupport = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-workspace-session-support-\(UUID().uuidString)", isDirectory: true)
+        let workspaceDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-workspace-session-repo-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: appSupport, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: workspaceDirectory, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: appSupport)
+            try? FileManager.default.removeItem(at: workspaceDirectory)
+        }
+
+        var workspace = makeSnapshot(version: SessionSnapshotSchema.currentVersion)
+            .windows[0]
+            .tabManager
+            .workspaces[0]
+        workspace.currentDirectory = workspaceDirectory.path
+        workspace.customTitle = "Workspace Local Session"
+
+        XCTAssertTrue(
+            SessionPersistenceStore.saveWorkspaceSnapshot(
+                workspace,
+                workingDirectory: workspaceDirectory.path,
+                bundleIdentifier: "dev.cmux.tests",
+                appSupportDirectory: appSupport
+            )
+        )
+
+        let loaded = try XCTUnwrap(
+            SessionPersistenceStore.loadWorkspaceSnapshot(
+                workingDirectory: workspaceDirectory.path,
+                bundleIdentifier: "dev.cmux.tests",
+                appSupportDirectory: appSupport
+            )
+        )
+        XCTAssertEqual(loaded.customTitle, "Workspace Local Session")
+        XCTAssertEqual(loaded.currentDirectory, workspaceDirectory.path)
+        XCTAssertFalse(
+            FileManager.default.fileExists(
+                atPath: workspaceDirectory.appendingPathComponent(".cmux/session.json").path
+            ),
+            "Workspace session persistence should not write private session data into the project directory"
+        )
+    }
+
+    func testWorkspaceSessionSaveCanonicalizesSnapshotWorkingDirectoryToKey() throws {
+        let appSupport = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-workspace-session-support-\(UUID().uuidString)", isDirectory: true)
+        let workspaceDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-workspace-session-repo-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: appSupport, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: workspaceDirectory, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: appSupport)
+            try? FileManager.default.removeItem(at: workspaceDirectory)
+        }
+
+        var workspace = makeSnapshot(version: SessionSnapshotSchema.currentVersion)
+            .windows[0]
+            .tabManager
+            .workspaces[0]
+        workspace.currentDirectory = "/tmp"
+        workspace.customTitle = "Canonicalized Workspace"
+
+        XCTAssertTrue(
+            SessionPersistenceStore.saveWorkspaceSnapshot(
+                workspace,
+                workingDirectory: workspaceDirectory.path,
+                bundleIdentifier: "dev.cmux.tests",
+                appSupportDirectory: appSupport
+            )
+        )
+
+        let loaded = try XCTUnwrap(
+            SessionPersistenceStore.loadWorkspaceSnapshot(
+                workingDirectory: workspaceDirectory.path,
+                bundleIdentifier: "dev.cmux.tests",
+                appSupportDirectory: appSupport
+            )
+        )
+        XCTAssertEqual(loaded.customTitle, "Canonicalized Workspace")
+        XCTAssertEqual(loaded.currentDirectory, workspaceDirectory.path)
+    }
+
     func testSaveSkipsRewritingIdenticalSnapshotData() throws {
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-session-tests-\(UUID().uuidString)", isDirectory: true)

--- a/cmuxTests/TabManagerSessionSnapshotTests.swift
+++ b/cmuxTests/TabManagerSessionSnapshotTests.swift
@@ -47,6 +47,81 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
         XCTAssertNotNil(manager.selectedTabId)
     }
 
+    func testInitialWorkspaceRestoresWorkspaceSessionForWorkingDirectory() throws {
+        let appSupport = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-workspace-session-support-\(UUID().uuidString)", isDirectory: true)
+        let workspaceDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-workspace-session-repo-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: appSupport, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: workspaceDirectory, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: appSupport)
+            try? FileManager.default.removeItem(at: workspaceDirectory)
+        }
+
+        var workspaceSnapshot = try XCTUnwrap(TabManager().selectedWorkspace)
+            .sessionSnapshot(includeScrollback: false)
+        workspaceSnapshot.currentDirectory = workspaceDirectory.path
+        workspaceSnapshot.customTitle = "Persisted Workspace"
+        XCTAssertTrue(
+            SessionPersistenceStore.saveWorkspaceSnapshot(
+                workspaceSnapshot,
+                workingDirectory: workspaceDirectory.path,
+                bundleIdentifier: "dev.cmux.tests",
+                appSupportDirectory: appSupport
+            )
+        )
+
+        let manager = TabManager(
+            initialWorkingDirectory: workspaceDirectory.path,
+            autoWelcomeIfNeeded: false,
+            workspaceSessionAppSupportDirectory: appSupport,
+            workspaceSessionBundleIdentifier: "dev.cmux.tests"
+        )
+
+        XCTAssertEqual(manager.tabs.count, 1)
+        XCTAssertEqual(manager.selectedWorkspace?.customTitle, "Persisted Workspace")
+        XCTAssertEqual(manager.selectedWorkspace?.currentDirectory, workspaceDirectory.path)
+    }
+
+    func testInitialWorkspaceRestoreCanBeDisabledForExplicitLayouts() throws {
+        let appSupport = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-workspace-session-support-\(UUID().uuidString)", isDirectory: true)
+        let workspaceDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-workspace-session-repo-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: appSupport, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: workspaceDirectory, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: appSupport)
+            try? FileManager.default.removeItem(at: workspaceDirectory)
+        }
+
+        var workspaceSnapshot = try XCTUnwrap(TabManager().selectedWorkspace)
+            .sessionSnapshot(includeScrollback: false)
+        workspaceSnapshot.currentDirectory = workspaceDirectory.path
+        workspaceSnapshot.customTitle = "Persisted Workspace"
+        XCTAssertTrue(
+            SessionPersistenceStore.saveWorkspaceSnapshot(
+                workspaceSnapshot,
+                workingDirectory: workspaceDirectory.path,
+                bundleIdentifier: "dev.cmux.tests",
+                appSupportDirectory: appSupport
+            )
+        )
+
+        let manager = TabManager(
+            initialWorkingDirectory: workspaceDirectory.path,
+            autoWelcomeIfNeeded: false,
+            workspaceSessionAppSupportDirectory: appSupport,
+            workspaceSessionBundleIdentifier: "dev.cmux.tests",
+            restoreWorkspaceSession: false
+        )
+
+        XCTAssertEqual(manager.tabs.count, 1)
+        XCTAssertNotEqual(manager.selectedWorkspace?.customTitle, "Persisted Workspace")
+        XCTAssertEqual(manager.selectedWorkspace?.currentDirectory, workspaceDirectory.path)
+    }
+
     func testSessionSnapshotIncludesRemoteWorkspacesForRestore() throws {
         let manager = TabManager()
         let remoteWorkspace = manager.addWorkspace(select: true)

--- a/cmuxTests/TabManagerSessionSnapshotTests.swift
+++ b/cmuxTests/TabManagerSessionSnapshotTests.swift
@@ -190,8 +190,12 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
         let workspace = try XCTUnwrap(manager.selectedWorkspace)
         workspace.setCustomTitle("User Change")
 
-        RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.2))
-
+        XCTAssertFalse(
+            waitForWorkspaceSessionRestore(manager, timeout: 1.0) { restored in
+                restored.customTitle == "Persisted Workspace"
+                    || restored.customDescription == "Restored Description"
+            }
+        )
         XCTAssertEqual(workspace.customTitle, "User Change")
         XCTAssertNil(workspace.customDescription)
         XCTAssertEqual(workspace.currentDirectory, workspaceDirectory.path)
@@ -231,8 +235,28 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
         )
 
         XCTAssertEqual(manager.tabs.count, 1)
+        XCTAssertFalse(
+            waitForWorkspaceSessionRestore(
+                manager,
+                expectedCustomTitle: "Persisted Workspace",
+                timeout: 1.0
+            )
+        )
         XCTAssertNotEqual(manager.selectedWorkspace?.customTitle, "Persisted Workspace")
         XCTAssertEqual(manager.selectedWorkspace?.currentDirectory, workspaceDirectory.path)
+    }
+
+    func testWorkspaceRestoreClearsMissingSessionRootDirectory() throws {
+        let manager = TabManager(initialWorkingDirectory: "/tmp/cmux-root")
+        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        XCTAssertEqual(workspace.workspaceSessionRootDirectory, "/tmp/cmux-root")
+
+        var snapshot = workspace.sessionSnapshot(includeScrollback: false)
+        snapshot.workspaceSessionRootDirectory = nil
+
+        workspace.restoreSessionSnapshot(snapshot)
+
+        XCTAssertNil(workspace.workspaceSessionRootDirectory)
     }
 
     func testSessionSnapshotIncludesRemoteWorkspacesForRestore() throws {

--- a/cmuxTests/TabManagerSessionSnapshotTests.swift
+++ b/cmuxTests/TabManagerSessionSnapshotTests.swift
@@ -8,6 +8,31 @@ import XCTest
 
 @MainActor
 final class TabManagerSessionSnapshotTests: XCTestCase {
+    private func waitForWorkspaceSessionRestore(
+        _ manager: TabManager,
+        expectedCustomTitle: String,
+        timeout: TimeInterval = 2.0
+    ) -> Bool {
+        waitForWorkspaceSessionRestore(manager, timeout: timeout) { workspace in
+            workspace.customTitle == expectedCustomTitle
+        }
+    }
+
+    private func waitForWorkspaceSessionRestore(
+        _ manager: TabManager,
+        timeout: TimeInterval = 2.0,
+        predicate: (Workspace) -> Bool
+    ) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if let workspace = manager.selectedWorkspace, predicate(workspace) {
+                return true
+            }
+            RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.01))
+        }
+        return manager.selectedWorkspace.map(predicate) ?? false
+    }
+
     func testSessionSnapshotSerializesWorkspacesAndRestoreRebuildsSelection() {
         let manager = TabManager()
         guard let firstWorkspace = manager.selectedWorkspace else {
@@ -80,8 +105,96 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
         )
 
         XCTAssertEqual(manager.tabs.count, 1)
+        XCTAssertTrue(waitForWorkspaceSessionRestore(manager, expectedCustomTitle: "Persisted Workspace"))
         XCTAssertEqual(manager.selectedWorkspace?.customTitle, "Persisted Workspace")
         XCTAssertEqual(manager.selectedWorkspace?.currentDirectory, workspaceDirectory.path)
+    }
+
+    func testInitialWorkspaceRestorePreservesExplicitTitle() throws {
+        let appSupport = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-workspace-session-support-\(UUID().uuidString)", isDirectory: true)
+        let workspaceDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-workspace-session-repo-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: appSupport, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: workspaceDirectory, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: appSupport)
+            try? FileManager.default.removeItem(at: workspaceDirectory)
+        }
+
+        var workspaceSnapshot = try XCTUnwrap(TabManager().selectedWorkspace)
+            .sessionSnapshot(includeScrollback: false)
+        workspaceSnapshot.currentDirectory = workspaceDirectory.path
+        workspaceSnapshot.customTitle = "Persisted Workspace"
+        workspaceSnapshot.customDescription = "Restored Description"
+        XCTAssertTrue(
+            SessionPersistenceStore.saveWorkspaceSnapshot(
+                workspaceSnapshot,
+                workingDirectory: workspaceDirectory.path,
+                bundleIdentifier: "dev.cmux.tests",
+                appSupportDirectory: appSupport
+            )
+        )
+
+        let manager = TabManager(
+            initialWorkspaceTitle: "Explicit Workspace",
+            initialWorkingDirectory: workspaceDirectory.path,
+            autoWelcomeIfNeeded: false,
+            workspaceSessionAppSupportDirectory: appSupport,
+            workspaceSessionBundleIdentifier: "dev.cmux.tests"
+        )
+
+        XCTAssertEqual(manager.tabs.count, 1)
+        XCTAssertTrue(
+            waitForWorkspaceSessionRestore(manager) { workspace in
+                workspace.customDescription == "Restored Description"
+            }
+        )
+        XCTAssertEqual(manager.selectedWorkspace?.customTitle, "Explicit Workspace")
+        XCTAssertEqual(manager.selectedWorkspace?.customDescription, "Restored Description")
+        XCTAssertEqual(manager.selectedWorkspace?.currentDirectory, workspaceDirectory.path)
+    }
+
+    func testInitialWorkspaceRestoreSkipsWhenWorkspaceMutatesBeforeAsyncRestoreApplies() throws {
+        let appSupport = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-workspace-session-support-\(UUID().uuidString)", isDirectory: true)
+        let workspaceDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-workspace-session-repo-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: appSupport, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: workspaceDirectory, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: appSupport)
+            try? FileManager.default.removeItem(at: workspaceDirectory)
+        }
+
+        var workspaceSnapshot = try XCTUnwrap(TabManager().selectedWorkspace)
+            .sessionSnapshot(includeScrollback: false)
+        workspaceSnapshot.currentDirectory = workspaceDirectory.path
+        workspaceSnapshot.customTitle = "Persisted Workspace"
+        workspaceSnapshot.customDescription = "Restored Description"
+        XCTAssertTrue(
+            SessionPersistenceStore.saveWorkspaceSnapshot(
+                workspaceSnapshot,
+                workingDirectory: workspaceDirectory.path,
+                bundleIdentifier: "dev.cmux.tests",
+                appSupportDirectory: appSupport
+            )
+        )
+
+        let manager = TabManager(
+            initialWorkingDirectory: workspaceDirectory.path,
+            autoWelcomeIfNeeded: false,
+            workspaceSessionAppSupportDirectory: appSupport,
+            workspaceSessionBundleIdentifier: "dev.cmux.tests"
+        )
+        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        workspace.setCustomTitle("User Change")
+
+        RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.2))
+
+        XCTAssertEqual(workspace.customTitle, "User Change")
+        XCTAssertNil(workspace.customDescription)
+        XCTAssertEqual(workspace.currentDirectory, workspaceDirectory.path)
     }
 
     func testInitialWorkspaceRestoreCanBeDisabledForExplicitLayouts() throws {


### PR DESCRIPTION
## Summary
- Add per-workspace session snapshot persistence keyed by canonical working directory.
- Restore a saved workspace session when opening a workspace for an explicit directory.
- Keep config/layout-driven workspace creation fresh by opting out of workspace session restore.

## Test Plan
- `git diff --check`
- `swiftc -parse Sources/SessionPersistence.swift Sources/TabManager.swift Sources/AppDelegate.swift Sources/CmuxConfigExecutor.swift Sources/TerminalController.swift cmuxTests/SessionPersistenceTests.swift cmuxTests/TabManagerSessionSnapshotTests.swift`
- Targeted `xcodebuild test` could not run locally because the active developer directory is CommandLineTools, not a full Xcode install.

## Notes
- Workspace session snapshots are stored in Application Support by hashed canonical working directory, not inside the project directory.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist per-directory workspace sessions and auto-restore them when opening that directory. Keys are stable across subdirectory changes; restore runs async with safety checks.

- **New Features**
  - Save/load workspace snapshots in Application Support, keyed by SHA-256 of the canonical directory; identical data skips rewrites.
  - Stabilized snapshot keys via `workspaceSessionRootDirectory` stored in snapshots; batch saves prefer this root over the live `currentDirectory`.
  - Auto-restore when creating a workspace with an explicit `workingDirectory` and no initial command/input/env; runs off the main thread, verifies the workspace didn’t change (title/cwd/panels), preserves explicit titles, updates the window title, refreshes Git metadata, and falls back to Welcome if nothing to restore.
  - Opt out via `restoreWorkspaceSession: false` (used for config/layout flows).
  - App-level session saves now cascade per-workspace snapshot writes after a successful or unchanged app snapshot write and when closing a window; save results now distinguish unchanged vs failed writes, and unchanged counts as success.

- **Migration**
  - `TabManager.init`/`addWorkspace` add: `workspaceSessionAppSupportDirectory`, `workspaceSessionBundleIdentifier`, `restoreWorkspaceSession` (default `true`).
  - `TerminalController` restores only for non-layout workspaces; `CmuxConfigExecutor` disables restore for config-driven workspaces.
  - No user action required.

<sup>Written for commit c20f276bbc45231b8dbcfc6e66e2ff08c0e159e4. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4300?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace-level session persistence: per-workspace state (custom title, current directory, panels) is saved and restorable.
  * Optional automatic restore when creating workspaces—only when using an explicit working directory and enabled.

* **Behavior**
  * Workspace snapshots stored separately with canonicalized directory keys; writes skip unchanged data and may run sync or async.
  * Restore is applied asynchronously, validated before applying, and won’t overwrite recent user changes.

* **Tests**
  * Added tests covering save/load, canonicalization, idempotent writes, and restore scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4300?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->