### PR TITLE
Preload CLI-created browser panes offscreen

### DIFF
--- a/Sources/AppearanceSettings.swift
+++ b/Sources/AppearanceSettings.swift
@@ -34,12 +34,19 @@ enum AppearanceSettings {
         let systemAppearance: () -> NSAppearance?
 
         static var live: LiveApplyEnvironment {
-            AppearanceSettings.liveEnvironmentProvider()
+            AppearanceSettings.currentLiveEnvironmentProvider()()
         }
     }
 
+    private static let liveEnvironmentProviderLock = NSLock()
     private static var liveEnvironmentProvider: () -> LiveApplyEnvironment = {
         AppearanceSettings.defaultLiveEnvironment()
+    }
+
+    private static func currentLiveEnvironmentProvider() -> () -> LiveApplyEnvironment {
+        liveEnvironmentProviderLock.lock()
+        defer { liveEnvironmentProviderLock.unlock() }
+        return liveEnvironmentProvider
     }
 
     private static func defaultLiveEnvironment() -> LiveApplyEnvironment {
@@ -202,10 +209,14 @@ enum AppearanceSettings {
     }
 
     static func setLiveEnvironmentProviderForTesting(_ provider: @escaping () -> LiveApplyEnvironment) {
+        liveEnvironmentProviderLock.lock()
+        defer { liveEnvironmentProviderLock.unlock() }
         liveEnvironmentProvider = provider
     }
 
     static func resetLiveEnvironmentProviderForTesting() {
+        liveEnvironmentProviderLock.lock()
+        defer { liveEnvironmentProviderLock.unlock() }
         liveEnvironmentProvider = {
             AppearanceSettings.defaultLiveEnvironment()
         }

--- a/Sources/AppearanceSettings.swift
+++ b/Sources/AppearanceSettings.swift
@@ -34,18 +34,26 @@ enum AppearanceSettings {
         let systemAppearance: () -> NSAppearance?
 
         static var live: LiveApplyEnvironment {
-            LiveApplyEnvironment(
-                setApplicationAppearance: { appearance in
-                    NSApplication.shared.appearance = appearance
-                },
-                synchronizeTerminalThemeWithAppearance: { appearance, source in
-                    GhosttyApp.shared.synchronizeThemeWithAppearance(appearance, source: source)
-                },
-                systemAppearance: {
-                    AppearanceSettings.systemNSAppearance()
-                }
-            )
+            AppearanceSettings.liveEnvironmentProvider()
         }
+    }
+
+    private static var liveEnvironmentProvider: () -> LiveApplyEnvironment = {
+        AppearanceSettings.defaultLiveEnvironment()
+    }
+
+    private static func defaultLiveEnvironment() -> LiveApplyEnvironment {
+        LiveApplyEnvironment(
+            setApplicationAppearance: { appearance in
+                NSApplication.shared.appearance = appearance
+            },
+            synchronizeTerminalThemeWithAppearance: { appearance, source in
+                GhosttyApp.shared.synchronizeThemeWithAppearance(appearance, source: source)
+            },
+            systemAppearance: {
+                AppearanceSettings.systemNSAppearance()
+            }
+        )
     }
 
     struct SystemAppearance {
@@ -190,6 +198,16 @@ enum AppearanceSettings {
             return NSAppearance(named: .darkAqua)
         case .auto:
             return nil
+        }
+    }
+
+    static func setLiveEnvironmentProviderForTesting(_ provider: @escaping () -> LiveApplyEnvironment) {
+        liveEnvironmentProvider = provider
+    }
+
+    static func resetLiveEnvironmentProviderForTesting() {
+        liveEnvironmentProvider = {
+            AppearanceSettings.defaultLiveEnvironment()
         }
     }
 }

--- a/Sources/KeyboardShortcutSettingsFileStore.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore.swift
@@ -84,7 +84,7 @@ final class CmuxSettingsFileStore {
         importedManagedDefaults = Self.loadImportedManagedDefaults()
 
         bootstrapPrimaryTemplateIfNeeded()
-        reload()
+        reload(synchronizeManagedAppearanceTerminalTheme: false)
         guard startWatching else { return }
 
         primaryWatcher = ShortcutSettingsFileWatcher(path: primaryPath, fileManager: fileManager) { [weak self] in
@@ -116,6 +116,10 @@ final class CmuxSettingsFileStore {
     }
 
     func reload() {
+        reload(synchronizeManagedAppearanceTerminalTheme: true)
+    }
+
+    private func reload(synchronizeManagedAppearanceTerminalTheme: Bool) {
         let previousState = synchronized {
             (
                 shortcuts: shortcutsByAction,
@@ -130,7 +134,8 @@ final class CmuxSettingsFileStore {
             changedManagedDefaultKeys: newOrChangedManagedDefaultKeys(
                 previous: previousState.importedManagedDefaults,
                 next: resolved.managedUserDefaults
-            )
+            ),
+            synchronizeManagedAppearanceTerminalTheme: synchronizeManagedAppearanceTerminalTheme
         )
         synchronized {
             shortcutsByAction = resolved.shortcuts
@@ -221,7 +226,8 @@ final class CmuxSettingsFileStore {
             snapshot: managedState.snapshot,
             importedManagedDefaults: managedState.importedManagedDefaults,
             changedManagedDefaultKeys: [],
-            updateBackups: false
+            updateBackups: false,
+            synchronizeManagedAppearanceTerminalTheme: true
         )
     }
 
@@ -861,7 +867,8 @@ final class CmuxSettingsFileStore {
         snapshot: ResolvedSettingsSnapshot,
         importedManagedDefaults: [String: ManagedSettingsValue],
         changedManagedDefaultKeys: Set<String>,
-        updateBackups: Bool = true
+        updateBackups: Bool = true,
+        synchronizeManagedAppearanceTerminalTheme: Bool
     ) {
         var backups = loadBackups()
         var sideEffects = ManagedDefaultBatchSideEffects()
@@ -889,7 +896,13 @@ final class CmuxSettingsFileStore {
 
         for identifier in currentManagedIdentifiers.subtracting(nextManagedIdentifiers) {
             guard let backup = backups[identifier] else { continue }
-            sideEffects.merge(restoreBackup(backup, for: identifier))
+            sideEffects.merge(
+                restoreBackup(
+                    backup,
+                    for: identifier,
+                    synchronizeManagedAppearanceTerminalTheme: synchronizeManagedAppearanceTerminalTheme
+                )
+            )
             backups.removeValue(forKey: identifier)
         }
 
@@ -899,7 +912,8 @@ final class CmuxSettingsFileStore {
                     value,
                     for: defaultsKey,
                     importedDefault: importedManagedDefaults[defaultsKey],
-                    forceApply: changedManagedDefaultKeys.contains(defaultsKey)
+                    forceApply: changedManagedDefaultKeys.contains(defaultsKey),
+                    synchronizeManagedAppearanceTerminalTheme: synchronizeManagedAppearanceTerminalTheme
                 )
             )
         }
@@ -927,7 +941,11 @@ final class CmuxSettingsFileStore {
         }
     }
 
-    private func restoreBackup(_ backup: BackupValue, for identifier: String) -> ManagedDefaultBatchSideEffects {
+    private func restoreBackup(
+        _ backup: BackupValue,
+        for identifier: String,
+        synchronizeManagedAppearanceTerminalTheme: Bool
+    ) -> ManagedDefaultBatchSideEffects {
         switch identifier {
         case Self.socketPasswordBackupIdentifier:
             switch backup {
@@ -940,7 +958,11 @@ final class CmuxSettingsFileStore {
             }
             return ManagedDefaultBatchSideEffects()
         default:
-            return restoreUserDefaultsBackup(backup, for: identifier)
+            return restoreUserDefaultsBackup(
+                backup,
+                for: identifier,
+                synchronizeManagedAppearanceTerminalTheme: synchronizeManagedAppearanceTerminalTheme
+            )
         }
     }
 
@@ -985,7 +1007,8 @@ final class CmuxSettingsFileStore {
 
     private func restoreUserDefaultsBackup(
         _ backup: BackupValue,
-        for defaultsKey: String
+        for defaultsKey: String,
+        synchronizeManagedAppearanceTerminalTheme: Bool
     ) -> ManagedDefaultBatchSideEffects {
         let defaults = UserDefaults.standard
         if defaultsKey == WorkspaceTabColorSettings.paletteKey {
@@ -1042,7 +1065,8 @@ final class CmuxSettingsFileStore {
         if didMutateStoredValue {
             return applyManagedDefaultSideEffects(
                 for: defaultsKey,
-                source: "cmuxConfig.restoreUserDefault"
+                source: "cmuxConfig.restoreUserDefault",
+                synchronizeAppearanceTerminalTheme: synchronizeManagedAppearanceTerminalTheme
             )
         }
         return ManagedDefaultBatchSideEffects()
@@ -1052,7 +1076,8 @@ final class CmuxSettingsFileStore {
         _ value: ManagedSettingsValue,
         for defaultsKey: String,
         importedDefault: ManagedSettingsValue?,
-        forceApply: Bool
+        forceApply: Bool,
+        synchronizeManagedAppearanceTerminalTheme: Bool
     ) -> ManagedDefaultBatchSideEffects {
         let defaults = UserDefaults.standard
         guard shouldApplyManagedUserDefaultsValue(
@@ -1127,7 +1152,8 @@ final class CmuxSettingsFileStore {
         if didMutateStoredValue {
             return applyManagedDefaultSideEffects(
                 for: defaultsKey,
-                source: "cmuxConfig.applyManagedDefault"
+                source: "cmuxConfig.applyManagedDefault",
+                synchronizeAppearanceTerminalTheme: synchronizeManagedAppearanceTerminalTheme
             )
         }
         return ManagedDefaultBatchSideEffects()
@@ -1207,7 +1233,8 @@ final class CmuxSettingsFileStore {
 
     private func applyManagedDefaultSideEffects(
         for defaultsKey: String,
-        source: String
+        source: String,
+        synchronizeAppearanceTerminalTheme: Bool
     ) -> ManagedDefaultBatchSideEffects {
         let notificationCenter = notificationCenter
         let notifyScrollBar = defaultsKey == TerminalScrollBarSettings.showScrollBarKey
@@ -1226,7 +1253,12 @@ final class CmuxSettingsFileStore {
             if let language {
                 LanguageSettings.apply(language)
             } else if shouldApplyAppearance {
-                AppearanceSettings.applyStoredMode(rawValue: appearanceRawValue, source: source)
+                AppearanceSettings.applyStoredMode(
+                    rawValue: appearanceRawValue,
+                    source: source,
+                    duringLaunch: !synchronizeAppearanceTerminalTheme,
+                    synchronizeTerminalTheme: synchronizeAppearanceTerminalTheme
+                )
             } else if let appIconMode {
                 AppIconSettings.applyIcon(appIconMode)
             }

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -493,7 +493,7 @@ final class BrowserProfileStore: ObservableObject {
         )
     }
 
-    private nonisolated static func removeItemIfExists(at url: URL) async {
+    @concurrent private nonisolated static func removeItemIfExists(at url: URL) async {
         await Task.detached(priority: .utility) {
             try? FileManager.default.removeItem(at: url)
         }.value

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -2701,7 +2701,7 @@ final class BrowserPanel: Panel, ObservableObject {
     var hasBackgroundPreloadHost: Bool {
         backgroundPreloadWindow != nil
     }
-    private let preloadsNavigationInBackground: Bool
+    private var shouldPreloadInitialNavigationInBackground: Bool
     private var backgroundPreloadWindow: NSWindow?
     private var isWebViewVisibleInUI: Bool = false
     private var isClosingWebViewLifecycle: Bool = false
@@ -3468,7 +3468,7 @@ final class BrowserPanel: Panel, ObservableObject {
         self.remoteProxyEndpoint = proxyEndpoint
         self.usesRemoteWorkspaceProxy = isRemoteWorkspace
         self.browserThemeMode = BrowserThemeSettings.mode()
-        self.preloadsNavigationInBackground = preloadInitialNavigationInBackground
+        self.shouldPreloadInitialNavigationInBackground = preloadInitialNavigationInBackground
         self.websiteDataStore = isRemoteWorkspace
             ? WKWebsiteDataStore(forIdentifier: remoteWebsiteDataStoreIdentifier ?? workspaceId)
             : BrowserProfileStore.shared.websiteDataStore(for: resolvedProfileID)
@@ -3617,7 +3617,6 @@ final class BrowserPanel: Panel, ObservableObject {
     }
 
     private func ensureBackgroundPreloadHostIfNeeded(reason: String) {
-        guard preloadsNavigationInBackground else { return }
         guard backgroundPreloadWindow == nil else { return }
         guard webView.window == nil else { return }
         guard webView.superview == nil else { return }
@@ -3630,6 +3629,7 @@ final class BrowserPanel: Panel, ObservableObject {
             defer: false
         )
         window.isReleasedWhenClosed = false
+        window.identifier = NSUserInterfaceItemIdentifier("cmux.browserBackgroundPreload")
         window.hasShadow = false
         window.alphaValue = 0
         window.ignoresMouseEvents = true
@@ -4771,7 +4771,10 @@ final class BrowserPanel: Panel, ObservableObject {
         webView.customUserAgent = BrowserUserAgentSettings.safariUserAgent
         hiddenWebViewDiscardManager.updateRestoredSessionRenderIntent(nil)
         shouldRenderWebView = true
-        ensureBackgroundPreloadHostIfNeeded(reason: "navigation")
+        if shouldPreloadInitialNavigationInBackground {
+            shouldPreloadInitialNavigationInBackground = false
+            ensureBackgroundPreloadHostIfNeeded(reason: "initial-navigation")
+        }
         if recordTypedNavigation {
             historyStore.recordTypedNavigation(url: originalURL)
         }

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -2678,6 +2678,7 @@ final class BrowserPanel: Panel, ObservableObject {
     private(set) var webViewLastHiddenAt: Date?
     private(set) var webViewLastVisibilityChangeAt: Date?
     private(set) var webViewLastVisibilityChangeReason: String?
+    private(set) var hasBackgroundPreloadHost = false
     private var isWebViewVisibleInUI: Bool = false
     private var isClosingWebViewLifecycle: Bool = false
 
@@ -3424,6 +3425,7 @@ final class BrowserPanel: Panel, ObservableObject {
         initialURL: URL? = nil,
         initialRequest: URLRequest? = nil,
         renderInitialNavigation: Bool = true,
+        preloadInitialNavigationInBackground: Bool = false,
         bypassInsecureHTTPHostOnce: String? = nil,
         proxyEndpoint: BrowserProxyEndpoint? = nil,
         isRemoteWorkspace: Bool = false,

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -3653,7 +3653,8 @@ final class BrowserPanel: Panel, ObservableObject {
 
     func releaseBackgroundPreloadHostIfAttachedToRealWindow(reason: String) {
         guard let preloadWindow = backgroundPreloadWindow else { return }
-        guard webView.window !== preloadWindow else { return }
+        guard let attachedWindow = webView.window else { return }
+        guard attachedWindow !== preloadWindow else { return }
         closeBackgroundPreloadHost(reason: reason)
     }
 

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -493,7 +493,7 @@ final class BrowserProfileStore: ObservableObject {
         )
     }
 
-    @concurrent private nonisolated static func removeItemIfExists(at url: URL) async {
+    @Sendable private nonisolated static func removeItemIfExists(at url: URL) async {
         await Task.detached(priority: .utility) {
             try? FileManager.default.removeItem(at: url)
         }.value

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -3675,7 +3675,7 @@ final class BrowserPanel: Panel, ObservableObject {
         guard webView.window == nil else { return }
         guard webView.superview == nil else { return }
 
-        let frame = NSRect(x: 0, y: 0, width: 800, height: 600)
+        let frame = NSRect(x: -10_000, y: -10_000, width: 800, height: 600)
         let window = NSWindow(
             contentRect: frame,
             styleMask: [.borderless],
@@ -3696,6 +3696,7 @@ final class BrowserPanel: Panel, ObservableObject {
         contentView.addSubview(webView)
         window.contentView = contentView
         backgroundPreloadWindow = window
+        window.orderFrontRegardless()
 
 #if DEBUG
         cmuxDebugLog(

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1291,6 +1291,26 @@ private func browserCopyExternalNavigationURL(_ url: URL) {
     NSPasteboard.general.setString(url.absoluteString, forType: .string)
 }
 
+func browserInteractiveModalHostWindow(_ window: NSWindow?) -> NSWindow? {
+    guard let window else { return nil }
+    guard window.isVisible else { return nil }
+    guard window.alphaValue > 0 else { return nil }
+    guard !window.ignoresMouseEvents else { return nil }
+    guard !window.isExcludedFromWindowsMenu else { return nil }
+    return window
+}
+
+func browserInteractiveModalHostWindow(for webView: WKWebView) -> NSWindow? {
+    browserInteractiveModalHostWindow(webView.window)
+}
+
+private func browserFallbackInteractiveModalHostWindow() -> NSWindow? {
+    if let keyWindow = browserInteractiveModalHostWindow(NSApp.keyWindow) {
+        return keyWindow
+    }
+    return browserInteractiveModalHostWindow(NSApp.mainWindow)
+}
+
 private func browserPresentExternalNavigationPrompt(
     for url: URL,
     in webView: WKWebView,
@@ -1319,7 +1339,7 @@ private func browserPresentExternalNavigationPrompt(
         completion(response == .alertFirstButtonReturn)
     }
 
-    if let window = webView.window {
+    if let window = browserInteractiveModalHostWindow(for: webView) {
         alert.beginSheetModal(for: window, completionHandler: handleResponse)
         return
     }
@@ -1349,7 +1369,7 @@ private func browserPresentExternalNavigationFailure(for url: URL, in webView: W
         }
     }
 
-    if let window = webView.window {
+    if let window = browserInteractiveModalHostWindow(for: webView) {
         alert.beginSheetModal(for: window, completionHandler: handleResponse)
         return
     }
@@ -3562,7 +3582,10 @@ final class BrowserPanel: Panel, ObservableObject {
         applyBrowserThemeModeIfNeeded()
         ReactGrabScriptLoader.prefetch()
         insecureHTTPAlertWindowProvider = { [weak self] in
-            self?.webView.window ?? NSApp.keyWindow ?? NSApp.mainWindow
+            if let self, let window = browserInteractiveModalHostWindow(for: self.webView) {
+                return window
+            }
+            return browserFallbackInteractiveModalHostWindow()
         }
 
         if let initialRequest {
@@ -6682,7 +6705,10 @@ extension BrowserPanel {
     func resetInsecureHTTPAlertHooksForTesting() {
         insecureHTTPAlertFactory = { NSAlert() }
         insecureHTTPAlertWindowProvider = { [weak self] in
-            self?.webView.window ?? NSApp.keyWindow ?? NSApp.mainWindow
+            if let self, let window = browserInteractiveModalHostWindow(for: self.webView) {
+                return window
+            }
+            return browserFallbackInteractiveModalHostWindow()
         }
     }
 
@@ -7678,7 +7704,7 @@ private class BrowserUIDelegate: NSObject, WKUIDelegate {
         for webView: WKWebView,
         completion: @escaping (NSApplication.ModalResponse) -> Void
     ) {
-        if let window = webView.window {
+        if let window = browserInteractiveModalHostWindow(for: webView) {
             alert.beginSheetModal(for: window, completionHandler: completion)
             return
         }

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -2678,7 +2678,11 @@ final class BrowserPanel: Panel, ObservableObject {
     private(set) var webViewLastHiddenAt: Date?
     private(set) var webViewLastVisibilityChangeAt: Date?
     private(set) var webViewLastVisibilityChangeReason: String?
-    private(set) var hasBackgroundPreloadHost = false
+    var hasBackgroundPreloadHost: Bool {
+        backgroundPreloadWindow != nil
+    }
+    private let preloadsNavigationInBackground: Bool
+    private var backgroundPreloadWindow: NSWindow?
     private var isWebViewVisibleInUI: Bool = false
     private var isClosingWebViewLifecycle: Bool = false
 
@@ -3032,6 +3036,7 @@ final class BrowserPanel: Panel, ObservableObject {
 
         webViewObservers.removeAll()
         webViewCancellables.removeAll()
+        closeBackgroundPreloadHost(reason: "discardHiddenWebView")
         BrowserWindowPortalRegistry.detach(webView: oldWebView)
         oldWebView.stopLoading()
         oldWebView.navigationDelegate = nil
@@ -3443,6 +3448,7 @@ final class BrowserPanel: Panel, ObservableObject {
         self.remoteProxyEndpoint = proxyEndpoint
         self.usesRemoteWorkspaceProxy = isRemoteWorkspace
         self.browserThemeMode = BrowserThemeSettings.mode()
+        self.preloadsNavigationInBackground = preloadInitialNavigationInBackground
         self.websiteDataStore = isRemoteWorkspace
             ? WKWebsiteDataStore(forIdentifier: remoteWebsiteDataStoreIdentifier ?? workspaceId)
             : BrowserProfileStore.shared.websiteDataStore(for: resolvedProfileID)
@@ -3587,6 +3593,60 @@ final class BrowserPanel: Panel, ObservableObject {
         }
     }
 
+    private func ensureBackgroundPreloadHostIfNeeded(reason: String) {
+        guard preloadsNavigationInBackground else { return }
+        guard backgroundPreloadWindow == nil else { return }
+        guard webView.window == nil else { return }
+        guard webView.superview == nil else { return }
+
+        let frame = NSRect(x: 0, y: 0, width: 800, height: 600)
+        let window = NSWindow(
+            contentRect: frame,
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.isReleasedWhenClosed = false
+        window.hasShadow = false
+        window.alphaValue = 0
+        window.ignoresMouseEvents = true
+        window.collectionBehavior = [.transient, .ignoresCycle, .stationary]
+        window.isExcludedFromWindowsMenu = true
+
+        let contentView = NSView(frame: frame)
+        webView.frame = contentView.bounds
+        webView.autoresizingMask = [.width, .height]
+        contentView.addSubview(webView)
+        window.contentView = contentView
+        backgroundPreloadWindow = window
+
+#if DEBUG
+        cmuxDebugLog(
+            "browser.backgroundPreload.host.create panel=\(id.uuidString.prefix(5)) " +
+            "reason=\(reason)"
+        )
+#endif
+    }
+
+    func releaseBackgroundPreloadHostIfAttachedToRealWindow(reason: String) {
+        guard let preloadWindow = backgroundPreloadWindow else { return }
+        guard webView.window !== preloadWindow else { return }
+        closeBackgroundPreloadHost(reason: reason)
+    }
+
+    private func closeBackgroundPreloadHost(reason: String) {
+        guard let preloadWindow = backgroundPreloadWindow else { return }
+        backgroundPreloadWindow = nil
+        preloadWindow.contentView = nil
+        preloadWindow.close()
+#if DEBUG
+        cmuxDebugLog(
+            "browser.backgroundPreload.host.close panel=\(id.uuidString.prefix(5)) " +
+            "reason=\(reason)"
+        )
+#endif
+    }
+
     func setRemoteProxyEndpoint(_ endpoint: BrowserProxyEndpoint?) {
         guard remoteProxyEndpoint != endpoint else { return }
         remoteProxyEndpoint = endpoint
@@ -3715,6 +3775,7 @@ final class BrowserPanel: Panel, ObservableObject {
         faviconTask?.cancel()
         faviconTask = nil
         faviconRefreshGeneration &+= 1
+        closeBackgroundPreloadHost(reason: "profileSwitch")
         BrowserWindowPortalRegistry.detach(webView: previousWebView)
         previousWebView.stopLoading()
         previousWebView.navigationDelegate = nil
@@ -4079,6 +4140,7 @@ final class BrowserPanel: Panel, ObservableObject {
         faviconTask?.cancel()
         faviconTask = nil
         faviconRefreshGeneration &+= 1
+        closeBackgroundPreloadHost(reason: reason)
         BrowserWindowPortalRegistry.detach(webView: oldWebView)
         oldWebView.stopLoading()
         oldWebView.navigationDelegate = nil
@@ -4218,6 +4280,7 @@ final class BrowserPanel: Panel, ObservableObject {
         // Ensure we don't keep a hidden WKWebView (or its content view) as first responder while
         // bonsplit/SwiftUI reshuffles views during close.
         unfocus()
+        closeBackgroundPreloadHost(reason: "close")
 
         // Snapshot first: popup close unregisters itself from popupControllers.
         let popupsToClose = popupControllers
@@ -4684,6 +4747,7 @@ final class BrowserPanel: Panel, ObservableObject {
         webView.customUserAgent = BrowserUserAgentSettings.safariUserAgent
         hiddenWebViewDiscardManager.updateRestoredSessionRenderIntent(nil)
         shouldRenderWebView = true
+        ensureBackgroundPreloadHostIfNeeded(reason: "navigation")
         if recordTypedNavigation {
             historyStore.recordTypedNavigation(url: originalURL)
         }
@@ -5018,6 +5082,7 @@ extension BrowserPanel {
         let oldWebView = webView
         webViewObservers.removeAll()
         webViewCancellables.removeAll()
+        closeBackgroundPreloadHost(reason: "contextReset")
         BrowserWindowPortalRegistry.detach(webView: oldWebView)
         oldWebView.stopLoading()
         oldWebView.navigationDelegate = nil

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1311,10 +1311,32 @@ private func browserFallbackInteractiveModalHostWindow() -> NSWindow? {
     return browserInteractiveModalHostWindow(NSApp.mainWindow)
 }
 
+typealias BrowserAlertPresenter = (
+    _ alert: NSAlert,
+    _ webView: WKWebView,
+    _ completion: @escaping (NSApplication.ModalResponse) -> Void,
+    _ cancel: @escaping () -> Void
+) -> Void
+
+func browserPresentAlert(
+    _ alert: NSAlert,
+    in webView: WKWebView,
+    completion: @escaping (NSApplication.ModalResponse) -> Void,
+    cancel: @escaping () -> Void = {}
+) {
+    _ = cancel
+    if let window = browserInteractiveModalHostWindow(for: webView) {
+        alert.beginSheetModal(for: window, completionHandler: completion)
+        return
+    }
+    completion(alert.runModal())
+}
+
 private func browserPresentExternalNavigationPrompt(
     for url: URL,
     in webView: WKWebView,
-    completion: @escaping (Bool) -> Void
+    completion: @escaping (Bool) -> Void,
+    presentAlert: BrowserAlertPresenter = browserPresentAlert
 ) {
     let alert = NSAlert()
     alert.alertStyle = .informational
@@ -1339,14 +1361,16 @@ private func browserPresentExternalNavigationPrompt(
         completion(response == .alertFirstButtonReturn)
     }
 
-    if let window = browserInteractiveModalHostWindow(for: webView) {
-        alert.beginSheetModal(for: window, completionHandler: handleResponse)
-        return
+    presentAlert(alert, webView, handleResponse) {
+        completion(false)
     }
-    handleResponse(alert.runModal())
 }
 
-private func browserPresentExternalNavigationFailure(for url: URL, in webView: WKWebView) {
+private func browserPresentExternalNavigationFailure(
+    for url: URL,
+    in webView: WKWebView,
+    presentAlert: BrowserAlertPresenter = browserPresentAlert
+) {
     let alert = NSAlert()
     alert.alertStyle = .warning
     alert.messageText = String(
@@ -1369,22 +1393,19 @@ private func browserPresentExternalNavigationFailure(for url: URL, in webView: W
         }
     }
 
-    if let window = browserInteractiveModalHostWindow(for: webView) {
-        alert.beginSheetModal(for: window, completionHandler: handleResponse)
-        return
-    }
-    handleResponse(alert.runModal())
+    presentAlert(alert, webView, handleResponse) {}
 }
 
 @discardableResult
 private func browserOpenExternalNavigationURL(
     _ url: URL,
     source: String,
-    webView: WKWebView
+    webView: WKWebView,
+    presentAlert: BrowserAlertPresenter = browserPresentAlert
 ) -> Bool {
     let opened = NSWorkspace.shared.open(url)
     if !opened {
-        browserPresentExternalNavigationFailure(for: url, in: webView)
+        browserPresentExternalNavigationFailure(for: url, in: webView, presentAlert: presentAlert)
     }
 #if DEBUG
     cmuxDebugLog(
@@ -1400,7 +1421,8 @@ func browserHandleExternalNavigation(
     _ url: URL,
     source: String,
     webView: WKWebView,
-    loadFallbackRequest: (URLRequest) -> Void
+    loadFallbackRequest: (URLRequest) -> Void,
+    presentAlert: @escaping BrowserAlertPresenter = browserPresentAlert
 ) -> Bool {
     guard let action = browserExternalNavigationAction(for: url) else { return false }
 
@@ -1417,18 +1439,28 @@ func browserHandleExternalNavigation(
         return true
 
     case let .promptToOpenApp(externalURL):
-        browserPresentExternalNavigationPrompt(for: externalURL, in: webView) { shouldOpenApp in
-            guard shouldOpenApp else {
+        browserPresentExternalNavigationPrompt(
+            for: externalURL,
+            in: webView,
+            completion: { shouldOpenApp in
+                guard shouldOpenApp else {
 #if DEBUG
-                cmuxDebugLog(
-                    "browser.navigation.external source=\(source) opened=0 prompt=1 allowed=0 " +
-                    "url=\(browserNavigationDebugURL(externalURL))"
-                )
+                    cmuxDebugLog(
+                        "browser.navigation.external source=\(source) opened=0 prompt=1 allowed=0 " +
+                        "url=\(browserNavigationDebugURL(externalURL))"
+                    )
 #endif
-                return
-            }
-            browserOpenExternalNavigationURL(externalURL, source: source, webView: webView)
-        }
+                    return
+                }
+                browserOpenExternalNavigationURL(
+                    externalURL,
+                    source: source,
+                    webView: webView,
+                    presentAlert: presentAlert
+                )
+            },
+            presentAlert: presentAlert
+        )
         return true
     }
 }
@@ -2703,6 +2735,12 @@ final class BrowserPanel: Panel, ObservableObject {
     }
     private var shouldPreloadInitialNavigationInBackground: Bool
     private var backgroundPreloadWindow: NSWindow?
+    private struct PendingInteractiveBrowserPrompt {
+        let present: (NSWindow, @escaping () -> Void) -> Void
+        let cancel: () -> Void
+    }
+    private var pendingInteractiveBrowserPrompts: [PendingInteractiveBrowserPrompt] = []
+    private var isPresentingPendingInteractiveBrowserPrompt = false
     private var isWebViewVisibleInUI: Bool = false
     private var isClosingWebViewLifecycle: Bool = false
 
@@ -2929,6 +2967,7 @@ final class BrowserPanel: Panel, ObservableObject {
         if visible {
             cancelHiddenWebViewDiscard()
             restoreDiscardedWebViewIfNeeded(reason: "visible.\(reason)")
+            drainPendingInteractiveBrowserPromptsIfPossible(reason: "visible.\(reason)")
         } else if changed || isFirstVisibilityRecord || !hiddenWebViewDiscardManager.hasScheduledDiscard {
             scheduleHiddenWebViewDiscardIfNeeded(reason: reason)
         }
@@ -3053,6 +3092,7 @@ final class BrowserPanel: Panel, ObservableObject {
         faviconTask = nil
         faviconRefreshGeneration &+= 1
         loadingGeneration &+= 1
+        cancelPendingInteractiveBrowserPrompts(reason: "discardHiddenWebView")
 
         webViewObservers.removeAll()
         webViewCancellables.removeAll()
@@ -3491,6 +3531,13 @@ final class BrowserPanel: Panel, ObservableObject {
         navDelegate.requestNavigation = { [weak self] request, intent in
             self?.requestNavigation(request, intent: intent)
         }
+        navDelegate.presentAlert = { [weak self] alert, webView, completion, cancel in
+            guard let self else {
+                cancel()
+                return
+            }
+            self.presentBrowserAlert(alert, in: webView, completion: completion, cancel: cancel)
+        }
         navDelegate.shouldBlockInsecureHTTPNavigation = { [weak self] url in
             self?.shouldBlockInsecureHTTPNavigation(to: url) ?? false
         }
@@ -3563,6 +3610,13 @@ final class BrowserPanel: Panel, ObservableObject {
         }
         browserUIDelegate.requestNavigation = { [weak self] request, intent in
             self?.requestNavigation(request, intent: intent)
+        }
+        browserUIDelegate.presentAlert = { [weak self] alert, webView, completion, cancel in
+            guard let self else {
+                cancel()
+                return
+            }
+            self.presentBrowserAlert(alert, in: webView, completion: completion, cancel: cancel)
         }
         browserUIDelegate.openPopup = { [weak self] configuration, windowFeatures in
             self?.createFloatingPopup(configuration: configuration, windowFeatures: windowFeatures)
@@ -3651,11 +3705,95 @@ final class BrowserPanel: Panel, ObservableObject {
 #endif
     }
 
+    private func shouldDeferPromptUntilInteractiveHost(for webView: WKWebView) -> Bool {
+        if shouldPreloadInitialNavigationInBackground {
+            return true
+        }
+        guard let preloadWindow = backgroundPreloadWindow else { return false }
+        let attachedWindow = webView.window
+        return attachedWindow == nil || attachedWindow === preloadWindow
+    }
+
+    private func presentBrowserAlert(
+        _ alert: NSAlert,
+        in webView: WKWebView,
+        completion: @escaping (NSApplication.ModalResponse) -> Void,
+        cancel: @escaping () -> Void
+    ) {
+        if let window = browserInteractiveModalHostWindow(for: webView) {
+            alert.beginSheetModal(for: window, completionHandler: completion)
+            return
+        }
+
+        guard shouldDeferPromptUntilInteractiveHost(for: webView) else {
+            browserPresentAlert(alert, in: webView, completion: completion, cancel: cancel)
+            return
+        }
+
+        pendingInteractiveBrowserPrompts.append(
+            PendingInteractiveBrowserPrompt(
+                present: { sheetWindow, didFinish in
+                    alert.beginSheetModal(for: sheetWindow) { response in
+                        completion(response)
+                        didFinish()
+                    }
+                },
+                cancel: cancel
+            )
+        )
+
+#if DEBUG
+        cmuxDebugLog(
+            "browser.prompt.queue panel=\(id.uuidString.prefix(5)) " +
+            "pending=\(pendingInteractiveBrowserPrompts.count)"
+        )
+#endif
+    }
+
+    private func drainPendingInteractiveBrowserPromptsIfPossible(reason: String) {
+        guard !isPresentingPendingInteractiveBrowserPrompt else { return }
+        guard !pendingInteractiveBrowserPrompts.isEmpty else { return }
+        guard let window = browserInteractiveModalHostWindow(for: webView) else { return }
+
+        let prompt = pendingInteractiveBrowserPrompts.removeFirst()
+        isPresentingPendingInteractiveBrowserPrompt = true
+
+#if DEBUG
+        cmuxDebugLog(
+            "browser.prompt.drain panel=\(id.uuidString.prefix(5)) " +
+            "reason=\(reason) remaining=\(pendingInteractiveBrowserPrompts.count)"
+        )
+#endif
+
+        prompt.present(window) { [weak self] in
+            guard let self else { return }
+            self.isPresentingPendingInteractiveBrowserPrompt = false
+            self.drainPendingInteractiveBrowserPromptsIfPossible(reason: "\(reason).next")
+        }
+    }
+
+    private func cancelPendingInteractiveBrowserPrompts(reason: String) {
+        guard !pendingInteractiveBrowserPrompts.isEmpty else { return }
+        let prompts = pendingInteractiveBrowserPrompts
+        pendingInteractiveBrowserPrompts.removeAll()
+        isPresentingPendingInteractiveBrowserPrompt = false
+
+#if DEBUG
+        cmuxDebugLog(
+            "browser.prompt.cancel panel=\(id.uuidString.prefix(5)) " +
+            "reason=\(reason) count=\(prompts.count)"
+        )
+#endif
+
+        prompts.forEach { $0.cancel() }
+    }
+
     func releaseBackgroundPreloadHostIfAttachedToRealWindow(reason: String) {
         guard let preloadWindow = backgroundPreloadWindow else { return }
         guard let attachedWindow = webView.window else { return }
         guard attachedWindow !== preloadWindow else { return }
         closeBackgroundPreloadHost(reason: reason)
+        drainPendingInteractiveBrowserPromptsIfPossible(reason: reason)
     }
 
     private func closeBackgroundPreloadHost(reason: String) {
@@ -3799,6 +3937,7 @@ final class BrowserPanel: Panel, ObservableObject {
         faviconTask?.cancel()
         faviconTask = nil
         faviconRefreshGeneration &+= 1
+        cancelPendingInteractiveBrowserPrompts(reason: "profileSwitch")
         closeBackgroundPreloadHost(reason: "profileSwitch")
         BrowserWindowPortalRegistry.detach(webView: previousWebView)
         previousWebView.stopLoading()
@@ -4164,6 +4303,7 @@ final class BrowserPanel: Panel, ObservableObject {
         faviconTask?.cancel()
         faviconTask = nil
         faviconRefreshGeneration &+= 1
+        cancelPendingInteractiveBrowserPrompts(reason: reason)
         closeBackgroundPreloadHost(reason: reason)
         BrowserWindowPortalRegistry.detach(webView: oldWebView)
         oldWebView.stopLoading()
@@ -4304,6 +4444,7 @@ final class BrowserPanel: Panel, ObservableObject {
         // Ensure we don't keep a hidden WKWebView (or its content view) as first responder while
         // bonsplit/SwiftUI reshuffles views during close.
         unfocus()
+        cancelPendingInteractiveBrowserPrompts(reason: "close")
         closeBackgroundPreloadHost(reason: "close")
 
         // Snapshot first: popup close unregisters itself from popupControllers.
@@ -4920,6 +5061,11 @@ final class BrowserPanel: Panel, ObservableObject {
             )
         }
 
+        if shouldDeferPromptUntilInteractiveHost(for: webView) {
+            presentBrowserAlert(alert, in: webView, completion: handleResponse, cancel: {})
+            return
+        }
+
         if let alertWindow = insecureHTTPAlertWindowProvider() {
             alert.beginSheetModal(for: alertWindow, completionHandler: handleResponse)
             return
@@ -5109,6 +5255,7 @@ extension BrowserPanel {
         let oldWebView = webView
         webViewObservers.removeAll()
         webViewCancellables.removeAll()
+        cancelPendingInteractiveBrowserPrompts(reason: "contextReset")
         closeBackgroundPreloadHost(reason: "contextReset")
         BrowserWindowPortalRegistry.detach(webView: oldWebView)
         oldWebView.stopLoading()
@@ -7343,6 +7490,7 @@ private class BrowserNavigationDelegate: NSObject, WKNavigationDelegate {
     var didTerminateWebContentProcess: ((WKWebView) -> Void)?
     var openInNewTab: ((URL) -> Void)?
     var requestNavigation: ((URLRequest, BrowserInsecureHTTPNavigationIntent) -> Void)?
+    var presentAlert: BrowserAlertPresenter = browserPresentAlert
     var shouldBlockInsecureHTTPNavigation: ((URL) -> Bool)?
     var handleBlockedInsecureHTTPNavigation: ((URLRequest, BrowserInsecureHTTPNavigationIntent) -> Void)?
     /// Direct reference to the download delegate — must be set synchronously in didBecome callbacks.
@@ -7571,7 +7719,8 @@ private class BrowserNavigationDelegate: NSObject, WKNavigationDelegate {
                 webView: webView,
                 loadFallbackRequest: { [requestNavigation] request in
                     requestNavigation?(request, .currentTab)
-                }
+                },
+                presentAlert: presentAlert
             )
             decisionHandler(.cancel)
             return
@@ -7689,6 +7838,7 @@ private class BrowserNavigationDelegate: NSObject, WKNavigationDelegate {
 private class BrowserUIDelegate: NSObject, WKUIDelegate {
     var openInNewTab: ((URL) -> Void)?
     var requestNavigation: ((URLRequest, BrowserInsecureHTTPNavigationIntent) -> Void)?
+    var presentAlert: BrowserAlertPresenter = browserPresentAlert
     var openPopup: ((WKWebViewConfiguration, WKWindowFeatures) -> WKWebView?)?
     var closeRequested: ((WKWebView) -> Void)?
 
@@ -7706,13 +7856,10 @@ private class BrowserUIDelegate: NSObject, WKUIDelegate {
     private func presentDialog(
         _ alert: NSAlert,
         for webView: WKWebView,
-        completion: @escaping (NSApplication.ModalResponse) -> Void
+        completion: @escaping (NSApplication.ModalResponse) -> Void,
+        cancel: @escaping () -> Void
     ) {
-        if let window = browserInteractiveModalHostWindow(for: webView) {
-            alert.beginSheetModal(for: window, completionHandler: completion)
-            return
-        }
-        completion(alert.runModal())
+        presentAlert(alert, webView, completion, cancel)
     }
 
     /// Called when the page requests a new window (window.open(), target=_blank, etc.).
@@ -7760,7 +7907,8 @@ private class BrowserUIDelegate: NSObject, WKUIDelegate {
                 webView: webView,
                 loadFallbackRequest: { [requestNavigation] request in
                     requestNavigation?(request, .currentTab)
-                }
+                },
+                presentAlert: presentAlert
             )
             return nil
         }
@@ -7870,7 +8018,12 @@ private class BrowserUIDelegate: NSObject, WKUIDelegate {
         alert.messageText = javaScriptDialogTitle(for: webView)
         alert.informativeText = message
         alert.addButton(withTitle: String(localized: "common.ok", defaultValue: "OK"))
-        presentDialog(alert, for: webView) { _ in completionHandler() }
+        presentDialog(
+            alert,
+            for: webView,
+            completion: { _ in completionHandler() },
+            cancel: completionHandler
+        )
     }
 
     func webView(
@@ -7885,9 +8038,16 @@ private class BrowserUIDelegate: NSObject, WKUIDelegate {
         alert.informativeText = message
         alert.addButton(withTitle: String(localized: "common.ok", defaultValue: "OK"))
         alert.addButton(withTitle: String(localized: "common.cancel", defaultValue: "Cancel"))
-        presentDialog(alert, for: webView) { response in
-            completionHandler(response == .alertFirstButtonReturn)
-        }
+        presentDialog(
+            alert,
+            for: webView,
+            completion: { response in
+                completionHandler(response == .alertFirstButtonReturn)
+            },
+            cancel: {
+                completionHandler(false)
+            }
+        )
     }
 
     func webView(
@@ -7908,13 +8068,20 @@ private class BrowserUIDelegate: NSObject, WKUIDelegate {
         field.stringValue = defaultText ?? ""
         alert.accessoryView = field
 
-        presentDialog(alert, for: webView) { response in
-            if response == .alertFirstButtonReturn {
-                completionHandler(field.stringValue)
-            } else {
+        presentDialog(
+            alert,
+            for: webView,
+            completion: { response in
+                if response == .alertFirstButtonReturn {
+                    completionHandler(field.stringValue)
+                } else {
+                    completionHandler(nil)
+                }
+            },
+            cancel: {
                 completionHandler(nil)
             }
-        }
+        )
     }
 }
 

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -7062,6 +7062,9 @@ struct WebViewRepresentable: NSViewRepresentable {
         let hostOwnsPortal = useLocalInlineHosting
             ? updateUsingLocalInlineHosting(nsView, context: context, webView: webView)
             : updateUsingWindowPortal(nsView, context: context, webView: webView)
+        if hostOwnsPortal {
+            panel.releaseBackgroundPreloadHostIfAttachedToRealWindow(reason: "representable.update")
+        }
         Self.applyWebViewFirstResponderPolicy(
             panel: panel,
             webView: webView,

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -5876,7 +5876,12 @@ class TerminalController {
                 }
 
                 let targetIndex = insertionIndexToRight(anchorTabId: anchorTabId, inPane: paneId)
-                guard let newPanel = workspace.newBrowserSurface(inPane: paneId, url: url, focus: focus) else {
+                guard let newPanel = workspace.newBrowserSurface(
+                    inPane: paneId,
+                    url: url,
+                    focus: focus,
+                    creationPolicy: .automationPreload
+                ) else {
                     result = .err(code: "internal_error", message: "Failed to create tab", data: nil)
                     return
                 }
@@ -6451,6 +6456,7 @@ class TerminalController {
                     insertFirst: insertFirst,
                     url: url,
                     focus: focus,
+                    creationPolicy: .automationPreload,
                     initialDividerPosition: initialDividerPosition.map { CGFloat($0) }
                 )?.id
             } else {
@@ -6526,7 +6532,12 @@ class TerminalController {
             let newPanelId: UUID?
             let focus = v2FocusAllowed(requested: v2Bool(params, "focus") ?? false)
             if panelType == .browser {
-                newPanelId = ws.newBrowserSurface(inPane: paneId, url: url, focus: focus)?.id
+                newPanelId = ws.newBrowserSurface(
+                    inPane: paneId,
+                    url: url,
+                    focus: focus,
+                    creationPolicy: .automationPreload
+                )?.id
             } else {
                 newPanelId = ws.newTerminalSurface(
                     inPane: paneId,
@@ -7842,6 +7853,7 @@ class TerminalController {
                     insertFirst: insertFirst,
                     url: url,
                     focus: focus,
+                    creationPolicy: .automationPreload,
                     initialDividerPosition: initialDividerPosition.map { CGFloat($0) }
                 )?.id
             } else {
@@ -9639,11 +9651,22 @@ class TerminalController {
             var placementStrategy = "split_right"
             let createdPanel: BrowserPanel?
             if let targetPane = ws.preferredRightSideTargetPane(fromPanelId: sourceSurfaceId) {
-                createdPanel = ws.newBrowserSurface(inPane: targetPane, url: url, focus: focus)
+                createdPanel = ws.newBrowserSurface(
+                    inPane: targetPane,
+                    url: url,
+                    focus: focus,
+                    creationPolicy: .automationPreload
+                )
                 createdSplit = false
                 placementStrategy = "reuse_right_sibling"
             } else {
-                createdPanel = ws.newBrowserSplit(from: sourceSurfaceId, orientation: .horizontal, url: url, focus: focus)
+                createdPanel = ws.newBrowserSplit(
+                    from: sourceSurfaceId,
+                    orientation: .horizontal,
+                    url: url,
+                    focus: focus,
+                    creationPolicy: .automationPreload
+                )
             }
 
             guard let browserPanelId = createdPanel?.id else {
@@ -12235,7 +12258,12 @@ class TerminalController {
                 return
             }
 
-            guard let panel = ws.newBrowserSurface(inPane: pane, url: url, focus: true) else {
+            guard let panel = ws.newBrowserSurface(
+                inPane: pane,
+                url: url,
+                focus: true,
+                creationPolicy: .automationPreload
+            ) else {
                 result = .err(code: "internal_error", message: "Failed to create browser tab", data: nil)
                 return
             }
@@ -15980,7 +16008,8 @@ class TerminalController {
                 from: focusedPanelId,
                 orientation: .horizontal,
                 url: url,
-                focus: focus
+                focus: focus,
+                creationPolicy: .automationPreload
             )?.id {
                 result = "OK \(browserPanelId.uuidString)"
             }
@@ -16421,7 +16450,8 @@ class TerminalController {
                     orientation: orientation,
                     insertFirst: insertFirst,
                     url: url,
-                    focus: focus
+                    focus: focus,
+                    creationPolicy: .automationPreload
                 )?.id
             } else {
                 newPanelId = tab.newTerminalSplit(
@@ -18041,7 +18071,12 @@ class TerminalController {
 
             let newPanelId: UUID?
             if panelType == .browser {
-                newPanelId = tab.newBrowserSurface(inPane: targetPaneId, url: url, focus: focus)?.id
+                newPanelId = tab.newBrowserSurface(
+                    inPane: targetPaneId,
+                    url: url,
+                    focus: focus,
+                    creationPolicy: .automationPreload
+                )?.id
             } else {
                 newPanelId = tab.newTerminalSurface(inPane: targetPaneId, focus: focus)?.id
             }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -7296,10 +7296,15 @@ struct ClosedBrowserPanelRestoreSnapshot {
 final class Workspace: Identifiable, ObservableObject {
     enum BrowserPanelCreationPolicy {
         case userInitiated
+        case automationPreload
         case restoration
 
         var permitsCreationWhenBrowserDisabled: Bool {
             self == .restoration
+        }
+
+        var preloadsInitialNavigationInBackground: Bool {
+            self == .automationPreload
         }
     }
 
@@ -10643,6 +10648,7 @@ final class Workspace: Identifiable, ObservableObject {
             ),
             initialURL: url,
             renderInitialNavigation: browserEnabled || creationPolicy != .restoration,
+            preloadInitialNavigationInBackground: creationPolicy.preloadsInitialNavigationInBackground,
             proxyEndpoint: remoteProxyEndpoint,
             isRemoteWorkspace: isRemoteWorkspace,
             remoteWebsiteDataStoreIdentifier: isRemoteWorkspace ? id : nil
@@ -10736,6 +10742,7 @@ final class Workspace: Identifiable, ObservableObject {
             initialURL: url,
             initialRequest: initialRequest,
             renderInitialNavigation: browserEnabled || creationPolicy != .restoration,
+            preloadInitialNavigationInBackground: creationPolicy.preloadsInitialNavigationInBackground,
             bypassInsecureHTTPHostOnce: bypassInsecureHTTPHostOnce,
             proxyEndpoint: remoteProxyEndpoint,
             isRemoteWorkspace: isRemoteWorkspace,

--- a/cmuxTests/BrowserConfigTests.swift
+++ b/cmuxTests/BrowserConfigTests.swift
@@ -1973,6 +1973,35 @@ final class BrowserInsecureHTTPAlertPresentationTests: XCTestCase {
         XCTAssertEqual(alertSpy.beginSheetModalCallCount, 0)
         XCTAssertEqual(alertSpy.runModalCallCount, 1)
     }
+
+    func testInsecureHTTPPromptDefersWhileBackgroundPreloadHasNoInteractiveHost() {
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            initialURL: URL(string: "about:blank")!,
+            preloadInitialNavigationInBackground: true,
+            isRemoteWorkspace: false
+        )
+        defer {
+            panel.resetInsecureHTTPAlertHooksForTesting()
+            panel.close()
+        }
+
+        XCTAssertTrue(panel.hasBackgroundPreloadHost)
+        XCTAssertNil(browserInteractiveModalHostWindow(for: panel.webView))
+
+        let alertSpy = BrowserInsecureHTTPAlertSpy()
+        panel.configureInsecureHTTPAlertHooksForTesting(
+            alertFactory: { alertSpy },
+            windowProvider: {
+                XCTFail("Background preload should not prompt on fallback windows")
+                return nil
+            }
+        )
+        panel.presentInsecureHTTPAlertForTesting(url: URL(string: "http://example.com")!)
+
+        XCTAssertEqual(alertSpy.beginSheetModalCallCount, 0)
+        XCTAssertEqual(alertSpy.runModalCallCount, 0)
+    }
 }
 
 

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -1441,6 +1441,8 @@ final class BrowserPanelWebViewLifecycleTests: XCTestCase {
         XCTAssertEqual(panel.webViewLifecycleState, .liveHidden)
         XCTAssertTrue(panel.hasBackgroundPreloadHost)
         XCTAssertNotNil(panel.webView.window)
+        XCTAssertEqual(panel.webView.window?.isVisible, true)
+        XCTAssertLessThan(panel.webView.window?.frame.minX ?? 0, -9_000)
     }
 
     func testBackgroundInitialNavigationDoesNotExposeHiddenHostAsModalParent() {

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -1443,6 +1443,20 @@ final class BrowserPanelWebViewLifecycleTests: XCTestCase {
         XCTAssertNotNil(panel.webView.window)
     }
 
+    func testBackgroundInitialNavigationDoesNotExposeHiddenHostAsModalParent() {
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            initialURL: URL(string: "about:blank")!,
+            preloadInitialNavigationInBackground: true,
+            isRemoteWorkspace: false
+        )
+        defer { panel.close() }
+
+        XCTAssertTrue(panel.hasBackgroundPreloadHost)
+        XCTAssertNotNil(panel.webView.window)
+        XCTAssertNil(browserInteractiveModalHostWindow(for: panel.webView))
+    }
+
     func testLifecycleTracksVisibleHiddenAndClosingStates() {
         let hiddenAt = Date(timeIntervalSince1970: 100)
         let duplicateHiddenAt = hiddenAt.addingTimeInterval(10)

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -1457,6 +1457,25 @@ final class BrowserPanelWebViewLifecycleTests: XCTestCase {
         XCTAssertNil(browserInteractiveModalHostWindow(for: panel.webView))
     }
 
+    func testBackgroundPreloadHostStaysOpenUntilWebViewHasRealWindow() {
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            initialURL: URL(string: "about:blank")!,
+            preloadInitialNavigationInBackground: true,
+            isRemoteWorkspace: false
+        )
+        defer { panel.close() }
+
+        XCTAssertTrue(panel.hasBackgroundPreloadHost)
+        panel.webView.removeFromSuperview()
+
+        XCTAssertNil(panel.webView.window)
+
+        panel.releaseBackgroundPreloadHostIfAttachedToRealWindow(reason: "test.detached")
+
+        XCTAssertTrue(panel.hasBackgroundPreloadHost)
+    }
+
     func testLifecycleTracksVisibleHiddenAndClosingStates() {
         let hiddenAt = Date(timeIntervalSince1970: 100)
         let duplicateHiddenAt = hiddenAt.addingTimeInterval(10)

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -1476,6 +1476,44 @@ final class BrowserPanelWebViewLifecycleTests: XCTestCase {
         XCTAssertTrue(panel.hasBackgroundPreloadHost)
     }
 
+    func testBackgroundPreloadIsConsumedByInitialNavigation() {
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            initialURL: URL(string: "about:blank")!,
+            preloadInitialNavigationInBackground: true,
+            isRemoteWorkspace: false
+        )
+        defer { panel.close() }
+
+        XCTAssertTrue(panel.hasBackgroundPreloadHost)
+
+        let frame = NSRect(x: 0, y: 0, width: 800, height: 600)
+        let realHostWindow = NSWindow(
+            contentRect: frame,
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        defer {
+            realHostWindow.contentView = nil
+            realHostWindow.close()
+        }
+        let contentView = NSView(frame: frame)
+        realHostWindow.contentView = contentView
+        panel.webView.removeFromSuperview()
+        contentView.addSubview(panel.webView)
+
+        panel.releaseBackgroundPreloadHostIfAttachedToRealWindow(reason: "test.realWindow")
+
+        XCTAssertFalse(panel.hasBackgroundPreloadHost)
+
+        panel.webView.removeFromSuperview()
+        realHostWindow.contentView = nil
+        panel.navigate(to: URL(string: "about:blank#second")!)
+
+        XCTAssertFalse(panel.hasBackgroundPreloadHost)
+    }
+
     func testLifecycleTracksVisibleHiddenAndClosingStates() {
         let hiddenAt = Date(timeIntervalSince1970: 100)
         let duplicateHiddenAt = hiddenAt.addingTimeInterval(10)

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -1428,6 +1428,21 @@ final class BrowserPanelWebViewLifecycleTests: XCTestCase {
         XCTAssertEqual(panel.webViewLifecycleState, .newTab)
     }
 
+    func testBackgroundInitialNavigationOwnsHeadlessWebKitHostBeforeViewAppears() {
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            initialURL: URL(string: "about:blank")!,
+            preloadInitialNavigationInBackground: true,
+            isRemoteWorkspace: false
+        )
+        defer { panel.close() }
+
+        XCTAssertTrue(panel.shouldRenderWebView)
+        XCTAssertEqual(panel.webViewLifecycleState, .liveHidden)
+        XCTAssertTrue(panel.hasBackgroundPreloadHost)
+        XCTAssertNotNil(panel.webView.window)
+    }
+
     func testLifecycleTracksVisibleHiddenAndClosingStates() {
         let hiddenAt = Date(timeIntervalSince1970: 100)
         let duplicateHiddenAt = hiddenAt.addingTimeInterval(10)

--- a/cmuxTests/KeyboardShortcutSettingsFileStoreStartupTests.swift
+++ b/cmuxTests/KeyboardShortcutSettingsFileStoreStartupTests.swift
@@ -21,6 +21,7 @@ final class KeyboardShortcutSettingsFileStoreStartupTests: XCTestCase {
     override func tearDown() {
         KeyboardShortcutSettings.settingsFileStore = originalSettingsFileStore
         AppIconSettings.resetLiveEnvironmentProviderForTesting()
+        AppearanceSettings.resetLiveEnvironmentProviderForTesting()
         KeyboardShortcutSettings.resetAll()
         super.tearDown()
     }
@@ -342,6 +343,79 @@ final class KeyboardShortcutSettingsFileStoreStartupTests: XCTestCase {
                 relaunchedStore.reload()
                 XCTAssertEqual(defaults.string(forKey: key), AppearanceMode.dark.rawValue)
             }
+        }
+    }
+
+    func testSettingsFileStoreInitialAppearanceReplayDoesNotSynchronizeTerminalTheme() throws {
+        let defaults = UserDefaults.standard
+        let key = AppearanceSettings.appearanceModeKey
+
+        try preservingDefaults(keys: [key, settingsFileBackupsDefaultsKey, importedManagedDefaultsKey]) {
+            defaults.removeObject(forKey: key)
+            defaults.removeObject(forKey: settingsFileBackupsDefaultsKey)
+            defaults.removeObject(forKey: importedManagedDefaultsKey)
+
+            let directoryURL = try makeTemporaryDirectory()
+            defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+            let settingsFileURL = directoryURL.appendingPathComponent("cmux.json", isDirectory: false)
+            try writeSettingsFile(
+                """
+                {
+                  "app": {
+                    "appearance": "dark"
+                  }
+                }
+                """,
+                to: settingsFileURL
+            )
+
+            var appliedAppearanceName: NSAppearance.Name?
+            var synchronizedAppearanceName: NSAppearance.Name?
+            var synchronizedSources: [String] = []
+            AppearanceSettings.setLiveEnvironmentProviderForTesting {
+                AppearanceSettings.LiveApplyEnvironment(
+                    setApplicationAppearance: { appearance in
+                        appliedAppearanceName = appearance?.bestMatch(from: [.darkAqua, .aqua])
+                    },
+                    synchronizeTerminalThemeWithAppearance: { appearance, source in
+                        synchronizedAppearanceName = appearance?.bestMatch(from: [.darkAqua, .aqua])
+                        synchronizedSources.append(source)
+                    },
+                    systemAppearance: {
+                        NSAppearance(named: .aqua)
+                    }
+                )
+            }
+
+            let store = KeyboardShortcutSettingsFileStore(
+                primaryPath: settingsFileURL.path,
+                fallbackPath: nil,
+                additionalFallbackPaths: [],
+                startWatching: false
+            )
+
+            XCTAssertEqual(defaults.string(forKey: key), AppearanceMode.dark.rawValue)
+            XCTAssertEqual(appliedAppearanceName, .darkAqua)
+            XCTAssertNil(synchronizedAppearanceName)
+            XCTAssertTrue(synchronizedSources.isEmpty)
+
+            try writeSettingsFile(
+                """
+                {
+                  "app": {
+                    "appearance": "light"
+                  }
+                }
+                """,
+                to: settingsFileURL
+            )
+            store.reload()
+
+            XCTAssertEqual(defaults.string(forKey: key), AppearanceMode.light.rawValue)
+            XCTAssertEqual(appliedAppearanceName, .aqua)
+            XCTAssertEqual(synchronizedAppearanceName, .aqua)
+            XCTAssertEqual(synchronizedSources, ["cmuxConfig.applyManagedDefault"])
         }
     }
 

--- a/scripts/lint_auxiliary_window_close_shortcuts.py
+++ b/scripts/lint_auxiliary_window_close_shortcuts.py
@@ -17,6 +17,8 @@ OWNER_LIST_NAME = "cmuxAuxiliaryWindowIdentifiers"
 # main window. Add to this set only when a window is intentionally not user
 # closable.
 IGNORED_IDENTIFIERS = {
+    # Hidden WebKit preload host; it is not user closable and must not own Cmd+W.
+    "cmux.browserBackgroundPreload",
     "cmux.bootstrap",
 }
 


### PR DESCRIPTION
## Summary
- Fixes #4342 by giving CLI/socket-created browser panes an automation preload creation policy.
- `BrowserPanel` now owns a temporary headless WebKit host so initial navigation can start before SwiftUI mounts the target workspace.
- Real browser portal attachment releases that temporary host, keeping visible rendering on the existing view path.

## Reproduction
- Tried the local tagged Debug app path without starting a new build. That older running build still mounted the hidden workspace, so the URL loaded there; the current root cause is the unmounted workspace path introduced by the idle background surface priming change.
- The regression test commit was pushed first, before the implementation commit, so CI can show the behavior gap.
- No cloud-mac video was produced; local functional coverage was the better fit here.

## Testing
- `git diff --check`
- `python3 scripts/lint_auxiliary_window_close_shortcuts.py`
- `PATH="$HOME/.cargo/bin:$PATH" CMUX_SKIP_ZIG_BUILD=1 ./scripts/reload.sh --tag issue-4342-browser-pane-background-load --launch`
- `CMUX_TAG=issue-4342-browser-pane-background-load scripts/cmux-debug-cli.sh list-workspaces`
- Local tests not run per repo policy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches browser panel lifecycle, window hosting, and modal/prompt presentation; regressions could impact navigation startup, prompt delivery, or hidden window cleanup. Changes are localized but involve async UI/WebKit behavior and new state transitions.
> 
> **Overview**
> CLI/socket-driven browser creation now uses a new `Workspace.BrowserPanelCreationPolicy.automationPreload`, enabling initial navigation to start *before* SwiftUI mounts the pane by hosting the `WKWebView` in a hidden, offscreen `NSWindow` that is released once the real portal/view attaches.
> 
> Browser prompts (JS dialogs, external-navigation prompts, insecure-HTTP alerts) are refactored to route through an injectable `BrowserAlertPresenter` and are **queued/deferred** while the web view lacks an interactive host window; queued prompts drain when the panel becomes visible/attached and are canceled on discard/profile switch/close. Managed settings reload gains a flag to skip terminal-theme synchronization on the initial replay of managed appearance, supported by a thread-safe, test-swappable `AppearanceSettings` live environment provider; adds/updates tests and lint allowlist (preload window identifier) plus a small Swift concurrency annotation (`@Sendable`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 998e1271479a945f6d068dca92bcaac9e0250c38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preloads CLI/socket-created browser panes offscreen so navigation starts immediately, then hands off when the view mounts. Fixes #4342; prevents URLs loading into hidden/stale workspaces and defers prompts until a real, visible window.

- **Bug Fixes**
  - Added `.automationPreload` creation policy across CLI/socket flows (TerminalController → Workspace → `BrowserPanel`) to start background navigation.
  - Hosted the `WKWebView` in a transparent, borderless offscreen `NSWindow`; keep it until a real window/portal attaches, then release. Preload intent is consumed on the first navigation only.
  - Queued browser prompts (JS dialogs, external-app prompts, insecure-HTTP) during preload and only present them on interactive hosts (visible, alpha > 0, not excluded/ignoring input); hidden preload hosts never parent modals and no fallback to key/main is used while preloading. Prompts drain on attach and cancel on lifecycle resets (profile switch, context reset, close).
  - Startup appearance: initial managed-appearance apply skips terminal-theme sync; added a locked, testable live env in `AppearanceSettings` and let `CmuxSettingsFileStore` control sync per reload. Tests cover preload-host lifecycle, deferred prompts, modal-host selection, and appearance sync.
  - Updated Cmd+W lint to ignore the hidden preload window; fixed a Swift concurrency warning by marking a background file removal helper `@Sendable`.

<sup>Written for commit 998e1271479a945f6d068dca92bcaac9e0250c38. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4345?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Browser pages can preload initial navigation in hidden background hosts to speed first display of new tabs, surfaces, and splits.
  * New creation mode enables automation-triggered preloading.

* **Behavior**
  * Modal dialogs and prompts now prefer an interactive host window for improved sheet/alert presentation.
  * Background preload hosts are created and cleared at lifecycle transitions; appearance/theme live-apply can be swapped for testing.
  * Settings reloads now control terminal-theme synchronization.

* **Tests**
  * Added tests for background preload and appearance/theme synchronization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4345?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->