### PR TITLE
Fix browser omnibar Option-Backspace URL deletion

### DIFF
--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -3141,6 +3141,53 @@ func omnibarPrefixAfterDeletingTrailingWord(from text: String) -> String {
     return nsText.substring(to: deletionStart)
 }
 
+struct OmnibarURLWordDeletion: Equatable {
+    let text: String
+    let selectedRange: NSRange
+}
+
+private let omnibarURLWordBoundaryCharacterSet = CharacterSet.whitespacesAndNewlines
+    .union(CharacterSet(charactersIn: ".:/?#&=@"))
+
+func omnibarTextAfterDeletingURLWordBackward(
+    text: String,
+    selectedRange: NSRange
+) -> OmnibarURLWordDeletion? {
+    let nsText = text as NSString
+    let textLength = nsText.length
+    guard selectedRange.location != NSNotFound,
+          selectedRange.length == 0,
+          selectedRange.location <= textLength,
+          selectedRange.location > 0 else {
+        return nil
+    }
+
+    let caret = selectedRange.location
+    guard !omnibarURLWordBoundaryCharacter(in: nsText, at: caret - 1) else {
+        return nil
+    }
+
+    var deletionStart = caret
+    while deletionStart > 0,
+          !omnibarURLWordBoundaryCharacter(in: nsText, at: deletionStart - 1) {
+        deletionStart -= 1
+    }
+
+    guard deletionStart < caret else { return nil }
+    let deletionRange = NSRange(location: deletionStart, length: caret - deletionStart)
+    let updated = nsText.replacingCharacters(in: deletionRange, with: "")
+    return OmnibarURLWordDeletion(
+        text: updated,
+        selectedRange: NSRange(location: deletionStart, length: 0)
+    )
+}
+
+private func omnibarURLWordBoundaryCharacter(in text: NSString, at index: Int) -> Bool {
+    guard index >= 0, index < text.length else { return true }
+    guard let scalar = UnicodeScalar(Int(text.character(at: index))) else { return false }
+    return omnibarURLWordBoundaryCharacterSet.contains(scalar)
+}
+
 private func typedQueryHasExplicitPathOrQuery(_ typedQuery: String) -> Bool {
     var normalized = typedQuery.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     if normalized.hasPrefix("https://") {
@@ -4267,6 +4314,14 @@ struct OmnibarTextFieldRepresentable: NSViewRepresentable {
                     return true
                 }
             case 51: // Backspace
+                if modifiers == [.option],
+                   let editor,
+                   handleOptionDeleteBackward(editor: editor) {
+#if DEBUG
+                    handled = true
+#endif
+                    return true
+                }
                 if modifiers.contains(.command) || modifiers.contains(.option) {
                     return false
                 }
@@ -4283,6 +4338,28 @@ struct OmnibarTextFieldRepresentable: NSViewRepresentable {
             }
 
             return false
+        }
+
+        private func handleOptionDeleteBackward(editor: NSTextView) -> Bool {
+            guard parent.inlineCompletion == nil else { return false }
+            guard let deletion = omnibarTextAfterDeletingURLWordBackward(
+                text: editor.string,
+                selectedRange: editor.selectedRange()
+            ) else {
+                return false
+            }
+
+            isProgrammaticMutation = true
+            editor.string = deletion.text
+            parentField?.stringValue = deletion.text
+            editor.setSelectedRange(deletion.selectedRange)
+            isProgrammaticMutation = false
+
+            parent.text = deletion.text
+            parent.onSelectionChanged(deletion.selectedRange, false)
+            lastPublishedSelection = deletion.selectedRange
+            lastPublishedHasMarkedText = false
+            return true
         }
     }
 

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -2178,7 +2178,11 @@ struct BrowserPanelView: View {
 
     private func handleInlineDeleteWordBackward() {
         guard let completion = inlineCompletion else { return }
-        let updated = omnibarPrefixAfterDeletingTrailingWord(from: completion.typedText)
+        let typedRange = NSRange(location: completion.typedText.utf16.count, length: 0)
+        let updated = omnibarTextAfterDeletingURLWordBackward(
+            text: completion.typedText,
+            selectedRange: typedRange
+        )?.text ?? omnibarPrefixAfterDeletingTrailingWord(from: completion.typedText)
         // Modified Backspace dismisses the current inline suggestion instead of
         // refetching suggestions for the shorter prefix.
         _ = omnibarReduce(state: &omnibarState, event: .bufferChanged(updated))
@@ -3149,11 +3153,16 @@ struct OmnibarURLWordDeletion: Equatable {
 
 private let omnibarURLWordBoundaryCharacterSet = CharacterSet.whitespacesAndNewlines
     .union(CharacterSet(charactersIn: ".:/?#&=@"))
+private let omnibarURLStructuralBoundaryCharacterSet = CharacterSet(charactersIn: ".:/?#&=@")
 
 func omnibarTextAfterDeletingURLWordBackward(
     text: String,
     selectedRange: NSRange
 ) -> OmnibarURLWordDeletion? {
+    guard text.rangeOfCharacter(from: omnibarURLStructuralBoundaryCharacterSet) != nil else {
+        return nil
+    }
+
     let nsText = text as NSString
     let textLength = nsText.length
     guard selectedRange.location != NSNotFound,

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -3159,10 +3159,6 @@ func omnibarTextAfterDeletingURLWordBackward(
     text: String,
     selectedRange: NSRange
 ) -> OmnibarURLWordDeletion? {
-    guard text.rangeOfCharacter(from: omnibarURLStructuralBoundaryCharacterSet) != nil else {
-        return nil
-    }
-
     let nsText = text as NSString
     let textLength = nsText.length
     guard selectedRange.location != NSNotFound,
@@ -3199,6 +3195,14 @@ func omnibarTextAfterDeletingURLWordBackward(
         }
     }
 
+    guard omnibarURLDeletionTouchesStructuralBoundary(
+        in: nsText,
+        deletionStart: deletionStart,
+        deletionEnd: deletionEnd
+    ) else {
+        return nil
+    }
+
     let deletionRange = NSRange(location: deletionStart, length: deletionEnd - deletionStart)
     let updated = nsText.replacingCharacters(in: deletionRange, with: "")
     return OmnibarURLWordDeletion(
@@ -3212,6 +3216,32 @@ private func omnibarURLWordBoundaryCharacter(in text: NSString, at index: Int) -
     guard index >= 0, index < text.length else { return true }
     guard let scalar = UnicodeScalar(Int(text.character(at: index))) else { return false }
     return omnibarURLWordBoundaryCharacterSet.contains(scalar)
+}
+
+private func omnibarURLStructuralBoundaryCharacter(in text: NSString, at index: Int) -> Bool {
+    guard index >= 0, index < text.length else { return false }
+    guard let scalar = UnicodeScalar(Int(text.character(at: index))) else { return false }
+    return omnibarURLStructuralBoundaryCharacterSet.contains(scalar)
+}
+
+private func omnibarURLDeletionTouchesStructuralBoundary(
+    in text: NSString,
+    deletionStart: Int,
+    deletionEnd: Int
+) -> Bool {
+    if omnibarURLStructuralBoundaryCharacter(in: text, at: deletionStart - 1) {
+        return true
+    }
+
+    var index = deletionStart
+    while index < deletionEnd {
+        if omnibarURLStructuralBoundaryCharacter(in: text, at: index) {
+            return true
+        }
+        index += 1
+    }
+
+    return omnibarURLStructuralBoundaryCharacter(in: text, at: deletionEnd)
 }
 
 private func typedQueryHasExplicitPathOrQuery(_ typedQuery: String) -> Bool {

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -3164,21 +3164,25 @@ func omnibarTextAfterDeletingURLWordBackward(
     }
 
     let caret = selectedRange.location
-    guard !omnibarURLWordBoundaryCharacter(in: nsText, at: caret - 1) else {
-        return nil
+    var scanEnd = caret
+    while scanEnd > 0,
+          omnibarURLWordBoundaryCharacter(in: nsText, at: scanEnd - 1) {
+        scanEnd -= 1
     }
+    guard scanEnd > 0 else { return nil }
 
-    var deletionStart = caret
+    var deletionStart = scanEnd
     while deletionStart > 0,
           !omnibarURLWordBoundaryCharacter(in: nsText, at: deletionStart - 1) {
         deletionStart -= 1
     }
 
-    guard deletionStart < caret else { return nil }
+    guard deletionStart < scanEnd else { return nil }
 
-    var deletionEnd = caret
-    if caret < textLength,
-       omnibarURLWordBoundaryCharacter(in: nsText, at: caret),
+    var deletionEnd = scanEnd == caret ? scanEnd : caret
+    if scanEnd == caret,
+       scanEnd < textLength,
+       omnibarURLWordBoundaryCharacter(in: nsText, at: scanEnd),
        (deletionStart == 0 || omnibarURLWordBoundaryCharacter(in: nsText, at: deletionStart - 1)) {
         deletionEnd += 1
     }
@@ -4134,6 +4138,12 @@ struct OmnibarTextFieldRepresentable: NSViewRepresentable {
             case #selector(NSResponder.deleteWordBackward(_:)):
                 if inlineCompletionSelectionIsActive(textView, inline: parent.inlineCompletion) {
                     parent.onDeleteWordBackwardWithInlineSelection()
+#if DEBUG
+                    handled = true
+#endif
+                    return true
+                }
+                if handleOptionDeleteBackward(editor: textView) {
 #if DEBUG
                     handled = true
 #endif

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -3174,7 +3174,15 @@ func omnibarTextAfterDeletingURLWordBackward(
     }
 
     guard deletionStart < caret else { return nil }
-    let deletionRange = NSRange(location: deletionStart, length: caret - deletionStart)
+
+    var deletionEnd = caret
+    if caret < textLength,
+       omnibarURLWordBoundaryCharacter(in: nsText, at: caret),
+       (deletionStart == 0 || omnibarURLWordBoundaryCharacter(in: nsText, at: deletionStart - 1)) {
+        deletionEnd += 1
+    }
+
+    let deletionRange = NSRange(location: deletionStart, length: deletionEnd - deletionStart)
     let updated = nsText.replacingCharacters(in: deletionRange, with: "")
     return OmnibarURLWordDeletion(
         text: updated,

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -3143,6 +3143,7 @@ func omnibarPrefixAfterDeletingTrailingWord(from text: String) -> String {
 
 struct OmnibarURLWordDeletion: Equatable {
     let text: String
+    let deletedRange: NSRange
     let selectedRange: NSRange
 }
 
@@ -3186,6 +3187,7 @@ func omnibarTextAfterDeletingURLWordBackward(
     let updated = nsText.replacingCharacters(in: deletionRange, with: "")
     return OmnibarURLWordDeletion(
         text: updated,
+        deletedRange: deletionRange,
         selectedRange: NSRange(location: deletionStart, length: 0)
     )
 }
@@ -4357,11 +4359,16 @@ struct OmnibarTextFieldRepresentable: NSViewRepresentable {
                 return false
             }
 
+            guard editor.shouldChangeText(in: deletion.deletedRange, replacementString: "") else {
+                return false
+            }
+            guard let textStorage = editor.textStorage else { return false }
+
             isProgrammaticMutation = true
-            editor.string = deletion.text
-            parentField?.stringValue = deletion.text
+            defer { isProgrammaticMutation = false }
+            textStorage.replaceCharacters(in: deletion.deletedRange, with: "")
+            editor.didChangeText()
             editor.setSelectedRange(deletion.selectedRange)
-            isProgrammaticMutation = false
 
             parent.text = deletion.text
             parent.onSelectionChanged(deletion.selectedRange, false)

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -3184,7 +3184,10 @@ func omnibarTextAfterDeletingURLWordBackward(
        scanEnd < textLength,
        omnibarURLWordBoundaryCharacter(in: nsText, at: scanEnd),
        (deletionStart == 0 || omnibarURLWordBoundaryCharacter(in: nsText, at: deletionStart - 1)) {
-        deletionEnd += 1
+        while deletionEnd < textLength,
+              omnibarURLWordBoundaryCharacter(in: nsText, at: deletionEnd) {
+            deletionEnd += 1
+        }
     }
 
     let deletionRange = NSRange(location: deletionStart, length: deletionEnd - deletionStart)

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -3159,6 +3159,10 @@ func omnibarTextAfterDeletingURLWordBackward(
     text: String,
     selectedRange: NSRange
 ) -> OmnibarURLWordDeletion? {
+    guard text.rangeOfCharacter(from: .whitespacesAndNewlines) == nil else {
+        return nil
+    }
+
     let nsText = text as NSString
     let textLength = nsText.length
     guard selectedRange.location != NSNotFound,

--- a/cmuxTests/OmnibarAndToolsTests.swift
+++ b/cmuxTests/OmnibarAndToolsTests.swift
@@ -644,6 +644,11 @@ final class OmnibarStateMachineTests: XCTestCase {
             harness.publishedSelectionRange,
             NSRange(location: "news.ycombinator.".utf16.count, length: 0)
         )
+        XCTAssertTrue(harness.editor.undoManager?.canUndo ?? false)
+
+        harness.editor.undoManager?.undo()
+
+        XCTAssertEqual(harness.editor.string, "news.ycombinator.com")
     }
 
     @MainActor
@@ -948,6 +953,12 @@ private final class OmnibarInlineDeletionHarness {
 @MainActor
 private final class OmnibarPlainDeletionHarness {
     var state = OmnibarState()
+    let window = NSWindow(
+        contentRect: NSRect(x: 0, y: 0, width: 320, height: 40),
+        styleMask: [.borderless],
+        backing: .buffered,
+        defer: false
+    )
     let editor = NSTextView()
     var publishedSelectionRange = NSRange(location: NSNotFound, length: 0)
 
@@ -955,8 +966,13 @@ private final class OmnibarPlainDeletionHarness {
         state.isFocused = true
         state.currentURLString = ""
         state.buffer = text
+        editor.allowsUndo = true
+        editor.frame = window.contentView?.bounds ?? .zero
+        window.contentView?.addSubview(editor)
+        window.makeFirstResponder(editor)
         editor.string = text
         editor.setSelectedRange(NSRange(location: selectedLocation ?? text.utf16.count, length: 0))
+        editor.undoManager?.removeAllActions()
     }
 
     func dispatchBackspace(

--- a/cmuxTests/OmnibarAndToolsTests.swift
+++ b/cmuxTests/OmnibarAndToolsTests.swift
@@ -1000,7 +1000,11 @@ private final class OmnibarInlineDeletionHarness {
 
     private func deleteWordBeforeInlineCompletion() {
         guard let inlineCompletion else { return }
-        let updated = omnibarPrefixAfterDeletingTrailingWord(from: inlineCompletion.typedText)
+        let typedRange = NSRange(location: inlineCompletion.typedText.utf16.count, length: 0)
+        let updated = omnibarTextAfterDeletingURLWordBackward(
+            text: inlineCompletion.typedText,
+            selectedRange: typedRange
+        )?.text ?? omnibarPrefixAfterDeletingTrailingWord(from: inlineCompletion.typedText)
         replaceTypedPrefixAndDismissSuggestions(with: updated)
     }
 

--- a/cmuxTests/OmnibarAndToolsTests.swift
+++ b/cmuxTests/OmnibarAndToolsTests.swift
@@ -645,6 +645,24 @@ final class OmnibarStateMachineTests: XCTestCase {
             NSRange(location: "news.ycombinator.".utf16.count, length: 0)
         )
     }
+
+    @MainActor
+    func testOptionBackspaceInMiddleDoesNotLeaveDoubleURLSeparators() throws {
+        let harness = OmnibarPlainDeletionHarness(
+            text: "news.ycombinator.com",
+            selectedLocation: "news.ycombinator".utf16.count
+        )
+
+        let handled = try harness.dispatchBackspace(modifiers: [.option])
+
+        XCTAssertTrue(handled)
+        XCTAssertEqual(harness.state.buffer, "news.com")
+        XCTAssertEqual(harness.editor.string, "news.com")
+        XCTAssertEqual(
+            harness.editor.selectedRange(),
+            NSRange(location: "news.".utf16.count, length: 0)
+        )
+    }
 }
 
 @MainActor
@@ -933,12 +951,12 @@ private final class OmnibarPlainDeletionHarness {
     let editor = NSTextView()
     var publishedSelectionRange = NSRange(location: NSNotFound, length: 0)
 
-    init(text: String) {
+    init(text: String, selectedLocation: Int? = nil) {
         state.isFocused = true
         state.currentURLString = ""
         state.buffer = text
         editor.string = text
-        editor.setSelectedRange(NSRange(location: text.utf16.count, length: 0))
+        editor.setSelectedRange(NSRange(location: selectedLocation ?? text.utf16.count, length: 0))
     }
 
     func dispatchBackspace(

--- a/cmuxTests/OmnibarAndToolsTests.swift
+++ b/cmuxTests/OmnibarAndToolsTests.swift
@@ -626,6 +626,25 @@ final class OmnibarStateMachineTests: XCTestCase {
         XCTAssertEqual(harness.inlineCompletion?.typedText, "gm")
         XCTAssertEqual(harness.inlineCompletion?.displayText, "gmail.com")
     }
+
+    @MainActor
+    func testOptionBackspaceDeletesOnlyFinalURLHostLabel() throws {
+        let harness = OmnibarPlainDeletionHarness(text: "news.ycombinator.com")
+
+        let handled = try harness.dispatchBackspace(modifiers: [.option])
+
+        XCTAssertTrue(handled)
+        XCTAssertEqual(harness.state.buffer, "news.ycombinator.")
+        XCTAssertEqual(harness.editor.string, "news.ycombinator.")
+        XCTAssertEqual(
+            harness.editor.selectedRange(),
+            NSRange(location: "news.ycombinator.".utf16.count, length: 0)
+        )
+        XCTAssertEqual(
+            harness.publishedSelectionRange,
+            NSRange(location: "news.ycombinator.".utf16.count, length: 0)
+        )
+    }
 }
 
 @MainActor
@@ -905,6 +924,80 @@ private final class OmnibarInlineDeletionHarness {
         inlineCompletion = nil
     }
 
+}
+
+
+@MainActor
+private final class OmnibarPlainDeletionHarness {
+    var state = OmnibarState()
+    let editor = NSTextView()
+    var publishedSelectionRange = NSRange(location: NSNotFound, length: 0)
+
+    init(text: String) {
+        state.isFocused = true
+        state.currentURLString = ""
+        state.buffer = text
+        editor.string = text
+        editor.setSelectedRange(NSRange(location: text.utf16.count, length: 0))
+    }
+
+    func dispatchBackspace(
+        modifiers: NSEvent.ModifierFlags,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws -> Bool {
+        let event = try XCTUnwrap(
+            NSEvent.keyEvent(
+                with: .keyDown,
+                location: .zero,
+                modifierFlags: modifiers,
+                timestamp: ProcessInfo.processInfo.systemUptime,
+                windowNumber: 0,
+                context: nil,
+                characters: "\u{7F}",
+                charactersIgnoringModifiers: "\u{7F}",
+                isARepeat: false,
+                keyCode: 51
+            ),
+            file: file,
+            line: line
+        )
+
+        return makeCoordinator().handleKeyEvent(event, editor: editor)
+    }
+
+    private func makeCoordinator() -> OmnibarTextFieldRepresentable.Coordinator {
+        OmnibarTextFieldRepresentable.Coordinator(
+            parent: OmnibarTextFieldRepresentable(
+                panelId: UUID(),
+                text: Binding(
+                    get: { self.state.buffer },
+                    set: { self.state.buffer = $0 }
+                ),
+                isFocused: Binding(
+                    get: { self.state.isFocused },
+                    set: { self.state.isFocused = $0 }
+                ),
+                selectAllRequestId: 0,
+                inlineCompletion: nil,
+                placeholder: "",
+                onTap: {},
+                onSubmit: {},
+                onEscape: {},
+                onFieldLostFocus: {},
+                onMoveSelection: { _ in },
+                onDeleteSelectedSuggestion: {},
+                onAcceptInlineCompletion: {},
+                onDeleteBackwardWithInlineSelection: {},
+                onClearTypedPrefixWithInlineSelection: {},
+                onDeleteWordBackwardWithInlineSelection: {},
+                onSelectionChanged: { range, _ in
+                    self.publishedSelectionRange = range
+                },
+                shouldSuppressWebViewFocus: { false }
+            )
+        )
+    }
 }
 
 

--- a/cmuxTests/OmnibarAndToolsTests.swift
+++ b/cmuxTests/OmnibarAndToolsTests.swift
@@ -611,6 +611,26 @@ final class OmnibarStateMachineTests: XCTestCase {
     }
 
     @MainActor
+    func testOptionBackspaceDeletesURLLabelBeforeInlineCompletion() throws {
+        let harness = OmnibarInlineDeletionHarness(
+            typedText: "news.ycombinator.c",
+            displayText: "news.ycombinator.com",
+            suggestions: [
+                .history(url: "https://news.ycombinator.com/", title: "Hacker News"),
+            ]
+        )
+
+        try harness.dispatchBackspace(
+            modifiers: [.option],
+            fallbackCommand: #selector(NSResponder.deleteWordBackward(_:))
+        )
+
+        XCTAssertEqual(harness.state.buffer, "news.ycombinator.")
+        XCTAssertNil(harness.inlineCompletion)
+        XCTAssertTrue(harness.state.suggestions.isEmpty)
+    }
+
+    @MainActor
     func testPlainBackspaceStillDeletesSingleCharacterWithInlineCompletion() throws {
         let harness = OmnibarInlineDeletionHarness(
             typedText: "gma",
@@ -712,6 +732,17 @@ final class OmnibarStateMachineTests: XCTestCase {
         XCTAssertEqual(harness.state.buffer, "example.com")
         XCTAssertEqual(harness.editor.string, "example.com")
         XCTAssertEqual(harness.editor.selectedRange(), NSRange(location: 0, length: 0))
+    }
+
+    @MainActor
+    func testOptionBackspaceForPlainSearchFallsThroughToNativeDeletion() throws {
+        let harness = OmnibarPlainDeletionHarness(text: "foo+bar")
+
+        let handled = try harness.dispatchBackspace(modifiers: [.option])
+
+        XCTAssertFalse(handled)
+        XCTAssertEqual(harness.state.buffer, "foo+bar")
+        XCTAssertEqual(harness.editor.string, "foo+bar")
     }
 }
 

--- a/cmuxTests/OmnibarAndToolsTests.swift
+++ b/cmuxTests/OmnibarAndToolsTests.swift
@@ -744,6 +744,20 @@ final class OmnibarStateMachineTests: XCTestCase {
         XCTAssertEqual(harness.state.buffer, "foo+bar")
         XCTAssertEqual(harness.editor.string, "foo+bar")
     }
+
+    @MainActor
+    func testOptionBackspaceBeforePlainWordInSearchWithURLLaterFallsThrough() throws {
+        let harness = OmnibarPlainDeletionHarness(
+            text: "foo bar.com",
+            selectedLocation: "foo".utf16.count
+        )
+
+        let handled = try harness.dispatchBackspace(modifiers: [.option])
+
+        XCTAssertFalse(handled)
+        XCTAssertEqual(harness.state.buffer, "foo bar.com")
+        XCTAssertEqual(harness.editor.string, "foo bar.com")
+    }
 }
 
 @MainActor

--- a/cmuxTests/OmnibarAndToolsTests.swift
+++ b/cmuxTests/OmnibarAndToolsTests.swift
@@ -668,6 +668,36 @@ final class OmnibarStateMachineTests: XCTestCase {
             NSRange(location: "news.".utf16.count, length: 0)
         )
     }
+
+    @MainActor
+    func testOptionBackspaceAfterURLSeparatorContinuesURLAwareDeletion() throws {
+        let harness = OmnibarPlainDeletionHarness(text: "news.ycombinator.")
+
+        let handled = try harness.dispatchBackspace(modifiers: [.option])
+
+        XCTAssertTrue(handled)
+        XCTAssertEqual(harness.state.buffer, "news.")
+        XCTAssertEqual(harness.editor.string, "news.")
+        XCTAssertEqual(
+            harness.editor.selectedRange(),
+            NSRange(location: "news.".utf16.count, length: 0)
+        )
+    }
+
+    @MainActor
+    func testDeleteWordBackwardCommandUsesURLAwareDeletionForPlainURL() throws {
+        let harness = OmnibarPlainDeletionHarness(text: "news.ycombinator.com")
+
+        let handled = harness.dispatchCommand(#selector(NSResponder.deleteWordBackward(_:)))
+
+        XCTAssertTrue(handled)
+        XCTAssertEqual(harness.state.buffer, "news.ycombinator.")
+        XCTAssertEqual(harness.editor.string, "news.ycombinator.")
+        XCTAssertEqual(
+            harness.editor.selectedRange(),
+            NSRange(location: "news.ycombinator.".utf16.count, length: 0)
+        )
+    }
 }
 
 @MainActor
@@ -998,6 +1028,10 @@ private final class OmnibarPlainDeletionHarness {
         )
 
         return makeCoordinator().handleKeyEvent(event, editor: editor)
+    }
+
+    func dispatchCommand(_ commandSelector: Selector) -> Bool {
+        makeCoordinator().control(NSTextField(), textView: editor, doCommandBy: commandSelector)
     }
 
     private func makeCoordinator() -> OmnibarTextFieldRepresentable.Coordinator {

--- a/cmuxTests/OmnibarAndToolsTests.swift
+++ b/cmuxTests/OmnibarAndToolsTests.swift
@@ -758,6 +758,20 @@ final class OmnibarStateMachineTests: XCTestCase {
         XCTAssertEqual(harness.state.buffer, "foo bar.com")
         XCTAssertEqual(harness.editor.string, "foo bar.com")
     }
+
+    @MainActor
+    func testOptionBackspaceAfterURLLikeTokenInSearchFallsThrough() throws {
+        let harness = OmnibarPlainDeletionHarness(
+            text: "foo.com bar",
+            selectedLocation: "foo.com".utf16.count
+        )
+
+        let handled = try harness.dispatchBackspace(modifiers: [.option])
+
+        XCTAssertFalse(handled)
+        XCTAssertEqual(harness.state.buffer, "foo.com bar")
+        XCTAssertEqual(harness.editor.string, "foo.com bar")
+    }
 }
 
 @MainActor

--- a/cmuxTests/OmnibarAndToolsTests.swift
+++ b/cmuxTests/OmnibarAndToolsTests.swift
@@ -698,6 +698,21 @@ final class OmnibarStateMachineTests: XCTestCase {
             NSRange(location: "news.ycombinator.".utf16.count, length: 0)
         )
     }
+
+    @MainActor
+    func testOptionBackspaceBeforeSchemeSeparatorConsumesSeparatorRun() throws {
+        let harness = OmnibarPlainDeletionHarness(
+            text: "https://example.com",
+            selectedLocation: "https".utf16.count
+        )
+
+        let handled = try harness.dispatchBackspace(modifiers: [.option])
+
+        XCTAssertTrue(handled)
+        XCTAssertEqual(harness.state.buffer, "example.com")
+        XCTAssertEqual(harness.editor.string, "example.com")
+        XCTAssertEqual(harness.editor.selectedRange(), NSRange(location: 0, length: 0))
+    }
 }
 
 @MainActor


### PR DESCRIPTION
## Summary

- Intercepts plain Option-Backspace in the browser omnibar before AppKit treats a full hostname as one word.
- Deletes back to URL-aware boundaries such as `.`, `/`, `?`, `#`, `&`, `=`, `@`, `:`, and whitespace.
- Adds regression coverage for `news.ycombinator.com` becoming `news.ycombinator.`.

## Testing

- PASS: `./scripts/lint-pbxproj-test-wiring.sh`
- PASS: `./scripts/reload.sh --tag urlwd`
- BLOCKED: AWS focused `xcodebuild ... -only-testing:cmuxTests/OmnibarStateMachineTests/testOptionBackspaceDeletesOnlyFinalURLHostLabel test`
  - Red attempt on `c76a54cd5` did not reach the test because the AWS builder ran out of disk while compiling the existing Rust FFI build step.
  - Green attempt on `41193e1ff` compiled but the first test run failed before execution because `testmanagerd` was unavailable in the non-GUI launch context; the GUI-context retry then hit AWS disk exhaustion while resolving Sentry artifacts.

## Dogfood

- Tagged build: `urlwd`
- Expected behavior: focus the cmux browser omnibar with `news.ycombinator.com`, press Option-Backspace once, and the field should read `news.ycombinator.` instead of becoming empty.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4651"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782118840&installation_id=133855650&pr_number=4651&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4651&signature=64379441ca0e57fde93b24bad462314b4a86de7c408ba26779fc613801f187d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes key handling and text mutation for the browser omnibar’s field editor, which can impact deletion semantics, selection, and undo behavior. Adds URL-aware parsing logic with several edge cases, increasing risk of regressions in text editing interactions.
> 
> **Overview**
> Fixes browser omnibar word-deletion so **Option-Backspace / `deleteWordBackward` become URL-aware** for single-token URLs, deleting back to boundaries like `.`, `/`, `?`, `#`, `&`, `=`, `@`, and `:` instead of AppKit treating the whole hostname as one word.
> 
> Adds `omnibarTextAfterDeletingURLWordBackward` (returns updated text + deleted/selection ranges) and wires it into both inline-completion deletion and plain editing by intercepting Option-Backspace and programmatically applying the deletion while preserving selection and undo.
> 
> Expands tests to cover URL host-label deletion, mid-string deletion without double separators, consuming separator runs (e.g. `https://`), command-based deletion, and fallthrough to native behavior for non-URL text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9476f314a14d0922fd713b34692156c34fa8c66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the browser omnibar so Option-Backspace and `deleteWordBackward` delete one URL segment using URL-aware boundaries in both plain text and inline-completion states. Consumes separator runs (e.g., `://`), avoids double separators, preserves undo/selection, and falls back to native deletion for non-URL text.

- **Bug Fixes**
  - Applies URL-aware deletion when inline completion is active or not; stops at `.`, `/`, `?`, `#`, `&`, `=`, `@`, `:`, or whitespace (caret only).
  - Routes key events and `deleteWordBackward` to the URL-aware path; consumes adjacent separator runs and removes lone delimiters; preserves caret/selection and undo; adds tests for inline completion, mid-string, after separators, scheme-run, command routing, and non-URL fallback.

<sup>Written for commit 55e4389ca8b662e1cb77897a9caa32667e18b176. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4651?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Omnibar: Option+Backspace and word-delete now remove URL segments cleanly (host labels and trailing separators), preserve caret/selection and undo history, and clear inline suggestions when deleting URL parts before typed text.

* **Tests**
  * Added unit tests covering Option+Backspace and command-based word deletion, selection/undo correctness, and URL-separator edge cases (plain and inline omnibar modes).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4651?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->