### PR TITLE
Fix split unread shortcut flash

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -11055,8 +11055,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                   workspace.panels[panelId] != nil else {
                 return false
             }
-            if notificationStore.hasManualUnread(forTabId: target.tabId) {
-                notificationStore.markRead(forTabId: target.tabId)
+            if notificationStore.hasWorkspaceScopedUnread(forTabId: target.tabId) {
+                notificationStore.markWorkspaceScopedUnreadRead(forTabId: target.tabId)
                 return true
             }
             let hasPanelUnread = workspace.manualUnreadPanelIds.contains(panelId) ||

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -5769,6 +5769,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     private struct FocusedTerminalShortcutContext {
         let tabManager: TabManager
+        let workspace: Workspace
         let workspaceId: UUID
         let panelId: UUID
     }
@@ -5796,12 +5797,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             ?? NSApp.mainWindow?.firstResponder
         guard let ghosttyView = cmuxOwningGhosttyView(for: responder),
               let workspaceId = ghosttyView.tabId,
-              let panelId = ghosttyView.terminalSurface?.id,
+              let surfaceId = ghosttyView.terminalSurface?.id,
               let manager = resolveShortcutTabManager(for: workspaceId, preferredWindow: targetWindow) else {
+            return nil
+        }
+        guard let workspace = manager.tabs.first(where: { $0.id == workspaceId }) else {
+            return nil
+        }
+        let panelId = workspace.panels[surfaceId] != nil
+            ? surfaceId
+            : workspace.panelIdFromSurfaceId(TabID(uuid: surfaceId))
+        guard let panelId else {
             return nil
         }
         return FocusedTerminalShortcutContext(
             tabManager: manager,
+            workspace: workspace,
             workspaceId: workspaceId,
             panelId: panelId
         )
@@ -11038,6 +11049,27 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
               let target = focusedNotificationTarget(preferredWindow: preferredWindow) else {
             return false
         }
+
+        if let panelId = target.panelId {
+            guard let workspace = target.workspace,
+                  workspace.panels[panelId] != nil else {
+                return false
+            }
+            if notificationStore.hasManualUnread(forTabId: target.tabId) {
+                notificationStore.markRead(forTabId: target.tabId)
+                return true
+            }
+            let hasPanelUnread = workspace.manualUnreadPanelIds.contains(panelId) ||
+                workspace.restoredUnreadPanelIds.contains(panelId) ||
+                notificationStore.hasUnreadNotification(forTabId: target.tabId, surfaceId: panelId)
+            if hasPanelUnread {
+                workspace.markPanelRead(panelId)
+            } else {
+                workspace.markPanelUnread(panelId)
+            }
+            return true
+        }
+
         if notificationStore.workspaceIsUnread(forTabId: target.tabId) {
             notificationStore.markRead(forTabId: target.tabId)
             return true
@@ -11063,7 +11095,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     private struct FocusedNotificationTarget {
         let tabId: UUID
-        let surfaceId: UUID?
+        let workspace: Workspace?
+        let panelId: UUID?
     }
 
     private enum FocusedNotificationMarkResult {
@@ -11085,7 +11118,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     ) -> FocusedNotificationMarkResult? {
         if let notificationId = notificationStore.markLatestNotificationAsOldestUnread(
             forTabId: target.tabId,
-            surfaceId: target.surfaceId
+            surfaceId: target.panelId
         ) {
             return .deferredNotification(notificationId)
         }
@@ -11094,23 +11127,31 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     private func focusedNotificationTarget(preferredWindow: NSWindow?) -> FocusedNotificationTarget? {
         if let terminalContext = focusedTerminalShortcutContext(preferredWindow: preferredWindow) {
-            return FocusedNotificationTarget(tabId: terminalContext.workspaceId, surfaceId: terminalContext.panelId)
+            return FocusedNotificationTarget(
+                tabId: terminalContext.workspaceId,
+                workspace: terminalContext.workspace,
+                panelId: terminalContext.panelId
+            )
         }
 
         let targetWindow = preferredWindow ?? NSApp.keyWindow ?? NSApp.mainWindow
         if let context = contextForMainWindow(targetWindow),
            let selectedTabId = context.tabManager.selectedTabId ?? context.tabManager.tabs.first?.id {
+            let workspace = context.tabManager.tabs.first(where: { $0.id == selectedTabId })
             return FocusedNotificationTarget(
                 tabId: selectedTabId,
-                surfaceId: context.tabManager.focusedSurfaceId(for: selectedTabId)
+                workspace: workspace,
+                panelId: workspace?.focusedPanelId
             )
         }
 
         if let activeManager = tabManager,
            let selectedTabId = activeManager.selectedTabId ?? activeManager.tabs.first?.id {
+            let workspace = activeManager.tabs.first(where: { $0.id == selectedTabId })
             return FocusedNotificationTarget(
                 tabId: selectedTabId,
-                surfaceId: activeManager.focusedSurfaceId(for: selectedTabId)
+                workspace: workspace,
+                panelId: workspace?.focusedPanelId
             )
         }
 

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -1123,6 +1123,12 @@ final class TerminalNotificationStore: ObservableObject {
         indexes.unreadByTabSurface.contains(TabSurfaceKey(tabId: tabId, surfaceId: surfaceId))
     }
 
+    func hasWorkspaceScopedUnread(forTabId tabId: UUID) -> Bool {
+        manualUnreadWorkspaceIds.contains(tabId) ||
+            restoredUnreadWorkspaceIds.contains(tabId) ||
+            hasUnreadNotification(forTabId: tabId, surfaceId: nil)
+    }
+
     func hasUnreadNotificationRequiringPaneFlash(forTabId tabId: UUID, surfaceId: UUID?) -> Bool {
         notifications.contains { notification in
             notification.matches(tabId: tabId, surfaceId: surfaceId) &&
@@ -1607,6 +1613,32 @@ final class TerminalNotificationStore: ObservableObject {
             center.removeDeliveredNotificationsOffMain(withIdentifiers: idsToClear)
             center.removePendingNotificationRequestsOffMain(withIdentifiers: idsToClear)
         }
+    }
+
+    @discardableResult
+    func markWorkspaceScopedUnreadRead(forTabId tabId: UUID) -> Bool {
+        var didChange = false
+        var updated = notifications
+        var idsToClear: [String] = []
+        for index in updated.indices {
+            guard updated[index].matches(tabId: tabId, surfaceId: nil),
+                  !updated[index].isRead else {
+                continue
+            }
+            updated[index].isRead = true
+            idsToClear.append(updated[index].id.uuidString)
+        }
+        if !idsToClear.isEmpty {
+            notifications = updated
+            didChange = true
+        }
+        didChange = setWorkspaceManualUnread(false, forTabId: tabId) || didChange
+        didChange = setWorkspaceRestoredUnread(false, forTabId: tabId) || didChange
+        if !idsToClear.isEmpty {
+            center.removeDeliveredNotificationsOffMain(withIdentifiers: idsToClear)
+            center.removePendingNotificationRequestsOffMain(withIdentifiers: idsToClear)
+        }
+        return didChange
     }
 
     func markUnread(forTabId tabId: UUID) {

--- a/cmuxTests/WorkspaceManualUnreadTests.swift
+++ b/cmuxTests/WorkspaceManualUnreadTests.swift
@@ -1105,6 +1105,46 @@ final class WorkspaceManualUnreadTests: XCTestCase {
         XCTAssertTrue(workspace.manualUnreadPanelIds.contains(splitPanel.id))
     }
 
+    func testFocusedUnreadShortcutMarksSplitPanelWithoutLeftPaneDismissFlash() throws {
+        let appDelegate = AppDelegate.shared ?? AppDelegate()
+        let manager = TabManager()
+        let store = TerminalNotificationStore.shared
+
+        let originalTabManager = appDelegate.tabManager
+        let originalNotificationStore = appDelegate.notificationStore
+
+        store.replaceNotificationsForTesting([])
+        appDelegate.tabManager = manager
+        appDelegate.notificationStore = store
+
+        defer {
+            store.replaceNotificationsForTesting([])
+            appDelegate.tabManager = originalTabManager
+            appDelegate.notificationStore = originalNotificationStore
+        }
+
+        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let leftPanelId = try XCTUnwrap(workspace.focusedPanelId)
+        let rightPanel = try XCTUnwrap(
+            workspace.newTerminalSplit(from: leftPanelId, orientation: .horizontal, focus: false)
+        )
+
+        workspace.focusPanel(rightPanel.id)
+
+        XCTAssertTrue(appDelegate.toggleFocusedNotificationUnread())
+
+        XCTAssertTrue(workspace.manualUnreadPanelIds.contains(rightPanel.id))
+        XCTAssertFalse(workspace.manualUnreadPanelIds.contains(leftPanelId))
+        XCTAssertFalse(store.hasManualUnread(forTabId: workspace.id))
+        XCTAssertTrue(store.hasPanelDerivedUnread(forTabId: workspace.id))
+
+        let flashTokenBeforeLeftClick = workspace.tmuxWorkspaceFlashToken
+
+        XCTAssertFalse(manager.dismissNotificationOnTerminalInteraction(tabId: workspace.id, surfaceId: leftPanelId))
+        XCTAssertEqual(workspace.tmuxWorkspaceFlashToken, flashTokenBeforeLeftClick)
+        XCTAssertTrue(workspace.manualUnreadPanelIds.contains(rightPanel.id))
+    }
+
     func testSessionRestorePreservesNotificationUnreadIndicator() throws {
         let appDelegate = AppDelegate.shared ?? AppDelegate()
         let store = TerminalNotificationStore.shared

--- a/cmuxTests/WorkspaceManualUnreadTests.swift
+++ b/cmuxTests/WorkspaceManualUnreadTests.swift
@@ -1183,6 +1183,98 @@ final class WorkspaceManualUnreadTests: XCTestCase {
         XCTAssertTrue(workspace.manualUnreadPanelIds.isEmpty)
     }
 
+    func testFocusedUnreadShortcutClearsRestoredWorkspaceUnreadBeforePanelToggle() throws {
+        let appDelegate = AppDelegate.shared ?? AppDelegate()
+        let manager = TabManager()
+        let store = TerminalNotificationStore.shared
+
+        let originalTabManager = appDelegate.tabManager
+        let originalNotificationStore = appDelegate.notificationStore
+
+        store.replaceNotificationsForTesting([])
+        appDelegate.tabManager = manager
+        appDelegate.notificationStore = store
+
+        defer {
+            store.replaceNotificationsForTesting([])
+            appDelegate.tabManager = originalTabManager
+            appDelegate.notificationStore = originalNotificationStore
+        }
+
+        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let leftPanelId = try XCTUnwrap(workspace.focusedPanelId)
+        let rightPanel = try XCTUnwrap(
+            workspace.newTerminalSplit(from: leftPanelId, orientation: .horizontal, focus: false)
+        )
+
+        workspace.focusPanel(rightPanel.id)
+        store.restoreUnreadIndicator(forTabId: workspace.id)
+
+        XCTAssertTrue(store.hasRestoredUnreadIndicator(forTabId: workspace.id))
+        XCTAssertTrue(store.workspaceIsUnread(forTabId: workspace.id))
+
+        XCTAssertTrue(appDelegate.toggleFocusedNotificationUnread())
+
+        XCTAssertFalse(store.hasRestoredUnreadIndicator(forTabId: workspace.id))
+        XCTAssertFalse(store.workspaceIsUnread(forTabId: workspace.id))
+        XCTAssertFalse(store.hasPanelDerivedUnread(forTabId: workspace.id))
+        XCTAssertTrue(workspace.manualUnreadPanelIds.isEmpty)
+        XCTAssertTrue(workspace.restoredUnreadPanelIds.isEmpty)
+    }
+
+    func testFocusedUnreadShortcutClearsWorkspaceNotificationWithoutClearingOtherPanelUnread() throws {
+        let appDelegate = AppDelegate.shared ?? AppDelegate()
+        let manager = TabManager()
+        let store = TerminalNotificationStore.shared
+
+        let originalTabManager = appDelegate.tabManager
+        let originalNotificationStore = appDelegate.notificationStore
+
+        store.replaceNotificationsForTesting([])
+        appDelegate.tabManager = manager
+        appDelegate.notificationStore = store
+
+        defer {
+            store.replaceNotificationsForTesting([])
+            appDelegate.tabManager = originalTabManager
+            appDelegate.notificationStore = originalNotificationStore
+        }
+
+        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let leftPanelId = try XCTUnwrap(workspace.focusedPanelId)
+        let rightPanel = try XCTUnwrap(
+            workspace.newTerminalSplit(from: leftPanelId, orientation: .horizontal, focus: false)
+        )
+        let notificationId = UUID()
+
+        workspace.focusPanel(leftPanelId)
+        store.replaceNotificationsForTesting([
+            TerminalNotification(
+                id: notificationId,
+                tabId: workspace.id,
+                surfaceId: nil,
+                title: "Workspace",
+                subtitle: "",
+                body: "",
+                createdAt: Date(),
+                isRead: false
+            ),
+        ])
+        workspace.markPanelUnread(rightPanel.id)
+
+        XCTAssertTrue(store.hasUnreadNotification(forTabId: workspace.id, surfaceId: nil))
+        XCTAssertTrue(workspace.manualUnreadPanelIds.contains(rightPanel.id))
+
+        XCTAssertTrue(appDelegate.toggleFocusedNotificationUnread())
+
+        XCTAssertFalse(store.hasUnreadNotification(forTabId: workspace.id, surfaceId: nil))
+        XCTAssertTrue(store.notifications.first(where: { $0.id == notificationId })?.isRead ?? false)
+        XCTAssertFalse(workspace.manualUnreadPanelIds.contains(leftPanelId))
+        XCTAssertTrue(workspace.manualUnreadPanelIds.contains(rightPanel.id))
+        XCTAssertTrue(store.hasPanelDerivedUnread(forTabId: workspace.id))
+        XCTAssertTrue(store.workspaceIsUnread(forTabId: workspace.id))
+    }
+
     func testSessionRestorePreservesNotificationUnreadIndicator() throws {
         let appDelegate = AppDelegate.shared ?? AppDelegate()
         let store = TerminalNotificationStore.shared

--- a/cmuxTests/WorkspaceManualUnreadTests.swift
+++ b/cmuxTests/WorkspaceManualUnreadTests.swift
@@ -1145,6 +1145,44 @@ final class WorkspaceManualUnreadTests: XCTestCase {
         XCTAssertTrue(workspace.manualUnreadPanelIds.contains(rightPanel.id))
     }
 
+    func testFocusedUnreadShortcutClearsWorkspaceManualUnreadBeforePanelToggle() throws {
+        let appDelegate = AppDelegate.shared ?? AppDelegate()
+        let manager = TabManager()
+        let store = TerminalNotificationStore.shared
+
+        let originalTabManager = appDelegate.tabManager
+        let originalNotificationStore = appDelegate.notificationStore
+
+        store.replaceNotificationsForTesting([])
+        appDelegate.tabManager = manager
+        appDelegate.notificationStore = store
+
+        defer {
+            store.replaceNotificationsForTesting([])
+            appDelegate.tabManager = originalTabManager
+            appDelegate.notificationStore = originalNotificationStore
+        }
+
+        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let leftPanelId = try XCTUnwrap(workspace.focusedPanelId)
+        let rightPanel = try XCTUnwrap(
+            workspace.newTerminalSplit(from: leftPanelId, orientation: .horizontal, focus: false)
+        )
+
+        workspace.focusPanel(rightPanel.id)
+        store.markUnread(forTabId: workspace.id)
+
+        XCTAssertTrue(store.hasManualUnread(forTabId: workspace.id))
+        XCTAssertTrue(store.workspaceIsUnread(forTabId: workspace.id))
+
+        XCTAssertTrue(appDelegate.toggleFocusedNotificationUnread())
+
+        XCTAssertFalse(store.hasManualUnread(forTabId: workspace.id))
+        XCTAssertFalse(store.workspaceIsUnread(forTabId: workspace.id))
+        XCTAssertFalse(store.hasPanelDerivedUnread(forTabId: workspace.id))
+        XCTAssertTrue(workspace.manualUnreadPanelIds.isEmpty)
+    }
+
     func testSessionRestorePreservesNotificationUnreadIndicator() throws {
         let appDelegate = AppDelegate.shared ?? AppDelegate()
         let store = TerminalNotificationStore.shared


### PR DESCRIPTION
## Summary
- Scope Cmd+Option+U unread toggles to the focused split panel.
- Resolve Bonsplit surface IDs to workspace panel IDs before toggling unread.
- Add coverage for marking the right split unread, then clicking the left split.

## Tests
- Red commit c2ac94b10: AWS M4 Pro cmux-unit `WorkspaceManualUnreadTests/testFocusedUnreadShortcutMarksSplitPanelWithoutLeftPaneDismissFlash` failed with the old workspace-level unread behavior.
- Green commit 2ce0a1d76: AWS M4 Pro cmux-unit `WorkspaceManualUnreadTests/testFocusedUnreadShortcutMarksSplitPanelWithoutLeftPaneDismissFlash` passed.
- Local tagged reload: `./scripts/reload.sh --tag unreadfix` passed.

## Proof
- Cloud run: https://github.com/manaflow-ai/cmux-loader/actions/runs/26318505599
- GUI video proof is blocked. CUA/Sky returned `cgWindowNotFound` after launching the tagged app, and native display frames were wallpaper-only, so no before or after video is accepted for this PR.
- Dogfood build: `unreadfix`, available through CMUX Tag Opener at http://127.0.0.1:17320/unreadfix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes keyboard shortcut behavior for unread state across splits and workspace/panel notification stores; well-covered by tests but touches user-visible notification UX.
> 
> **Overview**
> **Cmd+Option+U** unread toggling now targets the **focused split panel** instead of treating the whole workspace as one surface.
> 
> Shortcut resolution maps **Bonsplit surface IDs** to **workspace panel IDs** (via `panelIdFromSurfaceId` when the raw surface id is not a panel key). `toggleFocusedNotificationUnread` clears **workspace-scoped** unread (manual, restored, or workspace-level notifications) first, then toggles **panel** manual/restored/notification unread on the focused pane. Non-terminal targets use `focusedPanelId` on the selected workspace.
> 
> `TerminalNotificationStore` adds **`hasWorkspaceScopedUnread`** and **`markWorkspaceScopedUnreadRead`** so the shortcut can clear workspace-level state without wiping other panels’ unread. New unit tests cover split marking, left-pane interaction without spurious dismiss flash, and mixed workspace vs panel unread.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc280b83549859a4c42b1cbea6f9386c8fd3cf4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace-scoped unread detection and marking for notifications (handles workspace-level unread separate from panel-level).

* **Bug Fixes**
  * Toggling focused notification unread now applies to the specific panel in split views and falls back to workspace-level behavior when a panel can't be resolved.
  * Focused notification handling now consistently targets the correct panel from shortcuts or workspace focus.

* **Tests**
  * Added tests covering focused-unread behavior in split panels, toggling and clearing panel vs workspace unread state.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4612?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->