### PR TITLE
Add live status reporting to the Amp Neo session plugin

### DIFF
--- a/CLI/CMUXCLI+AmpExtension.swift
+++ b/CLI/CMUXCLI+AmpExtension.swift
@@ -4,8 +4,10 @@ extension CMUXCLI {
     private static let ampExtensionMarker = "cmux-amp-session-extension-marker"
     private static let ampExtensionFilename = "cmux-session.ts"
     private static let ampExtensionSource = #"""
-// cmux-amp-session-extension-marker v1
-// Bridges Amp session lifecycle events into cmux's restorable session store.
+// cmux-amp-session-extension-marker v2
+// Bridges Amp session lifecycle events into cmux's restorable session store
+// AND reports live agent status (idle/thinking/tool calls/done/error) into
+// the cmux tab status bar.
 // Installed by `cmux hooks amp install` or `cmux hooks setup`.
 // DO NOT EDIT MANUALLY. cmux upgrades this file in place.
 // @i-know-the-amp-plugin-api-is-wip-and-very-experimental-right-now
@@ -18,6 +20,8 @@ import type {
   AgentEndEvent,
   AgentStartEvent,
   SessionStartEvent,
+  ToolCallEvent,
+  ToolResultEvent,
 } from "@ampcode/plugin";
 
 function firstString(...values: unknown[]): string | null {
@@ -140,23 +144,296 @@ function threadIdFrom(event: { thread?: { id?: string } } | undefined, ctx?: Amp
   return firstString(event?.thread?.id, ctx?.thread?.id);
 }
 
+// ─── Live status reporting ────────────────────────────────────────────────
+// Fires `cmux set-status` / `cmux clear-status` / `cmux log` so the tab
+// status bar reflects what Amp is doing (idle, thinking, running cmd,
+// reading file X, etc.). All calls are fire-and-forget; failures never
+// disturb the agent.
+
+const STATUS_KEY = "amp";
+const LOG_SOURCE = "amp";
+
+// Short verbs shown in the cmux status bar for each Amp tool.
+function toolLabel(tool: string): string {
+  switch (tool) {
+    case "Read":
+      return "reading";
+    case "edit_file":
+    case "create_file":
+      return "editing";
+    case "Bash":
+      return "running";
+    case "Grep":
+    case "finder":
+    case "glob":
+      return "searching";
+    case "Task":
+      return "subagent";
+    case "oracle":
+      return "consulting oracle";
+    case "web_search":
+    case "read_web_page":
+      return "browsing";
+    case "mermaid":
+      return "diagramming";
+    case "handoff":
+      return "handing off";
+    case "skill":
+      return "loading skill";
+    case "todo_write":
+    case "todo_read":
+      return "planning";
+    default:
+      return tool;
+  }
+}
+
+// SF Symbol names rendered inside the cmux status badge.
+function toolIcon(tool: string): string {
+  switch (tool) {
+    case "Read":
+      return "eye";
+    case "edit_file":
+    case "create_file":
+      return "pencil";
+    case "Bash":
+      return "terminal";
+    case "Grep":
+    case "finder":
+    case "glob":
+      return "magnifyingglass";
+    case "Task":
+      return "person.2";
+    case "oracle":
+      return "sparkles";
+    case "web_search":
+    case "read_web_page":
+      return "globe";
+    case "todo_write":
+    case "todo_read":
+      return "checklist";
+    default:
+      return "hammer";
+  }
+}
+
+const COLOR = {
+  idle: "#adb5bd",
+  thinking: "#ffffff",
+  active: "#ffd700",
+  done: "#50fa7b",
+  error: "#ff5555",
+  interrupted: "#ffb86c",
+} as const;
+
+function truncate(s: string, max: number): string {
+  return s.length > max ? s.slice(0, max - 1) + "…" : s;
+}
+
+function basename(p: string): string {
+  const m = p.match(/[^/]+$/);
+  return m ? m[0] : p;
+}
+
+// Pin every cmux call to the workspace this plugin process was launched in.
+// cmux sets CMUX_WORKSPACE_ID in every pane env, so this is stable across
+// async callbacks. Without --workspace, cmux defaults to whichever pane is
+// globally focused at the moment of the call, which can be a different
+// workspace by the time our async handler runs.
+function workspaceArgs(): string[] {
+  const ws = process.env.CMUX_WORKSPACE_ID;
+  return ws ? ["--workspace", ws] : [];
+}
+
+function runCmux(args: string[]): void {
+  if (process.env.CMUX_AMP_HOOKS_DISABLED === "1") return;
+  if (!process.env.CMUX_SURFACE_ID) return;
+  const cmux = process.env.CMUX_AMP_CMUX_BIN || "cmux";
+  try {
+    const child = spawn(cmux, args, {
+      env: process.env,
+      stdio: ["ignore", "ignore", "ignore"],
+      detached: true,
+    });
+    child.on("error", () => {});
+    child.unref();
+  } catch (_) {}
+}
+
+function setStatus(label: string, icon: string, color: string): void {
+  runCmux([
+    "set-status",
+    STATUS_KEY,
+    label,
+    "--icon",
+    icon,
+    "--color",
+    color,
+    ...workspaceArgs(),
+  ]);
+}
+
+function clearStatus(): void {
+  runCmux(["clear-status", STATUS_KEY, ...workspaceArgs()]);
+}
+
+function wsLog(message: string, level: string = "info"): void {
+  runCmux([
+    "log",
+    "--level",
+    level,
+    "--source",
+    LOG_SOURCE,
+    ...workspaceArgs(),
+    "--",
+    message,
+  ]);
+}
+
+// Build a rich status label using Amp Neo helpers when available — e.g.
+//   "running: yarn test"
+//   "editing: cmux-status.ts"
+//   "reading: README.md"
+// Falls back to the bare tool name if helpers aren't present (older Amp).
+function detailedToolStatus(
+  event: ToolCallEvent,
+  helpers: unknown,
+): { label: string; icon: string } {
+  const baseLabel = toolLabel(event.tool);
+  const icon = toolIcon(event.tool);
+  const h = helpers as
+    | {
+        shellCommandFromToolCall?: (e: ToolCallEvent) => { command: string } | null;
+        filesModifiedByToolCall?: (e: ToolCallEvent) => string[] | null;
+        filePathFromURI?: (uri: string) => string;
+      }
+    | undefined;
+
+  try {
+    const shell = h?.shellCommandFromToolCall?.(event);
+    if (shell && typeof shell.command === "string") {
+      const cmd = shell.command.replace(/\s+/g, " ").trim();
+      return { label: `${baseLabel}: ${truncate(cmd, 32)}`, icon };
+    }
+  } catch (_) {}
+
+  try {
+    const files = h?.filesModifiedByToolCall?.(event);
+    if (files && files.length > 0) {
+      const first = files[0];
+      const p = h?.filePathFromURI ? h.filePathFromURI(first) : first;
+      return { label: `${baseLabel}: ${truncate(basename(p), 24)}`, icon };
+    }
+  } catch (_) {}
+
+  if (event.tool === "Read") {
+    const p = typeof (event.input as { path?: unknown }).path === "string"
+      ? (event.input as { path: string }).path
+      : null;
+    if (p) return { label: `${baseLabel}: ${truncate(basename(p), 24)}`, icon };
+  }
+
+  if (event.tool === "Grep" || event.tool === "glob") {
+    const input = event.input as { pattern?: unknown; query?: unknown };
+    const pattern =
+      typeof input.pattern === "string"
+        ? input.pattern
+        : typeof input.query === "string"
+          ? input.query
+          : null;
+    if (pattern) return { label: `${baseLabel}: ${truncate(pattern, 24)}`, icon };
+  }
+
+  return { label: baseLabel, icon };
+}
+
 export default function (amp: PluginAPI) {
   const cwdFromEnv = (): string =>
     firstString(process.env.PWD, process.cwd()) || process.cwd();
 
+  // `helpers` is part of the Neo Plugin API; gracefully degrade if absent.
+  const helpers = (amp as unknown as { helpers?: unknown }).helpers;
+
+  // Count of tool calls in flight. While > 0 we display the most recent
+  // tool's status; when it returns to 0 we flip back to "thinking".
+  let inFlightTools = 0;
+
+  // True between agent.start and agent.end. Used so that a tool.result that
+  // arrives after agent.end (cancellation/error races) cannot overwrite the
+  // final status badge with "thinking". cmux runs one Amp session per terminal
+  // pane, so a single flag is sufficient — concurrent threads would need a
+  // per-thread map.
+  let turnActive = false;
+
+  // Best-effort cleanup so the badge doesn't get stuck after agent exits.
+  const cleanup = () => {
+    try {
+      clearStatus();
+    } catch (_) {}
+  };
+  process.on("SIGINT", cleanup);
+  process.on("SIGTERM", cleanup);
+  process.on("exit", cleanup);
+
   amp.on("session.start", async (event: SessionStartEvent, ctx) => {
+    setStatus("idle", "circle", COLOR.idle);
     const sessionId = threadIdFrom(event, ctx);
     if (!sessionId) return;
     sendHook("session-start", sessionId, cwdFromEnv());
   });
 
   amp.on("agent.start", async (event: AgentStartEvent, ctx) => {
+    inFlightTools = 0;
+    turnActive = true;
+    setStatus("thinking", "brain", COLOR.thinking);
+    wsLog("prompt received");
     const sessionId = threadIdFrom(event, ctx);
     if (!sessionId) return;
     sendHook("prompt-submit", sessionId, cwdFromEnv());
   });
 
+  amp.on("tool.call", async (event: ToolCallEvent) => {
+    inFlightTools++;
+    const { label, icon } = detailedToolStatus(event, helpers);
+    if (turnActive) {
+      setStatus(label, icon, COLOR.active);
+    }
+    return { action: "allow" as const };
+  });
+
+  amp.on("tool.result", async (event: ToolResultEvent) => {
+    inFlightTools = Math.max(0, inFlightTools - 1);
+    if (event.status === "error") {
+      wsLog(`${event.tool} failed`, "error");
+    }
+    // Skip status updates after agent.end so a lagging tool.result can't
+    // overwrite the final badge (done/error/interrupted) with "thinking".
+    if (turnActive && inFlightTools === 0) {
+      setStatus("thinking", "brain", COLOR.thinking);
+    }
+  });
+
   amp.on("agent.end", async (event: AgentEndEvent, ctx) => {
+    inFlightTools = 0;
+    turnActive = false;
+    switch (event.status) {
+      case "done":
+        setStatus("done", "checkmark.circle", COLOR.done);
+        wsLog("turn complete", "success");
+        break;
+      case "error":
+        setStatus("error", "xmark.circle", COLOR.error);
+        wsLog("turn errored", "error");
+        break;
+      case "cancelled":
+        setStatus("interrupted", "pause.circle", COLOR.interrupted);
+        wsLog("turn interrupted", "warning");
+        break;
+      default:
+        setStatus(String(event.status ?? "done"), "questionmark.circle", COLOR.interrupted);
+        wsLog(`turn ended with unexpected status: ${event.status}`, "warning");
+        break;
+    }
     const sessionId = threadIdFrom(event, ctx);
     if (!sessionId) return;
     sendHook("stop", sessionId, cwdFromEnv());

--- a/CLI/CMUXCLI+AmpExtension.swift
+++ b/CLI/CMUXCLI+AmpExtension.swift
@@ -366,14 +366,25 @@ export default function (amp: PluginAPI) {
   let turnActive = false;
 
   // Best-effort cleanup so the badge doesn't get stuck after agent exits.
-  const cleanup = () => {
+  // Registering a SIGINT/SIGTERM listener disables Node's default exit-on-signal
+  // behavior, so we must explicitly call process.exit() to avoid leaving the
+  // plugin hung and blocking Amp's graceful shutdown.
+  const cleanupOnSignal = (signal: NodeJS.Signals) => {
+    try {
+      clearStatus();
+    } catch (_) {}
+    // 128 + signal number is the POSIX convention.
+    const code = signal === "SIGINT" ? 130 : signal === "SIGTERM" ? 143 : 0;
+    process.exit(code);
+  };
+  const cleanupOnExit = () => {
     try {
       clearStatus();
     } catch (_) {}
   };
-  process.on("SIGINT", cleanup);
-  process.on("SIGTERM", cleanup);
-  process.on("exit", cleanup);
+  process.on("SIGINT", () => cleanupOnSignal("SIGINT"));
+  process.on("SIGTERM", () => cleanupOnSignal("SIGTERM"));
+  process.on("exit", cleanupOnExit);
 
   amp.on("session.start", async (event: SessionStartEvent, ctx) => {
     setStatus("idle", "circle", COLOR.idle);

--- a/CLI/CMUXCLI+AmpExtension.swift
+++ b/CLI/CMUXCLI+AmpExtension.swift
@@ -365,26 +365,26 @@ export default function (amp: PluginAPI) {
   // per-thread map.
   let turnActive = false;
 
-  // Best-effort cleanup so the badge doesn't get stuck after agent exits.
-  // Registering a SIGINT/SIGTERM listener disables Node's default exit-on-signal
-  // behavior, so we must explicitly call process.exit() to avoid leaving the
-  // plugin hung and blocking Amp's graceful shutdown.
-  const cleanupOnSignal = (signal: NodeJS.Signals) => {
+  // Best-effort cleanup so the badge doesn't get stuck after the agent exits.
+  // We intentionally only hook the `exit` event and do NOT register custom
+  // SIGINT/SIGTERM listeners:
+  //   - Registering a SIGINT/SIGTERM listener would disable Node's default
+  //     exit-on-signal behavior, so we'd then be responsible for calling
+  //     process.exit() ourselves.
+  //   - We don't know whether the Amp plugin host runs us as a dedicated child
+  //     process or shares its process with other plugins; calling
+  //     process.exit() in the shared-process case would short-circuit the
+  //     host's graceful shutdown.
+  // Letting Node's default signal handler run is correct in both deployments:
+  //   - dedicated child: signal -> default handler -> process exits -> `exit`
+  //     event fires -> clearStatus() runs.
+  //   - shared host: host process orchestrates shutdown, our `exit` listener
+  //     still runs as part of normal teardown.
+  process.on("exit", () => {
     try {
       clearStatus();
     } catch (_) {}
-    // 128 + signal number is the POSIX convention.
-    const code = signal === "SIGINT" ? 130 : signal === "SIGTERM" ? 143 : 0;
-    process.exit(code);
-  };
-  const cleanupOnExit = () => {
-    try {
-      clearStatus();
-    } catch (_) {}
-  };
-  process.on("SIGINT", () => cleanupOnSignal("SIGINT"));
-  process.on("SIGTERM", () => cleanupOnSignal("SIGTERM"));
-  process.on("exit", cleanupOnExit);
+  });
 
   amp.on("session.start", async (event: SessionStartEvent, ctx) => {
     setStatus("idle", "circle", COLOR.idle);

--- a/Packages/CmuxSettings/Sources/CmuxSettings/Keys/AutomationCatalogSection.swift
+++ b/Packages/CmuxSettings/Sources/CmuxSettings/Keys/AutomationCatalogSection.swift
@@ -37,6 +37,12 @@ public struct AutomationCatalogSection: SettingCatalogSection {
         userDefaultsKey: "suppressSubagentNotifications"
     )
 
+    public let ampIntegration = DefaultsKey<Bool>(
+        id: "automation.ampIntegration",
+        defaultValue: true,
+        userDefaultsKey: "ampHooksEnabled"
+    )
+
     public let cursorIntegration = DefaultsKey<Bool>(
         id: "automation.cursorIntegration",
         defaultValue: false,

--- a/Packages/CmuxSettings/Sources/CmuxSettings/Keys/IntegrationsCatalogSection.swift
+++ b/Packages/CmuxSettings/Sources/CmuxSettings/Keys/IntegrationsCatalogSection.swift
@@ -15,6 +15,12 @@ public struct IntegrationsCatalogSection: SettingCatalogSection {
         userDefaultsKey: "claudeCodeCustomClaudePath"
     )
 
+    public let ampHooksEnabled = DefaultsKey<Bool>(
+        id: "integrations.amp.hooksEnabled",
+        defaultValue: true,
+        userDefaultsKey: "ampHooksEnabled"
+    )
+
     public let cursorHooksEnabled = DefaultsKey<Bool>(
         id: "integrations.cursor.hooksEnabled",
         defaultValue: false,

--- a/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/AutomationSection.swift
+++ b/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/AutomationSection.swift
@@ -17,6 +17,7 @@ public struct AutomationSection: View {
     @State private var claudePathModel: DefaultsValueModel<String>
     @State private var ripgrepPathModel: DefaultsValueModel<String>
     @State private var suppressSubagentModel: DefaultsValueModel<Bool>
+    @State private var ampModel: DefaultsValueModel<Bool>
     @State private var cursorModel: DefaultsValueModel<Bool>
     @State private var geminiModel: DefaultsValueModel<Bool>
     @State private var kiroModel: DefaultsValueModel<Bool>
@@ -52,6 +53,7 @@ public struct AutomationSection: View {
         _claudePathModel = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.integrations.claudeCodeCustomClaudePath))
         _ripgrepPathModel = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.integrations.ripgrepCustomBinaryPath))
         _suppressSubagentModel = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.integrations.suppressSubagentNotifications))
+        _ampModel = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.integrations.ampHooksEnabled))
         _cursorModel = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.integrations.cursorHooksEnabled))
         _geminiModel = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.integrations.geminiHooksEnabled))
         _kiroModel = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.integrations.kiroHooksEnabled))
@@ -71,6 +73,7 @@ public struct AutomationSection: View {
             claudePathCard
             ripgrepPathCard
             suppressSubagentCard
+            ampCard
             cursorCard
             geminiCard
             kiroCard
@@ -275,6 +278,26 @@ public struct AutomationSection: View {
             }
             SettingsCardDivider()
             SettingsCardNote(String(localized: "settings.automation.suppressSubagentNotifications.note", defaultValue: "Uses process ancestry from hook processes. Disable if nested Codex or Claude sessions should trigger completion notifications."))
+        }
+    }
+
+    @ViewBuilder
+    private var ampCard: some View {
+        SettingsCard {
+            SettingsCardRow(
+                configurationReview: .json("automation.ampIntegration"),
+                String(localized: "settings.automation.amp", defaultValue: "Amp Integration"),
+                subtitle: ampModel.current
+                    ? String(localized: "settings.automation.amp.subtitleOn", defaultValue: "Sidebar shows Amp agent status and notifications.")
+                    : String(localized: "settings.automation.amp.subtitleOff", defaultValue: "Amp runs without cmux integration.")
+            ) {
+                Toggle("", isOn: Binding(get: { ampModel.current }, set: { ampModel.set($0) }))
+                    .labelsHidden()
+                    .controlSize(.small)
+                    .accessibilityIdentifier("SettingsAmpHooksToggle")
+            }
+            SettingsCardDivider()
+            SettingsCardNote(String(localized: "settings.automation.amp.note", defaultValue: "Hooks must be installed with `cmux hooks amp install`. They no-op outside cmux terminals. When disabled, the installed Amp plugin stays inactive without needing to be removed."))
         }
     }
 

--- a/Sources/CmuxSettingsJSONPathSupport.swift
+++ b/Sources/CmuxSettingsJSONPathSupport.swift
@@ -142,6 +142,7 @@ extension CmuxSettingsFileStore {
         "automation.claudeBinaryPath",
         "automation.ripgrepBinaryPath",
         "automation.suppressSubagentNotifications",
+        "automation.ampIntegration",
         "automation.cursorIntegration",
         "automation.geminiIntegration",
         "automation.kiroIntegration",

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -6368,6 +6368,9 @@ final class TerminalSurface: Identifiable, ObservableObject {
             "CMUX_KIRO_NOTIFICATION_LEVEL",
             KiroIntegrationSettings.notificationLevel().rawValue
         )
+        if !AmpIntegrationSettings.hooksEnabled() {
+            setManagedEnvironmentValue("CMUX_AMP_HOOKS_DISABLED", "1")
+        }
 
         if let cliBinPath = Bundle.main.resourceURL?.appendingPathComponent("bin").path {
             let currentPath = env["PATH"]

--- a/Sources/KeyboardShortcutSettingsFileStore+Template.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore+Template.swift
@@ -164,6 +164,7 @@ extension CmuxSettingsFileStore {
                     "claudeBinaryPath": "",
                     "ripgrepBinaryPath": "",
                     "suppressSubagentNotifications": AgentSubagentNotificationSettings.defaultSuppressNotifications,
+                    "ampIntegration": AmpIntegrationSettings.defaultHooksEnabled,
                     "cursorIntegration": CursorIntegrationSettings.defaultHooksEnabled,
                     "geminiIntegration": GeminiIntegrationSettings.defaultHooksEnabled,
                     "kiroIntegration": KiroIntegrationSettings.defaultHooksEnabled,

--- a/Sources/KeyboardShortcutSettingsFileStore.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore.swift
@@ -867,6 +867,9 @@ final class CmuxSettingsFileStore {
         if let value = jsonBool(section["suppressSubagentNotifications"]) {
             snapshot.managedUserDefaults[AgentSubagentNotificationSettings.suppressNotificationsKey] = .bool(value)
         }
+        if let value = jsonBool(section["ampIntegration"]) {
+            snapshot.managedUserDefaults[AmpIntegrationSettings.hooksEnabledKey] = .bool(value)
+        }
         if let value = jsonBool(section["cursorIntegration"]) {
             snapshot.managedUserDefaults[CursorIntegrationSettings.hooksEnabledKey] = .bool(value)
         }

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -5120,6 +5120,18 @@ enum KiroIntegrationSettings {
     }
 }
 
+enum AmpIntegrationSettings {
+    static let hooksEnabledKey = "ampHooksEnabled"
+    static let defaultHooksEnabled = true
+
+    static func hooksEnabled(defaults: UserDefaults = .standard) -> Bool {
+        if defaults.object(forKey: hooksEnabledKey) == nil {
+            return defaultHooksEnabled
+        }
+        return defaults.bool(forKey: hooksEnabledKey)
+    }
+}
+
 enum WelcomeSettings {
     static let shownKey = "cmuxWelcomeShown"
 }

--- a/docs/agent-hooks.md
+++ b/docs/agent-hooks.md
@@ -134,6 +134,6 @@ Kiro Feed verbosity follows **Settings > Automation > Kiro Notification Level** 
 
 Run `cmux hooks <agent> install --yes` to reinstall one integration. Run `cmux hooks <agent> uninstall --yes` before editing generated files by hand.
 
-If Feed shows nothing, confirm the terminal has `CMUX_SURFACE_ID` and the hook file contains a `cmux hooks feed --source <agent>` command or OpenCode feed plugin. Pi, Rovo Dev, and Amp currently provide lifecycle and restore hooks only, so they do not create Feed approval cards.
+If Feed shows nothing, confirm the terminal has `CMUX_SURFACE_ID` and the hook file contains a `cmux hooks feed --source <agent>` command or OpenCode feed plugin. Pi and Rovo Dev currently provide lifecycle and restore hooks only, so they do not create Feed approval cards. Amp's bundled plugin reports live tab-status updates (idle / thinking / running / reading / done / error / interrupted) and lifecycle restore but does not create Feed approval cards.
 
 If relaunch does not resume an agent, check `~/.cmuxterm/<agent>-hook-sessions.json` for the saved session and verify the agent's resume command still works outside cmux.

--- a/web/data/cmux.schema.json
+++ b/web/data/cmux.schema.json
@@ -871,6 +871,11 @@
           "descriptionKey": "schemaDescriptions.automation.suppressSubagentNotifications",
           "description": "Suppress visible completion notifications and status mutations from nested Codex or Claude child agents while keeping their events in Feed telemetry."
         },
+        "ampIntegration": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable cmux integration hooks for Amp."
+        },
         "cursorIntegration": {
           "type": "boolean",
           "default": true,


### PR DESCRIPTION
## Summary

Extends the `cmux-session.ts` plugin already installed by `cmux hooks amp install` (added in #3710) to also drive the cmux **tab status bar** — so Amp Neo agents show live status in cmux without users needing any extra setup beyond what they already run for Amp session restore.

This **supersedes #2007**, which I'm closing in favor of this approach. The wrapper + bundled-plugin design from #2007 became redundant once @comp615 landed #3710: there's already a CLI-managed install path (`cmux hooks amp install`), an upgradable plugin marker, a built-in `.amp` `RestorableAgentKind`, a documented disable env var (`CMUX_AMP_HOOKS_DISABLED`), and a regression test that round-trips the plugin through Node. Stacking the wrapper on top of that would force users to manage two install mechanisms; merging status into the existing plugin keeps it to one.

## What you get

When `cmux hooks amp install` (or `cmux hooks setup`) has run, every Amp Neo session inside a cmux pane reports live status:

| State | Badge |
|---|---|
| `session.start` | `idle` (circle, gray) |
| `agent.start` | `thinking` (brain, white) |
| `tool.call` | tool-specific label + SF Symbol, gold |
| `tool.result` (back to 0 in-flight) | `thinking` |
| `agent.end` done | `done` (checkmark, green) |
| `agent.end` error | `error` (xmark, red) |
| `agent.end` cancelled | `interrupted` (pause, orange) |

Tool labels use the Neo `helpers.shellCommandFromToolCall` / `helpers.filesModifiedByToolCall` APIs when present to render `running: yarn test`, `editing: cmux-status.ts`, `reading: README.md`, etc. — and degrade to the bare tool name on older plugin APIs.

A workspace log line is also emitted on prompt received, tool errors, and turn outcomes.

## Design choices

- **Bumped marker from v1 to v2** so existing v1 installs upgrade in place on the next `cmux hooks amp install` / `cmux hooks setup` run. The marker check in `installAmpExtensionHooks` already covers this.
- **`spawn` detached + unref, fire-and-forget**. Matches the existing `sendHook` pattern in the same file. A broken cmux socket never blocks Amp.
- **Pinned to `CMUX_WORKSPACE_ID`** via `--workspace`. Without that, an async handler that fires after the user switches focus would write status to whichever pane is currently focused, not the one Amp is running in.
- **`CMUX_AMP_HOOKS_DISABLED=1` short-circuits everything** at the top of `runCmux`, including status. The settings toggle injects that env var via `setManagedEnvironmentValue`, parallel to Cursor and Gemini.
- **`CMUX_SURFACE_ID` guard** stays — same as existing `sendHook`. Outside cmux the plugin is a no-op.
- **No new install plumbing.** Reuses the existing `cmux hooks amp install` / `cmux hooks setup` flow, the existing test, and the existing uninstaller.

## Files changed

| File | What |
|---|---|
| `CLI/CMUXCLI+AmpExtension.swift` | Bumps plugin marker to v2; adds tool label/icon maps, `setStatus` / `clearStatus` / `wsLog` helpers, `detailedToolStatus`, in-flight tool counter, SIGINT/SIGTERM/exit cleanup, and `tool.call` / `tool.result` handlers. Adds tool-state transitions to the existing `session.start` / `agent.start` / `agent.end` handlers. |
| `Sources/cmuxApp.swift` | Adds `AmpIntegrationSettings` enum, `@AppStorage` binding, Settings UI card under Automation (parallel to Gemini's), and `resetAllSettings()` entry. |
| `Sources/GhosttyTerminalView.swift` | Injects `CMUX_AMP_HOOKS_DISABLED=1` into the managed pane env when the toggle is off. |
| `Resources/Localizable.xcstrings` | Four new keys (`settings.automation.amp[.note|.subtitleOn|.subtitleOff]`), localized en/ja/ko to match Gemini's coverage. |
| `docs/agent-hooks.md` | Updates the troubleshooting note: Amp now reports live tab-status updates in addition to lifecycle/restore. |

## Compatibility

- **Existing `cmux hooks amp install`** still installs the (now richer) plugin idempotently. v1 → v2 upgrade is automatic via the marker check.
- **Existing `tests/test_amp_extension_install.py`** keeps passing: it imports the plugin, fires `session.start` / `agent.start` / `agent.end`, and asserts the three `hooks amp <subcommand>` calls show up. My new spawns to `cmux set-status` / `cmux log` are additional args that fall into the same fake-cmux log; the existing substring assertions still match.
- **Existing `AgentLaunchSanitizerTests`** unaffected.
- **`.amp` `RestorableAgentKind`** and the sanitizer/env policy added in #3710 are unchanged.

## What's deliberately out of scope

- **No `automation.ampIntegration` JSON schema key** yet. The Settings card uses `configurationReview: .settingsOnly`, so it doesn't claim to be configurable via `cmux.json`. Happy to add the schema key + `KeyboardShortcutSettingsFileStore` plumbing in a follow-up if you want parity with Cursor/Gemini.
- **No `cmux_notify` agent tool, no workspace renaming, no command palette commands, no handoff tracking.** Those live in the external `block/cmux-amp` plugin and stay there for users who want the richer experience. The goal here is to land the high-leverage status reporting in core, not to absorb everything.
- **No new tests.** Per [AGENTS.md test policy](https://github.com/manaflow-ai/cmux/blob/main/AGENTS.md), I'd rather add a meaningful runtime test in a follow-up than test the source string. The existing `tests/test_amp_extension_install.py` exercises the new plugin source through Node end-to-end.

## Verification

- `CMUX_SKIP_ZIG_BUILD=1 xcodebuild -project cmux.xcodeproj -scheme cmux -configuration Debug -derivedDataPath /tmp/cmux-amp-status build` — `** BUILD SUCCEEDED **`.
- Manual install: `cmux hooks amp install --yes` writes the new v2 plugin; running Amp Neo inside a cmux pane shows the status badge transitions described above.

Co-authored-by: Amp <amp@ampcode.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4443"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds live status reporting to the Amp Neo session plugin so cmux tabs show real-time badges and concise workspace logs. Upgrades the plugin to v2, clears badges on process exit (no custom SIGINT/SIGTERM handlers), and adds a Settings/JSON toggle to enable or disable hooks.

- **New Features**
  - Tab badges: idle → thinking → tool-specific labels → done/error/interrupted; colors use `#hex` for `cmux set-status`.
  - Tool-aware labels via Neo helpers (running commands, editing/reading files, searching) with safe fallback.
  - Workspace logs on prompt, tool errors, and turn outcomes; calls are fire-and-forget and pinned to `--workspace $CMUX_WORKSPACE_ID`.
  - Guards tool-result races after `agent.end` so final badges stick; honors `CMUX_AMP_HOOKS_DISABLED` and no-ops outside cmux.

- **Migration**
  - Run `cmux hooks amp install` (or `cmux hooks setup`) to upgrade v1 → v2.
  - Configure via Settings → Automation → Amp Integration or `automation.ampIntegration: true/false` in `cmux.json` (injects `CMUX_AMP_HOOKS_DISABLED=1` when off).

<sup>Written for commit 2139a37644bcb9d5add566379af4e470da9c9bc0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live agent/tool status updates in the cmux tab status bar with richer labels, icons and badges (idle, thinking, done, error, cancelled); avoids stuck status on exit.

* **Settings**
  * New Amp Integration toggle in Automation settings; reset restores default. Terminal surfaces now honor the Amp hooks-disable setting.

* **Localization**
  * Added localized strings for the AMP integration settings (en, ja, ko).

* **Documentation**
  * Clarified Amp’s tab-status lifecycle and agent Feed behavior in troubleshooting guide.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4443?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->