### PR TITLE
Fix macOS 15 sidebar git probe memory leak

### DIFF
--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -3043,6 +3043,16 @@ class TabManager: ObservableObject {
         }
     }
 
+    private nonisolated static func gitProbeParentDirectoryPath(for path: String) -> String? {
+        let currentPath = (path as NSString).standardizingPath
+        guard currentPath != "/" else { return nil }
+
+        let parentPath = (currentPath as NSString).deletingLastPathComponent
+        let normalizedParentPath = parentPath.isEmpty ? "/" : parentPath
+        guard normalizedParentPath != currentPath else { return nil }
+        return normalizedParentPath
+    }
+
     private nonisolated static func gitDirectoryFromDotGitFile(
         _ dotGitURL: URL,
         relativeTo workTreeRootURL: URL
@@ -4890,6 +4900,10 @@ class TabManager: ObservableObject {
     }
 
 #if DEBUG
+    nonisolated static func gitProbeParentDirectoryPathForTesting(_ path: String) -> String? {
+        gitProbeParentDirectoryPath(for: path)
+    }
+
     nonisolated static func workspaceGitMetadataWatchedPathsForTesting(directory: String) -> [String] {
         workspaceGitMetadataWatcherDescriptor(for: directory)?.watchedPaths ?? []
     }

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -3006,16 +3006,19 @@ class TabManager: ObservableObject {
     }
 
     private nonisolated static func resolveGitRepository(containing directory: String) -> ResolvedGitRepository? {
-        let startURL = URL(fileURLWithPath: directory).standardizedFileURL
         let fileManager = FileManager.default
-        var currentURL = startURL
+        var currentPath = URL(fileURLWithPath: directory).standardizedFileURL.path
         var isDirectory: ObjCBool = false
 
-        if !fileManager.fileExists(atPath: currentURL.path, isDirectory: &isDirectory) || !isDirectory.boolValue {
-            currentURL.deleteLastPathComponent()
+        if !fileManager.fileExists(atPath: currentPath, isDirectory: &isDirectory) || !isDirectory.boolValue {
+            guard let parentPath = gitProbeParentDirectoryPath(for: currentPath) else {
+                return nil
+            }
+            currentPath = parentPath
         }
 
         while true {
+            let currentURL = URL(fileURLWithPath: currentPath)
             let dotGitURL = currentURL.appendingPathComponent(".git")
             if fileManager.fileExists(atPath: dotGitURL.path, isDirectory: &isDirectory) {
                 let gitDirectory: String?
@@ -3035,11 +3038,10 @@ class TabManager: ObservableObject {
                 }
             }
 
-            let parentURL = currentURL.deletingLastPathComponent()
-            if parentURL.path == currentURL.path {
+            guard let parentPath = gitProbeParentDirectoryPath(for: currentPath) else {
                 return nil
             }
-            currentURL = parentURL
+            currentPath = parentPath
         }
     }
 

--- a/cmuxTests/WorkspacePullRequestSidebarTests.swift
+++ b/cmuxTests/WorkspacePullRequestSidebarTests.swift
@@ -645,6 +645,40 @@ final class WorkspacePullRequestSidebarTests: XCTestCase {
         )
     }
 
+    func testSidebarGitMetadataProbeStopsAtFilesystemRoot() throws {
+        XCTAssertEqual(TabManager.gitProbeParentDirectoryPathForTesting("/Users/runner"), "/Users")
+        XCTAssertEqual(TabManager.gitProbeParentDirectoryPathForTesting("/Users"), "/")
+        XCTAssertNil(TabManager.gitProbeParentDirectoryPathForTesting("/"))
+        XCTAssertNil(TabManager.gitProbeParentDirectoryPathForTesting("/.."))
+        XCTAssertNil(TabManager.gitProbeParentDirectoryPathForTesting("/../.."))
+
+        let nonRepositoryURL = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "cmux-sidebar-git-root-stop-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: nonRepositoryURL, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: nonRepositoryURL)
+        }
+
+        var path = nonRepositoryURL.path
+        var visitedPaths: [String] = []
+        for _ in 0..<32 {
+            visitedPaths.append(path)
+            guard let parent = TabManager.gitProbeParentDirectoryPathForTesting(path) else {
+                break
+            }
+            path = parent
+        }
+
+        XCTAssertEqual(visitedPaths.last, "/")
+        XCTAssertFalse(
+            visitedPaths.contains { $0.hasPrefix("/..") },
+            "Git metadata parent traversal must not climb from / to /.. on macOS 15."
+        )
+        XCTAssertEqual(TabManager.workspaceGitMetadataWatchedPathsForTesting(directory: nonRepositoryURL.path), [])
+    }
+
     func testBranchOnlyGitReportDoesNotClearExistingDirtyState() throws {
         let manager = TabManager()
         let workspace = try XCTUnwrap(manager.selectedWorkspace)


### PR DESCRIPTION
Fixes https://github.com/manaflow-ai/cmux/issues/4529.

Root cause was the sidebar git metadata probe walking parent directories with `URL.deletingLastPathComponent()`. On macOS 15.7.4, `/` can climb to `/..`, then `/../..`, causing an unbounded Foundation URL allocation loop. The cloud Mac repro did not point at WebViews: `vmmap` showed MALLOC_MEDIUM growth, and `sample` pointed at `TabManager.resolveGitRepository(containing:)`.

Changes:
- Add a regression test for sidebar git metadata root traversal.
- Use string path parent traversal that stops at filesystem root.

Verification:
- `./scripts/test-unit.sh -derivedDataPath /tmp/cmux-issue4529-unit '-only-testing:cmuxTests/WorkspacePullRequestSidebarTests/testSidebarGitMetadataProbeStopsAtFilesystemRoot' test`
- Tagged reload: `./scripts/reload.sh --tag issue4529`
- macOS 15.7.4 cloud repro, signed 0.64.8: 2.7 GB to 32.0 GB physical footprint in 166s.
- macOS 15.7.4 cloud verification, fixed `issue4529` build: stayed at 73.5 MB max physical footprint over 71s.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4558"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782023551&installation_id=133855650&pr_number=4558&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4558&signature=5f798191d877b3193628d5fd5c4c7aeaf192e775623132887e9f4484bcdea8c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 2fc86e32d9a5ded9f1d323c2387604a292ac81ad. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a macOS 15 memory leak in the sidebar Git metadata probe by stopping parent traversal at the filesystem root. Prevents climbing from “/” to “/..” and the resulting unbounded allocations.

- **Bug Fixes**
  - Replaced URL-based parent traversal with a path-string helper that stops at “/” and avoids loops on macOS 15.
  - Added regression test `testSidebarGitMetadataProbeStopsAtFilesystemRoot`.
  - Verified on macOS 15.7.4: memory remains stable during probe.

<sup>Written for commit 2fc86e32d9a5ded9f1d323c2387604a292ac81ad. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4558?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved git repository detection logic for better reliability and performance.

* **Tests**
  * Added test coverage for edge cases in git metadata detection, including filesystem boundary handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4558?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->