### PR TITLE
Add New Worktree action to the titlebar + button menu

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -24624,6 +24624,23 @@
         }
       }
     },
+    "command.newWorktree.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New Worktree"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新規ワークツリー"
+          }
+        }
+      }
+    },
     "command.nextTabInPane.subtitle": {
       "extractionState": "manual",
       "localizations": {
@@ -41335,6 +41352,125 @@
           "stringUnit": {
             "state": "translated",
             "value": "Перемістити вкладку"
+          }
+        }
+      }
+    },
+    "dialog.newWorktree.create": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Create"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "作成"
+          }
+        }
+      }
+    },
+    "dialog.newWorktree.error.branchExists": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A branch with this name already exists. Pick a different name."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "この名前のブランチは既に存在します。別の名前を指定してください。"
+          }
+        }
+      }
+    },
+    "dialog.newWorktree.error.creationFailed.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could Not Create Worktree"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークツリーを作成できませんでした"
+          }
+        }
+      }
+    },
+    "dialog.newWorktree.error.invalidName": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invalid branch name. Try letters, numbers, dashes, or slashes — no spaces or special characters."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ブランチ名が無効です。英字、数字、ハイフン、スラッシュのみ使用できます。スペースや特殊文字は使えません。"
+          }
+        }
+      }
+    },
+    "dialog.newWorktree.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a name for the new branch and worktree."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新しいブランチとワークツリーの名前を入力してください。"
+          }
+        }
+      }
+    },
+    "dialog.newWorktree.placeholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Branch name"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ブランチ名"
+          }
+        }
+      }
+    },
+    "dialog.newWorktree.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New Worktree"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新規ワークツリー"
           }
         }
       }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -6637,6 +6637,295 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         )
     }
 
