### PR TITLE
Keep Cmd-Tab app switching off session snapshot path

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1698,7 +1698,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     func applicationWillResignActive(_ notification: Notification) {
         guard !isTerminatingApp else { return }
         clearConfiguredShortcutChordState()
-        saveSessionSnapshotAfterLoadingProcessDetectedIndexes(includeScrollback: false)
+        if Self.shouldSaveSessionSnapshotOnApplicationResign(isTerminatingApp: isTerminatingApp) {
+            saveSessionSnapshotAfterLoadingProcessDetectedIndexes(includeScrollback: false)
+        }
     }
 
     func persistSessionForUpdateRelaunch() {
@@ -3683,6 +3685,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     nonisolated static func shouldRunSessionAutosaveTick(isTerminatingApp: Bool) -> Bool {
         !isTerminatingApp
+    }
+
+    nonisolated static func shouldSaveSessionSnapshotOnApplicationResign(isTerminatingApp _: Bool) -> Bool {
+        // App switching must stay cheap. The autosave timer, window/session lifecycle,
+        // power-off, update relaunch, and termination paths still persist session state.
+        false
     }
 
     private func remainingSessionAutosaveTypingQuietPeriod(

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -611,6 +611,15 @@ final class SessionPersistenceTests: XCTestCase {
         )
     }
 
+    func testApplicationResignDoesNotTriggerSessionSnapshotSave() {
+        XCTAssertFalse(
+            AppDelegate.shouldSaveSessionSnapshotOnApplicationResign(isTerminatingApp: false)
+        )
+        XCTAssertFalse(
+            AppDelegate.shouldSaveSessionSnapshotOnApplicationResign(isTerminatingApp: true)
+        )
+    }
+
     func testSessionSnapshotSynchronousWritePolicy() {
         XCTAssertFalse(
             AppDelegate.shouldWriteSessionSnapshotSynchronously(


### PR DESCRIPTION
## Summary
- Stop scheduling a full session snapshot from `applicationWillResignActive`.
- Keep shortcut chord clearing on app resign.
- Add a session persistence policy test for the app-resign behavior.

## Verification
- `git diff --check`
- `./scripts/reload.sh --tag cmdtab`
- Cloud Mac stress repro: 21 workspaces, 321 terminal surfaces. Baseline app-resign path would schedule the same full-session snapshot measured at ~38 ms for that shape; fixed build keeps app switching off that path.

Unit tests were not run locally because local cmux Xcode tests launch `cmux DEV.app`; hosted checks should cover the added policy test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 647080916522d9451b5df6345c8a97a7714caa17. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4613"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782094844&installation_id=133855650&pr_number=4613&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4613&signature=75c907b347e053e1e6813081a2905c169ddfb117a0ff8fe21bc862153a8ddbf0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops saving a session snapshot when the app resigns active to keep Cmd-Tab app switching fast. Session state still persists via autosave and normal lifecycle paths.

- **Bug Fixes**
  - Gate `applicationWillResignActive` snapshot behind `shouldSaveSessionSnapshotOnApplicationResign` (returns false by default).
  - Keep clearing the shortcut chord on resign.
  - Add a test to enforce no snapshot on resign.
  - Avoids ~38 ms snapshot work during app switching on large sessions.

<sup>Written for commit 647080916522d9451b5df6345c8a97a7714caa17. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4613?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

