### PR TITLE
Add AWS runner inputs for optional CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -904,6 +904,13 @@ jobs:
             sleep 3
           done
 
+      - name: Reset UI automation services
+        run: |
+          set -euo pipefail
+          sudo pkill -9 testmanagerd 2>/dev/null || true
+          sudo pkill -9 automationmode-writer 2>/dev/null || true
+          sudo launchctl kickstart -k system/com.apple.dt.automationmode-writer 2>/dev/null || true
+
       - name: Run browser find focus UI regression
         run: |
           set -euo pipefail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ on:
           - warp-macos-15-arm64-6x
           - cmux-aws-macos-15
           - cmux-aws-m4pro
+          - cmux-aws-m4pro-gui
           - cmux-aws-m1ultra
       release_macos_runner:
         description: Runner for the optional macOS release build
@@ -32,6 +33,7 @@ on:
           - warp-macos-15-arm64-6x
           - cmux-aws-macos-15
           - cmux-aws-m4pro
+          - cmux-aws-m4pro-gui
           - cmux-aws-m1ultra
 
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ on:
           - cmux-aws-macos-15
           - cmux-aws-m4pro
           - cmux-aws-m4pro-gui
-          - cmux-aws-m4pro-bench
           - cmux-aws-m1ultra
       release_macos_runner:
         description: Runner for the optional macOS release build
@@ -35,7 +34,6 @@ on:
           - cmux-aws-macos-15
           - cmux-aws-m4pro
           - cmux-aws-m4pro-gui
-          - cmux-aws-m4pro-bench
           - cmux-aws-m1ultra
 
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,31 @@ on:
   workflow_dispatch:
     inputs:
       run_warpbuild_macos:
-        description: Run preserved WarpBuild macOS jobs
+        description: Run optional macOS jobs
         required: false
         default: false
         type: boolean
+      macos_runner:
+        description: Runner for optional macOS 15 debug jobs
+        required: false
+        default: warp-macos-15-arm64-6x
+        type: choice
+        options:
+          - warp-macos-15-arm64-6x
+          - cmux-aws-macos-15
+          - cmux-aws-m4pro
+          - cmux-aws-m1ultra
+      release_macos_runner:
+        description: Runner for the optional macOS release build
+        required: false
+        default: warp-macos-26-arm64-6x
+        type: choice
+        options:
+          - warp-macos-26-arm64-6x
+          - warp-macos-15-arm64-6x
+          - cmux-aws-macos-15
+          - cmux-aws-m4pro
+          - cmux-aws-m1ultra
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -159,7 +180,7 @@ jobs:
 
   tests:
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_warpbuild_macos }}
-    runs-on: warp-macos-15-arm64-6x
+    runs-on: ${{ inputs.macos_runner || 'warp-macos-15-arm64-6x' }}
     timeout-minutes: 30
     steps:
       - name: Checkout
@@ -335,7 +356,7 @@ jobs:
     # and performance regressions stay isolated. Broader interactive UI suites
     # still run via test-e2e.yml on GitHub-hosted runners.
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_warpbuild_macos }}
-    runs-on: warp-macos-15-arm64-6x
+    runs-on: ${{ inputs.macos_runner || 'warp-macos-15-arm64-6x' }}
     timeout-minutes: 20
     steps:
       - name: Checkout
@@ -522,7 +543,7 @@ jobs:
     # signing, notarization, and publishing. This catches DEBUG/Release boundary
     # mistakes before they reach main.
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_warpbuild_macos }}
-    runs-on: warp-macos-26-arm64-6x
+    runs-on: ${{ inputs.release_macos_runner || 'warp-macos-26-arm64-6x' }}
     timeout-minutes: 20
     steps:
       - name: Checkout
@@ -606,7 +627,7 @@ jobs:
 
   ui-regressions:
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_warpbuild_macos }}
-    runs-on: warp-macos-15-arm64-6x
+    runs-on: ${{ inputs.macos_runner || 'warp-macos-15-arm64-6x' }}
     timeout-minutes: 25
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ on:
           - cmux-aws-macos-15
           - cmux-aws-m4pro
           - cmux-aws-m4pro-gui
+          - cmux-aws-m4pro-bench
           - cmux-aws-m1ultra
       release_macos_runner:
         description: Runner for the optional macOS release build
@@ -34,6 +35,7 @@ on:
           - cmux-aws-macos-15
           - cmux-aws-m4pro
           - cmux-aws-m4pro-gui
+          - cmux-aws-m4pro-bench
           - cmux-aws-m1ultra
 
 concurrency:

