### PR TITLE
Add mouse back/forward buttons for workspace history navigation

### DIFF
--- a/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Context/CommandPaletteContextKeys.swift
+++ b/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Context/CommandPaletteContextKeys.swift
@@ -41,6 +41,10 @@ public struct CommandPaletteContextKeys: Hashable, Sendable {
     public static let workspaceCanMarkRead = CommandPaletteContextKeys(rawValue: "workspace.canMarkRead")
     /// Whether mark-unread is available for the workspace.
     public static let workspaceCanMarkUnread = CommandPaletteContextKeys(rawValue: "workspace.canMarkUnread")
+    /// Whether workspace focus history can navigate back.
+    public static let workspaceCanNavigateBack = CommandPaletteContextKeys(rawValue: "workspace.canNavigateBack")
+    /// Whether workspace focus history can navigate forward.
+    public static let workspaceCanNavigateForward = CommandPaletteContextKeys(rawValue: "workspace.canNavigateForward")
     /// Whether the sidebar matches the terminal background.
     public static let sidebarMatchTerminalBackground = CommandPaletteContextKeys(rawValue: "sidebar.matchTerminalBackground")
     /// Whether a panel has focus.

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Workspace/ControlCommandCoordinator+Workspace.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Workspace/ControlCommandCoordinator+Workspace.swift
@@ -47,6 +47,8 @@ extension ControlCommandCoordinator {
             return workspacePrevious(request.params)
         case "workspace.last":
             return workspaceLast(request.params)
+        case "workspace.last_forward":
+            return workspaceLastForward(request.params)
         case "workspace.equalize_splits":
             return workspaceEqualizeSplits(request.params)
         case "workspace.remote.configure":
@@ -667,6 +669,14 @@ extension ControlCommandCoordinator {
         workspaceNavigationResult(
             context?.controlSelectLastWorkspace(routing: routingSelectors(params)),
             notFoundMessage: "No previous workspace in history"
+        )
+    }
+
+    /// `workspace.last_forward` — navigate forward in workspace history.
+    func workspaceLastForward(_ params: [String: JSONValue]) -> ControlCallResult {
+        workspaceNavigationResult(
+            context?.controlSelectLastForwardWorkspace(routing: routingSelectors(params)),
+            notFoundMessage: "No next workspace in history"
         )
     }
 

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Workspace/ControlWorkspaceContext.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Workspace/ControlWorkspaceContext.swift
@@ -174,6 +174,13 @@ public protocol ControlWorkspaceContext: AnyObject {
     /// - Returns: The navigation resolution.
     func controlSelectLastWorkspace(routing: ControlRoutingSelectors) -> ControlWorkspaceNavigationResolution
 
+    /// Navigates forward in workspace history for `workspace.last_forward`.
+    ///
+    /// - Parameter routing: The routing selectors used for TabManager
+    ///   resolution.
+    /// - Returns: The navigation resolution.
+    func controlSelectLastForwardWorkspace(routing: ControlRoutingSelectors) -> ControlWorkspaceNavigationResolution
+
     /// Equalizes splits for `workspace.equalize_splits`.
     ///
     /// - Parameters:

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Workspace/ControlWorkspaceNavigationResolution.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Workspace/ControlWorkspaceNavigationResolution.swift
@@ -1,13 +1,14 @@
 public import Foundation
 
-/// The outcome of `workspace.next` / `workspace.previous` / `workspace.last`,
-/// after the coordinator has confirmed routing resolves a TabManager.
+/// The outcome of `workspace.next` / `workspace.previous` / `workspace.last` /
+/// `workspace.last_forward`, after the coordinator has confirmed routing
+/// resolves a TabManager.
 ///
-/// All three legacy bodies share this shape: focus the window, navigate, and on
+/// All legacy bodies share this shape: focus the window, navigate, and on
 /// success echo the now-selected workspace + window. The per-method `not_found`
-/// message (`"No workspace selected"` vs `"No previous workspace in history"`)
-/// is supplied by the coordinator, so the seam only signals which outcome
-/// occurred.
+/// message (`"No workspace selected"` vs `"No previous workspace in history"` /
+/// `"No next workspace in history"`) is supplied by the coordinator, so the seam
+/// only signals which outcome occurred.
 public enum ControlWorkspaceNavigationResolution: Sendable, Equatable {
     /// No TabManager resolved (legacy `unavailable` / "TabManager not
     /// available").

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandContextTestStubs.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandContextTestStubs.swift
@@ -322,6 +322,10 @@ extension ControlWorkspaceContext {
         .tabManagerUnavailable
     }
 
+    func controlSelectLastForwardWorkspace(routing: ControlRoutingSelectors) -> ControlWorkspaceNavigationResolution {
+        .tabManagerUnavailable
+    }
+
     func controlEqualizeWorkspaceSplits(
         routing: ControlRoutingSelectors,
         orientationFilter: String?

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -62885,6 +62885,482 @@
         }
       }
     },
+    "command.workspaceBack.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الرجوع في سجل مساحة العمل"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nazad u historiju radnog prostora"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tilbage i arbejdsområdehistorik"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zurück im Arbeitsbereichsverlauf"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Back in Workspace History"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atrás en el historial de espacio de trabajo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retour dans l'historique de l'espace de travail"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Indietro nella cronologia dell'area di lavoro"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペース履歴を戻る"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "작업 공간 기록에서 뒤로"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tilbake i arbeidsområdehistorikk"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wstecz w historii przestrzeni roboczej"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voltar no histórico da área de trabalho"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Назад в истории рабочего пространства"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ย้อนกลับในประวัติพื้นที่ทำงาน"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Çalışma Alanı Geçmişinde Geri"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Назад в історії робочої області"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在工作区历史中后退"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在工作區歷程中後退"
+          }
+        }
+      }
+    },
+    "command.workspaceBack.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تنقل مساحة العمل"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Navigacija radnog prostora"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arbejdsområdenavigation"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arbeitsbereichsnavigation"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workspace Navigation"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Navegación de espacio de trabajo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Navigation de l'espace de travail"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Navigazione area di lavoro"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースナビゲーション"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "작업 공간 탐색"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arbeidsområdenavigasjon"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nawigacja przestrzeni roboczej"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Navegação da área de trabalho"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Навигация рабочего пространства"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การนำทางพื้นที่ทำงาน"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Çalışma Alanı Navigasyonu"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Навігація робочої області"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "工作区导航"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "工作區導覽"
+          }
+        }
+      }
+    },
+    "command.workspaceForward.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الانتقال للأمام في سجل مساحة العمل"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Naprijed u historiju radnog prostora"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fremad i arbejdsområdehistorik"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vorwärts im Arbeitsbereichsverlauf"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Forward in Workspace History"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adelante en el historial de espacio de trabajo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avancer dans l'historique de l'espace de travail"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avanti nella cronologia dell'area di lavoro"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペース履歴を進む"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "작업 공간 기록에서 앞으로"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fremover i arbeidsområdehistorikk"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dalej w historii przestrzeni roboczej"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avançar no histórico da área de trabalho"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вперёд в истории рабочего пространства"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ไปข้างหน้าในประวัติพื้นที่ทำงาน"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Çalışma Alanı Geçmişinde İleri"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вперед в історії робочої області"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在工作区历史中前进"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在工作區歷程中前進"
+          }
+        }
+      }
+    },
+    "command.workspaceForward.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تنقل مساحة العمل"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Navigacija radnog prostora"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arbejdsområdenavigation"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arbeitsbereichsnavigation"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workspace Navigation"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Navegación de espacio de trabajo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Navigation de l'espace de travail"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Navigazione area di lavoro"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースナビゲーション"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "작업 공간 탐색"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arbeidsområdenavigasjon"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nawigacja przestrzeni roboczej"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Navegação da área de trabalho"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Навигация рабочего пространства"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การนำทางพื้นที่ทำงาน"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Çalışma Alanı Navigasyonu"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Навігація робочої області"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "工作区导航"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "工作區導覽"
+          }
+        }
+      }
+    },
     "command.pro.upgrade.title": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/App/CmuxMainWindow.swift
