### PR TITLE
Add internal draft composer

### DIFF
--- a/web/app/api/typefully/drafts/[id]/route.ts
+++ b/web/app/api/typefully/drafts/[id]/route.ts
@@ -1,0 +1,94 @@
+import { z } from "zod";
+import {
+  jsonResponse,
+  withAuthedTypefullyApiRoute,
+} from "../../../../../services/typefully/routeHelpers";
+import {
+  archiveTypefullyDraft,
+  runTypefullyWorkflow,
+  updateTypefullyDraft,
+} from "../../../../../services/typefully/workflows";
+import { setSpanAttributes } from "../../../../../services/telemetry";
+
+export const dynamic = "force-dynamic";
+
+const draftBodySchema = z.object({
+  title: z.string().max(240).default("Untitled draft"),
+  thread: z.array(z.string().max(10_000)).min(1).max(50).default([""]),
+});
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<Response> {
+  return withAuthedTypefullyApiRoute(
+    request,
+    "/api/typefully/drafts/[id]",
+    { "cmux.typefully.operation": "update" },
+    async ({ user, span }) => {
+      const { id } = await params;
+      setSpanAttributes(span, { "cmux.typefully.draft_id": id });
+
+      const parsed = await parseDraftBody(request);
+      if (!parsed.ok) return parsed.response;
+
+      const draft = await runTypefullyWorkflow(updateTypefullyDraft({
+        id,
+        userId: user.id,
+        draft: parsed.body,
+      }));
+      return jsonResponse({ draft });
+    },
+  );
+}
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<Response> {
+  return withAuthedTypefullyApiRoute(
+    request,
+    "/api/typefully/drafts/[id]",
+    { "cmux.typefully.operation": "archive" },
+    async ({ user, span }) => {
+      const { id } = await params;
+      setSpanAttributes(span, { "cmux.typefully.draft_id": id });
+      await runTypefullyWorkflow(archiveTypefullyDraft({ id, userId: user.id }));
+      return jsonResponse({ ok: true });
+    },
+  );
+}
+
+async function parseDraftBody(
+  request: Request,
+): Promise<
+  | { readonly ok: true; readonly body: z.infer<typeof draftBodySchema> }
+  | { readonly ok: false; readonly response: Response }
+> {
+  let rawBody: unknown;
+  try {
+    rawBody = await request.json();
+  } catch {
+    return {
+      ok: false,
+      response: jsonResponse({
+        error: "invalid_json",
+        message: "Draft body must be valid JSON.",
+      }, 400),
+    };
+  }
+
+  const parsed = draftBodySchema.safeParse(rawBody);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      response: jsonResponse({
+        error: "invalid_draft",
+        message: "Draft body must include a title and thread.",
+        issues: parsed.error.issues,
+      }, 400),
+    };
+  }
+
+  return { ok: true, body: parsed.data };
+}

--- a/web/app/api/typefully/drafts/route.ts
+++ b/web/app/api/typefully/drafts/route.ts
@@ -1,0 +1,85 @@
+import { z } from "zod";
+import {
+  jsonResponse,
+  withAuthedTypefullyApiRoute,
+} from "../../../../services/typefully/routeHelpers";
+import {
+  createTypefullyDraft,
+  listTypefullyDrafts,
+  runTypefullyWorkflow,
+} from "../../../../services/typefully/workflows";
+import { setSpanAttributes } from "../../../../services/telemetry";
+
+export const dynamic = "force-dynamic";
+
+const draftBodySchema = z.object({
+  title: z.string().max(240).default("Untitled draft"),
+  thread: z.array(z.string().max(10_000)).min(1).max(50).default([""]),
+});
+
+export async function GET(request: Request): Promise<Response> {
+  return withAuthedTypefullyApiRoute(
+    request,
+    "/api/typefully/drafts",
+    { "cmux.typefully.operation": "list" },
+    async ({ user, span }) => {
+      const drafts = await runTypefullyWorkflow(listTypefullyDrafts(user.id));
+      setSpanAttributes(span, { "cmux.typefully.draft_count": drafts.length });
+      return jsonResponse({ drafts });
+    },
+  );
+}
+
+export async function POST(request: Request): Promise<Response> {
+  return withAuthedTypefullyApiRoute(
+    request,
+    "/api/typefully/drafts",
+    { "cmux.typefully.operation": "create" },
+    async ({ user, span }) => {
+      const parsed = await parseDraftBody(request);
+      if (!parsed.ok) return parsed.response;
+
+      const draft = await runTypefullyWorkflow(createTypefullyDraft({
+        userId: user.id,
+        userEmail: user.email,
+        draft: parsed.body,
+      }));
+      setSpanAttributes(span, { "cmux.typefully.draft_id": draft.id });
+      return jsonResponse({ draft }, 201);
+    },
+  );
+}
+
+async function parseDraftBody(
+  request: Request,
+): Promise<
+  | { readonly ok: true; readonly body: z.infer<typeof draftBodySchema> }
+  | { readonly ok: false; readonly response: Response }
+> {
+  let rawBody: unknown;
+  try {
+    rawBody = await request.json();
+  } catch {
+    return {
+      ok: false,
+      response: jsonResponse({
+        error: "invalid_json",
+        message: "Draft body must be valid JSON.",
+      }, 400),
+    };
+  }
+
+  const parsed = draftBodySchema.safeParse(rawBody);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      response: jsonResponse({
+        error: "invalid_draft",
+        message: "Draft body must include a title and thread.",
+        issues: parsed.error.issues,
+      }, 400),
+    };
+  }
+
+  return { ok: true, body: parsed.data };
+}