+    /// Prompts the user for a branch name, then starts an async worktree
+    /// creation against the selected workspace's git project root. Returns
+    /// `false` (and beeps) when no resolvable project root is available or the
+    /// user cancels the prompt; otherwise returns `true` immediately and adds
+    /// the new workspace once `git worktree add` succeeds.
+    @discardableResult
+    func performNewWorktreeAction(
+        tabManager preferredTabManager: TabManager? = nil,
+        preferredWindow: NSWindow? = nil,
+        debugSource: String = "newWorktree"
+    ) -> Bool {
+        let context = preferredTabManager.flatMap { mainWindowContext(for: $0) }
+            ?? preferredWindow.flatMap { contextForMainWindow($0) }
+            ?? preferredMainWindowContextForWorkspaceCreation(event: nil, debugSource: debugSource)
+        guard let context else {
+            NSSound.beep()
+            return false
+        }
+        let tabManager = context.tabManager
+        // Reason: `extensionSidebarProjectRootPath` is the cached git-repo root
+        // for the workspace's cwd (computed by the same logic the sidebar "+"
+        // uses). Fall back to the raw cwd so the action still works before that
+        // async refresh has populated.
+        let rawRoot = tabManager.selectedWorkspace?.extensionSidebarProjectRootPath
+            ?? tabManager.selectedWorkspace?.currentDirectory
+        let projectRootPath = rawRoot?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !projectRootPath.isEmpty else {
+            NSSound.beep()
+#if DEBUG
+            cmuxDebugLog("newWorktree.noProjectRoot source=\(debugSource)")
+#endif
+            return false
+        }
+
+        guard let branchName = promptForNewWorktreeBranchName(projectRootPath: projectRootPath) else {
+#if DEBUG
+            cmuxDebugLog("newWorktree.cancelled source=\(debugSource)")
+#endif
+            return false
+        }
+
+#if DEBUG
+        cmuxDebugLog("newWorktree.start source=\(debugSource) project=\(projectRootPath) branch=\(branchName)")
+#endif
+        Task {
+            do {
+                let result = try await CmuxExtensionWorktreePrototype.createWorktree(
+                    projectRootPath: projectRootPath,
+                    seedDemoFiles: false,
+                    branchPrefix: "cmux-worktree",
+                    branchName: branchName
+                )
+                tabManager.addWorkspace(
+                    title: result.workspaceTitle,
+                    workingDirectory: result.worktreePath,
+                    initialTerminalCommand: result.initialCommand,
+                    inheritWorkingDirectory: false,
+                    select: true,
+                    eagerLoadTerminal: false
+                )
+            } catch {
+                NSSound.beep()
+#if DEBUG
+                cmuxDebugLog("newWorktree.failed source=\(debugSource) project=\(projectRootPath) error=\(error.localizedDescription)")
+#endif
+                presentNewWorktreeCreationFailureAlert(branchName: branchName, error: error)
+            }
+        }
+        return true
+    }
+
+    /// Loops the branch-name dialog until the user cancels or enters a name
+    /// that passes pre-creation validation (well-formed git ref, not already
+    /// taken). Returns nil on cancel/empty input.
+    private func promptForNewWorktreeBranchName(projectRootPath: String) -> String? {
+        var seedText = nextAvailableWorktreeBranchName(projectRootPath: projectRootPath)
+        var validationError: String?
+        while true {
+            guard let candidate = showNewWorktreeBranchDialog(
+                initialText: seedText,
+                errorMessage: validationError
+            ) else {
+                return nil
+            }
+            if let issue = branchNameValidationError(candidate, in: projectRootPath) {
+                seedText = candidate
+                validationError = issue
+                continue
+            }
+            return candidate
+        }
+    }
+
+    /// Suggests `<project>-worktree-<N>` with the smallest N that isn't
+    /// already a local branch. Falls back to `cmux-worktree-<N>` if the
+    /// project directory name sanitizes to empty.
+    private func nextAvailableWorktreeBranchName(projectRootPath: String) -> String {
+        let prefix = "\(worktreeBranchPrefix(for: projectRootPath))-worktree-"
+        let result = runGitSync([
+            "-C", projectRootPath,
+            "for-each-ref", "--format=%(refname:short)",
+            "refs/heads/\(prefix)*"
+        ])
+        var used = Set<Int>()
+        if result.exitCode == 0 {
+            for line in result.output.split(whereSeparator: { $0.isNewline }) {
+                let suffix = String(line).dropFirst(prefix.count)
+                if let n = Int(suffix), n > 0 {
+                    used.insert(n)
+                }
+            }
+        }
+        var n = 1
+        while used.contains(n) { n += 1 }
+        return "\(prefix)\(n)"
+    }
+
+    private func worktreeBranchPrefix(for projectRootPath: String) -> String {
+        let raw = URL(fileURLWithPath: projectRootPath, isDirectory: true)
+            .standardizedFileURL
+            .lastPathComponent
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        // Reason: branch names can't contain spaces or many special chars. Map
+        // anything outside [A-Za-z0-9._-] to '-' and collapse runs so the
+        // prefilled name is itself valid even when the dir has odd characters.
+        var sanitized = ""
+        var lastWasDash = false
+        for scalar in raw.unicodeScalars {
+            let isSafe = (scalar >= "A" && scalar <= "Z")
+                || (scalar >= "a" && scalar <= "z")
+                || (scalar >= "0" && scalar <= "9")
+                || scalar == "." || scalar == "_" || scalar == "-"
+            if isSafe {
+                sanitized.unicodeScalars.append(scalar)
+                lastWasDash = (scalar == "-")
+            } else if !lastWasDash {
+                sanitized.append("-")
+                lastWasDash = true
+            }
+        }
+        while sanitized.hasPrefix("-") || sanitized.hasPrefix(".") {
+            sanitized.removeFirst()
+        }
+        while sanitized.hasSuffix("-") || sanitized.hasSuffix(".") {
+            sanitized.removeLast()
+        }
+        return sanitized.isEmpty ? "cmux" : sanitized
+    }
+
+    private func showNewWorktreeBranchDialog(
+        initialText: String,
+        errorMessage: String?
+    ) -> String? {
+        let alert = NSAlert()
+        alert.messageText = String(
+            localized: "dialog.newWorktree.title",
+            defaultValue: "New Worktree"
+        )
+        alert.informativeText = String(
+            localized: "dialog.newWorktree.message",
+            defaultValue: "Enter a name for the new branch and worktree."
+        )
+
+        let accessoryWidth: CGFloat = 320
+        let inputHeight: CGFloat = 22
+        let input = NSTextField(string: initialText)
+        input.placeholderString = String(
+            localized: "dialog.newWorktree.placeholder",
+            defaultValue: "Branch name"
+        )
+
+        let accessoryView: NSView
+        if let errorMessage {
+            let errorLabel = NSTextField(wrappingLabelWithString: errorMessage)
+            errorLabel.font = NSFont.systemFont(ofSize: 11)
+            errorLabel.textColor = .systemRed
+            errorLabel.lineBreakMode = .byWordWrapping
+            errorLabel.maximumNumberOfLines = 4
+            errorLabel.preferredMaxLayoutWidth = accessoryWidth
+            let errorSize = errorLabel.sizeThatFits(NSSize(width: accessoryWidth, height: 0))
+            let errorHeight = max(errorSize.height, NSFont.systemFontSize * 1.4)
+            let spacing: CGFloat = 8
+            let totalHeight = errorHeight + spacing + inputHeight
+            let container = NSView(frame: NSRect(x: 0, y: 0, width: accessoryWidth, height: totalHeight))
+            errorLabel.frame = NSRect(x: 0, y: inputHeight + spacing, width: accessoryWidth, height: errorHeight)
+            input.frame = NSRect(x: 0, y: 0, width: accessoryWidth, height: inputHeight)
+            container.addSubview(errorLabel)
+            container.addSubview(input)
+            accessoryView = container
+        } else {
+            input.frame = NSRect(x: 0, y: 0, width: accessoryWidth, height: inputHeight)
+            accessoryView = input
+        }
+
+        alert.accessoryView = accessoryView
+        alert.addButton(withTitle: String(
+            localized: "dialog.newWorktree.create",
+            defaultValue: "Create"
+        ))
+        alert.addButton(withTitle: String(
+            localized: "common.cancel",
+            defaultValue: "Cancel"
+        ))
+        let alertWindow = alert.window
+        alertWindow.initialFirstResponder = input
+        DispatchQueue.main.async {
+            alertWindow.makeFirstResponder(input)
+            input.selectText(nil)
+        }
+
+        let response = alert.runModal()
+        guard response == .alertFirstButtonReturn else { return nil }
+        let trimmed = input.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        return trimmed
+    }
+
+    private func presentNewWorktreeCreationFailureAlert(branchName: String, error: Error) {
+        let alert = NSAlert()
+        alert.messageText = String(
+            localized: "dialog.newWorktree.error.creationFailed.title",
+            defaultValue: "Could Not Create Worktree"
+        )
+        let nsError = error as NSError
+        let details = (nsError.userInfo["CmuxExtensionWorktreePrototypeDetails"] as? String)
+            ?? error.localizedDescription
+        let trimmedDetails = details.trimmingCharacters(in: .whitespacesAndNewlines)
+        alert.informativeText = trimmedDetails.isEmpty
+            ? branchName
+            : "\(branchName)\n\n\(trimmedDetails)"
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: String(localized: "common.ok", defaultValue: "OK"))
+        alert.runModal()
+    }
+
+    /// Pre-creation validation. Returns a localized, user-facing message when
+    /// the name is malformed or already taken; nil when the name is OK to
+    /// attempt. We deliberately ignore errors from the helper itself — if `git`
+    /// can't even tell us, we let the actual `git worktree add` surface the
+    /// underlying problem via `presentNewWorktreeCreationFailureAlert`.
+    private func branchNameValidationError(_ branchName: String, in projectRootPath: String) -> String? {
+        let format = runGitSync(["check-ref-format", "--branch", branchName])
+        if format.exitCode != 0 {
+            return String(
+                localized: "dialog.newWorktree.error.invalidName",
+                defaultValue: "Invalid branch name. Try letters, numbers, dashes, or slashes — no spaces or special characters."
+            )
+        }
+        let exists = runGitSync([
+            "-C", projectRootPath,
+            "rev-parse", "--verify", "--quiet",
+            "refs/heads/\(branchName)"
+        ])
+        if exists.exitCode == 0 {
+            return String(
+                localized: "dialog.newWorktree.error.branchExists",
+                defaultValue: "A branch with this name already exists. Pick a different name."
+            )
+        }
+        return nil
+    }
+
+    private struct GitSyncResult {
+        let exitCode: Int32
+        let output: String
+    }
+
+    private func runGitSync(_ arguments: [String]) -> GitSyncResult {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["git"] + arguments
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            return GitSyncResult(exitCode: -1, output: "")
+        }
+        let data = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+        _ = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+        return GitSyncResult(
+            exitCode: process.terminationStatus,
+            output: String(data: data, encoding: .utf8) ?? ""
+        )
+    }
+
     private func mainWindowContext(for tabManager: TabManager) -> MainWindowContext? {
         mainWindowContexts.values.first(where: { $0.tabManager === tabManager })
     }
