### PR TITLE
fix: remove double-escape in markdown codespan renderer (#4144)

### DIFF
--- a/Resources/markdown-viewer/shell.html
+++ b/Resources/markdown-viewer/shell.html
@@ -951,8 +951,7 @@ html { scroll-behavior: smooth; }
     pedantic: false,
     renderer: {
       codespan(code) {
-        var raw = code || '';
-        return '<code>' + escapeHtml(raw) + '</code>';
+        return '<code>' + (code || '') + '</code>';
       },
       code(code, infostring, escaped) {
         var raw = code || '';

--- a/cmuxTests/MarkdownPanelTests.swift
+++ b/cmuxTests/MarkdownPanelTests.swift
@@ -1148,6 +1148,50 @@ final class MarkdownPanelTests: XCTestCase {
         )
     }
 
+    func testCodespanDoesNotDoubleEscapeHTMLEntities() async throws {
+        let markdownURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-codespan-escape-\(UUID().uuidString).md")
+
+        let frame = NSRect(x: 0, y: 0, width: 420, height: 260)
+        let webView = WKWebView(frame: frame, configuration: WKWebViewConfiguration())
+        let window = NSWindow(contentRect: frame, styleMask: [.borderless], backing: .buffered, defer: false)
+        window.contentView = webView
+        window.orderFrontRegardless()
+        defer {
+            webView.navigationDelegate = nil
+            window.close()
+        }
+
+        let loaded = expectation(description: "markdown shell loaded")
+        let loadDelegate = MarkdownShellLoadDelegate(expectation: loaded)
+        webView.navigationDelegate = loadDelegate
+        webView.loadHTMLString(
+            MarkdownViewerAssets.shared.shellHTML(isDark: true),
+            baseURL: markdownURL
+        )
+        await fulfillment(of: [loaded], timeout: 5)
+        if let error = loadDelegate.error {
+            throw error
+        }
+
+        try await renderMarkdown("`<>&\"'`\n", in: webView)
+
+        let codeHTML = try await webView.evaluateJavaScript(
+            """
+            (function() {
+              var code = document.querySelector('code');
+              return code ? code.innerHTML : null;
+            })();
+            """
+        )
+        let html = try XCTUnwrap(codeHTML as? String, "Expected a <code> element in rendered output")
+        XCTAssertTrue(html.contains("&amp;"), "codespan should preserve single-escaped ampersand: \(html)")
+        XCTAssertFalse(html.contains("&amp;amp;"), "codespan should not double-escape ampersand entities: \(html)")
+        XCTAssertTrue(html.contains("&lt;"), "codespan should preserve single-escaped less-than: \(html)")
+        XCTAssertTrue(html.contains("&gt;"), "codespan should preserve single-escaped greater-than: \(html)")
+        XCTAssertTrue(html.contains("\""), "codespan should render double-quote literally without double-escaping: \(html)")
+    }
+
     private func renderMarkdown(_ markdown: String, in webView: WKWebView) async throws {
         let data = try JSONSerialization.data(withJSONObject: [markdown])
         let literal = try XCTUnwrap(String(data: data, encoding: .utf8))


### PR DESCRIPTION
## Summary

- Fix double-escaping of HTML special characters (`<`, `>`, `&`, `"`, `'`) inside backtick spans in the markdown viewer
- The `marked` library already HTML-escapes inline code content before passing it to the `codespan` renderer; applying `escapeHtml()` again caused entities like `&lt;` to become `&amp;lt;`

## Root cause

In `Resources/markdown-viewer/shell.html`, the custom `codespan` renderer called `escapeHtml()` on already-escaped input from `marked`:

```javascript
// Before (double-escape)
codespan(code) {
    var raw = code || '';
    return '<code>' + escapeHtml(raw) + '</code>';
}

// After (correct)
codespan(code) {
    return '<code>' + (code || '') + '</code>';
}
```

## Test plan

- [x] CI: `testCodespanDoesNotDoubleEscapeHTMLEntities` should pass
- [x] Manual: open a markdown file with `` `<>&"'` `` in cmux markdown viewer — should render as `<>&"'` not `&lt;&gt;&amp;&quot;&#39;`
- [x] Verify fenced code blocks (` ``` `) are unaffected (they use a separate `code()` renderer that correctly applies `escapeHtml()` on raw input)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed double-escaping of HTML entities inside inline code so special characters (e.g., <, >, &, ") render correctly.

* **Tests**
  * Added an automated test verifying inline code renders HTML entities without being double-escaped and that quotes appear as expected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4431?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->