### PR TITLE
Forward Cmd+Up / Cmd+Down to browser pane (#4635)

### DIFF
--- a/Sources/App/ShortcutRoutingSupport.swift
+++ b/Sources/App/ShortcutRoutingSupport.swift
@@ -96,13 +96,18 @@ func shouldDispatchBrowserArrowViaFirstResponderKeyDown(
     guard !firstResponderHasMarkedText else { return false }
     guard (123...126).contains(keyCode) else { return false }
 
-    // Keep this narrow to avoid stealing app/browser shortcuts that layer onto
-    // modified arrow keys. Plain arrows should always flow through keyDown so
-    // web content such as Google Docs receives the event directly.
     let normalizedFlags = flags
         .intersection(.deviceIndependentFlagsMask)
         .subtracting([.numericPad, .function, .capsLock])
-    return normalizedFlags.isEmpty
+
+    if normalizedFlags.isEmpty {
+        return true
+    }
+
+    // Keep modified arrow routing narrow to avoid stealing cmux shortcuts such
+    // as Cmd+Option+Arrow pane focus. Browser document editors own Cmd+Up/Down
+    // as trusted keyDown navigation to the start/end of the document.
+    return normalizedFlags == [.command] && (keyCode == 125 || keyCode == 126)
 }
 
 func shouldDispatchBrowserOmnibarArrowViaFirstResponderKeyDown(

--- a/cmuxTests/BrowserArrowKeyForwardingTests.swift
+++ b/cmuxTests/BrowserArrowKeyForwardingTests.swift
@@ -21,9 +21,22 @@ final class BrowserArrowKeyForwardingTests: XCTestCase {
         }
     }
 
+    func testRoutesCommandUpAndDownWhenBrowserFirstResponder() {
+        for keyCode in [125, 126] as [UInt16] {
+            XCTAssertTrue(
+                shouldDispatchBrowserArrowViaFirstResponderKeyDown(
+                    keyCode: keyCode,
+                    firstResponderIsBrowser: true,
+                    flags: [.command]
+                ),
+                "Expected browser responder to own Cmd+vertical arrow keyCode \(keyCode)"
+            )
+        }
+    }
+
     func testDoesNotForceForwardArrowsOutsidePlainBrowserResponderPath() {
         XCTAssertFalse(shouldDispatchBrowserArrowViaFirstResponderKeyDown(keyCode: 123, firstResponderIsBrowser: false, flags: []))
         XCTAssertFalse(shouldDispatchBrowserArrowViaFirstResponderKeyDown(keyCode: 124, firstResponderIsBrowser: true, firstResponderHasMarkedText: true, flags: []))
-        XCTAssertFalse(shouldDispatchBrowserArrowViaFirstResponderKeyDown(keyCode: 125, firstResponderIsBrowser: true, flags: [.command]))
+        XCTAssertFalse(shouldDispatchBrowserArrowViaFirstResponderKeyDown(keyCode: 125, firstResponderIsBrowser: true, flags: [.command, .option]))
     }
 }

--- a/cmuxTests/BrowserArrowKeyForwardingTests.swift
+++ b/cmuxTests/BrowserArrowKeyForwardingTests.swift
@@ -39,6 +39,7 @@ final class BrowserArrowKeyForwardingTests: XCTestCase {
         XCTAssertFalse(shouldDispatchBrowserArrowViaFirstResponderKeyDown(keyCode: 124, firstResponderIsBrowser: true, firstResponderHasMarkedText: true, flags: []))
         XCTAssertFalse(shouldDispatchBrowserArrowViaFirstResponderKeyDown(keyCode: 123, firstResponderIsBrowser: true, flags: [.command]))
         XCTAssertFalse(shouldDispatchBrowserArrowViaFirstResponderKeyDown(keyCode: 124, firstResponderIsBrowser: true, flags: [.command]))
+        XCTAssertFalse(shouldDispatchBrowserArrowViaFirstResponderKeyDown(keyCode: 126, firstResponderIsBrowser: true, flags: [.command, .option]))
         XCTAssertFalse(shouldDispatchBrowserArrowViaFirstResponderKeyDown(keyCode: 125, firstResponderIsBrowser: true, flags: [.command, .option]))
     }
 }

--- a/cmuxTests/BrowserArrowKeyForwardingTests.swift
+++ b/cmuxTests/BrowserArrowKeyForwardingTests.swift
@@ -37,6 +37,8 @@ final class BrowserArrowKeyForwardingTests: XCTestCase {
     func testDoesNotForceForwardArrowsOutsidePlainBrowserResponderPath() {
         XCTAssertFalse(shouldDispatchBrowserArrowViaFirstResponderKeyDown(keyCode: 123, firstResponderIsBrowser: false, flags: []))
         XCTAssertFalse(shouldDispatchBrowserArrowViaFirstResponderKeyDown(keyCode: 124, firstResponderIsBrowser: true, firstResponderHasMarkedText: true, flags: []))
+        XCTAssertFalse(shouldDispatchBrowserArrowViaFirstResponderKeyDown(keyCode: 123, firstResponderIsBrowser: true, flags: [.command]))
+        XCTAssertFalse(shouldDispatchBrowserArrowViaFirstResponderKeyDown(keyCode: 124, firstResponderIsBrowser: true, flags: [.command]))
         XCTAssertFalse(shouldDispatchBrowserArrowViaFirstResponderKeyDown(keyCode: 125, firstResponderIsBrowser: true, flags: [.command, .option]))
     }
 }


### PR DESCRIPTION
## Summary

Fixes https://github.com/manaflow-ai/cmux/issues/4635.

Browser-focused vertical document navigation now gets routed through the existing trusted `keyDown` forwarding path instead of falling into the command-equivalent/menu fallback. The change is intentionally narrow: browser content owns plain arrows plus command-only Cmd+Up/Cmd+Down, while modified cmux shortcuts such as Cmd+Option+Arrow stay out of the browser forwarding path.

## Routing change

- Extended `shouldDispatchBrowserArrowViaFirstResponderKeyDown` to return true for browser-focused Cmd+Up and Cmd+Down.
- Kept the existing first-responder ownership boundary in `NSWindow.cmux_performKeyEquivalent`: the browser pane gets these keys only when the focused responder belongs to the WKWebView.
- Left Cmd+Left/Cmd+Right and Cmd+Option+Arrow outside the forced browser route so back/forward/editor/menu behavior and cmux pane-focus shortcuts are not broadened by this fix.

## Re-verified combos

Code-level routing coverage:

- Plain Up/Down/Left/Right still route to browser `keyDown` when the WKWebView is first responder.
- Cmd+Up and Cmd+Down now route to browser `keyDown` when the WKWebView is first responder.
- Cmd+Left and Cmd+Right are not newly force-forwarded by this change.
- Cmd+Option+Up and Cmd+Option+Down are not force-forwarded, preserving the cmux pane-focus shortcut family.
- Browser marked-text composition still prevents forced arrow forwarding.
- Non-browser first responder still prevents browser arrow forwarding.

Runtime Google Docs verification/video was not produced in this workspace because the task explicitly reserves dev builds and launches for HQ.

## Tests

- Added a failing regression test first in commit `0b29e8bc1`.
- Added the fix in commit `b43445b07`.
- Added symmetric Cmd+Option+Up negative coverage in commit `fd8c1b18d` after Greptile feedback.
- Not run locally per task instruction; CI will run the test suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced keyboard navigation support for Command+Up and Command+Down arrow key combinations to ensure proper routing and prevent conflicts with other shortcuts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4637?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->