### PR TITLE
Fix nightly tag push duplicate Authorization header

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -574,9 +574,13 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag -f nightly "${{ needs.decide.outputs.head_sha }}"
-          AUTH_HEADER="$(printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64 | tr -d '\n')"
-          git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${AUTH_HEADER}" \
-            push origin refs/tags/nightly --force
+          # Push via a tokenized URL so we neither rely on the persisted
+          # checkout credentials (which intermittently fail with "Device not
+          # configured" on self-hosted runners) nor overlay a second
+          # Authorization header on top of them (which makes GitHub reject the
+          # push with `remote: Duplicate header: "Authorization"`).
+          git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            refs/tags/nightly --force
 
       - name: Prune old nightly release assets
         if: needs.decide.outputs.should_publish == 'true' && steps.current_head_prebuild.outputs.still_current == 'true' && steps.current_head_postbuild.outputs.still_current == 'true'

--- a/tests/test_ci_nightly_tag_push_auth.sh
+++ b/tests/test_ci_nightly_tag_push_auth.sh
@@ -1,5 +1,16 @@
 #!/usr/bin/env bash
-# Guards the nightly tag update against checkout credential persistence changes.
+# Guards the nightly tag update against regressions to the auth approach.
+#
+# History:
+# - Originally relied on actions/checkout-persisted credentials, which
+#   intermittently failed with `fatal: could not read Username for
+#   'https://github.com': Device not configured` on the self-hosted runner.
+# - Then overlaid a second Authorization header via `-c
+#   http.https://github.com/.extraheader=AUTHORIZATION: basic …`, which made
+#   GitHub reject the push with `remote: Duplicate header: "Authorization"`
+#   because the persisted extraheader was still in effect.
+# - Now pushes to an explicit tokenized URL so the push neither depends on
+#   persisted creds nor overlays a second Authorization header.
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
@@ -9,12 +20,16 @@ if ! awk '
   /^      - name: Move nightly tag to built commit/ { in_step=1; next }
   in_step && /^      - name:/ { in_step=0 }
   in_step && /GITHUB_TOKEN: \$\{\{ github\.token \}\}/ { saw_token_env=1 }
-  in_step && /http\.https:\/\/github\.com\/\.extraheader=AUTHORIZATION: basic/ { saw_extraheader=1 }
-  in_step && /push origin refs\/tags\/nightly --force/ { saw_push=1 }
-  END { exit !(saw_token_env && saw_extraheader && saw_push) }
+  in_step && /x-access-token:\$\{GITHUB_TOKEN\}@github\.com\/\$\{GITHUB_REPOSITORY\}\.git/ { saw_token_url=1 }
+  in_step && /refs\/tags\/nightly --force/ { saw_push=1 }
+  in_step && /\.extraheader=AUTHORIZATION/ { saw_extraheader=1 }
+  END {
+    if (saw_extraheader) exit 1
+    exit !(saw_token_env && saw_token_url && saw_push)
+  }
 ' "$WORKFLOW_FILE"; then
-  echo "FAIL: nightly tag push must use explicit github.token auth"
+  echo "FAIL: nightly tag push must use a tokenized https URL with github.token (no extraheader overlay)"
   exit 1
 fi
 
-echo "PASS: nightly tag push uses explicit github.token auth"
+echo "PASS: nightly tag push uses tokenized https URL with github.token"


### PR DESCRIPTION
The previous fix (https://github.com/manaflow-ai/cmux/pull/4677) overlaid a second `AUTHORIZATION: basic …` extraheader on top of the one persisted by actions/checkout, so GitHub rejected the push with `remote: Duplicate header: "Authorization"` and the nightly job failed at the `Move nightly tag to built commit` step (https://github.com/manaflow-ai/cmux/actions/runs/26348656060).

Switches the push to an explicit `https://x-access-token:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git` URL. That avoids both:

- the duplicate-Authorization failure from the overlay, and
- the original `fatal: could not read Username for 'https://github.com': Device not configured` failure (https://github.com/manaflow-ai/cmux/actions/runs/26333137397) that #4677 was trying to fix, since we no longer depend on the persisted checkout creds being usable at push time.

The workflow guard `tests/test_ci_nightly_tag_push_auth.sh` is updated to require the tokenized URL form and to reject any reintroduction of the `.extraheader=AUTHORIZATION` overlay.

## Test plan
- [x] `./tests/test_ci_nightly_tag_push_auth.sh` passes
- [ ] Next nightly run (or `gh workflow run nightly.yml -f force=true` after merge) successfully pushes `refs/tags/nightly`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 092c3c3d089d8e7c5a975fe87e5769d86fde901c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4693"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782186131&installation_id=133855650&pr_number=4693&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4693&signature=18bbd1b0882bf98ea44c133f4f3c83e134cdfebd222be1e079d6be74e0548562"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes nightly tag push failures by switching to a tokenized HTTPS remote using `GITHUB_TOKEN`, avoiding duplicate Authorization headers and the intermittent "Device not configured" error. Updates the guard test to enforce this approach.

- **Bug Fixes**
  - Push `refs/tags/nightly` via `https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git`.
  - Remove `http.https://github.com/.extraheader=AUTHORIZATION: basic …` overlay that conflicted with `actions/checkout`.
  - Update `tests/test_ci_nightly_tag_push_auth.sh` to require the tokenized URL and reject any `.extraheader` usage.

<sup>Written for commit 092c3c3d089d8e7c5a975fe87e5769d86fde901c. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4693?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security and reliability of the nightly tag push mechanism in the CI/CD pipeline.

* **Tests**
  * Updated automated tests to validate the updated nightly tag push approach.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4693?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->