### PR TITLE
Fix stale agent resume after killed process

### DIFF
--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -8877,7 +8877,7 @@ class TabManager: ObservableObject {
 
 extension TabManager {
     func sessionAutosaveFingerprint(
-        restorableAgentIndex: RestorableAgentSessionIndex = .empty,
+        restorableAgentIndex: RestorableAgentSessionIndex? = nil,
         surfaceResumeBindingIndex: SurfaceResumeBindingIndex = .empty
     ) -> Int {
         var hasher = Hasher()
@@ -8926,7 +8926,7 @@ extension TabManager {
                     notificationStore?.notifications(forTabId: workspace.id, surfaceId: panelId) ?? [],
                     into: &hasher
                 )
-                let restorableAgent = restorableAgentIndex.snapshot(
+                let restorableAgent = restorableAgentIndex?.snapshot(
                     workspaceId: workspace.id,
                     panelId: panelId
                 )
@@ -8936,7 +8936,7 @@ extension TabManager {
                         panelId: panelId,
                         surfaceResumeBindingIndex: surfaceResumeBindingIndex,
                         restorableAgent: restorableAgent,
-                        restorableAgentIndexWasScanned: true
+                        restorableAgentIndexWasScanned: restorableAgentIndex != nil
                     ),
                     into: &hasher
                 )

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -9090,7 +9090,7 @@ extension TabManager {
 
     func sessionSnapshot(
         includeScrollback: Bool,
-        restorableAgentIndex: RestorableAgentSessionIndex = .empty,
+        restorableAgentIndex: RestorableAgentSessionIndex? = nil,
         surfaceResumeBindingIndex: SurfaceResumeBindingIndex? = nil
     ) -> SessionTabManagerSnapshot {
         let restorableTabs = tabs

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -8926,17 +8926,17 @@ extension TabManager {
                     notificationStore?.notifications(forTabId: workspace.id, surfaceId: panelId) ?? [],
                     into: &hasher
                 )
-                Self.hashRestorableAgentSnapshot(
-                    restorableAgentIndex.snapshot(
-                        workspaceId: workspace.id,
-                        panelId: panelId
-                    ),
-                    into: &hasher
+                let restorableAgent = restorableAgentIndex.snapshot(
+                    workspaceId: workspace.id,
+                    panelId: panelId
                 )
+                Self.hashRestorableAgentSnapshot(restorableAgent, into: &hasher)
                 Self.hashSurfaceResumeBindingSnapshot(
                     workspace.effectiveSurfaceResumeBinding(
                         panelId: panelId,
-                        surfaceResumeBindingIndex: surfaceResumeBindingIndex
+                        surfaceResumeBindingIndex: surfaceResumeBindingIndex,
+                        restorableAgent: restorableAgent,
+                        restorableAgentIndexWasScanned: true
                     ),
                     into: &hasher
                 )

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -425,8 +425,11 @@ extension Workspace {
             if invalidatedRestoredAgentFingerprintsByPanelId[panelId] == fingerprint {
                 clearRestoredAgentSnapshot(panelId: panelId)
             } else {
+                let previousFingerprint = restoredAgentSnapshotsByPanelId[panelId].map {
+                    TabManager.restorableAgentSnapshotFingerprint($0)
+                }
                 restoredAgentSnapshotsByPanelId[panelId] = restorableAgent
-                if restoredAgentResumeStatesByPanelId[panelId] == nil {
+                if previousFingerprint != fingerprint || restoredAgentResumeStatesByPanelId[panelId] == nil {
                     restoredAgentResumeStatesByPanelId[panelId] = restoredAgentResumeStateForAcceptedSnapshot(
                         panelId: panelId
                     )
@@ -434,10 +437,6 @@ extension Workspace {
                 invalidatedRestoredAgentFingerprintsByPanelId.removeValue(forKey: panelId)
             }
         } else if restorableAgentIndexWasScanned {
-            if let restoredAgent = restoredAgentSnapshotsByPanelId[panelId] {
-                clearRestoredAgentResumeBinding(panelId: panelId, restoredAgent: restoredAgent)
-            }
-            clearRestoredAgentSnapshot(panelId: panelId)
             invalidatedRestoredAgentFingerprintsByPanelId.removeValue(forKey: panelId)
         }
         let effectiveRestorableAgent = restoredAgentSnapshotsByPanelId[panelId]

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -903,7 +903,7 @@ extension Workspace {
         for panelId in panels.keys {
             guard let restoredAgent = restoredAgentSnapshotsByPanelId[panelId],
                   restorableAgentIndex.snapshot(workspaceId: id, panelId: panelId) == nil,
-                  !shouldPreserveRestoredAgentWhileResumeStarts(panelId: panelId) else {
+                  !shouldPreserveRestoredAgentWithoutLiveMatch(panelId: panelId) else {
                 continue
             }
             clearRestoredAgentResumeBinding(panelId: panelId, restoredAgent: restoredAgent)
@@ -918,7 +918,7 @@ extension Workspace {
             if agentHookBinding(binding, matches: restorableAgent) {
                 continue
             }
-            if shouldPreserveRestoredAgentWhileResumeStarts(panelId: panelId),
+            if shouldPreserveRestoredAgentWithoutLiveMatch(panelId: panelId),
                agentHookBinding(binding, matches: restoredAgentSnapshotsByPanelId[panelId]) {
                 continue
             }
@@ -959,7 +959,7 @@ extension Workspace {
         if restorableAgentIndexWasScanned,
            binding.isAgentHookBinding,
            !agentHookBinding(binding, matches: restorableAgent) {
-            if shouldPreserveRestoredAgentWhileResumeStarts(panelId: panelId),
+            if shouldPreserveRestoredAgentWithoutLiveMatch(panelId: panelId),
                agentHookBinding(binding, matches: restoredAgentSnapshotsByPanelId[panelId]) {
                 return binding
             }
@@ -987,11 +987,11 @@ extension Workspace {
         return true
     }
 
-    private func shouldPreserveRestoredAgentWhileResumeStarts(panelId: UUID) -> Bool {
+    private func shouldPreserveRestoredAgentWithoutLiveMatch(panelId: UUID) -> Bool {
         switch restoredAgentResumeStatesByPanelId[panelId] {
-        case .some(.awaitingAutoResumeCommand), .some(.autoResumeCommandRunning):
+        case .some(.manualResumeAvailable), .some(.awaitingAutoResumeCommand), .some(.autoResumeCommandRunning):
             return true
-        case .some(.manualResumeAvailable), .some(.observedAgentCommandRunning), nil:
+        case .some(.observedAgentCommandRunning), nil:
             return false
         }
     }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -918,7 +918,8 @@ extension Workspace {
             if agentHookBinding(binding, matches: restorableAgent) {
                 continue
             }
-            if shouldPreserveRestoredAgentWithoutLiveMatch(panelId: panelId),
+            if restorableAgent == nil,
+               shouldPreserveRestoredAgentWithoutLiveMatch(panelId: panelId),
                agentHookBinding(binding, matches: restoredAgentSnapshotsByPanelId[panelId]) {
                 continue
             }
@@ -959,7 +960,8 @@ extension Workspace {
         if restorableAgentIndexWasScanned,
            binding.isAgentHookBinding,
            !agentHookBinding(binding, matches: restorableAgent) {
-            if shouldPreserveRestoredAgentWithoutLiveMatch(panelId: panelId),
+            if restorableAgent == nil,
+               shouldPreserveRestoredAgentWithoutLiveMatch(panelId: panelId),
                agentHookBinding(binding, matches: restoredAgentSnapshotsByPanelId[panelId]) {
                 return binding
             }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -9133,9 +9133,9 @@ final class Workspace: Identifiable, ObservableObject {
             switch restoredAgentResumeStatesByPanelId[panelId] {
             case .some(.autoResumeCommandRunning), .some(.observedAgentCommandRunning):
                 invalidateRestoredAgentSnapshot(panelId: panelId, restoredAgent: restoredAgent)
-            case .some(.awaitingAutoResumeCommand):
-                invalidateRestoredAgentSnapshot(panelId: panelId, restoredAgent: restoredAgent)
-            case .some(.manualResumeAvailable), nil:
+            case .some(.awaitingAutoResumeCommand), .some(.manualResumeAvailable), nil:
+                // The first prompt can arrive before Ghostty's initialInput runs.
+                // Wait until commandRunning has been observed before treating promptIdle as completion.
                 break
             }
         case .unknown:

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -979,19 +979,19 @@ extension Workspace {
             return false
         }
         if let kind = binding.kind {
-            if let restorableKind = RestorableAgentKind(rawValue: kind) {
-                return restorableKind == restorableAgent.kind
-            }
-            return kind.compare(restorableAgent.kind.rawValue, options: [.caseInsensitive, .literal]) == .orderedSame
+            return kind.trimmingCharacters(in: .whitespacesAndNewlines).compare(
+                restorableAgent.kind.rawValue,
+                options: [.caseInsensitive, .literal]
+            ) == .orderedSame
         }
         return true
     }
 
     private func shouldPreserveRestoredAgentWithoutLiveMatch(panelId: UUID) -> Bool {
         switch restoredAgentResumeStatesByPanelId[panelId] {
-        case .some(.manualResumeAvailable), .some(.awaitingAutoResumeCommand), .some(.autoResumeCommandRunning):
+        case .some(.manualResumeAvailable), .some(.awaitingAutoResumeCommand):
             return true
-        case .some(.observedAgentCommandRunning), nil:
+        case .some(.autoResumeCommandRunning), .some(.observedAgentCommandRunning), nil:
             return false
         }
     }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -959,6 +959,10 @@ extension Workspace {
         if restorableAgentIndexWasScanned,
            binding.isAgentHookBinding,
            !agentHookBinding(binding, matches: restorableAgent) {
+            if shouldPreserveRestoredAgentWhileResumeStarts(panelId: panelId),
+               agentHookBinding(binding, matches: restoredAgentSnapshotsByPanelId[panelId]) {
+                return binding
+            }
             return nil
         }
         return binding

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -9133,7 +9133,9 @@ final class Workspace: Identifiable, ObservableObject {
             switch restoredAgentResumeStatesByPanelId[panelId] {
             case .some(.autoResumeCommandRunning), .some(.observedAgentCommandRunning):
                 invalidateRestoredAgentSnapshot(panelId: panelId, restoredAgent: restoredAgent)
-            case .some(.awaitingAutoResumeCommand), .some(.manualResumeAvailable), nil:
+            case .some(.awaitingAutoResumeCommand):
+                invalidateRestoredAgentSnapshot(panelId: panelId, restoredAgent: restoredAgent)
+            case .some(.manualResumeAvailable), nil:
                 break
             }
         case .unknown:

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -425,15 +425,16 @@ extension Workspace {
             if invalidatedRestoredAgentFingerprintsByPanelId[panelId] == fingerprint {
                 clearRestoredAgentSnapshot(panelId: panelId)
             } else {
-                let previousFingerprint = restoredAgentSnapshotsByPanelId[panelId].map {
-                    TabManager.restorableAgentSnapshotFingerprint($0)
-                }
-                restoredAgentSnapshotsByPanelId[panelId] = restorableAgent
-                if previousFingerprint != fingerprint || restoredAgentResumeStatesByPanelId[panelId] == nil {
+                let previousRestoredAgent = restoredAgentSnapshotsByPanelId[panelId]
+                let agentIdentityChanged = previousRestoredAgent.map {
+                    $0.kind != restorableAgent.kind || $0.sessionId != restorableAgent.sessionId
+                } ?? true
+                if agentIdentityChanged || restoredAgentResumeStatesByPanelId[panelId] == nil {
                     restoredAgentResumeStatesByPanelId[panelId] = restoredAgentResumeStateForAcceptedSnapshot(
                         panelId: panelId
                     )
                 }
+                restoredAgentSnapshotsByPanelId[panelId] = restorableAgent
                 invalidatedRestoredAgentFingerprintsByPanelId.removeValue(forKey: panelId)
             }
         } else if restorableAgentIndexWasScanned {
@@ -901,7 +902,8 @@ extension Workspace {
     func reconcileRestoredAgentSnapshots(using restorableAgentIndex: RestorableAgentSessionIndex) {
         for panelId in panels.keys {
             guard let restoredAgent = restoredAgentSnapshotsByPanelId[panelId],
-                  restorableAgentIndex.snapshot(workspaceId: id, panelId: panelId) == nil else {
+                  restorableAgentIndex.snapshot(workspaceId: id, panelId: panelId) == nil,
+                  !shouldPreserveRestoredAgentWhileResumeStarts(panelId: panelId) else {
                 continue
             }
             clearRestoredAgentResumeBinding(panelId: panelId, restoredAgent: restoredAgent)
@@ -913,9 +915,14 @@ extension Workspace {
     func reconcileAgentHookSurfaceResumeBindings(using restorableAgentIndex: RestorableAgentSessionIndex) {
         for (panelId, binding) in Array(surfaceResumeBindingsByPanelId) where binding.isAgentHookBinding {
             let restorableAgent = restorableAgentIndex.snapshot(workspaceId: id, panelId: panelId)
-            if !agentHookBinding(binding, matches: restorableAgent) {
-                surfaceResumeBindingsByPanelId.removeValue(forKey: panelId)
+            if agentHookBinding(binding, matches: restorableAgent) {
+                continue
             }
+            if shouldPreserveRestoredAgentWhileResumeStarts(panelId: panelId),
+               agentHookBinding(binding, matches: restoredAgentSnapshotsByPanelId[panelId]) {
+                continue
+            }
+            surfaceResumeBindingsByPanelId.removeValue(forKey: panelId)
         }
     }
 
@@ -974,6 +981,15 @@ extension Workspace {
             return kind.compare(restorableAgent.kind.rawValue, options: [.caseInsensitive, .literal]) == .orderedSame
         }
         return true
+    }
+
+    private func shouldPreserveRestoredAgentWhileResumeStarts(panelId: UUID) -> Bool {
+        switch restoredAgentResumeStatesByPanelId[panelId] {
+        case .some(.awaitingAutoResumeCommand), .some(.autoResumeCommandRunning):
+            return true
+        case .some(.manualResumeAvailable), .some(.observedAgentCommandRunning), nil:
+            return false
+        }
     }
 
     private func createPanel(from snapshot: SessionPanelSnapshot, inPane paneId: PaneID) -> UUID? {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -170,6 +170,10 @@ extension Workspace {
         if let surfaceResumeBindingIndex {
             reconcileSurfaceResumeBindings(using: surfaceResumeBindingIndex)
         }
+        if let restorableAgentIndex {
+            reconcileRestoredAgentSnapshots(using: restorableAgentIndex)
+            reconcileAgentHookSurfaceResumeBindings(using: restorableAgentIndex)
+        }
 
         let orderedPanelIds = sidebarOrderedPanelIds()
         var seen: Set<UUID> = []
@@ -183,14 +187,18 @@ extension Workspace {
 
         let panelSnapshots = allPanelIds
             .prefix(SessionPersistencePolicy.maxPanelsPerWorkspace)
-            .compactMap { panelId in
-                sessionPanelSnapshot(
+            .compactMap { panelId -> SessionPanelSnapshot? in
+                let restorableAgent = restorableAgentIndex?.snapshot(workspaceId: id, panelId: panelId)
+                return sessionPanelSnapshot(
                     panelId: panelId,
                     includeScrollback: includeScrollback,
-                    restorableAgent: restorableAgentIndex?.snapshot(workspaceId: id, panelId: panelId),
+                    restorableAgent: restorableAgent,
+                    restorableAgentIndexWasScanned: restorableAgentIndex != nil,
                     resumeBinding: effectiveSurfaceResumeBinding(
                         panelId: panelId,
-                        surfaceResumeBindingIndex: surfaceResumeBindingIndex
+                        surfaceResumeBindingIndex: surfaceResumeBindingIndex,
+                        restorableAgent: restorableAgent,
+                        restorableAgentIndexWasScanned: restorableAgentIndex != nil
                     )
                 )
             }
@@ -407,6 +415,7 @@ extension Workspace {
         panelId: UUID,
         includeScrollback: Bool,
         restorableAgent: SessionRestorableAgentSnapshot?,
+        restorableAgentIndexWasScanned: Bool,
         resumeBinding: SurfaceResumeBindingSnapshot?
     ) -> SessionPanelSnapshot? {
         guard let panel = panels[panelId] else { return nil }
@@ -424,6 +433,12 @@ extension Workspace {
                 }
                 invalidatedRestoredAgentFingerprintsByPanelId.removeValue(forKey: panelId)
             }
+        } else if restorableAgentIndexWasScanned {
+            if let restoredAgent = restoredAgentSnapshotsByPanelId[panelId] {
+                clearRestoredAgentResumeBinding(panelId: panelId, restoredAgent: restoredAgent)
+            }
+            clearRestoredAgentSnapshot(panelId: panelId)
+            invalidatedRestoredAgentFingerprintsByPanelId.removeValue(forKey: panelId)
         }
         let effectiveRestorableAgent = restoredAgentSnapshotsByPanelId[panelId]
 
@@ -884,21 +899,82 @@ extension Workspace {
         }
     }
 
+    func reconcileRestoredAgentSnapshots(using restorableAgentIndex: RestorableAgentSessionIndex) {
+        for panelId in panels.keys {
+            guard let restoredAgent = restoredAgentSnapshotsByPanelId[panelId],
+                  restorableAgentIndex.snapshot(workspaceId: id, panelId: panelId) == nil else {
+                continue
+            }
+            clearRestoredAgentResumeBinding(panelId: panelId, restoredAgent: restoredAgent)
+            clearRestoredAgentSnapshot(panelId: panelId)
+            invalidatedRestoredAgentFingerprintsByPanelId.removeValue(forKey: panelId)
+        }
+    }
+
+    func reconcileAgentHookSurfaceResumeBindings(using restorableAgentIndex: RestorableAgentSessionIndex) {
+        for (panelId, binding) in Array(surfaceResumeBindingsByPanelId) where binding.isAgentHookBinding {
+            let restorableAgent = restorableAgentIndex.snapshot(workspaceId: id, panelId: panelId)
+            if !agentHookBinding(binding, matches: restorableAgent) {
+                surfaceResumeBindingsByPanelId.removeValue(forKey: panelId)
+            }
+        }
+    }
+
     func effectiveSurfaceResumeBinding(
         panelId: UUID,
-        surfaceResumeBindingIndex: SurfaceResumeBindingIndex?
+        surfaceResumeBindingIndex: SurfaceResumeBindingIndex?,
+        restorableAgent: SessionRestorableAgentSnapshot? = nil,
+        restorableAgentIndexWasScanned: Bool = false
     ) -> SurfaceResumeBindingSnapshot? {
         let storedBinding = surfaceResumeBindingsByPanelId[panelId]
-        guard let surfaceResumeBindingIndex else {
-            return storedBinding
+        let binding: SurfaceResumeBindingSnapshot?
+        if let surfaceResumeBindingIndex {
+            let detectedBinding = surfaceResumeBindingIndex.binding(workspaceId: id, panelId: panelId)
+            if let storedBinding {
+                if let detectedBinding {
+                    if storedBinding.shouldYieldToDetectedSurfaceResumeBinding(detectedBinding) {
+                        binding = detectedBinding
+                    } else if storedBinding.isProcessDetected {
+                        binding = nil
+                    } else {
+                        binding = storedBinding
+                    }
+                } else {
+                    binding = storedBinding.isProcessDetected ? nil : storedBinding
+                }
+            } else {
+                binding = detectedBinding
+            }
+        } else {
+            binding = storedBinding
         }
 
-        let detectedBinding = surfaceResumeBindingIndex.binding(workspaceId: id, panelId: panelId)
-        guard let storedBinding else { return detectedBinding }
-        guard let detectedBinding else { return storedBinding.isProcessDetected ? nil : storedBinding }
-        if storedBinding.shouldYieldToDetectedSurfaceResumeBinding(detectedBinding) { return detectedBinding }
-        if storedBinding.isProcessDetected { return nil }
-        return storedBinding
+        guard let binding else { return nil }
+        if restorableAgentIndexWasScanned,
+           binding.isAgentHookBinding,
+           !agentHookBinding(binding, matches: restorableAgent) {
+            return nil
+        }
+        return binding
+    }
+
+    private func agentHookBinding(
+        _ binding: SurfaceResumeBindingSnapshot,
+        matches restorableAgent: SessionRestorableAgentSnapshot?
+    ) -> Bool {
+        guard binding.isAgentHookBinding else { return true }
+        guard let restorableAgent else { return false }
+        if let checkpointId = binding.checkpointId,
+           checkpointId != restorableAgent.sessionId {
+            return false
+        }
+        if let kind = binding.kind {
+            if let restorableKind = RestorableAgentKind(rawValue: kind) {
+                return restorableKind == restorableAgent.kind
+            }
+            return kind.compare(restorableAgent.kind.rawValue, options: [.caseInsensitive, .literal]) == .orderedSame
+        }
+        return true
     }
 
     private func createPanel(from snapshot: SessionPanelSnapshot, inPane paneId: PaneID) -> UUID? {

--- a/cmuxTests/AgentSessionAutoResumeSettingsTests.swift
+++ b/cmuxTests/AgentSessionAutoResumeSettingsTests.swift
@@ -269,6 +269,57 @@ final class AgentSessionAutoResumeSettingsTests: XCTestCase {
     }
 
     @MainActor
+    func testStaleAgentHookResumeBindingWithoutLiveRestorableAgentDoesNotAutoResume() throws {
+        try withRestoredDefaults(key: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey) {
+            let defaults = UserDefaults.standard
+            defaults.removeObject(forKey: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey) // autoResumeAgentSessions = true (default)
+
+            let source = Workspace()
+            let sourcePanelId = try XCTUnwrap(source.focusedPanelId)
+            XCTAssertTrue(
+                source.setSurfaceResumeBinding(
+                    SurfaceResumeBindingSnapshot(
+                        name: "Codex",
+                        kind: "codex",
+                        command: "codex resume killed-session",
+                        cwd: "/tmp/repo",
+                        checkpointId: "killed-session",
+                        source: "agent-hook",
+                        autoResume: true,
+                        updatedAt: 1_777_777_777
+                    ),
+                    panelId: sourcePanelId
+                )
+            )
+            source.setRestoredAgentSnapshotForTesting(
+                SessionRestorableAgentSnapshot(
+                    kind: .codex,
+                    sessionId: "killed-session",
+                    workingDirectory: "/tmp/repo"
+                ),
+                panelId: sourcePanelId
+            )
+
+            let snapshot = source.sessionSnapshot(
+                includeScrollback: false,
+                restorableAgentIndex: .empty
+            )
+
+            XCTAssertNil(snapshot.panels.first?.terminal?.agent)
+            XCTAssertNil(snapshot.panels.first?.terminal?.resumeBinding)
+            XCTAssertNil(source.restoredAgentSnapshotForTesting(panelId: sourcePanelId))
+            XCTAssertNil(source.surfaceResumeBinding(panelId: sourcePanelId))
+
+            let restored = Workspace()
+            restored.restoreSessionSnapshot(snapshot)
+            let restoredPanelId = try XCTUnwrap(restored.focusedPanelId)
+            let restoredPanel = try XCTUnwrap(restored.terminalPanel(for: restoredPanelId))
+
+            XCTAssertFalse(restoredPanel.surface.debugInitialInputMetadata().hasInitialInput)
+        }
+    }
+
+    @MainActor
     func testDisabledAutoResumeDoesNotRunAgentHookResumeBinding() throws {
         let defaults = UserDefaults.standard
         let key = AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey

--- a/cmuxTests/AgentSessionAutoResumeSettingsTests.swift
+++ b/cmuxTests/AgentSessionAutoResumeSettingsTests.swift
@@ -431,6 +431,88 @@ final class AgentSessionAutoResumeSettingsTests: XCTestCase {
     }
 
     @MainActor
+    func testRunningAgentHookResumeBindingClearsWhenLiveAgentDisappears() throws {
+        try withRestoredDefaults(key: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey) {
+            let defaults = UserDefaults.standard
+            defaults.removeObject(forKey: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey) // autoResumeAgentSessions = true (default)
+
+            let source = Workspace()
+            let sourcePanelId = try XCTUnwrap(source.focusedPanelId)
+            XCTAssertTrue(
+                source.setSurfaceResumeBinding(
+                    SurfaceResumeBindingSnapshot(
+                        name: "Codex",
+                        kind: "codex",
+                        command: "codex resume vanished-running-session",
+                        cwd: "/tmp/repo",
+                        checkpointId: "vanished-running-session",
+                        source: "agent-hook",
+                        autoResume: true,
+                        updatedAt: 1_777_777_777
+                    ),
+                    panelId: sourcePanelId
+                )
+            )
+            source.setRestoredAgentSnapshotForTesting(
+                SessionRestorableAgentSnapshot(
+                    kind: .codex,
+                    sessionId: "vanished-running-session",
+                    workingDirectory: "/tmp/repo"
+                ),
+                panelId: sourcePanelId
+            )
+            source.setRestoredAgentAutoResumePendingForTesting(true, panelId: sourcePanelId)
+            source.updatePanelShellActivityState(panelId: sourcePanelId, state: .commandRunning)
+
+            let snapshot = source.sessionSnapshot(
+                includeScrollback: false,
+                restorableAgentIndex: .empty
+            )
+
+            XCTAssertNil(snapshot.panels.first?.terminal?.agent)
+            XCTAssertNil(snapshot.panels.first?.terminal?.resumeBinding)
+            XCTAssertNil(source.restoredAgentSnapshotForTesting(panelId: sourcePanelId))
+            XCTAssertNil(source.surfaceResumeBinding(panelId: sourcePanelId))
+        }
+    }
+
+    @MainActor
+    func testRegistryOwnedAgentHookBindingMatchesCustomRawValue() throws {
+        let source = Workspace()
+        let sourcePanelId = try XCTUnwrap(source.focusedPanelId)
+        let sourceIndex = try makeRestorableAgentIndex(
+            kind: .pi,
+            workspaceId: source.id,
+            panelId: sourcePanelId,
+            sessionId: "pi-registry-session",
+            arguments: ["/usr/local/bin/pi", "--model", "anthropic/claude-sonnet-4-5"]
+        )
+        let bindingIndex = SurfaceResumeBindingIndex(bindingsByPanel: [
+            SurfaceResumeBindingIndex.PanelKey(workspaceId: source.id, panelId: sourcePanelId): SurfaceResumeBindingSnapshot(
+                name: "Pi",
+                kind: "pi",
+                command: "pi resume pi-registry-session",
+                cwd: "/tmp/repo",
+                checkpointId: "pi-registry-session",
+                source: "agent-hook",
+                autoResume: true,
+                updatedAt: 1_777_777_777
+            ),
+        ])
+
+        let snapshot = source.sessionSnapshot(
+            includeScrollback: false,
+            restorableAgentIndex: sourceIndex,
+            surfaceResumeBindingIndex: bindingIndex
+        )
+
+        XCTAssertEqual(snapshot.panels.first?.terminal?.agent?.kind, .custom("pi"))
+        XCTAssertEqual(snapshot.panels.first?.terminal?.agent?.sessionId, "pi-registry-session")
+        XCTAssertEqual(snapshot.panels.first?.terminal?.resumeBinding?.kind, "pi")
+        XCTAssertEqual(snapshot.panels.first?.terminal?.resumeBinding?.checkpointId, "pi-registry-session")
+    }
+
+    @MainActor
     func testDisabledAutoResumeDoesNotRunAgentHookResumeBinding() throws {
         let defaults = UserDefaults.standard
         let key = AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey
@@ -665,9 +747,11 @@ final class AgentSessionAutoResumeSettingsTests: XCTestCase {
     }
 
     private func makeRestorableAgentIndex(
+        kind: RestorableAgentKind = .codex,
         workspaceId: UUID,
         panelId: UUID,
-        sessionId: String
+        sessionId: String,
+        arguments: [String]? = nil
     ) throws -> RestorableAgentSessionIndex {
         let home = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-agent-auto-resume-\(UUID().uuidString)", isDirectory: true)
@@ -680,9 +764,20 @@ final class AgentSessionAutoResumeSettingsTests: XCTestCase {
                 unsetenv("CMUX_AGENT_HOOK_STATE_DIR")
             }
         }
-        let storeURL = RestorableAgentKind.codex.hookStoreFileURL(homeDirectory: home.path)
+        let storeURL = kind.hookStoreFileURL(homeDirectory: home.path)
         try FileManager.default.createDirectory(at: storeURL.deletingLastPathComponent(), withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: home) }
+        let executablePath = arguments?.first ?? "/usr/local/bin/\(kind.rawValue)"
+        let resolvedArguments = arguments ?? [executablePath, "--model", "gpt-5.4"]
+        let environment: [String: String]
+        switch kind {
+        case .codex:
+            environment = ["CODEX_HOME": "/tmp/codex"]
+        case .pi:
+            environment = ["PI_CODING_AGENT_DIR": "/tmp/pi"]
+        default:
+            environment = [:]
+        }
 
         let jsonObject: [String: Any] = [
             "version": 1,
@@ -694,11 +789,11 @@ final class AgentSessionAutoResumeSettingsTests: XCTestCase {
                     "cwd": "/tmp/repo",
                     "updatedAt": Date().timeIntervalSince1970,
                     "launchCommand": [
-                        "launcher": "codex",
-                        "executablePath": "/usr/local/bin/codex",
-                        "arguments": ["/usr/local/bin/codex", "--model", "gpt-5.4"],
+                        "launcher": kind.rawValue,
+                        "executablePath": executablePath,
+                        "arguments": resolvedArguments,
                         "workingDirectory": "/tmp/repo",
-                        "environment": ["CODEX_HOME": "/tmp/codex"],
+                        "environment": environment,
                         "capturedAt": Date().timeIntervalSince1970,
                         "source": "process",
                     ],

--- a/cmuxTests/AgentSessionAutoResumeSettingsTests.swift
+++ b/cmuxTests/AgentSessionAutoResumeSettingsTests.swift
@@ -381,7 +381,7 @@ final class AgentSessionAutoResumeSettingsTests: XCTestCase {
     }
 
     @MainActor
-    func testPendingAgentHookResumeBindingClearsWhenStartupReturnsToPrompt() throws {
+    func testPendingAgentHookResumeBindingSurvivesStartupPromptBeforeCommandRuns() throws {
         try withRestoredDefaults(key: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey) {
             let defaults = UserDefaults.standard
             defaults.removeObject(forKey: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey) // autoResumeAgentSessions = true (default)
@@ -393,9 +393,9 @@ final class AgentSessionAutoResumeSettingsTests: XCTestCase {
                     SurfaceResumeBindingSnapshot(
                         name: "Codex",
                         kind: "codex",
-                        command: "codex resume failed-startup-session",
+                        command: "codex resume prompt-before-command-session",
                         cwd: "/tmp/repo",
-                        checkpointId: "failed-startup-session",
+                        checkpointId: "prompt-before-command-session",
                         source: "agent-hook",
                         autoResume: true,
                         updatedAt: 1_777_777_777
@@ -406,7 +406,7 @@ final class AgentSessionAutoResumeSettingsTests: XCTestCase {
             source.setRestoredAgentSnapshotForTesting(
                 SessionRestorableAgentSnapshot(
                     kind: .codex,
-                    sessionId: "failed-startup-session",
+                    sessionId: "prompt-before-command-session",
                     workingDirectory: "/tmp/repo"
                 ),
                 panelId: sourcePanelId
@@ -419,11 +419,14 @@ final class AgentSessionAutoResumeSettingsTests: XCTestCase {
                 restorableAgentIndex: .empty
             )
 
-            XCTAssertNil(snapshot.panels.first?.terminal?.agent)
-            XCTAssertNil(snapshot.panels.first?.terminal?.resumeBinding)
-            XCTAssertNil(source.restoredAgentSnapshotForTesting(panelId: sourcePanelId))
-            XCTAssertNil(source.surfaceResumeBinding(panelId: sourcePanelId))
-            XCTAssertFalse(source.restoredAgentAutoResumePendingForTesting(panelId: sourcePanelId))
+            XCTAssertEqual(snapshot.panels.first?.terminal?.agent?.sessionId, "prompt-before-command-session")
+            XCTAssertEqual(snapshot.panels.first?.terminal?.resumeBinding?.checkpointId, "prompt-before-command-session")
+            XCTAssertEqual(
+                source.restoredAgentSnapshotForTesting(panelId: sourcePanelId)?.sessionId,
+                "prompt-before-command-session"
+            )
+            XCTAssertEqual(source.surfaceResumeBinding(panelId: sourcePanelId)?.checkpointId, "prompt-before-command-session")
+            XCTAssertTrue(source.restoredAgentAutoResumePendingForTesting(panelId: sourcePanelId))
         }
     }
 

--- a/cmuxTests/AgentSessionAutoResumeSettingsTests.swift
+++ b/cmuxTests/AgentSessionAutoResumeSettingsTests.swift
@@ -316,6 +316,9 @@ final class AgentSessionAutoResumeSettingsTests: XCTestCase {
             let restoredPanel = try XCTUnwrap(restored.terminalPanel(for: restoredPanelId))
 
             XCTAssertFalse(restoredPanel.surface.debugInitialInputMetadata().hasInitialInput)
+            let restoredSnapshot = restored.sessionSnapshot(includeScrollback: false)
+            XCTAssertNil(restoredSnapshot.panels.first?.terminal?.agent)
+            XCTAssertNil(restoredSnapshot.panels.first?.terminal?.resumeBinding)
         }
     }
 

--- a/cmuxTests/AgentSessionAutoResumeSettingsTests.swift
+++ b/cmuxTests/AgentSessionAutoResumeSettingsTests.swift
@@ -368,6 +368,53 @@ final class AgentSessionAutoResumeSettingsTests: XCTestCase {
     }
 
     @MainActor
+    func testPendingAgentHookResumeBindingClearsWhenStartupReturnsToPrompt() throws {
+        try withRestoredDefaults(key: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey) {
+            let defaults = UserDefaults.standard
+            defaults.removeObject(forKey: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey) // autoResumeAgentSessions = true (default)
+
+            let source = Workspace()
+            let sourcePanelId = try XCTUnwrap(source.focusedPanelId)
+            XCTAssertTrue(
+                source.setSurfaceResumeBinding(
+                    SurfaceResumeBindingSnapshot(
+                        name: "Codex",
+                        kind: "codex",
+                        command: "codex resume failed-startup-session",
+                        cwd: "/tmp/repo",
+                        checkpointId: "failed-startup-session",
+                        source: "agent-hook",
+                        autoResume: true,
+                        updatedAt: 1_777_777_777
+                    ),
+                    panelId: sourcePanelId
+                )
+            )
+            source.setRestoredAgentSnapshotForTesting(
+                SessionRestorableAgentSnapshot(
+                    kind: .codex,
+                    sessionId: "failed-startup-session",
+                    workingDirectory: "/tmp/repo"
+                ),
+                panelId: sourcePanelId
+            )
+            source.setRestoredAgentAutoResumePendingForTesting(true, panelId: sourcePanelId)
+
+            source.updatePanelShellActivityState(panelId: sourcePanelId, state: .promptIdle)
+            let snapshot = source.sessionSnapshot(
+                includeScrollback: false,
+                restorableAgentIndex: .empty
+            )
+
+            XCTAssertNil(snapshot.panels.first?.terminal?.agent)
+            XCTAssertNil(snapshot.panels.first?.terminal?.resumeBinding)
+            XCTAssertNil(source.restoredAgentSnapshotForTesting(panelId: sourcePanelId))
+            XCTAssertNil(source.surfaceResumeBinding(panelId: sourcePanelId))
+            XCTAssertFalse(source.restoredAgentAutoResumePendingForTesting(panelId: sourcePanelId))
+        }
+    }
+
+    @MainActor
     func testDisabledAutoResumeDoesNotRunAgentHookResumeBinding() throws {
         let defaults = UserDefaults.standard
         let key = AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey

--- a/cmuxTests/AgentSessionAutoResumeSettingsTests.swift
+++ b/cmuxTests/AgentSessionAutoResumeSettingsTests.swift
@@ -323,6 +323,51 @@ final class AgentSessionAutoResumeSettingsTests: XCTestCase {
     }
 
     @MainActor
+    func testPendingAgentHookResumeBindingSurvivesEmptyScanWhileResumeStarts() throws {
+        try withRestoredDefaults(key: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey) {
+            let defaults = UserDefaults.standard
+            defaults.removeObject(forKey: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey) // autoResumeAgentSessions = true (default)
+
+            let source = Workspace()
+            let sourcePanelId = try XCTUnwrap(source.focusedPanelId)
+            XCTAssertTrue(
+                source.setSurfaceResumeBinding(
+                    SurfaceResumeBindingSnapshot(
+                        name: "Codex",
+                        kind: "codex",
+                        command: "codex resume pending-session",
+                        cwd: "/tmp/repo",
+                        checkpointId: "pending-session",
+                        source: "agent-hook",
+                        autoResume: true,
+                        updatedAt: 1_777_777_777
+                    ),
+                    panelId: sourcePanelId
+                )
+            )
+            source.setRestoredAgentSnapshotForTesting(
+                SessionRestorableAgentSnapshot(
+                    kind: .codex,
+                    sessionId: "pending-session",
+                    workingDirectory: "/tmp/repo"
+                ),
+                panelId: sourcePanelId
+            )
+            source.setRestoredAgentAutoResumePendingForTesting(true, panelId: sourcePanelId)
+
+            let snapshot = source.sessionSnapshot(
+                includeScrollback: false,
+                restorableAgentIndex: .empty
+            )
+
+            XCTAssertEqual(snapshot.panels.first?.terminal?.agent?.sessionId, "pending-session")
+            XCTAssertEqual(snapshot.panels.first?.terminal?.resumeBinding?.checkpointId, "pending-session")
+            XCTAssertEqual(source.restoredAgentSnapshotForTesting(panelId: sourcePanelId)?.sessionId, "pending-session")
+            XCTAssertEqual(source.surfaceResumeBinding(panelId: sourcePanelId)?.checkpointId, "pending-session")
+        }
+    }
+
+    @MainActor
     func testDisabledAutoResumeDoesNotRunAgentHookResumeBinding() throws {
         let defaults = UserDefaults.standard
         let key = AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey

--- a/cmuxTests/AgentSessionAutoResumeSettingsTests.swift
+++ b/cmuxTests/AgentSessionAutoResumeSettingsTests.swift
@@ -265,6 +265,19 @@ final class AgentSessionAutoResumeSettingsTests: XCTestCase {
                 restored.sessionSnapshot(includeScrollback: false).panels.first?.terminal?.resumeBinding?.source,
                 "agent-hook"
             )
+
+            let postRestoreScanSnapshot = restored.sessionSnapshot(
+                includeScrollback: false,
+                restorableAgentIndex: .empty
+            )
+            XCTAssertEqual(
+                postRestoreScanSnapshot.panels.first?.terminal?.agent?.sessionId,
+                "codex-exited-binding-session"
+            )
+            XCTAssertEqual(
+                postRestoreScanSnapshot.panels.first?.terminal?.resumeBinding?.source,
+                "agent-hook"
+            )
         }
     }
 

--- a/cmuxTests/AgentSessionAutoResumeSettingsTests.swift
+++ b/cmuxTests/AgentSessionAutoResumeSettingsTests.swift
@@ -477,6 +477,56 @@ final class AgentSessionAutoResumeSettingsTests: XCTestCase {
     }
 
     @MainActor
+    func testPendingAgentHookBindingDoesNotOverrideDifferentLiveAgent() throws {
+        try withRestoredDefaults(key: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey) {
+            let defaults = UserDefaults.standard
+            defaults.removeObject(forKey: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey) // autoResumeAgentSessions = true (default)
+
+            let source = Workspace()
+            let sourcePanelId = try XCTUnwrap(source.focusedPanelId)
+            XCTAssertTrue(
+                source.setSurfaceResumeBinding(
+                    SurfaceResumeBindingSnapshot(
+                        name: "Codex",
+                        kind: "codex",
+                        command: "codex resume old-pending-session",
+                        cwd: "/tmp/repo",
+                        checkpointId: "old-pending-session",
+                        source: "agent-hook",
+                        autoResume: true,
+                        updatedAt: 1_777_777_777
+                    ),
+                    panelId: sourcePanelId
+                )
+            )
+            source.setRestoredAgentSnapshotForTesting(
+                SessionRestorableAgentSnapshot(
+                    kind: .codex,
+                    sessionId: "old-pending-session",
+                    workingDirectory: "/tmp/repo"
+                ),
+                panelId: sourcePanelId
+            )
+            source.setRestoredAgentAutoResumePendingForTesting(true, panelId: sourcePanelId)
+            let liveIndex = try makeRestorableAgentIndex(
+                workspaceId: source.id,
+                panelId: sourcePanelId,
+                sessionId: "new-live-session"
+            )
+
+            let snapshot = source.sessionSnapshot(
+                includeScrollback: false,
+                restorableAgentIndex: liveIndex
+            )
+
+            XCTAssertEqual(snapshot.panels.first?.terminal?.agent?.sessionId, "new-live-session")
+            XCTAssertNil(snapshot.panels.first?.terminal?.resumeBinding)
+            XCTAssertEqual(source.restoredAgentSnapshotForTesting(panelId: sourcePanelId)?.sessionId, "new-live-session")
+            XCTAssertNil(source.surfaceResumeBinding(panelId: sourcePanelId))
+        }
+    }
+
+    @MainActor
     func testRegistryOwnedAgentHookBindingMatchesCustomRawValue() throws {
         let source = Workspace()
         let sourcePanelId = try XCTUnwrap(source.focusedPanelId)

--- a/cmuxTests/AgentSessionAutoResumeSettingsTests.swift
+++ b/cmuxTests/AgentSessionAutoResumeSettingsTests.swift
@@ -381,6 +381,47 @@ final class AgentSessionAutoResumeSettingsTests: XCTestCase {
     }
 
     @MainActor
+    func testTabManagerPlainSnapshotPreservesPendingAgentHookResumeBinding() throws {
+        let manager = TabManager()
+        let source = try XCTUnwrap(manager.selectedWorkspace)
+        let sourcePanelId = try XCTUnwrap(source.focusedPanelId)
+        XCTAssertTrue(
+            source.setSurfaceResumeBinding(
+                SurfaceResumeBindingSnapshot(
+                    name: "Codex",
+                    kind: "codex",
+                    command: "codex resume manager-pending-session",
+                    cwd: "/tmp/repo",
+                    checkpointId: "manager-pending-session",
+                    source: "agent-hook",
+                    autoResume: true,
+                    updatedAt: 1_777_777_777
+                ),
+                panelId: sourcePanelId
+            )
+        )
+        source.setRestoredAgentSnapshotForTesting(
+            SessionRestorableAgentSnapshot(
+                kind: .codex,
+                sessionId: "manager-pending-session",
+                workingDirectory: "/tmp/repo"
+            ),
+            panelId: sourcePanelId
+        )
+        source.setRestoredAgentAutoResumePendingForTesting(true, panelId: sourcePanelId)
+
+        let snapshot = manager.sessionSnapshot(includeScrollback: false)
+
+        XCTAssertEqual(snapshot.workspaces.first?.panels.first?.terminal?.agent?.sessionId, "manager-pending-session")
+        XCTAssertEqual(
+            snapshot.workspaces.first?.panels.first?.terminal?.resumeBinding?.checkpointId,
+            "manager-pending-session"
+        )
+        XCTAssertEqual(source.restoredAgentSnapshotForTesting(panelId: sourcePanelId)?.sessionId, "manager-pending-session")
+        XCTAssertEqual(source.surfaceResumeBinding(panelId: sourcePanelId)?.checkpointId, "manager-pending-session")
+    }
+
+    @MainActor
     func testPendingAgentHookResumeBindingSurvivesStartupPromptBeforeCommandRuns() throws {
         try withRestoredDefaults(key: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey) {
             let defaults = UserDefaults.standard


### PR DESCRIPTION
Summary
- Drop cached restored-agent state when a fresh live/restorable scan no longer finds that panel.
- Ignore and remove hook-created resume bindings that no longer match a scanned live/restorable agent.
- Keep process-detected tmux bindings and disabled auto-resume behavior intact.

Tests
- CMUX_TEST_DESTINATION='platform=macOS,arch=arm64' ./scripts/test-unit.sh -derivedDataPath /tmp/cmux-resume-kill-red -only-testing:cmuxTests/AgentSessionAutoResumeSettingsTests/testStaleAgentHookResumeBindingWithoutLiveRestorableAgentDoesNotAutoResume test
- CMUX_TEST_DESTINATION='platform=macOS,arch=arm64' ./scripts/test-unit.sh -derivedDataPath /tmp/cmux-resume-kill-red -only-testing:cmuxTests/AgentSessionAutoResumeSettingsTests -only-testing:cmuxTests/SessionPersistenceTests/testSnapshotDropsStaleProcessDetectedSurfaceResumeBindingAfterCleanRedetection -only-testing:cmuxTests/SessionPersistenceTests/testSnapshotCachesNewProcessDetectedSurfaceResumeBindingForLaterNoScanSave -only-testing:cmuxTests/SessionPersistenceTests/testSnapshotPrefersProcessDetectedTmuxOverAgentHookBinding -only-testing:cmuxTests/SessionPersistenceTests/testAutosaveFingerprintIgnoresSurfaceResumeBindingUpdatedAt test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes session snapshot/autosave fingerprinting and resume-binding reconciliation logic, which can affect when sessions auto-resume or clear state across panels. Test coverage is expanded, but subtle edge cases around scan/no-scan behavior and binding matching could impact restore behavior.
> 
> **Overview**
> Fixes stale agent auto-resume state by making `restorableAgentIndex` optional in `TabManager` snapshot/fingerprint paths and treating “index provided” as a *completed live scan* signal.
> 
> When a scan is provided, `Workspace` now reconciles per-panel restored-agent snapshots and `agent-hook` resume bindings: it drops cached restored-agent state and removes `agent-hook` bindings that no longer match the scanned live agent (matching by session/checkpoint id and kind, case-insensitive, including custom kinds). It also preserves pending/manual resume cases while a resume is in-flight, refreshes resume-state when agent identity changes, and avoids clearing on early `promptIdle` before command-running is observed.
> 
> Adds extensive unit tests covering stale bindings, pending/manual preservation across empty scans, non-overriding of different live agents, and registry/custom kind matching; updates test helpers to generate restorable-agent indexes for multiple agent kinds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a44d2eced34c72024f0fc0a2623d97e7f7e3277. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782018735&installation_id=133855650&pr_number=4542&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4542&signature=a44ff92532ece82d0fd4c3fafcfa5d893df75eb7208a58e2dface14c8c5d4ca2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents stale auto-resume after a killed or changed agent by reconciling restored-agent snapshots and `agent-hook` bindings against live scans. Also makes restorable-agent scans optional so `TabManager` plain snapshots (no scan) keep valid pending resumes intact.

- **Bug Fixes**
  - Treat the restorable-agent index as optional; only drop restored-agent snapshots and `agent-hook` bindings when a scan is provided and no match is found. Keep state unchanged for no-scan snapshots (e.g., `TabManager` autosave).
  - Refresh resume state when the restored agent identity changes; clear stale invalidations after a scan that found nothing.
  - Validate `agent-hook` bindings during reconciliation and when computing the effective binding: kind is case-insensitive (supports registry/custom like `pi`) and checkpoint/session must match; never override a different live agent; keep a matching pending binding during startup.
  - Preserve pending auto-resume through the initial prompt; clear only after the command starts, and clear snapshot/binding if the running agent later disappears.

<sup>Written for commit 0a44d2eced34c72024f0fc0a2623d97e7f7e3277. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4542?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved session-restore reconciliation driven by a provided restorable-agent index to better reconcile restored agent state and resume bindings per panel.

* **Bug Fixes**
  * Reject stale agent-hook resume bindings when the index was scanned but no matching restored agent exists.
  * Refined startup resume-state handling to avoid preserving invalid restored agent snapshots.

* **Performance**
  * Avoided redundant per-panel snapshot recomputation during autosave/restore.

* **Tests**
  * Added tests covering stale resume bindings, pending resume survival, and startup clearance scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4542?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->