### PR TITLE
Treat stable socket aliases as implicit defaults

### DIFF
--- a/CLI/CLISocketPathResolver.swift
+++ b/CLI/CLISocketPathResolver.swift
@@ -80,6 +80,13 @@ enum CLISocketPathSource {
 }
 
 enum CLISocketPathResolver {
+    enum SocketPathEntry {
+        case missing
+        case socket(ownerUserID: uid_t)
+        case other(ownerUserID: uid_t)
+        case inaccessible(errnoCode: Int32)
+    }
+
     private static let appSupportDirectoryName = "cmux"
     private static let stableSocketFileName = "cmux.sock"
     static let legacyDefaultSocketPath = "/tmp/cmux.sock"
@@ -134,9 +141,17 @@ enum CLISocketPathResolver {
         requestedPath: String,
         source: CLISocketPathSource,
         environment: [String: String] = ProcessInfo.processInfo.environment,
-        bundleIdentifier: String? = currentAppBundleIdentifier()
+        bundleIdentifier: String? = currentAppBundleIdentifier(),
+        currentUserID: uid_t = getuid(),
+        inspectSocketPathEntry: (String) -> SocketPathEntry = inspectSocketPathEntry
     ) -> String {
         guard source == .implicitDefault else {
+            return requestedPath
+        }
+
+        let variant = SocketPathMarkerFiles.variant(bundleIdentifier: bundleIdentifier, environment: environment)
+        if case .stable = variant,
+           canConnect(to: requestedPath, currentUserID: currentUserID, inspectSocketPathEntry: inspectSocketPathEntry) {
             return requestedPath
         }
 
@@ -147,12 +162,20 @@ enum CLISocketPathResolver {
         ))
 
         // Prefer sockets that are currently accepting connections.
-        for path in candidates where canConnect(to: path) {
+        for path in candidates where canConnect(
+            to: path,
+            currentUserID: currentUserID,
+            inspectSocketPathEntry: inspectSocketPathEntry
+        ) {
             return path
         }
 
         // If the listener is still starting, prefer existing socket files.
-        for path in candidates where isSocketFile(path) {
+        for path in candidates where isOwnedSocketFile(
+            path,
+            currentUserID: currentUserID,
+            inspectSocketPathEntry: inspectSocketPathEntry
+        ) {
             return path
         }
 
@@ -273,12 +296,49 @@ enum CLISocketPathResolver {
     }
 
     private static func isSocketFile(_ path: String) -> Bool {
-        var st = stat()
-        return lstat(path, &st) == 0 && (st.st_mode & mode_t(S_IFMT)) == mode_t(S_IFSOCK)
+        if case .socket = inspectSocketPathEntry(path) {
+            return true
+        }
+        return false
     }
 
-    private static func canConnect(to path: String) -> Bool {
-        guard isSocketFile(path) else { return false }
+    private static func isOwnedSocketFile(
+        _ path: String,
+        currentUserID: uid_t,
+        inspectSocketPathEntry: (String) -> SocketPathEntry
+    ) -> Bool {
+        if case .socket(let ownerUserID) = inspectSocketPathEntry(path) {
+            return ownerUserID == currentUserID
+        }
+        return false
+    }
+
+    private static func inspectSocketPathEntry(_ path: String) -> SocketPathEntry {
+        var st = stat()
+        guard lstat(path, &st) == 0 else {
+            if errno == ENOENT {
+                return .missing
+            }
+            return .inaccessible(errnoCode: errno)
+        }
+        if (st.st_mode & mode_t(S_IFMT)) == mode_t(S_IFSOCK) {
+            return .socket(ownerUserID: st.st_uid)
+        }
+        return .other(ownerUserID: st.st_uid)
+    }
+
+    private static func canConnect(
+        to path: String,
+        currentUserID: uid_t,
+        inspectSocketPathEntry: (String) -> SocketPathEntry
+    ) -> Bool {
+        guard isOwnedSocketFile(
+            path,
+            currentUserID: currentUserID,
+            inspectSocketPathEntry: inspectSocketPathEntry
+        ) else {
+            return false
+        }
         let fd = socket(AF_UNIX, SOCK_STREAM, 0)
         guard fd >= 0 else { return false }
         defer { Darwin.close(fd) }
@@ -335,7 +395,7 @@ enum CLISocketPathResolver {
         let variant = SocketPathMarkerFiles.variant(bundleIdentifier: bundleIdentifier, environment: environment)
         let defaultPath = defaultSocketPath(bundleIdentifier: bundleIdentifier, environment: environment)
         if case .stable = variant {
-            return dedupe([defaultPath, legacyDefaultSocketPath])
+            return stableImplicitDefaultPaths()
         }
         return dedupe(
             [defaultPath] + stableImplicitDefaultPaths()

--- a/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
+++ b/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
@@ -383,6 +383,73 @@ final class CMUXCLIErrorOutputRegressionTests: XCTestCase {
         )
     }
 
+    func testBundledStableCLIFallsBackFromSymlinkedLegacyStableEnvSocket() throws {
+        let cliPath = try bundledCLIPath()
+        let fixedHomeURL = URL(fileURLWithPath: "/tmp/cmxh-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: fixedHomeURL) }
+        let socketDirectoryURL = fixedHomeURL
+            .appendingPathComponent("Library/Application Support/cmux", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: socketDirectoryURL,
+            withIntermediateDirectories: true
+        )
+        let defaultStableSocketPath = socketDirectoryURL
+            .appendingPathComponent("cmux.sock", isDirectory: false)
+            .path
+        let legacyStableSocketPath = "/tmp/cmux.sock"
+        let symlinkTargetSocketPath = "/tmp/cmux-symlink-target-\(UUID().uuidString).sock"
+        if lstatPathExists(legacyStableSocketPath) {
+            throw XCTSkip("Legacy stable cmux socket already exists at \(legacyStableSocketPath)")
+        }
+
+        let fakeStableCLIPath = try fakeTaggedBundledCLIPath(
+            sourceCLIPath: cliPath,
+            tagSlug: "stable-\(UUID().uuidString.lowercased())",
+            bundleIdentifier: "com.cmuxterm.app",
+            bundleName: "cmux"
+        )
+        let defaultResponder = try UnixSocketResponder(path: defaultStableSocketPath, response: "OK DEFAULT")
+        defer { defaultResponder.stop() }
+        let targetResponder = try UnixSocketResponder(path: symlinkTargetSocketPath, response: "OK TARGET")
+        defer { targetResponder.stop() }
+        XCTAssertEqual(symlink(symlinkTargetSocketPath, legacyStableSocketPath), 0)
+        defer { unlink(legacyStableSocketPath) }
+
+        var environment = ProcessInfo.processInfo.environment
+        for key in Array(environment.keys) where key.hasPrefix("CMUX_") {
+            environment.removeValue(forKey: key)
+        }
+        environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
+        environment["CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC"] = "5"
+        environment["CMUX_SOCKET_PATH"] = legacyStableSocketPath
+        environment["CFFIXED_USER_HOME"] = fixedHomeURL.path
+
+        let result = runProcess(
+            executablePath: fakeStableCLIPath,
+            arguments: ["ping"],
+            environment: environment,
+            timeout: 5
+        )
+
+        XCTAssertFalse(result.timedOut, result.stdout)
+        XCTAssertEqual(result.status, 0, result.stdout)
+        XCTAssertEqual(
+            result.stdout.trimmingCharacters(in: .whitespacesAndNewlines),
+            "OK DEFAULT",
+            result.stdout
+        )
+        XCTAssertEqual(
+            defaultResponder.receivedRequests.count,
+            1,
+            defaultResponder.receivedRequests.joined(separator: "\n")
+        )
+        XCTAssertTrue(
+            defaultResponder.receivedRequests.contains { $0.contains("ping") },
+            defaultResponder.receivedRequests.joined(separator: "\n")
+        )
+        XCTAssertEqual(targetResponder.receivedRequests, [])
+    }
+
     func testBundledStableCLIPreservesLiveLegacyStableEnvSocket() throws {
         let cliPath = try bundledCLIPath()
         let fixedHomeURL = URL(fileURLWithPath: "/tmp/cmxh-\(UUID().uuidString)", isDirectory: true)
@@ -1045,6 +1112,11 @@ final class CMUXCLIErrorOutputRegressionTests: XCTestCase {
 
     private func shellSingleQuote(_ value: String) -> String {
         "'\(value.replacingOccurrences(of: "'", with: "'\"'\"'"))'"
+    }
+
+    private func lstatPathExists(_ path: String) -> Bool {
+        var st = stat()
+        return lstat(path, &st) == 0
     }
 
     private func runShell(_ command: String, timeout: TimeInterval) -> ProcessRunResult {

--- a/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
+++ b/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
@@ -254,7 +254,7 @@ final class CMUXCLIErrorOutputRegressionTests: XCTestCase {
         }
     }
 
-    func testBundledStableCLIKeepsUserScopedStableEnvSocketExplicit() throws {
+    func testBundledStableCLIPreservesLiveUserScopedStableEnvSocket() throws {
         let cliPath = try bundledCLIPath()
         let fixedHomeURL = URL(fileURLWithPath: "/tmp/cmxh-\(UUID().uuidString)", isDirectory: true)
         defer { try? FileManager.default.removeItem(at: fixedHomeURL) }
@@ -267,7 +267,9 @@ final class CMUXCLIErrorOutputRegressionTests: XCTestCase {
         let defaultStableSocketPath = socketDirectoryURL
             .appendingPathComponent("cmux.sock", isDirectory: false)
             .path
-        let userScopedStableSocketPath = "/tmp/cmux-\(getuid()).sock"
+        let userScopedStableSocketPath = socketDirectoryURL
+            .appendingPathComponent("cmux-\(getuid()).sock", isDirectory: false)
+            .path
         if FileManager.default.fileExists(atPath: userScopedStableSocketPath) {
             throw XCTSkip("User-scoped stable cmux socket already exists at \(userScopedStableSocketPath)")
         }
@@ -307,9 +309,81 @@ final class CMUXCLIErrorOutputRegressionTests: XCTestCase {
             result.stdout
         )
         XCTAssertEqual(defaultResponder.receivedRequests, [])
+        XCTAssertEqual(
+            userScopedResponder.receivedRequests.count,
+            1,
+            userScopedResponder.receivedRequests.joined(separator: "\n")
+        )
+        XCTAssertTrue(
+            userScopedResponder.receivedRequests.contains { $0.contains("ping") },
+            userScopedResponder.receivedRequests.joined(separator: "\n")
+        )
     }
 
-    func testBundledStableCLITreatsLegacyStableEnvSocketAsImplicitDefault() throws {
+    func testBundledStableCLIFallsBackFromStaleUserScopedStableEnvSocket() throws {
+        let cliPath = try bundledCLIPath()
+        let fixedHomeURL = URL(fileURLWithPath: "/tmp/cmxh-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: fixedHomeURL) }
+        let socketDirectoryURL = fixedHomeURL
+            .appendingPathComponent("Library/Application Support/cmux", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: socketDirectoryURL,
+            withIntermediateDirectories: true
+        )
+        let defaultStableSocketPath = socketDirectoryURL
+            .appendingPathComponent("cmux.sock", isDirectory: false)
+            .path
+        let userScopedStableSocketPath = socketDirectoryURL
+            .appendingPathComponent("cmux-\(getuid()).sock", isDirectory: false)
+            .path
+        if FileManager.default.fileExists(atPath: userScopedStableSocketPath) {
+            throw XCTSkip("User-scoped stable cmux socket already exists at \(userScopedStableSocketPath)")
+        }
+
+        let fakeStableCLIPath = try fakeTaggedBundledCLIPath(
+            sourceCLIPath: cliPath,
+            tagSlug: "stable-\(UUID().uuidString.lowercased())",
+            bundleIdentifier: "com.cmuxterm.app",
+            bundleName: "cmux"
+        )
+        let defaultResponder = try UnixSocketResponder(path: defaultStableSocketPath, response: "OK DEFAULT")
+        defer { defaultResponder.stop() }
+
+        var environment = ProcessInfo.processInfo.environment
+        for key in Array(environment.keys) where key.hasPrefix("CMUX_") {
+            environment.removeValue(forKey: key)
+        }
+        environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
+        environment["CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC"] = "5"
+        environment["CMUX_SOCKET_PATH"] = userScopedStableSocketPath
+        environment["CFFIXED_USER_HOME"] = fixedHomeURL.path
+
+        let result = runProcess(
+            executablePath: fakeStableCLIPath,
+            arguments: ["ping"],
+            environment: environment,
+            timeout: 5
+        )
+
+        XCTAssertFalse(result.timedOut, result.stdout)
+        XCTAssertEqual(result.status, 0, result.stdout)
+        XCTAssertEqual(
+            result.stdout.trimmingCharacters(in: .whitespacesAndNewlines),
+            "OK DEFAULT",
+            result.stdout
+        )
+        XCTAssertEqual(
+            defaultResponder.receivedRequests.count,
+            1,
+            defaultResponder.receivedRequests.joined(separator: "\n")
+        )
+        XCTAssertTrue(
+            defaultResponder.receivedRequests.contains { $0.contains("ping") },
+            defaultResponder.receivedRequests.joined(separator: "\n")
+        )
+    }
+
+    func testBundledStableCLIPreservesLiveLegacyStableEnvSocket() throws {
         let cliPath = try bundledCLIPath()
         let fixedHomeURL = URL(fileURLWithPath: "/tmp/cmxh-\(UUID().uuidString)", isDirectory: true)
         defer { try? FileManager.default.removeItem(at: fixedHomeURL) }
@@ -358,10 +432,19 @@ final class CMUXCLIErrorOutputRegressionTests: XCTestCase {
         XCTAssertEqual(result.status, 0, result.stdout)
         XCTAssertEqual(
             result.stdout.trimmingCharacters(in: .whitespacesAndNewlines),
-            "OK DEFAULT",
+            "OK LEGACY",
             result.stdout
         )
-        XCTAssertEqual(legacyResponder.receivedRequests, [])
+        XCTAssertEqual(defaultResponder.receivedRequests, [])
+        XCTAssertEqual(
+            legacyResponder.receivedRequests.count,
+            1,
+            legacyResponder.receivedRequests.joined(separator: "\n")
+        )
+        XCTAssertTrue(
+            legacyResponder.receivedRequests.contains { $0.contains("ping") },
+            legacyResponder.receivedRequests.joined(separator: "\n")
+        )
     }
 
     func testBundledCLISkipsIdentifierlessNestedAppWhenResolvingTaggedSocket() throws {


### PR DESCRIPTION
Fixes https://github.com/manaflow-ai/cmux/issues/4770.

Summary:
- Treat the stable cmux socket family as implicit CLI defaults: Application Support `cmux.sock`, Application Support `cmux-<uid>.sock`, legacy `/tmp/cmux.sock`, and legacy `/tmp/cmux-<uid>.sock`.
- Let the existing resolver move away from a stale inherited stable alias to a live stable socket.
- Keep tagged debug, nightly, and staging resolution isolated. This version removes the previous caller-context RPC fallback and socket health timer.

Verification:
- `./scripts/reload.sh --tag sockfix`
- Regression commit: `Add stable socket alias fallback regression test`
- Fix commit: `Treat stable socket aliases as implicit defaults`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the CLI picks Unix domain sockets for stable builds (ownership checks and fallback across aliases), which affects all RPC routing when `CMUX_SOCKET_PATH` or defaults are wrong or stale.
> 
> **Overview**
> The stable CLI now treats **Application Support** `cmux.sock`, user-scoped `cmux-<uid>.sock`, and legacy `/tmp` stable paths as one **implicit default** family, so inherited `CMUX_SOCKET_PATH` values in that set are not pinned blindly.
> 
> **`CLISocketPathResolver`** inspects each path with `lstat` (missing, socket, other file, inaccessible) and only treats **Unix sockets owned by the current user** as connectable or as a “socket file” fallback. For stable builds it keeps a live requested alias when it accepts connections; otherwise it walks candidates and prefers a reachable owned socket, then an owned socket file while the app is still starting.
> 
> Regression tests cover stable CLI behavior: use a live user-scoped or legacy env socket when it works, fall back to the default stable socket when the alias is stale or a symlink to another listener, and assert traffic hits the expected responder.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c042cdaa42cbc57702e499ee24ec04dfc522f84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CLI now prefers a live user-scoped stable socket when present, so requests are routed to the user-scoped responder.
  * If the user-scoped stable socket is stale or unreachable, the CLI falls back to the system default stable socket.
  * Stable builds now recognize the expanded set of default stable socket locations for consistent routing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4774?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->