### PR TITLE
Fix workspace color picker context menu regression

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -13257,6 +13257,7 @@ struct SidebarWorkspaceSnapshotBuilder {
     }
 }
 
+@MainActor
 private final class SidebarTabItemContextMenuState: ObservableObject {
     var presentationFreezeActive = false
     var hasDeferredWorkspaceObservationInvalidation = false

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -13257,9 +13257,7 @@ struct SidebarWorkspaceSnapshotBuilder {
     }
 }
 
-@MainActor
-private final class SidebarTabItemContextMenuState: ObservableObject {
-    var presentationFreezeActive = false
+private struct SidebarTabItemContextMenuState {
     var hasDeferredWorkspaceObservationInvalidation = false
     var pendingWorkspaceSnapshot: SidebarWorkspaceSnapshotBuilder.Snapshot?
 }
@@ -13324,7 +13322,7 @@ private struct TabItemView: View, Equatable {
     let livePresentation: SidebarTabItemPresentationSnapshot
     @Binding var frozenPresentation: SidebarTabItemPresentationSnapshot?
     @State private var workspaceSnapshotStorage: SidebarWorkspaceSnapshotBuilder.Snapshot?
-    @StateObject private var contextMenuState = SidebarTabItemContextMenuState()
+    @State private var contextMenuState = SidebarTabItemContextMenuState()
     @State private var rowInteractionState = SidebarWorkspaceRowInteractionState()
     @State private var rowHeight: CGFloat = 1
     @State private var workspaceFinderDirectoryCache = WorkspaceFinderDirectoryCache()
@@ -14026,21 +14024,18 @@ private struct TabItemView: View, Equatable {
     }
 
     private func beginContextMenuPresentationFreeze() {
-        guard !contextMenuState.presentationFreezeActive else { return }
-        contextMenuState.presentationFreezeActive = true
+        guard frozenPresentation?.tabId != tab.id else { return }
         contextMenuState.hasDeferredWorkspaceObservationInvalidation = false
         contextMenuState.pendingWorkspaceSnapshot = nil
         frozenPresentation = livePresentation
     }
 
     private func endContextMenuPresentationFreeze() {
-        guard contextMenuState.presentationFreezeActive ||
-            frozenPresentation?.tabId == tab.id ||
+        guard frozenPresentation?.tabId == tab.id ||
             contextMenuState.hasDeferredWorkspaceObservationInvalidation
         else {
             return
         }
-        contextMenuState.presentationFreezeActive = false
         frozenPresentation = nil
         flushDeferredWorkspaceObservationInvalidation()
     }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -9489,12 +9489,7 @@ struct SidebarTabItemPresentationResolutionPolicy {
         frozen: SidebarTabItemPresentationSnapshot?
     ) -> SidebarTabItemPresentationSnapshot {
         guard let frozen, frozen.tabId == live.tabId else { return live }
-        return SidebarTabItemPresentationSnapshot(
-            tabId: live.tabId,
-            unreadCount: live.unreadCount,
-            latestNotificationText: live.latestNotificationText,
-            showsModifierShortcutHints: frozen.showsModifierShortcutHints
-        )
+        return frozen
     }
 }
 
@@ -13263,6 +13258,7 @@ struct SidebarWorkspaceSnapshotBuilder {
 }
 
 private final class SidebarTabItemContextMenuState: ObservableObject {
+    var presentationFreezeActive = false
     var hasDeferredWorkspaceObservationInvalidation = false
     var pendingWorkspaceSnapshot: SidebarWorkspaceSnapshotBuilder.Snapshot?
 }
@@ -13892,7 +13888,10 @@ private struct TabItemView: View, Equatable {
         .contentShape(Rectangle())
         .opacity(isBeingDragged ? 0.6 : 1)
         .overlay {
-            SidebarWorkspaceRowHoverTracker(rowInteractionState: $rowInteractionState)
+            SidebarWorkspaceRowHoverTracker(
+                rowInteractionState: $rowInteractionState,
+                onContextMenuTrackingChanged: handleContextMenuTrackingChanged
+            )
         }
         .overlay {
             MiddleClickCapture {
@@ -14006,16 +14005,43 @@ private struct TabItemView: View, Equatable {
             workspaceContextMenu
                 .onAppear {
                     rowInteractionState.contextMenuDidAppear()
-                    contextMenuState.hasDeferredWorkspaceObservationInvalidation = false
-                    contextMenuState.pendingWorkspaceSnapshot = nil
-                    frozenPresentation = livePresentation
+                    beginContextMenuPresentationFreeze()
                 }
                 .onDisappear {
                     rowInteractionState.contextMenuDidDisappear()
-                    frozenPresentation = nil
-                    flushDeferredWorkspaceObservationInvalidation()
+                    if !rowInteractionState.contextMenuVisible {
+                        endContextMenuPresentationFreeze()
+                    }
                 }
         }
+    }
+
+    private func handleContextMenuTrackingChanged(_ isTracking: Bool) {
+        if isTracking {
+            beginContextMenuPresentationFreeze()
+        } else {
+            endContextMenuPresentationFreeze()
+        }
+    }
+
+    private func beginContextMenuPresentationFreeze() {
+        guard !contextMenuState.presentationFreezeActive else { return }
+        contextMenuState.presentationFreezeActive = true
+        contextMenuState.hasDeferredWorkspaceObservationInvalidation = false
+        contextMenuState.pendingWorkspaceSnapshot = nil
+        frozenPresentation = livePresentation
+    }
+
+    private func endContextMenuPresentationFreeze() {
+        guard contextMenuState.presentationFreezeActive ||
+            frozenPresentation?.tabId == tab.id ||
+            contextMenuState.hasDeferredWorkspaceObservationInvalidation
+        else {
+            return
+        }
+        contextMenuState.presentationFreezeActive = false
+        frozenPresentation = nil
+        flushDeferredWorkspaceObservationInvalidation()
     }
 
     private func refreshWorkspaceSnapshot(force: Bool = false) {

--- a/Sources/Sidebar/SidebarWorkspaceRowHoverTracker.swift
+++ b/Sources/Sidebar/SidebarWorkspaceRowHoverTracker.swift
@@ -3,9 +3,21 @@ import SwiftUI
 
 struct SidebarWorkspaceRowHoverTracker: NSViewRepresentable {
     @Binding var rowInteractionState: SidebarWorkspaceRowInteractionState
+    var onContextMenuTrackingChanged: (Bool) -> Void = { _ in }
+
+    init(
+        rowInteractionState: Binding<SidebarWorkspaceRowInteractionState>,
+        onContextMenuTrackingChanged: @escaping (Bool) -> Void = { _ in }
+    ) {
+        self._rowInteractionState = rowInteractionState
+        self.onContextMenuTrackingChanged = onContextMenuTrackingChanged
+    }
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(rowInteractionState: $rowInteractionState)
+        Coordinator(
+            rowInteractionState: $rowInteractionState,
+            onContextMenuTrackingChanged: onContextMenuTrackingChanged
+        )
     }
 
     func makeNSView(context: Context) -> SidebarWorkspaceRowHoverTrackingView {
@@ -22,13 +34,19 @@ struct SidebarWorkspaceRowHoverTracker: NSViewRepresentable {
 
     func updateNSView(_ nsView: SidebarWorkspaceRowHoverTrackingView, context: Context) {
         context.coordinator.rowInteractionState = $rowInteractionState
+        context.coordinator.onContextMenuTrackingChanged = onContextMenuTrackingChanged
     }
 
     final class Coordinator {
         var rowInteractionState: Binding<SidebarWorkspaceRowInteractionState>
+        var onContextMenuTrackingChanged: (Bool) -> Void
 
-        init(rowInteractionState: Binding<SidebarWorkspaceRowInteractionState>) {
+        init(
+            rowInteractionState: Binding<SidebarWorkspaceRowInteractionState>,
+            onContextMenuTrackingChanged: @escaping (Bool) -> Void = { _ in }
+        ) {
             self.rowInteractionState = rowInteractionState
+            self.onContextMenuTrackingChanged = onContextMenuTrackingChanged
         }
 
         func pointerHoverChanged(_ hovering: Bool) {
@@ -41,6 +59,7 @@ struct SidebarWorkspaceRowHoverTracker: NSViewRepresentable {
             } else {
                 rowInteractionState.wrappedValue.contextMenuTrackingDidEnd()
             }
+            onContextMenuTrackingChanged(tracking)
         }
     }
 }

--- a/Sources/Sidebar/SidebarWorkspaceSnapshotRefreshPolicy.swift
+++ b/Sources/Sidebar/SidebarWorkspaceSnapshotRefreshPolicy.swift
@@ -113,9 +113,8 @@ struct SidebarWorkspaceRowInteractionState: Equatable {
     }
 
     mutating func contextMenuDidDisappear() {
-        if contextMenuLifecycle != .appKitTracking {
-            contextMenuLifecycle = .inactive
-        }
+        guard contextMenuLifecycle != .appKitTracking else { return }
+        contextMenuLifecycle = .inactive
         contextMenuTrackingSuppressesCloseButton = false
         applyDeferredPointerHovering()
     }

--- a/Sources/Sidebar/SidebarWorkspaceSnapshotRefreshPolicy.swift
+++ b/Sources/Sidebar/SidebarWorkspaceSnapshotRefreshPolicy.swift
@@ -78,10 +78,20 @@ struct SidebarWorkspaceSnapshotRefreshPolicy {
 }
 
 struct SidebarWorkspaceRowInteractionState: Equatable {
+    private enum ContextMenuLifecycle: Equatable {
+        case inactive
+        case swiftUIVisible
+        case appKitTracking
+    }
+
     private(set) var isPointerHovering = false
-    private(set) var contextMenuVisible = false
+    private var contextMenuLifecycle: ContextMenuLifecycle = .inactive
     private var contextMenuTrackingSuppressesCloseButton = false
     private var deferredPointerHoveringWhileContextMenuTracking: Bool?
+
+    var contextMenuVisible: Bool {
+        contextMenuLifecycle != .inactive
+    }
 
     mutating func setPointerHovering(_ hovering: Bool) {
         if contextMenuTrackingSuppressesCloseButton {
@@ -94,25 +104,31 @@ struct SidebarWorkspaceRowInteractionState: Equatable {
     }
 
     mutating func contextMenuDidAppear() {
-        contextMenuVisible = true
+        if contextMenuLifecycle != .appKitTracking {
+            contextMenuLifecycle = .swiftUIVisible
+        }
         contextMenuTrackingSuppressesCloseButton = true
         deferredPointerHoveringWhileContextMenuTracking = nil
         isPointerHovering = false
     }
 
     mutating func contextMenuDidDisappear() {
-        contextMenuVisible = false
+        if contextMenuLifecycle != .appKitTracking {
+            contextMenuLifecycle = .inactive
+        }
         contextMenuTrackingSuppressesCloseButton = false
         applyDeferredPointerHovering()
     }
 
     mutating func contextMenuTrackingDidBegin() {
+        contextMenuLifecycle = .appKitTracking
         contextMenuTrackingSuppressesCloseButton = true
         deferredPointerHoveringWhileContextMenuTracking = nil
         isPointerHovering = false
     }
 
     mutating func contextMenuTrackingDidEnd() {
+        contextMenuLifecycle = .inactive
         contextMenuTrackingSuppressesCloseButton = false
         applyDeferredPointerHovering()
     }

--- a/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
+++ b/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
@@ -380,6 +380,31 @@ final class SidebarWorkspaceRowInteractionStateTests: XCTestCase {
         )
     }
 
+    func testSwiftUIDisappearDuringAppKitTrackingKeepsHoverSuppressedUntilTrackingEnds() {
+        var state = SidebarWorkspaceRowInteractionState()
+
+        state.contextMenuTrackingDidBegin()
+        state.setPointerHovering(true)
+        state.contextMenuDidDisappear()
+
+        XCTAssertFalse(
+            state.shouldShowCloseButton(
+                canCloseWorkspace: true,
+                shortcutHintModeActive: false
+            ),
+            "SwiftUI context-menu disappearance must not drain deferred hover while AppKit still reports active menu tracking."
+        )
+
+        state.contextMenuTrackingDidEnd()
+
+        XCTAssertTrue(
+            state.shouldShowCloseButton(
+                canCloseWorkspace: true,
+                shortcutHintModeActive: false
+            )
+        )
+    }
+
     func testCoordinatorPreservesHoverExitWhileMenuTrackingSuppressesCloseButton() {
         var state = SidebarWorkspaceRowInteractionState()
         let binding = Binding<SidebarWorkspaceRowInteractionState>(

--- a/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
+++ b/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
@@ -206,7 +206,7 @@ final class SidebarSelectedWorkspaceScrollPolicyTests: XCTestCase {
 }
 
 final class SidebarTabItemPresentationResolutionPolicyTests: XCTestCase {
-    func testFrozenContextMenuPresentationDoesNotSuppressLiveNotificationState() {
+    func testFrozenContextMenuPresentationStabilizesNotificationState() {
         let tabId = UUID()
         let frozen = SidebarTabItemPresentationSnapshot(
             tabId: tabId,
@@ -226,8 +226,8 @@ final class SidebarTabItemPresentationResolutionPolicyTests: XCTestCase {
             frozen: frozen
         )
 
-        XCTAssertEqual(resolved.unreadCount, 1)
-        XCTAssertEqual(resolved.latestNotificationText, "done")
+        XCTAssertEqual(resolved.unreadCount, 0)
+        XCTAssertNil(resolved.latestNotificationText)
         XCTAssertTrue(resolved.showsModifierShortcutHints)
     }
 
@@ -273,6 +273,40 @@ final class SidebarTabItemPresentationResolutionPolicyTests: XCTestCase {
 }
 
 final class SidebarWorkspaceRowInteractionStateTests: XCTestCase {
+    func testContextMenuTrackingBeginMarksMenuVisibleBeforeSwiftUIContentAppears() {
+        var state = SidebarWorkspaceRowInteractionState()
+
+        state.contextMenuTrackingDidBegin()
+
+        XCTAssertTrue(
+            state.contextMenuVisible,
+            "AppKit menu tracking begins before SwiftUI context-menu content can appear, so workspace row updates must already be deferred."
+        )
+    }
+
+    func testContextMenuTrackingEndClearsMenuVisibilityWhenSwiftUIDisappearIsSkipped() {
+        var state = SidebarWorkspaceRowInteractionState()
+
+        state.contextMenuDidAppear()
+        state.contextMenuTrackingDidBegin()
+        state.contextMenuTrackingDidEnd()
+
+        XCTAssertFalse(
+            state.contextMenuVisible,
+            "AppKit menu tracking ending is the authoritative close signal when SwiftUI skips context-menu onDisappear."
+        )
+    }
+
+    func testSwiftUIOnlyContextMenuLifecycleStillMarksMenuVisible() {
+        var state = SidebarWorkspaceRowInteractionState()
+
+        state.contextMenuDidAppear()
+        XCTAssertTrue(state.contextMenuVisible)
+
+        state.contextMenuDidDisappear()
+        XCTAssertFalse(state.contextMenuVisible)
+    }
+
     func testHoverRevealIsIndependentFromStaleContextMenuVisibility() {
         var state = SidebarWorkspaceRowInteractionState()
 


### PR DESCRIPTION
Fixes #4646.

Regression context: #2560 was fixed by #2566 on 2026-04-07 by freezing `TabItemView` context-menu presentation and deferring workspace observation updates while the menu is open.

## Summary
- Restore full frozen sidebar row presentation while a workspace context menu is active so unread badge/preview and shortcut-hint publishes cannot change `TabItemView` equality and rebuild `.contextMenu` mid-submenu.
- Replace the menu visibility boolean with a single row menu lifecycle that treats AppKit `NSMenu` tracking and SwiftUI `.contextMenu` content as the same active phase. This covers the macOS 26 case where SwiftUI `.onAppear` may be late or skipped, and the inverse `.onDisappear`-skipped case.
- Start and stop the presentation freeze from the AppKit tracking callback too, so the freeze begins before SwiftUI menu content lifecycle callbacks are required.

## Root Cause
#4084 made frozen sidebar presentations keep unread count and latest notification text live during a context-menu freeze. Those fields participate in `TabItemView ==`, so notification-store publishes could still re-evaluate the row and rebuild `.contextMenu` while the Workspace Color submenu was open. Separately, the deferral gate only trusted SwiftUI `.contextMenu` `.onAppear`, while the row already had a more reliable AppKit menu-tracking signal.

## Regression Coverage
Two-commit red/green structure:
1. `e4f809c0d` changes/adds failing runtime policy tests for frozen presentation stability and AppKit menu-tracking visibility.
2. `515b8e45c` implements the fix.

## Verification
- `git diff --check`

Not run locally per repo/task policy: local tests/builds and `./scripts/reload.sh`.

Cloud Mac video: unavailable. `cloud-mac preflight` is currently blocked locally by unauthenticated `macfleet`, and `gh auth status` reports invalid keyring tokens. I still pushed the branch successfully over the repo remote, but cloud VM provisioning could not be started from this checkout.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4648"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782117481&installation_id=133855650&pr_number=4648&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4648&signature=81e4321ec85f19161c8d3b17aa82a8293ed69e8a1c78e5868345b24d4031e38d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touching sidebar row/menu interaction state and snapshot freezing logic could introduce subtle UI regressions (hover/close button visibility or deferred snapshot flushing), though changes are localized and backed by new tests.
> 
> **Overview**
> Fixes a sidebar workspace context-menu regression by **fully freezing** `SidebarTabItemPresentationSnapshot` while a row menu is active, preventing live unread/notification updates from rebuilding `TabItemView` (and its `.contextMenu`) mid-interaction.
> 
> Unifies menu visibility handling by replacing the simple boolean with a **SwiftUI + AppKit context-menu lifecycle** in `SidebarWorkspaceRowInteractionState`, and starts/ends the freeze based on both SwiftUI appear/disappear and AppKit `NSMenu` tracking callbacks (via a new `onContextMenuTrackingChanged` hook in `SidebarWorkspaceRowHoverTracker`). Adds/updates tests to cover the new freeze semantics and menu lifecycle edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6de0bbea9fd5317418475b52331b3426a02b3fd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the workspace color picker context menu regression by fully freezing the sidebar row while any menu is active and deriving visibility from a unified SwiftUI/AppKit lifecycle. Stops unread/preview changes from rebuilding the menu mid-submenu and keeps hover suppression until AppKit tracking ends.

- **Bug Fixes**
  - Return the frozen `SidebarTabItemPresentationSnapshot` during an active menu to stabilize unread count, preview text, and shortcut hints.
  - Start/end the freeze from AppKit `NSMenu` tracking and SwiftUI; ignore SwiftUI disappear while tracking and flush deferred workspace updates only after tracking ends; `SidebarWorkspaceRowHoverTracker` now reports tracking changes to drive the freeze.

- **Refactors**
  - Replace the boolean menu flag with a lifecycle state (inactive, SwiftUI-visible, AppKit-tracking) in `SidebarWorkspaceRowInteractionState` to unify visibility and close-button suppression across edge cases.

<sup>Written for commit 6de0bbea9fd5317418475b52331b3426a02b3fd6. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4648?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sidebar badges and notification text remain stable while context menus are open.
  * Context-menu interactions now preserve hover/close-button behavior and visibility across different menu lifecycles.
  * Sidebar presentation now consistently maintains state during menu operations.

* **Tests**
  * Added tests covering context-menu visibility and notification-state stabilization across interaction patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4648?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->