### PR TITLE
feat(cli): add resolveGrokExecutable helper (symmetric to claude/codex)

### DIFF
--- a/CLI/CMUXCLI+ExecutableResolution.swift
+++ b/CLI/CMUXCLI+ExecutableResolution.swift
@@ -131,7 +131,7 @@ extension CMUXCLI {
                FileManager.default.isExecutableFile(atPath: candidate),
                !isBundledProviderExecutable(at: candidate)
             {
-                return candidate
+                return URL(fileURLWithPath: candidate, isDirectory: false).standardizedFileURL.path
             }
         }
         let userHomeCandidate = NSString(string: "~/.grok/bin/grok").expandingTildeInPath
@@ -141,7 +141,7 @@ extension CMUXCLI {
            FileManager.default.isExecutableFile(atPath: userHomeCandidate),
            !isBundledProviderExecutable(at: userHomeCandidate)
         {
-            return userHomeCandidate
+            return URL(fileURLWithPath: userHomeCandidate, isDirectory: false).standardizedFileURL.path
         }
         return resolveExecutableInSearchPath("grok", searchPath: searchPath)
     }

--- a/CLI/CMUXCLI+ExecutableResolution.swift
+++ b/CLI/CMUXCLI+ExecutableResolution.swift
@@ -113,6 +113,39 @@ extension CMUXCLI {
         resolveExecutableInSearchPath("codex", searchPath: searchPath)
     }
 
+    func resolveGrokExecutable(searchPath: String?) -> String? {
+        // Prefer GROK_HOME/bin/grok when set (matches the AgentHookDef configDirEnvOverride),
+        // then the conventional ~/.grok/bin/grok symlink (what the installer creates),
+        // then fall back to grok in PATH.
+        if let grokHome = ProcessInfo.processInfo.environment["GROK_HOME"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+           !grokHome.isEmpty
+        {
+            let candidate = URL(fileURLWithPath: grokHome)
+                .appendingPathComponent("bin", isDirectory: true)
+                .appendingPathComponent("grok", isDirectory: false)
+                .path
+            var isDirectory: ObjCBool = false
+            if FileManager.default.fileExists(atPath: candidate, isDirectory: &isDirectory),
+               !isDirectory.boolValue,
+               FileManager.default.isExecutableFile(atPath: candidate),
+               !isBundledProviderExecutable(at: candidate)
+            {
+                return candidate
+            }
+        }
+        let userHomeCandidate = NSString(string: "~/.grok/bin/grok").expandingTildeInPath
+        var isDirectory: ObjCBool = false
+        if FileManager.default.fileExists(atPath: userHomeCandidate, isDirectory: &isDirectory),
+           !isDirectory.boolValue,
+           FileManager.default.isExecutableFile(atPath: userHomeCandidate),
+           !isBundledProviderExecutable(at: userHomeCandidate)
+        {
+            return userHomeCandidate
+        }
+        return resolveExecutableInSearchPath("grok", searchPath: searchPath)
+    }
+
     func providerExecutableSearchPath(searchPath: String?, includingExecutableAt executablePath: String? = nil) -> String {
         var directories = providerExecutableSearchDirectories(searchPath: searchPath)
         if let executablePath {


### PR DESCRIPTION
## Summary

Small follow-up polish after the main Grok Build hook integration.

The core support (the `AgentHookDef` for `grok` with `createConfigDirIfMissing: true`, `GROK_HOME` handling, `.grok/hooks/cmux-session.json`, nested hook format, and the event mappings for SessionStart / UserPromptSubmit / Stop / Notification / SessionEnd + PreToolUse feeding) landed previously.

This PR adds the matching executable resolver helper:

```swift
func resolveGrokExecutable(searchPath: String?) -> String?
```

It uses the same precedence the hook definitions expect:

1. `$GROK_HOME/bin/grok` (when the env override is set)
2. `~/.grok/bin/grok` (the standard symlink created by the official xAI installer)
3. `grok` anywhere in `$PATH`

This keeps the CLI consistent with the existing `resolveClaudeExecutable` (with its wrapper skip) and `resolveCodexExecutable` helpers.

## Context / Motivation

Users on cmux builds that predate the Grok hook definitions PR may still see:

```
cmux hooks setup grok
...
  grok: skipped (config dir not found)
```

(See `runSetupHooks` and the early `canUseMissingConfigDir` check in `CLI/cmux.swift`.)

Updating to a build containing the main Grok hook support (reportedly around 64.10) should resolve the primary symptom. This change is additional symmetry/polish on top.

## Test plan

- The change is a pure addition of a well-scoped helper (no behavior change to existing paths).
- Mirrors the structure and style of the sibling resolvers exactly.
- Will be exercised naturally once any Grok-specific launcher or advanced hook paths are added later.

## Related

- Core Grok hook support: the `AgentHookDef` entry + supporting hook generation / persistence code + tests in `CLIGenericHookPersistenceTests.swift`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4716"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782263160&installation_id=133855650&pr_number=4716&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4716&signature=c04e20114352230a4ac491c6c74f28353d473bdecb1d0c0cb8856c62f12d0af1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add and harden a `grok` executable resolver in the CLI, mirroring Claude/Codex, skipping bundled provider wrappers, and returning standardized absolute paths for consistent hook behavior.

- Prefer `$GROK_HOME/bin/grok` when set (trimmed; must be executable).
- Fallback to `~/.grok/bin/grok` (must be executable).
- Else resolve `grok` via `$PATH`.

<sup>Written for commit 784a2f7bb0c0685ec1fb66e067b6eb9a83a768f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4716?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved Grok executable resolution by checking, in order: an environment-based location, a user-directory location, and then the system search path.
  * Added validation to ensure the resolved path is an executable file and filters out bundled provider executables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->