### PR TITLE
Fix Git repository lookup loop for non-repo workspaces

### DIFF
--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -4890,6 +4890,10 @@ class TabManager: ObservableObject {
     }
 
 #if DEBUG
+    nonisolated static func resolvedGitRepositoryWorkTreeRootForTesting(directory: String) -> String? {
+        resolveGitRepository(containing: directory)?.workTreeRoot
+    }
+
     nonisolated static func workspaceGitMetadataWatchedPathsForTesting(directory: String) -> [String] {
         workspaceGitMetadataWatcherDescriptor(for: directory)?.watchedPaths ?? []
     }

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -3012,7 +3012,10 @@ class TabManager: ObservableObject {
         var isDirectory: ObjCBool = false
 
         if !fileManager.fileExists(atPath: currentURL.path, isDirectory: &isDirectory) || !isDirectory.boolValue {
-            currentURL.deleteLastPathComponent()
+            guard let parentURL = parentDirectoryURL(for: currentURL) else {
+                return nil
+            }
+            currentURL = parentURL
         }
 
         while true {
@@ -3035,12 +3038,30 @@ class TabManager: ObservableObject {
                 }
             }
 
-            let parentURL = currentURL.deletingLastPathComponent()
-            if parentURL.path == currentURL.path {
+            guard let parentURL = parentDirectoryURL(for: currentURL) else {
                 return nil
             }
             currentURL = parentURL
         }
+    }
+
+    private nonisolated static func parentDirectoryURL(for url: URL) -> URL? {
+        let currentPath = url.standardizedFileURL.path
+        guard currentPath != "/" else {
+            return nil
+        }
+
+        var components = currentPath.split(separator: "/", omittingEmptySubsequences: true).map(String.init)
+        guard !components.isEmpty else {
+            return nil
+        }
+        components.removeLast()
+
+        let parentPath = components.isEmpty ? "/" : "/" + components.joined(separator: "/")
+        guard parentPath != currentPath else {
+            return nil
+        }
+        return URL(fileURLWithPath: parentPath, isDirectory: true).standardizedFileURL
     }
 
     private nonisolated static func gitDirectoryFromDotGitFile(

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -776,6 +776,21 @@ final class TabManagerPullRequestProbeTests: XCTestCase {
         )
     }
 
+    func testResolveGitRepositoryStopsAtFilesystemRootForNonGitDirectory() throws {
+        XCTAssertNil(TabManager.resolvedGitRepositoryWorkTreeRootForTesting(directory: "/"))
+
+        let fileManager = FileManager.default
+        let directoryURL = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-git-root-stop-\(UUID().uuidString)", isDirectory: true)
+            .appendingPathComponent("nested", isDirectory: true)
+            .appendingPathComponent("workspace", isDirectory: true)
+        try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: directoryURL.deletingLastPathComponent().deletingLastPathComponent()) }
+
+        XCTAssertNil(TabManager.resolvedGitRepositoryWorkTreeRootForTesting(directory: directoryURL.path))
+        XCTAssertEqual(TabManager.workspaceGitMetadataWatchedPathsForTesting(directory: directoryURL.path), [])
+    }
+
     func testInheritedBackgroundWorkspaceFetchesGitBranchWithoutSelection() throws {
         let fileManager = FileManager.default
         let repoURL = fileManager.temporaryDirectory.appendingPathComponent(


### PR DESCRIPTION
## Summary
- Stop sidebar Git metadata repository resolution when path traversal reaches the filesystem root.
- Add a regression test for resolving Git metadata from `/` and a nested non-Git workspace directory.

## Testing
- `xcodebuild -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/cmux-gitloop -only-testing:cmuxTests/TabManagerPullRequestProbeTests/testResolveGitRepositoryStopsAtFilesystemRootForNonGitDirectory test`
- `./scripts/reload.sh --tag gitloop4529`
- AWS `cmux-aws-m4pro` macOS 15.7.4: old root traversal harness reproduces `/ -> /.. -> /../..` and exits `42`.
- AWS `cmux-aws-m4pro` macOS 15.7.4: fixed root traversal harness walks `/tmp/cmux-non-git/workspace -> /tmp/cmux-non-git -> /tmp -> /`, then exits `0`.

## Issues
- Closes https://github.com/manaflow-ai/cmux/issues/4529
- Related: https://github.com/manaflow-ai/cmux/issues/4529#issuecomment-4515437582
