### PR TITLE
Fix nightly tag push auth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Validate GhosttyKit checksum verification
         run: ./tests/test_ci_ghosttykit_checksum_verification.sh
 
+      - name: Validate nightly tag push auth
+        run: ./tests/test_ci_nightly_tag_push_auth.sh
+
       - name: Validate release asset guard
         run: node scripts/release_asset_guard.test.js
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -567,12 +567,16 @@ jobs:
 
       - name: Move nightly tag to built commit
         if: needs.decide.outputs.should_publish == 'true' && steps.current_head_prebuild.outputs.still_current == 'true' && steps.current_head_postbuild.outputs.still_current == 'true'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag -f nightly "${{ needs.decide.outputs.head_sha }}"
-          git push origin refs/tags/nightly --force
+          AUTH_HEADER="$(printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64 | tr -d '\n')"
+          git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${AUTH_HEADER}" \
+            push origin refs/tags/nightly --force
 
       - name: Prune old nightly release assets
         if: needs.decide.outputs.should_publish == 'true' && steps.current_head_prebuild.outputs.still_current == 'true' && steps.current_head_postbuild.outputs.still_current == 'true'

--- a/tests/test_ci_nightly_tag_push_auth.sh
+++ b/tests/test_ci_nightly_tag_push_auth.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Guards the nightly tag update against checkout credential persistence changes.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+WORKFLOW_FILE="$ROOT_DIR/.github/workflows/nightly.yml"
+
+if ! awk '
+  /^      - name: Move nightly tag to built commit/ { in_step=1; next }
+  in_step && /^      - name:/ { in_step=0 }
+  in_step && /GITHUB_TOKEN: \$\{\{ github\.token \}\}/ { saw_token_env=1 }
+  in_step && /http\.https:\/\/github\.com\/\.extraheader=AUTHORIZATION: basic/ { saw_extraheader=1 }
+  in_step && /push origin refs\/tags\/nightly --force/ { saw_push=1 }
+  END { exit !(saw_token_env && saw_extraheader && saw_push) }
+' "$WORKFLOW_FILE"; then
+  echo "FAIL: nightly tag push must use explicit github.token auth"
+  exit 1
+fi
+
+echo "PASS: nightly tag push uses explicit github.token auth"


### PR DESCRIPTION
## Summary
- make the nightly tag update push with an explicit github.token auth header
- add a workflow guard for the nightly tag push auth path

## Test
- ./tests/test_ci_self_hosted_guard.sh && ./tests/test_ci_create_dmg_pinned.sh && ./tests/test_ci_unit_test_spm_retry.sh && ./tests/test_ci_scheme_testaction_debug.sh && ./tests/test_ci_ghosttykit_checksum_verification.sh && ./tests/test_ci_nightly_tag_push_auth.sh && node scripts/release_asset_guard.test.js && ./tests/test_ci_ghosttykit_checksum_present.sh && ./tests/test_ci_swift_warning_budget.sh && ./tests/test_ci_swift_file_length_budget.sh && ./tests/test_ci_auxiliary_window_close_shortcuts.sh && ./tests/test_ci_pbxproj_test_wiring.sh

Fixes nightly publish failure in https://github.com/manaflow-ai/cmux/actions/runs/26333137397.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4677"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782177569&installation_id=133855650&pr_number=4677&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4677&signature=72e6b2061a6b56b6f9b6bdc5b19a6120fd6a58963a6d3407a323bbc0c643496a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: limited to GitHub Actions workflow behavior for updating the `nightly` tag and a CI guard test; no product code or runtime paths are affected.
> 
> **Overview**
> Fixes nightly publishing by changing the `nightly.yml` “Move nightly tag to built commit” step to push the `nightly` tag using an explicit `github.token`-derived HTTP `extraheader` auth header instead of relying on persisted checkout credentials.
> 
> Adds a new workflow guard script (`tests/test_ci_nightly_tag_push_auth.sh`) and wires it into `ci.yml` to ensure the token env + extraheader-based push pattern remains in place.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 315658a2c4e33fee206c49cdf660daabd1e553b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes nightly publish failures by pushing the `nightly` tag with explicit `github.token` auth and adding a CI guard to prevent regressions.

- **Bug Fixes**
  - Use explicit `GITHUB_TOKEN` with a basic auth extraheader for `git push` of `refs/tags/nightly`.
  - Add `tests/test_ci_nightly_tag_push_auth.sh` and wire it into `ci.yml` to enforce the auth path.

<sup>Written for commit 315658a2c4e33fee206c49cdf660daabd1e553b3. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4677?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated guard tests to validate authentication configuration in the nightly release pipeline.

* **Chores**
  * Enhanced the nightly release workflow to use explicit token-based authentication and authorization headers when pushing release tags, improving security and auditability of automated releases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4677?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->