### PR TITLE
fix(ssh): honor user-supplied ConnectTimeout in every ssh path; bump default 6 → 30s

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -7313,7 +7313,7 @@ struct CMUXCLI {
         )
         var parts: [String] = ["ssh"]
         if !hasSSHOptionKey(effectiveSSHOptions, key: "ConnectTimeout") {
-            parts += ["-o", "ConnectTimeout=6"]
+            parts += ["-o", "ConnectTimeout=30"]
         }
         if !hasSSHOptionKey(effectiveSSHOptions, key: "ServerAliveInterval") {
             parts += ["-o", "ServerAliveInterval=20"]

--- a/Sources/FileExplorerStore.swift
+++ b/Sources/FileExplorerStore.swift
@@ -545,18 +545,20 @@ final class ProcessSSHFileExplorerTransport: SSHFileExplorerTransport {
         return args
     }
 
+    // Mirrors the WorkspaceRemoteConfiguration/TerminalSSHSessionDetector helpers
+    // by treating any Unicode whitespace (not just space/tab) as a key/value
+    // separator. Worth keeping in sync if/when those copies get extracted into
+    // a shared SSH-option-parsing module (see PR discussion).
     private static func hasSSHOptionKey(_ options: [String], key: String) -> Bool {
         let loweredKey = key.lowercased()
-        for option in options {
-            let trimmed = option.trimmingCharacters(in: .whitespacesAndNewlines)
-            let separators: [Character] = ["=", " ", "\t"]
-            guard let idx = trimmed.firstIndex(where: { separators.contains($0) }) else {
-                if trimmed.lowercased() == loweredKey { return true }
-                continue
-            }
-            if trimmed[..<idx].lowercased() == loweredKey { return true }
+        return options.contains { option in
+            option
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .split(whereSeparator: { $0 == "=" || $0.isWhitespace })
+                .first
+                .map(String.init)?
+                .lowercased() == loweredKey
         }
-        return false
     }
 
     private static func runSSHListCommand(

--- a/Sources/FileExplorerStore.swift
+++ b/Sources/FileExplorerStore.swift
@@ -4,6 +4,27 @@ import Foundation
 import QuartzCore
 import SwiftUI
 
+/// Returns true when `options` already contains an SSH `-o`-style key=value
+/// (or `key value`) entry whose key matches `key` case-insensitively. Used by
+/// the file-explorer transport and `GitStatusProvider` to suppress cmux's
+/// injected default when the caller has already supplied the same option.
+///
+/// Mirrors the canonical copies in `WorkspaceRemoteConfiguration` and
+/// `TerminalSSHSessionDetector` (`$0 == "="` or `$0.isWhitespace` separator).
+/// Worth extracting into a shared `SSHOptionParsing` module — see PR #4713
+/// discussion.
+fileprivate func fileExplorerSSHOptionsContainKey(_ options: [String], key: String) -> Bool {
+    let loweredKey = key.lowercased()
+    return options.contains { option in
+        option
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .split(whereSeparator: { $0 == "=" || $0.isWhitespace })
+            .first
+            .map(String.init)?
+            .lowercased() == loweredKey
+    }
+}
+
 // MARK: - Explorer Visual Style
 
 enum FileExplorerStyle: Int, CaseIterable {
@@ -538,32 +559,11 @@ final class ProcessSSHFileExplorerTransport: SSHFileExplorerTransport {
         }
         // Batch mode, no TTY, connection timeout
         args += ["-o", "BatchMode=yes", "-T"]
-        if !hasSSHOptionKey(connection.sshOptions, key: "ConnectTimeout") {
+        if !fileExplorerSSHOptionsContainKey(connection.sshOptions, key: "ConnectTimeout") {
             args += ["-o", "ConnectTimeout=30"]
         }
         args += [connection.destination, command]
         return args
-    }
-
-    /// Returns true when `options` already contains an SSH `-o`-style key=value
-    /// (or `key value`) entry whose key matches `key` case-insensitively. Used
-    /// to suppress cmux's injected default when the caller has already supplied
-    /// the same option.
-    ///
-    /// Kept in sync with the canonical copies in
-    /// `WorkspaceRemoteConfiguration` and `TerminalSSHSessionDetector`
-    /// (`$0 == "="` or `$0.isWhitespace` separator). Worth extracting into a
-    /// shared `SSHOptionParsing` module — see PR #4713 discussion.
-    private static func hasSSHOptionKey(_ options: [String], key: String) -> Bool {
-        let loweredKey = key.lowercased()
-        return options.contains { option in
-            option
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-                .split(whereSeparator: { $0 == "=" || $0.isWhitespace })
-                .first
-                .map(String.init)?
-                .lowercased() == loweredKey
-        }
     }
 
     private static func runSSHListCommand(
@@ -1319,7 +1319,7 @@ enum GitStatusProvider {
         if let identityFile { args += ["-i", identityFile] }
         for option in sshOptions { args += ["-o", option] }
         args += ["-o", "BatchMode=yes", "-T"]
-        if !Self.hasSSHOptionKey(sshOptions, key: "ConnectTimeout") {
+        if !fileExplorerSSHOptionsContainKey(sshOptions, key: "ConnectTimeout") {
             args += ["-o", "ConnectTimeout=30"]
         }
         args += [destination, command]

--- a/Sources/FileExplorerStore.swift
+++ b/Sources/FileExplorerStore.swift
@@ -537,9 +537,26 @@ final class ProcessSSHFileExplorerTransport: SSHFileExplorerTransport {
             args += ["-o", option]
         }
         // Batch mode, no TTY, connection timeout
-        args += ["-o", "BatchMode=yes", "-o", "ConnectTimeout=5", "-T"]
+        args += ["-o", "BatchMode=yes", "-T"]
+        if !hasSSHOptionKey(connection.sshOptions, key: "ConnectTimeout") {
+            args += ["-o", "ConnectTimeout=30"]
+        }
         args += [connection.destination, command]
         return args
+    }
+
+    private static func hasSSHOptionKey(_ options: [String], key: String) -> Bool {
+        let loweredKey = key.lowercased()
+        for option in options {
+            let trimmed = option.trimmingCharacters(in: .whitespacesAndNewlines)
+            let separators: [Character] = ["=", " ", "\t"]
+            guard let idx = trimmed.firstIndex(where: { separators.contains($0) }) else {
+                if trimmed.lowercased() == loweredKey { return true }
+                continue
+            }
+            if trimmed[..<idx].lowercased() == loweredKey { return true }
+        }
+        return false
     }
 
     private static func runSSHListCommand(
@@ -1294,7 +1311,10 @@ enum GitStatusProvider {
         if let port { args += ["-p", String(port)] }
         if let identityFile { args += ["-i", identityFile] }
         for option in sshOptions { args += ["-o", option] }
-        args += ["-o", "BatchMode=yes", "-o", "ConnectTimeout=5", "-T"]
+        args += ["-o", "BatchMode=yes", "-T"]
+        if !Self.hasSSHOptionKey(sshOptions, key: "ConnectTimeout") {
+            args += ["-o", "ConnectTimeout=30"]
+        }
         args += [destination, command]
         process.arguments = args
         let pipe = Pipe()

--- a/Sources/FileExplorerStore.swift
+++ b/Sources/FileExplorerStore.swift
@@ -545,10 +545,15 @@ final class ProcessSSHFileExplorerTransport: SSHFileExplorerTransport {
         return args
     }
 
-    // Mirrors the WorkspaceRemoteConfiguration/TerminalSSHSessionDetector helpers
-    // by treating any Unicode whitespace (not just space/tab) as a key/value
-    // separator. Worth keeping in sync if/when those copies get extracted into
-    // a shared SSH-option-parsing module (see PR discussion).
+    /// Returns true when `options` already contains an SSH `-o`-style key=value
+    /// (or `key value`) entry whose key matches `key` case-insensitively. Used
+    /// to suppress cmux's injected default when the caller has already supplied
+    /// the same option.
+    ///
+    /// Kept in sync with the canonical copies in
+    /// `WorkspaceRemoteConfiguration` and `TerminalSSHSessionDetector`
+    /// (`$0 == "="` or `$0.isWhitespace` separator). Worth extracting into a
+    /// shared `SSHOptionParsing` module — see PR #4713 discussion.
     private static func hasSSHOptionKey(_ options: [String], key: String) -> Bool {
         let loweredKey = key.lowercased()
         return options.contains { option in

--- a/Sources/TerminalSSHSessionDetector.swift
+++ b/Sources/TerminalSSHSessionDetector.swift
@@ -123,9 +123,11 @@ struct DetectedSSHSession: Equatable {
     }
 
     private func scpArguments(localPath: String, remotePath: String) -> [String] {
-        var args: [String] = [
-            "-q",
-            "-o", "ConnectTimeout=6",
+        var args: [String] = ["-q"]
+        if !Self.hasSSHOptionKey(sshOptions, key: "ConnectTimeout") {
+            args += ["-o", "ConnectTimeout=30"]
+        }
+        args += [
             "-o", "ServerAliveInterval=20",
             "-o", "ServerAliveCountMax=2",
             "-o", "BatchMode=yes",
@@ -172,9 +174,11 @@ struct DetectedSSHSession: Equatable {
     }
 
     private func sshArguments(command: String) -> [String] {
-        var args: [String] = [
-            "-T",
-            "-o", "ConnectTimeout=6",
+        var args: [String] = ["-T"]
+        if !Self.hasSSHOptionKey(sshOptions, key: "ConnectTimeout") {
+            args += ["-o", "ConnectTimeout=30"]
+        }
+        args += [
             "-o", "ServerAliveInterval=20",
             "-o", "ServerAliveCountMax=2",
             "-o", "BatchMode=yes",

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -6503,8 +6503,11 @@ final class WorkspaceRemoteSessionController {
             }
             return normalizedSSHOptions(configuration.sshOptions)
         }()
-        var args: [String] = [
-            "-o", "ConnectTimeout=6",
+        var args: [String] = []
+        if !hasSSHOptionKey(effectiveSSHOptions, key: "ConnectTimeout") {
+            args += ["-o", "ConnectTimeout=30"]
+        }
+        args += [
             "-o", "ServerAliveInterval=20",
             "-o", "ServerAliveCountMax=2",
         ]

--- a/Sources/WorkspaceRemoteConfiguration.swift
+++ b/Sources/WorkspaceRemoteConfiguration.swift
@@ -155,7 +155,7 @@ nonisolated enum SSHPTYAttachStartupCommandBuilder {
         var arguments = ["ssh"]
         let options = sshOptionsWithRestoreControlDefaults(auth.sshOptions)
         if !hasSSHOptionKey(options, key: "ConnectTimeout") {
-            arguments += ["-o", "ConnectTimeout=6"]
+            arguments += ["-o", "ConnectTimeout=30"]
         }
         if !hasSSHOptionKey(options, key: "ServerAliveInterval") {
             arguments += ["-o", "ServerAliveInterval=20"]

--- a/Sources/WorkspaceRemoteSSHBatchCommandBuilder.swift
+++ b/Sources/WorkspaceRemoteSSHBatchCommandBuilder.swift
@@ -51,8 +51,11 @@ enum WorkspaceRemoteSSHBatchCommandBuilder {
 
     private static func batchArguments(configuration: WorkspaceRemoteConfiguration) -> [String] {
         let effectiveSSHOptions = backgroundSSHOptions(configuration.sshOptions)
-        var args: [String] = [
-            "-o", "ConnectTimeout=6",
+        var args: [String] = []
+        if !hasSSHOptionKey(effectiveSSHOptions, key: "ConnectTimeout") {
+            args += ["-o", "ConnectTimeout=30"]
+        }
+        args += [
             "-o", "ServerAliveInterval=20",
             "-o", "ServerAliveCountMax=2",
         ]

--- a/cmuxTests/WorkspaceRemoteConnectionTests.swift
+++ b/cmuxTests/WorkspaceRemoteConnectionTests.swift
@@ -2032,6 +2032,55 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
         XCTAssertTrue(arguments.contains(where: { $0 == "ControlPath /tmp/cmux-ssh-%C" || $0 == "ControlPath=/tmp/cmux-ssh-%C" }))
     }
 
+    func testDaemonTransportArgumentsInjectsDefaultConnectTimeoutWhenAbsent() {
+        let configuration = WorkspaceRemoteConfiguration(
+            destination: "cmux-macmini",
+            port: 2222,
+            identityFile: "/Users/test/.ssh/id_ed25519",
+            sshOptions: ["StrictHostKeyChecking=accept-new"],
+            localProxyPort: nil,
+            relayPort: nil,
+            relayID: nil,
+            relayToken: nil,
+            localSocketPath: nil,
+            terminalStartupCommand: nil
+        )
+
+        let arguments = WorkspaceRemoteSSHBatchCommandBuilder.daemonTransportArguments(
+            configuration: configuration,
+            remotePath: "/remote/cmuxd-remote"
+        )
+
+        XCTAssertTrue(arguments.contains("ConnectTimeout=30"))
+        XCTAssertFalse(arguments.contains(where: { $0.hasPrefix("ConnectTimeout=") && $0 != "ConnectTimeout=30" }))
+    }
+
+    func testDaemonTransportArgumentsHonorsUserConnectTimeoutOverride() {
+        let configuration = WorkspaceRemoteConfiguration(
+            destination: "cmux-macmini",
+            port: 2222,
+            identityFile: "/Users/test/.ssh/id_ed25519",
+            sshOptions: [
+                "ConnectTimeout=15",
+                "StrictHostKeyChecking=accept-new",
+            ],
+            localProxyPort: nil,
+            relayPort: nil,
+            relayID: nil,
+            relayToken: nil,
+            localSocketPath: nil,
+            terminalStartupCommand: nil
+        )
+
+        let arguments = WorkspaceRemoteSSHBatchCommandBuilder.daemonTransportArguments(
+            configuration: configuration,
+            remotePath: "/remote/cmuxd-remote"
+        )
+
+        XCTAssertTrue(arguments.contains("ConnectTimeout=15"))
+        XCTAssertFalse(arguments.contains("ConnectTimeout=30"))
+    }
+
     func testReverseRelayControlMasterArgumentsReuseConfiguredControlSocket() throws {
         let configuration = WorkspaceRemoteConfiguration(
             destination: "cmux-macmini",


### PR DESCRIPTION
Closes part of #4694.

## What

`cmux ssh <host>` defaults to `-o ConnectTimeout=6` (and `=5` in `FileExplorerStore`). Two of the eight call sites already guard with `hasSSHOptionKey`, so `cmux ssh --ssh-option ConnectTimeout=N` and ssh_config-equivalents wired through the URL request win there. The other six emit the value unconditionally, so the override is silently dropped on every other ssh code path.

This PR:

1. Adds the same `hasSSHOptionKey` guard to every unconditional `ConnectTimeout` emission. Touched files:
   - `Sources/Workspace.swift` (`sshCommonArguments`)
   - `Sources/WorkspaceRemoteSSHBatchCommandBuilder.swift` (`batchArguments`)
   - `Sources/TerminalSSHSessionDetector.swift` (`scpArguments`, `sshArguments`)
   - `Sources/FileExplorerStore.swift` (both private `sshArguments` helpers — also adds a local `hasSSHOptionKey` matching the pattern in the other files)
2. Bumps the default from 6s (and FileExplorer's 5s) to 30s. Also updates the conditional sites in `CLI/cmux.swift:baseSSHArguments` and `Sources/WorkspaceRemoteConfiguration.swift:sshForegroundAuthCommand` from 6 → 30 for consistency.

## Why 30s

- OpenSSH's own default is "no timeout" (TCP default, ~75s).
- 6s is shorter than the cold-start time of common proxy setups (jump hosts, IAP TCP tunnels, userspace WireGuard, Teleport, gcloud-style tunnels, etc.), so plain `cmux ssh <host>` fails on banner exchange where `ssh <host>` with the same config succeeds.
- 30s still fails far faster than OpenSSH's default for genuinely unreachable hosts, but accommodates legitimately slow proxies.
- Anyone wanting the old aggressive 6s can pass `--ssh-option ConnectTimeout=6` (which now actually works across every path) or set it in `~/.ssh/config` once the follow-up to respect ssh_config lands (#4694 item 1).

## Test

- Added two tests in `WorkspaceRemoteConnectionTests.swift`: one asserts the default `ConnectTimeout=30` is injected when the user supplies no override; the other asserts a user-supplied `ConnectTimeout=15` propagates through `daemonTransportArguments` and the default is not added.
- The other call sites use the identical helper pattern; covering each via test would require lifting several `private` helpers to `internal` for one assertion each and was scoped out.

## Not in this PR

Respecting `ConnectTimeout` from `~/.ssh/config` directly (#4694 item 1). That needs a `ssh -G <host>` probe plus caching and is a bigger change — happy to do it in a follow-up PR if you'd like.

---

Local build verified for the `cmux-cli` scheme only (full `cmux` / `cmux-unit` schemes need GhosttyKit set up, which I haven't done in this clone — CI will cover them).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4713"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782250733&installation_id=133855650&pr_number=4713&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4713&signature=8fe511583218d0776c2f4a9b3ed98ec30763e10d6ce2f92dc959f09d728d8277"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honor user-supplied ConnectTimeout across every SSH/SCP path and raise the default from 6s (5s in File Explorer) to 30s for more reliable connects behind slow proxies. This makes `--ssh-option ConnectTimeout=N` effective everywhere.

- **Bug Fixes**
  - Guard all SSH/SCP arg builders with `hasSSHOptionKey` so user `ConnectTimeout` wins.
  - Inject `ConnectTimeout=30` only when absent; aligns File Explorer and CLI defaults.
  - File Explorer and `GitStatusProvider` share a single `fileprivate` helper for SSH option parsing (split on `=` or any Unicode whitespace); fixes a compile error and matches other sites.
  - Added tests for default injection and user override.

<sup>Written for commit 89abec0a6fa95cfa643c1121da8610a749a23875. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4713?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Increased default SSH connection timeout from 6s to 30s to improve reliability on slower networks.
  * Improved detection and handling of user-provided SSH options so an explicit ConnectTimeout is preserved.
* **Tests**
  * Added tests validating default injection and preservation of user-specified SSH ConnectTimeout.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4713?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->