### PR TITLE
Keep Codex notifications after interrupted turns

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -694,6 +694,13 @@ private final class ClaudeHookSessionStore {
                             on: &record
                         )
                         markPromptTurnTerminal(normalizedTurnId, on: &record)
+                    } else if depthBeforeStop > turnStack.count {
+                        setActivePromptTurnStack(
+                            turnStack,
+                            totalDepth: max(0, totalDepthBeforeStop - 1),
+                            on: &record
+                        )
+                        markPromptTurnTerminal(normalizedTurnId, on: &record)
                     }
                     state.sessions[normalized] = record
                     return true

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -630,6 +630,7 @@ private final class ClaudeHookSessionStore {
         cwd: String?,
         transcriptPath: String? = nil,
         turnId: String? = nil,
+        terminalActivePromptTurnIds: Set<String> = [],
         pid: Int?,
         launchCommand: AgentHookLaunchCommandRecord?,
         lastSubtitle: String?,
@@ -672,7 +673,20 @@ private final class ClaudeHookSessionStore {
             let normalizedTurnId = normalizeOptional(turnId)
             if let normalizedTurnId {
                 var turnStack = activePromptTurnStack(from: record)
-                let totalDepthBeforeStop = max(depthBeforeStop, turnStack.count)
+                var totalDepthBeforeStop = max(depthBeforeStop, turnStack.count)
+                if let activeTurnId = turnStack.last,
+                   activeTurnId != normalizedTurnId {
+                    var removedTerminalTurnIds: [String] = []
+                    while let activeTurnId = turnStack.last,
+                          terminalActivePromptTurnIds.contains(activeTurnId) {
+                        removedTerminalTurnIds.append(turnStack.removeLast())
+                    }
+                    if !removedTerminalTurnIds.isEmpty {
+                        totalDepthBeforeStop = max(0, totalDepthBeforeStop - removedTerminalTurnIds.count)
+                        setActivePromptTurnStack(turnStack, totalDepth: totalDepthBeforeStop, on: &record)
+                        markPromptTurnsTerminal(removedTerminalTurnIds, on: &record)
+                    }
+                }
                 if let lastTurnId = turnStack.last {
                     if lastTurnId == normalizedTurnId {
                         let nested = totalDepthBeforeStop > 1
@@ -705,21 +719,22 @@ private final class ClaudeHookSessionStore {
                     state.sessions[normalized] = record
                     return true
                 }
-                if depthBeforeStop == 0, terminalPromptTurnSet(from: record).contains(normalizedTurnId) {
+                if totalDepthBeforeStop == 0, terminalPromptTurnSet(from: record).contains(normalizedTurnId) {
                     state.sessions[normalized] = record
                     return true
                 }
                 markPromptTurnTerminal(normalizedTurnId, on: &record)
-                if depthBeforeStop > 0 {
-                    if depthAfterStop == 0 {
+                if totalDepthBeforeStop > 0 {
+                    let depthAfterTurnStop = max(0, totalDepthBeforeStop - 1)
+                    if depthAfterTurnStop == 0 {
                         record.activePromptDepth = nil
                     } else {
-                        record.activePromptDepth = depthAfterStop
+                        record.activePromptDepth = depthAfterTurnStop
                     }
                     record.activePromptTurnId = nil
                     record.activePromptTurnIds = nil
                     state.sessions[normalized] = record
-                    return depthBeforeStop > 1
+                    return totalDepthBeforeStop > 1
                 }
             }
             if depthAfterStop == 0 {
@@ -24762,6 +24777,27 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                 fallbackKind: def.name,
                 cwd: cwd
             )
+            let terminalActivePromptTurnIdsForStop: Set<String>
+            if def.name == "codex",
+               let incomingTurnId = normalizedHookValue(input.turnId) {
+                let activePromptTurnStack = mapped?.activePromptTurnIds?
+                    .compactMap({ normalizedHookValue($0) }) ?? []
+                let activePromptTurnId = activePromptTurnStack.last ?? normalizedHookValue(mapped?.activePromptTurnId)
+                if let activeTurnId = activePromptTurnId,
+                   activeTurnId != incomingTurnId,
+                   let transcriptPath = normalizedHookValue(input.transcriptPath ?? mapped?.transcriptPath)
+                       ?? findCodexTranscriptPath(sessionId: sessionId, env: env) {
+                    let activeTurnIds = activePromptTurnStack.isEmpty ? [activeTurnId] : activePromptTurnStack
+                    terminalActivePromptTurnIdsForStop = codexTranscriptTerminalTurnIds(
+                        path: transcriptPath,
+                        turnIds: Set(activeTurnIds)
+                    )
+                } else {
+                    terminalActivePromptTurnIdsForStop = []
+                }
+            } else {
+                terminalActivePromptTurnIdsForStop = []
+            }
             let nestedPromptStop: Bool
             if !sessionId.isEmpty {
                 nestedPromptStop = (try? store.recordPromptStop(
@@ -24771,6 +24807,7 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                     cwd: cwd,
                     transcriptPath: input.transcriptPath ?? mapped?.transcriptPath,
                     turnId: input.turnId,
+                    terminalActivePromptTurnIds: terminalActivePromptTurnIdsForStop,
                     pid: pid,
                     launchCommand: launchCommand,
                     lastSubtitle: nil,

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -701,8 +701,13 @@ private final class ClaudeHookSessionStore {
                 record.activePromptTurnId = nil
                 record.activePromptTurnIds = nil
             } else {
-                record.activePromptDepth = depthAfterStop
-                if let normalizedTurnId {
+                let turnStack = activePromptTurnStack(from: record)
+                if !turnStack.isEmpty {
+                    setActivePromptTurnStack(Array(turnStack.prefix(depthAfterStop)), on: &record)
+                } else {
+                    record.activePromptDepth = depthAfterStop
+                }
+                if let normalizedTurnId, turnStack.isEmpty {
                     record.activePromptTurnId = normalizedTurnId
                     record.activePromptTurnIds = Array(repeating: normalizedTurnId, count: depthAfterStop)
                 }
@@ -19881,6 +19886,11 @@ struct CMUXCLI {
             if objectType == "turn_context",
                let payload = object["payload"] as? [String: Any] {
                 currentTurnId = firstString(in: payload, keys: ["turn_id", "turnId"])
+                if let currentTurnId = normalizedHookValue(currentTurnId),
+                   currentTurnId != excludedTurnId {
+                    terminalTurnIds.remove(currentTurnId)
+                    activeTurnIds.insert(currentTurnId)
+                }
                 continue
             }
 

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -539,6 +539,7 @@ private final class ClaudeHookSessionStore {
         transcriptPath: String? = nil,
         turnId: String? = nil,
         previousActivePromptTurnIsTerminal: Bool = false,
+        terminalActivePromptTurnIds: Set<String> = [],
         previousDepthOnlyPromptTurnIsTerminal: Bool = false,
         preserveActivePromptTurnStackOnTurnChange: Bool = false,
         pid: Int?,
@@ -593,6 +594,10 @@ private final class ClaudeHookSessionStore {
                           activeTurnId != normalizedTurnId {
                     if previousActivePromptTurnIsTerminal {
                         turnStack.removeLast()
+                        while let activeTurnId = turnStack.last,
+                              terminalActivePromptTurnIds.contains(activeTurnId) {
+                            turnStack.removeLast()
+                        }
                     } else if !preserveActivePromptTurnStackOnTurnChange {
                         turnStack.removeAll()
                     }
@@ -675,7 +680,7 @@ private final class ClaudeHookSessionStore {
                     return true
                 }
                 let lastPromptTurnId = normalizeOptional(record.lastPromptTurnId)
-                if let lastPromptTurnId, lastPromptTurnId != normalizedTurnId {
+                if depthBeforeStop == 0, let lastPromptTurnId, lastPromptTurnId != normalizedTurnId {
                     state.sessions[normalized] = record
                     return true
                 }
@@ -19805,12 +19810,14 @@ struct CMUXCLI {
         return .healthy
     }
 
-    private func codexTranscriptTurnHasTerminalEvent(path: String, turnId: String) -> Bool {
-        guard let normalizedTurnId = normalizedHookValue(turnId),
+    private func codexTranscriptTerminalTurnIds(path: String, turnIds: Set<String>) -> Set<String> {
+        let expectedTurnIds = Set(turnIds.compactMap { normalizedHookValue($0) })
+        guard !expectedTurnIds.isEmpty,
               let content = readTextFileTail(path: path, maxBytes: 512 * 1024) else {
-            return false
+            return []
         }
 
+        var terminalTurnIds = Set<String>()
         var currentTurnId: String?
         for line in content.split(separator: "\n", omittingEmptySubsequences: true) {
             let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -19841,15 +19848,15 @@ struct CMUXCLI {
             switch eventType {
             case "task_complete", "turn_complete", "turn_aborted":
                 let payloadTurnId = firstString(in: payload, keys: ["turn_id", "turnId"]) ?? currentTurnId
-                if payloadTurnId == normalizedTurnId {
-                    return true
+                if let payloadTurnId, expectedTurnIds.contains(payloadTurnId) {
+                    terminalTurnIds.insert(payloadTurnId)
                 }
             default:
                 break
             }
         }
 
-        return false
+        return terminalTurnIds
     }
 
     private func codexTranscriptHasTerminalEventExcluding(path: String, turnId: String) -> Bool {
@@ -24516,10 +24523,10 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                 cwd: hookCwd ?? mapped?.cwd
             )
             let transcriptPathForStore = input.transcriptPath ?? mapped?.transcriptPath
-            let activePromptTurnId = mapped?.activePromptTurnIds?
-                .reversed()
-                .compactMap({ normalizedHookValue($0) })
-                .first ?? normalizedHookValue(mapped?.activePromptTurnId)
+            let activePromptTurnStack = mapped?.activePromptTurnIds?
+                .compactMap({ normalizedHookValue($0) }) ?? []
+            let activePromptTurnId = activePromptTurnStack.last ?? normalizedHookValue(mapped?.activePromptTurnId)
+            let terminalActivePromptTurnIds: Set<String>
             let previousActivePromptTurnIsTerminal: Bool
             if def.name == "codex",
                let incomingTurnId = normalizedHookValue(input.turnId),
@@ -24527,11 +24534,14 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                activeTurnId != incomingTurnId,
                let transcriptPath = normalizedHookValue(transcriptPathForStore)
                    ?? findCodexTranscriptPath(sessionId: sessionId, env: env) {
-                previousActivePromptTurnIsTerminal = codexTranscriptTurnHasTerminalEvent(
+                let activeTurnIds = activePromptTurnStack.isEmpty ? [activeTurnId] : activePromptTurnStack
+                terminalActivePromptTurnIds = codexTranscriptTerminalTurnIds(
                     path: transcriptPath,
-                    turnId: activeTurnId
+                    turnIds: Set(activeTurnIds)
                 )
+                previousActivePromptTurnIsTerminal = terminalActivePromptTurnIds.contains(activeTurnId)
             } else {
+                terminalActivePromptTurnIds = []
                 previousActivePromptTurnIsTerminal = false
             }
             let previousDepthOnlyPromptTurnIsTerminal: Bool
@@ -24558,6 +24568,7 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                     transcriptPath: transcriptPathForStore,
                     turnId: input.turnId,
                     previousActivePromptTurnIsTerminal: previousActivePromptTurnIsTerminal,
+                    terminalActivePromptTurnIds: terminalActivePromptTurnIds,
                     previousDepthOnlyPromptTurnIsTerminal: previousDepthOnlyPromptTurnIsTerminal,
                     preserveActivePromptTurnStackOnTurnChange: def.name == "codex",
                     pid: pid,

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -437,6 +437,7 @@ private struct ClaudeHookSessionRecord: Codable {
     var runtimeStatus: AgentHookRuntimeStatus?
     var activePromptDepth: Int?
     var activePromptTurnId: String?
+    var activePromptTurnIds: [String]?
     var lastPromptTurnId: String?
     var startedAt: TimeInterval
     var updatedAt: TimeInterval
@@ -537,6 +538,7 @@ private final class ClaudeHookSessionStore {
         cwd: String?,
         transcriptPath: String? = nil,
         turnId: String? = nil,
+        previousActivePromptTurnIsTerminal: Bool = false,
         pid: Int?,
         launchCommand: AgentHookLaunchCommandRecord?,
         runtimeStatus: AgentHookRuntimeStatus? = nil,
@@ -572,14 +574,19 @@ private final class ClaudeHookSessionStore {
             )
             let normalizedTurnId = normalizeOptional(turnId)
             if let normalizedTurnId {
-                let activeTurnId = normalizeOptional(record.activePromptTurnId)
-                if activeTurnId != nil, activeTurnId != normalizedTurnId {
+                var turnStack = activePromptTurnStack(from: record)
+                if turnStack.isEmpty, max(0, record.activePromptDepth ?? 0) > 0 {
                     record.activePromptDepth = nil
-                } else if activeTurnId == nil, max(0, record.activePromptDepth ?? 0) > 0 {
-                    record.activePromptDepth = nil
+                } else if let activeTurnId = turnStack.last,
+                          activeTurnId != normalizedTurnId,
+                          previousActivePromptTurnIsTerminal {
+                    turnStack.removeAll()
                 }
-                record.activePromptTurnId = normalizedTurnId
+                turnStack.append(normalizedTurnId)
+                setActivePromptTurnStack(turnStack, on: &record)
                 record.lastPromptTurnId = normalizedTurnId
+                state.sessions[normalized] = record
+                return turnStack.count > 1
             }
             record.activePromptDepth = max(0, record.activePromptDepth ?? 0) + 1
             state.sessions[normalized] = record
@@ -635,34 +642,45 @@ private final class ClaudeHookSessionStore {
             )
             let depthAfterStop = max(0, depthBeforeStop - 1)
             let normalizedTurnId = normalizeOptional(turnId)
-            let activeTurnId = normalizeOptional(record.activePromptTurnId)
-            if let normalizedTurnId, let activeTurnId, activeTurnId != normalizedTurnId {
-                state.sessions[normalized] = record
-                return true
-            }
-            if let normalizedTurnId,
-               activeTurnId == nil,
-               let lastPromptTurnId = normalizeOptional(record.lastPromptTurnId),
-               lastPromptTurnId != normalizedTurnId {
-                state.sessions[normalized] = record
-                return true
-            }
-            if normalizedTurnId != nil,
-               activeTurnId == nil,
-               normalizeOptional(record.lastPromptTurnId) == nil,
-               depthBeforeStop > 0 {
-                record.activePromptDepth = nil
-                record.activePromptTurnId = nil
-                state.sessions[normalized] = record
-                return false
+            if let normalizedTurnId {
+                var turnStack = activePromptTurnStack(from: record)
+                if let lastTurnId = turnStack.last {
+                    if lastTurnId == normalizedTurnId {
+                        let nested = turnStack.count > 1
+                        turnStack.removeLast()
+                        setActivePromptTurnStack(turnStack, on: &record)
+                        state.sessions[normalized] = record
+                        return nested
+                    }
+                    if let staleIndex = turnStack.lastIndex(of: normalizedTurnId) {
+                        turnStack.remove(at: staleIndex)
+                        setActivePromptTurnStack(turnStack, on: &record)
+                    }
+                    state.sessions[normalized] = record
+                    return true
+                }
+                if let lastPromptTurnId = normalizeOptional(record.lastPromptTurnId),
+                   lastPromptTurnId != normalizedTurnId {
+                    state.sessions[normalized] = record
+                    return true
+                }
+                if normalizeOptional(record.lastPromptTurnId) == nil, depthBeforeStop > 0 {
+                    record.activePromptDepth = nil
+                    record.activePromptTurnId = nil
+                    record.activePromptTurnIds = nil
+                    state.sessions[normalized] = record
+                    return false
+                }
             }
             if depthAfterStop == 0 {
                 record.activePromptDepth = nil
                 record.activePromptTurnId = nil
+                record.activePromptTurnIds = nil
             } else {
                 record.activePromptDepth = depthAfterStop
                 if let normalizedTurnId {
                     record.activePromptTurnId = normalizedTurnId
+                    record.activePromptTurnIds = Array(repeating: normalizedTurnId, count: depthAfterStop)
                 }
             }
             state.sessions[normalized] = record
@@ -710,6 +728,7 @@ private final class ClaudeHookSessionStore {
                 runtimeStatus: nil,
                 activePromptDepth: nil,
                 activePromptTurnId: nil,
+                activePromptTurnIds: nil,
                 lastPromptTurnId: nil,
                 startedAt: now,
                 updatedAt: now
@@ -767,10 +786,36 @@ private final class ClaudeHookSessionStore {
             runtimeStatus: nil,
             activePromptDepth: nil,
             activePromptTurnId: nil,
+            activePromptTurnIds: nil,
             lastPromptTurnId: nil,
             startedAt: now,
             updatedAt: now
         )
+    }
+
+    private func activePromptTurnStack(from record: ClaudeHookSessionRecord) -> [String] {
+        if let activePromptTurnIds = record.activePromptTurnIds {
+            let normalized = activePromptTurnIds.compactMap { normalizeOptional($0) }
+            if !normalized.isEmpty {
+                return normalized
+            }
+        }
+        if let activePromptTurnId = normalizeOptional(record.activePromptTurnId) {
+            return [activePromptTurnId]
+        }
+        return []
+    }
+
+    private func setActivePromptTurnStack(_ stack: [String], on record: inout ClaudeHookSessionRecord) {
+        if stack.isEmpty {
+            record.activePromptDepth = nil
+            record.activePromptTurnId = nil
+            record.activePromptTurnIds = nil
+        } else {
+            record.activePromptDepth = stack.count
+            record.activePromptTurnId = stack.last
+            record.activePromptTurnIds = stack
+        }
     }
 
     private func update(
@@ -19741,6 +19786,53 @@ struct CMUXCLI {
         return .healthy
     }
 
+    private func codexTranscriptTurnHasTerminalEvent(path: String, turnId: String) -> Bool {
+        guard let normalizedTurnId = normalizedHookValue(turnId),
+              let content = readTextFileTail(path: path, maxBytes: 512 * 1024) else {
+            return false
+        }
+
+        var currentTurnId: String?
+        for line in content.split(separator: "\n", omittingEmptySubsequences: true) {
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty,
+                  let data = trimmed.data(using: .utf8),
+                  let object = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
+                  let objectType = object["type"] as? String else {
+                continue
+            }
+
+            if objectType == "turn_context",
+               let payload = object["payload"] as? [String: Any] {
+                currentTurnId = firstString(in: payload, keys: ["turn_id", "turnId"])
+                continue
+            }
+
+            guard objectType == "event_msg",
+                  let payload = object["payload"] as? [String: Any],
+                  let eventType = payload["type"] as? String else {
+                continue
+            }
+
+            if eventType == "task_started" {
+                currentTurnId = firstString(in: payload, keys: ["turn_id", "turnId"])
+                continue
+            }
+
+            switch eventType {
+            case "task_complete", "turn_complete", "turn_aborted":
+                let payloadTurnId = firstString(in: payload, keys: ["turn_id", "turnId"]) ?? currentTurnId
+                if payloadTurnId == normalizedTurnId {
+                    return true
+                }
+            default:
+                break
+            }
+        }
+
+        return false
+    }
+
     private func readCodexTranscriptUserInput(
         path: String,
         turnId: String?,
@@ -24355,6 +24447,24 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                 fallbackKind: def.name,
                 cwd: hookCwd ?? mapped?.cwd
             )
+            let transcriptPathForStore = input.transcriptPath ?? mapped?.transcriptPath
+            let previousActivePromptTurnIsTerminal: Bool
+            if def.name == "codex",
+               let incomingTurnId = normalizedHookValue(input.turnId),
+               let activeTurnId = mapped?.activePromptTurnIds?
+                   .reversed()
+                   .compactMap({ normalizedHookValue($0) })
+                   .first ?? normalizedHookValue(mapped?.activePromptTurnId),
+               activeTurnId != incomingTurnId,
+               let transcriptPath = normalizedHookValue(transcriptPathForStore)
+                   ?? findCodexTranscriptPath(sessionId: sessionId, env: env) {
+                previousActivePromptTurnIsTerminal = codexTranscriptTurnHasTerminalEvent(
+                    path: transcriptPath,
+                    turnId: activeTurnId
+                )
+            } else {
+                previousActivePromptTurnIsTerminal = false
+            }
             let nestedPromptSubmit: Bool
             if !sessionId.isEmpty {
                 nestedPromptSubmit = (try? store.recordPromptSubmit(
@@ -24362,8 +24472,9 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                     workspaceId: workspaceId,
                     surfaceId: surfaceId,
                     cwd: hookCwd ?? mapped?.cwd,
-                    transcriptPath: input.transcriptPath ?? mapped?.transcriptPath,
+                    transcriptPath: transcriptPathForStore,
                     turnId: input.turnId,
+                    previousActivePromptTurnIsTerminal: previousActivePromptTurnIsTerminal,
                     pid: pid,
                     launchCommand: launchCommand
                 )) ?? false

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -539,6 +539,7 @@ private final class ClaudeHookSessionStore {
         transcriptPath: String? = nil,
         turnId: String? = nil,
         previousActivePromptTurnIsTerminal: Bool = false,
+        preserveActivePromptTurnStackOnTurnChange: Bool = false,
         pid: Int?,
         launchCommand: AgentHookLaunchCommandRecord?,
         runtimeStatus: AgentHookRuntimeStatus? = nil,
@@ -578,9 +579,12 @@ private final class ClaudeHookSessionStore {
                 if turnStack.isEmpty, max(0, record.activePromptDepth ?? 0) > 0 {
                     record.activePromptDepth = nil
                 } else if let activeTurnId = turnStack.last,
-                          activeTurnId != normalizedTurnId,
-                          previousActivePromptTurnIsTerminal {
-                    turnStack.removeLast()
+                          activeTurnId != normalizedTurnId {
+                    if previousActivePromptTurnIsTerminal {
+                        turnStack.removeLast()
+                    } else if !preserveActivePromptTurnStackOnTurnChange {
+                        turnStack.removeAll()
+                    }
                 }
                 turnStack.append(normalizedTurnId)
                 setActivePromptTurnStack(turnStack, on: &record)
@@ -24475,6 +24479,7 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                     transcriptPath: transcriptPathForStore,
                     turnId: input.turnId,
                     previousActivePromptTurnIsTerminal: previousActivePromptTurnIsTerminal,
+                    preserveActivePromptTurnStackOnTurnChange: def.name == "codex",
                     pid: pid,
                     launchCommand: launchCommand
                 )) ?? false

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -539,6 +539,7 @@ private final class ClaudeHookSessionStore {
         transcriptPath: String? = nil,
         turnId: String? = nil,
         previousActivePromptTurnIsTerminal: Bool = false,
+        previousDepthOnlyPromptTurnIsTerminal: Bool = false,
         preserveActivePromptTurnStackOnTurnChange: Bool = false,
         pid: Int?,
         launchCommand: AgentHookLaunchCommandRecord?,
@@ -576,8 +577,18 @@ private final class ClaudeHookSessionStore {
             let normalizedTurnId = normalizeOptional(turnId)
             if let normalizedTurnId {
                 var turnStack = activePromptTurnStack(from: record)
-                if turnStack.isEmpty, max(0, record.activePromptDepth ?? 0) > 0 {
-                    record.activePromptDepth = nil
+                let legacyDepth = max(0, record.activePromptDepth ?? 0)
+                if turnStack.isEmpty, legacyDepth > 0 {
+                    if previousDepthOnlyPromptTurnIsTerminal {
+                        record.activePromptDepth = nil
+                    } else {
+                        record.activePromptDepth = legacyDepth + 1
+                        record.activePromptTurnId = nil
+                        record.activePromptTurnIds = nil
+                        record.lastPromptTurnId = normalizedTurnId
+                        state.sessions[normalized] = record
+                        return true
+                    }
                 } else if let activeTurnId = turnStack.last,
                           activeTurnId != normalizedTurnId {
                     if previousActivePromptTurnIsTerminal {
@@ -663,17 +674,21 @@ private final class ClaudeHookSessionStore {
                     state.sessions[normalized] = record
                     return true
                 }
-                if let lastPromptTurnId = normalizeOptional(record.lastPromptTurnId),
-                   lastPromptTurnId != normalizedTurnId {
+                let lastPromptTurnId = normalizeOptional(record.lastPromptTurnId)
+                if let lastPromptTurnId, lastPromptTurnId != normalizedTurnId {
                     state.sessions[normalized] = record
                     return true
                 }
-                if normalizeOptional(record.lastPromptTurnId) == nil, depthBeforeStop > 0 {
-                    record.activePromptDepth = nil
+                if depthBeforeStop > 0 {
+                    if depthAfterStop == 0 {
+                        record.activePromptDepth = nil
+                    } else {
+                        record.activePromptDepth = depthAfterStop
+                    }
                     record.activePromptTurnId = nil
                     record.activePromptTurnIds = nil
                     state.sessions[normalized] = record
-                    return false
+                    return depthBeforeStop > 1
                 }
             }
             if depthAfterStop == 0 {
@@ -19837,6 +19852,55 @@ struct CMUXCLI {
         return false
     }
 
+    private func codexTranscriptHasTerminalEventExcluding(path: String, turnId: String) -> Bool {
+        guard let excludedTurnId = normalizedHookValue(turnId),
+              let content = readTextFileTail(path: path, maxBytes: 512 * 1024) else {
+            return false
+        }
+
+        var currentTurnId: String?
+        for line in content.split(separator: "\n", omittingEmptySubsequences: true) {
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty,
+                  let data = trimmed.data(using: .utf8),
+                  let object = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
+                  let objectType = object["type"] as? String else {
+                continue
+            }
+
+            if objectType == "turn_context",
+               let payload = object["payload"] as? [String: Any] {
+                currentTurnId = firstString(in: payload, keys: ["turn_id", "turnId"])
+                continue
+            }
+
+            guard objectType == "event_msg",
+                  let payload = object["payload"] as? [String: Any],
+                  let eventType = payload["type"] as? String else {
+                continue
+            }
+
+            if eventType == "task_started" {
+                currentTurnId = firstString(in: payload, keys: ["turn_id", "turnId"])
+                continue
+            }
+
+            switch eventType {
+            case "task_complete", "turn_complete", "turn_aborted":
+                guard let payloadTurnId = firstString(in: payload, keys: ["turn_id", "turnId"]) ?? currentTurnId else {
+                    continue
+                }
+                if payloadTurnId != excludedTurnId {
+                    return true
+                }
+            default:
+                break
+            }
+        }
+
+        return false
+    }
+
     private func readCodexTranscriptUserInput(
         path: String,
         turnId: String?,
@@ -24452,13 +24516,14 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                 cwd: hookCwd ?? mapped?.cwd
             )
             let transcriptPathForStore = input.transcriptPath ?? mapped?.transcriptPath
+            let activePromptTurnId = mapped?.activePromptTurnIds?
+                .reversed()
+                .compactMap({ normalizedHookValue($0) })
+                .first ?? normalizedHookValue(mapped?.activePromptTurnId)
             let previousActivePromptTurnIsTerminal: Bool
             if def.name == "codex",
                let incomingTurnId = normalizedHookValue(input.turnId),
-               let activeTurnId = mapped?.activePromptTurnIds?
-                   .reversed()
-                   .compactMap({ normalizedHookValue($0) })
-                   .first ?? normalizedHookValue(mapped?.activePromptTurnId),
+               let activeTurnId = activePromptTurnId,
                activeTurnId != incomingTurnId,
                let transcriptPath = normalizedHookValue(transcriptPathForStore)
                    ?? findCodexTranscriptPath(sessionId: sessionId, env: env) {
@@ -24468,6 +24533,20 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                 )
             } else {
                 previousActivePromptTurnIsTerminal = false
+            }
+            let previousDepthOnlyPromptTurnIsTerminal: Bool
+            if def.name == "codex",
+               activePromptTurnId == nil,
+               max(0, mapped?.activePromptDepth ?? 0) > 0,
+               let incomingTurnId = normalizedHookValue(input.turnId),
+               let transcriptPath = normalizedHookValue(transcriptPathForStore)
+                   ?? findCodexTranscriptPath(sessionId: sessionId, env: env) {
+                previousDepthOnlyPromptTurnIsTerminal = codexTranscriptHasTerminalEventExcluding(
+                    path: transcriptPath,
+                    turnId: incomingTurnId
+                )
+            } else {
+                previousDepthOnlyPromptTurnIsTerminal = false
             }
             let nestedPromptSubmit: Bool
             if !sessionId.isEmpty {
@@ -24479,6 +24558,7 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                     transcriptPath: transcriptPathForStore,
                     turnId: input.turnId,
                     previousActivePromptTurnIsTerminal: previousActivePromptTurnIsTerminal,
+                    previousDepthOnlyPromptTurnIsTerminal: previousDepthOnlyPromptTurnIsTerminal,
                     preserveActivePromptTurnStackOnTurnChange: def.name == "codex",
                     pid: pid,
                     launchCommand: launchCommand

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -437,6 +437,7 @@ private struct ClaudeHookSessionRecord: Codable {
     var runtimeStatus: AgentHookRuntimeStatus?
     var activePromptDepth: Int?
     var activePromptTurnId: String?
+    var lastPromptTurnId: String?
     var startedAt: TimeInterval
     var updatedAt: TimeInterval
 }
@@ -578,6 +579,7 @@ private final class ClaudeHookSessionStore {
                     record.activePromptDepth = nil
                 }
                 record.activePromptTurnId = normalizedTurnId
+                record.lastPromptTurnId = normalizedTurnId
             }
             record.activePromptDepth = max(0, record.activePromptDepth ?? 0) + 1
             state.sessions[normalized] = record
@@ -638,7 +640,17 @@ private final class ClaudeHookSessionStore {
                 state.sessions[normalized] = record
                 return true
             }
-            if normalizedTurnId != nil, activeTurnId == nil, depthBeforeStop > 0 {
+            if let normalizedTurnId,
+               activeTurnId == nil,
+               let lastPromptTurnId = normalizeOptional(record.lastPromptTurnId),
+               lastPromptTurnId != normalizedTurnId {
+                state.sessions[normalized] = record
+                return true
+            }
+            if normalizedTurnId != nil,
+               activeTurnId == nil,
+               normalizeOptional(record.lastPromptTurnId) == nil,
+               depthBeforeStop > 0 {
                 record.activePromptDepth = nil
                 record.activePromptTurnId = nil
                 state.sessions[normalized] = record
@@ -698,6 +710,7 @@ private final class ClaudeHookSessionStore {
                 runtimeStatus: nil,
                 activePromptDepth: nil,
                 activePromptTurnId: nil,
+                lastPromptTurnId: nil,
                 startedAt: now,
                 updatedAt: now
             )
@@ -754,6 +767,7 @@ private final class ClaudeHookSessionStore {
             runtimeStatus: nil,
             activePromptDepth: nil,
             activePromptTurnId: nil,
+            lastPromptTurnId: nil,
             startedAt: now,
             updatedAt: now
         )

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -580,7 +580,7 @@ private final class ClaudeHookSessionStore {
                 } else if let activeTurnId = turnStack.last,
                           activeTurnId != normalizedTurnId,
                           previousActivePromptTurnIsTerminal {
-                    turnStack.removeAll()
+                    turnStack.removeLast()
                 }
                 turnStack.append(normalizedTurnId)
                 setActivePromptTurnStack(turnStack, on: &record)

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -586,21 +586,32 @@ private final class ClaudeHookSessionStore {
                     return true
                 } else if let activeTurnId = turnStack.last,
                           activeTurnId != normalizedTurnId {
+                    var removedTurnCount = 0
                     if previousActivePromptTurnIsTerminal {
                         turnStack.removeLast()
+                        removedTurnCount += 1
                         while let activeTurnId = turnStack.last,
                               terminalActivePromptTurnIds.contains(activeTurnId) {
                             turnStack.removeLast()
+                            removedTurnCount += 1
                         }
                     }
+                    let totalDepth = max(0, max(legacyDepth, turnStack.count + removedTurnCount) - removedTurnCount) + 1
+                    turnStack.append(normalizedTurnId)
+                    setActivePromptTurnStack(turnStack, totalDepth: totalDepth, on: &record)
+                    record.lastPromptTurnId = normalizedTurnId
+                    state.sessions[normalized] = record
+                    return totalDepth > 1
                 }
+                let totalDepth = max(legacyDepth, turnStack.count) + 1
                 turnStack.append(normalizedTurnId)
-                setActivePromptTurnStack(turnStack, on: &record)
+                setActivePromptTurnStack(turnStack, totalDepth: totalDepth, on: &record)
                 record.lastPromptTurnId = normalizedTurnId
                 state.sessions[normalized] = record
-                return turnStack.count > 1
+                return totalDepth > 1
             }
-            record.activePromptDepth = max(0, record.activePromptDepth ?? 0) + 1
+            let existingTurnStackDepth = activePromptTurnStack(from: record).count
+            record.activePromptDepth = max(max(0, record.activePromptDepth ?? 0), existingTurnStackDepth) + 1
             state.sessions[normalized] = record
             return (record.activePromptDepth ?? 0) > 1
         }
@@ -656,17 +667,26 @@ private final class ClaudeHookSessionStore {
             let normalizedTurnId = normalizeOptional(turnId)
             if let normalizedTurnId {
                 var turnStack = activePromptTurnStack(from: record)
+                let totalDepthBeforeStop = max(depthBeforeStop, turnStack.count)
                 if let lastTurnId = turnStack.last {
                     if lastTurnId == normalizedTurnId {
-                        let nested = turnStack.count > 1
+                        let nested = totalDepthBeforeStop > 1
                         turnStack.removeLast()
-                        setActivePromptTurnStack(turnStack, on: &record)
+                        setActivePromptTurnStack(
+                            turnStack,
+                            totalDepth: max(0, totalDepthBeforeStop - 1),
+                            on: &record
+                        )
                         state.sessions[normalized] = record
                         return nested
                     }
                     if let staleIndex = turnStack.lastIndex(of: normalizedTurnId) {
                         turnStack.remove(at: staleIndex)
-                        setActivePromptTurnStack(turnStack, on: &record)
+                        setActivePromptTurnStack(
+                            turnStack,
+                            totalDepth: max(0, totalDepthBeforeStop - 1),
+                            on: &record
+                        )
                     }
                     state.sessions[normalized] = record
                     return true
@@ -695,7 +715,11 @@ private final class ClaudeHookSessionStore {
             } else {
                 let turnStack = activePromptTurnStack(from: record)
                 if !turnStack.isEmpty {
-                    setActivePromptTurnStack(Array(turnStack.prefix(depthAfterStop)), on: &record)
+                    setActivePromptTurnStack(
+                        Array(turnStack.prefix(depthAfterStop)),
+                        totalDepth: depthAfterStop,
+                        on: &record
+                    )
                 } else {
                     record.activePromptDepth = depthAfterStop
                 }
@@ -827,15 +851,17 @@ private final class ClaudeHookSessionStore {
         return []
     }
 
-    private func setActivePromptTurnStack(_ stack: [String], on record: inout ClaudeHookSessionRecord) {
-        if stack.isEmpty {
+    private func setActivePromptTurnStack(_ stack: [String], totalDepth: Int? = nil, on record: inout ClaudeHookSessionRecord) {
+        let normalizedStack = stack.compactMap { normalizeOptional($0) }
+        let resolvedDepth = max(max(0, totalDepth ?? normalizedStack.count), normalizedStack.count)
+        if resolvedDepth == 0 {
             record.activePromptDepth = nil
             record.activePromptTurnId = nil
             record.activePromptTurnIds = nil
         } else {
-            record.activePromptDepth = stack.count
-            record.activePromptTurnId = stack.last
-            record.activePromptTurnIds = stack
+            record.activePromptDepth = resolvedDepth
+            record.activePromptTurnId = normalizedStack.last
+            record.activePromptTurnIds = normalizedStack.isEmpty ? nil : normalizedStack
         }
     }
 

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -19859,15 +19859,16 @@ struct CMUXCLI {
         return terminalTurnIds
     }
 
-    private func codexTranscriptLatestTurnHasTerminalEventExcluding(path: String, turnId: String) -> Bool {
+    private func codexTranscriptDepthOnlyStackIsTerminal(path: String, excludingTurnId turnId: String, activeDepth: Int) -> Bool {
         guard let excludedTurnId = normalizedHookValue(turnId),
+              activeDepth > 0,
               let content = readTextFileTail(path: path, maxBytes: 512 * 1024) else {
             return false
         }
 
         var currentTurnId: String?
-        var latestTurnId: String?
-        var latestTurnIsTerminal = false
+        var activeTurnIds = Set<String>()
+        var terminalTurnIds = Set<String>()
         for line in content.split(separator: "\n", omittingEmptySubsequences: true) {
             let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !trimmed.isEmpty,
@@ -19880,8 +19881,6 @@ struct CMUXCLI {
             if objectType == "turn_context",
                let payload = object["payload"] as? [String: Any] {
                 currentTurnId = firstString(in: payload, keys: ["turn_id", "turnId"])
-                latestTurnId = currentTurnId
-                latestTurnIsTerminal = false
                 continue
             }
 
@@ -19893,24 +19892,28 @@ struct CMUXCLI {
 
             if eventType == "task_started" {
                 currentTurnId = firstString(in: payload, keys: ["turn_id", "turnId"])
-                latestTurnId = currentTurnId
-                latestTurnIsTerminal = false
+                if let currentTurnId = normalizedHookValue(currentTurnId),
+                   currentTurnId != excludedTurnId {
+                    terminalTurnIds.remove(currentTurnId)
+                    activeTurnIds.insert(currentTurnId)
+                }
                 continue
             }
 
             switch eventType {
             case "task_complete", "turn_complete", "turn_aborted":
-                guard let payloadTurnId = firstString(in: payload, keys: ["turn_id", "turnId"]) ?? currentTurnId else {
+                guard let payloadTurnId = normalizedHookValue(firstString(in: payload, keys: ["turn_id", "turnId"]) ?? currentTurnId),
+                      payloadTurnId != excludedTurnId else {
                     continue
                 }
-                latestTurnId = payloadTurnId
-                latestTurnIsTerminal = true
+                activeTurnIds.remove(payloadTurnId)
+                terminalTurnIds.insert(payloadTurnId)
             default:
                 break
             }
         }
 
-        return latestTurnIsTerminal && latestTurnId != excludedTurnId
+        return activeTurnIds.isEmpty && terminalTurnIds.count >= activeDepth
     }
 
     private func readCodexTranscriptUserInput(
@@ -24549,16 +24552,18 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                 terminalActivePromptTurnIds = []
                 previousActivePromptTurnIsTerminal = false
             }
+            let legacyActivePromptDepth = max(0, mapped?.activePromptDepth ?? 0)
             let previousDepthOnlyPromptTurnIsTerminal: Bool
             if def.name == "codex",
                activePromptTurnId == nil,
-               max(0, mapped?.activePromptDepth ?? 0) > 0,
+               legacyActivePromptDepth > 0,
                let incomingTurnId = normalizedHookValue(input.turnId),
                let transcriptPath = normalizedHookValue(transcriptPathForStore)
                    ?? findCodexTranscriptPath(sessionId: sessionId, env: env) {
-                previousDepthOnlyPromptTurnIsTerminal = codexTranscriptLatestTurnHasTerminalEventExcluding(
+                previousDepthOnlyPromptTurnIsTerminal = codexTranscriptDepthOnlyStackIsTerminal(
                     path: transcriptPath,
-                    turnId: incomingTurnId
+                    excludingTurnId: incomingTurnId,
+                    activeDepth: legacyActivePromptDepth
                 )
             } else {
                 previousDepthOnlyPromptTurnIsTerminal = false

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -674,12 +674,15 @@ private final class ClaudeHookSessionStore {
             if let normalizedTurnId {
                 var turnStack = activePromptTurnStack(from: record)
                 var totalDepthBeforeStop = max(depthBeforeStop, turnStack.count)
-                if let activeTurnId = turnStack.last,
-                   activeTurnId != normalizedTurnId {
+                let terminalTurnIdsToPrune = terminalActivePromptTurnIds.subtracting([normalizedTurnId])
+                if !terminalTurnIdsToPrune.isEmpty {
                     var removedTerminalTurnIds: [String] = []
-                    while let activeTurnId = turnStack.last,
-                          terminalActivePromptTurnIds.contains(activeTurnId) {
-                        removedTerminalTurnIds.append(turnStack.removeLast())
+                    turnStack.removeAll { activeTurnId in
+                        if terminalTurnIdsToPrune.contains(activeTurnId) {
+                            removedTerminalTurnIds.append(activeTurnId)
+                            return true
+                        }
+                        return false
                     }
                     if !removedTerminalTurnIds.isEmpty {
                         totalDepthBeforeStop = max(0, totalDepthBeforeStop - removedTerminalTurnIds.count)
@@ -24783,14 +24786,16 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                 let activePromptTurnStack = mapped?.activePromptTurnIds?
                     .compactMap({ normalizedHookValue($0) }) ?? []
                 let activePromptTurnId = activePromptTurnStack.last ?? normalizedHookValue(mapped?.activePromptTurnId)
-                if let activeTurnId = activePromptTurnId,
-                   activeTurnId != incomingTurnId,
+                let activeTurnIds = activePromptTurnStack.isEmpty
+                    ? activePromptTurnId.map { [$0] } ?? []
+                    : activePromptTurnStack
+                let activeTurnIdsToCheck = activeTurnIds.filter { $0 != incomingTurnId }
+                if !activeTurnIdsToCheck.isEmpty,
                    let transcriptPath = normalizedHookValue(input.transcriptPath ?? mapped?.transcriptPath)
                        ?? findCodexTranscriptPath(sessionId: sessionId, env: env) {
-                    let activeTurnIds = activePromptTurnStack.isEmpty ? [activeTurnId] : activePromptTurnStack
                     terminalActivePromptTurnIdsForStop = codexTranscriptTerminalTurnIds(
                         path: transcriptPath,
-                        turnIds: Set(activeTurnIds)
+                        turnIds: Set(activeTurnIdsToCheck)
                     )
                 } else {
                     terminalActivePromptTurnIdsForStop = []

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -727,18 +727,20 @@ private final class ClaudeHookSessionStore {
                     return true
                 }
                 markPromptTurnTerminal(normalizedTurnId, on: &record)
-                if totalDepthBeforeStop > 0 {
-                    let depthAfterTurnStop = max(0, totalDepthBeforeStop - 1)
-                    if depthAfterTurnStop == 0 {
-                        record.activePromptDepth = nil
-                    } else {
-                        record.activePromptDepth = depthAfterTurnStop
-                    }
-                    record.activePromptTurnId = nil
-                    record.activePromptTurnIds = nil
+                if totalDepthBeforeStop == 0 {
                     state.sessions[normalized] = record
-                    return totalDepthBeforeStop > 1
+                    return false
                 }
+                let depthAfterTurnStop = max(0, totalDepthBeforeStop - 1)
+                if depthAfterTurnStop == 0 {
+                    record.activePromptDepth = nil
+                } else {
+                    record.activePromptDepth = depthAfterTurnStop
+                }
+                record.activePromptTurnId = nil
+                record.activePromptTurnIds = nil
+                state.sessions[normalized] = record
+                return totalDepthBeforeStop > 1
             }
             if depthAfterStop == 0 {
                 record.activePromptDepth = nil

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -436,6 +436,7 @@ private struct ClaudeHookSessionRecord: Codable {
     var lastEmittedNotificationAt: TimeInterval?
     var runtimeStatus: AgentHookRuntimeStatus?
     var activePromptDepth: Int?
+    var activePromptTurnId: String?
     var startedAt: TimeInterval
     var updatedAt: TimeInterval
 }
@@ -534,6 +535,7 @@ private final class ClaudeHookSessionStore {
         surfaceId: String,
         cwd: String?,
         transcriptPath: String? = nil,
+        turnId: String? = nil,
         pid: Int?,
         launchCommand: AgentHookLaunchCommandRecord?,
         runtimeStatus: AgentHookRuntimeStatus? = nil,
@@ -567,6 +569,16 @@ private final class ClaudeHookSessionStore {
                 updateRuntimeStatus: updateRuntimeStatus,
                 now: now
             )
+            let normalizedTurnId = normalizeOptional(turnId)
+            if let normalizedTurnId {
+                let activeTurnId = normalizeOptional(record.activePromptTurnId)
+                if activeTurnId != nil, activeTurnId != normalizedTurnId {
+                    record.activePromptDepth = nil
+                } else if activeTurnId == nil, max(0, record.activePromptDepth ?? 0) > 0 {
+                    record.activePromptDepth = nil
+                }
+                record.activePromptTurnId = normalizedTurnId
+            }
             record.activePromptDepth = max(0, record.activePromptDepth ?? 0) + 1
             state.sessions[normalized] = record
             return (record.activePromptDepth ?? 0) > 1
@@ -580,6 +592,7 @@ private final class ClaudeHookSessionStore {
         surfaceId: String,
         cwd: String?,
         transcriptPath: String? = nil,
+        turnId: String? = nil,
         pid: Int?,
         launchCommand: AgentHookLaunchCommandRecord?,
         lastSubtitle: String?,
@@ -619,7 +632,33 @@ private final class ClaudeHookSessionStore {
                 now: now
             )
             let depthAfterStop = max(0, depthBeforeStop - 1)
-            record.activePromptDepth = depthAfterStop == 0 ? nil : depthAfterStop
+            let normalizedTurnId = normalizeOptional(turnId)
+            let activeTurnId = normalizeOptional(record.activePromptTurnId)
+            let hasStalePromptDepthForDifferentTurn: Bool
+            if let normalizedTurnId {
+                if let activeTurnId {
+                    hasStalePromptDepthForDifferentTurn = activeTurnId != normalizedTurnId
+                } else {
+                    hasStalePromptDepthForDifferentTurn = depthBeforeStop > 0
+                }
+            } else {
+                hasStalePromptDepthForDifferentTurn = false
+            }
+            if hasStalePromptDepthForDifferentTurn {
+                record.activePromptDepth = nil
+                record.activePromptTurnId = nil
+                state.sessions[normalized] = record
+                return false
+            }
+            if depthAfterStop == 0 {
+                record.activePromptDepth = nil
+                record.activePromptTurnId = nil
+            } else {
+                record.activePromptDepth = depthAfterStop
+                if let normalizedTurnId {
+                    record.activePromptTurnId = normalizedTurnId
+                }
+            }
             state.sessions[normalized] = record
             return depthBeforeStop > 1
         }
@@ -664,6 +703,7 @@ private final class ClaudeHookSessionStore {
                 lastEmittedNotificationAt: nil,
                 runtimeStatus: nil,
                 activePromptDepth: nil,
+                activePromptTurnId: nil,
                 startedAt: now,
                 updatedAt: now
             )
@@ -719,6 +759,7 @@ private final class ClaudeHookSessionStore {
             lastEmittedNotificationAt: nil,
             runtimeStatus: nil,
             activePromptDepth: nil,
+            activePromptTurnId: nil,
             startedAt: now,
             updatedAt: now
         )
@@ -24314,6 +24355,7 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                     surfaceId: surfaceId,
                     cwd: hookCwd ?? mapped?.cwd,
                     transcriptPath: input.transcriptPath ?? mapped?.transcriptPath,
+                    turnId: input.turnId,
                     pid: pid,
                     launchCommand: launchCommand
                 )) ?? false
@@ -24508,6 +24550,7 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                     surfaceId: surfaceId,
                     cwd: cwd,
                     transcriptPath: input.transcriptPath ?? mapped?.transcriptPath,
+                    turnId: input.turnId,
                     pid: pid,
                     launchCommand: launchCommand,
                     lastSubtitle: nil,

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -19859,13 +19859,15 @@ struct CMUXCLI {
         return terminalTurnIds
     }
 
-    private func codexTranscriptHasTerminalEventExcluding(path: String, turnId: String) -> Bool {
+    private func codexTranscriptLatestTurnHasTerminalEventExcluding(path: String, turnId: String) -> Bool {
         guard let excludedTurnId = normalizedHookValue(turnId),
               let content = readTextFileTail(path: path, maxBytes: 512 * 1024) else {
             return false
         }
 
         var currentTurnId: String?
+        var latestTurnId: String?
+        var latestTurnIsTerminal = false
         for line in content.split(separator: "\n", omittingEmptySubsequences: true) {
             let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !trimmed.isEmpty,
@@ -19878,6 +19880,8 @@ struct CMUXCLI {
             if objectType == "turn_context",
                let payload = object["payload"] as? [String: Any] {
                 currentTurnId = firstString(in: payload, keys: ["turn_id", "turnId"])
+                latestTurnId = currentTurnId
+                latestTurnIsTerminal = false
                 continue
             }
 
@@ -19889,6 +19893,8 @@ struct CMUXCLI {
 
             if eventType == "task_started" {
                 currentTurnId = firstString(in: payload, keys: ["turn_id", "turnId"])
+                latestTurnId = currentTurnId
+                latestTurnIsTerminal = false
                 continue
             }
 
@@ -19897,15 +19903,14 @@ struct CMUXCLI {
                 guard let payloadTurnId = firstString(in: payload, keys: ["turn_id", "turnId"]) ?? currentTurnId else {
                     continue
                 }
-                if payloadTurnId != excludedTurnId {
-                    return true
-                }
+                latestTurnId = payloadTurnId
+                latestTurnIsTerminal = true
             default:
                 break
             }
         }
 
-        return false
+        return latestTurnIsTerminal && latestTurnId != excludedTurnId
     }
 
     private func readCodexTranscriptUserInput(
@@ -24551,7 +24556,7 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                let incomingTurnId = normalizedHookValue(input.turnId),
                let transcriptPath = normalizedHookValue(transcriptPathForStore)
                    ?? findCodexTranscriptPath(sessionId: sessionId, env: env) {
-                previousDepthOnlyPromptTurnIsTerminal = codexTranscriptHasTerminalEventExcluding(
+                previousDepthOnlyPromptTurnIsTerminal = codexTranscriptLatestTurnHasTerminalEventExcluding(
                     path: transcriptPath,
                     turnId: incomingTurnId
                 )

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -540,8 +540,6 @@ private final class ClaudeHookSessionStore {
         turnId: String? = nil,
         previousActivePromptTurnIsTerminal: Bool = false,
         terminalActivePromptTurnIds: Set<String> = [],
-        previousDepthOnlyPromptTurnIsTerminal: Bool = false,
-        preserveActivePromptTurnStackOnTurnChange: Bool = false,
         pid: Int?,
         launchCommand: AgentHookLaunchCommandRecord?,
         runtimeStatus: AgentHookRuntimeStatus? = nil,
@@ -580,16 +578,12 @@ private final class ClaudeHookSessionStore {
                 var turnStack = activePromptTurnStack(from: record)
                 let legacyDepth = max(0, record.activePromptDepth ?? 0)
                 if turnStack.isEmpty, legacyDepth > 0 {
-                    if previousDepthOnlyPromptTurnIsTerminal {
-                        record.activePromptDepth = nil
-                    } else {
-                        record.activePromptDepth = legacyDepth + 1
-                        record.activePromptTurnId = nil
-                        record.activePromptTurnIds = nil
-                        record.lastPromptTurnId = normalizedTurnId
-                        state.sessions[normalized] = record
-                        return true
-                    }
+                    record.activePromptDepth = legacyDepth + 1
+                    record.activePromptTurnId = nil
+                    record.activePromptTurnIds = nil
+                    record.lastPromptTurnId = normalizedTurnId
+                    state.sessions[normalized] = record
+                    return true
                 } else if let activeTurnId = turnStack.last,
                           activeTurnId != normalizedTurnId {
                     if previousActivePromptTurnIsTerminal {
@@ -598,8 +592,6 @@ private final class ClaudeHookSessionStore {
                               terminalActivePromptTurnIds.contains(activeTurnId) {
                             turnStack.removeLast()
                         }
-                    } else if !preserveActivePromptTurnStackOnTurnChange {
-                        turnStack.removeAll()
                     }
                 }
                 turnStack.append(normalizedTurnId)
@@ -19864,68 +19856,6 @@ struct CMUXCLI {
         return terminalTurnIds
     }
 
-    private func codexTranscriptDepthOnlyStackIsTerminal(path: String, excludingTurnId turnId: String, activeDepth: Int) -> Bool {
-        guard let excludedTurnId = normalizedHookValue(turnId),
-              activeDepth > 0,
-              let content = readTextFileTail(path: path, maxBytes: 512 * 1024) else {
-            return false
-        }
-
-        var currentTurnId: String?
-        var activeTurnIds = Set<String>()
-        var terminalTurnIds = Set<String>()
-        for line in content.split(separator: "\n", omittingEmptySubsequences: true) {
-            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !trimmed.isEmpty,
-                  let data = trimmed.data(using: .utf8),
-                  let object = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
-                  let objectType = object["type"] as? String else {
-                continue
-            }
-
-            if objectType == "turn_context",
-               let payload = object["payload"] as? [String: Any] {
-                currentTurnId = firstString(in: payload, keys: ["turn_id", "turnId"])
-                if let currentTurnId = normalizedHookValue(currentTurnId),
-                   currentTurnId != excludedTurnId {
-                    terminalTurnIds.remove(currentTurnId)
-                    activeTurnIds.insert(currentTurnId)
-                }
-                continue
-            }
-
-            guard objectType == "event_msg",
-                  let payload = object["payload"] as? [String: Any],
-                  let eventType = payload["type"] as? String else {
-                continue
-            }
-
-            if eventType == "task_started" {
-                currentTurnId = firstString(in: payload, keys: ["turn_id", "turnId"])
-                if let currentTurnId = normalizedHookValue(currentTurnId),
-                   currentTurnId != excludedTurnId {
-                    terminalTurnIds.remove(currentTurnId)
-                    activeTurnIds.insert(currentTurnId)
-                }
-                continue
-            }
-
-            switch eventType {
-            case "task_complete", "turn_complete", "turn_aborted":
-                guard let payloadTurnId = normalizedHookValue(firstString(in: payload, keys: ["turn_id", "turnId"]) ?? currentTurnId),
-                      payloadTurnId != excludedTurnId else {
-                    continue
-                }
-                activeTurnIds.remove(payloadTurnId)
-                terminalTurnIds.insert(payloadTurnId)
-            default:
-                break
-            }
-        }
-
-        return activeTurnIds.isEmpty && terminalTurnIds.count >= activeDepth
-    }
-
     private func readCodexTranscriptUserInput(
         path: String,
         turnId: String?,
@@ -24562,22 +24492,6 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                 terminalActivePromptTurnIds = []
                 previousActivePromptTurnIsTerminal = false
             }
-            let legacyActivePromptDepth = max(0, mapped?.activePromptDepth ?? 0)
-            let previousDepthOnlyPromptTurnIsTerminal: Bool
-            if def.name == "codex",
-               activePromptTurnId == nil,
-               legacyActivePromptDepth > 0,
-               let incomingTurnId = normalizedHookValue(input.turnId),
-               let transcriptPath = normalizedHookValue(transcriptPathForStore)
-                   ?? findCodexTranscriptPath(sessionId: sessionId, env: env) {
-                previousDepthOnlyPromptTurnIsTerminal = codexTranscriptDepthOnlyStackIsTerminal(
-                    path: transcriptPath,
-                    excludingTurnId: incomingTurnId,
-                    activeDepth: legacyActivePromptDepth
-                )
-            } else {
-                previousDepthOnlyPromptTurnIsTerminal = false
-            }
             let nestedPromptSubmit: Bool
             if !sessionId.isEmpty {
                 nestedPromptSubmit = (try? store.recordPromptSubmit(
@@ -24589,8 +24503,6 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                     turnId: input.turnId,
                     previousActivePromptTurnIsTerminal: previousActivePromptTurnIsTerminal,
                     terminalActivePromptTurnIds: terminalActivePromptTurnIds,
-                    previousDepthOnlyPromptTurnIsTerminal: previousDepthOnlyPromptTurnIsTerminal,
-                    preserveActivePromptTurnStackOnTurnChange: def.name == "codex",
                     pid: pid,
                     launchCommand: launchCommand
                 )) ?? false

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -439,6 +439,7 @@ private struct ClaudeHookSessionRecord: Codable {
     var activePromptTurnId: String?
     var activePromptTurnIds: [String]?
     var lastPromptTurnId: String?
+    var terminalPromptTurnIds: [String]?
     var startedAt: TimeInterval
     var updatedAt: TimeInterval
 }
@@ -497,6 +498,7 @@ private struct ClaudeHookSessionStoreFile: Codable {
 private final class ClaudeHookSessionStore {
     private static let defaultStatePath = "~/.cmuxterm/claude-hook-sessions.json"
     private static let maxStateAgeSeconds: TimeInterval = 60 * 60 * 24 * 7
+    private static let maxRememberedTerminalPromptTurnIds = 32
 
     private let statePath: String
     private let fileManager: FileManager
@@ -575,6 +577,7 @@ private final class ClaudeHookSessionStore {
             )
             let normalizedTurnId = normalizeOptional(turnId)
             if let normalizedTurnId {
+                markPromptTurnActive(normalizedTurnId, on: &record)
                 var turnStack = activePromptTurnStack(from: record)
                 let legacyDepth = max(0, record.activePromptDepth ?? 0)
                 if turnStack.isEmpty, legacyDepth > 0 {
@@ -587,18 +590,20 @@ private final class ClaudeHookSessionStore {
                 } else if let activeTurnId = turnStack.last,
                           activeTurnId != normalizedTurnId {
                     var removedTurnCount = 0
+                    var removedTerminalTurnIds: [String] = []
                     if previousActivePromptTurnIsTerminal {
-                        turnStack.removeLast()
+                        removedTerminalTurnIds.append(turnStack.removeLast())
                         removedTurnCount += 1
                         while let activeTurnId = turnStack.last,
                               terminalActivePromptTurnIds.contains(activeTurnId) {
-                            turnStack.removeLast()
+                            removedTerminalTurnIds.append(turnStack.removeLast())
                             removedTurnCount += 1
                         }
                     }
                     let totalDepth = max(0, max(legacyDepth, turnStack.count + removedTurnCount) - removedTurnCount) + 1
                     turnStack.append(normalizedTurnId)
                     setActivePromptTurnStack(turnStack, totalDepth: totalDepth, on: &record)
+                    markPromptTurnsTerminal(removedTerminalTurnIds, on: &record)
                     record.lastPromptTurnId = normalizedTurnId
                     state.sessions[normalized] = record
                     return totalDepth > 1
@@ -677,6 +682,7 @@ private final class ClaudeHookSessionStore {
                             totalDepth: max(0, totalDepthBeforeStop - 1),
                             on: &record
                         )
+                        markPromptTurnTerminal(normalizedTurnId, on: &record)
                         state.sessions[normalized] = record
                         return nested
                     }
@@ -687,15 +693,16 @@ private final class ClaudeHookSessionStore {
                             totalDepth: max(0, totalDepthBeforeStop - 1),
                             on: &record
                         )
+                        markPromptTurnTerminal(normalizedTurnId, on: &record)
                     }
                     state.sessions[normalized] = record
                     return true
                 }
-                let lastPromptTurnId = normalizeOptional(record.lastPromptTurnId)
-                if depthBeforeStop == 0, let lastPromptTurnId, lastPromptTurnId != normalizedTurnId {
+                if depthBeforeStop == 0, terminalPromptTurnSet(from: record).contains(normalizedTurnId) {
                     state.sessions[normalized] = record
                     return true
                 }
+                markPromptTurnTerminal(normalizedTurnId, on: &record)
                 if depthBeforeStop > 0 {
                     if depthAfterStop == 0 {
                         record.activePromptDepth = nil
@@ -775,6 +782,7 @@ private final class ClaudeHookSessionStore {
                 activePromptTurnId: nil,
                 activePromptTurnIds: nil,
                 lastPromptTurnId: nil,
+                terminalPromptTurnIds: nil,
                 startedAt: now,
                 updatedAt: now
             )
@@ -833,6 +841,7 @@ private final class ClaudeHookSessionStore {
             activePromptTurnId: nil,
             activePromptTurnIds: nil,
             lastPromptTurnId: nil,
+            terminalPromptTurnIds: nil,
             startedAt: now,
             updatedAt: now
         )
@@ -863,6 +872,37 @@ private final class ClaudeHookSessionStore {
             record.activePromptTurnId = normalizedStack.last
             record.activePromptTurnIds = normalizedStack.isEmpty ? nil : normalizedStack
         }
+    }
+
+    private func terminalPromptTurnStack(from record: ClaudeHookSessionRecord) -> [String] {
+        record.terminalPromptTurnIds?.compactMap { normalizeOptional($0) } ?? []
+    }
+
+    private func terminalPromptTurnSet(from record: ClaudeHookSessionRecord) -> Set<String> {
+        Set(terminalPromptTurnStack(from: record))
+    }
+
+    private func markPromptTurnActive(_ turnId: String, on record: inout ClaudeHookSessionRecord) {
+        var terminalTurnIds = terminalPromptTurnStack(from: record)
+        terminalTurnIds.removeAll { $0 == turnId }
+        record.terminalPromptTurnIds = terminalTurnIds.isEmpty ? nil : terminalTurnIds
+    }
+
+    private func markPromptTurnsTerminal(_ turnIds: [String], on record: inout ClaudeHookSessionRecord) {
+        for turnId in turnIds {
+            markPromptTurnTerminal(turnId, on: &record)
+        }
+    }
+
+    private func markPromptTurnTerminal(_ turnId: String, on record: inout ClaudeHookSessionRecord) {
+        guard let normalizedTurnId = normalizeOptional(turnId) else { return }
+        var terminalTurnIds = terminalPromptTurnStack(from: record)
+        terminalTurnIds.removeAll { $0 == normalizedTurnId }
+        terminalTurnIds.append(normalizedTurnId)
+        if terminalTurnIds.count > Self.maxRememberedTerminalPromptTurnIds {
+            terminalTurnIds.removeFirst(terminalTurnIds.count - Self.maxRememberedTerminalPromptTurnIds)
+        }
+        record.terminalPromptTurnIds = terminalTurnIds.isEmpty ? nil : terminalTurnIds
     }
 
     private func update(

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -634,17 +634,11 @@ private final class ClaudeHookSessionStore {
             let depthAfterStop = max(0, depthBeforeStop - 1)
             let normalizedTurnId = normalizeOptional(turnId)
             let activeTurnId = normalizeOptional(record.activePromptTurnId)
-            let hasStalePromptDepthForDifferentTurn: Bool
-            if let normalizedTurnId {
-                if let activeTurnId {
-                    hasStalePromptDepthForDifferentTurn = activeTurnId != normalizedTurnId
-                } else {
-                    hasStalePromptDepthForDifferentTurn = depthBeforeStop > 0
-                }
-            } else {
-                hasStalePromptDepthForDifferentTurn = false
+            if let normalizedTurnId, let activeTurnId, activeTurnId != normalizedTurnId {
+                state.sessions[normalized] = record
+                return true
             }
-            if hasStalePromptDepthForDifferentTurn {
+            if normalizedTurnId != nil, activeTurnId == nil, depthBeforeStop > 0 {
                 record.activePromptDepth = nil
                 record.activePromptTurnId = nil
                 state.sessions[normalized] = record

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -928,6 +928,85 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         )
     }
 
+    func testCodexDepthOnlySiblingStaysNestedAfterChildTerminalTranscript() throws {
+        let context = try makeClaudeHookContext(name: "codex-depth-only-child-terminal")
+        defer { context.cleanup() }
+
+        let sessionId = "depth-only-child-terminal-session"
+        let transcriptURL = context.root.appendingPathComponent("codex-depth-only-child-terminal.jsonl")
+        try [
+            #"{"type":"event_msg","payload":{"type":"task_started","turn_id":"parent-turn"}}"#,
+            #"{"type":"event_msg","payload":{"type":"task_started","turn_id":"child-turn"}}"#,
+            #"{"type":"event_msg","payload":{"type":"turn_complete","turn_id":"child-turn"}}"#,
+        ].joined(separator: "\n").write(to: transcriptURL, atomically: true, encoding: .utf8)
+        let stateURL = context.root.appendingPathComponent("codex-hook-sessions.json")
+        let now = Date().timeIntervalSince1970
+        let store: [String: Any] = [
+            "version": 1,
+            "sessions": [
+                sessionId: [
+                    "sessionId": sessionId,
+                    "workspaceId": context.workspaceId,
+                    "surfaceId": context.surfaceId,
+                    "cwd": context.root.path,
+                    "transcriptPath": transcriptURL.path,
+                    "runtimeStatus": "running",
+                    "activePromptDepth": 2,
+                    "startedAt": now,
+                    "updatedAt": now,
+                ],
+            ],
+        ]
+        try JSONSerialization.data(withJSONObject: store, options: [.prettyPrinted])
+            .write(to: stateURL, options: .atomic)
+
+        let launchEnvironment = codexLaunchEnvironment(context: context, sessionId: sessionId)
+        startAgentHookMockServerAccepting(context: context, connectionLimit: 64)
+
+        let childStop = runCodexHook(
+            context: context,
+            subcommand: "stop",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"child-turn","cwd":"\#(context.root.path)","transcript_path":"\#(transcriptURL.path)","hook_event_name":"Stop","last_assistant_message":"child done"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(childStop.timedOut, childStop.stderr)
+        XCTAssertEqual(childStop.status, 0, childStop.stderr)
+
+        let siblingPromptStart = context.state.commands.count
+        let siblingPrompt = runCodexHook(
+            context: context,
+            subcommand: "prompt-submit",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"sibling-turn","cwd":"\#(context.root.path)","transcript_path":"\#(transcriptURL.path)","hook_event_name":"UserPromptSubmit","prompt":"sibling"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(siblingPrompt.timedOut, siblingPrompt.stderr)
+        XCTAssertEqual(siblingPrompt.status, 0, siblingPrompt.stderr)
+        let siblingPromptCommands = Array(context.state.commands.dropFirst(siblingPromptStart))
+        XCTAssertFalse(
+            siblingPromptCommands.contains { self.jsonObject($0)?["method"] as? String == "surface.resume.set" },
+            "A sibling prompt must stay nested while the depth-only parent remains active, saw \(siblingPromptCommands)"
+        )
+        XCTAssertFalse(
+            siblingPromptCommands.contains { $0.hasPrefix("set_status codex Running ") },
+            "A sibling prompt must not rewrite parent Running status while the depth-only parent remains active, saw \(siblingPromptCommands)"
+        )
+
+        let siblingStopStart = context.state.commands.count
+        let siblingStop = runCodexHook(
+            context: context,
+            subcommand: "stop",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"sibling-turn","cwd":"\#(context.root.path)","transcript_path":"\#(transcriptURL.path)","hook_event_name":"Stop","last_assistant_message":"sibling done"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(siblingStop.timedOut, siblingStop.stderr)
+        XCTAssertEqual(siblingStop.status, 0, siblingStop.stderr)
+        let siblingStopCommands = Array(context.state.commands.dropFirst(siblingStopStart))
+        XCTAssertFalse(
+            siblingStopCommands.contains { $0.hasPrefix("notify_target") || $0.hasPrefix("set_status codex ") },
+            "A sibling Stop must stay nested while the depth-only parent remains active, saw \(siblingStopCommands)"
+        )
+    }
+
     func testCodexDepthOnlyTerminalPriorTurnResetsForCurrentNotification() throws {
         let context = try makeClaudeHookContext(name: "codex-depth-only-terminal-reset")
         defer { context.cleanup() }

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -749,6 +749,67 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         )
     }
 
+    func testCodexStopWithNewTurnIdPopsAnonymousDepthUnderKnownParent() throws {
+        let context = try makeClaudeHookContext(name: "codex-anonymous-depth-turn-stop")
+        defer { context.cleanup() }
+
+        let sessionId = "anonymous-depth-turn-stop-session"
+        let launchEnvironment = codexLaunchEnvironment(context: context, sessionId: sessionId)
+        startAgentHookMockServerAccepting(context: context, connectionLimit: 48)
+
+        let parentPrompt = runCodexHook(
+            context: context,
+            subcommand: "prompt-submit",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"parent-turn","cwd":"\#(context.root.path)","hook_event_name":"UserPromptSubmit","prompt":"parent"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(parentPrompt.timedOut, parentPrompt.stderr)
+        XCTAssertEqual(parentPrompt.status, 0, parentPrompt.stderr)
+
+        let anonymousChildPrompt = runCodexHook(
+            context: context,
+            subcommand: "prompt-submit",
+            standardInput: #"{"session_id":"\#(sessionId)","cwd":"\#(context.root.path)","hook_event_name":"UserPromptSubmit","prompt":"anonymous child"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(anonymousChildPrompt.timedOut, anonymousChildPrompt.stderr)
+        XCTAssertEqual(anonymousChildPrompt.status, 0, anonymousChildPrompt.stderr)
+
+        let childStopStart = context.state.commands.count
+        let childStop = runCodexHook(
+            context: context,
+            subcommand: "stop",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"child-turn","cwd":"\#(context.root.path)","hook_event_name":"Stop","last_assistant_message":"child done"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(childStop.timedOut, childStop.stderr)
+        XCTAssertEqual(childStop.status, 0, childStop.stderr)
+        let childStopCommands = Array(context.state.commands.dropFirst(childStopStart))
+        XCTAssertFalse(
+            childStopCommands.contains { $0.hasPrefix("notify_target") || $0.hasPrefix("set_status codex ") },
+            "The child Stop should pop anonymous depth without notifying, saw \(childStopCommands)"
+        )
+
+        let parentStopStart = context.state.commands.count
+        let parentStop = runCodexHook(
+            context: context,
+            subcommand: "stop",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"parent-turn","cwd":"\#(context.root.path)","hook_event_name":"Stop","last_assistant_message":"parent done"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(parentStop.timedOut, parentStop.stderr)
+        XCTAssertEqual(parentStop.status, 0, parentStop.stderr)
+        let parentStopCommands = Array(context.state.commands.dropFirst(parentStopStart))
+        XCTAssertTrue(
+            parentStopCommands.contains { $0.hasPrefix("notify_target_async \(context.workspaceId) \(context.surfaceId) Codex|") },
+            "The parent Stop must still notify after a child Stop supplies a new turn_id, saw \(parentStopCommands)"
+        )
+        XCTAssertTrue(
+            parentStopCommands.contains { $0.hasPrefix("set_status codex ") && $0.contains(" Idle ") },
+            "The parent Stop must still mark Codex idle after a child Stop supplies a new turn_id, saw \(parentStopCommands)"
+        )
+    }
+
     func testCodexStopAfterInterruptedPriorTurnStillNotifies() throws {
         let context = try makeClaudeHookContext(name: "codex-interrupted-turn-depth")
         defer { context.cleanup() }

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -508,6 +508,53 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         )
     }
 
+    func testCodexStopAfterInterruptedPriorTurnStillNotifies() throws {
+        let context = try makeClaudeHookContext(name: "codex-interrupted-turn-depth")
+        defer { context.cleanup() }
+
+        let sessionId = "interrupted-depth-session"
+        let launchEnvironment = codexLaunchEnvironment(context: context, sessionId: sessionId)
+        startAgentHookMockServerAccepting(context: context, connectionLimit: 32)
+
+        let interruptedPrompt = runCodexHook(
+            context: context,
+            subcommand: "prompt-submit",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"old-turn","cwd":"\#(context.root.path)","hook_event_name":"UserPromptSubmit","prompt":"interrupted"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(interruptedPrompt.timedOut, interruptedPrompt.stderr)
+        XCTAssertEqual(interruptedPrompt.status, 0, interruptedPrompt.stderr)
+
+        let currentPrompt = runCodexHook(
+            context: context,
+            subcommand: "prompt-submit",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"current-turn","cwd":"\#(context.root.path)","hook_event_name":"UserPromptSubmit","prompt":"finish now"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(currentPrompt.timedOut, currentPrompt.stderr)
+        XCTAssertEqual(currentPrompt.status, 0, currentPrompt.stderr)
+
+        let stopStart = context.state.commands.count
+        let currentStop = runCodexHook(
+            context: context,
+            subcommand: "stop",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"current-turn","cwd":"\#(context.root.path)","hook_event_name":"Stop","last_assistant_message":"current done"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(currentStop.timedOut, currentStop.stderr)
+        XCTAssertEqual(currentStop.status, 0, currentStop.stderr)
+        let stopCommands = Array(context.state.commands.dropFirst(stopStart))
+
+        XCTAssertTrue(
+            stopCommands.contains { $0.hasPrefix("notify_target_async \(context.workspaceId) \(context.surfaceId) Codex|") },
+            "A stale prompt depth from an interrupted prior turn must not suppress the current top-level completion notification, saw \(stopCommands)"
+        )
+        XCTAssertTrue(
+            stopCommands.contains { $0.hasPrefix("set_status codex ") && $0.contains(" Idle ") },
+            "A stale prompt depth from an interrupted prior turn must not leave Codex marked running, saw \(stopCommands)"
+        )
+    }
+
     func testManagedCodexSubagentStopDoesNotReplaceResumeBinding() throws {
         let context = try makeClaudeHookContext(name: "codex-managed-resume-guard")
         defer { context.cleanup() }

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -555,6 +555,65 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         )
     }
 
+    func testCodexStopFromStaleOlderTurnDoesNotNotifyWhileNewerTurnIsActive() throws {
+        let context = try makeClaudeHookContext(name: "codex-stale-turn-stop")
+        defer { context.cleanup() }
+
+        let sessionId = "stale-turn-stop-session"
+        let launchEnvironment = codexLaunchEnvironment(context: context, sessionId: sessionId)
+        startAgentHookMockServerAccepting(context: context, connectionLimit: 48)
+
+        let oldPrompt = runCodexHook(
+            context: context,
+            subcommand: "prompt-submit",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"old-turn","cwd":"\#(context.root.path)","hook_event_name":"UserPromptSubmit","prompt":"old"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(oldPrompt.timedOut, oldPrompt.stderr)
+        XCTAssertEqual(oldPrompt.status, 0, oldPrompt.stderr)
+
+        let currentPrompt = runCodexHook(
+            context: context,
+            subcommand: "prompt-submit",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"current-turn","cwd":"\#(context.root.path)","hook_event_name":"UserPromptSubmit","prompt":"current"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(currentPrompt.timedOut, currentPrompt.stderr)
+        XCTAssertEqual(currentPrompt.status, 0, currentPrompt.stderr)
+
+        let staleStopStart = context.state.commands.count
+        let staleStop = runCodexHook(
+            context: context,
+            subcommand: "stop",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"old-turn","cwd":"\#(context.root.path)","hook_event_name":"Stop","last_assistant_message":"old done"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(staleStop.timedOut, staleStop.stderr)
+        XCTAssertEqual(staleStop.status, 0, staleStop.stderr)
+        let staleStopCommands = Array(context.state.commands.dropFirst(staleStopStart))
+
+        XCTAssertFalse(
+            staleStopCommands.contains { $0.hasPrefix("notify_target") || $0.hasPrefix("set_status codex ") },
+            "A stale Stop from an older turn must not notify or mark the newer active turn idle, saw \(staleStopCommands)"
+        )
+
+        let currentStopStart = context.state.commands.count
+        let currentStop = runCodexHook(
+            context: context,
+            subcommand: "stop",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"current-turn","cwd":"\#(context.root.path)","hook_event_name":"Stop","last_assistant_message":"current done"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(currentStop.timedOut, currentStop.stderr)
+        XCTAssertEqual(currentStop.status, 0, currentStop.stderr)
+        let currentStopCommands = Array(context.state.commands.dropFirst(currentStopStart))
+
+        XCTAssertTrue(
+            currentStopCommands.contains { $0.hasPrefix("notify_target_async \(context.workspaceId) \(context.surfaceId) Codex|") },
+            "The current turn should still notify after a stale older Stop, saw \(currentStopCommands)"
+        )
+    }
+
     func testManagedCodexSubagentStopDoesNotReplaceResumeBinding() throws {
         let context = try makeClaudeHookContext(name: "codex-managed-resume-guard")
         defer { context.cleanup() }

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -508,6 +508,67 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         )
     }
 
+    func testCodexLegacyStopWithoutTurnIdPopsStoredTurnStack() throws {
+        let context = try makeClaudeHookContext(name: "codex-legacy-stop-turn-stack")
+        defer { context.cleanup() }
+
+        let sessionId = "legacy-stop-turn-stack-session"
+        let launchEnvironment = codexLaunchEnvironment(context: context, sessionId: sessionId)
+        startAgentHookMockServerAccepting(context: context, connectionLimit: 48)
+
+        let parentPrompt = runCodexHook(
+            context: context,
+            subcommand: "prompt-submit",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"parent-turn","cwd":"\#(context.root.path)","hook_event_name":"UserPromptSubmit","prompt":"parent"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(parentPrompt.timedOut, parentPrompt.stderr)
+        XCTAssertEqual(parentPrompt.status, 0, parentPrompt.stderr)
+
+        let childPrompt = runCodexHook(
+            context: context,
+            subcommand: "prompt-submit",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"child-turn","cwd":"\#(context.root.path)","hook_event_name":"UserPromptSubmit","prompt":"child"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(childPrompt.timedOut, childPrompt.stderr)
+        XCTAssertEqual(childPrompt.status, 0, childPrompt.stderr)
+
+        let legacyChildStopStart = context.state.commands.count
+        let legacyChildStop = runCodexHook(
+            context: context,
+            subcommand: "stop",
+            standardInput: #"{"session_id":"\#(sessionId)","cwd":"\#(context.root.path)","hook_event_name":"Stop","last_assistant_message":"child done"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(legacyChildStop.timedOut, legacyChildStop.stderr)
+        XCTAssertEqual(legacyChildStop.status, 0, legacyChildStop.stderr)
+        let legacyChildStopCommands = Array(context.state.commands.dropFirst(legacyChildStopStart))
+        XCTAssertFalse(
+            legacyChildStopCommands.contains { $0.hasPrefix("notify_target") || $0.hasPrefix("set_status codex ") },
+            "A legacy child Stop without a turn_id must stay nested, saw \(legacyChildStopCommands)"
+        )
+
+        let parentStopStart = context.state.commands.count
+        let parentStop = runCodexHook(
+            context: context,
+            subcommand: "stop",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"parent-turn","cwd":"\#(context.root.path)","hook_event_name":"Stop","last_assistant_message":"parent done"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(parentStop.timedOut, parentStop.stderr)
+        XCTAssertEqual(parentStop.status, 0, parentStop.stderr)
+        let parentStopCommands = Array(context.state.commands.dropFirst(parentStopStart))
+        XCTAssertTrue(
+            parentStopCommands.contains { $0.hasPrefix("notify_target_async \(context.workspaceId) \(context.surfaceId) Codex|") },
+            "The parent Stop must still notify after a legacy child Stop without a turn_id, saw \(parentStopCommands)"
+        )
+        XCTAssertTrue(
+            parentStopCommands.contains { $0.hasPrefix("set_status codex ") && $0.contains(" Idle ") },
+            "The parent Stop must still mark Codex idle after a legacy child Stop without a turn_id, saw \(parentStopCommands)"
+        )
+    }
+
     func testCodexStopAfterInterruptedPriorTurnStillNotifies() throws {
         let context = try makeClaudeHookContext(name: "codex-interrupted-turn-depth")
         defer { context.cleanup() }
@@ -853,6 +914,76 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         XCTAssertFalse(
             childStopCommands.contains { $0.hasPrefix("notify_target") || $0.hasPrefix("set_status codex ") },
             "A historical terminal turn must not let a child Stop notify while the parent is active, saw \(childStopCommands)"
+        )
+    }
+
+    func testCodexDepthOnlyTurnContextOnlyParentDoesNotResetActiveParent() throws {
+        let context = try makeClaudeHookContext(name: "codex-depth-only-context-parent")
+        defer { context.cleanup() }
+
+        let sessionId = "depth-only-context-parent-session"
+        let transcriptURL = context.root.appendingPathComponent("codex-depth-only-context-parent.jsonl")
+        try [
+            #"{"type":"turn_context","payload":{"turn_id":"old-turn"}}"#,
+            #"{"type":"event_msg","payload":{"type":"turn_complete","turn_id":"old-turn"}}"#,
+            #"{"type":"turn_context","payload":{"turn_id":"parent-turn"}}"#,
+        ].joined(separator: "\n").write(to: transcriptURL, atomically: true, encoding: .utf8)
+        let stateURL = context.root.appendingPathComponent("codex-hook-sessions.json")
+        let now = Date().timeIntervalSince1970
+        let store: [String: Any] = [
+            "version": 1,
+            "sessions": [
+                sessionId: [
+                    "sessionId": sessionId,
+                    "workspaceId": context.workspaceId,
+                    "surfaceId": context.surfaceId,
+                    "cwd": context.root.path,
+                    "transcriptPath": transcriptURL.path,
+                    "runtimeStatus": "running",
+                    "activePromptDepth": 1,
+                    "startedAt": now,
+                    "updatedAt": now,
+                ],
+            ],
+        ]
+        try JSONSerialization.data(withJSONObject: store, options: [.prettyPrinted])
+            .write(to: stateURL, options: .atomic)
+
+        let launchEnvironment = codexLaunchEnvironment(context: context, sessionId: sessionId)
+        startAgentHookMockServerAccepting(context: context, connectionLimit: 32)
+
+        let childPromptStart = context.state.commands.count
+        let childPrompt = runCodexHook(
+            context: context,
+            subcommand: "prompt-submit",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"child-turn","cwd":"\#(context.root.path)","transcript_path":"\#(transcriptURL.path)","hook_event_name":"UserPromptSubmit","prompt":"child"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(childPrompt.timedOut, childPrompt.stderr)
+        XCTAssertEqual(childPrompt.status, 0, childPrompt.stderr)
+        let childPromptCommands = Array(context.state.commands.dropFirst(childPromptStart))
+        XCTAssertFalse(
+            childPromptCommands.contains { self.jsonObject($0)?["method"] as? String == "surface.resume.set" },
+            "A non-terminal parent turn_context must not make a depth-only parent look finished, saw \(childPromptCommands)"
+        )
+        XCTAssertFalse(
+            childPromptCommands.contains { $0.hasPrefix("set_status codex Running ") },
+            "A non-terminal parent turn_context must not let the child rewrite parent Running status, saw \(childPromptCommands)"
+        )
+
+        let childStopStart = context.state.commands.count
+        let childStop = runCodexHook(
+            context: context,
+            subcommand: "stop",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"child-turn","cwd":"\#(context.root.path)","transcript_path":"\#(transcriptURL.path)","hook_event_name":"Stop","last_assistant_message":"child done"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(childStop.timedOut, childStop.stderr)
+        XCTAssertEqual(childStop.status, 0, childStop.stderr)
+        let childStopCommands = Array(context.state.commands.dropFirst(childStopStart))
+        XCTAssertFalse(
+            childStopCommands.contains { $0.hasPrefix("notify_target") || $0.hasPrefix("set_status codex ") },
+            "A non-terminal parent turn_context must not let a child Stop notify while the parent is active, saw \(childStopCommands)"
         )
     }
 

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -644,6 +644,111 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         )
     }
 
+    func testCodexTurnStackPreservesAnonymousDepthBetweenKnownTurns() throws {
+        let context = try makeClaudeHookContext(name: "codex-mixed-anonymous-depth")
+        defer { context.cleanup() }
+
+        let sessionId = "mixed-anonymous-depth-session"
+        let launchEnvironment = codexLaunchEnvironment(context: context, sessionId: sessionId)
+        startAgentHookMockServerAccepting(context: context, connectionLimit: 64)
+
+        let parentPrompt = runCodexHook(
+            context: context,
+            subcommand: "prompt-submit",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"parent-turn","cwd":"\#(context.root.path)","hook_event_name":"UserPromptSubmit","prompt":"parent"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(parentPrompt.timedOut, parentPrompt.stderr)
+        XCTAssertEqual(parentPrompt.status, 0, parentPrompt.stderr)
+
+        let anonymousChildPromptStart = context.state.commands.count
+        let anonymousChildPrompt = runCodexHook(
+            context: context,
+            subcommand: "prompt-submit",
+            standardInput: #"{"session_id":"\#(sessionId)","cwd":"\#(context.root.path)","hook_event_name":"UserPromptSubmit","prompt":"anonymous child"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(anonymousChildPrompt.timedOut, anonymousChildPrompt.stderr)
+        XCTAssertEqual(anonymousChildPrompt.status, 0, anonymousChildPrompt.stderr)
+        let anonymousChildPromptCommands = Array(context.state.commands.dropFirst(anonymousChildPromptStart))
+        XCTAssertFalse(
+            anonymousChildPromptCommands.contains { (self.jsonObject($0)?["method"] as? String)?.hasPrefix("surface.resume.") == true },
+            "An anonymous child under a known parent must not replace the parent resume binding, saw \(anonymousChildPromptCommands)"
+        )
+        XCTAssertFalse(
+            anonymousChildPromptCommands.contains { $0.hasPrefix("set_status codex Running ") },
+            "An anonymous child under a known parent must not rewrite parent Running status, saw \(anonymousChildPromptCommands)"
+        )
+
+        let grandchildPromptStart = context.state.commands.count
+        let grandchildPrompt = runCodexHook(
+            context: context,
+            subcommand: "prompt-submit",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"grandchild-turn","cwd":"\#(context.root.path)","hook_event_name":"UserPromptSubmit","prompt":"grandchild"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(grandchildPrompt.timedOut, grandchildPrompt.stderr)
+        XCTAssertEqual(grandchildPrompt.status, 0, grandchildPrompt.stderr)
+        let grandchildPromptCommands = Array(context.state.commands.dropFirst(grandchildPromptStart))
+        XCTAssertFalse(
+            grandchildPromptCommands.contains { (self.jsonObject($0)?["method"] as? String)?.hasPrefix("surface.resume.") == true },
+            "A known grandchild after anonymous depth must stay nested, saw \(grandchildPromptCommands)"
+        )
+        XCTAssertFalse(
+            grandchildPromptCommands.contains { $0.hasPrefix("set_status codex Running ") },
+            "A known grandchild after anonymous depth must not rewrite parent Running status, saw \(grandchildPromptCommands)"
+        )
+
+        let grandchildStopStart = context.state.commands.count
+        let grandchildStop = runCodexHook(
+            context: context,
+            subcommand: "stop",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"grandchild-turn","cwd":"\#(context.root.path)","hook_event_name":"Stop","last_assistant_message":"grandchild done"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(grandchildStop.timedOut, grandchildStop.stderr)
+        XCTAssertEqual(grandchildStop.status, 0, grandchildStop.stderr)
+        let grandchildStopCommands = Array(context.state.commands.dropFirst(grandchildStopStart))
+        XCTAssertFalse(
+            grandchildStopCommands.contains { $0.hasPrefix("notify_target") || $0.hasPrefix("set_status codex ") },
+            "Grandchild Stop must not collapse anonymous child depth and notify, saw \(grandchildStopCommands)"
+        )
+
+        let anonymousChildStopStart = context.state.commands.count
+        let anonymousChildStop = runCodexHook(
+            context: context,
+            subcommand: "stop",
+            standardInput: #"{"session_id":"\#(sessionId)","cwd":"\#(context.root.path)","hook_event_name":"Stop","last_assistant_message":"anonymous child done"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(anonymousChildStop.timedOut, anonymousChildStop.stderr)
+        XCTAssertEqual(anonymousChildStop.status, 0, anonymousChildStop.stderr)
+        let anonymousChildStopCommands = Array(context.state.commands.dropFirst(anonymousChildStopStart))
+        XCTAssertFalse(
+            anonymousChildStopCommands.contains { $0.hasPrefix("notify_target") || $0.hasPrefix("set_status codex ") },
+            "Anonymous child Stop must stay nested after a known grandchild Stop, saw \(anonymousChildStopCommands)"
+        )
+
+        let parentStopStart = context.state.commands.count
+        let parentStop = runCodexHook(
+            context: context,
+            subcommand: "stop",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"parent-turn","cwd":"\#(context.root.path)","hook_event_name":"Stop","last_assistant_message":"parent done"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(parentStop.timedOut, parentStop.stderr)
+        XCTAssertEqual(parentStop.status, 0, parentStop.stderr)
+        let parentStopCommands = Array(context.state.commands.dropFirst(parentStopStart))
+        XCTAssertTrue(
+            parentStopCommands.contains { $0.hasPrefix("notify_target_async \(context.workspaceId) \(context.surfaceId) Codex|") },
+            "The parent Stop must still notify after mixed anonymous depth, saw \(parentStopCommands)"
+        )
+        XCTAssertTrue(
+            parentStopCommands.contains { $0.hasPrefix("set_status codex ") && $0.contains(" Idle ") },
+            "The parent Stop must still mark Codex idle after mixed anonymous depth, saw \(parentStopCommands)"
+        )
+    }
+
     func testCodexStopAfterInterruptedPriorTurnStillNotifies() throws {
         let context = try makeClaudeHookContext(name: "codex-interrupted-turn-depth")
         defer { context.cleanup() }

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -689,6 +689,129 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         )
     }
 
+    func testCodexDepthOnlyLegacyNestingRemainsNestedWhenTurnIdsAppear() throws {
+        let context = try makeClaudeHookContext(name: "codex-depth-only-nested")
+        defer { context.cleanup() }
+
+        let sessionId = "depth-only-nested-session"
+        let stateURL = context.root.appendingPathComponent("codex-hook-sessions.json")
+        let now = Date().timeIntervalSince1970
+        let store: [String: Any] = [
+            "version": 1,
+            "sessions": [
+                sessionId: [
+                    "sessionId": sessionId,
+                    "workspaceId": context.workspaceId,
+                    "surfaceId": context.surfaceId,
+                    "cwd": context.root.path,
+                    "runtimeStatus": "running",
+                    "activePromptDepth": 1,
+                    "startedAt": now,
+                    "updatedAt": now,
+                ],
+            ],
+        ]
+        try JSONSerialization.data(withJSONObject: store, options: [.prettyPrinted])
+            .write(to: stateURL, options: .atomic)
+
+        let launchEnvironment = codexLaunchEnvironment(context: context, sessionId: sessionId)
+        startAgentHookMockServerAccepting(context: context, connectionLimit: 32)
+
+        let childPromptStart = context.state.commands.count
+        let childPrompt = runCodexHook(
+            context: context,
+            subcommand: "prompt-submit",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"child-turn","cwd":"\#(context.root.path)","hook_event_name":"UserPromptSubmit","prompt":"child"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(childPrompt.timedOut, childPrompt.stderr)
+        XCTAssertEqual(childPrompt.status, 0, childPrompt.stderr)
+        let childPromptCommands = Array(context.state.commands.dropFirst(childPromptStart))
+        XCTAssertFalse(
+            childPromptCommands.contains { self.jsonObject($0)?["method"] as? String == "surface.resume.set" },
+            "A legacy depth-only nested prompt that first gains a turn_id must remain nested, saw \(childPromptCommands)"
+        )
+        XCTAssertFalse(
+            childPromptCommands.contains { $0.hasPrefix("set_status codex Running ") },
+            "A legacy depth-only nested prompt that first gains a turn_id must not rewrite parent Running status, saw \(childPromptCommands)"
+        )
+
+        let childStopStart = context.state.commands.count
+        let childStop = runCodexHook(
+            context: context,
+            subcommand: "stop",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"child-turn","cwd":"\#(context.root.path)","hook_event_name":"Stop","last_assistant_message":"child done"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(childStop.timedOut, childStop.stderr)
+        XCTAssertEqual(childStop.status, 0, childStop.stderr)
+        let childStopCommands = Array(context.state.commands.dropFirst(childStopStart))
+        XCTAssertFalse(
+            childStopCommands.contains { $0.hasPrefix("notify_target") || $0.hasPrefix("set_status codex ") },
+            "A legacy depth-only nested Stop that first gains a turn_id must remain nested, saw \(childStopCommands)"
+        )
+    }
+
+    func testCodexDepthOnlyTerminalPriorTurnResetsForCurrentNotification() throws {
+        let context = try makeClaudeHookContext(name: "codex-depth-only-terminal-reset")
+        defer { context.cleanup() }
+
+        let sessionId = "depth-only-terminal-reset-session"
+        let transcriptURL = try writeCodexTerminalTranscript(
+            context: context,
+            name: "codex-depth-only-terminal-reset.jsonl",
+            turnId: "old-turn",
+            eventType: "turn_aborted"
+        )
+        let stateURL = context.root.appendingPathComponent("codex-hook-sessions.json")
+        let now = Date().timeIntervalSince1970
+        let store: [String: Any] = [
+            "version": 1,
+            "sessions": [
+                sessionId: [
+                    "sessionId": sessionId,
+                    "workspaceId": context.workspaceId,
+                    "surfaceId": context.surfaceId,
+                    "cwd": context.root.path,
+                    "transcriptPath": transcriptURL.path,
+                    "runtimeStatus": "running",
+                    "activePromptDepth": 2,
+                    "startedAt": now,
+                    "updatedAt": now,
+                ],
+            ],
+        ]
+        try JSONSerialization.data(withJSONObject: store, options: [.prettyPrinted])
+            .write(to: stateURL, options: .atomic)
+
+        let launchEnvironment = codexLaunchEnvironment(context: context, sessionId: sessionId)
+        startAgentHookMockServerAccepting(context: context, connectionLimit: 32)
+
+        let currentPrompt = runCodexHook(
+            context: context,
+            subcommand: "prompt-submit",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"current-turn","cwd":"\#(context.root.path)","transcript_path":"\#(transcriptURL.path)","hook_event_name":"UserPromptSubmit","prompt":"current"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(currentPrompt.timedOut, currentPrompt.stderr)
+        XCTAssertEqual(currentPrompt.status, 0, currentPrompt.stderr)
+
+        let currentStopStart = context.state.commands.count
+        let currentStop = runCodexHook(
+            context: context,
+            subcommand: "stop",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"current-turn","cwd":"\#(context.root.path)","transcript_path":"\#(transcriptURL.path)","hook_event_name":"Stop","last_assistant_message":"current done"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(currentStop.timedOut, currentStop.stderr)
+        XCTAssertEqual(currentStop.status, 0, currentStop.stderr)
+        let currentStopCommands = Array(context.state.commands.dropFirst(currentStopStart))
+        XCTAssertTrue(
+            currentStopCommands.contains { $0.hasPrefix("notify_target_async \(context.workspaceId) \(context.surfaceId) Codex|") },
+            "A terminal prior depth-only turn must reset so the current top-level Stop notifies, saw \(currentStopCommands)"
+        )
+    }
+
     func testCodexStopFromStaleOlderTurnDoesNotNotifyWhileNewerTurnIsActive() throws {
         let context = try makeClaudeHookContext(name: "codex-stale-turn-stop")
         defer { context.cleanup() }

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -432,7 +432,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         let parentPrompt = runCodexHook(
             context: context,
             subcommand: "prompt-submit",
-            standardInput: #"{"session_id":"\#(sessionId)","cwd":"\#(context.root.path)","hook_event_name":"UserPromptSubmit","prompt":"spawn subagent"}"#,
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"parent-turn","cwd":"\#(context.root.path)","hook_event_name":"UserPromptSubmit","prompt":"spawn subagent"}"#,
             extraEnvironment: launchEnvironment
         )
         XCTAssertFalse(parentPrompt.timedOut, parentPrompt.stderr)
@@ -446,7 +446,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         let childPrompt = runCodexHook(
             context: context,
             subcommand: "prompt-submit",
-            standardInput: #"{"session_id":"\#(sessionId)","cwd":"\#(context.root.path)","hook_event_name":"UserPromptSubmit","prompt":"return 1+1"}"#,
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"child-turn","cwd":"\#(context.root.path)","hook_event_name":"UserPromptSubmit","prompt":"return 1+1"}"#,
             extraEnvironment: launchEnvironment
         )
         XCTAssertFalse(childPrompt.timedOut, childPrompt.stderr)
@@ -465,7 +465,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         let childStop = runCodexHook(
             context: context,
             subcommand: "stop",
-            standardInput: #"{"session_id":"\#(sessionId)","cwd":"\#(context.root.path)","hook_event_name":"Stop","last_assistant_message":"2"}"#,
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"child-turn","cwd":"\#(context.root.path)","hook_event_name":"Stop","last_assistant_message":"2"}"#,
             extraEnvironment: launchEnvironment
         )
         XCTAssertFalse(childStop.timedOut, childStop.stderr)
@@ -488,7 +488,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         let parentStop = runCodexHook(
             context: context,
             subcommand: "stop",
-            standardInput: #"{"session_id":"\#(sessionId)","cwd":"\#(context.root.path)","hook_event_name":"Stop","last_assistant_message":"parent done"}"#,
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"parent-turn","cwd":"\#(context.root.path)","hook_event_name":"Stop","last_assistant_message":"parent done"}"#,
             extraEnvironment: launchEnvironment
         )
         XCTAssertFalse(parentStop.timedOut, parentStop.stderr)

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -614,6 +614,64 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         )
     }
 
+    func testCodexLateStopFromOlderTurnDoesNotNotifyAfterNewerTurnCompleted() throws {
+        let context = try makeClaudeHookContext(name: "codex-late-stale-turn-stop")
+        defer { context.cleanup() }
+
+        let sessionId = "late-stale-turn-stop-session"
+        let launchEnvironment = codexLaunchEnvironment(context: context, sessionId: sessionId)
+        startAgentHookMockServerAccepting(context: context, connectionLimit: 48)
+
+        let oldPrompt = runCodexHook(
+            context: context,
+            subcommand: "prompt-submit",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"old-turn","cwd":"\#(context.root.path)","hook_event_name":"UserPromptSubmit","prompt":"old"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(oldPrompt.timedOut, oldPrompt.stderr)
+        XCTAssertEqual(oldPrompt.status, 0, oldPrompt.stderr)
+
+        let currentPrompt = runCodexHook(
+            context: context,
+            subcommand: "prompt-submit",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"current-turn","cwd":"\#(context.root.path)","hook_event_name":"UserPromptSubmit","prompt":"current"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(currentPrompt.timedOut, currentPrompt.stderr)
+        XCTAssertEqual(currentPrompt.status, 0, currentPrompt.stderr)
+
+        let currentStopStart = context.state.commands.count
+        let currentStop = runCodexHook(
+            context: context,
+            subcommand: "stop",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"current-turn","cwd":"\#(context.root.path)","hook_event_name":"Stop","last_assistant_message":"current done"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(currentStop.timedOut, currentStop.stderr)
+        XCTAssertEqual(currentStop.status, 0, currentStop.stderr)
+        let currentStopCommands = Array(context.state.commands.dropFirst(currentStopStart))
+        XCTAssertTrue(
+            currentStopCommands.contains { $0.hasPrefix("notify_target_async \(context.workspaceId) \(context.surfaceId) Codex|") },
+            "The current turn should notify before a late stale Stop arrives, saw \(currentStopCommands)"
+        )
+
+        let lateStopStart = context.state.commands.count
+        let lateStop = runCodexHook(
+            context: context,
+            subcommand: "stop",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"old-turn","cwd":"\#(context.root.path)","hook_event_name":"Stop","last_assistant_message":"old done"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(lateStop.timedOut, lateStop.stderr)
+        XCTAssertEqual(lateStop.status, 0, lateStop.stderr)
+        let lateStopCommands = Array(context.state.commands.dropFirst(lateStopStart))
+
+        XCTAssertFalse(
+            lateStopCommands.contains { $0.hasPrefix("notify_target") || $0.hasPrefix("set_status codex ") },
+            "A late stale Stop from an older turn must not duplicate the newer turn completion, saw \(lateStopCommands)"
+        )
+    }
+
     func testManagedCodexSubagentStopDoesNotReplaceResumeBinding() throws {
         let context = try makeClaudeHookContext(name: "codex-managed-resume-guard")
         defer { context.cleanup() }

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -561,6 +561,103 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         )
     }
 
+    func testCodexTerminalNestedChildDoesNotClearParentTurnStack() throws {
+        let context = try makeClaudeHookContext(name: "codex-terminal-child-stack")
+        defer { context.cleanup() }
+
+        let sessionId = "terminal-child-stack-session"
+        let terminalChildTranscript = try writeCodexTerminalTranscript(
+            context: context,
+            name: "codex-terminal-child-stack.jsonl",
+            turnId: "child-turn",
+            eventType: "turn_complete"
+        )
+        let launchEnvironment = codexLaunchEnvironment(context: context, sessionId: sessionId)
+        startAgentHookMockServerAccepting(context: context, connectionLimit: 64)
+
+        let parentPrompt = runCodexHook(
+            context: context,
+            subcommand: "prompt-submit",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"parent-turn","cwd":"\#(context.root.path)","hook_event_name":"UserPromptSubmit","prompt":"spawn child"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(parentPrompt.timedOut, parentPrompt.stderr)
+        XCTAssertEqual(parentPrompt.status, 0, parentPrompt.stderr)
+
+        let childPrompt = runCodexHook(
+            context: context,
+            subcommand: "prompt-submit",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"child-turn","cwd":"\#(context.root.path)","transcript_path":"\#(terminalChildTranscript.path)","hook_event_name":"UserPromptSubmit","prompt":"first child"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(childPrompt.timedOut, childPrompt.stderr)
+        XCTAssertEqual(childPrompt.status, 0, childPrompt.stderr)
+
+        let siblingPromptStart = context.state.commands.count
+        let siblingPrompt = runCodexHook(
+            context: context,
+            subcommand: "prompt-submit",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"sibling-turn","cwd":"\#(context.root.path)","transcript_path":"\#(terminalChildTranscript.path)","hook_event_name":"UserPromptSubmit","prompt":"second child"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(siblingPrompt.timedOut, siblingPrompt.stderr)
+        XCTAssertEqual(siblingPrompt.status, 0, siblingPrompt.stderr)
+        let siblingPromptCommands = Array(context.state.commands.dropFirst(siblingPromptStart))
+        XCTAssertFalse(
+            siblingPromptCommands.contains { self.jsonObject($0)?["method"] as? String == "surface.resume.set" },
+            "A sibling child prompt after a terminal child transcript must stay nested, saw \(siblingPromptCommands)"
+        )
+        XCTAssertFalse(
+            siblingPromptCommands.contains { $0.hasPrefix("set_status codex Running ") },
+            "A sibling child prompt after a terminal child transcript must not rewrite parent Running status, saw \(siblingPromptCommands)"
+        )
+
+        let childStopStart = context.state.commands.count
+        let childStop = runCodexHook(
+            context: context,
+            subcommand: "stop",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"child-turn","cwd":"\#(context.root.path)","transcript_path":"\#(terminalChildTranscript.path)","hook_event_name":"Stop","last_assistant_message":"first child done"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(childStop.timedOut, childStop.stderr)
+        XCTAssertEqual(childStop.status, 0, childStop.stderr)
+        let childStopCommands = Array(context.state.commands.dropFirst(childStopStart))
+        XCTAssertFalse(
+            childStopCommands.contains { $0.hasPrefix("notify_target") || $0.hasPrefix("set_status codex ") },
+            "A late terminal child Stop must remain nested after a sibling child prompt, saw \(childStopCommands)"
+        )
+
+        let siblingStopStart = context.state.commands.count
+        let siblingStop = runCodexHook(
+            context: context,
+            subcommand: "stop",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"sibling-turn","cwd":"\#(context.root.path)","transcript_path":"\#(terminalChildTranscript.path)","hook_event_name":"Stop","last_assistant_message":"second child done"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(siblingStop.timedOut, siblingStop.stderr)
+        XCTAssertEqual(siblingStop.status, 0, siblingStop.stderr)
+        let siblingStopCommands = Array(context.state.commands.dropFirst(siblingStopStart))
+        XCTAssertFalse(
+            siblingStopCommands.contains { $0.hasPrefix("notify_target") || $0.hasPrefix("set_status codex ") },
+            "The sibling child Stop must not notify while the parent is active, saw \(siblingStopCommands)"
+        )
+
+        let parentStopStart = context.state.commands.count
+        let parentStop = runCodexHook(
+            context: context,
+            subcommand: "stop",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"parent-turn","cwd":"\#(context.root.path)","hook_event_name":"Stop","last_assistant_message":"parent done"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(parentStop.timedOut, parentStop.stderr)
+        XCTAssertEqual(parentStop.status, 0, parentStop.stderr)
+        let parentStopCommands = Array(context.state.commands.dropFirst(parentStopStart))
+        XCTAssertTrue(
+            parentStopCommands.contains { $0.hasPrefix("notify_target_async \(context.workspaceId) \(context.surfaceId) Codex|") },
+            "The parent Stop should still notify after terminal nested children, saw \(parentStopCommands)"
+        )
+    }
+
     func testCodexStopFromStaleOlderTurnDoesNotNotifyWhileNewerTurnIsActive() throws {
         let context = try makeClaudeHookContext(name: "codex-stale-turn-stop")
         defer { context.cleanup() }

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -569,6 +569,81 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         )
     }
 
+    func testGenericAgentTurnIdsStayNestedAcrossTurnChanges() throws {
+        let context = try makeClaudeHookContext(name: "generic-turn-stack")
+        defer { context.cleanup() }
+
+        let sessionId = "generic-turn-stack-session"
+        let launchEnvironment = agentLaunchEnvironment(context: context, kind: "gemini", executable: "/usr/local/bin/gemini")
+        startAgentHookMockServerAccepting(context: context, connectionLimit: 48)
+
+        let parentPrompt = runAgentHook(
+            context: context,
+            agent: "gemini",
+            subcommand: "prompt-submit",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"parent-turn","cwd":"\#(context.root.path)","hook_event_name":"BeforeAgent","prompt":"parent"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(parentPrompt.timedOut, parentPrompt.stderr)
+        XCTAssertEqual(parentPrompt.status, 0, parentPrompt.stderr)
+
+        let childPromptStart = context.state.commands.count
+        let childPrompt = runAgentHook(
+            context: context,
+            agent: "gemini",
+            subcommand: "prompt-submit",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"child-turn","cwd":"\#(context.root.path)","hook_event_name":"BeforeAgent","prompt":"child"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(childPrompt.timedOut, childPrompt.stderr)
+        XCTAssertEqual(childPrompt.status, 0, childPrompt.stderr)
+        let childPromptCommands = Array(context.state.commands.dropFirst(childPromptStart))
+        XCTAssertFalse(
+            childPromptCommands.contains { (self.jsonObject($0)?["method"] as? String)?.hasPrefix("surface.resume.") == true },
+            "A generic nested turn_id prompt must not replace the parent resume binding, saw \(childPromptCommands)"
+        )
+        XCTAssertFalse(
+            childPromptCommands.contains { $0.hasPrefix("set_status gemini Running ") },
+            "A generic nested turn_id prompt must not rewrite parent Running status, saw \(childPromptCommands)"
+        )
+
+        let childStopStart = context.state.commands.count
+        let childStop = runAgentHook(
+            context: context,
+            agent: "gemini",
+            subcommand: "stop",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"child-turn","cwd":"\#(context.root.path)","hook_event_name":"AfterAgent","last_assistant_message":"child done"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(childStop.timedOut, childStop.stderr)
+        XCTAssertEqual(childStop.status, 0, childStop.stderr)
+        let childStopCommands = Array(context.state.commands.dropFirst(childStopStart))
+        XCTAssertFalse(
+            childStopCommands.contains { $0.hasPrefix("notify_target") || $0.hasPrefix("set_status gemini ") },
+            "A generic nested turn_id Stop must not notify or mark the parent idle, saw \(childStopCommands)"
+        )
+
+        let parentStopStart = context.state.commands.count
+        let parentStop = runAgentHook(
+            context: context,
+            agent: "gemini",
+            subcommand: "stop",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"parent-turn","cwd":"\#(context.root.path)","hook_event_name":"AfterAgent","last_assistant_message":"parent done"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(parentStop.timedOut, parentStop.stderr)
+        XCTAssertEqual(parentStop.status, 0, parentStop.stderr)
+        let parentStopCommands = Array(context.state.commands.dropFirst(parentStopStart))
+        XCTAssertTrue(
+            parentStopCommands.contains { $0.hasPrefix("notify_target_async \(context.workspaceId) \(context.surfaceId) Gemini|") },
+            "The generic parent Stop must still notify after its nested child, saw \(parentStopCommands)"
+        )
+        XCTAssertTrue(
+            parentStopCommands.contains { $0.hasPrefix("set_status gemini ") && $0.contains(" Idle ") },
+            "The generic parent Stop must still mark Gemini idle, saw \(parentStopCommands)"
+        )
+    }
+
     func testCodexStopAfterInterruptedPriorTurnStillNotifies() throws {
         let context = try makeClaudeHookContext(name: "codex-interrupted-turn-depth")
         defer { context.cleanup() }
@@ -1138,12 +1213,12 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         )
     }
 
-    func testCodexDepthOnlyTerminalPriorTurnResetsForCurrentNotification() throws {
-        let context = try makeClaudeHookContext(name: "codex-depth-only-terminal-reset")
+    func testCodexDepthOnlyTerminalHistoryDoesNotResetUnknownActiveDepth() throws {
+        let context = try makeClaudeHookContext(name: "codex-depth-only-terminal-history")
         defer { context.cleanup() }
 
-        let sessionId = "depth-only-terminal-reset-session"
-        let transcriptURL = context.root.appendingPathComponent("codex-depth-only-terminal-reset.jsonl")
+        let sessionId = "depth-only-terminal-history-session"
+        let transcriptURL = context.root.appendingPathComponent("codex-depth-only-terminal-history.jsonl")
         try [
             #"{"type":"event_msg","payload":{"type":"task_started","turn_id":"old-parent-turn"}}"#,
             #"{"type":"event_msg","payload":{"type":"task_started","turn_id":"old-child-turn"}}"#,
@@ -1174,28 +1249,38 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         let launchEnvironment = codexLaunchEnvironment(context: context, sessionId: sessionId)
         startAgentHookMockServerAccepting(context: context, connectionLimit: 32)
 
-        let currentPrompt = runCodexHook(
+        let childPromptStart = context.state.commands.count
+        let childPrompt = runCodexHook(
             context: context,
             subcommand: "prompt-submit",
-            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"current-turn","cwd":"\#(context.root.path)","transcript_path":"\#(transcriptURL.path)","hook_event_name":"UserPromptSubmit","prompt":"current"}"#,
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"child-turn","cwd":"\#(context.root.path)","transcript_path":"\#(transcriptURL.path)","hook_event_name":"UserPromptSubmit","prompt":"child"}"#,
             extraEnvironment: launchEnvironment
         )
-        XCTAssertFalse(currentPrompt.timedOut, currentPrompt.stderr)
-        XCTAssertEqual(currentPrompt.status, 0, currentPrompt.stderr)
+        XCTAssertFalse(childPrompt.timedOut, childPrompt.stderr)
+        XCTAssertEqual(childPrompt.status, 0, childPrompt.stderr)
+        let childPromptCommands = Array(context.state.commands.dropFirst(childPromptStart))
+        XCTAssertFalse(
+            childPromptCommands.contains { (self.jsonObject($0)?["method"] as? String)?.hasPrefix("surface.resume.") == true },
+            "Terminal history alone must not make unknown depth-only active prompts look finished, saw \(childPromptCommands)"
+        )
+        XCTAssertFalse(
+            childPromptCommands.contains { $0.hasPrefix("set_status codex Running ") },
+            "Terminal history alone must not let the child rewrite parent Running status, saw \(childPromptCommands)"
+        )
 
-        let currentStopStart = context.state.commands.count
-        let currentStop = runCodexHook(
+        let childStopStart = context.state.commands.count
+        let childStop = runCodexHook(
             context: context,
             subcommand: "stop",
-            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"current-turn","cwd":"\#(context.root.path)","transcript_path":"\#(transcriptURL.path)","hook_event_name":"Stop","last_assistant_message":"current done"}"#,
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"child-turn","cwd":"\#(context.root.path)","transcript_path":"\#(transcriptURL.path)","hook_event_name":"Stop","last_assistant_message":"child done"}"#,
             extraEnvironment: launchEnvironment
         )
-        XCTAssertFalse(currentStop.timedOut, currentStop.stderr)
-        XCTAssertEqual(currentStop.status, 0, currentStop.stderr)
-        let currentStopCommands = Array(context.state.commands.dropFirst(currentStopStart))
-        XCTAssertTrue(
-            currentStopCommands.contains { $0.hasPrefix("notify_target_async \(context.workspaceId) \(context.surfaceId) Codex|") },
-            "A terminal prior depth-only turn must reset so the current top-level Stop notifies, saw \(currentStopCommands)"
+        XCTAssertFalse(childStop.timedOut, childStop.stderr)
+        XCTAssertEqual(childStop.status, 0, childStop.stderr)
+        let childStopCommands = Array(context.state.commands.dropFirst(childStopStart))
+        XCTAssertFalse(
+            childStopCommands.contains { $0.hasPrefix("notify_target") || $0.hasPrefix("set_status codex ") },
+            "Terminal history alone must not let a child Stop notify while unknown depth remains, saw \(childStopCommands)"
         )
     }
 
@@ -4815,15 +4900,25 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
     }
 
     private func codexLaunchEnvironment(context: ClaudeHookContext, sessionId: String) -> [String: String] {
+        agentLaunchEnvironment(
+            context: context,
+            kind: "codex",
+            executable: "/usr/local/bin/codex",
+            arguments: ["/usr/local/bin/codex", "--model", "gpt-5.4"]
+        )
+    }
+
+    private func agentLaunchEnvironment(
+        context: ClaudeHookContext,
+        kind: String,
+        executable: String,
+        arguments: [String]? = nil
+    ) -> [String: String] {
         [
-            "CMUX_AGENT_LAUNCH_KIND": "codex",
-            "CMUX_AGENT_LAUNCH_EXECUTABLE": "/usr/local/bin/codex",
+            "CMUX_AGENT_LAUNCH_KIND": kind,
+            "CMUX_AGENT_LAUNCH_EXECUTABLE": executable,
             "CMUX_AGENT_LAUNCH_CWD": context.root.path,
-            "CMUX_AGENT_LAUNCH_ARGV_B64": base64NULSeparated([
-                "/usr/local/bin/codex",
-                "--model",
-                "gpt-5.4",
-            ]),
+            "CMUX_AGENT_LAUNCH_ARGV_B64": base64NULSeparated(arguments ?? [executable]),
         ]
     }
 
@@ -4847,6 +4942,22 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         standardInput: String,
         extraEnvironment: [String: String] = [:]
     ) -> ProcessRunResult {
+        runAgentHook(
+            context: context,
+            agent: "codex",
+            subcommand: subcommand,
+            standardInput: standardInput,
+            extraEnvironment: extraEnvironment
+        )
+    }
+
+    private func runAgentHook(
+        context: ClaudeHookContext,
+        agent: String,
+        subcommand: String,
+        standardInput: String,
+        extraEnvironment: [String: String] = [:]
+    ) -> ProcessRunResult {
         var environment = [
             "HOME": context.root.path,
             "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
@@ -4861,7 +4972,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
 
         return runProcess(
             executablePath: context.cliPath,
-            arguments: ["hooks", "codex", subcommand],
+            arguments: ["hooks", agent, subcommand],
             environment: environment,
             standardInput: standardInput,
             timeout: 5

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -1518,6 +1518,53 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         )
     }
 
+    func testCodexStopWithUnseenTurnIdNotSuppressedAtIdleDepth() throws {
+        let context = try makeClaudeHookContext(name: "codex-unseen-turn-stop")
+        defer { context.cleanup() }
+
+        let sessionId = "unseen-turn-stop-session"
+        let launchEnvironment = codexLaunchEnvironment(context: context, sessionId: sessionId)
+        startAgentHookMockServerAccepting(context: context, connectionLimit: 48)
+
+        let oldPrompt = runCodexHook(
+            context: context,
+            subcommand: "prompt-submit",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"old-turn","cwd":"\#(context.root.path)","hook_event_name":"UserPromptSubmit","prompt":"old"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(oldPrompt.timedOut, oldPrompt.stderr)
+        XCTAssertEqual(oldPrompt.status, 0, oldPrompt.stderr)
+
+        let oldStop = runCodexHook(
+            context: context,
+            subcommand: "stop",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"old-turn","cwd":"\#(context.root.path)","hook_event_name":"Stop","last_assistant_message":"old done"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(oldStop.timedOut, oldStop.stderr)
+        XCTAssertEqual(oldStop.status, 0, oldStop.stderr)
+
+        let unseenStopStart = context.state.commands.count
+        let unseenStop = runCodexHook(
+            context: context,
+            subcommand: "stop",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"new-turn","cwd":"\#(context.root.path)","hook_event_name":"Stop","last_assistant_message":"new done"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(unseenStop.timedOut, unseenStop.stderr)
+        XCTAssertEqual(unseenStop.status, 0, unseenStop.stderr)
+        let unseenStopCommands = Array(context.state.commands.dropFirst(unseenStopStart))
+
+        XCTAssertTrue(
+            unseenStopCommands.contains { $0.hasPrefix("notify_target_async \(context.workspaceId) \(context.surfaceId) Codex|") },
+            "A Stop with a missed prompt-submit must still notify at idle depth, saw \(unseenStopCommands)"
+        )
+        XCTAssertTrue(
+            unseenStopCommands.contains { $0.hasPrefix("set_status codex ") },
+            "A Stop with a missed prompt-submit must still update Codex status, saw \(unseenStopCommands)"
+        )
+    }
+
     func testManagedCodexSubagentStopDoesNotReplaceResumeBinding() throws {
         let context = try makeClaudeHookContext(name: "codex-managed-resume-guard")
         defer { context.cleanup() }

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -1579,6 +1579,50 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         )
     }
 
+    func testCodexStopWithMissedPromptSubmitClearsTerminalStaleTurn() throws {
+        let context = try makeClaudeHookContext(name: "codex-missed-prompt-stale-turn")
+        defer { context.cleanup() }
+
+        let sessionId = "missed-prompt-stale-turn-session"
+        let transcriptURL = try writeCodexTerminalTranscript(
+            context: context,
+            name: "codex-missed-prompt-stale-turn.jsonl",
+            turnId: "old-turn",
+            eventType: "turn_aborted"
+        )
+        let launchEnvironment = codexLaunchEnvironment(context: context, sessionId: sessionId)
+        startAgentHookMockServerAccepting(context: context, connectionLimit: 32)
+
+        let oldPrompt = runCodexHook(
+            context: context,
+            subcommand: "prompt-submit",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"old-turn","cwd":"\#(context.root.path)","transcript_path":"\#(transcriptURL.path)","hook_event_name":"UserPromptSubmit","prompt":"old"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(oldPrompt.timedOut, oldPrompt.stderr)
+        XCTAssertEqual(oldPrompt.status, 0, oldPrompt.stderr)
+
+        let currentStopStart = context.state.commands.count
+        let currentStop = runCodexHook(
+            context: context,
+            subcommand: "stop",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"current-turn","cwd":"\#(context.root.path)","transcript_path":"\#(transcriptURL.path)","hook_event_name":"Stop","last_assistant_message":"current done"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(currentStop.timedOut, currentStop.stderr)
+        XCTAssertEqual(currentStop.status, 0, currentStop.stderr)
+        let currentStopCommands = Array(context.state.commands.dropFirst(currentStopStart))
+
+        XCTAssertTrue(
+            currentStopCommands.contains { $0.hasPrefix("notify_target_async \(context.workspaceId) \(context.surfaceId) Codex|") },
+            "A Stop after a missed prompt-submit must clear terminal stale turns and notify, saw \(currentStopCommands)"
+        )
+        XCTAssertTrue(
+            currentStopCommands.contains { $0.hasPrefix("set_status codex ") && $0.contains(" Idle ") },
+            "A Stop after a missed prompt-submit must mark Codex idle, saw \(currentStopCommands)"
+        )
+    }
+
     func testCodexStopWithUnseenTurnIdNotSuppressedAtIdleDepth() throws {
         let context = try makeClaudeHookContext(name: "codex-unseen-turn-stop")
         defer { context.cleanup() }

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -188,6 +188,37 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         )
     }
 
+    func testClaudePromptSubmitWithNewTurnDoesNotInheritInterruptedPromptDepth() throws {
+        let context = try makeClaudeHookContext(name: "claude-new-turn-after-interrupted")
+        defer { context.cleanup() }
+
+        let sessionId = "claude-interrupted-same-session"
+        let firstPrompt = runClaudeHook(
+            context: context,
+            arguments: ["hooks", "claude", "prompt-submit"],
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"old-turn","cwd":"\#(context.root.path)","hook_event_name":"PromptSubmit"}"#
+        )
+        XCTAssertFalse(firstPrompt.timedOut, firstPrompt.stderr)
+        XCTAssertEqual(firstPrompt.status, 0, firstPrompt.stderr)
+
+        let secondPromptStart = context.state.commands.count
+        let secondPrompt = runClaudeHook(
+            context: context,
+            arguments: ["hooks", "claude", "prompt-submit"],
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"current-turn","cwd":"\#(context.root.path)","hook_event_name":"PromptSubmit"}"#
+        )
+        XCTAssertFalse(secondPrompt.timedOut, secondPrompt.stderr)
+        XCTAssertEqual(secondPrompt.status, 0, secondPrompt.stderr)
+
+        let secondPromptCommands = Array(context.state.commands.dropFirst(secondPromptStart))
+        XCTAssertTrue(
+            secondPromptCommands.contains {
+                $0.hasPrefix("set_status claude_code Running --icon=bolt.fill --color=#4C8DFF --tab=\(context.workspaceId)")
+            },
+            "Claude must keep treating a new turn as top-level after an interrupted prior prompt, saw \(secondPromptCommands)"
+        )
+    }
+
     func testClaudePromptSubmitResumeBindingPersistsAuthSelectionMarkersWithoutValues() throws {
         let context = try makeClaudeHookContext(name: "claude-resume-env-redaction")
         defer { context.cleanup() }

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -1012,12 +1012,13 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         defer { context.cleanup() }
 
         let sessionId = "depth-only-terminal-reset-session"
-        let transcriptURL = try writeCodexTerminalTranscript(
-            context: context,
-            name: "codex-depth-only-terminal-reset.jsonl",
-            turnId: "old-turn",
-            eventType: "turn_aborted"
-        )
+        let transcriptURL = context.root.appendingPathComponent("codex-depth-only-terminal-reset.jsonl")
+        try [
+            #"{"type":"event_msg","payload":{"type":"task_started","turn_id":"old-parent-turn"}}"#,
+            #"{"type":"event_msg","payload":{"type":"task_started","turn_id":"old-child-turn"}}"#,
+            #"{"type":"event_msg","payload":{"type":"turn_aborted","turn_id":"old-child-turn"}}"#,
+            #"{"type":"event_msg","payload":{"type":"turn_aborted","turn_id":"old-parent-turn"}}"#,
+        ].joined(separator: "\n").write(to: transcriptURL, atomically: true, encoding: .utf8)
         let stateURL = context.root.appendingPathComponent("codex-hook-sessions.json")
         let now = Date().timeIntervalSince1970
         let store: [String: Any] = [

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -1401,6 +1401,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         let launchEnvironment = codexLaunchEnvironment(context: context, sessionId: sessionId)
         startAgentHookMockServerAccepting(context: context, connectionLimit: 64)
 
+        let childStopStart = context.state.commands.count
         let childStop = runCodexHook(
             context: context,
             subcommand: "stop",
@@ -1409,6 +1410,13 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         )
         XCTAssertFalse(childStop.timedOut, childStop.stderr)
         XCTAssertEqual(childStop.status, 0, childStop.stderr)
+        XCTAssertEqual(childStop.stdout.trimmingCharacters(in: .whitespacesAndNewlines), "{}")
+        XCTAssertEqual(childStop.stderr, "")
+        let childStopCommands = Array(context.state.commands.dropFirst(childStopStart))
+        XCTAssertFalse(
+            childStopCommands.contains { $0.hasPrefix("notify_target") || $0.hasPrefix("set_status codex ") },
+            "A late terminal child Stop must stay nested while the depth-only parent remains active, saw \(childStopCommands)"
+        )
 
         let siblingPromptStart = context.state.commands.count
         let siblingPrompt = runCodexHook(
@@ -1686,6 +1694,69 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         XCTAssertTrue(
             currentStopCommands.contains { $0.hasPrefix("set_status codex ") && $0.contains(" Idle ") },
             "A Stop after a missed prompt-submit must mark Codex idle, saw \(currentStopCommands)"
+        )
+    }
+
+    func testCodexStopWithMissedPromptSubmitClearsFullyTerminalStack() throws {
+        let context = try makeClaudeHookContext(name: "codex-missed-prompt-terminal-stack")
+        defer { context.cleanup() }
+
+        let sessionId = "missed-prompt-terminal-stack-session"
+        let transcriptURL = context.root.appendingPathComponent("codex-missed-prompt-terminal-stack.jsonl")
+        try [
+            #"{"type":"turn_context","payload":{"turn_id":"old-parent-turn"}}"#,
+            #"{"type":"event_msg","payload":{"type":"task_started","turn_id":"old-parent-turn"}}"#,
+            #"{"type":"event_msg","payload":{"type":"turn_aborted","turn_id":"old-parent-turn"}}"#,
+            #"{"type":"turn_context","payload":{"turn_id":"old-child-turn"}}"#,
+            #"{"type":"event_msg","payload":{"type":"task_started","turn_id":"old-child-turn"}}"#,
+            #"{"type":"event_msg","payload":{"type":"turn_aborted","turn_id":"old-child-turn"}}"#,
+            #"{"type":"turn_context","payload":{"turn_id":"current-turn"}}"#,
+            #"{"type":"event_msg","payload":{"type":"task_started","turn_id":"current-turn"}}"#,
+        ].joined(separator: "\n").write(to: transcriptURL, atomically: true, encoding: .utf8)
+        let stateURL = context.root.appendingPathComponent("codex-hook-sessions.json")
+        let now = Date().timeIntervalSince1970
+        let store: [String: Any] = [
+            "version": 1,
+            "sessions": [
+                sessionId: [
+                    "sessionId": sessionId,
+                    "workspaceId": context.workspaceId,
+                    "surfaceId": context.surfaceId,
+                    "cwd": context.root.path,
+                    "transcriptPath": transcriptURL.path,
+                    "runtimeStatus": "running",
+                    "activePromptDepth": 2,
+                    "activePromptTurnId": "old-child-turn",
+                    "activePromptTurnIds": ["old-parent-turn", "old-child-turn"],
+                    "startedAt": now,
+                    "updatedAt": now,
+                ],
+            ],
+        ]
+        try JSONSerialization.data(withJSONObject: store, options: [.prettyPrinted])
+            .write(to: stateURL, options: .atomic)
+
+        let launchEnvironment = codexLaunchEnvironment(context: context, sessionId: sessionId)
+        startAgentHookMockServerAccepting(context: context, connectionLimit: 32)
+
+        let currentStopStart = context.state.commands.count
+        let currentStop = runCodexHook(
+            context: context,
+            subcommand: "stop",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"current-turn","cwd":"\#(context.root.path)","transcript_path":"\#(transcriptURL.path)","hook_event_name":"Stop","last_assistant_message":"current done"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(currentStop.timedOut, currentStop.stderr)
+        XCTAssertEqual(currentStop.status, 0, currentStop.stderr)
+        let currentStopCommands = Array(context.state.commands.dropFirst(currentStopStart))
+
+        XCTAssertTrue(
+            currentStopCommands.contains { $0.hasPrefix("notify_target_async \(context.workspaceId) \(context.surfaceId) Codex|") },
+            "A missed prompt-submit Stop must clear a fully terminal stored stack and notify, saw \(currentStopCommands)"
+        )
+        XCTAssertTrue(
+            currentStopCommands.contains { $0.hasPrefix("set_status codex ") && $0.contains(" Idle ") },
+            "A missed prompt-submit Stop must clear a fully terminal stored stack and mark Codex idle, saw \(currentStopCommands)"
         )
     }
 

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -188,37 +188,6 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         )
     }
 
-    func testClaudePromptSubmitWithNewTurnDoesNotInheritInterruptedPromptDepth() throws {
-        let context = try makeClaudeHookContext(name: "claude-new-turn-after-interrupted")
-        defer { context.cleanup() }
-
-        let sessionId = "claude-interrupted-same-session"
-        let firstPrompt = runClaudeHook(
-            context: context,
-            arguments: ["hooks", "claude", "prompt-submit"],
-            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"old-turn","cwd":"\#(context.root.path)","hook_event_name":"PromptSubmit"}"#
-        )
-        XCTAssertFalse(firstPrompt.timedOut, firstPrompt.stderr)
-        XCTAssertEqual(firstPrompt.status, 0, firstPrompt.stderr)
-
-        let secondPromptStart = context.state.commands.count
-        let secondPrompt = runClaudeHook(
-            context: context,
-            arguments: ["hooks", "claude", "prompt-submit"],
-            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"current-turn","cwd":"\#(context.root.path)","hook_event_name":"PromptSubmit"}"#
-        )
-        XCTAssertFalse(secondPrompt.timedOut, secondPrompt.stderr)
-        XCTAssertEqual(secondPrompt.status, 0, secondPrompt.stderr)
-
-        let secondPromptCommands = Array(context.state.commands.dropFirst(secondPromptStart))
-        XCTAssertTrue(
-            secondPromptCommands.contains {
-                $0.hasPrefix("set_status claude_code Running --icon=bolt.fill --color=#4C8DFF --tab=\(context.workspaceId)")
-            },
-            "Claude must keep treating a new turn as top-level after an interrupted prior prompt, saw \(secondPromptCommands)"
-        )
-    }
-
     func testClaudePromptSubmitResumeBindingPersistsAuthSelectionMarkersWithoutValues() throws {
         let context = try makeClaudeHookContext(name: "claude-resume-env-redaction")
         defer { context.cleanup() }

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -513,13 +513,19 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         defer { context.cleanup() }
 
         let sessionId = "interrupted-depth-session"
+        let transcriptURL = try writeCodexTerminalTranscript(
+            context: context,
+            name: "codex-interrupted-turn-depth.jsonl",
+            turnId: "old-turn",
+            eventType: "turn_aborted"
+        )
         let launchEnvironment = codexLaunchEnvironment(context: context, sessionId: sessionId)
         startAgentHookMockServerAccepting(context: context, connectionLimit: 32)
 
         let interruptedPrompt = runCodexHook(
             context: context,
             subcommand: "prompt-submit",
-            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"old-turn","cwd":"\#(context.root.path)","hook_event_name":"UserPromptSubmit","prompt":"interrupted"}"#,
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"old-turn","cwd":"\#(context.root.path)","transcript_path":"\#(transcriptURL.path)","hook_event_name":"UserPromptSubmit","prompt":"interrupted"}"#,
             extraEnvironment: launchEnvironment
         )
         XCTAssertFalse(interruptedPrompt.timedOut, interruptedPrompt.stderr)
@@ -528,7 +534,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         let currentPrompt = runCodexHook(
             context: context,
             subcommand: "prompt-submit",
-            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"current-turn","cwd":"\#(context.root.path)","hook_event_name":"UserPromptSubmit","prompt":"finish now"}"#,
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"current-turn","cwd":"\#(context.root.path)","transcript_path":"\#(transcriptURL.path)","hook_event_name":"UserPromptSubmit","prompt":"finish now"}"#,
             extraEnvironment: launchEnvironment
         )
         XCTAssertFalse(currentPrompt.timedOut, currentPrompt.stderr)
@@ -538,7 +544,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         let currentStop = runCodexHook(
             context: context,
             subcommand: "stop",
-            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"current-turn","cwd":"\#(context.root.path)","hook_event_name":"Stop","last_assistant_message":"current done"}"#,
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"current-turn","cwd":"\#(context.root.path)","transcript_path":"\#(transcriptURL.path)","hook_event_name":"Stop","last_assistant_message":"current done"}"#,
             extraEnvironment: launchEnvironment
         )
         XCTAssertFalse(currentStop.timedOut, currentStop.stderr)
@@ -560,13 +566,19 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         defer { context.cleanup() }
 
         let sessionId = "stale-turn-stop-session"
+        let transcriptURL = try writeCodexTerminalTranscript(
+            context: context,
+            name: "codex-stale-turn-stop.jsonl",
+            turnId: "old-turn",
+            eventType: "turn_aborted"
+        )
         let launchEnvironment = codexLaunchEnvironment(context: context, sessionId: sessionId)
         startAgentHookMockServerAccepting(context: context, connectionLimit: 48)
 
         let oldPrompt = runCodexHook(
             context: context,
             subcommand: "prompt-submit",
-            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"old-turn","cwd":"\#(context.root.path)","hook_event_name":"UserPromptSubmit","prompt":"old"}"#,
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"old-turn","cwd":"\#(context.root.path)","transcript_path":"\#(transcriptURL.path)","hook_event_name":"UserPromptSubmit","prompt":"old"}"#,
             extraEnvironment: launchEnvironment
         )
         XCTAssertFalse(oldPrompt.timedOut, oldPrompt.stderr)
@@ -575,7 +587,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         let currentPrompt = runCodexHook(
             context: context,
             subcommand: "prompt-submit",
-            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"current-turn","cwd":"\#(context.root.path)","hook_event_name":"UserPromptSubmit","prompt":"current"}"#,
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"current-turn","cwd":"\#(context.root.path)","transcript_path":"\#(transcriptURL.path)","hook_event_name":"UserPromptSubmit","prompt":"current"}"#,
             extraEnvironment: launchEnvironment
         )
         XCTAssertFalse(currentPrompt.timedOut, currentPrompt.stderr)
@@ -585,7 +597,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         let staleStop = runCodexHook(
             context: context,
             subcommand: "stop",
-            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"old-turn","cwd":"\#(context.root.path)","hook_event_name":"Stop","last_assistant_message":"old done"}"#,
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"old-turn","cwd":"\#(context.root.path)","transcript_path":"\#(transcriptURL.path)","hook_event_name":"Stop","last_assistant_message":"old done"}"#,
             extraEnvironment: launchEnvironment
         )
         XCTAssertFalse(staleStop.timedOut, staleStop.stderr)
@@ -601,7 +613,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         let currentStop = runCodexHook(
             context: context,
             subcommand: "stop",
-            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"current-turn","cwd":"\#(context.root.path)","hook_event_name":"Stop","last_assistant_message":"current done"}"#,
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"current-turn","cwd":"\#(context.root.path)","transcript_path":"\#(transcriptURL.path)","hook_event_name":"Stop","last_assistant_message":"current done"}"#,
             extraEnvironment: launchEnvironment
         )
         XCTAssertFalse(currentStop.timedOut, currentStop.stderr)
@@ -619,13 +631,19 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         defer { context.cleanup() }
 
         let sessionId = "late-stale-turn-stop-session"
+        let transcriptURL = try writeCodexTerminalTranscript(
+            context: context,
+            name: "codex-late-stale-turn-stop.jsonl",
+            turnId: "old-turn",
+            eventType: "turn_aborted"
+        )
         let launchEnvironment = codexLaunchEnvironment(context: context, sessionId: sessionId)
         startAgentHookMockServerAccepting(context: context, connectionLimit: 48)
 
         let oldPrompt = runCodexHook(
             context: context,
             subcommand: "prompt-submit",
-            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"old-turn","cwd":"\#(context.root.path)","hook_event_name":"UserPromptSubmit","prompt":"old"}"#,
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"old-turn","cwd":"\#(context.root.path)","transcript_path":"\#(transcriptURL.path)","hook_event_name":"UserPromptSubmit","prompt":"old"}"#,
             extraEnvironment: launchEnvironment
         )
         XCTAssertFalse(oldPrompt.timedOut, oldPrompt.stderr)
@@ -634,7 +652,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         let currentPrompt = runCodexHook(
             context: context,
             subcommand: "prompt-submit",
-            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"current-turn","cwd":"\#(context.root.path)","hook_event_name":"UserPromptSubmit","prompt":"current"}"#,
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"current-turn","cwd":"\#(context.root.path)","transcript_path":"\#(transcriptURL.path)","hook_event_name":"UserPromptSubmit","prompt":"current"}"#,
             extraEnvironment: launchEnvironment
         )
         XCTAssertFalse(currentPrompt.timedOut, currentPrompt.stderr)
@@ -644,7 +662,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         let currentStop = runCodexHook(
             context: context,
             subcommand: "stop",
-            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"current-turn","cwd":"\#(context.root.path)","hook_event_name":"Stop","last_assistant_message":"current done"}"#,
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"current-turn","cwd":"\#(context.root.path)","transcript_path":"\#(transcriptURL.path)","hook_event_name":"Stop","last_assistant_message":"current done"}"#,
             extraEnvironment: launchEnvironment
         )
         XCTAssertFalse(currentStop.timedOut, currentStop.stderr)
@@ -659,7 +677,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         let lateStop = runCodexHook(
             context: context,
             subcommand: "stop",
-            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"old-turn","cwd":"\#(context.root.path)","hook_event_name":"Stop","last_assistant_message":"old done"}"#,
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"old-turn","cwd":"\#(context.root.path)","transcript_path":"\#(transcriptURL.path)","hook_event_name":"Stop","last_assistant_message":"old done"}"#,
             extraEnvironment: launchEnvironment
         )
         XCTAssertFalse(lateStop.timedOut, lateStop.stderr)
@@ -4169,6 +4187,20 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
                 "gpt-5.4",
             ]),
         ]
+    }
+
+    private func writeCodexTerminalTranscript(
+        context: ClaudeHookContext,
+        name: String,
+        turnId: String,
+        eventType: String = "turn_complete"
+    ) throws -> URL {
+        let transcriptURL = context.root.appendingPathComponent(name)
+        try [
+            #"{"type":"turn_context","payload":{"turn_id":"\#(turnId)"}}"#,
+            #"{"type":"event_msg","payload":{"type":"\#(eventType)","turn_id":"\#(turnId)"}}"#,
+        ].joined(separator: "\n").write(to: transcriptURL, atomically: true, encoding: .utf8)
+        return transcriptURL
     }
 
     private func runCodexHook(

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -785,6 +785,77 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         )
     }
 
+    func testCodexDepthOnlyHistoricalTerminalDoesNotResetActiveParent() throws {
+        let context = try makeClaudeHookContext(name: "codex-depth-only-history")
+        defer { context.cleanup() }
+
+        let sessionId = "depth-only-history-session"
+        let transcriptURL = context.root.appendingPathComponent("codex-depth-only-history.jsonl")
+        try [
+            #"{"type":"turn_context","payload":{"turn_id":"old-turn"}}"#,
+            #"{"type":"event_msg","payload":{"type":"turn_complete","turn_id":"old-turn"}}"#,
+            #"{"type":"turn_context","payload":{"turn_id":"parent-turn"}}"#,
+            #"{"type":"event_msg","payload":{"type":"task_started","turn_id":"parent-turn"}}"#,
+        ].joined(separator: "\n").write(to: transcriptURL, atomically: true, encoding: .utf8)
+        let stateURL = context.root.appendingPathComponent("codex-hook-sessions.json")
+        let now = Date().timeIntervalSince1970
+        let store: [String: Any] = [
+            "version": 1,
+            "sessions": [
+                sessionId: [
+                    "sessionId": sessionId,
+                    "workspaceId": context.workspaceId,
+                    "surfaceId": context.surfaceId,
+                    "cwd": context.root.path,
+                    "transcriptPath": transcriptURL.path,
+                    "runtimeStatus": "running",
+                    "activePromptDepth": 1,
+                    "startedAt": now,
+                    "updatedAt": now,
+                ],
+            ],
+        ]
+        try JSONSerialization.data(withJSONObject: store, options: [.prettyPrinted])
+            .write(to: stateURL, options: .atomic)
+
+        let launchEnvironment = codexLaunchEnvironment(context: context, sessionId: sessionId)
+        startAgentHookMockServerAccepting(context: context, connectionLimit: 32)
+
+        let childPromptStart = context.state.commands.count
+        let childPrompt = runCodexHook(
+            context: context,
+            subcommand: "prompt-submit",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"child-turn","cwd":"\#(context.root.path)","transcript_path":"\#(transcriptURL.path)","hook_event_name":"UserPromptSubmit","prompt":"child"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(childPrompt.timedOut, childPrompt.stderr)
+        XCTAssertEqual(childPrompt.status, 0, childPrompt.stderr)
+        let childPromptCommands = Array(context.state.commands.dropFirst(childPromptStart))
+        XCTAssertFalse(
+            childPromptCommands.contains { self.jsonObject($0)?["method"] as? String == "surface.resume.set" },
+            "A historical terminal turn must not make an active depth-only parent look finished, saw \(childPromptCommands)"
+        )
+        XCTAssertFalse(
+            childPromptCommands.contains { $0.hasPrefix("set_status codex Running ") },
+            "A historical terminal turn must not let the child rewrite parent Running status, saw \(childPromptCommands)"
+        )
+
+        let childStopStart = context.state.commands.count
+        let childStop = runCodexHook(
+            context: context,
+            subcommand: "stop",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"child-turn","cwd":"\#(context.root.path)","transcript_path":"\#(transcriptURL.path)","hook_event_name":"Stop","last_assistant_message":"child done"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(childStop.timedOut, childStop.stderr)
+        XCTAssertEqual(childStop.status, 0, childStop.stderr)
+        let childStopCommands = Array(context.state.commands.dropFirst(childStopStart))
+        XCTAssertFalse(
+            childStopCommands.contains { $0.hasPrefix("notify_target") || $0.hasPrefix("set_status codex ") },
+            "A historical terminal turn must not let a child Stop notify while the parent is active, saw \(childStopCommands)"
+        )
+    }
+
     func testCodexDepthOnlyParentStopNotifiesAfterChildTurnStops() throws {
         let context = try makeClaudeHookContext(name: "codex-depth-only-parent-stop")
         defer { context.cleanup() }

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -863,6 +863,72 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         )
     }
 
+    func testCodexStopPrunesLateTerminalPriorTurnBeforeCurrentStop() throws {
+        let context = try makeClaudeHookContext(name: "codex-late-terminal-prior-turn")
+        defer { context.cleanup() }
+
+        let sessionId = "late-terminal-prior-turn-session"
+        let transcriptURL = context.root.appendingPathComponent("codex-late-terminal-prior-turn.jsonl")
+        try [
+            #"{"type":"turn_context","payload":{"turn_id":"old-turn"}}"#,
+            #"{"type":"event_msg","payload":{"type":"task_started","turn_id":"old-turn"}}"#,
+        ].joined(separator: "\n").write(to: transcriptURL, atomically: true, encoding: .utf8)
+        let launchEnvironment = codexLaunchEnvironment(context: context, sessionId: sessionId)
+        startAgentHookMockServerAccepting(context: context, connectionLimit: 64)
+
+        let oldPrompt = runCodexHook(
+            context: context,
+            subcommand: "prompt-submit",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"old-turn","cwd":"\#(context.root.path)","transcript_path":"\#(transcriptURL.path)","hook_event_name":"UserPromptSubmit","prompt":"old"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(oldPrompt.timedOut, oldPrompt.stderr)
+        XCTAssertEqual(oldPrompt.status, 0, oldPrompt.stderr)
+
+        let currentPromptStart = context.state.commands.count
+        let currentPrompt = runCodexHook(
+            context: context,
+            subcommand: "prompt-submit",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"current-turn","cwd":"\#(context.root.path)","transcript_path":"\#(transcriptURL.path)","hook_event_name":"UserPromptSubmit","prompt":"current"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(currentPrompt.timedOut, currentPrompt.stderr)
+        XCTAssertEqual(currentPrompt.status, 0, currentPrompt.stderr)
+        let currentPromptCommands = Array(context.state.commands.dropFirst(currentPromptStart))
+        XCTAssertFalse(
+            currentPromptCommands.contains { self.jsonObject($0)?["method"] as? String == "surface.resume.set" },
+            "Before the late terminal transcript update, the current prompt should still look nested, saw \(currentPromptCommands)"
+        )
+
+        try [
+            #"{"type":"turn_context","payload":{"turn_id":"old-turn"}}"#,
+            #"{"type":"event_msg","payload":{"type":"task_started","turn_id":"old-turn"}}"#,
+            #"{"type":"event_msg","payload":{"type":"turn_aborted","turn_id":"old-turn"}}"#,
+            #"{"type":"turn_context","payload":{"turn_id":"current-turn"}}"#,
+            #"{"type":"event_msg","payload":{"type":"task_started","turn_id":"current-turn"}}"#,
+        ].joined(separator: "\n").write(to: transcriptURL, atomically: true, encoding: .utf8)
+
+        let currentStopStart = context.state.commands.count
+        let currentStop = runCodexHook(
+            context: context,
+            subcommand: "stop",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"current-turn","cwd":"\#(context.root.path)","transcript_path":"\#(transcriptURL.path)","hook_event_name":"Stop","last_assistant_message":"current done"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(currentStop.timedOut, currentStop.stderr)
+        XCTAssertEqual(currentStop.status, 0, currentStop.stderr)
+        let currentStopCommands = Array(context.state.commands.dropFirst(currentStopStart))
+
+        XCTAssertTrue(
+            currentStopCommands.contains { $0.hasPrefix("notify_target_async \(context.workspaceId) \(context.surfaceId) Codex|") },
+            "A late terminal prior turn must not suppress the current top-level completion notification, saw \(currentStopCommands)"
+        )
+        XCTAssertTrue(
+            currentStopCommands.contains { $0.hasPrefix("set_status codex ") && $0.contains(" Idle ") },
+            "A late terminal prior turn must not leave Codex marked running after the current Stop, saw \(currentStopCommands)"
+        )
+    }
+
     func testCodexTerminalNestedChildDoesNotClearParentTurnStack() throws {
         let context = try makeClaudeHookContext(name: "codex-terminal-child-stack")
         defer { context.cleanup() }

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -658,6 +658,70 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         )
     }
 
+    func testCodexTerminalInterruptedStackClearsBeforeCurrentPrompt() throws {
+        let context = try makeClaudeHookContext(name: "codex-terminal-stack-reset")
+        defer { context.cleanup() }
+
+        let sessionId = "terminal-stack-reset-session"
+        let transcriptURL = context.root.appendingPathComponent("codex-terminal-stack-reset.jsonl")
+        try [
+            #"{"type":"turn_context","payload":{"turn_id":"parent-turn"}}"#,
+            #"{"type":"event_msg","payload":{"type":"turn_aborted","turn_id":"parent-turn"}}"#,
+            #"{"type":"turn_context","payload":{"turn_id":"child-turn"}}"#,
+            #"{"type":"event_msg","payload":{"type":"turn_aborted","turn_id":"child-turn"}}"#,
+        ].joined(separator: "\n").write(to: transcriptURL, atomically: true, encoding: .utf8)
+        let launchEnvironment = codexLaunchEnvironment(context: context, sessionId: sessionId)
+        startAgentHookMockServerAccepting(context: context, connectionLimit: 64)
+
+        let parentPrompt = runCodexHook(
+            context: context,
+            subcommand: "prompt-submit",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"parent-turn","cwd":"\#(context.root.path)","hook_event_name":"UserPromptSubmit","prompt":"parent"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(parentPrompt.timedOut, parentPrompt.stderr)
+        XCTAssertEqual(parentPrompt.status, 0, parentPrompt.stderr)
+
+        let childPrompt = runCodexHook(
+            context: context,
+            subcommand: "prompt-submit",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"child-turn","cwd":"\#(context.root.path)","hook_event_name":"UserPromptSubmit","prompt":"child"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(childPrompt.timedOut, childPrompt.stderr)
+        XCTAssertEqual(childPrompt.status, 0, childPrompt.stderr)
+
+        let currentPromptStart = context.state.commands.count
+        let currentPrompt = runCodexHook(
+            context: context,
+            subcommand: "prompt-submit",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"current-turn","cwd":"\#(context.root.path)","transcript_path":"\#(transcriptURL.path)","hook_event_name":"UserPromptSubmit","prompt":"current"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(currentPrompt.timedOut, currentPrompt.stderr)
+        XCTAssertEqual(currentPrompt.status, 0, currentPrompt.stderr)
+        let currentPromptCommands = Array(context.state.commands.dropFirst(currentPromptStart))
+        XCTAssertTrue(
+            currentPromptCommands.contains { self.jsonObject($0)?["method"] as? String == "surface.resume.set" },
+            "A current prompt after a fully terminal interrupted stack must become top-level, saw \(currentPromptCommands)"
+        )
+
+        let currentStopStart = context.state.commands.count
+        let currentStop = runCodexHook(
+            context: context,
+            subcommand: "stop",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"current-turn","cwd":"\#(context.root.path)","transcript_path":"\#(transcriptURL.path)","hook_event_name":"Stop","last_assistant_message":"current done"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(currentStop.timedOut, currentStop.stderr)
+        XCTAssertEqual(currentStop.status, 0, currentStop.stderr)
+        let currentStopCommands = Array(context.state.commands.dropFirst(currentStopStart))
+        XCTAssertTrue(
+            currentStopCommands.contains { $0.hasPrefix("notify_target_async \(context.workspaceId) \(context.surfaceId) Codex|") },
+            "A current Stop after a fully terminal interrupted stack must notify, saw \(currentStopCommands)"
+        )
+    }
+
     func testCodexDepthOnlyLegacyNestingRemainsNestedWhenTurnIdsAppear() throws {
         let context = try makeClaudeHookContext(name: "codex-depth-only-nested")
         defer { context.cleanup() }
@@ -718,6 +782,78 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         XCTAssertFalse(
             childStopCommands.contains { $0.hasPrefix("notify_target") || $0.hasPrefix("set_status codex ") },
             "A legacy depth-only nested Stop that first gains a turn_id must remain nested, saw \(childStopCommands)"
+        )
+    }
+
+    func testCodexDepthOnlyParentStopNotifiesAfterChildTurnStops() throws {
+        let context = try makeClaudeHookContext(name: "codex-depth-only-parent-stop")
+        defer { context.cleanup() }
+
+        let sessionId = "depth-only-parent-stop-session"
+        let stateURL = context.root.appendingPathComponent("codex-hook-sessions.json")
+        let now = Date().timeIntervalSince1970
+        let store: [String: Any] = [
+            "version": 1,
+            "sessions": [
+                sessionId: [
+                    "sessionId": sessionId,
+                    "workspaceId": context.workspaceId,
+                    "surfaceId": context.surfaceId,
+                    "cwd": context.root.path,
+                    "runtimeStatus": "running",
+                    "activePromptDepth": 1,
+                    "startedAt": now,
+                    "updatedAt": now,
+                ],
+            ],
+        ]
+        try JSONSerialization.data(withJSONObject: store, options: [.prettyPrinted])
+            .write(to: stateURL, options: .atomic)
+
+        let launchEnvironment = codexLaunchEnvironment(context: context, sessionId: sessionId)
+        startAgentHookMockServerAccepting(context: context, connectionLimit: 48)
+
+        let childPrompt = runCodexHook(
+            context: context,
+            subcommand: "prompt-submit",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"child-turn","cwd":"\#(context.root.path)","hook_event_name":"UserPromptSubmit","prompt":"child"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(childPrompt.timedOut, childPrompt.stderr)
+        XCTAssertEqual(childPrompt.status, 0, childPrompt.stderr)
+
+        let childStopStart = context.state.commands.count
+        let childStop = runCodexHook(
+            context: context,
+            subcommand: "stop",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"child-turn","cwd":"\#(context.root.path)","hook_event_name":"Stop","last_assistant_message":"child done"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(childStop.timedOut, childStop.stderr)
+        XCTAssertEqual(childStop.status, 0, childStop.stderr)
+        let childStopCommands = Array(context.state.commands.dropFirst(childStopStart))
+        XCTAssertFalse(
+            childStopCommands.contains { $0.hasPrefix("notify_target") || $0.hasPrefix("set_status codex ") },
+            "The child Stop should close only the child depth, saw \(childStopCommands)"
+        )
+
+        let parentStopStart = context.state.commands.count
+        let parentStop = runCodexHook(
+            context: context,
+            subcommand: "stop",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"parent-turn","cwd":"\#(context.root.path)","hook_event_name":"Stop","last_assistant_message":"parent done"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(parentStop.timedOut, parentStop.stderr)
+        XCTAssertEqual(parentStop.status, 0, parentStop.stderr)
+        let parentStopCommands = Array(context.state.commands.dropFirst(parentStopStart))
+        XCTAssertTrue(
+            parentStopCommands.contains { $0.hasPrefix("notify_target_async \(context.workspaceId) \(context.surfaceId) Codex|") },
+            "The depth-only parent Stop must notify after its child turn stops, saw \(parentStopCommands)"
+        )
+        XCTAssertTrue(
+            parentStopCommands.contains { $0.hasPrefix("set_status codex ") && $0.contains(" Idle ") },
+            "The depth-only parent Stop must mark Codex idle, saw \(parentStopCommands)"
         )
     }
 


### PR DESCRIPTION
Summary
- Track Codex hook prompt depth by turn id so stale interrupted turns do not suppress later top-level Stop notifications
- Preserve nested prompt suppression when no turn boundary proves a new top-level turn
- Add regression coverage for interrupted prior turn depth

Verification
- git diff --check HEAD~2..HEAD
- ./scripts/reload.sh --tag codnotif
- isolated codnotif CLI hook repro: interrupted old turn then current Stop produced one notify_target_async and one Idle status
- isolated codnotif CLI hook repro: nested child Stop produced no notification, parent Stop produced one notification

Dogfood
- Tagged app built: http://127.0.0.1:17320/codnotif

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4583"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782042854&installation_id=133855650&pr_number=4583&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4583&signature=d00bb23d20b29e777af5b88bfc5302e41ca1cdd0cba2d72310d2a317955511f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes prompt/Stop nesting and notification suppression logic by persisting a per-`turn_id` prompt stack and pruning terminal turns via transcript parsing, which could affect when notifications/status updates fire across agents. Large, stateful behavioral change but scoped to agent-hook session tracking and covered by expanded integration regression tests.
> 
> **Overview**
> Ensures Codex (and other agent hooks) don’t lose top-level `Stop` notifications/status updates due to *stale or interrupted prior turns* by tracking prompt nesting with a persisted `turn_id` stack instead of relying solely on `activePromptDepth`.
> 
> Adds logic to prune/mark terminal turns (including late terminal updates) by scanning the Codex transcript, keeps a bounded history of terminal turn IDs, and updates `prompt-submit`/`stop` handling to reconcile legacy depth-only state with turn-aware stacks.
> 
> Expands `CLINotifyProcessIntegrationRegressionTests` with extensive scenarios around nested prompts, legacy events missing `turn_id`, interrupted/stale turns, and transcript-driven terminal detection to prevent regressions in notification suppression and Idle transitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b312130e2f0de1242f8d1c42160bea21a9d8344b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Codex Stop notifications after interrupted, unseen, stale, or late‑terminal turns so only the active top‑level Stop notifies and Codex returns to Idle. Tracks per‑`turn_id` prompt stacks, prunes terminal turns from the transcript (including late updates), and clears depth when the stack is fully terminal.

- **Bug Fixes**
  - Track nested prompts per `turn_id`; bridge legacy depth and anonymous prompts; on prompt/Stop, scan the transcript and drop terminal or stale prior turns before classifying the current event.
  - Ignore stale/late Stops from older turns; allow notification at idle depth when a prompt‑submit was missed; emit one notification for the active turn and set status to Idle; when pruning removes all turns, clear stored depth.
  - Preserve nesting behavior: generic agents keep parent/child semantics; legacy Stops without `turn_id` close only the child and don’t notify; a Stop with a new `turn_id` under a known parent pops anonymous child depth without notifying.

<sup>Written for commit b312130e2f0de1242f8d1c42160bea21a9d8344b. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4583?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prompt-turn tracking using explicit turn IDs so nested prompts and stops maintain correct parent/child relationships; prior depth-only histories are bridged and stacks are preserved or cleared appropriately.
  * Stale or late stop/terminal events no longer suppress or duplicate newer completion notifications.

* **Tests**
  * Added extensive regression tests (including transcript-based scenarios) covering nested/legacy nesting, stop timing, terminal flows, and notification correctness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4583?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->