### PR TITLE
Harden CI against Swift crash backtrace hangs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,8 +153,9 @@ jobs:
     timeout-minutes: 45
     env:
       CMUX_SKIP_ZIG_BUILD: "1"
-      # Keep Swift crash backtraces from opening the 30s interactive prompt in CI.
-      SWIFT_BACKTRACE: "interactive=no,color=no"
+      # XCTest app-host crashes can leave xcodebuild waiting in Swift's crash
+      # backtracer until the job timeout. Disable the crash catcher entirely.
+      SWIFT_BACKTRACE: "enable=no"
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/cmux.xcodeproj/xcshareddata/xcschemes/cmux-ci.xcscheme
+++ b/cmux.xcodeproj/xcshareddata/xcschemes/cmux-ci.xcscheme
@@ -22,6 +22,9 @@
     <MacroExpansion>
       <BuildableReference BuildableIdentifier="primary" BlueprintIdentifier="A5001050" BuildableName="cmux.app" BlueprintName="cmux" ReferencedContainer="container:cmux.xcodeproj"/>
     </MacroExpansion>
+    <EnvironmentVariables>
+      <EnvironmentVariable key="SWIFT_BACKTRACE" value="enable=no" isEnabled="YES"/>
+    </EnvironmentVariables>
   </TestAction>
   <LaunchAction buildConfiguration="Debug" selectedDebuggerIdentifier="Xcode.DebuggerFoundation.Debugger.LLDB" selectedLauncherIdentifier="Xcode.DebuggerFoundation.Launcher.LLDB" launchStyle="0" useCustomWorkingDirectory="NO" ignoresPersistentStateOnLaunch="YES" debugDocumentVersioning="YES" allowLocationSimulation="YES">
     <BuildableProductRunnable runnableDebuggingMode="0">

--- a/cmux.xcodeproj/xcshareddata/xcschemes/cmux-unit.xcscheme
+++ b/cmux.xcodeproj/xcshareddata/xcschemes/cmux-unit.xcscheme
@@ -20,7 +20,7 @@
       <BuildableReference BuildableIdentifier="primary" BlueprintIdentifier="A5001050" BuildableName="cmux.app" BlueprintName="cmux" ReferencedContainer="container:cmux.xcodeproj"/>
     </MacroExpansion>
     <EnvironmentVariables>
-      <EnvironmentVariable key="SWIFT_BACKTRACE" value="interactive=no,color=no" isEnabled="YES"/>
+      <EnvironmentVariable key="SWIFT_BACKTRACE" value="enable=no" isEnabled="YES"/>
     </EnvironmentVariables>
   </TestAction>
   <LaunchAction buildConfiguration="Debug" selectedDebuggerIdentifier="Xcode.DebuggerFoundation.Debugger.LLDB" selectedLauncherIdentifier="Xcode.DebuggerFoundation.Launcher.LLDB" launchStyle="0" useCustomWorkingDirectory="NO" ignoresPersistentStateOnLaunch="YES" debugDocumentVersioning="YES" allowLocationSimulation="YES">

--- a/cmux.xcodeproj/xcshareddata/xcschemes/cmux.xcscheme
+++ b/cmux.xcodeproj/xcshareddata/xcschemes/cmux.xcscheme
@@ -16,6 +16,9 @@
     <MacroExpansion>
       <BuildableReference BuildableIdentifier="primary" BlueprintIdentifier="A5001050" BuildableName="cmux.app" BlueprintName="cmux" ReferencedContainer="container:cmux.xcodeproj"/>
     </MacroExpansion>
+    <EnvironmentVariables>
+      <EnvironmentVariable key="SWIFT_BACKTRACE" value="enable=no" isEnabled="YES"/>
+    </EnvironmentVariables>
   </TestAction>
   <LaunchAction buildConfiguration="Release" selectedDebuggerIdentifier="Xcode.DebuggerFoundation.Debugger.LLDB" selectedLauncherIdentifier="Xcode.DebuggerFoundation.Launcher.LLDB" launchStyle="0" useCustomWorkingDirectory="NO" ignoresPersistentStateOnLaunch="NO" debugDocumentVersioning="YES" allowLocationSimulation="YES">
     <BuildableProductRunnable runnableDebuggingMode="0">


### PR DESCRIPTION
## Summary
- disable Swift crash catching in the CI unit-test environment with the documented `SWIFT_BACKTRACE=enable=no` setting
- keep all shared cmux test schemes (`cmux`, `cmux-ci`, `cmux-unit`) aligned so app-hosted XCTest/UI test runs inherit the same crash-backtrace guard

## Context
PR #4437's visible `tests` job timed out after XCTest restarted from `MarkdownPanelTests` crashes and the Swift crash backtracer prompt remained in the log. The previous `interactive=no` setting was not a documented Swift backtrace option, so this uses the supported `enable=no` switch to disable crash catching entirely.

## Validation
- `git diff --check`
- `xmllint --noout cmux.xcodeproj/xcshareddata/xcschemes/cmux.xcscheme cmux.xcodeproj/xcshareddata/xcschemes/cmux-ci.xcscheme cmux.xcodeproj/xcshareddata/xcschemes/cmux-unit.xcscheme`

I did not run local tests per repository policy; CI must validate this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI/scheme-only configuration change that just alters Swift crash backtrace behavior during tests, with no production code impact.
> 
> **Overview**
> Hardens macOS CI test runs against Swift crash-backtrace hangs by switching `SWIFT_BACKTRACE` to the documented `enable=no` setting in the `tests` GitHub Actions job.
> 
> Aligns Xcode test schemes (`cmux-unit`, `cmux-ci`, and `cmux`) to set the same environment variable during `TestAction`, ensuring app-hosted XCTest runs inherit the guard consistently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76799fe14a12bc042fdf93eced66a55c55c0537f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI and local test schemes updated to disable the Swift crash backtracer, ensuring tests run without the backtrace catcher.
  * Comments and test environment configurations adjusted to accurately reflect the new disabled behavior across CI and project test schemes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4440?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->