### PR TITLE
Fix Vault search cancellation crash

### DIFF
--- a/Sources/SessionIndexStore.swift
+++ b/Sources/SessionIndexStore.swift
@@ -1326,9 +1326,13 @@ final class SessionIndexStore: ObservableObject {
 
         return await withTaskCancellationHandler {
             guard cancellableProcess.shouldStart() else {
-                return nil as [URL]?
+                return []
             }
-            do { try process.run() } catch { return nil as [URL]? }
+            do {
+                try process.run()
+            } catch {
+                return Task.isCancelled ? [] : nil
+            }
             cancellableProcess.markStarted()
             defer { cancellableProcess.complete() }
             // Drain stdout BEFORE waitUntilExit. With many matches rg writes
@@ -1350,7 +1354,7 @@ final class SessionIndexStore: ObservableObject {
             case 1:
                 return []
             default:
-                return nil
+                return Task.isCancelled ? [] : nil
             }
         } onCancel: {
             // Fires synchronously when the awaiting Task is cancelled. Sends
@@ -1385,6 +1389,7 @@ final class SessionIndexStore: ObservableObject {
                     root: root.projectsRoot,
                     fileGlob: "*.jsonl"
                 ) else {
+                    if Task.isCancelled { return [] }
                     candidates.append(
                         contentsOf: enumerateClaudeJSONLCandidates(
                             root: root,

--- a/Sources/SessionIndexStore.swift
+++ b/Sources/SessionIndexStore.swift
@@ -47,6 +47,8 @@ final class ClaudeMetadataCache: @unchecked Sendable {
     }
 }
 
+// Safe to mark @unchecked Sendable: `lock` guards every mutable field. `onCancel`
+// is synchronous and cannot await an actor hop, so this helper uses NSLock instead.
 private final class SessionIndexCancellableProcess: @unchecked Sendable {
     private let process: Process
     private let lock = NSLock()

--- a/Sources/SessionIndexStore.swift
+++ b/Sources/SessionIndexStore.swift
@@ -2,6 +2,7 @@ import AppKit
 import Bonsplit
 import CMUXAgentLaunch
 import Combine
+import Darwin
 import Foundation
 import os
 import SQLite3
@@ -43,6 +44,60 @@ final class ClaudeMetadataCache: @unchecked Sendable {
                 .map(\.key)
             for k in oldestKeys { entries.removeValue(forKey: k) }
         }
+    }
+}
+
+private final class SessionIndexCancellableProcess: @unchecked Sendable {
+    private let process: Process
+    private let lock = NSLock()
+    private var processIdentifier: pid_t?
+    private var cancelled = false
+    private var completed = false
+
+    init(process: Process) {
+        self.process = process
+    }
+
+    func shouldStart() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return !cancelled && !completed
+    }
+
+    func markStarted() {
+        let pid = process.processIdentifier
+        let shouldTerminate: Bool
+        lock.lock()
+        processIdentifier = pid
+        shouldTerminate = cancelled && !completed
+        lock.unlock()
+
+        if shouldTerminate {
+            terminate(pid: pid)
+        }
+    }
+
+    func cancel() {
+        let pidToTerminate: pid_t?
+        lock.lock()
+        cancelled = true
+        pidToTerminate = completed ? nil : processIdentifier
+        lock.unlock()
+
+        if let pidToTerminate {
+            terminate(pid: pidToTerminate)
+        }
+    }
+
+    func complete() {
+        lock.lock()
+        completed = true
+        lock.unlock()
+    }
+
+    private func terminate(pid: pid_t) {
+        guard pid > 0, process.isRunning else { return }
+        _ = Darwin.kill(pid, SIGTERM)
     }
 }
 
@@ -1265,9 +1320,15 @@ final class SessionIndexStore: ObservableObject {
         if let nullDev = FileHandle(forWritingAtPath: "/dev/null") {
             process.standardError = nullDev
         }
+        let cancellableProcess = SessionIndexCancellableProcess(process: process)
 
         return await withTaskCancellationHandler {
+            guard cancellableProcess.shouldStart() else {
+                return nil as [URL]?
+            }
             do { try process.run() } catch { return nil as [URL]? }
+            cancellableProcess.markStarted()
+            defer { cancellableProcess.complete() }
             // Drain stdout BEFORE waitUntilExit. With many matches rg writes
             // more than the ~64 KB pipe buffer; reading until EOF lets rg
             // make progress and EOF arrives when rg closes its stdout on exit.
@@ -1293,7 +1354,7 @@ final class SessionIndexStore: ObservableObject {
             // Fires synchronously when the awaiting Task is cancelled. Sends
             // SIGTERM to rg, which closes stdout, lets readDataToEndOfFile
             // return, and unblocks the body so this call can complete cleanly.
-            process.terminate()
+            cancellableProcess.cancel()
         }
     }
 

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -1829,7 +1829,8 @@ final class UpdateTitlebarAccessoryController {
             queue: .main
         ) { [weak self] notification in
             guard let window = notification.object as? NSWindow else { return }
-            Task { @MainActor [weak self] in
+            Task { @MainActor [weak self, weak window] in
+                guard let window else { return }
                 self?.attachIfNeeded(to: window)
             }
         })
@@ -1840,7 +1841,8 @@ final class UpdateTitlebarAccessoryController {
             queue: .main
         ) { [weak self] notification in
             guard let window = notification.object as? NSWindow else { return }
-            Task { @MainActor [weak self] in
+            Task { @MainActor [weak self, weak window] in
+                guard let window else { return }
                 self?.attachIfNeeded(to: window)
             }
         })

--- a/cmuxTests/PortScannerTests.swift
+++ b/cmuxTests/PortScannerTests.swift
@@ -36,34 +36,3 @@ final class PortScannerProcessCaptureTests: XCTestCase {
         XCTAssertLessThanOrEqual(finalCount - baseline, 8)
     }
 }
-
-final class SessionIndexRipgrepCancellationTests: XCTestCase {
-    func testRipgrepCancellationBeforeLaunchDoesNotAbort() async throws {
-        try XCTSkipUnless(
-            RipgrepExecutableResolver.resolve(configuredPath: nil) != nil,
-            "ripgrep is required for session search cancellation behavior"
-        )
-
-        let rootURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        defer { try? FileManager.default.removeItem(at: rootURL) }
-        try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
-        try "needle\n".write(
-            to: rootURL.appendingPathComponent("session.jsonl"),
-            atomically: true,
-            encoding: .utf8
-        )
-
-        let task = Task { () -> [URL]? in
-            await Task.yield()
-            return await SessionIndexStore.ripgrepMatchingPaths(
-                needle: "needle",
-                root: rootURL.path,
-                fileGlob: "*.jsonl"
-            )
-        }
-        task.cancel()
-
-        _ = await task.value
-    }
-}

--- a/cmuxTests/PortScannerTests.swift
+++ b/cmuxTests/PortScannerTests.swift
@@ -36,3 +36,34 @@ final class PortScannerProcessCaptureTests: XCTestCase {
         XCTAssertLessThanOrEqual(finalCount - baseline, 8)
     }
 }
+
+final class SessionIndexRipgrepCancellationTests: XCTestCase {
+    func testRipgrepCancellationBeforeLaunchDoesNotAbort() async throws {
+        try XCTSkipUnless(
+            RipgrepExecutableResolver.resolve(configuredPath: nil) != nil,
+            "ripgrep is required for session search cancellation behavior"
+        )
+
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+        try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+        try "needle\n".write(
+            to: rootURL.appendingPathComponent("session.jsonl"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let task = Task { () -> [URL]? in
+            await Task.yield()
+            return await SessionIndexStore.ripgrepMatchingPaths(
+                needle: "needle",
+                root: rootURL.path,
+                fileGlob: "*.jsonl"
+            )
+        }
+        task.cancel()
+
+        _ = await task.value
+    }
+}

--- a/cmuxTests/RestorableAgentSessionIndexTests.swift
+++ b/cmuxTests/RestorableAgentSessionIndexTests.swift
@@ -324,17 +324,46 @@ final class SessionIndexRipgrepCancellationTests: XCTestCase {
             encoding: .utf8
         )
 
+        let gate = SessionIndexCancellationGate()
         let task = Task { () -> [URL]? in
-            await Task.yield()
+            await gate.waitForRelease()
             return await SessionIndexStore.ripgrepMatchingPaths(
                 needle: "needle",
                 root: rootURL.path,
                 fileGlob: "*.jsonl"
             )
         }
+        await gate.waitUntilReached()
         task.cancel()
+        await gate.release()
 
         let matches = await task.value
         XCTAssertEqual(matches, [])
+    }
+}
+
+private actor SessionIndexCancellationGate {
+    private var releaseContinuation: CheckedContinuation<Void, Never>?
+    private var reachedContinuation: CheckedContinuation<Void, Never>?
+
+    func waitForRelease() async {
+        await withCheckedContinuation { continuation in
+            releaseContinuation = continuation
+            reachedContinuation?.resume()
+            reachedContinuation = nil
+        }
+    }
+
+    func waitUntilReached() async {
+        if releaseContinuation != nil { return }
+        await withCheckedContinuation { continuation in
+            reachedContinuation = continuation
+        }
+    }
+
+    func release() {
+        let continuation = releaseContinuation
+        releaseContinuation = nil
+        continuation?.resume()
     }
 }

--- a/cmuxTests/RestorableAgentSessionIndexTests.swift
+++ b/cmuxTests/RestorableAgentSessionIndexTests.swift
@@ -306,3 +306,34 @@ final class RestorableAgentSessionIndexTests: XCTestCase {
         )
     }
 }
