### PR TITLE
Fix remapped Cmd+W close shortcuts

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -13541,8 +13541,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         guard !staleDefaultActions.isEmpty else { return false }
 
         for action in staleDefaultActions {
-            let currentShortcut = KeyboardShortcutSettings.shortcut(for: action)
-            if matchesKeyboardShortcutEvent(event, action: action, shortcut: currentShortcut) {
+            if currentShortcutMatchesKeyboardShortcutEvent(event, action: action) {
                 return false
             }
         }
@@ -13552,12 +13551,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
 
         for action in KeyboardShortcutSettings.Action.allCases {
-            let currentShortcut = KeyboardShortcutSettings.shortcut(for: action)
-            if matchesKeyboardShortcutEvent(event, action: action, shortcut: currentShortcut) {
+            if currentShortcutMatchesKeyboardShortcutEvent(event, action: action) {
                 return false
             }
         }
         return true
+    }
+
+    private func currentShortcutMatchesKeyboardShortcutEvent(
+        _ event: NSEvent,
+        action: KeyboardShortcutSettings.Action
+    ) -> Bool {
+        let currentShortcut = KeyboardShortcutSettings.shortcut(for: action)
+        if action.usesNumberedDigitMatching {
+            return numberedShortcutDigit(event: event, shortcut: currentShortcut) != nil
+        }
+        return matchesKeyboardShortcutEvent(event, action: action, shortcut: currentShortcut)
     }
 
     private func isMenuBackedShortcutAction(_ action: KeyboardShortcutSettings.Action) -> Bool {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -10890,6 +10890,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     static func installWindowResponderSwizzlesForTesting() {
         _ = didInstallApplicationAccessibilitySwizzle
         _ = didInstallApplicationSendActionSwizzle
+        _ = didInstallApplicationSendEventSwizzle
         _ = didInstallWindowKeyEquivalentSwizzle
         _ = didInstallWindowFirstResponderSwizzle
         _ = didInstallWindowSendEventSwizzle
@@ -13098,6 +13099,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     /// through the same app-level shortcut handler used by the local key monitor.
     @discardableResult
     func handleBrowserSurfaceKeyEquivalent(_ event: NSEvent) -> Bool {
+        handleConfiguredShortcutKeyEquivalent(event)
+    }
+
+    /// Route AppKit key-equivalent fallbacks through the same configured shortcut
+    /// dispatcher as the local key monitor before any stale menu item can run.
+    @discardableResult
+    func handleConfiguredShortcutKeyEquivalent(_ event: NSEvent) -> Bool {
         handleCustomShortcut(event: event)
     }
 
@@ -13526,23 +13534,43 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             .subtracting([.numericPad, .function, .capsLock])
         guard flags.contains(.command) else { return false }
 
-        for action in KeyboardShortcutSettings.Action.allCases {
+        let staleDefaultActions = KeyboardShortcutSettings.Action.allCases.filter { action in
+            isMenuBackedShortcutAction(action) &&
+                matchesKeyboardShortcutEvent(event, action: action, shortcut: action.defaultShortcut)
+        }
+        guard !staleDefaultActions.isEmpty else { return false }
+
+        for action in staleDefaultActions {
             let currentShortcut = KeyboardShortcutSettings.shortcut(for: action)
             if matchesKeyboardShortcutEvent(event, action: action, shortcut: currentShortcut) {
                 return false
             }
         }
 
-        for action in KeyboardShortcutSettings.Action.allCases where isMenuBackedShortcutAction(action) {
-            if matchesKeyboardShortcutEvent(event, action: action, shortcut: action.defaultShortcut) {
-                return true
+        if staleDefaultActions.contains(where: isCloseShortcutAction) {
+            return true
+        }
+
+        for action in KeyboardShortcutSettings.Action.allCases {
+            let currentShortcut = KeyboardShortcutSettings.shortcut(for: action)
+            if matchesKeyboardShortcutEvent(event, action: action, shortcut: currentShortcut) {
+                return false
             }
         }
-        return false
+        return true
     }
 
     private func isMenuBackedShortcutAction(_ action: KeyboardShortcutSettings.Action) -> Bool {
         action != .showHideAllWindows && action != .globalSearch
+    }
+
+    private func isCloseShortcutAction(_ action: KeyboardShortcutSettings.Action) -> Bool {
+        switch action {
+        case .closeTab, .closeWorkspace, .closeWindow:
+            return true
+        default:
+            return false
+        }
     }
 
     private func numberedShortcutDigit(event: NSEvent, stroke: ShortcutStroke) -> Int? {
@@ -14734,6 +14762,12 @@ private extension NSApplication {
             return
         }
         if AppDelegate.shared?.shouldSuppressStaleCmuxMenuShortcut(event: event) == true {
+            if AppDelegate.shared?.handleConfiguredShortcutKeyEquivalent(event) == true {
+#if DEBUG
+                cmuxDebugLog("app.sendEvent routed configured shortcut before stale cmux menu shortcut")
+#endif
+                return
+            }
             let responder = event.window?.firstResponder
                 ?? keyWindow?.firstResponder
                 ?? mainWindow?.firstResponder
@@ -15284,6 +15318,12 @@ private extension NSWindow {
             return true
         }
         if AppDelegate.shared?.shouldSuppressStaleCmuxMenuShortcut(event: event) == true {
+            if AppDelegate.shared?.handleConfiguredShortcutKeyEquivalent(event) == true {
+#if DEBUG
+                cmuxDebugLog("  → consumed by configured shortcut before stale cmux menu shortcut")
+#endif
+                return true
+            }
             if let firstResponderGhosttyView {
                 firstResponderGhosttyView.keyDown(with: event)
 #if DEBUG

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -5656,6 +5656,97 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         }
     }
 
+    func testStaleCloseDefaultShortcutsSuppressMenuFallbackAfterReassignment() {
+        assertStaleCloseDefaultShortcutSuppressesMenuFallback(
+            staleAction: .closeTab,
+            replacementAction: .newTab,
+            replacementShortcut: StoredShortcut(key: "w", command: true, shift: false, option: false, control: false),
+            remappedStaleShortcut: StoredShortcut(key: "w", command: true, shift: false, option: true, control: false)
+        )
+
+        assertStaleCloseDefaultShortcutSuppressesMenuFallback(
+            staleAction: .closeWorkspace,
+            replacementAction: .newWindow,
+            replacementShortcut: StoredShortcut(key: "w", command: true, shift: true, option: false, control: false),
+            remappedStaleShortcut: StoredShortcut(key: "w", command: true, shift: true, option: true, control: false)
+        )
+
+        assertStaleCloseDefaultShortcutSuppressesMenuFallback(
+            staleAction: .closeWindow,
+            replacementAction: .toggleFullScreen,
+            replacementShortcut: StoredShortcut(key: "w", command: true, shift: false, option: false, control: true),
+            remappedStaleShortcut: StoredShortcut(key: "w", command: true, shift: false, option: true, control: true)
+        )
+    }
+
+    func testApplicationSendEventRoutesReassignedCmdWBeforeStaleCloseTabMenuEquivalent() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        AppDelegate.installWindowResponderSwizzlesForTesting()
+
+        let windowId = appDelegate.createMainWindow()
+        guard let window = appDelegate.windowForMainWindowId(windowId),
+              let manager = appDelegate.tabManagerFor(windowId: windowId) else {
+            closeWindow(withId: windowId)
+            XCTFail("Expected a main window context")
+            return
+        }
+
+        let previousMainMenu = NSApp.mainMenu
+        let menuProbe = MenuActionProbe()
+
+        defer {
+            NSApp.mainMenu = previousMainMenu
+            closeWindow(withId: windowId)
+        }
+
+        let staleMenu = NSMenu(title: "Test")
+        let staleCloseItem = NSMenuItem(
+            title: "Close Tab",
+            action: #selector(MenuActionProbe.perform(_:)),
+            keyEquivalent: "w"
+        )
+        staleCloseItem.keyEquivalentModifierMask = [.command]
+        staleCloseItem.target = menuProbe
+        staleMenu.addItem(staleCloseItem)
+        NSApp.mainMenu = staleMenu
+
+        window.makeKeyAndOrderFront(nil)
+        window.displayIfNeeded()
+
+        guard let event = makeKeyDownEvent(
+            key: "w",
+            modifiers: [.command],
+            keyCode: 13,
+            windowNumber: window.windowNumber
+        ) else {
+            XCTFail("Failed to construct Cmd+W event")
+            return
+        }
+
+        let initialWorkspaceCount = manager.tabs.count
+        let remappedCloseTab = StoredShortcut(key: "w", command: true, shift: false, option: true, control: false)
+        let reassignedNewWorkspace = StoredShortcut(key: "w", command: true, shift: false, option: false, control: false)
+
+        withTemporaryShortcut(action: .closeTab, shortcut: remappedCloseTab) {
+            withTemporaryShortcut(action: .newTab, shortcut: reassignedNewWorkspace) {
+                NSApp.sendEvent(event)
+            }
+        }
+
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+
+        XCTAssertEqual(menuProbe.callCount, 0, "A stale Cmd+W Close Tab menu item must not run after Cmd+W is reassigned")
+        XCTAssertEqual(
+            manager.tabs.count,
+            initialWorkspaceCount + 1,
+            "The action currently assigned to Cmd+W should run before stale Close Tab menu fallback"
+        )
+    }
+
     func testApplicationSendEventSuppressesRemappedCmdDStaleMenuShortcut() {
         let previousMainMenu = NSApp.mainMenu
         let probeWindow = NSWindow(
@@ -6207,6 +6298,35 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         }
         KeyboardShortcutSettings.setShortcut(shortcut ?? action.defaultShortcut, for: action)
         body()
+    }
+
+    private func assertStaleCloseDefaultShortcutSuppressesMenuFallback(
+        staleAction: KeyboardShortcutSettings.Action,
+        replacementAction: KeyboardShortcutSettings.Action,
+        replacementShortcut: StoredShortcut,
+        remappedStaleShortcut: StoredShortcut,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared", file: file, line: line)
+            return
+        }
+        guard let event = makeKeyDownEvent(shortcut: replacementShortcut, windowNumber: 0) else {
+            XCTFail("Failed to construct reassigned close-default shortcut event", file: file, line: line)
+            return
+        }
+
+        withTemporaryShortcut(action: staleAction, shortcut: remappedStaleShortcut) {
+            withTemporaryShortcut(action: replacementAction, shortcut: replacementShortcut) {
+                XCTAssertTrue(
+                    appDelegate.shouldSuppressStaleCmuxMenuShortcut(event: event),
+                    "\(staleAction.rawValue) should suppress its stale default menu fallback after that key is reassigned",
+                    file: file,
+                    line: line
+                )
+            }
+        }
     }
 
     private func assertEscapeKeyUpIsConsumedAfterCommandPaletteOpenRequest(

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -5656,6 +5656,47 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         }
     }
 
+    func testCurrentNumberedDigitShortcutIsNotSuppressedAsStaleMenuShortcut() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        guard let event = makeKeyDownEvent(
+            key: "2",
+            modifiers: [.command],
+            keyCode: 19,
+            windowNumber: 0
+        ) else {
+            XCTFail("Failed to construct Cmd+2 event")
+            return
+        }
+
+        let remappedWorkspaceNumber = StoredShortcut(
+            key: "1",
+            command: false,
+            shift: false,
+            option: false,
+            control: true
+        )
+        let currentSurfaceNumber = StoredShortcut(
+            key: "1",
+            command: true,
+            shift: false,
+            option: false,
+            control: false
+        )
+
+        withTemporaryShortcut(action: .selectWorkspaceByNumber, shortcut: remappedWorkspaceNumber) {
+            withTemporaryShortcut(action: .selectSurfaceByNumber, shortcut: currentSurfaceNumber) {
+                XCTAssertFalse(
+                    appDelegate.shouldSuppressStaleCmuxMenuShortcut(event: event),
+                    "A current numbered-digit shortcut must own Cmd+2 before stale menu suppression"
+                )
+            }
+        }
+    }
+
     func testStaleCloseDefaultShortcutsSuppressMenuFallbackAfterReassignment() {
         assertStaleCloseDefaultShortcutSuppressesMenuFallback(
             staleAction: .closeTab,

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -5730,7 +5730,8 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
 
         let windowId = appDelegate.createMainWindow()
         guard let window = appDelegate.windowForMainWindowId(windowId),
-              let manager = appDelegate.tabManagerFor(windowId: windowId) else {
+              let manager = appDelegate.tabManagerFor(windowId: windowId),
+              let initialSidebarVisible = appDelegate.sidebarVisibility(windowId: windowId) else {
             closeWindow(withId: windowId)
             XCTFail("Expected a main window context")
             return
@@ -5770,10 +5771,10 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
 
         let initialWorkspaceCount = manager.tabs.count
         let remappedCloseTab = StoredShortcut(key: "w", command: true, shift: false, option: true, control: false)
-        let reassignedNewWorkspace = StoredShortcut(key: "w", command: true, shift: false, option: false, control: false)
+        let reassignedSidebarToggle = StoredShortcut(key: "w", command: true, shift: false, option: false, control: false)
 
         withTemporaryShortcut(action: .closeTab, shortcut: remappedCloseTab) {
-            withTemporaryShortcut(action: .newTab, shortcut: reassignedNewWorkspace) {
+            withTemporaryShortcut(action: .toggleSidebar, shortcut: reassignedSidebarToggle) {
                 NSApp.sendEvent(event)
             }
         }
@@ -5783,7 +5784,12 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         XCTAssertEqual(menuProbe.callCount, 0, "A stale Cmd+W Close Tab menu item must not run after Cmd+W is reassigned")
         XCTAssertEqual(
             manager.tabs.count,
-            initialWorkspaceCount + 1,
+            initialWorkspaceCount,
+            "Plain Cmd+W must not close a tab after Close Tab is remapped away"
+        )
+        XCTAssertEqual(
+            appDelegate.sidebarVisibility(windowId: windowId),
+            !initialSidebarVisible,
             "The action currently assigned to Cmd+W should run before stale Close Tab menu fallback"
         )
     }


### PR DESCRIPTION
Fixes #1488

## Summary
- Treat stale default close shortcuts as stale even when their key has been reassigned to another configured action.
- Route configured shortcut handling before stale close menu fallback at the application and window key-equivalent boundaries.
- Add regression coverage for Close Tab, Close Workspace, and Close Window defaults, plus Cmd+W reassignment before a stale Close Tab menu item.

## Reproduction / evidence
- Reviewed issue #1488, umbrella #3726, and stale PRs #1490 and #2512.
- Attempted local reproduction against an already-running tagged debug app without launching or rebuilding; that build already suppressed the simple remap-away case, so the regression targets the remaining split-owner fallback path where stale close defaults could still win after reassignment.

## Test structure
- Commit 1 adds the regression tests only.
- Commit 2 adds the fix.

## Testing
- CI: all required checks green on 2026-05-20.
- Tagged dev build: `CMUX_SKIP_ZIG_BUILD=1 ./scripts/reload.sh --tag issue-1488-cmd-w-remap-broken --launch` built successfully locally.
- Launch: `reload.sh` first socket check timed out, then the built tagged app was opened directly; `/tmp/cmux-debug-issue-1488-cmd-w-remap-broken.sock` was created and the app stayed running.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4406"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes event/shortcut routing for Command-key equivalents (including `Cmd+W`) and stale-menu suppression logic, which can subtly impact global keyboard handling across windows. Added regression tests reduce risk but behavior changes may affect edge-case shortcuts and AppKit menu interactions.
> 
> **Overview**
> Fixes cases where remapped **close** shortcuts (e.g., `Cmd+W`) could still trigger stale AppKit menu items.
> 
> Configured shortcut handling is now dispatched earlier (via new `handleConfiguredShortcutKeyEquivalent`) from both `NSApplication.sendEvent` and window key-equivalent paths, before any stale menu fallback runs.
> 
> Refines `shouldSuppressStaleCmuxMenuShortcut` to (1) treat default close shortcuts as stale even when their key is reassigned, and (2) avoid suppressing events owned by current numbered-digit shortcuts. Adds regression tests covering these scenarios, including an end-to-end `Cmd+W` reassignment against a mocked stale Close Tab menu item.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9e396cc6121284243c71528f801043b80e88e12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1488: remapped Cmd+W and other Close shortcuts no longer lose to stale menu items, and numbered-digit shortcuts (e.g., Cmd+2) keep working. Configured shortcuts now run before any menu fallback; Close defaults are considered stale once reassigned.

- **Bug Fixes**
  - Route configured shortcuts before menu fallbacks in `NSApplication.sendEvent` and `NSWindow.performKeyEquivalent` via a shared `handleConfiguredShortcutKeyEquivalent`.
  - Treat `.closeTab`, `.closeWorkspace`, and `.closeWindow` defaults as stale after reassignment; do not suppress current numbered-digit shortcuts.
  - Add isolated regression tests: reassigned Cmd+W beats a stale Close Tab menu via sendEvent; stale Close defaults; numbered-digit shortcuts.

<sup>Written for commit e9e396cc6121284243c71528f801043b80e88e12. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4406?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Configured keyboard shortcuts are now routed before stale menu fallbacks across application and window event paths.
  * Stale menu-shortcut suppression refined with explicit handling for close-related actions and more accurate suppression decisions.

* **Tests**
  * Added regression tests covering reassigned and temporarily remapped shortcuts, ensuring correct routing and suppression behavior for close and numbered-digit actions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4406?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