--- a/web/app/typefully/layout.tsx
+++ b/web/app/typefully/layout.tsx
@@ -1,0 +1,37 @@
+import type { Metadata } from "next";
+import { Geist, Geist_Mono } from "next/font/google";
+import "../globals.css";
+
+const geistSans = Geist({
+  variable: "--font-geist-sans",
+  subsets: ["latin"],
+});
+
+const geistMono = Geist_Mono({
+  variable: "--font-geist-mono",
+  subsets: ["latin"],
+});
+
+export const metadata: Metadata = {
+  title: "Manaflow Drafts",
+  description: "Internal thread drafting for Manaflow and cmux.",
+};
+
+export default function TypefullyLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        <meta name="theme-color" content="#fafafa" />
+      </head>
+      <body
+        className={`${geistSans.variable} ${geistMono.variable} bg-background text-foreground font-sans antialiased`}
+      >
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/web/app/typefully/page.tsx
+++ b/web/app/typefully/page.tsx
@@ -1,0 +1,96 @@
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import {
+  ALLOWED_TYPEFULLY_DOMAINS,
+  requireTypefullyUserFromCookies,
+  type TypefullyAccessDeniedReason,
+} from "../../services/typefully/auth";
+import {
+  listTypefullyDrafts,
+  runTypefullyWorkflow,
+} from "../../services/typefully/workflows";
+import { TypefullyApp } from "./typefully-app";
+
+export const dynamic = "force-dynamic";
+
+const SIGN_IN_PATH = `/handler/sign-in?after_auth_return_to=${encodeURIComponent("/typefully")}`;
+
+export default async function TypefullyPage() {
+  const access = await requireTypefullyUserFromCookies();
+  if (!access.ok) {
+    if (access.reason === "unauthenticated") {
+      redirect(SIGN_IN_PATH);
+    }
+    return <AccessDenied reason={access.reason} email={access.email} />;
+  }
+
+  const drafts = await runTypefullyWorkflow(listTypefullyDrafts(access.user.id));
+
+  return (
+    <TypefullyApp
+      initialDrafts={drafts}
+      userEmail={access.user.email}
+      signOutHref="/handler/sign-out"
+    />
+  );
+}
+
+function AccessDenied({
+  reason,
+  email,
+}: {
+  reason: TypefullyAccessDeniedReason;
+  email?: string | null;
+}) {
+  return (
+    <main className="min-h-screen bg-[#f6f7f8] px-6 py-10 text-[#191a1d]">
+      <div className="mx-auto flex min-h-[calc(100vh-5rem)] w-full max-w-xl flex-col justify-center">
+        <div className="border border-[#d9dde3] bg-white p-6 shadow-sm">
+          <p className="mb-2 text-xs font-medium uppercase text-[#69707d]">
+            Manaflow Drafts
+          </p>
+          <h1 className="text-2xl font-semibold tracking-tight">
+            Access blocked
+          </h1>
+          <p className="mt-3 text-sm leading-6 text-[#4f5663]">
+            {accessDeniedMessage(reason, email)}
+          </p>
+          <div className="mt-6 flex flex-wrap gap-2">
+            <a
+              href={SIGN_IN_PATH}
+              className="inline-flex h-9 items-center border border-[#191a1d] bg-[#191a1d] px-3 text-sm font-medium text-white"
+            >
+              Sign in with Google
+            </a>
+            <Link
+              href="/handler/sign-out"
+              className="inline-flex h-9 items-center border border-[#d9dde3] bg-white px-3 text-sm font-medium text-[#191a1d]"
+            >
+              Sign out
+            </Link>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}
+
+function accessDeniedMessage(
+  reason: TypefullyAccessDeniedReason,
+  email?: string | null,
+): string {
+  switch (reason) {
+    case "auth_not_configured":
+      return "Authentication is not configured for this deployment.";
+    case "email_missing":
+      return "Your account does not have a primary email address.";
+    case "email_unverified":
+      return `${email ?? "Your email"} is not verified.`;
+    case "domain_not_allowed":
+      return `${email ?? "Your email"} is not allowed. Use ${ALLOWED_TYPEFULLY_DOMAINS.join(", ")}.`;
+    case "google_required":
+      return "This workspace only allows Google sign-in.";
+    case "unauthenticated":
+      return "Sign in with Google to continue.";
+  }
+}

--- a/web/app/typefully/typefully-app.tsx
+++ b/web/app/typefully/typefully-app.tsx
@@ -1,0 +1,419 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import type React from "react";
+import Link from "next/link";
+import type { TypefullyDraft } from "../../services/typefully/workflows";
+
+type EditableDraft = {
+  readonly id: string | null;
+  readonly title: string;
+  readonly thread: readonly string[];
+  readonly createdAt: string | null;
+  readonly updatedAt: string | null;
+};
+
+type SaveState =
+  | { readonly kind: "idle"; readonly message: string }
+  | { readonly kind: "saving"; readonly message: string }
+  | { readonly kind: "error"; readonly message: string };
+
+const emptyDraft: EditableDraft = {
+  id: null,
+  title: "Untitled draft",
+  thread: [""],
+  createdAt: null,
+  updatedAt: null,
+};
+
+export function TypefullyApp({
+  initialDrafts,
+  userEmail,
+  signOutHref,
+}: {
+  initialDrafts: readonly TypefullyDraft[];
+  userEmail: string;
+  signOutHref: string;
+}) {
+  const [drafts, setDrafts] = useState<readonly TypefullyDraft[]>(initialDrafts);
+  const [activeId, setActiveId] = useState<string | null>(initialDrafts[0]?.id ?? null);
+  const [draft, setDraft] = useState<EditableDraft>(
+    initialDrafts[0] ? editableFromDraft(initialDrafts[0]) : emptyDraft,
+  );
+  const [saveState, setSaveState] = useState<SaveState>({
+    kind: "idle",
+    message: initialDrafts[0] ? "Ready" : "New draft",
+  });
+
+  const totalCharacters = useMemo(
+    () => draft.thread.reduce((total, part) => total + characterCount(part), 0),
+    [draft.thread],
+  );
+  const hasExistingDraft = draft.id !== null;
+
+  function selectDraft(next: TypefullyDraft) {
+    setActiveId(next.id);
+    setDraft(editableFromDraft(next));
+    setSaveState({ kind: "idle", message: "Ready" });
+  }
+
+  function newDraft() {
+    setActiveId(null);
+    setDraft(emptyDraft);
+    setSaveState({ kind: "idle", message: "New draft" });
+  }
+
+  function updateTitle(title: string) {
+    updateDraft({ title });
+  }
+
+  function updateThreadPart(index: number, value: string) {
+    const thread = draft.thread.map((part, partIndex) =>
+      partIndex === index ? value : part
+    );
+    updateDraft({ thread });
+  }
+
+  function addThreadPart() {
+    updateDraft({ thread: [...draft.thread, ""] });
+  }
+
+  function removeThreadPart(index: number) {
+    if (draft.thread.length <= 1) return;
+    updateDraft({ thread: draft.thread.filter((_, partIndex) => partIndex !== index) });
+  }
+
+  function splitFirstPost() {
+    const split = draft.thread
+      .join("\n\n")
+      .split(/\n{2,}/)
+      .map((part) => part.trim())
+      .filter(Boolean);
+    updateDraft({ thread: split.length > 0 ? split : [""] });
+  }
+
+  function updateDraft(patch: Partial<EditableDraft>) {
+    const next = { ...draft, ...patch };
+    setDraft(next);
+    if (next.id) {
+      setDrafts((currentDrafts) =>
+        currentDrafts.map((candidate) =>
+          candidate.id === next.id
+            ? {
+                ...candidate,
+                title: next.title,
+                thread: next.thread,
+                updatedAt: new Date().toISOString(),
+              }
+            : candidate
+        )
+      );
+    }
+    setSaveState({ kind: "idle", message: "Unsaved" });
+  }
+
+  async function saveDraft() {
+    setSaveState({ kind: "saving", message: "Saving" });
+    const payload = {
+      title: draft.title,
+      thread: draft.thread,
+    };
+    const path = draft.id
+      ? `/api/typefully/drafts/${encodeURIComponent(draft.id)}`
+      : "/api/typefully/drafts";
+    const method = draft.id ? "PATCH" : "POST";
+
+    try {
+      const response = await fetch(path, {
+        method,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const body = await response.json() as { draft?: TypefullyDraft; message?: string };
+      if (!response.ok || !body.draft) {
+        throw new Error(body.message ?? "Draft save failed");
+      }
+      const savedDraft = body.draft;
+      setDraft(editableFromDraft(savedDraft));
+      setActiveId(savedDraft.id);
+      setDrafts((currentDrafts) => upsertDraft(currentDrafts, savedDraft));
+      setSaveState({ kind: "idle", message: "Saved" });
+    } catch (err) {
+      setSaveState({
+        kind: "error",
+        message: err instanceof Error ? err.message : "Draft save failed",
+      });
+    }
+  }
+
+  async function deleteDraft() {
+    if (!draft.id) {
+      newDraft();
+      return;
+    }
+
+    setSaveState({ kind: "saving", message: "Deleting" });
+    try {
+      const response = await fetch(`/api/typefully/drafts/${encodeURIComponent(draft.id)}`, {
+        method: "DELETE",
+      });
+      if (!response.ok) {
+        const body = await response.json() as { message?: string };
+        throw new Error(body.message ?? "Delete failed");
+      }
+      const remaining = drafts.filter((candidate) => candidate.id !== draft.id);
+      setDrafts(remaining);
+      const next = remaining[0] ? editableFromDraft(remaining[0]) : emptyDraft;
+      setActiveId(next.id);
+      setDraft(next);
+      setSaveState({ kind: "idle", message: remaining[0] ? "Deleted" : "New draft" });
+    } catch (err) {
+      setSaveState({
+        kind: "error",
+        message: err instanceof Error ? err.message : "Delete failed",
+      });
+    }
+  }
+
+  function handleKeyDown(event: React.KeyboardEvent<HTMLDivElement>) {
+    if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "s") {
+      event.preventDefault();
+      void saveDraft();
+    }
+  }
+
+  return (
+    <main
+      className="flex min-h-screen flex-col bg-[#f6f7f8] text-[#191a1d]"
+      onKeyDown={handleKeyDown}
+    >
+      <header className="flex min-h-14 flex-wrap items-center justify-between gap-3 border-b border-[#d9dde3] bg-white px-4 py-3">
+        <div className="flex min-w-0 items-center gap-3">
+          <div className="flex h-8 w-8 shrink-0 items-center justify-center border border-[#191a1d] bg-[#191a1d] text-sm font-semibold text-white">
+            M
+          </div>
+          <div className="min-w-0">
+            <h1 className="truncate text-sm font-semibold">Manaflow Drafts</h1>
+            <p className="truncate text-xs text-[#69707d]">{userEmail}</p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <span className={statusClass(saveState.kind)}>{saveState.message}</span>
+          <button
+            type="button"
+            onClick={newDraft}
+            className="h-9 border border-[#c8ced8] bg-white px-3 text-sm font-medium hover:bg-[#eef1f5]"
+          >
+            New
+          </button>
+          <button
+            type="button"
+            onClick={() => void saveDraft()}
+            disabled={saveState.kind === "saving"}
+            className="h-9 border border-[#1f6f5b] bg-[#1f6f5b] px-3 text-sm font-medium text-white hover:bg-[#185a49] disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            Save
+          </button>
+          <Link
+            href={signOutHref}
+            className="inline-flex h-9 items-center border border-[#c8ced8] bg-white px-3 text-sm font-medium hover:bg-[#eef1f5]"
+          >
+            Sign out
+          </Link>
+        </div>
+      </header>
+
+      <div className="grid min-h-0 flex-1 grid-cols-1 lg:grid-cols-[280px_minmax(0,1fr)_320px]">
+        <aside className="min-h-0 border-b border-[#d9dde3] bg-white lg:border-b-0 lg:border-r">
+          <div className="flex h-12 items-center justify-between border-b border-[#e3e6eb] px-4">
+            <p className="text-xs font-medium uppercase text-[#69707d]">Drafts</p>
+            <p className="text-xs tabular-nums text-[#69707d]">{drafts.length}</p>
+          </div>
+          <div className="max-h-72 overflow-y-auto lg:max-h-[calc(100vh-6.5rem)]">
+            {drafts.length === 0 ? (
+              <div className="px-4 py-6 text-sm text-[#69707d]">No saved drafts</div>
+            ) : (
+              drafts.map((candidate) => (
+                <button
+                  key={candidate.id}
+                  type="button"
+                  onClick={() => selectDraft(candidate)}
+                  className={`block w-full border-b border-[#edf0f3] px-4 py-3 text-left hover:bg-[#f2f4f7] ${
+                    activeId === candidate.id ? "bg-[#edf7f3]" : "bg-white"
+                  }`}
+                >
+                  <span className="block truncate text-sm font-medium">
+                    {candidate.title}
+                  </span>
+                  <span className="mt-1 block truncate text-xs text-[#69707d]">
+                    {candidate.thread[0] || "Empty draft"}
+                  </span>
+                  <span className="mt-2 block text-[11px] text-[#8a919d]">
+                    {formatDate(candidate.updatedAt)}
+                  </span>
+                </button>
+              ))
+            )}
+          </div>
+        </aside>
+
+        <section className="min-h-0 overflow-y-auto bg-[#f6f7f8] px-4 py-4 lg:max-h-[calc(100vh-3.5rem)]">
+          <div className="mx-auto flex w-full max-w-3xl flex-col gap-3">
+            <input
+              value={draft.title}
+              onChange={(event) => updateTitle(event.target.value)}
+              className="h-12 w-full border border-[#c8ced8] bg-white px-3 text-lg font-semibold outline-none focus:border-[#1f6f5b] focus:ring-2 focus:ring-[#1f6f5b]/20"
+              placeholder="Draft title"
+            />
+
+            <div className="flex flex-wrap items-center justify-between gap-2 border border-[#d9dde3] bg-white px-3 py-2">
+              <div className="flex items-center gap-3 text-xs text-[#69707d]">
+                <span>{draft.thread.length} posts</span>
+                <span>{totalCharacters} chars</span>
+                {draft.updatedAt ? <span>{formatDate(draft.updatedAt)}</span> : null}
+              </div>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={splitFirstPost}
+                  className="h-8 border border-[#c8ced8] bg-white px-2 text-xs font-medium hover:bg-[#eef1f5]"
+                >
+                  Split
+                </button>
+                <button
+                  type="button"
+                  onClick={addThreadPart}
+                  className="h-8 border border-[#c8ced8] bg-white px-2 text-xs font-medium hover:bg-[#eef1f5]"
+                >
+                  Add post
+                </button>
+              </div>
+            </div>
+
+            {draft.thread.map((part, index) => {
+              const count = characterCount(part);
+              return (
+                <div
+                  key={`${draft.id ?? "new"}-${index}`}
+                  className="border border-[#d9dde3] bg-white"
+                >
+                  <div className="flex min-h-10 items-center justify-between border-b border-[#edf0f3] px-3">
+                    <div className="flex items-center gap-2 text-xs text-[#69707d]">
+                      <span className="font-mono tabular-nums">{index + 1}</span>
+                      <span className={count > 280 ? "text-[#b42318]" : ""}>
+                        {count}/280
+                      </span>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => removeThreadPart(index)}
+                      disabled={draft.thread.length <= 1}
+                      className="h-7 border border-transparent px-2 text-xs text-[#69707d] hover:border-[#d9dde3] hover:text-[#191a1d] disabled:cursor-not-allowed disabled:opacity-40"
+                    >
+                      Remove
+                    </button>
+                  </div>
+                  <textarea
+                    value={part}
+                    onChange={(event) => updateThreadPart(index, event.target.value)}
+                    className="min-h-44 w-full resize-y bg-white px-3 py-3 text-[15px] leading-7 outline-none"
+                    placeholder="Write a post"
+                  />
+                </div>
+              );
+            })}
+
+            <div className="flex flex-wrap justify-between gap-2 pb-8">
+              <button
+                type="button"
+                onClick={() => void deleteDraft()}
+                className="h-9 border border-[#d92d20] bg-white px-3 text-sm font-medium text-[#b42318] hover:bg-[#fff1f0]"
+              >
+                {hasExistingDraft ? "Delete" : "Clear"}
+              </button>
+              <button
+                type="button"
+                onClick={() => void saveDraft()}
+                disabled={saveState.kind === "saving"}
+                className="h-9 border border-[#1f6f5b] bg-[#1f6f5b] px-4 text-sm font-medium text-white hover:bg-[#185a49] disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                Save draft
+              </button>
+            </div>
+          </div>
+        </section>
+
+        <aside className="min-h-0 border-t border-[#d9dde3] bg-white lg:max-h-[calc(100vh-3.5rem)] lg:overflow-y-auto lg:border-l lg:border-t-0">
+          <div className="flex h-12 items-center justify-between border-b border-[#e3e6eb] px-4">
+            <p className="text-xs font-medium uppercase text-[#69707d]">Preview</p>
+            <p className="text-xs tabular-nums text-[#69707d]">{totalCharacters}</p>
+          </div>
+          <div className="space-y-3 p-4">
+            {draft.thread.map((part, index) => (
+              <article
+                key={`preview-${index}`}
+                className="border border-[#d9dde3] bg-[#fbfcfd] p-3"
+              >
+                <div className="mb-2 flex items-center justify-between gap-2 text-xs text-[#69707d]">
+                  <span>Post {index + 1}</span>
+                  <span className={characterCount(part) > 280 ? "text-[#b42318]" : ""}>
+                    {characterCount(part)}
+                  </span>
+                </div>
+                <p className="whitespace-pre-wrap break-words text-sm leading-6">
+                  {part || "Empty post"}
+                </p>
+              </article>
+            ))}
+          </div>
+        </aside>
+      </div>
+    </main>
+  );
+}
+
+function editableFromDraft(draft: TypefullyDraft): EditableDraft {
+  return {
+    id: draft.id,
+    title: draft.title,
+    thread: draft.thread.length > 0 ? draft.thread : [""],
+    createdAt: draft.createdAt,
+    updatedAt: draft.updatedAt,
+  };
+}
+
+function upsertDraft(
+  drafts: readonly TypefullyDraft[],
+  draft: TypefullyDraft,
+): readonly TypefullyDraft[] {
+  const existingIndex = drafts.findIndex((candidate) => candidate.id === draft.id);
+  if (existingIndex === -1) {
+    return [draft, ...drafts];
+  }
+  return drafts.map((candidate) => candidate.id === draft.id ? draft : candidate);
+}
+
+function characterCount(value: string): number {
+  return Array.from(value).length;
+}
+
+function formatDate(value: string): string {
+  return new Intl.DateTimeFormat("en", {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(new Date(value));
+}
+
+function statusClass(kind: SaveState["kind"]): string {
+  const base = "hidden h-7 items-center border px-2 text-xs sm:inline-flex";
+  switch (kind) {
+    case "saving":
+      return `${base} border-[#c8ced8] bg-[#eef1f5] text-[#4f5663]`;
+    case "error":
+      return `${base} border-[#fecdca] bg-[#fff1f0] text-[#b42318]`;
+    case "idle":
+      return `${base} border-[#c8eadf] bg-[#edf7f3] text-[#1f6f5b]`;
+  }
+}

--- a/web/db/migrations/20260520014254_opposite_giant_man/migration.sql
+++ b/web/db/migrations/20260520014254_opposite_giant_man/migration.sql
@@ -1,0 +1,14 @@
+CREATE TYPE "typefully_draft_status" AS ENUM('draft', 'archived');--> statement-breakpoint
+CREATE TABLE "typefully_drafts" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+	"user_id" text NOT NULL,
+	"user_email" text NOT NULL,
+	"title" text DEFAULT 'Untitled draft' NOT NULL,
+	"thread" jsonb DEFAULT '[""]' NOT NULL,
+	"status" "typefully_draft_status" DEFAULT 'draft'::"typefully_draft_status" NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX "typefully_drafts_user_updated_idx" ON "typefully_drafts" ("user_id","updated_at");--> statement-breakpoint
+CREATE INDEX "typefully_drafts_user_status_updated_idx" ON "typefully_drafts" ("user_id","status","updated_at");

--- a/web/db/migrations/20260520014254_opposite_giant_man/snapshot.json
+++ b/web/db/migrations/20260520014254_opposite_giant_man/snapshot.json
@@ -1,0 +1,1355 @@
+{
+  "version": "8",
+  "dialect": "postgres",
+  "id": "99f2aeee-9e2d-4c80-b1e7-300ce47f3f67",
+  "prevIds": [
+    "399a2558-b881-4169-98e1-5906059fc3fd"
+  ],
+  "ddl": [
+    {
+      "values": [
+        "draft",
+        "archived"
+      ],
+      "name": "typefully_draft_status",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "pty",
+        "rpc",
+        "ssh"
+      ],
+      "name": "vm_lease_kind",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "e2b",
+        "freestyle"
+      ],
+      "name": "vm_provider",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "provisioning",
+        "running",
+        "failed",
+        "paused",
+        "destroyed"
+      ],
+      "name": "vm_status",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "cloud_vm_billing_grants",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "cloud_vm_leases",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "cloud_vm_usage_events",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "cloud_vms",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "typefully_drafts",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_billing_grants"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "billing_customer_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_billing_grants"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "billing_customer_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_billing_grants"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "billing_plan_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_billing_grants"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "item_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_billing_grants"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "amount",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_billing_grants"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "reason",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_billing_grants"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "applied_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_billing_grants"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_billing_grants"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_billing_grants"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "vm_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "type": "vm_lease_kind",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "kind",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "token_hash",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "provider_identity_handle",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "transport",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{}'",
+      "generated": null,
+      "identity": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "consumed_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "revoked_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "billing_team_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "billing_plan_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "vm_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "event_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "type": "vm_provider",
+      "typeSchema": "public",
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "provider",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{}'",
+      "generated": null,
+      "identity": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "billing_team_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "billing_plan_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "vm_provider",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "provider",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "provider_vm_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image_version",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "vm_status",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'provisioning'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "idempotency_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "destroyed_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "failure_code",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "failure_message",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "typefully_drafts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "typefully_drafts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_email",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "typefully_drafts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'Untitled draft'",
+      "generated": null,
+      "identity": null,
+      "name": "title",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "typefully_drafts"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'[\"\"]'",
+      "generated": null,
+      "identity": null,
+      "name": "thread",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "typefully_drafts"
+    },
+    {
+      "type": "typefully_draft_status",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'draft'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "typefully_drafts"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "typefully_drafts"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "typefully_drafts"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "billing_customer_type",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "billing_customer_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vm_billing_grants_customer_created_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vm_billing_grants"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "billing_customer_type",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "billing_customer_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "item_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "reason",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vm_billing_grants_customer_item_reason_unique",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vm_billing_grants"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "vm_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "kind",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vm_leases_vm_kind_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "provider_identity_handle",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vm_leases_identity_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "expires_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vm_leases_user_expires_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "token_hash",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vm_leases_token_hash_unique",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vm_usage_events_user_created_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "billing_team_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vm_usage_events_billing_team_created_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "vm_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vm_usage_events_vm_created_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "event_type",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vm_usage_events_type_created_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "status",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vms_user_status_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "billing_team_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "status",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vms_billing_team_status_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "idempotency_key",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "\"idempotency_key\" is not null",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vms_user_idempotency_key_unique",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "provider",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "provider_vm_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "\"provider_vm_id\" is not null",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vms_provider_vm_id_unique",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "updated_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "typefully_drafts_user_updated_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "typefully_drafts"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "status",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "updated_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "typefully_drafts_user_status_updated_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "typefully_drafts"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "vm_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "cloud_vms",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "cloud_vm_leases_vm_id_cloud_vms_id_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "vm_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "cloud_vms",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "name": "cloud_vm_usage_events_vm_id_cloud_vms_id_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "cloud_vm_billing_grants_pkey",
+      "schema": "public",
+      "table": "cloud_vm_billing_grants",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "cloud_vm_leases_pkey",
+      "schema": "public",
+      "table": "cloud_vm_leases",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "cloud_vm_usage_events_pkey",
+      "schema": "public",
+      "table": "cloud_vm_usage_events",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "cloud_vms_pkey",
+      "schema": "public",
+      "table": "cloud_vms",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "typefully_drafts_pkey",
+      "schema": "public",
+      "table": "typefully_drafts",
+      "entityType": "pks"
+    }
+  ],
+  "renames": []
+}

