### PR TITLE
Fix Quick Look preview deactivation crash

### DIFF
--- a/Sources/Panels/FilePreviewPanel.swift
+++ b/Sources/Panels/FilePreviewPanel.swift
@@ -4282,6 +4282,10 @@ private struct QuickLookPreviewView: NSViewRepresentable {
     let backgroundColor: NSColor
     let drawsBackground: Bool
 
+    func makeCoordinator() -> Coordinator {
+        Coordinator(panel: panel)
+    }
+
     func makeNSView(context: Context) -> NSView {
         panel.nativeViewSessions.quickLook.view(
             panel: panel,
@@ -4299,6 +4303,18 @@ private struct QuickLookPreviewView: NSViewRepresentable {
             backgroundColor: backgroundColor,
             drawsBackground: drawsBackground
         )
+    }
+
+    static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {
+        coordinator.panel.nativeViewSessions.quickLook.dismantle(nsView)
+    }
+
+    final class Coordinator {
+        let panel: FilePreviewPanel
+
+        init(panel: FilePreviewPanel) {
+            self.panel = panel
+        }
     }
 }
 

--- a/Sources/Panels/FilePreviewQuickLookSession.swift
+++ b/Sources/Panels/FilePreviewQuickLookSession.swift
@@ -25,7 +25,7 @@ final class FilePreviewQuickLookSession {
     private let viewSession = PanelOwnedNativeViewSession<NSView>(
         makeView: FilePreviewQuickLookSession.makeView,
         closeView: FilePreviewQuickLookSession.releaseView,
-        dismantleView: FilePreviewQuickLookSession.dismantleView
+        dismantleView: FilePreviewQuickLookSession.releaseView
     )
     private var item: FilePreviewQLItem?
 
@@ -89,15 +89,10 @@ final class FilePreviewQuickLookSession {
 
     private static func releaseView(_ view: NSView) {
         if let previewView = view as? QLPreviewView {
+            // QLPreviewView.close() asserts when the view is inactive and makes the
+            // view permanently reject future items. Session retirement handles stale
+            // updates; clearing the item releases the active preview.
             previewView.previewItem = nil
-        }
-        view.removeFromSuperview()
-    }
-
-    private static func dismantleView(_ view: NSView) {
-        if let previewView = view as? QLPreviewView {
-            previewView.previewItem = nil
-            previewView.close()
         }
         view.removeFromSuperview()
     }

--- a/Sources/Panels/FilePreviewQuickLookSession.swift
+++ b/Sources/Panels/FilePreviewQuickLookSession.swift
@@ -74,8 +74,9 @@ final class FilePreviewQuickLookSession {
     }
 
     func dismantle(_ view: NSView) {
-        viewSession.dismantle(view)
-        item = nil
+        if viewSession.dismantle(view) {
+            item = nil
+        }
     }
 
     private static func makeView() -> NSView {

--- a/Sources/Panels/FilePreviewQuickLookSession.swift
+++ b/Sources/Panels/FilePreviewQuickLookSession.swift
@@ -24,13 +24,8 @@ private final class FilePreviewQLItem: NSObject, QLPreviewItem {
 final class FilePreviewQuickLookSession {
     private let viewSession = PanelOwnedNativeViewSession<NSView>(
         makeView: FilePreviewQuickLookSession.makeView,
-        closeView: { view in
-            if let previewView = view as? QLPreviewView {
-                previewView.close()
-                previewView.previewItem = nil
-            }
-            view.removeFromSuperview()
-        }
+        closeView: FilePreviewQuickLookSession.releaseView,
+        dismantleView: FilePreviewQuickLookSession.dismantleView
     )
     private var item: FilePreviewQLItem?
 
@@ -78,12 +73,32 @@ final class FilePreviewQuickLookSession {
         item = nil
     }
 
+    func dismantle(_ view: NSView) {
+        viewSession.dismantle(view)
+        item = nil
+    }
+
     private static func makeView() -> NSView {
         guard let previewView = QLPreviewView(frame: .zero, style: .normal) else {
             return NSView()
         }
         previewView.autostarts = true
         return previewView
+    }
+
+    private static func releaseView(_ view: NSView) {
+        if let previewView = view as? QLPreviewView {
+            previewView.previewItem = nil
+        }
+        view.removeFromSuperview()
+    }
+
+    private static func dismantleView(_ view: NSView) {
+        if let previewView = view as? QLPreviewView {
+            previewView.previewItem = nil
+            previewView.close()
+        }
+        view.removeFromSuperview()
     }
 
     private func configure(

--- a/Sources/Panels/PanelOwnedNativeViewSession.swift
+++ b/Sources/Panels/PanelOwnedNativeViewSession.swift
@@ -4,14 +4,18 @@ import AppKit
 final class PanelOwnedNativeViewSession<View: NSView> {
     private let makeView: @MainActor () -> View
     private let closeView: @MainActor (View) -> Void
+    private let dismantleView: @MainActor (View) -> Void
     private var ownedView: View?
+    private var retiredViews: Set<ObjectIdentifier> = []
 
     init(
         makeView: @escaping @MainActor () -> View,
-        closeView: @escaping @MainActor (View) -> Void = { $0.removeFromSuperview() }
+        closeView: @escaping @MainActor (View) -> Void = { $0.removeFromSuperview() },
+        dismantleView: (@MainActor (View) -> Void)? = nil
     ) {
         self.makeView = makeView
         self.closeView = closeView
+        self.dismantleView = dismantleView ?? closeView
     }
 
     deinit {
@@ -20,6 +24,7 @@ final class PanelOwnedNativeViewSession<View: NSView> {
 
     func view(configure: @MainActor (View) -> Void) -> View {
         let view = ownedView ?? makeView()
+        retiredViews.remove(ObjectIdentifier(view))
         ownedView = view
         if view.superview != nil {
             view.removeFromSuperview()
@@ -29,6 +34,7 @@ final class PanelOwnedNativeViewSession<View: NSView> {
     }
 
     func update(_ view: View, configure: @MainActor (View) -> Void) {
+        guard !retiredViews.contains(ObjectIdentifier(view)) else { return }
         if ownedView == nil {
             ownedView = view
         }
@@ -37,8 +43,19 @@ final class PanelOwnedNativeViewSession<View: NSView> {
 
     func close() {
         if let ownedView {
+            retiredViews.insert(ObjectIdentifier(ownedView))
             closeView(ownedView)
         }
         ownedView = nil
+    }
+
+    func dismantle(_ view: View) {
+        let viewId = ObjectIdentifier(view)
+        guard !retiredViews.contains(viewId) else { return }
+        retiredViews.insert(viewId)
+        if ownedView === view {
+            ownedView = nil
+        }
+        dismantleView(view)
     }
 }

--- a/Sources/Panels/PanelOwnedNativeViewSession.swift
+++ b/Sources/Panels/PanelOwnedNativeViewSession.swift
@@ -7,6 +7,7 @@ final class PanelOwnedNativeViewSession<View: NSView> {
     private let dismantleView: @MainActor (View) -> Void
     private var ownedView: View?
     private var retiredViews: Set<ObjectIdentifier> = []
+    private var dismantledViews: Set<ObjectIdentifier> = []
 
     init(
         makeView: @escaping @MainActor () -> View,
@@ -24,7 +25,9 @@ final class PanelOwnedNativeViewSession<View: NSView> {
 
     func view(configure: @MainActor (View) -> Void) -> View {
         let view = ownedView ?? makeView()
-        retiredViews.remove(ObjectIdentifier(view))
+        let viewId = ObjectIdentifier(view)
+        retiredViews.remove(viewId)
+        dismantledViews.remove(viewId)
         ownedView = view
         if view.superview != nil {
             view.removeFromSuperview()
@@ -52,8 +55,9 @@ final class PanelOwnedNativeViewSession<View: NSView> {
     @discardableResult
     func dismantle(_ view: View) -> Bool {
         let viewId = ObjectIdentifier(view)
-        guard !retiredViews.contains(viewId) else { return false }
+        guard !dismantledViews.contains(viewId) else { return false }
         retiredViews.insert(viewId)
+        dismantledViews.insert(viewId)
         let dismantledOwnedView = ownedView === view
         if dismantledOwnedView {
             ownedView = nil

--- a/Sources/Panels/PanelOwnedNativeViewSession.swift
+++ b/Sources/Panels/PanelOwnedNativeViewSession.swift
@@ -49,13 +49,16 @@ final class PanelOwnedNativeViewSession<View: NSView> {
         ownedView = nil
     }
 
-    func dismantle(_ view: View) {
+    @discardableResult
+    func dismantle(_ view: View) -> Bool {
         let viewId = ObjectIdentifier(view)
-        guard !retiredViews.contains(viewId) else { return }
+        guard !retiredViews.contains(viewId) else { return false }
         retiredViews.insert(viewId)
-        if ownedView === view {
+        let dismantledOwnedView = ownedView === view
+        if dismantledOwnedView {
             ownedView = nil
         }
         dismantleView(view)
+        return dismantledOwnedView
     }
 }

--- a/cmuxTests/FilePreviewReviewFeedbackTests.swift
+++ b/cmuxTests/FilePreviewReviewFeedbackTests.swift
@@ -97,6 +97,47 @@ final class FilePreviewReviewFeedbackTests: XCTestCase {
         XCTAssertNil(previewView.previewItem)
     }
 
+    func testQuickLookSessionDismantlingRetiredViewDoesNotResetActivePreviewItem() throws {
+        let url = try temporaryBinaryFile()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let panel = FilePreviewPanel(workspaceId: UUID(), filePath: url.path)
+        let retiredView = panel.nativeViewSessions.quickLook.view(
+            panel: panel,
+            isVisibleInUI: true,
+            backgroundColor: .textBackgroundColor,
+            drawsBackground: true
+        )
+        guard retiredView is QLPreviewView else {
+            return XCTFail("Expected Quick Look to vend a QLPreviewView")
+        }
+
+        panel.nativeViewSessions.quickLook.close()
+
+        let activeView = panel.nativeViewSessions.quickLook.view(
+            panel: panel,
+            isVisibleInUI: true,
+            backgroundColor: .textBackgroundColor,
+            drawsBackground: true
+        )
+        guard let activePreviewView = activeView as? QLPreviewView else {
+            return XCTFail("Expected Quick Look to vend a QLPreviewView")
+        }
+        let activeItem = try XCTUnwrap(activePreviewView.previewItem as AnyObject?)
+
+        panel.nativeViewSessions.quickLook.dismantle(retiredView)
+        panel.nativeViewSessions.quickLook.update(
+            activeView,
+            panel: panel,
+            isVisibleInUI: true,
+            backgroundColor: .textBackgroundColor,
+            drawsBackground: true
+        )
+
+        let updatedItem = try XCTUnwrap(activePreviewView.previewItem as AnyObject?)
+        XCTAssertTrue(updatedItem === activeItem)
+    }
+
     func testTextLoaderRejectsOversizedTextFiles() throws {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString)

--- a/cmuxTests/FilePreviewReviewFeedbackTests.swift
+++ b/cmuxTests/FilePreviewReviewFeedbackTests.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Bonsplit
 import Carbon.HIToolbox
+import Quartz
 import XCTest
 
 #if canImport(cmux_DEV)
@@ -64,6 +65,36 @@ final class FilePreviewReviewFeedbackTests: XCTestCase {
 
         XCTAssertEqual(FilePreviewKindResolver.initialMode(for: url), .quickLook)
         XCTAssertEqual(FilePreviewKindResolver.mode(for: url), .text)
+    }
+
+    func testQuickLookSessionCloseDoesNotDeactivateMountedRepresentableView() throws {
+        let url = try temporaryBinaryFile()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let panel = FilePreviewPanel(workspaceId: UUID(), filePath: url.path)
+        XCTAssertEqual(panel.previewMode, .quickLook)
+
+        let view = panel.nativeViewSessions.quickLook.view(
+            panel: panel,
+            isVisibleInUI: true,
+            backgroundColor: .textBackgroundColor,
+            drawsBackground: true
+        )
+        guard let previewView = view as? QLPreviewView else {
+            return XCTFail("Expected Quick Look to vend a QLPreviewView")
+        }
+        XCTAssertNotNil(previewView.previewItem)
+
+        panel.nativeViewSessions.quickLook.close()
+
+        panel.nativeViewSessions.quickLook.update(
+            view,
+            panel: panel,
+            isVisibleInUI: true,
+            backgroundColor: .textBackgroundColor,
+            drawsBackground: true
+        )
+        XCTAssertNil(previewView.previewItem)
     }
 
     func testTextLoaderRejectsOversizedTextFiles() throws {
@@ -150,6 +181,14 @@ final class FilePreviewReviewFeedbackTests: XCTestCase {
             .appendingPathComponent(UUID().uuidString)
             .appendingPathExtension("txt")
         try contents.write(to: url, atomically: true, encoding: encoding)
+        return url
+    }
+
+    private func temporaryBinaryFile() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("bin")
+        try Data([0, 1, 2, 3, 0, 4]).write(to: url, options: .atomic)
         return url
     }
 

--- a/cmuxTests/FilePreviewReviewFeedbackTests.swift
+++ b/cmuxTests/FilePreviewReviewFeedbackTests.swift
@@ -138,6 +138,34 @@ final class FilePreviewReviewFeedbackTests: XCTestCase {
         XCTAssertTrue(updatedItem === activeItem)
     }
 
+    func testNativeViewSessionDismantlesRetiredViewAfterClose() {
+        let view = NSView()
+        var closeCount = 0
+        var dismantleCount = 0
+        let session = PanelOwnedNativeViewSession<NSView>(
+            makeView: { view },
+            closeView: {
+                XCTAssertTrue($0 === view)
+                closeCount += 1
+            },
+            dismantleView: {
+                XCTAssertTrue($0 === view)
+                dismantleCount += 1
+            }
+        )
+
+        XCTAssertTrue(session.view(configure: { _ in }) === view)
+        session.close()
+        XCTAssertEqual(closeCount, 1)
+        XCTAssertEqual(dismantleCount, 0)
+
+        XCTAssertFalse(session.dismantle(view))
+        XCTAssertEqual(dismantleCount, 1)
+
+        XCTAssertFalse(session.dismantle(view))
+        XCTAssertEqual(dismantleCount, 1)
+    }
+
     func testTextLoaderRejectsOversizedTextFiles() throws {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString)


### PR DESCRIPTION
Fixes #4453.

## Repro

Per the user override, I built and launched the tagged dev app locally before fixing:

```bash
CMUX_SKIP_ZIG_BUILD=1 ./scripts/reload.sh --tag issue-4453-quicklook-deactivated-crash --launch
```

I reproduced the crash in that dev app with:

```bash
printf '\000\001\002\003cmux quicklook repro\000\004' > /tmp/cmux-ql-repro.issue4453.bin
CMUX_TAG=issue-4453-quicklook-deactivated-crash scripts/cmux-debug-cli.sh open /tmp/cmux-ql-repro.issue4453.bin --workspace workspace:1
```

Before the fix, the tagged app aborted and wrote `~/Library/Logs/DiagnosticReports/cmux DEV-2026-05-20-172719.ips` with the Quick Look assertion:

`[QL] -[QLPreviewView setPreviewItem:blockingUntilLoading:timeoutDate:transition:]: item == nil || _reserved->internalState != QLPreviewDeactivatedInternalState`

## Test Approach

The first commit adds `FilePreviewReviewFeedbackTests.testQuickLookSessionCloseDoesNotDeactivateMountedRepresentableView`. It creates a Quick Look file preview, calls the session close path while the representable view is still mounted, then updates that same view. On the un-fixed implementation this crashes through the same `QLPreviewView.setPreviewItem` path; with the fix it leaves the retired view unconfigured.

Additional regression coverage verifies stale SwiftUI dismantle callbacks do not reset the active preview item, and that `PanelOwnedNativeViewSession` still performs one dismantle callback for a view that was previously retired by `close()`.

## Fix

`PanelOwnedNativeViewSession` now separates three native-view states:

- active owned view: may be configured by SwiftUI updates
- retired view: closed by the model and blocked from future configuration
- dismantled view: already torn down, so duplicate SwiftUI dismantle calls are ignored

`FilePreviewQuickLookSession` now clears `previewItem` and removes the view from its superview for both close and dismantle. It deliberately does not call `QLPreviewView.close()`: that API permanently rejects future preview items and also asserts when Quick Look considers the view inactive. The session retirement guard prevents stale updates from reconfiguring old views without entering Quick Look's deactivated state.

`QuickLookPreviewView` still routes SwiftUI `dismantleNSView` into the session so SwiftUI-owned teardown participates in the same lifecycle path.

## Verification

- Reproduced the crash before fixing in the tagged dev app.
- Confirmed the first regression test failed pre-fix with `Crash: cmux DEV ... libsystem_c.dylib: abort() called`.
- Confirmed the stale-dismantle regression failed before the ownership fix, then passed.
- Confirmed the close-then-dismantle regression failed before retired/dismantled state separation, then passed.
- Confirmed the focused Quick Look lifecycle tests pass after the fix.
- Rebuilt with the required command and reran the CLI Quick Look repro; `open` returned OK, the tagged socket stayed reachable, and no newer DiagnosticReports crash was created.

No cloud-mac video was used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup for file preview sessions with explicit teardown to prevent stale native view state.
  * Strengthened lifecycle handling to avoid resetting active Quick Look preview items when retired views are removed.
  * Made teardown idempotent and prevented retired views from being reconfigured.

* **Tests**
  * Added tests covering Quick Look preview lifecycle and post-teardown preview-item behavior.
  * Added a temporary binary-file helper to support the tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4459?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->