+
+final class SessionIndexRipgrepCancellationTests: XCTestCase {
+    func testRipgrepCancellationBeforeLaunchDoesNotAbort() async throws {
+        try XCTSkipUnless(
+            RipgrepExecutableResolver.resolve(configuredPath: nil) != nil,
+            "ripgrep is required for session search cancellation behavior"
+        )
+
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+        try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+        try "needle\n".write(
+            to: rootURL.appendingPathComponent("session.jsonl"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let task = Task { () -> [URL]? in
+            await Task.yield()
+            return await SessionIndexStore.ripgrepMatchingPaths(
+                needle: "needle",
+                root: rootURL.path,
+                fileGlob: "*.jsonl"
+            )
+        }
+        task.cancel()
+
+        _ = await task.value
+    }
+}

--- a/cmuxTests/RestorableAgentSessionIndexTests.swift
+++ b/cmuxTests/RestorableAgentSessionIndexTests.swift
@@ -334,6 +334,7 @@ final class SessionIndexRipgrepCancellationTests: XCTestCase {
         }
         task.cancel()
 
-        _ = await task.value
+        let matches = await task.value
+        XCTAssertEqual(matches, [])
     }
 }


### PR DESCRIPTION
Summary
- Reproduced the supplied ghosttycrash as an NSInvalidArgumentException from Process.terminate() before Process.run() finished launching.
- Track the ripgrep process launch state and only send SIGTERM after the child has a pid.
- Add a cancellation regression test for the pre-launch path.

