### PR TITLE
Add Ghostty settings command palette action

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -25384,6 +25384,40 @@
         }
       }
     },
+    "command.openGhosttySettings.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ghostty Config Files"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ghostty設定ファイル"
+          }
+        }
+      }
+    },
+    "command.openGhosttySettings.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Ghostty Settings in TextEdit"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ghostty設定をTextEditで開く"
+          }
+        }
+      }
+    },
     "command.openSettings.subtitle": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -6592,6 +6592,21 @@ struct ContentView: View {
         )
         contributions.append(
             CommandPaletteCommandContribution(
+                commandId: "palette.openGhosttySettings",
+                title: constant(
+                    String(
+                        localized: "command.openGhosttySettings.title",
+                        defaultValue: "Open Ghostty Settings in TextEdit"
+                    )
+                ),
+                subtitle: constant(
+                    String(localized: "command.openGhosttySettings.subtitle", defaultValue: "Ghostty Config Files")
+                ),
+                keywords: ["open", "ghostty", "settings", "config", "configuration", "file", "textedit", "terminal"]
+            )
+        )
+        contributions.append(
+            CommandPaletteCommandContribution(
                 commandId: "palette.checkForUpdates",
                 title: constant(String(localized: "command.checkForUpdates.title", defaultValue: "Check for Updates")),
                 subtitle: constant(String(localized: "command.checkForUpdates.subtitle", defaultValue: "Global")),
@@ -7537,6 +7552,12 @@ struct ContentView: View {
             cmuxDebugLog("palette.openCmuxSettingsFile.invoke")
 #endif
             openCmuxSettingsFileInEditor()
+        }
+        registry.register(commandId: "palette.openGhosttySettings") {
+#if DEBUG
+            cmuxDebugLog("palette.openGhosttySettings.invoke")
+#endif
+            GhosttyApp.shared.openConfigurationInTextEdit()
         }
         registry.register(commandId: "palette.checkForUpdates") {
             AppDelegate.shared?.checkForUpdates(nil)

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3433,16 +3433,20 @@ class GhosttyApp {
     func openConfigurationInTextEdit() {
         #if os(macOS)
         let environment = ConfigSourceEnvironment.live()
-        let fileURL: URL
+        let fileURLs: [URL]
         do {
-            fileURL = try environment.materializeCmuxConfigFileIfNeeded()
+            fileURLs = try environment.materializedGhosttySettingsEditorURLs()
         } catch {
+            NSSound.beep()
+            return
+        }
+        guard !fileURLs.isEmpty else {
             NSSound.beep()
             return
         }
         let editorURL = URL(fileURLWithPath: "/System/Applications/TextEdit.app")
         let configuration = NSWorkspace.OpenConfiguration()
-        NSWorkspace.shared.open([fileURL], withApplicationAt: editorURL, configuration: configuration)
+        NSWorkspace.shared.open(fileURLs, withApplicationAt: editorURL, configuration: configuration)
         #endif
     }
 

--- a/Sources/Settings/ConfigSource.swift
+++ b/Sources/Settings/ConfigSource.swift
@@ -73,6 +73,33 @@ struct ConfigSourceEnvironment {
         return url
     }
 
+    func materializedGhosttySettingsEditorURLs() throws -> [URL] {
+        let cmuxURL = try materializeCmuxConfigFileIfNeeded()
+        let syncedSnapshot = ConfigSource.synced.snapshot(environment: self)
+
+        var collector = GhosttySettingsConfigFileCollector(
+            fileManager: fileManager,
+            homeDirectoryURL: homeDirectoryURL
+        )
+        collector.append(cmuxURL)
+        collector.append(syncedSnapshot.primaryURL)
+
+        for url in standaloneGhosttyDisplayCandidates where isRegularFile(at: url) {
+            collector.append(url)
+        }
+
+        for url in CmuxGhosttyConfigPathResolver.loadConfigURLs(
+            currentBundleIdentifier: currentBundleIdentifier,
+            appSupportDirectory: appSupportDirectoryURL,
+            fileManager: fileManager
+        ) {
+            collector.append(url)
+        }
+
+        collector.appendRecursiveConfigFileIncludes()
+        return collector.urls
+    }
+
     func writeCmuxConfigContents(_ contents: String) throws {
         let url = cmuxConfigURL
         try writeCmuxConfigContents(contents, to: url)
@@ -296,4 +323,145 @@ private struct ParsedConfigEntry {
     let value: String
     let sourceURL: URL
     let lineNumber: Int
+}
+
+private struct GhosttySettingsConfigFileCollector {
+    let fileManager: FileManager
+    let homeDirectoryURL: URL
+    private(set) var urls: [URL] = []
+    private var seenCanonicalPaths: Set<String> = []
+
+    init(fileManager: FileManager, homeDirectoryURL: URL) {
+        self.fileManager = fileManager
+        self.homeDirectoryURL = homeDirectoryURL
+    }
+
+    mutating func append(_ url: URL) {
+        let standardized = url.standardizedFileURL
+        let canonicalPath = standardized.resolvingSymlinksInPath().path
+        guard seenCanonicalPaths.insert(canonicalPath).inserted else { return }
+        urls.append(standardized)
+    }
+
+    mutating func appendRecursiveConfigFileIncludes() {
+        var queue = urls
+        var scannedCanonicalPaths: Set<String> = []
+
+        while !queue.isEmpty {
+            let url = queue.removeFirst()
+            let canonicalPath = url.resolvingSymlinksInPath().path
+            guard scannedCanonicalPaths.insert(canonicalPath).inserted else { continue }
+            guard isRegularFile(at: url),
+                  let contents = try? String(contentsOf: url, encoding: .utf8) else {
+                continue
+            }
+
+            for includeURL in Self.configFileIncludeURLs(
+                in: contents,
+                parentDirectoryURL: url.deletingLastPathComponent(),
+                homeDirectoryURL: homeDirectoryURL
+            ) where isRegularFile(at: includeURL) {
+                let beforeCount = urls.count
+                append(includeURL)
+                if urls.count > beforeCount {
+                    queue.append(includeURL)
+                }
+            }
+        }
+    }
+
+    private func isRegularFile(at url: URL) -> Bool {
+        if isDirectRegularFile(at: url) {
+            return true
+        }
+        guard let destination = try? fileManager.destinationOfSymbolicLink(atPath: url.path) else {
+            return false
+        }
+        let destinationURL: URL
+        if destination.hasPrefix("/") {
+            destinationURL = URL(fileURLWithPath: destination)
+        } else {
+            destinationURL = url.deletingLastPathComponent().appendingPathComponent(destination)
+        }
+        return isDirectRegularFile(at: destinationURL.standardizedFileURL.resolvingSymlinksInPath())
+    }
+
+    private func isDirectRegularFile(at url: URL) -> Bool {
+        guard let attributes = try? fileManager.attributesOfItem(atPath: url.path),
+              let type = attributes[.type] as? FileAttributeType else {
+            return false
+        }
+        return type == .typeRegular
+    }
+
+    private static func configFileIncludeURLs(
+        in contents: String,
+        parentDirectoryURL: URL,
+        homeDirectoryURL: URL
+    ) -> [URL] {
+        var urls: [URL] = []
+        for line in contents.components(separatedBy: .newlines) {
+            guard let entry = parsedGhosttyConfigEntry(from: line),
+                  entry.key == "config-file",
+                  var value = entry.value else {
+                continue
+            }
+
+            if value.isEmpty {
+                urls.removeAll()
+                continue
+            }
+            if !entry.valueWasQuoted, value.hasPrefix("?") {
+                value.removeFirst()
+            }
+            guard !value.isEmpty else { continue }
+
+            let expandedPath = expandTilde(in: value, homeDirectoryURL: homeDirectoryURL)
+            let includeURL: URL
+            if (expandedPath as NSString).isAbsolutePath {
+                includeURL = URL(fileURLWithPath: expandedPath, isDirectory: false)
+            } else {
+                includeURL = parentDirectoryURL.appendingPathComponent(expandedPath, isDirectory: false)
+            }
+            urls.append(includeURL.standardizedFileURL)
+        }
+        return urls
+    }
+
+    private static func parsedGhosttyConfigEntry(
+        from rawLine: String
+    ) -> (key: String, value: String?, valueWasQuoted: Bool)? {
+        var trimmed = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.hasPrefix("\u{FEFF}") {
+            trimmed.removeFirst()
+        }
+        if trimmed.isEmpty || trimmed.hasPrefix("#") { return nil }
+
+        guard let separatorIndex = trimmed.firstIndex(of: "=") else {
+            return (trimmed.trimmingCharacters(in: .whitespacesAndNewlines), nil, false)
+        }
+
+        let key = trimmed[..<separatorIndex].trimmingCharacters(in: .whitespacesAndNewlines)
+        var value = trimmed[trimmed.index(after: separatorIndex)...]
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let valueWasQuoted = value.count >= 2 && value.hasPrefix("\"") && value.hasSuffix("\"")
+
+        if valueWasQuoted {
+            value.removeFirst()
+            value.removeLast()
+        }
+
+        return (String(key), String(value), valueWasQuoted)
+    }
+
+    private static func expandTilde(in path: String, homeDirectoryURL: URL) -> String {
+        guard path == "~" || path.hasPrefix("~/") else {
+            return NSString(string: path).expandingTildeInPath
+        }
+        let homePath = homeDirectoryURL.path
+        if path == "~" {
+            return homePath
+        }
+        return (homePath as NSString).appendingPathComponent(String(path.dropFirst(2)))
+    }
 }

--- a/Sources/Settings/ConfigSource.swift
+++ b/Sources/Settings/ConfigSource.swift
@@ -75,14 +75,12 @@ struct ConfigSourceEnvironment {
 
     func materializedGhosttySettingsEditorURLs() throws -> [URL] {
         let cmuxURL = try materializeCmuxConfigFileIfNeeded()
-        let syncedSnapshot = ConfigSource.synced.snapshot(environment: self)
 
         var collector = GhosttySettingsConfigFileCollector(
             fileManager: fileManager,
             homeDirectoryURL: homeDirectoryURL
         )
         collector.append(cmuxURL)
-        collector.append(syncedSnapshot.primaryURL)
 
         for url in standaloneGhosttyDisplayCandidates where isRegularFile(at: url) {
             collector.append(url)

--- a/Sources/Settings/ConfigSource.swift
+++ b/Sources/Settings/ConfigSource.swift
@@ -404,6 +404,9 @@ private struct GhosttySettingsConfigFileCollector {
                   var value = entry.value else {
                 continue
             }
+            if !entry.valueWasQuoted {
+                value = strippingInlineComment(from: value)
+            }
 
             if value.isEmpty {
                 urls.removeAll()
@@ -424,6 +427,30 @@ private struct GhosttySettingsConfigFileCollector {
             urls.append(includeURL.standardizedFileURL)
         }
         return urls
+    }
+
+    private static func strippingInlineComment(from value: String) -> String {
+        var result = ""
+        var isEscaped = false
+
+        for character in value {
+            if isEscaped {
+                result.append(character)
+                isEscaped = false
+                continue
+            }
+            if character == "\\" {
+                result.append(character)
+                isEscaped = true
+                continue
+            }
+            if character == "#" {
+                break
+            }
+            result.append(character)
+        }
+
+        return result.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     private static func parsedGhosttyConfigEntry(

--- a/cmuxTests/GhosttyConfigPathResolverTests.swift
+++ b/cmuxTests/GhosttyConfigPathResolverTests.swift
@@ -463,7 +463,7 @@ final class GhosttyConfigPathResolverTests: XCTestCase {
             let standaloneConfigURL = ghosttyDirectory.appendingPathComponent("config", isDirectory: false)
             try """
             font-size = 14
-            config-file = includes/font.conf
+            config-file = includes/font.conf # shared font config
             config-file = ?missing.conf
             """.write(to: standaloneConfigURL, atomically: true, encoding: .utf8)
 

--- a/cmuxTests/GhosttyConfigPathResolverTests.swift
+++ b/cmuxTests/GhosttyConfigPathResolverTests.swift
@@ -412,7 +412,7 @@ final class GhosttyConfigPathResolverTests: XCTestCase {
         }
     }
 
-    func testGhosttySettingsEditorURLsMaterializeCmuxConfigAndPreviewWhenNoConfigExists() throws {
+    func testGhosttySettingsEditorURLsMaterializeCmuxConfigWhenNoConfigExists() throws {
         try withTemporaryHomeDirectory { homeDirectory in
             let environment = ConfigSourceEnvironment(
                 homeDirectoryURL: homeDirectory,
@@ -429,9 +429,9 @@ final class GhosttyConfigPathResolverTests: XCTestCase {
                 .deletingLastPathComponent()
                 .appendingPathComponent("config.synced-preview", isDirectory: false)
 
-            XCTAssertEqual(urls.map(\.path), [expectedConfigURL.path, expectedPreviewURL.path])
+            XCTAssertEqual(urls.map(\.path), [expectedConfigURL.path])
             XCTAssertTrue(FileManager.default.fileExists(atPath: expectedConfigURL.path))
-            XCTAssertTrue(FileManager.default.fileExists(atPath: expectedPreviewURL.path))
+            XCTAssertFalse(FileManager.default.fileExists(atPath: expectedPreviewURL.path))
         }
     }
 
@@ -487,15 +487,10 @@ final class GhosttyConfigPathResolverTests: XCTestCase {
             )
 
             let urls = try environment.materializedGhosttySettingsEditorURLs()
-            let previewURL = cmuxConfigURL
-                .deletingLastPathComponent()
-                .appendingPathComponent("config.synced-preview", isDirectory: false)
-
             XCTAssertEqual(
                 urls.map(\.path),
                 [
                     cmuxConfigURL.path,
-                    previewURL.path,
                     standaloneConfigURL.path,
                     ghosttyAppSupportConfigURL.path,
                     cmuxIncludeURL.path,

--- a/cmuxTests/GhosttyConfigPathResolverTests.swift
+++ b/cmuxTests/GhosttyConfigPathResolverTests.swift
@@ -412,6 +412,99 @@ final class GhosttyConfigPathResolverTests: XCTestCase {
         }
     }
 
+    func testGhosttySettingsEditorURLsMaterializeCmuxConfigAndPreviewWhenNoConfigExists() throws {
+        try withTemporaryHomeDirectory { homeDirectory in
+            let environment = ConfigSourceEnvironment(
+                homeDirectoryURL: homeDirectory,
+                currentBundleIdentifier: "com.cmuxterm.app.debug.empty"
+            )
+
+            let urls = try environment.materializedGhosttySettingsEditorURLs()
+            let expectedConfigURL = homeDirectory
+                .appendingPathComponent("Library", isDirectory: true)
+                .appendingPathComponent("Application Support", isDirectory: true)
+                .appendingPathComponent("com.cmuxterm.app.debug.empty", isDirectory: true)
+                .appendingPathComponent("config.ghostty", isDirectory: false)
+            let expectedPreviewURL = expectedConfigURL
+                .deletingLastPathComponent()
+                .appendingPathComponent("config.synced-preview", isDirectory: false)
+
+            XCTAssertEqual(urls.map(\.path), [expectedConfigURL.path, expectedPreviewURL.path])
+            XCTAssertTrue(FileManager.default.fileExists(atPath: expectedConfigURL.path))
+            XCTAssertTrue(FileManager.default.fileExists(atPath: expectedPreviewURL.path))
+        }
+    }
+
+    func testGhosttySettingsEditorURLsIncludeStandaloneAppSupportAndRecursiveConfigFiles() throws {
+        try withTemporaryHomeDirectory { homeDirectory in
+            let fileManager = FileManager.default
+            let appSupportDirectory = homeDirectory
+                .appendingPathComponent("Library", isDirectory: true)
+                .appendingPathComponent("Application Support", isDirectory: true)
+
+            let bundleIdentifier = "com.cmuxterm.app.debug.includes"
+            let cmuxConfigURL = try writeAppSupportConfig(
+                appSupportDirectory: appSupportDirectory,
+                bundleIdentifier: bundleIdentifier,
+                filename: "config.ghostty",
+                contents: "theme = cmux\nconfig-file = cmux-include.conf\n"
+            )
+            let cmuxIncludeURL = cmuxConfigURL
+                .deletingLastPathComponent()
+                .appendingPathComponent("cmux-include.conf", isDirectory: false)
+            try "font-size = 16\n".write(to: cmuxIncludeURL, atomically: true, encoding: .utf8)
+
+            let ghosttyDirectory = homeDirectory
+                .appendingPathComponent(".config", isDirectory: true)
+                .appendingPathComponent("ghostty", isDirectory: true)
+            let ghosttyIncludeDirectory = ghosttyDirectory.appendingPathComponent("includes", isDirectory: true)
+            try fileManager.createDirectory(at: ghosttyIncludeDirectory, withIntermediateDirectories: true)
+
+            let standaloneConfigURL = ghosttyDirectory.appendingPathComponent("config", isDirectory: false)
+            try """
+            font-size = 14
+            config-file = includes/font.conf
+            config-file = ?missing.conf
+            """.write(to: standaloneConfigURL, atomically: true, encoding: .utf8)
+
+            let standaloneIncludeURL = ghosttyIncludeDirectory.appendingPathComponent("font.conf", isDirectory: false)
+            try "font-family = Test\n".write(to: standaloneIncludeURL, atomically: true, encoding: .utf8)
+
+            let ghosttyAppSupportDirectory = appSupportDirectory
+                .appendingPathComponent("com.mitchellh.ghostty", isDirectory: true)
+            try fileManager.createDirectory(at: ghosttyAppSupportDirectory, withIntermediateDirectories: true)
+            let ghosttyAppSupportConfigURL = ghosttyAppSupportDirectory
+                .appendingPathComponent("config.ghostty", isDirectory: false)
+            try "background = #101010\n".write(
+                to: ghosttyAppSupportConfigURL,
+                atomically: true,
+                encoding: .utf8
+            )
+
+            let environment = ConfigSourceEnvironment(
+                homeDirectoryURL: homeDirectory,
+                currentBundleIdentifier: bundleIdentifier
+            )
+
+            let urls = try environment.materializedGhosttySettingsEditorURLs()
+            let previewURL = cmuxConfigURL
+                .deletingLastPathComponent()
+                .appendingPathComponent("config.synced-preview", isDirectory: false)
+
+            XCTAssertEqual(
+                urls.map(\.path),
+                [
+                    cmuxConfigURL.path,
+                    previewURL.path,
+                    standaloneConfigURL.path,
+                    ghosttyAppSupportConfigURL.path,
+                    cmuxIncludeURL.path,
+                    standaloneIncludeURL.path,
+                ]
+            )
+        }
+    }
+
     private func withTemporaryAppSupportDirectory(
         _ body: (URL) throws -> Void
     ) throws {


### PR DESCRIPTION
Summary:
- Adds an Open Ghostty Settings in TextEdit command to Cmd+Shift+P.
- Reuses the existing Ghostty settings menu action so the menu and palette open the same set of files.
- Opens source Ghostty config files only: the materialized cmux config, existing Ghostty config files, and recursive config-file includes in TextEdit. Generated sync previews are excluded.

Testing:
- git diff --check
- plutil -convert json -o /tmp/cmux-localizable-check.json Resources/Localizable.xcstrings
- ./scripts/reload.sh --tag ghostcfg
- GitHub Actions PR checks

Dogfood:
- Build tag: ghostcfg
- Open Cmd+Shift+P, run Open Ghostty Settings in TextEdit, and verify TextEdit opens every relevant source config file without opening config.synced-preview.

Demo Video:
- Not included. This is a command palette and TextEdit launch flow, and the tagged build is available for dogfood.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new filesystem-scanning logic to collect and open multiple Ghostty config files (including recursive `config-file` includes), which could affect what gets opened and has edge cases around symlinks/paths.
> 
> **Overview**
> Adds a new Command Palette action, **`Open Ghostty Settings in TextEdit`**, with localized title/subtitle, and wires it to the existing Ghostty settings open flow.
> 
> Updates the TextEdit launch to open *all relevant source Ghostty config files* (materialized cmux config, discovered Ghostty config locations, and recursively included `config-file` targets) while avoiding generated previews, with new tests covering URL collection and include resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0c1a600618b191b9d3a42c4133bcf9b0a11a053. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* New Command Palette command to quickly open and edit Ghostty settings directly in TextEdit
* Enhanced configuration support for managing multiple configuration files and nested includes

## Localization
* Added English and Japanese translations for the Ghostty settings command

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4654?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->