### PR TITLE
Fix terminal zoom on non-US ISO keyboard layouts

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -14960,16 +14960,28 @@ private extension NSWindow {
             // Preserve Ghostty's terminal font-size shortcuts (Cmd +/−/0) when
             // the terminal is focused. Otherwise our browser menu shortcuts can
             // consume the event even when no browser panel is focused.
-            if shouldRouteTerminalFontZoomShortcutToGhostty(
-                firstResponderIsGhostty: true,
+            //
+            // Dispatch the action by name rather than forwarding the raw NSEvent:
+            // Ghostty's internal keybind matcher uses US-layout keycodes, which
+            // mis-fires zoom-out for non-US ISO layouts (e.g. Swedish "+" sits
+            // at the US "-" position, keyCode 27). browserZoomShortcutAction
+            // already does layout-aware matching, so we trust its result and
+            // invoke the binding directly.
+            if let zoomAction = browserZoomShortcutAction(
                 flags: event.modifierFlags,
                 chars: event.charactersIgnoringModifiers ?? "",
                 keyCode: event.keyCode,
                 literalChars: event.characters
             ) {
-                ghosttyView.keyDown(with: event)
+                let bindingActionName: String
+                switch zoomAction {
+                case .zoomIn: bindingActionName = "increase_font_size:1"
+                case .zoomOut: bindingActionName = "decrease_font_size:1"
+                case .reset: bindingActionName = "reset_font_size"
+                }
+                _ = ghosttyView.performBindingAction(bindingActionName)
 #if DEBUG
-                cmuxDebugLog("zoom.shortcut stage=window.ghosttyKeyDownDirect event=\(Self.keyDescription(event)) handled=1")
+                cmuxDebugLog("zoom.shortcut stage=window.ghosttyBindingActionDirect action=\(bindingActionName) event=\(Self.keyDescription(event)) handled=1")
 #endif
                 return true
             }

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -1532,12 +1532,16 @@ struct ShortcutStroke: Equatable, Hashable {
             return true
         }
 
+        // Falling back to US-layout keycodes is only safe when the keyboard
+        // layout cannot produce a comparable ASCII character — otherwise a
+        // typed key (e.g. Swedish "+") could mask a different US-layout key
+        // sharing the same physical position (e.g. US "-") and fire the
+        // wrong action.
         let allowANSIKeyCodeFallback = flags.contains(.control)
             || (flags.contains(.command)
                 && !flags.contains(.control)
                 && (
-                    !Self.shouldRequireCharacterMatchForCommandShortcut(shortcutKey: shortcutKey)
-                        || (hasEventChars && !eventCharsAreASCII)
+                    (hasEventChars && !eventCharsAreASCII)
                         || (!hasEventChars && (layoutCharacter?.isEmpty ?? true))
                 ))
         if allowANSIKeyCodeFallback,
@@ -1675,6 +1679,14 @@ struct ShortcutStroke: Equatable, Hashable {
         eventKeyCode: UInt16
     ) -> String {
         let lowered = eventCharacter.lowercased()
+        // "+" and "_" are equivalent to "=" and "-" regardless of shift state.
+        // On non-US ISO layouts (e.g. Swedish) the "+" key is typed without shift,
+        // so the existing zoom-in/zoom-out bindings (key "=" / "-") must still match.
+        switch lowered {
+        case "+": return "="
+        case "_": return "-"
+        default: break
+        }
         guard applyShiftSymbolNormalization else { return lowered }
 
         switch lowered {
@@ -1687,8 +1699,6 @@ struct ShortcutStroke: Equatable, Hashable {
         case "\"": return "'"
         case "|": return "\\"
         case "~": return "`"
-        case "+": return "="
-        case "_": return "-"
         case "!": return eventKeyCode == 18 ? "1" : lowered // kVK_ANSI_1
         case "@": return eventKeyCode == 19 ? "2" : lowered // kVK_ANSI_2
         case "#": return eventKeyCode == 20 ? "3" : lowered // kVK_ANSI_3

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		E3309A09 /* AppDelegateEqualizeSplitsShortcutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3309A0A /* AppDelegateEqualizeSplitsShortcutTests.swift */; };
 		E3309A0B /* KeyboardShortcutSettingsEqualizeSplitsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3309A0C /* KeyboardShortcutSettingsEqualizeSplitsTests.swift */; };
 		A17110000000000000000001 /* KeyboardShortcutSpaceKeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17110000000000000000002 /* KeyboardShortcutSpaceKeyTests.swift */; };
+		A17110000000000000000003 /* KeyboardShortcutLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17110000000000000000004 /* KeyboardShortcutLayoutTests.swift */; };
 		D3610B010000000000000001 /* AgentSessionAutoResumeSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3610B010000000000000002 /* AgentSessionAutoResumeSettingsTests.swift */; };
 		C0DEF0A40000000000000001 /* CmuxConfigContextMenuTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEF0A40000000000000002 /* CmuxConfigContextMenuTests.swift */; };
 		D0B10000A1B2C3D4E5F60001 /* TerminalPaneDropTargetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B10001A1B2C3D4E5F60001 /* TerminalPaneDropTargetView.swift */; };