Test
- xcodebuild -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination "platform=macOS,arch=arm64" -derivedDataPath /tmp/cmux-crashrepro -only-testing:cmuxTests/SessionIndexRipgrepCancellationTests test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4411"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches async cancellation around `Process` management; incorrect state tracking could leak/leave orphaned `rg` processes or alter search fallback behavior, but the change is small and covered by a new regression test.
> 
> **Overview**
> Fixes a Vault/session search crash when cancelling a ripgrep-backed query before `Process.run()` fully launches by introducing `SessionIndexCancellableProcess` to track start/cancel/complete state and only send `SIGTERM` once a PID exists.
> 
> Adjusts `ripgrepMatchingPaths` to treat cancellation consistently as an empty result (`[]`) (including launch failures and non-zero exit), short-circuits Claude candidate enumeration on cancellation, and adds `SessionIndexRipgrepCancellationTests` to lock in the pre-launch cancellation behavior. Also tightens titlebar accessory window observer tasks by capturing `window` weakly to avoid acting on deallocated windows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7e8af78abc0eafe6c17490f01e596cfd847a0ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash in Vault search when cancelling before `ripgrep` finishes launching. Keeps cancellation semantics (cancelled searches return []) and avoids stale titlebar window captures when attaching the update accessory.

- **Bug Fixes**
  - Replaced unconditional `Process.terminate()` with a cancellable wrapper; sends SIGTERM via `Darwin.kill` only after a PID exists and the process is running, and safely handles pre-cancel.
  - Preserved cancellation behavior end-to-end: return [] on cancel (including launch errors and non-zero exit), short-circuit candidate enumeration when `Task.isCancelled`, and stabilized the regression test; also capture `window` weakly in async attach to prevent stale references.

<sup>Written for commit b7e8af78abc0eafe6c17490f01e596cfd847a0ca. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4411?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of search task cancellation so operations canceled before start are handled gracefully and do not produce spurious failures.
  * Ensured cancellation won't trigger unnecessary termination after a search completes.
  * Fixed titlebar window observer capture to validate window before attaching, avoiding timing-related attach issues.

* **Tests**
  * Added async test verifying cancellation-before-launch results in a clean stop with no matches; includes deterministic coordination to reproduce timing reliably.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4411?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->