--- a/tests/test_ci_self_hosted_guard.sh
+++ b/tests/test_ci_self_hosted_guard.sh
@@ -11,25 +11,27 @@ GHOSTTYKIT_FILE="$ROOT_DIR/.github/workflows/build-ghosttykit.yml"
 COMPAT_FILE="$ROOT_DIR/.github/workflows/ci-macos-compat.yml"
 
 check_warp_runner() {
-  local file="$1" job="$2"
-  if ! awk -v job="$job" '
+  local file="$1" job="$2" expected="${3:-}"
+  if ! awk -v job="$job" -v expected="$expected" '
     $0 ~ "^  "job":" { in_job=1; next }
     in_job && /^  [^[:space:]]/ { in_job=0 }
-    in_job && /runs-on:.*warp-macos-.*-arm64/ { saw_warp=1 }
-    in_job && /os: warp-macos-.*-arm64/ { saw_warp=1 }
+    in_job && expected != "" && /runs-on:/ && index($0, expected) { saw_warp=1 }
+    in_job && expected != "" && /os:/ && index($0, expected) { saw_warp=1 }
+    in_job && expected == "" && /runs-on:.*warp-macos-.*-arm64/ { saw_warp=1 }
+    in_job && expected == "" && /os: warp-macos-.*-arm64/ { saw_warp=1 }
     END { exit !(saw_warp) }
   ' "$file"; then
-    echo "FAIL: $job in $(basename "$file") must use a WarpBuild runner"
+    echo "FAIL: $job in $(basename "$file") must default to a WarpBuild runner"
     exit 1
   fi
-  echo "PASS: $job WarpBuild runner is present"
+  echo "PASS: $job WarpBuild default runner is present"
 }
 
 # ci.yml jobs
-check_warp_runner "$CI_FILE" "tests"
-check_warp_runner "$CI_FILE" "tests-build-and-lag"
-check_warp_runner "$CI_FILE" "release-build"
-check_warp_runner "$CI_FILE" "ui-regressions"
+check_warp_runner "$CI_FILE" "tests" "warp-macos-15-arm64-6x"
+check_warp_runner "$CI_FILE" "tests-build-and-lag" "warp-macos-15-arm64-6x"
+check_warp_runner "$CI_FILE" "release-build" "warp-macos-26-arm64-6x"
+check_warp_runner "$CI_FILE" "ui-regressions" "warp-macos-15-arm64-6x"
 
 # build-ghosttykit.yml
 check_warp_runner "$GHOSTTYKIT_FILE" "build-ghosttykit"


### PR DESCRIPTION
Adds workflow_dispatch runner choices for the optional macOS CI jobs so we can force them onto the AWS macfleet labels during benchmarking while keeping WarpBuild as the default.

Validation:
- ./tests/test_ci_self_hosted_guard.sh
- actionlint -ignore 'shellcheck reported issue' .github/workflows/ci.yml

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how optional `workflow_dispatch` macOS jobs select self-hosted runners, which can impact cost/capacity and execution environment. Risk is mitigated by defaults/guards still enforcing WarpBuild labels unless explicitly overridden.
> 
> **Overview**
> Adds `workflow_dispatch` inputs to choose the macOS runner for the optional macOS CI jobs, wiring `tests`, `tests-build-and-lag`, and `ui-regressions` to `inputs.macos_runner` and `release-build` to `inputs.release_macos_runner` while keeping WarpBuild as the default.
> 
> Improves UI regression reliability by resetting macOS UI automation services before running the browser-focus UI test, and tightens `test_ci_self_hosted_guard.sh` to assert each job’s expected default WarpBuild runner label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28cd01fecc1cb40519168fc7bac2a72adc47ff1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds runner-choice inputs to optional macOS CI jobs so we can route them to AWS labels while keeping WarpBuild as the default. Also improves UI regression stability by resetting macOS automation services.

- **New Features**
  - Added `macos_runner` and `release_macos_runner` inputs with defaults `warp-macos-15-arm64-6x` and `warp-macos-26-arm64-6x`; options include `cmux-aws-macos-15`, `cmux-aws-m4pro`, `cmux-aws-m4pro-gui`, and `cmux-aws-m1ultra` (removed temporary `cmux-aws-m4pro-bench`).
  - Applied to `tests`, `tests-build-and-lag`, `ui-regressions`, and `release-build` when `run_warpbuild_macos` is true; guard script updated to assert exact per-job WarpBuild defaults.

- **Bug Fixes**
  - In `ui-regressions`, reset `testmanagerd` and `automationmode-writer` (via `pkill`/`launchctl`) to reduce macOS UI test flakiness.

<sup>Written for commit 28cd01fecc1cb40519168fc7bac2a72adc47ff1c. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4368?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Manual CI dispatch now exposes selectable macOS runner choices (with defaults preserved) and updates the macOS dispatch description.
  * UI regression runs now include a pre-test macOS automation reset to improve test stability.

* **Tests**
  * CI validation tightened to assert the expected macOS runner per job, improving detection of runner misconfigurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4368?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->