### PR TITLE
Revert "Fix browser WebView refresh on workspace hide"

### DIFF
--- a/Sources/Panels/BrowserHiddenWebViewDiscardPolicy.swift
+++ b/Sources/Panels/BrowserHiddenWebViewDiscardPolicy.swift
@@ -8,7 +8,7 @@ nonisolated enum BrowserHiddenWebViewDiscardPolicy {
 
     static let enabledKey = "browserHiddenWebViewDiscardEnabled"
     static let hiddenDelayKey = "browserHiddenWebViewDiscardDelaySeconds"
-    static let defaultEnabled = false
+    static let defaultEnabled = true
     static let defaultHiddenDelay: TimeInterval = 300
     static let minimumHiddenDelay: TimeInterval = 0
     static let maximumHiddenDelay: TimeInterval = 3600

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -1479,66 +1479,6 @@ final class BrowserPanelPopupContextTests: XCTestCase {
 
 @MainActor
 final class BrowserPanelWebViewLifecycleTests: XCTestCase {
-    private static var hasHiddenDiscardEnabledEnvironmentOverride: Bool {
-        ProcessInfo.processInfo.environment["CMUX_BROWSER_HIDDEN_WEBVIEW_DISCARD_ENABLED"] != nil
-    }
-
-    private static var hiddenDiscardEnvironmentOverrideDisablesPolicy: Bool {
-        guard let value = ProcessInfo.processInfo.environment["CMUX_BROWSER_HIDDEN_WEBVIEW_DISCARD_ENABLED"]?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .lowercased() else {
-            return false
-        }
-        return ["0", "false", "no", "off"].contains(value)
-    }
-
-    private func withHiddenWebViewDiscardDefaults(
-        enabled: Bool?,
-        delay: TimeInterval? = nil,
-        _ body: () throws -> Void
-    ) rethrows {
-        let defaults = UserDefaults.standard
-        let previousEnabled = defaults.object(forKey: BrowserHiddenWebViewDiscardPolicy.enabledKey)
-        let previousDelay = defaults.object(forKey: BrowserHiddenWebViewDiscardPolicy.hiddenDelayKey)
-        defer {
-            if let previousEnabled {
-                defaults.set(previousEnabled, forKey: BrowserHiddenWebViewDiscardPolicy.enabledKey)
-            } else {
-                defaults.removeObject(forKey: BrowserHiddenWebViewDiscardPolicy.enabledKey)
-            }
-            if let previousDelay {
-                defaults.set(previousDelay, forKey: BrowserHiddenWebViewDiscardPolicy.hiddenDelayKey)
-            } else {
-                defaults.removeObject(forKey: BrowserHiddenWebViewDiscardPolicy.hiddenDelayKey)
-            }
-        }
-
-        if let enabled {
-            defaults.set(enabled, forKey: BrowserHiddenWebViewDiscardPolicy.enabledKey)
-        } else {
-            defaults.removeObject(forKey: BrowserHiddenWebViewDiscardPolicy.enabledKey)
-        }
-        if let delay {
-            defaults.set(delay, forKey: BrowserHiddenWebViewDiscardPolicy.hiddenDelayKey)
-        } else {
-            defaults.removeObject(forKey: BrowserHiddenWebViewDiscardPolicy.hiddenDelayKey)
-        }
-
-        try body()
-    }
-
-    private func waitForBrowserPanelWebViewToFinishLoading(
-        _ panel: BrowserPanel,
-        file: StaticString = #filePath,
-        line: UInt = #line
-    ) {
-        let deadline = Date().addingTimeInterval(1.0)
-        while panel.webView.isLoading,
-              RunLoop.main.run(mode: .default, before: deadline),
-              Date() < deadline {}
-        XCTAssertFalse(panel.webView.isLoading, "Timed out waiting for browser panel WebView to finish loading", file: file, line: line)
-    }
-
     func testHiddenDiscardPolicyReadsUserDefaults() throws {
         let suiteName = "cmux.browserHiddenDiscardPolicyTests.\(UUID().uuidString)"
         let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
@@ -1584,47 +1524,6 @@ final class BrowserPanelWebViewLifecycleTests: XCTestCase {
                 BrowserHiddenWebViewDiscardPolicy.hiddenDelay(defaults: defaults),
                 BrowserHiddenWebViewDiscardPolicy.defaultHiddenDelay
             )
-        }
-    }
-
-    func testDefaultWorkspaceVisibilityHidePreservesWebViewIdentityPastDiscardDelay() throws {
-        try XCTSkipIf(
-            Self.hasHiddenDiscardEnabledEnvironmentOverride,
-            "Environment override makes the default hidden-discard policy unobservable."
-        )
-
-        try withHiddenWebViewDiscardDefaults(enabled: nil, delay: 0) {
-            XCTAssertFalse(BrowserHiddenWebViewDiscardPolicy.isEnabled)
-
-            let hiddenAt = Date().addingTimeInterval(-1)
-            let panel = BrowserPanel(
-                workspaceId: UUID(),
-                initialURL: URL(string: "about:blank")!,
-                isRemoteWorkspace: false
-            )
-            defer { panel.close() }
-            waitForBrowserPanelWebViewToFinishLoading(panel)
-
-            panel.noteWebViewVisibility(true, reason: "test.workspace.visible")
-            XCTAssertEqual(panel.webViewLifecycleState, .liveVisible)
-            let originalWebView = panel.webView
-
-            panel.noteWebViewVisibility(false, reason: "test.workspace.hidden", now: hiddenAt)
-
-            XCTAssertTrue(
-                panel.webView === originalWebView,
-                "Workspace visibility hides must preserve the live WKWebView unless Browser Memory Saver is explicitly enabled"
-            )
-            XCTAssertTrue(panel.shouldRenderWebView)
-            XCTAssertEqual(panel.webViewLifecycleState, .liveHidden)
-
-            panel.noteWebViewVisibility(true, reason: "test.workspace.revisible")
-
-            XCTAssertTrue(
-                panel.webView === originalWebView,
-                "Re-showing a workspace-hidden browser should rebind the same WKWebView instead of navigating a replacement"
-            )
-            XCTAssertEqual(panel.webViewLifecycleState, .liveVisible)
         }
     }
 
@@ -1767,93 +1666,87 @@ final class BrowserPanelWebViewLifecycleTests: XCTestCase {
         XCTAssertEqual(panel.webViewLifecycleState, .closing)
     }
 
-    func testDiscardReplacesHiddenWebViewAndRestoresOnDemand() throws {
-        try XCTSkipIf(
-            Self.hiddenDiscardEnvironmentOverrideDisablesPolicy,
-            "Environment override disables Browser Memory Saver."
+    func testDiscardReplacesHiddenWebViewAndRestoresOnDemand() {
+        let discardedAt = Date(timeIntervalSince1970: 200)
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            initialURL: URL(string: "about:blank")!,
+            isRemoteWorkspace: false
         )
+        defer { panel.close() }
 
-        try withHiddenWebViewDiscardDefaults(enabled: true) {
-            let discardedAt = Date(timeIntervalSince1970: 200)
-            let panel = BrowserPanel(
-                workspaceId: UUID(),
-                initialURL: URL(string: "about:blank")!,
-                isRemoteWorkspace: false
-            )
-            defer { panel.close() }
+        let deadline = Date().addingTimeInterval(1.0)
+        while panel.webView.isLoading,
+              RunLoop.main.run(mode: .default, before: deadline),
+              Date() < deadline {}
+        XCTAssertFalse(panel.webView.isLoading, "Timed out waiting for about:blank to finish loading")
 
-            waitForBrowserPanelWebViewToFinishLoading(panel)
+        panel.noteWebViewVisibility(false, reason: "test.hidden", now: discardedAt)
+        let originalWebView = panel.webView
 
-            panel.noteWebViewVisibility(false, reason: "test.hidden", now: discardedAt)
-            let originalWebView = panel.webView
+        XCTAssertTrue(panel.discardHiddenWebViewForMemory(reason: "test.discard", now: discardedAt))
+        XCTAssertFalse(panel.webView === originalWebView)
+        XCTAssertFalse(panel.shouldRenderWebView)
+        XCTAssertEqual(panel.webViewLifecycleState, .discarded)
 
-            XCTAssertTrue(panel.discardHiddenWebViewForMemory(reason: "test.discard", now: discardedAt))
-            XCTAssertFalse(panel.webView === originalWebView)
-            XCTAssertFalse(panel.shouldRenderWebView)
-            XCTAssertEqual(panel.webViewLifecycleState, .discarded)
+        let discardedPayload = panel.webViewLifecycleTopPayload(now: discardedAt)
+        XCTAssertEqual(discardedPayload["state"] as? String, "discarded")
+        XCTAssertEqual(discardedPayload["last_discard_reason"] as? String, "test.discard")
+        XCTAssertNotNil(discardedPayload["discarded_at"] as? String)
 
-            let discardedPayload = panel.webViewLifecycleTopPayload(now: discardedAt)
-            XCTAssertEqual(discardedPayload["state"] as? String, "discarded")
-            XCTAssertEqual(discardedPayload["last_discard_reason"] as? String, "test.discard")
-            XCTAssertNotNil(discardedPayload["discarded_at"] as? String)
-
-            var observedStates: [BrowserWebViewLifecycleState] = []
-            var cancellable: AnyCancellable?
-            cancellable = panel.$webViewLifecycleState.sink { state in
-                observedStates.append(state)
-            }
-            defer { cancellable?.cancel() }
-
-            XCTAssertTrue(panel.restoreDiscardedWebViewIfNeeded(reason: "test.restore"))
-            XCTAssertTrue(panel.shouldRenderWebView)
-            XCTAssertEqual(panel.webViewLifecycleState, .liveHidden)
-            XCTAssertFalse(observedStates.contains(.newTab), "Restore emitted unexpected states: \(observedStates)")
-
-            panel.noteWebViewVisibility(true, reason: "test.visible")
-            XCTAssertEqual(panel.webViewLifecycleState, .liveVisible)
+        var observedStates: [BrowserWebViewLifecycleState] = []
+        var cancellable: AnyCancellable?
+        cancellable = panel.$webViewLifecycleState.sink { state in
+            observedStates.append(state)
         }
+        defer { cancellable?.cancel() }
+
+        XCTAssertTrue(panel.restoreDiscardedWebViewIfNeeded(reason: "test.restore"))
+        XCTAssertTrue(panel.shouldRenderWebView)
+        XCTAssertEqual(panel.webViewLifecycleState, .liveHidden)
+        XCTAssertFalse(observedStates.contains(.newTab), "Restore emitted unexpected states: \(observedStates)")
+
+        panel.noteWebViewVisibility(true, reason: "test.visible")
+        XCTAssertEqual(panel.webViewLifecycleState, .liveVisible)
     }
 
-    func testRestoredHistoryBackDoesNotEmitNewTabLifecycleState() throws {
-        try XCTSkipIf(
-            Self.hiddenDiscardEnvironmentOverrideDisablesPolicy,
-            "Environment override disables Browser Memory Saver."
+    func testRestoredHistoryBackDoesNotEmitNewTabLifecycleState() {
+        let discardedAt = Date(timeIntervalSince1970: 300)
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            initialURL: URL(string: "about:blank")!,
+            isRemoteWorkspace: false
         )
+        defer { panel.close() }
 
-        try withHiddenWebViewDiscardDefaults(enabled: true) {
-            let discardedAt = Date(timeIntervalSince1970: 300)
-            let panel = BrowserPanel(
-                workspaceId: UUID(),
-                initialURL: URL(string: "about:blank")!,
-                isRemoteWorkspace: false
-            )
-            defer { panel.close() }
+        let deadline = Date().addingTimeInterval(1.0)
+        while panel.webView.isLoading,
+              RunLoop.main.run(mode: .default, before: deadline),
+              Date() < deadline {}
+        XCTAssertFalse(panel.webView.isLoading, "Timed out waiting for about:blank to finish loading")
 
-            waitForBrowserPanelWebViewToFinishLoading(panel)
+        panel.restoreSessionNavigationHistory(
+            backHistoryURLStrings: ["https://example.test/back"],
+            forwardHistoryURLStrings: [],
+            currentURLString: "https://example.test/current"
+        )
+        XCTAssertTrue(panel.canGoBack)
 
-            panel.restoreSessionNavigationHistory(
-                backHistoryURLStrings: ["https://example.test/back"],
-                forwardHistoryURLStrings: [],
-                currentURLString: "https://example.test/current"
-            )
-            XCTAssertTrue(panel.canGoBack)
+        panel.noteWebViewVisibility(false, reason: "test.hidden", now: discardedAt)
+        XCTAssertTrue(panel.discardHiddenWebViewForMemory(reason: "test.discard", now: discardedAt))
+        XCTAssertEqual(panel.webViewLifecycleState, .discarded)
 
-            panel.noteWebViewVisibility(false, reason: "test.hidden", now: discardedAt)
-            XCTAssertTrue(panel.discardHiddenWebViewForMemory(reason: "test.discard", now: discardedAt))
-            XCTAssertEqual(panel.webViewLifecycleState, .discarded)
-
-            var observedStates: [BrowserWebViewLifecycleState] = []
-            var cancellable: AnyCancellable?
-            cancellable = panel.$webViewLifecycleState.sink { state in
-                observedStates.append(state)
-            }
-            defer { cancellable?.cancel() }
-
-            panel.goBack()
-
-            XCTAssertFalse(observedStates.contains(.newTab), "Back restore emitted unexpected states: \(observedStates)")
-            XCTAssertEqual(panel.webViewLifecycleState, .liveHidden)
+        var observedStates: [BrowserWebViewLifecycleState] = []
+        var cancellable: AnyCancellable?
+        cancellable = panel.$webViewLifecycleState.sink { state in
+            observedStates.append(state)
         }
+        defer { cancellable?.cancel() }
+
+        panel.goBack()
+
+        XCTAssertFalse(observedStates.contains(.newTab), "Back restore emitted unexpected states: \(observedStates)")
+        XCTAssertEqual(panel.webViewLifecycleState, .liveHidden)
     }
 }
 

--- a/web/data/cmux.schema.json
+++ b/web/data/cmux.schema.json
@@ -720,7 +720,7 @@
         },
         "discardHiddenWebViews": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "description": "Allow hidden browser tabs to release page memory and restore when shown again."
         },
         "hiddenWebViewDiscardDelaySeconds": {


### PR DESCRIPTION
Reverts manaflow-ai/cmux#4388

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4545"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782019007&installation_id=133855650&pr_number=4545&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4545&signature=d3fc28adc8d3a8753818c0f220cc442b47ef745932dc33f9aa24ca0e45c2c89a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default lifecycle behavior for hidden browser tabs by enabling WebView discarding by default, which can affect tab state retention and restore paths. Risk is moderate because it impacts runtime WebKit lifecycle/memory behavior and adjusts related tests to match the new default.
> 
> **Overview**
> Re-enables the browser “memory saver” behavior by default by flipping `BrowserHiddenWebViewDiscardPolicy.defaultEnabled` (and the `discardHiddenWebViews` config schema default) from `false` to `true`.
> 
> Updates `BrowserPanelWebViewLifecycleTests` to reflect the new always-on default: removes the test asserting workspace-hide preserves the same `WKWebView` when discarding is disabled, and simplifies discard/restore tests by dropping UserDefaults/environment-override scaffolding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8658c5a428d4d775816115b7be8e117c38f412e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the change that kept browser WebViews alive when workspaces are hidden. Hidden tabs are now discarded by default again to save memory and restored when shown.

- **Bug Fixes**
  - Set `BrowserHiddenWebViewDiscardPolicy.defaultEnabled` back to `true`.
  - Updated `web/data/cmux.schema.json` default for `discardHiddenWebViews` to `true`.
  - Simplified lifecycle tests to align with discard-on-hide defaults and removed keep-alive specific cases.

<sup>Written for commit 8658c5a428d4d775816115b7be8e117c38f412e6. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4545?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hidden web view discard feature is now enabled by default, improving memory management when browser panels are hidden.

* **Tests**
  * Updated test suite to verify discard and restore behavior for hidden web views.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4545?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->