### PR TITLE
Tighten review bot no-sleep rules

### DIFF
--- a/.github/review-bot-rules/runtime-no-hacky-sleeps.md
+++ b/.github/review-bot-rules/runtime-no-hacky-sleeps.md
@@ -1,6 +1,6 @@
 # Runtime No Hacky Sleeps
 
-Scope: TypeScript, JavaScript, shell, and non-Swift runtime scripts. Swift timing and blocking primitives are covered by `swift-blocking-runtime.md`.
+Scope: TypeScript, JavaScript, shell, and non-Swift build/runtime scripts. Swift timing and blocking primitives are covered by `swift-blocking-runtime.md`.
 
 Flag fixed delays used as synchronization in production application or runtime code.
 

--- a/.github/review-bot-rules/runtime-no-hacky-sleeps.md
+++ b/.github/review-bot-rules/runtime-no-hacky-sleeps.md
@@ -2,6 +2,8 @@
 
 Scope: TypeScript, JavaScript, shell, and non-Swift build/runtime scripts. Swift timing and blocking primitives are covered by `swift-blocking-runtime.md`.
 
+GitHub Actions workflow and action YAML is intentionally out of scope. Fixed waits there are CI orchestration unless the PR also changes a covered runtime script that uses the wait as product synchronization.
+
 Flag fixed delays used as synchronization in production application or runtime code.
 
 Report a failure when the diff introduces or materially expands any of these in non-test code:
@@ -13,6 +15,7 @@ Report a failure when the diff introduces or materially expands any of these in 
 Allowed cases:
 
 - Deterministic sleeps in tests or explicit test-only scaffolding.
+- GitHub Actions workflow or action YAML sleeps used only for CI orchestration.
 - User-visible animation or progress timing where the timer is purely presentation and not coordination.
 - Production retry or timeout logic implemented through a dedicated cancellation-aware abstraction with bounded deadlines and tests, where the delay is part of the product behavior rather than a race repair.
 - Existing delay code that the PR does not introduce or worsen.

