### PR TITLE
Add Blacksmith macOS runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+self-hosted-runner:
+  labels:
+    - blacksmith-6vcpu-macos-15
+    - blacksmith-6vcpu-macos-26

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -2,3 +2,5 @@ self-hosted-runner:
   labels:
     - blacksmith-6vcpu-macos-15
     - blacksmith-6vcpu-macos-26
+    - depot-macos-latest
+    - warp-macos-15-arm64-6x

--- a/.github/workflows/build-ghosttykit.yml
+++ b/.github/workflows/build-ghosttykit.yml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   build-ghosttykit:
-    runs-on: warp-macos-15-arm64-6x
+    runs-on: blacksmith-6vcpu-macos-15
     timeout-minutes: 20
     env:
       GHOSTTYKIT_CRASH_REPORT_SUBDIR: cmux/crash

--- a/.github/workflows/ci-macos-compat.yml
+++ b/.github/workflows/ci-macos-compat.yml
@@ -9,12 +9,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: warp-macos-15-arm64-6x
+          - os: blacksmith-6vcpu-macos-15
             timeout: 30
             startup_smoke: true
             virtual_display: true
             skip_zig: false
-          - os: warp-macos-26-arm64-6x
+          - os: blacksmith-6vcpu-macos-26
             timeout: 30
             startup_smoke: true
             virtual_display: false

--- a/.github/workflows/ci-macos-compat.yml
+++ b/.github/workflows/ci-macos-compat.yml
@@ -17,7 +17,7 @@ jobs:
           - os: blacksmith-6vcpu-macos-26
             timeout: 30
             startup_smoke: true
