### PR TITLE
Add defer-unread blog post, retitle session restore for SEO

### DIFF
--- a/web/app/[locale]/blog/defer-unread/page.tsx
+++ b/web/app/[locale]/blog/defer-unread/page.tsx
@@ -1,0 +1,76 @@
+import { useTranslations } from "next-intl";
+import { getTranslations } from "next-intl/server";
+import { buildAlternates } from "../../../../i18n/seo";
+import { Link } from "../../../../i18n/navigation";
+
+export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "blog.deferUnread" });
+  return {
+    title: t("metaTitle"),
+    description: t("metaDescription"),
+    keywords: [
+      "cmux", "terminal", "macOS", "notifications", "AI coding agents",
+      "keyboard shortcuts", "unread", "Cmd+Ctrl+U", "Cmd+Option+U",
+      "defer notifications", "mark unread",
+    ],
+    openGraph: {
+      title: t("metaTitle"),
+      description: t("metaDescription"),
+      type: "article",
+      publishedTime: "2026-05-21T00:00:00Z",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: t("metaTitle"),
+      description: t("metaDescription"),
+    },
+    alternates: buildAlternates(locale, "/blog/defer-unread"),
+  };
+}
+
+export default function DeferUnreadPage() {
+  const t = useTranslations("blog.posts.deferUnread");
+  const tc = useTranslations("common");
+
+  return (
+    <>
+      <div className="mb-8">
+        <Link
+          href="/blog"
+          className="text-sm text-muted hover:text-foreground transition-colors"
+        >
+          &larr; {tc("backToBlog")}
+        </Link>
+      </div>
+
+      <h1>{t("title")}</h1>
+      <time dateTime="2026-05-21" className="text-sm text-muted">
+        {t("date")}
+      </time>
+
+      <p className="mt-6">
+        {t.rich("p1", {
+          link: (chunks) => <Link href="/blog/cmd-shift-u">{chunks}</Link>,
+        })}
+      </p>
+
+      <p>{t("p2")}</p>
+
+      <p>{t("p3")}</p>
+
+      <video
+        src="/blog/defer-unread.mp4"
+        width={1824}
+        height={1080}
+        autoPlay
+        loop
+        muted
+        playsInline
+        className="my-6 rounded-lg w-full h-auto"
+      />
+
+      <p>{t("p4")}</p>
+    </>
+  );
+}

