### PR TITLE
Fix pane tab width regression after #4290

### DIFF
--- a/cmuxTests/PortalTabDragRoutingTests.swift
+++ b/cmuxTests/PortalTabDragRoutingTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import AppKit
+import SwiftUI
 @testable import Bonsplit
 
 #if canImport(cmux_DEV)
@@ -22,12 +23,137 @@ final class PortalTabDragRoutingTests: XCTestCase {
         }
     }
 
+    func testCompactPaneTabChromeStaysBelowDragHitMinimum() throws {
+        let appearance = BonsplitConfiguration.Appearance(
+            tabMinWidth: 140,
+            tabMaxWidth: 220,
+            splitButtons: []
+        )
+        let measuredWidth = try XCTUnwrap(
+            renderedSelectedPaneTabIndicatorWidth(
+                title: "~",
+                icon: "terminal.fill",
+                appearance: appearance
+            )
+        )
+
+        XCTAssertGreaterThan(
+            measuredWidth,
+            40,
+            "The regression measurement must prove the selected tab indicator actually rendered"
+        )
+        XCTAssertLessThanOrEqual(
+            measuredWidth,
+            80,
+            "Short pane-tab visible chrome should stay compact; drag affordance must come from hit testing, not a wider rendered tab"
+        )
+    }
+
     private func makeHostedTerminalView(frame: NSRect) -> GhosttySurfaceScrollView {
         let surfaceView = GhosttyNSView(frame: frame)
         let hostedView = GhosttySurfaceScrollView(surfaceView: surfaceView)
         hostedView.frame = frame
         hostedView.autoresizingMask = [.width, .height]
         return hostedView
+    }
+
+    private func renderedSelectedPaneTabIndicatorWidth(
+        title: String,
+        icon: String?,
+        appearance: BonsplitConfiguration.Appearance
+    ) -> CGFloat? {
+        let controller = BonsplitController(configuration: BonsplitConfiguration(appearance: appearance))
+        guard let pane = controller.internalController.rootNode.allPanes.first else { return nil }
+        let tab = TabItem(title: title, icon: icon)
+        pane.tabs = [tab]
+        pane.selectedTabId = tab.id
+
+        let size = NSSize(width: 180, height: appearance.tabBarHeight)
+        let hostingView = NSHostingView(
+            rootView: TabBarView(pane: pane, isFocused: true, showSplitButtons: false)
+                .environment(controller)
+                .environment(controller.internalController)
+        )
+        let window = NSWindow(
+            contentRect: NSRect(origin: .zero, size: size),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        window.isOpaque = false
+        window.backgroundColor = .clear
+        defer { window.orderOut(nil) }
+        guard let contentView = window.contentView else { return nil }
+
+        contentView.wantsLayer = true
+        contentView.layer?.backgroundColor = NSColor.clear.cgColor
+        hostingView.frame = NSRect(origin: .zero, size: size)
+        hostingView.autoresizingMask = [.width, .height]
+        contentView.addSubview(hostingView)
+
+        window.makeKeyAndOrderFront(nil)
+        let sampleRect = NSRect(x: 0, y: 0, width: size.width, height: 4)
+        return waitForHighSaturationWidth(
+            in: hostingView,
+            sampleRect: sampleRect
+        )
+    }
+
+    private func waitForHighSaturationWidth(
+        in view: NSView,
+        sampleRect: NSRect,
+        timeout: TimeInterval = 1.0
+    ) -> CGFloat? {
+        let deadline = Date().addingTimeInterval(timeout)
+        repeat {
+            view.layoutSubtreeIfNeeded()
+            view.displayIfNeeded()
+            if let width = highSaturationWidth(in: view, sampleRect: sampleRect) {
+                return width
+            }
+            _ = RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.01))
+        } while Date() < deadline
+        return highSaturationWidth(in: view, sampleRect: sampleRect)
+    }
+
+    private func highSaturationWidth(in view: NSView, sampleRect: NSRect) -> CGFloat? {
+        let integralBounds = view.bounds.integral
+        guard let bitmap = view.bitmapImageRepForCachingDisplay(in: integralBounds) else { return nil }
+        bitmap.size = integralBounds.size
+        view.cacheDisplay(in: integralBounds, to: bitmap)
+
+        let scaleX = CGFloat(bitmap.pixelsWide) / max(1, integralBounds.width)
+        let scaleY = CGFloat(bitmap.pixelsHigh) / max(1, integralBounds.height)
+        let minX = max(0, Int(floor(sampleRect.minX * scaleX)))
+        let maxX = min(bitmap.pixelsWide, Int(ceil(sampleRect.maxX * scaleX)))
+        let minY = max(0, Int(floor(sampleRect.minY * scaleY)))
+        let maxY = min(bitmap.pixelsHigh, Int(ceil(sampleRect.maxY * scaleY)))
+
+        var activeColumnCount = 0
+        for x in minX..<maxX {
+            var hasIndicatorPixel = false
+            for y in minY..<maxY {
+                guard let color = bitmap.colorAt(x: x, y: y),
+                      let rgb = color.usingColorSpace(.sRGB),
+                      rgb.alphaComponent > 0.05 else { continue }
+                let alpha = min(max(rgb.alphaComponent, 0), 1)
+                let red = rgb.redComponent * alpha
+                let green = rgb.greenComponent * alpha
+                let blue = rgb.blueComponent * alpha
+                let high = max(red, green, blue)
+                guard high > 0.01 else { continue }
+                let low = min(red, green, blue)
+                if (high - low) / high > 0.4 {
+                    hasIndicatorPixel = true
+                    break
+                }
+            }
+            if hasIndicatorPixel {
+                activeColumnCount += 1
+            }
+        }
+        guard activeColumnCount > 0 else { return nil }
+        return CGFloat(activeColumnCount) / scaleX
     }
 
     private struct TabStripPassThroughFixture {


### PR DESCRIPTION
Fixes #4433.\n\n## Summary\n- Adds a cmux regression test that renders a short pane tab and asserts compact visible chrome stays below the drag-hit minimum.\n- Updates Bonsplit to manaflow-ai/bonsplit#127, restoring compact visual pane-tab width while preserving #4290's minimal-mode drag routing through expanded hit-test rects.\n- Keeps empty tab-strip chrome available for explicit window dragging outside the expanded tab hit area.\n\n## Regression timing\n- #4290 merged at 2026-05-20 00:36 UTC and introduced the sizing side effect while fixing minimal-mode pane-tab drag routing.\n- This PR preserves the drag routing fix and moves the affordance back into hit testing instead of visual chrome width.\n\n## Testing\n- Not run locally: per repo/user instructions, I did not run reload.sh, bare xcodebuild, or local tests.\n- Bonsplit PR #127 remote CI: tests passed.\n- cmux CI is the validation gate for this branch.\n\n## Build handoff\n- HQ should run the tagged dev build after CI is green; I will report the exact command then.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4438"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a rendering-based XCTest that relies on SwiftUI/AppKit snapshot-style pixel scanning, which could be mildly flaky in CI but does not affect production code paths.
> 
> **Overview**
> Adds a new regression test in `PortalTabDragRoutingTests` that **renders a minimal/short pane tab via `TabBarView` inside an `NSHostingView`** and asserts the selected-tab indicator’s *visible* width stays compact (<= 80pt) to prevent tab chrome from expanding to satisfy drag hit targets.
> 
> The test measures width by caching the rendered view into a bitmap and scanning for high-saturation pixels, waiting briefly for SwiftUI layout/rendering to settle before asserting bounds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0370709a008e5165457f9cfc9ad41e75ebc942c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores compact pane tab width while keeping minimal‑mode drag routing intact. Adds a render-and-measure regression test to ensure the tab’s visible chrome stays narrow and drag comes from hit‑testing. Fixes #4433.

- **Bug Fixes**
  - Updated `bonsplit` to restore compact tab chrome and preserve drag routing via expanded hit‑test rects; keeps empty tab‑strip area for window dragging.
  - Added SwiftUI/AppKit regression test that hosts `TabBarView` and measures the selected‑tab indicator (<= 80pt) via bitmap sampling to pin compact chrome.

<sup>Written for commit f0370709a008e5165457f9cfc9ad41e75ebc942c. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4438?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an automated UI test that renders pane tabs and verifies the selected tab indicator width stays within expected bounds to ensure reliable hit-target sizing.

* **Chores**
  * Updated a vendored component to a newer revision.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4438?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->