### PR TITLE
Stop bundling example sidebars in the app

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2,7 +2,6 @@ import AppKit
 import Bonsplit
 import Combine
 import CmuxExtensionKit
-import CmuxExtensionSidebarExamples
 import ImageIO
 import Observation
 import SwiftUI
@@ -9374,7 +9373,7 @@ enum CmuxExtensionSidebarSelection {
     static let defaultProviderId = CmuxExtensionSidebarProviderID.defaultWorkspaces
 
     static var providers: [any CmuxExtensionSidebarProvider] {
-        SidebarExamples.providers
+        []
     }
 
     static var descriptors: [CmuxExtensionSidebarProviderDescriptor] {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -9982,12 +9982,6 @@ struct VerticalTabsSidebar: View {
                 ) { _ in
                 refreshExtensionSidebarSnapshot()
             }
-            .onReceive(
-                NotificationCenter.default.publisher(for: BrowserStackSidebar.stateDidLoadNotification)
-                    .receive(on: RunLoop.main)
-            ) { _ in
-                refreshExtensionSidebarSnapshot()
-            }
         }
     }
 

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -102,7 +102,6 @@
 		5EDB6027B346C46521A93C74 /* CMUXAuthCore in Frameworks */ = {isa = PBXBuildFile; productRef = 29813FE5A6CBC1019289A251 /* CMUXAuthCore */; };
 		AA11BB22CC33DD44EE550001 /* CMUXWorkstream in Frameworks */ = {isa = PBXBuildFile; productRef = AA11BB22CC33DD44EE550002 /* CMUXWorkstream */; };
 		C0DE45000000000000000001 /* CmuxExtensionKit in Frameworks */ = {isa = PBXBuildFile; productRef = C0DE45000000000000000002 /* CmuxExtensionKit */; };
-		C0DE46000000000000000001 /* CmuxExtensionSidebarExamples in Frameworks */ = {isa = PBXBuildFile; productRef = C0DE46000000000000000002 /* CmuxExtensionSidebarExamples */; };
 		3069F1D10000000000000005 /* CMUXPasteboardFidelity in Frameworks */ = {isa = PBXBuildFile; productRef = 3069F1D10000000000000006 /* CMUXPasteboardFidelity */; };
 		F53000A0A1B2C3D4E5F60718 /* CMUXAgentVault in Frameworks */ = {isa = PBXBuildFile; productRef = F53000A2A1B2C3D4E5F60718 /* CMUXAgentVault */; };
 		A5B00003A1B2C3D4E5F60718 /* CMUXAgentLaunch in Frameworks */ = {isa = PBXBuildFile; productRef = A5B00002A1B2C3D4E5F60718 /* CMUXAgentLaunch */; };
@@ -1079,7 +1078,6 @@
 				5EDB6027B346C46521A93C74 /* CMUXAuthCore in Frameworks */,
 				AA11BB22CC33DD44EE550001 /* CMUXWorkstream in Frameworks */,
 				C0DE45000000000000000001 /* CmuxExtensionKit in Frameworks */,
-				C0DE46000000000000000001 /* CmuxExtensionSidebarExamples in Frameworks */,
 				3069F1D10000000000000005 /* CMUXPasteboardFidelity in Frameworks */,
 				F53000A0A1B2C3D4E5F60718 /* CMUXAgentVault in Frameworks */,
 				A5B00003A1B2C3D4E5F60718 /* CMUXAgentLaunch in Frameworks */,
@@ -1721,7 +1719,6 @@
 				29813FE5A6CBC1019289A251 /* CMUXAuthCore */,
 				AA11BB22CC33DD44EE550002 /* CMUXWorkstream */,
 				C0DE45000000000000000002 /* CmuxExtensionKit */,
-				C0DE46000000000000000002 /* CmuxExtensionSidebarExamples */,
 				3069F1D10000000000000006 /* CMUXPasteboardFidelity */,
 				F53000A2A1B2C3D4E5F60718 /* CMUXAgentVault */,
 				A5B00002A1B2C3D4E5F60718 /* CMUXAgentLaunch */,
