### PR TITLE
feat: add preferred editor picker

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -47245,6 +47245,23 @@
         }
       }
     },
+    "menu.openInSublimeText": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Current Directory in Sublime Text"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在のディレクトリを Sublime Text で開く"
+          }
+        }
+      }
+    },
     "menu.openInTerminal": {
       "extractionState": "manual",
       "localizations": {
@@ -54671,6 +54688,57 @@
           "stringUnit": {
             "state": "translated",
             "value": "열기"
+          }
+        }
+      }
+    },
+    "settings.settingsJSON.openHint.customCommand": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opens with custom command: %@. Change in App → Open Files With."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "カスタムコマンド %@ で開きます。「App」→「ファイルを開くエディタ」で変更できます。"
+          }
+        }
+      }
+    },
+    "settings.settingsJSON.openHint.detectedEditor": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opens with %@. Change in App → Open Files With."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@で開きます。「App」→「ファイルを開くエディタ」で変更できます。"
+          }
+        }
+      }
+    },
+    "settings.settingsJSON.openHint.systemDefault": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opens with system default. Change in App → Open Files With."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "システム標準で開きます。「App」→「ファイルを開くエディタ」で変更できます。"
           }
         }
       }
@@ -111616,19 +111684,240 @@
         }
       }
     },
+    "settings.app.preferredEditor": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Files With"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ファイルを開くエディタ"
+          }
+        }
+      }
+    },
+    "settings.app.preferredEditor.custom.placeholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Editor command"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エディタコマンド"
+          }
+        }
+      }
+    },
+    "settings.app.preferredEditor.option.androidStudio": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Android Studio"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Android Studio"
+          }
+        }
+      }
+    },
+    "settings.app.preferredEditor.option.antigravity": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Antigravity"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Antigravity"
+          }
+        }
+      }
+    },
+    "settings.app.preferredEditor.option.cursor": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cursor"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cursor"
+          }
+        }
+      }
+    },
+    "settings.app.preferredEditor.option.custom": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Custom…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "カスタム…"
+          }
+        }
+      }
+    },
+    "settings.app.preferredEditor.option.intellij": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "IntelliJ IDEA"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "IntelliJ IDEA"
+          }
+        }
+      }
+    },
+    "settings.app.preferredEditor.option.sublimeText": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sublime Text"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sublime Text"
+          }
+        }
+      }
+    },
+    "settings.app.preferredEditor.option.systemDefault": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "System Default"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "システム標準"
+          }
+        }
+      }
+    },
+    "settings.app.preferredEditor.option.vscode": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VS Code"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VS Code"
+          }
+        }
+      }
+    },
+    "settings.app.preferredEditor.option.windsurf": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Windsurf"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Windsurf"
+          }
+        }
+      }
+    },
+    "settings.app.preferredEditor.option.xcode": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Xcode"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Xcode"
+          }
+        }
+      }
+    },
+    "settings.app.preferredEditor.option.zed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zed"
+          }
+        }
+      }
+    },
     "settings.app.preferredEditor.subtitle": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Command used when Cmd-click file previews are disabled or a file is unsupported. Leave empty for system default."
+            "value": "Choose an installed editor or enter a custom CLI command for files opened outside cmux."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Cmd+クリックのファイルプレビューが無効な場合、またはファイルが未対応の場合に使うコマンドです。空欄のままにするとシステムの既定で開きます。"
+            "value": "インストール済みのエディタを選択するか、cmux の外で開くファイルに使うカスタム CLI コマンドを入力します。"
           }
         }
       }

