### PR TITLE
Fix file explorer not refreshing on changes in nested subdirectories

### DIFF
--- a/Sources/FileExplorerStore.swift
+++ b/Sources/FileExplorerStore.swift
@@ -761,17 +761,36 @@ final class FileExplorerStore: ObservableObject {
     }
 
     /// Directories the local watcher should observe: the root plus every
-    /// currently expanded directory under it. A kqueue vnode source only fires
-    /// for the immediate contents of the one directory it watches, so a
-    /// root-only watch never notices entries created inside nested expanded
-    /// subdirectories (issue #4649). Paths from a previous root are filtered out
-    /// so the fd count stays bounded by what the user can actually see.
+    /// expanded directory that is currently *visible* in the tree. A kqueue
+    /// vnode source only fires for the immediate contents of the one directory
+    /// it watches, so a root-only watch never notices entries created inside
+    /// nested expanded subdirectories (issue #4649). The fd count stays bounded
+    /// by what the user can actually see: directories hidden under a collapsed
+    /// ancestor (and anything from a previous root) are excluded.
     private func watchedDirectoryPaths() -> Set<String> {
         var paths: Set<String> = [rootPath]
-        for path in expandedPaths where Self.path(path, isContainedIn: rootPath) {
+        for path in expandedPaths where isVisibleExpandedDirectory(path) {
             paths.insert(path)
         }
         return paths
+    }
+
+    /// Whether an expanded directory is actually rendered right now: it must
+    /// live under the current root and every directory between it and the root
+    /// must also be expanded. `collapse()` only forgets the collapsed node
+    /// itself (so re-expanding restores descendants), which is why a descendant
+    /// can remain in `expandedPaths` while hidden — such paths must not be
+    /// watched.
+    private func isVisibleExpandedDirectory(_ path: String) -> Bool {
+        guard Self.path(path, isContainedIn: rootPath) else { return false }
+        var ancestor = (path as NSString).deletingLastPathComponent
+        while ancestor != rootPath, Self.path(ancestor, isContainedIn: rootPath) {
+            if !expandedPaths.contains(ancestor) { return false }
+            let parent = (ancestor as NSString).deletingLastPathComponent
+            if parent == ancestor { break }
+            ancestor = parent
+        }
+        return true
     }
 
     private func setProvider(_ newProvider: FileExplorerProvider?, reloadIfAvailable: Bool = true) {
@@ -788,6 +807,11 @@ final class FileExplorerStore: ObservableObject {
     #if DEBUG
     func setProviderForTesting(_ newProvider: FileExplorerProvider?, reloadIfAvailable: Bool = true) {
         setProvider(newProvider, reloadIfAvailable: reloadIfAvailable)
+    }
+
+    /// Exposes the local watcher's target directory set for tests.
+    func watchedDirectoryPathsForTesting() -> Set<String> {
+        watchedDirectoryPaths()
     }
     #endif
 
@@ -1138,14 +1162,16 @@ final class FileExplorerStore: ObservableObject {
 /// created inside nested expanded subdirectories (issue #4649).
 ///
 /// Debounces events to avoid rapid-fire reloads during bulk operations (e.g.,
-/// git checkout). `watch(paths:)`/`stop()` are only called from the main actor;
-/// the per-source event handlers run on `watchQueue` and only touch the
-/// debounce work item.
+/// git checkout). `watch(paths:)`/`stop()` are only called from the main actor
+/// (so the `watches` map needs no extra synchronization), while the per-source
+/// event handlers run on `watchQueue`; `debounceWorkItem` is therefore touched
+/// from both and guarded by `debounceLock`.
 final class FileExplorerDirectoryWatcher {
     /// path -> live vnode source. Each source owns its file descriptor and
     /// closes it from its cancel handler, so cancelling is enough to release it.
     private var watches: [String: DispatchSourceFileSystemObject] = [:]
     private let watchQueue = DispatchQueue(label: "com.cmux.fileExplorerWatcher", qos: .utility)
+    private let debounceLock = NSLock()
     private var debounceWorkItem: DispatchWorkItem?
     private let onChange: () -> Void
 
@@ -1186,8 +1212,10 @@ final class FileExplorerDirectoryWatcher {
     }
 
     func stop() {
+        debounceLock.lock()
         debounceWorkItem?.cancel()
         debounceWorkItem = nil
+        debounceLock.unlock()
         for source in watches.values {
             source.cancel()
         }
@@ -1195,13 +1223,15 @@ final class FileExplorerDirectoryWatcher {
     }
 
     private func scheduleReload() {
-        debounceWorkItem?.cancel()
         let work = DispatchWorkItem { [weak self] in
             DispatchQueue.main.async {
                 self?.onChange()
             }
         }
+        debounceLock.lock()
+        debounceWorkItem?.cancel()
         debounceWorkItem = work
+        debounceLock.unlock()
         watchQueue.asyncAfter(deadline: .now() + 0.3, execute: work)
     }
 

--- a/Sources/FileExplorerStore.swift
+++ b/Sources/FileExplorerStore.swift
@@ -754,10 +754,24 @@ final class FileExplorerStore: ObservableObject {
                     self?.refreshGitStatus()
                 }
             }
-            directoryWatcher?.watch(path: rootPath)
+            directoryWatcher?.watch(paths: watchedDirectoryPaths())
         } else {
             directoryWatcher?.stop()
         }
+    }
+
+    /// Directories the local watcher should observe: the root plus every
+    /// currently expanded directory under it. A kqueue vnode source only fires
+    /// for the immediate contents of the one directory it watches, so a
+    /// root-only watch never notices entries created inside nested expanded
+    /// subdirectories (issue #4649). Paths from a previous root are filtered out
+    /// so the fd count stays bounded by what the user can actually see.
+    private func watchedDirectoryPaths() -> Set<String> {
+        var paths: Set<String> = [rootPath]
+        for path in expandedPaths where Self.path(path, isContainedIn: rootPath) {
+            paths.insert(path)
+        }
+        return paths
     }
 
     private func setProvider(_ newProvider: FileExplorerProvider?, reloadIfAvailable: Bool = true) {
@@ -798,6 +812,7 @@ final class FileExplorerStore: ObservableObject {
     func expand(node: FileExplorerNode) {
         guard node.isDirectory else { return }
         expandedPaths.insert(node.path)
+        updateDirectoryWatcher()
         if node.children == nil, loadTasks[node.path] == nil, !loadingPaths.contains(node.path) {
             node.isLoading = true
             node.error = nil
@@ -813,6 +828,7 @@ final class FileExplorerStore: ObservableObject {
 
     func collapse(node: FileExplorerNode) {
         expandedPaths.remove(node.path)
+        updateDirectoryWatcher()
         if pendingDescendIntoFirstChildPath == node.path {
             pendingDescendIntoFirstChildPath = nil
         }
@@ -1113,11 +1129,22 @@ final class FileExplorerStore: ObservableObject {
 
 // MARK: - Directory Watcher
 
-/// Watches a local directory for filesystem changes and calls back on the main thread.
-/// Debounces events to avoid rapid-fire reloads during bulk operations (e.g., git checkout).
+/// Watches a set of local directories for filesystem changes and calls back on
+/// the main thread.
+///
+/// A kqueue vnode source fires only for changes to the *immediate* contents of
+/// the directory it watches, so the store registers one source per visible
+/// (root + expanded) directory. Watching only the root would miss entries
+/// created inside nested expanded subdirectories (issue #4649).
+///
+/// Debounces events to avoid rapid-fire reloads during bulk operations (e.g.,
+/// git checkout). `watch(paths:)`/`stop()` are only called from the main actor;
+/// the per-source event handlers run on `watchQueue` and only touch the
+/// debounce work item.
 final class FileExplorerDirectoryWatcher {
-    private var fileDescriptor: Int32 = -1
-    private var watchSource: DispatchSourceFileSystemObject?
+    /// path -> live vnode source. Each source owns its file descriptor and
+    /// closes it from its cancel handler, so cancelling is enough to release it.
+    private var watches: [String: DispatchSourceFileSystemObject] = [:]
     private let watchQueue = DispatchQueue(label: "com.cmux.fileExplorerWatcher", qos: .utility)
     private var debounceWorkItem: DispatchWorkItem?
     private let onChange: () -> Void
@@ -1126,36 +1153,45 @@ final class FileExplorerDirectoryWatcher {
         self.onChange = onChange
     }
 
-    func watch(path: String) {
-        stop()
-        let fd = open(path, O_EVTONLY)
-        guard fd >= 0 else { return }
-        fileDescriptor = fd
-
-        let source = DispatchSource.makeFileSystemObjectSource(
-            fileDescriptor: fd,
-            eventMask: [.write, .link, .rename, .delete],
-            queue: watchQueue
-        )
-
-        source.setEventHandler { [weak self] in
-            self?.scheduleReload()
+    /// Watch exactly `paths`, adding sources for newly requested directories and
+    /// cancelling sources for directories no longer requested. Existing watches
+    /// are left untouched so in-flight events are not dropped. Paths that cannot
+    /// be opened (e.g. just deleted) are skipped and retried on the next call.
+    func watch(paths: Set<String>) {
+        for path in Array(watches.keys) where !paths.contains(path) {
+            watches.removeValue(forKey: path)?.cancel()
         }
 
-        source.setCancelHandler {
-            Darwin.close(fd)
-        }
+        for path in paths where watches[path] == nil {
+            let fd = open(path, O_EVTONLY)
+            guard fd >= 0 else { continue }
 
-        source.resume()
-        watchSource = source
+            let source = DispatchSource.makeFileSystemObjectSource(
+                fileDescriptor: fd,
+                eventMask: [.write, .link, .rename, .delete],
+                queue: watchQueue
+            )
+
+            source.setEventHandler { [weak self] in
+                self?.scheduleReload()
+            }
+
+            source.setCancelHandler {
+                Darwin.close(fd)
+            }
+
+            source.resume()
+            watches[path] = source
+        }
     }
 
     func stop() {
         debounceWorkItem?.cancel()
         debounceWorkItem = nil
-        watchSource?.cancel()
-        watchSource = nil
-        fileDescriptor = -1
+        for source in watches.values {
+            source.cancel()
+        }
+        watches.removeAll()
     }
 
     private func scheduleReload() {

--- a/cmuxTests/FileExplorerStoreTests.swift
+++ b/cmuxTests/FileExplorerStoreTests.swift
@@ -556,6 +556,40 @@ final class FileExplorerStoreTests: XCTestCase {
                 .contains { $0.name == "build" } ?? false
         }
     }
+
+    /// The watch set must stay bounded by what the user can actually see: the
+    /// root plus expanded directories whose whole ancestor chain is expanded.
+    /// Collapsing a parent hides its descendants (and stops watching them) while
+    /// still remembering their expansion state, so re-expanding restores both.
+    func testWatchSetTracksVisibleExpandedDirectoriesOnly() {
+        let store = FileExplorerStore()
+        store.setRootPath("/root")
+
+        let a = FileExplorerNode(name: "a", path: "/root/a", isDirectory: true)
+        a.children = []
+        let b = FileExplorerNode(name: "b", path: "/root/a/b", isDirectory: true)
+        b.children = []
+
+        store.expand(node: a)
+        store.expand(node: b)
+        XCTAssertEqual(
+            store.watchedDirectoryPathsForTesting(),
+            ["/root", "/root/a", "/root/a/b"]
+        )
+
+        // Collapsing `a` hides `b`; `b` must drop out of the watch set even
+        // though it stays in expandedPaths for state restoration.
+        store.collapse(node: a)
+        XCTAssertEqual(store.watchedDirectoryPathsForTesting(), ["/root"])
+        XCTAssertTrue(store.expandedPaths.contains("/root/a/b"))
+
+        // Re-expanding `a` makes `b` visible again, so it is watched again.
+        store.expand(node: a)
+        XCTAssertEqual(
+            store.watchedDirectoryPathsForTesting(),
+            ["/root", "/root/a", "/root/a/b"]
+        )
+    }
 }
 
 @MainActor

--- a/cmuxTests/FileExplorerStoreTests.swift
+++ b/cmuxTests/FileExplorerStoreTests.swift
@@ -506,6 +506,56 @@ final class FileExplorerStoreTests: XCTestCase {
         store.expand(node: node)
         XCTAssertFalse(store.isExpanded(node))
     }
+
+    // MARK: - Directory watching (issue #4649)
+
+    /// Regression test for https://github.com/manaflow-ai/cmux/issues/4649.
+    ///
+    /// The Files sidebar auto-refreshes from a kqueue vnode watch. A vnode source
+    /// only fires for changes to the *immediate* contents of the single directory
+    /// it watches, so watching only the root means an entry created inside an
+    /// already-expanded *nested* subdirectory is never noticed and never appears
+    /// in the tree until a restart. The store must watch every expanded
+    /// directory, not just the root.
+    ///
+    /// Uses a real `LocalFileExplorerProvider` against a temp directory so the
+    /// kqueue watch path is exercised end-to-end.
+    func testCreatingEntryInNestedExpandedDirectoryRefreshesTree() async throws {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory
+            .appendingPathComponent("cmux-watch-\(UUID().uuidString)", isDirectory: true)
+        let sub = root.appendingPathComponent("project-a", isDirectory: true)
+        try fm.createDirectory(at: sub, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: root) }
+
+        let store = FileExplorerStore()
+        store.setProviderForTesting(LocalFileExplorerProvider())
+        store.setRootPath(root.path)
+
+        try await waitFor("root lists project-a") {
+            store.rootNodes.contains { $0.name == "project-a" }
+        }
+
+        let subNode = try XCTUnwrap(store.rootNodes.first { $0.name == "project-a" })
+        store.expand(node: subNode)
+        try await waitFor("project-a finished its initial (empty) listing") {
+            store.rootNodes.first { $0.name == "project-a" }?.children != nil
+        }
+
+        // Create a folder *inside* the already-expanded nested subdirectory,
+        // mimicking an external tool (Finder / agent) scaffolding into it. This
+        // bumps the mtime of project-a but NOT of the root, so a root-only watch
+        // never fires and the tree never refreshes.
+        let created = sub.appendingPathComponent("build", isDirectory: true)
+        try fm.createDirectory(at: created, withIntermediateDirectories: true)
+
+        try await waitFor("build appears under project-a without a restart", timeout: 8.0) {
+            store.rootNodes
+                .first { $0.name == "project-a" }?
+                .children?
+                .contains { $0.name == "build" } ?? false
+        }
+    }
 }
 
 @MainActor


### PR DESCRIPTION
## Summary

Fixes #4649.

The Files sidebar only auto-refreshed from a single, non-recursive kqueue vnode watch on the explorer **root**. A vnode source only reports changes to the *immediate* contents of the one directory it watches, so creating/deleting/renaming an entry inside an already-expanded **nested** subdirectory never tripped the watch — the change stayed invisible until a restart, a root switch, or some unrelated activity happened to touch a *direct child of the root* and trigger a full reload.

This implements the issue's preferred fix (option 1): **watch every expanded directory, not just the root.**

## Changes

- `FileExplorerDirectoryWatcher` now manages one vnode source per path via `watch(paths:)`, diffing the requested set against live sources so existing watches are kept (in-flight events aren't dropped) and only deltas are added/removed. Each source owns and closes its own fd in its cancel handler.
- `updateDirectoryWatcher()` computes `{root} ∪ expandedPaths`, filtered to the current root via the existing containment helper so stale paths from a previous root don't leak file descriptors.
- `expand()` / `collapse()` resync the watch set, so the watched directories track exactly what the user can see.

`reload()` already re-lists every expanded subtree, so a single watcher firing is enough to refresh the visible tree. The fd count stays bounded by the directories the user has actually expanded, and `node_modules`/`.git` are only ever watched if the user explicitly expands them.

## Test plan

Two-commit red/green structure per the contributing rules:

1. **Commit 1** adds `testCreatingEntryInNestedExpandedDirectoryRefreshesTree`, which drives a real `LocalFileExplorerProvider` against a temp directory, expands a nested subdirectory, then creates a folder *inside* it and asserts it appears in the tree without a restart. This fails against the root-only watcher.
2. **Commit 2** adds the fix; the test passes.

The test exercises the kqueue watch end-to-end through the store's public API.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4720"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782283829&installation_id=133855650&pr_number=4720&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4720&signature=840e86767ea1248b6dc18c482d16149997c718092f4beb86f948710ddd9e2cd3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Watch the root and all visible expanded directories so nested folder changes refresh immediately. Prevents missing updates in expanded subfolders until a restart.

- **Bug Fixes**
  - Switched to per-path vnode watching via `watch(paths:)` in `FileExplorerDirectoryWatcher`, diffing adds/removes and closing fds on cancel.
  - `updateDirectoryWatcher()` now watches `{root} ∪ visibleExpandedPaths`: only paths under the current root whose full ancestor chain is expanded; `expand()`/`collapse()` resync the set so fd usage matches the visible tree.
  - Guarded debounce scheduling with a lock to avoid races between the watch queue and main thread.
  - Tests: regression for nested-dir refresh and a watch-set visibility test via `watchedDirectoryPathsForTesting()`.

<sup>Written for commit afc6dc274690740789e283c970cc242cf8f7147e. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4720?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File explorer now monitors changes in real-time across all expanded directories and nested subdirectories, improving responsiveness to filesystem updates.

* **Bug Fixes**
  * Directory watcher now stays in sync with expanded/collapsed folders so new files and folders appear reliably without restarting.

* **Tests**
  * Added regression tests validating nested expansion updates and that the watched set matches visible expanded directories.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4720?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->