### PR TITLE
Fix minimal-mode sidebar titlebar icon alignment

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1985,6 +1985,7 @@ struct ContentView: View {
                     debugSource: "titlebar.hiddenNewWorkspace"
                 )
             },
+            observedWindow: observedWindow,
             selection: $sidebarSelectionState.selection,
             selectedTabIds: $selectedTabIds,
             lastSidebarSelectionIndex: $lastSidebarSelectionIndex
@@ -9401,6 +9402,7 @@ struct VerticalTabsSidebar: View {
     let onSendFeedback: () -> Void
     let onToggleSidebar: () -> Void
     let onNewTab: () -> Void
+    let observedWindow: NSWindow?
     @EnvironmentObject var tabManager: TabManager
     @EnvironmentObject var notificationStore: TerminalNotificationStore
     @Binding var selection: SidebarSelection
@@ -9437,6 +9439,13 @@ struct VerticalTabsSidebar: View {
 
     private var isMinimalMode: Bool {
         WorkspacePresentationModeSettings.mode(for: workspacePresentationMode) == .minimal
+    }
+
+    private var minimalModeSidebarTitlebarControlsTopPadding: CGFloat {
+        guard let observedWindow else {
+            return MinimalModeSidebarTitlebarControlsMetrics.topInset
+        }
+        return minimalModeSidebarTitlebarControlsTopInset(in: observedWindow)
     }
 
     private var showsSidebarNotificationMessage: Bool {
@@ -9709,7 +9718,7 @@ struct VerticalTabsSidebar: View {
                             )
                             .padding(
                                 .top,
-                                MinimalModeTitlebarDebugSettings.leftControlsTopInset()
+                                minimalModeSidebarTitlebarControlsTopPadding
                             )
                     }
                 }

--- a/Sources/WindowDecorationsController.swift
+++ b/Sources/WindowDecorationsController.swift
@@ -412,11 +412,9 @@ final class WindowDecorationsController {
         }
 
         let contentBounds = contentView.bounds
-        target.frame = minimalModeSidebarTitlebarControlsFrame(in: window) ?? minimalModeSidebarTitlebarControlsFrame(
-            contentBounds: contentBounds,
-            contentViewIsFlipped: contentView.isFlipped,
-            trafficLightFrameInContent: nil
-        )
+        target.frame = MainActor.assumeIsolated {
+            minimalModeSidebarTitlebarControlsFrame(in: window)
+        }
 
         #if DEBUG
         if ProcessInfo.processInfo.environment["CMUX_UI_TEST_BONSPLIT_TAB_DRAG_SETUP"] == "1" {

--- a/Sources/WindowDecorationsController.swift
+++ b/Sources/WindowDecorationsController.swift
@@ -1,5 +1,6 @@
 import AppKit
 
+@MainActor
 final class WindowDecorationsController {
     private var observers: [NSObjectProtocol] = []
     private var didStart = false
@@ -412,9 +413,7 @@ final class WindowDecorationsController {
         }
 
         let contentBounds = contentView.bounds
-        target.frame = MainActor.assumeIsolated {
-            minimalModeSidebarTitlebarControlsFrame(in: window)
-        }
+        target.frame = minimalModeSidebarTitlebarControlsFrame(in: window)
 
         #if DEBUG
         if ProcessInfo.processInfo.environment["CMUX_UI_TEST_BONSPLIT_TAB_DRAG_SETUP"] == "1" {

--- a/Sources/WindowDecorationsController.swift
+++ b/Sources/WindowDecorationsController.swift
@@ -411,17 +411,11 @@ final class WindowDecorationsController {
             contentView.addSubview(target, positioned: .above, relativeTo: nil)
         }
 
-        let hostHeight = MinimalModeSidebarTitlebarControlsMetrics.hostHeight
         let contentBounds = contentView.bounds
-        let topInset = MinimalModeSidebarTitlebarControlsMetrics.topInset
-        let targetY = contentView.isFlipped
-            ? contentBounds.minY + topInset
-            : max(0, contentBounds.maxY - hostHeight - topInset)
-        target.frame = NSRect(
-            x: MinimalModeSidebarTitlebarControlsMetrics.leadingInset,
-            y: targetY,
-            width: MinimalModeSidebarTitlebarControlsMetrics.hostWidth,
-            height: hostHeight
+        target.frame = minimalModeSidebarTitlebarControlsFrame(in: window) ?? minimalModeSidebarTitlebarControlsFrame(
+            contentBounds: contentBounds,
+            contentViewIsFlipped: contentView.isFlipped,
+            trafficLightFrameInContent: nil
         )
 
         #if DEBUG

--- a/Sources/WindowDecorationsController.swift
+++ b/Sources/WindowDecorationsController.swift
@@ -412,13 +412,10 @@ final class WindowDecorationsController {
         }
 
         let contentBounds = contentView.bounds
-        let trafficLightFrameInContent: NSRect? = {
-            guard let closeButton = window.standardWindowButton(.closeButton),
-                  let closeButtonSuperview = closeButton.superview else {
-                return nil
-            }
-            return closeButtonSuperview.convert(closeButton.frame, to: contentView)
-        }()
+        let trafficLightFrameInContent = minimalModeTrafficLightFrameInContentCoordinates(
+            window: window,
+            contentView: contentView
+        )
         target.frame = minimalModeSidebarTitlebarControlsFrame(
             contentBounds: contentBounds,
             contentViewIsFlipped: contentView.isFlipped,

--- a/Sources/WindowDecorationsController.swift
+++ b/Sources/WindowDecorationsController.swift
@@ -1,6 +1,5 @@
 import AppKit
 
-@MainActor
 final class WindowDecorationsController {
     private var observers: [NSObjectProtocol] = []
     private var didStart = false
@@ -413,7 +412,23 @@ final class WindowDecorationsController {
         }
 
         let contentBounds = contentView.bounds
-        target.frame = minimalModeSidebarTitlebarControlsFrame(in: window)
+        let trafficLightFrameInContent: NSRect? = {
+            guard let closeButton = window.standardWindowButton(.closeButton),
+                  let closeButtonSuperview = closeButton.superview else {
+                return nil
+            }
+            return closeButtonSuperview.convert(closeButton.frame, to: contentView)
+        }()
+        target.frame = minimalModeSidebarTitlebarControlsFrame(
+            contentBounds: contentBounds,
+            contentViewIsFlipped: contentView.isFlipped,
+            trafficLightFrameInContent: trafficLightFrameInContent,
+            visualDownwardAdjustment: trafficLightFrameInContent == nil
+                ? 0
+                : MinimalModeSidebarTitlebarControlsMetrics.titlebarControlsOpticalYOffset(
+                    backingScaleFactor: window.backingScaleFactor
+                )
+        )
 
         #if DEBUG
         if ProcessInfo.processInfo.environment["CMUX_UI_TEST_BONSPLIT_TAB_DRAG_SETUP"] == "1" {

--- a/Sources/WindowDragHandleView.swift
+++ b/Sources/WindowDragHandleView.swift
@@ -714,14 +714,22 @@ func minimalModeSidebarTitlebarControlsFrame(
     )
 }
 
-@MainActor
-private func minimalModeTrafficLightFrameInContentCoordinates(for window: NSWindow) -> NSRect? {
-    guard let contentView = window.contentView,
-          let closeButton = window.standardWindowButton(.closeButton),
+func minimalModeTrafficLightFrameInContentCoordinates(
+    window: NSWindow,
+    contentView: NSView
+) -> NSRect? {
+    dispatchPrecondition(condition: .onQueue(.main))
+    guard let closeButton = window.standardWindowButton(.closeButton),
           let closeButtonSuperview = closeButton.superview else {
         return nil
     }
     return closeButtonSuperview.convert(closeButton.frame, to: contentView)
+}
+
+@MainActor
+private func minimalModeTrafficLightFrameInContentCoordinates(for window: NSWindow) -> NSRect? {
+    guard let contentView = window.contentView else { return nil }
+    return minimalModeTrafficLightFrameInContentCoordinates(window: window, contentView: contentView)
 }
 
 enum MinimalModeSidebarControlActionSlot: Int {

--- a/Sources/WindowDragHandleView.swift
+++ b/Sources/WindowDragHandleView.swift
@@ -634,10 +634,16 @@ enum MinimalModeSidebarTitlebarControlsMetrics {
     static let hostHeight: CGFloat = 28
     static let singleButtonHostWidth: CGFloat = hostHeight
 
+    static func titlebarControlsOpticalYOffset(backingScaleFactor: CGFloat?) -> CGFloat {
+        let scale = max(1.0, backingScaleFactor ?? 1.0)
+        return 1.0 / scale
+    }
+
     @MainActor
     static func titlebarControlsOpticalYOffset(in window: NSWindow?) -> CGFloat {
-        let scale = max(1.0, window?.backingScaleFactor ?? NSScreen.main?.backingScaleFactor ?? 1.0)
-        return 1.0 / scale
+        titlebarControlsOpticalYOffset(
+            backingScaleFactor: window?.backingScaleFactor ?? NSScreen.main?.backingScaleFactor
+        )
     }
 }
 

--- a/Sources/WindowDragHandleView.swift
+++ b/Sources/WindowDragHandleView.swift
@@ -664,16 +664,9 @@ func minimalModeSidebarTitlebarControlsTopInset(
     guard let contentView = window.contentView else {
         return MinimalModeSidebarTitlebarControlsMetrics.topInset(defaults: defaults)
     }
-    let trafficLightFrameInContent = minimalModeTrafficLightFrameInContentCoordinates(for: window)
-    let controlsFrame = minimalModeSidebarTitlebarControlsFrame(
-        contentBounds: contentView.bounds,
-        contentViewIsFlipped: contentView.isFlipped,
-        trafficLightFrameInContent: trafficLightFrameInContent,
-        visualDownwardAdjustment: trafficLightFrameInContent == nil
-            ? 0
-            : MinimalModeSidebarTitlebarControlsMetrics.titlebarControlsOpticalYOffset(in: window),
-        defaults: defaults
-    )
+    guard let controlsFrame = minimalModeSidebarTitlebarControlsFrame(in: window, defaults: defaults) else {
+        return MinimalModeSidebarTitlebarControlsMetrics.topInset(defaults: defaults)
+    }
     if contentView.isFlipped {
         return controlsFrame.minY - contentView.bounds.minY
     }

--- a/Sources/WindowDragHandleView.swift
+++ b/Sources/WindowDragHandleView.swift
@@ -634,21 +634,29 @@ enum MinimalModeSidebarTitlebarControlsMetrics {
     static let hostHeight: CGFloat = 28
     static let singleButtonHostWidth: CGFloat = hostHeight
 
+    @MainActor
     static func titlebarControlsOpticalYOffset(in window: NSWindow?) -> CGFloat {
         let scale = max(1.0, window?.backingScaleFactor ?? NSScreen.main?.backingScaleFactor ?? 1.0)
         return 1.0 / scale
     }
 }
 
+@MainActor
 func minimalModeSidebarTitlebarControlsFrame(
     in window: NSWindow,
     defaults: UserDefaults = .standard
-) -> NSRect? {
-    guard let contentView = window.contentView else { return nil }
+) -> NSRect {
+    let contentView = window.contentView
+    let contentBounds = contentView?.bounds ?? NSRect(
+        x: 0,
+        y: 0,
+        width: window.frame.width,
+        height: window.frame.height
+    )
     let trafficLightFrameInContent = minimalModeTrafficLightFrameInContentCoordinates(for: window)
     return minimalModeSidebarTitlebarControlsFrame(
-        contentBounds: contentView.bounds,
-        contentViewIsFlipped: contentView.isFlipped,
+        contentBounds: contentBounds,
+        contentViewIsFlipped: contentView?.isFlipped ?? false,
         trafficLightFrameInContent: trafficLightFrameInContent,
         visualDownwardAdjustment: trafficLightFrameInContent == nil
             ? 0
@@ -657,6 +665,7 @@ func minimalModeSidebarTitlebarControlsFrame(
     )
 }
 
+@MainActor
 func minimalModeSidebarTitlebarControlsTopInset(
     in window: NSWindow,
     defaults: UserDefaults = .standard
@@ -664,9 +673,7 @@ func minimalModeSidebarTitlebarControlsTopInset(
     guard let contentView = window.contentView else {
         return MinimalModeSidebarTitlebarControlsMetrics.topInset(defaults: defaults)
     }
-    guard let controlsFrame = minimalModeSidebarTitlebarControlsFrame(in: window, defaults: defaults) else {
-        return MinimalModeSidebarTitlebarControlsMetrics.topInset(defaults: defaults)
-    }
+    let controlsFrame = minimalModeSidebarTitlebarControlsFrame(in: window, defaults: defaults)
     if contentView.isFlipped {
         return controlsFrame.minY - contentView.bounds.minY
     }
@@ -701,6 +708,7 @@ func minimalModeSidebarTitlebarControlsFrame(
     )
 }
 
+@MainActor
 private func minimalModeTrafficLightFrameInContentCoordinates(for window: NSWindow) -> NSRect? {
     guard let contentView = window.contentView,
           let closeButton = window.standardWindowButton(.closeButton),

--- a/Sources/WindowDragHandleView.swift
+++ b/Sources/WindowDragHandleView.swift
@@ -633,6 +633,88 @@ enum MinimalModeSidebarTitlebarControlsMetrics {
     static let hostWidth: CGFloat = 124
     static let hostHeight: CGFloat = 28
     static let singleButtonHostWidth: CGFloat = hostHeight
+
+    static func titlebarControlsOpticalYOffset(in window: NSWindow?) -> CGFloat {
+        let scale = max(1.0, window?.backingScaleFactor ?? NSScreen.main?.backingScaleFactor ?? 1.0)
+        return 1.0 / scale
+    }
+}
+
+func minimalModeSidebarTitlebarControlsFrame(
+    in window: NSWindow,
+    defaults: UserDefaults = .standard
+) -> NSRect? {
+    guard let contentView = window.contentView else { return nil }
+    let trafficLightFrameInContent = minimalModeTrafficLightFrameInContentCoordinates(for: window)
+    return minimalModeSidebarTitlebarControlsFrame(
+        contentBounds: contentView.bounds,
+        contentViewIsFlipped: contentView.isFlipped,
+        trafficLightFrameInContent: trafficLightFrameInContent,
+        visualDownwardAdjustment: trafficLightFrameInContent == nil
+            ? 0
+            : MinimalModeSidebarTitlebarControlsMetrics.titlebarControlsOpticalYOffset(in: window),
+        defaults: defaults
+    )
+}
+
+func minimalModeSidebarTitlebarControlsTopInset(
+    in window: NSWindow,
+    defaults: UserDefaults = .standard
+) -> CGFloat {
+    guard let contentView = window.contentView else {
+        return MinimalModeSidebarTitlebarControlsMetrics.topInset(defaults: defaults)
+    }
+    let trafficLightFrameInContent = minimalModeTrafficLightFrameInContentCoordinates(for: window)
+    let controlsFrame = minimalModeSidebarTitlebarControlsFrame(
+        contentBounds: contentView.bounds,
+        contentViewIsFlipped: contentView.isFlipped,
+        trafficLightFrameInContent: trafficLightFrameInContent,
+        visualDownwardAdjustment: trafficLightFrameInContent == nil
+            ? 0
+            : MinimalModeSidebarTitlebarControlsMetrics.titlebarControlsOpticalYOffset(in: window),
+        defaults: defaults
+    )
+    if contentView.isFlipped {
+        return controlsFrame.minY - contentView.bounds.minY
+    }
+    return contentView.bounds.maxY - controlsFrame.maxY
+}
+
+func minimalModeSidebarTitlebarControlsFrame(
+    contentBounds: NSRect,
+    contentViewIsFlipped: Bool,
+    trafficLightFrameInContent: NSRect?,
+    visualDownwardAdjustment: CGFloat = 0,
+    defaults: UserDefaults = .standard
+) -> NSRect {
+    let hostHeight = MinimalModeSidebarTitlebarControlsMetrics.hostHeight
+    let targetY: CGFloat
+    if let trafficLightFrameInContent {
+        let centeredY = trafficLightFrameInContent.midY - hostHeight / 2.0
+        targetY = contentViewIsFlipped
+            ? centeredY + visualDownwardAdjustment
+            : centeredY - visualDownwardAdjustment
+    } else {
+        let topInset = MinimalModeSidebarTitlebarControlsMetrics.topInset(defaults: defaults)
+        targetY = contentViewIsFlipped
+            ? contentBounds.minY + topInset
+            : max(0, contentBounds.maxY - hostHeight - topInset)
+    }
+    return NSRect(
+        x: MinimalModeSidebarTitlebarControlsMetrics.leadingInset(defaults: defaults),
+        y: targetY,
+        width: MinimalModeSidebarTitlebarControlsMetrics.hostWidth,
+        height: hostHeight
+    )
+}
+
+private func minimalModeTrafficLightFrameInContentCoordinates(for window: NSWindow) -> NSRect? {
+    guard let contentView = window.contentView,
+          let closeButton = window.standardWindowButton(.closeButton),
+          let closeButtonSuperview = closeButton.superview else {
+        return nil
+    }
+    return closeButtonSuperview.convert(closeButton.frame, to: contentView)
 }
 
 enum MinimalModeSidebarControlActionSlot: Int {

--- a/cmuxTests/WindowAndDragTests.swift
+++ b/cmuxTests/WindowAndDragTests.swift
@@ -864,6 +864,8 @@ final class WindowDragHandleHitTests: XCTestCase {
     func testMinimalModeSidebarTitlebarControlsAlignWithTrafficLightCenter() {
         let defaults = UserDefaults.standard
         let savedMode = defaults.object(forKey: WorkspacePresentationModeSettings.modeKey)
+        // WindowDecorationsController.apply reads the production presentation-mode setting
+        // from UserDefaults.standard, so this test saves and restores the shared key narrowly.
         defaults.set(WorkspacePresentationModeSettings.Mode.minimal.rawValue, forKey: WorkspacePresentationModeSettings.modeKey)
         defer {
             if let savedMode {

--- a/cmuxTests/WindowAndDragTests.swift
+++ b/cmuxTests/WindowAndDragTests.swift
@@ -866,7 +866,11 @@ final class WindowDragHandleHitTests: XCTestCase {
         let savedMode = defaults.object(forKey: WorkspacePresentationModeSettings.modeKey)
         defaults.set(WorkspacePresentationModeSettings.Mode.minimal.rawValue, forKey: WorkspacePresentationModeSettings.modeKey)
         defer {
-            restoreDefaultsValue(savedMode, forKey: WorkspacePresentationModeSettings.modeKey, defaults: defaults)
+            if let savedMode {
+                defaults.set(savedMode, forKey: WorkspacePresentationModeSettings.modeKey)
+            } else {
+                defaults.removeObject(forKey: WorkspacePresentationModeSettings.modeKey)
+            }
         }
 
         let window = NSWindow(

--- a/cmuxTests/WindowAndDragTests.swift
+++ b/cmuxTests/WindowAndDragTests.swift
@@ -861,6 +861,55 @@ final class WindowDragHandleHitTests: XCTestCase {
         )
     }
 
+    func testMinimalModeSidebarTitlebarControlsAlignWithTrafficLightCenter() {
+        let defaults = UserDefaults.standard
+        let savedMode = defaults.object(forKey: WorkspacePresentationModeSettings.modeKey)
+        defaults.set(WorkspacePresentationModeSettings.Mode.minimal.rawValue, forKey: WorkspacePresentationModeSettings.modeKey)
+        defer {
+            restoreDefaultsValue(savedMode, forKey: WorkspacePresentationModeSettings.modeKey, defaults: defaults)
+        }
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 420, height: 180),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+        window.identifier = NSUserInterfaceItemIdentifier("cmux.main.test")
+        window.titlebarAppearsTransparent = true
+        window.titleVisibility = .hidden
+        defer { window.orderOut(nil) }
+
+        window.makeKeyAndOrderFront(nil)
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+        guard let closeButton = window.standardWindowButton(.closeButton),
+              let closeButtonSuperview = closeButton.superview else {
+            XCTFail("Expected close traffic-light button")
+            return
+        }
+
+        let controller = WindowDecorationsController()
+        controller.apply(to: window)
+
+        guard let target = contentView.subviews.compactMap({ $0 as? MinimalModeSidebarControlActionView }).first else {
+            XCTFail("Expected minimal sidebar titlebar click target")
+            return
+        }
+
+        let trafficLightFrame = closeButtonSuperview.convert(closeButton.frame, to: contentView)
+        XCTAssertEqual(
+            target.frame.midY,
+            trafficLightFrame.midY,
+            accuracy: 1.0,
+            "Minimal-mode sidebar controls should share the traffic-light vertical center"
+        )
+    }
+
     func testTitlebarChromeSettingsUseHardcodedDefaults() {
         let suiteName = "WindowDragHandleHitTests.titlebarChromeSettings.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!

--- a/cmuxTests/WindowAndDragTests.swift
+++ b/cmuxTests/WindowAndDragTests.swift
@@ -902,11 +902,15 @@ final class WindowDragHandleHitTests: XCTestCase {
         }
 
         let trafficLightFrame = closeButtonSuperview.convert(closeButton.frame, to: contentView)
+        let opticalYOffset = MinimalModeSidebarTitlebarControlsMetrics.titlebarControlsOpticalYOffset(in: window)
+        let expectedHostCenterY = contentView.isFlipped
+            ? trafficLightFrame.midY + opticalYOffset
+            : trafficLightFrame.midY - opticalYOffset
         XCTAssertEqual(
             target.frame.midY,
-            trafficLightFrame.midY,
-            accuracy: 1.0,
-            "Minimal-mode sidebar controls should share the traffic-light vertical center"
+            expectedHostCenterY,
+            accuracy: 0.25,
+            "Minimal-mode sidebar controls should compensate for the titlebar icon padding by one backing pixel"
         )
     }
 


### PR DESCRIPTION
Closes #4475.

## What changed
- Minimal-mode sidebar titlebar controls now derive their host frame from the live macOS close-button traffic-light frame instead of the old fixed `leftControlsTopInset`.
- The SwiftUI visible controls and the AppKit click target now share the same minimal-mode frame calculation, including a one-backing-pixel optical compensation for the existing `TitlebarControlsView` icon padding.
- Added a regression test that installs the minimal-mode click target in a real AppKit window and asserts the host center follows the traffic-light center plus the optical compensation.

## Regression source
Likely introduced by the minimal-mode toolbar removal path:
- `d13674f93 Hide window toolbar in minimal mode to eliminate titlebar gap`
- `f17415702 Remove toolbar entirely in minimal mode instead of just hiding`

Those commits moved minimal mode onto a separate overlay path while the standard titlebar accessory still used native titlebar metrics.

## Sibling #4469 / #4471 coordination
I checked `origin/issue-4469-fullscreen-titlebar-align` before editing. That work has already landed on `origin/main` as `296060b95 Align titlebar controls with traffic lights (#4471)`. This PR layers on top of that and does not re-fix #4469; it fixes the remaining minimal-mode-only overlay path.

## Screenshots
Sanitized titlebar crops captured from the tagged dev build:
- Before: `/tmp/cmux-issue-4475-screens/minimal-hover-before-titlebar.png`
- After: `/tmp/cmux-issue-4475-screens/minimal-hover-after-titlebar.png`

Full local captures are also available at:
- `/tmp/cmux-issue-4475-screens/minimal-hover-before.png`
- `/tmp/cmux-issue-4475-screens/minimal-hover-after.png`

I attempted to upload the cropped PNGs for inline PR rendering, but the available `gh gist` path rejects binary files and the unauthenticated upload fallbacks were unavailable. The after image was visually verified with the user before opening this PR.

## Test approach
Failing-test-first structure:
1. `c78167d17 test: cover minimal titlebar control alignment`
2. `278cbb695 fix: align minimal titlebar controls to traffic lights`

The regression test is in `cmuxTests/WindowAndDragTests.swift` and exercises the real `WindowDecorationsController` minimal click-target installation against AppKit traffic-light geometry.

## Verification
- Built with `CMUX_SKIP_ZIG_BUILD=1 ./scripts/reload.sh --tag issue-4475-minimal-mode-sidebar-icon-offset --launch`.
- Visually checked standard mode and minimal mode in the tagged dev app.
- Local XCTest was not run because the repo instructions say tests run in CI / GitHub Actions rather than locally.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4481"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781949773&installation_id=133855650&pr_number=4481&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4481&signature=6ee0ccf54cf81cb8b0b39906e48177d887f568269ffc1538ba1a8418c58c7450"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes minimal-mode titlebar control geometry and click-target placement based on live AppKit traffic-light frames, which could affect window interactions across macOS versions and scale factors.
> 
> **Overview**
> Fixes minimal-mode sidebar titlebar icon/click-target alignment by deriving the controls host frame from the window’s live traffic-light (close button) geometry instead of a fixed top inset, with a one-backing-pixel optical Y compensation.
> 
> Centralizes the frame/top-inset calculation in shared helpers and reuses it in both the AppKit `WindowDecorationsController` click target and the SwiftUI `VerticalTabsSidebar` padding (now passed `observedWindow`). Adds a regression XCTest that creates a real `NSWindow`, installs the minimal-mode click target, and asserts its center aligns to the traffic-light center plus the optical offset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79adecf86a1f2235c9d1e40f5de42f6c59f35031. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #4475 by aligning minimal-mode sidebar titlebar controls to the macOS close button using live geometry. Click targets and padding now match at all scales, and window decoration updates run on the main actor.

- **Bug Fixes**
  - Derive the host frame from live traffic-light bounds, handling flipped coordinates; fall back to the previous inset when unavailable, and apply a scale-aware one-pixel optical Y offset.
  - Centralize geometry in `minimalModeSidebarTitlebarControlsFrame` and reuse it for both the AppKit click target and SwiftUI padding; `ContentView` now passes `observedWindow` so `VerticalTabsSidebar` computes top padding via `minimalModeSidebarTitlebarControlsTopInset(in:)`.
  - Share a `minimalModeTrafficLightFrameInContentCoordinates` helper to convert the close-button frame into content coordinates for both AppKit and tests.
  - Mark `WindowDecorationsController` and helpers `@MainActor`; add a self-contained regression test that asserts the host center tracks the traffic-light center plus the optical offset, without introducing new warnings.

<sup>Written for commit 79adecf86a1f2235c9d1e40f5de42f6c59f35031. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4481?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Minimal-mode sidebar titlebar controls now align reliably with the window traffic‑light buttons across display scales and flipped/non‑flipped layouts; top padding and click targets are derived from the actual window geometry for consistent visual alignment and interaction.
* **Tests**
  * Added a UI regression test validating minimal‑mode sidebar controls align with the traffic‑light button center in minimal presentation mode.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4481?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->