### PR TITLE
Add Droid Vault sessions

### DIFF
--- a/Sources/SessionIndexRegisteredAgents.swift
+++ b/Sources/SessionIndexRegisteredAgents.swift
@@ -665,7 +665,7 @@ extension SessionIndexStore {
     }
 
     nonisolated private static func firstTopLevelTitle(in object: [String: Any]) -> String? {
-        if let title = firstText(in: object, keys: ["title", "prompt"]) {
+        if let title = firstText(in: object, keys: ["title", "sessionTitle", "prompt"]) {
             return title
         }
         guard shouldUseMessageAsTitle(object) else { return nil }

--- a/Sources/VaultAgentRegistry.swift
+++ b/Sources/VaultAgentRegistry.swift
@@ -137,6 +137,18 @@ struct CmuxVaultAgentRegistration: Codable, Hashable, Sendable {
             sessionDirectory: "~/.grok/sessions"
         )
     }
+
+    static var builtInDroid: CmuxVaultAgentRegistration {
+        CmuxVaultAgentRegistration(
+            id: "droid",
+            name: "Droid",
+            detect: CmuxVaultAgentDetectRule(processName: "droid", argvContains: ["droid"]),
+            sessionIdSource: .argvOption("--resume"),
+            resumeCommand: "droid --resume {{sessionId}}",
+            cwd: .preserve,
+            sessionDirectory: "~/.factory/sessions"
+        )
+    }
 }
 
 struct CmuxVaultAgentDetectRule: Codable, Hashable, Sendable {
@@ -342,6 +354,7 @@ struct CmuxVaultAgentRegistry: Sendable {
         var registrations = [
             CmuxVaultAgentRegistration.builtInPi,
             CmuxVaultAgentRegistration.builtInGrok,
+            CmuxVaultAgentRegistration.builtInDroid,
         ]
         for path in configPaths(homeDirectory: homeDirectory, workingDirectory: workingDirectory, environment: environment, fileManager: fileManager) {
             guard let config = decodeConfig(at: path, fileManager: fileManager) else { continue }

--- a/cmuxTests/PiVaultAgentPersistenceTests.swift
+++ b/cmuxTests/PiVaultAgentPersistenceTests.swift
@@ -79,6 +79,16 @@ final class PiVaultAgentPersistenceTests: XCTestCase {
         XCTAssertEqual(SessionAgent.grok.assetName, "AgentIcons/Grok")
     }
 
+    func testBuiltInDroidRegistrationUsesFactorySessionDirectory() {
+        let registration = CmuxVaultAgentRegistration.builtInDroid
+        let agent = RegisteredSessionAgent(registration: registration)
+
+        XCTAssertEqual(registration.id, "droid")
+        XCTAssertEqual(registration.sessionDirectory, "~/.factory/sessions")
+        XCTAssertEqual(agent.displayName, "Droid")
+        XCTAssertEqual(SessionAgent.registered(agent).displayName, "Droid")
+    }
+
     func testRegisteredAgentTemplateFailsClosedWhenPlaceholderIsUnavailable() {
         let registration = CmuxVaultAgentRegistration(
             id: "acme-agent",
@@ -229,6 +239,41 @@ final class PiVaultAgentPersistenceTests: XCTestCase {
         XCTAssertEqual(entry.sessionId, "native-session-123")
         XCTAssertEqual(entry.title, "Resume Acme")
         XCTAssertEqual(entry.gitBranch, "issue-3575-vault-pi-agent-support")
+    }
+
+    func testDroidSessionJSONLIndexesSessionTitleAndResumeCommand() async throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-droid-vault-\(UUID().uuidString)", isDirectory: true)
+        let sessionDir = tempDir.appendingPathComponent("-tmp-droid-repo", isDirectory: true)
+        try FileManager.default.createDirectory(at: sessionDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let sessionFile = sessionDir.appendingPathComponent("644a60e0-4cf9-4833-96ee-f72c4ad14d43.jsonl")
+        try """
+        {"type":"session_start","id":"644a60e0-4cf9-4833-96ee-f72c4ad14d43","sessionTitle":"Review Droid Vault sessions","cwd":"/tmp/droid repo"}
+        {"type":"message","message":{"role":"assistant","content":[{"type":"text","text":"assistant reply"}]}}
+        """.write(to: sessionFile, atomically: true, encoding: .utf8)
+
+        var registration = CmuxVaultAgentRegistration.builtInDroid
+        registration.sessionDirectory = tempDir.path
+
+        let entries = await SessionIndexStore.loadRegisteredAgentEntries(
+            registration: registration,
+            needle: "",
+            cwdFilter: nil,
+            offset: 0,
+            limit: 10
+        )
+
+        let entry = try XCTUnwrap(entries.first)
+        XCTAssertEqual(entry.agent, .registered(RegisteredSessionAgent(registration: registration)))
+        XCTAssertEqual(entry.sessionId, "644a60e0-4cf9-4833-96ee-f72c4ad14d43")
+        XCTAssertEqual(entry.title, "Review Droid Vault sessions")
+        XCTAssertEqual(entry.cwd, "/tmp/droid repo")
+        XCTAssertEqual(
+            entry.resumeCommand,
+            "cd '/tmp/droid repo' && 'droid' '--resume' '644a60e0-4cf9-4833-96ee-f72c4ad14d43'"
+        )
     }
 
     func testRegisteredAgentCWDFilterUsesJSONLMetadataNotFallback() async throws {


### PR DESCRIPTION
## Summary

- register Droid as a built-in Vault agent backed by `~/.factory/sessions`
- index Factory/Droid JSONL `sessionTitle` metadata for session titles
- add focused coverage for Droid registration, metadata extraction, and resume command generation

## Verification

- `git diff --check`
- local `xcodebuild test -project cmux.xcodeproj -scheme cmux-unit -destination 'platform=macOS' -only-testing:cmuxTests/PiVaultAgentPersistenceTests` could not run because active developer directory is Command Line Tools, not full Xcode
- inspected local `~/.factory/sessions` shape: JSONL metadata includes `id`, `title`, `sessionTitle`, and `cwd`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4430"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a built-in Droid Vault agent to discover and resume Droid sessions. Titles (preferring sessionTitle) and working directories are read from JSONL for accurate listing and one-shot resume.

- **New Features**
  - Register Droid agent (id: droid), detected by process name/argv; sessions read from `~/.factory/sessions`.
  - Resume via `--resume` using `droid --resume {{sessionId}}`; preserve cwd when generating the command.
  - Prefer `sessionTitle` for titles; index `cwd` from JSONL for correct resume context.
  - Unit tests for registration, metadata extraction, and resume command.

<sup>Written for commit d05f5ea1bf96bfb5feafd7151de85f3ea9f13efb. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4430?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new built-in agent with predefined detection rules, session handling, and directory management capabilities.
  * Enhanced session title detection to prioritize additional metadata fields before falling back to existing logic.

* **Tests**
  * Added tests verifying the new agent's configuration, session persistence, and command generation functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4430?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->