### PR TITLE
Annotate SSHFileExplorerTransport async methods with @concurrent

### DIFF
--- a/Sources/FileExplorerStore.swift
+++ b/Sources/FileExplorerStore.swift
@@ -269,7 +269,13 @@ struct SSHFileExplorerConnection: Equatable, Sendable {
 }
 
 protocol SSHFileExplorerTransport: AnyObject {
+    #if compiler(>=6.2)
+    @concurrent
+    #endif
     nonisolated func resolveHomePath(connection: SSHFileExplorerConnection) async throws -> String
+    #if compiler(>=6.2)
+    @concurrent
+    #endif
     nonisolated func listDirectory(
         path: String,
         connection: SSHFileExplorerConnection,
@@ -408,6 +414,9 @@ final class SSHFileExplorerProvider: FileExplorerProvider, @unchecked Sendable {
 final class ProcessSSHFileExplorerTransport: SSHFileExplorerTransport {
     static let shared = ProcessSSHFileExplorerTransport()
 
+    #if compiler(>=6.2)
+    @concurrent
+    #endif
     nonisolated func resolveHomePath(connection: SSHFileExplorerConnection) async throws -> String {
         let output = try await Self.runSSHCommand(
             connection: connection,
@@ -416,6 +425,9 @@ final class ProcessSSHFileExplorerTransport: SSHFileExplorerTransport {
         return output.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    #if compiler(>=6.2)
+    @concurrent
+    #endif
     nonisolated func listDirectory(
         path: String,
         connection: SSHFileExplorerConnection,


### PR DESCRIPTION
CodeRabbit's `swift-concurrent-annotation` rule flagged that `SSHFileExplorerTransport.resolveHomePath` and `listDirectory` are `nonisolated async` funcs that lack the `@concurrent` annotation required by Swift 6's `NonisolatedNonsendingByDefault` behavior. Without it the methods can end up running on the caller's actor (typically `@MainActor` via `FileExplorerStore`), which is exactly what the rule is designed to catch — both impls do shell I/O (`Process` subprocess + pipe reads in `ProcessSSHFileExplorerTransport.runSSHCommand` / `runSSHListCommand`), the workload that motivated the rule.

This adds `@concurrent` to both the protocol declaration and the `ProcessSSHFileExplorerTransport` impl, guarded by `#if compiler(>=6.2)` to match the existing pattern used by `Sources/TabManager.swift` (`resolveWorkspacePullRequestCandidateSeeds` and `githubRepositorySlugs`), so the codebase still builds on Swift toolchains older than the one that introduced `@concurrent`.

Surfaced by CodeRabbit during review of #4713. Independent of that PR — different file regions, no overlap.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4715"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782257979&installation_id=133855650&pr_number=4715&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4715&signature=dd7ee529fb261109611d3350ca25509ac85118b7c72cbfd82b8f9ed33db792e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `@concurrent` to nonisolated async methods in `SSHFileExplorerTransport` and `ProcessSSHFileExplorerTransport` so SSH I/O doesn’t run on the caller’s actor in Swift 6. Wrap the annotations with `#if compiler(>=6.2)` to keep older toolchains building.

<sup>Written for commit c5625c5c52e735a317cc6a8275cab5ac78a853f7. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4715?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated concurrency compatibility for Swift 6.2+ to enhance code stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4715?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->