### PR TITLE
Fix sidebar fade overlap

### DIFF
--- a/Sources/WindowChromeMetrics.swift
+++ b/Sources/WindowChromeMetrics.swift
@@ -39,7 +39,7 @@ enum SidebarWorkspaceListMetrics {
     }
 }
 
-struct SidebarWorkspaceScrollInsets: Equatable {
+nonisolated struct SidebarWorkspaceScrollInsets: Sendable, Equatable {
     static let workspaceList = SidebarWorkspaceScrollInsets(
         top: SidebarWorkspaceListMetrics.scrollTopInset,
         bottom: SidebarWorkspaceListMetrics.bottomScrimHeight

--- a/Sources/WindowChromeMetrics.swift
+++ b/Sources/WindowChromeMetrics.swift
@@ -31,8 +31,8 @@ enum RightSidebarChromeMetrics {
 enum SidebarWorkspaceListMetrics {
     static let firstRowTopOffset: CGFloat = MinimalModeChromeMetrics.titlebarHeight + 2
     static let rowVerticalPadding: CGFloat = 8
-    static let topScrimHeight: CGFloat = firstRowTopOffset + 20
-    static let bottomScrimHeight: CGFloat = topScrimHeight
+    static let topScrimHeight: CGFloat = firstRowTopOffset
+    static let bottomScrimHeight: CGFloat = firstRowTopOffset + 20
 
     static var scrollTopInset: CGFloat {
         max(0, firstRowTopOffset - rowVerticalPadding)

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -430,6 +430,7 @@
 		C1ADE00002A1B2C3D4E5F719 /* claude in Copy CLI */ = {isa = PBXBuildFile; fileRef = C1ADE00001A1B2C3D4E5F719 /* claude */; };
 		C1ADE10002A1B2C3D4E5F719 /* grok in Copy CLI */ = {isa = PBXBuildFile; fileRef = C1ADE10001A1B2C3D4E5F719 /* grok */; };
 		C2577000A1B2C3D4E5F60718 /* TerminalCmdClickUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2577001A1B2C3D4E5F60718 /* TerminalCmdClickUITests.swift */; };
+		4671A0000000000000000001 /* SidebarWorkspaceListMetricsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4671A0000000000000000002 /* SidebarWorkspaceListMetricsTests.swift */; };
 		CA39C0304FE351A21C372429 /* SidebarWidthPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0171AF1F49F7547191CEE5 /* SidebarWidthPolicyTests.swift */; };
 		CB23911D7E131E8FBC9B82B6 /* SidebarOrderingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC39DE4B96D1931C52AF7D68 /* SidebarOrderingTests.swift */; };
 		D0E0F0B0A1B2C3D4E5F60718 /* BrowserPaneNavigationKeybindUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0E0F0B1A1B2C3D4E5F60718 /* BrowserPaneNavigationKeybindUITests.swift */; };
@@ -1008,6 +1009,7 @@
 		DA7A10CA710E000000000002 /* InfoPlist.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
 		E1000001A1B2C3D4E5F60718 /* MenuKeyEquivalentRoutingUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuKeyEquivalentRoutingUITests.swift; sourceTree = "<group>"; };
 		E6FA9085A1B2C3D4E5F60718 /* WorkspaceDescriptionUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceDescriptionUITests.swift; sourceTree = "<group>"; };
+		4671A0000000000000000002 /* SidebarWorkspaceListMetricsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceListMetricsTests.swift; sourceTree = "<group>"; };
 		EE0171AF1F49F7547191CEE5 /* SidebarWidthPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWidthPolicyTests.swift; sourceTree = "<group>"; };
 		F1000002A1B2C3D4E5F60718 /* cmuxTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = cmuxTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		F1C1AA20B7E84D10A1C10001 /* InactivePaneFirstClickFocusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InactivePaneFirstClickFocusTests.swift; sourceTree = "<group>"; };
@@ -1653,6 +1655,7 @@
 				14A7DC53B9CA33BE2A421711 /* WorkspacePullRequestSidebarTests.swift */,
 				FEEDC0DEC0DEC0DEC0DE0002 /* FeedCoordinatorTests.swift */,
 				1D301919B10F22B8708E8883 /* WorkspaceManualUnreadTests.swift */,
+				4671A0000000000000000002 /* SidebarWorkspaceListMetricsTests.swift */,
 				EE0171AF1F49F7547191CEE5 /* SidebarWidthPolicyTests.swift */,
 				51D800000000000000000002 /* SidebarIdentifierFormattingTests.swift */,
 				C7A507000000000000000001 /* TaskManagerResourcesTests.swift */,
@@ -2449,6 +2452,7 @@
 				DCC935C5F55C1DCB33E25521 /* WorkspacePullRequestSidebarTests.swift in Sources */,
 				FEEDC0DEC0DEC0DEC0DE0001 /* FeedCoordinatorTests.swift in Sources */,
 				0F2C25F9170130F8DC09DD1B /* WorkspaceManualUnreadTests.swift in Sources */,
+				4671A0000000000000000001 /* SidebarWorkspaceListMetricsTests.swift in Sources */,
 				CA39C0304FE351A21C372429 /* SidebarWidthPolicyTests.swift in Sources */,
 				51D800000000000000000001 /* SidebarIdentifierFormattingTests.swift in Sources */,
 				C7A507000000000000000002 /* TaskManagerResourcesTests.swift in Sources */,

--- a/cmuxTests/SidebarWidthPolicyTests.swift
+++ b/cmuxTests/SidebarWidthPolicyTests.swift
@@ -62,6 +62,21 @@ final class SidebarWidthPolicyTests: XCTestCase {
         XCTAssertFalse(range.contains(675.9))
         XCTAssertFalse(range.contains(686.1))
     }
+
+    func testSidebarTopScrimDoesNotFadeFirstWorkspaceRow() {
+        let firstRowTop = SidebarWorkspaceScrollInsets.workspaceList.top
+            + SidebarWorkspaceListMetrics.rowVerticalPadding
+
+        XCTAssertEqual(
+            firstRowTop,
+            SidebarWorkspaceListMetrics.firstRowTopOffset,
+            accuracy: 0.001
+        )
+        XCTAssertLessThanOrEqual(
+            SidebarWorkspaceListMetrics.topScrimHeight,
+            firstRowTop
+        )
+    }
 }
 
 final class SidebarWorkspaceSelectionColorTests: XCTestCase {

--- a/cmuxTests/SidebarWidthPolicyTests.swift
+++ b/cmuxTests/SidebarWidthPolicyTests.swift
@@ -62,21 +62,6 @@ final class SidebarWidthPolicyTests: XCTestCase {
         XCTAssertFalse(range.contains(675.9))
         XCTAssertFalse(range.contains(686.1))
     }
-
-    func testSidebarTopScrimDoesNotFadeFirstWorkspaceRow() {
-        let firstRowTop = SidebarWorkspaceScrollInsets.workspaceList.top
-            + SidebarWorkspaceListMetrics.rowVerticalPadding
-
-        XCTAssertEqual(
-            firstRowTop,
-            SidebarWorkspaceListMetrics.firstRowTopOffset,
-            accuracy: 0.001
-        )
-        XCTAssertLessThanOrEqual(
-            SidebarWorkspaceListMetrics.topScrimHeight,
-            firstRowTop
-        )
-    }
 }
 
 final class SidebarWorkspaceSelectionColorTests: XCTestCase {

--- a/cmuxTests/SidebarWorkspaceListMetricsTests.swift
+++ b/cmuxTests/SidebarWorkspaceListMetricsTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+final class SidebarWorkspaceListMetricsTests: XCTestCase {
+    func testTopScrimDoesNotFadeFirstWorkspaceRow() {
+        let firstRowTop = SidebarWorkspaceScrollInsets.workspaceList.top
+            + SidebarWorkspaceListMetrics.rowVerticalPadding
+
+        XCTAssertEqual(
+            firstRowTop,
+            SidebarWorkspaceListMetrics.firstRowTopOffset,
+            accuracy: 0.001
+        )
+        XCTAssertEqual(
+            SidebarWorkspaceListMetrics.topScrimHeight,
+            firstRowTop,
+            accuracy: 0.001
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Stop the sidebar's top scroll-edge fade at the first workspace row boundary so the selected row background is not faded.
- Keep the existing bottom scroll-edge fade length unchanged.
- Add two-commit regression coverage so CI can show the test before the fix.

## Testing
- `git diff --check`
- `CMUX_SKIP_ZIG_BUILD=1 xcodebuild test -project cmux.xcodeproj -scheme cmux-unit -destination 'platform=macOS' -derivedDataPath /tmp/cmux-sidebar-fade-test -only-testing:cmuxTests/SidebarWidthPolicyTests` — passed, 7 tests.
- `CMUX_SKIP_ZIG_BUILD=1 ./scripts/reload.sh --tag sidebar-fade --launch` — built the tagged debug app successfully.
- Manual validation: launched `cmux DEV sidebar-fade.app`, selected a top visible workspace row in dark and light appearances, and confirmed the selected row stays solid instead of being faded by the top scroll scrim.

## Problem Screenshots
Dark mode problem:

<img width="800" alt="Gradient blur spilling over selected workspace tab in dark mode" src="https://github.com/jaytel0/cmux/releases/download/pr-4671-screenshots/gradient-blur-spill-dark.png">

Light mode problem:

<img width="800" alt="Gradient blur spilling over selected workspace tab in light mode" src="https://github.com/jaytel0/cmux/releases/download/pr-4671-screenshots/gradient-blur-spill-light.png">

## Confirmed Validation Screenshots
Dark mode fixed:

<img width="600" alt="Validated fix in dark mode: selected workspace row is solid and no longer faded at the top edge" src="https://github.com/jaytel0/cmux/releases/download/pr-4671-screenshots/sidebar-fade-fixed-dark.png">

Light mode fixed:

<img width="600" alt="Validated fix in light mode: selected workspace row is solid and no longer faded at the top edge" src="https://github.com/jaytel0/cmux/releases/download/pr-4671-screenshots/sidebar-fade-fixed-light.png">

## Demo Video
- Not recorded; before/after screenshots above show the visual regression and the validated fixed state.

## Checklist
- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (deferred while this PR is draft)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4671"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782148627&installation_id=133855650&pr_number=4671&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4671&signature=aabc28f50c1e458d4de57af8cbb1b5854898ae5d8ae60deb982e557374ab2651"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the sidebar’s top fade at the first workspace row so the selected row isn’t dimmed. Keeps the bottom fade length at `firstRowTopOffset + 20`, adds `SidebarWorkspaceListMetricsTests` to lock in the geometry, and marks `SidebarWorkspaceScrollInsets` as `nonisolated` and `Sendable`.

<sup>Written for commit 662faff1db8794d030e1563b147602ca7724e401. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4671?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted sidebar scrim heights so the top fade aligns precisely with the first workspace row, preventing the fade from overlapping row content and improving visual consistency.

* **Tests**
  * Added unit tests to verify scrim height and workspace row spacing calculations to prevent regressions and ensure consistent sidebar rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4671?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->