### PR TITLE
Move browser progress spinners to Core Animation

### DIFF
--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -32,15 +32,16 @@ private extension NSObject {
 private struct BrowserLayerBackedSpinner: NSViewRepresentable {
     let size: CGFloat
     let color: NSColor
+    var opacity: CGFloat = 1
 
     func makeNSView(context: Context) -> SpinnerView {
         let view = SpinnerView(frame: NSRect(x: 0, y: 0, width: size, height: size))
-        view.configure(size: size, color: color)
+        view.configure(size: size, color: color, opacity: opacity)
         return view
     }
 
     func updateNSView(_ nsView: SpinnerView, context: Context) {
-        nsView.configure(size: size, color: color)
+        nsView.configure(size: size, color: color, opacity: opacity)
     }
 
     final class SpinnerView: NSView {
@@ -49,6 +50,7 @@ private struct BrowserLayerBackedSpinner: NSViewRepresentable {
         private let arcLayer = CAShapeLayer()
         private var spinnerSize: CGFloat = 0
         private var spinnerColor: NSColor = .secondaryLabelColor
+        private var spinnerOpacity: CGFloat = 1
 
         override init(frame frameRect: NSRect) {
             super.init(frame: frameRect)
@@ -75,9 +77,10 @@ private struct BrowserLayerBackedSpinner: NSViewRepresentable {
             NSSize(width: spinnerSize, height: spinnerSize)
         }
 
-        func configure(size: CGFloat, color: NSColor) {
+        func configure(size: CGFloat, color: NSColor, opacity: CGFloat) {
             spinnerSize = size
             spinnerColor = color
+            spinnerOpacity = opacity
             invalidateIntrinsicContentSize()
             updateLayerColors()
             needsLayout = true
@@ -129,8 +132,9 @@ private struct BrowserLayerBackedSpinner: NSViewRepresentable {
             effectiveAppearance.performAsCurrentDrawingAppearance {
                 resolvedColor = spinnerColor.usingColorSpace(.deviceRGB) ?? spinnerColor
             }
-            trackLayer.strokeColor = resolvedColor.withAlphaComponent(0.20).cgColor
-            arcLayer.strokeColor = resolvedColor.cgColor
+            let baseAlpha = resolvedColor.alphaComponent
+            trackLayer.strokeColor = resolvedColor.withAlphaComponent(baseAlpha * spinnerOpacity * 0.20).cgColor
+            arcLayer.strokeColor = resolvedColor.withAlphaComponent(baseAlpha * spinnerOpacity).cgColor
         }
 
         private func updateLayerGeometry() {
@@ -1243,7 +1247,8 @@ struct BrowserPanelView: View {
                 HStack(spacing: 4) {
                     BrowserLayerBackedSpinner(
                         size: 12,
-                        color: NSColor.secondaryLabelColor.withAlphaComponent(0.75)
+                        color: .secondaryLabelColor,
+                        opacity: 0.75
                     )
                     .frame(width: 12, height: 12)
                     Text(String(localized: "browser.downloading", defaultValue: "Downloading..."))
@@ -4941,7 +4946,7 @@ struct OmnibarSuggestionsView: View {
             if searchSuggestionsEnabled, isLoadingRemoteSuggestions {
                 BrowserLayerBackedSpinner(
                     size: 13,
-                    color: NSColor.secondaryLabelColor.withAlphaComponent(0.75)
+                    color: .secondaryLabelColor
                 )
                     .frame(width: 13, height: 13)
                     .padding(.top, 7)

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -58,9 +58,9 @@ private struct BrowserLayerBackedSpinner: NSViewRepresentable {
 
             for shapeLayer in [trackLayer, arcLayer] {
                 shapeLayer.fillColor = NSColor.clear.cgColor
-                shapeLayer.contentsScale = NSScreen.main?.backingScaleFactor ?? 2
                 layer?.addSublayer(shapeLayer)
             }
+            updateContentsScale()
             arcLayer.lineCap = .round
             arcLayer.strokeStart = 0
             arcLayer.strokeEnd = 0.28
@@ -94,6 +94,7 @@ private struct BrowserLayerBackedSpinner: NSViewRepresentable {
 
         override func viewDidMoveToWindow() {
             super.viewDidMoveToWindow()
+            updateContentsScale()
             if window == nil {
                 stopAnimation()
             } else {
@@ -101,9 +102,26 @@ private struct BrowserLayerBackedSpinner: NSViewRepresentable {
             }
         }
 
+        override func viewDidChangeBackingProperties() {
+            super.viewDidChangeBackingProperties()
+            updateContentsScale()
+        }
+
         override func viewDidChangeEffectiveAppearance() {
             super.viewDidChangeEffectiveAppearance()
             updateLayerColors()
+        }
+
+        private func updateContentsScale() {
+            let scale = window?.backingScaleFactor
+                ?? window?.screen?.backingScaleFactor
+                ?? NSScreen.main?.backingScaleFactor
+                ?? 2
+            for shapeLayer in [trackLayer, arcLayer] {
+                shapeLayer.contentsScale = scale
+                shapeLayer.setNeedsDisplay()
+            }
+            layer?.setNeedsDisplay()
         }
 
         private func updateLayerColors() {

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 import WebKit
 import AppKit
 import ObjectiveC
+import QuartzCore
 
 private var cmuxBrowserPanelNeedsRenderingStateReattachKey: UInt8 = 0
 let browserOmnibarTextFieldIdentifier = NSUserInterfaceItemIdentifier("cmux.browserOmnibarTextField")
@@ -25,6 +26,130 @@ private extension NSObject {
         let fn = unsafeBitCast(method(for: selector), to: Fn.self)
         fn(self, selector)
         return true
+    }
+}
+
+private struct BrowserLayerBackedSpinner: NSViewRepresentable {
+    let size: CGFloat
+    let color: NSColor
+
+    func makeNSView(context: Context) -> SpinnerView {
+        let view = SpinnerView(frame: NSRect(x: 0, y: 0, width: size, height: size))
+        view.configure(size: size, color: color)
+        return view
+    }
+
+    func updateNSView(_ nsView: SpinnerView, context: Context) {
+        nsView.configure(size: size, color: color)
+    }
+
+    final class SpinnerView: NSView {
+        private static let animationKey = "cmux.browserSpinner.rotation"
+        private let trackLayer = CAShapeLayer()
+        private let arcLayer = CAShapeLayer()
+        private var spinnerSize: CGFloat = 0
+        private var spinnerColor: NSColor = .secondaryLabelColor
+
+        override init(frame frameRect: NSRect) {
+            super.init(frame: frameRect)
+            wantsLayer = true
+            layer = CALayer()
+            layer?.masksToBounds = false
+
+            for shapeLayer in [trackLayer, arcLayer] {
+                shapeLayer.fillColor = NSColor.clear.cgColor
+                shapeLayer.contentsScale = NSScreen.main?.backingScaleFactor ?? 2
+                layer?.addSublayer(shapeLayer)
+            }
+            arcLayer.lineCap = .round
+            arcLayer.strokeStart = 0
+            arcLayer.strokeEnd = 0.28
+        }
+
+        @available(*, unavailable)
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        override var intrinsicContentSize: NSSize {
+            NSSize(width: spinnerSize, height: spinnerSize)
+        }
+
+        func configure(size: CGFloat, color: NSColor) {
+            spinnerSize = size
+            spinnerColor = color
+            invalidateIntrinsicContentSize()
+            updateLayerColors()
+            needsLayout = true
+            layoutSubtreeIfNeeded()
+            if window != nil {
+                startAnimationIfNeeded()
+            }
+        }
+
+        override func layout() {
+            super.layout()
+            updateLayerGeometry()
+        }
+
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            if window == nil {
+                stopAnimation()
+            } else {
+                startAnimationIfNeeded()
+            }
+        }
+
+        override func viewDidChangeEffectiveAppearance() {
+            super.viewDidChangeEffectiveAppearance()
+            updateLayerColors()
+        }
+
+        private func updateLayerColors() {
+            var resolvedColor = spinnerColor
+            effectiveAppearance.performAsCurrentDrawingAppearance {
+                resolvedColor = spinnerColor.usingColorSpace(.deviceRGB) ?? spinnerColor
+            }
+            trackLayer.strokeColor = resolvedColor.withAlphaComponent(0.20).cgColor
+            arcLayer.strokeColor = resolvedColor.cgColor
+        }
+
+        private func updateLayerGeometry() {
+            let side = max(1, min(bounds.width, bounds.height, spinnerSize))
+            let origin = CGPoint(x: bounds.midX - side / 2, y: bounds.midY - side / 2)
+            let layerBounds = CGRect(origin: .zero, size: CGSize(width: side, height: side))
+            let frame = CGRect(origin: origin, size: layerBounds.size)
+            let lineWidth = max(1.6, side * 0.14)
+            let pathRect = layerBounds.insetBy(dx: lineWidth / 2, dy: lineWidth / 2)
+            let path = CGPath(ellipseIn: pathRect, transform: nil)
+
+            CATransaction.begin()
+            CATransaction.setDisableActions(true)
+            for shapeLayer in [trackLayer, arcLayer] {
+                shapeLayer.frame = frame
+                shapeLayer.bounds = layerBounds
+                shapeLayer.path = path
+                shapeLayer.lineWidth = lineWidth
+            }
+            CATransaction.commit()
+        }
+
+        private func startAnimationIfNeeded() {
+            guard arcLayer.animation(forKey: Self.animationKey) == nil else { return }
+            let animation = CABasicAnimation(keyPath: "transform.rotation.z")
+            animation.fromValue = 0
+            animation.toValue = CGFloat.pi * 2
+            animation.duration = 0.9
+            animation.repeatCount = .infinity
+            animation.timingFunction = CAMediaTimingFunction(name: .linear)
+            animation.isRemovedOnCompletion = false
+            arcLayer.add(animation, forKey: Self.animationKey)
+        }
+
+        private func stopAnimation() {
+            arcLayer.removeAnimation(forKey: Self.animationKey)
+        }
     }
 }
 
@@ -1098,8 +1223,11 @@ struct BrowserPanelView: View {
 
             if panel.isDownloading {
                 HStack(spacing: 4) {
-                    ProgressView()
-                        .controlSize(.small)
+                    BrowserLayerBackedSpinner(
+                        size: 12,
+                        color: NSColor.secondaryLabelColor.withAlphaComponent(0.75)
+                    )
+                    .frame(width: 12, height: 12)
                     Text(String(localized: "browser.downloading", defaultValue: "Downloading..."))
                         .font(.system(size: 11))
                         .foregroundStyle(.secondary)
@@ -4793,8 +4921,11 @@ struct OmnibarSuggestionsView: View {
         .frame(height: popupHeight, alignment: .top)
         .overlay(alignment: .topTrailing) {
             if searchSuggestionsEnabled, isLoadingRemoteSuggestions {
-                ProgressView()
-                    .controlSize(.small)
+                BrowserLayerBackedSpinner(
+                    size: 13,
+                    color: NSColor.secondaryLabelColor.withAlphaComponent(0.75)
+                )
+                    .frame(width: 13, height: 13)
                     .padding(.top, 7)
                     .padding(.trailing, 14)
                     .opacity(0.75)


### PR DESCRIPTION
## Summary
- replace browser download and remote suggestion ProgressView indicators with layer-backed Core Animation spinners
- keep loading state plumbing unchanged while moving animation frames off SwiftUI TimelineView/main-thread rendering

## Verification
- swift test in vendor/bonsplit
- AWS macOS app build with tagged DerivedData

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4641"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782104770&installation_id=133855650&pr_number=4641&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4641&signature=6def86e7da8c067cfeb79b8304f71d68d33de3b1974a92e0d21b21d592c1a00e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that swaps the loading indicator implementation; main potential issues are visual regressions (scaling/appearance) or animation lifecycle glitches.
> 
> **Overview**
> Swaps the browser’s small loading indicators (download status and remote omnibar suggestions) from SwiftUI `ProgressView` to a new `BrowserLayerBackedSpinner` implemented with `CAShapeLayer` rotation.
> 
> The new spinner handles backing scale and appearance changes, and starts/stops its animation based on window attachment to keep rendering crisp and avoid unnecessary work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ebf4947a33b24bb5c1fc4c2071492b201ec24ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the browser download and remote suggestion spinners with a Core Animation spinner for smoother, off‑main‑thread animation that adapts to light/dark mode. Loading logic stays the same; only the indicator changed.

- **Refactors**
  - Added `BrowserLayerBackedSpinner` (`NSViewRepresentable`) using `QuartzCore` and `CAShapeLayer` with a rotating arc and subtle track; resolves colors under `effectiveAppearance` to preserve dynamic system colors.
  - Replaced `ProgressView` in download status and omnibar suggestions with the new spinner (12px/13px, `.secondaryLabelColor`; download spinner uses 0.75 opacity).
  - Improved rendering: updates layer `contentsScale` on backing scale changes, refreshes colors on appearance changes, and starts/stops animation with window lifecycle to keep it crisp and avoid flicker.

<sup>Written for commit 0ebf4947a33b24bb5c1fc4c2071492b201ec24ee. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4641?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Replaced standard progress spinners with a custom circular loading indicator that adapts to system appearance and display scale.
  * Updated toolbar and omnibar to use compact, consistently colored 12–13px spinners with matching opacity for a cleaner, more cohesive loading experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4641?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->