### PR TITLE
Fix git probe CPU storms and hidden terminal drawables

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -6913,6 +6913,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     private var pendingSurfaceSize: CGSize?
     private var deferredSurfaceSizeRetryQueued = false
     private var lastDrawableSize: CGSize = .zero
+    private var hiddenDrawableResourcesTrimmed = false
     private var isFindEscapeSuppressionArmed = false
 #if DEBUG
     private var lastSizeSkipSignature: String?
@@ -6946,6 +6947,23 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     fileprivate var isVisibleInUI: Bool { visibleInUI }
     fileprivate func setVisibleInUI(_ visible: Bool) {
         visibleInUI = visible
+    }
+
+    fileprivate func trimHiddenDrawableResourcesForMemory() {
+        guard let metalLayer = layer as? CAMetalLayer else { return }
+        let trimmedSize = CGSize(width: 1, height: 1)
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        metalLayer.drawableSize = trimmedSize
+        CATransaction.commit()
+        lastDrawableSize = .zero
+        hiddenDrawableResourcesTrimmed = true
+    }
+
+    fileprivate func restoreHiddenDrawableResourcesIfNeeded() {
+        guard hiddenDrawableResourcesTrimmed else { return }
+        hiddenDrawableResourcesTrimmed = false
+        _ = updateSurfaceSize()
     }
 
     override init(frame frameRect: NSRect) {
@@ -7327,6 +7345,10 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             return false
         }
         pendingSurfaceSize = size
