### PR TITLE
Fix settings appearance dispatch_once reentrancy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,8 @@ jobs:
     timeout-minutes: 45
     env:
       CMUX_SKIP_ZIG_BUILD: "1"
+      # Keep Swift crash backtraces from opening the 30s interactive prompt in CI.
+      SWIFT_BACKTRACE: "interactive=no,color=no"
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1019,6 +1019,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             ]
         )
         AppIconLaunchState.markDidFinishLaunching()
+        AppearanceSettingsUserDefaultsObserver.shared.startObserving()
         if isRunningUnderXCTest {
             NSApp.setActivationPolicy(.regular)
         } else {
@@ -5877,7 +5878,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return .ok
 
         case .focus:
-            guard focusRightSidebarInActiveMainWindow(preferredWindow: preferredWindow) else {
+            // Remote focus should preserve the currently selected sidebar mode
+            // instead of reviving a stale keyboard-focus memory.
+            guard focusRightSidebarInActiveMainWindow(mode: state.mode, preferredWindow: preferredWindow) else {
                 return .failure(String(localized: "rightSidebar.remote.error.focusFailed", defaultValue: "ERROR: Failed to focus right sidebar"))
             }
             return .ok

--- a/Sources/AppearanceSettings.swift
+++ b/Sources/AppearanceSettings.swift
@@ -223,6 +223,88 @@ enum AppearanceSettings {
     }
 }
 
+final class AppearanceSettingsUserDefaultsObserver {
+    struct Environment {
+        let addDefaultsObserver: (@escaping () -> Void) -> NSObjectProtocol
+        let removeObserver: (NSObjectProtocol) -> Void
+        let currentRawValue: () -> String?
+        let applyStoredMode: (String?, String) -> AppearanceMode
+
+        static func live(
+            defaults: UserDefaults = .standard,
+            notificationCenter: NotificationCenter = .default
+        ) -> Environment {
+            Environment(
+                addDefaultsObserver: { handler in
+                    notificationCenter.addObserver(
+                        forName: UserDefaults.didChangeNotification,
+                        object: nil,
+                        queue: .main
+                    ) { _ in
+                        handler()
+                    }
+                },
+                removeObserver: { observer in
+                    notificationCenter.removeObserver(observer)
+                },
+                currentRawValue: {
+                    defaults.string(forKey: AppearanceSettings.appearanceModeKey)
+                },
+                applyStoredMode: { rawValue, source in
+                    AppearanceSettings.applyStoredMode(
+                        rawValue: rawValue,
+                        defaults: defaults,
+                        source: source
+                    )
+                }
+            )
+        }
+    }
+
+    static let shared = AppearanceSettingsUserDefaultsObserver()
+
+    private let environment: Environment
+    private var defaultsObserver: NSObjectProtocol?
+    private var lastObservedRawValue: String?
+    private var source: String
+
+    init(
+        environment: Environment = .live(),
+        source: String = "cmuxApp.appearanceDefaultsChanged"
+    ) {
+        self.environment = environment
+        self.source = source
+    }
+
+    deinit {
+        stopObserving()
+    }
+
+    func startObserving(source: String? = nil) {
+        if let source {
+            self.source = source
+        }
+        lastObservedRawValue = environment.currentRawValue()
+        guard defaultsObserver == nil else { return }
+        defaultsObserver = environment.addDefaultsObserver { [weak self] in
+            self?.applyIfChanged()
+        }
+    }
+
+    func stopObserving() {
+        guard let defaultsObserver else { return }
+        environment.removeObserver(defaultsObserver)
+        self.defaultsObserver = nil
+    }
+
+    private func applyIfChanged() {
+        let rawValue = environment.currentRawValue()
+        guard rawValue != lastObservedRawValue else { return }
+        let appliedMode = environment.applyStoredMode(rawValue, source)
+        lastObservedRawValue = appliedMode.rawValue
+    }
+}
+
 private struct AppearanceColorSchemeModifier: ViewModifier {
     @Environment(\.colorScheme) private var colorScheme
     let rawValue: String?

--- a/Sources/KeyboardShortcutSettingsFileStore.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore.swift
@@ -54,7 +54,6 @@ final class CmuxSettingsFileStore {
     private let fallbackPaths: [String]
     private let fileManager: FileManager
     private let notificationCenter: NotificationCenter
-    private let appearanceEnvironment: AppearanceSettings.LiveApplyEnvironment
     private let stateLock = NSLock()
 
     private var primaryWatcher: ShortcutSettingsFileWatcher?
@@ -76,7 +75,6 @@ final class CmuxSettingsFileStore {
         additionalFallbackPaths: [String] = [CmuxSettingsFileStore.defaultApplicationSupportFallbackPath].compactMap { $0 },
         fileManager: FileManager = .default,
         notificationCenter: NotificationCenter = .default,
-        appearanceEnvironment: AppearanceSettings.LiveApplyEnvironment = .live,
         startWatching: Bool = true
     ) {
         self.primaryPath = primaryPath
@@ -84,17 +82,13 @@ final class CmuxSettingsFileStore {
             .filter { $0 != primaryPath }
         self.fileManager = fileManager
         self.notificationCenter = notificationCenter
-        self.appearanceEnvironment = appearanceEnvironment
         importedManagedDefaults = Self.loadImportedManagedDefaults()
 
         bootstrapPrimaryTemplateIfNeeded()
         // The app init path loads cmux.json before applying language/appearance
         // itself. Running live default side effects here can initialize UI/runtime
         // singletons while this store singleton is still in its dispatch_once.
-        reload(
-            applyLiveDefaultSideEffects: false,
-            synchronizeManagedAppearanceTerminalTheme: false
-        )
+        reload(applyLiveDefaultSideEffects: false)
         guard startWatching else { return }
 
         primaryWatcher = ShortcutSettingsFileWatcher(path: primaryPath, fileManager: fileManager) { [weak self] in
@@ -126,20 +120,14 @@ final class CmuxSettingsFileStore {
     }
 
     func reload() {
-        reload(
-            applyLiveDefaultSideEffects: true,
-            synchronizeManagedAppearanceTerminalTheme: true
-        )
+        reload(applyLiveDefaultSideEffects: true)
     }
 
     func applyDeferredManagedDefaultSideEffects() {
         applyManagedDefaultBatchSideEffects(drainDeferredManagedDefaultSideEffects())
     }
 
-    private func reload(
-        applyLiveDefaultSideEffects: Bool,
-        synchronizeManagedAppearanceTerminalTheme: Bool
-    ) {
+    private func reload(applyLiveDefaultSideEffects: Bool) {
         let previousState = synchronized {
             (
                 shortcuts: shortcutsByAction,
@@ -155,8 +143,7 @@ final class CmuxSettingsFileStore {
                 previous: previousState.importedManagedDefaults,
                 next: resolved.managedUserDefaults
             ),
-            applyLiveDefaultSideEffects: applyLiveDefaultSideEffects,
-            synchronizeManagedAppearanceTerminalTheme: synchronizeManagedAppearanceTerminalTheme
+            applyLiveDefaultSideEffects: applyLiveDefaultSideEffects
         )
         synchronized {
             shortcutsByAction = resolved.shortcuts
@@ -248,8 +235,7 @@ final class CmuxSettingsFileStore {
             importedManagedDefaults: managedState.importedManagedDefaults,
             changedManagedDefaultKeys: [],
             updateBackups: false,
-            applyLiveDefaultSideEffects: true,
-            synchronizeManagedAppearanceTerminalTheme: true
+            applyLiveDefaultSideEffects: true
         )
     }
 
@@ -893,8 +879,7 @@ final class CmuxSettingsFileStore {
         importedManagedDefaults: [String: ManagedSettingsValue],
         changedManagedDefaultKeys: Set<String>,
         updateBackups: Bool = true,
-        applyLiveDefaultSideEffects: Bool,
-        synchronizeManagedAppearanceTerminalTheme: Bool
+        applyLiveDefaultSideEffects: Bool
     ) {
         var backups = loadBackups()
         var sideEffects = ManagedDefaultBatchSideEffects()
@@ -925,8 +910,7 @@ final class CmuxSettingsFileStore {
             sideEffects.merge(
                 restoreBackup(
                     backup,
-                    for: identifier,
-                    synchronizeManagedAppearanceTerminalTheme: synchronizeManagedAppearanceTerminalTheme
+                    for: identifier
                 )
             )
             backups.removeValue(forKey: identifier)
@@ -938,8 +922,7 @@ final class CmuxSettingsFileStore {
                     value,
                     for: defaultsKey,
                     importedDefault: importedManagedDefaults[defaultsKey],
-                    forceApply: changedManagedDefaultKeys.contains(defaultsKey),
-                    synchronizeManagedAppearanceTerminalTheme: synchronizeManagedAppearanceTerminalTheme
+                    forceApply: changedManagedDefaultKeys.contains(defaultsKey)
                 )
             )
         }
@@ -990,8 +973,7 @@ final class CmuxSettingsFileStore {
 
     private func restoreBackup(
         _ backup: BackupValue,
-        for identifier: String,
-        synchronizeManagedAppearanceTerminalTheme: Bool
+        for identifier: String
     ) -> ManagedDefaultBatchSideEffects {
         switch identifier {
         case Self.socketPasswordBackupIdentifier:
@@ -1007,8 +989,7 @@ final class CmuxSettingsFileStore {
         default:
             return restoreUserDefaultsBackup(
                 backup,
-                for: identifier,
-                synchronizeManagedAppearanceTerminalTheme: synchronizeManagedAppearanceTerminalTheme
+                for: identifier
             )
         }
     }
@@ -1054,8 +1035,7 @@ final class CmuxSettingsFileStore {
 
     private func restoreUserDefaultsBackup(
         _ backup: BackupValue,
-        for defaultsKey: String,
-        synchronizeManagedAppearanceTerminalTheme: Bool
+        for defaultsKey: String
     ) -> ManagedDefaultBatchSideEffects {
         let defaults = UserDefaults.standard
         if defaultsKey == WorkspaceTabColorSettings.paletteKey {
@@ -1110,11 +1090,7 @@ final class CmuxSettingsFileStore {
         }
 
         if didMutateStoredValue {
-            return managedDefaultSideEffects(
-                for: defaultsKey,
-                source: "cmuxConfig.restoreUserDefault",
-                synchronizeAppearanceTerminalTheme: synchronizeManagedAppearanceTerminalTheme
-            )
+            return managedDefaultSideEffects(for: defaultsKey)
         }
         return ManagedDefaultBatchSideEffects()
     }
@@ -1123,8 +1099,7 @@ final class CmuxSettingsFileStore {
         _ value: ManagedSettingsValue,
         for defaultsKey: String,
         importedDefault: ManagedSettingsValue?,
-        forceApply: Bool,
-        synchronizeManagedAppearanceTerminalTheme: Bool
+        forceApply: Bool
     ) -> ManagedDefaultBatchSideEffects {
         let defaults = UserDefaults.standard
         guard shouldApplyManagedUserDefaultsValue(
@@ -1197,11 +1172,7 @@ final class CmuxSettingsFileStore {
         }
 
         if didMutateStoredValue {
-            return managedDefaultSideEffects(
-                for: defaultsKey,
-                source: "cmuxConfig.applyManagedDefault",
-                synchronizeAppearanceTerminalTheme: synchronizeManagedAppearanceTerminalTheme
-            )
+            return managedDefaultSideEffects(for: defaultsKey)
         }
         return ManagedDefaultBatchSideEffects()
     }
@@ -1278,17 +1249,16 @@ final class CmuxSettingsFileStore {
         }
     }
 
-    private func managedDefaultSideEffects(
-        for defaultsKey: String,
-        source: String,
-        synchronizeAppearanceTerminalTheme: Bool
-    ) -> ManagedDefaultBatchSideEffects {
+    private func managedDefaultSideEffects(for defaultsKey: String) -> ManagedDefaultBatchSideEffects {
+        guard defaultsKey != AppearanceSettings.appearanceModeKey else {
+            // The app lifecycle-owned UserDefaults observer applies live
+            // appearance changes after launch. The settings file store only
+            // imports the default so it cannot reenter Ghostty while this
+            // singleton initializes.
+            return ManagedDefaultBatchSideEffects()
+        }
         var sideEffects = ManagedDefaultBatchSideEffects()
-        sideEffects.append(
-            defaultsKey: defaultsKey,
-            source: source,
-            synchronizeAppearanceTerminalTheme: synchronizeAppearanceTerminalTheme
-        )
+        sideEffects.append(defaultsKey: defaultsKey)
         return sideEffects
     }
 
@@ -1310,14 +1280,6 @@ final class CmuxSettingsFileStore {
                 if change.defaultsKey == LanguageSettings.languageKey {
                     let rawValue = UserDefaults.standard.string(forKey: change.defaultsKey) ?? ""
                     LanguageSettings.apply(AppLanguage(rawValue: rawValue) ?? .system)
-                } else if change.defaultsKey == AppearanceSettings.appearanceModeKey {
-                    AppearanceSettings.applyStoredMode(
-                        rawValue: UserDefaults.standard.string(forKey: change.defaultsKey),
-                        source: change.source,
-                        duringLaunch: !change.synchronizeAppearanceTerminalTheme,
-                        synchronizeTerminalTheme: change.synchronizeAppearanceTerminalTheme,
-                        environment: self.appearanceEnvironment
-                    )
                 } else if change.defaultsKey == AppIconSettings.modeKey {
                     AppIconSettings.applyIcon(AppIconSettings.resolvedMode())
                 }
@@ -1450,8 +1412,6 @@ private struct ResolvedSettingsSnapshot {
 
 private struct ManagedDefaultSideEffect {
     let defaultsKey: String
-    let source: String
-    let synchronizeAppearanceTerminalTheme: Bool
 }
 
 private struct ManagedDefaultBatchSideEffects {
@@ -1463,27 +1423,13 @@ private struct ManagedDefaultBatchSideEffects {
 
     mutating func merge(_ other: ManagedDefaultBatchSideEffects) {
         for change in other.changes {
-            append(
-                defaultsKey: change.defaultsKey,
-                source: change.source,
-                synchronizeAppearanceTerminalTheme: change.synchronizeAppearanceTerminalTheme
-            )
+            append(defaultsKey: change.defaultsKey)
         }
     }
 
-    mutating func append(
-        defaultsKey: String,
-        source: String,
-        synchronizeAppearanceTerminalTheme: Bool
-    ) {
+    mutating func append(defaultsKey: String) {
         changes.removeAll { $0.defaultsKey == defaultsKey }
-        changes.append(
-            ManagedDefaultSideEffect(
-                defaultsKey: defaultsKey,
-                source: source,
-                synchronizeAppearanceTerminalTheme: synchronizeAppearanceTerminalTheme
-            )
-        )
+        changes.append(ManagedDefaultSideEffect(defaultsKey: defaultsKey))
     }
 }
 

--- a/cmux.xcodeproj/xcshareddata/xcschemes/cmux-unit.xcscheme
+++ b/cmux.xcodeproj/xcshareddata/xcschemes/cmux-unit.xcscheme
@@ -19,6 +19,9 @@
     <MacroExpansion>
       <BuildableReference BuildableIdentifier="primary" BlueprintIdentifier="A5001050" BuildableName="cmux.app" BlueprintName="cmux" ReferencedContainer="container:cmux.xcodeproj"/>
     </MacroExpansion>
+    <EnvironmentVariables>
+      <EnvironmentVariable key="SWIFT_BACKTRACE" value="interactive=no,color=no" isEnabled="YES"/>
+    </EnvironmentVariables>
   </TestAction>
   <LaunchAction buildConfiguration="Debug" selectedDebuggerIdentifier="Xcode.DebuggerFoundation.Debugger.LLDB" selectedLauncherIdentifier="Xcode.DebuggerFoundation.Launcher.LLDB" launchStyle="0" useCustomWorkingDirectory="NO" ignoresPersistentStateOnLaunch="YES" debugDocumentVersioning="YES" allowLocationSimulation="YES">
     <BuildableProductRunnable runnableDebuggingMode="0">
@@ -33,4 +36,3 @@
   <AnalyzeAction buildConfiguration="Debug"/>
   <ArchiveAction buildConfiguration="Debug" revealArchiveInOrganizer="YES"/>
 </Scheme>
-

--- a/cmuxTests/AppearanceSettingsTests.swift
+++ b/cmuxTests/AppearanceSettingsTests.swift
@@ -309,6 +309,70 @@ final class AppearanceSettingsTests: XCTestCase {
         XCTAssertTrue(synchronizedAppearanceWasCleared)
     }
 
+    func testDefaultsObserverAppliesLiveAppearanceWhenStoredModeChanges() {
+        let suiteName = "AppearanceSettingsTests.DefaultsObserver.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Failed to create isolated UserDefaults suite")
+            return
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let notificationCenter = NotificationCenter()
+        var appliedAppearanceName: NSAppearance.Name?
+        var synchronizedAppearanceName: NSAppearance.Name?
+        var synchronizedSource: String?
+        let liveEnvironment = AppearanceSettings.LiveApplyEnvironment(
+            setApplicationAppearance: { appearance in
+                appliedAppearanceName = appearance?.bestMatch(from: [.darkAqua, .aqua])
+            },
+            synchronizeTerminalThemeWithAppearance: { appearance, source in
+                synchronizedAppearanceName = appearance?.bestMatch(from: [.darkAqua, .aqua])
+                synchronizedSource = source
+            },
+            systemAppearance: {
+                XCTFail("Dark mode should not resolve system appearance")
+                return nil
+            }
+        )
+        let observer = AppearanceSettingsUserDefaultsObserver(
+            environment: .init(
+                addDefaultsObserver: { handler in
+                    notificationCenter.addObserver(
+                        forName: UserDefaults.didChangeNotification,
+                        object: nil,
+                        queue: nil
+                    ) { _ in
+                        handler()
+                    }
+                },
+                removeObserver: { observer in
+                    notificationCenter.removeObserver(observer)
+                },
+                currentRawValue: {
+                    defaults.string(forKey: AppearanceSettings.appearanceModeKey)
+                },
+                applyStoredMode: { rawValue, source in
+                    AppearanceSettings.applyStoredMode(
+                        rawValue: rawValue,
+                        defaults: defaults,
+                        source: source,
+                        environment: liveEnvironment
+                    )
+                }
+            ),
+            source: "test.defaultsObserver"
+        )
+
+        defaults.set(AppearanceMode.system.rawValue, forKey: AppearanceSettings.appearanceModeKey)
+        observer.startObserving()
+        defaults.set(AppearanceMode.dark.rawValue, forKey: AppearanceSettings.appearanceModeKey)
+        notificationCenter.post(name: UserDefaults.didChangeNotification, object: defaults)
+
+        XCTAssertEqual(appliedAppearanceName, .darkAqua)
+        XCTAssertEqual(synchronizedAppearanceName, .darkAqua)
+        XCTAssertEqual(synchronizedSource, "test.defaultsObserver")
+    }
+
     private func withTemporaryAppearanceDefaults(
         appearanceMode: String,
         appleInterfaceStyle: String?,

--- a/cmuxTests/KeyboardShortcutSettingsFileStoreStartupTests.swift
+++ b/cmuxTests/KeyboardShortcutSettingsFileStoreStartupTests.swift
@@ -276,6 +276,78 @@ final class KeyboardShortcutSettingsFileStoreStartupTests: XCTestCase {
         }
     }
 
+    func testSettingsFileStoreDoesNotReachTerminalReloadThroughManagedAppearanceReplay() throws {
+        let defaults = UserDefaults.standard
+        let key = AppearanceSettings.appearanceModeKey
+
+        try preservingDefaults(keys: [key, settingsFileBackupsDefaultsKey, importedManagedDefaultsKey]) {
+            defaults.removeObject(forKey: key)
+            defaults.removeObject(forKey: settingsFileBackupsDefaultsKey)
+            defaults.removeObject(forKey: importedManagedDefaultsKey)
+
+            let directoryURL = try makeTemporaryDirectory()
+            defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+            let settingsFileURL = directoryURL.appendingPathComponent("cmux.json", isDirectory: false)
+            try writeSettingsFile(
+                """
+                {
+                  "app": {
+                    "appearance": "dark"
+                  }
+                }
+                """,
+                to: settingsFileURL
+            )
+
+            var storeInitInProgress = true
+            var reachedTerminalReloadDuringInit = false
+            var terminalReloadSources: [String] = []
+            let environment = AppearanceSettings.LiveApplyEnvironment(
+                setApplicationAppearance: { _ in },
+                synchronizeTerminalThemeWithAppearance: { _, source in
+                    if storeInitInProgress {
+                        reachedTerminalReloadDuringInit = true
+                    }
+                    terminalReloadSources.append(source)
+                },
+                systemAppearance: {
+                    NSAppearance(named: .aqua)
+                }
+            )
+
+            let store = KeyboardShortcutSettingsFileStore(
+                primaryPath: settingsFileURL.path,
+                fallbackPath: nil,
+                additionalFallbackPaths: [],
+                appearanceEnvironment: environment,
+                startWatching: false
+            )
+            storeInitInProgress = false
+
+            XCTAssertFalse(reachedTerminalReloadDuringInit)
+            XCTAssertTrue(terminalReloadSources.isEmpty)
+
+            try writeSettingsFile(
+                """
+                {
+                  "app": {
+                    "appearance": "light"
+                  }
+                }
+                """,
+                to: settingsFileURL
+            )
+            store.reload()
+
+            XCTAssertEqual(defaults.string(forKey: key), AppearanceMode.light.rawValue)
+            XCTAssertTrue(
+                terminalReloadSources.isEmpty,
+                "CmuxSettingsFileStore must not synchronously route managed appearance replay into Ghostty reloadConfiguration"
+            )
+        }
+    }
+
     func testSidebarMatchTerminalBackgroundUserDefaultSurvivesSettingsFileReapply() throws {
         let defaults = UserDefaults.standard
         let key = SidebarMatchTerminalBackgroundSettings.userDefaultsKey

--- a/cmuxTests/KeyboardShortcutSettingsFileStoreStartupTests.swift
+++ b/cmuxTests/KeyboardShortcutSettingsFileStoreStartupTests.swift
@@ -201,7 +201,7 @@ final class KeyboardShortcutSettingsFileStoreStartupTests: XCTestCase {
         XCTAssertEqual(dockTileNotificationCount, 0)
     }
 
-    func testManagedAppearanceInitialLoadDoesNotSynchronizeTerminalThemeUntilReload() throws {
+    func testManagedAppearanceReplayUpdatesDefaultWithoutLiveAppearanceApplication() throws {
         let defaults = UserDefaults.standard
         let key = AppearanceSettings.appearanceModeKey
 
@@ -227,31 +227,37 @@ final class KeyboardShortcutSettingsFileStoreStartupTests: XCTestCase {
 
             var appliedAppearanceNames: [NSAppearance.Name?] = []
             var synchronizedAppearanceNames: [(appearance: NSAppearance.Name?, source: String)] = []
-            let environment = AppearanceSettings.LiveApplyEnvironment(
-                setApplicationAppearance: { appearance in
-                    appliedAppearanceNames.append(appearance?.bestMatch(from: [.darkAqua, .aqua]))
-                },
-                synchronizeTerminalThemeWithAppearance: { appearance, source in
-                    synchronizedAppearanceNames.append((
-                        appearance: appearance?.bestMatch(from: [.darkAqua, .aqua]),
-                        source: source
-                    ))
-                },
-                systemAppearance: {
-                    NSAppearance(named: .aqua)
-                }
-            )
+            AppearanceSettings.setLiveEnvironmentProviderForTesting {
+                AppearanceSettings.LiveApplyEnvironment(
+                    setApplicationAppearance: { appearance in
+                        appliedAppearanceNames.append(appearance?.bestMatch(from: [.darkAqua, .aqua]))
+                    },
+                    synchronizeTerminalThemeWithAppearance: { appearance, source in
+                        synchronizedAppearanceNames.append((
+                            appearance: appearance?.bestMatch(from: [.darkAqua, .aqua]),
+                            source: source
+                        ))
+                    },
+                    systemAppearance: {
+                        NSAppearance(named: .aqua)
+                    }
+                )
+            }
 
             let store = KeyboardShortcutSettingsFileStore(
                 primaryPath: settingsFileURL.path,
                 fallbackPath: nil,
                 additionalFallbackPaths: [],
-                appearanceEnvironment: environment,
                 startWatching: false
             )
 
             XCTAssertEqual(defaults.string(forKey: key), AppearanceMode.dark.rawValue)
-            XCTAssertEqual(appliedAppearanceNames, [.darkAqua])
+            XCTAssertTrue(appliedAppearanceNames.isEmpty)
+            XCTAssertTrue(synchronizedAppearanceNames.isEmpty)
+
+            store.applyDeferredManagedDefaultSideEffects()
+
+            XCTAssertTrue(appliedAppearanceNames.isEmpty)
             XCTAssertTrue(synchronizedAppearanceNames.isEmpty)
 
             try withExtendedLifetime(store) {
@@ -269,10 +275,8 @@ final class KeyboardShortcutSettingsFileStoreStartupTests: XCTestCase {
             }
 
             XCTAssertEqual(defaults.string(forKey: key), AppearanceMode.light.rawValue)
-            XCTAssertEqual(appliedAppearanceNames, [.darkAqua, .aqua])
-            XCTAssertEqual(synchronizedAppearanceNames.count, 1)
-            XCTAssertEqual(synchronizedAppearanceNames.first?.appearance, .aqua)
-            XCTAssertEqual(synchronizedAppearanceNames.first?.source, "cmuxConfig.applyManagedDefault")
+            XCTAssertTrue(appliedAppearanceNames.isEmpty)
+            XCTAssertTrue(synchronizedAppearanceNames.isEmpty)
         }
     }
 
@@ -303,24 +307,25 @@ final class KeyboardShortcutSettingsFileStoreStartupTests: XCTestCase {
             var storeInitInProgress = true
             var reachedTerminalReloadDuringInit = false
             var terminalReloadSources: [String] = []
-            let environment = AppearanceSettings.LiveApplyEnvironment(
-                setApplicationAppearance: { _ in },
-                synchronizeTerminalThemeWithAppearance: { _, source in
-                    if storeInitInProgress {
-                        reachedTerminalReloadDuringInit = true
+            AppearanceSettings.setLiveEnvironmentProviderForTesting {
+                AppearanceSettings.LiveApplyEnvironment(
+                    setApplicationAppearance: { _ in },
+                    synchronizeTerminalThemeWithAppearance: { _, source in
+                        if storeInitInProgress {
+                            reachedTerminalReloadDuringInit = true
+                        }
+                        terminalReloadSources.append(source)
+                    },
+                    systemAppearance: {
+                        NSAppearance(named: .aqua)
                     }
-                    terminalReloadSources.append(source)
-                },
-                systemAppearance: {
-                    NSAppearance(named: .aqua)
-                }
-            )
+                )
+            }
 
             let store = KeyboardShortcutSettingsFileStore(
                 primaryPath: settingsFileURL.path,
                 fallbackPath: nil,
                 additionalFallbackPaths: [],
-                appearanceEnvironment: environment,
                 startWatching: false
             )
             storeInitInProgress = false
@@ -494,7 +499,7 @@ final class KeyboardShortcutSettingsFileStoreStartupTests: XCTestCase {
     }
 
     @MainActor
-    func testSettingsFileStoreInitialAppearanceReplayDoesNotSynchronizeTerminalTheme() throws {
+    func testSettingsFileStoreInitialAppearanceImportDoesNotApplyLiveAppearance() throws {
         let defaults = UserDefaults.standard
         let key = AppearanceSettings.appearanceModeKey
 
@@ -550,7 +555,7 @@ final class KeyboardShortcutSettingsFileStoreStartupTests: XCTestCase {
 
             store.applyDeferredManagedDefaultSideEffects()
 
-            XCTAssertEqual(appliedAppearanceName, .darkAqua)
+            XCTAssertNil(appliedAppearanceName)
             XCTAssertNil(synchronizedAppearanceName)
             XCTAssertTrue(synchronizedSources.isEmpty)
 
@@ -567,9 +572,9 @@ final class KeyboardShortcutSettingsFileStoreStartupTests: XCTestCase {
             store.reload()
 
             XCTAssertEqual(defaults.string(forKey: key), AppearanceMode.light.rawValue)
-            XCTAssertEqual(appliedAppearanceName, .aqua)
-            XCTAssertEqual(synchronizedAppearanceName, .aqua)
-            XCTAssertEqual(synchronizedSources, ["cmuxConfig.applyManagedDefault"])
+            XCTAssertNil(appliedAppearanceName)
+            XCTAssertNil(synchronizedAppearanceName)
+            XCTAssertTrue(synchronizedSources.isEmpty)
         }
     }
 


### PR DESCRIPTION
Fixes #4412.

## Summary
- Adds a regression test for the settings-file appearance replay path so the store cannot synchronously route managed appearance changes into Ghostty reloadConfiguration while the settings lifecycle is active.
- Removes live appearance application from CmuxSettingsFileStore managed-default side effects; the store now imports defaults and leaves app/terminal appearance application to the app appearance owner.
- Keeps deferred startup side effects for non-appearance settings such as language, app icon, scroll bar, and agent auto-resume notifications.

## Testing
- `git diff --check`
- Per repo/user policy, did not run local tests, `xcodebuild`, or `./scripts/reload.sh`.

## Notes
- Commit 1 is test-only and is expected to fail on the old settings-store-owned appearance replay path.
- Commit 2 applies the architectural fix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4415"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ownership of appearance application by moving it out of the settings-file store and into an app-lifecycle `UserDefaults` observer, which could affect when/if UI and terminal theme updates occur. Risk is mitigated by new regression tests covering startup and reload reentrancy paths.
> 
> **Overview**
> Prevents startup reentrancy by **stopping `CmuxSettingsFileStore` from applying live appearance / terminal-theme side effects** when importing managed `appearanceMode`; it now only persists the `UserDefaults` value and skips appearance-related side effects.
> 
> Adds an app-lifecycle `AppearanceSettingsUserDefaultsObserver` started in `AppDelegate` to apply live appearance changes when the stored mode actually changes, plus tests ensuring managed appearance imports/replays never trigger live appearance or Ghostty reload paths during init/reload. Also adjusts remote right-sidebar focus to preserve the current sidebar `mode`, and sets `SWIFT_BACKTRACE=interactive=no,color=no` in CI and the unit-test scheme to avoid interactive crash prompts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70bcbda20e1fee091258ba413116918cbc448f7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents re-entrant appearance updates by moving live appearance/terminal-theme application out of the settings file store and into the app via a `UserDefaults` observer. Fixes #4412.

- **Bug Fixes**
  - Removed all appearance and terminal-theme side effects from managed-defaults (backup/restore/reload); the store now only writes `UserDefaults`.
  - Added `AppearanceSettingsUserDefaultsObserver` and start it at launch; the app now applies live appearance when the stored mode changes.
  - Simplified API: removed `appearanceEnvironment` and sync flags; `reload(...)` no longer coordinates appearance, and the live env comes from `AppearanceSettings`.
  - Expanded tests to ensure managed appearance imports/reloads never apply live appearance, never synchronize terminal theme, and never reach Ghostty reload paths; added a test that the defaults observer applies live appearance on change.
  - Fixed right sidebar remote focus to pass `mode` to `focusRightSidebarInActiveMainWindow(...)`.

- **Dependencies**
  - Set `SWIFT_BACKTRACE=interactive=no,color=no` in CI and the unit-test scheme to avoid interactive prompts on Swift crashes.

<sup>Written for commit 70bcbda20e1fee091258ba413116918cbc448f7b. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4415?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Managed-default handling simplified so appearance defaults are persisted at startup/reload without applying live appearance or synchronizing terminal theme immediately.
  * Side-effect tracking/deduplication now depends only on the defaults key.

* **New Features**
  * Added a UserDefaults observer that reapplies stored appearance when the saved appearance mode changes.

* **Tests**
  * Updated and added tests to confirm defaults are stored without live application during init/reload and to verify the new defaults observer behavior.

* **Bug Fix**
  * Ensure right-sidebar focus uses the correct sidebar mode after hiding.

* **Chores**
  * CI and scheme: set Swift backtrace env to avoid interactive prompts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4415?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->