### PR TITLE
Require regression proof for bugfix PRs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -13,9 +13,6 @@ reviews:
   profile: assertive
   request_changes_workflow: true
   path_instructions:
-    - path: "**/*"
-      instructions: |
-        Apply `.github/review-bot-rules/bugfix-regression-proof.md` at the PR level. For any PR that fixes a bug, regression, crash, flaky behavior, data loss, or broken product/runtime behavior, require a behavior-level regression test with visible red-first/green-after proof in the PR history or checks.
     - path: "**/*.swift"
       instructions: |
         Apply the cmux custom Swift lint rules in `.github/review-bot-rules/` during review. Treat those files as the source of truth. Focus on production Swift changes and ignore test-only scaffolding unless it makes production behavior worse.
@@ -52,7 +49,7 @@ reviews:
       - name: "cmux bugfix regression proof"
         mode: error
         instructions: |
-          For PRs that fix a bug, regression, crash, flaky behavior, data loss, or broken product/runtime behavior, fail when the diff violates `.github/review-bot-rules/bugfix-regression-proof.md`: require a behavior-level regression test that fails before the fix and passes after it, visible as a red test-only commit followed by a green fix commit, or an identified pre-existing failing check plus final green check. Pass for PRs that do not claim or implement a bugfix, including docs-only changes, metadata-only changes, refactors with no claimed broken behavior, review-bot rule changes, and tests that verify runtime behavior, built artifacts, or user-visible outcomes.
+          For PRs that fix a bug, regression, crash, flaky behavior, data loss, or broken product/runtime behavior, fail when the diff violates `.github/review-bot-rules/bugfix-regression-proof.md`: require a behavior-level regression test that verifies runtime behavior, built artifacts, or user-visible outcomes, visible as a red test-only commit followed by a green fix commit, or an identified pre-existing failing check plus final green check. Do not accept source-shape checks as regression coverage. Pass for PRs that do not claim or implement a bugfix, including docs-only changes, metadata-only changes, refactors with no claimed broken behavior, and review-bot rule changes.
       - name: "cmux Swift actor isolation"
         mode: error
         instructions: |

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -13,6 +13,9 @@ reviews:
   profile: assertive
   request_changes_workflow: true
   path_instructions:
+    - path: "**/*"
+      instructions: |
+        Apply `.github/review-bot-rules/bugfix-regression-proof.md` at the PR level. For any PR that fixes a bug, regression, crash, flaky behavior, data loss, or broken product/runtime behavior, require a behavior-level regression test with visible red-first/green-after proof in the PR history or checks.
     - path: "**/*.swift"
       instructions: |
         Apply the cmux custom Swift lint rules in `.github/review-bot-rules/` during review. Treat those files as the source of truth. Focus on production Swift changes and ignore test-only scaffolding unless it makes production behavior worse.
@@ -46,6 +49,10 @@ reviews:
 
   pre_merge_checks:
     custom_checks:
+      - name: "cmux bugfix regression proof"
+        mode: error
+        instructions: |
+          For PRs that fix a bug, regression, crash, flaky behavior, data loss, or broken product/runtime behavior, fail when the diff violates `.github/review-bot-rules/bugfix-regression-proof.md`: require a behavior-level regression test that fails before the fix and passes after it, visible as a red test-only commit followed by a green fix commit, or an identified pre-existing failing check plus final green check. Pass for PRs that do not claim or implement a bugfix, including docs-only changes, metadata-only changes, refactors with no claimed broken behavior, review-bot rule changes, and tests that verify runtime behavior, built artifacts, or user-visible outcomes.
       - name: "cmux Swift actor isolation"
         mode: error
         instructions: |

--- a/.github/review-bot-rules/README.md
+++ b/.github/review-bot-rules/README.md
@@ -8,6 +8,7 @@ Greptile is configured to publish a GitHub status check and inline findings. Cod
 
 Current rules:
 
+- `bugfix-regression-proof.md`
 - `full-internationalization.md`
 - `runtime-no-hacky-sleeps.md`
 - `swift-actor-isolation.md`

--- a/.github/review-bot-rules/bugfix-regression-proof.md
+++ b/.github/review-bot-rules/bugfix-regression-proof.md
@@ -14,6 +14,7 @@ Apply this rule to PRs that fix a bug, regression, flaky behavior, crash, data l
 - PRs that do not claim or implement a bugfix, including pure features, docs-only changes, metadata-only changes, refactors with no claimed broken behavior, and review-bot rule changes.
 - A bugfix PR where the first relevant commit adds or adjusts only the failing behavior-level regression test, CI or a reviewer-run check goes red on that commit, and a later commit fixes the bug with the same check going green.
 - A bugfix PR where an already-checked-in test demonstrably failed before the fix and the PR identifies the failing pre-fix check plus the final green check.
+- Valid regression tests exercise runtime behavior, built artifacts, or user-visible outcomes instead of source shape.
 
 ## Report
 