+        guard visibleInUI else {
+            trimHiddenDrawableResourcesForMemory()
+            return false
+        }
         if let deferralReason = activeSurfaceResizeDeferralReason() {
             scheduleDeferredSurfaceSizeRetryIfNeeded()
 #if DEBUG
@@ -12052,10 +12074,12 @@ final class GhosttySurfaceScrollView: NSView {
                fr === surfaceView || fr.isDescendant(of: surfaceView) {
                 window.makeFirstResponder(nil)
             }
+            surfaceView.trimHiddenDrawableResourcesForMemory()
         } else if !wasVisible {
             // Workspace/sidebar selection can make an already-sized terminal visible again
             // without a portal frame delta or a focus handoff. Reuse the portal refresh
             // path so the Metal layer is nudged immediately on plain visibility restores.
+            surfaceView.restoreHiddenDrawableResourcesIfNeeded()
             refreshSurfaceNow(reason: "setVisibleInUI")
             scheduleAutomaticFirstResponderApply(reason: "setVisibleInUI")
         }

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -25,6 +25,36 @@ private let workspaceGitMetadataWatcherCallback: FSEventStreamCallback = { _, in
     box.handleEvent()
 }
 
+private let gitIndexHexDigits = Array("0123456789abcdef".utf8)
+
+private actor AsyncPermitLimiter {
+    private var availablePermits: Int
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    init(limit: Int) {
+        availablePermits = max(1, limit)
+    }
+
+    func acquire() async {
+        if availablePermits > 0 {
+            availablePermits -= 1
+            return
+        }
+
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+
+    func release() {
+        if waiters.isEmpty {
+            availablePermits += 1
+        } else {
+            waiters.removeFirst().resume()
+        }
+    }
+}
+
 private final class WorkspaceGitMetadataWatcher: @unchecked Sendable {
     struct Descriptor: Equatable, Sendable {
         let directory: String
@@ -1213,6 +1243,7 @@ class TabManager: ObservableObject {
     private var pendingPanelTitleUpdates: [PanelTitleUpdateKey: String] = [:]
     private let panelTitleUpdateCoalescer = NotificationBurstCoalescer(delay: 1.0 / 30.0)
     private var recentlyClosedBrowsers = RecentlyClosedBrowserStack(capacity: 20)
+    private static let initialWorkspaceGitProbeLimiter = AsyncPermitLimiter(limit: 2)
     private let initialWorkspaceGitProbeQueue = DispatchQueue(
         label: "com.cmux.initial-workspace-git-probe",
         qos: .utility
@@ -2700,7 +2731,9 @@ class TabManager: ObservableObject {
         }
 
         Task.detached(priority: .utility) { [weak self] in
-            let snapshot = await Self.initialWorkspaceGitMetadataSnapshot(for: expectedDirectory)
+            let snapshot = await Self.initialWorkspaceGitMetadataSnapshotWithBoundedConcurrency(
+                for: expectedDirectory
+            )
             guard !Task.isCancelled else { return }
             await MainActor.run { [weak self] in
                 self?.applyWorkspaceGitMetadataSnapshot(
@@ -2711,6 +2744,15 @@ class TabManager: ObservableObject {
                 )
             }
         }
+    }
+
+    private nonisolated static func initialWorkspaceGitMetadataSnapshotWithBoundedConcurrency(
+        for directory: String
+    ) async -> InitialWorkspaceGitMetadataSnapshot {
+        await initialWorkspaceGitProbeLimiter.acquire()
+        let snapshot = await initialWorkspaceGitMetadataSnapshot(for: directory)
+        await initialWorkspaceGitProbeLimiter.release()
+        return snapshot
     }
 
     private func cancelWorkspaceGitProbeTimers(for key: WorkspaceGitProbeKey) {
@@ -3789,9 +3831,7 @@ class TabManager: ObservableObject {
             let mtimeNanoseconds = readBigEndianUInt32(bytes, at: offset + 12)
             let mode = readBigEndianUInt32(bytes, at: offset + 24)
             let size = readBigEndianUInt32(bytes, at: offset + 36)
-            let objectID = bytes[(offset + 40)..<(offset + 60)].map {
-                String(format: "%02x", $0)
-            }.joined()
+            let objectID = gitIndexHexString(bytes[(offset + 40)..<(offset + 60)])
             let flags = readBigEndianUInt16(bytes, at: offset + 60)
             let pathLength = Int(flags & 0x0fff)
             let hasExtendedFlags = version >= 3 && (flags & 0x4000) != 0
@@ -3859,7 +3899,7 @@ class TabManager: ObservableObject {
             }
         }
 
-        let checksum = bytes[(bytes.count - 20)..<bytes.count].map { String(format: "%02x", $0) }.joined()
+        let checksum = gitIndexHexString(bytes[(bytes.count - 20)..<bytes.count])
         return GitIndexSnapshot(
             entries: entries,
             signature: checksum,
@@ -3897,7 +3937,26 @@ class TabManager: ObservableObject {
             appendString(entry.objectID)
             appendByte(0)
         }
-        return String(format: "%016llx", CUnsignedLongLong(hash))
+        return gitIndexFixedWidthHexString(hash)
+    }
+
+    private nonisolated static func gitIndexHexString<C: Collection>(_ bytes: C) -> String where C.Element == UInt8 {
+        var output: [UInt8] = []
+        output.reserveCapacity(bytes.count * 2)
+        for byte in bytes {
+            output.append(gitIndexHexDigits[Int(byte >> 4)])
+            output.append(gitIndexHexDigits[Int(byte & 0x0f)])
+        }
+        return String(decoding: output, as: UTF8.self)
+    }
+
+    private nonisolated static func gitIndexFixedWidthHexString(_ value: UInt64) -> String {
+        var output = [UInt8](repeating: 0, count: 16)
+        for index in output.indices {
+            let shift = UInt64((15 - index) * 4)
+            output[index] = gitIndexHexDigits[Int((value >> shift) & 0x0f)]
+        }
+        return String(decoding: output, as: UTF8.self)
     }
 
     private nonisolated static func gitlinkWorktreeCommit(
@@ -3960,7 +4019,7 @@ class TabManager: ObservableObject {
         guard let data = try? Data(contentsOf: indexURL), data.count >= 20 else {
             return nil
         }
-        return data.suffix(20).map { String(format: "%02x", $0) }.joined()
+        return gitIndexHexString(data.suffix(20))
     }
 
     private nonisolated static func readGitIndexV4PathStripLength(

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 import AppKit
 import SwiftUI
+import QuartzCore
 import UniformTypeIdentifiers
 import WebKit
 import ObjectiveC.runtime
@@ -2673,6 +2674,81 @@ final class TerminalNotificationDirectInteractionTests: XCTestCase {
             surface.debugForceRefreshCount(),
             1,
             "Restoring panel visibility should force a redraw even when focus recovery is inactive"
+        )
+#else
+        throw XCTSkip("Debug-only regression test")
+#endif
+    }
+
+    func testHiddenVisibilityTrimsMetalDrawableAndRestoresOnReveal() throws {
+#if DEBUG
+        let window = makeWindow()
+        defer { window.orderOut(nil) }
+
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        let surface = TerminalSurface(
+            tabId: UUID(),
+            context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
+            configTemplate: nil,
+            workingDirectory: nil
+        )
+        let hostedView = surface.hostedView
+        hostedView.frame = contentView.bounds
+        hostedView.autoresizingMask = [.width, .height]
+        contentView.addSubview(hostedView)
+
+        window.makeKeyAndOrderFront(nil)
+        window.displayIfNeeded()
+        contentView.layoutSubtreeIfNeeded()
+        hostedView.layoutSubtreeIfNeeded()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+
+        guard let surfaceView = surfaceView(in: hostedView) as? GhosttyNSView else {
+            XCTFail("Expected terminal surface view")
+            return
+        }
+        let metalLayer = try XCTUnwrap(
+            surfaceView.layer as? CAMetalLayer,
+            "Expected terminal surface view to use a CAMetalLayer"
+        )
+        XCTAssertNotNil(surface.surface, "Expected runtime surface before hiding the pane")
+
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        metalLayer.drawableSize = CGSize(width: 4096, height: 3072)
+        CATransaction.commit()
+
+        hostedView.setVisibleInUI(false)
+
+        XCTAssertEqual(
+            metalLayer.drawableSize.width,
+            1,
+            accuracy: 0.5,
+            "Hiding a terminal pane should release large hidden Metal drawables"
+        )
+        XCTAssertEqual(
+            metalLayer.drawableSize.height,
+            1,
+            accuracy: 0.5,
+            "Hiding a terminal pane should release large hidden Metal drawables"
+        )
+
+        hostedView.setVisibleInUI(true)
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+
+        XCTAssertGreaterThan(
+            metalLayer.drawableSize.width,
+            1,
+            "Revealing the pane should restore a usable drawable width"
+        )
+        XCTAssertGreaterThan(
+            metalLayer.drawableSize.height,
+            1,
+            "Revealing the pane should restore a usable drawable height"
         )
 #else
         throw XCTSkip("Debug-only regression test")


### PR DESCRIPTION
Fixes https://github.com/manaflow-ai/cmux/issues/4639

## Summary
- Bound initial workspace git metadata probes so restore cannot fan out unbounded detached scans.
- Replaced Git index hex formatting hot paths with lock-free byte encoding.
- Trim hidden terminal CAMetalLayer drawables to 1x1 and restore them on reveal.

## Verification
- ./scripts/reload.sh --tag cpuram
- Added TerminalAndGhosttyTests coverage for hidden drawable trimming and restore.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4640"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782104693&installation_id=133855650&pr_number=4640&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4640&signature=0a8301362d764e2a0194bd765eabdc44ed58119d5bb29081fd8614e947a55b71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches terminal rendering resource management and workspace Git probing paths; mistakes could cause missing redraws or stale Git status, but changes are localized and covered by a new regression test.
> 
> **Overview**
> Reduces CPU/memory spikes by **bounding initial workspace Git metadata probes** via an async permit limiter so restore can’t fan out unbounded detached scans.
> 
> Optimizes Git index parsing hot paths by replacing per-byte `String(format:)` hex building with faster byte-based encoders for object IDs, checksums, and content signatures.
> 
> When a terminal pane becomes hidden, **trims `CAMetalLayer.drawableSize` to `1x1`** to release large hidden drawables, and restores the drawable sizing on reveal; adds a debug regression test covering the trim/restore behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be7773207ef4a131274d87e67f56bdd6dc895406. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix CPU spikes from unbounded workspace git probes and reduce memory by trimming hidden terminal `CAMetalLayer` drawables to 1x1, restoring on reveal. Also speeds up Git index parsing by replacing hot-path hex formatting.

- **Bug Fixes**
  - Bound initial workspace git metadata probes with a permit limiter (limit 2) to prevent restore-time fan-out CPU storms.
  - Trim hidden terminal drawables to 1x1 when not visible and restore on reveal; added regression test to cover this behavior.

- **Performance**
  - Replaced `String(format:)` hex conversions with a lock-free byte encoder for Git index object IDs and checksums, plus fixed-width hex for hashes, reducing CPU and allocations.

<sup>Written for commit be7773207ef4a131274d87e67f56bdd6dc895406. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4640?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal memory usage optimization: drawable resources are now released when panes are hidden and restored when made visible again.

* **Performance Improvements**
  * Git metadata operations now use concurrency limiting for improved responsiveness.
  * Optimized git index data formatting for better efficiency.

* **Tests**
  * Added regression test for drawable resource management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4640?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->