--- a/web/app/[locale]/blog/defer-unread/page.tsx
+++ b/web/app/[locale]/blog/defer-unread/page.tsx
@@ -61,7 +61,7 @@ export default function DeferUnreadPage() {
 
       <video
         src="/blog/defer-unread.mp4"
-        width={1824}
+        width={1596}
         height={1080}
         autoPlay
         loop

--- a/web/app/[locale]/blog/page.tsx
+++ b/web/app/[locale]/blog/page.tsx
@@ -18,6 +18,7 @@ export async function generateMetadata({
 }
 
 const blogSlugs = [
+  "deferUnread",
   "sessionRestore",
   "cmuxSsh",
   "cmuxClaudeTeams",
@@ -30,6 +31,7 @@ const blogSlugs = [
 ] as const;
 
 const slugToPath: Record<string, string> = {
+  deferUnread: "defer-unread",
   sessionRestore: "session-restore",
   cmuxOmo: "cmux-omo",
   cmuxClaudeTeams: "cmux-claude-teams",

--- a/web/app/[locale]/components/blog-posts.ts
+++ b/web/app/[locale]/components/blog-posts.ts
@@ -1,11 +1,19 @@
 export const blogPosts = [
   {
+    slug: "defer-unread",
+    key: "deferUnread",
+    title: "Defer and toggle unread agents in cmux",
+    date: "2026-05-21",
+    summary:
+      "Two new keyboard shortcuts for managing unread coding agent notifications across cmux workspaces: Cmd+Ctrl+U defers, Cmd+Opt+U toggles.",
+  },
+  {
     slug: "session-restore",
     key: "sessionRestore",
-    title: "Session restore in cmux",
+    title: "How to resume Claude Code, Codex, and OpenCode sessions in cmux",
     date: "2026-05-13",
     summary:
-      "cmux restores layout, scrollback, browser history, and supported agent sessions when hooks have captured a resume token.",
+      "Restore Claude Code, Codex, OpenCode, Pi, Amp, Cursor CLI, Gemini, Rovo Dev, Copilot, CodeBuddy, Factory, and Qoder sessions automatically when cmux restarts.",
   },
   {
     slug: "cmux-ssh",

--- a/web/app/lib/agent-page-paths.ts
+++ b/web/app/lib/agent-page-paths.ts
@@ -32,6 +32,11 @@ const englishOnlyPages = [
 export const agentReadablePages = [
   { path: "/", title: "Home" },
   { path: "/blog", title: "Blog" },
+  { path: "/blog/defer-unread", title: "Defer and toggle unread agents in cmux" },
+  {
+    path: "/blog/session-restore",
+    title: "How to resume Claude Code, Codex, and OpenCode sessions in cmux",
+  },
   { path: "/blog/cmux-ssh", title: "cmux SSH" },
   {
     path: "/blog/cmux-claude-teams",

--- a/web/app/sitemap.ts
+++ b/web/app/sitemap.ts
@@ -6,7 +6,9 @@ export default function sitemap(): MetadataRoute.Sitemap {
 
   const paths = [
     { path: "", lastModified: "2026-03-18", changeFrequency: "weekly" as const, priority: 1 },
-    { path: "/blog", lastModified: "2026-03-18", changeFrequency: "weekly" as const, priority: 0.8 },
+    { path: "/blog", lastModified: "2026-05-21", changeFrequency: "weekly" as const, priority: 0.8 },
+    { path: "/blog/defer-unread", lastModified: "2026-05-21", changeFrequency: "monthly" as const, priority: 0.7 },
+    { path: "/blog/session-restore", lastModified: "2026-05-21", changeFrequency: "monthly" as const, priority: 0.7 },
     { path: "/blog/show-hn-launch", lastModified: "2026-02-21", changeFrequency: "monthly" as const, priority: 0.7 },
     { path: "/blog/introducing-cmux", lastModified: "2026-02-12", changeFrequency: "monthly" as const, priority: 0.7 },
     { path: "/blog/zen-of-cmux", lastModified: "2026-02-27", changeFrequency: "monthly" as const, priority: 0.7 },

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -109,8 +109,12 @@
     "metaDescription": "News and updates from the cmux team",
     "description": "News and updates from the cmux team",
     "sessionRestore": {
-      "metaTitle": "Session restore in cmux",
-      "metaDescription": "How cmux restores windows, workspaces, panes, scrollback, browser history, and supported agent sessions after relaunch."
+      "metaTitle": "How to resume Claude Code, Codex, and OpenCode sessions in cmux",
+      "metaDescription": "Restore Claude Code, Codex, OpenCode, Gemini, Cursor CLI, Amp, and other coding agent sessions automatically after cmux restarts. Window layout, scrollback, browser history, and native agent session IDs all come back."
+    },
+    "deferUnread": {
+      "metaTitle": "Defer and toggle unread agents in cmux (Cmd+Ctrl+U, Cmd+Opt+U)",
+      "metaDescription": "Two cmux keyboard shortcuts for managing unread coding agent notifications. Cmd+Ctrl+U keeps the current workspace unread and jumps to the next; Cmd+Opt+U toggles read/unread."
     },
     "zenOfCmux": {
       "metaTitle": "The Zen of cmux",
@@ -145,9 +149,18 @@
       "metaDescription": "A native macOS terminal built on Ghostty, designed for running multiple AI coding agents side by side."
     },
     "posts": {
+      "deferUnread": {
+        "title": "Defer and toggle unread agents in cmux",
+        "summary": "Two new keyboard shortcuts for managing unread coding agent notifications across cmux workspaces: Cmd+Ctrl+U defers, Cmd+Opt+U toggles.",
+        "date": "May 21, 2026",
+        "p1": "<link>Cmd+Shift+U</link> jumps to the latest unread agent. But sometimes I land on one I can't respond to yet. Two new shortcuts handle that case.",
+        "p2": "Cmd+Ctrl+U keeps the current workspace unread and jumps to the next unread. It moves the current workspace to the back of the cycle, so spamming Cmd+Ctrl+U walks through every unread without clearing any of them.",
+        "p3": "Cmd+Opt+U toggles read/unread on the current workspace.",
+        "p4": "Cmd+Ctrl+U shipped in v0.64.5, Cmd+Opt+U in v0.64.7."
+      },
       "sessionRestore": {
-        "title": "Session restore in cmux",
-        "summary": "cmux restores layout, scrollback, browser history, and supported agent sessions when hooks have captured a resume token.",
+        "title": "How to resume Claude Code, Codex, and OpenCode sessions in cmux",
+        "summary": "Restore Claude Code, Codex, OpenCode, Pi, Amp, Cursor CLI, Gemini, Rovo Dev, Copilot, CodeBuddy, Factory, and Qoder sessions automatically when cmux restarts.",
         "date": "May 13, 2026",
         "p1": "Terminal workflows survive interruptions better when the app can reconstruct the shape of your work. cmux now treats the workspace layout as durable state instead of something tied to one app process.",
         "p2": "The important boundary is live process state. cmux restores what it owns and what supported tools expose through their own resume APIs. It does not checkpoint arbitrary terminal processes.",

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -118,6 +118,10 @@
         "p3": "Cmd+Opt+Uは現在のワークスペースの既読/未読を切り替えます。",
         "p4": "Cmd+Ctrl+Uはv0.64.5、Cmd+Opt+Uはv0.64.7で出荷されました。"
       },
+      "sessionRestore": {
+        "title": "cmuxでClaude Code、Codex、OpenCodeのセッションを再開する方法",
+        "summary": "cmuxの再起動後にClaude Code、Codex、OpenCode、Pi、Amp、Cursor CLI、Gemini、Rovo Dev、Copilot、CodeBuddy、Factory、Qoderのセッションを自動で復元します。"
+      },
       "cmdShiftU": {
         "title": "Cmd+Shift+U",
         "summary": "Cmd+Shift+Uがcmuxのワークスペース間で完了したエージェントにどうナビゲートするか。",

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -109,6 +109,15 @@
     "metaDescription": "cmuxチームからのニュースとアップデート",
     "description": "cmuxチームからのニュースとアップデート",
     "posts": {
+      "deferUnread": {
+        "title": "cmuxで未読エージェントを保留・切り替えする",
+        "summary": "cmuxワークスペース間の未読コーディングエージェント通知を管理する新しいキーボードショートカット2つ。Cmd+Ctrl+Uで保留、Cmd+Opt+Uで切り替え。",
+        "date": "2026年5月21日",
+        "p1": "<link>Cmd+Shift+U</link>は最新の未読エージェントにジャンプします。でも、すぐには返信できない相手に着地することもあります。そのケースを2つの新しいショートカットが処理します。",
+        "p2": "Cmd+Ctrl+Uは現在のワークスペースを未読のまま保ち、次の未読にジャンプします。現在のワークスペースをサイクルの末尾に回すので、Cmd+Ctrl+Uを連打すれば、どれも既読にせずに未読を一周できます。",
+        "p3": "Cmd+Opt+Uは現在のワークスペースの既読/未読を切り替えます。",
+        "p4": "Cmd+Ctrl+Uはv0.64.5、Cmd+Opt+Uはv0.64.7で出荷されました。"
+      },
       "cmdShiftU": {
         "title": "Cmd+Shift+U",
         "summary": "Cmd+Shift+Uがcmuxのワークスペース間で完了したエージェントにどうナビゲートするか。",
@@ -169,6 +178,14 @@
     "zenOfCmux": {
       "metaTitle": "cmuxの禅",
       "metaDescription": "cmuxはソリューションではなくプリミティブ。組み合わせ可能なパーツを提供し、ワークフローはあなた次第。"
+    },
+    "deferUnread": {
+      "metaTitle": "cmuxで未読エージェントを保留・切り替えする（Cmd+Ctrl+U、Cmd+Opt+U）",
+      "metaDescription": "未読のコーディングエージェント通知を管理するcmuxのキーボードショートカット2つ。Cmd+Ctrl+Uは現在のワークスペースを未読のままにして次の未読にジャンプ、Cmd+Opt+Uは既読/未読を切り替えます。"
+    },
+    "sessionRestore": {
+      "metaTitle": "cmuxでClaude Code、Codex、OpenCodeのセッションを再開する方法",
+      "metaDescription": "cmuxの再起動後にClaude Code、Codex、OpenCode、Gemini、Cursor CLI、Ampなどのコーディングエージェントのセッションを自動で復元します。ウィンドウレイアウト、スクロールバック、ブラウザ履歴、ネイティブエージェントのセッションIDが戻ります。"
     },
     "cmdShiftU": {
       "metaTitle": "Cmd+Shift+U",


### PR DESCRIPTION
## Summary
- Add `/blog/defer-unread` post covering the two new cmux keyboard shortcuts: ⌘⌃U (defer current workspace as oldest unread and jump to next) and ⌘⌥U (toggle read/unread).
- Retitle the existing `/blog/session-restore` post and metadata for SEO. Lead with "Claude Code, Codex, and OpenCode" since those match real user search queries like "restore claude code session" and "resume codex session". Slug unchanged to preserve existing links.
- Non-English locales already fall back to English via `deepMergeMessages` in `web/i18n/request.ts`; `ja.json` gets full native translations for the new post and updated session-restore metadata.

## Testing
- `bunx tsc --noEmit` clean in `web/`.
- `bunx eslint <changed files>` clean.
- JSON validated for `en.json` and `ja.json`.
- Vercel preview will provide the visual check.

## Notes
- Demo video is 37 MB (cmd-ctrl-u-cmd-option-u.mp4), copied to `web/public/blog/defer-unread.mp4`.
- Reference post pattern: `web/app/[locale]/blog/cmd-shift-u/page.tsx`.
- Shortcut history: ⌘⌃U shipped in v0.64.5 (manaflow-ai/cmux#4086), ⌘⌥U shipped in v0.64.7 (manaflow-ai/cmux#4231).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4485"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781951052&installation_id=133855650&pr_number=4485&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4485&signature=661982c44c949ff1340c89eb0ee8cc82f7a860f194fc0d7be30d4c2ca041628f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to static blog content, localized strings, and sitemap/index listings with no runtime business logic changes beyond adding a new route.
> 
> **Overview**
> Adds a new localized blog post at `/blog/defer-unread` (with metadata, an inline link to `cmd-shift-u`, and an embedded demo video) and surfaces it on the blog index.
> 
> Retitles the existing `session-restore` post copy/metadata for SEO (slug unchanged) and updates supporting data sources (`blog-posts.ts`, `agentReadablePages`, and `sitemap.ts`) plus `en.json`/`ja.json` translations to reflect the new/updated post info.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87946f34d24840add60176389f6366997fe2b126. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new /blog/defer-unread post explaining two cmux shortcuts for managing unread agents (Cmd+Ctrl+U and Cmd+Opt+U). Retitles the session-restore post for SEO and updates the sitemap, blog nav, and agent-readable variants.

- **Content + SEO**
  - New post with localized metadata and an embedded demo video at /blog/defer-unread (re-encoded to ~3.9 MB; 1596×1080).
  - Blog index, pager, and slug mapping updated: `deferUnread` → defer-unread; agent-readable allowlist updated so .md/.txt variants exist; /blog/defer-unread and /blog/session-restore added to /sitemap.xml (lastModified 2026-05-21).
  - Session-restore retitled for search queries; Japanese title/summary added; slug unchanged and other locales fall back to English.

<sup>Written for commit 87946f34d24840add60176389f6366997fe2b126. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4485?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Published a new localized blog article about keyboard shortcuts for deferring/toggling unread agent notifications (localized title/date, inline link, embedded demo video); added to the blog index and public page listings.
  * Updated an existing blog post’s title/summary.

* **Documentation**
  * Updated SEO metadata for blog pages.
  * Added/updated English and Japanese translations for the new post and related metadata.

* **Chores**
  * Updated blog listings and sitemap with new URLs and revised last-modified dates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4485?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->