### PR TITLE
Allow five concurrent reload xcodebuilds

### DIFF
--- a/scripts/reload.sh
+++ b/scripts/reload.sh
@@ -512,7 +512,12 @@ XCODEBUILD_ARGS+=(build)
 XCODEBUILD_LOCK_DIR="${TMPDIR:-/tmp}/cmux-xcodebuild-$(id -u).locks"
 XCODEBUILD_LOCK_CONCURRENCY="${CMUX_XCODEBUILD_LOCK_CONCURRENCY:-5}"
 if ! is_positive_integer "$XCODEBUILD_LOCK_CONCURRENCY"; then
-  echo "error: CMUX_XCODEBUILD_LOCK_CONCURRENCY must be a positive integer" >&2
+  echo "error: xcodebuild lock concurrency must be a positive integer" >&2
+  exit 1
+fi
+XCODEBUILD_LOCK_WAIT_SECONDS="${CMUX_XCODEBUILD_LOCK_WAIT_SECONDS:-1800}"
+if ! is_positive_integer "$XCODEBUILD_LOCK_WAIT_SECONDS"; then
+  echo "error: xcodebuild lock wait timeout must be a positive integer" >&2
   exit 1
 fi
 # Xcode 26's SWBBuildService is a per-user singleton. Too many concurrent
@@ -521,48 +526,68 @@ fi
 python3 -c '
 import fcntl
 import os
+import signal
 import sys
-import time
 
 lock_dir = sys.argv[1]
 concurrency = int(sys.argv[2])
-command = sys.argv[3:]
+wait_seconds = int(sys.argv[3])
+command = sys.argv[4:]
 
 try:
     os.makedirs(lock_dir, mode=0o700, exist_ok=True)
 except OSError as exc:
     raise SystemExit(f"error: create lock dir: {exc}")
 
-def acquire_slot():
-    for slot in range(1, concurrency + 1):
-        lock_path = os.path.join(lock_dir, f"slot-{slot}.lock")
-        try:
-            fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
-        except OSError as exc:
-            raise SystemExit(f"error: open lock slot: {exc}")
+def next_ticket():
+    counter_path = os.path.join(lock_dir, "counter")
+    try:
+        fd = os.open(counter_path, os.O_CREAT | os.O_RDWR, 0o600)
+    except OSError as exc:
+        raise SystemExit(f"error: open lock counter: {exc}")
 
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        raw = os.read(fd, 64).decode().strip()
+        current = int(raw) if raw else 0
+        os.lseek(fd, 0, os.SEEK_SET)
+        os.ftruncate(fd, 0)
+        os.write(fd, f"{current + 1}\n".encode())
+        return current
+    except ValueError:
+        raise SystemExit("error: xcodebuild lock counter is corrupt")
+    except OSError as exc:
+        raise SystemExit(f"error: update lock counter: {exc}")
+    finally:
         try:
-            flags = fcntl.fcntl(fd, fcntl.F_GETFD)
-            fcntl.fcntl(fd, fcntl.F_SETFD, flags & ~fcntl.FD_CLOEXEC)
-        except OSError as exc:
             os.close(fd)
-            raise SystemExit(f"error: fcntl lock fd: {exc}")
+        except OSError:
+            pass
 
-        try:
-            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-            return fd, lock_path
-        except BlockingIOError:
-            os.close(fd)
-        except OSError as exc:
-            os.close(fd)
-            raise SystemExit(f"error: flock: {exc}")
-    return None, None
+def timeout_handler(signum, frame):
+    raise TimeoutError()
 
