### PR TITLE
Recover refused CLI socket listeners

### DIFF
--- a/CLI/CMUXCLI+Events.swift
+++ b/CLI/CMUXCLI+Events.swift
@@ -32,7 +32,7 @@ extension CMUXCLI {
         while true {
             let client = SocketClient(path: socketPath)
             do {
-                try client.connect()
+                try client.connect(allowListenerRestartRecovery: true)
                 try authenticateClientIfNeeded(
                     client,
                     explicitPassword: explicitPassword,

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -25,6 +25,29 @@ struct CLIError: Error, CustomStringConvertible {
     var description: String { message }
 }
 
+private struct SocketConnectionFailure: Error, CustomStringConvertible {
+    let path: String
+    let errnoCode: Int32
+
+    var description: String {
+        "Failed to connect to socket at \(path) (\(String(cString: strerror(errnoCode))), errno \(errnoCode))"
+    }
+}
+
+private enum CLISocketListenerRestartRequest {
+    static let notificationName = Notification.Name("com.cmuxterm.socket.restartListener")
+    static let socketPathUserInfoKey = "socketPath"
+
+    static func post(socketPath: String) throws {
+        DistributedNotificationCenter.default().postNotificationName(
+            notificationName,
+            object: nil,
+            userInfo: [socketPathUserInfoKey: socketPath],
+            deliverImmediately: true
+        )
+    }
+}
+
 private enum CLISocketEnvironment {
     static func socketPath(in environment: [String: String]) throws -> String? {
         let socketPath = normalized(environment["CMUX_SOCKET_PATH"])
@@ -987,9 +1010,40 @@ final class SocketClient {
         lastOperationTelemetry = operation
     }
 
-    func connect() throws {
+    func connect(
+        allowListenerRestartRecovery: Bool = false,
+        listenerRestartTimeout: TimeInterval = 2.0,
+        requestListenerRestart: ((String) throws -> Void)? = nil
+    ) throws {
         if socketFD >= 0 { return }
-        try connectOnce()
+        do {
+            try connectOnce()
+        } catch {
+            guard allowListenerRestartRecovery,
+                  Self.shouldRequestListenerRestart(after: error) else {
+                throw error
+            }
+
+            try (requestListenerRestart ?? CLISocketListenerRestartRequest.post)(path)
+            let recoveredClient = try Self.waitForConnectableSocket(
+                path: path,
+                timeout: listenerRestartTimeout
+            )
+            adoptConnection(from: recoveredClient)
+        }
+    }
+
+    static func shouldRequestListenerRestart(after error: Error) -> Bool {
+        guard let failure = error as? SocketConnectionFailure else { return false }
+        return failure.errnoCode == ECONNREFUSED
+    }
+
+    private func adoptConnection(from other: SocketClient) {
+        close()
+        socketFD = other.socketFD
+        lastConfiguredReceiveTimeout = other.lastConfiguredReceiveTimeout
+        other.socketFD = -1
+        other.lastConfiguredReceiveTimeout = nil
     }
 
     func close() {
@@ -1150,9 +1204,7 @@ final class SocketClient {
         let connectErrno = errno
         Darwin.close(socketFD)
         socketFD = -1
-        throw CLIError(
-            message: "Failed to connect to socket at \(path) (\(String(cString: strerror(connectErrno))), errno \(connectErrno))"
-        )
+        throw SocketConnectionFailure(path: path, errnoCode: connectErrno)
     }
 
     private static func parseRelayEndpoint(_ raw: String) -> RelayEndpoint? {
@@ -2397,7 +2449,7 @@ struct CMUXCLI {
             ]
         )
         do {
-            try client.connect()
+            try client.connect(allowListenerRestartRecovery: true)
             cliTelemetry.breadcrumb("socket.connect.success", data: ["path": resolvedSocketPath])
         } catch {
             cliTelemetry.breadcrumb("socket.connect.failure", data: ["path": resolvedSocketPath])
@@ -4010,7 +4062,7 @@ struct CMUXCLI {
         launchIfNeeded: Bool
     ) throws -> SocketClient {
         let client = SocketClient(path: socketPath)
-        if launchIfNeeded && (try? client.connect()) == nil {
+        if launchIfNeeded && (try? client.connect(allowListenerRestartRecovery: true)) == nil {
             client.close()
             try launchApp()
             let launchedClient = try SocketClient.waitForConnectableSocket(path: socketPath, timeout: 10)
@@ -4022,7 +4074,7 @@ struct CMUXCLI {
             return launchedClient
         }
 
-        try client.connect()
+        try client.connect(allowListenerRestartRecovery: true)
         try authenticateClientIfNeeded(
             client,
             explicitPassword: explicitPassword,
@@ -12932,7 +12984,7 @@ struct CMUXCLI {
         let client = SocketClient(path: socketPath)
 
         do {
-            try client.connect()
+            try client.connect(allowListenerRestartRecovery: true)
             try authenticateClientIfNeeded(
                 client,
                 explicitPassword: explicitPassword,
@@ -21935,7 +21987,7 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
         }
 
         let client = SocketClient(path: socketPath)
-        try client.connect()
+        try client.connect(allowListenerRestartRecovery: true)
         try authenticateClientIfNeeded(client, explicitPassword: socketPassword, socketPath: socketPath)
 
         var rawMode = TerminalRawMode()

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -133,6 +133,11 @@ private enum CmuxThemeNotifications {
     static let reloadConfig = Notification.Name("com.cmuxterm.themes.reload-config")
 }
 
+private enum CmuxSocketControlNotifications {
+    static let restartListener = Notification.Name("com.cmuxterm.socket.restartListener")
+    static let socketPathUserInfoKey = "socketPath"
+}
+
 func isCommandPaletteFocusStealingTerminalOrBrowserResponder(_ responder: NSResponder) -> Bool {
     if responder is GhosttyNSView || responder is WKWebView {
         return true
@@ -1040,6 +1045,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             self,
             selector: #selector(handleThemesReloadNotification(_:)),
             name: CmuxThemeNotifications.reloadConfig,
+            object: nil,
+            suspensionBehavior: .deliverImmediately
+        )
+        DistributedNotificationCenter.default().addObserver(
+            self,
+            selector: #selector(handleSocketListenerRestartNotification(_:)),
+            name: CmuxSocketControlNotifications.restartListener,
             object: nil,
             suspensionBehavior: .deliverImmediately
         )
@@ -14695,6 +14707,18 @@ private extension AppDelegate {
         DispatchQueue.main.async {
             GhosttyApp.shared.reloadConfiguration(source: "distributed.cmux.themes")
         }
+    }
+
+    @objc private func handleSocketListenerRestartNotification(_ notification: Notification) {
+        guard let config = socketListenerConfigurationIfEnabled() else { return }
+        let activePath = TerminalController.shared.activeSocketPath(preferredPath: config.path)
+        if let requestedPath = notification.userInfo?[CmuxSocketControlNotifications.socketPathUserInfoKey] as? String,
+           !requestedPath.isEmpty,
+           requestedPath != activePath {
+            return
+        }
+
+        restartSocketListenerIfEnabled(source: "distributedNotification")
     }
 }
 

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1063,6 +1063,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         )
         NotificationCenter.default.addObserver(
             self,
+            selector: #selector(handleSocketListenerNeedsRestart(_:)),
+            name: .socketListenerNeedsRestart,
+            object: TerminalController.shared
+        )
+        NotificationCenter.default.addObserver(
+            self,
             selector: #selector(handleFeedRequestFocus(_:)),
             name: .feedRequestFocus,
             object: nil
@@ -14719,6 +14725,12 @@ private extension AppDelegate {
         }
 
         restartSocketListenerIfEnabled(source: "distributedNotification")
+    }
+
+    @objc private func handleSocketListenerNeedsRestart(_ notification: Notification) {
+        guard !isTerminatingApp else { return }
+        let reason = (notification.userInfo?["reason"] as? String) ?? "unknown"
+        restartSocketListenerIfEnabled(source: "listener.\(reason)")
     }
 }
 

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -7,6 +7,7 @@ import WebKit
 
 extension Notification.Name {
     static let socketListenerDidStart = Notification.Name("cmux.socketListenerDidStart")
+    static let socketListenerNeedsRestart = Notification.Name("cmux.socketListenerNeedsRestart")
     static let terminalSurfaceDidBecomeReady = Notification.Name("cmux.terminalSurfaceDidBecomeReady")
     static let terminalSurfaceHostedViewDidMoveToWindow = Notification.Name("cmux.terminalSurfaceHostedViewDidMoveToWindow")
     static let mainWindowContextsDidChange = Notification.Name("cmux.mainWindowContextsDidChange")
@@ -1713,13 +1714,62 @@ class TerminalController {
     }
 
     private nonisolated func finishAcceptSourceCancel(listenerSocket: Int32, generation: UInt64) {
-        withListenerState {
-            guard activeAcceptLoopGeneration == generation, serverSocket == listenerSocket else { return }
+        let restartRequest = withListenerState { () -> (path: String, reason: String)? in
+            guard activeAcceptLoopGeneration == generation, serverSocket == listenerSocket else { return nil }
+            let cancelledPath = socketPath
+            isRunning = false
             acceptLoopAlive = false
+            activeAcceptLoopGeneration = 0
+            pendingAcceptLoopRearmGeneration = nil
+            serverSocket = -1
             listenerReadSource = nil
             listenerReadSourceSuspended = false
+            return (cancelledPath, "accept_source_cancelled")
         }
+
+        guard let restartRequest else { return }
+        unlinkSocketPathIfListenerStillInactive(restartRequest.path)
+        notifySocketListenerNeedsRestart(
+            path: restartRequest.path,
+            reason: restartRequest.reason,
+            generation: generation
+        )
     }
+
+    private nonisolated func notifySocketListenerNeedsRestart(path: String, reason: String, generation: UInt64) {
+        sentryBreadcrumb(
+            "socket.listener.restart_needed",
+            category: "socket",
+            data: socketListenerEventData(
+                stage: reason,
+                extra: [
+                    "path": path,
+                    "generation": generation
+                ]
+            )
+        )
+        NotificationCenter.default.post(
+            name: .socketListenerNeedsRestart,
+            object: self,
+            userInfo: [
+                "path": path,
+                "reason": reason,
+                "generation": generation
+            ]
+        )
+    }
+
+#if DEBUG
+    nonisolated func debugCancelActiveSocketListenerForTesting() {
+        let (sourceToCancel, sourceWasSuspended) = withListenerState {
+            (listenerReadSource, listenerReadSourceSuspended)
+        }
+        if sourceWasSuspended {
+            sourceToCancel?.resume()
+        }
+        sourceToCancel?.cancel()
+    }
+#endif
 
     private nonisolated func drainPendingSocketClients(listenerSocket: Int32, generation: UInt64) {
         while shouldContinueAcceptLoop(generation: generation) {

--- a/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
+++ b/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
@@ -103,6 +103,51 @@ final class CMUXCLIErrorOutputRegressionTests: XCTestCase {
         )
     }
 
+    func testBundledCLIRecoversRefusedSocketByRequestingListenerRestart() throws {
+        let cliPath = try bundledCLIPath()
+        let socketPath = "/tmp/cmux-cli-recover-\(UUID().uuidString.lowercased()).sock"
+        try bindClosedUnixSocket(at: socketPath)
+        defer { unlink(socketPath) }
+
+        var responder: UnixSocketResponder?
+        let notificationExpectation = expectation(description: "CLI requested socket listener restart")
+        let notificationObserver = SocketRestartNotificationObserver(socketPath: socketPath) {
+            responder = try UnixSocketResponder(path: socketPath, response: "PONG")
+        } onNotification: {
+            notificationExpectation.fulfill()
+        }
+        defer {
+            DistributedNotificationCenter.default().removeObserver(notificationObserver)
+            responder?.stop()
+        }
+
+        DistributedNotificationCenter.default().addObserver(
+            notificationObserver,
+            selector: #selector(SocketRestartNotificationObserver.handleNotification(_:)),
+            name: Notification.Name("com.cmuxterm.socket.restartListener"),
+            object: nil,
+            suspensionBehavior: .deliverImmediately
+        )
+
+        var environment = ProcessInfo.processInfo.environment
+        environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
+        environment["CMUX_SOCKET_PATH"] = socketPath
+        environment.removeValue(forKey: "CMUX_SOCKET")
+
+        let result = runProcessPumpingRunLoop(
+            executablePath: cliPath,
+            arguments: ["ping"],
+            environment: environment,
+            timeout: 5
+        )
+
+        wait(for: [notificationExpectation], timeout: 1)
+        XCTAssertNil(notificationObserver.error.map(String.init(describing:)))
+        XCTAssertFalse(result.timedOut, result.stdout)
+        XCTAssertEqual(result.status, 0, result.stdout)
+        XCTAssertEqual(result.stdout.trimmingCharacters(in: .whitespacesAndNewlines), "PONG", result.stdout)
+    }
+
     private func bundledCLIPath() throws -> String {
         let fileManager = FileManager.default
         let appBundleURL = Bundle(for: Self.self)
@@ -185,6 +230,52 @@ final class CMUXCLIErrorOutputRegressionTests: XCTestCase {
         return fakeCLIURL.path
     }
 
+    private func bindClosedUnixSocket(at path: String) throws {
+        unlink(path)
+        let listenerFD = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard listenerFD >= 0 else {
+            throw posixError("socket")
+        }
+
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        let maxLength = MemoryLayout.size(ofValue: address.sun_path)
+        guard path.utf8.count < maxLength else {
+            Darwin.close(listenerFD)
+            throw NSError(
+                domain: NSPOSIXErrorDomain,
+                code: Int(ENAMETOOLONG),
+                userInfo: [NSLocalizedDescriptionKey: "Unix socket path is too long: \(path)"]
+            )
+        }
+        path.withCString { pointer in
+            withUnsafeMutablePointer(to: &address.sun_path) { tuplePointer in
+                let buffer = UnsafeMutableRawPointer(tuplePointer).assumingMemoryBound(to: CChar.self)
+                strncpy(buffer, pointer, maxLength - 1)
+            }
+        }
+
+        let bindResult = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { socketPointer in
+                Darwin.bind(listenerFD, socketPointer, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard bindResult == 0 else {
+            let error = posixError("bind")
+            Darwin.close(listenerFD)
+            throw error
+        }
+        Darwin.close(listenerFD)
+    }
+
+    private func posixError(_ operation: String) -> NSError {
+        NSError(
+            domain: NSPOSIXErrorDomain,
+            code: Int(errno),
+            userInfo: [NSLocalizedDescriptionKey: "\(operation) failed: \(String(cString: strerror(errno)))"]
+        )
+    }
+
     private func shellSingleQuote(_ value: String) -> String {
         "'\(value.replacingOccurrences(of: "'", with: "'\"'\"'"))'"
     }
@@ -260,6 +351,72 @@ final class CMUXCLIErrorOutputRegressionTests: XCTestCase {
             stdout: String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? "",
             timedOut: timedOut
         )
+    }
+
+    private func runProcessPumpingRunLoop(
+        executablePath: String,
+        arguments: [String],
+        environment: [String: String],
+        timeout: TimeInterval
+    ) -> ProcessRunResult {
+        let process = Process()
+        let outputPipe = Pipe()
+        process.executableURL = URL(fileURLWithPath: executablePath)
+        process.arguments = arguments
+        process.environment = environment
+        process.standardInput = FileHandle.nullDevice
+        process.standardOutput = outputPipe
+        process.standardError = outputPipe
+
+        do {
+            try process.run()
+        } catch {
+            return ProcessRunResult(status: -1, stdout: String(describing: error), timedOut: false)
+        }
+
+        let deadline = Date().addingTimeInterval(timeout)
+        while process.isRunning && Date() < deadline {
+            RunLoop.current.run(mode: .default, before: Date(timeIntervalSinceNow: 0.02))
+        }
+
+        let timedOut = process.isRunning
+        if timedOut {
+            process.terminate()
+        }
+        process.waitUntilExit()
+
+        return ProcessRunResult(
+            status: process.terminationStatus,
+            stdout: String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? "",
+            timedOut: timedOut
+        )
+    }
+}
+
+private final class SocketRestartNotificationObserver: NSObject {
+    let socketPath: String
+    private let startResponder: () throws -> Void
+    private let onNotification: () -> Void
+    private(set) var error: Error?
+
+    init(socketPath: String, startResponder: @escaping () throws -> Void, onNotification: @escaping () -> Void) {
+        self.socketPath = socketPath
+        self.startResponder = startResponder
+        self.onNotification = onNotification
+    }
+
+    @objc func handleNotification(_ notification: Notification) {
+        guard let requestedPath = notification.userInfo?["socketPath"] as? String,
+              requestedPath == socketPath else {
+            return
+        }
+
+        do {
+            try startResponder()
+        } catch {
+            self.error = error
+        }
+        onNotification()
     }
 }
 

--- a/cmuxTests/TerminalControllerSocketSecurityTests.swift
+++ b/cmuxTests/TerminalControllerSocketSecurityTests.swift
@@ -49,6 +49,43 @@ final class TerminalControllerSocketSecurityTests: XCTestCase {
         XCTAssertEqual(try socketMode(at: restrictedPath), 0o600)
     }
 
+    func testUnexpectedAcceptSourceCancelRequestsRestartAndRemovesStaleSocket() throws {
+        let tabManager = TabManager()
+        let socketPath = makeSocketPath("cancel-restart")
+        let restartExpectation = expectation(description: "listener requested restart")
+        let recorder = SocketListenerRestartRecorder(
+            socketPath: socketPath,
+            expectation: restartExpectation
+        )
+        let observer = NotificationCenter.default.addObserver(
+            forName: .socketListenerNeedsRestart,
+            object: TerminalController.shared,
+            queue: .main
+        ) { notification in
+            recorder.handle(notification)
+        }
+        defer {
+            NotificationCenter.default.removeObserver(observer)
+        }
+
+        TerminalController.shared.start(
+            tabManager: tabManager,
+            socketPath: socketPath,
+            accessMode: .allowAll
+        )
+        try waitForSocket(at: socketPath)
+
+        TerminalController.shared.debugCancelActiveSocketListenerForTesting()
+        wait(for: [restartExpectation], timeout: 2)
+
+        XCTAssertNil(recorder.error)
+        XCTAssertEqual(recorder.reason, "accept_source_cancelled")
+        let health = TerminalController.shared.socketListenerHealth(expectedSocketPath: socketPath)
+        XCTAssertFalse(health.isRunning)
+        XCTAssertFalse(health.acceptLoopAlive)
+        XCTAssertFalse(health.socketPathExists)
+    }
+
     func testPasswordModeRejectsUnauthenticatedCommands() throws {
         let socketPath = makeSocketPath("password-mode")
         let tabManager = TabManager()
@@ -853,5 +890,29 @@ final class TerminalControllerSocketSecurityTests: XCTestCase {
             code: Int(errno),
             userInfo: [NSLocalizedDescriptionKey: "\(operation) failed: \(String(cString: strerror(errno)))"]
         )
+    }
+}
+
+private final class SocketListenerRestartRecorder {
+    let socketPath: String
+    let expectation: XCTestExpectation
+    private(set) var reason: String?
+    private(set) var error: String?
+
+    init(socketPath: String, expectation: XCTestExpectation) {
+        self.socketPath = socketPath
+        self.expectation = expectation
+    }
+
+    func handle(_ notification: Notification) {
+        guard let path = notification.userInfo?["path"] as? String,
+              path == socketPath else {
+            return
+        }
+        reason = notification.userInfo?["reason"] as? String
+        if reason == nil {
+            error = "missing restart reason"
+        }
+        expectation.fulfill()
     }
 }


### PR DESCRIPTION
## Summary
- Let CLI commands request a matching running app to restart its Unix socket listener after ECONNREFUSED.
- Apply the same recovery path to `cmux events`, so event consumers can reconnect without UI focus.
- Add regression coverage for the bundled CLI recovery flow.

## Verification
- `xcodebuild -project cmux.xcodeproj -scheme cmux-cli -configuration Debug -destination platform=macOS,arch=arm64 -derivedDataPath /tmp/cmux-sockwd build`
- `swift /tmp/cmux_socket_recovery_harness.swift /tmp/cmux-sockwd/Build/Products/Debug/cmux` returned `PONG`
- `./scripts/reload.sh --tag sockwd`

## Note
The local app-hosted `cmux-unit` runner exits before XCTest attaches on this machine, before the new test method runs. The direct harness verifies the same refused-socket recovery behavior end to end.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the CLI↔app socket connection path and adds automatic listener restart behavior on `ECONNREFUSED`, which could affect connectivity/restart loops if mis-triggered, but scope is limited to this failure mode.
> 
> **Overview**
> **CLI socket connections now self-heal on `ECONNREFUSED`.** `SocketClient.connect` gains an optional recovery mode that posts a distributed restart request (`com.cmuxterm.socket.restartListener`), waits briefly for the socket to become connectable, and then adopts the recovered connection.
> 
> This recovery is enabled across CLI entry points (including `cmux events` streaming, `ping`, and other client connects). The app side now listens for restart requests and also triggers restarts when the internal accept loop is unexpectedly cancelled, cleaning up stale socket paths.
> 
> Adds regression tests covering end-to-end CLI recovery via distributed notification and a listener-side test ensuring cancelled accept sources request restart and remove the stale socket.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca8eea768fbaabfddcf40eb1fd9a15bb269763d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically recover CLI connections when the Unix socket refuses connections by requesting the app to restart its listener and reconnecting. Adds a watchdog that restarts the listener if the app loses its accept source, and cleans up stale socket files.

- **New Features**
  - Added `SocketClient.connect(allowListenerRestartRecovery:)` to detect `ECONNREFUSED`, post `com.cmuxterm.socket.restartListener` with the socket path, wait up to 2s, and adopt the new connection.
  - Enabled recovery across CLI entry points, including `cmux events` and PI session extension.
  - App now restarts its listener on the distributed restart request (path-validated) and on internal `socketListenerNeedsRestart` signals.
  - Terminal listener posts `socketListenerNeedsRestart` with reason `accept_source_cancelled` and removes stale socket files before restart.
  - Added tests for refused-socket recovery and for restart-on-accept-source-loss with stale-socket cleanup.

<sup>Written for commit ca8eea768fbaabfddcf40eb1fd9a15bb269763d1. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4306?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic socket listener restart recovery: when a connection is refused, the app requests the listener restart and attempts to recover the connection transparently, improving reliability.
* **Bug Fixes**
  * Improved handling of listener restarts to avoid stale socket files and ensure recovered connections adopt prior state.
* **Tests**
  * Added regression and security tests validating restart request and recovery behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4306?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->