### PR TITLE
Fix #4410 NSConcreteTask terminationReason cancellation crash

### DIFF
--- a/Sources/AgentForkSupport.swift
+++ b/Sources/AgentForkSupport.swift
@@ -191,19 +191,21 @@ enum AgentForkSupport {
         }
 
         private func markTimedOutAndTerminate() {
-            let process: Process?
             lock.lock()
             guard !completed else {
                 lock.unlock()
                 return
             }
             timedOut = true
-            process = self.process
             lock.unlock()
 
             guard terminationGate.requestTermination() else {
                 return
             }
+            let process: Process?
+            lock.lock()
+            process = self.process
+            lock.unlock()
             guard let process else {
                 return
             }

--- a/Sources/AgentForkSupport.swift
+++ b/Sources/AgentForkSupport.swift
@@ -28,8 +28,8 @@ final class ProcessTerminationGate: @unchecked Sendable {
 
     func markFinished() {
         lock.lock()
+        defer { lock.unlock() }
         didFinish = true
-        lock.unlock()
     }
 }
 
@@ -155,8 +155,8 @@ enum AgentForkSupport {
             if terminationGate.markLaunched() {
                 if process.isRunning {
                     process.terminate()
+                    startKillTimer(processIdentifier: process.processIdentifier)
                 }
-                startKillTimer(processIdentifier: process.processIdentifier)
             }
         }
 

--- a/Sources/AgentForkSupport.swift
+++ b/Sources/AgentForkSupport.swift
@@ -2,6 +2,37 @@ import Foundation
 import CMUXAgentLaunch
 import Darwin
 
+/// Coordinates cancellation with `Process.run()`: Foundation raises an
+/// Objective-C exception if termination APIs touch a task before launch.
+final class ProcessTerminationGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var didLaunch = false
+    private var didFinish = false
+    private var terminationRequested = false
+
+    func requestTermination() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !didFinish else { return false }
+        terminationRequested = true
+        return didLaunch
+    }
+
+    func markLaunched() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !didFinish else { return false }
+        didLaunch = true
+        return terminationRequested
+    }
+
+    func markFinished() {
+        lock.lock()
+        didFinish = true
+        lock.unlock()
+    }
+}
+
 private actor OpenCodeVersionProbeCache {
     private var valuesByKey: [String: Bool] = [:]
 
@@ -50,6 +81,7 @@ enum AgentForkSupport {
         private var timeoutTimer: DispatchSourceTimer?
         private var killTimer: DispatchSourceTimer?
         private var continuation: CheckedContinuation<String?, Never>?
+        private let terminationGate = ProcessTerminationGate()
         private var completed = false
         private var timedOut = false
 
@@ -90,13 +122,13 @@ enum AgentForkSupport {
             if completed || timedOut {
                 completed = true
                 lock.unlock()
+                terminationGate.markFinished()
                 pipe.fileHandleForReading.readabilityHandler = nil
                 process.terminationHandler = nil
                 continuation.resume(returning: nil)
                 return
             }
             self.continuation = continuation
-            self.process = process
             self.pipe = pipe
             lock.unlock()
 
@@ -105,15 +137,25 @@ enum AgentForkSupport {
             do {
                 try process.run()
             } catch {
+                terminationGate.markFinished()
                 markFailedBeforeLaunch()
                 return
             }
 
             lock.lock()
-            let shouldTerminateAfterStart = timedOut && !completed
+            if completed {
+                lock.unlock()
+                terminationGate.markFinished()
+                process.terminationHandler = nil
+                return
+            }
+            self.process = process
             lock.unlock()
-            if shouldTerminateAfterStart {
-                process.terminate()
+
+            if terminationGate.markLaunched() {
+                if process.isRunning {
+                    process.terminate()
+                }
                 startKillTimer(processIdentifier: process.processIdentifier)
             }
         }
@@ -158,6 +200,9 @@ enum AgentForkSupport {
             process = self.process
             lock.unlock()
 
+            guard terminationGate.requestTermination() else {
+                return
+            }
             guard let process else {
                 return
             }
@@ -219,6 +264,7 @@ enum AgentForkSupport {
             timedOut = self.timedOut
             lock.unlock()
 
+            terminationGate.markFinished()
             timeoutTimer?.cancel()
             killTimer?.cancel()
             process?.terminationHandler = nil

--- a/Sources/AgentForkSupport.swift
+++ b/Sources/AgentForkSupport.swift
@@ -4,6 +4,7 @@ import Darwin
 
 /// Coordinates cancellation with `Process.run()`: Foundation raises an
 /// Objective-C exception if termination APIs touch a task before launch.
+/// `@unchecked Sendable` is safe here because all mutable state is protected by `lock`.
 final class ProcessTerminationGate: @unchecked Sendable {
     private let lock = NSLock()
     private var didLaunch = false

--- a/Sources/FileExplorerStore.swift
+++ b/Sources/FileExplorerStore.swift
@@ -437,6 +437,7 @@ final class ProcessSSHFileExplorerTransport: SSHFileExplorerTransport {
         private let outPipe = Pipe()
         private let errPipe = Pipe()
         private let lock = NSLock()
+        private let terminationGate = ProcessTerminationGate()
         private var cancelled = false
 
         init(connection: SSHFileExplorerConnection, command: String) {
@@ -454,18 +455,29 @@ final class ProcessSSHFileExplorerTransport: SSHFileExplorerTransport {
                 throw CancellationError()
             }
 
-            try process.run()
+            do {
+                try process.run()
+            } catch {
+                terminationGate.markFinished()
+                throw error
+            }
 
             lock.lock()
-            let shouldTerminate = cancelled && process.isRunning
+            let shouldTerminate = cancelled
             lock.unlock()
-            if shouldTerminate {
+            if terminationGate.markLaunched() || shouldTerminate {
+                guard process.isRunning else {
+                    process.waitUntilExit()
+                    terminationGate.markFinished()
+                    throw CancellationError()
+                }
                 process.terminate()
             }
 
             let data = outPipe.fileHandleForReading.readDataToEndOfFile()
             let stderrData = errPipe.fileHandleForReading.readDataToEndOfFile()
             process.waitUntilExit()
+            terminationGate.markFinished()
 
             return SSHCommandResult(
                 stdout: String(data: data, encoding: .utf8) ?? "",
@@ -477,12 +489,15 @@ final class ProcessSSHFileExplorerTransport: SSHFileExplorerTransport {
         func terminate() {
             lock.lock()
             cancelled = true
-            let isRunning = process.isRunning
             lock.unlock()
 
-            if isRunning {
-                process.terminate()
+            guard terminationGate.requestTermination() else {
+                return
             }
+            guard process.isRunning else {
+                return
+            }
+            process.terminate()
         }
     }
 

--- a/Sources/FileExplorerStore.swift
+++ b/Sources/FileExplorerStore.swift
@@ -479,9 +479,9 @@ final class ProcessSSHFileExplorerTransport: SSHFileExplorerTransport {
             process.waitUntilExit()
             terminationGate.markFinished()
             lock.lock()
-            let wasCancelled = cancelled
+            let cancelledAfterExit = cancelled
             lock.unlock()
-            if wasCancelled {
+            if cancelledAfterExit {
                 throw CancellationError()
             }
 

--- a/Sources/FileExplorerStore.swift
+++ b/Sources/FileExplorerStore.swift
@@ -478,6 +478,12 @@ final class ProcessSSHFileExplorerTransport: SSHFileExplorerTransport {
             let stderrData = errPipe.fileHandleForReading.readDataToEndOfFile()
             process.waitUntilExit()
             terminationGate.markFinished()
+            lock.lock()
+            let wasCancelled = cancelled
+            lock.unlock()
+            if wasCancelled {
+                throw CancellationError()
+            }
 
             return SSHCommandResult(
                 stdout: String(data: data, encoding: .utf8) ?? "",

--- a/Sources/SessionIndexStore.swift
+++ b/Sources/SessionIndexStore.swift
@@ -1265,9 +1265,18 @@ final class SessionIndexStore: ObservableObject {
         if let nullDev = FileHandle(forWritingAtPath: "/dev/null") {
             process.standardError = nullDev
         }
+        let terminationGate = ProcessTerminationGate()
 
         return await withTaskCancellationHandler {
-            do { try process.run() } catch { return nil as [URL]? }
+            do {
+                try process.run()
+            } catch {
+                terminationGate.markFinished()
+                return nil as [URL]?
+            }
+            if terminationGate.markLaunched(), process.isRunning {
+                process.terminate()
+            }
             // Drain stdout BEFORE waitUntilExit. With many matches rg writes
             // more than the ~64 KB pipe buffer; reading until EOF lets rg
             // make progress and EOF arrives when rg closes its stdout on exit.
@@ -1278,6 +1287,7 @@ final class SessionIndexStore: ObservableObject {
             // late and never fires → deadlock.)
             let data = outPipe.fileHandleForReading.readDataToEndOfFile()
             process.waitUntilExit()
+            terminationGate.markFinished()
             // rg exit codes: 0 = matches, 1 = no matches, 2 = error/terminated.
             switch process.terminationStatus {
             case 0:
@@ -1293,6 +1303,12 @@ final class SessionIndexStore: ObservableObject {
             // Fires synchronously when the awaiting Task is cancelled. Sends
             // SIGTERM to rg, which closes stdout, lets readDataToEndOfFile
             // return, and unblocks the body so this call can complete cleanly.
+            guard terminationGate.requestTermination() else {
+                return
+            }
+            guard process.isRunning else {
+                return
+            }
             process.terminate()
         }
     }

--- a/Sources/SessionIndexStore.swift
+++ b/Sources/SessionIndexStore.swift
@@ -1274,7 +1274,12 @@ final class SessionIndexStore: ObservableObject {
                 terminationGate.markFinished()
                 return nil as [URL]?
             }
-            if terminationGate.markLaunched(), process.isRunning {
+            if terminationGate.markLaunched() {
+                guard process.isRunning else {
+                    process.waitUntilExit()
+                    terminationGate.markFinished()
+                    return nil as [URL]?
+                }
                 process.terminate()
             }
             // Drain stdout BEFORE waitUntilExit. With many matches rg writes

--- a/Sources/SessionIndexStore.swift
+++ b/Sources/SessionIndexStore.swift
@@ -1293,6 +1293,9 @@ final class SessionIndexStore: ObservableObject {
             let data = outPipe.fileHandleForReading.readDataToEndOfFile()
             process.waitUntilExit()
             terminationGate.markFinished()
+            guard !Task.isCancelled else {
+                return nil
+            }
             // rg exit codes: 0 = matches, 1 = no matches, 2 = error/terminated.
             switch process.terminationStatus {
             case 0:

--- a/cmuxTests/PortScannerTests.swift
+++ b/cmuxTests/PortScannerTests.swift
@@ -36,3 +36,34 @@ final class PortScannerProcessCaptureTests: XCTestCase {
         XCTAssertLessThanOrEqual(finalCount - baseline, 8)
     }
 }
+
+final class ProcessTerminationGateTests: XCTestCase {
+    func testPrelaunchTerminationRequestIsDeferredUntilLaunch() {
+        let gate = ProcessTerminationGate()
+
+        XCTAssertFalse(
+            gate.requestTermination(),
+            "A cancellation that arrives before Process.run() succeeds must not touch the Process."
+        )
+        XCTAssertTrue(
+            gate.markLaunched(),
+            "Once launch succeeds, the deferred termination request should be applied to the running Process."
+        )
+        gate.markFinished()
+        XCTAssertFalse(
+            gate.requestTermination(),
+            "Late cancellation after completion must not touch Process termination state."
+        )
+    }
+
+    func testFinishedPrelaunchProcessIgnoresDeferredTermination() {
+        let gate = ProcessTerminationGate()
+
+        XCTAssertFalse(gate.requestTermination())
+        gate.markFinished()
+        XCTAssertFalse(
+            gate.markLaunched(),
+            "If launch fails and the run is already finished, no deferred termination should be applied."
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Reproduced the crash class locally from the artifact signature: touching `Process.terminationReason` before launch raises `NSInvalidArgumentException` with `*** -[NSConcreteTask terminationReason]: task not launched`; calling `Process.terminate()` before launch raises the sibling `task not launched` exception.
- Added a regression test for the launch/termination gate in the first commit (`d412f8b83`) before the production fix.
- Added a shared `ProcessTerminationGate` and wired it into cancellation-wrapped process launch paths for OpenCode fork probes, SSH file explorer commands, and session-index `rg` searches so cancellation defers termination until `Process.run()` has succeeded.

## Verification

- Repro source: `/tmp/cmux-crash-lldb-backtraces.txt` and Sentry/minidump metadata from issue 4410.
- Local crash probe: `swift -e` confirmed prelaunch `terminationReason` and `terminate()` trigger uncaught Objective-C exceptions matching the reported failure class.
- Local app build/tests intentionally not run per task instructions; CI is the verification path.

Fixes https://github.com/manaflow-ai/cmux/issues/4410

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches subprocess lifecycle/cancellation paths (timeouts, termination handlers, SSH commands), where races can cause hangs or missed cancellations if incorrect. Changes are localized and include targeted regression tests, reducing overall risk.
> 
> **Overview**
> Fixes a crash caused by cancelling/timeouting subprocesses *before* `Process.run()` has successfully launched by introducing a shared `ProcessTerminationGate` that defers `terminate()` until launch and ignores termination after completion.
> 
> Wires the gate into OpenCode fork version probing (`AgentForkSupport.CommandOutputRunner`) and SSH file explorer commands (`ProcessSSHFileExplorerTransport.SSHCommandProcess`), tightening post-launch checks (re-check `completed`, guard `isRunning`, consistently `markFinished`) and improving cancellation propagation after process exit.
> 
> Adds `ProcessTerminationGateTests` to cover pre-launch deferral and "finished-before-launch" behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7062dacb5d7ca85bd540eaa6ead1b1d63e9423d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4414"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash where cancellations or timeouts touched a `Process` before launch and triggered "task not launched" exceptions. Adds a shared `ProcessTerminationGate` to defer termination until `Process.run()` succeeds, resolve the launch/timeout race, and propagate cancellation after exit; fixes #4410.

- **Bug Fixes**
  - Added `ProcessTerminationGate` to defer termination until launch and ignore requests after finish; tests cover prelaunch deferral and finished-before-launch cases.
  - Applied to OpenCode version probes, SSH file explorer commands, and session-index `rg`.
  - Safer cancellation/timeout: only terminate when `process.isRunning`, re-check completion after `run()`, defer timeout kills until launch, always mark finished and clear handlers; after exit, cancellation returns `CancellationError` (SSH) or `nil` (probes/`rg`).

<sup>Written for commit 7062dacb5d7ca85bd540eaa6ead1b1d63e9423d5. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4414?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation safety for background subprocesses by adding coordinated launch/termination handling to avoid premature termination, race conditions, and spurious failures across file explorer, search, and indexing flows.
  * Ensured termination requests are deferred or ignored appropriately when processes are not yet running.

* **Tests**
  * Added tests covering subprocess termination lifecycle and edge-case cancellation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4414?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->