### PR TITLE
Fix Claude resume working directory

### DIFF
--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -510,6 +510,7 @@ struct SessionRestorableAgentSnapshot: Codable, Sendable {
     var kind: RestorableAgentKind
     var sessionId: String
     var workingDirectory: String?
+    var resumeWorkingDirectory: String? = nil
     var launchCommand: AgentLaunchCommandSnapshot?
     var registration: CmuxVaultAgentRegistration? = nil
 
@@ -518,7 +519,7 @@ struct SessionRestorableAgentSnapshot: Codable, Sendable {
             kind: kind,
             sessionId: sessionId,
             launchCommand: launchCommand,
-            workingDirectory: workingDirectory,
+            workingDirectory: resumeWorkingDirectory ?? workingDirectory,
             registrationOverride: registration
         )
     }
@@ -769,6 +770,12 @@ struct RestorableAgentSessionIndex: Sendable {
                     kind: kind,
                     sessionId: normalizedSessionId,
                     workingDirectory: normalizedWorkingDirectory(record.cwd),
+                    resumeWorkingDirectory: resumeWorkingDirectory(
+                        for: record,
+                        kind: kind,
+                        fileManager: fileManager,
+                        claudeTranscriptLookup: claudeTranscriptLookup
+                    ),
                     launchCommand: record.launchCommand,
                     registration: registration
                 )
