### PR TITLE
hygiene fix: CLAUDE.md violation in TabItemView

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -12329,10 +12329,15 @@ private struct TabItemView: View, Equatable {
 
     // Closures, Bindings, and object references are excluded from ==
     // because they're recreated every parent eval but don't affect rendering.
+    // Stored `@Environment` values (like `colorScheme`) are listed here so
+    // SwiftUI's `.equatable()` guard can compare them — adding an
+    // `@Environment` property without listing it is the documented
+    // CLAUDE.md "Snapshot boundary" pitfall.
     nonisolated static func == (lhs: TabItemView, rhs: TabItemView) -> Bool {
         lhs.tab === rhs.tab &&
         lhs.index == rhs.index &&
         lhs.isActive == rhs.isActive &&
+        lhs.colorScheme == rhs.colorScheme &&
         lhs.workspaceShortcutDigit == rhs.workspaceShortcutDigit &&
         lhs.workspaceShortcutModifierSymbol == rhs.workspaceShortcutModifierSymbol &&
         lhs.canCloseWorkspace == rhs.canCloseWorkspace &&


### PR DESCRIPTION
## Scope: hygiene only — does NOT claim to fix #4520

This patch fixes a documented anti-pattern in `TabItemView`. I want to be very explicit up-front:

- ✅ The code violation is real and matches the CLAUDE.md "Snapshot boundary" pitfall verbatim.
- ❌ I have **not** verified whether this violation is causally responsible for the v0.64.8 OOM regression tracked in #4520. The maintainers are better positioned to make that call.

If maintainers conclude this fix has no bearing on #4520, please still take the hygiene change on its own merit — or close, whichever you prefer.

## Summary

`TabItemView` declares `@Environment(\.colorScheme) private var colorScheme` (`Sources/ContentView.swift:12358`, introduced in commit `6f00d746` — *fix: derive chrome contrast from terminal themes*), but its `==` operator does not list `colorScheme`. CLAUDE.md explicitly forbids this:

> `TabItemView` in `ContentView.swift`: uses `Equatable` conformance + `.equatable()` to skip body re-evaluation during typing. **Do not add `@EnvironmentObject`, `@ObservedObject` (besides `tab`), or `@Binding` properties without updating the `==` function.**

This patch adds `lhs.colorScheme == rhs.colorScheme` to the existing `==` and extends the explanatory comment so future stored `@Environment` properties stay in sync.

## Why I noticed this

While digging into #4520 (severe v0.64.8 memory leak / OOM) I traced suspect views matching the hang stack's `ScrollView { GeometryReader { … _PaddingLayout × N … StackLayout } }` signature back to `VerticalTabsSidebar` → `workspaceRows` → `TabItemView`. Commit `6f00d746` added both the `@Environment(\.colorScheme)` in `TabItemView` and the sibling `.environment(\.colorScheme, appearance.sidebarContentColorScheme)` injection in `sidebarPanelContainer` (`Sources/ContentView.swift:2141`). My initial hypothesis was that the un-listed `@Environment` was breaking `.equatable()` and driving the AttributeGraph allocation cycle reflected in the hang report.

## Why I'm NOT claiming this fixes #4520

A more careful re-read of the hang report ruled my hypothesis out:

- **Main thread CPU time = 0.007 s in a 1.28 s sample window.** That's blocked-in-kernel, not spinning. The bottom of the main stack is `__bzero` → `*N ??? (kernel.release.t6000 + …)`. Treating that thread as a "tight SwiftUI loop" was a misread on my part.
- **The allocator pressure is on three `com.apple.root.utility-qos.cooperative` worker threads** running `TabManager.initialWorkspaceGitMetadataSnapshot` → `resolveGitRepository` → `URL.appendingPathComponent` / `URL.path` / `_CFRuntimeCreateInstance` → `szone_malloc_should_clear` → `__bzero` — also blocked in kernel because the system VM compressor is saturated.
- **`libcache.memorypressure` is actively reaping `NSImage` / `NSLayerContentsFacet` instances** in response to system memory pressure.
- The reporting user was in standard (non-minimal) `WorkspacePresentationMode`, the prior internal hypothesis around the minimal-mode titlebar overlay does not apply.
- Modern SwiftUI is also likely to no-op an `.environment(\.colorScheme, value)` injection when `value` is unchanged. The `.equatable()` guard may not even be the right lever for absorbing `@Environment` re-publications — even with this patch, an actual `colorScheme` value change would still invalidate the view. So the practical impact of this patch on layout volume is uncertain without a live test on a broken v0.64.8 build.

I posted the empirical hang/Jetsam evidence (without the speculative root-cause story) on #4520 as a separate comment so maintainers have the facts: https://github.com/manaflow-ai/cmux/issues/4520#issuecomment-4514510898

## What I'd ask a maintainer to do

1. Take or leave this patch on hygiene grounds.
2. If accepted, **do not** rely on it as a fix for #4520 without a separate before/after measurement on a v0.64.8 build.
3. The actual #4520 mechanism almost certainly involves the git-metadata scanner concurrency under memory pressure rather than this `==` omission — that's where I'd point further investigation.

## Testing

No test added. CLAUDE.md's test-quality policy explicitly states:

> If no meaningful behavioral or artifact-level test is practical, skip the fake regression test and state that explicitly.

A test that just constructs two `TabItemView` values differing only by `colorScheme` and asserts `!=` would only verify the source-text shape of `==`, which the same policy explicitly disallows. The behavioral effect (SwiftUI body re-evaluation counts) is not practically testable from XCTest. CI will catch any build/regression.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally (compile reasoning, not runtime — see "Why I'm NOT claiming this fixes #4520")
- [N/A] I added or updated tests for behavior changes — see Testing section
- [ ] I updated docs/changelog if needed — not applicable, hygiene fix
- [ ] I requested bot reviews after my latest commit (will paste trigger block after merge of any feedback)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4530"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782011926&installation_id=133855650&pr_number=4530&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4530&signature=d1b2683e42a5d02fc51f53342b58095499e7ef151d66d14c3cfdde8cdf7e31fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `colorScheme` to `TabItemView`’s `==` so SwiftUI `.equatable()` correctly accounts for environment changes and doesn’t skip necessary updates. Expanded the inline comment to require listing stored `@Environment` values in `==` to avoid the CLAUDE.md “Snapshot boundary” pitfall.

<sup>Written for commit 5c94c5c29df71ae05347419aa32373c7dc814618. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4530?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed color scheme responsiveness in tab navigation views to ensure UI updates correctly when system appearance changes.

* **Documentation**
  * Added inline clarification on environment state handling in view equality logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4530?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->