@@ -13801,6 +14090,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                     tabManager: context.tabManager,
                     preferredWindow: resolvedWindow(for: context) ?? preferredWindow,
                     debugSource: "configured.cmux.cloudvm"
+                )
+                if didStart { onExecuted?() }
+                return didStart
+            case .newWorktree:
+                let didStart = performNewWorktreeAction(
+                    tabManager: context.tabManager,
+                    debugSource: "configured.cmux.newWorktree"
                 )
                 if didStart { onExecuted?() }
                 return didStart

--- a/Sources/CmuxConfig.swift
+++ b/Sources/CmuxConfig.swift
@@ -1508,6 +1508,9 @@ struct CmuxResolvedConfigAction: Identifiable, Sendable, Hashable {
         case .cloudVM:
             title = String(localized: "command.cloudVM.title", defaultValue: "Start Cloud VM")
             keywords = ["cloud", "vm", "virtual", "machine", "remote"]
+        case .newWorktree:
+            title = String(localized: "command.newWorktree.title", defaultValue: "New Worktree")
+            keywords = ["new", "worktree", "git", "branch", "workspace"]
         case .newTerminal:
             title = String(localized: "command.newTerminalTab.title", defaultValue: "New Terminal Tab")
             keywords = ["new", "terminal", "tab", "surface"]
@@ -1832,6 +1835,7 @@ final class CmuxConfigStore: ObservableObject {
     private static let defaultNewWorkspaceContextMenu: [CmuxConfigContextMenuItem] = [
         .action(CmuxConfigContextMenuActionItem(action: CmuxSurfaceTabBarBuiltInAction.newWorkspace.configID)),
         .action(CmuxConfigContextMenuActionItem(action: CmuxSurfaceTabBarBuiltInAction.cloudVM.configID)),
+        .action(CmuxConfigContextMenuActionItem(action: CmuxSurfaceTabBarBuiltInAction.newWorktree.configID)),
     ]
 
     @Published private(set) var loadedCommands: [CmuxCommandDefinition] = []

--- a/Sources/CmuxSurfaceTabBarBuiltInAction.swift
+++ b/Sources/CmuxSurfaceTabBarBuiltInAction.swift
@@ -4,6 +4,7 @@ import Foundation
 enum CmuxSurfaceTabBarBuiltInAction: String, Codable, Sendable, CaseIterable, Hashable {
     case newWorkspace = "cmux.newWorkspace"
     case cloudVM = "cmux.cloudvm"
+    case newWorktree = "cmux.newWorktree"
     case newTerminal = "cmux.newTerminal"
     case newBrowser = "cmux.newBrowser"
     case splitRight = "cmux.splitRight"
@@ -17,6 +18,8 @@ enum CmuxSurfaceTabBarBuiltInAction: String, Codable, Sendable, CaseIterable, Ha
              "cmux.newCloudVM", "cmux.newCloudVm", "newCloudVM", "newCloudVm",
              "cmux.startCloudVM", "cmux.startCloudVm", "startCloudVM", "startCloudVm":
             self = .cloudVM
+        case "cmux.newWorktree", "newWorktree", "cmux.addWorktree", "addWorktree":
+            self = .newWorktree
         case "cmux.newTerminal", "newTerminal":
             self = .newTerminal
         case "cmux.newBrowser", "newBrowser":
@@ -40,6 +43,8 @@ enum CmuxSurfaceTabBarBuiltInAction: String, Codable, Sendable, CaseIterable, Ha
             return "plus.square"
         case .cloudVM:
             return "cloud"
+        case .newWorktree:
+            return "arrow.triangle.branch"
         case .newTerminal:
             return "terminal"
         case .newBrowser:
@@ -53,7 +58,7 @@ enum CmuxSurfaceTabBarBuiltInAction: String, Codable, Sendable, CaseIterable, Ha
 
     var bonsplitAction: BonsplitConfiguration.SplitActionButton.Action? {
         switch self {
-        case .newWorkspace, .cloudVM:
+        case .newWorkspace, .cloudVM, .newWorktree:
             return nil
         case .newTerminal:
             return .newTerminal

--- a/Sources/ExtensionWorktreePrototype.swift
+++ b/Sources/ExtensionWorktreePrototype.swift
@@ -3,7 +3,7 @@ import Foundation
 struct CmuxExtensionWorktreeCreationResult: Sendable {
     let worktreePath: String
     let workspaceTitle: String
-    let initialCommand: String
+    let initialCommand: String?
 }
 
 final class CmuxExtensionProcessTermination: @unchecked Sendable {
@@ -45,28 +45,47 @@ final class CmuxExtensionProcessTermination: @unchecked Sendable {
 }
 
 enum CmuxExtensionWorktreePrototype {
-    static func createWorktree(projectRootPath: String) async throws -> CmuxExtensionWorktreeCreationResult {
+    static func createWorktree(
+        projectRootPath: String,
+        seedDemoFiles: Bool = true,
+        branchPrefix: String = "cmux-sidebar",
+        branchName explicitBranchName: String? = nil
+    ) async throws -> CmuxExtensionWorktreeCreationResult {
         try await Task.detached(priority: .userInitiated) {
             let projectRoot = URL(fileURLWithPath: projectRootPath, isDirectory: true).standardizedFileURL
             try FileManager.default.createDirectory(at: projectRoot, withIntermediateDirectories: true)
             try await ensureGitRepository(at: projectRoot)
             try await ensureCmuxWorktreeDirectoryIsLocallyIgnored(projectRoot: projectRoot)
 
-            let branchName = "cmux-sidebar-\(Int(Date().timeIntervalSince1970))-\(UUID().uuidString.prefix(8).lowercased())"
+            let trimmedExplicitName = explicitBranchName?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let branchName: String
+            if let trimmedExplicitName, !trimmedExplicitName.isEmpty {
+                branchName = trimmedExplicitName
+            } else {
+                branchName = "\(branchPrefix)-\(Int(Date().timeIntervalSince1970))-\(UUID().uuidString.prefix(8).lowercased())"
+            }
             let worktreeRoot = projectRoot
                 .appendingPathComponent(".cmux", isDirectory: true)
                 .appendingPathComponent("worktrees", isDirectory: true)
             try FileManager.default.createDirectory(at: worktreeRoot, withIntermediateDirectories: true)
             let worktree = worktreeRoot.appendingPathComponent(branchName, isDirectory: true)
             try await run("git", ["-C", projectRoot.path, "worktree", "add", "-b", branchName, worktree.path, "HEAD"])
-            try writeSampleDevServerFiles(in: worktree, projectName: projectRoot.lastPathComponent)
 
-            let port = 4_100 + abs(branchName.hashValue % 800)
-            let samplePath = shellEscaped(worktree.appendingPathComponent("cmux-sample-dev", isDirectory: true).path)
+            let initialCommand: String?
+            if seedDemoFiles {
+                try writeSampleDevServerFiles(in: worktree, projectName: projectRoot.lastPathComponent)
+                let port = 4_100 + abs(branchName.hashValue % 800)
+                let samplePath = shellEscaped(worktree.appendingPathComponent("cmux-sample-dev", isDirectory: true).path)
+                initialCommand = "cd \(samplePath) && python3 -m http.server \(port)"
+            } else {
+                initialCommand = nil
+            }
+
             return CmuxExtensionWorktreeCreationResult(
                 worktreePath: worktree.path,
                 workspaceTitle: branchName,
-                initialCommand: "cd \(samplePath) && python3 -m http.server \(port)"
+                initialCommand: initialCommand
             )
         }.value
     }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -16781,6 +16781,12 @@ extension Workspace: BonsplitDelegate {
                     preferredWindow: presentingWindow,
                     debugSource: "surfaceTabBar.cloudVM"
                 )
+            case .newWorktree:
+                _ = AppDelegate.shared?.performNewWorktreeAction(
+                    tabManager: owningTabManager,
+                    preferredWindow: presentingWindow,
+                    debugSource: "surfaceTabBar.newWorktree"
+                )
             case .newTerminal, .newBrowser, .splitRight, .splitDown:
                 break
             }

--- a/cmuxTests/CmuxConfigContextMenuTests.swift
+++ b/cmuxTests/CmuxConfigContextMenuTests.swift
@@ -87,14 +87,16 @@ final class CmuxConfigContextMenuTests: XCTestCase {
     func testDefaultNewWorkspaceContextMenuIncludesCloudVM() throws {
         let store = try loadStore()
 
-        XCTAssertEqual(store.newWorkspaceContextMenuItems.count, 2)
-        guard store.newWorkspaceContextMenuItems.count == 2 else { return }
+        XCTAssertEqual(store.newWorkspaceContextMenuItems.count, 3)
+        guard store.newWorkspaceContextMenuItems.count == 3 else { return }
         guard case .action(let first) = store.newWorkspaceContextMenuItems[0],
-              case .action(let second) = store.newWorkspaceContextMenuItems[1] else {
+              case .action(let second) = store.newWorkspaceContextMenuItems[1],
+              case .action(let third) = store.newWorkspaceContextMenuItems[2] else {
             return XCTFail("Expected default context menu actions.")
         }
         XCTAssertEqual(first.action.id, CmuxSurfaceTabBarBuiltInAction.newWorkspace.configID)
         XCTAssertEqual(second.action.id, CmuxSurfaceTabBarBuiltInAction.cloudVM.configID)
+        XCTAssertEqual(third.action.id, CmuxSurfaceTabBarBuiltInAction.newWorktree.configID)
         XCTAssertTrue(store.configurationIssues.isEmpty)
     }
 
@@ -174,8 +176,8 @@ final class CmuxConfigContextMenuTests: XCTestCase {
         }
         """)
 
-        XCTAssertEqual(store.newWorkspaceContextMenuItems.count, 2)
-        guard store.newWorkspaceContextMenuItems.count == 2 else { return }
+        XCTAssertEqual(store.newWorkspaceContextMenuItems.count, 3)
+        guard store.newWorkspaceContextMenuItems.count == 3 else { return }
         guard case .action(let item) = store.newWorkspaceContextMenuItems[1] else {
             return XCTFail("Expected Cloud VM context-menu action.")
         }

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -6341,6 +6341,84 @@ final class ExtensionWorktreePrototypeTests: XCTestCase {
         XCTAssertEqual(status.trimmingCharacters(in: .whitespacesAndNewlines), "")
     }
 
+    func testCreateWorktreeWithoutDemoFilesSkipsSampleSeed() async throws {
+        let projectRoot = try makeEmptyGitProject()
+        defer { try? FileManager.default.removeItem(at: projectRoot.deletingLastPathComponent()) }
+
+        let result = try await CmuxExtensionWorktreePrototype.createWorktree(
+            projectRootPath: projectRoot.path,
+            seedDemoFiles: false,
+            branchPrefix: "cmux-worktree"
+        )
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: result.worktreePath))
+        XCTAssertTrue(
+            result.workspaceTitle.hasPrefix("cmux-worktree-"),
+            "expected branchPrefix to apply, got \(result.workspaceTitle)"
+        )
+        XCTAssertNil(result.initialCommand, "seedDemoFiles=false should produce no initial command")
+        let sampleDir = URL(fileURLWithPath: result.worktreePath, isDirectory: true)
+            .appendingPathComponent("cmux-sample-dev", isDirectory: true)
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: sampleDir.path),
+            "cmux-sample-dev directory should not be created when seedDemoFiles is false"
+        )
+    }
+
+    func testCreateWorktreeUsesExplicitBranchName() async throws {
+        let projectRoot = try makeEmptyGitProject()
+        defer { try? FileManager.default.removeItem(at: projectRoot.deletingLastPathComponent()) }
+
+        let explicitBranch = "feature/explicit-name-\(UUID().uuidString.prefix(6).lowercased())"
+        let result = try await CmuxExtensionWorktreePrototype.createWorktree(
+            projectRootPath: projectRoot.path,
+            seedDemoFiles: false,
+            branchName: explicitBranch
+        )
+
+        XCTAssertEqual(result.workspaceTitle, explicitBranch)
+        let branches = try runGit(["branch", "--list", explicitBranch], in: projectRoot)
+        XCTAssertTrue(
+            branches.contains(explicitBranch),
+            "expected branch \(explicitBranch) to be created, got: \(branches)"
+        )
+    }
+
+    func testCreateWorktreeEmptyExplicitBranchNameFallsBackToGeneratedName() async throws {
+        let projectRoot = try makeEmptyGitProject()
+        defer { try? FileManager.default.removeItem(at: projectRoot.deletingLastPathComponent()) }
+
+        let result = try await CmuxExtensionWorktreePrototype.createWorktree(
+            projectRootPath: projectRoot.path,
+            seedDemoFiles: false,
+            branchPrefix: "cmux-worktree",
+            branchName: "   "
+        )
+
+        XCTAssertTrue(
+            result.workspaceTitle.hasPrefix("cmux-worktree-"),
+            "whitespace-only branchName should fall back to generated prefix, got \(result.workspaceTitle)"
+        )
+    }
+
+    private func makeEmptyGitProject() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-worktree-prototype-\(UUID().uuidString)", isDirectory: true)
+        let projectRoot = root.appendingPathComponent("Project", isDirectory: true)
+        try FileManager.default.createDirectory(at: projectRoot, withIntermediateDirectories: true)
+        _ = try runGit(["init"], in: projectRoot)
+        try "hello\n".write(to: projectRoot.appendingPathComponent("README.md"), atomically: true, encoding: .utf8)
+        _ = try runGit(["add", "README.md"], in: projectRoot)
+        _ = try runGit([
+            "-c", "user.name=cmux Test",
+            "-c", "user.email=cmux@example.invalid",
+            "commit",
+            "-m",
+            "initial"
+        ], in: projectRoot)
+        return projectRoot
+    }
+
     @discardableResult
     private func runGit(_ arguments: [String], in directory: URL) throws -> String {
         let process = Process()


### PR DESCRIPTION
## Summary

- Adds a **New Worktree** entry to the right-click menu on the titlebar **+** (alongside New Workspace and Start Cloud VM), and registers it as a `cmux.newWorktree` built-in action so it can also be wired into `surfaceTabBarButtons` and `ui.newWorkspace.contextMenu` via `cmux.json`.
- Prompts for a branch name (prefilled `<project>-worktree-<N>`), validates pre-create (`git check-ref-format` + `git rev-parse --verify`), shows red inline error and loops the dialog with input preserved on validation failures, surfaces post-create git errors via NSAlert instead of a silent beep.
- Reuses the existing `CmuxExtensionWorktreePrototype.createWorktree` plumbing — adds `seedDemoFiles` / `branchPrefix` / `branchName` parameters. The titlebar action passes `seedDemoFiles: false` so the new workspace opens a plain shell rather than running the prototype's `python3 -m http.server` (which exited immediately and auto-closed the workspace). The existing sidebar `+` button is unchanged.

## Design notes

- **Shared dispatcher.** `AppDelegate.performNewWorktreeAction` is the single entry point and is called both from `executeConfiguredCmuxAction` (for the titlebar menu) and from `Workspace.executeSurfaceTabBarCommandButton` (for the surface tab bar), per the "shared behavior" policy in `CLAUDE.md`.
- **No new shortcut.** The action is menu-only for now; if a binding is desired later it would go through `KeyboardShortcutSettings` per the shortcut policy.
- **Sanitization.** The prefilled branch base sanitizes the project directory name to `[A-Za-z0-9._-]`, collapsing runs and trimming leading/trailing punctuation, so unusual directory names still produce a valid git ref.

## Test plan

- [x] Right-click **+** in titlebar; the menu shows New Workspace · Start Cloud VM · New Worktree
- [x] Click New Worktree from a git-backed workspace → dialog opens with `<project>-worktree-1` prefilled and selected
- [x] Create with the prefill → new workspace appears with a shell in `<repo>/.cmux/worktrees/<branch>` on the new branch; persists (doesn't auto-close)
- [x] Try a name that already exists (e.g. `main`) → red inline error in dialog, input preserved, can edit and retry
- [x] Try an invalid name like `foo bar` → red inline error for the format violation
- [x] Cancel the dialog → no worktree created, no debug noise
- [x] Existing sidebar **+** worktree button still works (defaults preserved)
- [x] Unit tests pass locally: `testCreateWorktreeKeepsCmuxDirectoryLocallyIgnored`, `testCreateWorktreeWithoutDemoFilesSkipsSampleSeed`, `testCreateWorktreeUsesExplicitBranchName`, `testCreateWorktreeEmptyExplicitBranchNameFallsBackToGeneratedName`, `testDefaultNewWorkspaceContextMenuIncludesCloudVM`, `testDefaultCloudVMMenuActionCanBeOverriddenByAlias`

## Localization

Added 8 new strings (`command.newWorktree.title`, `dialog.newWorktree.title/message/placeholder/create/error.invalidName/error.branchExists/error.creationFailed.title`) with English + Japanese translations. Other locales in `Resources/Localizable.xcstrings` will populate as `needs_review` on next Xcode sync and fall back to the English defaultValue at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782323656&installation_id=133855650&pr_number=4726&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4726&signature=35d6475acb75b3255d27353fcfcddcd2b6ed9bfcd747cbd2f6c61d95a1183b8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a New Worktree action that lets you create a git worktree from the current project and open it as a new workspace. It lives in the titlebar + menu and is configurable via `cmux.json`.

- **New Features**
  - Added `cmux.newWorktree` built-in action to the titlebar `+` menu; can be bound in `surfaceTabBarButtons` and `ui.newWorkspace.contextMenu` via `cmux.json`.
  - Dialog pre-fills `<project>-worktree-<N>`, validates git ref format and existing branches, shows inline errors, and preserves input.
  - Creates the worktree at `<repo>/.cmux/worktrees/<branch>` and opens it as a new workspace with a plain shell (no demo server). Existing sidebar `+` behavior is unchanged.
  - Shared handler in `AppDelegate.performNewWorktreeAction`; `createWorktree` now supports `seedDemoFiles`, `branchPrefix`, and `branchName`. Added EN/JA strings and tests.

<sup>Written for commit 5257695f3fcd135047d78306324c939771ee8d23. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4726?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "New Worktree" action enabling users to create Git worktrees with automatic branch validation and intelligent naming suggestions.

* **Tests**
  * Added test coverage for worktree creation functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4726?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->