--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -21,7 +21,7 @@
     {
       "id": "cmux-runtime-no-hacky-sleeps",
       "rule": "Flag fixed sleeps, delayed dispatch, timers, polling, or wall-clock waits used as synchronization in production non-Swift app/runtime code across TypeScript, JavaScript, shell, or build/runtime scripts. Fail race repairs for lifecycle, focus, rendering, socket, process, filesystem, network, teardown, startup, retry, or shared-state readiness unless they use a real signal or a dedicated cancellation-aware timeout/retry abstraction with tests. Swift files are covered by cmux-swift-blocking-runtime.",
-      "scope": ["web/app/**/*.ts", "web/app/**/*.tsx", "web/services/**/*.ts", "web/services/**/*.tsx", "web/db/**/*.ts", "web/data/**/*.ts", "web/i18n/**/*.ts", "web/scripts/**/*.ts", "web/scripts/**/*.tsx", "web/scripts/**/*.js", "web/scripts/**/*.jsx", "web/scripts/**/*.mjs", "web/scripts/**/*.cjs", "web/scripts/**/*.sh", "web/scripts/**/*.zsh", "web/*.ts", "web/*.mjs", "scripts/**/*.ts", "scripts/**/*.tsx", "scripts/**/*.js", "scripts/**/*.jsx", "scripts/**/*.mjs", "scripts/**/*.cjs", "scripts/**/*.sh", "scripts/**/*.zsh"],
+      "scope": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "**/*.mjs", "**/*.cjs", "**/*.sh", "**/*.zsh"],
       "severity": "high"
     },
     {

--- a/.greptile/files.json
+++ b/.greptile/files.json
@@ -18,7 +18,7 @@
     {
       "path": ".github/review-bot-rules/runtime-no-hacky-sleeps.md",
       "description": "Source-of-truth cmux review rule for fixed sleeps, delays, and polling used as runtime synchronization.",
-      "scope": ["web/app/**/*.ts", "web/app/**/*.tsx", "web/services/**/*.ts", "web/services/**/*.tsx", "web/db/**/*.ts", "web/data/**/*.ts", "web/i18n/**/*.ts", "web/scripts/**/*.ts", "web/scripts/**/*.tsx", "web/scripts/**/*.js", "web/scripts/**/*.jsx", "web/scripts/**/*.mjs", "web/scripts/**/*.cjs", "web/scripts/**/*.sh", "web/scripts/**/*.zsh", "web/*.ts", "web/*.mjs", "scripts/**/*.ts", "scripts/**/*.tsx", "scripts/**/*.js", "scripts/**/*.jsx", "scripts/**/*.mjs", "scripts/**/*.cjs", "scripts/**/*.sh", "scripts/**/*.zsh"]
+      "scope": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "**/*.mjs", "**/*.cjs", "**/*.sh", "**/*.zsh"]
     },
     {
       "path": ".github/review-bot-rules/full-internationalization.md",

--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -18,6 +18,14 @@ Review production Swift and runtime changes for:
 - Architectural fixes that patch symptoms while leaving bad state representable.
 - User-facing errors, alerts, command output, API error bodies, and recovery copy that expose implementation details.
 
+## Runtime No Hacky Sleeps
+
+For production non-Swift app/runtime code and build/runtime scripts, flag fixed sleeps, delayed dispatch, timers, polling, or wall-clock waits used as synchronization.
+
+Fail race repairs for lifecycle, focus, rendering, socket, process, filesystem, network, teardown, startup, retry, or shared-state readiness unless they use a real signal from the owning subsystem or a dedicated cancellation-aware timeout/retry abstraction with tests.
+
+Pass for deterministic test-only scaffolding, pure presentation animation or progress timing, and existing delay code the PR does not introduce or worsen. Swift sleeps are covered by the Swift blocking runtime rule.
+
 ## Full Internationalization
 
 For production user-facing text, require complete internationalization across every locale supported by the affected surface.

--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -24,7 +24,7 @@ For production non-Swift app/runtime code and build/runtime scripts, flag fixed 
 
 Fail race repairs for lifecycle, focus, rendering, socket, process, filesystem, network, teardown, startup, retry, or shared-state readiness unless they use a real signal from the owning subsystem or a dedicated cancellation-aware timeout/retry abstraction with tests.
 
-Pass for deterministic test-only scaffolding, pure presentation animation or progress timing, and existing delay code the PR does not introduce or worsen. Swift sleeps are covered by the Swift blocking runtime rule.
+Pass for deterministic test-only scaffolding, GitHub Actions workflow or action YAML sleeps used only for CI orchestration, pure presentation animation or progress timing, and existing delay code the PR does not introduce or worsen. Swift sleeps are covered by the Swift blocking runtime rule.
 
 ## Full Internationalization
 


### PR DESCRIPTION
## Summary
- Broaden Greptile no-sleep scope across TypeScript, JavaScript, shell, and build/runtime scripts.
- Add a dedicated Greptile rules section for runtime sleep-based synchronization.
- Clarify Swift remains covered by the existing Swift blocking-runtime checks.
- Clarify GitHub Actions workflow/action YAML sleeps are intentionally out of scope when used only for CI orchestration.

## Verification
- `jq empty .greptile/config.json && jq empty .greptile/files.json`
- `ruby -ryaml -e 'YAML.load_file(%q(.coderabbit.yaml)); puts "ok"'`\n- `git diff --check`\n\nMetadata-only change. No tagged app reload.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, metadata-only changes to Greptile review configuration and documentation; no production code behavior is modified. Primary risk is increased lint/review noise due to the expanded glob scope.
> 
> **Overview**
> Tightens and broadens the Greptile **"Runtime No Hacky Sleeps"** rule to apply to all `*.ts/tsx/js/...` and shell files repo-wide (instead of a curated set of `web/` and `scripts/` paths).
> 
> Clarifies the rule’s intent and exceptions by explicitly scoping it to non-Swift build/runtime scripts, adding an out-of-scope note for GitHub Actions YAML sleeps, and adding a dedicated **Runtime No Hacky Sleeps** section to `.greptile/rules.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 897ba6560bebc6e169ed052e633942f0f3d5d5bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance documenting a new review rule that flags timing-based synchronization patterns in production runtime and build scripts, with clear pass/fail scenarios and examples.

* **Chores**
  * Broadened the rule’s scope to cover additional runtime and script file types and locations, and explicitly permits workflow YAML sleeps used only for CI orchestration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4439?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->