### PR TITLE
Fix tmux compat CLI probes

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -13224,28 +13224,55 @@ struct CMUXCLI {
         fallback: String
     ) -> String {
         guard let format, !format.isEmpty else { return fallback }
-        var rendered = format
-        for (key, value) in context {
-            rendered = rendered.replacingOccurrences(of: "#{\(key)}", with: value)
-        }
-        rendered = rendered.replacingOccurrences(
-            of: "#\\{[^}]+\\}",
-            with: "",
-            options: .regularExpression
-        )
-        let shortAliases: [(alias: String, key: String)] = [
-            ("S", "session_name"),
-            ("I", "window_index"),
-            ("W", "window_name"),
-            ("P", "pane_index"),
-            ("T", "pane_title"),
-            ("D", "pane_id"),
+        let shortAliases: [Character: String] = [
+            "S": "session_name",
+            "I": "window_index",
+            "W": "window_name",
+            "P": "pane_index",
+            "T": "pane_title",
+            "D": "pane_id",
         ]
-        for entry in shortAliases {
-            rendered = rendered.replacingOccurrences(
-                of: "#\(entry.alias)",
-                with: context[entry.key] ?? ""
-            )
+        var rendered = ""
+        var index = format.startIndex
+        while index < format.endIndex {
+            let character = format[index]
+            guard character == "#" else {
+                rendered.append(character)
+                index = format.index(after: index)
+                continue
+            }
+
+            let nextIndex = format.index(after: index)
+            guard nextIndex < format.endIndex else {
+                rendered.append(character)
+                index = nextIndex
+                continue
+            }
+
+            let next = format[nextIndex]
+            if next == "#" {
+                rendered.append("#")
+                index = format.index(after: nextIndex)
+                continue
+            }
+
+            if next == "{",
+               let closeIndex = format[nextIndex...].firstIndex(of: "}") {
+                let keyStart = format.index(after: nextIndex)
+                let key = String(format[keyStart..<closeIndex])
+                rendered += context[key] ?? ""
+                index = format.index(after: closeIndex)
+                continue
+            }
+
+            if let key = shortAliases[next] {
+                rendered += context[key] ?? ""
+                index = format.index(after: nextIndex)
+                continue
+            }
+
+            rendered.append(character)
+            index = nextIndex
         }
         let trimmed = rendered.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? fallback : trimmed

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -16130,6 +16130,9 @@ struct CMUXCLI {
             )
             let optionName = parsed.positional.last ?? ""
             guard let value = tmuxCompatOptionValue(optionName) else {
+                if parsed.hasFlag("-q") {
+                    return
+                }
                 throw CLIError(message: "Unsupported tmux compatibility command: \(command) \(optionName)")
             }
             if parsed.hasFlag("-v") {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -13233,8 +13233,37 @@ struct CMUXCLI {
             with: "",
             options: .regularExpression
         )
+        let shortAliases: [(alias: String, key: String)] = [
+            ("S", "session_name"),
+            ("I", "window_index"),
+            ("W", "window_name"),
+            ("P", "pane_index"),
+            ("T", "pane_title"),
+            ("D", "pane_id"),
+        ]
+        for entry in shortAliases {
+            rendered = rendered.replacingOccurrences(
+                of: "#\(entry.alias)",
+                with: context[entry.key] ?? ""
+            )
+        }
         let trimmed = rendered.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? fallback : trimmed
+    }
+
+    private func tmuxCompatOptionValue(_ optionName: String) -> String? {
+        switch optionName {
+        case "default-terminal":
+            return "tmux-256color"
+        case "extended-keys":
+            return "on"
+        case "extended-keys-format":
+            return "csi-u"
+        case "status":
+            return "on"
+        default:
+            return nil
+        }
     }
 
     private func tmuxFormatContext(
@@ -13246,6 +13275,11 @@ struct CMUXCLI {
         let canonicalWorkspaceId = try resolveWorkspaceId(workspaceId, client: client)
         var context: [String: String] = [
             "session_name": "cmux",
+            "session_id": "$0",
+            "session_attached": "1",
+            "client_attached": "1",
+            "client_name": "cmux",
+            "client_tty": ProcessInfo.processInfo.environment["TTY"] ?? "",
             "window_id": "@\(canonicalWorkspaceId)",
             "window_uuid": canonicalWorkspaceId
         ]
@@ -16068,10 +16102,9 @@ struct CMUXCLI {
                 boolFlags: ["-g", "-q", "-s", "-v", "-w"]
             )
             let optionName = parsed.positional.last ?? ""
-            guard optionName == "extended-keys" else {
+            guard let value = tmuxCompatOptionValue(optionName) else {
                 throw CLIError(message: "Unsupported tmux compatibility command: \(command) \(optionName)")
             }
-            let value = "on"
             if parsed.hasFlag("-v") {
                 print(value)
             } else {

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -2335,7 +2335,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
                             "id": workspaceId,
                             "ref": "workspace:7",
                             "index": 7,
-                            "title": "Build",
+                            "title": "Build #S",
                         ]],
                     ]
                 )
@@ -2358,7 +2358,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
                             "id": surfaceId,
                             "ref": "surface:3",
                             "index": 3,
-                            "title": "Codex",
+                            "title": "Codex #P",
                             "focused": true,
                         ]],
                     ]
