### PR TITLE
Fix close shortcuts targeting original window

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -5709,6 +5709,36 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return NSApp.window(withWindowNumber: eventWindowNumber)
     }
 
+    private func mainWindowForFocusedCloseShortcut(event: NSEvent) -> NSWindow? {
+        // Close shortcuts are focused-window commands. Some AppKit key-equivalent
+        // paths can preserve stale event window metadata after a new window becomes
+        // key, so prefer the actual focused window before falling back to event data.
+        if let keyWindow = NSApp.keyWindow, isMainTerminalWindow(keyWindow) {
+            return keyWindow
+        }
+        if let mainWindow = NSApp.mainWindow, isMainTerminalWindow(mainWindow) {
+            return mainWindow
+        }
+        return mainWindowForShortcutEvent(event)
+    }
+
+    private func tabManagerForFocusedCloseShortcut(event: NSEvent) -> TabManager? {
+        if let targetWindow = mainWindowForFocusedCloseShortcut(event: event) {
+            return synchronizeActiveMainWindowContext(preferredWindow: targetWindow)
+        }
+        return preferredMainWindowContextForShortcutRouting(event: event)?.tabManager ?? tabManager
+    }
+
+    private func auxiliaryWindowForFocusedCloseShortcut(event: NSEvent) -> NSWindow? {
+        [
+            NSApp.keyWindow,
+            NSApp.mainWindow,
+            resolvedShortcutEventWindow(event),
+        ]
+        .compactMap { $0 }
+        .first { cmuxWindowShouldOwnCloseShortcut($0) }
+    }
+
     /// Re-sync app-level active window pointers from the currently focused main terminal window.
     /// This keeps menu/shortcut actions window-scoped even if the cached `tabManager` drifts.
     @discardableResult
