### PR TITLE
fix: open -a for editor commands, shortcut chords hint, legacy CLI migration

### DIFF
--- a/Sources/App/TerminalDirectoryOpenSupport.swift
+++ b/Sources/App/TerminalDirectoryOpenSupport.swift
@@ -332,27 +332,39 @@ enum TerminalDirectoryOpenTarget: String, CaseIterable {
     var preferredEditorCommand: String? {
         switch self {
         case .androidStudio:
-            return "studio"
+            return "open -a 'Android Studio'"
         case .antigravity:
-            return "antigravity"
+            return "open -a Antigravity"
         case .cursor:
-            return "cursor"
+            return "open -a Cursor"
         case .intellij:
-            return "idea"
+            return "open -a 'IntelliJ IDEA'"
         case .sublimeText:
-            return "subl"
+            return "open -a 'Sublime Text'"
         case .vscode:
-            return "code"
+            return "open -a 'Visual Studio Code'"
         case .windsurf:
-            return "windsurf"
+            return "open -a Windsurf"
         case .xcode:
-            return "xed"
+            return "open -a Xcode"
         case .zed:
-            return "zed"
+            return "open -a Zed"
         case .finder, .ghostty, .iterm2, .terminal, .tower, .vscodeInline, .warp:
             return nil
         }
     }
+
+    static let legacyCLICommands: [String: TerminalDirectoryOpenTarget] = [
+        "studio": .androidStudio,
+        "antigravity": .antigravity,
+        "cursor": .cursor,
+        "idea": .intellij,
+        "subl": .sublimeText,
+        "code": .vscode,
+        "windsurf": .windsurf,
+        "xed": .xcode,
+        "zed": .zed,
+    ]
 
     var preferredEditorDisplayName: String {
         switch self {

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -5002,13 +5002,22 @@ enum PreferredEditorSettings {
         TerminalDirectoryOpenTarget.availablePreferredEditorOptions(in: environment)
     }
 
+    static func migratedCommand(_ command: String) -> String? {
+        let trimmed = command.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let target = TerminalDirectoryOpenTarget.legacyCLICommands[trimmed] else { return nil }
+        return target.preferredEditorCommand
+    }
+
     static func selectionID(
         for command: String,
         editorOptions: [TerminalDirectoryOpenTarget.PreferredEditorOption]
     ) -> String {
         let trimmed = command.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return systemDefaultSelectionID }
-        return editorOptions.first { $0.command == trimmed }?.id ?? customSelectionID
+        if let match = editorOptions.first(where: { $0.command == trimmed }) { return match.id }
+        if let migrated = migratedCommand(trimmed),
+           let match = editorOptions.first(where: { $0.command == migrated }) { return match.id }
+        return customSelectionID
     }
 
     static func command(
@@ -5033,6 +5042,10 @@ enum PreferredEditorSettings {
             return .systemDefault
         }
         if let option = editorOptions.first(where: { $0.command == trimmed }) {
+            return .detectedEditor(displayName: option.displayName)
+        }
+        if let migrated = migratedCommand(trimmed),
+           let option = editorOptions.first(where: { $0.command == migrated }) {
             return .detectedEditor(displayName: option.displayName)
         }
         return .customCommand(trimmed)
@@ -5726,6 +5739,11 @@ struct SettingsView: View {
             command: preferredEditorCommand,
             editorOptions: preferredEditorOptions
         )
+    }
+
+    private var shortcutChordsEditorSubtitle: String {
+        let base = String(localized: "settings.shortcuts.chords.subtitle", defaultValue: "Add tmux-style multi-step shortcuts in cmux.json, for example [\"ctrl+b\", \"c\"].")
+        return base + " " + preferredEditorUsageHintText
     }
 
     private var supportedFileRoutingBinding: Binding<Bool> {
@@ -7672,7 +7690,7 @@ struct SettingsView: View {
                         SettingsCardRow(
                             configurationReview: .action,
                             String(localized: "settings.shortcuts.chords", defaultValue: "Shortcut Chords"),
-                            subtitle: String(localized: "settings.shortcuts.chords.subtitle", defaultValue: "Add tmux-style multi-step shortcuts in cmux.json, for example [\"ctrl+b\", \"c\"]."),
+                            subtitle: shortcutChordsEditorSubtitle,
                             searchAnchorID: SettingsSearchIndex.settingID(for: .keyboardShortcuts, idSuffix: "shortcut-chords")
                         ) {
                             HStack(spacing: 8) {

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -5742,8 +5742,10 @@ struct SettingsView: View {
     }
 
     private var shortcutChordsEditorSubtitle: String {
-        let base = String(localized: "settings.shortcuts.chords.subtitle", defaultValue: "Add tmux-style multi-step shortcuts in cmux.json, for example [\"ctrl+b\", \"c\"].")
-        return base + " " + preferredEditorUsageHintText
+        String(
+            localized: "settings.shortcuts.chords.subtitle.withEditorHint",
+            defaultValue: "Add tmux-style multi-step shortcuts in cmux.json, for example [\"ctrl+b\", \"c\"]. \(preferredEditorUsageHintText)"
+        )
     }
 
     private var supportedFileRoutingBinding: Binding<Bool> {


### PR DESCRIPTION
## Summary

Stacks on #4717. Three fixes found while dogfooding the editor picker:

- **`open -a` instead of bare CLI commands** — `cursor`, `code`, etc. can exit non-zero when launched from a macOS app process (minimal PATH, different env), triggering the `NSWorkspace.shared.open()` fallback. This caused both the editor AND the system default app (e.g. After Effects for `.json`) to open. `open -a` goes through LaunchServices and works reliably from app context.
- **Shortcut Chords "Opens with…" hint** — the Keyboard Shortcuts section has an "Open cmux.json" button but didn't show which editor would open it. Now the subtitle includes the same hint as the cmux.json section.
- **Legacy CLI migration** — users who had `cursor`/`code`/`zed` stored from the text field are matched to the correct picker entry and upgraded on selection.

Fixes the double-open bug reported in #4703.

## Testing

- Set preferred editor to Cursor → clicked "Open cmux.json" → opens only in Cursor (no After Effects)
- Verified legacy value `cursor` shows as "Cursor" in picker, migrates to `open -a Cursor` on re-select
- Verified Shortcut Chords subtitle shows "Opens with Cursor. Change in App → Open Files With."

## Demo Video

N/A — behavior fix, no new visual components.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4727"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782324337&installation_id=133855650&pr_number=4727&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4727&signature=acffb5c3c4c7527a9ca752205e4f07b26412555e440ffc8b2095bdf3249ddecd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch editor launch to `open -a` to stop double-opening and reliably open the selected editor from app context. Adds a locale-aware "Opens with…" hint to Shortcut Chords and migrates legacy CLI values to the correct picker entries (fixes #4703).

- **Bug Fixes**
  - Use `open -a` for Cursor, VS Code, Zed, Android Studio, IntelliJ, Sublime Text, Windsurf, Xcode, and others; prevents `NSWorkspace` fallback and double-open.
  - Shortcut Chords row now shows the same "Opens with…" editor hint as the `cmux.json` section, using a single locale-aware format string (handles CJK/RTL correctly).
  - Legacy CLI values (`studio`, `antigravity`, `cursor`, `idea`, `subl`, `code`, `windsurf`, `xed`, `zed`) auto-map to their `open -a` commands and upgrade on selection.

<sup>Written for commit 01cde9746af2516bdf93c53ae685118a0225dc5c. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4727?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

