### PR TITLE
Harden Eternal Terminal option parsing

### DIFF
--- a/Sources/RemoteShellSessionParsing.swift
+++ b/Sources/RemoteShellSessionParsing.swift
@@ -134,6 +134,20 @@ nonisolated enum RemoteShellSessionParsing {
             }
         }
 
+        func hasLaterDestinationCandidate(after valueIndex: Int) -> Bool {
+            let nextIndex = valueIndex + 1
+            guard nextIndex < arguments.count else { return false }
+
+            return arguments[nextIndex...].contains { argument in
+                !argument.hasPrefix("-") || argument == "-"
+            }
+        }
+
+        func malformedValueOptionAdvance(from nextIndex: Int) -> Int {
+            guard nextIndex < arguments.count else { return 1 }
+            return (!arguments[nextIndex].hasPrefix("-") || arguments[nextIndex] == "-") ? 2 : 1
+        }
+
         argumentLoop: while index < arguments.count {
             let argument = arguments[index]
             if argument == "--" {
@@ -155,6 +169,10 @@ nonisolated enum RemoteShellSessionParsing {
                 let nextIndex = index + 1
                 guard nextIndex < arguments.count,
                       consumeSSHOptionValue(arguments[nextIndex]) else {
+                    if destination != nil {
+                        index += malformedValueOptionAdvance(from: nextIndex)
+                        continue
+                    }
                     return nil
                 }
                 index += 2
@@ -162,7 +180,13 @@ nonisolated enum RemoteShellSessionParsing {
             }
             if argument.hasPrefix("--ssh-option=") {
                 let value = String(argument.dropFirst("--ssh-option=".count))
-                guard consumeSSHOptionValue(value) else { return nil }
+                guard consumeSSHOptionValue(value) else {
+                    if destination != nil {
+                        index += 1
+                        continue
+                    }
+                    return nil
+                }
                 index += 1
                 continue
             }
@@ -179,7 +203,13 @@ nonisolated enum RemoteShellSessionParsing {
                 }
                 if optionName == "telemetry" {
                     if parts.count == 2 {
-                        guard isBoolLiteral(String(parts[1])) else { return nil }
+                        guard isBoolLiteral(String(parts[1])) else {
+                            if destination != nil {
+                                index += 1
+                                continue
+                            }
+                            return nil
+                        }
                         index += 1
                     } else if index + 1 < arguments.count, isBoolLiteral(arguments[index + 1]) {
                         index += 2
@@ -190,7 +220,13 @@ nonisolated enum RemoteShellSessionParsing {
                 }
                 if optionName == "verbose" {
                     if parts.count == 2 {
-                        guard Int(String(parts[1])) != nil else { return nil }
+                        guard Int(String(parts[1])) != nil else {
+                            if destination != nil {
+                                index += 1
+                                continue
+                            }
+                            return nil
+                        }
                         index += 1
                     } else if index + 1 < arguments.count, Int(arguments[index + 1]) != nil {
                         index += 2
@@ -201,16 +237,34 @@ nonisolated enum RemoteShellSessionParsing {
                 }
                 if eternalTerminalLongValueOptions.contains(optionName) {
                     if parts.count == 2 {
-                        guard consumeETValue(String(parts[1]), for: optionName) else { return nil }
+                        guard consumeETValue(String(parts[1]), for: optionName) else {
+                            if destination != nil {
+                                index += 1
+                                continue
+                            }
+                            return nil
+                        }
                         index += 1
                     } else {
                         let nextIndex = index + 1
                         guard nextIndex < arguments.count,
                               consumeETValue(arguments[nextIndex], for: optionName) else {
+                            if destination != nil {
+                                index += malformedValueOptionAdvance(from: nextIndex)
+                                continue
+                            }
                             return nil
                         }
                         index += 2
                     }
+                    continue
+                }
+                if parts.count == 1,
+                   destination == nil,
+                   index + 1 < arguments.count,
+                   !arguments[index + 1].hasPrefix("-"),
+                   hasLaterDestinationCandidate(after: index + 1) {
+                    index += 2
                     continue
                 }
                 index += 1
@@ -243,12 +297,22 @@ nonisolated enum RemoteShellSessionParsing {
                 if eternalTerminalValueArgumentFlags.contains(option) {
                     if shortOptionIndex + 1 < shortOptions.count {
                         let value = String(shortOptions[(shortOptionIndex + 1)...])
-                        guard consumeETValue(value, for: option) else { return nil }
+                        guard consumeETValue(value, for: option) else {
+                            if destination != nil {
+                                index += 1
+                                continue argumentLoop
+                            }
+                            return nil
+                        }
                         index += 1
                     } else {
                         let nextIndex = index + 1
                         guard nextIndex < arguments.count,
                               consumeETValue(arguments[nextIndex], for: option) else {
+                            if destination != nil {
+                                index += malformedValueOptionAdvance(from: nextIndex)
+                                continue argumentLoop
+                            }
                             return nil
                         }
                         index += 2

--- a/Sources/RemoteShellSessionParsing.swift
+++ b/Sources/RemoteShellSessionParsing.swift
@@ -145,7 +145,7 @@ nonisolated enum RemoteShellSessionParsing {
             }
         }
 
-        while index < arguments.count {
+        argumentLoop: while index < arguments.count {
             let argument = arguments[index]
             if argument == "--" {
                 let nextIndex = index + 1
@@ -158,7 +158,8 @@ nonisolated enum RemoteShellSessionParsing {
                 if destination == nil {
                     destination = argument
                 }
-                break
+                index += 1
+                continue
             }
 
             if argument == "--ssh-option" {
@@ -188,7 +189,10 @@ nonisolated enum RemoteShellSessionParsing {
                     continue
                 }
                 if optionName == "telemetry" {
-                    if parts.count == 1, index + 1 < arguments.count, isBoolLiteral(arguments[index + 1]) {
+                    if parts.count == 2 {
+                        guard isBoolLiteral(String(parts[1])) else { return nil }
+                        index += 1
+                    } else if index + 1 < arguments.count, isBoolLiteral(arguments[index + 1]) {
                         index += 2
                     } else {
                         index += 1
@@ -198,10 +202,15 @@ nonisolated enum RemoteShellSessionParsing {
                 if optionName == "verbose" {
                     if parts.count == 2 {
                         guard Int(String(parts[1])) != nil else { return nil }
-                    } else if index + 1 < arguments.count, Int(arguments[index + 1]) != nil {
                         index += 1
+                    } else {
+                        let nextIndex = index + 1
+                        guard nextIndex < arguments.count,
+                              Int(arguments[nextIndex]) != nil else {
+                            return nil
+                        }
+                        index += 2
                     }
-                    index += 1
                     continue
                 }
                 if eternalTerminalLongValueOptions.contains(optionName) {
@@ -222,44 +231,57 @@ nonisolated enum RemoteShellSessionParsing {
                     index += 1
                     continue
                 }
-                return nil
-            }
-
-            let shortOptions = Array(argument.dropFirst())
-            guard let option = shortOptions.first else { return nil }
-            if option == "f" {
-                forwardAgent = true
-                guard shortOptions.count == 1 else { return nil }
                 index += 1
                 continue
             }
-            if option == "v" {
-                if shortOptions.count > 1 {
-                    guard Int(String(argument.dropFirst(2))) != nil else { return nil }
-                    index += 1
-                } else if index + 1 < arguments.count, Int(arguments[index + 1]) != nil {
-                    index += 2
-                } else {
-                    index += 1
-                }
-                continue
-            }
-            if eternalTerminalValueArgumentFlags.contains(option) {
-                if shortOptions.count > 1 {
-                    guard consumeETValue(String(argument.dropFirst(2)), for: option) else { return nil }
-                    index += 1
-                } else {
-                    let nextIndex = index + 1
-                    guard nextIndex < arguments.count,
-                          consumeETValue(arguments[nextIndex], for: option) else {
-                        return nil
+
+            let shortOptions = Array(argument.dropFirst())
+            guard !shortOptions.isEmpty else { return nil }
+            var shortOptionIndex = 0
+            while shortOptionIndex < shortOptions.count {
+                let option = shortOptions[shortOptionIndex]
+
+                if option == "v" {
+                    if shortOptionIndex + 1 < shortOptions.count {
+                        let value = String(shortOptions[(shortOptionIndex + 1)...])
+                        guard Int(value) != nil else { return nil }
+                        index += 1
+                    } else {
+                        let nextIndex = index + 1
+                        guard nextIndex < arguments.count,
+                              Int(arguments[nextIndex]) != nil else {
+                            return nil
+                        }
+                        index += 2
                     }
-                    index += 2
+                    continue argumentLoop
                 }
-                continue
-            }
-            guard shortOptions.allSatisfy({ eternalTerminalNoArgumentFlags.contains($0) }) else {
-                return nil
+
+                if eternalTerminalValueArgumentFlags.contains(option) {
+                    if shortOptionIndex + 1 < shortOptions.count {
+                        let value = String(shortOptions[(shortOptionIndex + 1)...])
+                        guard consumeETValue(value, for: option) else { return nil }
+                        index += 1
+                    } else {
+                        let nextIndex = index + 1
+                        guard nextIndex < arguments.count,
+                              consumeETValue(arguments[nextIndex], for: option) else {
+                            return nil
+                        }
+                        index += 2
+                    }
+                    continue argumentLoop
+                }
+
+                if eternalTerminalNoArgumentFlags.contains(option) {
+                    if option == "f" {
+                        forwardAgent = true
+                    }
+                    shortOptionIndex += 1
+                    continue
+                }
+
+                shortOptionIndex += 1
             }
             index += 1
         }

--- a/Sources/RemoteShellSessionParsing.swift
+++ b/Sources/RemoteShellSessionParsing.swift
@@ -203,13 +203,10 @@ nonisolated enum RemoteShellSessionParsing {
                     if parts.count == 2 {
                         guard Int(String(parts[1])) != nil else { return nil }
                         index += 1
-                    } else {
-                        let nextIndex = index + 1
-                        guard nextIndex < arguments.count,
-                              Int(arguments[nextIndex]) != nil else {
-                            return nil
-                        }
+                    } else if index + 1 < arguments.count, Int(arguments[index + 1]) != nil {
                         index += 2
+                    } else {
+                        index += 1
                     }
                     continue
                 }
@@ -246,13 +243,10 @@ nonisolated enum RemoteShellSessionParsing {
                         let value = String(shortOptions[(shortOptionIndex + 1)...])
                         guard Int(value) != nil else { return nil }
                         index += 1
-                    } else {
-                        let nextIndex = index + 1
-                        guard nextIndex < arguments.count,
-                              Int(arguments[nextIndex]) != nil else {
-                            return nil
-                        }
+                    } else if index + 1 < arguments.count, Int(arguments[index + 1]) != nil {
                         index += 2
+                    } else {
+                        index += 1
                     }
                     continue argumentLoop
                 }

--- a/Sources/RemoteShellSessionParsing.swift
+++ b/Sources/RemoteShellSessionParsing.swift
@@ -134,12 +134,24 @@ nonisolated enum RemoteShellSessionParsing {
             }
         }
 
-        func hasLaterDestinationCandidate(after valueIndex: Int) -> Bool {
+        func destinationCandidateScore(_ argument: String) -> Int {
+            let trimmed = argument.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { return 0 }
+            if trimmed.contains("@") { return 4 }
+            if trimmed.hasPrefix("[") && trimmed.contains("]") { return 3 }
+            if trimmed.contains(":") { return 3 }
+            if trimmed.contains(".") { return 2 }
+            return 1
+        }
+
+        func hasStrongerLaterDestinationCandidate(after valueIndex: Int, than candidate: String) -> Bool {
             let nextIndex = valueIndex + 1
             guard nextIndex < arguments.count else { return false }
+            let currentScore = destinationCandidateScore(candidate)
 
             return arguments[nextIndex...].contains { argument in
-                !argument.hasPrefix("-") || argument == "-"
+                (!argument.hasPrefix("-") || argument == "-") &&
+                    destinationCandidateScore(argument) > currentScore
             }
         }
 
@@ -263,7 +275,7 @@ nonisolated enum RemoteShellSessionParsing {
                    destination == nil,
                    index + 1 < arguments.count,
                    !arguments[index + 1].hasPrefix("-"),
-                   hasLaterDestinationCandidate(after: index + 1) {
+                   hasStrongerLaterDestinationCandidate(after: index + 1, than: arguments[index + 1]) {
                     index += 2
                     continue
                 }

--- a/Sources/RemoteShellSessionParsing.swift
+++ b/Sources/RemoteShellSessionParsing.swift
@@ -45,17 +45,6 @@ nonisolated enum RemoteShellSessionParsing {
         "tunnel",
         "username",
     ]
-    private static let eternalTerminalLongNoArgumentOptions: Set<String> = [
-        "forward-ssh-agent",
-        "help",
-        "kill-other-sessions",
-        "logtostdout",
-        "macserver",
-        "no-terminal",
-        "noexit",
-        "silent",
-        "version",
-    ]
     private static let filteredSSHOptionKeys: Set<String> = [
         "batchmode",
         "controlmaster",
@@ -224,10 +213,6 @@ nonisolated enum RemoteShellSessionParsing {
                     }
                     continue
                 }
-                if eternalTerminalLongNoArgumentOptions.contains(optionName) || parts.count == 2 {
-                    index += 1
-                    continue
-                }
                 index += 1
                 continue
             }
@@ -241,8 +226,12 @@ nonisolated enum RemoteShellSessionParsing {
                 if option == "v" {
                     if shortOptionIndex + 1 < shortOptions.count {
                         let value = String(shortOptions[(shortOptionIndex + 1)...])
-                        guard Int(value) != nil else { return nil }
-                        index += 1
+                        if Int(value) != nil {
+                            index += 1
+                            continue argumentLoop
+                        }
+                        shortOptionIndex += 1
+                        continue
                     } else if index + 1 < arguments.count, Int(arguments[index + 1]) != nil {
                         index += 2
                     } else {

--- a/cmuxTests/WorkspaceRemoteConnectionTests.swift
+++ b/cmuxTests/WorkspaceRemoteConnectionTests.swift
@@ -2137,6 +2137,48 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
         XCTAssertEqual(scpArgs.last, "lawrence@example.com:/tmp/cmux-drop-123.png")
     }
 
+    func testDetectsEternalTerminalSessionSkipsUnknownLongOptionValueBeforeDestination() {
+        let session = TerminalSSHSessionDetector.detectForTesting(
+            ttyName: "/dev/ttys004",
+            processes: [
+                .init(pid: 2145, pgid: 1967, tpgid: 1967, tty: "ttys004", executableName: "et"),
+            ],
+            argumentsByPID: [
+                2145: [
+                    "et",
+                    "--future-value",
+                    "ignored",
+                    "lawrence@example.com",
+                ],
+            ]
+        )
+
+        XCTAssertEqual(session?.destination, "lawrence@example.com")
+    }
+
+    func testDetectsEternalTerminalSessionKeepsDestinationWhenTrailingOptionIsMalformed() {
+        let session = TerminalSSHSessionDetector.detectForTesting(
+            ttyName: "/dev/ttys004",
+            processes: [
+                .init(pid: 2145, pgid: 1967, tpgid: 1967, tty: "ttys004", executableName: "et"),
+            ],
+            argumentsByPID: [
+                2145: [
+                    "et",
+                    "lawrence@example.com",
+                    "--port",
+                    "not-a-number",
+                    "--ssh-option",
+                    "Port=2200",
+                    "-p",
+                ],
+            ]
+        )
+
+        XCTAssertEqual(session?.destination, "lawrence@example.com")
+        XCTAssertEqual(session?.port, 2200)
+    }
+
     func testDetectsEternalTerminalSessionStripsNativeJumpHostServerPortForSCP() {
         let session = TerminalSSHSessionDetector.detectForTesting(
             ttyName: "/dev/ttys004",

--- a/cmuxTests/WorkspaceRemoteConnectionTests.swift
+++ b/cmuxTests/WorkspaceRemoteConnectionTests.swift
@@ -2156,6 +2156,25 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
         XCTAssertEqual(session?.destination, "lawrence@example.com")
     }
 
+    func testDetectsEternalTerminalSessionKeepsStrongUnknownLongOptionDestinationCandidate() {
+        let session = TerminalSSHSessionDetector.detectForTesting(
+            ttyName: "/dev/ttys004",
+            processes: [
+                .init(pid: 2145, pgid: 1967, tpgid: 1967, tty: "ttys004", executableName: "et"),
+            ],
+            argumentsByPID: [
+                2145: [
+                    "et",
+                    "--future-flag",
+                    "lawrence@example.com",
+                    "ignored-extra",
+                ],
+            ]
+        )
+
+        XCTAssertEqual(session?.destination, "lawrence@example.com")
+    }
+
     func testDetectsEternalTerminalSessionKeepsDestinationWhenTrailingOptionIsMalformed() {
         let session = TerminalSSHSessionDetector.detectForTesting(
             ttyName: "/dev/ttys004",

--- a/cmuxTests/WorkspaceRemoteConnectionTests.swift
+++ b/cmuxTests/WorkspaceRemoteConnectionTests.swift
@@ -2304,6 +2304,8 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
             ("long verbose before host", ["et", "--verbose", "lawrence@example.com"]),
             ("short verbose before host", ["et", "-v", "lawrence@example.com"]),
             ("short verbose after host", ["et", "lawrence@example.com", "-v"]),
+            ("short verbose clustered with known flag", ["et", "-vx", "lawrence@example.com"]),
+            ("short verbose clustered with unknown flag", ["et", "-vZ", "lawrence@example.com"]),
         ]
 
         for (name, arguments) in cases {

--- a/cmuxTests/WorkspaceRemoteConnectionTests.swift
+++ b/cmuxTests/WorkspaceRemoteConnectionTests.swift
@@ -2110,7 +2110,7 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
         XCTAssertEqual(scpArgs.last, "lawrence@[2001:db8::1:2022]:/tmp/cmux-drop-123.png")
     }
 
-    func testDetectsEternalTerminalSessionIgnoresOptionsAfterDestination() {
+    func testDetectsEternalTerminalSessionParsesOptionsAfterDestination() {
         let session = TerminalSSHSessionDetector.detectForTesting(
             ttyName: "/dev/ttys004",
             processes: [
@@ -2126,13 +2126,14 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
         )
 
         XCTAssertEqual(session?.destination, "lawrence@example.com")
-        XCTAssertNil(session?.port)
+        XCTAssertEqual(session?.port, 2200)
 
         let scpArgs = session?.scpArgumentsForTesting(
             localPath: "/tmp/local.png",
             remotePath: "/tmp/cmux-drop-123.png"
         ) ?? []
-        XCTAssertFalse(scpArgs.contains("-P"))
+        XCTAssertTrue(scpArgs.contains("-P"))
+        XCTAssertTrue(scpArgs.contains("2200"))
         XCTAssertEqual(scpArgs.last, "lawrence@example.com:/tmp/cmux-drop-123.png")
     }
 
@@ -2204,6 +2205,98 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
                 ]
             )
         )
+    }
+
+    func testDetectsEternalTerminalSessionWithCurrentETOptionSurface() {
+        let session = TerminalSSHSessionDetector.detectForTesting(
+            ttyName: "/dev/ttys004",
+            processes: [
+                .init(pid: 2145, pgid: 1967, tpgid: 1967, tty: "ttys004", executableName: "et"),
+            ],
+            argumentsByPID: [
+                2145: [
+                    "et",
+                    "--logtostdout",
+                    "--silent",
+                    "--no-terminal",
+                    "--noexit",
+                    "--kill-other-sessions",
+                    "--macserver",
+                    "--forward-ssh-agent",
+                    "--telemetry", "false",
+                    "--terminal-path=/usr/local/bin/etterminal",
+                    "--tunnel", "10080:80,10443:443",
+                    "--reversetunnel=10090:90",
+                    "--jserverfifo", "jump.fifo",
+                    "--serverfifo=server.fifo",
+                    "--ssh-socket", "/tmp/agent.sock",
+                    "--port", "2022",
+                    "--jport=2023",
+                    "--keepalive", "1",
+                    "--logdir", "/tmp/et-logs",
+                    "--command", "printf ok",
+                    "--ssh-option", "Port=2200",
+                    "--ssh-option=IdentityFile=/Users/test/.ssh/id_ed25519",
+                    "--ssh-option", "User=lawrence",
+                    "--host=example.com:2024",
+                ],
+            ]
+        )
+
+        XCTAssertEqual(session?.destination, "lawrence@example.com")
+        XCTAssertEqual(session?.port, 2200)
+        XCTAssertEqual(session?.identityFile, "/Users/test/.ssh/id_ed25519")
+        XCTAssertTrue(session?.forwardAgent == true)
+
+        let scpArgs = session?.scpArgumentsForTesting(
+            localPath: "/tmp/local.png",
+            remotePath: "/tmp/cmux-drop-123.png"
+        ) ?? []
+        XCTAssertTrue(scpArgs.contains("-A"))
+        XCTAssertTrue(scpArgs.contains("-P"))
+        XCTAssertTrue(scpArgs.contains("2200"))
+        XCTAssertFalse(scpArgs.contains("2022"))
+        XCTAssertFalse(scpArgs.contains("2023"))
+        XCTAssertFalse(scpArgs.contains("2024"))
+        XCTAssertEqual(scpArgs.last, "lawrence@example.com:/tmp/cmux-drop-123.png")
+    }
+
+    func testDetectsEternalTerminalSessionWithBundledShortAndUnknownOptions() {
+        let session = TerminalSSHSessionDetector.detectForTesting(
+            ttyName: "/dev/ttys004",
+            processes: [
+                .init(pid: 2145, pgid: 1967, tpgid: 1967, tty: "ttys004", executableName: "et"),
+            ],
+            argumentsByPID: [
+                2145: [
+                    "et",
+                    "--future-flag",
+                    "--future-value=ignored",
+                    "-ZefxN",
+                    "-v2",
+                    "-p2022",
+                    "-k1",
+                    "-l/tmp/et-logs",
+                    "-t10080:80",
+                    "-r10090:90",
+                    "-cprintf ok",
+                    "--ssh-option=User=lawrence",
+                    "example.com",
+                ],
+            ]
+        )
+
+        XCTAssertEqual(session?.destination, "lawrence@example.com")
+        XCTAssertNil(session?.port)
+        XCTAssertTrue(session?.forwardAgent == true)
+
+        let scpArgs = session?.scpArgumentsForTesting(
+            localPath: "/tmp/local.png",
+            remotePath: "/tmp/cmux-drop-123.png"
+        ) ?? []
+        XCTAssertTrue(scpArgs.contains("-A"))
+        XCTAssertFalse(scpArgs.contains("-P"))
+        XCTAssertEqual(scpArgs.last, "lawrence@example.com:/tmp/cmux-drop-123.png")
     }
 
     func testDaemonTransportArgumentsReuseConfiguredControlPath() {

--- a/cmuxTests/WorkspaceRemoteConnectionTests.swift
+++ b/cmuxTests/WorkspaceRemoteConnectionTests.swift
@@ -2299,6 +2299,28 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
         XCTAssertEqual(scpArgs.last, "lawrence@example.com:/tmp/cmux-drop-123.png")
     }
 
+    func testDetectsEternalTerminalSessionWithVerboseFlagWithoutLevel() {
+        let cases: [(String, [String])] = [
+            ("long verbose before host", ["et", "--verbose", "lawrence@example.com"]),
+            ("short verbose before host", ["et", "-v", "lawrence@example.com"]),
+            ("short verbose after host", ["et", "lawrence@example.com", "-v"]),
+        ]
+
+        for (name, arguments) in cases {
+            let session = TerminalSSHSessionDetector.detectForTesting(
+                ttyName: "/dev/ttys004",
+                processes: [
+                    .init(pid: 2145, pgid: 1967, tpgid: 1967, tty: "ttys004", executableName: "et"),
+                ],
+                argumentsByPID: [
+                    2145: arguments,
+                ]
+            )
+
+            XCTAssertEqual(session?.destination, "lawrence@example.com", name)
+        }
+    }
+
     func testDaemonTransportArgumentsReuseConfiguredControlPath() {
         let configuration = WorkspaceRemoteConfiguration(
             destination: "cmux-macmini",


### PR DESCRIPTION
## Summary
- stack on #4712 to mirror Eternal Terminal 6.2.11 option parsing more closely
- parse recognized ET options after the host, matching cxxopts behavior
- handle bundled short options and tolerate unknown ET options without dropping remote detection
- add regression coverage for the current ET option surface and bundled short flags

## Testing
- not run locally; CI will run the test suite
- local real-ET smoke will be run against the tagged dev build after PR creation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how ET sessions are inferred from live process argv, which affects remote connection/scp behavior; logic is complex but covered by new regression tests.
> 
> **Overview**
> **Eternal Terminal (`et`) command-line parsing** is reworked in `RemoteShellSessionParsing` so remote session detection and derived **scp** args track ET 6.2.11-style behavior more closely.
> 
> Parsing **no longer stops** at the first host-like token; it keeps scanning so **`--ssh-option`**, agent forwarding, and similar flags **after the destination** still update port, user, identity, and `-A` for scp. **Unknown long/short flags** are skipped instead of failing detection; unknown long options with a value before the host can consume a following token only when a **stronger later destination** exists. After a destination is known, **malformed option values** advance past bad tokens instead of returning nil.
> 
> **Bundled shorts** (e.g. `-ZefxN`, `-v2`, inline values) and **`--verbose` / `-v`** (with or without a level) are handled in a dedicated short-option loop. The old explicit long no-argument option whitelist is removed in favor of tolerant long-flag handling.
> 
> Tests in `WorkspaceRemoteConnectionTests` are renamed/expanded for options-after-host, unknown flags, trailing malformed values, the current ET option surface, bundled shorts, and verbose placement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3af70f86f183e84e6c5cb8c435aa30c56e1daa54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4732"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782333752&installation_id=133855650&pr_number=4732&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4732&signature=adce0d2b6c9352247c0d7cac42cca5620522caa92acdf7d1d54bc14047d2d4d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns Eternal Terminal (`et`) option parsing with ET 6.2.11 to improve remote-session detection and SCP argument generation. Adds support for options after the host, clustered short flags, and `--verbose`/`-v` with or without levels; prefers stronger host candidates when ambiguous; advances Linear 4321 toward full ET detection.

- Bug Fixes
  - Keep scanning after the destination; apply `--ssh-option` for user/port/identity anywhere; honor `-f` by adding `-A`.
  - Handle verbose anywhere: `--verbose`, `-v`, inline `-v2`, next-arg levels, and inside clusters (e.g., `-vx`, `-vZ`).
  - Be tolerant: ignore unknown ET flags; skip unknown long-option values before the host; prefer stronger destination candidates; do not abort on malformed values after the host; accept inline/spaced `--telemetry` booleans; add tests for current ET surface and these cases.

<sup>Written for commit 3af70f86f183e84e6c5cb8c435aa30c56e1daa54. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4732?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

