### PR TITLE
Fix CJK IME marked text commit handling

### DIFF
--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/ConfigDiscovery/GhosttyConfigDiscovery.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/ConfigDiscovery/GhosttyConfigDiscovery.swift
@@ -500,8 +500,8 @@ public struct GhosttyConfigDiscovery {
     }
 
     /// Whether cmux should load the legacy `config` file because the new
-    /// `config.ghostty` is empty (size 0). Only true when the legacy file is
-    /// non-empty and the new file is exactly empty.
+    /// `config.ghostty` is missing or empty. Only true when the legacy file is
+    /// non-empty and the new file is absent or exactly empty.
     ///
     /// Pure with respect to its inputs; an instance method (not a static
     /// namespace member) so call sites invoke it on the held discovery value
@@ -511,6 +511,7 @@ public struct GhosttyConfigDiscovery {
         legacyConfigFileSize: Int?
     ) -> Bool {
         guard let legacyConfigFileSize, legacyConfigFileSize > 0 else { return false }
+        guard let newConfigFileSize else { return true }
         return newConfigFileSize == 0
     }
 

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/GhosttyConfigDiscoveryTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/GhosttyConfigDiscoveryTests.swift
@@ -117,11 +117,11 @@ private struct NoFontProbe: GhosttyFontProbing {
 @Suite struct GhosttyConfigDiscoveryLegacyTests {
     private let discovery = GhosttyConfigDiscovery(fontProbe: NoFontProbe())
 
-    @Test func loadLegacyOnlyWhenNewIsEmptyAndLegacyNonEmpty() {
+    @Test func loadLegacyWhenNewIsMissingOrEmptyAndLegacyNonEmpty() {
         #expect(discovery.shouldLoadLegacyGhosttyConfig(newConfigFileSize: 0, legacyConfigFileSize: 10))
+        #expect(discovery.shouldLoadLegacyGhosttyConfig(newConfigFileSize: nil, legacyConfigFileSize: 10))
         #expect(!discovery.shouldLoadLegacyGhosttyConfig(newConfigFileSize: 5, legacyConfigFileSize: 10))
         #expect(!discovery.shouldLoadLegacyGhosttyConfig(newConfigFileSize: 0, legacyConfigFileSize: 0))
-        #expect(!discovery.shouldLoadLegacyGhosttyConfig(newConfigFileSize: nil, legacyConfigFileSize: 10))
     }
 
     @Test func includeLegacyInScanPathsWhenNewMissingOrEmpty() {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5900,6 +5900,10 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             keyEvent.composing = false
             for text in accumulatedText {
                 if shouldSendText(text) {
+                    if markedTextBefore {
+                        sendCommittedIMETextToSurface(text, action: action, sourceEvent: event)
+                        continue
+                    }
 #if DEBUG
                     let sendTimingStart = CmuxTypingTiming.start()
                     let ghosttySendStart = ProcessInfo.processInfo.systemUptime
@@ -5927,7 +5931,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                         extra: "textBytes=\(text.utf8.count)"
                     )
 #endif
-                } else {
+                } else if !markedTextBefore {
                     keyEvent.consumed_mods = GHOSTTY_MODS_NONE
                     keyEvent.text = nil
                     #if DEBUG
@@ -6044,6 +6048,38 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         }
 
         // Rendering is driven by Ghostty's wakeups/renderer.
+    }
+
+    @discardableResult
+    private func sendCommittedIMETextToSurface(
+        _ text: String,
+        action: ghostty_input_action_e,
+        sourceEvent: NSEvent
+    ) -> Bool {
+        guard let surface else { return false }
+
+        var keyEvent = ghostty_input_key_s()
+        keyEvent.action = action
+        keyEvent.keycode = 0
+        keyEvent.mods = GHOSTTY_MODS_NONE
+        keyEvent.consumed_mods = GHOSTTY_MODS_NONE
+        keyEvent.unshifted_codepoint = 0
+        keyEvent.composing = false
+
+        return text.withCString { ptr in
+            keyEvent.text = ptr
+#if DEBUG
+            return sendTimedGhosttyKey(
+                surface,
+                keyEvent,
+                path: "terminal.keyDown.committedIMETextGhosttySend",
+                event: sourceEvent,
+                extra: "textBytes=\(text.utf8.count)"
+            )
+#else
+            return sendGhosttyKey(surface, keyEvent)
+#endif
+        }
     }
 
     @discardableResult

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5901,6 +5901,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             for text in accumulatedText {
                 if shouldSendText(text) {
                     if markedTextBefore {
+                        imeConsumedKeyUps.insert(event.keyCode)
                         sendCommittedIMETextToSurface(text, action: action, sourceEvent: event)
                         continue
                     }

--- a/cmuxTests/CJKIMEMarkedSelectionTests.swift
+++ b/cmuxTests/CJKIMEMarkedSelectionTests.swift
@@ -214,6 +214,79 @@ final class CJKIMEMarkedSelectionTests: XCTestCase {
         )
     }
 
+    func testControlJCommitWhileMarkedTextIsActiveSendsOnlyCommittedText() throws {
+        let hostedTerminal = try makeHostedTerminalWindow()
+        let terminalSurface = hostedTerminal.surface
+        let window = hostedTerminal.window
+        let surfaceView = hostedTerminal.surfaceView
+        let previousKeyEventObserver = GhosttyNSView.debugGhosttySurfaceKeyEventObserver
+        let previousInputSourceOverride = KeyboardLayout.debugInputSourceIdOverride
+        let previousInterpretHook = cjkIMEInterpretKeyEventsHook
+        defer {
+            GhosttyNSView.debugGhosttySurfaceKeyEventObserver = previousKeyEventObserver
+            KeyboardLayout.debugInputSourceIdOverride = previousInputSourceOverride
+            cjkIMEInterpretKeyEventsHook = previousInterpretHook
+            window.orderOut(nil)
+            withExtendedLifetime(terminalSurface) {}
+        }
+
+        KeyboardLayout.debugInputSourceIdOverride = "com.apple.inputmethod.Kotoeri.RomajiTyping.Japanese"
+        installCJKIMEInterpretKeyEventsSwizzle()
+        cjkIMEInterpretKeyEventsHook = { candidateView, _ in
+            guard candidateView === surfaceView else { return false }
+            candidateView.insertText("日本", replacementRange: NSRange(location: 0, length: 2))
+            candidateView.setMarkedText(
+                "語",
+                selectedRange: NSRange(location: 1, length: 0),
+                replacementRange: NSRange(location: NSNotFound, length: 0)
+            )
+            return true
+        }
+
+        var pressedText: [(text: String, keyCode: UInt32, mods: UInt32)] = []
+        var pressedControlKeyCodes: [UInt32] = []
+        GhosttyNSView.debugGhosttySurfaceKeyEventObserver = { keyEvent in
+            previousKeyEventObserver?(keyEvent)
+            guard keyEvent.action == GHOSTTY_ACTION_PRESS else { return }
+            if let text = keyEvent.text {
+                pressedText.append((String(cString: text), keyEvent.keycode, keyEvent.mods.rawValue))
+            } else if keyEvent.mods.rawValue & GHOSTTY_MODS_CTRL.rawValue != 0 {
+                pressedControlKeyCodes.append(keyEvent.keycode)
+            }
+        }
+
+        surfaceView.setMarkedText(
+            "にほんご",
+            selectedRange: NSRange(location: 0, length: 2),
+            replacementRange: NSRange(location: NSNotFound, length: 0)
+        )
+
+        let event = try XCTUnwrap(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.control],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: window.windowNumber,
+            context: nil,
+            characters: "\n",
+            charactersIgnoringModifiers: "j",
+            isARepeat: false,
+            keyCode: UInt16(kVK_ANSI_J)
+        ))
+
+        window.makeFirstResponder(surfaceView)
+        withExtendedLifetime(terminalSurface) {
+            surfaceView.keyDown(with: event)
+        }
+
+        XCTAssertEqual(pressedText.map(\.text), ["日本"])
+        XCTAssertEqual(pressedText.map(\.keyCode), [0])
+        XCTAssertEqual(pressedText.map(\.mods), [GHOSTTY_MODS_NONE.rawValue])
+        XCTAssertEqual(pressedControlKeyCodes, [])
+        XCTAssertTrue(surfaceView.hasMarkedText(), "Remaining IME segments should stay in preedit")
+        XCTAssertEqual(surfaceView.attributedString().string, "語")
+    }
+
     func testKeyDownForKoreanPostCompositionHorizontalArrowsForwardsToTerminal() throws {
         let hostedTerminal = try makeHostedTerminalWindow()
         let terminalSurface = hostedTerminal.surface

--- a/cmuxTests/CJKIMEMarkedSelectionTests.swift
+++ b/cmuxTests/CJKIMEMarkedSelectionTests.swift
@@ -245,13 +245,17 @@ final class CJKIMEMarkedSelectionTests: XCTestCase {
 
         var pressedText: [(text: String, keyCode: UInt32, mods: UInt32)] = []
         var pressedControlKeyCodes: [UInt32] = []
+        var releasedControlKeyCodes: [UInt32] = []
         GhosttyNSView.debugGhosttySurfaceKeyEventObserver = { keyEvent in
             previousKeyEventObserver?(keyEvent)
-            guard keyEvent.action == GHOSTTY_ACTION_PRESS else { return }
-            if let text = keyEvent.text {
+            if keyEvent.action == GHOSTTY_ACTION_PRESS, let text = keyEvent.text {
                 pressedText.append((String(cString: text), keyEvent.keycode, keyEvent.mods.rawValue))
-            } else if keyEvent.mods.rawValue & GHOSTTY_MODS_CTRL.rawValue != 0 {
+            } else if keyEvent.action == GHOSTTY_ACTION_PRESS,
+                      keyEvent.mods.rawValue & GHOSTTY_MODS_CTRL.rawValue != 0 {
                 pressedControlKeyCodes.append(keyEvent.keycode)
+            } else if keyEvent.action == GHOSTTY_ACTION_RELEASE,
+                      keyEvent.mods.rawValue & GHOSTTY_MODS_CTRL.rawValue != 0 {
+                releasedControlKeyCodes.append(keyEvent.keycode)
             }
         }
 
@@ -273,16 +277,30 @@ final class CJKIMEMarkedSelectionTests: XCTestCase {
             isARepeat: false,
             keyCode: UInt16(kVK_ANSI_J)
         ))
+        let keyUp = try XCTUnwrap(NSEvent.keyEvent(
+            with: .keyUp,
+            location: .zero,
+            modifierFlags: [.control],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: window.windowNumber,
+            context: nil,
+            characters: "\n",
+            charactersIgnoringModifiers: "j",
+            isARepeat: false,
+            keyCode: UInt16(kVK_ANSI_J)
+        ))
 
         window.makeFirstResponder(surfaceView)
         withExtendedLifetime(terminalSurface) {
             surfaceView.keyDown(with: event)
+            surfaceView.keyUp(with: keyUp)
         }
 
         XCTAssertEqual(pressedText.map(\.text), ["日本"])
         XCTAssertEqual(pressedText.map(\.keyCode), [0])
         XCTAssertEqual(pressedText.map(\.mods), [GHOSTTY_MODS_NONE.rawValue])
         XCTAssertEqual(pressedControlKeyCodes, [])
+        XCTAssertEqual(releasedControlKeyCodes, [])
         XCTAssertTrue(surfaceView.hasMarkedText(), "Remaining IME segments should stay in preedit")
         XCTAssertEqual(surfaceView.attributedString().string, "語")
     }

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -890,8 +890,8 @@ final class GhosttyConfigTests: XCTestCase {
         )
     }
 
-    func testLegacyConfigFallbackDoesNotReloadLegacyFileWhenConfigGhosttyIsMissing() {
-        XCTAssertFalse(
+    func testLegacyConfigFallbackUsesLegacyFileWhenConfigGhosttyIsMissing() {
+        XCTAssertTrue(
             GhosttyApp.shouldLoadLegacyGhosttyConfig(
                 newConfigFileSize: nil,
                 legacyConfigFileSize: 42


### PR DESCRIPTION
## Summary

Send the text committed by IME interpretation when marked text is active, instead of dropping it and forwarding only the original key event to the terminal.

Covers Japanese IME commit paths triggered by control-key shortcuts, including both full and partial preedit commits.

## Testing

Included in this PR.

## Demo Video

For UI or behavior changes, include a short demo video (GitHub upload, Loom, or other direct link).

- Video URL or attachment:

Before:
<img width="500" alt="before" src="https://github.com/user-attachments/assets/25a49271-28ef-4277-ae8d-c7e9da4b61fe" />
Committed text is unexpectedly lost, and the trigger shortcut (Ctrl+J) leaks to the terminal.

After:
<img width="500" alt="after" src="https://github.com/user-attachments/assets/cca56c88-081e-4281-b0a8-c35e80bb9c52" />
Committed text is properly sent to the terminal, and the trigger shortcut (Ctrl+J) is consumed in IME.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4483"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781950580&installation_id=133855650&pr_number=4483&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4483&signature=1293582f61d671cf34808a628973219c5c66f7a9d4e85bd64d07390a87c92a4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CJK IME commit handling so committed text is sent to the terminal and the trigger shortcut is fully consumed (down and up). Also restores legacy config fallback: load legacy `config` when `config.ghostty` is missing or empty.

- **Bug Fixes**
  - Send IME-committed text via a synthetic text event (`keyCode` 0, no mods) when marked text is active; mark the trigger as IME-consumed so keyDown/keyUp don’t leak to the terminal.
  - Preserve remaining preedit segments after partial commits; add tests covering Ctrl+J commit and its keyUp.
  - Load legacy `config` if `config.ghostty` is absent or empty and the legacy file is non-empty; update discovery logic and tests.

<sup>Written for commit 1dc3a1f10dbdf4fd262ea4c788ce278539bc549a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4483?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IME composition handling so committed text chunks are properly routed and sent during marked/preedit input.
  * Prevented a spurious nil-text fallback key event from being emitted while IME composition is active, preserving preedit state.

* **Tests**
  * Added a test validating that Control+J commits only the IME-committed text and does not produce extra key events during marked text sessions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4483?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->