### PR TITLE
Fix Option dead-key accent composition

### DIFF
--- a/Sources/GhosttyNSView+IMEComposition.swift
+++ b/Sources/GhosttyNSView+IMEComposition.swift
@@ -140,6 +140,49 @@ extension GhosttyNSView {
         return flags.isEmpty || flags == [.shift]
     }
 
+    /// When `macos-option-as-alt` strips Option for terminal fallback encoding,
+    /// AppKit still needs the original Option event for dead-key composition
+    /// (`Option+n` then `a` -> `ã`). Use the original event only for text
+    /// interpretation; Ghostty fallback continues to use the translated event.
+    func textInputInterpretationEvent(original event: NSEvent, translated translationEvent: NSEvent) -> NSEvent {
+        shouldPreserveOriginalOptionDeadKeyEvent(
+            original: event,
+            translated: translationEvent
+        ) ? event : translationEvent
+    }
+
+    private func shouldPreserveOriginalOptionDeadKeyEvent(
+        original event: NSEvent,
+        translated translationEvent: NSEvent
+    ) -> Bool {
+        let originalFlags = textInputRelevantFlags(event.modifierFlags)
+        let translatedFlags = textInputRelevantFlags(translationEvent.modifierFlags)
+
+        guard originalFlags.contains(.option),
+              !translatedFlags.contains(.option),
+              !originalFlags.contains(.command),
+              !originalFlags.contains(.control) else {
+            return false
+        }
+
+        guard (event.characters ?? "").isEmpty,
+              let unmodifiedText = event.charactersIgnoringModifiers,
+              unmodifiedText.count == 1,
+              let scalar = unmodifiedText.unicodeScalars.first else {
+            return false
+        }
+
+        return scalar.value >= 0x20
+            && scalar.value != 0x7F
+            && !(0xF700...0xF8FF).contains(scalar.value)
+    }
+
+    private func textInputRelevantFlags(_ flags: NSEvent.ModifierFlags) -> NSEvent.ModifierFlags {
+        flags
+            .intersection(.deviceIndependentFlagsMask)
+            .subtracting([.numericPad, .function, .capsLock])
+    }
+
     func shouldBufferBopomofoInsertedPreedit(_ text: String, inputSourceId: String? = nil) -> Bool {
         guard !text.isEmpty else { return false }
         guard isBopomofoInputSource(inputSourceId ?? KeyboardLayout.id) else { return false }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -8218,6 +8218,10 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                 keyCode: event.keyCode
             ) ?? event
         }
+        let textInputEvent = textInputInterpretationEvent(
+            original: event,
+            translated: translationEvent
+        )
 
         // Set up text accumulator for interpretKeyEvents
         keyTextAccumulator = []
@@ -8235,7 +8239,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         let interpretTimingStart = CmuxTypingTiming.start()
         let interpretPhaseStart = ProcessInfo.processInfo.systemUptime
 #endif
