### PR TITLE
Fix session search ripgrep cancellation crash

### DIFF
--- a/Sources/SessionIndexStore.swift
+++ b/Sources/SessionIndexStore.swift
@@ -12,11 +12,13 @@ nonisolated private let sessionIndexLogger = Logger(
     category: "SessionIndexStore"
 )
 
+/// Locked cancellation state shared by synchronous `Process` callbacks.
+/// `onCancel` cannot await an actor, so mutable state stays behind `lock`.
 final class SessionIndexRipgrepCancellation: @unchecked Sendable {
     private let lock = NSLock()
     private let sendSignal: @Sendable (pid_t, Int32) -> Int32
     private var activeProcessIdentifier: pid_t?
-    private var finishedProcessIdentifiers = Set<pid_t>()
+    private var finishedProcessIdentifier: pid_t?
 
     init(sendSignal: @escaping @Sendable (pid_t, Int32) -> Int32 = Darwin.kill) {
         self.sendSignal = sendSignal
@@ -26,7 +28,7 @@ final class SessionIndexRipgrepCancellation: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
 
-        if finishedProcessIdentifiers.contains(processIdentifier) {
+        if finishedProcessIdentifier == processIdentifier {
             activeProcessIdentifier = nil
         } else {
             activeProcessIdentifier = processIdentifier
@@ -37,11 +39,7 @@ final class SessionIndexRipgrepCancellation: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
 
-        finishedProcessIdentifiers.insert(processIdentifier)
-        if finishedProcessIdentifiers.count > 16 {
-            finishedProcessIdentifiers.removeAll(keepingCapacity: true)
-            finishedProcessIdentifiers.insert(processIdentifier)
-        }
+        finishedProcessIdentifier = processIdentifier
         if activeProcessIdentifier == processIdentifier {
             activeProcessIdentifier = nil
         }

--- a/Sources/SessionIndexStore.swift
+++ b/Sources/SessionIndexStore.swift
@@ -1285,9 +1285,9 @@ final class SessionIndexStore: ObservableObject {
     /// cancelled (e.g. user types another key), `onCancel` signals the launched
     /// rg process instead of letting it grind to completion.
     nonisolated static func ripgrepMatchingPaths(
-        needle: String, root: String, fileGlob: String
+        needle: String, root: String, fileGlob: String, ripgrepPath: String? = nil
     ) async -> [URL]? {
-        guard let rg = resolvedRipgrepPath() else { return nil }
+        guard let rg = ripgrepPath ?? resolvedRipgrepPath() else { return nil }
         let process = Process()
         process.executableURL = URL(fileURLWithPath: rg)
         process.arguments = [

--- a/Sources/SessionIndexStore.swift
+++ b/Sources/SessionIndexStore.swift
@@ -1313,8 +1313,13 @@ final class SessionIndexStore: ObservableObject {
         }
 
         return await withTaskCancellationHandler {
-            guard !Task.isCancelled else { return nil as [URL]? }
-            do { try process.run() } catch { return nil as [URL]? }
+            guard !Task.isCancelled else { return [] }
+            do {
+                try process.run()
+            } catch {
+                if Task.isCancelled { return [] }
+                return nil as [URL]?
+            }
             cancellation.markStarted(processIdentifier: process.processIdentifier)
             if Task.isCancelled {
                 cancellation.cancel()
@@ -1330,6 +1335,7 @@ final class SessionIndexStore: ObservableObject {
             let data = outPipe.fileHandleForReading.readDataToEndOfFile()
             process.waitUntilExit()
             cancellation.markFinished(processIdentifier: process.processIdentifier)
+            if Task.isCancelled { return [] }
             // rg exit codes: 0 = matches, 1 = no matches, 2 = error/terminated.
             switch process.terminationStatus {
             case 0:

--- a/Sources/SessionIndexStore.swift
+++ b/Sources/SessionIndexStore.swift
@@ -48,6 +48,7 @@ final class SessionIndexRipgrepCancellation: @unchecked Sendable {
     func cancel() {
         lock.lock()
         let processIdentifier = activeProcessIdentifier
+        activeProcessIdentifier = nil
         lock.unlock()
 
         guard let processIdentifier else { return }

--- a/Sources/SessionIndexStore.swift
+++ b/Sources/SessionIndexStore.swift
@@ -2,6 +2,7 @@ import AppKit
 import Bonsplit
 import CMUXAgentLaunch
 import Combine
+import Darwin
 import Foundation
 import os
 import SQLite3
@@ -10,6 +11,51 @@ nonisolated private let sessionIndexLogger = Logger(
     subsystem: Bundle.main.bundleIdentifier ?? "com.cmuxterm.app",
     category: "SessionIndexStore"
 )
+
+final class SessionIndexRipgrepCancellation: @unchecked Sendable {
+    private let lock = NSLock()
+    private let sendSignal: @Sendable (pid_t, Int32) -> Int32
+    private var activeProcessIdentifier: pid_t?
+    private var finishedProcessIdentifiers = Set<pid_t>()
+
+    init(sendSignal: @escaping @Sendable (pid_t, Int32) -> Int32 = Darwin.kill) {
+        self.sendSignal = sendSignal
+    }
+
+    func markStarted(processIdentifier: pid_t) {
+        lock.lock()
+        defer { lock.unlock() }
+
+        if finishedProcessIdentifiers.contains(processIdentifier) {
+            activeProcessIdentifier = nil
+        } else {
+            activeProcessIdentifier = processIdentifier
+        }
+    }
+
+    func markFinished(processIdentifier: pid_t) {
+        lock.lock()
+        defer { lock.unlock() }
+
+        finishedProcessIdentifiers.insert(processIdentifier)
+        if finishedProcessIdentifiers.count > 16 {
+            finishedProcessIdentifiers.removeAll(keepingCapacity: true)
+            finishedProcessIdentifiers.insert(processIdentifier)
+        }
+        if activeProcessIdentifier == processIdentifier {
+            activeProcessIdentifier = nil
+        }
+    }
+
+    func cancel() {
+        lock.lock()
+        let processIdentifier = activeProcessIdentifier
+        lock.unlock()
+
+        guard let processIdentifier else { return }
+        _ = sendSignal(processIdentifier, SIGTERM)
+    }
+}
 
 // MARK: - Parsed metadata cache
 
@@ -1237,10 +1283,8 @@ final class SessionIndexStore: ObservableObject {
     /// URLs, or nil if rg isn't available or the run failed (caller falls back).
     ///
     /// Async by design so we can wire cancellation: when the awaiting Task is
-    /// cancelled (e.g. user types another key), `onCancel` calls
-    /// `process.terminate()`, killing the in-flight rg instead of letting it
-    /// grind to completion. Wait is also async (via `terminationHandler`) so we
-    /// don't tie up a cooperative-pool thread on `waitUntilExit`.
+    /// cancelled (e.g. user types another key), `onCancel` signals the launched
+    /// rg process instead of letting it grind to completion.
     nonisolated static func ripgrepMatchingPaths(
         needle: String, root: String, fileGlob: String
     ) async -> [URL]? {
@@ -1265,9 +1309,18 @@ final class SessionIndexStore: ObservableObject {
         if let nullDev = FileHandle(forWritingAtPath: "/dev/null") {
             process.standardError = nullDev
         }
+        let cancellation = SessionIndexRipgrepCancellation()
+        process.terminationHandler = { process in
+            cancellation.markFinished(processIdentifier: process.processIdentifier)
+        }
 
         return await withTaskCancellationHandler {
+            guard !Task.isCancelled else { return nil as [URL]? }
             do { try process.run() } catch { return nil as [URL]? }
+            cancellation.markStarted(processIdentifier: process.processIdentifier)
+            if Task.isCancelled {
+                cancellation.cancel()
+            }
             // Drain stdout BEFORE waitUntilExit. With many matches rg writes
             // more than the ~64 KB pipe buffer; reading until EOF lets rg
             // make progress and EOF arrives when rg closes its stdout on exit.
@@ -1278,6 +1331,7 @@ final class SessionIndexStore: ObservableObject {
             // late and never fires → deadlock.)
             let data = outPipe.fileHandleForReading.readDataToEndOfFile()
             process.waitUntilExit()
+            cancellation.markFinished(processIdentifier: process.processIdentifier)
             // rg exit codes: 0 = matches, 1 = no matches, 2 = error/terminated.
             switch process.terminationStatus {
             case 0:
@@ -1290,10 +1344,10 @@ final class SessionIndexStore: ObservableObject {
                 return nil
             }
         } onCancel: {
-            // Fires synchronously when the awaiting Task is cancelled. Sends
-            // SIGTERM to rg, which closes stdout, lets readDataToEndOfFile
-            // return, and unblocks the body so this call can complete cleanly.
-            process.terminate()
+            // Fires synchronously when the awaiting Task is cancelled. SIGTERM
+            // closes stdout, lets readDataToEndOfFile return, and unblocks the
+            // body so this call can complete cleanly.
+            cancellation.cancel()
         }
     }
 

--- a/cmuxTests/RovoDevSessionIndexTests.swift
+++ b/cmuxTests/RovoDevSessionIndexTests.swift
@@ -51,6 +51,46 @@ final class RovoDevSessionIndexTests: XCTestCase {
         XCTAssertTrue(sentSignals.isEmpty)
     }
 
+    func testRipgrepMatchingPathsCancellationDoesNotReportFailure() async throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.tempDir) }
+
+        let fakeRipgrep = fixture.tempDir.appendingPathComponent("rg")
+        try """
+        #!/bin/sh
+        exec /bin/sleep 10
+        """.write(to: fakeRipgrep, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: fakeRipgrep.path
+        )
+
+        let defaults = UserDefaults.standard
+        let previousPath = defaults.string(forKey: RipgrepIntegrationSettings.customRipgrepPathKey)
+        defaults.set(fakeRipgrep.path, forKey: RipgrepIntegrationSettings.customRipgrepPathKey)
+        defer {
+            if let previousPath {
+                defaults.set(previousPath, forKey: RipgrepIntegrationSettings.customRipgrepPathKey)
+            } else {
+                defaults.removeObject(forKey: RipgrepIntegrationSettings.customRipgrepPathKey)
+            }
+        }
+
+        let task = Task {
+            await SessionIndexStore.ripgrepMatchingPaths(
+                needle: "needle",
+                root: fixture.tempDir.path,
+                fileGlob: "*.jsonl"
+            )
+        }
+        try await Task.sleep(for: .milliseconds(50))
+        task.cancel()
+
+        let matches = await task.value
+
+        XCTAssertEqual(matches, [])
+    }
+
     func testRovoDevSessionIndexReadsMetadataAndResumeCommand() throws {
         let fixture = try makeFixture()
         defer { try? FileManager.default.removeItem(at: fixture.tempDir) }

--- a/cmuxTests/RovoDevSessionIndexTests.swift
+++ b/cmuxTests/RovoDevSessionIndexTests.swift
@@ -29,6 +29,7 @@ final class RovoDevSessionIndexTests: XCTestCase {
 
         cancellation.markStarted(processIdentifier: 12345)
         cancellation.cancel()
+        cancellation.cancel()
         cancellation.markFinished(processIdentifier: 12345)
         cancellation.cancel()
 

--- a/cmuxTests/RovoDevSessionIndexTests.swift
+++ b/cmuxTests/RovoDevSessionIndexTests.swift
@@ -66,22 +66,12 @@ final class RovoDevSessionIndexTests: XCTestCase {
             ofItemAtPath: fakeRipgrep.path
         )
 
-        let defaults = UserDefaults.standard
-        let previousPath = defaults.string(forKey: RipgrepIntegrationSettings.customRipgrepPathKey)
-        defaults.set(fakeRipgrep.path, forKey: RipgrepIntegrationSettings.customRipgrepPathKey)
-        defer {
-            if let previousPath {
-                defaults.set(previousPath, forKey: RipgrepIntegrationSettings.customRipgrepPathKey)
-            } else {
-                defaults.removeObject(forKey: RipgrepIntegrationSettings.customRipgrepPathKey)
-            }
-        }
-
         let task = Task {
             await SessionIndexStore.ripgrepMatchingPaths(
                 needle: "needle",
                 root: fixture.tempDir.path,
-                fileGlob: "*.jsonl"
+                fileGlob: "*.jsonl",
+                ripgrepPath: fakeRipgrep.path
             )
         }
         try await Task.sleep(for: .milliseconds(50))

--- a/cmuxTests/RovoDevSessionIndexTests.swift
+++ b/cmuxTests/RovoDevSessionIndexTests.swift
@@ -1,3 +1,4 @@
+import Darwin
 import XCTest
 
 #if canImport(cmux_DEV)
@@ -7,6 +8,49 @@ import XCTest
 #endif
 
 final class RovoDevSessionIndexTests: XCTestCase {
+    func testRipgrepCancellationDoesNotSignalBeforeProcessStarts() {
+        var sentSignals: [(pid_t, Int32)] = []
+        let cancellation = SessionIndexRipgrepCancellation { processIdentifier, signal in
+            sentSignals.append((processIdentifier, signal))
+            return 0
+        }
+
+        cancellation.cancel()
+
+        XCTAssertTrue(sentSignals.isEmpty)
+    }
+
+    func testRipgrepCancellationSignalsActiveProcess() {
+        var sentSignals: [(pid_t, Int32)] = []
+        let cancellation = SessionIndexRipgrepCancellation { processIdentifier, signal in
+            sentSignals.append((processIdentifier, signal))
+            return 0
+        }
+
+        cancellation.markStarted(processIdentifier: 12345)
+        cancellation.cancel()
+        cancellation.markFinished(processIdentifier: 12345)
+        cancellation.cancel()
+
+        XCTAssertEqual(sentSignals.count, 1)
+        XCTAssertEqual(sentSignals.first?.0, 12345)
+        XCTAssertEqual(sentSignals.first?.1, SIGTERM)
+    }
+
+    func testRipgrepCancellationDoesNotResurrectFinishedProcess() {
+        var sentSignals: [(pid_t, Int32)] = []
+        let cancellation = SessionIndexRipgrepCancellation { processIdentifier, signal in
+            sentSignals.append((processIdentifier, signal))
+            return 0
+        }
+
+        cancellation.markFinished(processIdentifier: 12345)
+        cancellation.markStarted(processIdentifier: 12345)
+        cancellation.cancel()
+
+        XCTAssertTrue(sentSignals.isEmpty)
+    }
+
     func testRovoDevSessionIndexReadsMetadataAndResumeCommand() throws {
         let fixture = try makeFixture()
         defer { try? FileManager.default.removeItem(at: fixture.tempDir) }


### PR DESCRIPTION
Crash triage:
- The local `.ghosttycrash` envelope at `/Users/lawrence/.local/state/cmux/crash/6f9d0e76-edf0-438b-38e0-0bc3fb415326.ghosttycrash` captured `/Applications/cmux.app` at `2026-05-19 17:08:06 PDT`.
- The minidump unwound through `CPPExceptionTerminate()` with cmux stack contents pointing at `SessionIndexStore.ripgrepMatchingPaths`.
- The likely cause was `Process.terminate()` from the cancellation handler when the `Process` was not safely running.

Changes:
- Track the launched ripgrep PID separately and signal it with `SIGTERM` on cancellation.
- Return before launch if the search task is already cancelled.
- Keep finished PIDs from being signaled by late cancellation races.

Tests:
- `xcodebuild -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-rgcancel-test '-only-testing:cmuxTests/RovoDevSessionIndexTests' test`\n\nDogfood:\n- Built tagged app `rgcan` with `./scripts/reload.sh --tag rgcan`.\n

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes process lifecycle/cancellation behavior for ripgrep-driven searches; while scoped, it affects async search results and signaling and could cause hangs or missed matches if edge cases are wrong.
> 
> **Overview**
> Fixes a crash/race when cancelling ripgrep-backed session searches by replacing `Process.terminate()` with an explicit, lock-protected SIGTERM sent only to the *currently running* ripgrep PID.
> 
> `ripgrepMatchingPaths` now short-circuits to `[]` when already cancelled (and when cancellation happens during/after launch) to avoid treating cancellation as a ripgrep failure and triggering fallback scanning, and it adds a `ripgrepPath` override to support test injection.
> 
> Adds focused unit + async integration tests validating cancellation behavior (no signal before start, one-shot signaling, no signaling of finished PIDs, and cancelled searches return empty results).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a64e4ef9f72b5c7bc264834bc2917cad49f202c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash when cancelling session search by sending SIGTERM to the live ripgrep PID and making cancellation one-shot. Also stops fallback searches after a cancel by returning empty results.

- **Bug Fixes**
  - Added `SessionIndexRipgrepCancellation` to track active/finished PIDs; send SIGTERM only to the active process, once.
  - Early-cancel before launch; if cancelled right after launch, signal immediately.
  - Drained stdout before wait; used `terminationHandler` and finish marks to avoid deadlocks and races.
  - On cancellation, return `[]` (before run, after start, and after exit) to avoid triggering fallback.
  - Replaced `Process.terminate()` with SIGTERM via `Darwin.kill`.
  - Added optional `ripgrepPath` to `ripgrepMatchingPaths` to inject a fake `rg` in tests without mutating global settings; tests cover one-shot signaling, no-signal-before-start, no-resurrection of finished PIDs, and an async case using a sleeping fake `rg` that returns `[]` on cancel.

<sup>Written for commit a64e4ef9f72b5c7bc264834bc2917cad49f202c1. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4413?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation for search operations: cancelling now sends SIGTERM to actively running search processes, tracks lifecycle to avoid duplicate signals, and returns an immediate empty result for cancelled searches.

* **Tests**
  * Added unit and async integration tests covering cancellation timing and lifecycle, ensuring cancelled searches yield no results and signal behavior is correct.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4413?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->