### PR TITLE
Make xcodebuild reload concurrency configurable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Validate release asset guard
         run: node scripts/release_asset_guard.test.js
 
+      - name: Validate xcodebuild concurrency runner
+        run: ./tests/test_ci_xcodebuild_concurrency_runner.sh
+
       - name: Validate current GhosttyKit checksum pin
         run: ./tests/test_ci_ghosttykit_checksum_present.sh
 

--- a/scripts/reload.sh
+++ b/scripts/reload.sh
@@ -10,6 +10,7 @@ BUNDLE_SET=0
 DERIVED_SET=0
 TAG=""
 LAUNCH=0
+XCODEBUILD_CONCURRENCY=""
 CMUX_DEBUG_LOG=""
 CMUX_DEV_PORT=""
 CMUX_DEV_PORT_END=""
@@ -190,6 +191,10 @@ Options:
   --name <app name>      Override app display/bundle name.
   --bundle-id <id>       Override bundle identifier.
   --derived-data <path>  Override derived data path.
+  --xcodebuild-concurrency <count>
+                         Max local xcodebuild jobs allowed through the per-user
+                         reload queue. Defaults to $CMUX_XCODEBUILD_CONCURRENCY,
+                         ~/.config/cmux/xcodebuild-concurrency, then 1.
   -h, --help             Show this help.
 EOF
 }
@@ -373,6 +378,14 @@ while [[ $# -gt 0 ]]; do
       DERIVED_SET=1
       shift 2
       ;;
+    --xcodebuild-concurrency)
+      XCODEBUILD_CONCURRENCY="${2:-}"
+      if [[ -z "$XCODEBUILD_CONCURRENCY" ]]; then
+        echo "error: --xcodebuild-concurrency requires a value" >&2
+        exit 1
+      fi
+      shift 2
+      ;;
     -h|--help)
       usage
       exit 0
@@ -509,55 +522,18 @@ if [[ "${CMUX_SKIP_ZIG_BUILD:-}" == "1" ]]; then
 fi
 XCODEBUILD_ARGS+=(build)
 
-XCODEBUILD_LOCK="${TMPDIR:-/tmp}/cmux-xcodebuild-$(id -u).lock"
+XCODEBUILD_LOCK_ROOT="${TMPDIR:-/tmp}/cmux-xcodebuild-$(id -u).slots"
 # Xcode 26's SWBBuildService is a per-user singleton. Concurrent xcodebuild
 # invocations (even with separate -derivedDataPath) share that daemon and can
-# crash it, SIGTERMing in-flight builds. Serialize via a per-user lock so
-# parallel reload.sh runs queue instead of trampling each other.
-python3 -c '
-import fcntl
-import os
-import sys
-
-lock_path = sys.argv[1]
-command = sys.argv[2:]
-
-try:
-    fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
-except OSError as exc:
-    raise SystemExit(f"error: open lock: {exc}")
-
-try:
-    flags = fcntl.fcntl(fd, fcntl.F_GETFD)
-    fcntl.fcntl(fd, fcntl.F_SETFD, flags & ~fcntl.FD_CLOEXEC)
-except OSError as exc:
-    raise SystemExit(f"error: fcntl lock fd: {exc}")
-
-try:
-    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-except BlockingIOError:
-    msg = f"==> Another xcodebuild is running; waiting for {lock_path}...\n"
-    # reload.sh saves the original stderr on fd 4 before redirecting to the
-    # log file. Surface the wait notice to the terminal so the user knows
-    # they are queued, not hung. Fall back to stderr (the log) if fd 4 is
-    # unavailable (e.g. when this script is run standalone).
-    try:
-        os.write(4, msg.encode())
-    except OSError:
-        sys.stderr.write(msg)
-        sys.stderr.flush()
-    try:
-        fcntl.flock(fd, fcntl.LOCK_EX)
-    except OSError as exc:
-        raise SystemExit(f"error: flock: {exc}")
-except OSError as exc:
-    raise SystemExit(f"error: flock: {exc}")
-
-try:
-    os.execvp(command[0], command)
-except OSError as exc:
-    raise SystemExit(f"error: exec: {exc}")
-' "$XCODEBUILD_LOCK" xcodebuild "${XCODEBUILD_ARGS[@]}"
+# crash it, SIGTERMing in-flight builds. Queue through a per-user slot lock so
+# machines with more headroom can opt into a higher local build limit.
+XCODEBUILD_RUNNER_ARGS=(
+  --lock-root "$XCODEBUILD_LOCK_ROOT"
+)
+if [[ -n "$XCODEBUILD_CONCURRENCY" ]]; then
+  XCODEBUILD_RUNNER_ARGS+=(--concurrency "$XCODEBUILD_CONCURRENCY")
+fi
+python3 "$PWD/scripts/xcodebuild-concurrency-runner.py" "${XCODEBUILD_RUNNER_ARGS[@]}" -- xcodebuild "${XCODEBUILD_ARGS[@]}"
 sleep 0.2
 
 FALLBACK_APP_NAME="$BASE_APP_NAME"