+++ b/Sources/App/CmuxMainWindow.swift
@@ -254,6 +254,57 @@ final class CmuxMainWindow: NSWindow {
         super.flagsChanged(with: event)
     }
 
+    override func sendEvent(_ event: NSEvent) {
+        if event.type == .otherMouseDown {
+            switch event.buttonNumber {
+            case 3, 4:
+                // If the event is targeted at a browser web view, let the browser
+                // handle its own page history (CmuxWebView already consumes these).
+                if isPointerOverBrowserWebView(event) {
+                    super.sendEvent(event)
+                    return
+                }
+                let appDelegate = MainActor.assumeIsolated { AppDelegate.shared }
+                if let appDelegate,
+                   let context = appDelegate.contextForMainTerminalWindow(self, reindex: false) {
+#if DEBUG
+                    let action = event.buttonNumber == 3 ? "navigateBack" : "navigateForward"
+                    cmuxDebugLog("window.mouse.backForward action=\(action) window=\(windowNumber)")
+#endif
+                    if event.buttonNumber == 3 {
+                        context.tabManager.navigateBack()
+                    } else {
+                        context.tabManager.navigateForward()
+                    }
+                    return
+                }
+            default:
+                break
+            }
+        }
+        super.sendEvent(event)
+    }
+
+    private func isPointerOverBrowserWebView(_ event: NSEvent) -> Bool {
+        if BrowserWindowPortalRegistry.webViewAtWindowPoint(event.locationInWindow, in: self) is CmuxWebView {
+            return true
+        }
+        guard let contentView,
+              let hitView = contentView.hitTest(event.locationInWindow) else {
+            return false
+        }
+        return isViewInsideBrowserWebView(hitView)
+    }
+
+    private func isViewInsideBrowserWebView(_ view: NSView) -> Bool {
+        var current: NSView? = view
+        while let v = current {
+            if v is CmuxWebView { return true }
+            current = v.superview
+        }
+        return false
+    }
+
     /// cmux owns main-window placement: it persists and restores window frames
     /// itself and disables AppKit window restoration (`isRestorable = false`),
     /// re-applying the saved frame only at startup.

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -6785,6 +6785,14 @@ struct ContentView: View {
                 CommandPaletteContextKeys.workspaceCanMarkUnread,
                 sidebarUnread.canMarkWorkspaceUnread(forWorkspaceIds: [workspace.id])
             )
