### PR TITLE
Add CI memory leak guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -754,7 +754,6 @@ jobs:
           name: task-manager-memory-${{ matrix.label }}
           path: |
             memory-leak-artifacts-${{ matrix.label }}
-            /tmp/cmux-memory-guard-*.log
           if-no-files-found: ignore
 
       - name: Cleanup virtual display

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -637,6 +637,8 @@ jobs:
 
   task-manager-memory-leak:
     name: Task Manager memory leak (${{ matrix.label }})
+    permissions:
+      contents: read
     runs-on: ${{ matrix.os }}
     timeout-minutes: 25
     strategy:
@@ -658,6 +660,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Select Xcode
         run: |
@@ -701,9 +704,19 @@ jobs:
           set -euo pipefail
           SOURCE_PACKAGES_DIR="$PWD/.ci-source-packages"
           mkdir -p "$SOURCE_PACKAGES_DIR"
-          xcodebuild -project cmux.xcodeproj -scheme cmux -configuration Debug \
-            -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_DIR" \
-            -resolvePackageDependencies
+          for attempt in 1 2 3; do
+            if xcodebuild -project cmux.xcodeproj -scheme cmux -configuration Debug \
+              -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_DIR" \
+              -resolvePackageDependencies; then
+              exit 0
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "Failed to resolve Swift packages after 3 attempts" >&2
+              exit 1
+            fi
+            echo "Package resolution failed on attempt $attempt, retrying..."
+            sleep $((attempt * 5))
+          done
 
       - name: Build app
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -635,6 +635,123 @@ jobs:
             ONLY_ACTIVE_ARCH=NO \
             CODE_SIGNING_ALLOWED=NO ASSETCATALOG_COMPILER_APPICON_NAME=AppIcon-Nightly build
 