@@ -12201,22 +12231,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // The Close Tab shortcut must close the focused panel even if first-responder
         // momentarily lags on a browser NSTextView during split focus transitions.
         if matchConfiguredShortcut(event: event, action: .closeTab) {
-            let targetWindow = resolvedShortcutEventWindow(event) ?? NSApp.keyWindow ?? NSApp.mainWindow
-            let routedManager = preferredMainWindowContextForShortcutRouting(event: event)?.tabManager ?? tabManager
+            let routedManager = tabManagerForFocusedCloseShortcut(event: event)
             // Browser popup windows primarily intercept the configured Close Tab shortcut
             // in BrowserPopupPanel. This AppDelegate path is a fallback for cases where
             // AppKit routes the event through the global shortcut handler first.
-            if let targetWindow = [targetWindow, NSApp.keyWindow]
-                .compactMap({ $0 })
-                .first(where: { $0.identifier?.rawValue == "cmux.browser-popup" }) {
+            if let targetWindow = auxiliaryWindowForFocusedCloseShortcut(event: event) {
 #if DEBUG
-                cmuxDebugLog("shortcut.closeTab route=browserPopup")
+                let route = targetWindow.identifier?.rawValue == "cmux.browser-popup" ? "browserPopup" : "auxWindow"
+                cmuxDebugLog("shortcut.closeTab route=\(route)")
 #endif
                 targetWindow.performClose(nil)
                 return true
-            } else if let targetWindow,
-               cmuxWindowShouldOwnCloseShortcut(targetWindow) {
-                targetWindow.performClose(nil)
             } else {
                 if let routedManager {
 #if DEBUG
@@ -12239,15 +12264,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
 
         if matchConfiguredShortcut(event: event, action: .closeWorkspace) {
-            tabManager?.closeCurrentWorkspaceWithConfirmation()
+            tabManagerForFocusedCloseShortcut(event: event)?.closeCurrentWorkspaceWithConfirmation()
             return true
         }
 
         if matchConfiguredShortcut(event: event, action: .closeWindow) {
-            guard let targetWindow = mainWindowForShortcutEvent(event) ?? event.window ?? NSApp.keyWindow ?? NSApp.mainWindow else {
+            guard let targetWindow = mainWindowForFocusedCloseShortcut(event: event) else {
                 NSSound.beep()
                 return true
             }
+            _ = synchronizeActiveMainWindowContext(preferredWindow: targetWindow)
             closeWindowWithConfirmation(targetWindow)
             return true
         }

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -1876,6 +1876,22 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         XCTAssertNotEqual(workspace.focusedPanelId, initialPanelId)
     }
 
+    func testCmdWTargetsFocusedWindowWhenEventWindowMetadataIsStale() {
+        assertCloseShortcutTargetsFocusedWindowWhenEventWindowMetadataIsStale(
+            actionName: "Cmd+W",
+            modifiers: [.command],
+            expectedAction: .closeTab
+        )
+    }
+
+    func testCmdShiftWTargetsFocusedWindowWhenEventWindowMetadataIsStale() {
+        assertCloseShortcutTargetsFocusedWindowWhenEventWindowMetadataIsStale(
+            actionName: "Cmd+Shift+W",
+            modifiers: [.command, .shift],
+            expectedAction: .closeWorkspace
+        )
+    }
+
     func testRemappedCloseTabDoesNotLetCmdWReachGhosttyCloseSurfaceFallback() throws {
         guard let appDelegate = AppDelegate.shared else {
             XCTFail("Expected AppDelegate.shared")
@@ -6334,6 +6350,111 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         window.orderOut(nil)
         window.close()
         RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+    }
+
+    private func assertCloseShortcutTargetsFocusedWindowWhenEventWindowMetadataIsStale(
+        actionName: String,
+        modifiers: NSEvent.ModifierFlags,
+        expectedAction: KeyboardShortcutSettings.Action,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared", file: file, line: line)
+            return
+        }
+
+        let defaults = UserDefaults.standard
+        let originalLastSurfaceCloseSetting = defaults.object(forKey: appDelegateLastSurfaceCloseShortcutDefaultsKey)
+        defaults.set(true, forKey: appDelegateLastSurfaceCloseShortcutDefaultsKey)
+        defer {
+            restoreDefaultsValue(
+                originalLastSurfaceCloseSetting,
+                forKey: appDelegateLastSurfaceCloseShortcutDefaultsKey,
+                defaults: defaults
+            )
+        }
+
+        let originalWindowId = UUID()
+        let focusedWindowId = UUID()
+        let originalManager = TabManager(autoWelcomeIfNeeded: false)
+        let focusedManager = TabManager(autoWelcomeIfNeeded: false)
+        let originalWindow = makeRegisteredShortcutRoutingWindow(id: originalWindowId)
+        let focusedWindow = makeRegisteredShortcutRoutingWindow(id: focusedWindowId)
+
+        appDelegate.registerMainWindow(
+            originalWindow,
+            windowId: originalWindowId,
+            tabManager: originalManager,
+            sidebarState: SidebarState(),
+            sidebarSelectionState: SidebarSelectionState()
+        )
+        appDelegate.registerMainWindow(
+            focusedWindow,
+            windowId: focusedWindowId,
+            tabManager: focusedManager,
+            sidebarState: SidebarState(),
+            sidebarSelectionState: SidebarSelectionState()
+        )
+
+        defer {
+            closeRegisteredShortcutRoutingWindow(originalWindow, id: originalWindowId)
+            closeRegisteredShortcutRoutingWindow(focusedWindow, id: focusedWindowId)
+        }
+
+        originalManager.addWorkspace(title: "original target", select: true, autoWelcomeIfNeeded: false)
+        focusedManager.addWorkspace(title: "focused target", select: true, autoWelcomeIfNeeded: false)
+
+        originalWindow.orderFront(nil)
+        focusedWindow.makeKeyAndOrderFront(nil)
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+
+        // Model the observed bug: the user-visible focused window is the new window,
+        // but the key event still carries the original window number.
+        appDelegate.tabManager = originalManager
+
+        let originalCountBefore = originalManager.tabs.count
+        let focusedCountBefore = focusedManager.tabs.count
+
+        guard let event = makeKeyDownEvent(
+            key: "w",
+            modifiers: modifiers,
+            keyCode: 13,
+            windowNumber: originalWindow.windowNumber
+        ) else {
+            XCTFail("Failed to construct \(actionName) event", file: file, line: line)
+            return
+        }
+
+        XCTAssertTrue(
+            KeyboardShortcutSettings.shortcut(for: expectedAction).matches(event: event),
+            "\(actionName) should match \(expectedAction)",
+            file: file,
+            line: line
+        )
+
+#if DEBUG
+        XCTAssertTrue(appDelegate.debugHandleCustomShortcut(event: event), file: file, line: line)
+#else
+        XCTFail("debugHandleCustomShortcut is only available in DEBUG", file: file, line: line)
+#endif
+
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+
+        XCTAssertEqual(
+            originalManager.tabs.count,
+            originalCountBefore,
+            "\(actionName) must not close a workspace in the original window when another window is focused",
+            file: file,
+            line: line
+        )
+        XCTAssertEqual(
+            focusedManager.tabs.count,
+            focusedCountBefore - 1,
+            "\(actionName) should close the selected workspace in the focused window",
+            file: file,
+            line: line
+        )
     }
 
     @discardableResult

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -6366,8 +6366,10 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
 
         let defaults = UserDefaults.standard
         let originalLastSurfaceCloseSetting = defaults.object(forKey: appDelegateLastSurfaceCloseShortcutDefaultsKey)
+        let previousTabManager = appDelegate.tabManager
         defaults.set(true, forKey: appDelegateLastSurfaceCloseShortcutDefaultsKey)
         defer {
+            appDelegate.tabManager = previousTabManager
             restoreDefaultsValue(
                 originalLastSurfaceCloseSetting,
                 forKey: appDelegateLastSurfaceCloseShortcutDefaultsKey,
@@ -6402,8 +6404,25 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
             closeRegisteredShortcutRoutingWindow(focusedWindow, id: focusedWindowId)
         }
 
-        originalManager.addWorkspace(title: "original target", select: true, autoWelcomeIfNeeded: false)
-        focusedManager.addWorkspace(title: "focused target", select: true, autoWelcomeIfNeeded: false)
+        let originalWorkspace = originalManager.addWorkspace(title: "original target", select: true, autoWelcomeIfNeeded: false)
+        let focusedWorkspace = focusedManager.addWorkspace(title: "focused target", select: true, autoWelcomeIfNeeded: false)
+
+        switch expectedAction {
+        case .closeTab:
+            guard let originalPanelId = originalWorkspace.focusedPanelId,
+                  originalWorkspace.newTerminalSplit(from: originalPanelId, orientation: .horizontal) != nil,
+                  let focusedPanelId = focusedWorkspace.focusedPanelId,
+                  focusedWorkspace.newTerminalSplit(from: focusedPanelId, orientation: .horizontal) != nil else {
+                XCTFail("Expected split panels for \(actionName)", file: file, line: line)
+                return
+            }
+        case .closeWorkspace:
+            originalManager.addWorkspace(title: "original survivor", select: false, autoWelcomeIfNeeded: false)
+            focusedManager.addWorkspace(title: "focused survivor", select: false, autoWelcomeIfNeeded: false)
+        default:
+            XCTFail("Unexpected close shortcut action \(expectedAction)", file: file, line: line)
+            return
+        }
 
         originalWindow.orderFront(nil)
         focusedWindow.makeKeyAndOrderFront(nil)
@@ -6413,8 +6432,10 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         // but the key event still carries the original window number.
         appDelegate.tabManager = originalManager
 
-        let originalCountBefore = originalManager.tabs.count
-        let focusedCountBefore = focusedManager.tabs.count
+        let originalTabCountBefore = originalManager.tabs.count
+        let focusedTabCountBefore = focusedManager.tabs.count
+        let originalPanelCountBefore = originalWorkspace.panels.count
+        let focusedPanelCountBefore = focusedWorkspace.panels.count
 
         guard let event = makeKeyDownEvent(
             key: "w",
@@ -6443,18 +6464,52 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
 
         XCTAssertEqual(
             originalManager.tabs.count,
-            originalCountBefore,
+            originalTabCountBefore,
             "\(actionName) must not close a workspace in the original window when another window is focused",
             file: file,
             line: line
         )
-        XCTAssertEqual(
-            focusedManager.tabs.count,
-            focusedCountBefore - 1,
-            "\(actionName) should close the selected workspace in the focused window",
-            file: file,
-            line: line
-        )
+
+        switch expectedAction {
+        case .closeTab:
+            XCTAssertEqual(
+                originalWorkspace.panels.count,
+                originalPanelCountBefore,
+                "\(actionName) must not close a panel in the original window when another window is focused",
+                file: file,
+                line: line
+            )
+            XCTAssertEqual(
+                focusedManager.tabs.count,
+                focusedTabCountBefore,
+                "\(actionName) should keep the focused workspace open when closing one of multiple panels",
+                file: file,
+                line: line
+            )
+            XCTAssertEqual(
+                focusedWorkspace.panels.count,
+                focusedPanelCountBefore - 1,
+                "\(actionName) should close the selected panel in the focused window",
+                file: file,
+                line: line
+            )
+        case .closeWorkspace:
+            XCTAssertEqual(
+                focusedManager.tabs.count,
+                focusedTabCountBefore - 1,
+                "\(actionName) should close the selected workspace in the focused window",
+                file: file,
+                line: line
+            )
+            XCTAssertFalse(
+                focusedManager.tabs.contains { $0.id == focusedWorkspace.id },
+                "\(actionName) should remove the selected workspace in the focused window",
+                file: file,
+                line: line
+            )
+        default:
+            break
+        }
     }
 
     @discardableResult


### PR DESCRIPTION
## Summary
- Add a regression test for close shortcuts when key-event window metadata points at the original window while a newer window is focused.
- Fix close shortcut routing so focused-window close actions target the focused main window.

## Testing
- Not run locally per repository/task instructions; CI will run the test suite.

Fixes #4614

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4615"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782096461&installation_id=133855650&pr_number=4615&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4615&signature=0e66909a6e7f6c652faaa64b7bf35ecb753e99516c8947846a32bd80e972324f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global keyboard shortcut routing for close actions (`Cmd+W`, `Cmd+Shift+W`, close window), which can affect multi-window behavior and regress edge cases involving auxiliary windows.
> 
> **Overview**
> Fixes close-shortcut routing so **focused-window close actions** prefer `NSApp.keyWindow`/`NSApp.mainWindow` over potentially stale `NSEvent` window metadata, and syncs the active main-window context before executing close operations.
> 
> This introduces focused close helpers (`mainWindowForFocusedCloseShortcut`, `tabManagerForFocusedCloseShortcut`, `auxiliaryWindowForFocusedCloseShortcut`) to consistently decide between auxiliary windows (e.g., browser popups) and the focused main window’s `TabManager`.
> 
> Adds regression tests ensuring `Cmd+W` (close tab/panel) and `Cmd+Shift+W` (close workspace) act on the **currently focused window** even when the key event’s `windowNumber` points at an older window.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12056b5e4f5fe918df09b0c086d4384522f41899. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route close shortcuts to the focused window so tabs, workspaces, and windows close in the right place, even when the key event has stale window metadata. Adds stricter regression tests for Cmd+W and Cmd+Shift+W. Fixes #4614.

- **Bug Fixes**
  - Close Tab/Workspace/Window now prefer the focused `keyWindow`/`mainWindow` and resync app context; only fall back to the event’s window.
  - Auxiliary windows (e.g., browser popups) take ownership of close; otherwise actions route to the focused window’s `TabManager`.

<sup>Written for commit 12056b5e4f5fe918df09b0c086d4384522f41899. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4615?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cmd+W and Cmd+Shift+W now consistently target the currently focused window (avoids acting on the wrong window when multiple windows/panels are open).
  * Close-Window shortcut now resolves the intended window more reliably and provides a subtle alert if no target is available.

* **Tests**
  * Added regression tests to ensure close shortcuts continue to target the focused window in stale-window scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4615?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->