@@ -1855,7 +1852,6 @@
 				40B63BB4A170F0BD2D1DEFD1 /* XCLocalSwiftPackageReference "CMUXAuthCore" */,
 				AA11BB22CC33DD44EE550003 /* XCLocalSwiftPackageReference "CMUXWorkstream" */,
 				C0DE45000000000000000003 /* XCLocalSwiftPackageReference "CmuxExtensionKit" */,
-				C0DE46000000000000000003 /* XCLocalSwiftPackageReference "CmuxExtensionSidebarExamples" */,
 				3069F1D10000000000000007 /* XCLocalSwiftPackageReference "CMUXPasteboardFidelity" */,
 				F53000A1A1B2C3D4E5F60718 /* XCLocalSwiftPackageReference "CMUXAgentVault" */,
 				A5B00001A1B2C3D4E5F60718 /* XCLocalSwiftPackageReference "CMUXAgentLaunch" */,
@@ -2887,10 +2883,6 @@
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/CmuxExtensionKit;
 		};
-		C0DE46000000000000000003 /* XCLocalSwiftPackageReference "CmuxExtensionSidebarExamples" */ = {
-			isa = XCLocalSwiftPackageReference;
-			relativePath = Examples/CmuxExtensionSidebarExamples;
-		};
 		3069F1D10000000000000007 /* XCLocalSwiftPackageReference "CMUXPasteboardFidelity" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/CMUXPasteboardFidelity;
@@ -2967,11 +2959,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = C0DE45000000000000000003 /* XCLocalSwiftPackageReference "CmuxExtensionKit" */;
 			productName = CmuxExtensionKit;
-		};
-		C0DE46000000000000000002 /* CmuxExtensionSidebarExamples */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = C0DE46000000000000000003 /* XCLocalSwiftPackageReference "CmuxExtensionSidebarExamples" */;
-			productName = CmuxExtensionSidebarExamples;
 		};
 		3069F1D10000000000000006 /* CMUXPasteboardFidelity */ = {
 			isa = XCSwiftPackageProductDependency;


### PR DESCRIPTION
## Summary

The sidebar picker shipped six toy example providers (project worktrees, attention queue, dev server, last prompt, super compact, browser stack) that demoed the `CmuxExtensionSidebarProvider` API. They weren't real features. Dropped from the app target so the picker only shows the default workspaces sidebar.

`Examples/CmuxExtensionSidebarExamples/` stays in the repo as a buildable Swift package — kept as reference material for users authoring their own provider. Just no longer linked into the app.

This is the first of two PRs. The second will add docs for vibecoding your own sidebar (beta) and a right-click "Open docs" item on the sidebar picker chip.

## Test plan

- [ ] Open the sidebar picker → only "Default Workspaces" appears
- [ ] Sidebar still renders workspaces correctly
- [ ] Build succeeds (Xcode no longer pulls in the Examples package)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4662"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782129936&installation_id=133855650&pr_number=4662&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4662&signature=62b7e4602fe310798ccedac8a3bf39630f4ab1c87807303e2ab14b607774df05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes a single NotificationCenter trigger for refreshing the extension sidebar snapshot, reducing redundant updates without touching core rendering or data flows.
> 
> **Overview**
> Stops listening for `BrowserStackSidebar.stateDidLoadNotification` to trigger `refreshExtensionSidebarSnapshot()` in `ContentView`, leaving sidebar refreshes driven only by the existing immediate and debounced observation publishers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43f3f0669ecd9d14adf7358668e27944e69b4444. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the toy example sidebars from the app so the picker only shows the Default Workspaces sidebar. Also removed a leftover `BrowserStackSidebar` notification listener to fix the build after dropping the examples.

- **Dependencies**
  - Removed `CmuxExtensionSidebarExamples` from the app target and Xcode project; kept sources under `Examples/CmuxExtensionSidebarExamples/` as a buildable package.

- **Bug Fixes**
  - Dropped the unused `BrowserStackSidebar.stateDidLoadNotification` subscription in `ContentView` (it was only posted by the removed examples).

<sup>Written for commit 43f3f0669ecd9d14adf7358668e27944e69b4444. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4662?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed sidebar example providers from the extension configuration and updated framework dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4662?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->