### PR TITLE
Wire up force-click "Look Up" on the terminal surface

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -6624,6 +6624,11 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     var cellSize: CGSize = .zero
     private var lastKnownMousePointInView: NSPoint?
 
+    /// Last observed trackpad pressure stage. Tracks the rising edge of a
+    /// stage-2 force click so we only invoke the system Look Up popover
+    /// once per gesture rather than on every pressure update.
+    private var prevPressureStage: Int = 0
+
     /// Coalesce high-frequency scrollbar updates into a single main-thread
     /// dispatch.  The action callback (which may fire thousands of times per
     /// second during bulk output like `seq 1 100000`) stores the latest value
@@ -9529,6 +9534,75 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         }
         guard let surface = surface else { return }
         _ = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_MIDDLE, modsFromEvent(event))
+    }
+
+    /// Forward trackpad pressure changes to Ghostty and bridge the rising
+    /// edge of a stage-2 force click to AppKit's Quick Look / dictionary
+    /// popover, gated on the user's system Force Click preference. Mirrors
+    /// upstream Ghostty's `SurfaceView_AppKit.swift` so we get the same
+    /// behavior Apple's Terminal.app and iTerm2 expose for force-click
+    /// "Look Up".
+    override func pressureChange(with event: NSEvent) {
+        guard let surface = surface else {
+            super.pressureChange(with: event)
+            return
+        }
+
+        ghostty_surface_mouse_pressure(surface, UInt32(event.stage), Double(event.pressure))
+
+        let stage = event.stage
+        guard prevPressureStage < 2 else {
+            prevPressureStage = stage
+            return
+        }
+        prevPressureStage = stage
+        guard stage == 2 else { return }
+
+        // Apple's "Force Click and haptic feedback" toggle lives in
+        // NSGlobalDomain. Skip the popover if the user has disabled it.
+        guard UserDefaults.standard.bool(forKey: "com.apple.trackpad.forceClick") else { return }
+        quickLook(with: event)
+    }
+
+    override func quickLook(with event: NSEvent) {
+        guard let surface = surface else {
+            super.quickLook(with: event)
+            return
+        }
+
+        var text = ghostty_text_s()
+        guard ghostty_surface_quicklook_word(surface, &text) else {
+            super.quickLook(with: event)
+            return
+        }
+        defer { ghostty_surface_free_text(surface, &text) }
+        guard text.text_len > 0, let textPtr = text.text else {
+            super.quickLook(with: event)
+            return
+        }
+
+        let wordData = Data(bytes: textPtr, count: Int(text.text_len))
+        guard let word = String(data: wordData, encoding: .utf8), !word.isEmpty else {
+            super.quickLook(with: event)
+            return
+        }
+
+        var attributes: [NSAttributedString.Key: Any] = [:]
+        if let fontRaw = ghostty_surface_quicklook_font(surface) {
+            // ghostty_surface_quicklook_font returns a +1 retained CTFont;
+            // Swift will retain again when we stash it in the dictionary, so
+            // we balance with an explicit release to avoid the leak that hit
+            // upstream (see manaflow-ai/cmux#4163 for prior CTFont fallout).
+            let font = Unmanaged<CTFont>.fromOpaque(fontRaw)
+            attributes[.font] = font.takeUnretainedValue()
+            font.release()
+        }
+
+        // Ghostty reports cell coords in a top-left origin; AppKit views
+        // here are bottom-left, so flip Y.
+        let pt = NSPoint(x: text.tl_px_x, y: frame.size.height - text.tl_px_y)
+        let str = NSAttributedString(string: word, attributes: attributes)
+        showDefinition(for: str, at: pt)
     }
 
     override func menu(for event: NSEvent) -> NSMenu? {


### PR DESCRIPTION
## Summary

- Adds `pressureChange(with:)` and `quickLook(with:)` overrides on `GhosttyNSView` so a stage-2 force click on a word triggers the system Look Up popover (Dictionary / Wikipedia / smart actions), matching Apple's Terminal.app, iTerm2, and upstream Ghostty.
- Adds a single stored property `prevPressureStage: Int` to detect the rising edge of stage 2.
- All C symbols used (`ghostty_surface_mouse_pressure`, `ghostty_surface_quicklook_word`, `ghostty_surface_quicklook_font`, `ghostty_surface_free_text`) are already exported by the pinned `manaflow-ai/ghostty` submodule. `_quicklook_word` and `_free_text` are already called elsewhere in `GhosttyTerminalView.swift` (the cmd-click path resolver at L8767), so no submodule bump is required.

Fixes #4344.

## Why this was missing

`GhosttyNSView` is a hand-written reimplementation of upstream Ghostty's `macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift`. The mouse, key, IME, drag, and scroll overrides were all ported but the `pressureChange(with:)` and `quickLook(with:)` overrides were not, so AppKit's force-click → Look Up plumbing had nothing to forward to.

## How it works

- `pressureChange(with:)` first forwards `event.stage` and `event.pressure` to the core via `ghostty_surface_mouse_pressure` (matching upstream — Ghostty's core uses this for its own pressure-aware state). Then, on the rising edge of stage 2, and only when the user has Force Click enabled in System Settings (`com.apple.trackpad.forceClick` in `NSGlobalDomain`), it invokes `quickLook(with:)`.
- `quickLook(with:)` asks Ghostty for the word under the cursor via `ghostty_surface_quicklook_word`, pulls the matching `CTFont` via `ghostty_surface_quicklook_font` (with the same `Unmanaged.fromOpaque` / explicit-release dance upstream uses to balance the +1 retain — see #4163 / #1496 for prior CTFont fallout), flips Ghostty's top-left coords to AppKit bottom-left, and calls the public `NSView.showDefinition(for:at:)`.

## Differences from upstream Ghostty

- Reads the system Force Click pref from `UserDefaults.standard` rather than upstream's `UserDefaults.ghostty` (cmux has no `UserDefaults.ghostty` extension; the key lives in `NSGlobalDomain` so the value is the same).
- Decodes the word with `Data` + `String(data:encoding:)` rather than `String(cString:)`, matching cmux's existing safe-decode pattern in `resolveWordUnderCursorPath`.
- Always updates `prevPressureStage` before any early-return path so the rising-edge guard re-arms after every gesture (upstream's variant locks the field at 2 once stage 2 is reached, which can stop subsequent force clicks from firing — happy to revert that detail if it's intentional).

## Test plan

- [ ] System Settings → Trackpad → "Force Click and haptic feedback" enabled.
- [ ] Force-click a word in a terminal pane → dictionary popover appears.
- [ ] Force-click empty space → nothing (no crash).
- [ ] Disable Force Click in System Settings, re-test → no popover.
- [ ] Force-click multiple words consecutively → popover fires every time (regression check for the rising-edge re-arm).
- [ ] Right-click context menu, double-click word selection, cmd-click path open — all unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable force-click Look Up (Dictionary/Wikipedia) in terminal panes by implementing `pressureChange(with:)` and `quickLook(with:)` in `GhosttyNSView`. Matches Apple's Terminal and upstream Ghostty; fixes #4344.

- New Features
  - Triggers system Look Up on stage-2 force click; forwards pressure via `ghostty_surface_mouse_pressure`.
  - Fires once per gesture using `prevPressureStage`; respects `com.apple.trackpad.forceClick`.
  - Gets word/font via `ghostty_surface_quicklook_word` and `_quicklook_font`, balances CTFont retain, flips coords, then calls `NSView.showDefinition`.
  - Uses existing symbols from `@manaflow-ai/ghostty`; no submodule update.

<sup>Written for commit 3ca61f915af4e3dcb9f2da0de6c216e23dfda59c. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4346?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added Quick Look support triggered by Force Click on the trackpad
- Respects macOS trackpad force click preferences
- Text under cursor previews with proper font rendering

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4346?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->