### PR TITLE
fix: rewrite sidebar workspace context menu in AppKit NSMenu (#2003)

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -12124,6 +12124,27 @@ struct VerticalTabsSidebar: View {
             }
         }
 
+        let precomputedHasLatestNotifications = contextMenuWorkspaceIds.contains { notificationStore.latestNotification(forTabId: $0) != nil }
+        let canMarkWorkspaceRead = notificationStore.canMarkWorkspaceRead(forTabIds: contextMenuWorkspaceIds)
+        let canMarkWorkspaceUnread = notificationStore.canMarkWorkspaceUnread(forTabIds: contextMenuWorkspaceIds)
+        let referenceWindowId = AppDelegate.shared?.windowId(for: tabManager)
+        let precomputedHasCustomColorInSelection = contextMenuWorkspaceIds.contains { id in
+            tabManager.tabs.first(where: { $0.id == id })?.customColor != nil
+        }
+        let targetWorkspaces = contextMenuWorkspaceIds.compactMap { id in
+            tabManager.tabs.first(where: { $0.id == id })
+        }
+        let eligibleTargets = targetWorkspaces.filter { !$0.isPinned }
+        let eligibleTargetIds = eligibleTargets.map(\.id)
+        let allTargetsInSameGroup: UUID? = {
+            let groupIds = eligibleTargets.map(\.groupId)
+            guard let first = groupIds.first, groupIds.allSatisfy({ $0 == first }) else {
+                return nil
+            }
+            return first
+        }()
+        let hasAnyGroupedTarget = eligibleTargets.contains { $0.groupId != nil }
+
         // Per-row drag/drop snapshots. Reading `dragState` here in the parent
         // is intentional: the parent owns the @Observable store, and these
         // value snapshots are what get passed to the row. The row's
