### PR TITLE
Stop exporting CLAUDE_CONFIG_DIR=$HOME/.claude in the Resume-in-new-tab launch command

### DIFF
--- a/Resources/bin/claude
+++ b/Resources/bin/claude
@@ -35,12 +35,22 @@ cmux_socket_available() {
         "$cmux_bin" --socket "$socket" ping >/dev/null 2>&1
 }
 
+normalize_claude_config_dir() {
+    # Issue #4255: Claude treats CLAUDE_CONFIG_DIR being set to its default
+    # path differently from the variable being absent, so normalize that case.
+    if [[ "${CLAUDE_CONFIG_DIR:-}" == "$HOME/.claude" ]]; then
+        unset CLAUDE_CONFIG_DIR
+    fi
+}
+
 # Pass through if not in a cmux terminal, hooks are disabled, or the cmux
 # socket is unavailable (stale env / app not running).
 IN_CMUX=0
 if [[ -n "$CMUX_SURFACE_ID" ]]; then
     IN_CMUX=1
 fi
+
+normalize_claude_config_dir
 
 if [[ "$IN_CMUX" == "0" || "$CMUX_CLAUDE_HOOKS_DISABLED" == "1" ]] || ! cmux_socket_available; then
     # In cmux-launched shells, preserve old behavior and always clear nested


### PR DESCRIPTION
## Summary

There are two independent fix sites; the primary one (1) is sufficient on its own, and (2) is a defense-in-depth wrapper-side patch that masks future regressions.

1. **Primary fix — stop emitting the redundant env prefix.** Find where the Vault resume launch command is assembled and only include the `env CLAUDE_CONFIG_DIR=...` prefix when the value to be exported is **not** equal to `$HOME/.claude` (i.e. when the user really is on a non-default custom config dir). Candidate sites the reporter flagged via grep:
   - `Packages/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchEnvironmentPolicy.swift` — likely owns the env-var allowlist policy.
   - `Sources/TerminalStartupEnvironment.swift` — likely owns the terminal-side startup env composition.
   - `Sources/RestorableAgentSession.swift` — likely owns the resume command string assembly (matches the grep hit pattern from #4256, which is the companion issue at the same code path).

   Also drop the two `CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV*` variables from the emitted command — they are wrapper-internal and the wrapper unsets them anyway. Keep them inside the wrapper code path; just stop exporting them to the user's external shell.

2. **Defense-in-depth in the wrapper (`Resources/bin/claude`).** At the end of `normalize_claude_config_dir()`, after the legacy-path rewrite block, add:

   ```bash
   if [[ "$CLAUDE_CONFIG_DIR" == "$HOME/.claude" ]]; then
       unset CLAUDE_CONFIG_DIR
   fi
   ```

   This means even if a future code path regresses and re-exports the default value, the wrapper unsets it before exec'ing claude. Tiny behavior change for the (probably empty) set of users who deliberately set `CLAUDE_CONFIG_DIR=$HOME/.claude` to force the custom-config-dir code path — documented in the PR.

3. **Do not change** the non-default `CLAUDE_CONFIG_DIR` path. Users with a genuinely custom config dir (multi-account workflows, container setups) must continue to see it exported. The fix is conditional on equality with `$HOME/.claude`.

## Why this matters

The GUI command emitted by cmux's "Vault by folder → Resume in new tab" feature always begins with:

```
env CLAUDE_CONFIG_DIR=$HOME/.claude \
    CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV=1 \
    CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV_KEYS=CLAUDE_CONFIG_DIR \
    claude --resume <id> ...
```

`$HOME/.claude` is the Claude CLI's default for `CLAUDE_CONFIG_DIR`. But because Claude CLI distinguishes "variable not set" from "variable set to the default value" (via something equivalent to `!!process.env.CLAUDE_CONFIG_DIR` rather than a value comparison), the act of exporting the var takes Claude down its "custom config dir" branch, which fails to read the existing keychain credential and forces the user to re-authenticate every Vault resume.

Reporter (treerobin06) bisected this with five command variants on cmux 0.64.6 / macOS 26.4.1 / Apple Silicon. Removing the `env CLAUDE_CONFIG_DIR=...` prefix is the only variable that flips behavior from "re-auth prompt" to "session resumes cleanly". The two `CMUX_PRESERVE_*` env vars are inert outside the cmux-bundled `Resources/bin/claude` wrapper (the wrapper already unsets them before exec'ing the real claude binary), so they are dead weight in the emitted command.

## Testing

1. **Vault resume default OAuth**: sign in normally, run a session, Cmd-Q, reopen cmux, Vault by folder → Resume in new tab. Generated command must not contain `CLAUDE_CONFIG_DIR=$HOME/.claude` and must not contain `CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV*`. Pasting the command into a fresh shell resumes the session without re-auth prompt.
2. **Vault resume with custom CLAUDE_CONFIG_DIR**: launch cmux with `CLAUDE_CONFIG_DIR=/tmp/alt-claude-config claude` once; create a session; Cmd-Q; reopen and use Resume in new tab. The generated command MUST still export `CLAUDE_CONFIG_DIR=/tmp/alt-claude-config` because the value is non-default.
3. **Wrapper unit**: `Resources/bin/claude` invoked with `CLAUDE_CONFIG_DIR=$HOME/.claude` env set must unset the variable before exec; with `CLAUDE_CONFIG_DIR=/some/other/path` must preserve it.
4. **Five-variant bisection regression**: reproduce reporter's table A-E; only variant E (the original buggy emission) should be impossible to produce; A-D continue to work; the new "default-omitted" variant is a sixth row that also works.
5. **No regression on companion #4256 cd-target path**: the `cd '/path' && ...` portion of the same emitted command remains unchanged here; #4256 is a separate plan.

Fixes #4255

AI was used for assistance.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4401"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents forced re-auth when using “Resume in new tab” by normalizing the environment: if `CLAUDE_CONFIG_DIR` equals `$HOME/.claude`, the wrapper unsets it so the CLI treats it as default. Fixes #4255.

- **Bug Fixes**
  - In `Resources/bin/claude`, added and invoked `normalize_claude_config_dir` to unset `CLAUDE_CONFIG_DIR` only when it equals `$HOME/.claude`; non-default paths are preserved.

<sup>Written for commit cf098c2a4eb104642141e41ddab0bf291d5f6f20. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4401?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Claude configuration directory environment normalization in the cmux wrapper to improve consistency when default paths are used.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4401?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->