@@ -607,6 +608,7 @@
 		C34670040000000000000002 /* KeyboardShortcutTestSettingsIsolation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardShortcutTestSettingsIsolation.swift; sourceTree = "<group>"; };
 		E3309A0C /* KeyboardShortcutSettingsEqualizeSplitsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardShortcutSettingsEqualizeSplitsTests.swift; sourceTree = "<group>"; };
 		A17110000000000000000002 /* KeyboardShortcutSpaceKeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardShortcutSpaceKeyTests.swift; sourceTree = "<group>"; };
+		A17110000000000000000004 /* KeyboardShortcutLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardShortcutLayoutTests.swift; sourceTree = "<group>"; };
 		D3610B010000000000000002 /* AgentSessionAutoResumeSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentSessionAutoResumeSettingsTests.swift; sourceTree = "<group>"; };
 		7E7E6EF344A568AC7FEE3715 /* cmuxUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = cmuxUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		818DBCD4AB69EB72573E8138 /* SidebarResizeUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarResizeUITests.swift; sourceTree = "<group>"; };
@@ -1533,6 +1535,7 @@
 				C34670020000000000000002 /* KeyboardShortcutContextTests.swift */,
 				E3309A0C /* KeyboardShortcutSettingsEqualizeSplitsTests.swift */,
 				A17110000000000000000002 /* KeyboardShortcutSpaceKeyTests.swift */,
+				A17110000000000000000004 /* KeyboardShortcutLayoutTests.swift */,
 				1A1B2C3D4E5F607180000004 /* WorkspacePromptSubmitTests.swift */,
 				C0DE31390000000000000102 /* CMUXOpenCommandTests.swift */,
 				C0DE31390000000000000106 /* CMUXCLIErrorOutputRegressionTests.swift */,
@@ -2294,6 +2297,7 @@
 				C34670020000000000000001 /* KeyboardShortcutContextTests.swift in Sources */,
 				E3309A0B /* KeyboardShortcutSettingsEqualizeSplitsTests.swift in Sources */,
 				A17110000000000000000001 /* KeyboardShortcutSpaceKeyTests.swift in Sources */,
+				A17110000000000000000003 /* KeyboardShortcutLayoutTests.swift in Sources */,
 				1A1B2C3D4E5F607180000003 /* WorkspacePromptSubmitTests.swift in Sources */,
 				C0DE31390000000000000101 /* CMUXOpenCommandTests.swift in Sources */,
 				C0DE31390000000000000105 /* CMUXCLIErrorOutputRegressionTests.swift in Sources */,