--- a/Sources/App/TerminalDirectoryOpenSupport.swift
+++ b/Sources/App/TerminalDirectoryOpenSupport.swift
@@ -103,10 +103,15 @@ enum TerminalDirectoryOpenTarget: String, CaseIterable {
 
     struct PreferredEditorOption: Identifiable, Hashable {
         let target: TerminalDirectoryOpenTarget
+        let command: String
 
         var id: String { target.rawValue }
-        var command: String { target.preferredEditorCommand ?? "" }
         var displayName: String { target.preferredEditorDisplayName }
+
+        fileprivate init(target: TerminalDirectoryOpenTarget, command: String) {
+            self.target = target
+            self.command = command
+        }
     }
 
     static var preferredEditorTargets: [Self] {
@@ -128,10 +133,10 @@ enum TerminalDirectoryOpenTarget: String, CaseIterable {
     ) -> [PreferredEditorOption] {
         preferredEditorTargets.compactMap { target in
             guard target.isAvailable(in: environment),
-                  target.preferredEditorCommand != nil else {
+                  let command = target.preferredEditorCommand else {
                 return nil
             }
-            return PreferredEditorOption(target: target)
+            return PreferredEditorOption(target: target, command: command)
         }
     }
 

--- a/Sources/App/TerminalDirectoryOpenSupport.swift
+++ b/Sources/App/TerminalDirectoryOpenSupport.swift
@@ -69,6 +69,7 @@ enum TerminalDirectoryOpenTarget: String, CaseIterable {
     case ghostty
     case intellij
     case iterm2
+    case sublimeText
     case terminal
     case tower
     case vscode
@@ -100,6 +101,40 @@ enum TerminalDirectoryOpenTarget: String, CaseIterable {
         Set(commandPaletteShortcutTargets.filter { $0.isAvailable(in: environment) })
     }
 
+    struct PreferredEditorOption: Identifiable, Hashable {
+        let target: TerminalDirectoryOpenTarget
+
+        var id: String { target.rawValue }
+        var command: String { target.preferredEditorCommand ?? "" }
+        var displayName: String { target.preferredEditorDisplayName }
+    }
+
+    static var preferredEditorTargets: [Self] {
+        [
+            .cursor,
+            .vscode,
+            .zed,
+            .sublimeText,
+            .windsurf,
+            .xcode,
+            .intellij,
+            .androidStudio,
+            .antigravity,
+        ]
+    }
+
+    static func availablePreferredEditorOptions(
+        in environment: DetectionEnvironment = .live
+    ) -> [PreferredEditorOption] {
+        preferredEditorTargets.compactMap { target in
+            guard target.isAvailable(in: environment),
+                  target.preferredEditorCommand != nil else {
+                return nil
+            }
+            return PreferredEditorOption(target: target)
+        }
+    }
+
     var commandPaletteCommandId: String {
         "palette.terminalOpenDirectory.\(rawValue)"
     }
@@ -120,6 +155,8 @@ enum TerminalDirectoryOpenTarget: String, CaseIterable {
             return String(localized: "menu.openInIntelliJ", defaultValue: "Open Current Directory in IntelliJ IDEA")
         case .iterm2:
             return String(localized: "menu.openInITerm2", defaultValue: "Open Current Directory in iTerm2")
+        case .sublimeText:
+            return String(localized: "menu.openInSublimeText", defaultValue: "Open Current Directory in Sublime Text")
         case .terminal:
             return String(localized: "menu.openInTerminal", defaultValue: "Open Current Directory in Terminal")
         case .tower:
@@ -156,6 +193,8 @@ enum TerminalDirectoryOpenTarget: String, CaseIterable {
             return common + ["intellij", "idea", "jetbrains"]
         case .iterm2:
             return common + ["iterm", "iterm2", "terminal", "shell"]
+        case .sublimeText:
+            return common + ["sublime", "subl", "text", "editor"]
         case .terminal:
             return common + ["terminal", "shell"]
         case .tower:
@@ -254,6 +293,8 @@ enum TerminalDirectoryOpenTarget: String, CaseIterable {
                 "/Applications/iTerm.app",
                 "/Applications/iTerm2.app",
             ]
+        case .sublimeText:
+            return ["/Applications/Sublime Text.app"]
         case .terminal:
             return ["/System/Applications/Utilities/Terminal.app"]
         case .tower:
@@ -280,6 +321,56 @@ enum TerminalDirectoryOpenTarget: String, CaseIterable {
                 "/Applications/Zed Preview.app",
                 "/Applications/Zed Nightly.app",
             ]
+        }
+    }
+
+    var preferredEditorCommand: String? {
+        switch self {
+        case .androidStudio:
+            return "studio"
+        case .antigravity:
+            return "antigravity"
+        case .cursor:
+            return "cursor"
+        case .intellij:
+            return "idea"
+        case .sublimeText:
+            return "subl"
+        case .vscode:
+            return "code"
+        case .windsurf:
+            return "windsurf"
+        case .xcode:
+            return "xed"
+        case .zed:
+            return "zed"
+        case .finder, .ghostty, .iterm2, .terminal, .tower, .vscodeInline, .warp:
+            return nil
+        }
+    }
+
+    var preferredEditorDisplayName: String {
+        switch self {
+        case .androidStudio:
+            return String(localized: "settings.app.preferredEditor.option.androidStudio", defaultValue: "Android Studio")
+        case .antigravity:
+            return String(localized: "settings.app.preferredEditor.option.antigravity", defaultValue: "Antigravity")
+        case .cursor:
+            return String(localized: "settings.app.preferredEditor.option.cursor", defaultValue: "Cursor")
+        case .intellij:
+            return String(localized: "settings.app.preferredEditor.option.intellij", defaultValue: "IntelliJ IDEA")
+        case .sublimeText:
+            return String(localized: "settings.app.preferredEditor.option.sublimeText", defaultValue: "Sublime Text")
+        case .vscode:
+            return String(localized: "settings.app.preferredEditor.option.vscode", defaultValue: "VS Code")
+        case .windsurf:
+            return String(localized: "settings.app.preferredEditor.option.windsurf", defaultValue: "Windsurf")
+        case .xcode:
+            return String(localized: "settings.app.preferredEditor.option.xcode", defaultValue: "Xcode")
+        case .zed:
+            return String(localized: "settings.app.preferredEditor.option.zed", defaultValue: "Zed")
+        case .finder, .ghostty, .iterm2, .terminal, .tower, .vscodeInline, .warp:
+            return commandPaletteTitle
         }
     }
 

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -4978,6 +4978,14 @@ enum CmdClickSupportedFileRouteSettings {
 
 enum PreferredEditorSettings {
     static let key = "preferredEditorCommand"
+    static let systemDefaultSelectionID = "system-default"
+    static let customSelectionID = "custom"
+
+    enum UsageDescription: Equatable {
+        case systemDefault
+        case detectedEditor(displayName: String)
+        case customCommand(String)
+    }
 
     /// Returns the configured editor command, or nil to use system default.
     static func resolvedCommand(defaults: UserDefaults = .standard) -> String? {
@@ -4986,6 +4994,73 @@ enum PreferredEditorSettings {
             return nil
         }
         return stored
+    }
+
+    static func detectedEditorOptions(
+        in environment: TerminalDirectoryOpenTarget.DetectionEnvironment = .live
+    ) -> [TerminalDirectoryOpenTarget.PreferredEditorOption] {
+        TerminalDirectoryOpenTarget.availablePreferredEditorOptions(in: environment)
+    }
+
+    static func selectionID(
+        for command: String,
+        editorOptions: [TerminalDirectoryOpenTarget.PreferredEditorOption]
+    ) -> String {
+        let trimmed = command.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return systemDefaultSelectionID }
+        return editorOptions.first { $0.command == trimmed }?.id ?? customSelectionID
+    }
+
+    static func command(
+        forSelectionID selectionID: String,
+        editorOptions: [TerminalDirectoryOpenTarget.PreferredEditorOption]
+    ) -> String? {
+        if selectionID == systemDefaultSelectionID {
+            return ""
+        }
+        if selectionID == customSelectionID {
+            return nil
+        }
+        return editorOptions.first { $0.id == selectionID }?.command
+    }
+
+    static func usageDescription(
+        command: String?,
+        editorOptions: [TerminalDirectoryOpenTarget.PreferredEditorOption]
+    ) -> UsageDescription {
+        guard let trimmed = command?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else {
+            return .systemDefault
+        }
+        if let option = editorOptions.first(where: { $0.command == trimmed }) {
+            return .detectedEditor(displayName: option.displayName)
+        }
+        return .customCommand(trimmed)
+    }
+
+    static func usageHintText(
+        command: String?,
+        editorOptions: [TerminalDirectoryOpenTarget.PreferredEditorOption]
+    ) -> String {
+        switch usageDescription(command: command, editorOptions: editorOptions) {
+        case .systemDefault:
+            return String(
+                localized: "settings.settingsJSON.openHint.systemDefault",
+                defaultValue: "Opens with system default. Change in App → Open Files With."
+            )
+        case .detectedEditor(let displayName):
+            let format = String(
+                localized: "settings.settingsJSON.openHint.detectedEditor",
+                defaultValue: "Opens with %@. Change in App → Open Files With."
+            )
+            return String.localizedStringWithFormat(format, displayName)
+        case .customCommand(let command):
+            let format = String(
+                localized: "settings.settingsJSON.openHint.customCommand",
+                defaultValue: "Opens with custom command: %@. Change in App → Open Files With."
+            )
+            return String.localizedStringWithFormat(format, command)
+        }
     }
 
     /// Open a file path with the user's preferred editor, falling back to system default.
@@ -5211,6 +5286,8 @@ struct SettingsView: View {
     @AppStorage(TelemetrySettings.sendAnonymousTelemetryKey)
     private var sendAnonymousTelemetry = TelemetrySettings.defaultSendAnonymousTelemetry
     @AppStorage(PreferredEditorSettings.key) private var preferredEditorCommand = ""
+    @State private var preferredEditorOptions = PreferredEditorSettings.detectedEditorOptions()
+    @State private var preferredEditorForcesCustomSelection = false
     @AppStorage(CmdClickSupportedFileRouteSettings.key)
     private var openSupportedFilesInCmux = CmdClickSupportedFileRouteSettings.defaultValue
     @AppStorage(CmdClickMarkdownRouteSettings.key) private var openMarkdownInCmuxViewer = CmdClickMarkdownRouteSettings.defaultValue
@@ -5595,6 +5672,65 @@ struct SettingsView: View {
                 BrowserAvailabilitySettings.setDisabled(!newValue)
                 browserDisabled = !newValue
             }
+        )
+    }
+
+    private var preferredEditorSelectionBinding: Binding<String> {
+        Binding(
+            get: {
+                if preferredEditorForcesCustomSelection {
+                    return PreferredEditorSettings.customSelectionID
+                }
+                return PreferredEditorSettings.selectionID(
+                    for: preferredEditorCommand,
+                    editorOptions: preferredEditorOptions
+                )
+            },
+            set: { selectionID in
+                if selectionID == PreferredEditorSettings.customSelectionID {
+                    preferredEditorForcesCustomSelection = true
+                    if PreferredEditorSettings.selectionID(
+                        for: preferredEditorCommand,
+                        editorOptions: preferredEditorOptions
+                    ) != PreferredEditorSettings.customSelectionID {
+                        preferredEditorCommand = ""
+                    }
+                    return
+                }
+
+                preferredEditorForcesCustomSelection = false
+                guard let command = PreferredEditorSettings.command(
+                    forSelectionID: selectionID,
+                    editorOptions: preferredEditorOptions
+                ) else {
+                    return
+                }
+                preferredEditorCommand = command
+            }
+        )
+    }
+
+    private var preferredEditorCustomCommandBinding: Binding<String> {
+        Binding(
+            get: { preferredEditorCommand },
+            set: { newValue in
+                preferredEditorForcesCustomSelection = true
+                preferredEditorCommand = newValue
+            }
+        )
+    }
+
+    private var shouldShowPreferredEditorCustomCommand: Bool {
+        preferredEditorForcesCustomSelection || PreferredEditorSettings.selectionID(
+            for: preferredEditorCommand,
+            editorOptions: preferredEditorOptions
+        ) == PreferredEditorSettings.customSelectionID
+    }
+
+    private var preferredEditorUsageHintText: String {
+        PreferredEditorSettings.usageHintText(
+            command: preferredEditorCommand,
+            editorOptions: preferredEditorOptions
         )
     }
 
@@ -6288,14 +6424,35 @@ struct SettingsView: View {
                         SettingsCardRow(
                             configurationReview: .json("app.preferredEditor"),
                             String(localized: "settings.app.preferredEditor", defaultValue: "Open Files With"),
-                            subtitle: String(localized: "settings.app.preferredEditor.subtitle", defaultValue: "Command used when Cmd-click file previews are disabled or a file is unsupported. Leave empty for system default.")
+                            subtitle: String(localized: "settings.app.preferredEditor.subtitle", defaultValue: "Choose an installed editor or enter a custom CLI command for files opened outside cmux."),
+                            controlWidth: 260
                         ) {
-                            TextField(
-                                String(localized: "settings.app.preferredEditor.placeholder", defaultValue: "e.g. code, zed, subl"),
-                                text: $preferredEditorCommand
-                            )
-                            .textFieldStyle(.roundedBorder)
-                            .frame(width: 200)
+                            VStack(alignment: .trailing, spacing: 6) {
+                                Picker("", selection: preferredEditorSelectionBinding) {
+                                    Text(String(localized: "settings.app.preferredEditor.option.systemDefault", defaultValue: "System Default"))
+                                        .tag(PreferredEditorSettings.systemDefaultSelectionID)
+                                    ForEach(preferredEditorOptions) { option in
+                                        Text(option.displayName).tag(option.id)
+                                    }
+                                    Text(String(localized: "settings.app.preferredEditor.option.custom", defaultValue: "Custom…"))
+                                        .tag(PreferredEditorSettings.customSelectionID)
+                                }
+                                .labelsHidden()
+                                .pickerStyle(.menu)
+                                .frame(width: 220)
+                                .accessibilityIdentifier("SettingsPreferredEditorPicker")
+
+                                if shouldShowPreferredEditorCustomCommand {
+                                    TextField(
+                                        String(localized: "settings.app.preferredEditor.custom.placeholder", defaultValue: "Editor command"),
+                                        text: preferredEditorCustomCommandBinding
+                                    )
+                                    .textFieldStyle(.roundedBorder)
+                                    .font(.system(.body, design: .monospaced))
+                                    .frame(width: 220)
+                                    .accessibilityIdentifier("SettingsPreferredEditorCustomCommandField")
+                                }
+                            }
                         }
 
                         SettingsCardDivider()
@@ -7743,20 +7900,30 @@ struct SettingsView: View {
                             controlWidth: 330,
                             searchAnchorID: SettingsSearchIndex.settingID(for: .settingsJSON, idSuffix: "open-file")
                         ) {
-                            HStack(spacing: 8) {
-                                Text(KeyboardShortcutSettings.settingsFileStore.settingsFileDisplayPath())
-                                    .font(.system(size: 11, weight: .medium, design: .monospaced))
-                                    .foregroundStyle(.secondary)
-                                    .lineLimit(1)
-                                    .truncationMode(.middle)
-                                    .frame(maxWidth: .infinity, alignment: .trailing)
+                            VStack(alignment: .trailing, spacing: 3) {
+                                HStack(spacing: 8) {
+                                    Text(KeyboardShortcutSettings.settingsFileStore.settingsFileDisplayPath())
+                                        .font(.system(size: 11, weight: .medium, design: .monospaced))
+                                        .foregroundStyle(.secondary)
+                                        .lineLimit(1)
+                                        .truncationMode(.middle)
+                                        .frame(maxWidth: .infinity, alignment: .trailing)
 
-                                Button(String(localized: "settings.settingsJSON.openButton", defaultValue: "Open")) {
-                                    openCmuxSettingsFileInEditor()
+                                    Button(String(localized: "settings.settingsJSON.openButton", defaultValue: "Open")) {
+                                        openCmuxSettingsFileInEditor()
+                                    }
+                                    .buttonStyle(.bordered)
+                                    .controlSize(.small)
+                                    .accessibilityIdentifier("SettingsJSONOpenButton")
                                 }
-                                .buttonStyle(.bordered)
-                                .controlSize(.small)
-                                .accessibilityIdentifier("SettingsJSONOpenButton")
+
+                                Text(preferredEditorUsageHintText)
+                                    .font(.caption2)
+                                    .foregroundStyle(.secondary)
+                                    .lineLimit(2)
+                                    .multilineTextAlignment(.trailing)
+                                    .fixedSize(horizontal: false, vertical: true)
+                                    .accessibilityIdentifier("SettingsJSONPreferredEditorHint")
                             }
                             .accessibilityIdentifier("SettingsJSONOpenFileRowActions")
                         }
@@ -7812,6 +7979,7 @@ struct SettingsView: View {
             didLoadBrowserHistoryForSettings = BrowserHistoryStore.shared.isLoaded
             browserHistoryEntryCount = didLoadBrowserHistoryForSettings ? BrowserHistoryStore.shared.entries.count : 0
             browserInsecureHTTPAllowlistDraft = browserInsecureHTTPAllowlist
+            preferredEditorOptions = PreferredEditorSettings.detectedEditorOptions()
             reloadWorkspaceTabColorSettings()
             refreshNotificationCustomSoundStatus()
             let target = SettingsWindowPresenter.consumePendingContentNavigationTarget()

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -5689,12 +5689,6 @@ struct SettingsView: View {
             set: { selectionID in
                 if selectionID == PreferredEditorSettings.customSelectionID {
                     preferredEditorForcesCustomSelection = true
-                    if PreferredEditorSettings.selectionID(
-                        for: preferredEditorCommand,
-                        editorOptions: preferredEditorOptions
-                    ) != PreferredEditorSettings.customSelectionID {
-                        preferredEditorCommand = ""
-                    }
                     return
                 }
 
@@ -5714,7 +5708,7 @@ struct SettingsView: View {
         Binding(
             get: { preferredEditorCommand },
             set: { newValue in
-                preferredEditorForcesCustomSelection = true
+                preferredEditorForcesCustomSelection = !newValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                 preferredEditorCommand = newValue
             }
         )
@@ -8111,6 +8105,7 @@ struct SettingsView: View {
         geminiHooksEnabled = GeminiIntegrationSettings.defaultHooksEnabled
         sendAnonymousTelemetry = TelemetrySettings.defaultSendAnonymousTelemetry
         preferredEditorCommand = ""
+        preferredEditorForcesCustomSelection = false
         CmdClickSupportedFileRouteSettings.setEnabled(CmdClickSupportedFileRouteSettings.defaultValue)
         openSupportedFilesInCmux = CmdClickSupportedFileRouteSettings.defaultValue
         openMarkdownInCmuxViewer = CmdClickMarkdownRouteSettings.defaultValue

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -2042,6 +2042,121 @@ final class TerminalDirectoryOpenTargetAvailabilityTests: XCTestCase {
         XCTAssertFalse(targets.contains(where: { $0.commandPaletteTitle == "Open Current Directory in IDE" }))
         XCTAssertFalse(targets.contains(where: { $0.commandPaletteCommandId == "palette.terminalOpenDirectory" }))
     }
+
+    func testPreferredEditorOptionsReuseDetectedEditorTargetsAndMapToCommands() {
+        let env = environment(
+            existingPaths: [
+                "/Applications/Cursor.app",
+                "/Applications/Visual Studio Code.app",
+                "/Applications/Zed.app",
+                "/Applications/Sublime Text.app",
+                "/Applications/Ghostty.app",
+                "/System/Library/CoreServices/Finder.app",
+                "/System/Applications/Utilities/Terminal.app",
+            ]
+        )
+
+        let options = TerminalDirectoryOpenTarget.availablePreferredEditorOptions(in: env)
+
+        XCTAssertEqual(
+            options.map(\.target),
+            [.cursor, .vscode, .zed, .sublimeText]
+        )
+        XCTAssertEqual(
+            options.map(\.command),
+            ["cursor", "code", "zed", "subl"]
+        )
+    }
+
+    func testPreferredEditorOptionsSupportLaunchServicesFallback() {
+        let cursorPath = "/Volumes/Tools/Cursor.app"
+        let sublimePath = "/Volumes/Tools/Sublime Text.app"
+        let env = environment(
+            existingPaths: [cursorPath, sublimePath],
+            applicationPathsByName: [
+                "Cursor": cursorPath,
+                "Sublime Text": sublimePath,
+            ]
+        )
+
+        let options = TerminalDirectoryOpenTarget.availablePreferredEditorOptions(in: env)
+
+        XCTAssertEqual(options.map(\.target), [.cursor, .sublimeText])
+        XCTAssertEqual(options.map(\.command), ["cursor", "subl"])
+    }
+
+    func testPreferredEditorSelectionMapsDetectedEditorsToStoredCommands() {
+        let env = environment(
+            existingPaths: [
+                "/Applications/Visual Studio Code.app",
+                "/Applications/Zed.app",
+            ]
+        )
+        let options = TerminalDirectoryOpenTarget.availablePreferredEditorOptions(in: env)
+
+        XCTAssertEqual(
+            PreferredEditorSettings.selectionID(for: "", editorOptions: options),
+            PreferredEditorSettings.systemDefaultSelectionID
+        )
+        XCTAssertEqual(
+            PreferredEditorSettings.selectionID(for: " code ", editorOptions: options),
+            TerminalDirectoryOpenTarget.vscode.rawValue
+        )
+        XCTAssertEqual(
+            PreferredEditorSettings.command(
+                forSelectionID: TerminalDirectoryOpenTarget.zed.rawValue,
+                editorOptions: options
+            ),
+            "zed"
+        )
+        XCTAssertEqual(
+            PreferredEditorSettings.command(
+                forSelectionID: PreferredEditorSettings.systemDefaultSelectionID,
+                editorOptions: options
+            ),
+            ""
+        )
+        XCTAssertNil(
+            PreferredEditorSettings.command(
+                forSelectionID: PreferredEditorSettings.customSelectionID,
+                editorOptions: options
+            )
+        )
+    }
+
+    func testPreferredEditorSelectionTreatsUnknownCommandsAsCustom() {
+        let env = environment(existingPaths: ["/Applications/Visual Studio Code.app"])
+        let options = TerminalDirectoryOpenTarget.availablePreferredEditorOptions(in: env)
+
+        XCTAssertEqual(
+            PreferredEditorSettings.selectionID(for: "code --reuse-window", editorOptions: options),
+            PreferredEditorSettings.customSelectionID
+        )
+    }
+
+    func testPreferredEditorUsageDescriptionForSettingsJSONHint() throws {
+        let env = environment(
+            existingPaths: [
+                "/Applications/Cursor.app",
+                "/Applications/Visual Studio Code.app",
+            ]
+        )
+        let options = TerminalDirectoryOpenTarget.availablePreferredEditorOptions(in: env)
+        let cursorDisplayName = try XCTUnwrap(options.first { $0.target == .cursor }?.displayName)
+
+        XCTAssertEqual(
+            PreferredEditorSettings.usageDescription(command: "  ", editorOptions: options),
+            .systemDefault
+        )
+        XCTAssertEqual(
+            PreferredEditorSettings.usageDescription(command: "cursor", editorOptions: options),
+            .detectedEditor(displayName: cursorDisplayName)
+        )
+        XCTAssertEqual(
+            PreferredEditorSettings.usageDescription(command: "code --reuse-window", editorOptions: options),
+            .customCommand("code --reuse-window")
+        )
+    }
 }
 
 


### PR DESCRIPTION
## Summary
- replace the bare preferred editor command field with a picker backed by TerminalDirectoryOpenTarget detection
- keep preferredEditorCommand as the stored setting for system default, detected editor commands, and custom commands
- add a cmux.json settings hint that shows which editor will open the file

Fixes #4703

## Testing
- Added unit coverage for detected editor -> CLI command mapping, picker selection -> stored command mapping, and cmux.json hint classification in TerminalDirectoryOpenTargetAvailabilityTests.
- Did not run local tests, xcodebuild, or reload.sh per task instructions; CI is the verification path.
- SwiftUI picker wiring is not unit-tested because it is view integration around AppStorage/State and would be brittle without a UI harness.

## Compatibility
- Compatible with #2695 because the picker writes the same preferredEditorCommand value that PreferredEditorSettings.open(...) already reads.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4717"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782275315&installation_id=133855650&pr_number=4717&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4717&signature=26c642540bad5e2f338f165622ac0897fa48e204cd743c274f12caae34b31533"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and preference wiring only; stored key and `PreferredEditorSettings.open` behavior stay compatible.
> 
> **Overview**
> Replaces the **Open Files With** free-text field with a **menu picker** (System Default, auto-detected installed editors, or **Custom…** with a monospaced CLI field) while still persisting the same `preferredEditorCommand` value for existing open paths.
> 
> Editor detection and CLI mapping live on `TerminalDirectoryOpenTarget` (including new **Sublime Text** for “open current directory” and preferred-editor options). `PreferredEditorSettings` adds selection IDs, command resolution, and hint text; the **cmux.json** row shows which editor will open the config file.
> 
> Adds localization for the picker and hints, plus unit tests for detection, selection mapping, and hint classification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf1dfb0834c8f26c3669f654aea692946826921c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Preferred Editor picker in Settings that auto-detects installed editors and maps them to CLI commands. Keeps `preferredEditorCommand` for backward compatibility and shows which editor will open `cmux.json` (Fixes #4703).

- **New Features**
  - Detects popular editors (Cursor, VS Code, Zed, Sublime Text, Xcode, IntelliJ) via app paths or Launch Services; maps to CLI commands.
  - Supports System Default, detected editors, or a Custom… command with a monospaced field.
  - Persists selection by writing the resolved CLI to `preferredEditorCommand`.
  - Adds Sublime Text to “Open Current Directory in …”.
  - Adds unit tests for detection, selection ↔ command mapping, and hint text.

- **Bug Fixes**
  - Preserves Custom… selection when editing non-standard commands so it doesn’t reset to a detected editor.

<sup>Written for commit cf1dfb0834c8f26c3669f654aea692946826921c. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4717?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Sublime Text as a preferred editor option.
  * Replaced freeform editor field with a picker plus optional custom command input and live detection of installed editors.
  * Settings now show contextual hint text describing the configured editor usage.

* **Documentation**
  * English and Japanese localization added/updated for editor selection UI and related hints.

* **Tests**
  * Added unit tests covering preferred-editor detection, selection mapping, and hint generation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4717?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->