### PR TITLE
fix: sidebar PR detection for fork-based PRs

### DIFF
--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -881,10 +881,9 @@ _cmux_report_pr_for_path() {
     [[ -n "$CMUX_TAB_ID" ]] || return 0
     [[ -n "$CMUX_PANEL_ID" ]] || return 0
 
-    local branch repo_slug="" gh_output="" gh_error="" err_file="" gh_status number state url status_opt=""
+    local branch gh_output="" gh_error="" err_file="" gh_status number state url status_opt=""
     local now prefix="" branch_file="" repo_file="" result_file="" timestamp_file="" no_pr_branch_file=""
     local cache_branch="" cache_result="" cache_no_pr_branch=""
-    local -a gh_repo_args=()
     now="$(_cmux_now)"
     branch="$(_cmux_git_branch_for_path "$repo_path" 2>/dev/null || true)"
     if [[ -z "$branch" ]] || ! command -v gh >/dev/null 2>&1; then
@@ -914,17 +913,14 @@ _cmux_report_pr_for_path() {
         _cmux_pr_debug_log "$branch" "cache-miss"
     fi
 
-    repo_slug="$(_cmux_github_repo_slug_for_path "$repo_path")"
-    if [[ -n "$repo_slug" ]]; then
-        gh_repo_args=(--repo "$repo_slug")
-    fi
-
+    # Don't pass --repo to gh; let it resolve the repository from git tracking
+    # info in the working directory.  This handles fork-based PRs where origin
+    # points to the fork but the PR targets the upstream (parent) repo.
     err_file="$(/usr/bin/mktemp "${TMPDIR:-/tmp}/cmux-gh-pr-view.XXXXXX" 2>/dev/null || true)"
     [[ -n "$err_file" ]] || return 1
     gh_output="$(
         builtin cd "$repo_path" 2>/dev/null \
             && gh pr view "$branch" \
-                "${gh_repo_args[@]}" \
                 --json number,state,url \
                 --jq '[.number, .state, .url] | @tsv' \
                 2>"$err_file"

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -1013,12 +1013,10 @@ _cmux_report_pr_for_path() {
     [[ -n "$CMUX_TAB_ID" ]] || return 0
     [[ -n "$CMUX_PANEL_ID" ]] || return 0
 
-    local branch repo_slug="" gh_output="" gh_error="" err_file="" number state url status_opt="" gh_status
+    local branch gh_output="" gh_error="" err_file="" number state url status_opt="" gh_status
     local now="${EPOCHSECONDS:-$SECONDS}"
     local prefix="" branch_file="" repo_file="" result_file="" timestamp_file="" no_pr_branch_file=""
     local cache_branch="" cache_result="" cache_no_pr_branch=""
-    local -a gh_repo_args
-    gh_repo_args=()
     branch="$(_cmux_git_branch_for_path "$repo_path" 2>/dev/null || true)"
     if [[ -z "$branch" ]] || ! command -v gh >/dev/null 2>&1; then
         _cmux_pr_debug_log "$branch" "cache-miss:clear"
@@ -1047,17 +1045,14 @@ _cmux_report_pr_for_path() {
         _cmux_pr_debug_log "$branch" "cache-miss"
     fi
 
-    repo_slug="$(_cmux_github_repo_slug_for_path "$repo_path")"
-    if [[ -n "$repo_slug" ]]; then
-        gh_repo_args=(--repo "$repo_slug")
-    fi
-
+    # Don't pass --repo to gh; let it resolve the repository from git tracking
+    # info in the working directory.  This handles fork-based PRs where origin
+    # points to the fork but the PR targets the upstream (parent) repo.
     err_file="$(/usr/bin/mktemp "${TMPDIR:-/tmp}/cmux-gh-pr-view.XXXXXX" 2>/dev/null || true)"
     [[ -n "$err_file" ]] || return 1
     gh_output="$(
         builtin cd "$repo_path" 2>/dev/null \
             && gh pr view "$branch" \
-                "${gh_repo_args[@]}" \
                 --json number,state,url \
                 --jq '[.number, .state, .url] | @tsv' \
                 2>"$err_file"


### PR DESCRIPTION
## Summary

Fixes #4586 — sidebar shows `pr=none` for any workspace where the open PR comes from a fork.

## Root cause

`_cmux_report_pr_for_path` in the zsh/bash shell integrations calls:
```
gh pr view "$branch" --repo "$repo_slug"
```
where `$repo_slug` is derived from the `origin` remote URL. For fork-based workflows where `origin` points to the user's fork (e.g. `Kiryous/kibana`), this queries the fork repo — which has no PRs — instead of the upstream (`elastic/kibana`).

## Fix

Drop `--repo` from the `gh pr view` call. Since we already `cd` into the repo working directory, `gh` can resolve the correct repository — including fork→parent relationships — via git tracking info automatically.

Changed in both `cmux-zsh-integration.zsh` and `cmux-bash-integration.bash`.

## Testing

- Both shell scripts pass syntax validation (`zsh -n`, `bash -n`)
- The `_cmux_github_repo_slug_for_path` utility function (and its tests) are unchanged
- No automated regression test added: verifying this fix requires a real fork-based repo with a cross-repo PR and live GitHub API access, which is not practical in the existing shell integration test harness. Manual verification: `gh pr view <branch>` from a fork worktree correctly finds cross-repo PRs while `gh pr view <branch> --repo <fork>` does not.