+            snapshot.setBool(
+                CommandPaletteContextKeys.workspaceCanNavigateBack,
+                tabManager.canNavigateBack
+            )
+            snapshot.setBool(
+                CommandPaletteContextKeys.workspaceCanNavigateForward,
+                tabManager.canNavigateForward
+            )
         }
 
         if let panelContext = focusedPanelContext {
@@ -7392,6 +7400,26 @@ struct ContentView: View {
                 subtitle: constant(String(localized: "command.previousWorkspace.subtitle", defaultValue: "Workspace Navigation")),
                 keywords: ["previous", "workspace", "navigate"],
                 when: { $0.bool(CommandPaletteContextKeys.hasWorkspace) }
+            )
+        )
+        contributions.append(
+            CommandPaletteCommandContribution(
+                commandId: "palette.workspaceBack",
+                title: constant(String(localized: "command.workspaceBack.title", defaultValue: "Back in Workspace History")),
+                subtitle: constant(String(localized: "command.workspaceBack.subtitle", defaultValue: "Workspace Navigation")),
+                keywords: ["back", "workspace", "history", "navigate"],
+                when: { $0.bool(CommandPaletteContextKeys.hasWorkspace) },
+                enablement: { $0.bool(CommandPaletteContextKeys.workspaceCanNavigateBack) }
+            )
+        )
+        contributions.append(
+            CommandPaletteCommandContribution(
+                commandId: "palette.workspaceForward",
+                title: constant(String(localized: "command.workspaceForward.title", defaultValue: "Forward in Workspace History")),
+                subtitle: constant(String(localized: "command.workspaceForward.subtitle", defaultValue: "Workspace Navigation")),
+                keywords: ["forward", "workspace", "history", "navigate"],
+                when: { $0.bool(CommandPaletteContextKeys.hasWorkspace) },
+                enablement: { $0.bool(CommandPaletteContextKeys.workspaceCanNavigateForward) }
             )
         )
         contributions.append(
@@ -8434,6 +8462,12 @@ struct ContentView: View {
         }
         registry.register(commandId: "palette.previousWorkspace") {
             tabManager.selectPreviousTab()
+        }
+        registry.register(commandId: "palette.workspaceBack") {
+            tabManager.navigateBack()
+        }
+        registry.register(commandId: "palette.workspaceForward") {
+            tabManager.navigateForward()
         }
         registry.register(commandId: "palette.moveWorkspaceUp") {
             tabManager.moveSelectedWorkspace(by: -1)

--- a/Sources/TerminalController+ControlWorkspaceContext.swift
+++ b/Sources/TerminalController+ControlWorkspaceContext.swift
@@ -343,6 +343,21 @@ extension TerminalController: ControlWorkspaceContext {
         return .resolved(workspaceID: after, windowID: windowId)
     }
 
+    func controlSelectLastForwardWorkspace(routing: ControlRoutingSelectors) -> ControlWorkspaceNavigationResolution {
+        guard let tabManager = resolveTabManager(routing: routing) else {
+            return .tabManagerUnavailable
+        }
+        guard let before = tabManager.selectedTabId else { return .notFound }
+        if let windowId = AppDelegate.shared?.windowId(for: tabManager) {
+            _ = AppDelegate.shared?.focusMainWindow(windowId: windowId)
+            setActiveTabManager(tabManager)
+        }
+        tabManager.navigateForward()
+        guard let after = tabManager.selectedTabId, after != before else { return .notFound }
+        let windowId = AppDelegate.shared?.windowId(for: tabManager)
+        return .resolved(workspaceID: after, windowID: windowId)
+    }
+
     // MARK: - Equalize
 
     func controlEqualizeWorkspaceSplits(

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -269,6 +269,7 @@ class TerminalController {
         "workspace.next",
         "workspace.previous",
         "workspace.last",
+        "workspace.last_forward",
         "workspace.group.focus",
         "workspace.cloud_vm_open",
         "surface.focus",
@@ -2237,7 +2238,7 @@ class TerminalController {
         // prompt_submit/rename) + workspace.group.* handled by ControlCommandCoordinator.
         // workspace.action (forwards to the still-shared v2WorkspaceAction) and
         // extension.sidebar.snapshot handled by ControlCommandCoordinator.
-        // workspace.next/previous/last/equalize_splits + workspace.remote.* (configure/
+        // workspace.next/previous/last/last_forward/equalize_splits + workspace.remote.* (configure/
         // foreground_auth_ready/reconnect/disconnect/status/pty_attach_end/
         // terminal_session_end) handled by ControlCommandCoordinator. The worker-lane
         // workspace.remote.pty_* methods stay on the app-side worker path.
@@ -2456,6 +2457,7 @@ class TerminalController {
             "workspace.next",
             "workspace.previous",
             "workspace.last",
+            "workspace.last_forward",
             "workspace.equalize_splits",
             "workspace.remote.configure",
             "workspace.remote.foreground_auth_ready",


### PR DESCRIPTION
## Summary

This PR enables multi-button mice (e.g., Logitech MX Master) to navigate through workspace/tab history using mouse buttons 3 (back) and 4 (forward), matching the familiar browser-like UX.

## Changes

- **Mouse event interception** in `CmuxMainWindow.sendEvent()` for `.otherMouseDown` with button 3/4
- **Smart passthrough**: When the cursor is over a browser web view (`CmuxWebView`), events pass through so browser page history continues to work as before
- **Command palette entries** for "Back in Workspace History" and "Forward in Workspace History" with proper enablement conditions
- **Socket v2 command** `workspace.last_forward` to match the existing `workspace.last` command
- **Localized strings** added for command palette (English and Japanese)

## Testing

- All Swift source files compile successfully (verified via `xcodebuild`)
- The existing `CmuxWebView` already handles mouse back/forward for browser page history; this change extends the same UX to workspace history navigation
- Command palette entries are gated by `canNavigateBack` / `canNavigateForward` so they only appear when history is available

## Notes

- Debug logging is wrapped in `#if DEBUG` per project policy
- No breaking changes to existing socket/CLI contracts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4504"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781998503&installation_id=133855650&pr_number=4504&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4504&signature=f28c7a12ad878faddc424198776674b9749d16c402bee154c3c2d4d2c04fbb6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds mouse back/forward buttons (3/4) to navigate workspace history. Browser web views and portals keep handling their own page history when hovered.

- **New Features**
  - Intercept mouse buttons 3/4 in the main window to navigate workspace history.
  - Pass events through when hovering a `CmuxWebView` or browser portal.
  - Add command palette actions for workspace Back/Forward with enablement via new context keys; localized.
  - Add socket v2 command `workspace.last_forward` to mirror `workspace.last`.

- **Refactors**
  - Add `workspace.last_forward` to v2 capabilities, register as a focus‑intent command, and align forward/back not-found messages.
  - Use `MainActor.assumeIsolated` for `AppDelegate.shared` access in `sendEvent`.

<sup>Written for commit 56c756f86b5b821d760c4719c1283c45e4fbc300. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Back/forward mouse buttons navigate workspace history with context-aware behavior to avoid interfering with embedded web views.
  * Workspace navigation commands added to the command palette, enabled/disabled dynamically based on availability.
  * New programmatic command to move workspace selection forward and return updated workspace/window identifiers when selection changes.

* **Localization**
  * Added English and Japanese translations for the workspace navigation commands.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4504?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->