### PR TITLE
Fix Ghostty split theme appearance resolution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,6 +247,21 @@ jobs:
             sleep $((attempt * 5))
           done
 
+      - name: Run Ghostty split-theme appearance regression
+        run: |
+          set -euo pipefail
+          SOURCE_PACKAGES_DIR="$PWD/.ci-source-packages"
+          xcodebuild -project cmux.xcodeproj -scheme cmux-unit -configuration Debug \
+            -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_DIR" \
+            -disableAutomaticPackageResolution \
+            -destination "platform=macOS" \
+            CMUX_SKIP_ZIG_BUILD=1 \
+            -only-testing:cmuxTests/AppearanceSettingsTests/testSplitGhosttyThemeUsesStoredDarkModeWhenAppAppearanceIsStaleLight \
+            -only-testing:cmuxTests/AppearanceSettingsTests/testSplitGhosttyThemeUsesStoredLightModeWhenAppAppearanceIsStaleDark \
+            -only-testing:cmuxTests/AppearanceSettingsTests/testSplitGhosttyThemeUsesSystemLightWhenAppAppearanceIsStaleDark \
+            -only-testing:cmuxTests/AppearanceSettingsTests/testSplitGhosttyThemeUsesSystemDarkWhenAppAppearanceIsStaleLight \
+            test
+
       - name: Run unit tests
         run: |
           set -euo pipefail

--- a/Sources/AppearanceSettings.swift
+++ b/Sources/AppearanceSettings.swift
@@ -100,15 +100,23 @@ enum AppearanceSettings {
         return resolved
     }
 
+    /// Returns the Ghostty terminal color-scheme preference.
+    /// - Note: `colorSchemePreference` keeps the `appAppearance` parameter for API compatibility
+    ///   and intentionally ignores it.
     static func colorSchemePreference(
-        appAppearance: NSAppearance? = nil,
+        appAppearance _: NSAppearance? = nil,
         defaults: UserDefaults = .standard,
         systemAppearance: SystemAppearance? = nil
     ) -> GhosttyConfig.ColorSchemePreference {
-        if let appAppearance {
-            return appAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua ? .dark : .light
-        }
+        terminalColorSchemePreference(defaults: defaults, systemAppearance: systemAppearance)
+    }
 
+    // Ghostty split-theme resolution follows cmux's persisted appearance mode.
+    // AppKit view/window appearances can lag during live mode changes.
+    static func terminalColorSchemePreference(
+        defaults: UserDefaults = .standard,
+        systemAppearance: SystemAppearance? = nil
+    ) -> GhosttyConfig.ColorSchemePreference {
         let mode = mode(for: defaults.string(forKey: appearanceModeKey))
         if mode == .light { return .light }
         if mode == .dark { return .dark }

--- a/Sources/GhosttyConfig.swift
+++ b/Sources/GhosttyConfig.swift
@@ -512,8 +512,12 @@ struct GhosttyConfig {
         }
     }
 