-fd, lock_path = acquire_slot()
-if fd is None:
+ticket = next_ticket()
+slot = (ticket % concurrency) + 1
+lock_path = os.path.join(lock_dir, f"slot-{slot}.lock")
+try:
+    fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+except OSError as exc:
+    raise SystemExit(f"error: open lock slot: {exc}")
+
+try:
+    flags = fcntl.fcntl(fd, fcntl.F_GETFD)
+    fcntl.fcntl(fd, fcntl.F_SETFD, flags & ~fcntl.FD_CLOEXEC)
+except OSError as exc:
+    os.close(fd)
+    raise SystemExit(f"error: fcntl lock fd: {exc}")
+
+try:
+    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+except BlockingIOError:
     msg = (
         f"==> xcodebuild concurrency limit reached ({concurrency}); "
-        f"waiting for a slot in {lock_dir}...\n"
+        f"waiting for slot {slot}/{concurrency}...\n"
     )
     # reload.sh saves the original stderr on fd 4 before redirecting to the
     # log file. Surface the wait notice to the terminal so the user knows
@@ -573,15 +598,31 @@ if fd is None:
     except OSError:
         sys.stderr.write(msg)
         sys.stderr.flush()
-    while fd is None:
-        time.sleep(0.2)
-        fd, lock_path = acquire_slot()
+    previous_handler = signal.signal(signal.SIGALRM, timeout_handler)
+    signal.alarm(wait_seconds)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+    except TimeoutError:
+        os.close(fd)
+        raise SystemExit(
+            f"error: timed out waiting for xcodebuild slot after {wait_seconds}s "
+            f"(slot {slot}/{concurrency}); check for stuck xcodebuild processes"
+        )
+    except OSError as exc:
+        os.close(fd)
+        raise SystemExit(f"error: flock: {exc}")
+    finally:
+        signal.alarm(0)
+        signal.signal(signal.SIGALRM, previous_handler)
+except OSError as exc:
+    os.close(fd)
+    raise SystemExit(f"error: flock: {exc}")
 
 try:
     os.execvp(command[0], command)
 except OSError as exc:
     raise SystemExit(f"error: exec: {exc}")
-' "$XCODEBUILD_LOCK_DIR" "$XCODEBUILD_LOCK_CONCURRENCY" xcodebuild "${XCODEBUILD_ARGS[@]}"
+' "$XCODEBUILD_LOCK_DIR" "$XCODEBUILD_LOCK_CONCURRENCY" "$XCODEBUILD_LOCK_WAIT_SECONDS" xcodebuild "${XCODEBUILD_ARGS[@]}"
 sleep 0.2
 
 FALLBACK_APP_NAME="$BASE_APP_NAME"

--- a/scripts/reload.sh
+++ b/scripts/reload.sh
@@ -509,34 +509,61 @@ if [[ "${CMUX_SKIP_ZIG_BUILD:-}" == "1" ]]; then
 fi
 XCODEBUILD_ARGS+=(build)
 
-XCODEBUILD_LOCK="${TMPDIR:-/tmp}/cmux-xcodebuild-$(id -u).lock"
-# Xcode 26's SWBBuildService is a per-user singleton. Concurrent xcodebuild
-# invocations (even with separate -derivedDataPath) share that daemon and can
-# crash it, SIGTERMing in-flight builds. Serialize via a per-user lock so
-# parallel reload.sh runs queue instead of trampling each other.
+XCODEBUILD_LOCK_DIR="${TMPDIR:-/tmp}/cmux-xcodebuild-$(id -u).locks"
+XCODEBUILD_LOCK_CONCURRENCY="${CMUX_XCODEBUILD_LOCK_CONCURRENCY:-5}"
+if ! is_positive_integer "$XCODEBUILD_LOCK_CONCURRENCY"; then
+  echo "error: CMUX_XCODEBUILD_LOCK_CONCURRENCY must be a positive integer" >&2
+  exit 1
+fi
+# Xcode 26's SWBBuildService is a per-user singleton. Too many concurrent
+# xcodebuild invocations can trample that daemon, so cap reload.sh builds at
+# five per user while still allowing useful parallel tagged builds.
 python3 -c '
 import fcntl
 import os
 import sys
+import time
 
-lock_path = sys.argv[1]
-command = sys.argv[2:]
+lock_dir = sys.argv[1]
+concurrency = int(sys.argv[2])
+command = sys.argv[3:]
 
 try:
-    fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+    os.makedirs(lock_dir, mode=0o700, exist_ok=True)
 except OSError as exc:
-    raise SystemExit(f"error: open lock: {exc}")
+    raise SystemExit(f"error: create lock dir: {exc}")
 
-try:
-    flags = fcntl.fcntl(fd, fcntl.F_GETFD)
-    fcntl.fcntl(fd, fcntl.F_SETFD, flags & ~fcntl.FD_CLOEXEC)
-except OSError as exc:
-    raise SystemExit(f"error: fcntl lock fd: {exc}")
+def acquire_slot():
+    for slot in range(1, concurrency + 1):
+        lock_path = os.path.join(lock_dir, f"slot-{slot}.lock")
+        try:
+            fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+        except OSError as exc:
+            raise SystemExit(f"error: open lock slot: {exc}")
 
-try:
-    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-except BlockingIOError:
-    msg = f"==> Another xcodebuild is running; waiting for {lock_path}...\n"
+        try:
+            flags = fcntl.fcntl(fd, fcntl.F_GETFD)
+            fcntl.fcntl(fd, fcntl.F_SETFD, flags & ~fcntl.FD_CLOEXEC)
+        except OSError as exc:
+            os.close(fd)
+            raise SystemExit(f"error: fcntl lock fd: {exc}")
+
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return fd, lock_path
+        except BlockingIOError:
+            os.close(fd)
+        except OSError as exc:
+            os.close(fd)
+            raise SystemExit(f"error: flock: {exc}")
+    return None, None
+
+fd, lock_path = acquire_slot()
+if fd is None:
+    msg = (
+        f"==> xcodebuild concurrency limit reached ({concurrency}); "
+        f"waiting for a slot in {lock_dir}...\n"
+    )
     # reload.sh saves the original stderr on fd 4 before redirecting to the
     # log file. Surface the wait notice to the terminal so the user knows
     # they are queued, not hung. Fall back to stderr (the log) if fd 4 is
@@ -546,18 +573,15 @@ except BlockingIOError:
     except OSError:
         sys.stderr.write(msg)
         sys.stderr.flush()
-    try:
-        fcntl.flock(fd, fcntl.LOCK_EX)
-    except OSError as exc:
-        raise SystemExit(f"error: flock: {exc}")
-except OSError as exc:
-    raise SystemExit(f"error: flock: {exc}")
+    while fd is None:
+        time.sleep(0.2)
+        fd, lock_path = acquire_slot()
 
 try:
     os.execvp(command[0], command)
 except OSError as exc:
     raise SystemExit(f"error: exec: {exc}")
-' "$XCODEBUILD_LOCK" xcodebuild "${XCODEBUILD_ARGS[@]}"
+' "$XCODEBUILD_LOCK_DIR" "$XCODEBUILD_LOCK_CONCURRENCY" xcodebuild "${XCODEBUILD_ARGS[@]}"
 sleep 0.2
 
 FALLBACK_APP_NAME="$BASE_APP_NAME"

--- a/scripts/reload.sh
+++ b/scripts/reload.sh
@@ -592,9 +592,9 @@ def wait_for_any_slot():
         for slot in range(1, concurrency + 1):
             pid = os.fork()
             if pid == 0:
-                parent_sock.close()
-                fd, _ = open_slot(slot)
                 try:
+                    parent_sock.close()
+                    fd, _ = open_slot(slot)
                     fcntl.flock(fd, fcntl.LOCK_EX)
                     payload = array.array("i", [fd])
                     child_sock.sendmsg(

--- a/scripts/reload.sh
+++ b/scripts/reload.sh
@@ -524,9 +524,12 @@ fi
 # xcodebuild invocations can trample that daemon, so cap reload.sh builds at
 # five per user while still allowing useful parallel tagged builds.
 python3 -c '
+import array
 import fcntl
 import os
+import select
 import signal
+import socket
 import sys
 
 lock_dir = sys.argv[1]
@@ -539,55 +542,109 @@ try:
 except OSError as exc:
     raise SystemExit(f"error: create lock dir: {exc}")
 
-def next_ticket():
-    counter_path = os.path.join(lock_dir, "counter")
+def open_slot(slot):
+    lock_path = os.path.join(lock_dir, f"slot-{slot}.lock")
     try:
-        fd = os.open(counter_path, os.O_CREAT | os.O_RDWR, 0o600)
+        fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
     except OSError as exc:
-        raise SystemExit(f"error: open lock counter: {exc}")
+        raise SystemExit(f"error: open lock slot: {exc}")
 
     try:
-        fcntl.flock(fd, fcntl.LOCK_EX)
-        raw = os.read(fd, 64).decode().strip()
-        current = int(raw) if raw else 0
-        os.lseek(fd, 0, os.SEEK_SET)
-        os.ftruncate(fd, 0)
-        os.write(fd, f"{current + 1}\n".encode())
-        return current
-    except ValueError:
-        raise SystemExit("error: xcodebuild lock counter is corrupt")
+        os.set_inheritable(fd, True)
     except OSError as exc:
-        raise SystemExit(f"error: update lock counter: {exc}")
-    finally:
+        os.close(fd)
+        raise SystemExit(f"error: fcntl lock fd: {exc}")
+    return fd, lock_path
+
+def try_acquire_any_slot():
+    for slot in range(1, concurrency + 1):
+        fd, lock_path = open_slot(slot)
         try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return fd, slot, lock_path
+        except BlockingIOError:
             os.close(fd)
+        except OSError as exc:
+            os.close(fd)
+            raise SystemExit(f"error: flock: {exc}")
+    return None, None, None
+
+def stop_waiters(children):
+    for pid in children:
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+        except OSError:
+            pass
+    for pid in children:
+        try:
+            os.waitpid(pid, 0)
+        except ChildProcessError:
+            pass
         except OSError:
             pass
 
-def timeout_handler(signum, frame):
-    raise TimeoutError()
+def wait_for_any_slot():
+    parent_sock, child_sock = socket.socketpair()
+    children = []
+    try:
+        for slot in range(1, concurrency + 1):
+            pid = os.fork()
+            if pid == 0:
+                parent_sock.close()
+                fd, _ = open_slot(slot)
+                try:
+                    fcntl.flock(fd, fcntl.LOCK_EX)
+                    payload = array.array("i", [fd])
+                    child_sock.sendmsg(
+                        [f"{slot}".encode()],
+                        [(socket.SOL_SOCKET, socket.SCM_RIGHTS, payload)],
+                    )
+                except BaseException:
+                    os._exit(1)
+                os._exit(0)
+            children.append(pid)
+        child_sock.close()
 
-ticket = next_ticket()
-slot = (ticket % concurrency) + 1
-lock_path = os.path.join(lock_dir, f"slot-{slot}.lock")
-try:
-    fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
-except OSError as exc:
-    raise SystemExit(f"error: open lock slot: {exc}")
+        ready, _, _ = select.select([parent_sock], [], [], wait_seconds)
+        if not ready:
+            raise SystemExit(
+                f"error: timed out waiting for xcodebuild slot after {wait_seconds}s; "
+                "check for stuck xcodebuild processes"
+            )
 
-try:
-    flags = fcntl.fcntl(fd, fcntl.F_GETFD)
-    fcntl.fcntl(fd, fcntl.F_SETFD, flags & ~fcntl.FD_CLOEXEC)
-except OSError as exc:
-    os.close(fd)
-    raise SystemExit(f"error: fcntl lock fd: {exc}")
+        msg, ancdata, _, _ = parent_sock.recvmsg(
+            16,
+            socket.CMSG_LEN(array.array("i").itemsize),
+        )
+        received = array.array("i")
+        for level, ctype, data in ancdata:
+            if level == socket.SOL_SOCKET and ctype == socket.SCM_RIGHTS:
+                received.frombytes(data[: array.array("i").itemsize])
+        if not received:
+            raise SystemExit("error: failed to receive xcodebuild lock slot")
+        fd = received[0]
+        os.set_inheritable(fd, True)
+        try:
+            slot = int(msg.decode())
+        except ValueError:
+            slot = 0
+        lock_path = os.path.join(lock_dir, f"slot-{slot}.lock")
+        return fd, slot, lock_path
+    finally:
+        stop_waiters(children)
+        parent_sock.close()
+        try:
+            child_sock.close()
+        except OSError:
+            pass
 
-try:
-    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-except BlockingIOError:
+fd, slot, lock_path = try_acquire_any_slot()
+if fd is None:
     msg = (
         f"==> xcodebuild concurrency limit reached ({concurrency}); "
-        f"waiting for slot {slot}/{concurrency}...\n"
+        "waiting for the next available slot...\n"
     )
     # reload.sh saves the original stderr on fd 4 before redirecting to the
     # log file. Surface the wait notice to the terminal so the user knows
@@ -598,25 +655,7 @@ except BlockingIOError:
     except OSError:
         sys.stderr.write(msg)
         sys.stderr.flush()
-    previous_handler = signal.signal(signal.SIGALRM, timeout_handler)
-    signal.alarm(wait_seconds)
-    try:
-        fcntl.flock(fd, fcntl.LOCK_EX)
-    except TimeoutError:
-        os.close(fd)
-        raise SystemExit(
-            f"error: timed out waiting for xcodebuild slot after {wait_seconds}s "
-            f"(slot {slot}/{concurrency}); check for stuck xcodebuild processes"
-        )
-    except OSError as exc:
-        os.close(fd)
-        raise SystemExit(f"error: flock: {exc}")
-    finally:
-        signal.alarm(0)
-        signal.signal(signal.SIGALRM, previous_handler)
-except OSError as exc:
-    os.close(fd)
-    raise SystemExit(f"error: flock: {exc}")
+    fd, slot, lock_path = wait_for_any_slot()
 
 try:
     os.execvp(command[0], command)


### PR DESCRIPTION
Summary:
- Replace the exclusive reload xcodebuild lock with five per-user flock slots.
- Scan all slots first, then wait on every slot with blocking flock helpers so queued builds take the next slot that actually frees.
- Keep positive-integer overrides for lock concurrency and wait timeout, defaulting to 5 slots and 1800 seconds.

Testing:
- bash -n scripts/reload.sh
- Embedded lock Python parses
- Synthetic contention check observed max concurrency 5
- Synthetic wait-any check acquired a fast freed slot instead of waiting for a slow slot
- ./scripts/reload.sh --tag xlock5

Checklist:
- [x] Focused verification run
- [x] Tagged reload built for dogfood
- [x] Review feedback addressed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved build concurrency: xcodebuild can run in parallel with a configurable concurrency limit (CMUX_XCODEBUILD_LOCK_CONCURRENCY) and bounded wait timeout (CMUX_XCODEBUILD_LOCK_WAIT_SECONDS). When the limit is reached, callers see a “concurrency limit reached … waiting” message; waiting times out with an error.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4599?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `reload.sh` build-serialization mechanism to a multi-slot locking scheme with forking/wait logic, which could affect developer build reliability or lead to stuck waits if bugs exist. Scope is limited to the dev build script and is guarded by validation and timeouts.
> 
> **Overview**
> `scripts/reload.sh` replaces the single per-user `xcodebuild` lock with a **configurable multi-slot (default 5) locking system** to allow several tagged reload builds to run in parallel without overwhelming Xcode 26’s `SWBBuildService`.
> 
> It adds env-configurable **concurrency** (`CMUX_XCODEBUILD_LOCK_CONCURRENCY`) and **wait timeout** (`CMUX_XCODEBUILD_LOCK_WAIT_SECONDS`) with positive-integer validation, and updates the embedded Python to scan for a free slot first, otherwise queue by waiting on *any* slot to free and emitting a terminal-visible “queued” message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93113e3cd6c60d7022a3f1bdd6e155d0ef437ee1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->