### PR TITLE
Fix CLI socket autodiscovery test timeout handling

### DIFF
--- a/tests/test_cli_socket_autodiscovery.py
+++ b/tests/test_cli_socket_autodiscovery.py
@@ -80,6 +80,8 @@ class PingServer:
                 server.settimeout(min(0.2, remaining))
                 try:
                     conn, _ = server.accept()
+                # GitHub's macOS Python can report socket polling timeouts as
+                # socket.timeout rather than built-in TimeoutError.
                 except (socket.timeout, TimeoutError):
                     continue
                 connection_thread = threading.Thread(

--- a/tests/test_cli_socket_autodiscovery.py
+++ b/tests/test_cli_socket_autodiscovery.py
@@ -80,7 +80,7 @@ class PingServer:
                 server.settimeout(min(0.2, remaining))
                 try:
                     conn, _ = server.accept()
-                except TimeoutError:
+                except (socket.timeout, TimeoutError):
                     continue
                 connection_thread = threading.Thread(
                     target=self._handle_connection,
@@ -108,7 +108,7 @@ class PingServer:
                     if not chunk:
                         break
                     data += chunk
-            except (ConnectionResetError, TimeoutError):
+            except (ConnectionResetError, socket.timeout, TimeoutError):
                 return
 
             if b"ping" in data:


### PR DESCRIPTION
## Summary
- Treat Python socket.timeout as a normal poll timeout in the fake PingServer used by test_cli_socket_autodiscovery.py.
- Keep connect-only socket probes from failing the test server before the CLI sends the real ping.

## Validation
- python3 -m py_compile tests/test_cli_socket_autodiscovery.py
- git diff --check

Follow-up for main CI failure on merge commit 592dae9684ca35df596be26d88467ab77a34a0b6: tests/test_cli_socket_autodiscovery.py failed with 'socket server error: timed out'.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4441"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that broadens handled timeout/reset exceptions to avoid flaky failures on macOS/Python socket timeout behavior.
> 
> **Overview**
> Makes the `PingServer` in `tests/test_cli_socket_autodiscovery.py` more tolerant of socket polling/recv timeouts.
> 
> The accept loop now treats `socket.timeout` the same as `TimeoutError` and continues waiting, and the connection read handler also ignores `socket.timeout` so connect-only probes/timeouts don’t surface as test server errors before the real `ping` arrives.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61b579feb5836a6dcb5c6262e311d386ff57039a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix flaky CLI socket autodiscovery test by treating Python `socket.timeout` as a normal poll timeout in the fake server, and documenting platform-specific timeout behavior to avoid failures on slow or noisy connections.

- **Bug Fixes**
  - Accept loop now continues on `(socket.timeout, TimeoutError)` instead of erroring.
  - Read loop now ignores `(ConnectionResetError, socket.timeout, TimeoutError)` so connect-only probes don’t fail the server before the real ping.

<sup>Written for commit 61b579feb5836a6dcb5c6262e311d386ff57039a. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4441?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure socket timeout handling: socket timeouts are now treated like TimeoutError during connection acceptance and per-connection reads, preventing premature breaks and ensuring clean, predictable test behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4441?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->