### PR TITLE
Fix .ts files opening as media player in file preview

### DIFF
--- a/Sources/Panels/FilePreviewPanel.swift
+++ b/Sources/Panels/FilePreviewPanel.swift
@@ -709,6 +709,10 @@ enum FilePreviewKindResolver {
 
     private static func initialResolution(for url: URL) -> Resolution {
         let ext = url.pathExtension.lowercased()
+        if knownTextFile(url: url, includeResourceContentType: false) {
+            return .resolved(.text)
+        }
+
         if let type = UTType(filenameExtension: ext),
            let mediaMode = mediaMode(for: type) {
             return .resolved(mediaMode)
@@ -716,10 +720,6 @@ enum FilePreviewKindResolver {
 
         if ext == "plist" {
             return .needsSniff
-        }
-
-        if knownTextFile(url: url, includeResourceContentType: false) {
-            return .resolved(.text)
         }
 
         return .needsSniff
@@ -731,14 +731,14 @@ enum FilePreviewKindResolver {
             return .resolved(.quickLook)
         }
 
+        if knownTextFile(url: url, includeResourceContentType: true) {
+            return .resolved(.text)
+        }
+
         for type in contentTypes(for: url) {
             if let mediaMode = mediaMode(for: type) {
                 return .resolved(mediaMode)
             }
-        }
-
-        if knownTextFile(url: url, includeResourceContentType: true) {
-            return .resolved(.text)
         }
 
         return .needsSniff

--- a/Sources/Panels/FilePreviewPanel.swift
+++ b/Sources/Panels/FilePreviewPanel.swift
@@ -709,6 +709,10 @@ enum FilePreviewKindResolver {
 
     private static func initialResolution(for url: URL) -> Resolution {
         let ext = url.pathExtension.lowercased()
+        if ext == "plist" {
+            return .needsSniff
+        }
+
         if knownTextFile(url: url, includeResourceContentType: false) {
             return .resolved(.text)
         }
@@ -716,10 +720,6 @@ enum FilePreviewKindResolver {
         if let type = UTType(filenameExtension: ext),
            let mediaMode = mediaMode(for: type) {
             return .resolved(mediaMode)
-        }
-
-        if ext == "plist" {
-            return .needsSniff
         }
 
         return .needsSniff

--- a/cmuxTests/WindowAndDragTests.swift
+++ b/cmuxTests/WindowAndDragTests.swift
@@ -2585,6 +2585,19 @@ final class FilePreviewPanelTextSavingTests: XCTestCase {
         XCTAssertEqual(FilePreviewKindResolver.tabIconName(for: url), "doc.richtext")
     }
 
+    func testTypeScriptExtensionResolvesToTextNotMediaPlayer() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("ts")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        try Data("export const greeting: string = \"hi\"\n".utf8).write(to: url)
+
+        XCTAssertEqual(FilePreviewKindResolver.initialMode(for: url), .text)
+        XCTAssertEqual(FilePreviewKindResolver.mode(for: url), .text)
+        XCTAssertEqual(FilePreviewKindResolver.tabIconName(for: url), "doc.text")
+    }
+
     func testUTF16TextWithBOMStillResolvesAsText() throws {
         let url = try temporaryTextFile(contents: "hello", encoding: .utf16)
         defer { try? FileManager.default.removeItem(at: url) }


### PR DESCRIPTION
## Summary
- `.ts` (TypeScript) files were opening in the AVPlayer-backed media preview instead of the text editor
- On macOS, `UTType(filenameExtension: "ts")` resolves to `public.mpeg-2-transport-stream`, which conforms to `.movie`. `FilePreviewKindResolver` was checking media UTType conformance *before* consulting its own text-extension allowlist (which does contain `"ts"`), so the media branch always won
- Reordered both `initialResolution` and `resolvedResolution` in `Sources/Panels/FilePreviewPanel.swift` so the explicit text-file allowlist wins over UTType-based media classification

Two-commit structure per the regression test policy: commit 1 adds the failing test, commit 2 applies the fix.

## Test plan
- [ ] CI: `testTypeScriptExtensionResolvesToTextNotMediaPlayer` red on commit 1, green on commit 2
- [ ] Manually open a `.ts` file in the cmux file preview and confirm it opens in the text editor with the `doc.text` icon
- [ ] Open a real `.mov`/`.mp4` and confirm media playback still works
- [ ] Open a binary `.plist` and confirm it still routes to QuickLook (not text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `.ts` files opening in the media player by prioritizing the text extension allowlist over UTType-based media detection. TypeScript files now open in the text editor; preserves QuickLook for binary `plist` files and media behavior is unchanged.

- **Bug Fixes**
  - Reordered resolution in `FilePreviewPanel.swift`: `plist` check first, then `knownTextFile(...)`, then media UTType in the appropriate paths.
  - Added regression test `testTypeScriptExtensionResolvesToTextNotMedia`.

<sup>Written for commit 7f75b05b982d3f31cd3ecba06953fb205f38efab. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4380?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file preview classification so text-based files (e.g., TypeScript) are recognized and opened as text rather than media; adjusted detection precedence to favor text in ambiguous cases.
* **Tests**
  * Added a unit test ensuring TypeScript files resolve to text preview and show the correct text icon.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4380?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->