### PR TITLE
Prototype local cmux config packs

### DIFF
--- a/Sources/CmuxConfig.swift
+++ b/Sources/CmuxConfig.swift
@@ -2549,6 +2549,9 @@ final class CmuxConfigStore: ObservableObject {
             }
             guard FileManager.default.fileExists(atPath: path) else {
                 issues.append(schemaIssue(path: path, message: "pack file does not exist"))
+                if let recoveryWatchPath = packRecoveryWatchPath(for: path) {
+                    watchPaths.append(recoveryWatchPath)
+                }
                 continue
             }
             watchPaths.append(path)
@@ -2575,6 +2578,21 @@ final class CmuxConfigStore: ObservableObject {
             ))
         }
         return entries
+    }
+
+    private func packRecoveryWatchPath(for path: String) -> String? {
+        var candidate = (path as NSString).deletingLastPathComponent
+        while !candidate.isEmpty {
+            var isDirectory: ObjCBool = false
+            if FileManager.default.fileExists(atPath: candidate, isDirectory: &isDirectory),
+               isDirectory.boolValue {
+                return candidate
+            }
+            let parent = (candidate as NSString).deletingLastPathComponent
+            if parent == candidate { return nil }
+            candidate = parent
+        }
+        return nil
     }
 
     private func resolvedPackPath(_ rawPath: String, relativeToConfig configPath: String) -> String {

--- a/Sources/CmuxConfig.swift
+++ b/Sources/CmuxConfig.swift
@@ -1505,7 +1505,8 @@ struct CmuxResolvedConfigAction: Identifiable, Sendable, Hashable {
 
     func applying(
         _ definition: CmuxConfigActionDefinition,
-        sourcePath: String?
+        actionSourcePath: String?,
+        iconSourcePath: String?
     ) -> CmuxResolvedConfigAction? {
         var next = self
         next.title = definition.title ?? next.title
@@ -1517,12 +1518,12 @@ struct CmuxResolvedConfigAction: Identifiable, Sendable, Hashable {
         next.shortcut = definition.shortcut ?? next.shortcut
         if let icon = definition.icon {
             next.icon = icon
-            next.iconSourcePath = sourcePath
+            next.iconSourcePath = iconSourcePath ?? actionSourcePath
         }
         next.tooltip = definition.tooltip ?? next.tooltip
         next.confirm = definition.confirm ?? next.confirm
         next.terminalCommandTarget = definition.terminalCommandTarget ?? next.terminalCommandTarget
-        next.actionSourcePath = sourcePath ?? next.actionSourcePath
+        next.actionSourcePath = actionSourcePath ?? next.actionSourcePath
         if let action = definition.action {
             next.action = action
         }
@@ -1532,7 +1533,8 @@ struct CmuxResolvedConfigAction: Identifiable, Sendable, Hashable {
     static func fromDefinition(
         id: String,
         definition: CmuxConfigActionDefinition,
-        sourcePath: String?
+        actionSourcePath: String?,
+        iconSourcePath: String?
     ) -> CmuxResolvedConfigAction? {
         guard let action = definition.action else { return nil }
         let title = definition.title
@@ -1550,8 +1552,8 @@ struct CmuxResolvedConfigAction: Identifiable, Sendable, Hashable {
             action: action,
             confirm: definition.confirm,
             terminalCommandTarget: definition.terminalCommandTarget,
-            actionSourcePath: sourcePath,
-            iconSourcePath: definition.icon == nil ? nil : sourcePath
+            actionSourcePath: actionSourcePath,
+            iconSourcePath: definition.icon == nil ? nil : (iconSourcePath ?? actionSourcePath)
         )
     }
 
@@ -1920,7 +1922,8 @@ final class CmuxConfigStore: ObservableObject {
 
     private struct ActionEntry {
         let definition: CmuxConfigActionDefinition
-        let sourcePath: String?
+        let actionSourcePath: String?
+        let iconSourcePath: String?
     }
 
     private struct ResolvedSurfaceTabBarButtonEntry {
@@ -1964,6 +1967,7 @@ final class CmuxConfigStore: ObservableObject {
 
     private struct ConfigEntry {
         let path: String
+        let sourcePath: String
         let config: CmuxConfigFile
     }
 
@@ -2172,15 +2176,21 @@ final class CmuxConfigStore: ObservableObject {
         if let issue = globalParseResult.issue {
             issues.append(issue)
         }
+        var globalPackWatchPaths: [String] = []
         let globalPackEntries = packEntries(
             declaredBy: globalConfig,
             sourcePath: globalConfigPath,
-            issues: &issues
+            inheritedSourcePath: globalConfigPath,
+            issues: &issues,
+            watchPaths: &globalPackWatchPaths
         )
+        var localPackWatchPaths: [String] = []
         let localPackEntries = packEntries(
             declaredBy: localConfig,
             sourcePath: localPath,
-            issues: &issues
+            inheritedSourcePath: nil,
+            issues: &issues,
+            watchPaths: &localPackWatchPaths
         )
         let localHookPaths = resolvedLocalNotificationHookPaths(fallbackLocalPath: localPath)
         let localHookParseResults = localHookPaths.map { path in
@@ -2192,18 +2202,31 @@ final class CmuxConfigStore: ObservableObject {
             issues.append(issue)
         }
         let localActions = mergedActionEntries(
-            primary: localConfig.map { actionEntries(from: $0.actions, sourcePath: localPath) } ?? [:],
+            primary: localConfig.map {
+                actionEntries(from: $0.actions, actionSourcePath: localPath, iconSourcePath: localPath)
+            } ?? [:],
             fallback: actionEntries(from: localPackEntries)
         )
         let globalActions = mergedActionEntries(
-            primary: globalConfig.map { actionEntries(from: $0.actions, sourcePath: globalConfigPath) } ?? [:],
+            primary: globalConfig.map {
+                actionEntries(
+                    from: $0.actions,
+                    actionSourcePath: globalConfigPath,
+                    iconSourcePath: globalConfigPath
+                )
+            } ?? [:],
             fallback: actionEntries(from: globalPackEntries)
         )
-        let localDirectEntries = localConfig.map { [ConfigEntry(path: localPath ?? "", config: $0)] } ?? []
-        let globalDirectEntries = globalConfig.map { [ConfigEntry(path: globalConfigPath, config: $0)] } ?? []
+        let localDirectEntries: [ConfigEntry] = {
+            guard let localPath, let localConfig else { return [] }
+            return [ConfigEntry(path: localPath, sourcePath: localPath, config: localConfig)]
+        }()
+        let globalDirectEntries = globalConfig.map {
+            [ConfigEntry(path: globalConfigPath, sourcePath: globalConfigPath, config: $0)]
+        } ?? []
         let localConfigEntries = localDirectEntries + Array(localPackEntries.reversed())
         let globalConfigEntries = globalDirectEntries + Array(globalPackEntries.reversed())
-        let packWatchPaths = (globalPackEntries + localPackEntries).map(\.path)
+        let packWatchPaths = globalPackWatchPaths + localPackWatchPaths
 
         // Local config takes precedence
         for entry in localConfigEntries {
@@ -2212,29 +2235,29 @@ final class CmuxConfigStore: ObservableObject {
                configuredNewWorkspaceCommandName == nil,
                let newWorkspaceActionID = localConfig.ui?.newWorkspace?.action {
                 configuredNewWorkspaceActionID = newWorkspaceActionID
-                configuredNewWorkspaceActionSourcePath = entry.path
+                configuredNewWorkspaceActionSourcePath = entry.sourcePath
             }
             if configuredNewWorkspaceContextMenu == nil,
                let contextMenu = localConfig.ui?.newWorkspace?.contextMenu {
                 configuredNewWorkspaceContextMenu = contextMenu
-                configuredNewWorkspaceContextMenuSourcePath = entry.path
+                configuredNewWorkspaceContextMenuSourcePath = entry.sourcePath
             }
             if configuredNewWorkspaceActionID == nil,
                configuredNewWorkspaceCommandName == nil,
                let newWorkspaceCommand = localConfig.newWorkspaceCommand {
                 configuredNewWorkspaceCommandName = newWorkspaceCommand
-                configuredNewWorkspaceCommandSourcePath = entry.path
+                configuredNewWorkspaceCommandSourcePath = entry.sourcePath
             }
             if configuredSurfaceTabBarButtons == nil,
                let buttons = localConfig.surfaceTabBarButtons {
-                configuredSurfaceTabBarButtons = buttons
-                configuredSurfaceTabBarButtonSourcePath = entry.path
+                configuredSurfaceTabBarButtons = surfaceTabBarButtons(buttons, from: entry)
+                configuredSurfaceTabBarButtonSourcePath = entry.sourcePath
             }
             for command in localConfig.commands {
                 if !seenNames.contains(command.name) {
                     commands.append(command)
                     seenNames.insert(command.name)
-                    sourcePaths[command.id] = entry.path
+                    sourcePaths[command.id] = entry.sourcePath
                 }
             }
         }
@@ -2246,29 +2269,29 @@ final class CmuxConfigStore: ObservableObject {
                configuredNewWorkspaceCommandName == nil,
                let newWorkspaceActionID = globalConfig.ui?.newWorkspace?.action {
                 configuredNewWorkspaceActionID = newWorkspaceActionID
-                configuredNewWorkspaceActionSourcePath = entry.path
+                configuredNewWorkspaceActionSourcePath = entry.sourcePath
             }
             if configuredNewWorkspaceContextMenu == nil,
                let contextMenu = globalConfig.ui?.newWorkspace?.contextMenu {
                 configuredNewWorkspaceContextMenu = contextMenu
-                configuredNewWorkspaceContextMenuSourcePath = entry.path
+                configuredNewWorkspaceContextMenuSourcePath = entry.sourcePath
             }
             if configuredNewWorkspaceActionID == nil,
                configuredNewWorkspaceCommandName == nil,
                let newWorkspaceCommand = globalConfig.newWorkspaceCommand {
                 configuredNewWorkspaceCommandName = newWorkspaceCommand
-                configuredNewWorkspaceCommandSourcePath = entry.path
+                configuredNewWorkspaceCommandSourcePath = entry.sourcePath
             }
             if configuredSurfaceTabBarButtons == nil,
                let buttons = globalConfig.surfaceTabBarButtons {
-                configuredSurfaceTabBarButtons = buttons
-                configuredSurfaceTabBarButtonSourcePath = entry.path
+                configuredSurfaceTabBarButtons = surfaceTabBarButtons(buttons, from: entry)
+                configuredSurfaceTabBarButtonSourcePath = entry.sourcePath
             }
             for command in globalConfig.commands {
                 if !seenNames.contains(command.name) {
                     commands.append(command)
                     seenNames.insert(command.name)
-                    sourcePaths[command.id] = entry.path
+                    sourcePaths[command.id] = entry.sourcePath
                 }
             }
         }
@@ -2430,13 +2453,32 @@ final class CmuxConfigStore: ObservableObject {
         }
     }
 
+    private func surfaceTabBarButtons(
+        _ buttons: [CmuxSurfaceTabBarButton],
+        from entry: ConfigEntry
+    ) -> [CmuxSurfaceTabBarButton] {
+        buttons.map { button in
+            var sourced = button
+            sourced.actionSourcePath = sourced.actionSourcePath ?? entry.sourcePath
+            if sourced.icon != nil {
+                sourced.iconSourcePath = sourced.iconSourcePath ?? entry.path
+            }
+            return sourced
+        }
+    }
+
     private func actionEntries(
         from actions: [String: CmuxConfigActionDefinition],
-        sourcePath: String?
+        actionSourcePath: String?,
+        iconSourcePath: String?
     ) -> [String: ActionEntry] {
         var entries: [String: ActionEntry] = [:]
         for (id, definition) in actions {
-            entries[canonicalActionID(id)] = ActionEntry(definition: definition, sourcePath: sourcePath)
+            entries[canonicalActionID(id)] = ActionEntry(
+                definition: definition,
+                actionSourcePath: actionSourcePath,
+                iconSourcePath: iconSourcePath
+            )
         }
         return entries
     }
@@ -2445,7 +2487,11 @@ final class CmuxConfigStore: ObservableObject {
         var merged: [String: ActionEntry] = [:]
         for entry in entries {
             merged = mergedActionEntries(
-                primary: actionEntries(from: entry.config.actions, sourcePath: entry.path),
+                primary: actionEntries(
+                    from: entry.config.actions,
+                    actionSourcePath: entry.sourcePath,
+                    iconSourcePath: entry.path
+                ),
                 fallback: merged
             )
         }
@@ -2462,25 +2508,31 @@ final class CmuxConfigStore: ObservableObject {
     private func packEntries(
         declaredBy config: CmuxConfigFile?,
         sourcePath: String?,
-        issues: inout [CmuxConfigIssue]
+        inheritedSourcePath: String?,
+        issues: inout [CmuxConfigIssue],
+        watchPaths: inout [String]
     ) -> [ConfigEntry] {
         guard let config, let sourcePath else { return [] }
         var visited = Set<String>()
         return packEntries(
             references: config.packs,
             declaringConfigPath: sourcePath,
+            inheritedSourcePath: inheritedSourcePath,
             depth: 0,
             visited: &visited,
-            issues: &issues
+            issues: &issues,
+            watchPaths: &watchPaths
         )
     }
 
     private func packEntries(
         references: [CmuxConfigPackReference],
         declaringConfigPath: String,
+        inheritedSourcePath: String?,
         depth: Int,
         visited: inout Set<String>,
-        issues: inout [CmuxConfigIssue]
+        issues: inout [CmuxConfigIssue],
+        watchPaths: inout [String]
     ) -> [ConfigEntry] {
         guard depth < 8 else {
             issues.append(schemaIssue(path: declaringConfigPath, message: "packs nesting is too deep"))
@@ -2499,6 +2551,7 @@ final class CmuxConfigStore: ObservableObject {
                 issues.append(schemaIssue(path: path, message: "pack file does not exist"))
                 continue
             }
+            watchPaths.append(path)
 
             visited.insert(canonical)
             let result = parseConfig(at: path)
@@ -2509,11 +2562,17 @@ final class CmuxConfigStore: ObservableObject {
             entries.append(contentsOf: packEntries(
                 references: packConfig.packs,
                 declaringConfigPath: path,
+                inheritedSourcePath: inheritedSourcePath,
                 depth: depth + 1,
                 visited: &visited,
-                issues: &issues
+                issues: &issues,
+                watchPaths: &watchPaths
             ))
-            entries.append(ConfigEntry(path: path, config: packConfig))
+            entries.append(ConfigEntry(
+                path: path,
+                sourcePath: inheritedSourcePath ?? path,
+                config: packConfig
+            ))
         }
         return entries
     }
@@ -2567,12 +2626,17 @@ final class CmuxConfigStore: ObservableObject {
             for (id, entry) in entries {
                 let registryID = CmuxSurfaceTabBarBuiltInAction(configID: id)?.configID ?? id
                 if let existing = registry[registryID] {
-                    guard let resolved = existing.applying(entry.definition, sourcePath: entry.sourcePath) else { continue }
+                    guard let resolved = existing.applying(
+                        entry.definition,
+                        actionSourcePath: entry.actionSourcePath,
+                        iconSourcePath: entry.iconSourcePath
+                    ) else { continue }
                     registry[registryID] = resolved
                 } else if let resolved = CmuxResolvedConfigAction.fromDefinition(
                     id: id,
                     definition: entry.definition,
-                    sourcePath: entry.sourcePath
+                    actionSourcePath: entry.actionSourcePath,
+                    iconSourcePath: entry.iconSourcePath
                 ) {
                     registry[id] = resolved
                 } else {

--- a/Sources/CmuxConfig.swift
+++ b/Sources/CmuxConfig.swift
@@ -1423,7 +1423,9 @@ struct CmuxSurfaceTabBarButton: Codable, Sendable, Hashable, Identifiable {
                 tooltip: tooltip,
                 action: .builtIn(builtIn),
                 confirm: confirm,
-                terminalCommandTarget: terminalCommandTarget
+                terminalCommandTarget: terminalCommandTarget,
+                actionSourcePath: actionSourcePath,
+                iconSourcePath: iconSourcePath
             )
         }
 
@@ -2761,7 +2763,9 @@ final class CmuxConfigStore: ObservableObject {
                     tooltip: button.tooltip,
                     action: .builtIn(builtIn),
                     confirm: button.confirm,
-                    terminalCommandTarget: button.terminalCommandTarget
+                    terminalCommandTarget: button.terminalCommandTarget,
+                    actionSourcePath: button.actionSourcePath,
+                    iconSourcePath: button.iconSourcePath
                 ),
                 terminalCommandSourcePath: nil
             )

--- a/Sources/CmuxConfig.swift
+++ b/Sources/CmuxConfig.swift
@@ -7,7 +7,61 @@ extension CodingUserInfoKey {
     static let cmuxWorkspaceColorDefaults = CodingUserInfoKey(rawValue: "cmuxWorkspaceColorDefaults")!
 }
 
+struct CmuxConfigPackReference: Codable, Sendable, Hashable {
+    var path: String
+
+    private enum CodingKeys: String, CodingKey {
+        case path
+    }
+
+    init(path: String) {
+        self.path = path
+    }
+
+    init(from decoder: Decoder) throws {
+        if let container = try? decoder.singleValueContainer(),
+           let rawPath = try? container.decode(String.self) {
+            path = try Self.validatedPath(rawPath, codingPath: decoder.codingPath)
+            return
+        }
+
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        path = try Self.validatedPath(
+            try container.decode(String.self, forKey: .path),
+            codingPath: decoder.codingPath + [CodingKeys.path]
+        )
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(path)
+    }
+
+    private static func validatedPath(_ rawPath: String, codingPath: [CodingKey]) throws -> String {
+        let path = rawPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !path.isEmpty else {
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(
+                    codingPath: codingPath,
+                    debugDescription: "pack path must not be blank"
+                )
+            )
+        }
+        guard !path.lowercased().hasPrefix("http://"),
+              !path.lowercased().hasPrefix("https://") else {
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(
+                    codingPath: codingPath,
+                    debugDescription: "pack path must be a local file or directory"
+                )
+            )
+        }
+        return path
+    }
+}
+
 struct CmuxConfigFile: Codable, Sendable {
+    var packs: [CmuxConfigPackReference]
     var actions: [String: CmuxConfigActionDefinition]
     var ui: CmuxConfigUIDefinition?
     var notifications: CmuxNotificationConfigDefinition?
@@ -17,10 +71,11 @@ struct CmuxConfigFile: Codable, Sendable {
     var vault: CmuxVaultConfigDefinition?
 
     private enum CodingKeys: String, CodingKey {
-        case actions, ui, notifications, newWorkspaceCommand, surfaceTabBarButtons, commands, vault
+        case packs, actions, ui, notifications, newWorkspaceCommand, surfaceTabBarButtons, commands, vault
     }
 
     init(
+        packs: [CmuxConfigPackReference] = [],
         actions: [String: CmuxConfigActionDefinition] = [:],
         ui: CmuxConfigUIDefinition? = nil,
         notifications: CmuxNotificationConfigDefinition? = nil,
@@ -29,6 +84,7 @@ struct CmuxConfigFile: Codable, Sendable {
         commands: [CmuxCommandDefinition] = [],
         vault: CmuxVaultConfigDefinition? = nil
     ) {
+        self.packs = packs
         self.actions = actions
         self.ui = ui
         self.notifications = notifications
@@ -40,6 +96,7 @@ struct CmuxConfigFile: Codable, Sendable {
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
+        packs = try container.decodeIfPresent([CmuxConfigPackReference].self, forKey: .packs) ?? []
         let decodedActions = try container.decodeIfPresent(
             [String: CmuxConfigActionDefinition].self,
             forKey: .actions
@@ -1905,6 +1962,11 @@ final class CmuxConfigStore: ObservableObject {
         let issue: CmuxConfigIssue?
     }
 
+    private struct ConfigEntry {
+        let path: String
+        let config: CmuxConfigFile
+    }
+
     private var surfaceTabBarWorkspaceCommands: [String: CmuxResolvedCommand] = [:]
     private var resolvedNewWorkspaceCommandCache: CmuxResolvedCommand?
     private var resolvedNewWorkspaceActionCache: CmuxResolvedConfigAction?
@@ -2103,10 +2165,6 @@ final class CmuxConfigStore: ObservableObject {
         let globalParseResult = parseConfig(at: globalConfigPath)
         let localConfig = localParseResult?.config
         let globalConfig = globalParseResult.config
-        let localHookPaths = resolvedLocalNotificationHookPaths(fallbackLocalPath: localPath)
-        let localHookParseResults = localHookPaths.map { path in
-            (path: path, result: parseConfig(at: path))
-        }
         var issues = [CmuxConfigIssue]()
         if let issue = localParseResult?.issue {
             issues.append(issue)
@@ -2114,73 +2172,101 @@ final class CmuxConfigStore: ObservableObject {
         if let issue = globalParseResult.issue {
             issues.append(issue)
         }
+        let globalPackEntries = packEntries(
+            declaredBy: globalConfig,
+            sourcePath: globalConfigPath,
+            issues: &issues
+        )
+        let localPackEntries = packEntries(
+            declaredBy: localConfig,
+            sourcePath: localPath,
+            issues: &issues
+        )
+        let localHookPaths = resolvedLocalNotificationHookPaths(fallbackLocalPath: localPath)
+        let localHookParseResults = localHookPaths.map { path in
+            (path: path, result: parseConfig(at: path))
+        }
         for hookParseResult in localHookParseResults {
             guard hookParseResult.path != localPath,
                   let issue = hookParseResult.result.issue else { continue }
             issues.append(issue)
         }
-        let localActions = localConfig.map { actionEntries(from: $0.actions, sourcePath: localPath) } ?? [:]
-        let globalActions = globalConfig.map { actionEntries(from: $0.actions, sourcePath: globalConfigPath) } ?? [:]
+        let localActions = mergedActionEntries(
+            primary: localConfig.map { actionEntries(from: $0.actions, sourcePath: localPath) } ?? [:],
+            fallback: actionEntries(from: localPackEntries)
+        )
+        let globalActions = mergedActionEntries(
+            primary: globalConfig.map { actionEntries(from: $0.actions, sourcePath: globalConfigPath) } ?? [:],
+            fallback: actionEntries(from: globalPackEntries)
+        )
+        let localDirectEntries = localConfig.map { [ConfigEntry(path: localPath ?? "", config: $0)] } ?? []
+        let globalDirectEntries = globalConfig.map { [ConfigEntry(path: globalConfigPath, config: $0)] } ?? []
+        let localConfigEntries = localDirectEntries + Array(localPackEntries.reversed())
+        let globalConfigEntries = globalDirectEntries + Array(globalPackEntries.reversed())
 
         // Local config takes precedence
-        if let localConfig {
-            if let newWorkspaceActionID = localConfig.ui?.newWorkspace?.action {
+        for entry in localConfigEntries {
+            let localConfig = entry.config
+            if configuredNewWorkspaceActionID == nil,
+               let newWorkspaceActionID = localConfig.ui?.newWorkspace?.action {
                 configuredNewWorkspaceActionID = newWorkspaceActionID
-                configuredNewWorkspaceActionSourcePath = localPath
+                configuredNewWorkspaceActionSourcePath = entry.path
             }
-            if let contextMenu = localConfig.ui?.newWorkspace?.contextMenu {
+            if configuredNewWorkspaceContextMenu == nil,
+               let contextMenu = localConfig.ui?.newWorkspace?.contextMenu {
                 configuredNewWorkspaceContextMenu = contextMenu
-                configuredNewWorkspaceContextMenuSourcePath = localPath
+                configuredNewWorkspaceContextMenuSourcePath = entry.path
             }
             if configuredNewWorkspaceActionID == nil,
+               configuredNewWorkspaceCommandName == nil,
                let newWorkspaceCommand = localConfig.newWorkspaceCommand {
                 configuredNewWorkspaceCommandName = newWorkspaceCommand
-                configuredNewWorkspaceCommandSourcePath = localPath
+                configuredNewWorkspaceCommandSourcePath = entry.path
             }
-            if let buttons = localConfig.surfaceTabBarButtons {
+            if configuredSurfaceTabBarButtons == nil,
+               let buttons = localConfig.surfaceTabBarButtons {
                 configuredSurfaceTabBarButtons = buttons
-                configuredSurfaceTabBarButtonSourcePath = localPath
+                configuredSurfaceTabBarButtonSourcePath = entry.path
             }
             for command in localConfig.commands {
                 if !seenNames.contains(command.name) {
                     commands.append(command)
                     seenNames.insert(command.name)
-                    if let localPath {
-                        sourcePaths[command.id] = localPath
-                    }
+                    sourcePaths[command.id] = entry.path
                 }
             }
         }
 
         // Global config fills in the rest
-        if let globalConfig {
+        for entry in globalConfigEntries {
+            let globalConfig = entry.config
             if configuredNewWorkspaceActionID == nil,
                configuredNewWorkspaceCommandName == nil,
                let newWorkspaceActionID = globalConfig.ui?.newWorkspace?.action {
                 configuredNewWorkspaceActionID = newWorkspaceActionID
-                configuredNewWorkspaceActionSourcePath = globalConfigPath
+                configuredNewWorkspaceActionSourcePath = entry.path
             }
             if configuredNewWorkspaceContextMenu == nil,
                let contextMenu = globalConfig.ui?.newWorkspace?.contextMenu {
                 configuredNewWorkspaceContextMenu = contextMenu
-                configuredNewWorkspaceContextMenuSourcePath = globalConfigPath
+                configuredNewWorkspaceContextMenuSourcePath = entry.path
             }
             if configuredNewWorkspaceActionID == nil,
                configuredNewWorkspaceCommandName == nil,
                let newWorkspaceCommand = globalConfig.newWorkspaceCommand {
                 configuredNewWorkspaceCommandName = newWorkspaceCommand
-                configuredNewWorkspaceCommandSourcePath = globalConfigPath
+                configuredNewWorkspaceCommandSourcePath = entry.path
             }
             if configuredSurfaceTabBarButtons == nil,
                let buttons = globalConfig.surfaceTabBarButtons {
                 configuredSurfaceTabBarButtons = buttons
-                configuredSurfaceTabBarButtonSourcePath = globalConfigPath
+                configuredSurfaceTabBarButtonSourcePath = entry.path
             }
             for command in globalConfig.commands {
                 if !seenNames.contains(command.name) {
                     commands.append(command)
                     seenNames.insert(command.name)
-                    sourcePaths[command.id] = globalConfigPath
+                    sourcePaths[command.id] = entry.path
                 }
             }
         }
@@ -2349,11 +2435,98 @@ final class CmuxConfigStore: ObservableObject {
         actions.mapValues { ActionEntry(definition: $0, sourcePath: sourcePath) }
     }
 
+    private func actionEntries(from entries: [ConfigEntry]) -> [String: ActionEntry] {
+        var merged: [String: ActionEntry] = [:]
+        for entry in entries {
+            merged = mergedActionEntries(
+                primary: actionEntries(from: entry.config.actions, sourcePath: entry.path),
+                fallback: merged
+            )
+        }
+        return merged
+    }
+
     private func mergedActionEntries(
         primary: [String: ActionEntry],
         fallback: [String: ActionEntry]
     ) -> [String: ActionEntry] {
         fallback.merging(primary) { _, primary in primary }
+    }
+
+    private func packEntries(
+        declaredBy config: CmuxConfigFile?,
+        sourcePath: String?,
+        issues: inout [CmuxConfigIssue]
+    ) -> [ConfigEntry] {
+        guard let config, let sourcePath else { return [] }
+        var visited = Set<String>()
+        return packEntries(
+            references: config.packs,
+            declaringConfigPath: sourcePath,
+            depth: 0,
+            visited: &visited,
+            issues: &issues
+        )
+    }
+
+    private func packEntries(
+        references: [CmuxConfigPackReference],
+        declaringConfigPath: String,
+        depth: Int,
+        visited: inout Set<String>,
+        issues: inout [CmuxConfigIssue]
+    ) -> [ConfigEntry] {
+        guard depth < 8 else {
+            issues.append(schemaIssue(path: declaringConfigPath, message: "packs nesting is too deep"))
+            return []
+        }
+
+        var entries: [ConfigEntry] = []
+        for reference in references {
+            let path = resolvedPackPath(reference.path, relativeToConfig: declaringConfigPath)
+            let canonical = Self.canonicalPath(path)
+            guard !visited.contains(canonical) else {
+                issues.append(schemaIssue(path: declaringConfigPath, message: "pack cycle ignored: \(path)"))
+                continue
+            }
+            guard FileManager.default.fileExists(atPath: path) else {
+                issues.append(schemaIssue(path: path, message: "pack file does not exist"))
+                continue
+            }
+
+            visited.insert(canonical)
+            let result = parseConfig(at: path)
+            if let issue = result.issue {
+                issues.append(issue)
+            }
+            guard let packConfig = result.config else { continue }
+            entries.append(contentsOf: packEntries(
+                references: packConfig.packs,
+                declaringConfigPath: path,
+                depth: depth + 1,
+                visited: &visited,
+                issues: &issues
+            ))
+            entries.append(ConfigEntry(path: path, config: packConfig))
+        }
+        return entries
+    }
+
+    private func resolvedPackPath(_ rawPath: String, relativeToConfig configPath: String) -> String {
+        let expanded = (rawPath as NSString).expandingTildeInPath
+        let resolved: String
+        if (expanded as NSString).isAbsolutePath {
+            resolved = expanded
+        } else {
+            let base = (configPath as NSString).deletingLastPathComponent
+            resolved = (base as NSString).appendingPathComponent(expanded)
+        }
+
+        var isDirectory: ObjCBool = false
+        if FileManager.default.fileExists(atPath: resolved, isDirectory: &isDirectory), isDirectory.boolValue {
+            return ((resolved as NSString).appendingPathComponent("cmux.pack.json") as NSString).standardizingPath
+        }
+        return (resolved as NSString).standardizingPath
     }
 
     private func sanitizeConfigText(_ text: String) -> String {

--- a/Sources/CmuxConfig.swift
+++ b/Sources/CmuxConfig.swift
@@ -2515,13 +2515,13 @@ final class CmuxConfigStore: ObservableObject {
         watchPaths: inout [String]
     ) -> [ConfigEntry] {
         guard let config, let sourcePath else { return [] }
-        var visited = Set<String>()
+        var pathStack = Set<String>()
         return packEntries(
             references: config.packs,
             declaringConfigPath: sourcePath,
             inheritedSourcePath: inheritedSourcePath,
             depth: 0,
-            visited: &visited,
+            pathStack: &pathStack,
             issues: &issues,
             watchPaths: &watchPaths
         )
@@ -2532,7 +2532,7 @@ final class CmuxConfigStore: ObservableObject {
         declaringConfigPath: String,
         inheritedSourcePath: String?,
         depth: Int,
-        visited: inout Set<String>,
+        pathStack: inout Set<String>,
         issues: inout [CmuxConfigIssue],
         watchPaths: inout [String]
     ) -> [ConfigEntry] {
@@ -2545,7 +2545,7 @@ final class CmuxConfigStore: ObservableObject {
         for reference in references {
             let path = resolvedPackPath(reference.path, relativeToConfig: declaringConfigPath)
             let canonical = Self.canonicalPath(path)
-            guard !visited.contains(canonical) else {
+            guard !pathStack.contains(canonical) else {
                 issues.append(schemaIssue(path: declaringConfigPath, message: "pack cycle ignored: \(path)"))
                 continue
             }
@@ -2558,26 +2558,28 @@ final class CmuxConfigStore: ObservableObject {
             }
             watchPaths.append(path)
 
-            visited.insert(canonical)
+            pathStack.insert(canonical)
             let result = parseConfig(at: path)
             if let issue = result.issue {
                 issues.append(issue)
             }
-            guard let packConfig = result.config else { continue }
-            entries.append(contentsOf: packEntries(
-                references: packConfig.packs,
-                declaringConfigPath: path,
-                inheritedSourcePath: inheritedSourcePath,
-                depth: depth + 1,
-                visited: &visited,
-                issues: &issues,
-                watchPaths: &watchPaths
-            ))
-            entries.append(ConfigEntry(
-                path: path,
-                sourcePath: inheritedSourcePath ?? path,
-                config: packConfig
-            ))
+            if let packConfig = result.config {
+                entries.append(contentsOf: packEntries(
+                    references: packConfig.packs,
+                    declaringConfigPath: path,
+                    inheritedSourcePath: inheritedSourcePath,
+                    depth: depth + 1,
+                    pathStack: &pathStack,
+                    issues: &issues,
+                    watchPaths: &watchPaths
+                ))
+                entries.append(ConfigEntry(
+                    path: path,
+                    sourcePath: inheritedSourcePath ?? path,
+                    config: packConfig
+                ))
+            }
+            pathStack.remove(canonical)
         }
         return entries
     }

--- a/Sources/CmuxConfig.swift
+++ b/Sources/CmuxConfig.swift
@@ -2203,11 +2203,13 @@ final class CmuxConfigStore: ObservableObject {
         let globalDirectEntries = globalConfig.map { [ConfigEntry(path: globalConfigPath, config: $0)] } ?? []
         let localConfigEntries = localDirectEntries + Array(localPackEntries.reversed())
         let globalConfigEntries = globalDirectEntries + Array(globalPackEntries.reversed())
+        let packWatchPaths = (globalPackEntries + localPackEntries).map(\.path)
 
         // Local config takes precedence
         for entry in localConfigEntries {
             let localConfig = entry.config
             if configuredNewWorkspaceActionID == nil,
+               configuredNewWorkspaceCommandName == nil,
                let newWorkspaceActionID = localConfig.ui?.newWorkspace?.action {
                 configuredNewWorkspaceActionID = newWorkspaceActionID
                 configuredNewWorkspaceActionSourcePath = entry.path
@@ -2346,7 +2348,7 @@ final class CmuxConfigStore: ObservableObject {
         configurationIssues = issues
         if fileWatchingEnabled {
             updateLocalHookFileWatchers(
-                paths: localHookPaths,
+                paths: localHookPaths + packWatchPaths,
                 primaryLocalPath: localPath
             )
         }
@@ -2432,7 +2434,11 @@ final class CmuxConfigStore: ObservableObject {
         from actions: [String: CmuxConfigActionDefinition],
         sourcePath: String?
     ) -> [String: ActionEntry] {
-        actions.mapValues { ActionEntry(definition: $0, sourcePath: sourcePath) }
+        var entries: [String: ActionEntry] = [:]
+        for (id, definition) in actions {
+            entries[canonicalActionID(id)] = ActionEntry(definition: definition, sourcePath: sourcePath)
+        }
+        return entries
     }
 
     private func actionEntries(from entries: [ConfigEntry]) -> [String: ActionEntry] {

--- a/cmuxTests/CmuxConfigTests.swift
+++ b/cmuxTests/CmuxConfigTests.swift
@@ -1709,6 +1709,57 @@ final class CmuxConfigDecodingTests: XCTestCase {
         XCTAssertEqual(store.resolvedAction(id: "team.tests")?.terminalCommand, "npm run fixed")
     }
 
+    @MainActor
+    func testPackWatcherReloadsWhenMissingPackFileIsCreated() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "cmux-config-pack-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        let projectDirectory = root.appendingPathComponent("project", isDirectory: true)
+        let cmuxDirectory = projectDirectory.appendingPathComponent(".cmux", isDirectory: true)
+        let packDirectory = cmuxDirectory.appendingPathComponent("packs/team", isDirectory: true)
+        try FileManager.default.createDirectory(at: packDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let configURL = cmuxDirectory.appendingPathComponent("cmux.json")
+        let packURL = packDirectory.appendingPathComponent("cmux.pack.json")
+        try """
+        {
+          "packs": ["./packs/team"]
+        }
+        """.write(to: configURL, atomically: true, encoding: .utf8)
+
+        let store = CmuxConfigStore(
+            globalConfigPath: root.appendingPathComponent("missing-global.json").path,
+            localConfigPath: configURL.path,
+            startFileWatchers: true
+        )
+        store.loadAll()
+        XCTAssertNil(store.resolvedAction(id: "team.tests"))
+        XCTAssertEqual(store.configurationIssues.first?.sourcePath, packURL.path)
+
+        let loaded = expectation(description: "created pack file is loaded")
+        loaded.assertForOverFulfill = false
+        var cancellable: AnyCancellable?
+        cancellable = store.$loadedActions.dropFirst().sink { actions in
+            if actions.contains(where: { $0.id == "team.tests" }) {
+                loaded.fulfill()
+            }
+        }
+
+        try """
+        {
+          "actions": {
+            "team.tests": { "type": "command", "command": "npm test" }
+          }
+        }
+        """.write(to: packURL, atomically: true, encoding: .utf8)
+
+        await fulfillment(of: [loaded], timeout: 3)
+        cancellable?.cancel()
+        XCTAssertEqual(store.resolvedAction(id: "team.tests")?.terminalCommand, "npm test")
+    }
+
     func testDecodeEmptyCommandsArray() throws {
         let json = """
         { "commands": [] }

--- a/cmuxTests/CmuxConfigTests.swift
+++ b/cmuxTests/CmuxConfigTests.swift
@@ -1264,6 +1264,22 @@ final class CmuxConfigDecodingTests: XCTestCase {
         XCTAssertNil(button.terminalCommand)
     }
 
+    func testBuiltInActionReferencePreservesConfiguredSources() throws {
+        let button = CmuxSurfaceTabBarButton(
+            id: "pack-terminal",
+            icon: .imagePath("icons/terminal.svg"),
+            action: .actionReference("newTerminal"),
+            actionSourcePath: "/tmp/global/cmux.json",
+            iconSourcePath: "/tmp/global/packs/team/cmux.pack.json"
+        )
+
+        let resolved = try button.resolved(actions: [:], codingPath: [])
+
+        XCTAssertEqual(resolved.action, .builtIn(.newTerminal))
+        XCTAssertEqual(resolved.actionSourcePath, "/tmp/global/cmux.json")
+        XCTAssertEqual(resolved.iconSourcePath, "/tmp/global/packs/team/cmux.pack.json")
+    }
+
     func testSurfaceTabBarWorkspaceCommandButtonRoundTrips() throws {
         let original = CmuxSurfaceTabBarButton(
             id: "new-dev",
@@ -1607,6 +1623,11 @@ final class CmuxConfigDecodingTests: XCTestCase {
                   "command": "npm run inline",
                   "icon": { "type": "image", "path": "icons/inline.svg" }
                 },
+                {
+                  "id": "personal.terminal",
+                  "action": "newTerminal",
+                  "icon": { "type": "image", "path": "icons/terminal.svg" }
+                },
                 { "action": "personal.tests" }
               ]
             }
@@ -1632,6 +1653,9 @@ final class CmuxConfigDecodingTests: XCTestCase {
         let inlineButton = try XCTUnwrap(store.surfaceTabBarButtons.first { $0.id == "personal.inline" })
         XCTAssertEqual(inlineButton.actionSourcePath, globalConfigURL.path)
         XCTAssertEqual(inlineButton.iconSourcePath, packURL.path)
+        let builtInButton = try XCTUnwrap(store.surfaceTabBarButtons.first { $0.id == "personal.terminal" })
+        XCTAssertNil(builtInButton.actionSourcePath)
+        XCTAssertEqual(builtInButton.iconSourcePath, packURL.path)
         let actionButton = try XCTUnwrap(store.surfaceTabBarButtons.first { $0.id == "personal.tests" })
         XCTAssertEqual(actionButton.actionSourcePath, globalConfigURL.path)
         XCTAssertEqual(actionButton.iconSourcePath, packURL.path)

--- a/cmuxTests/CmuxConfigTests.swift
+++ b/cmuxTests/CmuxConfigTests.swift
@@ -1445,6 +1445,109 @@ final class CmuxConfigDecodingTests: XCTestCase {
     }
 
     @MainActor
+    func testPackSharedDependenciesDoNotReportCycle() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "cmux-config-pack-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        let projectDirectory = root.appendingPathComponent("project", isDirectory: true)
+        let cmuxDirectory = projectDirectory.appendingPathComponent(".cmux", isDirectory: true)
+        let baseDirectory = cmuxDirectory.appendingPathComponent("packs/base", isDirectory: true)
+        let teamDirectory = cmuxDirectory.appendingPathComponent("packs/team", isDirectory: true)
+        try FileManager.default.createDirectory(at: baseDirectory, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: teamDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let configURL = cmuxDirectory.appendingPathComponent("cmux.json")
+        let basePackURL = baseDirectory.appendingPathComponent("cmux.pack.json")
+        let teamPackURL = teamDirectory.appendingPathComponent("cmux.pack.json")
+        try """
+        {
+          "packs": ["./packs/base", "./packs/team"]
+        }
+        """.write(to: configURL, atomically: true, encoding: .utf8)
+        try """
+        {
+          "actions": {
+            "base.shared": { "type": "command", "command": "echo base" }
+          }
+        }
+        """.write(to: basePackURL, atomically: true, encoding: .utf8)
+        try """
+        {
+          "packs": ["../base"],
+          "actions": {
+            "team.tests": { "type": "command", "command": "npm test" }
+          }
+        }
+        """.write(to: teamPackURL, atomically: true, encoding: .utf8)
+
+        let store = CmuxConfigStore(
+            globalConfigPath: root.appendingPathComponent("missing-global.json").path,
+            localConfigPath: configURL.path,
+            startFileWatchers: false
+        )
+        store.loadAll()
+
+        XCTAssertEqual(store.resolvedAction(id: "base.shared")?.terminalCommand, "echo base")
+        XCTAssertEqual(store.resolvedAction(id: "team.tests")?.terminalCommand, "npm test")
+        XCTAssertTrue(store.configurationIssues.isEmpty)
+    }
+
+    @MainActor
+    func testPackRecursiveDependencyReportsCycle() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "cmux-config-pack-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        let projectDirectory = root.appendingPathComponent("project", isDirectory: true)
+        let cmuxDirectory = projectDirectory.appendingPathComponent(".cmux", isDirectory: true)
+        let baseDirectory = cmuxDirectory.appendingPathComponent("packs/base", isDirectory: true)
+        let teamDirectory = cmuxDirectory.appendingPathComponent("packs/team", isDirectory: true)
+        try FileManager.default.createDirectory(at: baseDirectory, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: teamDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let configURL = cmuxDirectory.appendingPathComponent("cmux.json")
+        let basePackURL = baseDirectory.appendingPathComponent("cmux.pack.json")
+        let teamPackURL = teamDirectory.appendingPathComponent("cmux.pack.json")
+        try """
+        {
+          "packs": ["./packs/team"]
+        }
+        """.write(to: configURL, atomically: true, encoding: .utf8)
+        try """
+        {
+          "packs": ["../team"],
+          "actions": {
+            "base.shared": { "type": "command", "command": "echo base" }
+          }
+        }
+        """.write(to: basePackURL, atomically: true, encoding: .utf8)
+        try """
+        {
+          "packs": ["../base"],
+          "actions": {
+            "team.tests": { "type": "command", "command": "npm test" }
+          }
+        }
+        """.write(to: teamPackURL, atomically: true, encoding: .utf8)
+
+        let store = CmuxConfigStore(
+            globalConfigPath: root.appendingPathComponent("missing-global.json").path,
+            localConfigPath: configURL.path,
+            startFileWatchers: false
+        )
+        store.loadAll()
+
+        XCTAssertEqual(store.resolvedAction(id: "base.shared")?.terminalCommand, "echo base")
+        XCTAssertEqual(store.resolvedAction(id: "team.tests")?.terminalCommand, "npm test")
+        XCTAssertTrue(store.configurationIssues.contains {
+            $0.kind == .schemaError && ($0.message?.contains("pack cycle ignored") ?? false)
+        })
+    }
+
+    @MainActor
     func testConfigDirectEntriesOverridePackEntries() throws {
         let root = FileManager.default.temporaryDirectory.appendingPathComponent(
             "cmux-config-pack-\(UUID().uuidString)",

--- a/cmuxTests/CmuxConfigTests.swift
+++ b/cmuxTests/CmuxConfigTests.swift
@@ -1478,6 +1478,98 @@ final class CmuxConfigDecodingTests: XCTestCase {
         XCTAssertTrue(store.configurationIssues.isEmpty)
     }
 
+    @MainActor
+    func testConfigNewWorkspaceCommandOverridesPackAction() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "cmux-config-pack-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        let packDirectory = root.appendingPathComponent("packs/team", isDirectory: true)
+        try FileManager.default.createDirectory(at: packDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let configURL = root.appendingPathComponent("cmux.json")
+        let packURL = packDirectory.appendingPathComponent("cmux.pack.json")
+        try """
+        {
+          "packs": ["./packs/team"],
+          "newWorkspaceCommand": "Local Dev",
+          "commands": [
+            { "name": "Local Dev", "workspace": { "name": "Local" } }
+          ]
+        }
+        """.write(to: configURL, atomically: true, encoding: .utf8)
+        try """
+        {
+          "actions": {
+            "team.dev": { "type": "workspaceCommand", "commandName": "Pack Dev" }
+          },
+          "ui": {
+            "newWorkspace": { "action": "team.dev" }
+          },
+          "commands": [
+            { "name": "Pack Dev", "workspace": { "name": "Pack" } }
+          ]
+        }
+        """.write(to: packURL, atomically: true, encoding: .utf8)
+
+        let store = CmuxConfigStore(
+            globalConfigPath: root.appendingPathComponent("missing-global.json").path,
+            localConfigPath: configURL.path,
+            startFileWatchers: false
+        )
+        store.loadAll()
+
+        let command = try XCTUnwrap(store.resolvedNewWorkspaceCommand())
+        XCTAssertEqual(command.command.name, "Local Dev")
+        XCTAssertEqual(command.sourcePath, configURL.path)
+        XCTAssertEqual(store.newWorkspaceCommandName, "Local Dev")
+        XCTAssertNil(store.newWorkspaceActionID)
+        XCTAssertTrue(store.configurationIssues.isEmpty)
+    }
+
+    @MainActor
+    func testConfigDirectBuiltInActionAliasOverridesPackAlias() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "cmux-config-pack-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        let packDirectory = root.appendingPathComponent("packs/team", isDirectory: true)
+        try FileManager.default.createDirectory(at: packDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let configURL = root.appendingPathComponent("cmux.json")
+        let packURL = packDirectory.appendingPathComponent("cmux.pack.json")
+        try """
+        {
+          "packs": ["./packs/team"],
+          "actions": {
+            "cmux.newTerminal": { "type": "command", "command": "echo local" }
+          }
+        }
+        """.write(to: configURL, atomically: true, encoding: .utf8)
+        try """
+        {
+          "actions": {
+            "newTerminal": { "type": "command", "command": "echo pack" }
+          }
+        }
+        """.write(to: packURL, atomically: true, encoding: .utf8)
+
+        let store = CmuxConfigStore(
+            globalConfigPath: root.appendingPathComponent("missing-global.json").path,
+            localConfigPath: configURL.path,
+            startFileWatchers: false
+        )
+        store.loadAll()
+
+        let action = try XCTUnwrap(store.resolvedAction(id: "newTerminal"))
+        XCTAssertEqual(action.id, "cmux.newTerminal")
+        XCTAssertEqual(action.terminalCommand, "echo local")
+        XCTAssertEqual(action.actionSourcePath, configURL.path)
+        XCTAssertTrue(store.configurationIssues.isEmpty)
+    }
+
     func testDecodeEmptyCommandsArray() throws {
         let json = """
         { "commands": [] }

--- a/cmuxTests/CmuxConfigTests.swift
+++ b/cmuxTests/CmuxConfigTests.swift
@@ -25,7 +25,8 @@ final class CmuxConfigDecodingTests: XCTestCase {
                 CmuxResolvedConfigAction.fromDefinition(
                     id: id,
                     definition: definition,
-                    sourcePath: sourcePath
+                    actionSourcePath: sourcePath,
+                    iconSourcePath: sourcePath
                 ).map { (id, $0) }
             }
         )
@@ -1568,6 +1569,144 @@ final class CmuxConfigDecodingTests: XCTestCase {
         XCTAssertEqual(action.terminalCommand, "echo local")
         XCTAssertEqual(action.actionSourcePath, configURL.path)
         XCTAssertTrue(store.configurationIssues.isEmpty)
+    }
+
+    @MainActor
+    func testGlobalPackUsesGlobalTrustSourceAndPackIconSource() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "cmux-config-pack-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        let globalDirectory = root.appendingPathComponent("global", isDirectory: true)
+        let packDirectory = globalDirectory.appendingPathComponent("packs/personal", isDirectory: true)
+        try FileManager.default.createDirectory(at: packDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let globalConfigURL = globalDirectory.appendingPathComponent("cmux.json")
+        let packURL = packDirectory.appendingPathComponent("cmux.pack.json")
+        try """
+        {
+          "packs": ["./packs/personal"]
+        }
+        """.write(to: globalConfigURL, atomically: true, encoding: .utf8)
+        try """
+        {
+          "actions": {
+            "personal.tests": {
+              "type": "command",
+              "title": "Personal Tests",
+              "command": "npm test",
+              "icon": { "type": "image", "path": "icons/tests.svg" }
+            }
+          },
+          "ui": {
+            "surfaceTabBar": {
+              "buttons": [
+                {
+                  "id": "personal.inline",
+                  "command": "npm run inline",
+                  "icon": { "type": "image", "path": "icons/inline.svg" }
+                },
+                { "action": "personal.tests" }
+              ]
+            }
+          },
+          "commands": [
+            { "name": "Personal Shell", "command": "echo personal" }
+          ]
+        }
+        """.write(to: packURL, atomically: true, encoding: .utf8)
+
+        let store = CmuxConfigStore(
+            globalConfigPath: globalConfigURL.path,
+            localConfigPath: nil,
+            startFileWatchers: false
+        )
+        store.loadAll()
+
+        let action = try XCTUnwrap(store.resolvedAction(id: "personal.tests"))
+        XCTAssertEqual(action.actionSourcePath, globalConfigURL.path)
+        XCTAssertEqual(action.iconSourcePath, packURL.path)
+        XCTAssertEqual(store.commandSourcePaths[store.loadedCommands[0].id], globalConfigURL.path)
+        XCTAssertEqual(store.surfaceTabBarButtonSourcePath, globalConfigURL.path)
+        let inlineButton = try XCTUnwrap(store.surfaceTabBarButtons.first { $0.id == "personal.inline" })
+        XCTAssertEqual(inlineButton.actionSourcePath, globalConfigURL.path)
+        XCTAssertEqual(inlineButton.iconSourcePath, packURL.path)
+        let actionButton = try XCTUnwrap(store.surfaceTabBarButtons.first { $0.id == "personal.tests" })
+        XCTAssertEqual(actionButton.actionSourcePath, globalConfigURL.path)
+        XCTAssertEqual(actionButton.iconSourcePath, packURL.path)
+        XCTAssertEqual(store.surfaceTabBarCommandSourcePaths["personal.tests"], globalConfigURL.path)
+        XCTAssertTrue(store.configurationIssues.isEmpty)
+    }
+
+    @MainActor
+    func testPackWatcherReloadsAfterInvalidPackIsFixed() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "cmux-config-pack-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        let projectDirectory = root.appendingPathComponent("project", isDirectory: true)
+        let cmuxDirectory = projectDirectory.appendingPathComponent(".cmux", isDirectory: true)
+        let packDirectory = cmuxDirectory.appendingPathComponent("packs/team", isDirectory: true)
+        try FileManager.default.createDirectory(at: packDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let configURL = cmuxDirectory.appendingPathComponent("cmux.json")
+        let packURL = packDirectory.appendingPathComponent("cmux.pack.json")
+        try """
+        {
+          "packs": ["./packs/team"]
+        }
+        """.write(to: configURL, atomically: true, encoding: .utf8)
+        try """
+        {
+          "actions": {
+            "team.tests": { "type": "command", "command": "npm test" }
+          }
+        }
+        """.write(to: packURL, atomically: true, encoding: .utf8)
+
+        let store = CmuxConfigStore(
+            globalConfigPath: root.appendingPathComponent("missing-global.json").path,
+            localConfigPath: configURL.path,
+            startFileWatchers: true
+        )
+        store.loadAll()
+        XCTAssertNotNil(store.resolvedAction(id: "team.tests"))
+
+        let invalidLoaded = expectation(description: "invalid pack is reported")
+        invalidLoaded.assertForOverFulfill = false
+        var issueCancellable: AnyCancellable?
+        issueCancellable = store.$configurationIssues.dropFirst().sink { issues in
+            if issues.contains(where: { $0.kind == .schemaError && $0.sourcePath == packURL.path }) {
+                invalidLoaded.fulfill()
+            }
+        }
+
+        try "{".write(to: packURL, atomically: true, encoding: .utf8)
+        await fulfillment(of: [invalidLoaded], timeout: 3)
+        issueCancellable?.cancel()
+        XCTAssertNil(store.resolvedAction(id: "team.tests"))
+
+        let fixedLoaded = expectation(description: "fixed pack is reloaded")
+        fixedLoaded.assertForOverFulfill = false
+        var actionCancellable: AnyCancellable?
+        actionCancellable = store.$loadedActions.dropFirst().sink { actions in
+            if actions.contains(where: { $0.id == "team.tests" && $0.terminalCommand == "npm run fixed" }) {
+                fixedLoaded.fulfill()
+            }
+        }
+
+        try """
+        {
+          "actions": {
+            "team.tests": { "type": "command", "command": "npm run fixed" }
+          }
+        }
+        """.write(to: packURL, atomically: true, encoding: .utf8)
+        await fulfillment(of: [fixedLoaded], timeout: 3)
+        actionCancellable?.cancel()
+        XCTAssertEqual(store.resolvedAction(id: "team.tests")?.terminalCommand, "npm run fixed")
     }
 
     func testDecodeEmptyCommandsArray() throws {

--- a/cmuxTests/CmuxConfigTests.swift
+++ b/cmuxTests/CmuxConfigTests.swift
@@ -1336,6 +1336,148 @@ final class CmuxConfigDecodingTests: XCTestCase {
         XCTAssertTrue(config.commands.isEmpty)
     }
 
+    func testDecodePacksAcceptsStringsAndObjects() throws {
+        let json = """
+        {
+          "packs": [
+            "./packs/team",
+            { "path": "~/.config/cmux/packs/personal/cmux.pack.json" }
+          ]
+        }
+        """
+        let config = try decode(json)
+
+        XCTAssertEqual(config.packs.map(\.path), [
+            "./packs/team",
+            "~/.config/cmux/packs/personal/cmux.pack.json"
+        ])
+    }
+
+    func testDecodePacksRejectsRemotePaths() {
+        let json = """
+        {
+          "packs": ["https://example.com/cmux-pack.json"]
+        }
+        """
+
+        XCTAssertThrowsError(try decode(json))
+    }
+
+    @MainActor
+    func testConfigStoreLoadsActionsCommandsAndButtonsFromPack() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "cmux-config-pack-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        let projectDirectory = root.appendingPathComponent("project", isDirectory: true)
+        let cmuxDirectory = projectDirectory.appendingPathComponent(".cmux", isDirectory: true)
+        let packDirectory = cmuxDirectory.appendingPathComponent("packs/team", isDirectory: true)
+        try FileManager.default.createDirectory(at: packDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let configURL = cmuxDirectory.appendingPathComponent("cmux.json")
+        let packURL = packDirectory.appendingPathComponent("cmux.pack.json")
+        try """
+        {
+          "packs": ["./packs/team"]
+        }
+        """.write(to: configURL, atomically: true, encoding: .utf8)
+        try """
+        {
+          "actions": {
+            "team.tests": {
+              "type": "command",
+              "title": "Team Tests",
+              "command": "npm test",
+              "target": "currentTerminal"
+            }
+          },
+          "ui": {
+            "surfaceTabBar": {
+              "buttons": [
+                {
+                  "action": "team.tests",
+                  "icon": { "type": "symbol", "name": "checkmark.circle" }
+                }
+              ]
+            }
+          },
+          "commands": [
+            { "name": "Team Shell", "command": "echo team" }
+          ]
+        }
+        """.write(to: packURL, atomically: true, encoding: .utf8)
+
+        let store = CmuxConfigStore(
+            globalConfigPath: root.appendingPathComponent("missing-global.json").path,
+            localConfigPath: configURL.path,
+            startFileWatchers: false
+        )
+        store.loadAll()
+
+        let action = try XCTUnwrap(store.resolvedAction(id: "team.tests"))
+        XCTAssertEqual(action.terminalCommand, "npm test")
+        XCTAssertEqual(action.actionSourcePath, packURL.path)
+        XCTAssertEqual(store.loadedCommands.map(\.name), ["Team Shell"])
+        XCTAssertEqual(store.commandSourcePaths[store.loadedCommands[0].id], packURL.path)
+        XCTAssertEqual(store.surfaceTabBarButtons.map(\.id), ["team.tests"])
+        XCTAssertEqual(store.surfaceTabBarButtons.first?.terminalCommand, "npm test")
+        XCTAssertEqual(store.surfaceTabBarButtonSourcePath, packURL.path)
+        XCTAssertEqual(store.surfaceTabBarCommandSourcePaths["team.tests"], packURL.path)
+        XCTAssertTrue(store.configurationIssues.isEmpty)
+    }
+
+    @MainActor
+    func testConfigDirectEntriesOverridePackEntries() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "cmux-config-pack-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        let packDirectory = root.appendingPathComponent("packs/team", isDirectory: true)
+        try FileManager.default.createDirectory(at: packDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let configURL = root.appendingPathComponent("cmux.json")
+        let packURL = packDirectory.appendingPathComponent("cmux.pack.json")
+        try """
+        {
+          "packs": ["./packs/team"],
+          "actions": {
+            "team.tests": { "type": "command", "command": "npm run local-test" }
+          },
+          "commands": [
+            { "name": "Dev", "command": "echo local" }
+          ]
+        }
+        """.write(to: configURL, atomically: true, encoding: .utf8)
+        try """
+        {
+          "actions": {
+            "team.tests": { "type": "command", "command": "npm test" }
+          },
+          "commands": [
+            { "name": "Dev", "command": "echo pack" },
+            { "name": "Lint", "command": "npm run lint" }
+          ]
+        }
+        """.write(to: packURL, atomically: true, encoding: .utf8)
+
+        let store = CmuxConfigStore(
+            globalConfigPath: root.appendingPathComponent("missing-global.json").path,
+            localConfigPath: configURL.path,
+            startFileWatchers: false
+        )
+        store.loadAll()
+
+        let action = try XCTUnwrap(store.resolvedAction(id: "team.tests"))
+        XCTAssertEqual(action.terminalCommand, "npm run local-test")
+        XCTAssertEqual(action.actionSourcePath, configURL.path)
+        XCTAssertEqual(store.loadedCommands.map(\.name), ["Dev", "Lint"])
+        XCTAssertEqual(store.commandSourcePaths[store.loadedCommands[0].id], configURL.path)
+        XCTAssertEqual(store.commandSourcePaths[store.loadedCommands[1].id], packURL.path)
+        XCTAssertTrue(store.configurationIssues.isEmpty)
+    }
+
     func testDecodeEmptyCommandsArray() throws {
         let json = """
         { "commands": [] }

--- a/examples/cmux-pack-template/README.md
+++ b/examples/cmux-pack-template/README.md
@@ -1,0 +1,15 @@
+# cmux Pack Template
+
+Prototype pack for sharing cmux actions, commands, and UI defaults.
+
+Fork or clone a pack into the project, then load it from a project config:
+
+```json
+{
+  "packs": ["./packs/team-defaults"]
+}
+```
+
+cmux resolves a directory pack to `cmux.pack.json`, so the example above loads `./packs/team-defaults/cmux.pack.json`.
+
+Pack entries use the same schema as `cmux.json`. Project configs override pack entries with the same action id or command name. Pack paths are local files or directories only.

--- a/examples/cmux-pack-template/README.md
+++ b/examples/cmux-pack-template/README.md
@@ -12,4 +12,4 @@ Fork or clone a pack into the project, then load it from a project config:
 
 cmux resolves a directory pack to `cmux.pack.json`, so the example above loads `./packs/team-defaults/cmux.pack.json`.
 
-Pack entries use the same schema as `cmux.json`. Project configs override pack entries with the same action id or command name. Pack paths are local files or directories only.
+Pack entries use the `cmux.json` action, command, and UI-default syntax. Project configs override pack entries with the same action id or command name. Pack paths are local files or directories only.

--- a/examples/cmux-pack-template/cmux.pack.json
+++ b/examples/cmux-pack-template/cmux.pack.json
@@ -1,0 +1,60 @@
+{
+  "actions": {
+    "team.tests": {
+      "type": "command",
+      "title": "Team Tests",
+      "subtitle": "Run the shared test command",
+      "command": "npm test",
+      "target": "currentTerminal",
+      "icon": { "type": "symbol", "name": "checkmark.circle" },
+      "keywords": ["test", "ci", "team"]
+    },
+    "team.dev-workspace": {
+      "type": "workspaceCommand",
+      "title": "Team Dev Workspace",
+      "commandName": "Team Dev"
+    }
+  },
+  "ui": {
+    "surfaceTabBar": {
+      "buttons": [
+        "newTerminal",
+        "newBrowser",
+        { "action": "team.tests" },
+        { "action": "team.dev-workspace" }
+      ]
+    },
+    "newWorkspace": {
+      "contextMenu": [
+        "cmux.newWorkspace",
+        "team.dev-workspace",
+        "-",
+        "team.tests"
+      ]
+    }
+  },
+  "commands": [
+    {
+      "name": "Team Dev",
+      "description": "Start the team's default dev layout.",
+      "workspace": {
+        "name": "Team Dev",
+        "layout": {
+          "split": "horizontal",
+          "children": [
+            {
+              "type": "terminal",
+              "name": "App",
+              "command": "npm run dev"
+            },
+            {
+              "type": "terminal",
+              "name": "Tests",
+              "command": "npm test -- --watch"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/examples/cmux-pack-template/cmux.pack.json
+++ b/examples/cmux-pack-template/cmux.pack.json
@@ -40,17 +40,29 @@
       "workspace": {
         "name": "Team Dev",
         "layout": {
-          "split": "horizontal",
+          "direction": "horizontal",
           "children": [
             {
-              "type": "terminal",
-              "name": "App",
-              "command": "npm run dev"
+              "pane": {
+                "surfaces": [
+                  {
+                    "type": "terminal",
+                    "name": "App",
+                    "command": "npm run dev"
+                  }
+                ]
+              }
             },
             {
-              "type": "terminal",
-              "name": "Tests",
-              "command": "npm test -- --watch"
+              "pane": {
+                "surfaces": [
+                  {
+                    "type": "terminal",
+                    "name": "Tests",
+                    "command": "npm test -- --watch"
+                  }
+                ]
+              }
             }
           ]
         }

--- a/web/data/cmux.schema.json
+++ b/web/data/cmux.schema.json
@@ -18,6 +18,34 @@
       "default": 1,
       "description": "Schema version for forward-compatible migrations. Newer versions are parsed on a best-effort basis."
     },
+    "packs": {
+      "title": "packs",
+      "description": "Local cmux pack files or directories to load before this config. Directory entries resolve to cmux.pack.json. Entries may be strings or objects with a path field.",
+      "type": "array",
+      "items": {
+        "oneOf": [
+          {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^(?!https?://).+"
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["path"],
+            "properties": {
+              "path": {
+                "type": "string",
+                "minLength": 1,
+                "pattern": "^(?!https?://).+",
+                "description": "Local file or directory path, relative to this config file unless absolute."
+              }
+            }
+          }
+        ]
+      },
+      "default": []
+    },
     "actions": {
       "title": "actions",
       "description": "Action registry used by the surface tab bar, Command Palette, shortcuts, and plus-button menu.",


### PR DESCRIPTION
## Summary
- add local-only `packs` entries to `cmux.json` so projects can load shared config files or directories
- merge pack actions, commands, new-workspace wiring, and surface tab bar buttons behind direct project/global config
- add a starter pack under `examples/cmux-pack-template` and document `packs` in the JSON schema
- fix pack attribution and cycle handling for built-in buttons, global packs, missing packs, invalid packs, and shared dependencies

## Verification
- `git diff --check`
- `jq . web/data/cmux.schema.json >/dev/null`
- `jq . examples/cmux-pack-template/cmux.pack.json >/dev/null`
- `./scripts/reload.sh --tag custom-packs` (`BUILD SUCCEEDED`)
- `/Users/lawrence/fun/cmuxterm-hq/skills/codex-review/scripts/codex-review --mode branch` clean
- GitHub PR checks green: 16 successful, 0 pending, 0 failing
- Vercel preview ready: https://cmux-git-feat-custom-packs-prototype-manaflow.vercel.app
- Vercel staging preview ready: https://cmux-staging-git-feat-custom-packs-prototype-manaflow.vercel.app