### PR TITLE
Add OMP agent integration

### DIFF
--- a/CLI/CMUXCLI+AgentHookDefinitions.swift
+++ b/CLI/CMUXCLI+AgentHookDefinitions.swift
@@ -164,6 +164,14 @@ extension CMUXCLI {
             events: []
         ),
         AgentHookDef(
+            name: "omp", displayName: "OMP", statusKey: "omp",
+            configDir: ".omp/agent", configFile: "extensions/cmux-session.ts", configDirEnvOverride: "PI_CODING_AGENT_DIR",
+            binaryName: "omp",
+            sessionStoreSuffix: "omp", disableEnvVar: "CMUX_OMP_HOOKS_DISABLED",
+            hookMarker: "cmux hooks omp", format: .flat,
+            events: []
+        ),
+        AgentHookDef(
             name: "amp", displayName: "Amp", statusKey: "amp",
             configDir: ".config/amp", configFile: "plugins/cmux-session.ts",
             sessionStoreSuffix: "amp", disableEnvVar: "CMUX_AMP_HOOKS_DISABLED",

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -9698,7 +9698,7 @@ struct CMUXCLI {
             agent. Claude Code hooks are injected automatically by the cmux Claude wrapper.
 
             Agents:
-              codex, grok, opencode, pi, amp, cursor, gemini, rovodev (alias: rovo), hermes-agent, copilot, codebuddy, factory, qoder
+              codex, grok, opencode, pi, omp, amp, cursor, gemini, rovodev (alias: rovo), hermes-agent, copilot, codebuddy, factory, qoder
 
             Hook targets:
               setup              Install hooks for all supported agents on PATH
@@ -9712,6 +9712,7 @@ struct CMUXCLI {
               ~/.config/opencode/plugins/cmux-session.js
               ~/.config/opencode/plugins/cmux-feed.js
               ~/.pi/agent/extensions/cmux-session.ts
+              ~/.omp/agent/extensions/cmux-session.ts
               ~/.config/amp/plugins/cmux-session.ts
               See docs/agent-hooks.md for the full integration matrix.
 
@@ -20939,10 +20940,176 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
 }
 """#
 
+    private static let ompExtensionMarker = "cmux-omp-session-extension-marker"
+    private static let ompExtensionFilename = "cmux-session.ts"
+    private static let ompExtensionSource = #"""
+// cmux-omp-session-extension-marker v1
+// Bridges OMP session lifecycle events into cmux's restorable session store.
+// Installed by `cmux hooks omp install` or `cmux hooks setup`.
+// DO NOT EDIT MANUALLY. cmux upgrades this file in place.
+
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { AgentEndEvent, ExtensionAPI, ExtensionContext } from "@oh-my-pi/pi-coding-agent";
+
+function firstString(...values: unknown[]): string | null {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim().length > 0) return value.trim();
+  }
+  return null;
+}
+
+function resolveExecutable(name: string): string {
+  const pathEnv = process.env.PATH || "";
+  for (const dir of pathEnv.split(path.delimiter)) {
+    if (!dir) continue;
+    const candidate = path.join(dir, name);
+    try {
+      fs.accessSync(candidate, fs.constants.X_OK);
+      return candidate;
+    } catch (_) {}
+  }
+  return name;
+}
+
+function looksLikeOmpExecutable(value: string): boolean {
+  const base = path.basename(value).toLowerCase();
+  return base === "omp";
+}
+
+function looksLikeOmpScript(value: string): boolean {
+  const normalized = value.replaceAll("\\", "/");
+  const base = path.basename(normalized).toLowerCase();
+  return (
+    normalized.includes("/@oh-my-pi/pi-coding-agent/") ||
+    normalized.includes("/packages/coding-agent/") ||
+    (base === "cli.js" && normalized.includes("pi-coding-agent")) ||
+    (base === "cli.ts" && normalized.includes("coding-agent"))
+  );
+}
+
+function normalizedLaunchArgv(): string[] {
+  const raw = Array.isArray(process.argv) ? process.argv.map((value) => String(value)) : [];
+  if (raw.length === 0) return [resolveExecutable("omp")];
+  if (looksLikeOmpExecutable(raw[0])) return raw;
+  if (raw.length > 1 && looksLikeOmpScript(raw[1])) {
+    return [resolveExecutable("omp"), ...raw.slice(2)];
+  }
+  return [resolveExecutable("omp"), ...raw.slice(1)];
+}
+
+function base64NulSeparated(values: string[]): string {
+  const bytes: Buffer[] = [];
+  for (const value of values) {
+    bytes.push(Buffer.from(String(value), "utf8"));
+    bytes.push(Buffer.from([0]));
+  }
+  return Buffer.concat(bytes).toString("base64");
+}
+
+function hookEnvironment(cwd: string): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  delete env.AMP_API_KEY;
+  if (!env.CMUX_AGENT_LAUNCH_ARGV_B64) {
+    const argv = normalizedLaunchArgv();
+    env.CMUX_AGENT_LAUNCH_KIND = "omp";
+    env.CMUX_AGENT_LAUNCH_EXECUTABLE = argv[0] || resolveExecutable("omp");
+    env.CMUX_AGENT_LAUNCH_ARGV_B64 = base64NulSeparated(argv);
+    env.CMUX_AGENT_LAUNCH_CWD = cwd || process.cwd();
+  }
+  return env;
+}
+
+function eventName(subcommand: string): string {
+  switch (subcommand) {
+    case "session-start":
+      return "SessionStart";
+    case "prompt-submit":
+      return "UserPromptSubmit";
+    case "stop":
+      return "Stop";
+    default:
+      return subcommand;
+  }
+}
+
+function textFromContent(content: unknown): string | null {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return null;
+  const parts: string[] = [];
+  for (const block of content) {
+    if (!block || typeof block !== "object") continue;
+    const typed = block as { type?: unknown; text?: unknown };
+    if (typed.type === "text" && typeof typed.text === "string") parts.push(typed.text);
+  }
+  return parts.join("\n") || null;
+}
+
+function lastAssistantMessage(event: AgentEndEvent): string | undefined {
+  for (let index = event.messages.length - 1; index >= 0; index -= 1) {
+    const message = event.messages[index];
+    if (!message || typeof message !== "object") continue;
+    const typed = message as { role?: unknown; content?: unknown };
+    if (typed.role !== "assistant") continue;
+    const text = firstString(textFromContent(typed.content));
+    if (text) return text;
+  }
+  return undefined;
+}
+
+function sendHook(subcommand: string, ctx: ExtensionContext, extra: Record<string, unknown> = {}): void {
+  if (process.env.CMUX_OMP_HOOKS_DISABLED === "1") return;
+  if (!process.env.CMUX_SURFACE_ID) return;
+
+  const sessionId = firstString(ctx.sessionManager.getSessionId());
+  if (!sessionId) return;
+
+  const cwd = firstString(ctx.cwd, process.cwd()) || process.cwd();
+  const payload: Record<string, unknown> = {
+    session_id: sessionId,
+    cwd,
+    hook_event_name: eventName(subcommand),
+    event: eventName(subcommand),
+    ...extra,
+  };
+  const cmux = process.env.CMUX_OMP_CMUX_BIN || "cmux";
+  try {
+    spawnSync(cmux, ["hooks", "omp", subcommand], {
+      input: JSON.stringify(payload),
+      encoding: "utf8",
+      env: hookEnvironment(cwd),
+      stdio: ["pipe", "ignore", "ignore"],
+      timeout: 5000,
+    });
+  } catch (_) {}
+}
+
+export default function cmuxOmpSessionExtension(omp: ExtensionAPI) {
+  omp.on("session_start", async (_event, ctx) => {
+    sendHook("session-start", ctx);
+  });
+
+  omp.on("before_agent_start", async (event, ctx) => {
+    sendHook("prompt-submit", ctx, { prompt: event.prompt });
+  });
+
+  omp.on("agent_end", async (event, ctx) => {
+    sendHook("stop", ctx, { last_assistant_message: lastAssistantMessage(event) });
+  });
+}
+"""#
+
     private func piExtensionURL(for def: AgentHookDef) -> URL {
         URL(fileURLWithPath: def.resolvedConfigDir(), isDirectory: true)
             .appendingPathComponent("extensions", isDirectory: true)
             .appendingPathComponent(Self.piExtensionFilename, isDirectory: false)
+    }
+
+    private func ompExtensionURL(for def: AgentHookDef) -> URL {
+        URL(fileURLWithPath: def.resolvedConfigDir(), isDirectory: true)
+            .appendingPathComponent("extensions", isDirectory: true)
+            .appendingPathComponent(Self.ompExtensionFilename, isDirectory: false)
     }
 
     private func installPiExtensionHooks(_ def: AgentHookDef) throws {
@@ -20978,6 +21145,39 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
         print("Pi hooks installed at \(extensionURL.path)")
     }
 
+    private func installOmpExtensionHooks(_ def: AgentHookDef) throws {
+        let extensionURL = ompExtensionURL(for: def)
+        let skipConfirm = ProcessInfo.processInfo.arguments.contains("--yes")
+            || ProcessInfo.processInfo.arguments.contains("-y")
+        let existing = (try? String(contentsOf: extensionURL, encoding: .utf8)) ?? ""
+        if existing == Self.ompExtensionSource {
+            print("OMP hooks already up to date at \(extensionURL.path)")
+            return
+        }
+        if !existing.isEmpty, !existing.contains(Self.ompExtensionMarker) {
+            throw CLIError(message: "\(extensionURL.path) exists and is not a cmux extension; leaving it alone")
+        }
+        if !skipConfirm {
+            Self.printInstallPreview(
+                path: extensionURL.path,
+                oldContent: existing,
+                newContent: Self.ompExtensionSource,
+                fallbackContent: Self.ompExtensionSource
+            )
+            print("\nProceed? [y/N] ", terminator: "")
+            guard readLine()?.lowercased().hasPrefix("y") == true else {
+                print("Aborted.")
+                return
+            }
+        }
+        try FileManager.default.createDirectory(
+            at: extensionURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Self.ompExtensionSource.write(to: extensionURL, atomically: true, encoding: .utf8)
+        print("OMP hooks installed at \(extensionURL.path)")
+    }
+
     private func uninstallPiExtensionHooks(_ def: AgentHookDef) throws {
         let extensionURL = piExtensionURL(for: def)
         let fm = FileManager.default
@@ -20992,6 +21192,22 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
         }
         try fm.removeItem(at: extensionURL)
         print("Removed Pi cmux extension from \(extensionURL.path)")
+    }
+
+    private func uninstallOmpExtensionHooks(_ def: AgentHookDef) throws {
+        let extensionURL = ompExtensionURL(for: def)
+        let fm = FileManager.default
+        guard fm.fileExists(atPath: extensionURL.path) else {
+            print("No OMP cmux extension found at \(extensionURL.path)")
+            return
+        }
+        let existing = (try? String(contentsOf: extensionURL, encoding: .utf8)) ?? ""
+        guard existing.contains(Self.ompExtensionMarker) else {
+            print("Refusing to remove \(extensionURL.path): missing cmux marker")
+            return
+        }
+        try fm.removeItem(at: extensionURL)
+        print("Removed OMP cmux extension from \(extensionURL.path)")
     }
 
     private func installRovoDevHooks(_ def: AgentHookDef) throws {
@@ -21084,6 +21300,10 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
         }
         if def.name == "pi" {
             try installPiExtensionHooks(def)
+            return
+        }
+        if def.name == "omp" {
+            try installOmpExtensionHooks(def)
             return
         }
         if def.name == "amp" {
@@ -21416,6 +21636,10 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
         }
         if def.name == "pi" {
             try uninstallPiExtensionHooks(def)
+            return
+        }
+        if def.name == "omp" {
+            try uninstallOmpExtensionHooks(def)
             return
         }
         if def.name == "amp" {
@@ -25695,7 +25919,7 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
         for def in Self.agentDefs {
             if let agentFilterDef, agentFilterDef.name != def.name { continue }
             let configDir = def.resolvedConfigDir()
-            let canUseMissingConfigDir = def.name == "opencode" || def.name == "pi" || def.name == "amp" || (!isUninstall && def.name == "rovodev")
+            let canUseMissingConfigDir = def.name == "opencode" || def.name == "pi" || def.name == "omp" || def.name == "amp" || (!isUninstall && def.name == "rovodev")
             if !canUseMissingConfigDir, !fm.fileExists(atPath: configDir) {
                 print("  \(def.name): skipped (config dir not found)")
                 skipped += 1

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ cmux hooks setup --agent opencode
 
 `cmux hooks setup` installs supported agents it can find and prints a summary
 for skipped agents. Supported resume integrations include Claude Code, Codex,
-Grok, OpenCode, Pi, Amp, Cursor CLI, Gemini, Rovo Dev, Copilot, CodeBuddy,
+Grok, OpenCode, Pi, OMP, Amp, Cursor CLI, Gemini, Rovo Dev, Copilot, CodeBuddy,
 Factory, and Qoder. Claude Code is handled by the cmux Claude wrapper when Claude
 integration is enabled in Settings.
 

--- a/Sources/TaskManagerTypes.swift
+++ b/Sources/TaskManagerTypes.swift
@@ -409,6 +409,14 @@ struct CmuxTaskManagerCodingAgentDefinition: Equatable {
             argumentNeedles: ["opencode", "opencode-ai", "open-code", "oh-my-openagent"]
         ),
         CmuxTaskManagerCodingAgentDefinition(
+            id: "omp",
+            displayName: "OMP",
+            assetName: nil,
+            launchKinds: ["omp"],
+            directBasenames: ["omp"],
+            argumentNeedles: ["@oh-my-pi/pi-coding-agent"]
+        ),
+        CmuxTaskManagerCodingAgentDefinition(
             id: "pi",
             displayName: "Pi",
             assetName: "AgentIcons/Pi",

--- a/Sources/VaultAgentRegistry.swift
+++ b/Sources/VaultAgentRegistry.swift
@@ -121,6 +121,18 @@ struct CmuxVaultAgentRegistration: Codable, Hashable, Sendable {
             sessionDirectory: "~/.pi/agent/sessions"
         )
     }
+
+    static var builtInOmp: CmuxVaultAgentRegistration {
+        CmuxVaultAgentRegistration(
+            id: "omp",
+            name: "OMP",
+            detect: CmuxVaultAgentDetectRule(processName: "omp", argvContains: ["omp", "@oh-my-pi/pi-coding-agent"]),
+            sessionIdSource: .piSessionFile,
+            resumeCommand: "{{executable}} --session {{sessionId}}",
+            cwd: .preserve,
+            sessionDirectory: "~/.omp/agent/sessions"
+        )
+    }
 }
 
 struct CmuxVaultAgentDetectRule: Codable, Hashable, Sendable {
@@ -301,7 +313,10 @@ struct CmuxVaultAgentRegistry: Sendable {
         environment: [String: String] = ProcessInfo.processInfo.environment,
         fileManager: FileManager = .default
     ) -> CmuxVaultAgentRegistry {
-        var registrations = [CmuxVaultAgentRegistration.builtInPi]
+        var registrations = [
+            CmuxVaultAgentRegistration.builtInPi,
+            CmuxVaultAgentRegistration.builtInOmp,
+        ]
         for path in configPaths(homeDirectory: homeDirectory, workingDirectory: workingDirectory, environment: environment, fileManager: fileManager) {
             guard let config = decodeConfig(at: path, fileManager: fileManager) else { continue }
             registrations.append(contentsOf: config.vault?.agents ?? [])

--- a/cmuxTests/PiVaultAgentPersistenceTests.swift
+++ b/cmuxTests/PiVaultAgentPersistenceTests.swift
@@ -68,6 +68,17 @@ final class PiVaultAgentPersistenceTests: XCTestCase {
         XCTAssertEqual(SessionAgent.registered(agent).assetName, "AgentIcons/Pi")
     }
 
+    func testBuiltInOmpRegistrationUsesOmpSessionDefaults() {
+        let registration = CmuxVaultAgentRegistration.builtInOmp
+
+        XCTAssertEqual(registration.id, "omp")
+        XCTAssertEqual(registration.name, "OMP")
+        XCTAssertEqual(registration.detect.processName, "omp")
+        XCTAssertEqual(registration.sessionIdSource, .piSessionFile)
+        XCTAssertEqual(registration.resumeCommand, "{{executable}} --session {{sessionId}}")
+        XCTAssertEqual(registration.sessionDirectory, "~/.omp/agent/sessions")
+    }
+
     func testRegisteredAgentTemplateFailsClosedWhenPlaceholderIsUnavailable() {
         let registration = CmuxVaultAgentRegistration(
             id: "acme-agent",

--- a/cmuxTests/TaskManagerResourcesTests.swift
+++ b/cmuxTests/TaskManagerResourcesTests.swift
@@ -535,6 +535,15 @@ final class TaskManagerResourcesTests: XCTestCase {
             )?.id,
             "codex"
         )
+        XCTAssertEqual(
+            CmuxTaskManagerCodingAgentDefinition.matchingDefinition(
+                processName: "node",
+                processPath: nil,
+                arguments: ["node", "/usr/local/lib/node_modules/@oh-my-pi/pi-coding-agent/src/cli.ts"],
+                environment: [:]
+            )?.id,
+            "omp"
+        )
     }
 
     func testCodingAgentMatcherCoversSupportedAgentExecutableNames() {
@@ -544,6 +553,7 @@ final class TaskManagerResourcesTests: XCTestCase {
             ("opencode", "opencode"),
             ("pi", "pi"),
             ("pi-coding-agent", "pi"),
+            ("omp", "omp"),
             ("amp", "amp"),
             ("cursor-agent", "cursor"),
             ("gemini", "gemini"),

--- a/docs/agent-hooks.md
+++ b/docs/agent-hooks.md
@@ -11,7 +11,7 @@ cmux hooks setup --agent <agent>
 cmux hooks uninstall <agent>
 ```
 
-Supported agent names are `codex`, `grok`, `opencode`, `pi`, `amp`, `cursor`, `gemini`, `rovodev` (or `rovo`), `copilot`, `codebuddy`, `factory`, and `qoder`. `cmux hooks setup` skips agents whose binary is not on `PATH` and prints a summary.
+Supported agent names are `codex`, `grok`, `opencode`, `pi`, `omp`, `amp`, `cursor`, `gemini`, `rovodev` (or `rovo`), `copilot`, `codebuddy`, `factory`, and `qoder`. `cmux hooks setup` skips agents whose binary is not on `PATH` and prints a summary.
 
 ## Integrations
 
@@ -22,6 +22,7 @@ Supported agent names are `codex`, `grok`, `opencode`, `pi`, `amp`, `cursor`, `g
 | Grok | `grok` | `~/.grok/hooks/cmux-session.json` | `grok -r <id>` | PreToolUse |
 | OpenCode | `opencode` | `~/.config/opencode/plugins/cmux-session.js`, `~/.config/opencode/plugins/cmux-feed.js` | `opencode --session <id>` | plugin event bus |
 | Pi | `pi` | `~/.pi/agent/extensions/cmux-session.ts` | `pi --session <id>` | none |
+| OMP | `omp` | `~/.omp/agent/extensions/cmux-session.ts` | `omp --session <id>` | none |
 | Amp | `amp` | `~/.config/amp/plugins/cmux-session.ts` | `amp threads continue <id>` | none |
 | Cursor CLI | `cursor-agent` | `~/.cursor/hooks.json` | `cursor-agent --resume <id>` | beforeShellExecution |
 | Gemini | `gemini` | `~/.gemini/settings.json` | `gemini --resume <id>` | PreToolUse |

--- a/docs/feed.md
+++ b/docs/feed.md
@@ -85,6 +85,7 @@ Installs supported agent hooks whose binaries are on `PATH`. See [Agent hook int
 | Factory      | `~/.factory/settings.json`                | PreToolUse               |
 | Qoder        | `~/.qoder/settings.json`                  | PreToolUse               |
 | Pi           | `~/.pi/agent/extensions/cmux-session.ts`  | lifecycle only           |
+| OMP          | `~/.omp/agent/extensions/cmux-session.ts` | lifecycle only           |
 | Rovo Dev     | `~/.rovodev/config.yml`                   | lifecycle only           |
 
 Individual agents:

--- a/docs/vault.md
+++ b/docs/vault.md
@@ -51,8 +51,8 @@ For a generic agent that exposes the current session as an argv option:
 ```
 
 Supported `resumeCommand` placeholders are `{{sessionId}}`, `{{sessionPath}}`,
-`{{executable}}`, `{{cwd}}`, and `{{sessionDir}}`. Pi uses `pi --session <id-or-path>`
-instead of `pi --continue` so Vault reopens the exact saved session.
+`{{executable}}`, `{{cwd}}`, and `{{sessionDir}}`. Pi and OMP use
+`<binary> --session <id-or-path>` so Vault reopens the exact saved session.
 `resumeCommand` must include either `{{sessionId}}` or `{{sessionPath}}`, for
 example `pi --session {{sessionId}}`.
 

--- a/tests/test_omp_extension_install.py
+++ b/tests/test_omp_extension_install.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""
+Regression test: the generated OMP extension is importable and emits cmux hook calls.
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+from claude_teams_test_utils import resolve_cmux_cli
+
+
+def make_executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def main() -> int:
+    bun = shutil.which("bun")
+    if bun is None:
+        print("SKIP: bun not found")
+        return 0
+
+    try:
+        cli_path = resolve_cmux_cli()
+    except Exception as exc:
+        print(f"FAIL: {exc}")
+        return 1
+
+    with tempfile.TemporaryDirectory(prefix="cmux-omp-extension-") as td:
+        root = Path(td)
+        config_dir = root / "omp-agent"
+        env = os.environ.copy()
+        env["PI_CODING_AGENT_DIR"] = str(config_dir)
+
+        install = subprocess.run(
+            [cli_path, "hooks", "omp", "install", "--yes"],
+            capture_output=True,
+            text=True,
+            check=False,
+            env=env,
+            timeout=20,
+        )
+        if install.returncode != 0:
+            print("FAIL: omp extension install failed")
+            print(f"exit={install.returncode}")
+            print(f"stdout={install.stdout.strip()}")
+            print(f"stderr={install.stderr.strip()}")
+            return 1
+
+        extension_path = config_dir / "extensions" / "cmux-session.ts"
+        if not extension_path.exists():
+            print(f"FAIL: expected extension at {extension_path}")
+            return 1
+        extension_text = extension_path.read_text(encoding="utf-8")
+        if "cmux-omp-session-extension-marker" not in extension_text:
+            print(f"FAIL: expected cmux marker in {extension_path}")
+            return 1
+
+        fake_cmux = root / "fake-cmux"
+        fake_args_log = root / "fake-cmux-args.log"
+        fake_stdin_log = root / "fake-cmux-stdin.log"
+        fake_env_log = root / "fake-cmux-env.log"
+        make_executable(
+            fake_cmux,
+            """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$FAKE_CMUX_ARGS_LOG"
+cat >> "$FAKE_CMUX_STDIN_LOG"
+printf '\n---\n' >> "$FAKE_CMUX_STDIN_LOG"
+{
+  printf 'kind=%s\n' "${CMUX_AGENT_LAUNCH_KIND-}"
+  printf 'cwd=%s\n' "${CMUX_AGENT_LAUNCH_CWD-}"
+  printf 'argv=%s\n' "${CMUX_AGENT_LAUNCH_ARGV_B64-}"
+} >> "$FAKE_CMUX_ENV_LOG"
+""",
+        )
+
+        check_env = env.copy()
+        check_env["CMUX_TEST_OMP_EXTENSION_PATH"] = str(extension_path)
+        check_env["CMUX_SURFACE_ID"] = "surface-omp-test"
+        check_env["CMUX_OMP_CMUX_BIN"] = str(fake_cmux)
+        check_env["FAKE_CMUX_ARGS_LOG"] = str(fake_args_log)
+        check_env["FAKE_CMUX_STDIN_LOG"] = str(fake_stdin_log)
+        check_env["FAKE_CMUX_ENV_LOG"] = str(fake_env_log)
+        check_source = """
+const extensionPath = process.env.CMUX_TEST_OMP_EXTENSION_PATH;
+const mod = await import(extensionPath);
+if (typeof mod.default !== "function") throw new Error("missing default export");
+const handlers = new Map();
+mod.default({
+  on(name, handler) {
+    handlers.set(name, handler);
+  }
+});
+for (const name of ["session_start", "before_agent_start", "agent_end"]) {
+  if (typeof handlers.get(name) !== "function") throw new Error(`missing ${name}`);
+}
+process.argv.splice(
+  0,
+  process.argv.length,
+  "/Users/example/.bun/bin/omp",
+  "--model",
+  "anthropic/claude-sonnet-4-5"
+);
+const ctx = {
+  cwd: "/tmp/omp-project",
+  sessionManager: {
+    getSessionId() { return "omp-session-test"; }
+  }
+};
+await handlers.get("session_start")({}, ctx);
+await handlers.get("before_agent_start")({ prompt: "hello omp" }, ctx);
+await handlers.get("agent_end")({
+  messages: [
+    { role: "user", content: "hello omp" },
+    { role: "assistant", content: [{ type: "text", text: "done" }] }
+  ],
+  stopReason: "completed"
+}, ctx);
+"""
+        check = subprocess.run(
+            [bun, "--eval", check_source],
+            cwd=root,
+            capture_output=True,
+            text=True,
+            check=False,
+            env=check_env,
+            timeout=20,
+        )
+        if check.returncode != 0:
+            print("FAIL: generated OMP extension is not importable")
+            print(f"exit={check.returncode}")
+            print(f"stdout={check.stdout.strip()}")
+            print(f"stderr={check.stderr.strip()}")
+            return 1
+
+        args_log = fake_args_log.read_text(encoding="utf-8") if fake_args_log.exists() else ""
+        stdin_log = fake_stdin_log.read_text(encoding="utf-8") if fake_stdin_log.exists() else ""
+        env_log = fake_env_log.read_text(encoding="utf-8") if fake_env_log.exists() else ""
+        for expected in [
+            "hooks omp session-start",
+            "hooks omp prompt-submit",
+            "hooks omp stop",
+        ]:
+            if expected not in args_log:
+                print(f"FAIL: extension did not invoke {expected}, got {args_log!r}")
+                return 1
+        if '"session_id":"omp-session-test"' not in stdin_log:
+            print(f"FAIL: extension did not pass session id, got {stdin_log!r}")
+            return 1
+        if '"prompt":"hello omp"' not in stdin_log or '"last_assistant_message":"done"' not in stdin_log:
+            print(f"FAIL: extension did not pass prompt/assistant payload, got {stdin_log!r}")
+            return 1
+        if "kind=omp" not in env_log or "cwd=/tmp/omp-project" not in env_log or "argv=" not in env_log:
+            print(f"FAIL: extension did not pass launch metadata environment, got {env_log!r}")
+            return 1
+        argv_line = next((line for line in env_log.splitlines() if line.startswith("argv=")), "")
+        try:
+            decoded_argv = [
+                value
+                for value in base64.b64decode(argv_line.removeprefix("argv=")).decode("utf-8").split("\0")
+                if value
+            ]
+        except Exception as exc:
+            print(f"FAIL: extension launch argv was not valid base64 NUL data: {exc}; env={env_log!r}")
+            return 1
+        expected_argv = [
+            "/Users/example/.bun/bin/omp",
+            "--model",
+            "anthropic/claude-sonnet-4-5",
+        ]
+        if decoded_argv != expected_argv:
+            print(f"FAIL: extension captured wrong OMP launch argv; expected {expected_argv!r}, got {decoded_argv!r}")
+            return 1
+
+    print("PASS: generated OMP extension installs and emits cmux hooks")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/web/app/[locale]/docs/session-restore/page.tsx
+++ b/web/app/[locale]/docs/session-restore/page.tsx
@@ -88,6 +88,12 @@ cmux surface resume clear --checkpoint work`}</CodeBlock>
             <td>{t("none")}</td>
           </tr>
           <tr>
+            <td>OMP</td>
+            <td><code>omp</code></td>
+            <td><code>omp --session &lt;id&gt;</code></td>
+            <td>{t("none")}</td>
+          </tr>
+          <tr>
             <td>Amp</td>
             <td><code>amp</code></td>
             <td><code>amp threads continue &lt;id&gt;</code></td>

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -158,7 +158,7 @@
         "baselineItemScrollback": "Terminal scrollback, best effort",
         "baselineItemBrowser": "Browser URL and navigation history",
         "agentTitle": "Agent sessions need hooks",
-        "agentP": "Claude Code, Codex, OpenCode, Pi, Amp, Cursor CLI, Gemini, Rovo Dev, Copilot, CodeBuddy, Factory, and Qoder can resume when cmux has a native session ID. For most agents, install the integration with <code>cmux hooks setup</code>.",
+        "agentP": "Claude Code, Codex, OpenCode, Pi, OMP, Amp, Cursor CLI, Gemini, Rovo Dev, Copilot, CodeBuddy, Factory, and Qoder can resume when cmux has a native session ID. For most agents, install the integration with <code>cmux hooks setup</code>.",
         "agentP2": "The setup command installs supported agents whose binaries are on PATH and skips the rest. Claude Code is handled by the cmux Claude wrapper when Claude integration is enabled in Settings.",
         "implementationTitle": "How it works",
         "implementationP1": "cmux writes a JSON session snapshot under Application Support with the window tree, workspace metadata, pane layout, terminal cwd, scrollback replay data, and browser navigation state.",


### PR DESCRIPTION
Summary:
- add an `omp` hook target that installs a cmux session extension under `~/.omp/agent/extensions`
- bridge OMP lifecycle events into cmux session restore using `omp --session <id>`
- add task manager detection, Vault registration, docs, and focused regression coverage

Testing:
- `git diff --check`
- `python3 -m py_compile tests/test_omp_extension_install.py tests/test_pi_extension_install.py`
- `swiftc -parse CLI/cmux.swift CLI/CMUXCLI+AgentHookDefinitions.swift Sources/VaultAgentRegistry.swift Sources/TaskManagerTypes.swift cmuxTests/PiVaultAgentPersistenceTests.swift cmuxTests/TaskManagerResourcesTests.swift`

Not run:
- full xcodebuild suite, because this local environment only has Command Line Tools selected, not full Xcode
- generated extension smoke test, because this fresh clone has no built cmux CLI recorded

Contribution note:
- I read CONTRIBUTING.md and understand the GPL-3.0-or-later and additional contribution license terms.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OMP agent integration so cmux can capture session IDs, resume OMP sessions with Vault, and install a native OMP session hook. This enables `omp --session <id>` restore and brings OMP parity with Pi.

- **New Features**
  - Added `omp` hook target that installs `~/.omp/agent/extensions/cmux-session.ts`.
  - Bridged OMP lifecycle events to `cmux hooks omp {session-start,prompt-submit,stop}` and captured launch metadata via `CMUX_AGENT_LAUNCH_*` (disable with `CMUX_OMP_HOOKS_DISABLED=1`). Uses `@oh-my-pi/pi-coding-agent` types.
  - Added task manager detection for OMP (process `omp`, argv contains `@oh-my-pi/pi-coding-agent`).
  - Registered OMP in Vault with `omp --session {{sessionId}}` and `~/.omp/agent/sessions`.
  - Updated docs/UI to list OMP integration and added targeted tests for extension install and resume flow.

- **Migration**
  - Install: `cmux hooks setup` or `cmux hooks omp install --yes`. Uninstall: `cmux hooks omp uninstall`.
  - Optional: set `PI_CODING_AGENT_DIR` to override the OMP config dir.

<sup>Written for commit 2588b6ee5deeb518d13d773ff2d5b2872d710660. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4379?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added OMP as a supported coding agent with integration for cmux hooks, enabling automatic session lifecycle tracking across session start, agent activity, and session end events.
  * Extended session restore functionality to recognize and restore OMP coding sessions using native cmux session IDs.

* **Documentation**
  * Updated agent integration documentation to include OMP configuration paths, resume commands, and hook installation procedures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4379?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->