--- a/web/db/schema.ts
+++ b/web/db/schema.ts
@@ -23,6 +23,11 @@ export const vmStatus = pgEnum("vm_status", [
 
 export const vmLeaseKind = pgEnum("vm_lease_kind", ["pty", "rpc", "ssh"]);
 
+export const typefullyDraftStatus = pgEnum("typefully_draft_status", [
+  "draft",
+  "archived",
+]);
+
 export const cloudVms = pgTable(
   "cloud_vms",
   {
@@ -122,5 +127,23 @@ export const cloudVmBillingGrants = pgTable(
       .on(table.billingCustomerType, table.billingCustomerId, table.createdAt),
     uniqueIndex("cloud_vm_billing_grants_customer_item_reason_unique")
       .on(table.billingCustomerType, table.billingCustomerId, table.itemId, table.reason),
+  ],
+);
+
+export const typefullyDrafts = pgTable(
+  "typefully_drafts",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    userId: text("user_id").notNull(),
+    userEmail: text("user_email").notNull(),
+    title: text("title").notNull().default("Untitled draft"),
+    thread: jsonb("thread").$type<string[]>().notNull().default(sql`'[""]'::jsonb`),
+    status: typefullyDraftStatus("status").notNull().default("draft"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("typefully_drafts_user_updated_idx").on(table.userId, table.updatedAt),
+    index("typefully_drafts_user_status_updated_idx").on(table.userId, table.status, table.updatedAt),
   ],
 );

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -63,5 +63,5 @@ export default function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/((?!api|_next|_vercel|agent-page-variant|handler).*)"],
+  matcher: ["/((?!api|_next|_vercel|agent-page-variant|handler|typefully).*)"],
 };

--- a/web/services/typefully/access.ts
+++ b/web/services/typefully/access.ts
@@ -1,0 +1,72 @@
+import type { CurrentServerUser } from "@stackframe/stack";
+
+export const ALLOWED_TYPEFULLY_DOMAINS = [
+  "manaflow.com",
+  "manaflow.ai",
+  "cmux.com",
+] as const;
+
+export type TypefullyUser = {
+  readonly id: string;
+  readonly email: string;
+  readonly displayName: string | null;
+};
+
+export type TypefullyAccessDeniedReason =
+  | "auth_not_configured"
+  | "unauthenticated"
+  | "email_missing"
+  | "email_unverified"
+  | "domain_not_allowed"
+  | "google_required";
+
+export type TypefullyAccessResult =
+  | { readonly ok: true; readonly user: TypefullyUser }
+  | {
+      readonly ok: false;
+      readonly reason: TypefullyAccessDeniedReason;
+      readonly email?: string | null;
+    };
+
+type StackUserLike = Pick<
+  CurrentServerUser,
+  "id" | "displayName" | "primaryEmail" | "primaryEmailVerified" | "oauthProviders"
+>;
+
+export function typefullyAccessForUser(user: StackUserLike | null): TypefullyAccessResult {
+  if (!user) {
+    return { ok: false, reason: "unauthenticated" };
+  }
+
+  const email = user.primaryEmail?.trim().toLowerCase() ?? null;
+  if (!email) {
+    return { ok: false, reason: "email_missing" };
+  }
+  if (!user.primaryEmailVerified) {
+    return { ok: false, reason: "email_unverified", email };
+  }
+  if (!isAllowedTypefullyEmail(email)) {
+    return { ok: false, reason: "domain_not_allowed", email };
+  }
+  if (!hasGoogleOAuthProvider(user)) {
+    return { ok: false, reason: "google_required", email };
+  }
+
+  return {
+    ok: true,
+    user: {
+      id: user.id,
+      email,
+      displayName: user.displayName,
+    },
+  };
+}
+
+export function isAllowedTypefullyEmail(email: string): boolean {
+  const domain = email.trim().toLowerCase().split("@").at(-1);
+  return ALLOWED_TYPEFULLY_DOMAINS.some((allowed) => domain === allowed);
+}
+
+export function hasGoogleOAuthProvider(user: Pick<StackUserLike, "oauthProviders">): boolean {
+  return user.oauthProviders.some((provider) => provider.id === "google");
+}

--- a/web/services/typefully/auth.ts
+++ b/web/services/typefully/auth.ts
@@ -1,0 +1,38 @@
+import { getStackServerApp, isStackConfigured } from "../../app/lib/stack";
+import {
+  typefullyAccessForUser,
+  type TypefullyAccessResult,
+} from "./access";
+
+export {
+  ALLOWED_TYPEFULLY_DOMAINS,
+  hasGoogleOAuthProvider,
+  isAllowedTypefullyEmail,
+  typefullyAccessForUser,
+  type TypefullyAccessDeniedReason,
+  type TypefullyAccessResult,
+  type TypefullyUser,
+} from "./access";
+
+export async function requireTypefullyUserFromRequest(
+  request: Request,
+): Promise<TypefullyAccessResult> {
+  if (!isStackConfigured()) {
+    return { ok: false, reason: "auth_not_configured" };
+  }
+
+  const user = await getStackServerApp().getUser({
+    tokenStore: request as unknown as { headers: { get(name: string): string | null } },
+    or: "return-null",
+  });
+  return typefullyAccessForUser(user);
+}
+
+export async function requireTypefullyUserFromCookies(): Promise<TypefullyAccessResult> {
+  if (!isStackConfigured()) {
+    return { ok: false, reason: "auth_not_configured" };
+  }
+
+  const user = await getStackServerApp().getUser({ or: "return-null" });
+  return typefullyAccessForUser(user);
+}

--- a/web/services/typefully/errors.ts
+++ b/web/services/typefully/errors.ts
@@ -1,0 +1,63 @@
+import * as Data from "effect/Data";
+
+export class TypefullyDatabaseError extends Data.TaggedError("TypefullyDatabaseError")<{
+  readonly operation: string;
+  readonly cause: unknown;
+}> {}
+
+export class TypefullyDraftNotFoundError extends Data.TaggedError("TypefullyDraftNotFoundError")<{
+  readonly draftId: string;
+}> {}
+
+export type TypefullyWorkflowError =
+  | TypefullyDatabaseError
+  | TypefullyDraftNotFoundError;
+
+export function isTypefullyDatabaseError(err: unknown): err is TypefullyDatabaseError {
+  return (err as { _tag?: string } | null)?._tag === "TypefullyDatabaseError";
+}
+
+export function isTypefullyDraftNotFoundError(err: unknown): err is TypefullyDraftNotFoundError {
+  return (err as { _tag?: string } | null)?._tag === "TypefullyDraftNotFoundError";
+}
+
+const typefullyWorkflowErrorTags = new Set([
+  "TypefullyDatabaseError",
+  "TypefullyDraftNotFoundError",
+]);
+
+export function typefullyWorkflowErrorCause(err: unknown): TypefullyWorkflowError | null {
+  if (!err || typeof err !== "object") return null;
+  const tag = (err as { _tag?: unknown })._tag;
+  if (typeof tag === "string" && typefullyWorkflowErrorTags.has(tag)) {
+    return err as TypefullyWorkflowError;
+  }
+  const fiberCause = effectFiberFailureCause(err);
+  const fiberFailure = typefullyWorkflowErrorFromEffectCause(fiberCause);
+  if (fiberFailure) return fiberFailure;
+  const cause = (err as { cause?: unknown }).cause;
+  if (cause && cause !== err) return typefullyWorkflowErrorCause(cause);
+  return null;
+}
+
+function effectFiberFailureCause(err: object): unknown {
+  const symbol = Object.getOwnPropertySymbols(err).find((candidate) =>
+    candidate.description === "effect/Runtime/FiberFailure/Cause"
+  );
+  return symbol ? (err as Record<symbol, unknown>)[symbol] : null;
+}
+
+function typefullyWorkflowErrorFromEffectCause(cause: unknown): TypefullyWorkflowError | null {
+  if (!cause || typeof cause !== "object") return null;
+  const tag = (cause as { _tag?: unknown })._tag;
+  if (tag === "Fail") {
+    const failure = (cause as { failure?: unknown; error?: unknown }).failure ??
+      (cause as { error?: unknown }).error;
+    return typefullyWorkflowErrorCause(failure);
+  }
+  if (tag === "Sequential" || tag === "Parallel") {
+    return typefullyWorkflowErrorFromEffectCause((cause as { left?: unknown }).left) ??
+      typefullyWorkflowErrorFromEffectCause((cause as { right?: unknown }).right);
+  }
+  return typefullyWorkflowErrorFromEffectCause((cause as { cause?: unknown }).cause);
+}

--- a/web/services/typefully/repository.ts
+++ b/web/services/typefully/repository.ts
@@ -1,0 +1,109 @@
+import { and, desc, eq } from "drizzle-orm";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import { cloudDb } from "../../db/client";
+import { typefullyDrafts } from "../../db/schema";
+import { TypefullyDatabaseError } from "./errors";
+
+export type TypefullyDraftRow = typeof typefullyDrafts.$inferSelect;
+export type TypefullyDraftStatus = TypefullyDraftRow["status"];
+
+export type TypefullyDraftInput = {
+  readonly title: string;
+  readonly thread: readonly string[];
+};
+
+export type TypefullyDraftRepositoryShape = {
+  readonly listDrafts: (userId: string) => Effect.Effect<TypefullyDraftRow[], TypefullyDatabaseError>;
+  readonly createDraft: (input: {
+    readonly userId: string;
+    readonly userEmail: string;
+    readonly title: string;
+    readonly thread: readonly string[];
+  }) => Effect.Effect<TypefullyDraftRow, TypefullyDatabaseError>;
+  readonly updateDraft: (input: {
+    readonly id: string;
+    readonly userId: string;
+    readonly title: string;
+    readonly thread: readonly string[];
+  }) => Effect.Effect<TypefullyDraftRow | null, TypefullyDatabaseError>;
+  readonly archiveDraft: (input: {
+    readonly id: string;
+    readonly userId: string;
+  }) => Effect.Effect<boolean, TypefullyDatabaseError>;
+};
+
+export class TypefullyDraftRepository extends Context.Tag("cmux/TypefullyDraftRepository")<
+  TypefullyDraftRepository,
+  TypefullyDraftRepositoryShape
+>() {}
+
+function dbEffect<A>(
+  operation: string,
+  run: () => Promise<A>,
+): Effect.Effect<A, TypefullyDatabaseError> {
+  return Effect.tryPromise({
+    try: run,
+    catch: (cause) => new TypefullyDatabaseError({ operation, cause }),
+  });
+}
+
+export const TypefullyDraftRepositoryLive = Layer.succeed(TypefullyDraftRepository, {
+  listDrafts: (userId) =>
+    dbEffect("listDrafts", async () => {
+      const db = cloudDb();
+      return await db
+        .select()
+        .from(typefullyDrafts)
+        .where(and(eq(typefullyDrafts.userId, userId), eq(typefullyDrafts.status, "draft")))
+        .orderBy(desc(typefullyDrafts.updatedAt));
+    }),
+
+  createDraft: (input) =>
+    dbEffect("createDraft", async () => {
+      const db = cloudDb();
+      const [draft] = await db
+        .insert(typefullyDrafts)
+        .values({
+          userId: input.userId,
+          userEmail: input.userEmail,
+          title: input.title,
+          thread: [...input.thread],
+        })
+        .returning();
+      if (!draft) {
+        throw new Error("insert did not return a draft row");
+      }
+      return draft;
+    }),
+
+  updateDraft: (input) =>
+    dbEffect("updateDraft", async () => {
+      const db = cloudDb();
+      const [draft] = await db
+        .update(typefullyDrafts)
+        .set({
+          title: input.title,
+          thread: [...input.thread],
+          updatedAt: new Date(),
+        })
+        .where(and(eq(typefullyDrafts.id, input.id), eq(typefullyDrafts.userId, input.userId)))
+        .returning();
+      return draft ?? null;
+    }),
+
+  archiveDraft: (input) =>
+    dbEffect("archiveDraft", async () => {
+      const db = cloudDb();
+      const [draft] = await db
+        .update(typefullyDrafts)
+        .set({
+          status: "archived",
+          updatedAt: new Date(),
+        })
+        .where(and(eq(typefullyDrafts.id, input.id), eq(typefullyDrafts.userId, input.userId)))
+        .returning({ id: typefullyDrafts.id });
+      return Boolean(draft);
+    }),
+});

--- a/web/services/typefully/routeHelpers.ts
+++ b/web/services/typefully/routeHelpers.ts
@@ -1,0 +1,128 @@
+import { type Span } from "@opentelemetry/api";
+import { recordSpanError, withApiRouteSpan, type MaybeAttributes } from "../telemetry";
+import {
+  requireTypefullyUserFromRequest,
+  type TypefullyAccessDeniedReason,
+  type TypefullyUser,
+} from "./auth";
+import {
+  isTypefullyDatabaseError,
+  isTypefullyDraftNotFoundError,
+} from "./errors";
+
+export type AuthedTypefullyRouteContext = {
+  readonly user: TypefullyUser;
+  readonly span: Span;
+};
+
+export async function withAuthedTypefullyApiRoute(
+  request: Request,
+  route: string,
+  attributes: MaybeAttributes,
+  handler: (context: AuthedTypefullyRouteContext) => Promise<Response>,
+): Promise<Response> {
+  return withApiRouteSpan(
+    request,
+    route,
+    { "cmux.subsystem": "typefully-lite", ...attributes },
+    async (span) => {
+      try {
+        const access = await requireTypefullyUserFromRequest(request);
+        if (!access.ok) {
+          return typefullyAuthErrorResponse(access.reason, access.email);
+        }
+        if (requiresBrowserMutationProtection(request.method) && !browserMutationOriginAllowed(request)) {
+          return jsonResponse({ error: "forbidden" }, 403);
+        }
+        return await handler({ user: access.user, span });
+      } catch (err) {
+        recordSpanError(span, err);
+        console.error(`typefully route failed: ${route}`, err);
+        const workflowError = typefullyWorkflowErrorResponse(err);
+        if (workflowError) return workflowError;
+        return jsonResponse({
+          error: "typefully_internal_error",
+          message: "Draft request failed unexpectedly.",
+        }, 500);
+      }
+    },
+  );
+}
+
+export function jsonResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function typefullyAuthErrorResponse(
+  reason: TypefullyAccessDeniedReason,
+  email?: string | null,
+): Response {
+  const status = reason === "unauthenticated" ? 401 : 403;
+  return jsonResponse({
+    error: reason,
+    message: typefullyAuthMessage(reason, email),
+  }, status);
+}
+
+function typefullyAuthMessage(
+  reason: TypefullyAccessDeniedReason,
+  email?: string | null,
+): string {
+  switch (reason) {
+    case "auth_not_configured":
+      return "Authentication is not configured.";
+    case "unauthenticated":
+      return "Sign in with Google to save drafts.";
+    case "email_missing":
+      return "Your account does not have a primary email.";
+    case "email_unverified":
+      return `${email ?? "This email"} is not verified.`;
+    case "domain_not_allowed":
+      return `${email ?? "This email"} is not allowed. Use a manaflow.com, manaflow.ai, or cmux.com account.`;
+    case "google_required":
+      return "This workspace only allows Google sign-in.";
+  }
+}
+
+function typefullyWorkflowErrorResponse(err: unknown): Response | null {
+  if (isTypefullyDraftNotFoundError(err)) {
+    return jsonResponse({
+      error: "draft_not_found",
+      message: "Draft not found.",
+    }, 404);
+  }
+
+  if (isTypefullyDatabaseError(err)) {
+    return jsonResponse({
+      error: "draft_storage_unavailable",
+      message: "Draft storage is temporarily unavailable.",
+    }, 503);
+  }
+
+  return null;
+}
+
+function requiresBrowserMutationProtection(method: string): boolean {
+  return ["POST", "PUT", "PATCH", "DELETE"].includes(method.toUpperCase());
+}
+
+function browserMutationOriginAllowed(request: Request): boolean {
+  const origin = request.headers.get("origin")?.trim();
+  const secFetchSite = request.headers.get("sec-fetch-site")?.trim().toLowerCase();
+  if (secFetchSite === "cross-site") return false;
+  if (!origin) return false;
+
+  const requestOrigin = requestURLOrigin(request);
+  return Boolean(requestOrigin && origin === requestOrigin);
+}
+
+function requestURLOrigin(request: Request): string | null {
+  try {
+    return new URL(request.url).origin;
+  } catch {
+    return null;
+  }
+}

--- a/web/services/typefully/workflows.ts
+++ b/web/services/typefully/workflows.ts
@@ -1,0 +1,113 @@
+import * as Effect from "effect/Effect";
+import {
+  TypefullyDraftNotFoundError,
+  typefullyWorkflowErrorCause,
+  type TypefullyWorkflowError,
+} from "./errors";
+import {
+  TypefullyDraftRepository,
+  TypefullyDraftRepositoryLive,
+  type TypefullyDraftInput,
+  type TypefullyDraftRow,
+} from "./repository";
+
+export type TypefullyDraft = {
+  readonly id: string;
+  readonly title: string;
+  readonly thread: readonly string[];
+  readonly createdAt: string;
+  readonly updatedAt: string;
+};
+
+export async function runTypefullyWorkflow<A>(
+  program: Effect.Effect<A, TypefullyWorkflowError, TypefullyDraftRepository>,
+): Promise<A> {
+  try {
+    return await Effect.runPromise(program.pipe(Effect.provide(TypefullyDraftRepositoryLive)));
+  } catch (err) {
+    throw typefullyWorkflowErrorCause(err) ?? err;
+  }
+}
+
+export function listTypefullyDrafts(userId: string) {
+  return Effect.gen(function* () {
+    const repo = yield* TypefullyDraftRepository;
+    const rows = yield* repo.listDrafts(userId);
+    return rows.map(draftFromRow);
+  });
+}
+
+export function createTypefullyDraft(input: {
+  readonly userId: string;
+  readonly userEmail: string;
+  readonly draft: TypefullyDraftInput;
+}) {
+  return Effect.gen(function* () {
+    const repo = yield* TypefullyDraftRepository;
+    const normalized = normalizeDraftInput(input.draft);
+    const row = yield* repo.createDraft({
+      userId: input.userId,
+      userEmail: input.userEmail,
+      title: normalized.title,
+      thread: normalized.thread,
+    });
+    return draftFromRow(row);
+  });
+}
+
+export function updateTypefullyDraft(input: {
+  readonly id: string;
+  readonly userId: string;
+  readonly draft: TypefullyDraftInput;
+}) {
+  return Effect.gen(function* () {
+    const repo = yield* TypefullyDraftRepository;
+    const normalized = normalizeDraftInput(input.draft);
+    const row = yield* repo.updateDraft({
+      id: input.id,
+      userId: input.userId,
+      title: normalized.title,
+      thread: normalized.thread,
+    });
+    if (!row) {
+      return yield* Effect.fail(new TypefullyDraftNotFoundError({ draftId: input.id }));
+    }
+    return draftFromRow(row);
+  });
+}
+
+export function archiveTypefullyDraft(input: {
+  readonly id: string;
+  readonly userId: string;
+}) {
+  return Effect.gen(function* () {
+    const repo = yield* TypefullyDraftRepository;
+    const archived = yield* repo.archiveDraft(input);
+    if (!archived) {
+      return yield* Effect.fail(new TypefullyDraftNotFoundError({ draftId: input.id }));
+    }
+  });
+}
+
+export function normalizeDraftInput(input: TypefullyDraftInput): TypefullyDraftInput {
+  const title = input.title.trim().slice(0, 180) || "Untitled draft";
+  const thread = input.thread
+    .map((part) => part.replace(/\r\n/g, "\n").trimEnd().slice(0, 8000))
+    .filter((part, index) => index === 0 || part.trim().length > 0)
+    .slice(0, 50);
+
+  return {
+    title,
+    thread: thread.length > 0 ? thread : [""],
+  };
+}
+
+function draftFromRow(row: TypefullyDraftRow): TypefullyDraft {
+  return {
+    id: row.id,
+    title: row.title,
+    thread: row.thread,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}

--- a/web/tests/typefully-auth.test.ts
+++ b/web/tests/typefully-auth.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  hasGoogleOAuthProvider,
+  isAllowedTypefullyEmail,
+  typefullyAccessForUser,
+} from "../services/typefully/access";
+
+const baseUser = {
+  id: "user-1",
+  displayName: "Test User",
+  primaryEmail: "writer@manaflow.com",
+  primaryEmailVerified: true,
+  oauthProviders: [{ id: "google" }],
+};
+
+describe("Typefully auth gate", () => {
+  test("allows Google users from approved domains", () => {
+    expect(typefullyAccessForUser(baseUser)).toEqual({
+      ok: true,
+      user: {
+        id: "user-1",
+        email: "writer@manaflow.com",
+        displayName: "Test User",
+      },
+    });
+    expect(isAllowedTypefullyEmail("writer@manaflow.ai")).toBe(true);
+    expect(isAllowedTypefullyEmail("writer@cmux.com")).toBe(true);
+  });
+
+  test("blocks non-approved domains", () => {
+    expect(typefullyAccessForUser({
+      ...baseUser,
+      primaryEmail: "writer@example.com",
+    })).toEqual({
+      ok: false,
+      reason: "domain_not_allowed",
+      email: "writer@example.com",
+    });
+  });
+
+  test("requires Google OAuth", () => {
+    expect(hasGoogleOAuthProvider({ oauthProviders: [{ id: "github" }] })).toBe(false);
+    expect(typefullyAccessForUser({
+      ...baseUser,
+      oauthProviders: [{ id: "github" }],
+    })).toEqual({
+      ok: false,
+      reason: "google_required",
+      email: "writer@manaflow.com",
+    });
+  });
+
+  test("requires a verified primary email", () => {
+    expect(typefullyAccessForUser({
+      ...baseUser,
+      primaryEmailVerified: false,
+    })).toEqual({
+      ok: false,
+      reason: "email_unverified",
+      email: "writer@manaflow.com",
+    });
+  });
+});

--- a/web/tests/typefully-workflows.test.ts
+++ b/web/tests/typefully-workflows.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import { normalizeDraftInput } from "../services/typefully/workflows";
+
+describe("Typefully draft workflow helpers", () => {
+  test("normalizes empty draft input into a persisted shape", () => {
+    expect(normalizeDraftInput({ title: "   ", thread: [] })).toEqual({
+      title: "Untitled draft",
+      thread: [""],
+    });
+  });
+
+  test("keeps the first empty post and drops later empty posts", () => {
+    expect(normalizeDraftInput({
+      title: " Launch notes ",
+      thread: ["", "  ", "Ship it\n\n"],
+    })).toEqual({
+      title: "Launch notes",
+      thread: ["", "Ship it"],
+    });
+  });
+
+  test("caps drafts to the persisted limits", () => {
+    const normalized = normalizeDraftInput({
+      title: "x".repeat(240),
+      thread: Array.from({ length: 60 }, (_, index) => `post ${index}`),
+    });
+    expect(normalized.title).toHaveLength(180);
+    expect(normalized.thread).toHaveLength(50);
+  });
+});


### PR DESCRIPTION
Adds a small internal Typefully-style draft composer at /typefully.

- Uses existing Stack Auth and requires a verified Google account from manaflow.com, manaflow.ai, or cmux.com.
- Persists drafts in Postgres with a new typefully_drafts table and authenticated draft APIs.
- Includes focused auth and draft normalization tests.

Verification:
- bun test
- bunx tsc --noEmit --pretty false
- bun lint (passes with pre-existing warnings)
- bun db:check
- SKIP_ENV_VALIDATION=1 bun run build
- local HTTP check for /typefully and /api/typefully/drafts auth gating

Deployment note: the new table requires applying the included Drizzle migration before authenticated users can save drafts on a target environment.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4422"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new authenticated drafts surface area (UI + API) plus a new Postgres table/migration; correctness depends on auth gating and input normalization, and deployments must apply the migration to avoid runtime failures.
> 
> **Overview**
> Adds a new internal drafts composer at `/typefully`, including a client UI for editing multi-post threads with save/delete, keyboard shortcut support, and server-side access-denied handling.
> 
> Introduces authenticated draft APIs (`GET/POST /api/typefully/drafts`, `PATCH/DELETE /api/typefully/drafts/[id]`) with request validation, telemetry spans, and browser-mutation origin protection; APIs call new Effect-based workflows that normalize input, map domain errors to HTTP responses, and persist via a new Drizzle-backed `typefully_drafts` table (with `draft`/`archived` status).
> 
> Updates middleware matching to exclude `/typefully` from `next-intl` routing, and adds focused tests for the auth gate and draft normalization behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9116e4f9c6365222e0770fd3ad5bf4980ac9a455. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an internal Typefully-style draft composer at /typefully with authenticated draft CRUD APIs and Postgres persistence, gated to verified Google accounts on manaflow.com, manaflow.ai, or cmux.com. This enables team-only thread drafting with a simple UI and tests.

- New Features
  - UI at /typefully to draft multi-post threads with split/add/remove, live preview, counts, and Cmd/Ctrl+S save.
  - Auth gate via Stack Auth: verified Google sign-in only; helpful access screen with sign-in/out links.
  - Draft APIs: /api/typefully/drafts (GET, POST) and /api/typefully/drafts/[id] (PATCH, DELETE) with same-origin protection and telemetry.
  - Storage: new typefully_drafts table with indexes; list/create/update/archive workflows and input normalization; typed repository and error handling.
  - Tests for auth gating and draft normalization.
  - Proxy update to bypass middleware for /typefully.

- Migration
  - Apply the included Drizzle migration to create typefully_drafts before deploying.
  - Ensure Stack Auth is configured with Google OAuth and allowed domains for access.

<sup>Written for commit 9116e4f9c6365222e0770fd3ad5bf4980ac9a455. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4422?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Typefully draft management system with create, edit, save, and delete capabilities.
  * Implemented email-based access control for Typefully features.
  * Added draft preview and character counting functionality.
  * Integrated Google OAuth authentication for Typefully access.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4422?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->