-            virtual_display: false
+            virtual_display: true
             skip_zig: true  # zig 0.15.2 MachO linker can't resolve libSystem on macOS 26
     runs-on: ${{ matrix.os }}
     timeout-minutes: ${{ matrix.timeout }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Validate WarpBuild runner guards
+      - name: Validate Blacksmith runner guards
         run: ./tests/test_ci_self_hosted_guard.sh
 
       - name: Validate create-dmg version pinning
@@ -149,7 +149,7 @@ jobs:
           bun test tests/vm-db-read-model.test.ts
 
   tests:
-    runs-on: warp-macos-15-arm64-6x
+    runs-on: blacksmith-6vcpu-macos-15
     timeout-minutes: 45
     env:
       CMUX_SKIP_ZIG_BUILD: "1"
@@ -323,11 +323,11 @@ jobs:
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_pi_extension_install.py
 
   tests-build-and-lag:
-    # Build the full cmux scheme and run the lag regression on WarpBuild.
+    # Build the full cmux scheme and run the lag regression on Blacksmith.
     # Keep lag validation separate from UI regressions so functional UI failures
     # and performance regressions stay isolated. Broader interactive UI suites
     # still run via test-e2e.yml on GitHub-hosted runners.
-    runs-on: warp-macos-15-arm64-6x
+    runs-on: blacksmith-6vcpu-macos-15
     timeout-minutes: 20
     steps:
       - name: Checkout
@@ -513,7 +513,7 @@ jobs:
     # Compile the same unsigned universal Release app that nightly builds before
     # signing, notarization, and publishing. This catches DEBUG/Release boundary
     # mistakes before they reach main.
-    runs-on: warp-macos-26-arm64-6x
+    runs-on: blacksmith-6vcpu-macos-26
     timeout-minutes: 20
     steps:
       - name: Checkout
@@ -596,7 +596,7 @@ jobs:
             CODE_SIGNING_ALLOWED=NO ASSETCATALOG_COMPILER_APPICON_NAME=AppIcon-Nightly build
 
   ui-regressions:
-    runs-on: warp-macos-15-arm64-6x
+    runs-on: blacksmith-6vcpu-macos-15
     timeout-minutes: 25
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -428,6 +428,17 @@ jobs:
       - name: Validate Swift warning budget
         run: python3 scripts/swift_warning_budget.py --log /tmp/cmux-build-output.txt
 
+      - name: Create virtual display
+        run: |
+          set -euo pipefail
+          clang -framework Foundation -framework CoreGraphics \
+            -o /tmp/create-virtual-display scripts/create-virtual-display.m
+          /tmp/create-virtual-display &
+          VDISPLAY_PID=$!
+          echo "VDISPLAY_PID=$VDISPLAY_PID" >> "$GITHUB_ENV"
+          sleep 3
+          kill -0 "$VDISPLAY_PID"
+
       - name: Run CoreAnimation main-thread startup regression
         run: |
           set -euo pipefail
@@ -446,17 +457,6 @@ jobs:
           CMUX_CA_ASSERT_HOLD_SECONDS=15 \
           CMUX_TAG="ci-ca-main-thread" \
           ./scripts/verify-main-thread-ca-transactions.sh "$APP"
-
-      - name: Create virtual display
-        run: |
-          set -euo pipefail
-          clang -framework Foundation -framework CoreGraphics \
-            -o /tmp/create-virtual-display scripts/create-virtual-display.m
-          /tmp/create-virtual-display &
-          VDISPLAY_PID=$!
-          echo "VDISPLAY_PID=$VDISPLAY_PID" >> "$GITHUB_ENV"
-          sleep 3
-          kill -0 "$VDISPLAY_PID"
 
       - name: Run workspace churn typing-lag regression
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -100,7 +100,7 @@ jobs:
   build-sign-notarize-nightly:
     needs: decide
     if: needs.decide.outputs.should_build == 'true'
-    runs-on: warp-macos-26-arm64-6x
+    runs-on: blacksmith-6vcpu-macos-26
     timeout-minutes: 20
     steps:
       - name: Checkout build ref

--- a/.github/workflows/perf-activation.yml
+++ b/.github/workflows/perf-activation.yml
@@ -13,9 +13,10 @@ on:
         required: false
         default: warp-macos-15-arm64-6x
         type: choice
-        # This benchmark intentionally stays on WarpBuild because it asserts
-        # real Cmd-Tab visible-window behavior. Blacksmith and Depot comparison
-        # runs are manual until they can surface the benchmark app window.
+        # This benchmark intentionally stays on WarpBuild for pull_request
+        # because it asserts real Cmd-Tab visible-window behavior. Blacksmith
+        # and Depot are workflow_dispatch-only options for manual provider
+        # comparison until they can surface the benchmark app window.
         options:
           - warp-macos-15-arm64-6x
           - depot-macos-latest

--- a/.github/workflows/perf-activation.yml
+++ b/.github/workflows/perf-activation.yml
@@ -86,6 +86,25 @@ jobs:
       - name: Build tagged app
         run: ./scripts/reload.sh --tag "$PERF_TAG"
 
+      - name: Create virtual display
+        run: |
+          set -euo pipefail
+          READY_PATH="/tmp/cmux-virtual-display-ready"
+          rm -f "$READY_PATH"
+          clang -framework Foundation -framework CoreGraphics \
+            -o /tmp/create-virtual-display scripts/create-virtual-display.m
+          /tmp/create-virtual-display --ready-path "$READY_PATH" &
+          VDISPLAY_PID=$!
+          echo "VDISPLAY_PID=$VDISPLAY_PID" >> "$GITHUB_ENV"
+          for attempt in 1 2 3 4 5; do
+            if [ -f "$READY_PATH" ]; then
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Virtual display was not ready" >&2
+          exit 1
+
       - name: Run activation session benchmark
         run: |
           set -euo pipefail
@@ -173,5 +192,8 @@ jobs:
       - name: Cleanup tagged app
         if: always()
         run: |
+          if [ -n "${VDISPLAY_PID:-}" ]; then
+            kill "$VDISPLAY_PID" >/dev/null 2>&1 || true
+          fi
           pkill -f "cmux DEV ${PERF_TAG}.app/Contents/MacOS/cmux DEV" || true
           rm -f "/tmp/cmux-debug-${PERF_TAG}.sock"

--- a/.github/workflows/perf-activation.yml
+++ b/.github/workflows/perf-activation.yml
@@ -11,13 +11,14 @@ on:
       runner:
         description: macOS runner
         required: false
-        default: blacksmith-6vcpu-macos-15
+        default: depot-macos-latest
         type: choice
-        # Depot stays available only for manual fallback and provider comparison
-        # runs. Pull requests use the Blacksmith fallback below.
+        # The Cmd-Tab benchmark needs a runner session that can surface visible
+        # app windows. Blacksmith is kept as a manual provider comparison option,
+        # while pull requests stay on Depot until that benchmark works there.
         options:
-          - blacksmith-6vcpu-macos-15
           - depot-macos-latest
+          - blacksmith-6vcpu-macos-15
       workspace_count:
         description: Fixture workspace count
         required: false
@@ -37,7 +38,7 @@ concurrency:
 
 jobs:
   activation-session:
-    runs-on: ${{ inputs.runner || 'blacksmith-6vcpu-macos-15' }}
+    runs-on: ${{ inputs.runner || 'depot-macos-latest' }}
     timeout-minutes: 45
     env:
       PERF_TAG: perfci
@@ -87,6 +88,7 @@ jobs:
         run: ./scripts/reload.sh --tag "$PERF_TAG"
 
       - name: Create virtual display
+        if: ${{ startsWith(inputs.runner || 'depot-macos-latest', 'blacksmith-') }}
         run: |
           set -euo pipefail
           READY_PATH="/tmp/cmux-virtual-display-ready"

--- a/.github/workflows/perf-activation.yml
+++ b/.github/workflows/perf-activation.yml
@@ -11,10 +11,12 @@ on:
       runner:
         description: macOS runner
         required: false
-        default: warp-macos-15-arm64-6x
+        default: blacksmith-6vcpu-macos-15
         type: choice
+        # Depot stays available only for manual fallback and provider comparison
+        # runs. Pull requests use the Blacksmith fallback below.
         options:
-          - warp-macos-15-arm64-6x
+          - blacksmith-6vcpu-macos-15
           - depot-macos-latest
       workspace_count:
         description: Fixture workspace count
@@ -35,7 +37,7 @@ concurrency:
 
 jobs:
   activation-session:
-    runs-on: ${{ inputs.runner || 'warp-macos-15-arm64-6x' }}
+    runs-on: ${{ inputs.runner || 'blacksmith-6vcpu-macos-15' }}
     timeout-minutes: 45
     env:
       PERF_TAG: perfci

--- a/.github/workflows/perf-activation.yml
+++ b/.github/workflows/perf-activation.yml
@@ -11,12 +11,13 @@ on:
       runner:
         description: macOS runner
         required: false
-        default: depot-macos-latest
+        default: warp-macos-15-arm64-6x
         type: choice
-        # The Cmd-Tab benchmark needs a runner session that can surface visible
-        # app windows. Blacksmith is kept as a manual provider comparison option,
-        # while pull requests stay on Depot until that benchmark works there.
+        # This benchmark intentionally stays on WarpBuild because it asserts
+        # real Cmd-Tab visible-window behavior. Blacksmith and Depot comparison
+        # runs are manual until they can surface the benchmark app window.
         options:
+          - warp-macos-15-arm64-6x
           - depot-macos-latest
           - blacksmith-6vcpu-macos-15
       workspace_count:
@@ -38,7 +39,7 @@ concurrency:
 
 jobs:
   activation-session:
-    runs-on: ${{ inputs.runner || 'depot-macos-latest' }}
+    runs-on: ${{ inputs.runner || 'warp-macos-15-arm64-6x' }}
     timeout-minutes: 45
     env:
       PERF_TAG: perfci
@@ -88,7 +89,7 @@ jobs:
         run: ./scripts/reload.sh --tag "$PERF_TAG"
 
       - name: Create virtual display
-        if: ${{ startsWith(inputs.runner || 'depot-macos-latest', 'blacksmith-') }}
+        if: ${{ startsWith(inputs.runner || 'warp-macos-15-arm64-6x', 'blacksmith-') }}
         run: |
           set -euo pipefail
           READY_PATH="/tmp/cmux-virtual-display-ready"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   build-sign-notarize:
-    runs-on: warp-macos-26-arm64-6x
+    runs-on: blacksmith-6vcpu-macos-26
     timeout-minutes: 20
     steps:
       - name: Checkout

--- a/.github/workflows/test-blacksmith.yml
+++ b/.github/workflows/test-blacksmith.yml
@@ -1,4 +1,4 @@
-name: Run tests on Depot
+name: Run tests on Blacksmith
 
 on:
   workflow_dispatch:
@@ -28,7 +28,7 @@ on:
 
 jobs:
   tests:
-    runs-on: warp-macos-15-arm64-6x
+    runs-on: blacksmith-6vcpu-macos-15
     timeout-minutes: 20
     steps:
       - name: Checkout

--- a/docs/internal/skills-customization-ideas.md
+++ b/docs/internal/skills-customization-ideas.md
@@ -63,7 +63,7 @@ Keep the examples library focused on reusable end-user workflows:
 - SSH devbox: remote terminal plus local browser or notes surface.
 - Review PR: GitHub terminal, PR browser, and notes or markdown panel.
 - Docs workspace: docs dev server, browser preview, and markdown viewer.
-- CI watch: GitHub Actions, WarpBuild, Feed TUI, and release monitors.
+- CI watch: GitHub Actions, Blacksmith, Feed TUI, and release monitors.
 - Quick agent buttons: Codex and Claude tab bar buttons with Command Palette entries.
 
 Use the Promotion Rule when an example starts to exceed

--- a/tests/test_ci_self_hosted_guard.sh
+++ b/tests/test_ci_self_hosted_guard.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Regression test for https://github.com/manaflow-ai/cmux/issues/385.
-# Ensures paid CI jobs use WarpBuild runners.
+# Ensures paid CI jobs use Blacksmith runners.
 # Fork PRs are gated by GitHub's built-in "Require approval for outside
 # collaborators" setting, so workflow-level fork guards are not needed.
 set -euo pipefail
@@ -9,30 +9,38 @@ ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 CI_FILE="$ROOT_DIR/.github/workflows/ci.yml"
 GHOSTTYKIT_FILE="$ROOT_DIR/.github/workflows/build-ghosttykit.yml"
 COMPAT_FILE="$ROOT_DIR/.github/workflows/ci-macos-compat.yml"
+NIGHTLY_FILE="$ROOT_DIR/.github/workflows/nightly.yml"
+RELEASE_FILE="$ROOT_DIR/.github/workflows/release.yml"
+TEST_BLACKSMITH_FILE="$ROOT_DIR/.github/workflows/test-blacksmith.yml"
 
-check_warp_runner() {
+check_blacksmith_runner() {
   local file="$1" job="$2"
   if ! awk -v job="$job" '
     $0 ~ "^  "job":" { in_job=1; next }
     in_job && /^  [^[:space:]]/ { in_job=0 }
-    in_job && /runs-on:.*warp-macos-.*-arm64/ { saw_warp=1 }
-    in_job && /os: warp-macos-.*-arm64/ { saw_warp=1 }
-    END { exit !(saw_warp) }
+    in_job && /runs-on:.*blacksmith-[0-9]+vcpu-macos-/ { saw_blacksmith=1 }
+    in_job && /os: blacksmith-[0-9]+vcpu-macos-/ { saw_blacksmith=1 }
+    END { exit !(saw_blacksmith) }
   ' "$file"; then
-    echo "FAIL: $job in $(basename "$file") must use a WarpBuild runner"
+    echo "FAIL: $job in $(basename "$file") must use a Blacksmith runner"
     exit 1
   fi
-  echo "PASS: $job WarpBuild runner is present"
+  echo "PASS: $job Blacksmith runner is present"
 }
 
 # ci.yml jobs
-check_warp_runner "$CI_FILE" "tests"
-check_warp_runner "$CI_FILE" "tests-build-and-lag"
-check_warp_runner "$CI_FILE" "release-build"
-check_warp_runner "$CI_FILE" "ui-regressions"
+check_blacksmith_runner "$CI_FILE" "tests"
+check_blacksmith_runner "$CI_FILE" "tests-build-and-lag"
+check_blacksmith_runner "$CI_FILE" "release-build"
+check_blacksmith_runner "$CI_FILE" "ui-regressions"
 
 # build-ghosttykit.yml
-check_warp_runner "$GHOSTTYKIT_FILE" "build-ghosttykit"
+check_blacksmith_runner "$GHOSTTYKIT_FILE" "build-ghosttykit"
 
-# ci-macos-compat.yml (uses matrix.os with WarpBuild runners)
-check_warp_runner "$COMPAT_FILE" "compat-tests"
+# ci-macos-compat.yml (uses matrix.os with Blacksmith runners)
+check_blacksmith_runner "$COMPAT_FILE" "compat-tests"
+
+# Other macOS build workflows
+check_blacksmith_runner "$NIGHTLY_FILE" "build-sign-notarize-nightly"
+check_blacksmith_runner "$RELEASE_FILE" "build-sign-notarize"
+check_blacksmith_runner "$TEST_BLACKSMITH_FILE" "tests"

--- a/tests/test_ci_self_hosted_guard.sh
+++ b/tests/test_ci_self_hosted_guard.sh
@@ -29,6 +29,20 @@ check_blacksmith_runner() {
   echo "PASS: $job Blacksmith runner is present"
 }
 
+check_no_warp_runner() {
+  local file="$1" job="$2"
+  if awk -v job="$job" '
+    $0 ~ "^  "job":" { in_job=1; next }
+    in_job && /^  [^[:space:]]/ { in_job=0 }
+    in_job && /warp-macos-/ { saw_warp=1 }
+    END { exit !(saw_warp) }
+  ' "$file"; then
+    echo "FAIL: $job in $(basename "$file") must not use a WarpBuild runner"
+    exit 1
+  fi
+  echo "PASS: $job WarpBuild runner is absent"
+}
+
 # ci.yml jobs
 check_blacksmith_runner "$CI_FILE" "tests"
 check_blacksmith_runner "$CI_FILE" "tests-build-and-lag"
@@ -45,4 +59,4 @@ check_blacksmith_runner "$COMPAT_FILE" "compat-tests"
 check_blacksmith_runner "$NIGHTLY_FILE" "build-sign-notarize-nightly"
 check_blacksmith_runner "$RELEASE_FILE" "build-sign-notarize"
 check_blacksmith_runner "$TEST_BLACKSMITH_FILE" "tests"
-check_blacksmith_runner "$PERF_FILE" "activation-session"
+check_no_warp_runner "$PERF_FILE" "activation-session"

--- a/tests/test_ci_self_hosted_guard.sh
+++ b/tests/test_ci_self_hosted_guard.sh
@@ -29,20 +29,6 @@ check_blacksmith_runner() {
   echo "PASS: $job Blacksmith runner is present"
 }
 
-check_no_warp_runner() {
-  local file="$1" job="$2"
-  if awk -v job="$job" '
-    $0 ~ "^  "job":" { in_job=1; next }
-    in_job && /^  [^[:space:]]/ { in_job=0 }
-    in_job && /warp-macos-/ { saw_warp=1 }
-    END { exit !(saw_warp) }
-  ' "$file"; then
-    echo "FAIL: $job in $(basename "$file") must not use a WarpBuild runner"
-    exit 1
-  fi
-  echo "PASS: $job WarpBuild runner is absent"
-}
-
 check_warp_exception() {
   local file="$1" job="$2"
   if ! awk -v job="$job" '

--- a/tests/test_ci_self_hosted_guard.sh
+++ b/tests/test_ci_self_hosted_guard.sh
@@ -43,6 +43,20 @@ check_no_warp_runner() {
   echo "PASS: $job WarpBuild runner is absent"
 }
 
+check_warp_exception() {
+  local file="$1" job="$2"
+  if ! awk -v job="$job" '
+    $0 ~ "^  "job":" { in_job=1; next }
+    in_job && /^  [^[:space:]]/ { in_job=0 }
+    in_job && /runs-on:.*warp-macos-/ { saw_warp=1 }
+    END { exit !(saw_warp) }
+  ' "$file"; then
+    echo "FAIL: $job in $(basename "$file") must keep the GUI-capable WarpBuild runner exception"
+    exit 1
+  fi
+  echo "PASS: $job WarpBuild runner exception is present"
+}
+
 # ci.yml jobs
 check_blacksmith_runner "$CI_FILE" "tests"
 check_blacksmith_runner "$CI_FILE" "tests-build-and-lag"
@@ -59,4 +73,4 @@ check_blacksmith_runner "$COMPAT_FILE" "compat-tests"
 check_blacksmith_runner "$NIGHTLY_FILE" "build-sign-notarize-nightly"
 check_blacksmith_runner "$RELEASE_FILE" "build-sign-notarize"
 check_blacksmith_runner "$TEST_BLACKSMITH_FILE" "tests"
-check_no_warp_runner "$PERF_FILE" "activation-session"
+check_warp_exception "$PERF_FILE" "activation-session"

--- a/tests/test_ci_self_hosted_guard.sh
+++ b/tests/test_ci_self_hosted_guard.sh
@@ -12,6 +12,7 @@ COMPAT_FILE="$ROOT_DIR/.github/workflows/ci-macos-compat.yml"
 NIGHTLY_FILE="$ROOT_DIR/.github/workflows/nightly.yml"
 RELEASE_FILE="$ROOT_DIR/.github/workflows/release.yml"
 TEST_BLACKSMITH_FILE="$ROOT_DIR/.github/workflows/test-blacksmith.yml"
+PERF_FILE="$ROOT_DIR/.github/workflows/perf-activation.yml"
 
 check_blacksmith_runner() {
   local file="$1" job="$2"
@@ -44,3 +45,4 @@ check_blacksmith_runner "$COMPAT_FILE" "compat-tests"
 check_blacksmith_runner "$NIGHTLY_FILE" "build-sign-notarize-nightly"
 check_blacksmith_runner "$RELEASE_FILE" "build-sign-notarize"
 check_blacksmith_runner "$TEST_BLACKSMITH_FILE" "tests"
+check_blacksmith_runner "$PERF_FILE" "activation-session"


### PR DESCRIPTION
## Summary
- Switch macOS build and test workflows from WarpBuild labels to pinned Blacksmith macOS 15/26 runner labels.
- Rename the manual macOS test workflow to Blacksmith and update runner guard coverage.
- Leave activation performance on its existing WarpBuild runner because the Cmd-Tab visibility benchmark failed on Blacksmith and on the Depot lane in this PR.
- Update internal CI provider wording.

## Testing
- ./tests/test_ci_self_hosted_guard.sh
- ruby -e 'require "psych"; Dir[".github/workflows/*.yml"].sort.each { |f| Psych.load_file(f); puts "parsed #{f}" }'\n- git diff --check\n- ./tests/test_ci_create_dmg_pinned.sh\n- ./tests/test_ci_unit_test_spm_retry.sh\n- ./tests/test_ci_scheme_testaction_debug.sh\n- ./tests/test_ci_ghosttykit_checksum_verification.sh\n- node scripts/release_asset_guard.test.js\n- ./tests/test_ci_ghosttykit_checksum_present.sh\n- ./tests/test_ci_swift_warning_budget.sh\n- ./tests/test_ci_swift_file_length_budget.sh\n- ./tests/test_ci_auxiliary_window_close_shortcuts.sh\n\n## Notes\n- Blacksmith runner labels follow https://docs.blacksmith.sh/blacksmith-runners/overview.\n- Earlier CI attempts proved Blacksmith jobs provisioned. They also showed activation perf should stay outside this migration because its Cmd-Tab benchmark timed out waiting for a visible window.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI infrastructure changes (runner migration and display emulation tweaks) can cause build/test flakiness or break macOS pipelines if Blacksmith runner environments differ from WarpBuild.
> 
> **Overview**
> **Moves macOS CI/build/release workloads to Blacksmith.** Updates `ci.yml`, `nightly.yml`, `release.yml`, `build-ghosttykit.yml`, `ci-macos-compat.yml`, and the manual test workflow to run on `blacksmith-6vcpu-macos-15/26` instead of WarpBuild labels.
> 
> **Adjusts workflow reliability checks.** Adds Blacksmith runner labels to `actionlint` config, strengthens `tests/test_ci_self_hosted_guard.sh` to require Blacksmith across more workflows (while explicitly allowing the activation perf job to remain on WarpBuild), and adds/relocates virtual display creation steps where needed for Blacksmith-based UI/perf runs.
> 
> Updates internal docs wording from WarpBuild to Blacksmith and expands `perf-activation.yml` runner choices to include Blacksmith for manual comparisons.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc5e2fa24001458678a0500ba06f770699d05a05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched CI and release macOS runners to a new Blacksmith runner infrastructure across workflows (nightly, release, compatibility, build, and test jobs); runner labels were added to CI linting config.
* **Tests**
  * Strengthened CI guard tests to require the new runner, forbid the deprecated runner, and broadened workflow coverage.
* **Documentation**
  * Updated internal examples and workflow names/choices to reflect the new runner options and added a new runner choice for performance activation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4393?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->