--- a/.github/review-bot-rules/bugfix-regression-proof.md
+++ b/.github/review-bot-rules/bugfix-regression-proof.md
@@ -1,0 +1,20 @@
+# Bugfix Regression Proof
+
+Apply this rule to PRs that fix a bug, regression, flaky behavior, crash, data loss, broken user flow, or previously incorrect product/runtime behavior.
+
+## Fail
+
+- A bugfix PR changes production app, runtime, CLI, web, script, build, or release behavior without adding or updating a behavior-level regression test for the exact broken path.
+- The regression test lands in the same commit as the fix, or only after the fix, so the PR history does not show a red test-only commit followed by a green fix commit.
+- The PR claims an existing test covered the bug but does not identify the pre-fix failing test/check and the final passing test/check.
+- The test only checks source shape, project metadata, string presence, or implementation snippets instead of runtime behavior, built artifacts, or user-visible outcomes.
+
+## Pass
+
+- PRs that do not claim or implement a bugfix, including pure features, docs-only changes, metadata-only changes, refactors with no claimed broken behavior, and review-bot rule changes.
+- A bugfix PR where the first relevant commit adds or adjusts only the failing behavior-level regression test, CI or a reviewer-run check goes red on that commit, and a later commit fixes the bug with the same check going green.
+- A bugfix PR where an already-checked-in test demonstrably failed before the fix and the PR identifies the failing pre-fix check plus the final green check.
+
+## Report
+
+When this rule fails, name the bugfix signal from the PR title, body, issue, or diff, identify the missing red-first/green-after evidence, and ask for the smallest behavior-level regression test commit that fails before the fix and passes after it.

