### PR TITLE
Fix Git repository search root traversal

### DIFF
--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -3044,7 +3044,16 @@ class TabManager: ObservableObject {
     }
 
     nonisolated static func shouldStopGitRepositorySearch(currentURL: URL, parentURL: URL) -> Bool {
-        parentURL.path == currentURL.path
+        if parentURL.path == currentURL.path {
+            return true
+        }
+
+        let standardizedCurrentPath = currentURL.standardizedFileURL.path
+        if standardizedCurrentPath == "/" {
+            return true
+        }
+
+        return parentURL.standardizedFileURL.path == standardizedCurrentPath
     }
 
     private nonisolated static func gitDirectoryFromDotGitFile(

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -3036,11 +3036,15 @@ class TabManager: ObservableObject {
             }
 
             let parentURL = currentURL.deletingLastPathComponent()
-            if parentURL.path == currentURL.path {
+            if Self.shouldStopGitRepositorySearch(currentURL: currentURL, parentURL: parentURL) {
                 return nil
             }
             currentURL = parentURL
         }
+    }
+
+    nonisolated static func shouldStopGitRepositorySearch(currentURL: URL, parentURL: URL) -> Bool {
+        parentURL.path == currentURL.path
     }
 
     private nonisolated static func gitDirectoryFromDotGitFile(

--- a/cmuxTests/WorkspacePullRequestSidebarTests.swift
+++ b/cmuxTests/WorkspacePullRequestSidebarTests.swift
@@ -425,6 +425,42 @@ private func gitIndexUInt32Field<T: BinaryInteger>(_ value: T) -> UInt32 {
     UInt32(truncatingIfNeeded: UInt64(truncatingIfNeeded: value))
 }
 
+final class GitRepositorySearchRootStopTests: XCTestCase {
+    func testRootParentVariantsStopRepositorySearch() {
+        let rootURL = URL(fileURLWithPath: "/")
+
+        XCTAssertTrue(
+            TabManager.shouldStopGitRepositorySearch(
+                currentURL: rootURL,
+                parentURL: URL(fileURLWithPath: "/")
+            )
+        )
+        XCTAssertTrue(
+            TabManager.shouldStopGitRepositorySearch(
+                currentURL: rootURL,
+                parentURL: URL(fileURLWithPath: "/..")
+            ),
+            "Older Foundation versions can report /.. as the parent of /; repository search must still stop at root."
+        )
+        XCTAssertTrue(
+            TabManager.shouldStopGitRepositorySearch(
+                currentURL: URL(fileURLWithPath: "/.."),
+                parentURL: URL(fileURLWithPath: "/../..")
+            ),
+            "Repository search should also stop if an older Foundation URL has already escaped above root."
+        )
+    }
+
+    func testNonRootParentDoesNotStopRepositorySearch() {
+        XCTAssertFalse(
+            TabManager.shouldStopGitRepositorySearch(
+                currentURL: URL(fileURLWithPath: "/tmp/cmux-4520-nongit"),
+                parentURL: URL(fileURLWithPath: "/tmp")
+            )
+        )
+    }
+}
+
 @MainActor
 final class WorkspacePullRequestSidebarTests: XCTestCase {
     func testSidebarPullRequestsIgnoreStaleWorkspaceLevelCacheWithoutPanelState() throws {


### PR DESCRIPTION
## Summary
- add a regression test for older Foundation behavior where deleting the last path component at `/` can produce `/..` and continue upward
- stop Git repository search at root-equivalent paths so a restored non-Git workspace cannot spin allocating ever-longer parent paths

## Verification
- Confirmed the regression-only commit failed as intended on `cmux-unit` x86_64: `GitRepositorySearchRootStopTests.testRootParentVariantsStopRepositorySearch` failed for `/ -> /..` and `/.. -> /../..`.
- After the fix, the same targeted test passed: `xcodebuild test -project cmux.xcodeproj -scheme cmux-unit -destination platform=macOS,arch=x86_64 -derivedDataPath /Users/austinwang/Library/Developer/Xcode/DerivedData/cmux-issue-4520-repro-memory-leak-unit-x86_64 -only-testing:cmuxTests/GitRepositorySearchRootStopTests`.

## Repro evidence
Issue repro details and vmmap/sample evidence were posted at https://github.com/manaflow-ai/cmux/issues/4520#issuecomment-4515623001.

## Remote dev build
A fixed x86_64 dev app was copied to the macOS 15.7.5 repro host at `/Users/austinywang/Applications/cmux-dev-issue-4520-repro-memory-leak/cmux DEV issue-4520-repro-memory-leak.app`.
Zip SHA256: `3752598358b058553bbf339809441ebc218ea94c9cd251cd560382eb6de96933`.

Fixes #4520

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4557"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782022922&installation_id=133855650&pr_number=4557&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4557&signature=660d64b56b5fb0463fff0b234cbaa0e935832def13a0e90d4b4778a7396e5c89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts filesystem traversal termination for Git repository detection, which could affect when repos are discovered across different Foundation URL behaviors. Change is small and covered by new unit tests for root/`/..` edge cases.
> 
> **Overview**
> Fixes Git repository discovery to **stop traversing when reaching root-equivalent paths** (including older Foundation cases where `deletingLastPathComponent()` can yield `/..` and continue upward), preventing unbounded parent-path growth.
> 
> Refactors the stop condition into `TabManager.shouldStopGitRepositorySearch(...)` and adds `GitRepositorySearchRootStopTests` to lock in the expected behavior at `/`, `/..`, and a normal non-root directory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3640031e0b1d19d033c1664a7dee46fa7301b45e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop Git repository search at root-equivalent paths to prevent walking to `/..` and beyond. This fixes the memory growth loop in non‑Git workspaces (fixes #4520).

- **Bug Fixes**
  - Added `TabManager.shouldStopGitRepositorySearch(...)` to stop at `/`, when the standardized parent equals the current path, or when Foundation returns `/..`-style parents.
  - Added tests to guard against `/ -> /.. -> /../..` traversal and to ensure normal parent traversal still works.

<sup>Written for commit 3640031e0b1d19d033c1664a7dee46fa7301b45e. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4557?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Git repository detection by improving termination logic for directory search operations to properly recognize and stop at filesystem boundaries, preventing unnecessary traversal.

* **Tests**
  * Added validation tests to ensure Git repository search correctly terminates at filesystem boundaries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4557?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->