### PR TITLE
Simplify Grok and Antigravity hook dispatch

### DIFF
--- a/CLI/CMUXCLI+AgentHookDefinitions.swift
+++ b/CLI/CMUXCLI+AgentHookDefinitions.swift
@@ -21,6 +21,10 @@ extension CMUXCLI {
         let events: [HookEvent]
         let aliases: Set<String>
         let publishesStopNotification: Bool
+        /// Some agents do not preserve cmux's surface marker in hook subprocesses.
+        let requiresSurfaceEnvironment: Bool
+        /// Some hook parsers treat `$CMUX_*` in command strings as required env.
+        let usesHookEnvironmentVariables: Bool
         /// Feed-hook events. Each entry installs a second hook for
         /// `agentEvent` that invokes `cmux hooks feed --source <name>`
         /// with a 120s timeout so the socket reply wait doesn't trip the
@@ -81,6 +85,8 @@ extension CMUXCLI {
              format: HookFormat, events: [HookEvent],
              aliases: Set<String> = [],
              publishesStopNotification: Bool = true,
+             requiresSurfaceEnvironment: Bool = true,
+             usesHookEnvironmentVariables: Bool = true,
              feedHookEvents: [String] = [],
              postInstallAction: PostInstallAction? = nil) {
             self.name = name; self.displayName = displayName; self.statusKey = statusKey
@@ -92,6 +98,8 @@ extension CMUXCLI {
             self.sessionStoreSuffix = sessionStoreSuffix; self.disableEnvVar = disableEnvVar
             self.hookMarker = hookMarker; self.format = format; self.events = events
             self.publishesStopNotification = publishesStopNotification
+            self.requiresSurfaceEnvironment = requiresSurfaceEnvironment
+            self.usesHookEnvironmentVariables = usesHookEnvironmentVariables
             self.aliases = Set(aliases.compactMap { alias in
                 let normalized = alias.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
                 return normalized.isEmpty ? nil : normalized
@@ -148,6 +156,8 @@ extension CMUXCLI {
                 .init(agentEvent: "SessionEnd", cmuxSubcommand: "session-end"),
             ],
             publishesStopNotification: false,
+            requiresSurfaceEnvironment: false,
+            usesHookEnvironmentVariables: false,
             feedHookEvents: ["PreToolUse"]
         ),
         AgentHookDef(
@@ -213,6 +223,7 @@ extension CMUXCLI {
                 .init(agentEvent: "SessionEnd", cmuxSubcommand: "session-end"),
             ],
             aliases: ["agy"],
+            requiresSurfaceEnvironment: false,
             feedHookEvents: ["PreToolUse", "PostToolUse"]
         ),
         AgentHookDef(
@@ -309,175 +320,23 @@ extension CMUXCLI {
         agentHookShellCommand("cmux hooks feed --source \(def.name) --event \(agentEvent)", for: def)
     }
 
-    private static let grokPinnedHookMarker = "cmux-grok-hook-v2"
-    private static let antigravityPinnedHookMarker = "cmux-antigravity-hook-v2"
+    private static let legacyPinnedHookMarkers: [String: String] = [
+        "grok": "cmux-grok-hook-v2",
+        "antigravity": "cmux-antigravity-hook-v2",
+    ]
 
     private static func agentHookShellCommand(_ command: String, for def: AgentHookDef) -> String {
-        if usesPinnedHookDispatch(def) {
-            return pinnedAgentHookShellCommand(command, for: def)
-        }
         let routedArguments = command.hasPrefix("cmux ") ? String(command.dropFirst("cmux ".count)) : command
-        return "cmux_cli=\"${CMUX_BUNDLED_CLI_PATH:-}\"; if [ -z \"$cmux_cli\" ] || [ ! -x \"$cmux_cli\" ]; then cmux_cli=\"$(command -v cmux 2>/dev/null || true)\"; fi; if [ -n \"$CMUX_SURFACE_ID\" ] && [ \"$\(def.disableEnvVar)\" != \"1\" ] && [ -n \"$cmux_cli\" ]; then { if [ -n \"${CMUX_SOCKET_PATH:-}\" ]; then \"$cmux_cli\" --socket \"$CMUX_SOCKET_PATH\" \(routedArguments); else \"$cmux_cli\" \(routedArguments); fi; } || echo '{}'; else echo '{}'; fi"
-    }
-
-    private static func usesPinnedHookDispatch(_ def: AgentHookDef) -> Bool {
-        def.name == "grok" || def.name == "antigravity"
-    }
-
-    private static func pinnedHookMarker(for def: AgentHookDef) -> String {
-        def.name == "antigravity" ? antigravityPinnedHookMarker : grokPinnedHookMarker
-    }
-
-    private static func pinnedAgentHookShellCommand(_ command: String, for def: AgentHookDef) -> String {
-        let routedArguments = command.hasPrefix("cmux ") ? String(command.dropFirst("cmux ".count)) : command
-        let socketPath = pinnedAgentHookSocketPath()
-        let shellTraceStart = pinnedHookShellTraceCommand(
-            agentName: def.name,
-            phase: "start",
-            routedArguments: routedArguments,
-            socketPath: socketPath
-        )
-        let shellTraceDisabled = pinnedHookShellTraceCommand(
-            agentName: def.name,
-            phase: "disabled",
-            routedArguments: routedArguments,
-            socketPath: socketPath
-        )
-        let shellTraceExit = pinnedHookShellTraceCommand(
-            agentName: def.name,
-            phase: "exit",
-            routedArguments: routedArguments,
-            socketPath: socketPath,
-            statusExpression: "$cmux_hook_status"
-        )
-        let fallbackInvocation = pinnedHookInvocation(
-            executable: "cmux",
-            routedArguments: routedArguments,
-            socketPath: socketPath
-        )
-        let dispatch: String
-        if let cliPath = pinnedAgentHookCLIPath() {
-            let quotedCLIPath = shellSingleQuote(cliPath)
-            let primaryInvocation = pinnedHookInvocation(
-                executable: quotedCLIPath,
-                routedArguments: routedArguments,
-                socketPath: socketPath
-            )
-            dispatch = "if [ -x \(quotedCLIPath) ]; then \(primaryInvocation); elif command -v cmux >/dev/null 2>&1; then \(fallbackInvocation); else echo '{}'; fi"
-        } else {
-            dispatch = "command -v cmux >/dev/null 2>&1 && \(fallbackInvocation) || echo '{}'"
+        if !def.usesHookEnvironmentVariables {
+            return "printenv \(def.disableEnvVar) | grep -qx 1 && echo '{}' || { command -v cmux >/dev/null 2>&1 && cmux \(routedArguments) || echo '{}'; }"
         }
-        return ": \(pinnedHookMarker(for: def)); \(shellTraceStart); printenv \(def.disableEnvVar) | grep -qx 1 && { \(shellTraceDisabled); echo '{}'; } || { \(dispatch); cmux_hook_status=$?; \(shellTraceExit); exit $cmux_hook_status; }"
-    }
-
-    private static func pinnedHookInvocation(
-        executable: String,
-        routedArguments: String,
-        socketPath: String?
-    ) -> String {
-        if let socketPath {
-            return "\(executable) --socket \(shellSingleQuote(socketPath)) \(routedArguments)"
-        }
-        return "\(executable) \(routedArguments)"
-    }
-
-    private static func pinnedAgentHookCLIPath(
-        env: [String: String] = ProcessInfo.processInfo.environment,
-        arguments: [String] = ProcessInfo.processInfo.arguments
-    ) -> String? {
-        if let bundledPath = normalizedHookInstallValue(env["CMUX_BUNDLED_CLI_PATH"]) {
-            let expanded = NSString(string: bundledPath).expandingTildeInPath
-            if isExecutableFilePath(expanded) {
-                return expanded
-            }
-        }
-        if let arg0 = normalizedHookInstallValue(arguments.first) {
-            let expanded = NSString(string: arg0).expandingTildeInPath
-            if expanded.hasPrefix("/"), isExecutableFilePath(expanded) {
-                return expanded
-            }
-        }
-        if let executablePath = Bundle.main.executableURL?.path,
-           !executablePath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
-           isExecutableFilePath(executablePath) {
-            return executablePath
-        }
-        return nil
-    }
-
-    private static func isExecutableFilePath(_ path: String) -> Bool {
-        var isDirectory: ObjCBool = false
-        guard FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory),
-              !isDirectory.boolValue
-        else {
-            return false
-        }
-        return FileManager.default.isExecutableFile(atPath: path)
-    }
-
-    private static func pinnedAgentHookSocketPath(
-        env: [String: String] = ProcessInfo.processInfo.environment
-    ) -> String? {
-        if let socketPath = normalizedHookInstallValue(env["CMUX_SOCKET_PATH"]) {
-            return NSString(string: socketPath).expandingTildeInPath
-        }
-        guard let tag = normalizedHookInstallValue(env["CMUX_TAG"]) else {
-            return nil
-        }
-        let slug = tag
-            .lowercased()
-            .replacingOccurrences(of: "[^a-z0-9]+", with: "-", options: .regularExpression)
-            .trimmingCharacters(in: CharacterSet(charactersIn: "-"))
-        guard !slug.isEmpty else { return nil }
-        return "/tmp/cmux-debug-\(slug).sock"
-    }
-
-    private static func pinnedHookShellTraceCommand(
-        agentName: String,
-        phase: String,
-        routedArguments: String,
-        socketPath: String?,
-        statusExpression: String? = nil
-    ) -> String {
-#if DEBUG
-        let logPath = shellSingleQuote(pinnedHookShellTraceLogPath(socketPath: socketPath))
-        let event = shellSingleQuote(routedArguments)
-        let socket = shellSingleQuote(socketPath.map { URL(fileURLWithPath: $0).lastPathComponent } ?? "nil")
-        let statusField = statusExpression == nil ? "" : " status=%s"
-        let statusArgument = statusExpression.map { " \($0)" } ?? ""
-        return "printf '%s \(agentName)Hook.shell phase=%s event=%s pid=%s ppid=%s socket=%s\(statusField)\\n' \"$(date +%s)\" \(shellSingleQuote(phase)) \(event) \"$$\" \"${PPID:-}\" \(socket)\(statusArgument) >> \(logPath) 2>/dev/null || true"
-#else
-        return ":"
-#endif
-    }
-
-    private static func pinnedHookShellTraceLogPath(socketPath: String?) -> String {
-        guard let socketPath else {
-            return "/tmp/cmux-debug.log"
-        }
-        let socketName = URL(fileURLWithPath: socketPath).lastPathComponent
-        if socketName.hasPrefix("cmux-debug-"), socketName.hasSuffix(".sock") {
-            return URL(fileURLWithPath: "/tmp", isDirectory: true)
-                .appendingPathComponent(String(socketName.dropLast(".sock".count)) + ".log")
-                .path
-        }
-        return "/tmp/cmux-debug.log"
-    }
-
-    private static func normalizedHookInstallValue(_ value: String?) -> String? {
-        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
-              !trimmed.isEmpty else {
-            return nil
-        }
-        return trimmed
-    }
-
-    private static func shellSingleQuote(_ value: String) -> String {
-        "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
+        let surfaceGate = def.requiresSurfaceEnvironment ? "[ -n \"$CMUX_SURFACE_ID\" ] && " : ""
+        return "cmux_cli=\"${CMUX_BUNDLED_CLI_PATH:-}\"; if [ -z \"$cmux_cli\" ] || [ ! -x \"$cmux_cli\" ]; then cmux_cli=\"$(command -v cmux 2>/dev/null || true)\"; fi; if \(surfaceGate)[ \"$\(def.disableEnvVar)\" != \"1\" ] && [ -n \"$cmux_cli\" ]; then { if [ -n \"${CMUX_SOCKET_PATH:-}\" ]; then \"$cmux_cli\" --socket \"$CMUX_SOCKET_PATH\" \(routedArguments); else \"$cmux_cli\" \(routedArguments); fi; } || echo '{}'; else echo '{}'; fi"
     }
 
     static func isCmuxOwnedHookCommand(_ command: String, for def: AgentHookDef, includeLegacy: Bool = true) -> Bool {
-        if usesPinnedHookDispatch(def), command.contains(pinnedHookMarker(for: def)) {
+        if let legacyPinnedHookMarker = legacyPinnedHookMarkers[def.name],
+           command.contains(legacyPinnedHookMarker) {
             return true
         }
         if def.events.contains(where: { hookCommandString(for: def, event: $0) == command })

--- a/cmuxTests/CLIGenericHookPersistenceTests.swift
+++ b/cmuxTests/CLIGenericHookPersistenceTests.swift
@@ -570,8 +570,16 @@ extension CLINotifyProcessIntegrationRegressionTests {
             }
         XCTAssertFalse(allCommands.isEmpty)
         XCTAssertTrue(
-            allCommands.allSatisfy { $0.contains("cmux-antigravity-hook-v2") },
-            "Expected Antigravity hooks to use the pinned dispatch path, saw \(allCommands)"
+            allCommands.allSatisfy { $0.contains(#"cmux_cli="${CMUX_BUNDLED_CLI_PATH:-}""#) },
+            "Expected Antigravity hooks to use the shared bundled CLI dispatch path, saw \(allCommands)"
+        )
+        XCTAssertTrue(
+            allCommands.allSatisfy { $0.contains("command -v cmux") },
+            "Expected Antigravity hooks to fall back to the PATH cmux, saw \(allCommands)"
+        )
+        XCTAssertFalse(
+            allCommands.contains { $0.contains("cmux-antigravity-hook-v2") },
+            "Antigravity hooks should not use the old pinned dispatch marker, saw \(allCommands)"
         )
         XCTAssertFalse(
             allCommands.contains { $0.contains("'\(root.path)'") || $0.contains("\"\(root.path)\"") },
@@ -1974,6 +1982,10 @@ extension CLINotifyProcessIntegrationRegressionTests {
             allCommands.contains { $0.contains("[ -n \"$CMUX_SURFACE_ID\" ]") },
             "Grok strips CMUX_* from hook subprocesses, so installed commands must not gate on CMUX_SURFACE_ID. Saw \(allCommands)"
         )
+        XCTAssertTrue(
+            allCommands.allSatisfy { $0.contains("command -v cmux") },
+            "Expected Grok hooks to fall back to the PATH cmux, saw \(allCommands)"
+        )
         XCTAssertFalse(
             allCommands.contains { $0.contains("$CMUX_") },
             "Grok treats $VAR references as required hook environment, so installed commands must avoid CMUX variable interpolation. Saw \(allCommands)"
@@ -1984,25 +1996,25 @@ extension CLINotifyProcessIntegrationRegressionTests {
         )
     }
 
-    func testGrokHookInstallPinsInstallingCLIAndSocketWithoutCMUXInterpolation() throws {
+    func testGrokHookInstallUsesSimplePathDispatchWithoutSurfaceGate() throws {
         let cliPath = try bundledCLIPath()
         let root = FileManager.default.temporaryDirectory
-            .appendingPathComponent("cmux-grok-hook-pin-\(UUID().uuidString)", isDirectory: true)
+            .appendingPathComponent("cmux-grok-hook-simple-dispatch-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: root) }
 
-        let pinnedCLI = root.appendingPathComponent("cmux pinned dev cli", isDirectory: false)
-        try "#!/bin/sh\nexit 0\n".write(to: pinnedCLI, atomically: true, encoding: .utf8)
-        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: pinnedCLI.path)
+        let bundledCLI = root.appendingPathComponent("cmux bundled dev cli", isDirectory: false)
+        try "#!/bin/sh\nexit 0\n".write(to: bundledCLI, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: bundledCLI.path)
 
-        let socketPath = "/tmp/cmux-debug-grok-pin.sock"
+        let socketPath = "/tmp/cmux-debug-grok-shared.sock"
         let result = runProcess(
             executablePath: cliPath,
             arguments: ["hooks", "grok", "install", "--yes"],
             environment: [
                 "HOME": root.path,
                 "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
-                "CMUX_BUNDLED_CLI_PATH": pinnedCLI.path,
+                "CMUX_BUNDLED_CLI_PATH": bundledCLI.path,
                 "CMUX_SOCKET_PATH": socketPath,
                 "CMUX_CLI_SENTRY_DISABLED": "1",
             ],
@@ -2027,20 +2039,28 @@ extension CLINotifyProcessIntegrationRegressionTests {
 
         XCTAssertFalse(allCommands.isEmpty)
         XCTAssertTrue(
-            allCommands.allSatisfy { $0.contains("cmux-grok-hook-v2") },
-            "Expected installed Grok hooks to carry the owned-hook marker, saw \(allCommands)"
+            allCommands.allSatisfy { $0.contains("command -v cmux") },
+            "Expected installed Grok hooks to use the simple PATH cmux dispatch, saw \(allCommands)"
         )
-        XCTAssertTrue(
-            allCommands.allSatisfy { $0.contains("'\(pinnedCLI.path)'") },
-            "Expected installed Grok hooks to pin the installing CLI path, saw \(allCommands)"
+        XCTAssertFalse(
+            allCommands.contains { $0.contains("cmux-grok-hook-v2") },
+            "Grok hooks should not use the old pinned dispatch marker, saw \(allCommands)"
         )
-        XCTAssertTrue(
-            allCommands.allSatisfy { $0.contains("--socket '\(socketPath)'") },
-            "Expected installed Grok hooks to pin the installing socket path, saw \(allCommands)"
+        XCTAssertFalse(
+            allCommands.contains { $0.contains("'\(bundledCLI.path)'") || $0.contains("\"\(bundledCLI.path)\"") },
+            "Grok hooks should not embed the installing CLI path, saw \(allCommands)"
+        )
+        XCTAssertFalse(
+            allCommands.contains { $0.contains("--socket '\(socketPath)'") || $0.contains("--socket \"\(socketPath)\"") },
+            "Grok hooks should not embed the installing socket path, saw \(allCommands)"
+        )
+        XCTAssertFalse(
+            allCommands.contains { $0.contains("[ -n \"$CMUX_SURFACE_ID\" ]") },
+            "Grok hooks must still dispatch when Grok does not preserve CMUX_SURFACE_ID, saw \(allCommands)"
         )
         XCTAssertFalse(
             allCommands.contains { $0.contains("$CMUX_") },
-            "Grok hook commands must not depend on CMUX environment interpolation, saw \(allCommands)"
+            "Grok hooks must avoid CMUX variable interpolation, saw \(allCommands)"
         )
     }
 


### PR DESCRIPTION
## Summary
- remove the bespoke pinned dispatch path for Grok and Antigravity hooks
- keep Grok on a short PATH-based command with no `$CMUX_*` interpolation
- move Antigravity to the shared bundled-CLI wrapper while skipping only the surface-id gate
- keep legacy pinned markers recognized so reinstall/uninstall can clean old hooks

## Verification
- `git diff --check`
- `./scripts/setup.sh`
- `./scripts/reload.sh --tag aghooks`
- generated Grok and Antigravity hook configs with the built `aghooks` CLI and checked for no old pinned markers

XCTest not run locally because local xcodebuild test is prohibited for cmux.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4574"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782038507&installation_id=133855650&pr_number=4574&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4574&signature=8ded052256f890adf9641fb48ab0c662c3877fcffed238a81ce1639aec2bf1a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the shell commands written into Grok and Antigravity hook configs, which could break hook execution or cleanup if agent-specific assumptions are wrong; coverage is primarily via updated XCTest expectations.
> 
> **Overview**
> Simplifies Grok and Antigravity hook command generation by **removing the special pinned-dispatch path** and replacing it with per-agent flags that control whether hook commands require `CMUX_SURFACE_ID` and whether they may reference `CMUX_*` variables.
> 
> Grok now installs a short PATH-based `cmux` invocation with no `$CMUX_*` interpolation, while Antigravity uses the shared bundled-CLI wrapper but skips the surface-id gate; uninstall/reinstall logic still recognizes legacy pinned markers for pruning old hook entries. Tests are updated to assert the new command shapes, PATH fallback behavior, and absence of legacy pinned markers/embedded install paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a71302acf4840a7f0cc2389fb9a2362e8a3c03d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies Grok and Antigravity hook dispatch by removing the bespoke pinned path and using a shared, simpler command. This reduces brittleness while keeping legacy markers so upgrades can clean old hooks.

- **Refactors**
  - Deleted the pinned dispatch path and helpers; all hooks now use the shared shell command builder.
  - Grok: uses a short PATH-based `cmux` command, no `CMUX_SURFACE_ID` gate, and no `$CMUX_*` interpolation.
  - Antigravity: uses the bundled CLI wrapper via `CMUX_BUNDLED_CLI_PATH` with PATH `cmux` fallback; skips only the `CMUX_SURFACE_ID` gate.
  - Legacy pinned markers are still recognized so reinstall/uninstall can remove old hooks.
  - Tests updated to assert the new dispatch paths and ensure old markers are absent.

<sup>Written for commit 9a71302acf4840a7f0cc2389fb9a2362e8a3c03d. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4574?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration options for hook environment requirements.

* **Refactor**
  * Simplified hook installation to use standard PATH dispatch instead of pinned locations.
  * Removed legacy pinned hook behavior and markers.
  * Updated hook routing logic for cleaner configuration handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4574?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->