### PR TITLE
Fix QuickLook crash after proxy icon split close

### DIFF
--- a/Sources/Panels/FilePreviewPanel.swift
+++ b/Sources/Panels/FilePreviewPanel.swift
@@ -4282,12 +4282,22 @@ private struct QuickLookPreviewView: NSViewRepresentable {
     let backgroundColor: NSColor
     let drawsBackground: Bool
 
+    final class Coordinator {
+        var quickLook: FilePreviewQuickLookSession?
+
+        init(panel: FilePreviewPanel) {
+            quickLook = panel.nativeViewSessions.quickLook
+        }
+    }
+
     func makeCoordinator() -> Coordinator {
         Coordinator(panel: panel)
     }
 
     func makeNSView(context: Context) -> NSView {
-        panel.nativeViewSessions.quickLook.view(
+        let quickLook = panel.nativeViewSessions.quickLook
+        context.coordinator.quickLook = quickLook
+        return quickLook.view(
             panel: panel,
             isVisibleInUI: isVisibleInUI,
             backgroundColor: backgroundColor,
@@ -4296,7 +4306,9 @@ private struct QuickLookPreviewView: NSViewRepresentable {
     }
 
     func updateNSView(_ nsView: NSView, context: Context) {
-        panel.nativeViewSessions.quickLook.update(
+        let quickLook = panel.nativeViewSessions.quickLook
+        context.coordinator.quickLook = quickLook
+        quickLook.update(
             nsView,
             panel: panel,
             isVisibleInUI: isVisibleInUI,
@@ -4306,15 +4318,8 @@ private struct QuickLookPreviewView: NSViewRepresentable {
     }
 
     static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {
-        coordinator.panel.nativeViewSessions.quickLook.dismantle(nsView)
-    }
-
-    final class Coordinator {
-        let panel: FilePreviewPanel
-
-        init(panel: FilePreviewPanel) {
-            self.panel = panel
-        }
+        coordinator.quickLook?.dismantle(nsView)
+        coordinator.quickLook = nil
     }
 }
 

--- a/Sources/Panels/FilePreviewQuickLookSession.swift
+++ b/Sources/Panels/FilePreviewQuickLookSession.swift
@@ -22,11 +22,7 @@ private final class FilePreviewQLItem: NSObject, QLPreviewItem {
 
 @MainActor
 final class FilePreviewQuickLookSession {
-    private let viewSession = PanelOwnedNativeViewSession<NSView>(
-        makeView: FilePreviewQuickLookSession.makeView,
-        closeView: FilePreviewQuickLookSession.releaseView,
-        dismantleView: FilePreviewQuickLookSession.releaseView
-    )
+    private let liveViews = NSHashTable<NSView>.weakObjects()
     private var item: FilePreviewQLItem?
 
     deinit {
@@ -39,15 +35,16 @@ final class FilePreviewQuickLookSession {
         backgroundColor: NSColor,
         drawsBackground: Bool
     ) -> NSView {
-        viewSession.view {
-            configure(
-                $0,
-                panel: panel,
-                isVisibleInUI: isVisibleInUI,
-                backgroundColor: backgroundColor,
-                drawsBackground: drawsBackground
-            )
-        }
+        let view = Self.makeView()
+        liveViews.add(view)
+        configure(
+            view,
+            panel: panel,
+            isVisibleInUI: isVisibleInUI,
+            backgroundColor: backgroundColor,
+            drawsBackground: drawsBackground
+        )
+        return view
     }
 
     func update(
@@ -57,26 +54,31 @@ final class FilePreviewQuickLookSession {
         backgroundColor: NSColor,
         drawsBackground: Bool
     ) {
-        viewSession.update(view) {
-            configure(
-                $0,
-                panel: panel,
-                isVisibleInUI: isVisibleInUI,
-                backgroundColor: backgroundColor,
-                drawsBackground: drawsBackground
-            )
+        guard liveViews.contains(view) else { return }
+        configure(
+            view,
+            panel: panel,
+            isVisibleInUI: isVisibleInUI,
+            backgroundColor: backgroundColor,
+            drawsBackground: drawsBackground
+        )
+    }
+
+    func dismantle(_ view: NSView) {
+        guard liveViews.contains(view) else { return }
+        liveViews.remove(view)
+        Self.releaseView(view)
+        if liveViews.allObjects.isEmpty {
+            item = nil
         }
     }
 
     func close() {
-        viewSession.close()
-        item = nil
-    }
-
-    func dismantle(_ view: NSView) {
-        if viewSession.dismantle(view) {
-            item = nil
+        for view in liveViews.allObjects {
+            Self.releaseView(view)
         }
+        liveViews.removeAllObjects()
+        item = nil
     }
 
     private static func makeView() -> NSView {

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		4378399A7C0245EF8186F306 /* OmnibarAndToolsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B09C007F42697761B5F1A2AB /* OmnibarAndToolsTests.swift */; };
 		46F6AC15863EC84DCD3770A2 /* TerminalAndGhosttyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FC74F2C27127CC565B3E8C /* TerminalAndGhosttyTests.swift */; };
 		C35610000000000000000001 /* FinderFileDropRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C35610000000000000000002 /* FinderFileDropRegressionTests.swift */; };
+		C44550000000000000000001 /* PanelOwnedNativeViewSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C44550000000000000000002 /* PanelOwnedNativeViewSessionTests.swift */; };
 		51D800000000000000000001 /* SidebarIdentifierFormattingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51D800000000000000000002 /* SidebarIdentifierFormattingTests.swift */; };
 		C0DE35530000000000000101 /* BundledCLILinkageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE35530000000000000102 /* BundledCLILinkageTests.swift */; };
 		C37800000000000000000001 /* VMSSHCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C37800000000000000000002 /* VMSSHCommandTests.swift */; };
@@ -568,6 +569,7 @@
 /* Begin PBXFileReference section */
 		02FC74F2C27127CC565B3E8C /* TerminalAndGhosttyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalAndGhosttyTests.swift; sourceTree = "<group>"; };
 		C35610000000000000000002 /* FinderFileDropRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinderFileDropRegressionTests.swift; sourceTree = "<group>"; };
+		C44550000000000000000002 /* PanelOwnedNativeViewSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanelOwnedNativeViewSessionTests.swift; sourceTree = "<group>"; };
 		D0B10009A1B2C3D4E5F60001 /* PortalTabDragRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortalTabDragRoutingTests.swift; sourceTree = "<group>"; };
 		D0B1000DA1B2C3D4E5F60001 /* CmuxWebViewDragRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxWebViewDragRoutingTests.swift; sourceTree = "<group>"; };
 		D0B1000FA1B2C3D4E5F60001 /* BrowserPaneDropRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserPaneDropRoutingTests.swift; sourceTree = "<group>"; };
@@ -1579,6 +1581,7 @@
 					D0B1000FA1B2C3D4E5F60001 /* BrowserPaneDropRoutingTests.swift */,
 					02FC74F2C27127CC565B3E8C /* TerminalAndGhosttyTests.swift */,
 					C35610000000000000000002 /* FinderFileDropRegressionTests.swift */,
+					C44550000000000000000002 /* PanelOwnedNativeViewSessionTests.swift */,
 					3069F1D10000000000000004 /* GhosttyPasteboardFidelityTests.swift */,
 					D7AB34400000000000000004 /* GhosttyTerminalViewVisibilityPolicyTests.swift */,
 					D7AB00000000000000000012 /* WorkspaceAdjacentPaneMoveTests.swift */,
@@ -2360,6 +2363,7 @@
 				D0B1000EA1B2C3D4E5F60001 /* BrowserPaneDropRoutingTests.swift in Sources */,
 				46F6AC15863EC84DCD3770A2 /* TerminalAndGhosttyTests.swift in Sources */,
 				C35610000000000000000001 /* FinderFileDropRegressionTests.swift in Sources */,
+				C44550000000000000000001 /* PanelOwnedNativeViewSessionTests.swift in Sources */,
 				3069F1D10000000000000003 /* GhosttyPasteboardFidelityTests.swift in Sources */,
 				D7AB34400000000000000003 /* GhosttyTerminalViewVisibilityPolicyTests.swift in Sources */,
 				D7AB00000000000000000011 /* WorkspaceAdjacentPaneMoveTests.swift in Sources */,

--- a/cmuxTests/PanelOwnedNativeViewSessionTests.swift
+++ b/cmuxTests/PanelOwnedNativeViewSessionTests.swift
@@ -1,0 +1,90 @@
+import AppKit
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+final class PanelOwnedNativeViewSessionTests: XCTestCase {
+    private final class ProbeView: NSView {
+        var isClosed = false
+        var configureCount = 0
+    }
+
+    func testUpdateAfterCloseDoesNotReAdoptClosedNativeView() {
+        var makeCount = 0
+        let session = PanelOwnedNativeViewSession<ProbeView>(
+            makeView: {
+                makeCount += 1
+                return ProbeView(frame: .zero)
+            },
+            closeView: { view in
+                view.isClosed = true
+                view.removeFromSuperview()
+            }
+        )
+
+        let initialView = session.view { view in
+            XCTAssertFalse(view.isClosed)
+            view.configureCount += 1
+        }
+
+        XCTAssertEqual(makeCount, 1)
+        XCTAssertEqual(initialView.configureCount, 1)
+
+        session.close()
+
+        XCTAssertTrue(initialView.isClosed)
+
+        session.update(initialView) { view in
+            XCTFail("Closed native views must not be re-adopted or configured after the panel session closes")
+            view.configureCount += 1
+        }
+
+        XCTAssertEqual(initialView.configureCount, 1)
+
+        let replacementView = session.view { view in
+            XCTAssertFalse(view.isClosed)
+            view.configureCount += 1
+        }
+
+        XCTAssertFalse(replacementView === initialView)
+        XCTAssertEqual(replacementView.configureCount, 1)
+        XCTAssertEqual(makeCount, 2)
+    }
+
+    func testQuickLookSessionCreatesFreshViewForEachRepresentableMount() throws {
+        let fileURL = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("cmux-4455-quicklook-\(UUID().uuidString).bin")
+        try Data([0, 1, 2, 3]).write(to: fileURL)
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        let panel = FilePreviewPanel(workspaceId: UUID(), filePath: fileURL.path)
+        let session = FilePreviewQuickLookSession()
+
+        let firstView = session.view(
+            panel: panel,
+            isVisibleInUI: true,
+            backgroundColor: .clear,
+            drawsBackground: false
+        )
+        let remountedView = session.view(
+            panel: panel,
+            isVisibleInUI: true,
+            backgroundColor: .clear,
+            drawsBackground: false
+        )
+
+        XCTAssertFalse(
+            firstView === remountedView,
+            "QuickLook views must be owned by the SwiftUI representable mount, because AppKit can deactivate a QLPreviewView when that mount is removed"
+        )
+
+        session.dismantle(firstView)
+        session.dismantle(remountedView)
+        panel.close()
+    }
+}


### PR DESCRIPTION
## Summary
- Add regression coverage for the native preview lifecycle that allowed stale AppKit views to be configured after teardown.
- Keep generic panel-owned native views from re-adopting closed instances.
- Make QuickLook preview views owned by each SwiftUI representable mount and dismantled through `dismantleNSView`, so a deactivated `QLPreviewView` is never reused or given a non-nil preview item again.

## Root cause
Closing the split could close/deactivate the `QLPreviewView` while SwiftUI still had a mounted `QuickLookPreviewView`. A later SwiftUI make/update pass reused that deactivated native view and called `setPreviewItem` with a non-nil item, tripping QuickLook's internal assertion:

`item == nil || _reserved->internalState != QLPreviewDeactivatedInternalState`

## Verification
- Built with the required local command:
  `CMUX_SKIP_ZIG_BUILD=1 ./scripts/reload.sh --tag issue-4455-proxy-icon-split-close-crash --launch`
- Confirmed the old build still crashed from the same QuickLook assertion when opening a QuickLook-backed file preview, splitting it off, and closing the new split pane.
- Rebuilt with the fix and repeated the controlled lifecycle twice: open QuickLook-backed file preview -> `split-off` into a new pane -> close that split pane. The DEV app stayed alive and no new `.ips` or sentry-native crash envelope was written.
- Tried the real titlebar proxy-icon drag through local Computer Use. The app exposed the proxy icon and started the drag, but AppKit reported `operation=0` on drop, so this local automation could not complete the exact proxy-icon drop gesture. The committed test is therefore a focused Swift unit test on the native QuickLook/session lifecycle that the crash stack hit.

Fixes #4455

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4460"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781923384&installation_id=133855650&pr_number=4460&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4460&signature=a51accc6ea22a77b7867659ae7bc3d0c87e57c31596aa70ef325f7c78b47737e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive tests for file preview view lifecycle and remounting behavior, validating proper view management across open/close cycles.

* **Bug Fixes**
  * Enhanced file preview panel view management to properly clean up and reconfigure preview views during lifecycle transitions.
  * Improved view state tracking to prevent stale preview view instances from being incorrectly reused.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4460?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes native QuickLook view ownership/teardown semantics and introduces multi-view tracking, which could affect file preview lifecycle and resource cleanup across SwiftUI mount/unmount events.
> 
> **Overview**
> Fixes a QuickLook crash by changing `QuickLookPreviewView` to *dismantle* the underlying AppKit preview via `dismantleNSView`, and by having its coordinator track the current `FilePreviewQuickLookSession` instance.
> 
> Refactors `FilePreviewQuickLookSession` to stop reusing a single panel-owned `QLPreviewView`; it now creates a fresh view per SwiftUI representable mount, tracks live views via a weak `NSHashTable`, ignores updates for stale views, and only clears the shared preview item when all live views are dismantled/closed.
> 
> Adds unit coverage (`PanelOwnedNativeViewSessionTests`) to prevent re-adopting/configuring closed native views after session close and to assert QuickLook views are recreated per mount.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 724ecbc4e63c2cbdf61235f7c2e67c9a76169f98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->