### PR TITLE
Fix sidebar hover close after context menu

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -9369,15 +9369,11 @@ struct SidebarTabItemPresentationSnapshot: Equatable {
 struct SidebarTabItemPresentationResolutionPolicy {
     static func resolved(
         live: SidebarTabItemPresentationSnapshot,
-        frozen: SidebarTabItemPresentationSnapshot?
+        frozen: SidebarTabItemPresentationSnapshot?,
+        contextMenuVisible: Bool
     ) -> SidebarTabItemPresentationSnapshot {
-        guard let frozen, frozen.tabId == live.tabId else { return live }
-        return SidebarTabItemPresentationSnapshot(
-            tabId: live.tabId,
-            unreadCount: live.unreadCount,
-            latestNotificationText: live.latestNotificationText,
-            showsModifierShortcutHints: frozen.showsModifierShortcutHints
-        )
+        guard contextMenuVisible, let frozen, frozen.tabId == live.tabId else { return live }
+        return frozen
     }
 }
 
@@ -9865,14 +9861,9 @@ struct VerticalTabsSidebar: View {
             latestNotificationText: liveLatestNotificationText,
             showsModifierShortcutHints: liveShowsModifierShortcutHints
         )
-        let frozenPresentation = frozenTabItemPresentation?.tabId == tab.id
+        let frozenPresentationSnapshot = frozenTabItemPresentation?.tabId == tab.id
             ? frozenTabItemPresentation
             : nil
-        let resolvedPresentation = SidebarTabItemPresentationResolutionPolicy.resolved(
-            live: livePresentation,
-            frozen: frozenPresentation
-        )
-
         return TabItemView(
             tabManager: tabManager,
             notificationStore: notificationStore,
@@ -9886,13 +9877,13 @@ struct VerticalTabsSidebar: View {
             workspaceShortcutModifierSymbol: renderContext.workspaceNumberShortcut.numberedDigitHintPrefix,
             canCloseWorkspace: renderContext.canCloseWorkspace,
             accessibilityWorkspaceCount: renderContext.workspaceCount,
-            unreadCount: resolvedPresentation.unreadCount,
-            latestNotificationText: resolvedPresentation.latestNotificationText,
+            unreadCount: livePresentation.unreadCount,
+            latestNotificationText: livePresentation.latestNotificationText,
             rowSpacing: tabRowSpacing,
             setSelectionToTabs: { selection = .tabs },
             selectedTabIds: $selectedTabIds,
             lastSidebarSelectionIndex: $lastSidebarSelectionIndex,
-            showsModifierShortcutHints: resolvedPresentation.showsModifierShortcutHints,
+            showsModifierShortcutHints: livePresentation.showsModifierShortcutHints,
             dragAutoScrollController: dragAutoScrollController,
             draggedTabId: $draggedTabId,
             dropIndicator: $dropIndicator,
@@ -9904,6 +9895,7 @@ struct VerticalTabsSidebar: View {
             contextMenuPinState: contextMenuPinState,
             settings: renderContext.tabItemSettings,
             livePresentation: livePresentation,
+            frozenPresentationSnapshot: frozenPresentationSnapshot,
             frozenPresentation: $frozenTabItemPresentation
         )
         .equatable()
@@ -12304,8 +12296,9 @@ private struct TabItemView: View, Equatable {
     private static let workspaceObservationCoalesceInterval: RunLoop.SchedulerTimeType.Stride = .milliseconds(40)
     private static let legacyVMWebSocketDescription = "VM WebSocket PTY"
 
-    // Closures, Bindings, and object references are excluded from ==
-    // because they're recreated every parent eval but don't affect rendering.
+    // Closures, binding identities, and object references are excluded from ==
+    // because they're recreated every parent eval. Pass plain values for binding
+    // state read during body rendering so Equatable can compare them directly.
     nonisolated static func == (lhs: TabItemView, rhs: TabItemView) -> Bool {
         lhs.tab === rhs.tab &&
         lhs.index == rhs.index &&
@@ -12324,6 +12317,7 @@ private struct TabItemView: View, Equatable {
         lhs.allRemoteContextMenuTargetsDisconnected == rhs.allRemoteContextMenuTargetsDisconnected &&
         lhs.allContextMenuWorkspacesHideTerminalScrollBar == rhs.allContextMenuWorkspacesHideTerminalScrollBar &&
         lhs.contextMenuPinState == rhs.contextMenuPinState &&
+        lhs.frozenPresentationSnapshot == rhs.frozenPresentationSnapshot &&
         lhs.settings == rhs.settings
     }
 
@@ -12358,6 +12352,7 @@ private struct TabItemView: View, Equatable {
     let contextMenuPinState: WorkspaceActionDispatcher.PinState?
     let settings: SidebarTabItemSettingsSnapshot
     let livePresentation: SidebarTabItemPresentationSnapshot
+    let frozenPresentationSnapshot: SidebarTabItemPresentationSnapshot?
     @Binding var frozenPresentation: SidebarTabItemPresentationSnapshot?
     @State private var workspaceSnapshotStorage: SidebarWorkspaceSnapshotBuilder.Snapshot?
     @StateObject private var contextMenuState = SidebarTabItemContextMenuState()
@@ -12384,6 +12379,26 @@ private struct TabItemView: View, Equatable {
 
     private var alwaysShowShortcutHints: Bool {
         settings.alwaysShowShortcutHints
+    }
+
+    private var resolvedPresentation: SidebarTabItemPresentationSnapshot {
+        SidebarTabItemPresentationResolutionPolicy.resolved(
+            live: livePresentation,
+            frozen: frozenPresentationSnapshot,
+            contextMenuVisible: rowInteractionState.contextMenuVisible
+        )
+    }
+
+    private var resolvedUnreadCount: Int {
+        resolvedPresentation.unreadCount
+    }
+
+    private var resolvedLatestNotificationText: String? {
+        resolvedPresentation.latestNotificationText
+    }
+
+    private var resolvedShowsModifierShortcutHints: Bool {
+        resolvedPresentation.showsModifierShortcutHints
     }
 
     private var sidebarShowGitBranch: Bool {
@@ -12495,7 +12510,7 @@ private struct TabItemView: View, Equatable {
     private var showCloseButton: Bool {
         rowInteractionState.shouldShowCloseButton(
             canCloseWorkspace: canCloseWorkspace,
-            shortcutHintModeActive: showsModifierShortcutHints || alwaysShowShortcutHints
+            shortcutHintModeActive: resolvedShowsModifierShortcutHints || alwaysShowShortcutHints
         )
     }
 
@@ -12505,7 +12520,7 @@ private struct TabItemView: View, Equatable {
     }
 
     private var showsWorkspaceShortcutHint: Bool {
-        (showsModifierShortcutHints || alwaysShowShortcutHints) && workspaceShortcutLabel != nil
+        (resolvedShowsModifierShortcutHints || alwaysShowShortcutHints) && workspaceShortcutLabel != nil
     }
 
     private var remoteWorkspaceSidebarText: String? {
@@ -12579,7 +12594,7 @@ private struct TabItemView: View, Equatable {
                         .lineLimit(1)
                 }
             }
-            .padding(.top, latestNotificationText == nil ? 1 : 2)
+            .padding(.top, resolvedLatestNotificationText == nil ? 1 : 2)
             .safeHelp(workspaceSnapshot.remoteStateHelpText)
         }
     }
@@ -12616,7 +12631,7 @@ private struct TabItemView: View, Equatable {
         let moveDownActionText = String(localized: "sidebar.workspace.moveDownAction", defaultValue: "Move Down")
         let finderDirectoryPath = WorkspaceFinderDirectoryResolver.path(for: tab)
         let finderDirectoryCacheKey = WorkspaceFinderDirectoryCacheKey(path: finderDirectoryPath)
-        let latestNotificationSubtitle = latestNotificationText
+        let latestNotificationSubtitle = resolvedLatestNotificationText
         let conversationMessageSubtitle = !settings.hidesAllDetails && settings.iMessageModeEnabled
             ? workspaceSnapshot.latestConversationMessage?
                 .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -12627,11 +12642,11 @@ private struct TabItemView: View, Equatable {
 
         VStack(alignment: .leading, spacing: 4) {
             HStack(spacing: 8) {
-                if unreadCount > 0 {
+                if resolvedUnreadCount > 0 {
                     ZStack {
                         Circle()
                             .fill(activeUnreadBadgeFillColor)
-                        Text("\(unreadCount)")
+                        Text("\(resolvedUnreadCount)")
                             .font(.system(size: 9, weight: .semibold))
                             .foregroundColor(.white)
                     }
@@ -12899,9 +12914,18 @@ private struct TabItemView: View, Equatable {
             }
         }
         .contentShape(Rectangle())
+        .onContinuousHover { phase in
+            switch phase {
+            case .active:
+                rowInteractionState.setPointerHovering(true)
+            case .ended:
+                rowInteractionState.setPointerHovering(false)
+            }
+        }
         .opacity(isBeingDragged ? 0.6 : 1)
         .overlay {
             SidebarWorkspaceRowHoverTracker(rowInteractionState: $rowInteractionState)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
         .overlay {
             MiddleClickCapture {
@@ -13013,18 +13037,38 @@ private struct TabItemView: View, Equatable {
         }
         .contextMenu {
             workspaceContextMenu
-                .onAppear {
-                    rowInteractionState.contextMenuDidAppear()
-                    contextMenuState.hasDeferredWorkspaceObservationInvalidation = false
-                    contextMenuState.pendingWorkspaceSnapshot = nil
-                    frozenPresentation = livePresentation
-                }
-                .onDisappear {
-                    rowInteractionState.contextMenuDidDisappear()
-                    frozenPresentation = nil
-                    flushDeferredWorkspaceObservationInvalidation()
-                }
+                .onAppear(perform: contextMenuAppeared)
+                .onDisappear(perform: contextMenuDisappeared)
         }
+        .onChange(
+            of: rowInteractionState.contextMenuVisible,
+            perform: contextMenuVisibilityChanged
+        )
+    }
+
+    private func contextMenuAppeared() {
+        rowInteractionState.contextMenuDidAppear()
+        contextMenuState.hasDeferredWorkspaceObservationInvalidation = false
+        contextMenuState.pendingWorkspaceSnapshot = nil
+        frozenPresentation = livePresentation
+    }
+
+    private func contextMenuDisappeared() {
+        rowInteractionState.contextMenuDidDisappear()
+        clearFrozenPresentationForCurrentTab()
+        flushDeferredWorkspaceObservationInvalidation()
+    }
+
+    private func contextMenuVisibilityChanged(_ isVisible: Bool) {
+        guard !isVisible else { return }
+        guard frozenPresentation?.tabId == tab.id else { return }
+        clearFrozenPresentationForCurrentTab()
+        flushDeferredWorkspaceObservationInvalidation()
+    }
+
+    private func clearFrozenPresentationForCurrentTab() {
+        guard frozenPresentation?.tabId == tab.id else { return }
+        frozenPresentation = nil
     }
 
     private func refreshWorkspaceSnapshot(force: Bool = false) {

--- a/Sources/Sidebar/SidebarWorkspaceRowHoverTracker.swift
+++ b/Sources/Sidebar/SidebarWorkspaceRowHoverTracker.swift
@@ -80,7 +80,7 @@ final class SidebarWorkspaceRowHoverTrackingView: NSView {
         }
         let nextTrackingArea = NSTrackingArea(
             rect: .zero,
-            options: [.mouseEnteredAndExited, .activeAlways, .inVisibleRect],
+            options: [.mouseEnteredAndExited, .mouseMoved, .activeAlways, .inVisibleRect],
             owner: self,
             userInfo: nil
         )
@@ -100,6 +100,10 @@ final class SidebarWorkspaceRowHoverTrackingView: NSView {
     }
 
     override func mouseEntered(with event: NSEvent) {
+        reconcileCurrentPointerLocation()
+    }
+
+    override func mouseMoved(with event: NSEvent) {
         reconcileCurrentPointerLocation()
     }
 

--- a/Sources/Sidebar/SidebarWorkspaceSnapshotRefreshPolicy.swift
+++ b/Sources/Sidebar/SidebarWorkspaceSnapshotRefreshPolicy.swift
@@ -95,7 +95,6 @@ struct SidebarWorkspaceRowInteractionState: Equatable {
 
     mutating func contextMenuDidAppear() {
         contextMenuVisible = true
-        contextMenuTrackingSuppressesCloseButton = true
         deferredPointerHoveringWhileContextMenuTracking = nil
         isPointerHovering = false
     }
@@ -113,6 +112,7 @@ struct SidebarWorkspaceRowInteractionState: Equatable {
     }
 
     mutating func contextMenuTrackingDidEnd() {
+        contextMenuVisible = false
         contextMenuTrackingSuppressesCloseButton = false
         applyDeferredPointerHovering()
     }

--- a/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
+++ b/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
@@ -206,7 +206,7 @@ final class SidebarSelectedWorkspaceScrollPolicyTests: XCTestCase {
 }
 
 final class SidebarTabItemPresentationResolutionPolicyTests: XCTestCase {
-    func testFrozenContextMenuPresentationDoesNotSuppressLiveNotificationState() {
+    func testStaleFrozenContextMenuPresentationDoesNotSuppressLiveShortcutHintState() {
         let tabId = UUID()
         let frozen = SidebarTabItemPresentationSnapshot(
             tabId: tabId,
@@ -223,11 +223,41 @@ final class SidebarTabItemPresentationResolutionPolicyTests: XCTestCase {
 
         let resolved = SidebarTabItemPresentationResolutionPolicy.resolved(
             live: live,
-            frozen: frozen
+            frozen: frozen,
+            contextMenuVisible: false
         )
 
         XCTAssertEqual(resolved.unreadCount, 1)
         XCTAssertEqual(resolved.latestNotificationText, "done")
+        XCTAssertFalse(
+            resolved.showsModifierShortcutHints,
+            "A stale frozen context-menu presentation must not keep shortcut-hint mode active after the live modifier state is false, because shortcut-hint mode suppresses the hover close button."
+        )
+    }
+
+    func testVisibleContextMenuFreezesPresentationState() {
+        let tabId = UUID()
+        let frozen = SidebarTabItemPresentationSnapshot(
+            tabId: tabId,
+            unreadCount: 0,
+            latestNotificationText: nil,
+            showsModifierShortcutHints: true
+        )
+        let live = SidebarTabItemPresentationSnapshot(
+            tabId: tabId,
+            unreadCount: 1,
+            latestNotificationText: "done",
+            showsModifierShortcutHints: false
+        )
+
+        let resolved = SidebarTabItemPresentationResolutionPolicy.resolved(
+            live: live,
+            frozen: frozen,
+            contextMenuVisible: true
+        )
+
+        XCTAssertEqual(resolved.unreadCount, 0)
+        XCTAssertNil(resolved.latestNotificationText)
         XCTAssertTrue(resolved.showsModifierShortcutHints)
     }
 
@@ -241,7 +271,8 @@ final class SidebarTabItemPresentationResolutionPolicyTests: XCTestCase {
 
         let resolved = SidebarTabItemPresentationResolutionPolicy.resolved(
             live: live,
-            frozen: nil
+            frozen: nil,
+            contextMenuVisible: true
         )
 
         XCTAssertEqual(resolved, live)
@@ -263,7 +294,8 @@ final class SidebarTabItemPresentationResolutionPolicyTests: XCTestCase {
 
         let resolved = SidebarTabItemPresentationResolutionPolicy.resolved(
             live: live,
-            frozen: frozen
+            frozen: frozen,
+            contextMenuVisible: true
         )
 
         XCTAssertEqual(resolved.unreadCount, 1)
@@ -299,6 +331,18 @@ final class SidebarWorkspaceRowInteractionStateTests: XCTestCase {
         )
     }
 
+    func testAppKitMenuTrackingEndClearsStaleContextMenuVisibility() {
+        var state = SidebarWorkspaceRowInteractionState()
+
+        state.contextMenuDidAppear()
+        state.contextMenuTrackingDidEnd()
+
+        XCTAssertFalse(
+            state.contextMenuVisible,
+            "AppKit menu tracking ending is authoritative when SwiftUI misses context-menu disappearance."
+        )
+    }
+
     func testContextMenuTrackingBeginHidesExistingCloseButtonBeforeSwiftUIMenuAppears() {
         var state = SidebarWorkspaceRowInteractionState()
 
@@ -325,6 +369,7 @@ final class SidebarWorkspaceRowInteractionStateTests: XCTestCase {
         var state = SidebarWorkspaceRowInteractionState()
 
         state.contextMenuDidAppear()
+        state.contextMenuTrackingDidBegin()
         state.setPointerHovering(true)
 
         XCTAssertFalse(
@@ -343,6 +388,21 @@ final class SidebarWorkspaceRowInteractionStateTests: XCTestCase {
                 shortcutHintModeActive: false
             ),
             "Once AppKit menu tracking ends, the last reconciled pointer position may reveal the close affordance even if SwiftUI menu state is stale."
+        )
+    }
+
+    func testStaleSwiftUIContextMenuVisibilityDoesNotSuppressFutureHoverWithoutTracking() {
+        var state = SidebarWorkspaceRowInteractionState()
+
+        state.contextMenuDidAppear()
+        state.setPointerHovering(true)
+
+        XCTAssertTrue(
+            state.shouldShowCloseButton(
+                canCloseWorkspace: true,
+                shortcutHintModeActive: false
+            ),
+            "SwiftUI context-menu visibility is not authoritative close-button suppression after AppKit menu tracking has ended or was missed."
         )
     }
 


### PR DESCRIPTION
Summary:
- Clears stale sidebar frozen presentation after AppKit menu tracking ends.
- Keeps shortcut hints frozen only while the matching context menu is actually visible.
- Adds regression coverage for stale frozen shortcut hints and stale context-menu visibility.

Red test:
- Commit b5a1f6d89 added the failing regression test. Before the fix, SidebarTabItemPresentationResolutionPolicyTests.testFrozenContextMenuPresentationDoesNotSuppressLiveNotificationOrShortcutHintState failed because a stale frozen shortcut-hint state stayed active.

Green pass:
- CMUX_TAG=sidebarx CMUX_SOCKET_PATH=/tmp/cmux-debug-sidebarx-unit.sock xcodebuild -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/cmux-sidebarx-unit '-only-testing:cmuxTests/SidebarTabItemPresentationResolutionPolicyTests' '-only-testing:cmuxTests/SidebarWorkspaceRowInteractionStateTests' test
- Result: TEST SUCCEEDED, 16 tests passed.

Cloud proof:
- Cloud run: https://github.com/manaflow-ai/cmux-loader/actions/runs/26071560643
- Before build tag on cloud: sxbef, launched from main.
- Video proof blocker: CUA SSH capture degraded to wallpaper-only frames and get_app_state returned cgWindowNotFound, so no valid before/after GUI proof is claimed in this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sidebar interaction/rendering around context-menu and pointer tracking; regressions could affect hover close-button visibility and tab-row presentation during/after menus, but changes are localized and covered by unit tests.
> 
> **Overview**
> Fixes a sidebar bug where *stale context-menu state* could leave tab-row UI (notably shortcut-hint mode and the hover close button) stuck after a context menu closes.
> 
> Presentation freezing is now gated on `contextMenuVisible` (via `SidebarTabItemPresentationResolutionPolicy`), resolution is moved into `TabItemView`, and frozen presentation is explicitly cleared on SwiftUI disappearance *and* when `rowInteractionState.contextMenuVisible` flips false. AppKit hover tracking is tightened by reconciling pointer location on `mouseMoved` and making `contextMenuTrackingDidEnd()` authoritative by clearing `contextMenuVisible`.
> 
> Adds/updates unit tests to cover stale frozen shortcut hints, visible-menu freezing behavior, and clearing stale context-menu visibility after AppKit tracking ends.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a874186f8b5403fc4c876b28f183925953b83b99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the sidebar hover close button and stale shortcut hints after context menus. Presentation freezes only while the row’s menu is visible, and hover state restores live UI when the menu closes or tracking ends.

- **Bug Fixes**
  - Resolution policy now takes `contextMenuVisible` and returns the frozen snapshot only when true; otherwise returns live.
  - `TabItemView` resolves presentation using `rowInteractionState.contextMenuVisible`, adds `frozenPresentationSnapshot` to `Equatable`, refactors context-menu appear/disappear handlers, and clears stale frozen state via `onChange` of visibility.
  - `VerticalTabsSidebar` passes `frozenPresentationSnapshot` and keeps unread/notification/shortcut-hint values live; parent-side resolution removed.
  - Restores hover reliability: `onContinuousHover` added to the row; `SidebarWorkspaceRowHoverTracker` now tracks `.mouseMoved`; stale SwiftUI context-menu visibility no longer suppresses the close button after AppKit tracking ends.
  - Tests added/updated for stale hover suppression, visible-menu freezing, and tracking-end visibility clearing.

<sup>Written for commit a874186f8b5403fc4c876b28f183925953b83b99. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4329?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Context menus no longer cause stale or frozen sidebar visuals; the live tab presentation is shown unless the menu is open for that tab.
  * Shortcut-hint, unread badge, and latest-notification states update reliably when context menus open or close, preventing lingering UI artifacts.
  * Context-menu visibility is cleared when menu tracking ends to avoid stale UI.

* **Tests**
  * Added and updated tests verifying context-menu visibility handling and presentation resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4329?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->