### PR TITLE
Fix sidebar edge fade background

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -9781,14 +9781,12 @@ struct VerticalTabsSidebar: View {
                     Color.clear.frame(height: scrollInsets.bottom)
                         .allowsHitTesting(false)
                 }
-                .overlay(alignment: .top) {
-                    SidebarTopScrim(height: sidebarTopScrimHeight)
-                        .allowsHitTesting(false)
-                }
-                .overlay(alignment: .bottom) {
-                    SidebarBottomScrim(height: sidebarBottomScrimHeight)
-                        .allowsHitTesting(false)
-                }
+                .mask(
+                    SidebarWorkspaceScrollEdgeFadeMask(
+                        topHeight: sidebarTopScrimHeight,
+                        bottomHeight: sidebarBottomScrimHeight
+                    )
+                )
                 .overlay(alignment: .top) {
                     // The sidebar top strip remains draggable and handles
                     // double-clicks with the standard titlebar action.
@@ -9932,14 +9930,12 @@ struct VerticalTabsSidebar: View {
                 Color.clear.frame(height: SidebarWorkspaceScrollInsets.workspaceList.bottom)
                     .allowsHitTesting(false)
             }
-            .overlay(alignment: .top) {
-                SidebarTopScrim(height: sidebarTopScrimHeight)
-                    .allowsHitTesting(false)
-            }
-            .overlay(alignment: .bottom) {
-                SidebarBottomScrim(height: sidebarBottomScrimHeight)
-                    .allowsHitTesting(false)
-            }
+            .mask(
+                SidebarWorkspaceScrollEdgeFadeMask(
+                    topHeight: sidebarTopScrimHeight,
+                    bottomHeight: sidebarBottomScrimHeight
+                )
+            )
             .overlay(alignment: .top) {
                 WindowDragHandleView()
                     .frame(height: sidebarTitlebarInteractionHeight)

--- a/Sources/SidebarScrim.swift
+++ b/Sources/SidebarScrim.swift
@@ -1,49 +1,43 @@
-import AppKit
 import SwiftUI
 
-struct SidebarTopScrim: View {
-    let height: CGFloat
+struct SidebarWorkspaceScrollEdgeFadeMask: View {
+    let topHeight: CGFloat
+    let bottomHeight: CGFloat
 
     var body: some View {
-        SidebarEdgeScrim(height: height, edge: .top)
+        VStack(spacing: 0) {
+            SidebarEdgeFadeGradient(edge: .top)
+                .frame(height: topHeight)
+            Rectangle()
+                .fill(Color.black)
+            SidebarEdgeFadeGradient(edge: .bottom)
+                .frame(height: bottomHeight)
+        }
     }
 }
 
-struct SidebarBottomScrim: View {
-    let height: CGFloat
-
-    var body: some View {
-        SidebarEdgeScrim(height: height, edge: .bottom)
-    }
-}
-
-struct SidebarEdgeScrim: View {
+private struct SidebarEdgeFadeGradient: View {
     enum Edge {
         case top
         case bottom
     }
 
-    let height: CGFloat
     let edge: Edge
 
     var body: some View {
-        SidebarEdgeBlurEffect()
-            .frame(height: height)
-            .mask(
-                LinearGradient(
-                    colors: gradientColors,
-                    startPoint: .top,
-                    endPoint: .bottom
-                )
-            )
+        LinearGradient(
+            colors: maskColors,
+            startPoint: .top,
+            endPoint: .bottom
+        )
     }
 
-    private var gradientColors: [Color] {
+    private var maskColors: [Color] {
         let colors = [
-            Color.black.opacity(0.95),
-            Color.black.opacity(0.75),
-            Color.black.opacity(0.35),
-            Color.clear,
+            Color.black.opacity(0.05),
+            Color.black.opacity(0.25),
+            Color.black.opacity(0.65),
+            Color.black,
         ]
         switch edge {
         case .top:
@@ -52,17 +46,4 @@ struct SidebarEdgeScrim: View {
             return Array(colors.reversed())
         }
     }
-}
-
-struct SidebarEdgeBlurEffect: NSViewRepresentable {
-    func makeNSView(context: Context) -> NSVisualEffectView {
-        let view = NSVisualEffectView()
-        view.blendingMode = .withinWindow
-        view.material = .underWindowBackground
-        view.state = .active
-        view.isEmphasized = false
-        return view
-    }
-
-    func updateNSView(_ nsView: NSVisualEffectView, context: Context) {}
 }


### PR DESCRIPTION
Summary:
- Replace sidebar edge scrim overlays with masks on sidebar scroll content.
- Let faded rows reveal the actual sidebar background/material underneath instead of drawing a separate visual effect layer.
- Apply the same mask to the default workspace list and extension sidebar list.

Tests:
- `git diff --check`
- `xcrun swiftc -parse Sources/SidebarScrim.swift Sources/ContentView.swift cmuxTests/WindowAppearanceSnapshotTests.swift`
- `./scripts/reload.sh --tag sidegrad`
- GitHub checks pass on commit `8c429e2d0` after rerunning transient `web-typecheck` setup failure.

Dogfood:
- `sidegrad` is built from commit `8c429e2d0` for visual approval before merge.