@@ -12186,11 +12207,20 @@ struct VerticalTabsSidebar: View {
             onDragStart: onDragStart,
             tabDropDelegateFactory: tabDropDelegateFactory,
             contextMenuWorkspaceIds: contextMenuWorkspaceIds,
+            orderedWorkspaceIds: sidebarReorderIds,
             remoteContextMenuWorkspaceIds: remoteContextMenuWorkspaceIds,
             allRemoteContextMenuTargetsConnecting: allRemoteContextMenuTargetsConnecting,
             allRemoteContextMenuTargetsDisconnected: allRemoteContextMenuTargetsDisconnected,
             contextMenuPinState: contextMenuPinState,
             workspaceGroupMenuSnapshot: renderContext.workspaceGroupMenuSnapshot,
+            eligibleTargetIds: eligibleTargetIds,
+            allTargetsInSameGroup: allTargetsInSameGroup,
+            hasAnyGroupedTarget: hasAnyGroupedTarget,
+            canMarkWorkspaceRead: canMarkWorkspaceRead,
+            canMarkWorkspaceUnread: canMarkWorkspaceUnread,
+            hasLatestNotifications: precomputedHasLatestNotifications,
+            referenceWindowId: referenceWindowId,
+            hasCustomColorInSelection: precomputedHasCustomColorInSelection,
             settings: renderContext.tabItemSettings,
             onContextMenuAppear: onContextMenuAppear,
             onContextMenuDisappear: onContextMenuDisappear
@@ -14657,11 +14687,20 @@ struct TabItemView: View, Equatable {
         lhs.rowSpacing == rhs.rowSpacing &&
         lhs.showsModifierShortcutHints == rhs.showsModifierShortcutHints &&
         lhs.contextMenuWorkspaceIds == rhs.contextMenuWorkspaceIds &&
+        lhs.orderedWorkspaceIds == rhs.orderedWorkspaceIds &&
         lhs.remoteContextMenuWorkspaceIds == rhs.remoteContextMenuWorkspaceIds &&
         lhs.allRemoteContextMenuTargetsConnecting == rhs.allRemoteContextMenuTargetsConnecting &&
         lhs.allRemoteContextMenuTargetsDisconnected == rhs.allRemoteContextMenuTargetsDisconnected &&
         lhs.contextMenuPinState == rhs.contextMenuPinState &&
         lhs.workspaceGroupMenuSnapshot == rhs.workspaceGroupMenuSnapshot &&
+        lhs.eligibleTargetIds == rhs.eligibleTargetIds &&
+        lhs.allTargetsInSameGroup == rhs.allTargetsInSameGroup &&
+        lhs.hasAnyGroupedTarget == rhs.hasAnyGroupedTarget &&
+        lhs.canMarkWorkspaceRead == rhs.canMarkWorkspaceRead &&
+        lhs.canMarkWorkspaceUnread == rhs.canMarkWorkspaceUnread &&
+        lhs.hasLatestNotifications == rhs.hasLatestNotifications &&
+        lhs.referenceWindowId == rhs.referenceWindowId &&
+        lhs.hasCustomColorInSelection == rhs.hasCustomColorInSelection &&
         lhs.isBeingDragged == rhs.isBeingDragged &&
         lhs.topDropIndicatorVisible == rhs.topDropIndicatorVisible &&
         lhs.settings == rhs.settings
@@ -14699,14 +14738,23 @@ struct TabItemView: View, Equatable {
     let onDragStart: () -> NSItemProvider
     /// Factory invoked from `body` with the row's measured `rowHeight`. Closure
     /// captures the parent's `dragState`, so TabItemView itself never holds an
-    /// `@Observable` store reference (snapshot-boundary rule).
+    /// `@Observable store reference (snapshot-boundary rule).
     let tabDropDelegateFactory: (CGFloat) -> SidebarTabDropDelegate
     let contextMenuWorkspaceIds: [UUID]
+    let orderedWorkspaceIds: [UUID]
     let remoteContextMenuWorkspaceIds: [UUID]
     let allRemoteContextMenuTargetsConnecting: Bool
     let allRemoteContextMenuTargetsDisconnected: Bool
     let contextMenuPinState: WorkspaceActionDispatcher.PinState?
     let workspaceGroupMenuSnapshot: WorkspaceGroupMenuSnapshot
+    let eligibleTargetIds: [UUID]
+    let allTargetsInSameGroup: UUID?
+    let hasAnyGroupedTarget: Bool
+    let canMarkWorkspaceRead: Bool
+    let canMarkWorkspaceUnread: Bool
+    let hasLatestNotifications: Bool
+    let referenceWindowId: UUID?
+    let hasCustomColorInSelection: Bool
     let settings: SidebarTabItemSettingsSnapshot
     /// Called from this row's contextMenu.onAppear so the parent can freeze
     /// `showsModifierShortcutHints` to the value it last passed in. Prevents
@@ -15448,20 +15496,48 @@ struct TabItemView: View, Equatable {
         .accessibilityAction(named: Text(moveDownActionText)) {
             moveBy(1)
         }
-        .contextMenu {
-            workspaceContextMenu
-                .onAppear {
+        .overlay(
+            WorkspaceContextMenuOverlay(
+                isPinned: tab.isPinned,
+                referenceWindowId: referenceWindowId,
+                hasCustomColorInSelection: hasCustomColorInSelection,
+                index: index,
+                tabCount: accessibilityWorkspaceCount,
+                orderedWorkspaceIds: orderedWorkspaceIds,
+                contextMenuWorkspaceIds: contextMenuWorkspaceIds,
+                remoteContextMenuWorkspaceIds: remoteContextMenuWorkspaceIds,
+                allRemoteContextMenuTargetsConnecting: allRemoteContextMenuTargetsConnecting,
+                allRemoteContextMenuTargetsDisconnected: allRemoteContextMenuTargetsDisconnected,
+                contextMenuPinState: contextMenuPinState,
+                hasCustomTitle: tab.hasCustomTitle,
+                hasCustomDescription: tab.hasCustomDescription,
+                copyableSidebarSSHError: workspaceSnapshot.copyableSidebarSSHError,
+                finderDirectoryURL: workspaceFinderDirectoryCache.url(for: WorkspaceFinderDirectoryCacheKey(path: contextMenuWorkspaceIds.count > 1 ? nil : WorkspaceFinderDirectoryResolver.path(for: tab))),
+                hasLatestNotifications: hasLatestNotifications,
+                canMarkWorkspaceRead: canMarkWorkspaceRead,
+                canMarkWorkspaceUnread: canMarkWorkspaceUnread,
+                colorScheme: colorScheme,
+                activeTabIndicatorStyle: activeTabIndicatorStyle,
+                eligibleTargetIds: eligibleTargetIds,
+                allTargetsInSameGroup: allTargetsInSameGroup,
+                hasAnyGroupedTarget: hasAnyGroupedTarget,
+                workspaceGroupMenuSnapshot: workspaceGroupMenuSnapshot,
+                onAction: { action in
+                    handleMenuAction(action)
+                },
+                onMenuWillOpen: {
                     rowInteractionState.contextMenuDidAppear()
                     contextMenuState.hasDeferredWorkspaceObservationInvalidation = false
                     contextMenuState.pendingWorkspaceSnapshot = nil
                     onContextMenuAppear()
-                }
-                .onDisappear {
+                },
+                onMenuDidClose: {
                     rowInteractionState.contextMenuDidDisappear()
                     onContextMenuDisappear()
                     flushDeferredWorkspaceObservationInvalidation()
                 }
-        }
+            )
+        )
     }
 
     private func refreshWorkspaceSnapshot(force: Bool = false) {
@@ -15504,61 +15580,10 @@ struct TabItemView: View, Equatable {
         }
     }
 
-    @ViewBuilder
-    private var workspaceContextMenu: some View {
+    private func handleMenuAction(_ action: WorkspaceContextMenuAction) {
         let targetIds = contextMenuWorkspaceIds
-        let isMulti = targetIds.count > 1
-        let tabColorPalette = WorkspaceTabColorSettings.palette()
-        let shouldPin = contextMenuPinState?.pinned ?? !tab.isPinned
-        let reconnectLabel = contextMenuLabel(
-            multi: String(localized: "contextMenu.reconnectWorkspaces", defaultValue: "Reconnect Workspaces"),
-            single: String(localized: "contextMenu.reconnectWorkspace", defaultValue: "Reconnect Workspace"),
-            isMulti: isMulti)
-        let disconnectLabel = contextMenuLabel(
-            multi: String(localized: "contextMenu.disconnectWorkspaces", defaultValue: "Disconnect Workspaces"),
-            single: String(localized: "contextMenu.disconnectWorkspace", defaultValue: "Disconnect Workspace"),
-            isMulti: isMulti)
-        let pinLabel = shouldPin
-            ? contextMenuLabel(
-                multi: String(localized: "contextMenu.pinWorkspaces", defaultValue: "Pin Workspaces"),
-                single: String(localized: "contextMenu.pinWorkspace", defaultValue: "Pin Workspace"),
-                isMulti: isMulti)
-            : contextMenuLabel(
-                multi: String(localized: "contextMenu.unpinWorkspaces", defaultValue: "Unpin Workspaces"),
-                single: String(localized: "contextMenu.unpinWorkspace", defaultValue: "Unpin Workspace"),
-                isMulti: isMulti)
-        let closeLabel = contextMenuLabel(
-            multi: String(localized: "contextMenu.closeWorkspaces", defaultValue: "Close Workspaces"),
-            single: String(localized: "contextMenu.closeWorkspace", defaultValue: "Close Workspace"),
-            isMulti: isMulti)
-        let markReadLabel = contextMenuLabel(
-            multi: String(localized: "contextMenu.markWorkspacesRead", defaultValue: "Mark Workspaces as Read"),
-            single: String(localized: "contextMenu.markWorkspaceRead", defaultValue: "Mark Workspace as Read"),
-            isMulti: isMulti)
-        let markUnreadLabel = contextMenuLabel(
-            multi: String(localized: "contextMenu.markWorkspacesUnread", defaultValue: "Mark Workspaces as Unread"),
-            single: String(localized: "contextMenu.markWorkspaceUnread", defaultValue: "Mark Workspace as Unread"),
-            isMulti: isMulti)
-        let clearLatestNotificationLabel = contextMenuLabel(
-            multi: String(localized: "contextMenu.clearLatestNotifications", defaultValue: "Clear Latest Notifications"),
-            single: String(localized: "contextMenu.clearLatestNotification", defaultValue: "Clear Latest Notification"),
-            isMulti: isMulti)
-        let copyWorkspaceIDLabel = contextMenuLabel(
-            multi: String(localized: "contextMenu.copyWorkspaceIDs", defaultValue: "Copy Workspace IDs"),
-            single: String(localized: "contextMenu.copyWorkspaceID", defaultValue: "Copy Workspace ID"),
-            isMulti: isMulti)
-        let copyWorkspaceLinkLabel = contextMenuLabel(
-            multi: String(localized: "contextMenu.copyWorkspaceLinks", defaultValue: "Copy Workspace Links"),
-            single: String(localized: "contextMenu.copyWorkspaceLink", defaultValue: "Copy Workspace Link"),
-            isMulti: isMulti)
-        let renameWorkspaceShortcut = KeyboardShortcutSettings.shortcut(for: .renameWorkspace)
-        let editWorkspaceDescriptionShortcut = KeyboardShortcutSettings.shortcut(for: .editWorkspaceDescription)
-        let closeWorkspaceShortcut = KeyboardShortcutSettings.shortcut(for: .closeWorkspace)
-        let finderDirectoryCacheKey = WorkspaceFinderDirectoryCacheKey(
-            path: isMulti ? nil : WorkspaceFinderDirectoryResolver.path(for: tab)
-        )
-        let finderDirectoryURL = workspaceFinderDirectoryCache.url(for: finderDirectoryCacheKey)
-        Button(pinLabel) {
+        switch action {
+        case .togglePin:
             guard let contextMenuPinState else {
                 NSSound.beep()
                 return
@@ -15568,211 +15593,114 @@ struct TabItemView: View, Equatable {
                 refreshWorkspaceSnapshot(force: true)
             }
             syncSelectionAfterMutation()
-        }
-        .disabled(contextMenuPinState == nil)
-
-        workspaceGroupContextMenuSection(targetIds: targetIds, isMulti: isMulti)
-
-        if let key = renameWorkspaceShortcut.keyEquivalent {
-            Button(String(localized: "contextMenu.renameWorkspace", defaultValue: "Rename Workspace…")) {
-                promptRename()
+            
+        case .rename:
+            promptRename()
+            
+        case .removeCustomName:
+            tabManager.clearCustomTitle(tabId: tab.id)
+            
+        case .editDescription:
+            beginWorkspaceDescriptionEditFromContextMenu()
+            
+        case .clearDescription:
+            tabManager.clearCustomDescription(tabId: tab.id)
+            
+        case .reconnectRemote:
+            for workspace in remoteContextMenuWorkspaces() {
+                workspace.reconnectRemoteConnection()
             }
-            .keyboardShortcut(key, modifiers: renameWorkspaceShortcut.eventModifiers)
-        } else {
-            Button(String(localized: "contextMenu.renameWorkspace", defaultValue: "Rename Workspace…")) {
-                promptRename()
+            
+        case .disconnectRemote:
+            for workspace in remoteContextMenuWorkspaces() {
+                workspace.disconnectRemoteConnection(clearConfiguration: false)
             }
-        }
-
-        if tab.hasCustomTitle {
-            Button(String(localized: "contextMenu.removeCustomWorkspaceName", defaultValue: "Remove Custom Workspace Name")) {
-                tabManager.clearCustomTitle(tabId: tab.id)
+            
+        case .clearColor:
+            applyTabColor(nil, targetIds: targetIds)
+            
+        case .chooseCustomColor:
+            promptCustomColor(targetIds: targetIds)
+            
+        case .applyColor(let hex):
+            applyTabColor(hex, targetIds: targetIds)
+            
+        case .copySshError:
+            if let sanitizedError = sanitizedCopyableSidebarSSHError() {
+                WorkspaceSurfaceIdentifierClipboardText.copy(sanitizedError)
             }
-        }
-
-        if !isMulti {
-            if let key = editWorkspaceDescriptionShortcut.keyEquivalent {
-                Button(String(localized: "contextMenu.editWorkspaceDescription", defaultValue: "Edit Workspace Description…")) {
-                    beginWorkspaceDescriptionEditFromContextMenu()
-                }
-                .keyboardShortcut(key, modifiers: editWorkspaceDescriptionShortcut.eventModifiers)
-            } else {
-                Button(String(localized: "contextMenu.editWorkspaceDescription", defaultValue: "Edit Workspace Description…")) {
-                    beginWorkspaceDescriptionEditFromContextMenu()
-                }
-            }
-
-            if tab.hasCustomDescription {
-                Button(String(localized: "contextMenu.clearWorkspaceDescription", defaultValue: "Clear Workspace Description")) {
-                    tabManager.clearCustomDescription(tabId: tab.id)
-                }
-            }
-
-        }
-
-        if !remoteContextMenuWorkspaceIds.isEmpty {
-            Divider()
-
-            Button(reconnectLabel) {
-                for workspace in remoteContextMenuWorkspaces() {
-                    workspace.reconnectRemoteConnection()
-                }
-            }
-            .disabled(allRemoteContextMenuTargetsConnecting)
-
-            Button(disconnectLabel) {
-                for workspace in remoteContextMenuWorkspaces() {
-                    workspace.disconnectRemoteConnection(clearConfiguration: false)
-                }
-            }
-            .disabled(allRemoteContextMenuTargetsDisconnected)
-        }
-
-        Menu(String(localized: "contextMenu.workspaceColor", defaultValue: "Workspace Color")) {
-            if tab.customColor != nil {
-                Button {
-                    applyTabColor(nil, targetIds: targetIds)
-                } label: {
-                    Label(String(localized: "contextMenu.clearColor", defaultValue: "Clear Color"), systemImage: "xmark.circle")
-                }
-            }
-
-            Button {
-                promptCustomColor(targetIds: targetIds)
-            } label: {
-                Label(String(localized: "contextMenu.chooseCustomColor", defaultValue: "Choose Custom Color…"), systemImage: "paintpalette")
-            }
-
-            if !tabColorPalette.isEmpty {
-                Divider()
-            }
-
-            ForEach(tabColorPalette, id: \.id) { entry in
-                Button {
-                    applyTabColor(entry.hex, targetIds: targetIds)
-                } label: {
-                    Label {
-                        Text(entry.name)
-                    } icon: {
-                        Image(nsImage: coloredCircleImage(color: tabColorSwatchColor(for: entry.hex)))
-                    }
-                }
-            }
-        }
-
-        if let copyableSidebarSSHError = workspaceSnapshot.copyableSidebarSSHError {
-            Button(String(localized: "contextMenu.copySshError", defaultValue: "Copy SSH Error")) {
-                WorkspaceSurfaceIdentifierClipboardText.copy(copyableSidebarSSHError)
-            }
-        }
-
-        Divider()
-
-        Button(String(localized: "contextMenu.moveUp", defaultValue: "Move Up")) {
+            
+        case .moveUp:
             moveBy(-1)
-        }
-        .disabled(index == 0)
-
-        Button(String(localized: "contextMenu.moveDown", defaultValue: "Move Down")) {
+            
+        case .moveDown:
             moveBy(1)
-        }
-        .disabled(index >= tabManager.tabs.count - 1)
-
-        Button(String(localized: "contextMenu.moveToTop", defaultValue: "Move to Top")) {
+            
+        case .moveToTop:
             tabManager.moveTabsToTop(Set(targetIds))
             syncSelectionAfterMutation()
-        }
-        .disabled(targetIds.isEmpty)
-
-        let referenceWindowId = AppDelegate.shared?.windowId(for: tabManager)
-        let windowMoveTargets = AppDelegate.shared?.windowMoveTargets(referenceWindowId: referenceWindowId) ?? []
-        let moveMenuTitle = targetIds.count > 1
-            ? String(localized: "contextMenu.moveWorkspacesToWindow", defaultValue: "Move Workspaces to Window")
-            : String(localized: "contextMenu.moveWorkspaceToWindow", defaultValue: "Move Workspace to Window")
-        Menu(moveMenuTitle) {
-            Button(String(localized: "contextMenu.newWindow", defaultValue: "New Window")) {
-                moveWorkspacesToNewWindow(targetIds)
-            }
-            .disabled(targetIds.isEmpty)
-
-            if !windowMoveTargets.isEmpty {
-                Divider()
-            }
-
-            ForEach(windowMoveTargets) { target in
-                Button(target.label) {
-                    moveWorkspaces(targetIds, toWindow: target.windowId)
-                }
-                .disabled(target.isCurrentWindow || targetIds.isEmpty)
-            }
-        }
-        .disabled(targetIds.isEmpty)
-
-        Divider()
-
-        if let key = closeWorkspaceShortcut.keyEquivalent {
-            Button(closeLabel) {
-                closeTabs(targetIds, allowPinned: true)
-            }
-            .keyboardShortcut(key, modifiers: closeWorkspaceShortcut.eventModifiers)
-            .disabled(targetIds.isEmpty)
-        } else {
-            Button(closeLabel) {
-                closeTabs(targetIds, allowPinned: true)
-            }
-            .disabled(targetIds.isEmpty)
-        }
-
-        Button(String(localized: "contextMenu.closeOtherWorkspaces", defaultValue: "Close Other Workspaces")) {
+            
+        case .moveToNewWindow:
+            moveWorkspacesToNewWindow(targetIds)
+            
+        case .moveToWindow(let windowId):
+            moveWorkspaces(targetIds, toWindow: windowId)
+            
+        case .close:
+            closeTabs(targetIds, allowPinned: true)
+            
+        case .closeOthers:
             closeOtherTabs(targetIds)
-        }
-        .disabled(tabManager.tabs.count <= 1 || targetIds.count == tabManager.tabs.count)
-
-        Button(String(localized: "contextMenu.closeWorkspacesBelow", defaultValue: "Close Workspaces Below")) {
+            
+        case .closeBelow:
             closeTabsBelow(tabId: tab.id)
-        }
-        .disabled(index >= tabManager.tabs.count - 1)
-
-        Button(String(localized: "contextMenu.closeWorkspacesAbove", defaultValue: "Close Workspaces Above")) {
+            
+        case .closeAbove:
             closeTabsAbove(tabId: tab.id)
-        }
-        .disabled(index == 0)
-
-        Divider()
-
-        Button(markReadLabel) {
+            
+        case .markRead:
             markTabsRead(targetIds)
-        }
-        .disabled(!notificationStore.canMarkWorkspaceRead(forTabIds: targetIds))
-
-        Button(markUnreadLabel) {
+            
+        case .markUnread:
             markTabsUnread(targetIds)
-        }
-        .disabled(!notificationStore.canMarkWorkspaceUnread(forTabIds: targetIds))
-
-        Button(clearLatestNotificationLabel) {
+            
+        case .clearLatestNotification:
             clearLatestNotifications(targetIds)
-        }
-        .disabled(!hasLatestNotifications(in: targetIds))
-
-        Divider()
-
-        Button(copyWorkspaceIDLabel) {
+            
+        case .copyWorkspaceID:
             copyWorkspaceIdsToPasteboard(targetIds)
-        }
-        .disabled(targetIds.isEmpty)
-
-        Button(copyWorkspaceLinkLabel) {
+            
+        case .copyWorkspaceLink:
             copyWorkspaceLinksToPasteboard(targetIds)
-        }
-        .disabled(targetIds.isEmpty)
-
-        if !isMulti {
-            Button(String(localized: "contextMenu.showWorkspaceInFinder", defaultValue: "Show in Finder")) {
-                workspaceFinderDirectoryOpenRequest = WorkspaceFinderDirectoryOpenRequest(directoryURL: finderDirectoryURL)
+            
+        case .showInFinder:
+            let isMulti = contextMenuWorkspaceIds.count > 1
+            let finderDirectoryPath = WorkspaceFinderDirectoryResolver.path(for: tab)
+            let lookupKey = WorkspaceFinderDirectoryCacheKey(path: isMulti ? nil : finderDirectoryPath)
+            let finderDirectoryURL = workspaceFinderDirectoryCache.url(for: lookupKey)
+            workspaceFinderDirectoryOpenRequest = WorkspaceFinderDirectoryOpenRequest(directoryURL: finderDirectoryURL)
+            
+        case .newGroupFromSelection(let eligibleTargetIds):
+            promptNewWorkspaceGroup(workspaceIds: eligibleTargetIds)
+            
+        case .addToGroup(let eligibleTargetIds, let groupId):
+            for id in eligibleTargetIds {
+                tabManager.addWorkspaceToGroup(workspaceId: id, groupId: groupId)
             }
-            .disabled(finderDirectoryURL == nil)
+            
+        case .removeFromGroup(let eligibleTargetIds):
+            for id in eligibleTargetIds {
+                tabManager.removeWorkspaceFromGroup(workspaceId: id)
+            }
         }
+    }
+
+    private func sanitizedCopyableSidebarSSHError() -> String? {
+        guard let rawError = workspaceSnapshot.copyableSidebarSSHError else { return nil }
+        let trimmed = rawError.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let homePath = FileManager.default.homeDirectoryForCurrentUser.path
+        return trimmed.replacingOccurrences(of: homePath, with: "~")
     }
 
     private var backgroundColor: Color {

--- a/Sources/Sidebar/WorkspaceContextMenuOverlay.swift
+++ b/Sources/Sidebar/WorkspaceContextMenuOverlay.swift
@@ -1,0 +1,504 @@
+import AppKit
+import Foundation
+import SwiftUI
+
+enum WorkspaceContextMenuAction {
+    case togglePin
+    case rename
+    case removeCustomName
+    case editDescription
+    case clearDescription
+    case reconnectRemote
+    case disconnectRemote
+    case clearColor
+    case chooseCustomColor
+    case applyColor(hex: String)
+    case copySshError
+    case moveUp
+    case moveDown
+    case moveToTop
+    case moveToNewWindow
+    case moveToWindow(windowId: UUID)
+    case close
+    case closeOthers
+    case closeBelow
+    case closeAbove
+    case markRead
+    case markUnread
+    case clearLatestNotification
+    case copyWorkspaceID
+    case copyWorkspaceLink
+    case showInFinder
+    
+    // Grouping
+    case newGroupFromSelection(eligibleTargetIds: [UUID])
+    case addToGroup(eligibleTargetIds: [UUID], groupId: UUID)
+    case removeFromGroup(eligibleTargetIds: [UUID])
+}
+
+@MainActor
+struct WorkspaceContextMenuOverlay: NSViewRepresentable {
+    let isPinned: Bool
+    let referenceWindowId: UUID?
+    let hasCustomColorInSelection: Bool
+    let index: Int
+    let tabCount: Int
+    let orderedWorkspaceIds: [UUID]
+    let contextMenuWorkspaceIds: [UUID]
+    let remoteContextMenuWorkspaceIds: [UUID]
+    let allRemoteContextMenuTargetsConnecting: Bool
+    let allRemoteContextMenuTargetsDisconnected: Bool
+    let contextMenuPinState: WorkspaceActionDispatcher.PinState?
+    let hasCustomTitle: Bool
+    let hasCustomDescription: Bool
+    let copyableSidebarSSHError: String?
+    let finderDirectoryURL: URL?
+    let hasLatestNotifications: Bool
+    let canMarkWorkspaceRead: Bool
+    let canMarkWorkspaceUnread: Bool
+    let colorScheme: ColorScheme
+    let activeTabIndicatorStyle: SidebarActiveTabIndicatorStyle
+    
+    // Grouping properties passed from TabItemView
+    let eligibleTargetIds: [UUID]
+    let allTargetsInSameGroup: UUID?
+    let hasAnyGroupedTarget: Bool
+    let workspaceGroupMenuSnapshot: WorkspaceGroupMenuSnapshot
+    
+    let onAction: (WorkspaceContextMenuAction) -> Void
+    let onMenuWillOpen: () -> Void
+    let onMenuDidClose: () -> Void
+
+    nonisolated static func isMoveToTopEnabled(
+        contextMenuWorkspaceIds: [UUID],
+        orderedWorkspaceIds: [UUID],
+        fallbackIndex: Int
+    ) -> Bool {
+        guard !contextMenuWorkspaceIds.isEmpty else { return false }
+        let selectedIds = Set(contextMenuWorkspaceIds)
+        let selectedIndexes = orderedWorkspaceIds.indices.compactMap { index in
+            selectedIds.contains(orderedWorkspaceIds[index]) ? index : nil
+        }
+        let minSelectedIndex = selectedIndexes.min() ?? fallbackIndex
+        return minSelectedIndex > 0
+    }
+
+    func makeNSView(context: Context) -> MenuHostView {
+        let view = MenuHostView()
+        view.coordinator = context.coordinator
+        return view
+    }
+
+    func updateNSView(_ nsView: MenuHostView, context: Context) {
+        context.coordinator.overlay = self
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(overlay: self)
+    }
+
+    @MainActor
+    class Coordinator: NSObject, NSMenuDelegate {
+        var overlay: WorkspaceContextMenuOverlay
+
+        init(overlay: WorkspaceContextMenuOverlay) {
+            self.overlay = overlay
+            super.init()
+        }
+
+        private func contextMenuLabel(multi: String, single: String, isMulti: Bool) -> String {
+            isMulti ? multi : single
+        }
+
+        private func tabColorSwatchColor(for hex: String) -> NSColor {
+            WorkspaceTabColorSettings.displayNSColor(
+                hex: hex,
+                colorScheme: overlay.colorScheme,
+                forceBright: overlay.activeTabIndicatorStyle == .leftRail
+            ) ?? NSColor(hex: hex) ?? .gray
+        }
+
+        func buildMenu() -> NSMenu {
+            let menu = NSMenu(title: String(localized: "contextMenu.title", defaultValue: "Workspace Context Menu"))
+            menu.autoenablesItems = false
+
+            let isMulti = overlay.contextMenuWorkspaceIds.count > 1
+            let shouldPin = overlay.contextMenuPinState?.pinned ?? !overlay.isPinned
+
+            let pinLabel = shouldPin
+                ? contextMenuLabel(
+                    multi: String(localized: "contextMenu.pinWorkspaces", defaultValue: "Pin Workspaces"),
+                    single: String(localized: "contextMenu.pinWorkspace", defaultValue: "Pin Workspace"),
+                    isMulti: isMulti)
+                : contextMenuLabel(
+                    multi: String(localized: "contextMenu.unpinWorkspaces", defaultValue: "Unpin Workspaces"),
+                    single: String(localized: "contextMenu.unpinWorkspace", defaultValue: "Unpin Workspace"),
+                    isMulti: isMulti)
+
+            // Pin / Unpin
+            let pinItem = NSMenuItem(title: pinLabel, action: #selector(handleMenuItemAction(_:)), keyEquivalent: "")
+            pinItem.target = self
+            pinItem.representedObject = WorkspaceContextMenuAction.togglePin
+            pinItem.isEnabled = overlay.contextMenuPinState != nil
+            menu.addItem(pinItem)
+
+            // Workspace Groups section
+            if !overlay.eligibleTargetIds.isEmpty {
+                let groupSelectedShortcut = KeyboardShortcutSettings.shortcut(for: .groupSelectedWorkspaces)
+                let groupSelectedLabel = isMulti
+                    ? String(localized: "contextMenu.workspaceGroup.newFromSelection", defaultValue: "New Group from Selection")
+                    : String(localized: "contextMenu.workspaceGroup.newFromWorkspace", defaultValue: "New Group from Workspace")
+
+                let newGroupItem = NSMenuItem(title: groupSelectedLabel, action: #selector(handleMenuItemAction(_:)), keyEquivalent: "")
+                newGroupItem.target = self
+                newGroupItem.representedObject = WorkspaceContextMenuAction.newGroupFromSelection(eligibleTargetIds: overlay.eligibleTargetIds)
+                if let key = groupSelectedShortcut.menuItemKeyEquivalent {
+                    newGroupItem.keyEquivalent = key
+                    newGroupItem.keyEquivalentModifierMask = groupSelectedShortcut.modifierFlags
+                }
+                menu.addItem(newGroupItem)
+
+                // Move to Group
+                let groups = overlay.workspaceGroupMenuSnapshot.items
+                let moveMenu = NSMenu(title: String(localized: "contextMenu.workspaceGroup.moveTo", defaultValue: "Move to Group"))
+                moveMenu.autoenablesItems = false
+                
+                for group in groups {
+                    let groupItem = NSMenuItem(title: group.name, action: #selector(handleMenuItemAction(_:)), keyEquivalent: "")
+                    groupItem.target = self
+                    groupItem.representedObject = WorkspaceContextMenuAction.addToGroup(eligibleTargetIds: overlay.eligibleTargetIds, groupId: group.id)
+                    groupItem.isEnabled = overlay.allTargetsInSameGroup != group.id
+                    moveMenu.addItem(groupItem)
+                }
+
+                let moveSubmenuItem = NSMenuItem(title: String(localized: "contextMenu.workspaceGroup.moveTo", defaultValue: "Move to Group"), action: nil, keyEquivalent: "")
+                moveSubmenuItem.submenu = moveMenu
+                moveSubmenuItem.isEnabled = !groups.isEmpty
+                menu.addItem(moveSubmenuItem)
+
+                // Remove from Group
+                if overlay.hasAnyGroupedTarget {
+                    let removeItem = NSMenuItem(title: String(localized: "contextMenu.workspaceGroup.remove", defaultValue: "Remove from Group"), action: #selector(handleMenuItemAction(_:)), keyEquivalent: "")
+                    removeItem.target = self
+                    removeItem.representedObject = WorkspaceContextMenuAction.removeFromGroup(eligibleTargetIds: overlay.eligibleTargetIds)
+                    menu.addItem(removeItem)
+                }
+            }
+
+            // Rename
+            let renameShortcut = KeyboardShortcutSettings.shortcut(for: .renameWorkspace)
+            let renameItem = NSMenuItem(title: String(localized: "contextMenu.renameWorkspace", defaultValue: "Rename Workspace…"), action: #selector(handleMenuItemAction(_:)), keyEquivalent: "")
+            renameItem.target = self
+            renameItem.representedObject = WorkspaceContextMenuAction.rename
+            if let key = renameShortcut.menuItemKeyEquivalent {
+                renameItem.keyEquivalent = key
+                renameItem.keyEquivalentModifierMask = renameShortcut.modifierFlags
+            }
+            menu.addItem(renameItem)
+
+            // Remove Custom Name
+            if overlay.hasCustomTitle {
+                let removeNameItem = NSMenuItem(title: String(localized: "contextMenu.removeCustomWorkspaceName", defaultValue: "Remove Custom Workspace Name"), action: #selector(handleMenuItemAction(_:)), keyEquivalent: "")
+                removeNameItem.target = self
+                removeNameItem.representedObject = WorkspaceContextMenuAction.removeCustomName
+                menu.addItem(removeNameItem)
+            }
+
+            // Description
+            if !isMulti {
+                let editShortcut = KeyboardShortcutSettings.shortcut(for: .editWorkspaceDescription)
+                let editItem = NSMenuItem(title: String(localized: "contextMenu.editWorkspaceDescription", defaultValue: "Edit Workspace Description…"), action: #selector(handleMenuItemAction(_:)), keyEquivalent: "")
+                editItem.target = self
+                editItem.representedObject = WorkspaceContextMenuAction.editDescription
+                if let key = editShortcut.menuItemKeyEquivalent {
+                    editItem.keyEquivalent = key
+                    editItem.keyEquivalentModifierMask = editShortcut.modifierFlags
+                }
+                menu.addItem(editItem)
+
+                if overlay.hasCustomDescription {
+                    let clearDescItem = NSMenuItem(title: String(localized: "contextMenu.clearWorkspaceDescription", defaultValue: "Clear Workspace Description"), action: #selector(handleMenuItemAction(_:)), keyEquivalent: "")
+                    clearDescItem.target = self
+                    clearDescItem.representedObject = WorkspaceContextMenuAction.clearDescription
+                    menu.addItem(clearDescItem)
+                }
+            }
+
+            // Remote Connection
+            if !overlay.remoteContextMenuWorkspaceIds.isEmpty {
+                menu.addItem(NSMenuItem.separator())
+
+                let reconnectLabel = contextMenuLabel(
+                    multi: String(localized: "contextMenu.reconnectWorkspaces", defaultValue: "Reconnect Workspaces"),
+                    single: String(localized: "contextMenu.reconnectWorkspace", defaultValue: "Reconnect Workspace"),
+                    isMulti: isMulti)
+                let disconnectLabel = contextMenuLabel(
+                    multi: String(localized: "contextMenu.disconnectWorkspaces", defaultValue: "Disconnect Workspaces"),
+                    single: String(localized: "contextMenu.disconnectWorkspace", defaultValue: "Disconnect Workspace"),
+                    isMulti: isMulti)
+
+                let reconnectItem = NSMenuItem(title: reconnectLabel, action: #selector(handleMenuItemAction(_:)), keyEquivalent: "")
+                reconnectItem.target = self
+                reconnectItem.representedObject = WorkspaceContextMenuAction.reconnectRemote
+                reconnectItem.isEnabled = !overlay.allRemoteContextMenuTargetsConnecting
+                menu.addItem(reconnectItem)
+
+                let disconnectItem = NSMenuItem(title: disconnectLabel, action: #selector(handleMenuItemAction(_:)), keyEquivalent: "")
+                disconnectItem.target = self
+                disconnectItem.representedObject = WorkspaceContextMenuAction.disconnectRemote
+                disconnectItem.isEnabled = !overlay.allRemoteContextMenuTargetsDisconnected
+                menu.addItem(disconnectItem)
+            }
+
+            // Workspace Color
+            let colorMenu = NSMenu(title: String(localized: "contextMenu.workspaceColor", defaultValue: "Workspace Color"))
+            colorMenu.autoenablesItems = false
+            if overlay.hasCustomColorInSelection {
+                let clearColorItem = NSMenuItem(title: String(localized: "contextMenu.clearColor", defaultValue: "Clear Color"), action: #selector(handleMenuItemAction(_:)), keyEquivalent: "")
+                clearColorItem.target = self
+                clearColorItem.representedObject = WorkspaceContextMenuAction.clearColor
+                clearColorItem.image = NSImage(systemSymbolName: "xmark.circle", accessibilityDescription: nil)
+                colorMenu.addItem(clearColorItem)
+            }
+
+            let chooseColorItem = NSMenuItem(title: String(localized: "contextMenu.chooseCustomColor", defaultValue: "Choose Custom Color…"), action: #selector(handleMenuItemAction(_:)), keyEquivalent: "")
+            chooseColorItem.target = self
+            chooseColorItem.representedObject = WorkspaceContextMenuAction.chooseCustomColor
+            chooseColorItem.image = NSImage(systemSymbolName: "paintpalette", accessibilityDescription: nil)
+            colorMenu.addItem(chooseColorItem)
+
+            let tabColorPalette = WorkspaceTabColorSettings.palette()
+            if !tabColorPalette.isEmpty {
+                colorMenu.addItem(NSMenuItem.separator())
+            }
+
+            for entry in tabColorPalette {
+                let swatchItem = NSMenuItem(title: entry.name, action: #selector(handleMenuItemAction(_:)), keyEquivalent: "")
+                swatchItem.target = self
+                swatchItem.representedObject = WorkspaceContextMenuAction.applyColor(hex: entry.hex)
+                swatchItem.image = coloredCircleImage(color: tabColorSwatchColor(for: entry.hex))
+                colorMenu.addItem(swatchItem)
+            }
+
+            let colorSubmenuItem = NSMenuItem(title: String(localized: "contextMenu.workspaceColor", defaultValue: "Workspace Color"), action: nil, keyEquivalent: "")
+            colorSubmenuItem.submenu = colorMenu
+            menu.addItem(colorSubmenuItem)
+
+            // Copy SSH Error
+            if overlay.copyableSidebarSSHError != nil {
+                let copySshItem = NSMenuItem(title: String(localized: "contextMenu.copySshError", defaultValue: "Copy SSH Error"), action: #selector(handleMenuItemAction(_:)), keyEquivalent: "")
+                copySshItem.target = self
+                copySshItem.representedObject = WorkspaceContextMenuAction.copySshError
+                menu.addItem(copySshItem)
+            }
+
+            menu.addItem(NSMenuItem.separator())
+
+            // Move Up
+            let moveUpItem = NSMenuItem(title: String(localized: "contextMenu.moveUp", defaultValue: "Move Up"), action: #selector(handleMenuItemAction(_:)), keyEquivalent: "")
+            moveUpItem.target = self
+            moveUpItem.representedObject = WorkspaceContextMenuAction.moveUp
+            moveUpItem.isEnabled = overlay.index > 0
+            menu.addItem(moveUpItem)
+
+            // Move Down
+            let moveDownItem = NSMenuItem(title: String(localized: "contextMenu.moveDown", defaultValue: "Move Down"), action: #selector(handleMenuItemAction(_:)), keyEquivalent: "")
+            moveDownItem.target = self
+            moveDownItem.representedObject = WorkspaceContextMenuAction.moveDown
+            moveDownItem.isEnabled = overlay.index < overlay.tabCount - 1
+            menu.addItem(moveDownItem)
+
+            // Move to Top
+            let moveToTopItem = NSMenuItem(title: String(localized: "contextMenu.moveToTop", defaultValue: "Move to Top"), action: #selector(handleMenuItemAction(_:)), keyEquivalent: "")
+            moveToTopItem.target = self
+            moveToTopItem.representedObject = WorkspaceContextMenuAction.moveToTop
+            moveToTopItem.isEnabled = WorkspaceContextMenuOverlay.isMoveToTopEnabled(
+                contextMenuWorkspaceIds: overlay.contextMenuWorkspaceIds,
+                orderedWorkspaceIds: overlay.orderedWorkspaceIds,
+                fallbackIndex: overlay.index
+            )
+            menu.addItem(moveToTopItem)
+
+            // Move to Window
+            let moveMenuTitle = isMulti
+                ? String(localized: "contextMenu.moveWorkspacesToWindow", defaultValue: "Move Workspaces to Window")
+                : String(localized: "contextMenu.moveWorkspaceToWindow", defaultValue: "Move Workspace to Window")
+
+            let moveWindowMenu = NSMenu(title: moveMenuTitle)
+            moveWindowMenu.autoenablesItems = false
+
+            let newWindowItem = NSMenuItem(title: String(localized: "contextMenu.newWindow", defaultValue: "New Window"), action: #selector(handleMenuItemAction(_:)), keyEquivalent: "")
+            newWindowItem.target = self
+            newWindowItem.representedObject = WorkspaceContextMenuAction.moveToNewWindow
+            newWindowItem.isEnabled = !overlay.contextMenuWorkspaceIds.isEmpty
+            moveWindowMenu.addItem(newWindowItem)
+
+            let windowMoveTargets = AppDelegate.shared?.windowMoveTargets(referenceWindowId: overlay.referenceWindowId) ?? []
+
+            if !windowMoveTargets.isEmpty {
+                moveWindowMenu.addItem(NSMenuItem.separator())
+            }
+
+            for target in windowMoveTargets {
+                let targetItem = NSMenuItem(title: target.label, action: #selector(handleMenuItemAction(_:)), keyEquivalent: "")
+                targetItem.target = self
+                targetItem.representedObject = WorkspaceContextMenuAction.moveToWindow(windowId: target.windowId)
+                targetItem.isEnabled = !target.isCurrentWindow && !overlay.contextMenuWorkspaceIds.isEmpty
+                moveWindowMenu.addItem(targetItem)
+            }
+
+            let moveSubmenuItem = NSMenuItem(title: moveMenuTitle, action: nil, keyEquivalent: "")
+            moveSubmenuItem.submenu = moveWindowMenu
+            moveSubmenuItem.isEnabled = !overlay.contextMenuWorkspaceIds.isEmpty
+            menu.addItem(moveSubmenuItem)
+
+            menu.addItem(NSMenuItem.separator())
+
+            // Close
+            let closeLabel = contextMenuLabel(
+                multi: String(localized: "contextMenu.closeWorkspaces", defaultValue: "Close Workspaces"),
+                single: String(localized: "contextMenu.closeWorkspace", defaultValue: "Close Workspace"),
+                isMulti: isMulti)
+            let closeShortcut = KeyboardShortcutSettings.shortcut(for: .closeWorkspace)
+            let closeItem = NSMenuItem(title: closeLabel, action: #selector(handleMenuItemAction(_:)), keyEquivalent: "")
+            closeItem.target = self
+            closeItem.representedObject = WorkspaceContextMenuAction.close
+            closeItem.isEnabled = !overlay.contextMenuWorkspaceIds.isEmpty
+            if let key = closeShortcut.menuItemKeyEquivalent {
+                closeItem.keyEquivalent = key
+                closeItem.keyEquivalentModifierMask = closeShortcut.modifierFlags
+            }
+            menu.addItem(closeItem)
+
+            // Close Others
+            let closeOthersItem = NSMenuItem(title: String(localized: "contextMenu.closeOtherWorkspaces", defaultValue: "Close Other Workspaces"), action: #selector(handleMenuItemAction(_:)), keyEquivalent: "")
+            closeOthersItem.target = self
+            closeOthersItem.representedObject = WorkspaceContextMenuAction.closeOthers
+            closeOthersItem.isEnabled = overlay.tabCount > 1 && overlay.contextMenuWorkspaceIds.count < overlay.tabCount
+            menu.addItem(closeOthersItem)
+
+            // Close Below
+            let closeBelowItem = NSMenuItem(title: String(localized: "contextMenu.closeWorkspacesBelow", defaultValue: "Close Workspaces Below"), action: #selector(handleMenuItemAction(_:)), keyEquivalent: "")
+            closeBelowItem.target = self
+            closeBelowItem.representedObject = WorkspaceContextMenuAction.closeBelow
+            closeBelowItem.isEnabled = overlay.index < overlay.tabCount - 1
+            menu.addItem(closeBelowItem)
+
+            // Close Above
+            let closeAboveItem = NSMenuItem(title: String(localized: "contextMenu.closeWorkspacesAbove", defaultValue: "Close Workspaces Above"), action: #selector(handleMenuItemAction(_:)), keyEquivalent: "")
+            closeAboveItem.target = self
+            closeAboveItem.representedObject = WorkspaceContextMenuAction.closeAbove
+            closeAboveItem.isEnabled = overlay.index > 0
+            menu.addItem(closeAboveItem)
+
+            menu.addItem(NSMenuItem.separator())
+
+            // Mark Read
+            let markReadLabel = contextMenuLabel(
+                multi: String(localized: "contextMenu.markWorkspacesRead", defaultValue: "Mark Workspaces as Read"),
+                single: String(localized: "contextMenu.markWorkspaceRead", defaultValue: "Mark Workspace as Read"),
+                isMulti: isMulti)
+            let markReadItem = NSMenuItem(title: markReadLabel, action: #selector(handleMenuItemAction(_:)), keyEquivalent: "")
+            markReadItem.target = self
+            markReadItem.representedObject = WorkspaceContextMenuAction.markRead
+            markReadItem.isEnabled = overlay.canMarkWorkspaceRead
+            menu.addItem(markReadItem)
+
+            // Mark Unread
+            let markUnreadLabel = contextMenuLabel(
+                multi: String(localized: "contextMenu.markWorkspacesUnread", defaultValue: "Mark Workspaces as Unread"),
+                single: String(localized: "contextMenu.markWorkspaceUnread", defaultValue: "Mark Workspace as Unread"),
+                isMulti: isMulti)
+            let markUnreadItem = NSMenuItem(title: markUnreadLabel, action: #selector(handleMenuItemAction(_:)), keyEquivalent: "")
+            markUnreadItem.target = self
+            markUnreadItem.representedObject = WorkspaceContextMenuAction.markUnread
+            markUnreadItem.isEnabled = overlay.canMarkWorkspaceUnread
+            menu.addItem(markUnreadItem)
+
+            // Clear Latest Notification
+            let clearLatestLabel = contextMenuLabel(
+                multi: String(localized: "contextMenu.clearLatestNotifications", defaultValue: "Clear Latest Notifications"),
+                single: String(localized: "contextMenu.clearLatestNotification", defaultValue: "Clear Latest Notification"),
+                isMulti: isMulti)
+            let clearLatestItem = NSMenuItem(title: clearLatestLabel, action: #selector(handleMenuItemAction(_:)), keyEquivalent: "")
+            clearLatestItem.target = self
+            clearLatestItem.representedObject = WorkspaceContextMenuAction.clearLatestNotification
+            clearLatestItem.isEnabled = overlay.hasLatestNotifications
+            menu.addItem(clearLatestItem)
+
+            menu.addItem(NSMenuItem.separator())
+
+            // Copy Workspace ID
+            let copyIDLabel = contextMenuLabel(
+                multi: String(localized: "contextMenu.copyWorkspaceIDs", defaultValue: "Copy Workspace IDs"),
+                single: String(localized: "contextMenu.copyWorkspaceID", defaultValue: "Copy Workspace ID"),
+                isMulti: isMulti)
+            let copyIDItem = NSMenuItem(title: copyIDLabel, action: #selector(handleMenuItemAction(_:)), keyEquivalent: "")
+            copyIDItem.target = self
+            copyIDItem.representedObject = WorkspaceContextMenuAction.copyWorkspaceID
+            copyIDItem.isEnabled = !overlay.contextMenuWorkspaceIds.isEmpty
+            menu.addItem(copyIDItem)
+
+            // Copy Workspace Link
+            let copyLinkLabel = contextMenuLabel(
+                multi: String(localized: "contextMenu.copyWorkspaceLinks", defaultValue: "Copy Workspace Links"),
+                single: String(localized: "contextMenu.copyWorkspaceLink", defaultValue: "Copy Workspace Link"),
+                isMulti: isMulti)
+            let copyLinkItem = NSMenuItem(title: copyLinkLabel, action: #selector(handleMenuItemAction(_:)), keyEquivalent: "")
+            copyLinkItem.target = self
+            copyLinkItem.representedObject = WorkspaceContextMenuAction.copyWorkspaceLink
+            copyLinkItem.isEnabled = !overlay.contextMenuWorkspaceIds.isEmpty
+            menu.addItem(copyLinkItem)
+
+            // Show in Finder
+            if !isMulti {
+                let finderItem = NSMenuItem(title: String(localized: "contextMenu.showWorkspaceInFinder", defaultValue: "Show in Finder"), action: #selector(handleMenuItemAction(_:)), keyEquivalent: "")
+                finderItem.target = self
+                finderItem.representedObject = WorkspaceContextMenuAction.showInFinder
+                finderItem.isEnabled = overlay.finderDirectoryURL != nil
+                menu.addItem(finderItem)
+            }
+
+            return menu
+        }
+
+        @objc func handleMenuItemAction(_ sender: NSMenuItem) {
+            guard let action = sender.representedObject as? WorkspaceContextMenuAction else { return }
+            overlay.onAction(action)
+        }
+
+        func menuWillOpen(_ menu: NSMenu) {
+            overlay.onMenuWillOpen()
+        }
+
+        func menuDidClose(_ menu: NSMenu) {
+            overlay.onMenuDidClose()
+        }
+    }
+}
+
+@MainActor
+class MenuHostView: NSView {
+    weak var coordinator: WorkspaceContextMenuOverlay.Coordinator?
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        guard let currentEvent = NSApp.currentEvent else {
+            return nil
+        }
+
+        let isRightClick = currentEvent.type == .rightMouseDown
+        let isControlClick = currentEvent.type == .leftMouseDown && currentEvent.modifierFlags.contains(.control)
+
+        if isRightClick || isControlClick {
+            return self
+        }
+        return nil
+    }
+
+    override func menu(for event: NSEvent) -> NSMenu? {
+        guard let coordinator = coordinator else { return nil }
+        let menu = coordinator.buildMenu()
+        menu.delegate = coordinator
+        return menu
+    }
+}

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -442,6 +442,7 @@
 		5C3E0454B6C24B02A2F091A8 /* ShortcutRoutingSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = B42A82C6AA614E74873D9A5F /* ShortcutRoutingSupport.swift */; };
 		F6001000A1B2C3D4E5F60718 /* ShortcutUnbindingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6001001A1B2C3D4E5F60718 /* ShortcutUnbindingTests.swift */; };
 		211A75777F433ED8BA5AE208 /* SidebarAppearanceSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 243632BA1DBBA36FD46E0610 /* SidebarAppearanceSupport.swift */; };
+		C0DEE0000000000000000002 /* WorkspaceContextMenuOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEE0000000000000000001 /* WorkspaceContextMenuOverlay.swift */; };
 		D7AB34300000000000000003 /* SidebarBonsplitTabWorkspaceDropOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB34300000000000000004 /* SidebarBonsplitTabWorkspaceDropOverlay.swift */; };
 		EA1F00000000000000000003 /* SidebarDirectoryText.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA1F00000000000000000004 /* SidebarDirectoryText.swift */; };
 		D7AB34300000000000000001 /* SidebarDropPlanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB34300000000000000002 /* SidebarDropPlanner.swift */; };
@@ -1065,6 +1066,7 @@
 		B42A82C6AA614E74873D9A5F /* ShortcutRoutingSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/ShortcutRoutingSupport.swift; sourceTree = "<group>"; };
 		F6001001A1B2C3D4E5F60718 /* ShortcutUnbindingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutUnbindingTests.swift; sourceTree = "<group>"; };
 		243632BA1DBBA36FD46E0610 /* SidebarAppearanceSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarAppearanceSupport.swift; sourceTree = "<group>"; };
+		C0DEE0000000000000000001 /* WorkspaceContextMenuOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/WorkspaceContextMenuOverlay.swift; sourceTree = "<group>"; };
 		D7AB34300000000000000004 /* SidebarBonsplitTabWorkspaceDropOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarBonsplitTabWorkspaceDropOverlay.swift; sourceTree = "<group>"; };
 		EA1F00000000000000000004 /* SidebarDirectoryText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarDirectoryText.swift; sourceTree = "<group>"; };
 		D7AB34300000000000000002 /* SidebarDropPlanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarDropPlanner.swift; sourceTree = "<group>"; };
@@ -1442,6 +1444,7 @@
 				9960CC3992F3C44489E7627C /* WorkspaceRuntimeSettings.swift */,
 				D36A00010000000000000002 /* AgentHibernationController.swift */,
 				243632BA1DBBA36FD46E0610 /* SidebarAppearanceSupport.swift */,
+				C0DEE0000000000000000001 /* WorkspaceContextMenuOverlay.swift */,
 				D50D9BCE46701FBA91C2EFB6 /* SidebarWorkspaceSnapshotRefreshPolicy.swift */,
 				D35450020000000000000002 /* SidebarWorkspaceRowHoverTracker.swift */,
 				C9A57104C9A57104C9A57104 /* SidebarWorkspaceGroupConfigOpener.swift */,
@@ -2485,6 +2488,7 @@
 				125BAEF2FE3B454547B964D1 /* ShortcutHintPill.swift in Sources */,
 				5C3E0454B6C24B02A2F091A8 /* ShortcutRoutingSupport.swift in Sources */,
 				211A75777F433ED8BA5AE208 /* SidebarAppearanceSupport.swift in Sources */,
+				C0DEE0000000000000000002 /* WorkspaceContextMenuOverlay.swift in Sources */,
 				D7AB34300000000000000003 /* SidebarBonsplitTabWorkspaceDropOverlay.swift in Sources */,
 				EA1F00000000000000000003 /* SidebarDirectoryText.swift in Sources */,
 				D7AB34300000000000000001 /* SidebarDropPlanner.swift in Sources */,


### PR DESCRIPTION
## Summary

Replaces SwiftUI `.contextMenu` / nested `Menu` for the sidebar workspace right-click menu with an AppKit `NSMenu` hosted by a transparent `NSViewRepresentable` overlay. Closes #2003.

## Why the previous patches didn't fully fix it

Earlier fixes (`9d4220b17`, `cdcb16a34`, `b0e6b35fd`) each shaved off a specific invalidation source but couldn't address the architecture: SwiftUI tears down any expanded `Menu` whenever the host view body re-evaluates. The sidebar body re-evaluates at 1–4 Hz under normal terminal output, so the color submenu — which has the most items and the longest hover distance — gets dismissed before the cursor reaches a color.

Detailed source analysis with SwiftUI's `_printChanges()` + a publish-frequency watcher identified 5 invalidation sources in the ContentView body:

1. `titlebarText: @State` writes (≈1 Hz)
2. `.onReceive(.ghosttyDidSetTitle)` — emit invalidates host body even with an empty closure (undocumented Apple behavior; `NotificationCenter.addObserver` directly avoids it)
3. `fileExplorerStore: @StateObject` internal `@Published` (≈1.5 Hz)
4–5. `notificationStore: @EnvironmentObject` re-renders on every read

Patching all of those still leaves a ≈1 Hz floor from `\PaneState.tabs` (`@Observable` macro). The repository's existing `Snapshot boundary for list subtrees` rule (CLAUDE.md, motivated by #2586) mitigates row churn but not parent body churn — and parent body churn is what kills the SwiftUI submenu. The fix is to move the menu off the SwiftUI render tree entirely.

## Approach

**New file `Sources/Sidebar/WorkspaceContextMenuOverlay.swift`**

- `WorkspaceContextMenuOverlay: NSViewRepresentable` (`@MainActor`)
- `MenuHostView: NSView` with `hitTest(_:)` that claims the event only on `.rightMouseDown` or `control + .leftMouseDown`. All other events (drag, left-click, hover) pass through to the SwiftUI hierarchy underneath, so drag-to-reorder, selection, and hover highlight are untouched.
- `Coordinator: NSObject, NSMenuDelegate` (`@MainActor`) builds the `NSMenu` per right-click from a Workspace snapshot. The `@MainActor` isolation lets the delegate read `AppDelegate.shared` and workspace properties directly without cross-actor hops.
- `WorkspaceContextMenuAction` enum covers full parity with the old SwiftUI menu: pin/unpin, rename, remove custom name, edit/clear description, reconnect/disconnect SSH, scrollbar toggle, color palette (16 entries) + custom color + clear, move-to-window targets pulled dynamically via `windowMoveTargets(referenceWindowId:)`, close current/others/above/below, mark read/unread, clear latest notification, copy UUID, show in Finder.
- Color swatches rendered via `coloredCircleImage(color:)` (`NSImage`) since `NSMenuItem` doesn't accept SwiftUI views.

**`Sources/ContentView.swift`** — replaces the `.contextMenu { ... Menu("Workspace Color") { ... } ... }` chain with `.overlay(WorkspaceContextMenuOverlay(...))`. Wires menu open/close into the existing `rowInteractionState.contextMenuDidAppear()` / `contextMenuDidDisappear()` so the sidebar's anti-jitter pause logic still triggers. `handleMenuAction(_:)` dispatches the action enum to the existing functions previously called by the SwiftUI menu items.

**`cmux.xcodeproj/project.pbxproj`** — registers the new file in `PBXBuildFile`, `PBXFileReference`, `PBXGroup`, and `PBXSourcesBuildPhase`.

## Testing

- `./scripts/reload.sh --tag nsmenu-sidebar-context-menu` — Debug build completes cleanly (`reload succeeded in 16s`), no concurrency warnings.
- Manual verification on the tagged debug build with a terminal running high-rate stdout: right-click sidebar → Workspace Color submenu opens and stays open across all 16 color items, zero flicker, zero premature dismissal. Same with Move-to-Window and Workspace Settings submenus.
- Left-click selection, drag-to-reorder, hover highlight, and scroll all still work (`hitTest` pass-through verified).

**Not added: an automated regression test.** Driving NSMenu interaction under high-rate publish in XCTest would need a non-trivial UI harness. Happy to add one if a preferred test seam exists — guidance from maintainers would help.

Closes #2003.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4633"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782101238&installation_id=133855650&pr_number=4633&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4633&signature=b5131024ac99fd74fd7940808b6f9a67d1c9af5a6933dc5f559a724670a4a62d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrites the sidebar workspace context menu to an AppKit `NSMenu` via a transparent `NSViewRepresentable` overlay so submenus don’t close during SwiftUI re-renders. Adds workspace grouping and “Copy Workspace Link” actions; shortcuts are preserved, items use precomputed state, and drag/selection/hover/scroll behavior is unchanged.

- **Bug Fixes**
  - Stops submenu flicker/early dismissal under high stdout by detaching the menu from the SwiftUI lifecycle.
  - Workspace Color and Move-to-Window submenus stay open; open/close still trigger existing anti-jitter hooks.
  - Correctly enables “Move to Top” only when the selected block isn’t already at the top.
  - Deterministic “Show in Finder” enablement using a cached Finder URL from the parent.
  - “Copy SSH Error” now sanitizes text (trims and replaces the home path).

- **Refactors**
  - Adds `WorkspaceContextMenuOverlay` and a `WorkspaceContextMenuAction` enum; builds an `NSMenu` per click and only captures right-/control-clicks. Enum now includes workspace grouping (new group, move to group, remove from group) and “Copy Workspace Link”.
  - Replaces `.contextMenu` with `.overlay(...)`, routing actions through `handleMenuAction(_)`; `menuWillOpen/DidClose` drive the existing hooks.
  - Precomputes tab count, ordered workspace IDs, reference window ID, canMarkWorkspaceRead/Unread, hasLatestNotifications, hasCustomColor/title/description, and workspace grouping state (eligible target IDs, all targets in same group, has any grouped target); resolves the Finder URL in the parent and passes it down.
  - Adds a localized menu title and registers the new file in `cmux.xcodeproj`.

<sup>Written for commit 863fad9a477ddf5b6bbcfbab931fac56d443e1fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4633?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New workspace context menu overlay with full set of actions (pin/rename/remove name, edit/clear description, remote connect/disconnect, terminal scrollbar toggle, color actions, move/close variants, mark read/unread, clear notifications, copy SSH error/ID, Show in Finder).

* **Performance**
  * Sidebar rows now precompute and cache menu inputs (including Finder directory) to avoid unnecessary row recomputation.

* **Bug Fixes**
  * Menu lifecycle reliably snapshots and flushes deferred workspace state.

* **Localization**
  * Added localized title for the workspace context menu (English/Japanese).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4633?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->