--- a/cmuxTests/KeyboardShortcutLayoutTests.swift
+++ b/cmuxTests/KeyboardShortcutLayoutTests.swift
@@ -1,0 +1,173 @@
+import XCTest
+import AppKit
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+// Regression coverage for issue #3362 ("Alternative keyboard layouts not
+// considered for hotkeys"). The original symptom on a Swedish ISO layout was:
+// pressing ⌘+"+" (which sits at the US "-" physical position, keyCode 27)
+// fired the .browserZoomOut shortcut instead of .browserZoomIn, because the
+// matcher fell back to US-layout keycodes whenever a command symbol shortcut
+// failed character-based matching.
+final class KeyboardShortcutLayoutTests: XCTestCase {
+
+    private static func swedishLayoutCharacter(keyCode: UInt16, modifierFlags: NSEvent.ModifierFlags) -> String? {
+        // Subset of the Swedish ISO Mac layout sufficient for these tests.
+        // keyCode 27 = US "-" position; on Swedish it produces "+" unshifted
+        // and "?" with shift.
+        let shifted = modifierFlags.contains(.shift)
+        switch keyCode {
+        case 24: return shifted ? "`" : "´"        // US "="
+        case 27: return shifted ? "?" : "+"        // US "-"
+        case 29: return shifted ? "=" : "0"        // US "0"
+        case 13: return shifted ? "W" : "w"        // US "w"
+        default: return nil
+        }
+    }
+
+    private static func russianLayoutCharacter(keyCode: UInt16, modifierFlags: NSEvent.ModifierFlags) -> String? {
+        // Russian PC layout — non-Latin characters at every position.
+        switch keyCode {
+        case 13: return modifierFlags.contains(.shift) ? "Ц" : "ц"   // US "w"
+        case 27: return modifierFlags.contains(.shift) ? "_" : "-"   // US "-"
+        case 24: return modifierFlags.contains(.shift) ? "+" : "="   // US "="
+        default: return nil
+        }
+    }
+
+    // MARK: - Issue #3362: Swedish ⌘+ should zoom in, not zoom out
+
+    func testSwedishCommandPlusMatchesBrowserZoomIn() {
+        let shortcut = KeyboardShortcutSettings.shortcut(for: .browserZoomIn).firstStroke
+        XCTAssertTrue(
+            shortcut.matches(
+                keyCode: 27,              // physical position of US "-"
+                modifierFlags: [.command],
+                eventCharacter: "+",      // Swedish layout produces "+" at this key without shift
+                layoutCharacterProvider: Self.swedishLayoutCharacter
+            ),
+            "Swedish ⌘+ should match browserZoomIn (=), not be rejected"
+        )
+    }
+
+    func testSwedishCommandPlusDoesNotMatchBrowserZoomOut() {
+        let shortcut = KeyboardShortcutSettings.shortcut(for: .browserZoomOut).firstStroke
+        XCTAssertFalse(
+            shortcut.matches(
+                keyCode: 27,
+                modifierFlags: [.command],
+                eventCharacter: "+",
+                layoutCharacterProvider: Self.swedishLayoutCharacter
+            ),
+            "Swedish ⌘+ must NOT match browserZoomOut (-) via US-layout keycode fallback"
+        )
+    }
+
+    func testSwedishCommandUnderscoreMatchesBrowserZoomOut() {
+        // Shift+"+" on Swedish produces "?", not "_". "_" on Swedish ISO requires
+        // shift+"-" key. This still exercises the unconditional "_" → "-" mapping.
+        let shortcut = KeyboardShortcutSettings.shortcut(for: .browserZoomOut).firstStroke
+        XCTAssertTrue(
+            shortcut.matches(
+                keyCode: 27,
+                modifierFlags: [.command],
+                eventCharacter: "_",
+                layoutCharacterProvider: { _, _ in "_" }
+            )
+        )
+    }
+
+    // MARK: - US-layout baseline still works
+
+    func testUSCommandEqualsMatchesBrowserZoomIn() {
+        let shortcut = KeyboardShortcutSettings.shortcut(for: .browserZoomIn).firstStroke
+        XCTAssertTrue(
+            shortcut.matches(
+                keyCode: 24,
+                modifierFlags: [.command],
+                eventCharacter: "=",
+                layoutCharacterProvider: { _, _ in "=" }
+            )
+        )
+    }
+
+    func testUSCommandShiftEqualsRecordedAsPlusMatchesBrowserZoomIn() {
+        // Pressing ⌘⇧= on US — charactersIgnoringModifiers reports "+".
+        // Stored shortcut is "=" with command-only modifiers, so matching with
+        // shift held would fail the modifier check; we instead verify the
+        // shortcut variant with both command+shift via the recorded form.
+        // This test confirms "+" → "=" normalization remains correct when shift
+        // IS held (it always was — this is the baseline that must keep working).
+        let stroke = ShortcutStroke(key: "=", command: true, shift: true, option: false, control: false)
+        XCTAssertTrue(
+            stroke.matches(
+                keyCode: 24,
+                modifierFlags: [.command, .shift],
+                eventCharacter: "+",
+                layoutCharacterProvider: { _, _ in "+" }
+            )
+        )
+    }
+
+    func testUSCommandMinusMatchesBrowserZoomOut() {
+        let shortcut = KeyboardShortcutSettings.shortcut(for: .browserZoomOut).firstStroke
+        XCTAssertTrue(
+            shortcut.matches(
+                keyCode: 27,
+                modifierFlags: [.command],
+                eventCharacter: "-",
+                layoutCharacterProvider: { _, _ in "-" }
+            )
+        )
+    }
+
+    // MARK: - Non-Latin layouts still fall back to US keycodes
+
+    func testRussianCommandWMatchesCloseTabViaKeycodeFallback() {
+        // Non-ASCII typed character must still fall back to US-layout keycode
+        // so that ⌘W remains reachable on Cyrillic/Greek/etc. layouts.
+        let shortcut = KeyboardShortcutSettings.shortcut(for: .closeTab).firstStroke
+        XCTAssertTrue(
+            shortcut.matches(
+                keyCode: 13,
+                modifierFlags: [.command],
+                eventCharacter: "ц",
+                layoutCharacterProvider: Self.russianLayoutCharacter
+            ),
+            "Non-Latin layouts must still reach Cmd+W via US-layout keycode fallback"
+        )
+    }
+
+    func testRussianCommandMinusKeyMatchesBrowserZoomOut() {
+        // Russian layout produces "-" at keyCode 27 unshifted — ASCII char matches.
+        let shortcut = KeyboardShortcutSettings.shortcut(for: .browserZoomOut).firstStroke
+        XCTAssertTrue(
+            shortcut.matches(
+                keyCode: 27,
+                modifierFlags: [.command],
+                eventCharacter: "-",
+                layoutCharacterProvider: Self.russianLayoutCharacter
+            )
+        )
+    }
+
+    // MARK: - Anti-regression: avoid masking the physical-key mismatch case
+
+    func testCommandSymbolShortcutRejectsPhysicalKeyWhenCharacterIsUnrelatedASCII() {
+        // A hypothetical user types an ASCII "k" via keyCode 27. The "-" shortcut
+        // must NOT match — neither by character nor by keycode fallback.
+        let shortcut = KeyboardShortcutSettings.shortcut(for: .browserZoomOut).firstStroke
+        XCTAssertFalse(
+            shortcut.matches(
+                keyCode: 27,
+                modifierFlags: [.command],
+                eventCharacter: "k",
+                layoutCharacterProvider: { _, _ in "k" }
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary

On Swedish (and other non-US ISO) layouts, pressing **⌘+** in a focused terminal pane fires **zoom-out** instead of zoom-in. The `+` key on Swedish sits at the physical position of US `-` (keyCode 27), so US-keycode-based matchers route the keystroke to the wrong action.

This PR fixes it at three layers:

1. **`AppDelegate.swift` — main fix.** When a zoom shortcut is detected and the terminal owns first responder, cmux was forwarding the raw `NSEvent` to Ghostty. Ghostty's internal keybind matcher then resolved the event by US-layout keycode, mis-firing decrease_font_size on Swedish ⌘+. Instead, dispatch the action by name via `ghostty_surface_binding_action` using the result of the already-layout-aware `browserZoomShortcutAction` helper.

2. **`KeyboardShortcutSettings.swift` — `matches`.** The ANSI-keycode fallback fired unconditionally for symbol command shortcuts, masking the typed ASCII character even when it clearly didn't match the bound shortcut key. Letter shortcuts already required a character match in that case; symbol shortcuts now do too. Non-Latin layouts still fall back to US keycodes (`hasEventChars && !eventCharsAreASCII`) so ⌘W remains reachable on Cyrillic/etc.

3. **`KeyboardShortcutSettings.swift` — `normalizedShortcutEventCharacter`.** `"+"` → `"="` and `"_"` → `"-"` were gated on `applyShiftSymbolNormalization`. On Swedish (and similar ISO layouts) `+` is typed without shift, so the gate left the typed `"+"` un-mapped and Cmd+`+` could not match the zoom-in binding stored as `"="`. These two mappings are now unconditional; nothing binds to literal `+`/`_` so there is no conflict.

## Test plan

- [x] New `KeyboardShortcutLayoutTests` (9 tests, all passing):
  - Swedish ⌘+ matches `.browserZoomIn` and does **not** match `.browserZoomOut`
  - Swedish ⌘_ maps to `.browserZoomOut`
  - US ⌘=, ⌘⇧= (typed as `+`), ⌘− baselines preserved
  - Russian ⌘W still resolves via US-keycode fallback (non-ASCII typed char)
  - Anti-regression: an unrelated ASCII char at the same physical position does **not** match through the keycode fallback
- [x] Manual test on a Swedish ISO keyboard:
  - ⌘+ in a terminal pane zooms in
  - ⌘− zooms out
  - ⌘0 resets

Fixes #3362
Refs #1456

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes terminal zoom shortcuts on non‑US ISO layouts (e.g., Swedish). Cmd + now zooms in (not out) when a terminal pane is focused.

- **Bug Fixes**
  - Route zoom shortcuts to Ghostty by action name using the layout‑aware `browserZoomShortcutAction`, instead of forwarding raw `NSEvent`.
  - Require a character match for Command symbol shortcuts before falling back to US ANSI keycodes; non‑Latin layouts still use the fallback.
  - Normalize "+"→"=" and "_"→"-" unconditionally so stored zoom bindings match on layouts where "+" is unshifted.
  - Added `KeyboardShortcutLayoutTests` covering Swedish ⌘+, US baselines, and Russian ⌘W.

<sup>Written for commit 0804909e2a0a0360baf1d9bf818c0b86344afc14. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4302?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard shortcut detection across international keyboard layouts (Swedish, Russian, etc.)
  * Fixed font zoom keyboard shortcuts in the terminal to function correctly across different layouts
  * Enhanced keyboard event matching to ensure shortcuts work reliably regardless of physical keyboard configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4302?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->