+  task-manager-memory-leak:
+    name: Task Manager memory leak (${{ matrix.label }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: macos-15
+            os: warp-macos-15-arm64-6x
+            virtual_display: true
+            skip_zig: false
+          - label: macos-26
+            os: warp-macos-26-arm64-6x
+            virtual_display: false
+            skip_zig: true
+    env:
+      CMUX_SKIP_ZIG_BUILD: ${{ matrix.skip_zig && '1' || '0' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: recursive
+
+      - name: Select Xcode
+        run: |
+          set -euo pipefail
+          if [ -d "/Applications/Xcode.app/Contents/Developer" ]; then
+            XCODE_DIR="/Applications/Xcode.app/Contents/Developer"
+          else
+            XCODE_APP="$(find /Applications -maxdepth 1 -type d -name 'Xcode*.app' -print 2>/dev/null | sort | tail -n 1 || true)"
+            if [ -n "$XCODE_APP" ]; then
+              XCODE_DIR="$XCODE_APP/Contents/Developer"
+            else
+              echo "No Xcode.app found under /Applications" >&2
+              exit 1
+            fi
+          fi
+          echo "DEVELOPER_DIR=$XCODE_DIR" >> "$GITHUB_ENV"
+          export DEVELOPER_DIR="$XCODE_DIR"
+          xcodebuild -version
+          xcrun --sdk macosx --show-sdk-path
+          sw_vers
+
+      - name: Download pre-built GhosttyKit.xcframework
+        run: ./scripts/download-prebuilt-ghosttykit.sh
+
+      - name: Install zig
+        if: ${{ !matrix.skip_zig }}
+        run: ./scripts/install-zig-ci.sh
+
+      - name: Install Rust
+        run: ./scripts/install-rust-ci.sh
+
+      - name: Cache Swift packages
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: .ci-source-packages
+          key: spm-memory-leak-${{ matrix.label }}-${{ hashFiles('cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+          restore-keys: spm-memory-leak-${{ matrix.label }}-
+
+      - name: Resolve Swift packages
+        run: |
+          set -euo pipefail
+          SOURCE_PACKAGES_DIR="$PWD/.ci-source-packages"
+          mkdir -p "$SOURCE_PACKAGES_DIR"
+          xcodebuild -project cmux.xcodeproj -scheme cmux -configuration Debug \
+            -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_DIR" \
+            -resolvePackageDependencies
+
+      - name: Build app
+        run: |
+          set -euo pipefail
+          SOURCE_PACKAGES_DIR="$PWD/.ci-source-packages"
+          xcodebuild -project cmux.xcodeproj -scheme cmux -configuration Debug \
+            -derivedDataPath "build-memory-leak-${{ matrix.label }}" \
+            -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_DIR" \
+            -disableAutomaticPackageResolution \
+            -destination "platform=macOS" build
+
+      - name: Create virtual display
+        if: matrix.virtual_display
+        run: |
+          set -euo pipefail
+          clang -framework Foundation -framework CoreGraphics \
+            -o /tmp/create-virtual-display scripts/create-virtual-display.m
+          /tmp/create-virtual-display &
+          echo "VDISPLAY_PID=$!" >> "$GITHUB_ENV"
+          sleep 3
+
+      - name: Run two-minute Task Manager memory leak guard
+        run: |
+          set -euo pipefail
+          APP="build-memory-leak-${{ matrix.label }}/Build/Products/Debug/cmux DEV.app"
+          python3 tests/test_task_manager_memory_leak_guard.py \
+            --app "$APP" \
+            --duration-seconds 120 \
+            --artifacts "memory-leak-artifacts-${{ matrix.label }}"
+
+      - name: Upload memory samples
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: task-manager-memory-${{ matrix.label }}
+          path: |
+            memory-leak-artifacts-${{ matrix.label }}
+            /tmp/cmux-memory-guard-*.log
+          if-no-files-found: ignore
+
+      - name: Cleanup virtual display
+        if: always() && matrix.virtual_display
+        run: |
+          if [ -n "${VDISPLAY_PID:-}" ]; then
+            kill "$VDISPLAY_PID" >/dev/null 2>&1 || true
+          fi
+          rm -f /tmp/create-virtual-display
+
   ui-regressions:
     runs-on: warp-macos-15-arm64-6x
     timeout-minutes: 25

--- a/Sources/TaskManagerWindowController.swift
+++ b/Sources/TaskManagerWindowController.swift
@@ -42,6 +42,14 @@ final class TaskManagerWindowController: NSWindowController, NSWindowDelegate {
         NSRunningApplication.current.activate(options: [.activateAllWindows])
     }
 
+#if DEBUG
+    func debugSnapshotPayload() -> [String: Any] {
+        var payload = model.debugSnapshotPayload()
+        payload["visible"] = window?.isVisible == true
+        return payload
+    }
+#endif
+
     func windowWillClose(_ notification: Notification) {
         model.stop()
     }
@@ -280,6 +288,29 @@ final class CmuxTaskManagerModel {
         sortedAggregateRows = sortOrder.sortedRows(snapshot.aggregateRows)
         sortedChildMemoryRows = sortOrder.sortedRows(snapshot.childMemoryRows)
     }
+
+#if DEBUG
+    func debugSnapshotPayload() -> [String: Any] {
+        let allRows = sortedAgentRows + sortedAggregateRows + sortedChildMemoryRows + sortedRows
+        let workspaceIds = Array(Set(allRows.compactMap { $0.workspaceId?.uuidString })).sorted()
+        return [
+            "has_loaded_resource_usage": snapshot.hasLoadedResourceUsage,
+            "is_initial_loading": isInitialLoading,
+            "is_refreshing": isRefreshing,
+            "error_message": errorMessage ?? NSNull(),
+            "row_count": allRows.count,
+            "hierarchy_row_count": sortedRows.count,
+            "agent_row_count": sortedAgentRows.count,
+            "aggregate_row_count": sortedAggregateRows.count,
+            "child_memory_row_count": sortedChildMemoryRows.count,
+            "workspace_row_count": allRows.filter { $0.kind == .workspace }.count,
+            "terminal_surface_row_count": allRows.filter { $0.kind == .terminalSurface }.count,
+            "workspace_ids": workspaceIds,
+            "workspace_count": workspaceIds.count,
+            "sampled": snapshot.sampledAt != nil
+        ]
+    }
+#endif
 
     private func sendSignal(_ signal: Int32, toProcessId processId: Int) -> String? {
         guard processId > 1, processId != Int(getpid()) else { return nil }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -210,6 +210,7 @@ class TerminalController {
         "debug.command_palette.toggle",
         "debug.notification.focus",
         "debug.app.activate",
+        "debug.task_manager.show",
         "debug.right_sidebar.focus",
         "feed.jump"
     ]
@@ -3201,6 +3202,8 @@ class TerminalController {
             return v2Result(id: id, self.v2DebugType(params: params))
         case "debug.app.activate":
             return v2Result(id: id, self.v2DebugActivateApp())
+        case "debug.task_manager.show":
+            return v2Result(id: id, self.v2DebugTaskManagerShow())
         case "debug.command_palette.toggle":
             return v2Result(id: id, self.v2DebugToggleCommandPalette(params: params))
         case "debug.command_palette.rename_tab.open":
@@ -3464,6 +3467,7 @@ class TerminalController {
             "debug.shortcut.simulate",
             "debug.type",
             "debug.app.activate",
+            "debug.task_manager.show",
             "debug.command_palette.toggle",
             "debug.command_palette.rename_tab.open",
             "debug.command_palette.visible",
@@ -13754,6 +13758,15 @@ class TerminalController {
     private func v2DebugActivateApp() -> V2CallResult {
         let resp = activateApp()
         return resp == "OK" ? .ok([:]) : .err(code: "internal_error", message: resp, data: nil)
+    }
+
+    private func v2DebugTaskManagerShow() -> V2CallResult {
+        var visible = false
+        v2MainSync {
+            TaskManagerWindowController.shared.show()
+            visible = TaskManagerWindowController.shared.window?.isVisible == true
+        }
+        return .ok(["visible": visible])
     }
 
     private func v2DebugToggleCommandPalette(params: [String: Any]) -> V2CallResult {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -13762,6 +13762,8 @@ class TerminalController {
 
     private func v2DebugTaskManagerShow() -> V2CallResult {
         var visible = false
+        // DEBUG socket command handlers are invoked off the main thread; keep
+        // this in the existing v2MainSync pattern until the V2 dispatcher is async.
         v2MainSync {
             TaskManagerWindowController.shared.show()
             visible = TaskManagerWindowController.shared.window?.isVisible == true

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -13775,6 +13775,7 @@ class TerminalController {
     }
 
     private func v2DebugTaskManagerSnapshot() -> V2CallResult {
+#if DEBUG
         var payload: [String: Any] = [:]
         // DEBUG socket command handlers are invoked off the main thread; keep
         // this in the existing v2MainSync pattern until the V2 dispatcher is async.
@@ -13782,6 +13783,9 @@ class TerminalController {
             payload = TaskManagerWindowController.shared.debugSnapshotPayload()
         }
         return .ok(payload)
+#else
+        return .err(code: "unavailable", message: "Debug methods are unavailable in Release builds", data: nil)
+#endif
     }
 
     private func v2DebugToggleCommandPalette(params: [String: Any]) -> V2CallResult {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -3204,6 +3204,8 @@ class TerminalController {
             return v2Result(id: id, self.v2DebugActivateApp())
         case "debug.task_manager.show":
             return v2Result(id: id, self.v2DebugTaskManagerShow())
+        case "debug.task_manager.snapshot":
+            return v2Result(id: id, self.v2DebugTaskManagerSnapshot())
         case "debug.command_palette.toggle":
             return v2Result(id: id, self.v2DebugToggleCommandPalette(params: params))
         case "debug.command_palette.rename_tab.open":
@@ -3468,6 +3470,7 @@ class TerminalController {
             "debug.type",
             "debug.app.activate",
             "debug.task_manager.show",
+            "debug.task_manager.snapshot",
             "debug.command_palette.toggle",
             "debug.command_palette.rename_tab.open",
             "debug.command_palette.visible",
@@ -13769,6 +13772,16 @@ class TerminalController {
             visible = TaskManagerWindowController.shared.window?.isVisible == true
         }
         return .ok(["visible": visible])
+    }
+
+    private func v2DebugTaskManagerSnapshot() -> V2CallResult {
+        var payload: [String: Any] = [:]
+        // DEBUG socket command handlers are invoked off the main thread; keep
+        // this in the existing v2MainSync pattern until the V2 dispatcher is async.
+        v2MainSync {
+            payload = TaskManagerWindowController.shared.debugSnapshotPayload()
+        }
+        return .ok(payload)
     }
 
     private func v2DebugToggleCommandPalette(params: [String: Any]) -> V2CallResult {

--- a/tests/test_ci_self_hosted_guard.sh
+++ b/tests/test_ci_self_hosted_guard.sh
@@ -29,6 +29,7 @@ check_warp_runner() {
 check_warp_runner "$CI_FILE" "tests"
 check_warp_runner "$CI_FILE" "tests-build-and-lag"
 check_warp_runner "$CI_FILE" "release-build"
+check_warp_runner "$CI_FILE" "task-manager-memory-leak"
 check_warp_runner "$CI_FILE" "ui-regressions"
 
 # build-ghosttykit.yml

--- a/tests/test_task_manager_memory_leak_guard.py
+++ b/tests/test_task_manager_memory_leak_guard.py
@@ -1,0 +1,475 @@
+#!/usr/bin/env python3
+"""
+Two-minute Task Manager memory leak guard.
+
+This exercises the leak class fixed for 0.64.8: Task Manager refreshes mutate a
+snapshot every three seconds while a lazy row tree is rendered. If rows miss the
+snapshot boundary/equatable cache, repeated refreshes produce sustained app RSS
+growth. The detector self-check below proves the guard rejects that growth shape.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import plistlib
+import socket
+import statistics
+import subprocess
+import sys
+import time
+import uuid
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_DURATION_SECONDS = 120.0
+DEFAULT_SAMPLE_INTERVAL_SECONDS = 3.0
+DEFAULT_WARMUP_SECONDS = 15.0
+DEFAULT_WORKSPACE_COUNT = 10
+DEFAULT_MAX_GROWTH_MB = 128.0
+DEFAULT_MAX_SLOPE_MB_PER_MIN = 64.0
+
+
+@dataclass(frozen=True)
+class MemorySample:
+    elapsed_seconds: float
+    rss_bytes: int
+
+
+@dataclass(frozen=True)
+class TrendResult:
+    failed: bool
+    reason: str
+    baseline_mb: float
+    final_mb: float
+    growth_mb: float
+    slope_mb_per_min: float
+    peak_mb: float
+    sample_count: int
+
+
+class SocketClient:
+    def __init__(self, path: str, response_timeout: float = 5.0) -> None:
+        self.path = path
+        self.response_timeout = response_timeout
+
+    def send_line(self, line: str) -> str:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+            sock.settimeout(self.response_timeout)
+            sock.connect(self.path)
+            sock.sendall((line + "\n").encode("utf-8"))
+            chunks: list[bytes] = []
+            while True:
+                chunk = sock.recv(1024 * 1024)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+                if len(chunk) < 1024 * 1024:
+                    break
+        return b"".join(chunks).decode("utf-8", errors="replace").strip()
+
+    def v2(self, method: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        frame = {
+            "id": str(uuid.uuid4()),
+            "method": method,
+            "params": params or {},
+        }
+        raw = self.send_line(json.dumps(frame, separators=(",", ":")))
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(f"{method} returned invalid JSON: {raw!r}") from exc
+        if not payload.get("ok"):
+            raise RuntimeError(f"{method} failed: {payload}")
+        result = payload.get("result")
+        return result if isinstance(result, dict) else {}
+
+
+def resolve_app_path(explicit: str | None) -> Path:
+    candidates: list[Path] = []
+    if explicit:
+        candidates.append(Path(explicit).expanduser())
+    for key in ("CMUX_MEMORY_GUARD_APP", "CMUX_APP_PATH"):
+        value = os.environ.get(key)
+        if value:
+            candidates.append(Path(value).expanduser())
+    candidates.extend(Path.cwd().glob("build-memory-leak/Build/Products/Debug/cmux DEV.app"))
+    candidates.extend(Path.cwd().glob("build*/Build/Products/Debug/cmux DEV.app"))
+    candidates.extend(Path.home().glob("Library/Developer/Xcode/DerivedData/cmux-*/Build/Products/Debug/cmux DEV*.app"))
+
+    existing = [path for path in candidates if path.exists()]
+    if not existing:
+        raise RuntimeError("Unable to find built cmux app. Pass --app or set CMUX_APP_PATH.")
+    existing.sort(key=lambda path: path.stat().st_mtime, reverse=True)
+    return existing[0]
+
+
+def executable_for_app(app_path: Path) -> Path:
+    if app_path.suffix != ".app":
+        if os.access(app_path, os.X_OK):
+            return app_path
+        raise RuntimeError(f"{app_path} is not an executable or .app bundle")
+
+    plist_path = app_path / "Contents" / "Info.plist"
+    with plist_path.open("rb") as handle:
+        info = plistlib.load(handle)
+    executable_name = info.get("CFBundleExecutable")
+    if not executable_name:
+        raise RuntimeError(f"{plist_path} is missing CFBundleExecutable")
+    executable = app_path / "Contents" / "MacOS" / str(executable_name)
+    if not executable.exists():
+        raise RuntimeError(f"App executable not found at {executable}")
+    return executable
+
+
+def launch_app(app_path: Path, socket_path: str, cmuxd_socket: str, log_path: str, tag: str) -> subprocess.Popen[str]:
+    executable = executable_for_app(app_path)
+    env = dict(os.environ)
+    for key in (
+        "CMUX_SOCKET",
+        "CMUX_SOCKET_PATH",
+        "CMUX_SOCKET_PASSWORD",
+        "CMUX_SOCKET_MODE",
+        "CMUX_TAB_ID",
+        "CMUX_PANEL_ID",
+        "CMUX_SURFACE_ID",
+        "CMUX_WORKSPACE_ID",
+        "CMUXD_UNIX_PATH",
+        "CMUX_DEBUG_LOG",
+    ):
+        env.pop(key, None)
+
+    env.update(
+        {
+            "CMUX_UI_TEST_MODE": "1",
+            "CMUX_SOCKET_MODE": "allowAll",
+            "CMUX_SOCKET_PATH": socket_path,
+            "CMUXD_UNIX_PATH": cmuxd_socket,
+            "CMUX_DISABLE_SESSION_RESTORE": "1",
+            "CMUX_DEBUG_LOG": log_path,
+            "CMUX_TAG": tag,
+        }
+    )
+    args = [
+        str(executable),
+        "-AppleLanguages",
+        "(en)",
+        "-AppleLocale",
+        "en_US",
+        "-ApplePersistenceIgnoreState",
+        "YES",
+        "-NSQuitAlwaysKeepsWindows",
+        "NO",
+        "-menuBarOnly",
+        "false",
+    ]
+    return subprocess.Popen(
+        args,
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+
+
+def wait_for_socket(client: SocketClient, proc: subprocess.Popen[str], timeout: float) -> None:
+    deadline = time.monotonic() + timeout
+    last_error = ""
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            raise RuntimeError(f"cmux exited before socket became ready, exit={proc.returncode}")
+        try:
+            if client.send_line("ping") == "PONG":
+                return
+        except OSError as exc:
+            last_error = str(exc)
+        time.sleep(0.1)
+    raise RuntimeError(f"socket did not answer ping at {client.path}: {last_error}")
+
+
+def terminal_surface(name: str) -> dict[str, Any]:
+    return {"type": "terminal", "name": name}
+
+
+def pane(name: str) -> dict[str, Any]:
+    return {
+        "pane": {
+            "surfaces": [
+                terminal_surface(f"{name}-a"),
+                terminal_surface(f"{name}-b"),
+            ]
+        }
+    }
+
+
+def four_pane_layout(prefix: str) -> dict[str, Any]:
+    return {
+        "direction": "horizontal",
+        "children": [
+            {
+                "direction": "vertical",
+                "children": [
+                    pane(f"{prefix}-tl"),
+                    pane(f"{prefix}-bl"),
+                ],
+            },
+            {
+                "direction": "vertical",
+                "children": [
+                    pane(f"{prefix}-tr"),
+                    pane(f"{prefix}-br"),
+                ],
+            },
+        ],
+    }
+
+
+def seed_workspaces(client: SocketClient, count: int) -> list[str]:
+    workspace_ids: list[str] = []
+    for index in range(count):
+        result = client.v2(
+            "workspace.create",
+            {
+                "title": f"Memory Guard {index + 1:02d}",
+                "focus": False,
+                "layout": four_pane_layout(f"mem-{index + 1:02d}"),
+            },
+        )
+        workspace_id = result.get("workspace_id")
+        if isinstance(workspace_id, str):
+            workspace_ids.append(workspace_id)
+    if len(workspace_ids) != count:
+        raise RuntimeError(f"created {len(workspace_ids)} workspaces, expected {count}")
+    return workspace_ids
+
+
+def rss_bytes(pid: int) -> int:
+    result = subprocess.run(
+        ["/bin/ps", "-o", "rss=", "-p", str(pid)],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"ps failed for pid {pid}: {result.stderr.strip()}")
+    text = result.stdout.strip()
+    if not text:
+        raise RuntimeError(f"ps returned no RSS for pid {pid}")
+    return int(text.splitlines()[-1].strip()) * 1024
+
+
+def collect_samples(pid: int, duration: float, interval: float) -> list[MemorySample]:
+    samples: list[MemorySample] = []
+    started = time.monotonic()
+    next_sample = started
+    while True:
+        now = time.monotonic()
+        if now < next_sample:
+            time.sleep(next_sample - now)
+            continue
+        elapsed = time.monotonic() - started
+        samples.append(MemorySample(elapsed_seconds=elapsed, rss_bytes=rss_bytes(pid)))
+        if elapsed >= duration:
+            return samples
+        next_sample += interval
+
+
+def median_mb(values: list[int]) -> float:
+    return statistics.median(values) / (1024 * 1024)
+
+
+def slope_mb_per_minute(samples: list[MemorySample]) -> float:
+    if len(samples) < 2:
+        return 0.0
+    xs = [sample.elapsed_seconds / 60.0 for sample in samples]
+    ys = [sample.rss_bytes / (1024 * 1024) for sample in samples]
+    mean_x = statistics.mean(xs)
+    mean_y = statistics.mean(ys)
+    denominator = sum((x - mean_x) ** 2 for x in xs)
+    if denominator <= 0:
+        return 0.0
+    return sum((x - mean_x) * (y - mean_y) for x, y in zip(xs, ys)) / denominator
+
+
+def classify_trend(samples: list[MemorySample], max_growth_mb: float, max_slope_mb_per_min: float) -> TrendResult:
+    if len(samples) < 8:
+        return TrendResult(
+            failed=True,
+            reason=f"not enough samples ({len(samples)} < 8)",
+            baseline_mb=0,
+            final_mb=0,
+            growth_mb=0,
+            slope_mb_per_min=0,
+            peak_mb=0,
+            sample_count=len(samples),
+        )
+
+    window = min(5, max(2, len(samples) // 5))
+    baseline_mb = median_mb([sample.rss_bytes for sample in samples[:window]])
+    final_mb = median_mb([sample.rss_bytes for sample in samples[-window:]])
+    growth_mb = final_mb - baseline_mb
+    slope = slope_mb_per_minute(samples)
+    peak_mb = max(sample.rss_bytes for sample in samples) / (1024 * 1024)
+
+    reasons: list[str] = []
+    if growth_mb > max_growth_mb:
+        reasons.append(f"growth {growth_mb:.1f} MB > {max_growth_mb:.1f} MB")
+    if slope > max_slope_mb_per_min and growth_mb > max_growth_mb * 0.5:
+        reasons.append(f"slope {slope:.1f} MB/min > {max_slope_mb_per_min:.1f} MB/min")
+    failed = bool(reasons)
+    return TrendResult(
+        failed=failed,
+        reason="; ".join(reasons) if reasons else "within memory growth limits",
+        baseline_mb=baseline_mb,
+        final_mb=final_mb,
+        growth_mb=growth_mb,
+        slope_mb_per_min=slope,
+        peak_mb=peak_mb,
+        sample_count=len(samples),
+    )
+
+
+def detector_self_check(max_growth_mb: float, max_slope_mb_per_min: float) -> None:
+    stable = [
+        MemorySample(elapsed_seconds=float(index * 3), rss_bytes=int((620 + math.sin(index / 2) * 3) * 1024 * 1024))
+        for index in range(41)
+    ]
+    stable_result = classify_trend(stable, max_growth_mb, max_slope_mb_per_min)
+    if stable_result.failed:
+        raise RuntimeError(f"detector rejected stable synthetic trend: {stable_result}")
+
+    leak = [
+        MemorySample(elapsed_seconds=float(index * 3), rss_bytes=int((620 + index * 5.0) * 1024 * 1024))
+        for index in range(41)
+    ]
+    leak_result = classify_trend(leak, max_growth_mb, max_slope_mb_per_min)
+    if not leak_result.failed:
+        raise RuntimeError(f"detector failed to reject synthetic leak trend: {leak_result}")
+    print(
+        "PASS: detector rejects leak-shaped growth "
+        f"(synthetic growth={leak_result.growth_mb:.1f} MB, slope={leak_result.slope_mb_per_min:.1f} MB/min)"
+    )
+
+
+def write_artifacts(artifacts_dir: Path | None, samples: list[MemorySample], trend: TrendResult) -> None:
+    if artifacts_dir is None:
+        return
+    artifacts_dir.mkdir(parents=True, exist_ok=True)
+    (artifacts_dir / "task-manager-memory-samples.json").write_text(
+        json.dumps(
+            {
+                "trend": asdict(trend),
+                "samples": [asdict(sample) for sample in samples],
+            },
+            indent=2,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+
+def tail_file(path: Path, line_count: int = 80) -> str:
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except FileNotFoundError:
+        return ""
+    return "\n".join(lines[-line_count:])
+
+
+def run_guard(args: argparse.Namespace) -> int:
+    detector_self_check(args.max_growth_mb, args.max_slope_mb_per_min)
+
+    app_path = resolve_app_path(args.app)
+    run_id = uuid.uuid4().hex[:8]
+    tag = f"memci-{run_id}"
+    socket_path = f"/tmp/cmux-memory-guard-{run_id}.sock"
+    cmuxd_socket = f"/tmp/cmux-memory-guard-{run_id}-cmuxd.sock"
+    log_path = f"/tmp/cmux-memory-guard-{run_id}.log"
+    artifacts_dir = Path(args.artifacts).expanduser() if args.artifacts else None
+
+    for path in (socket_path, cmuxd_socket):
+        try:
+            os.unlink(path)
+        except FileNotFoundError:
+            pass
+
+    proc = launch_app(app_path, socket_path, cmuxd_socket, log_path, tag)
+    client = SocketClient(socket_path, response_timeout=10.0)
+    samples: list[MemorySample] = []
+    trend = TrendResult(True, "not run", 0, 0, 0, 0, 0, 0)
+    try:
+        wait_for_socket(client, proc, timeout=20.0)
+        workspace_ids = seed_workspaces(client, args.workspace_count)
+        show_result = client.v2("debug.task_manager.show")
+        print(
+            "Task Manager memory guard setup: "
+            f"pid={proc.pid} app={app_path} workspaces={len(workspace_ids)} visible={show_result.get('visible')}"
+        )
+        time.sleep(args.warmup_seconds)
+        samples = collect_samples(proc.pid, args.duration_seconds, args.sample_interval_seconds)
+        trend = classify_trend(samples, args.max_growth_mb, args.max_slope_mb_per_min)
+        write_artifacts(artifacts_dir, samples, trend)
+        print(
+            "Task Manager memory guard result: "
+            f"baseline={trend.baseline_mb:.1f} MB final={trend.final_mb:.1f} MB "
+            f"growth={trend.growth_mb:.1f} MB slope={trend.slope_mb_per_min:.1f} MB/min "
+            f"peak={trend.peak_mb:.1f} MB samples={trend.sample_count}"
+        )
+        if trend.failed:
+            print(f"FAIL: {trend.reason}")
+            print("--- cmux debug log tail ---")
+            print(tail_file(Path(log_path)))
+            return 1
+        print(f"PASS: {trend.reason}")
+        return 0
+    finally:
+        write_artifacts(artifacts_dir, samples, trend)
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5.0)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=5.0)
+        for path in (socket_path, cmuxd_socket):
+            try:
+                os.unlink(path)
+            except FileNotFoundError:
+                pass
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--app", help="Path to cmux .app or executable. Defaults to latest built Debug app.")
+    parser.add_argument("--duration-seconds", type=float, default=DEFAULT_DURATION_SECONDS)
+    parser.add_argument("--sample-interval-seconds", type=float, default=DEFAULT_SAMPLE_INTERVAL_SECONDS)
+    parser.add_argument("--warmup-seconds", type=float, default=DEFAULT_WARMUP_SECONDS)
+    parser.add_argument("--workspace-count", type=int, default=DEFAULT_WORKSPACE_COUNT)
+    parser.add_argument("--max-growth-mb", type=float, default=DEFAULT_MAX_GROWTH_MB)
+    parser.add_argument("--max-slope-mb-per-min", type=float, default=DEFAULT_MAX_SLOPE_MB_PER_MIN)
+    parser.add_argument("--artifacts", help="Directory for JSON samples.")
+    parser.add_argument("--self-check-only", action="store_true", help="Only validate the leak detector thresholds.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    if args.duration_seconds <= 0:
+        raise SystemExit("--duration-seconds must be positive")
+    if args.sample_interval_seconds <= 0:
+        raise SystemExit("--sample-interval-seconds must be positive")
+    if args.workspace_count <= 0:
+        raise SystemExit("--workspace-count must be positive")
+    if args.self_check_only:
+        detector_self_check(args.max_growth_mb, args.max_slope_mb_per_min)
+        return 0
+    return run_guard(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/test_task_manager_memory_leak_guard.py
+++ b/tests/test_task_manager_memory_leak_guard.py
@@ -15,6 +15,7 @@ import json
 import math
 import os
 import plistlib
+import shutil
 import socket
 import statistics
 import subprocess
@@ -146,6 +147,7 @@ def launch_app(app_path: Path, socket_path: str, cmuxd_socket: str, log_path: st
         "CMUX_SOCKET_PATH",
         "CMUX_SOCKET_PASSWORD",
         "CMUX_SOCKET_MODE",
+        "CMUX_SOCKET_ENABLE",
         "CMUX_ALLOW_SOCKET_OVERRIDE",
         "CMUX_TAB_ID",
         "CMUX_PANEL_ID",
@@ -159,6 +161,7 @@ def launch_app(app_path: Path, socket_path: str, cmuxd_socket: str, log_path: st
     env.update(
         {
             "CMUX_UI_TEST_MODE": "1",
+            "CMUX_SOCKET_ENABLE": "1",
             "CMUX_SOCKET_MODE": "allowAll",
             "CMUX_ALLOW_SOCKET_OVERRIDE": "1",
             "CMUX_SOCKET_PATH": socket_path,
@@ -407,7 +410,12 @@ def detector_self_check(max_growth_mb: float, max_slope_mb_per_min: float) -> No
     )
 
 
-def write_artifacts(artifacts_dir: Path | None, samples: list[MemorySample], trend: TrendResult) -> None:
+def write_artifacts(
+    artifacts_dir: Path | None,
+    samples: list[MemorySample],
+    trend: TrendResult,
+    log_path: Path | None = None,
+) -> None:
     if artifacts_dir is None:
         return
     artifacts_dir.mkdir(parents=True, exist_ok=True)
@@ -422,6 +430,8 @@ def write_artifacts(artifacts_dir: Path | None, samples: list[MemorySample], tre
         ),
         encoding="utf-8",
     )
+    if log_path is not None and log_path.exists():
+        shutil.copyfile(log_path, artifacts_dir / "cmux-memory-guard.log")
 
 
 def tail_file(path: Path, line_count: int = 80) -> str:
@@ -487,7 +497,7 @@ def run_guard(args: argparse.Namespace) -> int:
         print(tail_file(Path(log_path)))
         raise
     finally:
-        write_artifacts(artifacts_dir, samples, trend)
+        write_artifacts(artifacts_dir, samples, trend, Path(log_path))
         if proc.poll() is None:
             proc.terminate()
             try:

--- a/tests/test_task_manager_memory_leak_guard.py
+++ b/tests/test_task_manager_memory_leak_guard.py
@@ -62,15 +62,18 @@ class SocketClient:
             sock.settimeout(self.response_timeout)
             sock.connect(self.path)
             sock.sendall((line + "\n").encode("utf-8"))
-            chunks: list[bytes] = []
-            while True:
-                chunk = sock.recv(1024 * 1024)
+            data = bytearray()
+            deadline = time.monotonic() + self.response_timeout
+            while b"\n" not in data:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise TimeoutError(f"timed out waiting for response to {line!r}")
+                sock.settimeout(remaining)
+                chunk = sock.recv(8192)
                 if not chunk:
-                    break
-                chunks.append(chunk)
-                if len(chunk) < 1024 * 1024:
-                    break
-        return b"".join(chunks).decode("utf-8", errors="replace").strip()
+                    raise RuntimeError(f"socket closed while waiting for response to {line!r}")
+                data.extend(chunk)
+        return data.split(b"\n", 1)[0].decode("utf-8", errors="replace").strip()
 
     def v2(self, method: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
         frame = {
@@ -413,7 +416,6 @@ def run_guard(args: argparse.Namespace) -> int:
         time.sleep(args.warmup_seconds)
         samples = collect_samples(proc.pid, args.duration_seconds, args.sample_interval_seconds)
         trend = classify_trend(samples, args.max_growth_mb, args.max_slope_mb_per_min)
-        write_artifacts(artifacts_dir, samples, trend)
         print(
             "Task Manager memory guard result: "
             f"baseline={trend.baseline_mb:.1f} MB final={trend.final_mb:.1f} MB "

--- a/tests/test_task_manager_memory_leak_guard.py
+++ b/tests/test_task_manager_memory_leak_guard.py
@@ -29,6 +29,7 @@ from typing import Any
 DEFAULT_DURATION_SECONDS = 120.0
 DEFAULT_SAMPLE_INTERVAL_SECONDS = 3.0
 DEFAULT_WARMUP_SECONDS = 15.0
+DEFAULT_DATA_TIMEOUT_SECONDS = 30.0
 DEFAULT_WORKSPACE_COUNT = 10
 DEFAULT_MAX_GROWTH_MB = 128.0
 DEFAULT_MAX_SLOPE_MB_PER_MIN = 64.0
@@ -260,6 +261,43 @@ def seed_workspaces(client: SocketClient, count: int) -> list[str]:
     return workspace_ids
 
 
+def wait_for_task_manager_rows(client: SocketClient, workspace_ids: list[str], timeout: float) -> dict[str, Any]:
+    expected_workspace_ids = set(workspace_ids)
+    deadline = time.monotonic() + timeout
+    last_snapshot: dict[str, Any] = {}
+
+    while time.monotonic() < deadline:
+        snapshot = client.v2("debug.task_manager.snapshot")
+        last_snapshot = snapshot
+        error_message = snapshot.get("error_message")
+        if isinstance(error_message, str) and error_message:
+            raise RuntimeError(f"Task Manager reported an error while loading rows: {error_message}")
+
+        loaded_workspace_ids = {
+            value for value in snapshot.get("workspace_ids", [])
+            if isinstance(value, str)
+        }
+        if (
+            snapshot.get("visible") is True
+            and snapshot.get("has_loaded_resource_usage") is True
+            and int(snapshot.get("row_count") or 0) > 0
+            and expected_workspace_ids.issubset(loaded_workspace_ids)
+        ):
+            return snapshot
+
+        time.sleep(0.5)
+
+    loaded_workspace_ids = {
+        value for value in last_snapshot.get("workspace_ids", [])
+        if isinstance(value, str)
+    }
+    missing = sorted(expected_workspace_ids - loaded_workspace_ids)
+    raise RuntimeError(
+        "Task Manager did not load seeded workspace rows before sampling: "
+        f"missing={missing} last_snapshot={last_snapshot}"
+    )
+
+
 def rss_bytes(pid: int) -> int:
     result = subprocess.run(
         ["/bin/ps", "-o", "rss=", "-p", str(pid)],
@@ -421,9 +459,12 @@ def run_guard(args: argparse.Namespace) -> int:
         show_result = client.v2("debug.task_manager.show")
         if show_result.get("visible") is not True:
             raise RuntimeError(f"Task Manager did not become visible: {show_result}")
+        data_snapshot = wait_for_task_manager_rows(client, workspace_ids, args.data_timeout_seconds)
         print(
             "Task Manager memory guard setup: "
-            f"pid={proc.pid} app={app_path} workspaces={len(workspace_ids)} visible={show_result.get('visible')}"
+            f"pid={proc.pid} app={app_path} workspaces={len(workspace_ids)} "
+            f"visible={show_result.get('visible')} rows={data_snapshot.get('row_count')} "
+            f"task_manager_workspaces={data_snapshot.get('workspace_count')}"
         )
         time.sleep(args.warmup_seconds)
         samples = collect_samples(proc.pid, args.duration_seconds, args.sample_interval_seconds)
@@ -470,6 +511,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--duration-seconds", type=float, default=DEFAULT_DURATION_SECONDS)
     parser.add_argument("--sample-interval-seconds", type=float, default=DEFAULT_SAMPLE_INTERVAL_SECONDS)
     parser.add_argument("--warmup-seconds", type=float, default=DEFAULT_WARMUP_SECONDS)
+    parser.add_argument("--data-timeout-seconds", type=float, default=DEFAULT_DATA_TIMEOUT_SECONDS)
     parser.add_argument("--workspace-count", type=int, default=DEFAULT_WORKSPACE_COUNT)
     parser.add_argument("--max-growth-mb", type=float, default=DEFAULT_MAX_GROWTH_MB)
     parser.add_argument("--max-slope-mb-per-min", type=float, default=DEFAULT_MAX_SLOPE_MB_PER_MIN)
@@ -484,6 +526,8 @@ def main(argv: list[str]) -> int:
         raise SystemExit("--duration-seconds must be positive")
     if args.sample_interval_seconds <= 0:
         raise SystemExit("--sample-interval-seconds must be positive")
+    if args.data_timeout_seconds <= 0:
+        raise SystemExit("--data-timeout-seconds must be positive")
     if args.workspace_count <= 0:
         raise SystemExit("--workspace-count must be positive")
     if args.self_check_only:

--- a/tests/test_task_manager_memory_leak_guard.py
+++ b/tests/test_task_manager_memory_leak_guard.py
@@ -93,13 +93,21 @@ class SocketClient:
 
 
 def resolve_app_path(explicit: str | None) -> Path:
-    candidates: list[Path] = []
     if explicit:
-        candidates.append(Path(explicit).expanduser())
+        path = Path(explicit).expanduser()
+        if not path.exists():
+            raise RuntimeError(f"--app points to a missing path: {path}")
+        return path
+
     for key in ("CMUX_MEMORY_GUARD_APP", "CMUX_APP_PATH"):
         value = os.environ.get(key)
         if value:
-            candidates.append(Path(value).expanduser())
+            path = Path(value).expanduser()
+            if not path.exists():
+                raise RuntimeError(f"{key} points to a missing path: {path}")
+            return path
+
+    candidates: list[Path] = []
     candidates.extend(Path.cwd().glob("build-memory-leak/Build/Products/Debug/cmux DEV.app"))
     candidates.extend(Path.cwd().glob("build*/Build/Products/Debug/cmux DEV.app"))
     candidates.extend(Path.home().glob("Library/Developer/Xcode/DerivedData/cmux-*/Build/Products/Debug/cmux DEV*.app"))
@@ -137,6 +145,7 @@ def launch_app(app_path: Path, socket_path: str, cmuxd_socket: str, log_path: st
         "CMUX_SOCKET_PATH",
         "CMUX_SOCKET_PASSWORD",
         "CMUX_SOCKET_MODE",
+        "CMUX_ALLOW_SOCKET_OVERRIDE",
         "CMUX_TAB_ID",
         "CMUX_PANEL_ID",
         "CMUX_SURFACE_ID",
@@ -150,6 +159,7 @@ def launch_app(app_path: Path, socket_path: str, cmuxd_socket: str, log_path: st
         {
             "CMUX_UI_TEST_MODE": "1",
             "CMUX_SOCKET_MODE": "allowAll",
+            "CMUX_ALLOW_SOCKET_OVERRIDE": "1",
             "CMUX_SOCKET_PATH": socket_path,
             "CMUXD_UNIX_PATH": cmuxd_socket,
             "CMUX_DISABLE_SESSION_RESTORE": "1",
@@ -409,6 +419,8 @@ def run_guard(args: argparse.Namespace) -> int:
         wait_for_socket(client, proc, timeout=20.0)
         workspace_ids = seed_workspaces(client, args.workspace_count)
         show_result = client.v2("debug.task_manager.show")
+        if show_result.get("visible") is not True:
+            raise RuntimeError(f"Task Manager did not become visible: {show_result}")
         print(
             "Task Manager memory guard setup: "
             f"pid={proc.pid} app={app_path} workspaces={len(workspace_ids)} visible={show_result.get('visible')}"

--- a/tests/test_task_manager_memory_leak_guard.py
+++ b/tests/test_task_manager_memory_leak_guard.py
@@ -71,7 +71,7 @@ class SocketClient:
                 sock.settimeout(remaining)
                 chunk = sock.recv(8192)
                 if not chunk:
-                    raise RuntimeError(f"socket closed while waiting for response to {line!r}")
+                    raise ConnectionError(f"socket closed while waiting for response to {line!r}")
                 data.extend(chunk)
         return data.split(b"\n", 1)[0].decode("utf-8", errors="replace").strip()
 
@@ -441,6 +441,10 @@ def run_guard(args: argparse.Namespace) -> int:
             return 1
         print(f"PASS: {trend.reason}")
         return 0
+    except Exception:
+        print("--- cmux debug log tail ---")
+        print(tail_file(Path(log_path)))
+        raise
     finally:
         write_artifacts(artifacts_dir, samples, trend)
         if proc.poll() is None:
@@ -449,7 +453,10 @@ def run_guard(args: argparse.Namespace) -> int:
                 proc.wait(timeout=5.0)
             except subprocess.TimeoutExpired:
                 proc.kill()
-                proc.wait(timeout=5.0)
+                try:
+                    proc.wait(timeout=5.0)
+                except subprocess.TimeoutExpired:
+                    print(f"WARN: cmux did not exit after SIGKILL, pid={proc.pid}")
         for path in (socket_path, cmuxd_socket):
             try:
                 os.unlink(path)

--- a/tests/test_task_manager_memory_leak_guard.py
+++ b/tests/test_task_manager_memory_leak_guard.py
@@ -315,10 +315,13 @@ def rss_bytes(pid: int) -> int:
     text = result.stdout.strip()
     if not text:
         raise RuntimeError(f"ps returned no RSS for pid {pid}")
-    return int(text.splitlines()[-1].strip()) * 1024
+    rss = int(text.splitlines()[-1].strip()) * 1024
+    if rss <= 0:
+        raise RuntimeError(f"ps returned non-positive RSS for pid {pid}: {rss}")
+    return rss
 
 
-def collect_samples(pid: int, duration: float, interval: float) -> list[MemorySample]:
+def collect_samples(proc: subprocess.Popen[str], duration: float, interval: float) -> list[MemorySample]:
     samples: list[MemorySample] = []
     started = time.monotonic()
     next_sample = started
@@ -328,7 +331,9 @@ def collect_samples(pid: int, duration: float, interval: float) -> list[MemorySa
             time.sleep(next_sample - now)
             continue
         elapsed = time.monotonic() - started
-        samples.append(MemorySample(elapsed_seconds=elapsed, rss_bytes=rss_bytes(pid)))
+        if proc.poll() is not None:
+            raise RuntimeError(f"cmux exited during memory sampling, exit={proc.returncode}")
+        samples.append(MemorySample(elapsed_seconds=elapsed, rss_bytes=rss_bytes(proc.pid)))
         if elapsed >= duration:
             return samples
         next_sample += interval
@@ -411,6 +416,25 @@ def detector_self_check(max_growth_mb: float, max_slope_mb_per_min: float) -> No
     )
 
 
+def sampler_exit_self_check() -> None:
+    proc = subprocess.Popen(["/bin/sh", "-c", "exit 42"])
+    try:
+        for _ in range(20):
+            if proc.poll() is not None:
+                break
+            time.sleep(0.01)
+        try:
+            collect_samples(proc, duration=0, interval=1)
+        except RuntimeError as exc:
+            if "cmux exited during memory sampling" in str(exc):
+                print("PASS: sampler rejects exited app process")
+                return
+            raise
+        raise RuntimeError("sampler accepted an exited app process")
+    finally:
+        proc.wait(timeout=1)
+
+
 def write_artifacts(
     artifacts_dir: Path | None,
     samples: list[MemorySample],
@@ -445,6 +469,7 @@ def tail_file(path: Path, line_count: int = 80) -> str:
 
 def run_guard(args: argparse.Namespace) -> int:
     detector_self_check(args.max_growth_mb, args.max_slope_mb_per_min)
+    sampler_exit_self_check()
 
     app_path = resolve_app_path(args.app)
     run_id = uuid.uuid4().hex[:8]
@@ -478,7 +503,7 @@ def run_guard(args: argparse.Namespace) -> int:
             f"task_manager_workspaces={data_snapshot.get('workspace_count')}"
         )
         time.sleep(args.warmup_seconds)
-        samples = collect_samples(proc.pid, args.duration_seconds, args.sample_interval_seconds)
+        samples = collect_samples(proc, args.duration_seconds, args.sample_interval_seconds)
         trend = classify_trend(samples, args.max_growth_mb, args.max_slope_mb_per_min)
         print(
             "Task Manager memory guard result: "
@@ -543,6 +568,7 @@ def main(argv: list[str]) -> int:
         raise SystemExit("--workspace-count must be positive")
     if args.self_check_only:
         detector_self_check(args.max_growth_mb, args.max_slope_mb_per_min)
+        sampler_exit_self_check()
         return 0
     return run_guard(args)
 

--- a/tests/test_task_manager_memory_leak_guard.py
+++ b/tests/test_task_manager_memory_leak_guard.py
@@ -268,13 +268,14 @@ def wait_for_task_manager_rows(client: SocketClient, workspace_ids: list[str], t
     expected_workspace_ids = set(workspace_ids)
     deadline = time.monotonic() + timeout
     last_snapshot: dict[str, Any] = {}
+    last_error_message = ""
 
     while time.monotonic() < deadline:
         snapshot = client.v2("debug.task_manager.snapshot")
         last_snapshot = snapshot
         error_message = snapshot.get("error_message")
         if isinstance(error_message, str) and error_message:
-            raise RuntimeError(f"Task Manager reported an error while loading rows: {error_message}")
+            last_error_message = error_message
 
         loaded_workspace_ids = {
             value for value in snapshot.get("workspace_ids", [])
@@ -297,7 +298,7 @@ def wait_for_task_manager_rows(client: SocketClient, workspace_ids: list[str], t
     missing = sorted(expected_workspace_ids - loaded_workspace_ids)
     raise RuntimeError(
         "Task Manager did not load seeded workspace rows before sampling: "
-        f"missing={missing} last_snapshot={last_snapshot}"
+        f"missing={missing} last_error={last_error_message!r} last_snapshot={last_snapshot}"
     )
 
 


### PR DESCRIPTION
Adds a two-minute RSS growth guard to the main CI workflow on both macOS runners:

- macOS 15: `warp-macos-15-arm64-6x` with virtual display
- macOS 26: `warp-macos-26-arm64-6x`

The harness launches the built debug app with an isolated socket, creates a nontrivial workspace set, opens Task Manager through a DEBUG-only socket method, warms up, then samples app RSS every 3 seconds for 120 seconds. It fails on sustained growth over 128 MB or a high positive slope, and uploads JSON samples plus cmux debug logs.

The detector also has a self-check that rejects a synthetic leak-shaped trend, so threshold regressions fail before app launch. This targets the 0.64.8 leak class from https://github.com/manaflow-ai/cmux/issues/4529, including the Task Manager refresh path and the workspace/sidebar git-probe pressure that the seeded workspaces exercise.

Validation run locally:

- `python3 tests/test_task_manager_memory_leak_guard.py --self-check-only`
- `python3 -m py_compile tests/test_task_manager_memory_leak_guard.py`
- `git diff --check`
- `actionlint -ignore 'label "warp-macos-[0-9]+-arm64-6x" is unknown' -ignore 'SC2012' -ignore 'SC2034' .github/workflows/ci.yml`\n- `CMUX_SKIP_ZIG_BUILD=1 xcodebuildmcp macos build --project-path cmux.xcodeproj --scheme cmux --configuration Debug --derived-data-path /tmp/cmux-memci-check --prefer-xcodebuild true --output text`\n

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4575"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782038564&installation_id=133855650&pr_number=4575&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4575&signature=16caa609a468a9cbb14df95d6a6a9750a89693d6edfeb6f87f092262c94367ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new macOS CI job that builds and launches the app to sample RSS over time, which may introduce CI flakiness/time cost if runners or Task Manager data readiness are unstable. Also adds new DEBUG socket methods for Task Manager visibility/snapshots that must remain correctly gated from Release builds.
> 
> **Overview**
> Adds a new `task-manager-memory-leak` job to the main CI workflow (macOS 15 + macOS 26 matrix) that builds a Debug app, optionally starts a virtual display, runs a two‑minute RSS sampling guard, and uploads memory/log artifacts.
> 
> Introduces a new Python harness (`tests/test_task_manager_memory_leak_guard.py`) that launches cmux with an isolated socket, seeds multiple workspaces, opens Task Manager via DEBUG socket commands, waits for rows to load, then fails CI on sustained RSS growth (growth/slope thresholds) while emitting JSON samples and log tails.
> 
> Extends the DEBUG socket API in `TerminalController` with `debug.task_manager.show` and `debug.task_manager.snapshot`, and adds DEBUG-only snapshot payload helpers in `TaskManagerWindowController`/`CmuxTaskManagerModel` to report visibility, load state, row counts, and workspace IDs; updates the self-hosted runner guard to require the new CI job uses WarpBuild.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfc37096026c9e8dfd9e57f38e4bdaaa858f3c3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a 2‑minute CI guard that opens Task Manager and samples app RSS to catch memory regressions on `warp-macos-15-arm64-6x` and `warp-macos-26-arm64-6x`. It fails on >128 MB growth, steep slope (>64 MB/min when growth >64 MB), or if the app exits during sampling, and uploads JSON samples plus the cmux debug log.

- **New Features**
  - CI job `task-manager-memory-leak` on macOS 15/26: select Xcode, fetch prebuilt `GhosttyKit.xcframework`, install Rust (+ Zig on 15), cache/resolve SPM with retry, build Debug, run the guard, upload `memory-leak-artifacts-<label>`; uses Warp self‑hosted runners.
  - DEBUG v2 sockets: `debug.task_manager.show` (returns `visible`) and `debug.task_manager.snapshot` (DEBUG‑only; `unavailable` in Release) with `visible`, load state, row counts, and `workspace_ids`.
  - Guard `tests/test_task_manager_memory_leak_guard.py`: seeds 10 workspaces, waits for rows, 15s warmup, 120s sampling every 3s, synthetic self‑check, emits metrics and artifacts (JSON + cmux log).

- **Bug Fixes**
  - Fails fast if the app exits during sampling (with a sampler self‑check).
  - Tolerates transient Task Manager refresh errors while rows load to reduce false failures.

<sup>Written for commit dfc37096026c9e8dfd9e57f38e4bdaaa858f3c3e. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4575?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a Task Manager memory-leak guard that launches the app, seeds deterministic 4‑pane workspaces, samples RSS over time, classifies growth via median/slope rules with a self‑check, and emits a JSON artifact of samples/results.
  * Added a debug command to query Task Manager visibility and enhanced debug snapshot output with visibility, resource/load state, row counts, and sampling info.
* **Chores**
  * Added a CI job to run the memory‑leak guard across macOS variants (with optional virtual display) and updated CI checks to ensure the job runs on the intended runner.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4575?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->