### PR TITLE
Fix read-screen for background helper terminals

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -6343,6 +6343,29 @@ final class TerminalSurface: Identifiable, ObservableObject {
         }
     }
 
+    @MainActor
+    func ensureBackgroundSurfaceStartedForSocketAccess(reason: String) {
+        guard allowsRuntimeSurfaceCreation() else { return }
+        guard surface == nil else { return }
+    #if DEBUG
+        let startedAt = ProcessInfo.processInfo.systemUptime
+    #endif
+        if let view = attachedView, view.window != nil {
+            createSurface(for: view)
+        } else {
+            startRuntimeUsingHeadlessWindowIfNeeded(reason: reason)
+        }
+    #if DEBUG
+        let elapsedMs = (ProcessInfo.processInfo.systemUptime - startedAt) * 1000.0
+        let view = attachedView ?? surfaceView
+        cmuxDebugLog(
+            "surface.socket_access.start surface=\(id.uuidString.prefix(8)) " +
+            "reason=\(reason) inWindow=\(view.window != nil ? 1 : 0) " +
+            "ready=\(surface != nil ? 1 : 0) ms=\(String(format: "%.2f", elapsedMs))"
+        )
+    #endif
+    }
+
     private func writeTextData(_ data: Data, to surface: ghostty_surface_t) {
         data.withUnsafeBytes { rawBuffer in
             guard let baseAddress = rawBuffer.baseAddress?.assumingMemoryBound(to: CChar.self) else { return }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -7811,6 +7811,9 @@ class TerminalController {
     }
 
     private func readTerminalTextBase64(terminalPanel: TerminalPanel, includeScrollback: Bool = false, lineLimit: Int? = nil) -> String {
+        if terminalPanel.surface.surface == nil {
+            terminalPanel.surface.ensureBackgroundSurfaceStartedForSocketAccess(reason: "terminalController.readText")
+        }
         guard let surface = terminalPanel.surface.surface else { return "ERROR: Terminal surface not found" }
 
         func readSelectionText(pointTag: ghostty_point_tag_e) -> String? {

--- a/tests_v2/test_cli_background_terminal_helpers_start_pty.py
+++ b/tests_v2/test_cli_background_terminal_helpers_start_pty.py
@@ -92,6 +92,31 @@ def _wait_for_read_screen(cli: str, workspace_ref: str, surface_ref: str, token:
     raise cmuxError(f"read-screen never observed {token!r} for {surface_ref}: {last_output!r}")
 
 
+def _wait_for_read_screen_ready(cli: str, workspace_ref: str, surface_ref: str, label: str) -> None:
+    deadline = time.time() + 8.0
+    last_output = ""
+    while time.time() < deadline:
+        code, output = _run_cli(
+            cli,
+            [
+                "read-screen",
+                "--workspace",
+                workspace_ref,
+                "--surface",
+                surface_ref,
+                "--scrollback",
+                "--lines",
+                "80",
+            ],
+            check=False,
+        )
+        last_output = output
+        if code == 0:
+            return
+        time.sleep(0.1)
+    raise cmuxError(f"read-screen did not start {label} helper terminal {surface_ref}: {last_output!r}")
+
+
 def _exercise_helper(cli: str, workspace_ref: str, surface_ref: str, label: str) -> None:
     token = f"CMUX_HELPER_PTY_{label}_{int(time.time() * 1000)}"
     _run_cli(
@@ -179,6 +204,7 @@ def main() -> int:
                 ],
             )
             helper_surface_ref = _extract_ref(surface_output, "surface")
+            _wait_for_read_screen_ready(cli, workspace_ref, helper_surface_ref, "surface")
             _exercise_helper(cli, workspace_ref, helper_surface_ref, "surface")
 
             _, pane_output = _run_cli(
@@ -196,6 +222,7 @@ def main() -> int:
                 ],
             )
             helper_pane_surface_ref = _extract_ref(pane_output, "surface")
+            _wait_for_read_screen_ready(cli, workspace_ref, helper_pane_surface_ref, "pane")
             _exercise_helper(cli, workspace_ref, helper_pane_surface_ref, "pane")
 
             current = c._call("workspace.current") or {}


### PR DESCRIPTION
Fixes CLI-created helper terminals in background workspaces so read-screen starts the hidden runtime instead of returning Terminal surface not found.\n\nVerification:\n- ./scripts/reload.sh --tag wkspfix\n- CMUX_SOCKET_PATH=/tmp/cmux-debug-wkspfix.sock CMUXTERM_CLI="/Users/lawrence/Library/Developer/Xcode/DerivedData/cmux-wkspfix/Build/Products/Debug/cmux DEV wkspfix.app/Contents/Resources/bin/cmux" python3 tests_v2/test_cli_background_terminal_helpers_start_pty.py

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit dbe02769f1754c614b496d047ae2d75426057c73. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes read-screen for CLI-created helper terminals in background workspaces by starting the hidden runtime on demand. Prevents "Terminal surface not found" errors.

- **Bug Fixes**
  - Start background terminal surfaces before read-screen when the surface is nil, using a headless window if needed.
  - Added a regression test that waits for read-screen readiness for helper surface and pane.

<sup>Written for commit dbe02769f1754c614b496d047ae2d75426057c73. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4449?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4449"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781910807&installation_id=133855650&pr_number=4449&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4449&signature=a1d5de0c22727084e664eb9745c300c8068cb5668174127d29e7fef293f4a96c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of background terminal operations by ensuring proper surface initialization before socket access.
  * Enhanced terminal text reading to handle cases where surfaces aren't immediately available.

* **Tests**
  * Added readiness verification check for background terminal operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4449?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->