### PR TITLE
Move resume command approvals into cmux.json

### DIFF
--- a/Sources/CmuxSettingsJSONPathSupport.swift
+++ b/Sources/CmuxSettingsJSONPathSupport.swift
@@ -69,6 +69,7 @@ extension CmuxSettingsFileStore {
         "app.commandPaletteSearchesAllSurfaces",
         "terminal.showScrollBar",
         "terminal.autoResumeAgentSessions",
+        "terminal.resumeCommands",
         "notifications.dockBadge",
         "notifications.showInMenuBar",
         "notifications.unreadPaneRing",

--- a/Sources/JSONCParser.swift
+++ b/Sources/JSONCParser.swift
@@ -252,7 +252,7 @@ enum JSONCObjectEditor {
         let parentIndent = propertyIndent(for: root, in: source)
         let childIndent = parentIndent + "  "
         let childProperty = propertyText(key: childKey, valueJSON: childValueJSON, indent: childIndent)
-        let parentProperty = "\(parentIndent)\"\(parentKey)\": {\n\(childProperty)\n\(parentIndent)}"
+        let parentProperty = "\(parentIndent)\(quotedJSONString(parentKey)): {\n\(childProperty)\n\(parentIndent)}"
         return inserting(parentProperty, into: root, in: source)
     }
 
@@ -495,7 +495,18 @@ enum JSONCObjectEditor {
     }
 
     private static func propertyText(key: String, valueJSON: String, indent: String) -> String {
-        "\(indent)\"\(key)\": \(valueJSONForProperty(valueJSON, propertyIndent: indent))"
+        "\(indent)\(quotedJSONString(key)): \(valueJSONForProperty(valueJSON, propertyIndent: indent))"
+    }
+
+    private static func quotedJSONString(_ value: String) -> String {
+        let encoder = JSONEncoder()
+        if let data = try? encoder.encode(value),
+           let encoded = String(data: data, encoding: .utf8) {
+            return encoded
+        }
+        return "\"" + value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"") + "\""
     }
 
     private static func valueJSONForProperty(_ valueJSON: String, propertyIndent: String) -> String {

--- a/Sources/JSONCParser.swift
+++ b/Sources/JSONCParser.swift
@@ -9,13 +9,13 @@ enum JSONCParser {
         return Data(normalized.utf8)
     }
 
-    private static func sourceString(from data: Data) throws -> String {
+    static func source(data: Data) throws -> (text: String, encoding: String.Encoding) {
         if let encoding = detectedJSONEncoding(for: data),
            let source = String(data: data, encoding: encoding) {
-            return source
+            return (source, encoding)
         }
         if let source = String(data: data, encoding: .utf8) {
-            return source
+            return (source, .utf8)
         }
 
         var convertedString: NSString?
@@ -38,15 +38,20 @@ enum JSONCParser {
         )
 
         if let convertedString, !usedLossyConversion.boolValue {
-            return convertedString as String
+            let stringEncoding = encoding == 0 ? String.Encoding.utf8 : String.Encoding(rawValue: encoding)
+            return (convertedString as String, stringEncoding)
         }
         if encoding != 0, !usedLossyConversion.boolValue {
             let stringEncoding = String.Encoding(rawValue: encoding)
-            if let source = String(data: data, encoding: stringEncoding) {
-                return source
+            if let string = String(data: data, encoding: stringEncoding) {
+                return (string, stringEncoding)
             }
         }
         throw JSONCError.invalidTextEncoding
+    }
+
+    private static func sourceString(from data: Data) throws -> String {
+        try source(data: data).text
     }
 
     private static func detectedJSONEncoding(for data: Data) -> String.Encoding? {
@@ -225,6 +230,7 @@ enum JSONCObjectEditor {
         in source: String
     ) -> String? {
         guard let root = rootObject(in: source) else { return nil }
+        let newline = preferredNewline(in: source)
 
         if let parent = root.property(named: parentKey) {
             let parentValueStart = skipWhitespaceAndComments(in: source, from: parent.valueStart)
@@ -233,7 +239,10 @@ enum JSONCObjectEditor {
                let parentObject = parseObject(in: source, at: parentValueStart) {
                 if let child = parentObject.property(named: childKey) {
                     let childIndent = indentationBeforeLine(containing: child.keyStart, in: source)
-                    let replacement = valueJSONForProperty(childValueJSON, propertyIndent: childIndent)
+                    let replacement = withPreferredNewline(
+                        valueJSONForProperty(childValueJSON, propertyIndent: childIndent),
+                        newline: newline
+                    )
                     return replacing(source, from: child.valueStart, to: child.valueEnd, with: replacement)
                 }
 
@@ -245,7 +254,7 @@ enum JSONCObjectEditor {
             let parentIndent = indentationBeforeLine(containing: parent.keyStart, in: source)
             let childIndent = parentIndent + "  "
             let childProperty = propertyText(key: childKey, valueJSON: childValueJSON, indent: childIndent)
-            let replacement = "{\n\(childProperty)\n\(parentIndent)}"
+            let replacement = withPreferredNewline("{\n\(childProperty)\n\(parentIndent)}", newline: newline)
             return replacing(source, from: parent.valueStart, to: parent.valueEnd, with: replacement)
         }
 
@@ -515,6 +524,21 @@ enum JSONCObjectEditor {
         return ([first] + lines.dropFirst().map { propertyIndent + $0 }).joined(separator: "\n")
     }
 
+    private static func preferredNewline(in source: String) -> String {
+        if source.contains("\r\n") {
+            return "\r\n"
+        }
+        if source.contains("\r") {
+            return "\r"
+        }
+        return "\n"
+    }
+
+    private static func withPreferredNewline(_ text: String, newline: String) -> String {
+        guard newline != "\n" else { return text }
+        return text.replacingOccurrences(of: "\n", with: newline)
+    }
+
     private static func replacing(
         _ source: String,
         from start: String.Index,
@@ -530,6 +554,8 @@ enum JSONCObjectEditor {
         var updated = source
         let closeOffset = source.distance(from: source.startIndex, to: object.closeBrace)
         let closingIndent = indentationBeforeLine(containing: object.closeBrace, in: source)
+        let newline = preferredNewline(in: source)
+        let normalizedPropertyText = withPreferredNewline(propertyText, newline: newline)
 
         if let lastProperty = object.properties.last,
            !hasTrailingComma(after: lastProperty, before: object.closeBrace, in: source) {
@@ -540,7 +566,7 @@ enum JSONCObjectEditor {
 
         let adjustedCloseOffset = closeOffset + (object.properties.isEmpty || hasTrailingComma(after: object.properties.last, before: object.closeBrace, in: source) ? 0 : 1)
         let closeIndex = updated.index(updated.startIndex, offsetBy: adjustedCloseOffset)
-        updated.insert(contentsOf: "\n\(propertyText)\n\(closingIndent)", at: closeIndex)
+        updated.insert(contentsOf: "\(newline)\(normalizedPropertyText)\(newline)\(closingIndent)", at: closeIndex)
         return updated
     }
 

--- a/Sources/JSONCParser.swift
+++ b/Sources/JSONCParser.swift
@@ -216,3 +216,326 @@ enum JSONCParser {
         }
     }
 }
+
+enum JSONCObjectEditor {
+    static func setNestedObjectProperty(
+        parentKey: String,
+        childKey: String,
+        childValueJSON: String,
+        in source: String
+    ) -> String? {
+        guard let root = rootObject(in: source) else { return nil }
+
+        if let parent = root.property(named: parentKey) {
+            let parentValueStart = skipWhitespaceAndComments(in: source, from: parent.valueStart)
+            guard parentValueStart < source.endIndex else { return nil }
+            if source[parentValueStart] == "{",
+               let parentObject = parseObject(in: source, at: parentValueStart) {
+                if let child = parentObject.property(named: childKey) {
+                    let childIndent = indentationBeforeLine(containing: child.keyStart, in: source)
+                    let replacement = valueJSONForProperty(childValueJSON, propertyIndent: childIndent)
+                    return replacing(source, from: child.valueStart, to: child.valueEnd, with: replacement)
+                }
+
+                let childIndent = propertyIndent(for: parentObject, in: source)
+                let childProperty = propertyText(key: childKey, valueJSON: childValueJSON, indent: childIndent)
+                return inserting(childProperty, into: parentObject, in: source)
+            }
+
+            let parentIndent = indentationBeforeLine(containing: parent.keyStart, in: source)
+            let childIndent = parentIndent + "  "
+            let childProperty = propertyText(key: childKey, valueJSON: childValueJSON, indent: childIndent)
+            let replacement = "{\n\(childProperty)\n\(parentIndent)}"
+            return replacing(source, from: parent.valueStart, to: parent.valueEnd, with: replacement)
+        }
+
+        let parentIndent = propertyIndent(for: root, in: source)
+        let childIndent = parentIndent + "  "
+        let childProperty = propertyText(key: childKey, valueJSON: childValueJSON, indent: childIndent)
+        let parentProperty = "\(parentIndent)\"\(parentKey)\": {\n\(childProperty)\n\(parentIndent)}"
+        return inserting(parentProperty, into: root, in: source)
+    }
+
+    private struct ObjectRange {
+        let openBrace: String.Index
+        let closeBrace: String.Index
+        let properties: [PropertyRange]
+
+        func property(named key: String) -> PropertyRange? {
+            properties.first { $0.key == key }
+        }
+    }
+
+    private struct PropertyRange {
+        let key: String
+        let keyStart: String.Index
+        let valueStart: String.Index
+        let valueEnd: String.Index
+    }
+
+    private static func rootObject(in source: String) -> ObjectRange? {
+        var index = skipWhitespaceAndComments(in: source, from: source.startIndex)
+        if index < source.endIndex, source[index] == "\u{feff}" {
+            index = source.index(after: index)
+            index = skipWhitespaceAndComments(in: source, from: index)
+        }
+        guard index < source.endIndex, source[index] == "{" else { return nil }
+        return parseObject(in: source, at: index)
+    }
+
+    private static func parseObject(in source: String, at openBrace: String.Index) -> ObjectRange? {
+        guard openBrace < source.endIndex, source[openBrace] == "{" else { return nil }
+        guard let closeBrace = matchingContainerEnd(in: source, at: openBrace) else { return nil }
+
+        var properties: [PropertyRange] = []
+        var index = source.index(after: openBrace)
+        while true {
+            index = skipWhitespaceAndComments(in: source, from: index)
+            guard index < closeBrace else {
+                return ObjectRange(openBrace: openBrace, closeBrace: closeBrace, properties: properties)
+            }
+            if source[index] == "," {
+                index = source.index(after: index)
+                continue
+            }
+            guard source[index] == "\"",
+                  let parsedKey = parseJSONString(in: source, at: index) else {
+                return nil
+            }
+
+            index = skipWhitespaceAndComments(in: source, from: parsedKey.end)
+            guard index < closeBrace, source[index] == ":" else { return nil }
+            index = source.index(after: index)
+            let valueStart = skipWhitespaceAndComments(in: source, from: index)
+            guard valueStart < closeBrace,
+                  let valueEnd = skipValue(in: source, from: valueStart) else {
+                return nil
+            }
+
+            properties.append(PropertyRange(
+                key: parsedKey.value,
+                keyStart: parsedKey.start,
+                valueStart: valueStart,
+                valueEnd: valueEnd
+            ))
+            index = valueEnd
+        }
+    }
+
+    private static func matchingContainerEnd(in source: String, at start: String.Index) -> String.Index? {
+        let opening = source[start]
+        let closing: Character
+        if opening == "{" {
+            closing = "}"
+        } else if opening == "[" {
+            closing = "]"
+        } else {
+            return nil
+        }
+
+        var stack: [Character] = [closing]
+        var index = source.index(after: start)
+        while index < source.endIndex {
+            let character = source[index]
+            if character == "\"" {
+                guard let stringEnd = parseJSONString(in: source, at: index)?.end else { return nil }
+                index = stringEnd
+                continue
+            }
+            if character == "/" {
+                let next = source.index(after: index)
+                if next < source.endIndex, source[next] == "/" {
+                    index = source.index(after: next)
+                    while index < source.endIndex, source[index] != "\n" {
+                        index = source.index(after: index)
+                    }
+                    continue
+                }
+                if next < source.endIndex, source[next] == "*" {
+                    index = source.index(after: next)
+                    while index < source.endIndex {
+                        let following = source.index(after: index)
+                        if source[index] == "*", following < source.endIndex, source[following] == "/" {
+                            index = source.index(after: following)
+                            break
+                        }
+                        index = following
+                    }
+                    continue
+                }
+            }
+            if character == "{" {
+                stack.append("}")
+            } else if character == "[" {
+                stack.append("]")
+            } else if character == stack.last {
+                stack.removeLast()
+                if stack.isEmpty {
+                    return index
+                }
+            }
+            index = source.index(after: index)
+        }
+        return nil
+    }
+
+    private static func skipValue(in source: String, from start: String.Index) -> String.Index? {
+        guard start < source.endIndex else { return nil }
+        let character = source[start]
+        if character == "{" || character == "[" {
+            guard let end = matchingContainerEnd(in: source, at: start) else { return nil }
+            return source.index(after: end)
+        }
+        if character == "\"" {
+            return parseJSONString(in: source, at: start)?.end
+        }
+
+        var index = start
+        while index < source.endIndex {
+            let current = source[index]
+            if current == "," || current == "}" || current == "]" || current.isWhitespace {
+                return index
+            }
+            if current == "/" {
+                let next = source.index(after: index)
+                if next < source.endIndex, source[next] == "/" || source[next] == "*" {
+                    return index
+                }
+            }
+            index = source.index(after: index)
+        }
+        return index
+    }
+
+    private static func parseJSONString(in source: String, at start: String.Index) -> (start: String.Index, end: String.Index, value: String)? {
+        guard start < source.endIndex, source[start] == "\"" else { return nil }
+        var index = source.index(after: start)
+        var isEscaped = false
+        while index < source.endIndex {
+            let character = source[index]
+            if isEscaped {
+                isEscaped = false
+            } else if character == "\\" {
+                isEscaped = true
+            } else if character == "\"" {
+                let end = source.index(after: index)
+                let raw = String(source[start..<end])
+                guard let data = raw.data(using: .utf8),
+                      let value = try? JSONDecoder().decode(String.self, from: data) else {
+                    return nil
+                }
+                return (start, end, value)
+            }
+            index = source.index(after: index)
+        }
+        return nil
+    }
+
+    private static func skipWhitespaceAndComments(in source: String, from start: String.Index) -> String.Index {
+        var index = start
+        while index < source.endIndex {
+            let character = source[index]
+            if character.isWhitespace || character == "\u{feff}" {
+                index = source.index(after: index)
+                continue
+            }
+            if character == "/" {
+                let next = source.index(after: index)
+                if next < source.endIndex, source[next] == "/" {
+                    index = source.index(after: next)
+                    while index < source.endIndex, source[index] != "\n" {
+                        index = source.index(after: index)
+                    }
+                    continue
+                }
+                if next < source.endIndex, source[next] == "*" {
+                    index = source.index(after: next)
+                    while index < source.endIndex {
+                        let following = source.index(after: index)
+                        if source[index] == "*", following < source.endIndex, source[following] == "/" {
+                            index = source.index(after: following)
+                            break
+                        }
+                        index = following
+                    }
+                    continue
+                }
+            }
+            return index
+        }
+        return index
+    }
+
+    private static func propertyIndent(for object: ObjectRange, in source: String) -> String {
+        indentationBeforeLine(containing: object.closeBrace, in: source) + "  "
+    }
+
+    private static func indentationBeforeLine(containing index: String.Index, in source: String) -> String {
+        var lineStart = index
+        while lineStart > source.startIndex {
+            let previous = source.index(before: lineStart)
+            if source[previous] == "\n" || source[previous] == "\r" {
+                break
+            }
+            lineStart = previous
+        }
+
+        var indentation = ""
+        var cursor = lineStart
+        while cursor < source.endIndex {
+            let character = source[cursor]
+            if character == " " || character == "\t" {
+                indentation.append(character)
+                cursor = source.index(after: cursor)
+                continue
+            }
+            break
+        }
+        return indentation
+    }
+
+    private static func propertyText(key: String, valueJSON: String, indent: String) -> String {
+        "\(indent)\"\(key)\": \(valueJSONForProperty(valueJSON, propertyIndent: indent))"
+    }
+
+    private static func valueJSONForProperty(_ valueJSON: String, propertyIndent: String) -> String {
+        let lines = valueJSON.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        guard let first = lines.first else { return valueJSON }
+        return ([first] + lines.dropFirst().map { propertyIndent + $0 }).joined(separator: "\n")
+    }
+
+    private static func replacing(
+        _ source: String,
+        from start: String.Index,
+        to end: String.Index,
+        with replacement: String
+    ) -> String {
+        var updated = source
+        updated.replaceSubrange(start..<end, with: replacement)
+        return updated
+    }
+
+    private static func inserting(_ propertyText: String, into object: ObjectRange, in source: String) -> String {
+        var updated = source
+        let closeOffset = source.distance(from: source.startIndex, to: object.closeBrace)
+        let closingIndent = indentationBeforeLine(containing: object.closeBrace, in: source)
+
+        if let lastProperty = object.properties.last,
+           !hasTrailingComma(after: lastProperty, before: object.closeBrace, in: source) {
+            let commaOffset = source.distance(from: source.startIndex, to: lastProperty.valueEnd)
+            let commaIndex = updated.index(updated.startIndex, offsetBy: commaOffset)
+            updated.insert(",", at: commaIndex)
+        }
+
+        let adjustedCloseOffset = closeOffset + (object.properties.isEmpty || hasTrailingComma(after: object.properties.last, before: object.closeBrace, in: source) ? 0 : 1)
+        let closeIndex = updated.index(updated.startIndex, offsetBy: adjustedCloseOffset)
+        updated.insert(contentsOf: "\n\(propertyText)\n\(closingIndent)", at: closeIndex)
+        return updated
+    }
+
+    private static func hasTrailingComma(after property: PropertyRange?, before closeBrace: String.Index, in source: String) -> Bool {
+        guard let property else { return false }
+        let index = skipWhitespaceAndComments(in: source, from: property.valueEnd)
+        return index < closeBrace && source[index] == ","
+    }
+}

--- a/Sources/KeyboardShortcutSettingsFileStore+Template.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore+Template.swift
@@ -81,6 +81,7 @@ extension CmuxSettingsFileStore {
                 "terminal": [
                     "showScrollBar": TerminalScrollBarSettings.defaultShowScrollBar,
                     "autoResumeAgentSessions": AgentSessionAutoResumeSettings.defaultAutoResumeAgentSessions,
+                    "resumeCommands": [],
                 ],
             ],
             [

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -1067,21 +1067,24 @@ enum SurfaceResumeApprovalStore {
                 return false
             case .parsed:
                 guard let existingData = fileManager.contents(atPath: fileURL.path),
-                      let source = String(data: existingData, encoding: .utf8),
+                      let decodedSource = try? JSONCParser.source(data: existingData),
                       let updatedSource = JSONCObjectEditor.setNestedObjectProperty(
                           parentKey: settingsTerminalSectionKey,
                           childKey: settingsRecordsKey,
                           childValueJSON: recordsJSON,
-                          in: source
+                          in: decodedSource.text
                       ) else {
                     return false
                 }
-                let sanitized = try JSONCParser.preprocess(data: Data(updatedSource.utf8))
+                guard let updatedData = updatedSource.data(using: decodedSource.encoding) else {
+                    return false
+                }
+                let sanitized = try JSONCParser.preprocess(data: updatedData)
                 guard let root = try JSONSerialization.jsonObject(with: sanitized, options: []) as? [String: Any],
                       JSONSerialization.isValidJSONObject(root) else {
                     return false
                 }
-                data = Data(updatedSource.utf8)
+                data = updatedData
             }
 
             try fileManager.createDirectory(

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -1040,32 +1040,50 @@ enum SurfaceResumeApprovalStore {
     ) -> Bool {
         do {
             let rootLoadResult = loadCmuxSettingsRoot(fileURL: fileURL)
-            var root: [String: Any]
-            switch rootLoadResult {
-            case .missing:
-                root = [
-                    "$schema": CmuxSettingsFileStore.schemaURLString,
-                    "schemaVersion": CmuxSettingsFileStore.currentSchemaVersion,
-                ]
-            case .invalid:
-                return false
-            case .parsed(let parsedRoot):
-                root = parsedRoot
-            }
 
             let encoder = JSONEncoder()
-            encoder.outputFormatting = [.sortedKeys]
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
             let recordsData = try encoder.encode(records)
             let recordsValue = try JSONSerialization.jsonObject(with: recordsData, options: [])
-
-            var terminalSection = root[settingsTerminalSectionKey] as? [String: Any] ?? [:]
-            terminalSection[settingsRecordsKey] = recordsValue
-            root[settingsTerminalSectionKey] = terminalSection
-
-            guard JSONSerialization.isValidJSONObject(root) else {
+            guard let recordsJSON = String(data: recordsData, encoding: .utf8) else {
                 return false
             }
-            let data = try JSONSerialization.data(withJSONObject: root, options: [.prettyPrinted, .sortedKeys])
+
+            let data: Data
+            switch rootLoadResult {
+            case .missing:
+                let root: [String: Any] = [
+                    "$schema": CmuxSettingsFileStore.schemaURLString,
+                    "schemaVersion": CmuxSettingsFileStore.currentSchemaVersion,
+                    settingsTerminalSectionKey: [
+                        settingsRecordsKey: recordsValue,
+                    ],
+                ]
+                guard JSONSerialization.isValidJSONObject(root) else {
+                    return false
+                }
+                data = try JSONSerialization.data(withJSONObject: root, options: [.prettyPrinted, .sortedKeys])
+            case .invalid:
+                return false
+            case .parsed:
+                guard let existingData = fileManager.contents(atPath: fileURL.path),
+                      let source = String(data: existingData, encoding: .utf8),
+                      let updatedSource = JSONCObjectEditor.setNestedObjectProperty(
+                          parentKey: settingsTerminalSectionKey,
+                          childKey: settingsRecordsKey,
+                          childValueJSON: recordsJSON,
+                          in: source
+                      ) else {
+                    return false
+                }
+                let sanitized = try JSONCParser.preprocess(data: Data(updatedSource.utf8))
+                guard let root = try JSONSerialization.jsonObject(with: sanitized, options: []) as? [String: Any],
+                      JSONSerialization.isValidJSONObject(root) else {
+                    return false
+                }
+                data = Data(updatedSource.utf8)
+            }
+
             try fileManager.createDirectory(
                 at: fileURL.deletingLastPathComponent(),
                 withIntermediateDirectories: true

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -633,9 +633,40 @@ enum SurfaceResumeApprovalStore {
             guard fileURL.standardizedFileURL.path == defaultURL().standardizedFileURL.path else {
                 return loaded.records
             }
-            return loadStandaloneRecords(fileURL: legacyDefaultURL(), fileManager: fileManager)
+            let legacyURL = legacyURL(forCmuxSettingsURL: fileURL)
+            let legacyRecords = loadStandaloneRecords(fileURL: legacyURL, fileManager: fileManager)
+            guard !legacyRecords.isEmpty else {
+                return loaded.records
+            }
+            _ = migrateLegacyRecordsIfNeeded(
+                fileURL: fileURL,
+                fileManager: fileManager,
+                legacyFileURL: legacyURL
+            )
+            return legacyRecords
         }
         return loadStandaloneRecords(fileURL: fileURL, fileManager: fileManager)
+    }
+
+    @discardableResult
+    static func migrateLegacyRecordsIfNeeded(
+        fileURL: URL = defaultURL(),
+        fileManager: FileManager = .default,
+        legacyFileURL: URL? = nil
+    ) -> Bool {
+        guard storesRecordsInCmuxSettings(fileURL) else {
+            return false
+        }
+        let loaded = loadRecordsFromCmuxSettings(fileURL: fileURL)
+        guard !loaded.hasResumeCommandsKey else {
+            return false
+        }
+        let legacyURL = legacyFileURL ?? legacyURL(forCmuxSettingsURL: fileURL)
+        let legacyRecords = loadStandaloneRecords(fileURL: legacyURL, fileManager: fileManager)
+        guard !legacyRecords.isEmpty else {
+            return false
+        }
+        return writeRecordsToCmuxSettings(records: legacyRecords, fileURL: fileURL, fileManager: fileManager)
     }
 
     private static func loadStandaloneRecords(
@@ -944,9 +975,8 @@ enum SurfaceResumeApprovalStore {
         fileURL.lastPathComponent == "cmux.json"
     }
 
-    private static func legacyDefaultURL() -> URL {
-        FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".config/cmux", isDirectory: true)
+    private static func legacyURL(forCmuxSettingsURL fileURL: URL) -> URL {
+        fileURL.deletingLastPathComponent()
             .appendingPathComponent(legacyFileName, isDirectory: false)
     }
 

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -601,8 +601,10 @@ enum SurfaceResumeApprovalSignature {
 
 enum SurfaceResumeApprovalStore {
     static let didChangeNotification = Notification.Name("cmux.surfaceResumeApprovalsDidChange")
-    private static let defaultFileName = "resume-commands.json"
+    private static let legacyFileName = "resume-commands.json"
     private static let secretFileName = ".surface-resume-approval-secret"
+    private static let settingsTerminalSectionKey = "terminal"
+    private static let settingsRecordsKey = "resumeCommands"
     private static let keychainService = "com.cmuxterm.app.surface-resume-approvals"
     private static let keychainAccount = "hmac-secret-v1"
 
@@ -616,14 +618,29 @@ enum SurfaceResumeApprovalStore {
            !override.isEmpty {
             return URL(fileURLWithPath: (override as NSString).expandingTildeInPath, isDirectory: false)
         }
-        return FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".config/cmux", isDirectory: true)
-            .appendingPathComponent(defaultFileName, isDirectory: false)
+        return URL(fileURLWithPath: CmuxSettingsFileStore.defaultPrimaryPath, isDirectory: false)
     }
 
     static func loadRecords(
         fileURL: URL = defaultURL(),
         fileManager: FileManager = .default
+    ) -> [SurfaceResumeApprovalRecord] {
+        if storesRecordsInCmuxSettings(fileURL) {
+            let loaded = loadRecordsFromCmuxSettings(fileURL: fileURL)
+            if loaded.hasResumeCommandsKey {
+                return loaded.records
+            }
+            guard fileURL.standardizedFileURL.path == defaultURL().standardizedFileURL.path else {
+                return loaded.records
+            }
+            return loadStandaloneRecords(fileURL: legacyDefaultURL(), fileManager: fileManager)
+        }
+        return loadStandaloneRecords(fileURL: fileURL, fileManager: fileManager)
+    }
+
+    private static func loadStandaloneRecords(
+        fileURL: URL,
+        fileManager: FileManager
     ) -> [SurfaceResumeApprovalRecord] {
         guard let data = try? Data(contentsOf: fileURL) else { return [] }
         if let file = try? JSONDecoder().decode(StoredFile.self, from: data) {
@@ -843,6 +860,9 @@ enum SurfaceResumeApprovalStore {
         fileURL: URL = defaultURL(),
         fileManager: FileManager = .default
     ) -> Bool {
+        if storesRecordsInCmuxSettings(fileURL) {
+            return write(records: [], fileURL: fileURL, fileManager: fileManager)
+        }
         try? fileManager.removeItem(at: fileURL)
         NotificationCenter.default.post(name: didChangeNotification, object: nil)
         return true
@@ -890,6 +910,18 @@ enum SurfaceResumeApprovalStore {
         fileURL: URL,
         fileManager: FileManager
     ) -> Bool {
+        if storesRecordsInCmuxSettings(fileURL) {
+            return writeRecordsToCmuxSettings(records: records, fileURL: fileURL, fileManager: fileManager)
+        }
+        return writeStandaloneRecords(records: records, fileURL: fileURL, fileManager: fileManager)
+    }
+
+    @discardableResult
+    private static func writeStandaloneRecords(
+        records: [SurfaceResumeApprovalRecord],
+        fileURL: URL,
+        fileManager: FileManager
+    ) -> Bool {
         do {
             try fileManager.createDirectory(
                 at: fileURL.deletingLastPathComponent(),
@@ -899,6 +931,87 @@ enum SurfaceResumeApprovalStore {
             let encoder = JSONEncoder()
             encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
             let data = try encoder.encode(StoredFile(version: 1, records: records))
+            try data.write(to: fileURL, options: [.atomic])
+            try? fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: fileURL.path)
+            NotificationCenter.default.post(name: didChangeNotification, object: nil)
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    private static func storesRecordsInCmuxSettings(_ fileURL: URL) -> Bool {
+        fileURL.lastPathComponent == "cmux.json"
+    }
+
+    private static func legacyDefaultURL() -> URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".config/cmux", isDirectory: true)
+            .appendingPathComponent(legacyFileName, isDirectory: false)
+    }
+
+    private static func loadRecordsFromCmuxSettings(
+        fileURL: URL
+    ) -> (records: [SurfaceResumeApprovalRecord], hasResumeCommandsKey: Bool) {
+        guard let root = loadCmuxSettingsRoot(fileURL: fileURL) else {
+            return ([], false)
+        }
+        guard let terminalSection = root[settingsTerminalSectionKey] as? [String: Any],
+              let rawRecords = terminalSection[settingsRecordsKey] else {
+            return ([], false)
+        }
+        guard JSONSerialization.isValidJSONObject(rawRecords),
+              let data = try? JSONSerialization.data(withJSONObject: rawRecords, options: []),
+              let records = try? JSONDecoder().decode([SurfaceResumeApprovalRecord].self, from: data) else {
+            NSLog("[SurfaceResumeApprovalStore] ignoring invalid terminal.%@ in %@", settingsRecordsKey, fileURL.path)
+            return ([], true)
+        }
+        return (records, true)
+    }
+
+    private static func loadCmuxSettingsRoot(fileURL: URL) -> [String: Any]? {
+        guard let data = try? Data(contentsOf: fileURL), !data.isEmpty else {
+            return nil
+        }
+        do {
+            let sanitized = try JSONCParser.preprocess(data: data)
+            return try JSONSerialization.jsonObject(with: sanitized, options: []) as? [String: Any]
+        } catch {
+            NSLog("[SurfaceResumeApprovalStore] parse error at %@: %@", fileURL.path, String(describing: error))
+            return nil
+        }
+    }
+
+    @discardableResult
+    private static func writeRecordsToCmuxSettings(
+        records: [SurfaceResumeApprovalRecord],
+        fileURL: URL,
+        fileManager: FileManager
+    ) -> Bool {
+        do {
+            var root = loadCmuxSettingsRoot(fileURL: fileURL) ?? [
+                "$schema": CmuxSettingsFileStore.schemaURLString,
+                "schemaVersion": CmuxSettingsFileStore.currentSchemaVersion,
+            ]
+
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.sortedKeys]
+            let recordsData = try encoder.encode(records)
+            let recordsValue = try JSONSerialization.jsonObject(with: recordsData, options: [])
+
+            var terminalSection = root[settingsTerminalSectionKey] as? [String: Any] ?? [:]
+            terminalSection[settingsRecordsKey] = recordsValue
+            root[settingsTerminalSectionKey] = terminalSection
+
+            guard JSONSerialization.isValidJSONObject(root) else {
+                return false
+            }
+            let data = try JSONSerialization.data(withJSONObject: root, options: [.prettyPrinted, .sortedKeys])
+            try fileManager.createDirectory(
+                at: fileURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try? fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: fileURL.deletingLastPathComponent().path)
             try data.write(to: fileURL, options: [.atomic])
             try? fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: fileURL.path)
             NotificationCenter.default.post(name: didChangeNotification, object: nil)

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -613,6 +613,12 @@ enum SurfaceResumeApprovalStore {
         var records: [SurfaceResumeApprovalRecord]
     }
 
+    private enum CmuxSettingsRootLoadResult {
+        case missing
+        case invalid
+        case parsed([String: Any])
+    }
+
     static func defaultURL(environment: [String: String] = ProcessInfo.processInfo.environment) -> URL {
         if let override = environment["CMUX_SURFACE_RESUME_APPROVAL_STORE_PATH"]?.trimmingCharacters(in: .whitespacesAndNewlines),
            !override.isEmpty {
@@ -628,6 +634,9 @@ enum SurfaceResumeApprovalStore {
         if storesRecordsInCmuxSettings(fileURL) {
             let loaded = loadRecordsFromCmuxSettings(fileURL: fileURL)
             if loaded.hasResumeCommandsKey {
+                return loaded.records
+            }
+            guard loaded.canWriteSettings else {
                 return loaded.records
             }
             guard fileURL.standardizedFileURL.path == defaultURL().standardizedFileURL.path else {
@@ -659,6 +668,9 @@ enum SurfaceResumeApprovalStore {
         }
         let loaded = loadRecordsFromCmuxSettings(fileURL: fileURL)
         guard !loaded.hasResumeCommandsKey else {
+            return false
+        }
+        guard loaded.canWriteSettings else {
             return false
         }
         let legacyURL = legacyFileURL ?? legacyURL(forCmuxSettingsURL: fileURL)
@@ -982,33 +994,40 @@ enum SurfaceResumeApprovalStore {
 
     private static func loadRecordsFromCmuxSettings(
         fileURL: URL
-    ) -> (records: [SurfaceResumeApprovalRecord], hasResumeCommandsKey: Bool) {
-        guard let root = loadCmuxSettingsRoot(fileURL: fileURL) else {
-            return ([], false)
+    ) -> (records: [SurfaceResumeApprovalRecord], hasResumeCommandsKey: Bool, canWriteSettings: Bool) {
+        let root: [String: Any]
+        switch loadCmuxSettingsRoot(fileURL: fileURL) {
+        case .missing:
+            return ([], false, true)
+        case .invalid:
+            return ([], false, false)
+        case .parsed(let parsedRoot):
+            root = parsedRoot
         }
         guard let terminalSection = root[settingsTerminalSectionKey] as? [String: Any],
               let rawRecords = terminalSection[settingsRecordsKey] else {
-            return ([], false)
+            return ([], false, true)
         }
         guard JSONSerialization.isValidJSONObject(rawRecords),
               let data = try? JSONSerialization.data(withJSONObject: rawRecords, options: []),
               let records = try? JSONDecoder().decode([SurfaceResumeApprovalRecord].self, from: data) else {
-            NSLog("[SurfaceResumeApprovalStore] ignoring invalid terminal.%@ in %@", settingsRecordsKey, fileURL.path)
-            return ([], true)
+            return ([], true, true)
         }
-        return (records, true)
+        return (records, true, true)
     }
 
-    private static func loadCmuxSettingsRoot(fileURL: URL) -> [String: Any]? {
+    private static func loadCmuxSettingsRoot(fileURL: URL) -> CmuxSettingsRootLoadResult {
         guard let data = try? Data(contentsOf: fileURL), !data.isEmpty else {
-            return nil
+            return .missing
         }
         do {
             let sanitized = try JSONCParser.preprocess(data: data)
-            return try JSONSerialization.jsonObject(with: sanitized, options: []) as? [String: Any]
+            guard let root = try JSONSerialization.jsonObject(with: sanitized, options: []) as? [String: Any] else {
+                return .invalid
+            }
+            return .parsed(root)
         } catch {
-            NSLog("[SurfaceResumeApprovalStore] parse error at %@: %@", fileURL.path, String(describing: error))
-            return nil
+            return .invalid
         }
     }
 
@@ -1019,10 +1038,19 @@ enum SurfaceResumeApprovalStore {
         fileManager: FileManager
     ) -> Bool {
         do {
-            var root = loadCmuxSettingsRoot(fileURL: fileURL) ?? [
-                "$schema": CmuxSettingsFileStore.schemaURLString,
-                "schemaVersion": CmuxSettingsFileStore.currentSchemaVersion,
-            ]
+            let rootLoadResult = loadCmuxSettingsRoot(fileURL: fileURL)
+            var root: [String: Any]
+            switch rootLoadResult {
+            case .missing:
+                root = [
+                    "$schema": CmuxSettingsFileStore.schemaURLString,
+                    "schemaVersion": CmuxSettingsFileStore.currentSchemaVersion,
+                ]
+            case .invalid:
+                return false
+            case .parsed(let parsedRoot):
+                root = parsedRoot
+            }
 
             let encoder = JSONEncoder()
             encoder.outputFormatting = [.sortedKeys]

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -629,23 +629,24 @@ enum SurfaceResumeApprovalStore {
 
     static func loadRecords(
         fileURL: URL = defaultURL(),
-        fileManager: FileManager = .default
+        fileManager: FileManager = .default,
+        defaultSettingsURL: URL = defaultURL()
     ) -> [SurfaceResumeApprovalRecord] {
         if storesRecordsInCmuxSettings(fileURL) {
             let loaded = loadRecordsFromCmuxSettings(fileURL: fileURL)
             if loaded.hasResumeCommandsKey {
                 return loaded.records
             }
-            guard loaded.canWriteSettings else {
-                return loaded.records
-            }
-            guard fileURL.standardizedFileURL.path == defaultURL().standardizedFileURL.path else {
+            guard fileURL.standardizedFileURL.path == defaultSettingsURL.standardizedFileURL.path else {
                 return loaded.records
             }
             let legacyURL = legacyURL(forCmuxSettingsURL: fileURL)
             let legacyRecords = loadStandaloneRecords(fileURL: legacyURL, fileManager: fileManager)
             guard !legacyRecords.isEmpty else {
                 return loaded.records
+            }
+            guard loaded.canWriteSettings else {
+                return legacyRecords
             }
             _ = migrateLegacyRecordsIfNeeded(
                 fileURL: fileURL,

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -7740,7 +7740,7 @@ private struct SurfaceResumeApprovalSettingsCard: View {
     var body: some View {
         SettingsCard {
             SettingsCardRow(
-                configurationReview: .settingsOnly,
+                configurationReview: .json("terminal.resumeCommands"),
                 String(localized: "settings.terminal.resumeCommands", defaultValue: "Resume Commands"),
                 subtitle: String(
                     localized: "settings.terminal.resumeCommands.subtitle",

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -7735,10 +7735,7 @@ struct SettingsView: View {
 }
 
 private struct SurfaceResumeApprovalSettingsCard: View {
-    @State private var records: [SurfaceResumeApprovalRecord] = []
-    @State private var prefixDrafts: [String: String] = [:]
-    @State private var statusMessage: String?
-    @State private var statusIsError = false
+    @State private var recordCount = 0
 
     var body: some View {
         SettingsCard {
@@ -7749,45 +7746,20 @@ private struct SurfaceResumeApprovalSettingsCard: View {
                     localized: "settings.terminal.resumeCommands.subtitle",
                     defaultValue: "Review signed command prefixes that can restore non-agent terminal surfaces."
                 ),
-                controlWidth: 80,
+                controlWidth: 170,
                 searchAnchorID: SettingsSearchIndex.settingID(for: .terminal, idSuffix: "resume-commands")
             ) {
-                Text(String(format: "%d", records.count))
-                    .font(.caption.monospacedDigit())
-                    .foregroundColor(.secondary)
-            }
+                HStack(spacing: 8) {
+                    Text(String(format: "%d", recordCount))
+                        .font(.caption.monospacedDigit())
+                        .foregroundColor(.secondary)
 
-            if records.isEmpty {
-                SettingsCardDivider()
-                Text(String(localized: "settings.terminal.resumeCommands.empty", defaultValue: "No custom resume commands have been approved."))
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                    .padding(.horizontal, 14)
-                    .padding(.vertical, 10)
-            } else {
-                ForEach(records) { record in
-                    SettingsCardDivider()
-                    SurfaceResumeApprovalRecordRow(
-                        record: record,
-                        prefixDraft: Binding(
-                            get: { prefixDrafts[record.id] ?? record.commandPrefixText },
-                            set: { prefixDrafts[record.id] = $0 }
-                        ),
-                        isValid: SurfaceResumeApprovalStore.isValid(record),
-                        onPolicyChange: { policy in updatePolicy(record, policy: policy) },
-                        onSavePrefix: { savePrefix(record) },
-                        onDelete: { delete(record) }
-                    )
+                    Button(String(localized: "settings.settingsJSON.openButton", defaultValue: "Open")) {
+                        openCmuxSettingsFileInEditor()
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
                 }
-            }
-
-            if let statusMessage {
-                SettingsCardDivider()
-                Text(statusMessage)
-                    .font(.caption)
-                    .foregroundColor(statusIsError ? .red : .secondary)
-                    .padding(.horizontal, 14)
-                    .padding(.vertical, 9)
             }
         }
         .onAppear(perform: reload)
@@ -7797,175 +7769,7 @@ private struct SurfaceResumeApprovalSettingsCard: View {
     }
 
     private func reload() {
-        let loadedRecords = SurfaceResumeApprovalStore.loadRecords()
-            .sorted { lhs, rhs in lhs.updatedAt > rhs.updatedAt }
-        records = loadedRecords
-        let validIds = Set(loadedRecords.map(\.id))
-        prefixDrafts = prefixDrafts.filter { validIds.contains($0.key) }
-        for record in loadedRecords where prefixDrafts[record.id] == nil {
-            prefixDrafts[record.id] = record.commandPrefixText
-        }
-    }
-
-    private func updatePolicy(_ record: SurfaceResumeApprovalRecord, policy: SurfaceResumeApprovalPolicy) {
-        guard SurfaceResumeApprovalStore.update(recordId: record.id, policy: policy) else {
-            setStatus(
-                String(localized: "settings.terminal.resumeCommands.updateFailed", defaultValue: "Could not update the resume command approval."),
-                isError: true
-            )
-            return
-        }
-        setStatus(String(localized: "settings.terminal.resumeCommands.updated", defaultValue: "Resume command approval updated."))
-        reload()
-    }
-
-    private func savePrefix(_ record: SurfaceResumeApprovalRecord) {
-        let draft = prefixDrafts[record.id] ?? record.commandPrefixText
-        guard let tokens = SurfaceResumeCommandCanonicalizer.tokens(from: draft), !tokens.isEmpty else {
-            setStatus(
-                String(localized: "settings.terminal.resumeCommands.invalidPrefix", defaultValue: "Enter a valid shell-style command prefix."),
-                isError: true
-            )
-            return
-        }
-        guard SurfaceResumeApprovalStore.update(recordId: record.id, commandPrefix: tokens) else {
-            setStatus(
-                String(localized: "settings.terminal.resumeCommands.updateFailed", defaultValue: "Could not update the resume command approval."),
-                isError: true
-            )
-            return
-        }
-        setStatus(String(localized: "settings.terminal.resumeCommands.updated", defaultValue: "Resume command approval updated."))
-        reload()
-    }
-
-    private func delete(_ record: SurfaceResumeApprovalRecord) {
-        guard SurfaceResumeApprovalStore.delete(recordId: record.id) else {
-            setStatus(
-                String(localized: "settings.terminal.resumeCommands.deleteFailed", defaultValue: "Could not delete the resume command approval."),
-                isError: true
-            )
-            return
-        }
-        setStatus(String(localized: "settings.terminal.resumeCommands.deleted", defaultValue: "Resume command approval deleted."))
-        reload()
-    }
-
-    private func setStatus(_ message: String, isError: Bool = false) {
-        statusMessage = message
-        statusIsError = isError
-    }
-}
-
-private struct SurfaceResumeApprovalRecordRow: View {
-    let record: SurfaceResumeApprovalRecord
-    @Binding var prefixDraft: String
-    let isValid: Bool
-    let onPolicyChange: (SurfaceResumeApprovalPolicy) -> Void
-    let onSavePrefix: () -> Void
-    let onDelete: () -> Void
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack(alignment: .top, spacing: 12) {
-                VStack(alignment: .leading, spacing: 3) {
-                    Text(record.name ?? record.commandPrefixText)
-                        .font(.system(size: 13, weight: .medium))
-                        .lineLimit(1)
-                    Text(summaryText)
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                        .lineLimit(2)
-                }
-                Spacer(minLength: 12)
-                Picker("", selection: policyBinding) {
-                    ForEach(SurfaceResumeApprovalPolicy.allCases, id: \.self) { policy in
-                        Text(policy.localizedSettingsTitle).tag(policy)
-                    }
-                }
-                .labelsHidden()
-                .pickerStyle(.menu)
-                .disabled(!isValid)
-                .frame(width: 136)
-            }
-
-            TextField(
-                String(localized: "settings.terminal.resumeCommands.prefixPlaceholder", defaultValue: "Command prefix"),
-                text: $prefixDraft
-            )
-            .textFieldStyle(.roundedBorder)
-            .font(.system(.caption, design: .monospaced))
-            .disabled(!isValid)
-            .onSubmit(onSavePrefix)
-
-            HStack(spacing: 8) {
-                if !isValid {
-                    Text(String(localized: "settings.terminal.resumeCommands.invalidSignature", defaultValue: "Signature does not match. Delete this approval and approve the command again."))
-                        .font(.caption)
-                        .foregroundColor(.red)
-                        .lineLimit(2)
-                } else {
-                    Text(record.source ?? String(localized: "settings.terminal.resumeCommands.sourceUnknown", defaultValue: "Unknown source"))
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                        .lineLimit(1)
-                }
-                Spacer()
-                Button(String(localized: "settings.terminal.resumeCommands.save", defaultValue: "Save")) {
-                    onSavePrefix()
-                }
-                .controlSize(.small)
-                .disabled(!isValid)
-                Button(String(localized: "settings.terminal.resumeCommands.delete", defaultValue: "Delete"), role: .destructive) {
-                    onDelete()
-                }
-                .controlSize(.small)
-            }
-        }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 10)
-    }
-
-    private var policyBinding: Binding<SurfaceResumeApprovalPolicy> {
-        Binding(
-            get: { record.policy },
-            set: { onPolicyChange($0) }
-        )
-    }
-
-    private var summaryText: String {
-        var parts = [
-            String(
-                format: String(localized: "settings.terminal.resumeCommands.prefixSummary", defaultValue: "Prefix: %@"),
-                record.commandPrefixText
-            )
-        ]
-        if let cwd = record.cwd {
-            parts.append(String(
-                format: String(localized: "settings.terminal.resumeCommands.cwdOnlySummary", defaultValue: "cwd: %@"),
-                cwd
-            ))
-        }
-        if !record.environmentKeys.isEmpty {
-            parts.append(String(
-                format: String(localized: "settings.terminal.resumeCommands.envSummary", defaultValue: "env: %@"),
-                record.environmentKeys.joined(separator: ", ")
-            ))
-        }
-        return parts.joined(separator: ", ")
-    }
-}
-
-private extension SurfaceResumeApprovalPolicy {
-    var localizedSettingsTitle: String {
-        switch self {
-        case .manual:
-            return String(localized: "settings.terminal.resumeCommands.policy.manual", defaultValue: "Manual")
-        case .prompt:
-            return String(localized: "settings.terminal.resumeCommands.policy.prompt", defaultValue: "Ask")
-        case .auto:
-            return String(localized: "settings.terminal.resumeCommands.policy.auto", defaultValue: "Auto")
-        }
+        recordCount = SurfaceResumeApprovalStore.loadRecords().count
     }
 }
 

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -4283,6 +4283,73 @@ extension SessionPersistenceTests {
         XCTAssertEqual(validRecords.first?.policy, .auto)
     }
 
+    func testSurfaceResumeApprovalMigratesLegacyRecordsIntoCmuxJSON() throws {
+        let settingsURL = try makeSurfaceResumeApprovalCmuxSettingsURL()
+        let legacyURL = settingsURL.deletingLastPathComponent()
+            .appendingPathComponent("resume-commands.json", isDirectory: false)
+        let secret = Data("approval-secret".utf8)
+        try """
+        {
+          "$schema": "https://raw.githubusercontent.com/manaflow-ai/cmux/main/web/data/cmux.schema.json",
+          "schemaVersion": 1,
+          "terminal": {
+            "showScrollBar": false
+          },
+          "rightSidebar": {
+            "width": 320
+          }
+        }
+        """.write(to: settingsURL, atomically: true, encoding: .utf8)
+
+        let binding = SurfaceResumeBindingSnapshot(
+            name: "tmux work",
+            kind: "tmux",
+            command: "tmux attach -t work",
+            cwd: "/tmp/project",
+            source: "cli",
+            environment: ["PATH": "/usr/bin:/bin"]
+        )
+
+        let record = try XCTUnwrap(SurfaceResumeApprovalStore.approve(
+            binding: binding,
+            policy: .auto,
+            commandPrefix: ["tmux", "attach"],
+            fileURL: legacyURL,
+            signingSecret: secret
+        ))
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: legacyURL.path))
+        XCTAssertTrue(SurfaceResumeApprovalStore.migrateLegacyRecordsIfNeeded(
+            fileURL: settingsURL,
+            legacyFileURL: legacyURL
+        ))
+
+        let root = try jsonObject(at: settingsURL)
+        let terminal = try XCTUnwrap(root["terminal"] as? [String: Any])
+        XCTAssertEqual(terminal["showScrollBar"] as? Bool, false)
+        let rightSidebar = try XCTUnwrap(root["rightSidebar"] as? [String: Any])
+        XCTAssertEqual((rightSidebar["width"] as? NSNumber)?.intValue, 320)
+        let storedRecords = try XCTUnwrap(terminal["resumeCommands"] as? [[String: Any]])
+        XCTAssertEqual(storedRecords.count, 1)
+        XCTAssertEqual(storedRecords.first?["id"] as? String, record.id)
+
+        let validRecords = SurfaceResumeApprovalStore.validRecords(
+            fileURL: settingsURL,
+            signingSecret: secret
+        )
+        XCTAssertEqual(validRecords.map(\.id), [record.id])
+        XCTAssertTrue(FileManager.default.fileExists(atPath: legacyURL.path))
+
+        XCTAssertFalse(SurfaceResumeApprovalStore.migrateLegacyRecordsIfNeeded(
+            fileURL: settingsURL,
+            legacyFileURL: legacyURL
+        ))
+        let rootAfterSecondMigration = try jsonObject(at: settingsURL)
+        let terminalAfterSecondMigration = try XCTUnwrap(rootAfterSecondMigration["terminal"] as? [String: Any])
+        let storedRecordsAfterSecondMigration = try XCTUnwrap(terminalAfterSecondMigration["resumeCommands"] as? [[String: Any]])
+        XCTAssertEqual(storedRecordsAfterSecondMigration.count, 1)
+    }
+
     func testSurfaceResumeApprovalPromptsForUnknownManualProposal() throws {
         let binding = SurfaceResumeBindingSnapshot(
             command: "tmux attach -t work",

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -4238,6 +4238,51 @@ extension SessionPersistenceTests {
         ))
     }
 
+    func testSurfaceResumeApprovalWritesRecordsIntoCmuxJSON() throws {
+        let settingsURL = try makeSurfaceResumeApprovalCmuxSettingsURL()
+        let secret = Data("approval-secret".utf8)
+        try """
+        {
+          "$schema": "https://raw.githubusercontent.com/manaflow-ai/cmux/main/web/data/cmux.schema.json",
+          "schemaVersion": 1,
+          "terminal": {
+            "showScrollBar": false
+          }
+        }
+        """.write(to: settingsURL, atomically: true, encoding: .utf8)
+
+        let binding = SurfaceResumeBindingSnapshot(
+            name: "tmux work",
+            kind: "tmux",
+            command: "tmux attach -t work",
+            cwd: "/tmp/project",
+            source: "cli",
+            environment: ["PATH": "/usr/bin:/bin"]
+        )
+
+        let record = try XCTUnwrap(SurfaceResumeApprovalStore.approve(
+            binding: binding,
+            policy: .auto,
+            commandPrefix: ["tmux", "attach"],
+            fileURL: settingsURL,
+            signingSecret: secret
+        ))
+
+        let root = try jsonObject(at: settingsURL)
+        let terminal = try XCTUnwrap(root["terminal"] as? [String: Any])
+        XCTAssertEqual(terminal["showScrollBar"] as? Bool, false)
+        let storedRecords = try XCTUnwrap(terminal["resumeCommands"] as? [[String: Any]])
+        XCTAssertEqual(storedRecords.count, 1)
+        XCTAssertEqual(storedRecords.first?["id"] as? String, record.id)
+
+        let validRecords = SurfaceResumeApprovalStore.validRecords(
+            fileURL: settingsURL,
+            signingSecret: secret
+        )
+        XCTAssertEqual(validRecords.map(\.id), [record.id])
+        XCTAssertEqual(validRecords.first?.policy, .auto)
+    }
+
     func testSurfaceResumeApprovalPromptsForUnknownManualProposal() throws {
         let binding = SurfaceResumeBindingSnapshot(
             command: "tmux attach -t work",
@@ -4345,6 +4390,21 @@ extension SessionPersistenceTests {
             try? FileManager.default.removeItem(at: root)
         }
         return root.appendingPathComponent("resume-commands.json", isDirectory: false)
+    }
+
+    private func makeSurfaceResumeApprovalCmuxSettingsURL() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-surface-resume-settings-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: root)
+        }
+        return root.appendingPathComponent("cmux.json", isDirectory: false)
+    }
+
+    private func jsonObject(at url: URL) throws -> [String: Any] {
+        let data = try Data(contentsOf: url)
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
     }
 
     @MainActor

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -4241,7 +4241,7 @@ extension SessionPersistenceTests {
     func testSurfaceResumeApprovalWritesRecordsIntoCmuxJSON() throws {
         let settingsURL = try makeSurfaceResumeApprovalCmuxSettingsURL()
         let secret = Data("approval-secret".utf8)
-        try """
+        let initialSettings = """
         {
           "$schema": "https://raw.githubusercontent.com/manaflow-ai/cmux/main/web/data/cmux.schema.json",
           // keep root comment
@@ -4251,7 +4251,8 @@ extension SessionPersistenceTests {
             "showScrollBar": false
           }
         }
-        """.write(to: settingsURL, atomically: true, encoding: .utf8)
+        """.replacingOccurrences(of: "\n", with: "\r\n")
+        try initialSettings.write(to: settingsURL, atomically: true, encoding: .utf8)
 
         let binding = SurfaceResumeBindingSnapshot(
             name: "tmux work",
@@ -4279,6 +4280,7 @@ extension SessionPersistenceTests {
         let updatedSettings = try String(contentsOf: settingsURL, encoding: .utf8)
         XCTAssertTrue(updatedSettings.contains("// keep root comment"))
         XCTAssertTrue(updatedSettings.contains("// keep terminal comment"))
+        XCTAssertTrue(updatedSettings.contains("\r\n    \"resumeCommands\""))
 
         let validRecords = SurfaceResumeApprovalStore.validRecords(
             fileURL: settingsURL,
@@ -4286,6 +4288,49 @@ extension SessionPersistenceTests {
         )
         XCTAssertEqual(validRecords.map(\.id), [record.id])
         XCTAssertEqual(validRecords.first?.policy, .auto)
+    }
+
+    func testSurfaceResumeApprovalWritesNonUTF8CmuxJSON() throws {
+        let settingsURL = try makeSurfaceResumeApprovalCmuxSettingsURL()
+        let secret = Data("approval-secret".utf8)
+        let initialSettings = """
+        {
+          "$schema": "https://raw.githubusercontent.com/manaflow-ai/cmux/main/web/data/cmux.schema.json",
+          // keep utf16 comment
+          "schemaVersion": 1,
+          "terminal": {
+            "showScrollBar": false
+          }
+        }
+        """
+        try XCTUnwrap(initialSettings.data(using: .utf16LittleEndian))
+            .write(to: settingsURL, options: [.atomic])
+
+        let binding = SurfaceResumeBindingSnapshot(
+            name: "tmux work",
+            kind: "tmux",
+            command: "tmux attach -t work",
+            cwd: "/tmp/project",
+            source: "cli",
+            environment: ["PATH": "/usr/bin:/bin"]
+        )
+
+        let record = try XCTUnwrap(SurfaceResumeApprovalStore.approve(
+            binding: binding,
+            policy: .auto,
+            commandPrefix: ["tmux", "attach"],
+            fileURL: settingsURL,
+            signingSecret: secret
+        ))
+
+        let updatedData = try Data(contentsOf: settingsURL)
+        let updatedSettings = try XCTUnwrap(String(data: updatedData, encoding: .utf16LittleEndian))
+        XCTAssertTrue(updatedSettings.contains("// keep utf16 comment"))
+        XCTAssertTrue(updatedSettings.contains("\"resumeCommands\""))
+        let root = try jsonObject(at: settingsURL)
+        let terminal = try XCTUnwrap(root["terminal"] as? [String: Any])
+        let storedRecords = try XCTUnwrap(terminal["resumeCommands"] as? [[String: Any]])
+        XCTAssertEqual(storedRecords.first?["id"] as? String, record.id)
     }
 
     func testSurfaceResumeApprovalMigratesLegacyRecordsIntoCmuxJSON() throws {

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -4244,8 +4244,10 @@ extension SessionPersistenceTests {
         try """
         {
           "$schema": "https://raw.githubusercontent.com/manaflow-ai/cmux/main/web/data/cmux.schema.json",
+          // keep root comment
           "schemaVersion": 1,
           "terminal": {
+            // keep terminal comment
             "showScrollBar": false
           }
         }
@@ -4274,6 +4276,9 @@ extension SessionPersistenceTests {
         let storedRecords = try XCTUnwrap(terminal["resumeCommands"] as? [[String: Any]])
         XCTAssertEqual(storedRecords.count, 1)
         XCTAssertEqual(storedRecords.first?["id"] as? String, record.id)
+        let updatedSettings = try String(contentsOf: settingsURL, encoding: .utf8)
+        XCTAssertTrue(updatedSettings.contains("// keep root comment"))
+        XCTAssertTrue(updatedSettings.contains("// keep terminal comment"))
 
         let validRecords = SurfaceResumeApprovalStore.validRecords(
             fileURL: settingsURL,
@@ -4291,10 +4296,8 @@ extension SessionPersistenceTests {
         try """
         {
           "$schema": "https://raw.githubusercontent.com/manaflow-ai/cmux/main/web/data/cmux.schema.json",
+          // keep migration comment
           "schemaVersion": 1,
-          "terminal": {
-            "showScrollBar": false
-          },
           "rightSidebar": {
             "width": 320
           }
@@ -4326,12 +4329,13 @@ extension SessionPersistenceTests {
 
         let root = try jsonObject(at: settingsURL)
         let terminal = try XCTUnwrap(root["terminal"] as? [String: Any])
-        XCTAssertEqual(terminal["showScrollBar"] as? Bool, false)
         let rightSidebar = try XCTUnwrap(root["rightSidebar"] as? [String: Any])
         XCTAssertEqual((rightSidebar["width"] as? NSNumber)?.intValue, 320)
         let storedRecords = try XCTUnwrap(terminal["resumeCommands"] as? [[String: Any]])
         XCTAssertEqual(storedRecords.count, 1)
         XCTAssertEqual(storedRecords.first?["id"] as? String, record.id)
+        let updatedSettings = try String(contentsOf: settingsURL, encoding: .utf8)
+        XCTAssertTrue(updatedSettings.contains("// keep migration comment"))
 
         let validRecords = SurfaceResumeApprovalStore.validRecords(
             fileURL: settingsURL,
@@ -4526,7 +4530,8 @@ extension SessionPersistenceTests {
 
     private func jsonObject(at url: URL) throws -> [String: Any] {
         let data = try Data(contentsOf: url)
-        return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let sanitized = try JSONCParser.preprocess(data: data)
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: sanitized) as? [String: Any])
     }
 
     @MainActor

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -4350,6 +4350,55 @@ extension SessionPersistenceTests {
         XCTAssertEqual(storedRecordsAfterSecondMigration.count, 1)
     }
 
+    func testSurfaceResumeApprovalDoesNotOverwriteInvalidCmuxJSON() throws {
+        let settingsURL = try makeSurfaceResumeApprovalCmuxSettingsURL()
+        let legacyURL = settingsURL.deletingLastPathComponent()
+            .appendingPathComponent("resume-commands.json", isDirectory: false)
+        let secret = Data("approval-secret".utf8)
+        let invalidSettingsData = Data("{ \"terminal\":".utf8)
+        try invalidSettingsData.write(to: settingsURL, options: [.atomic])
+
+        let binding = SurfaceResumeBindingSnapshot(
+            name: "tmux work",
+            kind: "tmux",
+            command: "tmux attach -t work",
+            cwd: "/tmp/project",
+            source: "cli",
+            environment: ["PATH": "/usr/bin:/bin"]
+        )
+
+        let legacyRecord = try XCTUnwrap(SurfaceResumeApprovalStore.approve(
+            binding: binding,
+            policy: .auto,
+            commandPrefix: ["tmux", "attach"],
+            fileURL: legacyURL,
+            signingSecret: secret
+        ))
+
+        XCTAssertFalse(SurfaceResumeApprovalStore.migrateLegacyRecordsIfNeeded(
+            fileURL: settingsURL,
+            legacyFileURL: legacyURL
+        ))
+        XCTAssertEqual(try Data(contentsOf: settingsURL), invalidSettingsData)
+
+        XCTAssertNotNil(SurfaceResumeApprovalStore.approve(
+            binding: binding,
+            policy: .auto,
+            commandPrefix: ["tmux", "attach"],
+            fileURL: settingsURL,
+            signingSecret: secret
+        ))
+        XCTAssertEqual(try Data(contentsOf: settingsURL), invalidSettingsData)
+        XCTAssertTrue(SurfaceResumeApprovalStore.validRecords(
+            fileURL: settingsURL,
+            signingSecret: secret
+        ).isEmpty)
+        XCTAssertEqual(SurfaceResumeApprovalStore.validRecords(
+            fileURL: legacyURL,
+            signingSecret: secret
+        ).map(\.id), [legacyRecord.id])
+    }
+
     func testSurfaceResumeApprovalPromptsForUnknownManualProposal() throws {
         let binding = SurfaceResumeBindingSnapshot(
             command: "tmux attach -t work",

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -4375,6 +4375,12 @@ extension SessionPersistenceTests {
             signingSecret: secret
         ))
 
+        XCTAssertEqual(SurfaceResumeApprovalStore.loadRecords(
+            fileURL: settingsURL,
+            defaultSettingsURL: settingsURL
+        ).map(\.id), [legacyRecord.id])
+        XCTAssertEqual(try Data(contentsOf: settingsURL), invalidSettingsData)
+
         XCTAssertFalse(SurfaceResumeApprovalStore.migrateLegacyRecordsIfNeeded(
             fileURL: settingsURL,
             legacyFileURL: legacyURL

--- a/web/data/cmux.schema.json
+++ b/web/data/cmux.schema.json
@@ -315,6 +315,74 @@
           "type": "boolean",
           "default": true,
           "description": "Automatically run agent resume commands for restored terminal sessions when cmux reopens after quit. Set false to restore panes while keeping Claude Code, Codex, OpenCode, and other saved agent sessions idle until you resume them manually."
+        },
+        "resumeCommands": {
+          "type": "array",
+          "default": [],
+          "description": "Signed command-prefix approvals for restoring non-agent terminal surfaces. cmux writes this list when you approve a surface resume command.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["version", "id", "commandPrefix", "environmentKeys", "policy", "createdAt", "updatedAt", "signature"],
+            "properties": {
+              "version": {
+                "type": "integer",
+                "const": 1
+              },
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "commandPrefix": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "description": "Shell argv prefix that must match the saved resume command."
+              },
+              "cwd": {
+                "type": "string",
+                "description": "Optional working directory that must match the saved resume command."
+              },
+              "environment": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Optional non-sensitive environment values that must match the saved resume command."
+              },
+              "environmentKeys": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "source": {
+                "type": "string"
+              },
+              "policy": {
+                "type": "string",
+                "enum": ["manual", "prompt", "auto"]
+              },
+              "createdAt": {
+                "type": "number"
+              },
+              "updatedAt": {
+                "type": "number"
+              },
+              "lastUsedAt": {
+                "type": "number"
+              },
+              "signature": {
+                "type": "string",
+                "description": "HMAC signature for the record. Changing signed fields invalidates the approval."
+              }
+            }
+          }
         }
       }
     },


### PR DESCRIPTION
## Summary
- store surface resume command approvals under `terminal.resumeCommands` in `~/.config/cmux/cmux.json`
- keep legacy `resume-commands.json` as a read fallback until the first cmux.json write
- replace the Settings editor with a count and an Open button for cmux.json

## Tests
- `jq empty web/data/cmux.schema.json web/data/cmux-settings.schema.json`
- `CMUX_SKIP_ZIG_BUILD=1 xcodebuild -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/cmux-resume-json-test -only-testing:cmuxTests/SessionPersistenceTests/testSurfaceResumeApprovalWritesRecordsIntoCmuxJSON test`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4538"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782017985&installation_id=133855650&pr_number=4538&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4538&signature=dc3a2c984ef1b9ad36c9f7e3d45e84fe1f238dfdab38314d0f0846460818f2da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `cmux.json` is decoded/rewritten, including preserving original text encoding and newline style; mistakes here could corrupt user config files. The behavior is covered by updated tests, but it still touches persistence and file I/O paths.
> 
> **Overview**
> Improves JSONC in-place editing so updates to `cmux.json` preserve the file’s *original text encoding* and *newline style* (e.g., CRLF), instead of forcing UTF-8/`\n`.
> 
> `JSONCParser` now exposes `source(data:)` to return both decoded text and detected `String.Encoding`, and `SessionPersistence` writes updated settings using that encoding. `JSONCObjectEditor` normalizes inserted/replaced fragments to the preferred newline sequence, and tests were extended to cover CRLF preservation and UTF-16LE settings files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92a2ccd9fb1e60c1695332b84656258b7292235b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move surface resume command approvals into `cmux.json` under `terminal.resumeCommands` with JSONC-aware in-place edits that preserve comments, encoding, and line endings. Simplifies the Settings card to show a count with an Open button, and safely migrates from `resume-commands.json`.

- **New Features**
  - Persist approvals to `terminal.resumeCommands` in `cmux.json`; schema updated, template default `[]`, and JSON path support added.
  - Auto-migrate from `resume-commands.json` when the key is missing and settings are valid/writable; legacy file is retained.

- **Bug Fixes**
  - Preserve original file encoding and newline style when writing `cmux.json`.
  - Escape property keys in the JSONC editor to prevent invalid writes when keys contain special characters.
  - Treat invalid `cmux.json` as read-only: no writes or migration, and continue reading approvals from the legacy file.

<sup>Written for commit 92a2ccd9fb1e60c1695332b84656258b7292235b. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4538?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Resume command approvals can be stored in the main settings file under a new terminal.resumeCommands entry (legacy standalone file still supported and migrated when appropriate).

* **Refactor**
  * Settings card simplified to show only approval count and an “Open” action for the settings editor.
  * Persistence unified to handle settings-stored approvals with safe migration and fallback.

* **Tests**
  * Added tests for read/write, migration, and resilience with invalid settings files.

* **Documentation**
  * Schema and template updated to include the resumeCommands setting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4538?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->