### PR TITLE
Disable TextBox interactive glass chrome

### DIFF
--- a/Sources/TextBoxInput.swift
+++ b/Sources/TextBoxInput.swift
@@ -127,7 +127,8 @@ private struct TextBoxInputGlassPillBackground: View {
         let shape = RoundedRectangle(cornerRadius: TextBoxLayout.pillCornerRadius, style: .continuous)
 
 #if compiler(>=6.2)
-        if #available(macOS 26.0, *) {
+        if #available(macOS 26.0, *),
+           TextBoxInputChromeBackgroundPolicy.style(glassEffectAvailable: true) == .swiftUIGlass {
             shape
                 .fill(Color.clear)
                 .glassEffect(.regular.interactive(true), in: shape)

--- a/Sources/TextBoxInputChromeBackgroundPolicy.swift
+++ b/Sources/TextBoxInputChromeBackgroundPolicy.swift
@@ -1,0 +1,10 @@
+enum TextBoxInputChromeBackgroundStyle: Equatable {
+    case materialFallback
+    case swiftUIGlass
+}
+
+enum TextBoxInputChromeBackgroundPolicy {
+    static func style(glassEffectAvailable: Bool) -> TextBoxInputChromeBackgroundStyle {
+        glassEffectAvailable ? .swiftUIGlass : .materialFallback
+    }
+}

--- a/Sources/TextBoxInputChromeBackgroundPolicy.swift
+++ b/Sources/TextBoxInputChromeBackgroundPolicy.swift
@@ -4,7 +4,7 @@ enum TextBoxInputChromeBackgroundStyle: Equatable {
 }
 
 enum TextBoxInputChromeBackgroundPolicy {
-    static func style(glassEffectAvailable: Bool) -> TextBoxInputChromeBackgroundStyle {
-        glassEffectAvailable ? .swiftUIGlass : .materialFallback
+    static func style(glassEffectAvailable _: Bool) -> TextBoxInputChromeBackgroundStyle {
+        .materialFallback
     }
 }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -265,6 +265,7 @@
 		A5001290 /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = A5001291 /* MarkdownUI */; };
 		A50012F1 /* Backport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50012F0 /* Backport.swift */; };
 		A50012F3 /* KeyboardShortcutSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50012F2 /* KeyboardShortcutSettings.swift */; };
+		C0DE7B110000000000000001 /* TextBoxInputChromeBackgroundPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE7B110000000000000002 /* TextBoxInputChromeBackgroundPolicy.swift */; };
 		C0DE7B100000000000000001 /* TextBoxInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE7B100000000000000002 /* TextBoxInput.swift */; };
 		C1713004C1713004C1713004 /* KeyboardShortcutSettingsLookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1713003C1713003C1713003 /* KeyboardShortcutSettingsLookup.swift */; };
 		A50012F7 /* KeyboardShortcutRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50012F6 /* KeyboardShortcutRecorder.swift */; };
@@ -839,6 +840,7 @@
 		A5001241 /* WindowDecorationsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowDecorationsController.swift; sourceTree = "<group>"; };
 		A50012F0 /* Backport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Backport.swift; sourceTree = "<group>"; };
 		A50012F2 /* KeyboardShortcutSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardShortcutSettings.swift; sourceTree = "<group>"; };
+		C0DE7B110000000000000002 /* TextBoxInputChromeBackgroundPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextBoxInputChromeBackgroundPolicy.swift; sourceTree = "<group>"; };
 		C0DE7B100000000000000002 /* TextBoxInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextBoxInput.swift; sourceTree = "<group>"; };
 		C1713003C1713003C1713003 /* KeyboardShortcutSettingsLookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardShortcutSettingsLookup.swift; sourceTree = "<group>"; };
 		A50012F6 /* KeyboardShortcutRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardShortcutRecorder.swift; sourceTree = "<group>"; };
@@ -1307,6 +1309,7 @@
 					B9000017A1B2C3D4E5F60719 /* WindowDragHandleView.swift */,
 					A50012F0 /* Backport.swift */,
 					A50012F2 /* KeyboardShortcutSettings.swift */,
+				C0DE7B110000000000000002 /* TextBoxInputChromeBackgroundPolicy.swift */,
 				C0DE7B100000000000000002 /* TextBoxInput.swift */,
 					C1713003C1713003C1713003 /* KeyboardShortcutSettingsLookup.swift */,
 				C34670030000000000000002 /* KeyboardShortcutContext.swift */,
