### PR TITLE
Fix markdown files with trailing punctuation detected as URLs

### DIFF
--- a/Sources/CommandClickFileOpenRouter.swift
+++ b/Sources/CommandClickFileOpenRouter.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 
 enum CommandClickFileOpenRouter {
@@ -21,5 +22,69 @@ enum CommandClickFileOpenRouter {
             return false
         }
         return workspace.openOrFocusFilePreviewSplit(from: sourcePanelId, filePath: filePath) != nil
+    }
+
+    /// Resolve the working directory for a terminal surface, preferring the
+    /// per-panel directory, then the panel's requested working directory,
+    /// then the workspace-level directory.
+    @MainActor
+    static func resolveWorkingDirectory(
+        workspace: Workspace,
+        surfaceId: UUID
+    ) -> String? {
+        if let dir = workspace.panelDirectories[surfaceId]?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+           !dir.isEmpty {
+            return dir
+        }
+        if let dir = workspace.terminalPanel(for: surfaceId)?
+            .requestedWorkingDirectory?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+           !dir.isEmpty {
+            return dir
+        }
+        let dir = workspace.currentDirectory
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return dir.isEmpty ? nil : dir
+    }
+
+    /// Schedule a file open in cmux, deferred to the next runloop tick.
+    ///
+    /// Ghostty's `Surface.openUrl` holds an internal `os_unfair_lock` when it
+    /// dispatches into Swift; opening a new panel synchronously re-enters
+    /// Ghostty and deadlocks (#3370). This helper defers the split creation
+    /// via `DispatchQueue.main.async` and re-validates the workspace and path
+    /// at dispatch time (TOCTOU). When routing fails, `fallback` is called so
+    /// the caller can open the file externally.
+    @MainActor
+    static func deferredOpenFileInCmux(
+        workspace: Workspace,
+        preferredWorkspaceId: UUID,
+        surfaceId: UUID,
+        filePath: String,
+        fallback: (@MainActor @Sendable () -> Void)? = nil
+    ) {
+        DispatchQueue.main.async {
+            let resolvedWorkspace = AppDelegate.shared?.workspaceContainingPanel(
+                panelId: surfaceId,
+                preferredWorkspaceId: preferredWorkspaceId
+            )?.workspace ?? workspace
+            guard !resolvedWorkspace.isRemoteTerminalSurface(surfaceId) else {
+                fallback?()
+                return
+            }
+            guard shouldRouteInCmux(path: filePath) else {
+                fallback?()
+                return
+            }
+            if openInCmux(
+                workspace: resolvedWorkspace,
+                sourcePanelId: surfaceId,
+                filePath: filePath
+            ) {
+                return
+            }
+            fallback?()
+        }
     }
 }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -4350,6 +4350,48 @@ class GhosttyApp {
             #if DEBUG
             cmuxDebugLog("link.openURL raw=\(urlString)")
             #endif
+
+            // Try file-path resolution before URL classification.
+            // Ghostty's link detection can match relative file paths that
+            // contain slashes or dots (e.g. "docs/spec.md.") as URLs.
+            // Attempt to resolve the raw string as a local file first
+            // (with trailing-punctuation trimming via cmuxResolveQuicklookPath).
+            // If the file exists and cmux can handle it, route through the
+            // file viewer instead of the browser.
+            let trimmedUrlString = urlString.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmedUrlString.isEmpty,
+               !NSString(string: trimmedUrlString).isAbsolutePath,
+               URL(string: trimmedUrlString)?.scheme == nil {
+                let filePathRouted: Bool = performOnMain {
+                    guard let termSurface = surfaceView.terminalSurface,
+                          let workspace = termSurface.owningWorkspace(),
+                          !workspace.isRemoteTerminalSurface(termSurface.id) else {
+                        return false
+                    }
+                    let cwd = CommandClickFileOpenRouter.resolveWorkingDirectory(
+                        workspace: workspace,
+                        surfaceId: termSurface.id
+                    )
+                    guard let resolvedPath = cmuxResolveQuicklookPath(trimmedUrlString, cwd: cwd),
+                          CommandClickFileOpenRouter.shouldRouteInCmux(path: resolvedPath) else {
+                        return false
+                    }
+                    #if DEBUG
+                    cmuxDebugLog("link.openURL resolvedAsFilePath=\(resolvedPath)")
+                    #endif
+                    CommandClickFileOpenRouter.deferredOpenFileInCmux(
+                        workspace: workspace,
+                        preferredWorkspaceId: workspace.id,
+                        surfaceId: termSurface.id,
+                        filePath: resolvedPath
+                    )
+                    return true
+                }
+                if filePathRouted {
+                    return true
+                }
+            }
+
             guard let target = resolveTerminalOpenURLTarget(urlString) else {
                 #if DEBUG
                 cmuxDebugLog("link.openURL resolve failed, returning false")
@@ -4368,65 +4410,18 @@ class GhosttyApp {
                fileURLHost == nil || fileURLHost?.isEmpty == true || fileURLHost == "localhost" {
                 let fileURL = target.url
                 let routed: Bool = performOnMain {
-                    // Remote-surface guard runs before shouldRoute so we never
-                    // stat a local path on the main thread for a remote workspace.
                     guard let termSurface = surfaceView.terminalSurface,
                           let workspace = termSurface.owningWorkspace(),
                           !workspace.isRemoteTerminalSurface(termSurface.id),
                           CommandClickFileOpenRouter.shouldRouteInCmux(path: fileURL.path) else {
                         return false
                     }
-                    // Defer the split creation. Ghostty's Surface.openUrl holds
-                    // an internal os_unfair_lock when it dispatches into this
-                    // Swift handler; opening a new panel synchronously triggers
-                    // Surface.encodeKey on the focus path, which tries to
-                    // acquire the same lock and aborts (recursive os_unfair_lock
-                    // — see crash reports referenced in #3370).
-                    //
-                    // CAVEAT — timing-based mitigation: this works because the
-                    // Ghostty C side currently releases the surface lock within
-                    // the same runloop cycle that dispatches this callback,
-                    // which is an undocumented Ghostty implementation detail.
-                    // If a future Ghostty change moves the unlock to a later
-                    // tick, every Swift caller that re-enters Surface state
-                    // from inside performOnMain (not just this one) will
-                    // silently regress to the same crash. The structural fix
-                    // is to dispatch the OPEN_URL callback asynchronously from
-                    // C so the lock is always released before any Swift runs
-                    // — tracked in #3560. Until that lands, do NOT remove
-                    // this DispatchQueue.main.async.
-                    let preferredWorkspaceId = workspace.id
-                    let surfaceId = termSurface.id
-                    DispatchQueue.main.async {
-                        // Re-resolve workspace at dispatch time: tabs can move
-                        // between workspaces in the runloop gap, so the
-                        // captured value may be stale. Mirrors the deferred
-                        // browser path's pattern.
-                        let resolvedWorkspace = AppDelegate.shared?.workspaceContainingPanel(
-                            panelId: surfaceId,
-                            preferredWorkspaceId: preferredWorkspaceId
-                        )?.workspace ?? workspace
-                        // Re-apply the sync remote-surface gate; panel may have moved.
-                        guard !resolvedWorkspace.isRemoteTerminalSurface(surfaceId) else {
-                            NSWorkspace.shared.open(fileURL)
-                            return
-                        }
-                        // TOCTOU re-check: file may have been removed/renamed
-                        // since the synchronous gate. Fall through if so.
-                        guard CommandClickFileOpenRouter.shouldRouteInCmux(path: fileURL.path) else {
-                            NSWorkspace.shared.open(fileURL)
-                            return
-                        }
-                        if CommandClickFileOpenRouter.openInCmux(
-                            workspace: resolvedWorkspace,
-                            sourcePanelId: surfaceId,
-                            filePath: fileURL.path
-                        ) {
-                            return
-                        }
-                        // Split creation failed (source pane gone between
-                        // commit and dispatch). Surface via system opener so
-                        // the click is not silently lost.
+                    CommandClickFileOpenRouter.deferredOpenFileInCmux(
+                        workspace: workspace,
+                        preferredWorkspaceId: workspace.id,
+                        surfaceId: termSurface.id,
+                        filePath: fileURL.path
+                    ) {
                         NSWorkspace.shared.open(fileURL)
                     }
                     return true
@@ -9277,17 +9272,10 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         workspace: Workspace,
         terminalSurface: TerminalSurface
     ) -> String? {
-        if let dir = workspace.panelDirectories[terminalSurface.id]?.trimmingCharacters(in: .whitespacesAndNewlines),
-           !dir.isEmpty {
-            return dir
-        }
-        if let dir = workspace.terminalPanel(for: terminalSurface.id)?
-            .requestedWorkingDirectory?.trimmingCharacters(in: .whitespacesAndNewlines),
-           !dir.isEmpty {
-            return dir
-        }
-        let dir = workspace.currentDirectory.trimmingCharacters(in: .whitespacesAndNewlines)
-        return dir.isEmpty ? nil : dir
+        CommandClickFileOpenRouter.resolveWorkingDirectory(
+            workspace: workspace,
+            surfaceId: terminalSurface.id
+        )
     }
 
     private func pointIsUsableForWordResolution(_ point: NSPoint) -> Bool {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -4379,12 +4379,15 @@ class GhosttyApp {
                     #if DEBUG
                     cmuxDebugLog("link.openURL resolvedAsFilePath=\(resolvedPath)")
                     #endif
+                    let fileURL = URL(fileURLWithPath: resolvedPath)
                     CommandClickFileOpenRouter.deferredOpenFileInCmux(
                         workspace: workspace,
                         preferredWorkspaceId: workspace.id,
                         surfaceId: termSurface.id,
                         filePath: resolvedPath
-                    )
+                    ) {
+                        NSWorkspace.shared.open(fileURL)
+                    }
                     return true
                 }
                 if filePathRouted {

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -4703,6 +4703,77 @@ final class TerminalCmdClickPathPunctuationTrimmingTests: XCTestCase {
             literalPath
         )
     }
+
+    // MARK: - Relative path + trailing punctuation (bug #4569)
+
+    func testResolveQuicklookResolvesRelativeMarkdownPathWithTrailingDot() {
+        let cwd = "/Users/dev/project"
+        let existingFile = "/Users/dev/project/docs/specs/2026-05-22-test.md"
+
+        XCTAssertEqual(
+            cmuxResolveQuicklookPathForTesting(
+                "docs/specs/2026-05-22-test.md.",
+                cwd: cwd,
+                existingPaths: [existingFile]
+            ),
+            existingFile
+        )
+    }
+
+    func testResolveQuicklookResolvesRelativePathWithTrailingComma() {
+        let cwd = "/Users/dev/project"
+        let existingFile = "/Users/dev/project/src/main.swift"
+
+        XCTAssertEqual(
+            cmuxResolveQuicklookPathForTesting(
+                "src/main.swift,",
+                cwd: cwd,
+                existingPaths: [existingFile]
+            ),
+            existingFile
+        )
+    }
+
+    func testResolveQuicklookReturnsNilForRelativePathThatDoesNotExist() {
+        XCTAssertNil(
+            cmuxResolveQuicklookPathForTesting(
+                "docs/nonexistent.md.",
+                cwd: "/Users/dev/project",
+                existingPaths: []
+            )
+        )
+    }
+}
+
+// MARK: - Scheme detection gate for file-path-before-URL resolution (bug #4569)
+
+final class TerminalOpenURLSchemeGateTests: XCTestCase {
+    func testRelativePathWithTrailingDotHasNoScheme() {
+        XCTAssertNil(URL(string: "docs/specs/2026-05-22-test.md.")?.scheme)
+    }
+
+    func testBareDomainWithSlashHasNoScheme() {
+        // resolveBrowserNavigableURL handles these, but they have no scheme
+        XCTAssertNil(URL(string: "example.com/docs")?.scheme)
+    }
+
+    func testHTTPSURLHasScheme() {
+        XCTAssertEqual(URL(string: "https://example.com/path")?.scheme, "https")
+    }
+
+    func testFileURLHasScheme() {
+        XCTAssertEqual(URL(string: "file:///tmp/test.md")?.scheme, "file")
+    }
+
+    func testMailtoURLHasScheme() {
+        XCTAssertEqual(URL(string: "mailto:test@example.com")?.scheme, "mailto")
+    }
+
+    func testAbsolutePathHasNoScheme() {
+        // Absolute paths are filtered by isAbsolutePath before the scheme check,
+        // but verify URL(string:) doesn't synthesize a scheme for them.
+        XCTAssertNil(URL(string: "/tmp/test.md")?.scheme)
+    }
 }
 
 


### PR DESCRIPTION
Fixes #4569

## Problem

When terminal output contains a file path followed by sentence punctuation (e.g. `Spec written to docs/specs/2026-05-22-test.md.`), Ghostty's link detection matches the entire string including the trailing period. The `OPEN_URL` handler classifies it as a web URL (`https://docs/specs/2026-05-22-test.md.`) and opens the browser sidebar instead of the markdown preview.

## Fix

Added a file-path resolution step in the `OPEN_URL` handler **before** URL classification. For strings without a URL scheme and that aren't absolute paths, the handler calls `cmuxResolveQuicklookPath` — which already strips trailing sentence punctuation (`.`, `,`, `;`, etc.) — against the terminal's working directory. If the trimmed path resolves to an existing file that cmux can preview (markdown or supported file type), it routes through the file viewer instead of the browser.

## Guards

- Only attempted for strings without a URL scheme (doesn't affect `https://`, `file://`, `mailto:`, etc.)
- Skips absolute paths (already handled by `resolveTerminalOpenURLTarget`)
- Respects remote-workspace guard (no local `stat` for remote terminals)
- Uses the same deferred `DispatchQueue.main.async` split-creation pattern to avoid the Ghostty `os_unfair_lock` deadlock (#3370 / #3560)
- Falls through to normal URL resolution if the file doesn't exist or isn't a routable type

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4594"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782084630&installation_id=133855650&pr_number=4594&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4594&signature=199bab1b0eb68e0f962ad8a12a9a8cc8c29e8e0d54f6af2a16253284632c1f3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect URL detection for relative file paths with trailing punctuation by resolving local paths before URL classification, so docs/spec.md. opens in the file viewer instead of the browser. Adds a fallback to open externally if in-app routing fails. Fixes #4569.

- **Bug Fixes**
  - Added a pre-classification file-path check in OPEN_URL using `cmuxResolveQuicklookPath` to trim trailing punctuation and route previewable files through the viewer, with a system-opener fallback if routing fails.
  - Guarded behavior: only for schemeless, non-absolute strings; skips remote terminals; falls back to normal URL handling.
  - Added tests for relative paths with trailing dot/comma, non-existent paths, and the `URL(string:)?.scheme` gate.

- **Refactors**
  - Extracted `resolveWorkingDirectory` and used it across the link handler and `GhosttyNSView` to unify CWD lookup.
  - Added `deferredOpenFileInCmux` to centralize deferred split creation with workspace re-resolution and TOCTOU checks; replaced regex scheme detection with `URL(string:)?.scheme == nil`.

<sup>Written for commit 5a1e70e5d1764fc313b098d5812f672a9bd572ad. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4594?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Command-click now better detects and opens local file paths (including relative paths with trailing punctuation) instead of incorrectly opening them in a browser.
  * Improved working-directory selection when resolving file paths from the terminal, including safer handling for remote sessions.
  * More reliable routing to terminal panes for local file opens, with a deferred open fallback when needed.

* **Tests**
  * Added regression and scheme-validation tests for file-path and URL resolution edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4594?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->