### PR TITLE
Fix Vault resume for non-ASCII paths

### DIFF
--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -1,8 +1,14 @@
 import Foundation
 import CMUXAgentLaunch
 
-fileprivate func shellSingleQuoted(_ value: String) -> String {
-    "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
+fileprivate func shellQuoted(_ value: String) -> String {
+    if value.utf8.contains(where: { $0 >= 0x80 }) {
+        let octalBytes = value.utf8
+            .map { String(format: #"\%03o"#, Int($0)) }
+            .joined()
+        return #""$(printf '"# + octalBytes + #"')""#
+    }
+    return "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
 }
 
 enum AgentResumeCommandBuilder {
@@ -92,12 +98,12 @@ enum AgentResumeCommandBuilder {
         }
         commandParts.append(contentsOf: argv)
 
-        var shellCommand = commandParts.map(shellSingleQuoted).joined(separator: " ")
+        var shellCommand = commandParts.map(shellQuoted).joined(separator: " ")
         let cwd = !includeWorkingDirectoryPrefix || customRegistration?.cwd == .ignore
             ? nil
             : normalized(workingDirectory ?? launchCommand?.workingDirectory)
         if let cwd {
-            shellCommand = "cd \(shellSingleQuoted(cwd)) && \(shellCommand)"
+            shellCommand = "cd \(shellQuoted(cwd)) && \(shellCommand)"
         }
         return shellCommand
     }
@@ -596,7 +602,7 @@ struct SessionRestorableAgentSnapshot: Codable, Sendable {
             return nil
         }
 
-        let scriptInput = "/bin/zsh \(shellSingleQuoted(scriptURL.path))\n"
+        let scriptInput = "/bin/zsh \(shellQuoted(scriptURL.path))\n"
         return scriptInput.utf8.count <= Self.maxInlineStartupInputBytes ? scriptInput : nil
     }
 }

--- a/Sources/SessionIndexModels.swift
+++ b/Sources/SessionIndexModels.swift
@@ -437,11 +437,21 @@ struct SessionEntry: Identifiable, Hashable {
 
     /// Single-quote a value for safe shell injection. Escapes embedded single quotes.
     static func shellQuote(_ value: String) -> String {
+        if value.utf8.contains(where: { $0 >= 0x80 }) {
+            return shellPrintfQuote(value)
+        }
         if value.range(of: "[^A-Za-z0-9_./:=+-]", options: .regularExpression) == nil {
             return value
         }
         let escaped = value.replacingOccurrences(of: "'", with: #"'\''"#)
         return "'\(escaped)'"
+    }
+
+    private static func shellPrintfQuote(_ value: String) -> String {
+        let octalBytes = value.utf8
+            .map { String(format: #"\%03o"#, Int($0)) }
+            .joined()
+        return #""$(printf '"# + octalBytes + #"')""#
     }
 
     var displayTitle: String {

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -1948,6 +1948,52 @@ final class SocketListenerAcceptPolicyTests: XCTestCase {
         )
     }
 
+    func testRestorableAgentResumeCommandEscapesNonAsciiWorkingDirectoryAsAsciiShellInput() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-agent-resume-\(UUID().uuidString)", isDirectory: true)
+        let cwdURL = root
+            .appendingPathComponent("中文路径", isDirectory: true)
+            .appendingPathComponent("uam-service", isDirectory: true)
+        try FileManager.default.createDirectory(at: cwdURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let snapshot = SessionRestorableAgentSnapshot(
+            kind: .claude,
+            sessionId: "claude-session-123",
+            workingDirectory: cwdURL.path,
+            launchCommand: AgentLaunchCommandSnapshot(
+                launcher: "claude",
+                executablePath: "/opt/Claude Code/bin/claude",
+                arguments: [
+                    "/opt/Claude Code/bin/claude",
+                    "--model",
+                    "sonnet"
+                ],
+                workingDirectory: cwdURL.path,
+                environment: ["CLAUDE_CONFIG_DIR": cwdURL.path],
+                capturedAt: 123,
+                source: "environment"
+            )
+        )
+
+        let command = try XCTUnwrap(snapshot.resumeCommand)
+        XCTAssertTrue(command.utf8.allSatisfy { $0 < 0x80 })
+        let separator = try XCTUnwrap(command.range(of: " && "))
+        let cdCommand = String(command[..<separator.lowerBound])
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/zsh")
+        process.arguments = ["-fc", "\(cdCommand) && pwd"]
+        let output = Pipe()
+        process.standardOutput = output
+        try process.run()
+        process.waitUntilExit()
+        let data = output.fileHandleForReading.readDataToEndOfFile()
+
+        XCTAssertEqual(process.terminationStatus, 0)
+        XCTAssertEqual(String(data: data, encoding: .utf8)?.trimmingCharacters(in: .newlines), cwdURL.path)
+    }
+
     func testSessionEntryClaudeResumeCommandChangesToSessionCwdBeforeResume() throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-claude-resume-\(UUID().uuidString)", isDirectory: true)
@@ -1984,6 +2030,51 @@ final class SocketListenerAcceptPolicyTests: XCTestCase {
             entry.resumeCommand,
             "cd /Users/tiffanysun/fun && claude --resume a22293b7-bcef-4707-8439-2f538c8517a4"
         )
+    }
+
+    func testSessionEntryClaudeResumeCommandEscapesNonAsciiCwdAsAsciiShellInput() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-claude-resume-\(UUID().uuidString)", isDirectory: true)
+        let cwdURL = root
+            .appendingPathComponent("中文路径", isDirectory: true)
+            .appendingPathComponent("uam-service", isDirectory: true)
+        try FileManager.default.createDirectory(at: cwdURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let entry = SessionEntry(
+            id: "claude:4d8cfb79-ef17-41a7-a0ac-2f0c25ac1519",
+            agent: .claude,
+            sessionId: "4d8cfb79-ef17-41a7-a0ac-2f0c25ac1519",
+            title: "resume me",
+            cwd: cwdURL.path,
+            gitBranch: nil,
+            pullRequest: nil,
+            modified: Date(timeIntervalSince1970: 0),
+            fileURL: nil,
+            specifics: .claude(
+                model: "gpt-5.5",
+                permissionMode: "bypassPermissions",
+                configDirectoryForResume: nil
+            )
+        )
+
+        let command = try XCTUnwrap(entry.resumeCommand)
+        XCTAssertTrue(
+            command.utf8.allSatisfy { $0 < 0x80 },
+            "Startup input for Ghostty must stay ASCII-only so UTF-8 paths are reconstructed by the shell instead of being mojibaked before execution."
+        )
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/zsh")
+        process.arguments = ["-fc", "cd \(SessionEntry.shellQuote(cwdURL.path)) && pwd"]
+        let output = Pipe()
+        process.standardOutput = output
+        try process.run()
+        process.waitUntilExit()
+        let data = output.fileHandleForReading.readDataToEndOfFile()
+
+        XCTAssertEqual(process.terminationStatus, 0)
+        XCTAssertEqual(String(data: data, encoding: .utf8)?.trimmingCharacters(in: .newlines), cwdURL.path)
     }
 
     func testRestorableAgentStartupInputUsesInlineCommandWhenShort() {


### PR DESCRIPTION
## Summary
- Encode non-ASCII Vault resume command arguments as ASCII-only shell input before terminal startup injection.
- Apply the same quoting behavior to restorable agent resume commands.
- Add regression coverage for Claude Vault resume and restorable agent resume with non-ASCII working directories.

Fixes #4587

## Test plan
- Not run locally: `./scripts/reload.sh --tag fix-claude-nonascii-resume` is blocked because `zig` is not installed.
- Not run locally: tagged `xcodebuild` is blocked because `xcode-select` points to Command Line Tools instead of a full Xcode install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4588"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782047937&installation_id=133855650&pr_number=4588&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4588&signature=b2e641f2ec210b427fc092726d20c8f43aa44adc10fd6d5d5d075537a680c270"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes resume commands for Claude Vault and restorable agents when paths contain non-ASCII characters. Arguments and CWD are now encoded as ASCII-only shell input to prevent mojibake during terminal startup injection. Fixes #4587

- **Bug Fixes**
  - Added ASCII-safe quoting: non-ASCII bytes are emitted via `$(printf '\ooo')`, otherwise single-quoted; used in `AgentResumeCommandBuilder` and `SessionEntry.shellQuote`.
  - Applied the same quoting to inline `/bin/zsh` script startup input for restorable agents.
  - Added regression tests to verify commands are ASCII-only and `cd` resolves the correct non-ASCII path.

<sup>Written for commit e7e2564e0ddab4ce84b18ce1a7871fbea650755c. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4588?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shell command generation to properly handle non-ASCII characters in file paths and working directories, ensuring resume/fork operations work correctly with international path names.

* **Tests**
  * Added test coverage for resume commands with non-ASCII working directory paths to verify proper character escaping and execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4588?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->