@@ -2061,6 +2064,7 @@
 					B9000018A1B2C3D4E5F60719 /* WindowDragHandleView.swift in Sources */,
 					A50012F1 /* Backport.swift in Sources */,
 					A50012F3 /* KeyboardShortcutSettings.swift in Sources */,
+				C0DE7B110000000000000001 /* TextBoxInputChromeBackgroundPolicy.swift in Sources */,
 				C0DE7B100000000000000001 /* TextBoxInput.swift in Sources */,
 					C1713004C1713004C1713004 /* KeyboardShortcutSettingsLookup.swift in Sources */,
 				C34670030000000000000001 /* KeyboardShortcutContext.swift in Sources */,

--- a/cmuxTests/WindowAppearanceSnapshotTests.swift
+++ b/cmuxTests/WindowAppearanceSnapshotTests.swift
@@ -9,6 +9,13 @@ import SwiftUI
 #endif
 
 final class WindowAppearanceSnapshotTests: XCTestCase {
+    func testTextBoxChromeUsesStableMaterialWhenGlassEffectIsAvailable() {
+        XCTAssertEqual(
+            TextBoxInputChromeBackgroundPolicy.style(glassEffectAvailable: true),
+            .materialFallback
+        )
+    }
+
     func testUnifiedSurfaceBackdropsUseSingleWindowRootBackdrop() {
         let snapshot = makeSnapshot(unifySurfaceBackdrops: true)
 

--- a/tests/test_textbox_chrome_background_policy.sh
+++ b/tests/test_textbox_chrome_background_policy.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/cmux-textbox-policy.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+swiftc \
+  -module-cache-path "$TMP_DIR/module-cache" \
+  "$REPO_ROOT/Sources/TextBoxInputChromeBackgroundPolicy.swift" \
+  "$REPO_ROOT/tests/textbox_chrome_background_policy_regression.swift" \
+  -o "$TMP_DIR/textbox_chrome_background_policy_regression"
+
+"$TMP_DIR/textbox_chrome_background_policy_regression"

--- a/tests/textbox_chrome_background_policy_regression.swift
+++ b/tests/textbox_chrome_background_policy_regression.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+@main
+struct TextBoxChromeBackgroundPolicyRegressionTest {
+    static func main() {
+        let actual = TextBoxInputChromeBackgroundPolicy.style(glassEffectAvailable: true)
+        if actual != .materialFallback {
+            fputs(
+                "expected TextBox chrome to use materialFallback when glass is available, got \(actual)\n",
+                stderr
+            )
+            exit(1)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a regression test covering TextBox chrome selection when SwiftUI glass is available
- route TextBox chrome through a policy so the live TextBox uses stable material instead of interactive glass
- avoid the macOS 26 interactive glass path seen in the crash dump while using Cmd+Shift+A TextBox

## Test plan
- tests/test_textbox_chrome_background_policy.sh

## Crash evidence
- Sentry event: 188398bf-d32d-4544-f3ea-8237e80e7f83
- release: 1.3.2-HEAD-+ff6e126
- LLDB minidump main thread was in AppKit/SwiftUI text menu/selection invalidation
- process had 656 threads, including hundreds of CVDisplayLink threads, matching the interactive glass TextBox chrome path

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4775"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782366337&installation_id=133855650&pr_number=4775&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4775&signature=cb79e541e824af2d87dddfb1f243c8e5b9a44443508b6ff2a0bc5a532683cbad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable SwiftUI interactive glass for TextBox chrome to prevent a macOS 26 selection crash (e.g., Cmd+Shift+A). TextBox now uses a stable material background via a simple policy hook.

- **Bug Fixes**
  - Route chrome through `TextBoxInputChromeBackgroundPolicy` to always return `.materialFallback` when glass is available.
  - Add regression tests (Swift + shell harness) and an XCTest to lock the behavior.

<sup>Written for commit 1868971f575feecfc85be5080d47bfec3c381c6e. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4775?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a chrome background policy system to control text box visual rendering on macOS 26, with configurable styling options.

* **Bug Fixes**
  * Glass-effect rendering now conditionally applies based on system policies, defaulting to a stable material appearance.

* **Tests**
  * Added regression tests to ensure text box appearance behavior remains stable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4775?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->