-    static func currentColorSchemePreference(appAppearance: NSAppearance? = nil, defaults: UserDefaults = .standard, systemAppearance: AppearanceSettings.SystemAppearance? = nil) -> ColorSchemePreference {
-        AppearanceSettings.colorSchemePreference(appAppearance: appAppearance, defaults: defaults, systemAppearance: systemAppearance)
+    static func currentColorSchemePreference(
+        appAppearance _: NSAppearance? = nil,
+        defaults: UserDefaults = .standard,
+        systemAppearance: AppearanceSettings.SystemAppearance? = nil
+    ) -> ColorSchemePreference {
+        return AppearanceSettings.terminalColorSchemePreference(defaults: defaults, systemAppearance: systemAppearance)
     }
 
     static func resolveThemeName(

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3319,10 +3319,8 @@ class GhosttyApp {
         }
     }
 
-    func synchronizeThemeWithAppearance(_ appearance: NSAppearance?, source: String) {
-        let currentColorScheme = GhosttyConfig.currentColorSchemePreference(
-            appAppearance: appearance ?? NSApp?.effectiveAppearance
-        )
+    func synchronizeThemeWithAppearance(_: NSAppearance?, source: String) {
+        let currentColorScheme = GhosttyConfig.currentColorSchemePreference()
         let plan = Self.appearanceSynchronizationPlan(
             previousColorScheme: lastAppearanceColorScheme,
             currentColorScheme: currentColorScheme

--- a/cmuxTests/AppearanceSettingsTests.swift
+++ b/cmuxTests/AppearanceSettingsTests.swift
@@ -290,6 +290,103 @@ final class AppearanceSettingsTests: XCTestCase {
         )
     }
 
+    func testSplitGhosttyThemeUsesStoredDarkModeWhenAppAppearanceIsStaleLight() {
+        let suiteName = "AppearanceSettingsTests.SplitThemeStoredDark.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Failed to create isolated UserDefaults suite")
+            return
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(AppearanceMode.dark.rawValue, forKey: AppearanceSettings.appearanceModeKey)
+
+        let preferredColorScheme = GhosttyConfig.currentColorSchemePreference(
+            appAppearance: NSAppearance(named: .aqua),
+            defaults: defaults,
+            systemAppearance: .init(interfaceStyle: "Dark")
+        )
+        let resolvedTheme = GhosttyConfig.resolveThemeName(
+            from: "light:Catppuccin Latte,dark:Apple System Colors",
+            preferredColorScheme: preferredColorScheme
+        )
+
+        XCTAssertEqual(preferredColorScheme, .dark)
+        XCTAssertEqual(resolvedTheme, "Apple System Colors")
+    }
+
+    func testSplitGhosttyThemeUsesStoredLightModeWhenAppAppearanceIsStaleDark() {
+        let suiteName = "AppearanceSettingsTests.SplitThemeStoredLight.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Failed to create isolated UserDefaults suite")
+            return
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(AppearanceMode.light.rawValue, forKey: AppearanceSettings.appearanceModeKey)
+
+        let preferredColorScheme = GhosttyConfig.currentColorSchemePreference(
+            appAppearance: NSAppearance(named: .darkAqua),
+            defaults: defaults,
+            systemAppearance: .init(interfaceStyle: "Dark")
+        )
+        let resolvedTheme = GhosttyConfig.resolveThemeName(
+            from: "light:Catppuccin Latte,dark:Apple System Colors",
+            preferredColorScheme: preferredColorScheme
+        )
+
+        XCTAssertEqual(preferredColorScheme, .light)
+        XCTAssertEqual(resolvedTheme, "Catppuccin Latte")
+    }
+
+    func testSplitGhosttyThemeUsesSystemLightWhenAppAppearanceIsStaleDark() {
+        let suiteName = "AppearanceSettingsTests.SplitThemeSystemLight.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Failed to create isolated UserDefaults suite")
+            return
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(AppearanceMode.system.rawValue, forKey: AppearanceSettings.appearanceModeKey)
+        defaults.removeObject(forKey: "AppleInterfaceStyle")
+
+        let preferredColorScheme = GhosttyConfig.currentColorSchemePreference(
+            appAppearance: NSAppearance(named: .darkAqua),
+            defaults: defaults,
+            systemAppearance: .init(interfaceStyle: nil)
+        )
+        let resolvedTheme = GhosttyConfig.resolveThemeName(
+            from: "light:Monokai Pro Light,dark:Monokai Pro Machine",
+            preferredColorScheme: preferredColorScheme
+        )
+
+        XCTAssertEqual(preferredColorScheme, .light)
+        XCTAssertEqual(resolvedTheme, "Monokai Pro Light")
+    }
+
+    func testSplitGhosttyThemeUsesSystemDarkWhenAppAppearanceIsStaleLight() {
+        let suiteName = "AppearanceSettingsTests.SplitThemeSystemDark.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Failed to create isolated UserDefaults suite")
+            return
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(AppearanceMode.system.rawValue, forKey: AppearanceSettings.appearanceModeKey)
+
+        let preferredColorScheme = GhosttyConfig.currentColorSchemePreference(
+            appAppearance: NSAppearance(named: .aqua),
+            defaults: defaults,
+            systemAppearance: .init(interfaceStyle: "Dark")
+        )
+        let resolvedTheme = GhosttyConfig.resolveThemeName(
+            from: "light:Monokai Pro Light,dark:Monokai Pro Machine",
+            preferredColorScheme: preferredColorScheme
+        )
+
+        XCTAssertEqual(preferredColorScheme, .dark)
+        XCTAssertEqual(resolvedTheme, "Monokai Pro Machine")
+    }
+
     func testColorSchemeOverrideIsExplicitOnlyForManualLightAndDarkModes() {
         XCTAssertEqual(AppearanceSettings.colorSchemeOverride(for: AppearanceMode.light.rawValue), .light)
         XCTAssertEqual(AppearanceSettings.colorSchemeOverride(for: AppearanceMode.dark.rawValue), .dark)
@@ -476,4 +573,5 @@ final class AppearanceSettingsTests: XCTestCase {
             defaults.removeObject(forKey: key)
         }
     }
+
 }


### PR DESCRIPTION
## Summary
- Add a targeted behavior regression for Ghostty split theme resolution when AppKit appearance is stale.
- Resolve Ghostty terminal color scheme from cmux persisted appearance mode plus AppleInterfaceStyle for system-following mode.
- Stop using NSAppearance.effectiveAppearance as the selector for light:X,dark:Y terminal themes.

## Testing
- Red proof: test-only commit 4ab9f3ef3 failed the targeted CI `tests` check before the fix: https://github.com/manaflow-ai/cmux/actions/runs/26282849180/job/77363084053
- Green proof: fix commit 342b33253 passed all PR checks; `tests` passed here: https://github.com/manaflow-ai/cmux/actions/runs/26284200080/job/77367582343
- Local tests/builds not run per issue constraints; verification is through GitHub Actions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how terminal theme selection decides light vs dark, which can affect user-visible theming across the app; coverage is improved via new targeted regression tests and a dedicated CI step.
> 
> **Overview**
> Fixes Ghostty split-theme resolution so `light:...,dark:...` theme selection uses **cmux’s persisted `appearanceMode` + `AppleInterfaceStyle`** (system-following) instead of `NSAppearance`/`effectiveAppearance`, avoiding incorrect theme picks during live appearance transitions.
> 
> Adds targeted regression tests for stale-appearance scenarios and runs them explicitly in CI before the broader unit-test suite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 497ee7fc8ee45a823312ab40b23aff48885d3c2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved color scheme resolution to correctly handle cases where stored appearance settings become out of sync with the current system appearance.

* **Tests**
  * Added regression tests for appearance preference synchronization scenarios.

* **Chores**
  * Updated CI pipeline to run appearance-related tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4567?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->