### PR TITLE
Fix browser back race during provisional navigation

### DIFF
--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -3456,20 +3456,20 @@ final class BrowserPanel: Panel, ObservableObject {
         let boundHistoryStore = historyStore
 
         navigationDelegate.didStartProvisionalNavigation = { [weak self] webView in
-            Task { @MainActor [weak self] in
+            MainActor.assumeIsolated {
                 guard let self, self.isCurrentWebView(webView, instanceID: boundWebViewInstanceID) else { return }
                 self.isMainFrameProvisionalNavigationActive = true
             }
         }
         navigationDelegate.didCommit = { [weak self] webView in
-            Task { @MainActor [weak self] in
+            MainActor.assumeIsolated {
                 guard let self, self.isCurrentWebView(webView, instanceID: boundWebViewInstanceID) else { return }
                 self.isMainFrameProvisionalNavigationActive = false
                 self.publishCommittedURL(from: webView)
             }
         }
         navigationDelegate.didFinish = { [weak self] webView in
-            Task { @MainActor [weak self] in
+            MainActor.assumeIsolated {
                 guard let self, self.isCurrentWebView(webView, instanceID: boundWebViewInstanceID) else { return }
                 self.isMainFrameProvisionalNavigationActive = false
                 self.publishCommittedURL(from: webView)
@@ -3478,11 +3478,10 @@ final class BrowserPanel: Panel, ObservableObject {
                 self.refreshFavicon(from: webView)
                 // Keep find-in-page open through load completion and refresh matches for the new DOM.
                 self.restoreFindStateAfterNavigation(replaySearch: true)
-                GlobalSearchCoordinator.shared.captureBrowserPanel(self)
             }
         }
         navigationDelegate.didFailNavigation = { [weak self] failedWebView, failedURL in
-            Task { @MainActor in
+            MainActor.assumeIsolated {
                 guard let self, self.isCurrentWebView(failedWebView, instanceID: boundWebViewInstanceID) else { return }
                 self.isMainFrameProvisionalNavigationActive = false
                 if let url = URL(string: failedURL) {
@@ -3498,7 +3497,7 @@ final class BrowserPanel: Panel, ObservableObject {
             }
         }
         navigationDelegate.didCancelProvisionalNavigation = { [weak self] webView in
-            Task { @MainActor [weak self] in
+            MainActor.assumeIsolated {
                 guard let self, self.isCurrentWebView(webView, instanceID: boundWebViewInstanceID) else { return }
                 self.isMainFrameProvisionalNavigationActive = false
             }
@@ -7583,6 +7582,7 @@ private class BrowserNavigationDelegate: NSObject, WKNavigationDelegate {
         // navigation response is converted into a download via .download policy.
         // This is expected and should not show an error page.
         if nsError.domain == "WebKitErrorDomain", nsError.code == 102 {
+            didCancelProvisionalNavigation?(webView)
             return
         }
 

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -4196,11 +4196,12 @@ final class BrowserPanel: Panel, ObservableObject {
         let observedWebViewInstanceID = webViewInstanceID
 
         // URL changes
-        let urlObserver = webView.observe(\.url, options: [.new]) { [weak self] webView, _ in
-            Task { @MainActor in
+        let urlObserver = webView.observe(\.url, options: [.new]) { [weak self] webView, change in
+            let observedURL = change.newValue ?? webView.url
+            MainActor.assumeIsolated {
                 guard let self, self.isCurrentWebView(webView, instanceID: observedWebViewInstanceID) else { return }
                 guard !self.isMainFrameProvisionalNavigationActive else { return }
-                self.currentURL = Self.remoteProxyDisplayURL(for: webView.url)
+                self.currentURL = Self.remoteProxyDisplayURL(for: observedURL)
                 GlobalSearchCoordinator.shared.captureBrowserPanel(self)
             }
         }

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -2773,6 +2773,7 @@ final class BrowserPanel: Panel, ObservableObject {
     private var restoredBackHistoryStack: [URL] = []
     private var restoredForwardHistoryStack: [URL] = []
     private var restoredHistoryCurrentURL: URL?
+    private var isMainFrameProvisionalNavigationActive: Bool = false
 
     /// Published estimated progress (0.0 - 1.0)
     @Published private(set) var estimatedProgress: Double = 0.0
@@ -3099,6 +3100,7 @@ final class BrowserPanel: Panel, ObservableObject {
         closeBackgroundPreloadHost(reason: "discardHiddenWebView")
         BrowserWindowPortalRegistry.detach(webView: oldWebView)
         oldWebView.stopLoading()
+        isMainFrameProvisionalNavigationActive = false
         oldWebView.navigationDelegate = nil
         oldWebView.uiDelegate = nil
         if let oldCmuxWebView = oldWebView as? CmuxWebView {
@@ -3453,9 +3455,24 @@ final class BrowserPanel: Panel, ObservableObject {
         let boundWebViewInstanceID = webViewInstanceID
         let boundHistoryStore = historyStore
 
+        navigationDelegate.didStartProvisionalNavigation = { [weak self] webView in
+            Task { @MainActor [weak self] in
+                guard let self, self.isCurrentWebView(webView, instanceID: boundWebViewInstanceID) else { return }
+                self.isMainFrameProvisionalNavigationActive = true
+            }
+        }
+        navigationDelegate.didCommit = { [weak self] webView in
+            Task { @MainActor [weak self] in
+                guard let self, self.isCurrentWebView(webView, instanceID: boundWebViewInstanceID) else { return }
+                self.isMainFrameProvisionalNavigationActive = false
+                self.publishCommittedURL(from: webView)
+            }
+        }
         navigationDelegate.didFinish = { [weak self] webView in
             Task { @MainActor [weak self] in
                 guard let self, self.isCurrentWebView(webView, instanceID: boundWebViewInstanceID) else { return }
+                self.isMainFrameProvisionalNavigationActive = false
+                self.publishCommittedURL(from: webView)
                 self.realignRestoredSessionHistoryToLiveCurrentIfPossible()
                 boundHistoryStore.recordVisit(url: webView.url, title: webView.title)
                 self.refreshFavicon(from: webView)
@@ -3467,6 +3484,10 @@ final class BrowserPanel: Panel, ObservableObject {
         navigationDelegate.didFailNavigation = { [weak self] failedWebView, failedURL in
             Task { @MainActor in
                 guard let self, self.isCurrentWebView(failedWebView, instanceID: boundWebViewInstanceID) else { return }
+                self.isMainFrameProvisionalNavigationActive = false
+                if let url = URL(string: failedURL) {
+                    self.currentURL = Self.remoteProxyDisplayURL(for: url) ?? url
+                }
                 // Clear stale title/favicon from the previous page so the tab
                 // shows the failed URL instead of the old page's branding.
                 self.pageTitle = failedURL.isEmpty ? "" : failedURL
@@ -3476,6 +3497,17 @@ final class BrowserPanel: Panel, ObservableObject {
                 self.restoreFindStateAfterNavigation(replaySearch: false)
             }
         }
+        navigationDelegate.didCancelProvisionalNavigation = { [weak self] webView in
+            Task { @MainActor [weak self] in
+                guard let self, self.isCurrentWebView(webView, instanceID: boundWebViewInstanceID) else { return }
+                self.isMainFrameProvisionalNavigationActive = false
+            }
+        }
+    }
+
+    private func publishCommittedURL(from webView: WKWebView) {
+        currentURL = Self.remoteProxyDisplayURL(for: webView.url)
+        GlobalSearchCoordinator.shared.captureBrowserPanel(self)
     }
 
     private func isCurrentWebView(_ candidate: WKWebView, instanceID: UUID? = nil) -> Bool {
@@ -3942,6 +3974,7 @@ final class BrowserPanel: Panel, ObservableObject {
         closeBackgroundPreloadHost(reason: "profileSwitch")
         BrowserWindowPortalRegistry.detach(webView: previousWebView)
         previousWebView.stopLoading()
+        isMainFrameProvisionalNavigationActive = false
         previousWebView.navigationDelegate = nil
         previousWebView.uiDelegate = nil
         if let previousCmuxWebView = previousWebView as? CmuxWebView {
@@ -4167,6 +4200,7 @@ final class BrowserPanel: Panel, ObservableObject {
         let urlObserver = webView.observe(\.url, options: [.new]) { [weak self] webView, _ in
             Task { @MainActor in
                 guard let self, self.isCurrentWebView(webView, instanceID: observedWebViewInstanceID) else { return }
+                guard !self.isMainFrameProvisionalNavigationActive else { return }
                 self.currentURL = Self.remoteProxyDisplayURL(for: webView.url)
                 GlobalSearchCoordinator.shared.captureBrowserPanel(self)
             }
@@ -4308,6 +4342,7 @@ final class BrowserPanel: Panel, ObservableObject {
         closeBackgroundPreloadHost(reason: reason)
         BrowserWindowPortalRegistry.detach(webView: oldWebView)
         oldWebView.stopLoading()
+        isMainFrameProvisionalNavigationActive = false
         oldWebView.navigationDelegate = nil
         oldWebView.uiDelegate = nil
         if let oldCmuxWebView = oldWebView as? CmuxWebView {
@@ -4459,6 +4494,7 @@ final class BrowserPanel: Panel, ObservableObject {
         }
 
         webView.stopLoading()
+        isMainFrameProvisionalNavigationActive = false
         webView.navigationDelegate = nil
         webView.uiDelegate = nil
         navigationDelegate = nil
@@ -5260,6 +5296,7 @@ extension BrowserPanel {
         closeBackgroundPreloadHost(reason: "contextReset")
         BrowserWindowPortalRegistry.detach(webView: oldWebView)
         oldWebView.stopLoading()
+        isMainFrameProvisionalNavigationActive = false
         oldWebView.navigationDelegate = nil
         oldWebView.uiDelegate = nil
         if let oldCmuxWebView = oldWebView as? CmuxWebView {
@@ -5332,11 +5369,17 @@ func resolveBrowserNavigableURL(_ input: String) -> URL? {
 }
 
 extension BrowserPanel {
+    private func cancelInFlightNavigationBeforeHistoryTraversal() {
+        guard webView.isLoading else { return }
+        webView.stopLoading()
+        isMainFrameProvisionalNavigationActive = false
+    }
 
     /// Go back in history
     func goBack() {
         guard canGoBack else { return }
         reactivateDiscardedWebViewWithoutNavigation(reason: "goBack")
+        cancelInFlightNavigationBeforeHistoryTraversal()
         if usesRestoredSessionHistory {
             realignRestoredSessionHistoryToLiveCurrentIfPossible()
 
@@ -5371,6 +5414,7 @@ extension BrowserPanel {
     func goForward() {
         guard canGoForward else { return }
         reactivateDiscardedWebViewWithoutNavigation(reason: "goForward")
+        cancelInFlightNavigationBeforeHistoryTraversal()
         if usesRestoredSessionHistory {
             realignRestoredSessionHistoryToLiveCurrentIfPossible()
 
@@ -5503,6 +5547,7 @@ extension BrowserPanel {
     /// Stop loading
     func stopLoading() {
         webView.stopLoading()
+        isMainFrameProvisionalNavigationActive = false
     }
 
     private static func windowContainsInspectorViews(_ root: NSView) -> Bool {
@@ -7486,8 +7531,11 @@ func browserNavigationShouldOpenSimpleUserGesturePopupInCurrentTab(
 }
 
 private class BrowserNavigationDelegate: NSObject, WKNavigationDelegate {
+    var didStartProvisionalNavigation: ((WKWebView) -> Void)?
+    var didCommit: ((WKWebView) -> Void)?
     var didFinish: ((WKWebView) -> Void)?
     var didFailNavigation: ((WKWebView, String) -> Void)?
+    var didCancelProvisionalNavigation: ((WKWebView) -> Void)?
     var didTerminateWebContentProcess: ((WKWebView) -> Void)?
     var openInNewTab: ((URL) -> Void)?
     var requestNavigation: ((URLRequest, BrowserInsecureHTTPNavigationIntent) -> Void)?
@@ -7502,6 +7550,11 @@ private class BrowserNavigationDelegate: NSObject, WKNavigationDelegate {
 
     func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
         lastAttemptedURL = webView.url
+        didStartProvisionalNavigation?(webView)
+    }
+
+    func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
+        didCommit?(webView)
     }
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
@@ -7522,6 +7575,7 @@ private class BrowserNavigationDelegate: NSObject, WKNavigationDelegate {
 
         // Cancelled navigations (e.g. rapid typing) are not real errors.
         if nsError.domain == NSURLErrorDomain, nsError.code == NSURLErrorCancelled {
+            didCancelProvisionalNavigation?(webView)
             return
         }
 

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -5369,7 +5369,7 @@ func resolveBrowserNavigableURL(_ input: String) -> URL? {
 
 extension BrowserPanel {
     private func cancelInFlightNavigationBeforeHistoryTraversal() {
-        guard webView.isLoading else { return }
+        guard webView.isLoading || isMainFrameProvisionalNavigationActive else { return }
         webView.stopLoading()
         isMainFrameProvisionalNavigationActive = false
     }

--- a/cmuxTests/BrowserConfigTests.swift
+++ b/cmuxTests/BrowserConfigTests.swift
@@ -2491,6 +2491,12 @@ final class BrowserSessionHistoryRestoreTests: XCTestCase {
         }
 
         func releaseHeldBResponses() {
+            queue.async { [weak self] in
+                self?.releaseHeldBResponsesOnQueue()
+            }
+        }
+
+        private func releaseHeldBResponsesOnQueue() {
             let connections: [NWConnection]
             lock.lock()
             connections = heldBConnections
@@ -2591,24 +2597,27 @@ final class BrowserSessionHistoryRestoreTests: XCTestCase {
         }
     }
 
-    @discardableResult
     private func waitUntil(
         _ description: String,
         timeout: TimeInterval = 5.0,
         file: StaticString = #filePath,
         line: UInt = #line,
         predicate: () -> Bool
-    ) -> Bool {
+    ) throws {
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
             if predicate() {
-                return true
+                return
             }
             RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.01))
         }
 
         XCTFail("Timed out waiting for \(description)", file: file, line: line)
-        return false
+        throw BrowserTestTimeout(description: description)
+    }
+
+    private struct BrowserTestTimeout: Error, CustomStringConvertible {
+        let description: String
     }
 
     private func waitForBrowserPanel(
@@ -2750,50 +2759,28 @@ final class BrowserSessionHistoryRestoreTests: XCTestCase {
         XCTAssertEqual(panel.pageTitle, "Race A")
 
         panel.navigate(to: pageB)
-        waitUntil("server to receive provisional page B request") {
+        try waitUntil("server to receive provisional page B request") {
             server.didReceiveBRequest
         }
-        waitUntil("browser back availability during provisional page B navigation") {
+        try waitUntil("browser back availability during provisional page B navigation") {
             panel.canGoBack && panel.webView.isLoading
         }
 
         panel.goBack()
-        waitUntil("published URL to remain or return to page A before page B commits") {
-            panel.currentURL?.path == pageA.path
+        try waitUntil("back action to cancel provisional page B before it can commit") {
+            panel.currentURL?.path == pageA.path && !panel.webView.isLoading
         }
 
         server.releaseHeldBResponses()
-        waitUntil("browser navigation to settle after racing back against page B") {
-            !panel.webView.isLoading && (panel.pageTitle == "Race A" || panel.pageTitle == "Race B")
+        try waitUntil("browser to remain on page A after held page B response is released") {
+            !panel.webView.isLoading &&
+                panel.pageTitle == "Race A" &&
+                panel.currentURL?.path == pageA.path
         }
 
-        let renderedMarker: String
-        switch panel.pageTitle {
-        case "Race A":
-            renderedMarker = "A"
-        case "Race B":
-            renderedMarker = "B"
-        default:
-            XCTFail("Unexpected rendered page title after navigation race: \(panel.pageTitle)")
-            return
-        }
         let publishedURL = try XCTUnwrap(panel.currentURL)
-        let expectedMarker: String
-        switch publishedURL.path {
-        case pageA.path:
-            expectedMarker = "A"
-        case pageB.path:
-            expectedMarker = "B"
-        default:
-            XCTFail("Unexpected published URL after navigation race: \(publishedURL.absoluteString)")
-            return
-        }
-
-        XCTAssertEqual(
-            renderedMarker,
-            expectedMarker,
-            "Published URL \(publishedURL.absoluteString) disagrees with rendered page marker \(renderedMarker)"
-        )
+        XCTAssertEqual(publishedURL.path, pageA.path)
+        XCTAssertEqual(panel.pageTitle, "Race A")
     }
 
     func testWebViewReplacementAfterProcessTerminationUpdatesInstanceIdentity() {

--- a/cmuxTests/BrowserConfigTests.swift
+++ b/cmuxTests/BrowserConfigTests.swift
@@ -7,6 +7,7 @@ import WebKit
 import ObjectiveC.runtime
 import Bonsplit
 import UserNotifications
+import Network
 
 #if canImport(cmux_DEV)
 @testable import cmux_DEV
@@ -2438,6 +2439,137 @@ final class BrowserJavaScriptDialogDelegateTests: XCTestCase {
 
 @MainActor
 final class BrowserSessionHistoryRestoreTests: XCTestCase {
+    private final class ProvisionalNavigationRaceServer {
+        enum ServerError: Error {
+            case listenerDidNotBecomeReady
+            case listenerPortUnavailable
+        }
+
+        private let listener: NWListener
+        private let queue = DispatchQueue(label: "cmux.browser.provisional-navigation-race-server")
+        private let lock = NSLock()
+        private var heldBConnections: [NWConnection] = []
+        private var receivedBRequest = false
+        private(set) var port: UInt16 = 0
+
+        init() throws {
+            let parameters = NWParameters.tcp
+            parameters.requiredLocalEndpoint = .hostPort(
+                host: NWEndpoint.Host("127.0.0.1"),
+                port: .any
+            )
+            listener = try NWListener(using: parameters)
+
+            let ready = DispatchSemaphore(value: 0)
+            listener.stateUpdateHandler = { state in
+                if case .ready = state {
+                    ready.signal()
+                }
+            }
+            listener.newConnectionHandler = { [weak self] connection in
+                self?.handle(connection)
+            }
+            listener.start(queue: queue)
+
+            guard ready.wait(timeout: .now() + 2.0) == .success else {
+                throw ServerError.listenerDidNotBecomeReady
+            }
+            guard let port = listener.port?.rawValue else {
+                throw ServerError.listenerPortUnavailable
+            }
+            self.port = port
+        }
+
+        var didReceiveBRequest: Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            return receivedBRequest
+        }
+
+        func url(path: String) -> URL {
+            URL(string: "http://127.0.0.1:\(port)\(path)")!
+        }
+
+        func releaseHeldBResponses() {
+            let connections: [NWConnection]
+            lock.lock()
+            connections = heldBConnections
+            heldBConnections.removeAll()
+            lock.unlock()
+
+            for connection in connections {
+                sendPage("B", on: connection)
+            }
+        }
+
+        func stop() {
+            listener.cancel()
+            releaseHeldBResponses()
+        }
+
+        private func handle(_ connection: NWConnection) {
+            connection.start(queue: queue)
+            receiveRequest(on: connection)
+        }
+
+        private func receiveRequest(on connection: NWConnection, buffer: Data = Data()) {
+            connection.receive(minimumIncompleteLength: 1, maximumLength: 4096) { [weak self] data, _, _, error in
+                guard let self else { return }
+                if error != nil {
+                    connection.cancel()
+                    return
+                }
+
+                var nextBuffer = buffer
+                if let data {
+                    nextBuffer.append(data)
+                }
+
+                guard let requestText = String(data: nextBuffer, encoding: .utf8),
+                      requestText.contains("\r\n\r\n") else {
+                    self.receiveRequest(on: connection, buffer: nextBuffer)
+                    return
+                }
+
+                let requestLine = requestText.split(separator: "\r\n", maxSplits: 1).first ?? ""
+                let path = requestLine.split(separator: " ").dropFirst().first.map(String.init) ?? "/"
+                if path == "/b" {
+                    self.lock.lock()
+                    self.receivedBRequest = true
+                    self.heldBConnections.append(connection)
+                    self.lock.unlock()
+                    return
+                }
+
+                self.sendPage("A", on: connection)
+            }
+        }
+
+        private func sendPage(_ marker: String, on connection: NWConnection) {
+            let body = """
+            <!doctype html>
+            <html>
+            <head><title>Race \(marker)</title></head>
+            <body>
+            <script>window.__cmuxRacePage = "\(marker)";</script>
+            <main id="page">Race \(marker)</main>
+            </body>
+            </html>
+            """
+            let response = """
+            HTTP/1.1 200 OK\r
+            Content-Type: text/html; charset=utf-8\r
+            Content-Length: \(body.utf8.count)\r
+            Connection: close\r
+            \r
+            \(body)
+            """
+            connection.send(content: Data(response.utf8), completion: .contentProcessed { _ in
+                connection.cancel()
+            })
+        }
+    }
+
     private func writeBrowserFixturePage(
         at url: URL,
         title: String,
@@ -2457,6 +2589,26 @@ final class BrowserSessionHistoryRestoreTests: XCTestCase {
             XCTFail("Failed to write browser fixture page: \(error)", file: file, line: line)
             throw error
         }
+    }
+
+    @discardableResult
+    private func waitUntil(
+        _ description: String,
+        timeout: TimeInterval = 5.0,
+        file: StaticString = #filePath,
+        line: UInt = #line,
+        predicate: () -> Bool
+    ) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if predicate() {
+                return true
+            }
+            RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.01))
+        }
+
+        XCTFail("Timed out waiting for \(description)", file: file, line: line)
+        return false
     }
 
     private func waitForBrowserPanel(
@@ -2583,6 +2735,65 @@ final class BrowserSessionHistoryRestoreTests: XCTestCase {
 
         panel.goBack()
         waitForBrowserPanel(panel, url: pageA)
+    }
+
+    func testBackDuringProvisionalNavigationDoesNotDesyncPublishedURLFromRenderedPage() throws {
+        let server = try ProvisionalNavigationRaceServer()
+        defer { server.stop() }
+
+        let pageA = server.url(path: "/a")
+        let pageB = server.url(path: "/b")
+        let panel = BrowserPanel(workspaceId: UUID(), initialURL: pageA)
+        defer { panel.close() }
+
+        waitForBrowserPanel(panel, url: pageA)
+        XCTAssertEqual(panel.pageTitle, "Race A")
+
+        panel.navigate(to: pageB)
+        waitUntil("server to receive provisional page B request") {
+            server.didReceiveBRequest
+        }
+        waitUntil("browser back availability during provisional page B navigation") {
+            panel.canGoBack && panel.webView.isLoading
+        }
+
+        panel.goBack()
+        waitUntil("published URL to remain or return to page A before page B commits") {
+            panel.currentURL?.path == pageA.path
+        }
+
+        server.releaseHeldBResponses()
+        waitUntil("browser navigation to settle after racing back against page B") {
+            !panel.webView.isLoading && (panel.pageTitle == "Race A" || panel.pageTitle == "Race B")
+        }
+
+        let renderedMarker: String
+        switch panel.pageTitle {
+        case "Race A":
+            renderedMarker = "A"
+        case "Race B":
+            renderedMarker = "B"
+        default:
+            XCTFail("Unexpected rendered page title after navigation race: \(panel.pageTitle)")
+            return
+        }
+        let publishedURL = try XCTUnwrap(panel.currentURL)
+        let expectedMarker: String
+        switch publishedURL.path {
+        case pageA.path:
+            expectedMarker = "A"
+        case pageB.path:
+            expectedMarker = "B"
+        default:
+            XCTFail("Unexpected published URL after navigation race: \(publishedURL.absoluteString)")
+            return
+        }
+
+        XCTAssertEqual(
+            renderedMarker,
+            expectedMarker,
+            "Published URL \(publishedURL.absoluteString) disagrees with rendered page marker \(renderedMarker)"
+        )
     }
 
     func testWebViewReplacementAfterProcessTerminationUpdatesInstanceIdentity() {

--- a/cmuxTests/BrowserConfigTests.swift
+++ b/cmuxTests/BrowserConfigTests.swift
@@ -2445,6 +2445,7 @@ final class BrowserSessionHistoryRestoreTests: XCTestCase {
             case listenerPortUnavailable
         }
 
+        private static let queueKey = DispatchSpecificKey<Void>()
         private let listener: NWListener
         private let queue = DispatchQueue(label: "cmux.browser.provisional-navigation-race-server")
         private let lock = NSLock()
@@ -2459,6 +2460,7 @@ final class BrowserSessionHistoryRestoreTests: XCTestCase {
                 port: .any
             )
             listener = try NWListener(using: parameters)
+            queue.setSpecific(key: Self.queueKey, value: ())
 
             let ready = DispatchSemaphore(value: 0)
             listener.stateUpdateHandler = { state in
@@ -2490,13 +2492,16 @@ final class BrowserSessionHistoryRestoreTests: XCTestCase {
             URL(string: "http://127.0.0.1:\(port)\(path)")!
         }
 
-        func releaseHeldBResponses() {
-            queue.async { [weak self] in
-                self?.releaseHeldBResponsesOnQueue()
+        func releaseHeldBResponses() -> Int {
+            if DispatchQueue.getSpecific(key: Self.queueKey) != nil {
+                return releaseHeldBResponsesOnQueue()
+            }
+            return queue.sync {
+                releaseHeldBResponsesOnQueue()
             }
         }
 
-        private func releaseHeldBResponsesOnQueue() {
+        private func releaseHeldBResponsesOnQueue() -> Int {
             let connections: [NWConnection]
             lock.lock()
             connections = heldBConnections
@@ -2506,11 +2511,12 @@ final class BrowserSessionHistoryRestoreTests: XCTestCase {
             for connection in connections {
                 sendPage("B", on: connection)
             }
+            return connections.count
         }
 
         func stop() {
             listener.cancel()
-            releaseHeldBResponses()
+            _ = releaseHeldBResponses()
         }
 
         private func handle(_ connection: NWConnection) {
@@ -2771,7 +2777,8 @@ final class BrowserSessionHistoryRestoreTests: XCTestCase {
             panel.currentURL?.path == pageA.path && !panel.webView.isLoading
         }
 
-        server.releaseHeldBResponses()
+        let releasedBResponseCount = server.releaseHeldBResponses()
+        XCTAssertGreaterThan(releasedBResponseCount, 0)
         try waitUntil("browser to remain on page A after held page B response is released") {
             !panel.webView.isLoading &&
                 panel.pageTitle == "Race A" &&

--- a/cmuxTests/BrowserConfigTests.swift
+++ b/cmuxTests/BrowserConfigTests.swift
@@ -2771,10 +2771,12 @@ final class BrowserSessionHistoryRestoreTests: XCTestCase {
         try waitUntil("browser back availability during provisional page B navigation") {
             panel.canGoBack && panel.webView.isLoading
         }
+        XCTAssertFalse(panel.canGoForward)
 
         panel.goBack()
-        try waitUntil("back action to cancel provisional page B before it can commit") {
+        try waitUntil("back action to expose page B as forward history before it can commit") {
             panel.currentURL?.path == pageA.path && !panel.webView.isLoading
+                && panel.canGoForward
         }
 
         let releasedBResponseCount = server.releaseHeldBResponses()


### PR DESCRIPTION
## Summary
- Adds deterministic coverage for pressing browser back while the next page is still provisional.
- Keeps BrowserPanel currentURL publication tied to committed navigation state instead of provisional URL churn.
- Cancels in-flight provisional loading before browser history traversal, so the Back action wins as page A plus page A URL instead of allowing B to commit later.

Fixes #4396

## Repro
- Reproduced with an in-process loopback HTTP server test that loads page A, holds page B before commit, calls BrowserPanel.goBack(), then verifies the browser remains on page A after the held page B response is released.
- No cloud-mac video: this race is covered more cleanly by a deterministic BrowserPanel state-machine regression test.

## Testing
- Not run locally per repository policy. CI is the validation path for this PR.
- Commit structure: first commit adds the regression test; second commit adds the fix; third commit tightens the regression harness based on bot review feedback.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches `BrowserPanel` navigation/state publication and history traversal behavior, which can impact tab URL/title correctness and back/forward UX. Changes are localized but timing-sensitive and rely on WKNavigation delegate ordering.
> 
> **Overview**
> Fixes a race where hitting **Back** during a provisional navigation could leave `BrowserPanel.currentURL` (and search capture) reflecting the provisional URL even though the rendered page remained on the prior commit.
> 
> The panel now tracks whether a main-frame provisional navigation is active, publishes `currentURL` only on **commit/finish**, ignores KVO URL churn during provisional loads, and explicitly cancels any in-flight load before `goBack`/`goForward`. Adds a deterministic regression test using an in-process `NWListener` server that holds the second response to reproduce the back-during-provisional scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bf92abbfccb63db676d3ffa744fea7837d03a28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented URL/title desynchronization when navigating back during a provisional page load; history traversal and stop/loading now reliably cancel in-flight provisional navigations so the UI reflects the correct page.

* **Tests**
  * Added a regression test that reproduces and guards against back-navigation desync during provisional loading.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4397?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->