@@ -2397,7 +2397,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
                 "__tmux-compat",
                 "display-message",
                 "-p",
-                "#S:#I:#W:#P:#{session_attached}:#{pane_id}",
+                "#S:#I:#W:#P:#T:##S:#{session_attached}:#{pane_id}",
             ],
             environment: environment,
             timeout: 5
@@ -2406,7 +2406,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         wait(for: [serverHandled], timeout: 5)
         XCTAssertFalse(result.timedOut, result.stderr)
         XCTAssertEqual(result.status, 0, result.stderr)
-        XCTAssertEqual(result.stdout, "cmux:7:Build:2:1:%\(paneId)\n")
+        XCTAssertEqual(result.stdout, "cmux:7:Build #S:2:Codex #P:#S:1:%\(paneId)\n")
         XCTAssertTrue(
             state.commands.contains { $0.contains(#""method":"surface.current""#) },
             "Expected display-message to resolve tmux context through the socket, saw \(state.commands)"
@@ -2420,6 +2420,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
 
         let cases: [(arguments: [String], expected: String)] = [
             (["__tmux-compat", "show-options", "-sv", "default-terminal"], "tmux-256color\n"),
+            (["__tmux-compat", "show-options", "-sv", "extended-keys"], "on\n"),
             (["__tmux-compat", "show-option", "-sv", "extended-keys-format"], "csi-u\n"),
             (["__tmux-compat", "show", "-sv", "status"], "on\n"),
         ]

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -2304,6 +2304,140 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         }
     }
 
+    func testTmuxCompatDisplayMessageSubstitutesShortFormatsAndAttachedState() throws {
+        let cliPath = try bundledCLIPath()
+        let socketPath = makeSocketPath("tmuxfmt")
+        let listenerFD = try bindUnixSocket(at: socketPath)
+        let state = MockSocketServerState()
+        let workspaceId = "11111111-1111-1111-1111-111111111111"
+        let paneId = "22222222-2222-2222-2222-222222222222"
+        let surfaceId = "33333333-3333-3333-3333-333333333333"
+
+        defer {
+            Darwin.close(listenerFD)
+            unlink(socketPath)
+        }
+
+        let serverHandled = startMockServer(listenerFD: listenerFD, state: state) { line in
+            guard let payload = self.jsonObject(line),
+                  let id = payload["id"] as? String,
+                  let method = payload["method"] as? String else {
+                return self.malformedRequestResponse(raw: line)
+            }
+
+            switch method {
+            case "workspace.list":
+                return self.v2Response(
+                    id: id,
+                    ok: true,
+                    result: [
+                        "workspaces": [[
+                            "id": workspaceId,
+                            "ref": "workspace:7",
+                            "index": 7,
+                            "title": "Build",
+                        ]],
+                    ]
+                )
+            case "surface.current":
+                return self.v2Response(
+                    id: id,
+                    ok: true,
+                    result: [
+                        "workspace_id": workspaceId,
+                        "pane_id": paneId,
+                        "surface_id": surfaceId,
+                    ]
+                )
+            case "surface.list":
+                return self.v2Response(
+                    id: id,
+                    ok: true,
+                    result: [
+                        "surfaces": [[
+                            "id": surfaceId,
+                            "ref": "surface:3",
+                            "index": 3,
+                            "title": "Codex",
+                            "focused": true,
+                        ]],
+                    ]
+                )
+            case "pane.list":
+                return self.v2Response(
+                    id: id,
+                    ok: true,
+                    result: [
+                        "panes": [[
+                            "id": paneId,
+                            "ref": "pane:2",
+                            "index": 2,
+                            "focused": true,
+                        ]],
+                    ]
+                )
+            default:
+                return self.v2Response(
+                    id: id,
+                    ok: false,
+                    error: ["code": "unexpected_method", "message": "Unexpected method \(method)"]
+                )
+            }
+        }
+
+        var environment = ProcessInfo.processInfo.environment
+        environment["CMUX_SOCKET_PATH"] = socketPath
+        environment["CMUX_WORKSPACE_ID"] = workspaceId
+        environment["CMUX_SURFACE_ID"] = surfaceId
+        environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
+
+        let result = runProcess(
+            executablePath: cliPath,
+            arguments: [
+                "__tmux-compat",
+                "display-message",
+                "-p",
+                "#S:#I:#W:#P:#{session_attached}:#{pane_id}",
+            ],
+            environment: environment,
+            timeout: 5
+        )
+
+        wait(for: [serverHandled], timeout: 5)
+        XCTAssertFalse(result.timedOut, result.stderr)
+        XCTAssertEqual(result.status, 0, result.stderr)
+        XCTAssertEqual(result.stdout, "cmux:7:Build:2:1:%\(paneId)\n")
+        XCTAssertTrue(
+            state.commands.contains { $0.contains(#""method":"surface.current""#) },
+            "Expected display-message to resolve tmux context through the socket, saw \(state.commands)"
+        )
+    }
+
+    func testTmuxCompatShowOptionsHandlesCommonReadOnlyProbes() throws {
+        let cliPath = try bundledCLIPath()
+        var environment = ProcessInfo.processInfo.environment
+        environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
+
+        let cases: [(arguments: [String], expected: String)] = [
+            (["__tmux-compat", "show-options", "-sv", "default-terminal"], "tmux-256color\n"),
+            (["__tmux-compat", "show-option", "-sv", "extended-keys-format"], "csi-u\n"),
+            (["__tmux-compat", "show", "-sv", "status"], "on\n"),
+        ]
+
+        for item in cases {
+            let result = runProcess(
+                executablePath: cliPath,
+                arguments: item.arguments,
+                environment: environment,
+                timeout: 5
+            )
+
+            XCTAssertFalse(result.timedOut, result.stderr)
+            XCTAssertEqual(result.status, 0, result.stderr)
+            XCTAssertEqual(result.stdout, item.expected)
+        }
+    }
+
     private func notificationRows(from stdout: String) throws -> [[String: Any]] {
         let data = Data(stdout.utf8)
         return try XCTUnwrap(

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -2437,6 +2437,16 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
             XCTAssertEqual(result.status, 0, result.stderr)
             XCTAssertEqual(result.stdout, item.expected)
         }
+
+        let quietUnsupported = runProcess(
+            executablePath: cliPath,
+            arguments: ["__tmux-compat", "show-options", "-q", "-s", "-v", "unsupported-option"],
+            environment: environment,
+            timeout: 5
+        )
+        XCTAssertFalse(quietUnsupported.timedOut, quietUnsupported.stderr)
+        XCTAssertEqual(quietUnsupported.status, 0, quietUnsupported.stderr)
+        XCTAssertEqual(quietUnsupported.stdout, "")
     }
 
     private func notificationRows(from stdout: String) throws -> [[String: Any]] {


### PR DESCRIPTION
Summary

- Handle common tmux short format aliases in `cmux __tmux-compat display-message`.
- Populate attached/client fields for tmux format probes.
- Return stable values for read-only `show-options` probes used by shell integrations.

Regression proof

- Red commit: `5df0f644d test: cover tmux compat probes`
- Before the fix, the focused test failed because `#S:#I:#W:#P` stayed literal, `#{session_attached}` was empty, and `show-options -sv default-terminal` was rejected.
- Fix commit: `b9575bca3 fix: handle tmux compat probes`

Verification

```bash
xcodebuild -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/cmux-tmux-red '-only-testing:cmuxTests/CLINotifyProcessIntegrationRegressionTests/testTmuxCompatDisplayMessageSubstitutesShortFormatsAndAttachedState' '-only-testing:cmuxTests/CLINotifyProcessIntegrationRegressionTests/testTmuxCompatShowOptionsHandlesCommonReadOnlyProbes' test
```

Result: passed, 2 tests, 0 failures.

Issues

Fixes https://github.com/manaflow-ai/cmux/issues/3239
Fixes https://github.com/manaflow-ai/cmux/issues/2671
Fixes https://github.com/manaflow-ai/cmux/issues/3190
Fixes https://github.com/manaflow-ai/cmux/issues/3157

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes tmux compatibility parsing/output used by shell integrations; behavior changes are localized but could affect scripts relying on previous (buggy) output or error handling.
> 
> **Overview**
> Fixes `__tmux-compat` tmux probe behavior used by shell integrations.
> 
> `display-message -p` now parses tmux format strings more like tmux (supports `##` escapes, `#{...}` keys, and short aliases like `#S/#I/#W/#P/#T/#D`) and the render context now includes attached/client fields (`session_id`, `session_attached`, `client_attached`, `client_name`, `client_tty`). `show-options`/`show-option`/`show` now return stable read-only values for common probes (`default-terminal`, `extended-keys`, `extended-keys-format`, `status`) and honor `-q` by exiting successfully on unsupported options.
> 
> Adds integration regression tests covering short-format substitution/attached state rendering and the supported `show-options -sv` probes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25208c0f2f3dcab0214ebb5deaf7038d15922abe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores tmux compatibility for CLI probes. Adds safe short-alias parsing in `display-message`, sets attached/client fields, returns stable values for common read-only `show-options`, and keeps unsupported probes silent with `-q`.

- **Bug Fixes**
  - Expand short aliases in `display-message -p` (`#S`, `#I`, `#W`, `#P`, `#T`, `#D`) with safe parsing and `##` escape handling.
  - Populate format context with `session_id`, `session_attached=1`, `client_attached=1`, `client_name`, `client_tty`; render `#{pane_id}`.
  - Support `show-options`/`show-option`/`show -sv` for `default-terminal`, `extended-keys`, `extended-keys-format`, `status`.
  - Respect `-q` to keep unsupported option probes silent.

<sup>Written for commit 25208c0f2f3dcab0214ebb5deaf7038d15922abe. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4348?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced tmux compatibility: supports short format aliases and additional context fields (session/client state and TTY) for richer message formatting
  * Improved validation for tmux option commands with clearer unsupported-option handling

* **Tests**
  * Added integration regression tests covering format interpolation, attached-state rendering, and common read-only option probes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4348?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
Fixes https://github.com/manaflow-ai/cmux/issues/2750