### PR TITLE
Fix browser WebView refresh on workspace hide

### DIFF
--- a/Sources/Panels/BrowserHiddenWebViewDiscardPolicy.swift
+++ b/Sources/Panels/BrowserHiddenWebViewDiscardPolicy.swift
@@ -8,7 +8,7 @@ nonisolated enum BrowserHiddenWebViewDiscardPolicy {
 
     static let enabledKey = "browserHiddenWebViewDiscardEnabled"
     static let hiddenDelayKey = "browserHiddenWebViewDiscardDelaySeconds"
-    static let defaultEnabled = true
+    static let defaultEnabled = false
     static let defaultHiddenDelay: TimeInterval = 300
     static let minimumHiddenDelay: TimeInterval = 0
     static let maximumHiddenDelay: TimeInterval = 3600

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -1364,6 +1364,66 @@ final class BrowserPanelPopupContextTests: XCTestCase {
 
 @MainActor
 final class BrowserPanelWebViewLifecycleTests: XCTestCase {
+    private static var hasHiddenDiscardEnabledEnvironmentOverride: Bool {
+        ProcessInfo.processInfo.environment["CMUX_BROWSER_HIDDEN_WEBVIEW_DISCARD_ENABLED"] != nil
+    }
+
+    private static var hiddenDiscardEnvironmentOverrideDisablesPolicy: Bool {
+        guard let value = ProcessInfo.processInfo.environment["CMUX_BROWSER_HIDDEN_WEBVIEW_DISCARD_ENABLED"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased() else {
+            return false
+        }
+        return ["0", "false", "no", "off"].contains(value)
+    }
+
+    private func withHiddenWebViewDiscardDefaults(
+        enabled: Bool?,
+        delay: TimeInterval? = nil,
+        _ body: () throws -> Void
+    ) rethrows {
+        let defaults = UserDefaults.standard
+        let previousEnabled = defaults.object(forKey: BrowserHiddenWebViewDiscardPolicy.enabledKey)
+        let previousDelay = defaults.object(forKey: BrowserHiddenWebViewDiscardPolicy.hiddenDelayKey)
+        defer {
+            if let previousEnabled {
+                defaults.set(previousEnabled, forKey: BrowserHiddenWebViewDiscardPolicy.enabledKey)
+            } else {
+                defaults.removeObject(forKey: BrowserHiddenWebViewDiscardPolicy.enabledKey)
+            }
+            if let previousDelay {
+                defaults.set(previousDelay, forKey: BrowserHiddenWebViewDiscardPolicy.hiddenDelayKey)
+            } else {
+                defaults.removeObject(forKey: BrowserHiddenWebViewDiscardPolicy.hiddenDelayKey)
+            }
+        }
+
+        if let enabled {
+            defaults.set(enabled, forKey: BrowserHiddenWebViewDiscardPolicy.enabledKey)
+        } else {
+            defaults.removeObject(forKey: BrowserHiddenWebViewDiscardPolicy.enabledKey)
+        }
+        if let delay {
+            defaults.set(delay, forKey: BrowserHiddenWebViewDiscardPolicy.hiddenDelayKey)
+        } else {
+            defaults.removeObject(forKey: BrowserHiddenWebViewDiscardPolicy.hiddenDelayKey)
+        }
+
+        try body()
+    }
+
+    private func waitForBrowserPanelWebViewToFinishLoading(
+        _ panel: BrowserPanel,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let deadline = Date().addingTimeInterval(1.0)
+        while panel.webView.isLoading,
+              RunLoop.main.run(mode: .default, before: deadline),
+              Date() < deadline {}
+        XCTAssertFalse(panel.webView.isLoading, "Timed out waiting for browser panel WebView to finish loading", file: file, line: line)
+    }
+
     func testHiddenDiscardPolicyReadsUserDefaults() throws {
         let suiteName = "cmux.browserHiddenDiscardPolicyTests.\(UUID().uuidString)"
         let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
@@ -1409,6 +1469,47 @@ final class BrowserPanelWebViewLifecycleTests: XCTestCase {
                 BrowserHiddenWebViewDiscardPolicy.hiddenDelay(defaults: defaults),
                 BrowserHiddenWebViewDiscardPolicy.defaultHiddenDelay
             )
+        }
+    }
+
+    func testDefaultWorkspaceVisibilityHidePreservesWebViewIdentityPastDiscardDelay() throws {
+        try XCTSkipIf(
+            Self.hasHiddenDiscardEnabledEnvironmentOverride,
+            "Environment override makes the default hidden-discard policy unobservable."
+        )
+
+        try withHiddenWebViewDiscardDefaults(enabled: nil, delay: 0) {
+            XCTAssertFalse(BrowserHiddenWebViewDiscardPolicy.isEnabled)
+
+            let hiddenAt = Date().addingTimeInterval(-1)
+            let panel = BrowserPanel(
+                workspaceId: UUID(),
+                initialURL: URL(string: "about:blank")!,
+                isRemoteWorkspace: false
+            )
+            defer { panel.close() }
+            waitForBrowserPanelWebViewToFinishLoading(panel)
+
+            panel.noteWebViewVisibility(true, reason: "test.workspace.visible")
+            XCTAssertEqual(panel.webViewLifecycleState, .liveVisible)
+            let originalWebView = panel.webView
+
+            panel.noteWebViewVisibility(false, reason: "test.workspace.hidden", now: hiddenAt)
+
+            XCTAssertTrue(
+                panel.webView === originalWebView,
+                "Workspace visibility hides must preserve the live WKWebView unless Browser Memory Saver is explicitly enabled"
+            )
+            XCTAssertTrue(panel.shouldRenderWebView)
+            XCTAssertEqual(panel.webViewLifecycleState, .liveHidden)
+
+            panel.noteWebViewVisibility(true, reason: "test.workspace.revisible")
+
+            XCTAssertTrue(
+                panel.webView === originalWebView,
+                "Re-showing a workspace-hidden browser should rebind the same WKWebView instead of navigating a replacement"
+            )
+            XCTAssertEqual(panel.webViewLifecycleState, .liveVisible)
         }
     }
 
@@ -1551,87 +1652,93 @@ final class BrowserPanelWebViewLifecycleTests: XCTestCase {
         XCTAssertEqual(panel.webViewLifecycleState, .closing)
     }
 
-    func testDiscardReplacesHiddenWebViewAndRestoresOnDemand() {
-        let discardedAt = Date(timeIntervalSince1970: 200)
-        let panel = BrowserPanel(
-            workspaceId: UUID(),
-            initialURL: URL(string: "about:blank")!,
-            isRemoteWorkspace: false
+    func testDiscardReplacesHiddenWebViewAndRestoresOnDemand() throws {
+        try XCTSkipIf(
+            Self.hiddenDiscardEnvironmentOverrideDisablesPolicy,
+            "Environment override disables Browser Memory Saver."
         )
-        defer { panel.close() }
 
-        let deadline = Date().addingTimeInterval(1.0)
-        while panel.webView.isLoading,
-              RunLoop.main.run(mode: .default, before: deadline),
-              Date() < deadline {}
-        XCTAssertFalse(panel.webView.isLoading, "Timed out waiting for about:blank to finish loading")
+        try withHiddenWebViewDiscardDefaults(enabled: true) {
+            let discardedAt = Date(timeIntervalSince1970: 200)
+            let panel = BrowserPanel(
+                workspaceId: UUID(),
+                initialURL: URL(string: "about:blank")!,
+                isRemoteWorkspace: false
+            )
+            defer { panel.close() }
 
-        panel.noteWebViewVisibility(false, reason: "test.hidden", now: discardedAt)
-        let originalWebView = panel.webView
+            waitForBrowserPanelWebViewToFinishLoading(panel)
 
-        XCTAssertTrue(panel.discardHiddenWebViewForMemory(reason: "test.discard", now: discardedAt))
-        XCTAssertFalse(panel.webView === originalWebView)
-        XCTAssertFalse(panel.shouldRenderWebView)
-        XCTAssertEqual(panel.webViewLifecycleState, .discarded)
+            panel.noteWebViewVisibility(false, reason: "test.hidden", now: discardedAt)
+            let originalWebView = panel.webView
 
-        let discardedPayload = panel.webViewLifecycleTopPayload(now: discardedAt)
-        XCTAssertEqual(discardedPayload["state"] as? String, "discarded")
-        XCTAssertEqual(discardedPayload["last_discard_reason"] as? String, "test.discard")
-        XCTAssertNotNil(discardedPayload["discarded_at"] as? String)
+            XCTAssertTrue(panel.discardHiddenWebViewForMemory(reason: "test.discard", now: discardedAt))
+            XCTAssertFalse(panel.webView === originalWebView)
+            XCTAssertFalse(panel.shouldRenderWebView)
+            XCTAssertEqual(panel.webViewLifecycleState, .discarded)
 
-        var observedStates: [BrowserWebViewLifecycleState] = []
-        var cancellable: AnyCancellable?
-        cancellable = panel.$webViewLifecycleState.sink { state in
-            observedStates.append(state)
+            let discardedPayload = panel.webViewLifecycleTopPayload(now: discardedAt)
+            XCTAssertEqual(discardedPayload["state"] as? String, "discarded")
+            XCTAssertEqual(discardedPayload["last_discard_reason"] as? String, "test.discard")
+            XCTAssertNotNil(discardedPayload["discarded_at"] as? String)
+
+            var observedStates: [BrowserWebViewLifecycleState] = []
+            var cancellable: AnyCancellable?
+            cancellable = panel.$webViewLifecycleState.sink { state in
+                observedStates.append(state)
+            }
+            defer { cancellable?.cancel() }
+
+            XCTAssertTrue(panel.restoreDiscardedWebViewIfNeeded(reason: "test.restore"))
+            XCTAssertTrue(panel.shouldRenderWebView)
+            XCTAssertEqual(panel.webViewLifecycleState, .liveHidden)
+            XCTAssertFalse(observedStates.contains(.newTab), "Restore emitted unexpected states: \(observedStates)")
+
+            panel.noteWebViewVisibility(true, reason: "test.visible")
+            XCTAssertEqual(panel.webViewLifecycleState, .liveVisible)
         }
-        defer { cancellable?.cancel() }
-
-        XCTAssertTrue(panel.restoreDiscardedWebViewIfNeeded(reason: "test.restore"))
-        XCTAssertTrue(panel.shouldRenderWebView)
-        XCTAssertEqual(panel.webViewLifecycleState, .liveHidden)
-        XCTAssertFalse(observedStates.contains(.newTab), "Restore emitted unexpected states: \(observedStates)")
-
-        panel.noteWebViewVisibility(true, reason: "test.visible")
-        XCTAssertEqual(panel.webViewLifecycleState, .liveVisible)
     }
 
-    func testRestoredHistoryBackDoesNotEmitNewTabLifecycleState() {
-        let discardedAt = Date(timeIntervalSince1970: 300)
-        let panel = BrowserPanel(
-            workspaceId: UUID(),
-            initialURL: URL(string: "about:blank")!,
-            isRemoteWorkspace: false
+    func testRestoredHistoryBackDoesNotEmitNewTabLifecycleState() throws {
+        try XCTSkipIf(
+            Self.hiddenDiscardEnvironmentOverrideDisablesPolicy,
+            "Environment override disables Browser Memory Saver."
         )
-        defer { panel.close() }
 
-        let deadline = Date().addingTimeInterval(1.0)
-        while panel.webView.isLoading,
-              RunLoop.main.run(mode: .default, before: deadline),
-              Date() < deadline {}
-        XCTAssertFalse(panel.webView.isLoading, "Timed out waiting for about:blank to finish loading")
+        try withHiddenWebViewDiscardDefaults(enabled: true) {
+            let discardedAt = Date(timeIntervalSince1970: 300)
+            let panel = BrowserPanel(
+                workspaceId: UUID(),
+                initialURL: URL(string: "about:blank")!,
+                isRemoteWorkspace: false
+            )
+            defer { panel.close() }
 
-        panel.restoreSessionNavigationHistory(
-            backHistoryURLStrings: ["https://example.test/back"],
-            forwardHistoryURLStrings: [],
-            currentURLString: "https://example.test/current"
-        )
-        XCTAssertTrue(panel.canGoBack)
+            waitForBrowserPanelWebViewToFinishLoading(panel)
 
-        panel.noteWebViewVisibility(false, reason: "test.hidden", now: discardedAt)
-        XCTAssertTrue(panel.discardHiddenWebViewForMemory(reason: "test.discard", now: discardedAt))
-        XCTAssertEqual(panel.webViewLifecycleState, .discarded)
+            panel.restoreSessionNavigationHistory(
+                backHistoryURLStrings: ["https://example.test/back"],
+                forwardHistoryURLStrings: [],
+                currentURLString: "https://example.test/current"
+            )
+            XCTAssertTrue(panel.canGoBack)
 
-        var observedStates: [BrowserWebViewLifecycleState] = []
-        var cancellable: AnyCancellable?
-        cancellable = panel.$webViewLifecycleState.sink { state in
-            observedStates.append(state)
+            panel.noteWebViewVisibility(false, reason: "test.hidden", now: discardedAt)
+            XCTAssertTrue(panel.discardHiddenWebViewForMemory(reason: "test.discard", now: discardedAt))
+            XCTAssertEqual(panel.webViewLifecycleState, .discarded)
+
+            var observedStates: [BrowserWebViewLifecycleState] = []
+            var cancellable: AnyCancellable?
+            cancellable = panel.$webViewLifecycleState.sink { state in
+                observedStates.append(state)
+            }
+            defer { cancellable?.cancel() }
+
+            panel.goBack()
+
+            XCTAssertFalse(observedStates.contains(.newTab), "Back restore emitted unexpected states: \(observedStates)")
+            XCTAssertEqual(panel.webViewLifecycleState, .liveHidden)
         }
-        defer { cancellable?.cancel() }
-
-        panel.goBack()
-
-        XCTAssertFalse(observedStates.contains(.newTab), "Back restore emitted unexpected states: \(observedStates)")
-        XCTAssertEqual(panel.webViewLifecycleState, .liveHidden)
     }
 }
 

--- a/web/data/cmux.schema.json
+++ b/web/data/cmux.schema.json
@@ -709,7 +709,7 @@
         },
         "discardHiddenWebViews": {
           "type": "boolean",
-          "default": true,
+          "default": false,
           "description": "Allow hidden browser tabs to release page memory and restore when shown again."
         },
         "hiddenWebViewDiscardDelaySeconds": {


### PR DESCRIPTION
## Summary
- make Browser Memory Saver opt-in so normal workspace hide/show keeps the live WKWebView and DOM state
- add a regression test for hiding past the discard delay without replacing the WKWebView
- keep explicit memory-saver discard coverage by enabling the policy inside those tests

Fixes #4387

## Verification
- Not run locally per task instruction; CI will run the checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default browser tab lifecycle behavior by disabling hidden WebView discarding unless explicitly enabled, which could affect memory usage and tab restore behavior. Risk is mitigated by updated and new unit tests around discard/restore and workspace hide/show identity preservation.
> 
> **Overview**
> Makes **Browser Memory Saver opt-in** by changing `BrowserHiddenWebViewDiscardPolicy.defaultEnabled` and the settings schema `browser.discardHiddenWebViews` default from `true` to `false`, so normal workspace hide/show keeps the same live `WKWebView` and DOM state.
> 
> Updates `BrowserPanelWebViewLifecycleTests` to manage discard-related `UserDefaults` per-test, skip appropriately when environment overrides make behavior unobservable, add a regression test asserting WebView identity is preserved when hidden past the discard delay with the policy disabled, and explicitly enable the policy in discard/restore tests to keep coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 233dbe4b515d381e6dd7412e6553be9e34138429. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Browser Memory Saver opt-in so hidden tabs no longer auto-discard. Keeps the live `WKWebView` and DOM when a workspace is hidden and re-shown, fixing the refresh regression (addresses #4387).

- **Bug Fixes**
  - Default `BrowserHiddenWebViewDiscardPolicy` to disabled; update `discardHiddenWebViews` default in `web/data/cmux.schema.json` to `false`.
  - Preserve `WKWebView` identity across workspace hide/show to avoid reloads.
  - Add regression tests for the default-preserve behavior and for explicit memory-saver discard paths (with environment override handling).

<sup>Written for commit 233dbe4b515d381e6dd7412e6553be9e34138429. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4388?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

