### PR TITLE
feat(vault): configurable session title policy for Claude Code

### DIFF
--- a/Sources/SessionIndexStore.swift
+++ b/Sources/SessionIndexStore.swift
@@ -648,13 +648,17 @@ final class SessionIndexStore: ObservableObject {
         return combined.sorted { $0.modified > $1.modified }
     }
 
-    private struct ClaudeParsed {
+    struct ClaudeParsed {
         var title: String = ""
         var cwd: String?
         var branch: String?
         var pr: PullRequestLink?
         var model: String?
         var permissionMode: String?
+        /// User-set title from `/name`. Highest precedence when present.
+        var customTitle: String?
+        /// Claude Code auto-generated title from the first turn.
+        var aiTitle: String?
     }
 
     private struct ClaudeSessionRoot: Hashable {
@@ -728,7 +732,12 @@ final class SessionIndexStore: ObservableObject {
         return roots
     }
 
-    nonisolated private static func extractClaudeMetadata(head: String, tail: String, projectDir: String) -> ClaudeParsed {
+    nonisolated static func extractClaudeMetadata(
+        head: String,
+        tail: String,
+        projectDir: String,
+        titlePolicy: CmuxVaultSessionTitlePolicy = .renameable
+    ) -> ClaudeParsed {
         var out = ClaudeParsed()
         out.cwd = decodeClaudeProjectDir(projectDir)
 
@@ -793,10 +802,39 @@ final class SessionIndexStore: ObservableObject {
                let model = message["model"] as? String, !model.isEmpty {
                 out.model = model
             }
+            // Claude Code writes session-level title metadata as standalone JSONL
+            // records near the end of the file. Capture the three known shapes
+            // so the sidebar reflects /name renames instead of stale first-line.
+            switch type {
+            case "custom-title":
+                if let t = (obj["customTitle"] as? String)?
+                    .trimmingCharacters(in: .whitespacesAndNewlines),
+                   !t.isEmpty {
+                    out.customTitle = t
+                }
+            case "ai-title":
+                if let t = (obj["aiTitle"] as? String)?
+                    .trimmingCharacters(in: .whitespacesAndNewlines),
+                   !t.isEmpty {
+                    out.aiTitle = t
+                }
+            default: break
+            }
         }
         // Strip the [1m] suffix some Claude internal model IDs carry (claude-opus-4-7[1m]).
         if let m = out.model, let bracket = m.firstIndex(of: "[") {
             out.model = String(m[..<bracket])
+        }
+        // Title precedence depends on policy. `.renameable` (default) honors the
+        // user's `/name` rename and the agent-generated title; `.firstMessageOnly`
+        // sticks with the first-user-message scrape from the head loop.
+        switch titlePolicy {
+        case .renameable:
+            if let override = out.customTitle ?? out.aiTitle {
+                out.title = override
+            }
+        case .firstMessageOnly:
+            break
         }
         return out
     }
@@ -1381,6 +1419,9 @@ final class SessionIndexStore: ObservableObject {
         let roots = claudeSessionRoots()
         guard !roots.isEmpty else { return [] }
         let fm = FileManager.default
+        let titlePolicy = CmuxVaultAgentRegistry
+            .loadBuiltInAgentConfigs(workingDirectory: cwdFilter)[CmuxVaultBuiltInAgentID.claudeCode]?
+            .sessionTitlePolicy ?? .renameable
 
         // Pre-filter via rg when we have a needle — rg is parallel, mmaps the
         // file, and scans the WHOLE file (not just our 128 KB head), so it both
@@ -1487,7 +1528,12 @@ final class SessionIndexStore: ObservableObject {
                             true
                         )
                     }
-                    let parsed = extractClaudeMetadata(head: head, tail: tail, projectDir: candidate.dirName)
+                    let parsed = extractClaudeMetadata(
+                        head: head,
+                        tail: tail,
+                        projectDir: candidate.dirName,
+                        titlePolicy: titlePolicy
+                    )
                     if let cwdFilter, parsed.cwd != cwdFilter { return (idx, nil, false) }
                     let sid = candidate.url.deletingPathExtension().lastPathComponent
                     let entry = SessionEntry(

--- a/Sources/VaultAgentRegistry.swift
+++ b/Sources/VaultAgentRegistry.swift
@@ -3,9 +3,39 @@ import OSLog
 
 struct CmuxVaultConfigDefinition: Codable, Hashable, Sendable {
     var agents: [CmuxVaultAgentRegistration]
+    /// Per-built-in-agent overrides keyed by canonical id (see `CmuxVaultBuiltInAgentID`).
+    /// Missing keys fall back to each built-in's defaults.
+    var builtIns: [String: CmuxVaultBuiltInAgentConfig]
 
-    init(agents: [CmuxVaultAgentRegistration] = []) {
+    init(
+        agents: [CmuxVaultAgentRegistration] = [],
+        builtIns: [String: CmuxVaultBuiltInAgentConfig] = [:]
+    ) {
         self.agents = agents
+        self.builtIns = builtIns
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.agents = try container.decodeIfPresent([CmuxVaultAgentRegistration].self, forKey: .agents) ?? []
+        let rawBuiltIns = try container.decodeIfPresent([String: CmuxVaultBuiltInAgentConfig].self, forKey: .builtIns) ?? [:]
+        var normalized: [String: CmuxVaultBuiltInAgentConfig] = [:]
+        for (rawKey, value) in rawBuiltIns {
+            guard let canonical = cmuxVaultBuiltInAgentID(forConfigKey: rawKey) else {
+                throw DecodingError.dataCorruptedError(
+                    forKey: .builtIns,
+                    in: container,
+                    debugDescription: "Unknown built-in agent key '\(rawKey)'"
+                )
+            }
+            normalized[canonical] = value
+        }
+        self.builtIns = normalized
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case agents
+        case builtIns
     }
 }
 
@@ -308,6 +338,67 @@ enum CmuxVaultAgentCWDPolicy: String, Codable, Hashable, Sendable {
     }
 }
 
+enum CmuxVaultSessionTitlePolicy: String, Codable, Hashable, Sendable {
+    /// User `/name` wins, then agent-generated title (e.g. Claude Code `ai-title`),
+    /// then first user message.
+    case renameable
+    /// Always use the first user message; ignore agent rename signals.
+    case firstMessageOnly
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let value = try container.decode(String.self).trimmingCharacters(in: .whitespacesAndNewlines)
+        switch value {
+        case "renameable": self = .renameable
+        case "firstMessageOnly", "firstMessage": self = .firstMessageOnly
+        default:
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Unknown Vault session title policy '\(value)'")
+            )
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
+}
+
+struct CmuxVaultBuiltInAgentConfig: Codable, Hashable, Sendable {
+    var sessionTitlePolicy: CmuxVaultSessionTitlePolicy
+
+    init(sessionTitlePolicy: CmuxVaultSessionTitlePolicy = .renameable) {
+        self.sessionTitlePolicy = sessionTitlePolicy
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let policy = try container.decodeIfPresent(CmuxVaultSessionTitlePolicy.self, forKey: .sessionTitlePolicy)
+        self.sessionTitlePolicy = policy ?? .renameable
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case sessionTitlePolicy
+    }
+}
+
+/// Canonical id strings for cmux-shipped agents referenced from `vault.builtIns`.
+enum CmuxVaultBuiltInAgentID {
+    static let claudeCode = "claude"
+}
+
+/// Normalize a built-in agent key as written in cmux.json to its canonical id.
+/// Mirrors `CmuxConfigAgentKind`'s tolerant decoder for Claude Code.
+func cmuxVaultBuiltInAgentID(forConfigKey key: String) -> String? {
+    let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
+    switch trimmed {
+    case "claude", "claude-code", "claudeCode":
+        return CmuxVaultBuiltInAgentID.claudeCode
+    default:
+        return nil
+    }
+}
+
 struct CmuxVaultAgentRegistry: Sendable {
     private static let logger = Logger(subsystem: "ai.manaflow.cmux", category: "VaultAgentRegistry")
 
@@ -362,6 +453,25 @@ struct CmuxVaultAgentRegistry: Sendable {
             registrations.append(contentsOf: config.vault?.agents ?? [])
         }
         return CmuxVaultAgentRegistry(registrations: registrations)
+    }
+
+    /// Merged `vault.builtIns` map across global + local cmux.json. Local entries win.
+    /// Returns canonical ids (see `CmuxVaultBuiltInAgentID`).
+    static func loadBuiltInAgentConfigs(
+        homeDirectory: String = NSHomeDirectory(),
+        workingDirectory: String? = nil,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        fileManager: FileManager = .default
+    ) -> [String: CmuxVaultBuiltInAgentConfig] {
+        var merged: [String: CmuxVaultBuiltInAgentConfig] = [:]
+        for path in configPaths(homeDirectory: homeDirectory, workingDirectory: workingDirectory, environment: environment, fileManager: fileManager) {
+            guard let config = decodeConfig(at: path, fileManager: fileManager),
+                  let builtIns = config.vault?.builtIns else { continue }
+            for (key, value) in builtIns {
+                merged[key] = value
+            }
+        }
+        return merged
     }
 
     private static func configPaths(

--- a/cmuxTests/SessionIndexViewTests.swift
+++ b/cmuxTests/SessionIndexViewTests.swift
@@ -56,6 +56,65 @@ final class SessionIndexViewTests: XCTestCase {
         )
     }
 
+    func testRenameableTitlePolicyHonorsCustomTitleOverFirstMessage() {
+        // Head has a real first user message; tail has a `/name` rename record.
+        // Default policy (`renameable`) must surface the rename, not the first message.
+        let head = """
+        {"type":"user","message":{"role":"user","content":"first user message"}}
+        """
+        let tail = """
+        {"type":"custom-title","customTitle":"renamed by user"}
+        """
+
+        let parsed = SessionIndexStore.extractClaudeMetadata(
+            head: head,
+            tail: tail,
+            projectDir: "-Users-test",
+            titlePolicy: .renameable
+        )
+
+        XCTAssertEqual(parsed.title, "renamed by user")
+    }
+
+    func testFirstMessageOnlyTitlePolicyIgnoresCustomTitle() {
+        // Same fixture as the renameable test, but the opt-in policy must
+        // skip the override block and stick with the first user message.
+        let head = """
+        {"type":"user","message":{"role":"user","content":"first user message"}}
+        """
+        let tail = """
+        {"type":"custom-title","customTitle":"renamed by user"}
+        """
+
+        let parsed = SessionIndexStore.extractClaudeMetadata(
+            head: head,
+            tail: tail,
+            projectDir: "-Users-test",
+            titlePolicy: .firstMessageOnly
+        )
+
+        XCTAssertEqual(parsed.title, "first user message")
+    }
+
+    func testRenameableTitlePolicyFallsBackToAiTitleWhenNoCustomTitle() {
+        // No `custom-title`, but an `ai-title` exists — renameable must use it.
+        let head = """
+        {"type":"user","message":{"role":"user","content":"first user message"}}
+        """
+        let tail = """
+        {"type":"ai-title","aiTitle":"auto-generated summary"}
+        """
+
+        let parsed = SessionIndexStore.extractClaudeMetadata(
+            head: head,
+            tail: tail,
+            projectDir: "-Users-test",
+            titlePolicy: .renameable
+        )
+
+        XCTAssertEqual(parsed.title, "auto-generated summary")
+    }
+
     func testClaudeResumeCommandPinsSnapshotConfigDirectory() throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-session-index-\(UUID().uuidString)", isDirectory: true)


### PR DESCRIPTION
## Situation

cmux's Vault sidebar scrapes each Claude Code session's first user message from `~/.claude/projects/<project>/<session>.jsonl` and displays that as the session title.

Claude Code also writes `custom-title` records to the same JSONL when a user runs `/name`, plus `ai-title` records from its own auto-titler. These appear downstream of the first user message.

## Problem

The sidebar ignores both `custom-title` and `ai-title` records. A user who renames a session via `/name` still sees the stale first-line scrape in cmux's Vault — the rename is invisible.

When I asked @austinywang on Discord about cmux using these additional name sources ([link](https://discord.com/channels/1324643092963266570/1427131805160702054/1507926795737894983)), he suggested making this configurable.

## Solution

Add `vault.builtIns.claude.sessionTitlePolicy` to cmux.json. The parser now reads `custom-title` and `ai-title` records, and the policy decides whether to surface them.

| Policy | Title precedence |
|---|---|
| `renameable` (new default) | `/name` → `ai-title` → first user message |
| `firstMessageOnly` | first user message only (today's behavior) |

Default `renameable` is chosen empirically: sessions with early attachments or file-history snapshots push the user's first message out of `headByteCap` (64 KB), so `firstMessageOnly` falls through to "Untitled chat" for those sessions. `renameable` rescues them via `custom-title`.

## Config shape

```json
{
  "vault": {
    "builtIns": {
      "claude": { "sessionTitlePolicy": "firstMessageOnly" }
    }
  }
}
```

Top-level `builtIns` is a keyed dict — Codex / Pi can grow their own entries later without schema churn. Key tolerance for Claude Code mirrors `CmuxConfigAgentKind`: `"claude"` (canonical), `"claude-code"`, and `"claudeCode"` all decode to the same agent. Global + project-local cmux.json layers are merged, local wins (matches how `vault.agents` already merges).

## Naming rationale

- `CmuxVaultSessionTitlePolicy` (suffix `Policy`) mirrors the sibling `CmuxVaultAgentCWDPolicy` in the same file.
- Field `sessionTitlePolicy` uses the project's existing terminology (`SessionIndexStore`, `SessionIndexView`).
- Built-in-agent key `"claude"` matches the canonical id from `CmuxConfigAgentKind`'s encoder.

## Caveats / out of scope

- `ClaudeMetadataCache` keys on `(url, mtime)` only. Changing policy in cmux.json doesn't invalidate already-cached entries until the JSONL mtime changes or the app restarts. New sessions pick up the new policy immediately.
- The right sidebar has no auto-refresh (no FSEvents watcher or polling). Visible policy changes today still require the refresh button or a restart. Follow-up `cmux right-sidebar refresh vault` CLI verb queued separately.
- Custom agents (`vault.agents`) don't have title parsing today, so the `builtIns` knob is built-in-only by design. If custom agents grow title extraction later, the natural home is a new field on `CmuxVaultAgentRegistration` (describes extraction recipe, not just policy ladder).

## Test plan

- [x] Unit tests in `cmuxTests/SessionIndexViewTests.swift`: renameable honors `custom-title`, `firstMessageOnly` ignores it, renameable falls back to `ai-title` when no `custom-title`.
- [x] Compile-checked the test target locally (`xcodebuild ... -scheme cmux-unit build-for-testing`).
- [x] Dogfooded in a tagged Debug build: default behavior matches prior behavior; `firstMessageOnly` cleanly reverts to first-message titles.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4718"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782280695&installation_id=133855650&pr_number=4718&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4718&signature=2fb5e8db4b597d2460fcba6a7d00f512782bccf0fc6ccb5932155ddfc254b0e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a configurable policy for how the Vault sidebar titles Claude Code sessions. By default it honors `/name` and AI-generated titles; you can opt into first-message-only.

- **New Features**
  - New `cmux.json` key: `vault.builtIns.claude.sessionTitlePolicy`.
  - Policies: `renameable` (default: `/name` → AI title → first user message) and `firstMessageOnly` (first user message only).
  - Parses `custom-title` and `ai-title` records from Claude Code session JSONL; applies precedence per policy.
  - Built-in agent keys accept `claude`, `claude-code`, or `claudeCode`; global and project configs merge (project wins).

- **Migration**
  - No changes required. To restore the old behavior, set `vault.builtIns.claude.sessionTitlePolicy` to `firstMessageOnly`.

<sup>Written for commit 3527150aaf4c8ef04b88e076c3cc8cac49e5a59e. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4718?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable built-in agent overrides via settings
  * Introduced session title policy options for Claude Code sessions (renameable or first-message-only)
  * Enhanced metadata parsing to recognize custom and AI-generated session titles

* **Tests**
  * Added test coverage for session title selection behavior under different policy configurations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4718?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->