@@ -793,6 +800,61 @@ struct RestorableAgentSessionIndex: Sendable {
 
     private static func normalizedWorkingDirectory(_ rawValue: String?) -> String? {
         normalizedNonEmptyValue(rawValue)
+    }
+
+    private static func resumeWorkingDirectory(
+        for record: RestorableAgentHookSessionRecord,
+        kind: RestorableAgentKind,
+        fileManager: FileManager,
+        claudeTranscriptLookup: ClaudeTranscriptLookupCache
+    ) -> String? {
+        let hookCwd = normalizedWorkingDirectory(record.cwd)
+        guard kind == .claude else {
+            return nil
+        }
+
+        let launchCwd = normalizedWorkingDirectory(record.launchCommand?.workingDirectory)
+        var seenCandidates: Set<String> = []
+        let candidates = [launchCwd, hookCwd].compactMap { candidate -> String? in
+            guard let candidate, seenCandidates.insert(candidate).inserted else { return nil }
+            return candidate
+        }
+
+        func overrideIfNeeded(_ selected: String?) -> String? {
+            guard selected != hookCwd else { return nil }
+            return selected
+        }
+
+        if let transcriptPath = normalizedNonEmptyValue(record.transcriptPath) {
+            let expandedPath = (transcriptPath as NSString).expandingTildeInPath
+            for cwd in candidates where claudeTranscriptPath(expandedPath, matchesWorkingDirectory: cwd) {
+                return overrideIfNeeded(cwd)
+            }
+        }
+
+        if let sessionId = normalizedNonEmptyValue(record.sessionId),
+           claudeSessionIdIsSafeFilename(sessionId) {
+            let roots = claudeTranscriptLookup.configRoots(for: record)
+            for cwd in candidates {
+                for root in roots where claudeTranscriptFileExists(
+                    configRoot: root,
+                    projectDirName: encodeClaudeProjectDir(cwd),
+                    sessionId: sessionId,
+                    fileManager: fileManager
+                ) {
+                    return overrideIfNeeded(cwd)
+                }
+            }
+        }
+
+        return overrideIfNeeded(launchCwd ?? hookCwd)
+    }
+
+    private static func claudeTranscriptPath(_ transcriptPath: String, matchesWorkingDirectory cwd: String) -> Bool {
+        let projectDirName = URL(fileURLWithPath: transcriptPath)
+            .deletingLastPathComponent()
+            .lastPathComponent
+        return projectDirName == encodeClaudeProjectDir(cwd)
     }
 
     private static func hookRecordIsRestorable(

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -948,6 +948,15 @@ extension Workspace {
                     "autoResume=\(autoResumeAgentSessions ? 1 : 0) " +
                     "replayScrollback=\(shouldReplayScrollback ? 1 : 0)"
                 )
+                if let cwd = restorableAgent.workingDirectory,
+                   let resumeCwd = restorableAgent.resumeWorkingDirectory,
+                   cwd != resumeCwd {
+                    cmuxDebugLog(
+                        "session.restore.agent.resumeCwd panel=\(snapshot.id.uuidString.prefix(5)) " +
+                        "kind=\(restorableAgent.kind.rawValue) session=\(sessionPreview) " +
+                        "cwd=\(String(cwd.prefix(160))) resumeCwd=\(String(resumeCwd.prefix(160)))"
+                    )
+                }
             }
             if let resumeBinding {
                 cmuxDebugLog(

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -1500,6 +1500,72 @@ final class SessionPersistenceTests: XCTestCase {
         return RestorableAgentSessionIndex.load(homeDirectory: home.path)
     }
 
+    func testClaudeHookResumeUsesTranscriptProjectDirectoryWhenHookCwdMoved() throws {
+        let fileManager = FileManager.default
+        let home = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-claude-resume-cwd-\(UUID().uuidString)", isDirectory: true)
+        let storeDir = home.appendingPathComponent(".cmuxterm", isDirectory: true)
+        try fileManager.createDirectory(at: storeDir, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: home) }
+
+        let sessionId = "1d1fb186-204f-4a4d-b1a9-d284e01a31ba"
+        let workspaceId = UUID()
+        let panelId = UUID()
+        let launchCwd = "/Users/test-user/git"
+        let hookCwd = "/Users/test-user/git/worktrees/products/DEV-219209-wonitemcache-event-logger"
+        let transcriptURL = home
+            .appendingPathComponent(".claude", isDirectory: true)
+            .appendingPathComponent("projects", isDirectory: true)
+            .appendingPathComponent("-Users-test-user-git", isDirectory: true)
+            .appendingPathComponent("\(sessionId).jsonl", isDirectory: false)
+        try fileManager.createDirectory(
+            at: transcriptURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try #"{"type":"assistant","message":{"content":[{"type":"text","text":"done"}]}}"#
+            .write(to: transcriptURL, atomically: true, encoding: .utf8)
+
+        let storeURL = storeDir.appendingPathComponent("claude-hook-sessions.json", isDirectory: false)
+        let json = """
+        {
+          "version": 1,
+          "sessions": {
+            "\(sessionId)": {
+              "sessionId": "\(sessionId)",
+              "workspaceId": "\(workspaceId.uuidString)",
+              "surfaceId": "\(panelId.uuidString)",
+              "cwd": "\(hookCwd)",
+              "transcriptPath": "\(transcriptURL.path)",
+              "updatedAt": 123,
+              "launchCommand": {
+                "launcher": "claude",
+                "executablePath": "/opt/homebrew/bin/claude",
+                "arguments": [
+                  "/opt/homebrew/bin/claude",
+                  "--dangerously-skip-permissions"
+                ],
+                "workingDirectory": "\(launchCwd)",
+                "environment": {},
+                "capturedAt": 122,
+                "source": "environment"
+              }
+            }
+          }
+        }
+        """
+        try json.write(to: storeURL, atomically: true, encoding: .utf8)
+
+        let index = RestorableAgentSessionIndex.load(homeDirectory: home.path)
+        let snapshot = try XCTUnwrap(index.snapshot(workspaceId: workspaceId, panelId: panelId))
+
+        XCTAssertEqual(snapshot.workingDirectory, hookCwd)
+        XCTAssertEqual(snapshot.resumeWorkingDirectory, launchCwd)
+        XCTAssertEqual(
+            snapshot.resumeCommand,
+            "cd '/Users/test-user/git' && '/opt/homebrew/bin/claude' '--resume' '\(sessionId)' '--dangerously-skip-permissions'"
+        )
+    }
+
     private func makeSnapshot(version: Int) -> AppSessionSnapshot {
         let workspace = SessionWorkspaceSnapshot(
             processTitle: "Terminal",


### PR DESCRIPTION
## Summary
- keep the live hook cwd as the restored panel working directory
- add a Claude-only resume cwd override when the transcript belongs to the original launch/project cwd
- add regression coverage for restoring a Claude session after the hook cwd moved into a worktree

## Root cause
Claude resolves `--resume <session>` against the encoded project directory under its transcript store. cmux was using the hook/live cwd for the generated `cd ... && claude --resume ...` command. After a cmux restart, hooks could report a worktree cwd while the transcript still lived under the original launch cwd, so Claude could not find the session and reported `No conversation found with session ID`.

## Fix
`SessionRestorableAgentSnapshot` now keeps `workingDirectory` for restored panel/UI behavior and uses an optional `resumeWorkingDirectory` only when building the resume command. For Claude hook records, the index resolves that override from the transcript path or transcript lookup roots, preferring the launch cwd when it matches the transcript project directory.

## Validation
- `CMUX_SKIP_ZIG_BUILD=1 xcodebuild test -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-fix-claude-resume-cwd -only-testing:cmuxTests/SessionPersistenceTests/testClaudeHookResumeUsesTranscriptProjectDirectoryWhenHookCwdMoved`
- `CMUX_SKIP_ZIG_BUILD=1 ./scripts/reload.sh --tag fix-claude-resume-cwd`

`CMUX_SKIP_ZIG_BUILD=1` was used because the local machine has Zig 0.16.0 while the checked-out Ghostty submodule requires Zig 0.15.2.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4428"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Claude session resume when the hook cwd moved (e.g., into a worktree) by resolving the resume cwd from the transcript’s project directory. UI keeps showing the live hook cwd; only the resume command uses the override.

- Introduced `resumeWorkingDirectory` in `SessionRestorableAgentSnapshot`; used only for building the resume command. `workingDirectory` remains for panel/UI behavior.
- Claude-specific resolution picks the launch cwd or hook cwd that matches the transcript project dir (via transcript path or lookup roots), plus debug logging when they differ; added a regression test for the worktree scenario.

<sup>Written for commit 67f252bd834d0aeee2caa5b9b7efbd338e8ad597. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4428?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

