### PR TITLE
Allow bounded parallel reload builds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,12 @@ After making code changes, always use `reload.sh --tag` to build. **Never run ba
 ./scripts/reload.sh --tag <your-branch-slug>
 ```
 
+Tagged reloads are allowed to build in parallel. `reload.sh` isolates Xcode temp, package, and module-cache roots per tag, then takes one of five shared build slots before running `xcodebuild`. Override only when you are intentionally benchmarking or debugging build capacity:
+
+```bash
+CMUX_XCODEBUILD_MAX_CONCURRENCY=5 CMUX_XCODEBUILD_JOBS=3 ./scripts/reload.sh --tag <your-branch-slug>
+```
+
 If you only need to verify the build compiles (no launch), use a tagged derivedDataPath:
 
 ```bash

--- a/scripts/reload.sh
+++ b/scripts/reload.sh
@@ -221,6 +221,24 @@ is_positive_integer() {
   (( numeric > 0 ))
 }
 
+choose_xcodebuild_concurrency() {
+  local value="${CMUX_XCODEBUILD_MAX_CONCURRENCY:-5}"
+  if ! is_positive_integer "$value"; then
+    echo "error: CMUX_XCODEBUILD_MAX_CONCURRENCY must be a positive integer" >&2
+    exit 1
+  fi
+  echo "$((10#$value))"
+}
+
+choose_xcodebuild_jobs() {
+  local value="${CMUX_XCODEBUILD_JOBS:-3}"
+  if ! is_positive_integer "$value"; then
+    echo "error: CMUX_XCODEBUILD_JOBS must be a positive integer" >&2
+    exit 1
+  fi
+  echo "$((10#$value))"
+}
+
 choose_cmux_dev_port() {
   if is_valid_port "${CMUX_PORT:-}"; then
     echo "$CMUX_PORT"
@@ -485,6 +503,8 @@ XCODEBUILD_ARGS=(
 if [[ -n "$DERIVED_DATA" ]]; then
   XCODEBUILD_ARGS+=(-derivedDataPath "$DERIVED_DATA")
 fi
+XCODEBUILD_JOBS="$(choose_xcodebuild_jobs)"
+XCODEBUILD_ARGS+=(-jobs "$XCODEBUILD_JOBS")
 if [[ -z "$TAG" ]]; then
   XCODEBUILD_ARGS+=(
     INFOPLIST_KEY_CFBundleName="$APP_NAME"
@@ -496,57 +516,94 @@ fi
 if [[ "${CMUX_SKIP_ZIG_BUILD:-}" == "1" ]]; then
   XCODEBUILD_ARGS+=(CMUX_SKIP_ZIG_BUILD=1)
 fi
+if [[ -n "$DERIVED_DATA" ]]; then
+  XCODEBUILD_PACKAGE_DIR="${CMUX_XCODEBUILD_PACKAGE_DIR:-$DERIVED_DATA/SourcePackages}"
+  XCODEBUILD_ISOLATION_DIR="${CMUX_XCODEBUILD_ISOLATION_DIR:-$DERIVED_DATA/Build/CMUXBuildIsolation}"
+  XCODEBUILD_TMPDIR="${CMUX_XCODEBUILD_TMPDIR:-$XCODEBUILD_ISOLATION_DIR/tmp}"
+  XCODEBUILD_CLANG_MODULE_CACHE="${CMUX_XCODEBUILD_CLANG_MODULE_CACHE:-$XCODEBUILD_ISOLATION_DIR/clang-modules}"
+  XCODEBUILD_SWIFT_MODULE_CACHE="${CMUX_XCODEBUILD_SWIFT_MODULE_CACHE:-$XCODEBUILD_ISOLATION_DIR/swift-modules}"
+  XCODEBUILD_SHARED_PRECOMPS_DIR="${CMUX_XCODEBUILD_SHARED_PRECOMPS_DIR:-$XCODEBUILD_ISOLATION_DIR/precompiled-headers}"
+  mkdir -p \
+    "$XCODEBUILD_PACKAGE_DIR" \
+    "$XCODEBUILD_TMPDIR" \
+    "$XCODEBUILD_CLANG_MODULE_CACHE" \
+    "$XCODEBUILD_SWIFT_MODULE_CACHE" \
+    "$XCODEBUILD_SHARED_PRECOMPS_DIR"
+  XCODEBUILD_ARGS+=(
+    -clonedSourcePackagesDirPath "$XCODEBUILD_PACKAGE_DIR"
+    COMPILER_INDEX_STORE_ENABLE=NO
+    INDEX_ENABLE_DATA_STORE=NO
+    CLANG_MODULE_CACHE_PATH="$XCODEBUILD_CLANG_MODULE_CACHE"
+    SWIFT_MODULE_CACHE_PATH="$XCODEBUILD_SWIFT_MODULE_CACHE"
+    SHARED_PRECOMPS_DIR="$XCODEBUILD_SHARED_PRECOMPS_DIR"
+  )
+fi
 XCODEBUILD_ARGS+=(build)
 
-XCODEBUILD_LOCK="${TMPDIR:-/tmp}/cmux-xcodebuild-$(id -u).lock"
-# Xcode 26's SWBBuildService is a per-user singleton. Concurrent xcodebuild
-# invocations (even with separate -derivedDataPath) share that daemon and can
-# crash it, SIGTERMing in-flight builds. Serialize via a per-user lock so
-# parallel reload.sh runs queue instead of trampling each other.
-python3 -c '
+XCODEBUILD_MAX_CONCURRENCY="$(choose_xcodebuild_concurrency)"
+XCODEBUILD_SLOT_DIR="${CMUX_XCODEBUILD_SLOT_DIR:-/tmp/cmux-xcodebuild-$(id -u).slots}"
+# Keep tagged reloads parallel but bounded. Each build gets isolated temp,
+# package, and module-cache roots above, while this slot lease limits aggregate
+# Xcode pressure on the per-user SWBBuildService.
+mkdir -p "$XCODEBUILD_SLOT_DIR"
+(
+  if [[ -n "${XCODEBUILD_TMPDIR:-}" ]]; then
+    export TMPDIR="${XCODEBUILD_TMPDIR%/}/"
+  fi
+  python3 -c '
 import fcntl
 import os
 import sys
+import time
 
-lock_path = sys.argv[1]
-command = sys.argv[2:]
+max_concurrency = int(sys.argv[1])
+slot_dir = sys.argv[2]
+command = sys.argv[3:]
 
-try:
-    fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
-except OSError as exc:
-    raise SystemExit(f"error: open lock: {exc}")
-
-try:
-    flags = fcntl.fcntl(fd, fcntl.F_GETFD)
-    fcntl.fcntl(fd, fcntl.F_SETFD, flags & ~fcntl.FD_CLOEXEC)
-except OSError as exc:
-    raise SystemExit(f"error: fcntl lock fd: {exc}")
-
-try:
-    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-except BlockingIOError:
-    msg = f"==> Another xcodebuild is running; waiting for {lock_path}...\n"
-    # reload.sh saves the original stderr on fd 4 before redirecting to the
-    # log file. Surface the wait notice to the terminal so the user knows
-    # they are queued, not hung. Fall back to stderr (the log) if fd 4 is
-    # unavailable (e.g. when this script is run standalone).
+def surface(message):
+    data = message.encode()
     try:
-        os.write(4, msg.encode())
+        os.write(4, data)
+        return
     except OSError:
-        sys.stderr.write(msg)
-        sys.stderr.flush()
-    try:
-        fcntl.flock(fd, fcntl.LOCK_EX)
-    except OSError as exc:
-        raise SystemExit(f"error: flock: {exc}")
-except OSError as exc:
-    raise SystemExit(f"error: flock: {exc}")
+        pass
+    os.write(2, data)
 
-try:
-    os.execvp(command[0], command)
-except OSError as exc:
-    raise SystemExit(f"error: exec: {exc}")
-' "$XCODEBUILD_LOCK" xcodebuild "${XCODEBUILD_ARGS[@]}"
+waited = False
+while True:
+    for slot in range(1, max_concurrency + 1):
+        lock_path = os.path.join(slot_dir, f"slot-{slot}.lock")
+        try:
+            fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+        except OSError as exc:
+            raise SystemExit(f"error: open xcodebuild slot: {exc}")
+
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            os.close(fd)
+            continue
+        except OSError as exc:
+            os.close(fd)
+            raise SystemExit(f"error: acquire xcodebuild slot: {exc}")
+
+        try:
+            flags = fcntl.fcntl(fd, fcntl.F_GETFD)
+            fcntl.fcntl(fd, fcntl.F_SETFD, flags & ~fcntl.FD_CLOEXEC)
+        except OSError as exc:
+            raise SystemExit(f"error: fcntl xcodebuild slot fd: {exc}")
+
+        try:
+            os.execvp(command[0], command)
+        except OSError as exc:
+            raise SystemExit(f"error: exec: {exc}")
+
+    if not waited:
+        surface(f"==> All {max_concurrency} xcodebuild slots are busy; waiting for {slot_dir}...\n")
+        waited = True
+    time.sleep(2)
+' "$XCODEBUILD_MAX_CONCURRENCY" "$XCODEBUILD_SLOT_DIR" xcodebuild "${XCODEBUILD_ARGS[@]}"
+)
 sleep 0.2
 
 FALLBACK_APP_NAME="$BASE_APP_NAME"

--- a/scripts/reload.sh
+++ b/scripts/reload.sh
@@ -542,6 +542,7 @@ XCODEBUILD_ARGS+=(build)
 
 XCODEBUILD_MAX_CONCURRENCY="$(choose_xcodebuild_concurrency)"
 XCODEBUILD_SLOT_DIR="${CMUX_XCODEBUILD_SLOT_DIR:-/tmp/cmux-xcodebuild-$(id -u).slots}"
+XCODEBUILD_EXCLUSIVE_KEY="${DERIVED_DATA:-}"
 # Keep tagged reloads parallel but bounded. Each build gets isolated temp,
 # package, and module-cache roots above, while this slot lease limits aggregate
 # Xcode pressure on the per-user SWBBuildService.
@@ -552,6 +553,7 @@ mkdir -p "$XCODEBUILD_SLOT_DIR"
   fi
   python3 -c '
 import fcntl
+import hashlib
 import os
 import queue
 import sys
@@ -559,7 +561,8 @@ import threading
 
 max_concurrency = int(sys.argv[1])
 slot_dir = sys.argv[2]
-command = sys.argv[3:]
+exclusive_key = sys.argv[3]
+command = sys.argv[4:]
 
 def surface(message):
     data = message.encode()
@@ -593,6 +596,27 @@ def acquire_slot(slot, blocking):
 def make_inheritable(fd):
     flags = fcntl.fcntl(fd, fcntl.F_GETFD)
     fcntl.fcntl(fd, fcntl.F_SETFD, flags & ~fcntl.FD_CLOEXEC)
+
+exclusive_fd = None
+if exclusive_key:
+    lock_key = os.path.realpath(exclusive_key)
+    lock_digest = hashlib.sha256(lock_key.encode()).hexdigest()[:32]
+    lock_path = os.path.join(slot_dir, f"derived-{lock_digest}.lock")
+    exclusive_fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        try:
+            fcntl.flock(exclusive_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            surface(f"==> Waiting for xcodebuild lock for {lock_key}...\n")
+            while True:
+                try:
+                    fcntl.flock(exclusive_fd, fcntl.LOCK_EX)
+                    break
+                except InterruptedError:
+                    continue
+    except OSError:
+        os.close(exclusive_fd)
+        raise
 
 errors = []
 for slot in range(1, max_concurrency + 1):
@@ -632,12 +656,14 @@ else:
         if len(errors) == max_concurrency:
             raise SystemExit(f"error: acquire xcodebuild slot: {errors[0]}")
 
+if exclusive_fd is not None:
+    make_inheritable(exclusive_fd)
 make_inheritable(acquired_fd)
 try:
     os.execvp(command[0], command)
 except OSError as exc:
     raise SystemExit(f"error: exec: {exc}")
-' "$XCODEBUILD_MAX_CONCURRENCY" "$XCODEBUILD_SLOT_DIR" xcodebuild "${XCODEBUILD_ARGS[@]}"
+' "$XCODEBUILD_MAX_CONCURRENCY" "$XCODEBUILD_SLOT_DIR" "$XCODEBUILD_EXCLUSIVE_KEY" xcodebuild "${XCODEBUILD_ARGS[@]}"
 )
 sleep 0.2
 

--- a/scripts/reload.sh
+++ b/scripts/reload.sh
@@ -585,12 +585,14 @@ def acquire_slot(slot, blocking):
                 os.close(fd)
                 return None
 
-        flags = fcntl.fcntl(fd, fcntl.F_GETFD)
-        fcntl.fcntl(fd, fcntl.F_SETFD, flags & ~fcntl.FD_CLOEXEC)
         return fd
     except OSError:
         os.close(fd)
         raise
+
+def make_inheritable(fd):
+    flags = fcntl.fcntl(fd, fcntl.F_GETFD)
+    fcntl.fcntl(fd, fcntl.F_SETFD, flags & ~fcntl.FD_CLOEXEC)
 
 errors = []
 for slot in range(1, max_concurrency + 1):
@@ -630,6 +632,7 @@ else:
         if len(errors) == max_concurrency:
             raise SystemExit(f"error: acquire xcodebuild slot: {errors[0]}")
 
+make_inheritable(acquired_fd)
 try:
     os.execvp(command[0], command)
 except OSError as exc:

--- a/scripts/reload.sh
+++ b/scripts/reload.sh
@@ -553,8 +553,9 @@ mkdir -p "$XCODEBUILD_SLOT_DIR"
   python3 -c '
 import fcntl
 import os
+import queue
 import sys
-import time
+import threading
 
 max_concurrency = int(sys.argv[1])
 slot_dir = sys.argv[2]
@@ -569,39 +570,70 @@ def surface(message):
         pass
     os.write(2, data)
 
-waited = False
-while True:
+def acquire_slot(slot, blocking):
+    lock_path = os.path.join(slot_dir, f"slot-{slot}.lock")
+    fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        operation = fcntl.LOCK_EX if blocking else (fcntl.LOCK_EX | fcntl.LOCK_NB)
+        while True:
+            try:
+                fcntl.flock(fd, operation)
+                break
+            except InterruptedError:
+                continue
+            except BlockingIOError:
+                os.close(fd)
+                return None
+
+        flags = fcntl.fcntl(fd, fcntl.F_GETFD)
+        fcntl.fcntl(fd, fcntl.F_SETFD, flags & ~fcntl.FD_CLOEXEC)
+        return fd
+    except OSError:
+        os.close(fd)
+        raise
+
+errors = []
+for slot in range(1, max_concurrency + 1):
+    try:
+        acquired_fd = acquire_slot(slot, blocking=False)
+    except OSError as exc:
+        errors.append(f"slot {slot}: {exc}")
+        continue
+    if acquired_fd is not None:
+        break
+else:
+    if len(errors) == max_concurrency:
+        raise SystemExit(f"error: acquire xcodebuild slot: {errors[0]}")
+
+    surface(f"==> All {max_concurrency} xcodebuild slots are busy; waiting for {slot_dir}...\n")
+    results = queue.Queue()
+
+    def wait_for_slot(slot):
+        try:
+            fd = acquire_slot(slot, blocking=True)
+        except OSError as exc:
+            results.put(("error", slot, str(exc)))
+            return
+        results.put(("acquired", slot, fd))
+
     for slot in range(1, max_concurrency + 1):
-        lock_path = os.path.join(slot_dir, f"slot-{slot}.lock")
-        try:
-            fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
-        except OSError as exc:
-            raise SystemExit(f"error: open xcodebuild slot: {exc}")
+        thread = threading.Thread(target=wait_for_slot, args=(slot,), daemon=True)
+        thread.start()
 
-        try:
-            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-        except BlockingIOError:
-            os.close(fd)
-            continue
-        except OSError as exc:
-            os.close(fd)
-            raise SystemExit(f"error: acquire xcodebuild slot: {exc}")
+    errors = []
+    while True:
+        kind, slot, value = results.get()
+        if kind == "acquired":
+            acquired_fd = value
+            break
+        errors.append(f"slot {slot}: {value}")
+        if len(errors) == max_concurrency:
+            raise SystemExit(f"error: acquire xcodebuild slot: {errors[0]}")
 
-        try:
-            flags = fcntl.fcntl(fd, fcntl.F_GETFD)
-            fcntl.fcntl(fd, fcntl.F_SETFD, flags & ~fcntl.FD_CLOEXEC)
-        except OSError as exc:
-            raise SystemExit(f"error: fcntl xcodebuild slot fd: {exc}")
-
-        try:
-            os.execvp(command[0], command)
-        except OSError as exc:
-            raise SystemExit(f"error: exec: {exc}")
-
-    if not waited:
-        surface(f"==> All {max_concurrency} xcodebuild slots are busy; waiting for {slot_dir}...\n")
-        waited = True
-    time.sleep(2)
+try:
+    os.execvp(command[0], command)
+except OSError as exc:
+    raise SystemExit(f"error: exec: {exc}")
 ' "$XCODEBUILD_MAX_CONCURRENCY" "$XCODEBUILD_SLOT_DIR" xcodebuild "${XCODEBUILD_ARGS[@]}"
 )
 sleep 0.2


### PR DESCRIPTION
## Summary
- replace reload.sh's single xcodebuild lock with five shared build slots
- isolate tagged build temp, SwiftPM, module-cache, and precomp roots per DerivedData
- default each xcodebuild to `-jobs 3` and document override knobs

## Verification
- `git diff --check`
- `bash -n scripts/reload.sh`
- Five concurrent tagged reload smoke run: `prld1`..`prld5` all exited 0 in 274-282s with `CMUX_SKIP_ZIG_BUILD=1`, `CMUX_XCODEBUILD_MAX_CONCURRENCY=5`, `CMUX_XCODEBUILD_JOBS=3`
- `./scripts/reload.sh --tag par5` succeeded in 375s
- `http://localhost:9140` is served from this worktree's `web` directory and `curl -fsS http://localhost:9140` succeeds

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the local build pipeline and locking around `xcodebuild`, which could cause build hangs or cache/DerivedData contention if misconfigured, but is limited to developer tooling.
> 
> **Overview**
> **Allows parallel tagged `reload.sh` builds while keeping Xcode load bounded.** The script replaces the single per-user `xcodebuild` lock with a configurable slot-based lease (`CMUX_XCODEBUILD_MAX_CONCURRENCY`, default 5) and adds a default `xcodebuild -jobs` setting (`CMUX_XCODEBUILD_JOBS`, default 3).
> 
> **Improves isolation for concurrent builds** by segregating SwiftPM packages, temp dirs, module caches, and precompiled headers under the tagged `DerivedData`, and disabling indexing to reduce cross-build interference; `CLAUDE.md` is updated to document the new parallelism/override knobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b30ff2b33d5a307c539b52a9089f8a2acc9a6590. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable bounded parallel reload builds. Tagged runs can now build concurrently (up to 5) with per-tag isolated caches, non-polling slot waits, and per-`DerivedData` serialization to avoid duplicate output races, improving speed while keeping `xcodebuild` stable.

- **New Features**
  - Slot-based concurrency for `xcodebuild` in `reload.sh` (default 5 via `CMUX_XCODEBUILD_MAX_CONCURRENCY`), with non-polling waits, a clear wait notice when all slots are busy, the slot lease held by inheriting only the selected slot’s lock, and an exclusive per-`DerivedData` lock to serialize duplicate outputs.
  - Per-tag isolation of temp, SwiftPM packages, module caches, and precompiled headers under `DerivedData`; sets `TMPDIR` and disables indexing to reduce interference.
  - Default `xcodebuild -jobs 3`, configurable via `CMUX_XCODEBUILD_JOBS`.

<sup>Written for commit b30ff2b33d5a307c539b52a9089f8a2acc9a6590. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4369?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enable parallel Xcode builds with configurable concurrency limits and per-run job counts via environment variables.
  * Safer derived-data usage with per-run isolation for build, temp, and module-cache locations.
  * Per-user build “slot” locking to bound concurrent build processes and reduce cross-build interference.

* **Documentation**
  * Clarified build-parallelism behavior and documented environment-variable overrides.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4369?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->