--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -7,6 +7,12 @@
   "instructions": "Apply cmux's custom review rules from .github/review-bot-rules/ during review. Treat those files as the source of truth. Focus on production Swift and runtime changes, and ignore test-only scaffolding unless it makes production behavior worse. Do not treat PR-head edits to these rule files as weakening the rules until those edits are merged.",
   "rules": [
     {
+      "id": "cmux-bugfix-regression-proof",
+      "rule": "Flag bugfix PRs that lack behavior-level regression proof. If the PR title, body, linked issue, or diff says it fixes a bug, regression, crash, flaky behavior, data loss, or broken product/runtime behavior, require a regression test for the exact broken path with visible red-first/green-after evidence: a test-only commit that fails before the fix followed by a fix commit that makes the same check pass, or an identified pre-existing failing check plus final green check. Pass for PRs that do not claim or implement a bugfix, including docs-only changes, metadata-only changes, refactors with no claimed broken behavior, review-bot rule changes, and tests that verify runtime behavior, built artifacts, or user-visible outcomes.",
+      "scope": ["**/*"],
+      "severity": "high"
+    },
+    {
       "id": "cmux-swift-actor-isolation",
       "rule": "Flag new or materially worsened Swift 6 actor isolation mistakes in production Swift: implicit MainActor value models or service protocols, file-scoped helpers that should be nonisolated, shared mutable Sendable reference types without isolation, or UI-bound stores used from background contexts.",
       "scope": ["**/*.swift", "**/Package.swift"],

--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -8,7 +8,7 @@
   "rules": [
     {
       "id": "cmux-bugfix-regression-proof",
-      "rule": "Flag bugfix PRs that lack behavior-level regression proof. If the PR title, body, linked issue, or diff says it fixes a bug, regression, crash, flaky behavior, data loss, or broken product/runtime behavior, require a regression test for the exact broken path with visible red-first/green-after evidence: a test-only commit that fails before the fix followed by a fix commit that makes the same check pass, or an identified pre-existing failing check plus final green check. Pass for PRs that do not claim or implement a bugfix, including docs-only changes, metadata-only changes, refactors with no claimed broken behavior, review-bot rule changes, and tests that verify runtime behavior, built artifacts, or user-visible outcomes.",
+      "rule": "Flag bugfix PRs that lack behavior-level regression proof. If the PR title, body, linked issue, or diff says it fixes a bug, regression, crash, flaky behavior, data loss, or broken product/runtime behavior, require a regression test for the exact broken path that verifies runtime behavior, built artifacts, or user-visible outcomes, with visible red-first/green-after evidence: a test-only commit that fails before the fix followed by a fix commit that makes the same check pass, or an identified pre-existing failing check plus final green check. Do not accept source-shape checks as regression coverage. Pass for PRs that do not claim or implement a bugfix, including docs-only changes, metadata-only changes, refactors with no claimed broken behavior, and review-bot rule changes.",
       "scope": ["**/*"],
       "severity": "high"
     },

--- a/.greptile/files.json
+++ b/.greptile/files.json
@@ -1,6 +1,11 @@
 {
   "files": [
     {
+      "path": ".github/review-bot-rules/bugfix-regression-proof.md",
+      "description": "Source-of-truth cmux review rule for bugfix regression test proof and red-first/green-after commit structure.",
+      "scope": ["**/*"]
+    },
+    {
       "path": ".github/review-bot-rules/swift-actor-isolation.md",
       "description": "Source-of-truth cmux lint rule for Swift actor isolation review.",
       "scope": ["**/*.swift", "**/Package.swift"]

--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -25,7 +25,9 @@ For PRs that fix a bug, regression, crash, flaky behavior, data loss, or broken 
 
 Flag bugfix PRs that do not show red-first/green-after proof in PR history or checks. The expected shape is a test-only commit that fails before the fix, followed by a fix commit that makes the same check pass. If an existing test already failed before the fix, the PR must identify that pre-fix failing check and the final green check.
 
-Pass for PRs that do not claim or implement a bugfix, including docs-only changes, metadata-only changes, refactors with no claimed broken behavior, review-bot rule changes, and tests that verify runtime behavior, built artifacts, or user-visible outcomes. Do not accept source-shape tests as regression coverage.
+Pass for PRs that do not claim or implement a bugfix, including docs-only changes, metadata-only changes, refactors with no claimed broken behavior, and review-bot rule changes.
+
+For bugfix PRs, valid regression tests must exercise runtime behavior, built artifacts, or user-visible outcomes. Do not accept source-shape tests as regression coverage.
 
 ## Runtime No Hacky Sleeps
 

--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -6,6 +6,7 @@ Greptile should treat the rules in that directory as the source of truth for cmu
 
 Review production Swift and runtime changes for:
 
+- Bugfix PRs that lack behavior-level regression test proof with red-first/green-after evidence.
 - Swift actor isolation mistakes.
 - Blocking runtime primitives and timing-based synchronization.
 - Fixed sleeps, delays, and polling used as hacky synchronization.
@@ -17,6 +18,14 @@ Review production Swift and runtime changes for:
 - SwiftUI state and layout patterns that cause stale state, broad invalidation, or render-time mutation.
 - Architectural fixes that patch symptoms while leaving bad state representable.
 - User-facing errors, alerts, command output, API error bodies, and recovery copy that expose implementation details.
+
+## Bugfix Regression Proof
+
+For PRs that fix a bug, regression, crash, flaky behavior, data loss, or broken product/runtime behavior, require a behavior-level regression test for the exact broken path.
+
+Flag bugfix PRs that do not show red-first/green-after proof in PR history or checks. The expected shape is a test-only commit that fails before the fix, followed by a fix commit that makes the same check pass. If an existing test already failed before the fix, the PR must identify that pre-fix failing check and the final green check.
+
+Pass for PRs that do not claim or implement a bugfix, including docs-only changes, metadata-only changes, refactors with no claimed broken behavior, review-bot rule changes, and tests that verify runtime behavior, built artifacts, or user-visible outcomes. Do not accept source-shape tests as regression coverage.
 
 ## Runtime No Hacky Sleeps
 


### PR DESCRIPTION
Adds a shared review-bot rule requiring bugfix PRs to include behavior-level regression proof with red-first/green-after evidence. Wires the rule into CodeRabbit and Greptile as a high-severity blocking check.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4486"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781951917&installation_id=133855650&pr_number=4486&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4486&signature=cb67c2fd0af5e486912fdcd52bf6cb04bdf0fd9010fc771bd804d45cafd0a834"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only review-bot configuration/rules, not product code. Main impact is stricter merge gating for PRs labeled/worded as bugfixes, which could block merges if teams don’t follow the new red-first/green-after evidence expectation.
> 
> **Overview**
> Introduces a new rule, `bugfix-regression-proof.md`, requiring bugfix PRs to include *behavior-level* regression coverage and visible **red-first/green-after** evidence (or a clearly identified pre-fix failing check).
> 
> Wires this rule into CodeRabbit as a blocking `pre_merge_check` and into Greptile as a high-severity rule, and updates the rules index/docs to list the new policy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6540867b75a8f7f506fa14bafb21f74dd1612bb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a shared review rule that requires bugfix PRs to prove regression coverage with a failing test first and passing after. Enforced as a blocking `CodeRabbit` check and a high-severity `Greptile` rule, with clear guidance on what counts as valid behavior-level proof.

- **New Features**
  - Added `.github/review-bot-rules/bugfix-regression-proof.md` with pass/fail/report guidance; valid tests must verify runtime behavior, built artifacts, or user-visible outcomes (reject source-shape checks).
  - Updated `.coderabbit.yaml` to add a repo-wide blocking check: “cmux bugfix regression proof”.
  - Updated `Greptile` (`.greptile/config.json`, `.greptile/rules.md`, `.greptile/files.json`) to add a high-severity rule, expand guidance, and surface findings; listed the rule in `.github/review-bot-rules/README.md`.

- **Migration**
  - For bugfix PRs: add a failing behavior-level test first, then a fix that turns the same check green; or identify a pre-existing failing check and the final passing check.
  - No change for non-bugfix PRs (docs-only, metadata-only, refactors, or rule changes).

<sup>Written for commit 6540867b75a8f7f506fa14bafb21f74dd1612bb8. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4486?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new review rule requiring behavior-level regression evidence (red-first/green-after or equivalent) for PRs that implement bugfixes affecting runtime behavior.
  * Integrated the rule into the repository's review/config tooling so it applies across the codebase.

* **Documentation**
  * Added guidance and a README entry describing the new bugfix regression-proof rule and pass/fail/report criteria.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4486?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->