--- a/scripts/xcodebuild-concurrency-runner.py
+++ b/scripts/xcodebuild-concurrency-runner.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Run xcodebuild behind a per-user configurable slot lock."""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import os
+import pathlib
+import re
+import shlex
+import sys
+import time
+
+
+DEFAULT_CONFIG_FILE = pathlib.Path.home() / ".config/cmux/xcodebuild-concurrency"
+WAIT_NOTICE_INTERVAL_SECONDS = 30
+WAIT_POLL_SECONDS = 1
+
+
+class ConfigError(Exception):
+    pass
+
+
+def write_user(message: str) -> None:
+    try:
+        os.write(4, message.encode("utf-8"))
+    except OSError:
+        sys.stderr.write(message)
+        sys.stderr.flush()
+
+
+def parse_positive_int(raw_value: str, source: str) -> int:
+    value = raw_value.strip()
+    if not re.fullmatch(r"[0-9]+", value):
+        raise ConfigError(f"{source} must be a positive integer, got {raw_value!r}")
+    parsed = int(value, 10)
+    if parsed < 1:
+        raise ConfigError(f"{source} must be a positive integer, got {raw_value!r}")
+    return parsed
+
+
+def first_config_value(path: pathlib.Path) -> str | None:
+    try:
+        contents = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        raise ConfigError(f"could not read {path}: {exc}") from exc
+
+    for line in contents.splitlines():
+        value = line.split("#", 1)[0].strip()
+        if value:
+            return value
+    return None
+
+
+def choose_concurrency(args: argparse.Namespace) -> int:
+    if args.concurrency:
+        return parse_positive_int(args.concurrency, "--xcodebuild-concurrency")
+
+    env_value = os.environ.get("CMUX_XCODEBUILD_CONCURRENCY")
+    if env_value:
+        return parse_positive_int(env_value, "CMUX_XCODEBUILD_CONCURRENCY")
+
+    config_file = pathlib.Path(
+        args.config_file
+        or os.environ.get("CMUX_XCODEBUILD_CONCURRENCY_FILE")
+        or DEFAULT_CONFIG_FILE
+    )
+    config_value = first_config_value(config_file)
+    if config_value:
+        return parse_positive_int(config_value, str(config_file))
+
+    return 1
+
+
+def lock_file_path(lock_root: pathlib.Path, slot_index: int) -> pathlib.Path:
+    return lock_root / f"slot-{slot_index}.lock"
+
+
+def try_acquire_slot(
+    lock_root: pathlib.Path,
+    concurrency: int,
+    command: list[str],
+) -> tuple[int, int] | None:
+    for slot_index in range(concurrency):
+        path = lock_file_path(lock_root, slot_index)
+        fd = os.open(path, os.O_CREAT | os.O_RDWR, 0o600)
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            os.close(fd)
+            continue
+        except OSError:
+            os.close(fd)
+            raise
+
+        os.set_inheritable(fd, True)
+        record = (
+            f"pid={os.getpid()}\n"
+            f"slot={slot_index + 1}/{concurrency}\n"
+            f"cwd={os.getcwd()}\n"
+            f"command={shlex.join(command)}\n"
+        )
+        os.ftruncate(fd, 0)
+        os.write(fd, record.encode("utf-8"))
+        os.lseek(fd, 0, os.SEEK_SET)
+        return slot_index, fd
+
+    return None
+
+
+def acquire_slot(
+    lock_root: pathlib.Path,
+    concurrency: int,
+    command: list[str],
+) -> tuple[int, int]:
+    lock_root.mkdir(mode=0o700, parents=True, exist_ok=True)
+    announced = False
+    start = time.monotonic()
+    next_notice = start + WAIT_NOTICE_INTERVAL_SECONDS
+
+    while True:
+        acquired = try_acquire_slot(lock_root, concurrency, command)
+        if acquired is not None:
+            if announced:
+                slot_index, _ = acquired
+                write_user(
+                    f"==> xcodebuild slot {slot_index + 1}/{concurrency} acquired.\n"
+                )
+            return acquired
+
+        now = time.monotonic()
+        if not announced:
+            write_user(
+                f"==> All {concurrency} local xcodebuild slots are busy; "
+                f"waiting under {lock_root}...\n"
+            )
+            announced = True
+        elif now >= next_notice:
+            elapsed = int(now - start)
+            write_user(
+                f"==> Still waiting for a local xcodebuild slot "
+                f"({elapsed}s; limit {concurrency})...\n"
+            )
+            next_notice = now + WAIT_NOTICE_INTERVAL_SECONDS
+
+        time.sleep(WAIT_POLL_SECONDS)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run a command while holding a configurable xcodebuild slot lock."
+    )
+    parser.add_argument("--lock-root", required=True)
+    parser.add_argument("--concurrency")
+    parser.add_argument("--config-file")
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    args = parser.parse_args(argv)
+    if args.command and args.command[0] == "--":
+        args.command = args.command[1:]
+    if not args.command:
+        parser.error("missing command after --")
+    return args
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    try:
+        concurrency = choose_concurrency(args)
+        acquire_slot(pathlib.Path(args.lock_root), concurrency, args.command)
+    except ConfigError as exc:
+        print(f"xcodebuild concurrency config error: {exc}", file=sys.stderr)
+        return 2
+    except OSError as exc:
+        print(f"xcodebuild concurrency lock error: {exc}", file=sys.stderr)
+        return 1
+
+    # Keep the slot lock fd open across exec. If xcodebuild is killed by
+    # SIGTERM/SIGKILL, the kernel closes the fd and releases the slot.
+    os.environ["CMUX_XCODEBUILD_SLOT_HELD"] = "1"
+    try:
+        os.execvp(args.command[0], args.command)
+    except OSError as exc:
+        print(f"xcodebuild concurrency exec error: {exc}", file=sys.stderr)
+        return 127
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/test_ci_xcodebuild_concurrency_runner.sh
+++ b/tests/test_ci_xcodebuild_concurrency_runner.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+RUNNER="$ROOT_DIR/scripts/xcodebuild-concurrency-runner.py"
+TMP_DIR="$(mktemp -d)"
+declare -a CHILD_PIDS=()
+
+cleanup() {
+  for pid in "${CHILD_PIDS[@]:-}"; do
+    kill "$pid" 2>/dev/null || true
+  done
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+wait_for_file() {
+  local path="$1"
+  local attempts="${2:-100}"
+  for ((i = 0; i < attempts; i++)); do
+    if [[ -f "$path" ]]; then
+      return 0
+    fi
+    sleep 0.05
+  done
+  echo "timed out waiting for $path" >&2
+  return 1
+}
+
+assert_file_absent_for() {
+  local path="$1"
+  local attempts="${2:-12}"
+  for ((i = 0; i < attempts; i++)); do
+    if [[ -f "$path" ]]; then
+      echo "expected $path to remain absent" >&2
+      return 1
+    fi
+    sleep 0.05
+  done
+}
+
+wait_for_pattern() {
+  local path="$1"
+  local pattern="$2"
+  local attempts="${3:-100}"
+  for ((i = 0; i < attempts; i++)); do
+    if [[ -f "$path" ]] && grep -Fq "$pattern" "$path"; then
+      return 0
+    fi
+    sleep 0.05
+  done
+  echo "timed out waiting for $pattern in $path" >&2
+  [[ -f "$path" ]] && cat "$path" >&2
+  return 1
+}
+
+cat > "$TMP_DIR/hold.py" <<'PY'
+import pathlib
+import sys
+import time
+
+ready = pathlib.Path(sys.argv[1])
+release = pathlib.Path(sys.argv[2])
+ready.write_text("ready\n", encoding="utf-8")
+
+deadline = time.time() + 20
+while not release.exists():
+    if time.time() > deadline:
+        raise SystemExit(f"timed out waiting for {release}")
+    time.sleep(0.05)
+PY
+
+cat > "$TMP_DIR/touch.py" <<'PY'
+import pathlib
+import sys
+
+pathlib.Path(sys.argv[1]).write_text("done\n", encoding="utf-8")
+PY
+
+cat > "$TMP_DIR/require_slot_env.py" <<'PY'
+import os
+import pathlib
+import sys
+
+if os.environ.get("CMUX_XCODEBUILD_SLOT_HELD") != "1":
+    raise SystemExit("missing CMUX_XCODEBUILD_SLOT_HELD")
+pathlib.Path(sys.argv[1]).write_text("slot env set\n", encoding="utf-8")
+PY
+
+CMUX_XCODEBUILD_CONCURRENCY=1 \
+  "$RUNNER" --lock-root "$TMP_DIR/slots-env" -- \
+  python3 "$TMP_DIR/require_slot_env.py" "$TMP_DIR/slot-env.done" \
+  >"$TMP_DIR/slot-env.out" 2>&1
+wait_for_file "$TMP_DIR/slot-env.done"
+
+CMUX_XCODEBUILD_CONCURRENCY=1 \
+  "$RUNNER" --lock-root "$TMP_DIR/slots-one" -- \
+  python3 "$TMP_DIR/hold.py" "$TMP_DIR/one.ready" "$TMP_DIR/one.release" \
+  >"$TMP_DIR/one-holder.out" 2>&1 &
+one_holder_pid="$!"
+CHILD_PIDS+=("$one_holder_pid")
+wait_for_file "$TMP_DIR/one.ready"
+
+CMUX_XCODEBUILD_CONCURRENCY=1 \
+  "$RUNNER" --lock-root "$TMP_DIR/slots-one" -- \
+  python3 "$TMP_DIR/touch.py" "$TMP_DIR/one-queued.done" \
+  >"$TMP_DIR/one-queued.out" 2>&1 &
+one_queued_pid="$!"
+CHILD_PIDS+=("$one_queued_pid")
+
+wait_for_pattern "$TMP_DIR/one-queued.out" "All 1 local xcodebuild slots are busy"
+assert_file_absent_for "$TMP_DIR/one-queued.done"
+touch "$TMP_DIR/one.release"
+wait "$one_holder_pid"
+wait "$one_queued_pid"
+CHILD_PIDS=()
+wait_for_file "$TMP_DIR/one-queued.done"
+
+CMUX_XCODEBUILD_CONCURRENCY=1 \
+  "$RUNNER" --lock-root "$TMP_DIR/slots-term" -- \
+  python3 "$TMP_DIR/hold.py" "$TMP_DIR/term.ready" "$TMP_DIR/term.release" \
+  >"$TMP_DIR/term-holder.out" 2>&1 &
+term_holder_pid="$!"
+CHILD_PIDS+=("$term_holder_pid")
+wait_for_file "$TMP_DIR/term.ready"
+
+CMUX_XCODEBUILD_CONCURRENCY=1 \
+  "$RUNNER" --lock-root "$TMP_DIR/slots-term" -- \
+  python3 "$TMP_DIR/touch.py" "$TMP_DIR/term-queued.done" \
+  >"$TMP_DIR/term-queued.out" 2>&1 &
+term_queued_pid="$!"
+CHILD_PIDS+=("$term_queued_pid")
+
+wait_for_pattern "$TMP_DIR/term-queued.out" "All 1 local xcodebuild slots are busy"
+assert_file_absent_for "$TMP_DIR/term-queued.done"
+kill -TERM "$term_holder_pid"
+term_status=0
+wait "$term_holder_pid" 2>/dev/null || term_status="$?"
+if [[ "$term_status" -ne 143 ]]; then
+  echo "expected SIGTERM holder status 143, got $term_status" >&2
+  exit 1
+fi
+wait "$term_queued_pid"
+CHILD_PIDS=()
+wait_for_file "$TMP_DIR/term-queued.done"
+
+CMUX_XCODEBUILD_CONCURRENCY=1 \
+  "$RUNNER" --lock-root "$TMP_DIR/slots-kill" -- \
+  python3 "$TMP_DIR/hold.py" "$TMP_DIR/kill.ready" "$TMP_DIR/kill.release" \
+  >"$TMP_DIR/kill-holder.out" 2>&1 &
+kill_holder_pid="$!"
+CHILD_PIDS+=("$kill_holder_pid")
+wait_for_file "$TMP_DIR/kill.ready"
+
+CMUX_XCODEBUILD_CONCURRENCY=1 \
+  "$RUNNER" --lock-root "$TMP_DIR/slots-kill" -- \
+  python3 "$TMP_DIR/touch.py" "$TMP_DIR/kill-queued.done" \
+  >"$TMP_DIR/kill-queued.out" 2>&1 &
+kill_queued_pid="$!"
+CHILD_PIDS+=("$kill_queued_pid")
+
+wait_for_pattern "$TMP_DIR/kill-queued.out" "All 1 local xcodebuild slots are busy"
+assert_file_absent_for "$TMP_DIR/kill-queued.done"
+kill -KILL "$kill_holder_pid"
+kill_status=0
+wait "$kill_holder_pid" 2>/dev/null || kill_status="$?"
+if [[ "$kill_status" -ne 137 ]]; then
+  echo "expected SIGKILL holder status 137, got $kill_status" >&2
+  exit 1
+fi
+wait "$kill_queued_pid"
+CHILD_PIDS=()
+wait_for_file "$TMP_DIR/kill-queued.done"
+
+printf '2\n' > "$TMP_DIR/concurrency"
+CMUX_XCODEBUILD_CONCURRENCY_FILE="$TMP_DIR/concurrency" \
+  "$RUNNER" --lock-root "$TMP_DIR/slots-two" -- \
+  python3 "$TMP_DIR/hold.py" "$TMP_DIR/two.ready" "$TMP_DIR/two.release" \
+  >"$TMP_DIR/two-holder.out" 2>&1 &
+two_holder_pid="$!"
+CHILD_PIDS+=("$two_holder_pid")
+wait_for_file "$TMP_DIR/two.ready"
+
+CMUX_XCODEBUILD_CONCURRENCY_FILE="$TMP_DIR/concurrency" \
+  "$RUNNER" --lock-root "$TMP_DIR/slots-two" -- \
+  python3 "$TMP_DIR/touch.py" "$TMP_DIR/two-parallel.done" \
+  >"$TMP_DIR/two-parallel.out" 2>&1
+wait_for_file "$TMP_DIR/two-parallel.done"
+touch "$TMP_DIR/two.release"
+wait "$two_holder_pid"
+CHILD_PIDS=()
+
+if "$RUNNER" --lock-root "$TMP_DIR/invalid" --concurrency 0 -- true \
+  >"$TMP_DIR/invalid.out" 2>&1; then
+  echo "expected invalid concurrency to fail" >&2
+  exit 1
+fi
+
+if ! grep -Fq "positive integer" "$TMP_DIR/invalid.out"; then
+  echo "expected invalid concurrency error" >&2
+  cat "$TMP_DIR/invalid.out" >&2
+  exit 1
+fi
+
+echo "PASS: xcodebuild concurrency runner gates commands by configurable slots"


### PR DESCRIPTION
Summary:
- Replace the single reload xcodebuild lock with a per-user slot runner.
- Add `--xcodebuild-concurrency`, `CMUX_XCODEBUILD_CONCURRENCY`, and `~/.config/cmux/xcodebuild-concurrency` support.
- Cover queued builds, config-file concurrency, invalid config, inherited slot markers, and forced `SIGTERM`/`SIGKILL` slot release in CI.

Verification:
- `./tests/test_ci_xcodebuild_concurrency_runner.sh`
- `for i in 1 2 3; do ./tests/test_ci_xcodebuild_concurrency_runner.sh; done`
- `python3 -m py_compile scripts/xcodebuild-concurrency-runner.py`
- `git diff --check`
- `./scripts/reload.sh --tag xcbcon --xcodebuild-concurrency 4` succeeded in 335s.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4609"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782092109&installation_id=133855650&pr_number=4609&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4609&signature=7bf60693f7a9c1d11ea20c4eec1d406c3dc8d5880ecedccca83e12e09fa98c8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `scripts/reload.sh` build execution model from a single global lock to a configurable slot-based gate, which could impact local developer workflows and build stability if misconfigured. Risk is limited to build tooling/CI (no runtime app logic), and is covered by a new CI test.
> 
> **Overview**
> **Makes `reload.sh` xcodebuild concurrency configurable.** The single per-user xcodebuild mutex is replaced with a per-user *slot* runner so multiple local `xcodebuild` invocations can proceed up to a chosen limit while still protecting Xcode 26’s shared build service.
> 
> Adds `scripts/xcodebuild-concurrency-runner.py` (config via `--xcodebuild-concurrency`, `CMUX_XCODEBUILD_CONCURRENCY`, or `~/.config/cmux/xcodebuild-concurrency`) and wires it into `scripts/reload.sh`. CI now runs `tests/test_ci_xcodebuild_concurrency_runner.sh` to cover queuing behavior, config parsing, env inheritance marker, and slot release on `SIGTERM`/`SIGKILL`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8455ab2bcd75541481d6a4083fe3b63ab7d763e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make xcodebuild reloads run through a per-user slot runner with configurable concurrency, replacing the single global lock. This prevents overlapping builds from crashing the Xcode build service and lets faster machines opt into more parallelism.

- **New Features**
  - `scripts/reload.sh` adds `--xcodebuild-concurrency`; also reads `CMUX_XCODEBUILD_CONCURRENCY` or `~/.config/cmux/xcodebuild-concurrency` (default 1). `CMUX_XCODEBUILD_CONCURRENCY_FILE` is supported.
  - New `scripts/xcodebuild-concurrency-runner.py` manages per-user slot locks under `${TMPDIR}/cmux-xcodebuild-<uid>.slots`, inherits the lock FD so slots auto-release on `SIGTERM`/`SIGKILL`, and prints queue/slot notices.
  - CI adds `tests/test_ci_xcodebuild_concurrency_runner.sh` and a workflow step covering queuing, config-file concurrency, invalid config, and forced slot release.

<sup>Written for commit 8455ab2bcd75541481d6a4083fe3b63ab7d763e7. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4609?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

