### PR TITLE
Fix Ghostty startup color scheme reentrancy

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1666,6 +1666,17 @@ class GhosttyApp {
         case never
     }
 
+    private enum SingletonConstructionPhase {
+        case constructing
+        case constructed
+    }
+
+    private struct RuntimeColorSchemeSync {
+        let colorScheme: GhosttyConfig.ColorSchemePreference
+        let runtimeColorScheme: ghostty_color_scheme_e
+        let source: String
+    }
+
     static let shared = GhosttyApp()
     private static let releaseBundleIdentifier = "com.cmuxterm.app"
     private static let fallbackAppearanceConfig = GhosttyConfig()
@@ -1845,6 +1856,9 @@ class GhosttyApp {
     private var defaultBackgroundUpdateScope: GhosttyDefaultBackgroundUpdateScope = .unscoped
     private var defaultBackgroundScopeSource: String = "initialize"
     private var lastAppearanceColorScheme: GhosttyConfig.ColorSchemePreference?
+    private var singletonConstructionPhase: SingletonConstructionPhase = .constructing
+    private var pendingInitialRuntimeColorSchemeSync: RuntimeColorSchemeSync?
+    private var activeRuntimeColorSchemeReloadPreference: GhosttyConfig.ColorSchemePreference?
     private lazy var defaultBackgroundNotificationDispatcher: GhosttyDefaultBackgroundNotificationDispatcher =
         // Theme chrome should track terminal theme changes in the same frame.
         // Keep coalescing semantics, but flush in the next main turn instead of waiting ~1 frame.
@@ -1931,6 +1945,7 @@ class GhosttyApp {
 
     private init() {
         initializeGhostty()
+        singletonConstructionPhase = .constructed
     }
 
     #if DEBUG
@@ -2001,10 +2016,11 @@ class GhosttyApp {
         runtimeConfig.userdata = Unmanaged.passUnretained(self).toOpaque()
         runtimeConfig.supports_selection_clipboard = true
         runtimeConfig.wakeup_cb = { userdata in
-            GhosttyApp.shared.scheduleTick()
+            GhosttyApp.instance(fromUserdata: userdata)?.scheduleTick()
         }
         runtimeConfig.action_cb = { app, target, action in
-            return GhosttyApp.shared.handleAction(target: target, action: action)
+            guard let instance = GhosttyApp.instance(fromRuntimeApp: app) else { return false }
+            return instance.handleAction(target: target, action: action)
         }
         // Some GhosttyKit builds import this callback as returning `Void` in Swift even
         // though the C ABI returns `bool`. Store the C-compatible shim explicitly so the
@@ -2154,7 +2170,11 @@ class GhosttyApp {
         }
 
         // Notify observers that a usable config is available (initial load).
-        synchronizeGhosttyRuntimeColorScheme(initialColorScheme, source: "initialize")
+        pendingInitialRuntimeColorSchemeSync = RuntimeColorSchemeSync(
+            colorScheme: initialColorScheme,
+            runtimeColorScheme: Self.ghosttyRuntimeColorScheme(for: initialColorScheme),
+            source: "initialize"
+        )
         lastAppearanceColorScheme = initialColorScheme
         GhosttyConfig.invalidateLoadCache()
         NotificationCenter.default.post(name: .ghosttyConfigDidReload, object: nil)
@@ -2183,6 +2203,16 @@ class GhosttyApp {
         })
 
         #endif
+    }
+
+    private static func instance(fromUserdata userdata: UnsafeMutableRawPointer?) -> GhosttyApp? {
+        guard let userdata else { return nil }
+        return Unmanaged<GhosttyApp>.fromOpaque(userdata).takeUnretainedValue()
+    }
+
+    private static func instance(fromRuntimeApp runtimeApp: ghostty_app_t?) -> GhosttyApp? {
+        guard let runtimeApp else { return nil }
+        return instance(fromUserdata: ghostty_app_userdata(runtimeApp))
     }
 
     private func loadInlineGhosttyConfig(
@@ -3119,6 +3149,8 @@ class GhosttyApp {
     }
 
     func tick() {
+        synchronizePendingInitialRuntimeColorSchemeIfNeeded()
+
         _tickLock.lock()
         _tickScheduled = false
         _tickLock.unlock()
@@ -3156,6 +3188,7 @@ class GhosttyApp {
             }
         }
         let reloadColorScheme = preferredColorScheme ?? GhosttyConfig.currentColorSchemePreference()
+        synchronizePendingInitialRuntimeColorSchemeIfNeeded()
         guard let app else {
             logThemeAction("reload skipped source=\(source) soft=\(soft) reason=no_app")
             return
@@ -3211,6 +3244,7 @@ class GhosttyApp {
         let currentColorScheme = GhosttyConfig.currentColorSchemePreference(
             appAppearance: appearance ?? NSApp?.effectiveAppearance
         )
+        synchronizePendingInitialRuntimeColorSchemeIfNeeded()
         let plan = Self.appearanceSynchronizationPlan(
             previousColorScheme: lastAppearanceColorScheme,
             currentColorScheme: currentColorScheme
@@ -3261,11 +3295,41 @@ class GhosttyApp {
         source: String
     ) {
         guard let app else { return }
+        activeRuntimeColorSchemeReloadPreference = colorScheme
+        defer { activeRuntimeColorSchemeReloadPreference = nil }
         ghostty_app_set_color_scheme(app, runtimeColorScheme)
         if backgroundLogEnabled {
             let schemeLabel = colorScheme == .dark ? "dark" : "light"
             logBackground("app color scheme source=\(source) scheme=\(schemeLabel)")
         }
+    }
+
+    private func synchronizePendingInitialRuntimeColorSchemeIfNeeded() {
+        guard pendingInitialRuntimeColorSchemeSync != nil else { return }
+        guard Thread.isMainThread else {
+            DispatchQueue.main.sync {
+                self.synchronizePendingInitialRuntimeColorSchemeIfNeeded()
+            }
+            return
+        }
+        guard singletonConstructionPhase == .constructed,
+              let pending = pendingInitialRuntimeColorSchemeSync else { return }
+
+        pendingInitialRuntimeColorSchemeSync = nil
+        synchronizeGhosttyRuntimeColorScheme(
+            pending.runtimeColorScheme,
+            colorScheme: pending.colorScheme,
+            source: pending.source
+        )
+    }
+
+    func runtimeAppForSurfaceCreation(source: String) -> ghostty_app_t? {
+        synchronizePendingInitialRuntimeColorSchemeIfNeeded()
+        guard let app else {
+            logThemeAction("runtime app unavailable source=\(source)")
+            return nil
+        }
+        return app
     }
 
     func openConfigurationInTextEdit() {
@@ -3611,8 +3675,8 @@ class GhosttyApp {
                 source: source,
                 scope: .app
             )
-            DispatchQueue.main.async {
-                GhosttyApp.shared.applyBackgroundToKeyWindow()
+            DispatchQueue.main.async { [weak self] in
+                self?.applyBackgroundToKeyWindow()
             }
         case GHOSTTY_ACTION_COLOR_KIND_FOREGROUND:
             applyDefaultBackground(
@@ -3754,6 +3818,8 @@ class GhosttyApp {
     }
 
     private func handleAction(target: ghostty_target_s, action: ghostty_action_s) -> Bool {
+        synchronizePendingInitialRuntimeColorSchemeIfNeeded()
+
         if target.tag != GHOSTTY_TARGET_SURFACE {
             if action.tag == GHOSTTY_ACTION_RELOAD_CONFIG ||
                 action.tag == GHOSTTY_ACTION_CONFIG_CHANGE ||
@@ -3805,7 +3871,11 @@ class GhosttyApp {
                 let soft = action.action.reload_config.soft
                 logThemeAction("reload request target=app soft=\(soft)")
                 performOnMain {
-                    GhosttyApp.shared.reloadConfiguration(soft: soft, source: "action.reload_config.app")
+                    self.reloadConfiguration(
+                        soft: soft,
+                        source: "action.reload_config.app",
+                        preferredColorScheme: activeRuntimeColorSchemeReloadPreference
+                    )
                 }
                 return true
             }
@@ -3823,8 +3893,8 @@ class GhosttyApp {
                     source: "action.config_change.app",
                     scope: .app
                 )
-                DispatchQueue.main.async {
-                    GhosttyApp.shared.applyBackgroundToKeyWindow()
+                DispatchQueue.main.async { [weak self] in
+                    self?.applyBackgroundToKeyWindow()
                 }
                 return true
             }
@@ -4108,7 +4178,12 @@ class GhosttyApp {
                 "reload request target=surface tab=\(surfaceView.tabId?.uuidString ?? "nil") surface=\(surfaceView.terminalSurface?.id.uuidString ?? "nil") soft=\(soft)"
             )
             return performOnMain {
-                GhosttyApp.shared.reloadSurfaceConfiguration(target.target.surface, soft: soft, source: "action.reload_config.surface tab=\(surfaceView.tabId?.uuidString ?? "nil") surface=\(surfaceView.terminalSurface?.id.uuidString ?? "nil")")
+                self.reloadSurfaceConfiguration(
+                    target.target.surface,
+                    soft: soft,
+                    source: "action.reload_config.surface tab=\(surfaceView.tabId?.uuidString ?? "nil") surface=\(surfaceView.terminalSurface?.id.uuidString ?? "nil")",
+                    preferredColorScheme: activeRuntimeColorSchemeReloadPreference
+                )
                 surfaceView.terminalSurface?.hostedView.refreshHostBackgroundAfterGhosttyConfigReload()
                 surfaceView.terminalSurface?.forceRefresh(reason: "surface.reloadConfig")
                 return true
@@ -5381,7 +5456,7 @@ final class TerminalSurface: Identifiable, ObservableObject {
         Self.surfaceLog("createSurface start surface=\(id.uuidString) tab=\(tabId.uuidString) bounds=\(view.bounds) inWindow=\(view.window != nil) resources=\(resourcesDir) terminfo=\(terminfo) xdg=\(xdg) manpath=\(manpath)")
         #endif
 
-        guard let app = GhosttyApp.shared.app else {
+        guard let app = GhosttyApp.shared.runtimeAppForSurfaceCreation(source: "surface.create") else {
             print("Ghostty app not initialized")
             #if DEBUG
             Self.surfaceLog("createSurface FAILED surface=\(id.uuidString): ghostty app not initialized")

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1943,6 +1943,7 @@ class GhosttyApp {
     }
 
     private init() {
+        dispatchPrecondition(condition: .onQueue(.main))
         initializeGhostty()
         singletonConstructionPhase = .constructed
     }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3302,7 +3302,6 @@ class GhosttyApp {
     }
 
     private func synchronizePendingInitialRuntimeColorSchemeIfNeeded() {
-        guard pendingInitialRuntimeColorSchemeSync != nil else { return }
         assert(Thread.isMainThread, "Initial Ghostty runtime color-scheme sync must flush from a main-thread lifecycle point")
         guard Thread.isMainThread else {
             return

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1864,6 +1864,7 @@ class GhosttyApp {
     private var lastAppearanceColorScheme: GhosttyConfig.ColorSchemePreference?
     private var singletonConstructionPhase: SingletonConstructionPhase = .constructing
     private var pendingInitialRuntimeColorSchemeSync: RuntimeColorSchemeSync?
+    private var isSynchronizingGhosttyRuntimeColorScheme = false
     private lazy var defaultBackgroundNotificationDispatcher: GhosttyDefaultBackgroundNotificationDispatcher =
         // Theme chrome should track terminal theme changes in the same frame.
         // Keep coalescing semantics, but flush in the next main turn instead of waiting ~1 frame.
@@ -3296,6 +3297,11 @@ class GhosttyApp {
         source: String
     ) {
         guard let app else { return }
+        let wasSynchronizingRuntimeColorScheme = isSynchronizingGhosttyRuntimeColorScheme
+        isSynchronizingGhosttyRuntimeColorScheme = true
+        defer {
+            isSynchronizingGhosttyRuntimeColorScheme = wasSynchronizingRuntimeColorScheme
+        }
         ghostty_app_set_color_scheme(app, runtimeColorScheme)
         if backgroundLogEnabled {
             let schemeLabel = colorScheme == .dark ? "dark" : "light"
@@ -3907,6 +3913,7 @@ class GhosttyApp {
                     self.reloadConfiguration(
                         soft: soft,
                         source: "action.reload_config.app",
+                        reloadSettingsFromFile: !self.isSynchronizingGhosttyRuntimeColorScheme,
                         preferredColorScheme: reloadColorScheme
                     )
                 }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1858,7 +1858,6 @@ class GhosttyApp {
     private var lastAppearanceColorScheme: GhosttyConfig.ColorSchemePreference?
     private var singletonConstructionPhase: SingletonConstructionPhase = .constructing
     private var pendingInitialRuntimeColorSchemeSync: RuntimeColorSchemeSync?
-    private var activeRuntimeColorSchemeReloadPreference: GhosttyConfig.ColorSchemePreference?
     private lazy var defaultBackgroundNotificationDispatcher: GhosttyDefaultBackgroundNotificationDispatcher =
         // Theme chrome should track terminal theme changes in the same frame.
         // Keep coalescing semantics, but flush in the next main turn instead of waiting ~1 frame.
@@ -3265,12 +3264,12 @@ class GhosttyApp {
             )
         }
         guard case let .reload(colorScheme, runtimeColorScheme) = plan else { return }
+        lastAppearanceColorScheme = colorScheme
         synchronizeGhosttyRuntimeColorScheme(
             runtimeColorScheme,
             colorScheme: colorScheme,
             source: source
         )
-        lastAppearanceColorScheme = colorScheme
         reloadConfiguration(
             source: "appearanceSync:\(source)",
             reloadSettingsFromFile: false,
@@ -3295,8 +3294,6 @@ class GhosttyApp {
         source: String
     ) {
         guard let app else { return }
-        activeRuntimeColorSchemeReloadPreference = colorScheme
-        defer { activeRuntimeColorSchemeReloadPreference = nil }
         ghostty_app_set_color_scheme(app, runtimeColorScheme)
         if backgroundLogEnabled {
             let schemeLabel = colorScheme == .dark ? "dark" : "light"
@@ -3306,10 +3303,8 @@ class GhosttyApp {
 
     private func synchronizePendingInitialRuntimeColorSchemeIfNeeded() {
         guard pendingInitialRuntimeColorSchemeSync != nil else { return }
+        assert(Thread.isMainThread, "Initial Ghostty runtime color-scheme sync must flush from a main-thread lifecycle point")
         guard Thread.isMainThread else {
-            DispatchQueue.main.sync {
-                self.synchronizePendingInitialRuntimeColorSchemeIfNeeded()
-            }
             return
         }
         guard singletonConstructionPhase == .constructed,
@@ -3818,8 +3813,6 @@ class GhosttyApp {
     }
 
     private func handleAction(target: ghostty_target_s, action: ghostty_action_s) -> Bool {
-        synchronizePendingInitialRuntimeColorSchemeIfNeeded()
-
         if target.tag != GHOSTTY_TARGET_SURFACE {
             if action.tag == GHOSTTY_ACTION_RELOAD_CONFIG ||
                 action.tag == GHOSTTY_ACTION_CONFIG_CHANGE ||
@@ -3869,12 +3862,13 @@ class GhosttyApp {
 
             if action.tag == GHOSTTY_ACTION_RELOAD_CONFIG {
                 let soft = action.action.reload_config.soft
+                let reloadColorScheme = lastAppearanceColorScheme
                 logThemeAction("reload request target=app soft=\(soft)")
                 performOnMain {
                     self.reloadConfiguration(
                         soft: soft,
                         source: "action.reload_config.app",
-                        preferredColorScheme: activeRuntimeColorSchemeReloadPreference
+                        preferredColorScheme: reloadColorScheme
                     )
                 }
                 return true
@@ -4174,6 +4168,7 @@ class GhosttyApp {
             return true
         case GHOSTTY_ACTION_RELOAD_CONFIG:
             let soft = action.action.reload_config.soft
+            let reloadColorScheme = lastAppearanceColorScheme
             logThemeAction(
                 "reload request target=surface tab=\(surfaceView.tabId?.uuidString ?? "nil") surface=\(surfaceView.terminalSurface?.id.uuidString ?? "nil") soft=\(soft)"
             )
@@ -4182,7 +4177,7 @@ class GhosttyApp {
                     target.target.surface,
                     soft: soft,
                     source: "action.reload_config.surface tab=\(surfaceView.tabId?.uuidString ?? "nil") surface=\(surfaceView.terminalSurface?.id.uuidString ?? "nil")",
-                    preferredColorScheme: activeRuntimeColorSchemeReloadPreference
+                    preferredColorScheme: reloadColorScheme
                 )
                 surfaceView.terminalSurface?.hostedView.refreshHostBackgroundAfterGhosttyConfigReload()
                 surfaceView.terminalSurface?.forceRefresh(reason: "surface.reloadConfig")

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3861,9 +3861,9 @@ class GhosttyApp {
 
             if action.tag == GHOSTTY_ACTION_RELOAD_CONFIG {
                 let soft = action.action.reload_config.soft
-                let reloadColorScheme = lastAppearanceColorScheme
                 logThemeAction("reload request target=app soft=\(soft)")
                 performOnMain {
+                    let reloadColorScheme = self.lastAppearanceColorScheme
                     self.reloadConfiguration(
                         soft: soft,
                         source: "action.reload_config.app",
@@ -4167,11 +4167,11 @@ class GhosttyApp {
             return true
         case GHOSTTY_ACTION_RELOAD_CONFIG:
             let soft = action.action.reload_config.soft
-            let reloadColorScheme = lastAppearanceColorScheme
             logThemeAction(
                 "reload request target=surface tab=\(surfaceView.tabId?.uuidString ?? "nil") surface=\(surfaceView.terminalSurface?.id.uuidString ?? "nil") soft=\(soft)"
             )
             return performOnMain {
+                let reloadColorScheme = self.lastAppearanceColorScheme
                 self.reloadSurfaceConfiguration(
                     target.target.surface,
                     soft: soft,


### PR DESCRIPTION
## Summary
- Fixes #4317.
- Routes Ghostty runtime wakeup/action callbacks through the runtime `userdata` owner instead of `GhosttyApp.shared`, so callbacks cannot reenter singleton construction.
- Defers the initial Ghostty runtime color-scheme sync until the singleton is fully constructed, then flushes it before the first tick, appearance sync, reload, or surface creation.
- Preserves #4278 intent by carrying the startup color-scheme preference into the Ghostty reload action emitted by `ghostty_app_set_color_scheme`.

## Testing
- `git diff --check -- Sources/GhosttyTerminalView.swift`
- Did not add a failing regression test first: the crash is a reentrant `dispatch_once` abort caused by Ghostty C callbacks during Swift static initialization, and a unit test would either exercise singleton process-global state unsafely or assert implementation shape rather than behavior. Verification is CI plus the required tagged app launch after CI is green.
- Per repo/user policy, no local tests and no local dev-app build before CI is green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches `GhosttyApp` initialization and theme/config reload paths, so regressions could affect app startup and runtime appearance syncing. Changes are localized but involve threading/reentrancy guards around C callbacks.
> 
> **Overview**
> Fixes a startup crash caused by Ghostty runtime callbacks reentering `GhosttyApp.shared` during construction by tracking a construction phase, enforcing main-thread initialization, and deferring the first runtime color-scheme sync into a pending buffer that is flushed from safe main-thread lifecycle points (tick/appearance sync/config reload/surface creation).
> 
> Adjusts reload handling to preserve the startup color-scheme across `ghostty_app_set_color_scheme`-triggered reload actions, and avoids reloading settings-from-file during internal color-scheme synchronization to prevent feedback loops.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4d09d5e569e0e00e19dc3322d73f591477f0fe7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a startup crash (reentrant `dispatch_once`) by preventing runtime callbacks and color-scheme sync from reentering `GhosttyApp` during construction. Defers and flushes the initial runtime color scheme only from main-thread lifecycle points and avoids settings reload while syncing color changes. Fixes #4317.

- **Bug Fixes**
  - Route `wakeup_cb` and `action_cb` via runtime `userdata` to the owning instance; avoid `GhosttyApp.shared` during construction.
  - Defer the initial runtime color-scheme sync; flush only on main at first tick, appearance sync, reloads, and surface creation.
  - Require main-queue initialization and gate the first flush behind a construction-phase flag.
  - Preserve startup color-scheme across reloads by passing `lastAppearanceColorScheme`; read and flush only on main.
  - Skip settings reload during runtime color-scheme application to prevent reentrant reloads.

<sup>Written for commit b4d09d5e569e0e00e19dc3322d73f591477f0fe7. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4319?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Defer applying the initial runtime color scheme until startup completes to prevent mismatched themes on launch.
  * Fix synchronization ordering so appearance and theme settings are applied consistently across reloads and when creating new terminal surfaces.
  * Ensure color updates target the correct runtime instance; surface creation now safely handles unavailable runtime and logs when sync cannot proceed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4319?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->