-        interpretKeyEvents([translationEvent])
+        interpretKeyEvents([textInputEvent])
 #if DEBUG
         interpretMs = (ProcessInfo.processInfo.systemUptime - interpretPhaseStart) * 1000.0
         CmuxTypingTiming.logDuration(
@@ -8273,7 +8277,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             before: markedStateBefore,
             after: (markedText.string, markedSelectedRange),
             accumulatedText: accumulatedText,
-            event: event,
+            event: textInputEvent,
             inputSourceId: keyboardIdBefore
         ) {
             imeConsumedKeyUps.insert(event.keyCode)
@@ -8353,7 +8357,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             }
 
             if shouldSendCommittedIMEConfirmKey(
-                event: translationEvent,
+                event: textInputEvent,
                 markedTextBefore: markedTextBefore
             ) {
                 keyEvent.consumed_mods = GHOSTTY_MODS_NONE

--- a/cmuxTests/CJKIMEInputTests.swift
+++ b/cmuxTests/CJKIMEInputTests.swift
@@ -2127,6 +2127,131 @@ final class GhosttyKeyEquivalentRegressionTests: XCTestCase {
 }
 
 @MainActor
+final class DeadKeyCompositionRegressionTests: XCTestCase {
+    func testOptionTildeDeadKeyUsesOriginalEventBeforeAltTranslation() {
+        _ = NSApplication.shared
+
+        let surface = TerminalSurface(
+            tabId: UUID(),
+            context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
+            configTemplate: nil,
+            workingDirectory: nil
+        )
+        let hostedView = surface.hostedView
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 360, height: 240),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        let previousInterpretHook = cjkIMEInterpretKeyEventsHook
+        defer {
+            GhosttyNSView.debugGhosttySurfaceKeyEventObserver = nil
+            cjkIMEInterpretKeyEventsHook = previousInterpretHook
+            window.orderOut(nil)
+        }
+
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+        hostedView.frame = contentView.bounds
+        hostedView.autoresizingMask = [.width, .height]
+        contentView.addSubview(hostedView)
+
+        window.makeKeyAndOrderFront(nil)
+        window.displayIfNeeded()
+        contentView.layoutSubtreeIfNeeded()
+        hostedView.setVisibleInUI(true)
+        hostedView.setActive(true)
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+
+        guard let view = findGhosttyNSView(in: hostedView) else {
+            XCTFail("Expected hosted GhosttyNSView")
+            return
+        }
+
+        var deadKeyPrimed = false
+        installCJKIMEInterpretKeyEventsSwizzle()
+        cjkIMEInterpretKeyEventsHook = { candidateView, events in
+            guard candidateView === view,
+                  let event = events.first else { return false }
+
+            let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+            if event.keyCode == 45,
+               flags.contains(.option),
+               !flags.contains(.command),
+               !flags.contains(.control),
+               (event.characters ?? "").isEmpty {
+                deadKeyPrimed = true
+                candidateView.setMarkedText(
+                    "~",
+                    selectedRange: NSRange(location: 1, length: 0),
+                    replacementRange: NSRange(location: NSNotFound, length: 0)
+                )
+                return true
+            }
+
+            if event.keyCode == 0, deadKeyPrimed, candidateView.hasMarkedText() {
+                candidateView.insertText("ã", replacementRange: NSRange(location: NSNotFound, length: 0))
+                return true
+            }
+
+            return false
+        }
+
+        var pressedText: [String] = []
+        var pressedKeycodes: [UInt32] = []
+        GhosttyNSView.debugGhosttySurfaceKeyEventObserver = { keyEvent in
+            guard keyEvent.action == GHOSTTY_ACTION_PRESS else { return }
+            if let text = keyEvent.text {
+                pressedText.append(String(cString: text))
+            } else {
+                pressedKeycodes.append(keyEvent.keycode)
+            }
+        }
+
+        guard let optionN = NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.option],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: window.windowNumber,
+            context: nil,
+            characters: "",
+            charactersIgnoringModifiers: "n",
+            isARepeat: false,
+            keyCode: 45
+        ), let aKey = NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [],
+            timestamp: ProcessInfo.processInfo.systemUptime + 0.01,
+            windowNumber: window.windowNumber,
+            context: nil,
+            characters: "a",
+            charactersIgnoringModifiers: "a",
+            isARepeat: false,
+            keyCode: 0
+        ) else {
+            XCTFail("Failed to create dead-key events")
+            return
+        }
+
+        window.makeFirstResponder(view)
+        withExtendedLifetime(surface) {
+            view.keyDown(with: optionN)
+            view.keyDown(with: aKey)
+        }
+
+        XCTAssertEqual(pressedText, ["ã"])
+        XCTAssertEqual(pressedKeycodes, [], "Dead-key composition should not leak raw Alt-N key events")
+        XCTAssertFalse(view.hasMarkedText(), "Composition should clear after the composed character commits")
+    }
+}
+
+@MainActor
 final class GhosttyOptionDeleteRegressionTests: XCTestCase {
     func testOptionDeletePreservesAltAsModifierForWordDelete() {
         _ = NSApplication.shared


### PR DESCRIPTION
## Summary
- Preserve the original Option-modified key event for AppKit text interpretation when Ghostty's option-as-alt translation would otherwise strip Option from a possible dead-key starter.
- Keep Ghostty fallback encoding on the translated event so non-composing Alt key behavior is unchanged.
- Add a regression that drives the terminal keyDown path for Option+n followed by a and expects the composed `ã` commit without leaking raw Alt-N.

Fixes #4377.

## Verification
- Reproduced the pre-fix failure locally on an isolated tagged build from commit `6743285cf` (`issue-4377-before-deadkeys`): `echo ` + `Option+n` + `a` rendered plain `a` instead of `ã`.
- Built and launched the current branch with `CMUX_SKIP_ZIG_BUILD=1 ./scripts/reload.sh --tag issue-4377-accented-chars-deadkeys --launch`; the same sequence produced `ã`, and `echo não` echoed `não` back from the shell.
- CI required checks are green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches macOS keyDown/IME interpretation paths and event modifier translation, which can subtly affect text input and shortcut handling across layouts; adds a focused regression test to catch the intended behavior.
> 
> **Overview**
> Fixes a macOS regression where `macos-option-as-alt` could break dead-key accent composition by stripping the Option modifier before AppKit interprets the key.
> 
> The terminal `keyDown` path now chooses between the original and translated `NSEvent` for `interpretKeyEvents` (and related IME suppression/confirm logic), preserving the original Option event only for likely dead-key starters while keeping Ghostty’s fallback encoding on the translated event.
> 
> Adds a regression test that simulates `Option+n` then `a` and asserts the composed `ã` is committed without leaking raw Alt key events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a8db0b6e3a82ae5b9cef025d305462a4f45c9ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix dead-key accent composition on macOS by preserving the original Option-modified key for text interpretation while keeping Alt translation for terminal fallback. Option+n then a now commits "ã" without emitting a raw Alt-N (fixes #4377).

- **Bug Fixes**
  - Route the original Option event to `interpretKeyEvents` when `macos-option-as-alt` would strip Option; keep the translated event for terminal fallback encoding.
  - Add a regression test covering Option+n → a to assert "ã" commits and no raw Alt-N is sent.

<sup>Written for commit 8a8db0b6e3a82ae5b9cef025d305462a4f45c9ef. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4382?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved Option key handling issues in text input interpretation on macOS when Option-as-Alt behavior is enabled
  * Improved IME text-input interpretation flow consistency
  * Fixed dead-key composition handling with CJK Input Method Editor to prevent raw key events from appearing in terminal output

* **Tests**
  * Added comprehensive tests for dead-key composition behavior with CJK IME

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4382?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->