### PR TITLE
Add Omarchy packaging scaffold

### DIFF
--- a/packaging/omarchy/PKGBUILD.disabled
+++ b/packaging/omarchy/PKGBUILD.disabled
@@ -1,0 +1,30 @@
+# This is intentionally disabled: cmux is currently macOS-only and cannot be
+# built as a runnable Arch/Omarchy package until a Linux target exists.
+#
+# Rename to PKGBUILD and complete after Linux support is added.
+
+pkgname=cmux
+pkgver=0
+pkgrel=1
+pkgdesc='Ghostty-based terminal with vertical tabs and AI agent notifications'
+arch=('x86_64' 'aarch64')
+url='https://github.com/abobneil/cmux'
+license=('GPL-3.0-or-later')
+
+# TODO: Fill these in once Linux support exists.
+depends=()
+makedepends=()
+source=("git+$url.git")
+sha256sums=('SKIP')
+
+build() {
+  cd "$srcdir/cmux"
+  echo 'cmux is currently macOS-only; no Linux build target exists yet.' >&2
+  return 1
+}
+
+package() {
+  cd "$srcdir/cmux"
+  echo 'cmux is currently macOS-only; no Linux package artifacts exist yet.' >&2
+  return 1
+}

--- a/packaging/omarchy/README.md
+++ b/packaging/omarchy/README.md
@@ -1,0 +1,41 @@
+# cmux for Omarchy / Arch Linux
+
+This directory is a packaging scaffold for Omarchy (Arch Linux + Hyprland).
+
+## Current status
+
+`cmux` cannot currently be packaged as a runnable Omarchy/Arch Linux app because the upstream application is macOS-only:
+
+- Swift sources import `AppKit`, `SwiftUI`, and `Darwin`.
+- The project is built with `cmux.xcodeproj` / Xcode.
+- The app uses macOS entitlements and macOS-specific integrations.
+- There is no Linux build target or Linux release artifact.
+
+Because of that, a normal `PKGBUILD` cannot produce a working Linux package yet. The Linux port needs to land before Omarchy packaging can be completed.
+
+## Proposed Omarchy package shape after Linux support exists
+
+Once cmux has a Linux target, package it as an Arch package with:
+
+- executable installed to `/usr/bin/cmux`
+- desktop file installed to `/usr/share/applications/cmux.desktop`
+- icon installed under `/usr/share/icons/hicolor/.../apps/cmux.png` or SVG equivalent
+- runtime dependencies declared in `depends=()`
+- build dependencies declared in `makedepends=()`
+
+Omarchy users would then install it with one of:
+
+```bash
+makepkg -si
+# or, if published to AUR:
+omarchy pkg aur add cmux
+```
+
+## Porting checklist
+
+1. Add a Linux build target separate from the macOS AppKit target.
+2. Replace AppKit-only UI/windowing code with a Linux-capable UI stack.
+3. Replace macOS notification/keychain/menu-bar integrations with Linux/FreeDesktop equivalents.
+4. Replace Darwin-only process, PTY, and socket calls with portable Foundation/Glibc code where possible.
+5. Verify Ghostty/libghostty availability and linking on Arch Linux.
+6. Add a real `packaging/omarchy/PKGBUILD` once a Linux binary can be built.


### PR DESCRIPTION
## Summary

- What changed?
- Why?

## Testing

- How did you test this change?
- What did you verify manually?

## Demo Video

For UI or behavior changes, include a short demo video (GitHub upload, Loom, or other direct link).

- Video URL or attachment:

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [ ] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added an Omarchy/Arch Linux packaging scaffold for `cmux` with a disabled `PKGBUILD` and a README that outlines the Linux port requirements and packaging plan. This sets up packaging work but does not build anything until a Linux target exists.

- New Features
  - Added `packaging/omarchy/PKGBUILD.disabled` that intentionally fails since `cmux` is macOS-only today.
  - Added `packaging/omarchy/README.md` with the porting checklist and the intended package layout (binary, desktop file, icons, deps).

<sup>Written for commit 90a8213b26f5047f5e2f003b2772fbaa3fd50e1a. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4320?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Arch Linux packaging status documentation explaining the current macOS-only limitations and outlining prerequisites for future Linux packaging support.

* **Chores**
  * Added disabled package build configuration file as infrastructure preparation for eventual Arch Linux packaging once Linux support is available.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4320?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->