### PR TITLE
Fix cmux terminal environment injection

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5296,8 +5296,43 @@ final class TerminalSurface: Identifiable, ObservableObject {
     private var searchNeedleCancellable: AnyCancellable?
     var currentKeyStateIndicatorText: String? { surfaceView.currentKeyStateIndicatorText }
 
+    private static func cmuxContextEnvironment(
+        workspaceId: UUID,
+        surfaceId: UUID,
+        socketPath: String
+    ) -> CmuxContextEnvironment {
+        CmuxContextEnvironment(
+            workspaceId: workspaceId,
+            surfaceId: surfaceId,
+            socketPath: socketPath
+        )
+    }
+
+    /// Pre-spawn lookup for managed context keys and explicit startup overrides.
+    /// Full runtime-only values such as bundle, port, PATH, and shell-integration
+    /// entries are assembled when a Ghostty surface is created.
+    @MainActor
     func startupEnvironmentValue(_ key: String) -> String? {
-        additionalEnvironment[key] ?? initialEnvironmentOverrides[key]
+        let socketPath = TerminalController.shared.activeSocketPath(
+            preferredPath: SocketControlSettings.socketPath()
+        )
+        var environment: [String: String] = [:]
+        var protectedKeys: Set<String> = []
+        Self.applyManagedCmuxContextEnvironment(
+            Self.cmuxContextEnvironment(
+                workspaceId: tabId,
+                surfaceId: id,
+                socketPath: socketPath
+            ),
+            to: &environment,
+            protectedKeys: &protectedKeys
+        )
+        return Self.mergedStartupEnvironment(
+            base: environment,
+            protectedKeys: protectedKeys,
+            additionalEnvironment: additionalEnvironment,
+            initialEnvironmentOverrides: initialEnvironmentOverrides
+        )[key]
     }
 
     init(
@@ -6053,15 +6088,18 @@ final class TerminalSurface: Identifiable, ObservableObject {
             protectedStartupEnvironmentKeys.insert(key)
         }
 
-        setManagedEnvironmentValue("CMUX_SURFACE_ID", id.uuidString)
-        setManagedEnvironmentValue("CMUX_WORKSPACE_ID", tabId.uuidString)
-        // Backward-compatible shell integration keys used by existing scripts/tests.
-        setManagedEnvironmentValue("CMUX_PANEL_ID", id.uuidString)
-        setManagedEnvironmentValue("CMUX_TAB_ID", tabId.uuidString)
         let socketPath = TerminalController.shared.activeSocketPath(
             preferredPath: SocketControlSettings.socketPath()
         )
-        setManagedEnvironmentValue("CMUX_SOCKET_PATH", socketPath)
+        Self.applyManagedCmuxContextEnvironment(
+            Self.cmuxContextEnvironment(
+                workspaceId: tabId,
+                surfaceId: id,
+                socketPath: socketPath
+            ),
+            to: &env,
+            protectedKeys: &protectedStartupEnvironmentKeys
+        )
         setManagedEnvironmentValue("CMUX_SOCKET", "")
         if let inheritedClaudeConfigDir = ProcessInfo.processInfo.environment["CLAUDE_CONFIG_DIR"],
            !inheritedClaudeConfigDir.isEmpty {

--- a/Sources/TerminalStartupEnvironment.swift
+++ b/Sources/TerminalStartupEnvironment.swift
@@ -2,6 +2,12 @@ import Foundation
 import CMUXAgentLaunch
 
 extension TerminalSurface {
+    struct CmuxContextEnvironment: Equatable, Sendable {
+        let workspaceId: UUID
+        let surfaceId: UUID
+        let socketPath: String
+    }
+
     static let managedTerminalType = "xterm-256color"
     static let managedTerminalProgram = "ghostty"
     static let managedColorTerm = "truecolor"
@@ -24,6 +30,25 @@ extension TerminalSurface {
         protectedKeys.insert("COLORTERM")
         environment["TERM_PROGRAM"] = managedTerminalProgram
         protectedKeys.insert("TERM_PROGRAM")
+    }
+
+    static func applyManagedCmuxContextEnvironment(
+        _ context: CmuxContextEnvironment,
+        to environment: inout [String: String],
+        protectedKeys: inout Set<String>
+    ) {
+        let values = [
+            "CMUX_SURFACE_ID": context.surfaceId.uuidString,
+            "CMUX_WORKSPACE_ID": context.workspaceId.uuidString,
+            "CMUX_PANEL_ID": context.surfaceId.uuidString,
+            "CMUX_TAB_ID": context.workspaceId.uuidString,
+            "CMUX_SOCKET_PATH": context.socketPath
+        ]
+
+        for (key, value) in values {
+            environment[key] = value
+            protectedKeys.insert(key)
+        }
     }
 
     static func applyManagedGitWatchEnvironment(

--- a/cmuxTests/GhosttyTerminalStartupEnvironmentTests.swift
+++ b/cmuxTests/GhosttyTerminalStartupEnvironmentTests.swift
@@ -7,6 +7,36 @@ import XCTest
 #endif
 
 final class GhosttyTerminalStartupEnvironmentTests: XCTestCase {
+    @MainActor
+    func testTerminalSurfaceStartupEnvironmentIncludesCmuxContextValues() throws {
+        let workspaceId = UUID()
+        let surface = TerminalSurface(
+            tabId: workspaceId,
+            context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
+            configTemplate: nil
+        )
+        defer { TerminalSurfaceRegistry.shared.unregister(surface) }
+
+        let expectedContextValues = [
+            "CMUX_WORKSPACE_ID": workspaceId.uuidString,
+            "CMUX_SURFACE_ID": surface.id.uuidString,
+            "CMUX_TAB_ID": workspaceId.uuidString,
+            "CMUX_PANEL_ID": surface.id.uuidString
+        ]
+
+        for (key, expectedValue) in expectedContextValues {
+            let value = try XCTUnwrap(surface.startupEnvironmentValue(key), "\(key) should be present")
+            XCTAssertFalse(value.isEmpty, "\(key) should be non-empty")
+            XCTAssertEqual(value, expectedValue)
+        }
+
+        let socketPath = try XCTUnwrap(
+            surface.startupEnvironmentValue("CMUX_SOCKET_PATH"),
+            "CMUX_SOCKET_PATH should be present"
+        )
+        XCTAssertFalse(socketPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+    }
+
     func testApplyManagedTerminalIdentityEnvironmentOverridesInheritedValues() {
         var environment = [
             "TERM": "xterm-ghostty",


### PR DESCRIPTION
## Summary
- Add a regression test covering all five managed CMUX terminal context variables.
- Centralize CMUX terminal context env assembly so runtime surface creation and startup environment lookup share the same path.

Fixes #4714.

## Verification
- Not run locally: user explicitly prohibited xcodebuild and reload.sh in this workspace; CI is expected to run the regression test.

## Commit structure
- Commit 1: failing regression test only.
- Commit 2: fix that makes the regression pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4728"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782330371&installation_id=133855650&pr_number=4728&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4728&signature=2aab0531ff75fe346a6ac2b0bc06eee9e80ca922d0a8cc6344a91efd26750957"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to terminal startup environment assembly and protected keys; no auth or data-path changes, with regression test coverage.
> 
> **Overview**
> **CMUX terminal context env vars** (`CMUX_WORKSPACE_ID`, `CMUX_SURFACE_ID`, `CMUX_PANEL_ID`, `CMUX_TAB_ID`, `CMUX_SOCKET_PATH`) are now built in one place via `applyManagedCmuxContextEnvironment` and used both when a Ghostty surface is created and in pre-spawn `startupEnvironmentValue` lookups (which previously only merged overrides and could miss managed context keys).
> 
> A small `CmuxContextEnvironment` type carries workspace/surface IDs and the active socket path. A new regression test asserts all five keys are present and correct on `TerminalSurface.startupEnvironmentValue`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25eaca486b21f60cf603e1f1bbcba5eafd9cbcd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated CMUX context handling for terminal surfaces: workspace/surface/panel/tab IDs and socket path are computed once and applied as managed, protected environment values to prevent accidental overrides and ensure consistent startup environments.

* **Tests**
  * Added test coverage verifying CMUX-related environment variables and socket path are populated and match expected values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4728?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->