### PR TITLE
Fix git probe ancestor walk leaking tens of GB on macOS 14/15 (#4529)

### DIFF
--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -904,7 +904,7 @@ class TabManager: ObservableObject {
         let pullRequest: WorkspacePullRequestSnapshot
     }
 
-    private struct ResolvedGitRepository: Equatable, Sendable {
+    struct ResolvedGitRepository: Equatable, Sendable {
         let workTreeRoot: String
         let gitDirectory: String
         let commonDirectory: String
@@ -3005,17 +3005,41 @@ class TabManager: ObservableObject {
         )
     }
 
-    private nonisolated static func resolveGitRepository(containing directory: String) -> ResolvedGitRepository? {
-        let startURL = URL(fileURLWithPath: directory).standardizedFileURL
+    // Hard cap on ancestor-walk depth. Generous (PATH_MAX is 1024, real-world
+    // depth rarely exceeds a few dozen) so we never loop unbounded even if a
+    // future Foundation change reintroduces the macOS 14/15 "URL never
+    // converges at root" behavior. See https://github.com/manaflow-ai/cmux/issues/4529.
+    static let gitProbeMaxAncestorAscent = 4096
+
+    /// Pure step function: compute the parent directory URL to visit next
+    /// while walking up looking for a `.git` entry. Returns nil at the
+    /// filesystem root. Exposed for unit tests; the `parentResolver` injection
+    /// point lets a test emulate the macOS 14/15 `URL.deletingLastPathComponent`
+    /// behavior on a macOS-26 CI runner.
+    nonisolated static func gitProbeNextAncestor(
+        _ current: URL,
+        parentResolver: (URL) -> URL = { $0.deletingLastPathComponent() }
+    ) -> URL? {
+        let parent = parentResolver(current)
+        if parent.path == current.path {
+            return nil
+        }
+        return parent
+    }
+
+    nonisolated static func resolveGitRepository(containing directory: String) -> ResolvedGitRepository? {
         let fileManager = FileManager.default
-        var currentURL = startURL
+        var currentURL = URL(fileURLWithPath: directory).standardizedFileURL
         var isDirectory: ObjCBool = false
 
         if !fileManager.fileExists(atPath: currentURL.path, isDirectory: &isDirectory) || !isDirectory.boolValue {
-            currentURL.deleteLastPathComponent()
+            guard let parent = gitProbeNextAncestor(currentURL) else { return nil }
+            currentURL = parent
         }
 
-        while true {
+        var iterations = 0
+        while iterations < Self.gitProbeMaxAncestorAscent {
+            iterations += 1
             let dotGitURL = currentURL.appendingPathComponent(".git")
             if fileManager.fileExists(atPath: dotGitURL.path, isDirectory: &isDirectory) {
                 let gitDirectory: String?
@@ -3035,12 +3059,10 @@ class TabManager: ObservableObject {
                 }
             }
 
-            let parentURL = currentURL.deletingLastPathComponent()
-            if parentURL.path == currentURL.path {
-                return nil
-            }
-            currentURL = parentURL
+            guard let parent = gitProbeNextAncestor(currentURL) else { return nil }
+            currentURL = parent
         }
+        return nil
     }
 
     private nonisolated static func gitDirectoryFromDotGitFile(

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -3016,11 +3016,24 @@ class TabManager: ObservableObject {
     /// filesystem root. Exposed for unit tests; the `parentResolver` injection
     /// point lets a test emulate the macOS 14/15 `URL.deletingLastPathComponent`
     /// behavior on a macOS-26 CI runner.
+    ///
+    /// `standardizedFileURL` is load-bearing: on macOS 14 and 15
+    /// `URL(fileURLWithPath: "/").deletingLastPathComponent()` returns
+    /// `URL("/..")` rather than `URL("/")`, and iterating that operation
+    /// without standardization grows the path string forever (`/..`,
+    /// `/../..`, `/../../..`, …). The walk never converged, the
+    /// `Task.detached(priority: .utility)` git probe spun at 200 % CPU,
+    /// and the surrounding autorelease pool retained the per-iteration
+    /// `NSURL`/`NSString` allocations — adding up to tens of GB of RSS
+    /// within minutes. Apple silently fixed the underlying Foundation
+    /// behavior in macOS 26. Standardizing here collapses `/..` back to
+    /// `/` so the path-equal stop condition fires on every macOS.
+    /// https://github.com/manaflow-ai/cmux/issues/4529
     nonisolated static func gitProbeNextAncestor(
         _ current: URL,
         parentResolver: (URL) -> URL = { $0.deletingLastPathComponent() }
     ) -> URL? {
-        let parent = parentResolver(current)
+        let parent = parentResolver(current).standardizedFileURL
         if parent.path == current.path {
             return nil
         }

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -3009,7 +3009,7 @@ class TabManager: ObservableObject {
     // depth rarely exceeds a few dozen) so we never loop unbounded even if a
     // future Foundation change reintroduces the macOS 14/15 "URL never
     // converges at root" behavior. See https://github.com/manaflow-ai/cmux/issues/4529.
-    static let gitProbeMaxAncestorAscent = 4096
+    nonisolated static let gitProbeMaxAncestorAscent = 4096
 
     /// Pure step function: compute the parent directory URL to visit next
     /// while walking up looking for a `.git` entry. Returns nil at the

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -3034,7 +3034,7 @@ class TabManager: ObservableObject {
         parentResolver: (URL) -> URL = { $0.deletingLastPathComponent() }
     ) -> URL? {
         let parent = parentResolver(current).standardizedFileURL
-        if parent.path == current.path {
+        if parent.path == current.standardizedFileURL.path {
             return nil
         }
         return parent

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -373,6 +373,7 @@
 		B7F9A602B7F9A602B7F9A602 /* WindowChromeMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7F9A603B7F9A603B7F9A603 /* WindowChromeMetrics.swift */; };
 		B7F9A604B7F9A604B7F9A604 /* RightSidebarChromeStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7F9A605B7F9A605B7F9A605 /* RightSidebarChromeStyle.swift */; };
 		B6BF3DC98DB1495E57900199 /* TabManagerUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42092CDB2109E250F7F2A76E /* TabManagerUnitTests.swift */; };
+		A22D2CB77E62CB829A5F2CCB /* TabManagerGitProbeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14AFBB8BBE5E7833EC1EFC70 /* TabManagerGitProbeTests.swift */; };
 		B8F266236A1A3D9A45BD840F /* SidebarResizeUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 818DBCD4AB69EB72573E8138 /* SidebarResizeUITests.swift */; };
 		C0DE34020000000000000005 /* HelpMenuUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE34020000000000000006 /* HelpMenuUITests.swift */; };
 		B8F266246A1A3D9A45BD840F /* SidebarHelpMenuUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F266256A1A3D9A45BD840F /* SidebarHelpMenuUITests.swift */; };
@@ -607,6 +608,7 @@
 		A9D9000000000000000F0016 /* markdown-viewer */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder; path = "markdown-viewer"; sourceTree = "<group>"; };
 		FEEDC0DEC0DEC0DEC0DE0002 /* FeedCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedCoordinatorTests.swift; sourceTree = "<group>"; };
 		42092CDB2109E250F7F2A76E /* TabManagerUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerUnitTests.swift; sourceTree = "<group>"; };
+		14AFBB8BBE5E7833EC1EFC70 /* TabManagerGitProbeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerGitProbeTests.swift; sourceTree = "<group>"; };
 		43430FA5929121E2EAAB3091 /* AuthEnvironment.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AuthEnvironment.swift; sourceTree = "<group>"; };
 		C3677001000000000000002 /* CmuxSSHURLRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxSSHURLRequestTests.swift; sourceTree = "<group>"; };
 		491751CE2321474474F27DCF /* TerminalControllerSocketSecurityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalControllerSocketSecurityTests.swift; sourceTree = "<group>"; };
@@ -1628,6 +1630,7 @@
 				B09C007F42697761B5F1A2AB /* OmnibarAndToolsTests.swift */,
 				D2C075029771815DD5DA1332 /* NotificationAndMenuBarTests.swift */,
 				42092CDB2109E250F7F2A76E /* TabManagerUnitTests.swift */,
+				14AFBB8BBE5E7833EC1EFC70 /* TabManagerGitProbeTests.swift */,
 				14A7DC53B9CA33BE2A421711 /* WorkspacePullRequestSidebarTests.swift */,
 				FEEDC0DEC0DEC0DEC0DE0002 /* FeedCoordinatorTests.swift */,
 				1D301919B10F22B8708E8883 /* WorkspaceManualUnreadTests.swift */,
@@ -2415,6 +2418,7 @@
 					C2B6A97D1F2E4C71A8B9D001 /* BrowserOmnibarPerformanceSupportTests.swift in Sources */,
 					734F49D37E543DD01C2F4FEF /* NotificationAndMenuBarTests.swift in Sources */,
 				B6BF3DC98DB1495E57900199 /* TabManagerUnitTests.swift in Sources */,
+				A22D2CB77E62CB829A5F2CCB /* TabManagerGitProbeTests.swift in Sources */,
 				DCC935C5F55C1DCB33E25521 /* WorkspacePullRequestSidebarTests.swift in Sources */,
 				FEEDC0DEC0DEC0DEC0DE0001 /* FeedCoordinatorTests.swift in Sources */,
 				0F2C25F9170130F8DC09DD1B /* WorkspaceManualUnreadTests.swift in Sources */,

--- a/cmuxTests/TabManagerGitProbeTests.swift
+++ b/cmuxTests/TabManagerGitProbeTests.swift
@@ -1,0 +1,105 @@
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+// Regression coverage for https://github.com/manaflow-ai/cmux/issues/4529.
+//
+// On macOS 14 and 15, Foundation's `URL(fileURLWithPath: "/").deletingLastPathComponent()`
+// returns `URL("/..")` instead of `URL("/")`, and iterating that operation
+// never converges — the path grows `/..`, `/../..`, `/../../..`, etc. Apple
+// silently fixed the behavior in macOS 26.
+//
+// `TabManager.resolveGitRepository(containing:)` walked ancestor directories
+// looking for a `.git` entry and stopped only when `parentURL.path ==
+// currentURL.path`. With the broken Foundation behavior the stop condition
+// never fired, the `while true` body spun on a `Task.detached(priority:
+// .utility)` thread, and every iteration allocated a longer NSString path
+// plus several autoreleased FileManager and URL temporaries. With no
+// `autoreleasepool` around the loop the surrounding pool never drained and
+// the process accumulated tens of GB of retained strings.
+//
+// These tests inject a parent walker that emulates the macOS 14/15 behavior
+// so the regression is deterministic on the macOS 26 CI runner that ships
+// with the repo. `testGitProbeAscentTerminatesUnderMacOS14StyleParentWalker`
+// is the canary that fails before the standardization fix and passes after.
+final class TabManagerGitProbeAncestorWalkTests: XCTestCase {
+    // Mimics macOS 14/15's broken `URL.deletingLastPathComponent()`:
+    // at `/`, returns `/..`; after that, appends another `/..` each call.
+    // Anywhere else, defers to Foundation's normal behavior.
+    private func macOS14StyleParentWalker(_ url: URL) -> URL {
+        let p = url.path
+        if p == "/" {
+            return URL(fileURLWithPath: "/..")
+        }
+        if p.hasPrefix("/..") {
+            return URL(fileURLWithPath: p + "/..")
+        }
+        return url.deletingLastPathComponent()
+    }
+
+    func testGitProbeAscentTerminatesUnderMacOS14StyleParentWalker() {
+        // Walk up from a deep path using the buggy macOS 14/15 walker. The
+        // fix in `gitProbeNextAncestor` is to standardize the parent URL so
+        // `/..` collapses back to `/` and the path-equal stop condition
+        // fires. Without that, this loop hits the test cap.
+        var current: URL? = URL(fileURLWithPath: "/Users/test/cmux")
+        var iterations = 0
+        let cap = 50
+        while let url = current, iterations < cap {
+            current = TabManager.gitProbeNextAncestor(url, parentResolver: macOS14StyleParentWalker)
+            iterations += 1
+        }
+        XCTAssertNil(current, "ascent must converge to nil at the filesystem root")
+        XCTAssertLessThan(iterations, 10, "convergence must be O(depth), not unbounded")
+    }
+
+    func testGitProbeAscentTerminatesFromDotsURLUnderMacOS14StyleWalker() {
+        // Direct exposure of the bug shape: starting at `/..`, the buggy
+        // walker returns `/../..`. The fix must still converge.
+        var current: URL? = URL(fileURLWithPath: "/..")
+        var iterations = 0
+        let cap = 50
+        while let url = current, iterations < cap {
+            current = TabManager.gitProbeNextAncestor(url, parentResolver: macOS14StyleParentWalker)
+            iterations += 1
+        }
+        XCTAssertNil(current, "ascent from `/..` must converge to nil")
+        XCTAssertLessThan(iterations, 5)
+    }
+
+    func testGitProbeAscentTerminatesUnderRealFoundation() {
+        // Sanity: with real Foundation, the loop must also terminate on the
+        // current macOS. Defends against future regressions that break the
+        // native path too.
+        var current: URL? = URL(fileURLWithPath: "/Users")
+        var iterations = 0
+        let cap = 50
+        while let url = current, iterations < cap {
+            current = TabManager.gitProbeNextAncestor(url)
+            iterations += 1
+        }
+        XCTAssertNil(current)
+        XCTAssertLessThan(iterations, 10)
+    }
+
+    func testResolveGitRepositoryReturnsNilAtRootInBoundedTime() throws {
+        let started = Date()
+        let result = TabManager.resolveGitRepository(containing: "/")
+        let elapsed = Date().timeIntervalSince(started)
+        XCTAssertNil(result, "filesystem root is not a git repository")
+        XCTAssertLessThan(elapsed, 1.0, "must terminate quickly even when no .git is found")
+    }
+
+    func testGitProbeAscentCapIsGenerous() {
+        // The cap exists as defense-in-depth against a future Foundation
+        // regression of this bug class. It must be high enough that
+        // legitimate deeply-nested checkouts still succeed, but finite so a
+        // broken `deletingLastPathComponent` can never burn unbounded RSS.
+        XCTAssertGreaterThanOrEqual(TabManager.gitProbeMaxAncestorAscent, 1024)
+        XCTAssertLessThanOrEqual(TabManager.gitProbeMaxAncestorAscent, 1 << 20)
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/manaflow-ai/cmux/issues/4529
Fixes https://github.com/manaflow-ai/cmux/issues/4520

## Root cause

`TabManager.resolveGitRepository(containing:)` (added in commit `e53b9794e`, #2797) walks ancestor directories looking for a `.git` entry and stops only when `parentURL.path == currentURL.path`. On **macOS 14 and 15** `URL(fileURLWithPath: "/").deletingLastPathComponent()` returns `URL("/..")` rather than `URL("/")`, and iterating that operation never converges:

```
/  ->  /..  ->  /../..  ->  /../../..  ->  /../../../..  -> …
```

The stop condition is unreachable on those macOS versions. The probe runs on `Task.detached(priority: .utility)` with no `autoreleasepool`, so every spin retains another set of `NSURL` / `NSString` / `FileManager` allocations and the surrounding pool never drains. RSS climbs at multiple GB/min, CPU pegs at 200 %, and the OS eventually OOMs the app.

Apple silently fixed the underlying Foundation behavior in macOS 26. The repo's CI runner (`macos-26` default per `repo/CLAUDE.md`) and most maintainer machines are on macOS 26, so the regression slipped through review. **Every reporter on #4529 and #4520 is on macOS 14.x or 15.x.**

## Empirical verification

Provisioned six AWS Mac builders on macOS 15.7.4 24G517 (matching @ma-pony's hang report from #4520) and ran v0.64.8 from the published DMG. RSS sampled every 15 s for 7.5 min:

| Scenario | Start | End | Δ | Rate | CPU |
|---|---|---|---|---|---|
| v0.64.8 default (any cwd, 3 hosts) | ~3.8 GB | ~28 GB | +24 GB | **3.2 GB/min** | **200 %** sustained |
| v0.64.8 + `{\"sidebar\":{\"watchGitStatus\":false}}` | 242 MB | 242 MB | +0 | flat | 0.5 % |
| v0.64.7 baseline (pre-regression) | 200 MB | 200 MB | +4 MB | flat | 0.5 % |

The workaround already documented in #4529 (disabling sidebar git status watching) eliminates the leak exactly because it skips the broken probe. v0.64.7 is clean because the pure-Swift `resolveGitRepository` was added in v0.64.8.

URL behavior was also independently confirmed on the same host:
```
$ ssh cmux-aws-m4pro xcrun swift /tmp/url_probe_remote.swift
=== Version 15.7.4 (Build 24G517) ===
iter 0: / -> /.. | equal=false
iter 1: /.. -> /../.. | equal=false
iter 2: /../.. -> /../../.. | equal=false
…
```

## Fix

Standardize the parent URL inside the new `gitProbeNextAncestor` helper. `URL.standardizedFileURL` collapses `/..` back to `/`, so the existing path-equal stop condition fires on every macOS.

Belt-and-suspenders defenses also applied:
- `gitProbeMaxAncestorAscent = 4096` hard cap on the ancestor walk so any future Foundation regression of this bug class still terminates instead of leaking.
- `resolveGitRepository` refactored to call `gitProbeNextAncestor` everywhere it ascends, including the initial \"input path is a file, walk up\" trim.

## Two-commit regression structure

Per `repo/CLAUDE.md`, split into red/green so CI proves the test catches the bug.

CI runs on macOS 26 where Foundation already behaves correctly, so a test against the real `URL.deletingLastPathComponent()` can't fail. The test instead injects a `parentResolver` closure that **emulates the macOS 14/15 behavior** even on a macOS 26 runner. With that injected walker:

- Commit 1 (red): `gitProbeNextAncestor` does not standardize. The injected walker grows `/`, `/..`, `/../..`, … forever. The test hits its 50-iteration cap and fails.
- Commit 2 (green): `.standardizedFileURL` is applied. The walker's `/..` collapses to `/`, the path-equal stop condition fires, the loop converges in ~3 iterations and the test passes.

## Scope

This PR fixes the **dominant** 0.64.8 leak — the one that fires on launch regardless of user activity. The other two leak vectors identified during investigation already have open fix PRs from @austinywang:
- https://github.com/manaflow-ai/cmux/pull/4548 — bound hidden browser WebView retention (the WebContent process accumulation reported in #4539)
- https://github.com/manaflow-ai/cmux/pull/4536 — bound unbounded Vault JSONL history scans

Recommend a `macos-15` CI job in a follow-up to defend against any future regression of this exact class.

## Test plan
- [x] Tagged debug build green (`xcodebuild -derivedDataPath /tmp/cmux-issue-4529-git-probe-url-loop build`)
- [x] Red commit demonstrates failing canary test on the injected walker
- [x] Green commit demonstrates passing canary test
- [ ] Manual repro on a macOS 15 host: launch v0.64.8 → confirm RSS curve. Then build the patched DEV app via `./scripts/reload.sh --tag issue-4529-git-probe-url-loop` → re-launch → confirm RSS stays flat.
- [ ] Unit tests (`cmux-unit` scheme) on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4552"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782022257&installation_id=133855650&pr_number=4552&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4552&signature=ea8b377721430ad3e0ba7d72182afa6c3464699e58895d1d65d0a07be5b3944a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the git repository discovery loop used during workspace probing; mistakes could cause false negatives/positives for repo detection, but the change is localized and backed by new unit tests targeting the macOS 14/15 infinite-walk regression.
> 
> **Overview**
> Fixes `TabManager.resolveGitRepository(containing:)` potentially looping forever while walking parent directories (macOS 14/15 `URL.deletingLastPathComponent()` root behavior), which could drive high CPU and unbounded memory growth.
> 
> Introduces `gitProbeNextAncestor` (with URL standardization) plus a hard iteration cap (`gitProbeMaxAncestorAscent`) and routes all ancestor ascents through it; adds `TabManagerGitProbeTests` to deterministically emulate the macOS 14/15 behavior and assert bounded convergence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1febb75508fae5d963644d231aad376c7e1613d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a runaway ancestor walk in the Git repo probe on macOS 14/15 that caused 200% CPU and multi‑GB/min memory growth. Ensures the walk converges by standardizing URLs and adding a hard cap. Fixes #4529 and #4520.

- **Bug Fixes**
  - Standardize both parent and current URLs in `gitProbeNextAncestor` via `standardizedFileURL`, collapsing `/..` to `/` and handling unstandardized inputs so the root stop condition triggers on macOS 14/15 and when callers pass `/..`.
  - Add `gitProbeMaxAncestorAscent = 4096` to hard‑cap the ancestor walk and prevent unbounded loops.

- **Refactors**
  - Route all ascents in `resolveGitRepository(containing:)` through `gitProbeNextAncestor`; expose `ResolvedGitRepository` internally and add `TabManagerGitProbeTests.swift` to emulate macOS 14/15 behavior and verify convergence.
  - Mark `gitProbeMaxAncestorAscent` as `nonisolated` to resolve Swift 6 actor‑isolation warnings.

<sup>Written for commit e1febb75508fae5d963644d231aad376c7e1613d. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4552?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Git repository detection to use a capped, deterministic ancestor walk, preventing non-terminating searches and avoiding performance and memory issues when probing parent directories.

* **Tests**
  * Added regression and convergence tests to ensure repository probing terminates reliably across edge-case directory behaviors and remains bounded in ascent.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4552?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->