### PR TITLE
Fix browser file upload drops

### DIFF
--- a/Sources/BrowserPaneDropTargetView.swift
+++ b/Sources/BrowserPaneDropTargetView.swift
@@ -79,6 +79,12 @@ final class BrowserPaneDropTargetView: NSView {
         }
 
         let pasteboardTypes = NSPasteboard(name: .drag).types
+        if shouldDeferPlainExternalFileDropToHostedWebView(pasteboardTypes: pasteboardTypes, at: point) {
+#if DEBUG
+            logHitTestDecision(capture: false, pasteboardTypes: pasteboardTypes, eventType: NSApp.currentEvent?.type)
+#endif
+            return nil
+        }
         let eventType = NSApp.currentEvent?.type
         let capture = Self.shouldCaptureHitTesting(
             pasteboardTypes: pasteboardTypes,
@@ -112,6 +118,12 @@ final class BrowserPaneDropTargetView: NSView {
         }
 
         let location = convert(sender.draggingLocation, from: nil)
+        if shouldDeferPlainExternalFileDropToHostedWebView(sender, at: location) {
+#if DEBUG
+            cmuxDebugLog("browser.paneDrop.prepare allowed=0 reason=plainExternalWebContentFileDrop")
+#endif
+            return false
+        }
         if shouldRouteFileDropToHostedWebView(sender, at: location) {
             clearDragState(phase: "prepare.text")
             let webView = activeFileDropWebView ?? slotView?.hostedWebViewForFileDrop(at: location)
@@ -142,6 +154,12 @@ final class BrowserPaneDropTargetView: NSView {
         }
 
         let location = convert(sender.draggingLocation, from: nil)
+        if shouldDeferPlainExternalFileDropToHostedWebView(sender, at: location) {
+#if DEBUG
+            cmuxDebugLog("browser.paneDrop.perform allowed=0 reason=plainExternalWebContentFileDrop")
+#endif
+            return false
+        }
         let zone = BrowserPaneDropRouting.zone(
             for: location,
             in: bounds.size,
@@ -301,6 +319,12 @@ final class BrowserPaneDropTargetView: NSView {
             topChromeHeight: slotView?.effectivePaneTopChromeHeight() ?? 0
         )
 
+        if shouldDeferPlainExternalFileDropToHostedWebView(sender, at: location) {
+            exitActiveFileDropWebView(sender)
+            clearDragState(phase: "\(phase).webContent")
+            return []
+        }
+
         if shouldRouteFileDropToHostedWebView(sender, at: location) {
             clearDragState(phase: "\(phase).text")
             return updateHostedWebViewDragState(sender, at: location)
@@ -347,6 +371,24 @@ final class BrowserPaneDropTargetView: NSView {
             modifierFlags: DragOverlayRoutingPolicy.currentModifierFlags,
             canDropAsText: canDropIntoHostedWebView
         )
+    }
+
+    private func shouldDeferPlainExternalFileDropToHostedWebView(
+        _ sender: any NSDraggingInfo,
+        at location: NSPoint
+    ) -> Bool {
+        shouldDeferPlainExternalFileDropToHostedWebView(
+            pasteboardTypes: sender.draggingPasteboard.types,
+            at: location
+        )
+    }
+
+    private func shouldDeferPlainExternalFileDropToHostedWebView(
+        pasteboardTypes: [NSPasteboard.PasteboardType]?,
+        at location: NSPoint
+    ) -> Bool {
+        guard DragOverlayRoutingPolicy.isPlainExternalFileDrop(pasteboardTypes) else { return false }
+        return slotView?.hostedWebViewForFileDrop(at: location) != nil
     }
 
     private func updateHostedWebViewDragState(_ sender: any NSDraggingInfo, at location: NSPoint) -> NSDragOperation {

--- a/Sources/DragOverlayRoutingPolicy.swift
+++ b/Sources/DragOverlayRoutingPolicy.swift
@@ -215,6 +215,13 @@ enum DragOverlayRoutingPolicy {
         hasFileURL(pasteboardTypes) || hasFilePreviewTransfer(pasteboardTypes)
     }
 
+    static func isPlainExternalFileDrop(_ pasteboardTypes: [NSPasteboard.PasteboardType]?) -> Bool {
+        hasFileURL(pasteboardTypes)
+            && !hasFilePreviewTransfer(pasteboardTypes)
+            && !hasBonsplitTabTransfer(pasteboardTypes)
+            && !hasSidebarTabReorder(pasteboardTypes)
+    }
+
     static func fileURLs(from pasteboard: NSPasteboard) -> [URL] {
         let fileURLs = PasteboardFileURLReader.fileURLs(from: pasteboard)
         if !fileURLs.isEmpty {

--- a/Sources/FileDropOverlayView.swift
+++ b/Sources/FileDropOverlayView.swift
@@ -130,6 +130,9 @@ final class FileDropOverlayView: NSView {
         if shouldDeferFileDropOverlayToBonsplitTabBar(at: point) {
             return nil
         }
+        if shouldDeferPlainExternalFileDropToWebContent(pasteboardTypes: pb.types, at: convert(point, to: nil)) {
+            return nil
+        }
 
         return super.hitTest(point)
     }
@@ -237,7 +240,7 @@ final class FileDropOverlayView: NSView {
         exitActiveDragTargets(sender)
     }
 
-    private func exitActiveDragTargets(_ sender: (any NSDraggingInfo)?) {
+    func exitActiveDragTargets(_ sender: (any NSDraggingInfo)?) {
         if let prev = activeDragWebView {
             prev.draggingExited(sender)
             activeDragWebView = nil
@@ -255,6 +258,12 @@ final class FileDropOverlayView: NSView {
             pasteboardTypes: types,
             hasLocalDraggingSource: hasLocalDraggingSource
         )
+        if shouldDeferPlainExternalFileDropToWebContent(sender) {
+            preparedDragWebView = nil
+            preparedPaneDropTarget = nil
+            exitActiveDragTargets(sender)
+            return false
+        }
         if shouldRouteFileDropToTextDestination(sender) {
             let paneDropTarget = activePaneDropTarget ?? paneDropTargetForTextDrop(at: sender.draggingLocation)
             exitActiveDragTargets(sender)
@@ -315,6 +324,13 @@ final class FileDropOverlayView: NSView {
             pasteboardTypes: types,
             hasLocalDraggingSource: hasLocalDraggingSource
         )
+        if shouldDeferPlainExternalFileDropToWebContent(sender) {
+            hintBadgeView.hide()
+            preparedDragWebView = nil
+            preparedPaneDropTarget = nil
+            exitActiveDragTargets(sender)
+            return false
+        }
         if shouldRouteFileDropToTextDestination(sender) {
             hintBadgeView.hide()
             didPerformDragAsText = false

--- a/Sources/FileDropOverlayViewHitTesting.swift
+++ b/Sources/FileDropOverlayViewHitTesting.swift
@@ -13,6 +13,11 @@ extension FileDropOverlayView {
             hasLocalDraggingSource: hasLocalDraggingSource
         )
         updateHintBadge(sender: sender, pasteboardTypes: types)
+        if shouldDeferPlainExternalFileDropToWebContent(sender) {
+            hintBadgeView.hide()
+            exitActiveDragTargets(sender)
+            return []
+        }
 
         if shouldRouteFileDropToTextDestination(sender) {
             let paneDropTarget = paneDropTargetForTextDrop(at: loc)
@@ -115,6 +120,21 @@ extension FileDropOverlayView {
             modifierFlags: DragOverlayRoutingPolicy.currentModifierFlags,
             canDropAsText: canDropAsText
         )
+    }
+
+    func shouldDeferPlainExternalFileDropToWebContent(_ sender: any NSDraggingInfo) -> Bool {
+        shouldDeferPlainExternalFileDropToWebContent(
+            pasteboardTypes: sender.draggingPasteboard.types,
+            at: sender.draggingLocation
+        )
+    }
+
+    func shouldDeferPlainExternalFileDropToWebContent(
+        pasteboardTypes: [NSPasteboard.PasteboardType]?,
+        at windowPoint: NSPoint
+    ) -> Bool {
+        guard DragOverlayRoutingPolicy.isPlainExternalFileDrop(pasteboardTypes) else { return false }
+        return webViewUnderPoint(windowPoint) != nil
     }
 
     private func updateHintBadge(

--- a/Sources/FileDropOverlayViewHitTesting.swift
+++ b/Sources/FileDropOverlayViewHitTesting.swift
@@ -12,12 +12,12 @@ extension FileDropOverlayView {
             pasteboardTypes: types,
             hasLocalDraggingSource: hasLocalDraggingSource
         )
-        updateHintBadge(sender: sender, pasteboardTypes: types)
         if shouldDeferPlainExternalFileDropToWebContent(sender) {
             hintBadgeView.hide()
             exitActiveDragTargets(sender)
             return []
         }
+        updateHintBadge(sender: sender, pasteboardTypes: types)
 
         if shouldRouteFileDropToTextDestination(sender) {
             let paneDropTarget = paneDropTargetForTextDrop(at: loc)

--- a/cmuxTests/BrowserPaneDropRoutingTests.swift
+++ b/cmuxTests/BrowserPaneDropRoutingTests.swift
@@ -310,6 +310,65 @@ final class BrowserPaneDropRoutingTests: XCTestCase {
         XCTAssertEqual(webView.dragCalls, ["entered", "prepare", "perform", "conclude"])
     }
 
+    func testBrowserPanePlainExternalFileDropDoesNotInterceptWebContentUpload() throws {
+        let defaults = UserDefaults.standard
+        let savedDefaultBehavior = defaults.object(forKey: FileDropBehaviorSettings.defaultBehaviorKey)
+        defaults.set(FileDropDefaultBehavior.text.rawValue, forKey: FileDropBehaviorSettings.defaultBehaviorKey)
+        defer {
+            if let savedDefaultBehavior {
+                defaults.set(savedDefaultBehavior, forKey: FileDropBehaviorSettings.defaultBehaviorKey)
+            } else {
+                defaults.removeObject(forKey: FileDropBehaviorSettings.defaultBehaviorKey)
+            }
+        }
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 360, height: 240),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer {
+            NotificationCenter.default.post(name: NSWindow.willCloseNotification, object: window)
+            window.orderOut(nil)
+        }
+
+        let root = NSView(frame: window.contentView?.bounds ?? NSRect(x: 0, y: 0, width: 360, height: 240))
+        root.autoresizingMask = [.width, .height]
+        window.contentView = root
+
+        let slot = WindowBrowserSlotView(frame: NSRect(x: 20, y: 20, width: 260, height: 160))
+        root.addSubview(slot)
+        let webView = DragSpyWebView(frame: slot.bounds, configuration: WKWebViewConfiguration())
+        slot.addSubview(webView)
+        slot.pinHostedWebView(webView)
+        slot.setPaneDropContext(BrowserPaneDropContext(
+            workspaceId: UUID(),
+            panelId: UUID(),
+            paneId: PaneID(id: UUID())
+        ))
+        slot.layoutSubtreeIfNeeded()
+
+        let target = try XCTUnwrap(slot.paneDropTargetForDrop(at: NSPoint(x: slot.bounds.midX, y: slot.bounds.midY)))
+        let pasteboard = NSPasteboard(name: NSPasteboard.Name("cmux.test.browser-pane.web-upload.\(UUID().uuidString)"))
+        pasteboard.clearContents()
+        XCTAssertTrue(pasteboard.writeObjects([URL(fileURLWithPath: "/tmp/upload.png") as NSURL]))
+
+        let dropPoint = slot.convert(NSPoint(x: slot.bounds.midX, y: slot.bounds.midY), to: nil)
+        let dragInfo = MockDraggingInfo(window: window, location: dropPoint, pasteboard: pasteboard)
+
+        XCTAssertEqual(target.draggingEntered(dragInfo), [])
+        XCTAssertFalse(target.prepareForDragOperation(dragInfo))
+        XCTAssertFalse(target.performDragOperation(dragInfo))
+        target.concludeDragOperation(dragInfo)
+
+        XCTAssertEqual(
+            webView.dragCalls,
+            [],
+            "Plain external files over browser web content must be left for WebKit's native file-upload drag destination"
+        )
+    }
+
     func testBrowserPaneFilePreviewOnlyDragUsesPaneDropPathInsteadOfHostedWebView() throws {
         let defaults = UserDefaults.standard
         let savedDefaultBehavior = defaults.object(forKey: FileDropBehaviorSettings.defaultBehaviorKey)

--- a/cmuxTests/BrowserPaneDropRoutingTests.swift
+++ b/cmuxTests/BrowserPaneDropRoutingTests.swift
@@ -255,61 +255,6 @@ final class BrowserPaneDropRoutingTests: XCTestCase {
         XCTAssertTrue(syntheticTransfer.isFilePreview)
     }
 
-    func testBrowserPaneFileDropDefaultUsesHostedWebViewLifecycle() throws {
-        let defaults = UserDefaults.standard
-        let savedDefaultBehavior = defaults.object(forKey: FileDropBehaviorSettings.defaultBehaviorKey)
-        defaults.set(FileDropDefaultBehavior.text.rawValue, forKey: FileDropBehaviorSettings.defaultBehaviorKey)
-        defer {
-            if let savedDefaultBehavior {
-                defaults.set(savedDefaultBehavior, forKey: FileDropBehaviorSettings.defaultBehaviorKey)
-            } else {
-                defaults.removeObject(forKey: FileDropBehaviorSettings.defaultBehaviorKey)
-            }
-        }
-
-        let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 360, height: 240),
-            styleMask: [.titled, .closable],
-            backing: .buffered,
-            defer: false
-        )
-        defer {
-            NotificationCenter.default.post(name: NSWindow.willCloseNotification, object: window)
-            window.orderOut(nil)
-        }
-
-        let root = NSView(frame: window.contentView?.bounds ?? NSRect(x: 0, y: 0, width: 360, height: 240))
-        root.autoresizingMask = [.width, .height]
-        window.contentView = root
-
-        let slot = WindowBrowserSlotView(frame: NSRect(x: 20, y: 20, width: 260, height: 160))
-        root.addSubview(slot)
-        let webView = DragSpyWebView(frame: slot.bounds, configuration: WKWebViewConfiguration())
-        slot.addSubview(webView)
-        slot.pinHostedWebView(webView)
-        slot.setPaneDropContext(BrowserPaneDropContext(
-            workspaceId: UUID(),
-            panelId: UUID(),
-            paneId: PaneID(id: UUID())
-        ))
-        slot.layoutSubtreeIfNeeded()
-
-        let target = try XCTUnwrap(slot.paneDropTargetForDrop(at: NSPoint(x: slot.bounds.midX, y: slot.bounds.midY)))
-        let pasteboard = NSPasteboard(name: NSPasteboard.Name("cmux.test.browser-pane.file-drop.\(UUID().uuidString)"))
-        pasteboard.clearContents()
-        XCTAssertTrue(pasteboard.writeObjects([URL(fileURLWithPath: "/tmp/upload.png") as NSURL]))
-
-        let dropPoint = slot.convert(NSPoint(x: slot.bounds.midX, y: slot.bounds.midY), to: nil)
-        let dragInfo = MockDraggingInfo(window: window, location: dropPoint, pasteboard: pasteboard)
-
-        XCTAssertEqual(target.draggingEntered(dragInfo), .copy)
-        XCTAssertTrue(target.prepareForDragOperation(dragInfo))
-        XCTAssertTrue(target.performDragOperation(dragInfo))
-        target.concludeDragOperation(dragInfo)
-
-        XCTAssertEqual(webView.dragCalls, ["entered", "prepare", "perform", "conclude"])
-    }
-
     func testBrowserPanePlainExternalFileDropDoesNotInterceptWebContentUpload() throws {
         let defaults = UserDefaults.standard
         let savedDefaultBehavior = defaults.object(forKey: FileDropBehaviorSettings.defaultBehaviorKey)

--- a/cmuxTests/FileDropOverlayViewTests.swift
+++ b/cmuxTests/FileDropOverlayViewTests.swift
@@ -196,7 +196,7 @@ final class FileDropOverlayViewTests: XCTestCase {
         )
     }
 
-    func testOverlayDelegatesBrowserFileDragLifecycleToPortalHostedWebView() {
+    func testOverlayDoesNotInterceptPlainBrowserFileUploadDrop() {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 420, height: 280),
             styleMask: [.titled, .closable],
@@ -244,15 +244,15 @@ final class FileDropOverlayViewTests: XCTestCase {
             pasteboard: pasteboard
         )
 
-        XCTAssertEqual(overlay.draggingEntered(dragInfo), .copy)
-        XCTAssertTrue(overlay.prepareForDragOperation(dragInfo))
-        XCTAssertTrue(overlay.performDragOperation(dragInfo))
+        XCTAssertEqual(overlay.draggingEntered(dragInfo), [])
+        XCTAssertFalse(overlay.prepareForDragOperation(dragInfo))
+        XCTAssertFalse(overlay.performDragOperation(dragInfo))
         overlay.concludeDragOperation(dragInfo)
 
         XCTAssertEqual(
             webView.dragCalls,
-            ["entered", "prepare", "perform", "conclude"],
-            "Finder file drops over browser panes should still reach the portal-hosted WKWebView"
+            [],
+            "Plain file drops over browser panes should be left to WebKit's native file-upload drag destination"
         )
     }
 
@@ -316,8 +316,8 @@ final class FileDropOverlayViewTests: XCTestCase {
             pasteboard: pasteboard
         )
 
-        XCTAssertEqual(overlay.draggingEntered(dragInfo), .copy)
-        XCTAssertTrue(overlay.prepareForDragOperation(dragInfo))
+        XCTAssertEqual(overlay.draggingEntered(dragInfo), [])
+        XCTAssertFalse(overlay.prepareForDragOperation(dragInfo))
         XCTAssertFalse(overlay.performDragOperation(dragInfo))
         XCTAssertFalse(overlay.didPerformDragAsText)
         XCTAssertNil(overlay.performedTextDragWebView)
@@ -325,8 +325,8 @@ final class FileDropOverlayViewTests: XCTestCase {
         overlay.concludeDragOperation(dragInfo)
         XCTAssertEqual(
             webView.dragCalls,
-            ["entered", "prepare", "perform"],
-            "Rejected text drops should not be recorded as performed or receive a text-route conclude"
+            [],
+            "Plain browser file uploads should not be recorded as performed text drops"
         )
     }
 }


### PR DESCRIPTION
Summary
- Let plain external file drops over browser panes fall through to the native WebKit drag destination.
- Keep cmux-owned transfer types routed through the overlay.
- Avoid transient drag-hint churn before deferring browser file drops.

Testing
- Red commit: 00f4c4be0 test: cover browser file upload drop routing
- Red failure: browser-pane plain file drop returned .copy, prepared/performed through the overlay, and forwarded entered/prepare/perform/conclude to the hosted web view.
- Green commits: a681d5428 fix: let browser file uploads use native drop routing, 65cced75d fix: avoid browser file drop hint churn
- Passed: xcodebuild -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination "platform=macOS,arch=arm64" -derivedDataPath /tmp/cmux-fdrop-review "-only-testing:cmuxTests/BrowserPaneDropRoutingTests" "-only-testing:cmuxTests/FileDropOverlayViewTests" test
- Tagged reload passed: ./scripts/reload.sh --tag fdrop

Cloud proof
- First before-proof run hit Setup Assistant/loginwindow capture failure and did not produce valid before video: https://github.com/manaflow-ai/cmux-loader/actions/runs/26076168381
- Replacement cloud run was healthy for CUA, but I did not capture a valid before/after website file-dropper repro video before handoff: https://github.com/manaflow-ai/cmux-loader/actions/runs/26076811874
- Proof verdict: automated regression coverage is green; full-screen cloud GUI proof remains missing for this specific drag-to-file-dropper path.

Checklist
- [x] Regression test committed before the fix
- [x] Focused drop-routing tests pass
- [x] Tagged dogfood build produced
- [ ] Full-screen before/after cloud GUI proof captured