### PR TITLE
feat(core): add Antigravity to RestorableAgentKind to fix relaunch restore

### DIFF
--- a/Sources/RestorableAgentTypes.swift
+++ b/Sources/RestorableAgentTypes.swift
@@ -28,6 +28,7 @@ enum RestorableAgentKind: Codable, Hashable, Sendable {
         .gemini,
         // Antigravity is registry-owned so the built-in Vault registration can be
         // overridden by project config while direct .antigravity values still encode.
+        .antigravity,
         .opencode,
         .rovodev,
         .hermesAgent,

--- a/Sources/RestorableAgentTypes.swift
+++ b/Sources/RestorableAgentTypes.swift
@@ -26,8 +26,6 @@ enum RestorableAgentKind: Codable, Hashable, Sendable {
         .amp,
         .cursor,
         .gemini,
-        // Antigravity is registry-owned so the built-in Vault registration can be
-        // overridden by project config while direct .antigravity values still encode.
         .antigravity,
         .opencode,
         .rovodev,


### PR DESCRIPTION
Fixes relaunch/restart restore for Antigravity sessions. Previously, Antigravity sessions were decoded without proper mapping support in RestorableAgentKind.allCases, causing custom registration mismatch errors that aborted relaunch restoration. Adding .antigravity to allCases resolves this fully.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4673"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782152447&installation_id=133855650&pr_number=4673&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4673&signature=5dc0961bb3d992cb15fe7a7109a1ffd20dce8bc6be5b8bb4d425f88527262aab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `.antigravity` to `RestorableAgentKind.allCases` so Antigravity sessions restore on relaunch. Also removes an obsolete registry-owned comment and fixes decode/registration mismatches when projects override the built‑in Vault registration.

<sup>Written for commit cf9845aa84b26ba506ca2a36b2036ec6c234d3c9. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4673?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Antigravity agents are now supported and available for restoration.
  * Antigravity will appear in agent selection lists and can be restored through existing restore flows, matching the behavior of other agent types without any changes required to user workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4673?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->