### PR TITLE
Add headless cmux attach foundation

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -3600,6 +3600,14 @@ struct CMUXCLI {
                 idFormat: idFormat,
                 windowOverride: windowId
             )
+        case "headless":
+            try runHeadlessCommand(
+                commandArgs: commandArgs,
+                client: client,
+                jsonOutput: jsonOutput,
+                idFormat: idFormat,
+                windowOverride: windowId
+            )
         case "ssh-pty-attach":
             try runSSHPTYAttach(commandArgs: commandArgs, client: client)
         case "ssh-session-list":
@@ -6415,6 +6423,181 @@ struct CMUXCLI {
             jsonOutput: jsonOutput,
             idFormat: idFormat
         )
+    }
+
+    private func runHeadlessCommand(
+        commandArgs: [String],
+        client: SocketClient,
+        jsonOutput: Bool,
+        idFormat: CLIIDFormat,
+        windowOverride: String?
+    ) throws {
+        guard let subcommand = commandArgs.first?.lowercased() else {
+            throw CLIError(message: "Usage: cmux headless attach <destination> --id <instance> [flags]")
+        }
+        switch subcommand {
+        case "attach":
+            try runHeadlessAttach(
+                commandArgs: Array(commandArgs.dropFirst()),
+                client: client,
+                jsonOutput: jsonOutput,
+                idFormat: idFormat,
+                windowOverride: windowOverride
+            )
+        default:
+            throw CLIError(message: "Unknown headless subcommand: \(subcommand). Usage: cmux headless attach <destination> --id <instance>")
+        }
+    }
+
+    private func runHeadlessAttach(
+        commandArgs: [String],
+        client: SocketClient,
+        jsonOutput: Bool,
+        idFormat: CLIIDFormat,
+        windowOverride: String?
+    ) throws {
+        let localSocketPath = client.socketPath
+        let remoteRelayPort = generateRemoteRelayPort()
+        let relayID = UUID().uuidString.lowercased()
+        let relayToken = try randomHex(byteCount: 32)
+        let (headlessIDRaw, remainingArgs) = parseOption(commandArgs, name: "--id")
+        guard headlessIDRaw != nil else {
+            throw CLIError(message: "headless attach requires --id <instance>")
+        }
+        guard let headlessID = normalizedHeadlessInstanceID(headlessIDRaw) else {
+            throw CLIError(message: "headless attach: --id must be 1-64 characters using letters, numbers, '.', '_' or '-'")
+        }
+
+        let sshOptions = try parseSSHCommandOptions(
+            remainingArgs,
+            localSocketPath: localSocketPath,
+            remoteRelayPort: remoteRelayPort,
+            windowOverride: windowOverride
+        )
+        guard sshOptions.extraArguments.isEmpty else {
+            throw CLIError(message: "headless attach does not accept remote command args")
+        }
+
+        let remoteSSHOptions = effectiveSSHOptions(
+            sshOptions.sshOptions,
+            remoteRelayPort: sshOptions.remoteRelayPort
+        )
+        let remoteShellCommand = buildInteractiveRemoteShellScript(
+            remoteRelayPort: sshOptions.remoteRelayPort,
+            shellFeatures: scopedGhosttyShellFeaturesValue(),
+            terminfoSource: localXtermGhosttyTerminfoSource()
+        )
+        let startupCommand = headlessAttachStartupCommand(remoteShellCommand: remoteShellCommand)
+        var workspaceCreateParams: [String: Any] = [
+            "initial_command": startupCommand,
+        ]
+        try applyWindowOrCallerContext(to: &workspaceCreateParams, client: client, windowRaw: sshOptions.windowRaw)
+
+        let workspaceCreate = try client.sendV2(method: "workspace.create", params: workspaceCreateParams)
+        guard let workspaceId = workspaceCreate["workspace_id"] as? String, !workspaceId.isEmpty else {
+            throw CLIError(message: "workspace.create did not return workspace_id")
+        }
+        let workspaceWindowId = (workspaceCreate["window_id"] as? String)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let configuredPayload: [String: Any]
+        do {
+            let workspaceTitle = sshOptions.workspaceName?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let effectiveTitle = workspaceTitle?.isEmpty == false ? workspaceTitle! : "headless:\(headlessID)"
+            _ = try client.sendV2(method: "workspace.rename", params: [
+                "workspace_id": workspaceId,
+                "title": effectiveTitle,
+            ])
+
+            var configureParams: [String: Any] = [
+                "workspace_id": workspaceId,
+                "destination": sshOptions.destination,
+                "auto_connect": true,
+                "headless_instance_id": headlessID,
+                "terminal_startup_command": startupCommand,
+                "preserve_after_terminal_exit": true,
+                "relay_port": sshOptions.remoteRelayPort,
+                "relay_id": relayID,
+                "relay_token": relayToken,
+                "local_socket_path": sshOptions.localSocketPath,
+            ]
+            if let port = sshOptions.port {
+                configureParams["port"] = port
+            }
+            if let identityFile = normalizedSSHIdentityPath(sshOptions.identityFile) {
+                configureParams["identity_file"] = identityFile
+            }
+            if !remoteSSHOptions.isEmpty {
+                configureParams["ssh_options"] = remoteSSHOptions
+            }
+
+            configuredPayload = try client.sendV2(method: "workspace.remote.configure", params: configureParams)
+            var selectParams: [String: Any] = ["workspace_id": workspaceId]
+            if let workspaceWindowId, !workspaceWindowId.isEmpty {
+                selectParams["window_id"] = workspaceWindowId
+            }
+            if !sshOptions.noFocus {
+                _ = try client.sendV2(method: "workspace.select", params: selectParams)
+            }
+        } catch {
+            do {
+                _ = try client.sendV2(method: "workspace.close", params: ["workspace_id": workspaceId])
+            } catch {
+                let warning = "Warning: failed to rollback workspace \(workspaceId): \(error)\n"
+                FileHandle.standardError.write(Data(warning.utf8))
+            }
+            throw error
+        }
+
+        var payload = configuredPayload
+        payload["headless_instance_id"] = headlessID
+        payload["remote_relay_port"] = sshOptions.remoteRelayPort
+        if jsonOutput {
+            print(jsonString(formatIDs(payload, mode: idFormat)))
+        } else {
+            let workspaceHandle = formatHandle(payload, kind: "workspace", idFormat: idFormat) ?? workspaceId
+            let remote = payload["remote"] as? [String: Any]
+            let state = (remote?["state"] as? String) ?? "unknown"
+            print("OK workspace=\(workspaceHandle) target=\(sshOptions.displayDestination) headless=\(headlessID) state=\(state)")
+        }
+    }
+
+    private func normalizedHeadlessInstanceID(_ raw: String?) -> String? {
+        guard let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else {
+            return nil
+        }
+        guard trimmed.count <= 64 else {
+            return nil
+        }
+        for scalar in trimmed.unicodeScalars {
+            let value = scalar.value
+            let isDigit = value >= 48 && value <= 57
+            let isUpper = value >= 65 && value <= 90
+            let isLower = value >= 97 && value <= 122
+            let isPunctuation = scalar == "." || scalar == "_" || scalar == "-"
+            guard isDigit || isUpper || isLower || isPunctuation else {
+                return nil
+            }
+        }
+        return trimmed
+    }
+
+    private func headlessAttachStartupCommand(remoteShellCommand: String) -> String {
+        let currentExecutable = shellQuote(resolvedExecutableURL()?.path ?? (args.first ?? "cmux"))
+        let commandB64 = Data(remoteShellCommand.utf8).base64EncodedString()
+        let attachCommand = "\"$cmux_headless_attach_cli\" --socket \"$CMUX_SOCKET_PATH\" ssh-pty-attach --wait --workspace \"$CMUX_WORKSPACE_ID\" --session-id \"$cmux_headless_session_id\" --attachment-id \"${CMUX_SURFACE_ID:-}\" --command-b64 \(shellQuote(commandB64))"
+        return ([
+            "cmux_headless_attach_cli=\"${CMUX_BUNDLED_CLI_PATH:-}\"",
+            "if [ -z \"$cmux_headless_attach_cli\" ] || [ ! -x \"$cmux_headless_attach_cli\" ]; then cmux_headless_attach_cli=\(currentExecutable); fi",
+            "if [ -z \"$cmux_headless_attach_cli\" ] || [ ! -x \"$cmux_headless_attach_cli\" ]; then cmux_headless_attach_cli=\"$(command -v cmux 2>/dev/null || true)\"; fi",
+            "if [ -z \"$cmux_headless_attach_cli\" ]; then printf '%s\\n' '[cmux] bundled CLI not found for headless attach.' >&2; exit 127; fi",
+            "if [ -z \"${CMUX_SOCKET_PATH:-}\" ]; then printf '%s\\n' '[cmux] required configuration missing for headless attach.' >&2; exit 1; fi",
+            "if [ -z \"${CMUX_WORKSPACE_ID:-}\" ]; then printf '%s\\n' '[cmux] required workspace context missing for headless attach.' >&2; exit 1; fi",
+            "if [ -z \"${CMUX_SURFACE_ID:-}\" ]; then printf '%s\\n' '[cmux] required terminal context missing for headless attach.' >&2; exit 1; fi",
+            "cmux_headless_session_id=\"headless-$CMUX_WORKSPACE_ID-$CMUX_SURFACE_ID\"",
+        ] + sshPTYAttachRetryLoopLines(command: attachCommand)).joined(separator: "\n")
     }
 
     /// Generic "open a workspace, SSH into the remote, bootstrap cmuxd-remote, forward socket,
@@ -12256,6 +12439,25 @@ struct CMUXCLI {
               cmux ssh dev@my-host
               cmux ssh dev@my-host --name "gpu-box" --port 2222 --identity ~/.ssh/id_ed25519
               cmux ssh dev@my-host --ssh-option UserKnownHostsFile=/dev/null --ssh-option StrictHostKeyChecking=no
+            """
+        case "headless":
+            return """
+            Usage: cmux headless attach <destination> --id <instance> [flags]
+
+            Attach the desktop app to an existing named cmux headless instance on a remote machine.
+
+            Flags:
+              --id <instance>        Headless instance id on the remote host
+              --name <title>         Optional workspace title
+              --port <n>             SSH port
+              --identity <path>      SSH identity file path
+              --ssh-option <opt>     Extra SSH -o option (repeatable)
+              --window <id|ref|index> Target window for the managed workspace
+              --no-focus             Create workspace without switching to it
+
+            Example:
+              cmux headless attach dev@my-host --id work
+              cmux headless attach dev@my-host --id gpu --name "gpu headless" --port 2222
             """
         case "ssh-session-list":
             return """
@@ -29794,6 +29996,7 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
           list-workspaces [--window <id|ref|index>]
           new-workspace [--name <title>] [--description <text>] [--cwd <path>] [--command <text>] [--layout <json>] [--window <id|ref|index>] [--focus <true|false>]
           ssh <destination> [--name <title>] [--port <n>] [--identity <path>] [--ssh-option <opt>] [--window <id|ref|index>] [--no-focus] [-- <remote-command-args>]
+          headless attach <destination> --id <instance> [--name <title>] [--port <n>] [--identity <path>] [--ssh-option <opt>] [--window <id|ref|index>] [--no-focus]
           ssh-session-list [--workspace <id|ref|index> | --all-workspaces]
           ssh-session-attach --session-id <id> [--workspace <id|ref|index>] [--pane <id|ref|index> | --split <left|right|up|down>]
           ssh-session-cleanup [--workspace <id|ref|index> | --all-workspaces] (--session-id <id> | --all)

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -6206,6 +6206,8 @@ class TerminalController {
             .trimmingCharacters(in: .whitespacesAndNewlines)
         let daemonWebSocketSessionID = v2RawString(params, "daemon_websocket_session_id")?
             .trimmingCharacters(in: .whitespacesAndNewlines)
+        let headlessInstanceID = v2RawString(params, "headless_instance_id")?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
         let daemonWebSocketExpiresAtUnix = (params["daemon_websocket_expires_at_unix"] as? Int64)
             ?? Int64((params["daemon_websocket_expires_at_unix"] as? Double) ?? 0)
         let rawDaemonHeaders = params["daemon_websocket_headers"] as? [String: Any] ?? [:]
@@ -6286,6 +6288,7 @@ class TerminalController {
                 terminalStartupCommand: terminalStartupCommand?.isEmpty == true ? nil : terminalStartupCommand,
                 foregroundAuthToken: foregroundAuthToken?.isEmpty == true ? nil : foregroundAuthToken,
                 daemonWebSocketEndpoint: daemonWebSocketEndpoint,
+                headlessInstanceID: headlessInstanceID?.isEmpty == true ? nil : headlessInstanceID,
                 preserveAfterTerminalExit: preserveAfterTerminalExit,
                 skipDaemonBootstrap: skipDaemonBootstrap
             )

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -7538,7 +7538,11 @@ final class WorkspaceRemoteSessionController {
 
     private func helloRemoteDaemonLocked(remotePath: String) throws -> DaemonHello {
         let request = #"{"id":1,"method":"hello","params":{}}"#
-        let script = "printf '%s\\n' \(Self.shellSingleQuoted(request)) | \(Self.shellSingleQuoted(remotePath)) serve --stdio"
+        let daemonCommand = WorkspaceRemoteSSHBatchCommandBuilder.daemonTransportCommand(
+            configuration: configuration,
+            remotePath: remotePath
+        )
+        let script = "printf '%s\\n' \(Self.shellSingleQuoted(request)) | \(daemonCommand)"
         let command = "sh -c \(Self.shellSingleQuoted(script))"
         let result = try sshExec(arguments: sshCommonArguments(batchMode: true) + [configuration.destination, command], timeout: 12)
         guard result.status == 0 else {

--- a/Sources/WorkspaceRemoteConfiguration.swift
+++ b/Sources/WorkspaceRemoteConfiguration.swift
@@ -61,6 +61,7 @@ nonisolated struct SessionRemoteWorkspaceSnapshot: Codable, Equatable, Sendable 
     var sshOptions: [String]
     var preserveAfterTerminalExit: Bool?
     var skipDaemonBootstrap: Bool?
+    var headlessInstanceID: String?
 }
 
 struct WorkspaceRemoteWebSocketDaemonEndpoint: Equatable {
@@ -286,6 +287,7 @@ struct WorkspaceRemoteConfiguration: Equatable {
     let terminalStartupCommand: String?
     let foregroundAuthToken: String?
     let daemonWebSocketEndpoint: WorkspaceRemoteWebSocketDaemonEndpoint?
+    let headlessInstanceID: String?
     let preserveAfterTerminalExit: Bool
     /// True for cloud-VM remotes (Freestyle snapshots) where cmuxd-remote is pre-baked in
     /// the image and started via systemd. Skip the upload+exec bootstrap entirely and synthesize
@@ -307,6 +309,7 @@ struct WorkspaceRemoteConfiguration: Equatable {
         terminalStartupCommand: String?,
         foregroundAuthToken: String? = nil,
         daemonWebSocketEndpoint: WorkspaceRemoteWebSocketDaemonEndpoint? = nil,
+        headlessInstanceID: String? = nil,
         preserveAfterTerminalExit: Bool = false,
         skipDaemonBootstrap: Bool = false
     ) {
@@ -323,13 +326,15 @@ struct WorkspaceRemoteConfiguration: Equatable {
         self.terminalStartupCommand = terminalStartupCommand
         self.foregroundAuthToken = foregroundAuthToken
         self.daemonWebSocketEndpoint = daemonWebSocketEndpoint
+        self.headlessInstanceID = Self.normalizedOptional(headlessInstanceID)
         self.preserveAfterTerminalExit = preserveAfterTerminalExit
         self.skipDaemonBootstrap = skipDaemonBootstrap
     }
 
     var displayTarget: String {
-        guard let port else { return destination }
-        return "\(destination):\(port)"
+        let base = port.map { "\(destination):\($0)" } ?? destination
+        guard let headlessInstanceID else { return base }
+        return "\(base)#\(headlessInstanceID)"
     }
 
     var proxyBrokerTransportKey: String {
@@ -341,6 +346,7 @@ struct WorkspaceRemoteConfiguration: Equatable {
         let normalizedLocalProxyPort = localProxyPort.map(String.init) ?? ""
         let normalizedOptions = Self.proxyBrokerSSHOptions(sshOptions).joined(separator: "\u{1f}")
         let normalizedWebSocketDaemon = daemonWebSocketEndpoint?.proxyBrokerKeyComponent ?? ""
+        let normalizedHeadlessInstance = headlessInstanceID ?? ""
         let normalizedRequiredCapabilities = preserveAfterTerminalExit ? "pty.session" : ""
         return [
             normalizedTransport,
@@ -351,9 +357,14 @@ struct WorkspaceRemoteConfiguration: Equatable {
             normalizedOptions,
             normalizedLocalProxyPort,
             normalizedWebSocketDaemon,
+            normalizedHeadlessInstance,
             normalizedRequiredCapabilities,
         ]
             .joined(separator: "\u{1e}")
+    }
+
+    private static func normalizedOptional(_ value: String?) -> String? {
+        WorkspaceRemoteSSHOptionFilter.normalizedOptional(value)
     }
 
     private static func proxyBrokerSSHOptions(_ options: [String]) -> [String] {
@@ -376,6 +387,8 @@ extension SessionRemoteWorkspaceSnapshot {
             preserveAfterTerminalExit == true &&
             skipDaemonBootstrap != true &&
             SSHPTYAttachStartupCommandBuilder.sshOptionsSupportReusableForegroundAuth(optionsWithRestoreControlDefaults)
+        let normalizedHeadlessInstanceID = WorkspaceRemoteSSHOptionFilter.normalizedOptional(headlessInstanceID)
+        let preserveHeadlessSession = normalizedHeadlessInstanceID != nil
         let restoredSSHOptions = preservePTYSession ? optionsWithRestoreControlDefaults : normalizedOptions
         let foregroundAuthToken = preservePTYSession ? UUID().uuidString.lowercased() : nil
         let foregroundAuth = foregroundAuthToken.map {
@@ -385,6 +398,20 @@ extension SessionRemoteWorkspaceSnapshot {
                 identityFile: Self.normalizedIdentityPath(identityFile),
                 sshOptions: restoredSSHOptions,
                 token: $0
+            )
+        }
+        let terminalStartupCommand: String?
+        if preservePTYSession {
+            terminalStartupCommand = SSHPTYAttachStartupCommandBuilder.command(
+                foregroundAuth: foregroundAuth,
+                requireExisting: false
+            )
+        } else if preserveHeadlessSession {
+            terminalStartupCommand = SSHPTYAttachStartupCommandBuilder.command(requireExisting: false)
+        } else {
+            terminalStartupCommand = sshReconnectCommand(
+                destination: normalizedDestination,
+                port: normalizedPort
             )
         }
         return WorkspaceRemoteConfiguration(
@@ -398,18 +425,11 @@ extension SessionRemoteWorkspaceSnapshot {
             relayID: nil,
             relayToken: nil,
             localSocketPath: nil,
-            terminalStartupCommand: preservePTYSession
-                ? SSHPTYAttachStartupCommandBuilder.command(
-                    foregroundAuth: foregroundAuth,
-                    requireExisting: false
-                )
-                : sshReconnectCommand(
-                    destination: normalizedDestination,
-                    port: normalizedPort
-                ),
+            terminalStartupCommand: terminalStartupCommand,
             foregroundAuthToken: foregroundAuthToken,
             daemonWebSocketEndpoint: nil,
-            preserveAfterTerminalExit: preservePTYSession,
+            headlessInstanceID: normalizedHeadlessInstanceID,
+            preserveAfterTerminalExit: preservePTYSession || preserveHeadlessSession,
             skipDaemonBootstrap: skipDaemonBootstrap == true
         )
     }
@@ -470,7 +490,8 @@ extension WorkspaceRemoteConfiguration {
             identityFile: WorkspaceRemoteSSHOptionFilter.normalizedIdentityPath(identityFile),
             sshOptions: WorkspaceRemoteSSHOptionFilter.durableOptions(sshOptions),
             preserveAfterTerminalExit: preserveAfterTerminalExit ? true : nil,
-            skipDaemonBootstrap: skipDaemonBootstrap
+            skipDaemonBootstrap: skipDaemonBootstrap,
+            headlessInstanceID: headlessInstanceID
         )
     }
 }

--- a/Sources/WorkspaceRemoteSSHBatchCommandBuilder.swift
+++ b/Sources/WorkspaceRemoteSSHBatchCommandBuilder.swift
@@ -10,11 +10,21 @@ enum WorkspaceRemoteSSHBatchCommandBuilder {
         configuration: WorkspaceRemoteConfiguration,
         remotePath: String
     ) -> [String] {
-        let script = "exec \(shellSingleQuoted(remotePath)) serve --stdio"
+        let script = daemonTransportCommand(configuration: configuration, remotePath: remotePath)
         let command = "sh -c \(shellSingleQuoted(script))"
         return ["-T"]
             + batchArguments(configuration: configuration)
             + ["-o", "RequestTTY=no", configuration.destination, command]
+    }
+
+    static func daemonTransportCommand(
+        configuration: WorkspaceRemoteConfiguration,
+        remotePath: String
+    ) -> String {
+        if let headlessInstanceID = normalizedOptional(configuration.headlessInstanceID) {
+            return "exec \(shellSingleQuoted(remotePath)) headless connect --id \(shellSingleQuoted(headlessInstanceID))"
+        }
+        return "exec \(shellSingleQuoted(remotePath)) serve --stdio"
     }
 
     static func daemonSocketForwardArguments(
@@ -91,6 +101,14 @@ enum WorkspaceRemoteSSHBatchCommandBuilder {
             guard !trimmed.isEmpty else { return nil }
             return trimmed
         }
+    }
+
+    private static func normalizedOptional(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else {
+            return nil
+        }
+        return trimmed
     }
 
     private static func backgroundSSHOptions(_ options: [String]) -> [String] {

--- a/daemon/remote/README.md
+++ b/daemon/remote/README.md
@@ -7,11 +7,28 @@ Go remote daemon for `cmux ssh` bootstrap, capability negotiation, and remote pr
 1. `cmuxd-remote version`
 2. `cmuxd-remote serve --stdio`
 3. `cmuxd-remote serve --ws --auth-lease-file <path> [--rpc-auth-lease-file <path>] [--listen 127.0.0.1:7777]`
-4. `cmuxd-remote cli <command> [args...]` — relay cmux commands to the local app over the reverse SSH forward
+4. `cmuxd-remote serve --unix [--id <id>] [--name <name>] [--socket <path>] [--registry-dir <dir>]` — run a named headless cmux instance
+5. `cmuxd-remote headless list [--json] [--registry-dir <dir>]`
+6. `cmuxd-remote headless connect (--id <id> | --socket <path>) [--registry-dir <dir>]`
+7. `cmuxd-remote cli <command> [args...]` — relay cmux commands to the local app over the reverse SSH forward
 
 `serve --ws` is explicit opt-in for cloud VM images only. The normal `cmux ssh`
 code path continues to use `serve --stdio` over an SSH exec channel and does not
 open a WebSocket listener.
+
+`serve --unix` is the daemon-side foundation for headless cmux. It keeps PTY
+sessions alive in a long-running process, listens on a Unix socket, and writes an
+instance record to `~/.cmux/headless/instances/<id>.json` by default. The desktop
+app can discover instances with `headless list` and bridge stdio to an existing
+instance with `headless connect`, including over SSH:
+
+```bash
+ssh devbox cmuxd-remote headless connect --id work
+```
+
+That bridge speaks the same newline-delimited JSON RPC as `serve --stdio`, so the
+desktop attach path can reuse the existing remote daemon client while targeting a
+long-lived instance instead of starting a transient daemon per workspace.
 
 When invoked as `cmux` (via wrapper/symlink installed during bootstrap), the binary auto-dispatches to the `cli` subcommand. This is busybox-style argv[0] detection.
 

--- a/daemon/remote/cmd/cmuxd-remote/headless.go
+++ b/daemon/remote/cmd/cmuxd-remote/headless.go
@@ -1,0 +1,430 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"syscall"
+	"time"
+)
+
+type unixHeadlessServerConfig struct {
+	SocketPath  string
+	InstanceID  string
+	Name        string
+	RegistryDir string
+	Shell       string
+}
+
+type headlessInstanceRecord struct {
+	Version       int      `json:"version"`
+	ID            string   `json:"id"`
+	Name          string   `json:"name,omitempty"`
+	Transport     string   `json:"transport"`
+	SocketPath    string   `json:"socket_path"`
+	PID           int      `json:"pid"`
+	StartedAt     string   `json:"started_at"`
+	GoOS          string   `json:"goos"`
+	GoArch        string   `json:"goarch"`
+	DaemonVersion string   `json:"daemon_version"`
+	Capabilities  []string `json:"capabilities"`
+}
+
+type headlessInstanceStatus struct {
+	headlessInstanceRecord
+	Online      bool   `json:"online"`
+	StaleReason string `json:"stale_reason,omitempty"`
+}
+
+func runUnixHeadlessServer(ctx context.Context, cfg unixHeadlessServerConfig, stderr io.Writer) error {
+	instanceID, err := normalizeHeadlessInstanceID(cfg.InstanceID)
+	if err != nil {
+		return err
+	}
+	socketPath := strings.TrimSpace(cfg.SocketPath)
+	if socketPath == "" {
+		socketPath = defaultHeadlessSocketPath(instanceID)
+	}
+	absSocketPath, err := filepath.Abs(socketPath)
+	if err != nil {
+		return fmt.Errorf("resolve socket path: %w", err)
+	}
+	registryDir := strings.TrimSpace(cfg.RegistryDir)
+	if registryDir == "" {
+		registryDir = defaultHeadlessRegistryDir()
+	}
+	absRegistryDir, err := filepath.Abs(registryDir)
+	if err != nil {
+		return fmt.Errorf("resolve registry directory: %w", err)
+	}
+
+	if err := prepareUnixSocketPath(absSocketPath); err != nil {
+		return err
+	}
+	listener, err := net.Listen("unix", absSocketPath)
+	if err != nil {
+		return err
+	}
+	defer listener.Close()
+	defer os.Remove(absSocketPath)
+
+	hub := newWebSocketPTYHub(wsPTYServerConfig{Shell: strings.TrimSpace(cfg.Shell)}, stderr)
+	defer hub.closeAll()
+
+	record := headlessInstanceRecord{
+		Version:       1,
+		ID:            instanceID,
+		Name:          strings.TrimSpace(cfg.Name),
+		Transport:     "unix",
+		SocketPath:    absSocketPath,
+		PID:           os.Getpid(),
+		StartedAt:     time.Now().UTC().Format(time.RFC3339Nano),
+		GoOS:          runtime.GOOS,
+		GoArch:        runtime.GOARCH,
+		DaemonVersion: version,
+		Capabilities:  daemonCapabilities(),
+	}
+	if record.Name == "" {
+		record.Name = instanceID
+	}
+	if err := registerHeadlessInstance(absRegistryDir, record); err != nil {
+		return err
+	}
+	defer unregisterHeadlessInstance(absRegistryDir, instanceID)
+
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+				return err
+			}
+		}
+		go func(conn net.Conn) {
+			defer conn.Close()
+			_ = serveRPCFrames(conn, conn, hub, false)
+		}(conn)
+	}
+}
+
+func runHeadless(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		headlessUsage(stderr)
+		return 2
+	}
+	switch args[0] {
+	case "list":
+		return runHeadlessList(args[1:], stdout, stderr)
+	case "connect":
+		return runHeadlessConnect(args[1:], stdin, stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "cmuxd-remote headless: unknown subcommand %q\n", args[0])
+		headlessUsage(stderr)
+		return 2
+	}
+}
+
+func headlessUsage(w io.Writer) {
+	_, _ = fmt.Fprintln(w, "Usage:")
+	_, _ = fmt.Fprintln(w, "  cmuxd-remote headless list [--json] [--registry-dir <dir>]")
+	_, _ = fmt.Fprintln(w, "  cmuxd-remote headless connect (--id <id> | --socket <path>) [--registry-dir <dir>]")
+}
+
+func runHeadlessList(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("headless list", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	jsonOutput := fs.Bool("json", false, "print JSON")
+	registryDir := fs.String("registry-dir", "", "headless instance registry directory")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "headless list does not accept positional arguments")
+		return 2
+	}
+
+	statuses, err := readHeadlessInstanceStatuses(strings.TrimSpace(*registryDir))
+	if err != nil {
+		fmt.Fprintf(stderr, "headless list: %v\n", err)
+		return 1
+	}
+	if *jsonOutput {
+		payload := map[string]any{"instances": statuses}
+		data, err := json.MarshalIndent(payload, "", "  ")
+		if err != nil {
+			fmt.Fprintf(stderr, "headless list: encode JSON: %v\n", err)
+			return 1
+		}
+		_, _ = fmt.Fprintln(stdout, string(data))
+		return 0
+	}
+	if len(statuses) == 0 {
+		_, _ = fmt.Fprintln(stdout, "No headless cmux instances")
+		return 0
+	}
+	for _, status := range statuses {
+		state := "online"
+		if !status.Online {
+			state = "offline"
+		}
+		name := status.Name
+		if name == "" {
+			name = status.ID
+		}
+		_, _ = fmt.Fprintf(stdout, "%s\t%s\t%s\t%s\n", status.ID, state, name, status.SocketPath)
+	}
+	return 0
+}
+
+func runHeadlessConnect(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("headless connect", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	instanceID := fs.String("id", "default", "headless instance id")
+	socketPath := fs.String("socket", "", "headless instance Unix socket path")
+	registryDir := fs.String("registry-dir", "", "headless instance registry directory")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "headless connect does not accept positional arguments")
+		return 2
+	}
+
+	targetSocket := strings.TrimSpace(*socketPath)
+	if targetSocket == "" {
+		record, err := findHeadlessInstance(strings.TrimSpace(*registryDir), strings.TrimSpace(*instanceID))
+		if err != nil {
+			fmt.Fprintf(stderr, "headless connect: %v\n", err)
+			return 1
+		}
+		targetSocket = record.SocketPath
+	}
+	conn, err := net.Dial("unix", targetSocket)
+	if err != nil {
+		fmt.Fprintf(stderr, "headless connect: %v\n", err)
+		return 1
+	}
+	defer conn.Close()
+
+	if err := proxyHeadlessConnection(conn, stdin, stdout); err != nil {
+		fmt.Fprintf(stderr, "headless connect: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+func proxyHeadlessConnection(conn net.Conn, stdin io.Reader, stdout io.Writer) error {
+	type copyResult struct {
+		direction string
+		err       error
+	}
+	errs := make(chan copyResult, 2)
+	go func() {
+		_, err := io.Copy(conn, stdin)
+		if closeWriter, ok := conn.(interface{ CloseWrite() error }); ok {
+			_ = closeWriter.CloseWrite()
+		} else {
+			_ = conn.Close()
+		}
+		errs <- copyResult{direction: "stdin", err: err}
+	}()
+	go func() {
+		_, err := io.Copy(stdout, conn)
+		errs <- copyResult{direction: "stdout", err: err}
+	}()
+
+	var firstErr error
+	for i := 0; i < 2; i++ {
+		result := <-errs
+		if result.err != nil && !errors.Is(result.err, net.ErrClosed) && firstErr == nil {
+			firstErr = result.err
+		}
+		if result.direction == "stdout" {
+			return firstErr
+		}
+	}
+	return firstErr
+}
+
+func findHeadlessInstance(registryDir string, rawID string) (headlessInstanceStatus, error) {
+	instanceID, err := normalizeHeadlessInstanceID(rawID)
+	if err != nil {
+		return headlessInstanceStatus{}, err
+	}
+	statuses, err := readHeadlessInstanceStatuses(registryDir)
+	if err != nil {
+		return headlessInstanceStatus{}, err
+	}
+	for _, status := range statuses {
+		if status.ID == instanceID {
+			if !status.Online {
+				return headlessInstanceStatus{}, fmt.Errorf("instance %q is offline: %s", instanceID, status.StaleReason)
+			}
+			return status, nil
+		}
+	}
+	return headlessInstanceStatus{}, fmt.Errorf("instance %q not found", instanceID)
+}
+
+func readHeadlessInstanceStatuses(registryDir string) ([]headlessInstanceStatus, error) {
+	dir := strings.TrimSpace(registryDir)
+	if dir == "" {
+		dir = defaultHeadlessRegistryDir()
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	statuses := make([]headlessInstanceStatus, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, entry.Name()))
+		if err != nil {
+			continue
+		}
+		var record headlessInstanceRecord
+		if err := json.Unmarshal(data, &record); err != nil {
+			continue
+		}
+		if _, err := normalizeHeadlessInstanceID(record.ID); err != nil {
+			continue
+		}
+		statuses = append(statuses, statusHeadlessInstance(record))
+	}
+	sort.Slice(statuses, func(i, j int) bool {
+		if statuses[i].Online != statuses[j].Online {
+			return statuses[i].Online
+		}
+		return statuses[i].ID < statuses[j].ID
+	})
+	return statuses, nil
+}
+
+func statusHeadlessInstance(record headlessInstanceRecord) headlessInstanceStatus {
+	status := headlessInstanceStatus{headlessInstanceRecord: record}
+	if strings.TrimSpace(record.SocketPath) == "" {
+		status.StaleReason = "missing socket path"
+		return status
+	}
+	info, err := os.Lstat(record.SocketPath)
+	if err != nil {
+		status.StaleReason = "socket missing"
+		return status
+	}
+	if info.Mode()&os.ModeSocket == 0 {
+		status.StaleReason = "socket path is not a Unix socket"
+		return status
+	}
+	if record.PID > 0 && !processExists(record.PID) {
+		status.StaleReason = "process is not running"
+		return status
+	}
+	status.Online = true
+	return status
+}
+
+func registerHeadlessInstance(registryDir string, record headlessInstanceRecord) error {
+	if err := os.MkdirAll(registryDir, 0o700); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		return err
+	}
+	path := headlessRegistryPath(registryDir, record.ID)
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, append(data, '\n'), 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+func unregisterHeadlessInstance(registryDir string, instanceID string) {
+	id, err := normalizeHeadlessInstanceID(instanceID)
+	if err != nil {
+		return
+	}
+	_ = os.Remove(headlessRegistryPath(registryDir, id))
+}
+
+func headlessRegistryPath(registryDir string, instanceID string) string {
+	return filepath.Join(registryDir, instanceID+".json")
+}
+
+func prepareUnixSocketPath(socketPath string) error {
+	if err := os.MkdirAll(filepath.Dir(socketPath), 0o700); err != nil {
+		return err
+	}
+	info, err := os.Lstat(socketPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	if info.Mode()&os.ModeSocket == 0 {
+		return fmt.Errorf("socket path exists and is not a Unix socket: %s", socketPath)
+	}
+	conn, dialErr := net.DialTimeout("unix", socketPath, 150*time.Millisecond)
+	if dialErr == nil {
+		_ = conn.Close()
+		return fmt.Errorf("socket already accepts connections: %s", socketPath)
+	}
+	return os.Remove(socketPath)
+}
+
+func normalizeHeadlessInstanceID(raw string) (string, error) {
+	id := strings.TrimSpace(raw)
+	if id == "" {
+		id = "default"
+	}
+	if len(id) > 64 {
+		return "", fmt.Errorf("headless instance id is too long")
+	}
+	for _, r := range id {
+		if (r >= 'a' && r <= 'z') ||
+			(r >= 'A' && r <= 'Z') ||
+			(r >= '0' && r <= '9') ||
+			r == '-' || r == '_' || r == '.' {
+			continue
+		}
+		return "", fmt.Errorf("headless instance id %q contains unsupported characters", id)
+	}
+	return id, nil
+}
+
+func defaultHeadlessRegistryDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil || strings.TrimSpace(home) == "" {
+		return filepath.Join(os.TempDir(), fmt.Sprintf("cmux-headless-%d", os.Getuid()), "instances")
+	}
+	return filepath.Join(home, ".cmux", "headless", "instances")
+}
+
+func defaultHeadlessSocketPath(instanceID string) string {
+	return filepath.Join("/tmp", fmt.Sprintf("cmux-headless-%d-%s.sock", os.Getuid(), instanceID))
+}
+
+func processExists(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	err := syscall.Kill(pid, 0)
+	return err == nil || errors.Is(err, syscall.EPERM)
+}

--- a/daemon/remote/cmd/cmuxd-remote/headless_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/headless_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestHeadlessListReportsRegisteredUnixInstance(t *testing.T) {
+	registryDir := t.TempDir()
+	socketPath := makeShortUnixSocketPath(t)
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen unix: %v", err)
+	}
+	defer listener.Close()
+
+	record := headlessInstanceRecord{
+		Version:       1,
+		ID:            "dev",
+		Name:          "Development",
+		Transport:     "unix",
+		SocketPath:    socketPath,
+		PID:           os.Getpid(),
+		StartedAt:     time.Now().UTC().Format(time.RFC3339Nano),
+		GoOS:          "darwin",
+		GoArch:        "arm64",
+		DaemonVersion: version,
+		Capabilities:  daemonCapabilities(),
+	}
+	if err := registerHeadlessInstance(registryDir, record); err != nil {
+		t.Fatalf("register instance: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := run(
+		[]string{"headless", "list", "--json", "--registry-dir", registryDir},
+		strings.NewReader(""),
+		&stdout,
+		&stderr,
+	)
+	if code != 0 {
+		t.Fatalf("headless list exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	var payload struct {
+		Instances []headlessInstanceStatus `json:"instances"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("decode list output: %v\n%s", err, stdout.String())
+	}
+	if len(payload.Instances) != 1 {
+		t.Fatalf("instances len = %d, want 1: %#v", len(payload.Instances), payload.Instances)
+	}
+	instance := payload.Instances[0]
+	if instance.ID != "dev" || instance.Name != "Development" || !instance.Online {
+		t.Fatalf("unexpected instance: %#v", instance)
+	}
+	if instance.SocketPath != socketPath {
+		t.Fatalf("socket path = %q, want %q", instance.SocketPath, socketPath)
+	}
+}
+
+func TestHeadlessConnectBridgesRPCFrames(t *testing.T) {
+	socketPath := makeShortUnixSocketPath(t)
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen unix: %v", err)
+	}
+	defer listener.Close()
+
+	done := make(chan string, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			done <- "accept failed: " + err.Error()
+			return
+		}
+		defer conn.Close()
+		buffer := make([]byte, 4096)
+		n, err := conn.Read(buffer)
+		if err != nil {
+			done <- "read failed: " + err.Error()
+			return
+		}
+		done <- string(buffer[:n])
+		_, _ = conn.Write([]byte(`{"id":1,"ok":true,"result":{"pong":true}}` + "\n"))
+	}()
+
+	var stdout, stderr bytes.Buffer
+	code := run(
+		[]string{"headless", "connect", "--socket", socketPath},
+		strings.NewReader(`{"id":1,"method":"ping","params":{}}`+"\n"),
+		&stdout,
+		&stderr,
+	)
+	if code != 0 {
+		t.Fatalf("headless connect exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	select {
+	case received := <-done:
+		if !strings.Contains(received, `"method":"ping"`) {
+			t.Fatalf("bridge sent %q, want ping request", received)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("server did not receive bridged request")
+	}
+	if got := strings.TrimSpace(stdout.String()); got != `{"id":1,"ok":true,"result":{"pong":true}}` {
+		t.Fatalf("stdout = %q", got)
+	}
+}

--- a/daemon/remote/cmd/cmuxd-remote/main.go
+++ b/daemon/remote/cmd/cmuxd-remote/main.go
@@ -115,7 +115,7 @@ func shouldRunCLIForInvocation(argv0 string, args []string) bool {
 
 func isDaemonEntryCommand(arg string) bool {
 	switch arg {
-	case "version", "serve", "cli":
+	case "version", "serve", "cli", "headless":
 		return true
 	default:
 		return false
@@ -137,15 +137,30 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		fs.SetOutput(stderr)
 		stdio := fs.Bool("stdio", false, "serve over stdin/stdout")
 		ws := fs.Bool("ws", false, "serve terminal PTY transport over WebSocket")
+		unixSocket := fs.Bool("unix", false, "serve a named headless instance over a Unix socket")
 		listen := fs.String("listen", "127.0.0.1:7777", "address for --ws")
+		socketPath := fs.String("socket", "", "Unix socket path for --unix")
+		instanceID := fs.String("id", "default", "headless instance id for --unix")
+		instanceName := fs.String("name", "", "human-readable headless instance name for --unix")
+		registryDir := fs.String("registry-dir", "", "headless instance registry directory for --unix")
 		authLeaseFile := fs.String("auth-lease-file", "", "required lease JSON path for --ws")
 		rpcAuthLeaseFile := fs.String("rpc-auth-lease-file", "", "optional daemon RPC lease JSON path for --ws /rpc")
 		shell := fs.String("shell", "", "shell path for --ws PTY sessions")
 		if err := fs.Parse(args[1:]); err != nil {
 			return 2
 		}
-		if *stdio == *ws {
-			_, _ = fmt.Fprintln(stderr, "serve requires exactly one of --stdio or --ws")
+		modeCount := 0
+		if *stdio {
+			modeCount++
+		}
+		if *ws {
+			modeCount++
+		}
+		if *unixSocket {
+			modeCount++
+		}
+		if modeCount != 1 {
+			_, _ = fmt.Fprintln(stderr, "serve requires exactly one of --stdio, --ws, or --unix")
 			return 2
 		}
 		if *ws {
@@ -164,6 +179,19 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 			}
 			return 0
 		}
+		if *unixSocket {
+			if err := runUnixHeadlessServer(context.Background(), unixHeadlessServerConfig{
+				SocketPath:  strings.TrimSpace(*socketPath),
+				InstanceID:  strings.TrimSpace(*instanceID),
+				Name:        strings.TrimSpace(*instanceName),
+				RegistryDir: strings.TrimSpace(*registryDir),
+				Shell:       strings.TrimSpace(*shell),
+			}, stderr); err != nil {
+				_, _ = fmt.Fprintf(stderr, "serve --unix failed: %v\n", err)
+				return 1
+			}
+			return 0
+		}
 		if err := runStdioServer(stdin, stdout); err != nil {
 			_, _ = fmt.Fprintf(stderr, "serve failed: %v\n", err)
 			return 1
@@ -171,6 +199,8 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		return 0
 	case "cli":
 		return runCLI(args[1:])
+	case "headless":
+		return runHeadless(args[1:], stdin, stdout, stderr)
 	default:
 		usage(stderr)
 		return 2
@@ -182,10 +212,16 @@ func usage(w io.Writer) {
 	_, _ = fmt.Fprintln(w, "  cmuxd-remote version")
 	_, _ = fmt.Fprintln(w, "  cmuxd-remote serve --stdio")
 	_, _ = fmt.Fprintln(w, "  cmuxd-remote serve --ws --auth-lease-file <path> [--rpc-auth-lease-file <path>] [--listen 127.0.0.1:7777]")
+	_, _ = fmt.Fprintln(w, "  cmuxd-remote serve --unix [--id <id>] [--name <name>] [--socket <path>] [--registry-dir <dir>]")
+	_, _ = fmt.Fprintln(w, "  cmuxd-remote headless <list|connect> [args...]")
 	_, _ = fmt.Fprintln(w, "  cmuxd-remote cli <command> [args...]")
 }
 
 func runStdioServer(stdin io.Reader, stdout io.Writer) error {
+	return serveRPCFrames(stdin, stdout, newWebSocketPTYHub(wsPTYServerConfig{}, io.Discard), true)
+}
+
+func serveRPCFrames(stdin io.Reader, stdout io.Writer, ptyHub *wsPTYHub, ownsPTYHub bool) error {
 	writer := &stdioFrameWriter{
 		writer: bufio.NewWriter(stdout),
 	}
@@ -194,8 +230,8 @@ func runStdioServer(stdin io.Reader, stdout io.Writer) error {
 		nextSessionID: 1,
 		streams:       map[string]*streamState{},
 		sessions:      map[string]*sessionState{},
-		ptyHub:        newWebSocketPTYHub(wsPTYServerConfig{}, io.Discard),
-		ownsPTYHub:    true,
+		ptyHub:        ptyHub,
+		ownsPTYHub:    ownsPTYHub,
 		frameWriter:   writer,
 	}
 	defer server.closeAll()
@@ -345,18 +381,9 @@ func (s *rpcServer) handleRequest(req rpcRequest) rpcResponse {
 			ID: req.ID,
 			OK: true,
 			Result: map[string]any{
-				"name":    "cmuxd-remote",
-				"version": version,
-				"capabilities": []string{
-					"session.basic",
-					"session.resize.min",
-					"proxy.http_connect",
-					"proxy.socks5",
-					"proxy.stream",
-					"proxy.stream.push",
-					"pty.session",
-					"pty.session.token",
-				},
+				"name":         "cmuxd-remote",
+				"version":      version,
+				"capabilities": daemonCapabilities(),
 			},
 		}
 	case "ping":
@@ -408,6 +435,19 @@ func (s *rpcServer) handleRequest(req rpcRequest) rpcResponse {
 				Message: fmt.Sprintf("unknown method %q", req.Method),
 			},
 		}
+	}
+}
+
+func daemonCapabilities() []string {
+	return []string{
+		"session.basic",
+		"session.resize.min",
+		"proxy.http_connect",
+		"proxy.socks5",
+		"proxy.stream",
+		"proxy.stream.push",
+		"pty.session",
+		"pty.session.token",
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds the first headless cmux slice:

- `cmuxd-remote serve --unix` runs a named long-lived headless instance with a shared PTY hub.
- `cmuxd-remote headless list` and `headless connect` discover and bridge to named Unix-socket instances.
- `cmux headless attach <destination> --id <instance>` creates a desktop remote workspace attached to an existing headless instance over SSH.
- Remote app configuration now carries `headless_instance_id` and routes daemon RPC through `headless connect --id` instead of a transient `serve --stdio` process.

Prior art checked:

- https://github.com/manaflow-ai/cmux/pull/3004, remote attach foundation.
- https://github.com/manaflow-ai/cmux/pull/3685, Rust cmux multiplexer/server/client foundation.
- https://github.com/manaflow-ai/cmux/pull/4240, tmux session attach surface.
- https://github.com/manaflow-ai/cmux/pull/2620, amux remote daemon/tmux compatibility attempt.
- https://github.com/manaflow-ai/cmux/pull/4748, tmux control panel integration.

## Verification

- `swiftc -parse CLI/cmux.swift Sources/WorkspaceRemoteConfiguration.swift Sources/WorkspaceRemoteSSHBatchCommandBuilder.swift Sources/TerminalController.swift Sources/Workspace.swift`
- `go test -ldflags=-linkmode=external ./cmd/cmuxd-remote`
- `git diff --check`
- Live smoke: built `cmuxd-remote`, ran `serve --unix --id smoke`, verified `headless list --json`, and verified `headless connect --id smoke` returned a valid `hello` RPC response.
- `./scripts/reload.sh --tag headless`

## Dogfood

1. On a remote Mac/Linux host, start a headless instance:
   ```bash
   cmuxd-remote serve --unix --id work
   ```
2. In the tagged desktop app, run:
   ```bash
   cmux headless attach user@host --id work
   ```
3. The new workspace should connect to the existing remote headless instance, open a remote shell through the persistent PTY bridge, and keep the named headless daemon running after local terminal surfaces close.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782373340&installation_id=133855650&pr_number=4786&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4786&signature=3285415e53cc48294eee588ba1b00bb582b2b3b0aaa7d83f7bf12e5de505aae2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes remote SSH daemon bootstrap and workspace RPC routing; reuses existing PTY/relay patterns but misconfiguration could attach to the wrong instance or leave stale registry entries.
> 
> **Overview**
> Introduces **headless cmux**: long-lived remote daemon instances the desktop can attach to instead of spawning a transient `serve --stdio` per workspace.
> 
> **Remote daemon (`cmuxd-remote`)** adds `serve --unix` (named instance, Unix socket, registry under `~/.cmux/headless/instances/`), plus `headless list` and `headless connect` to discover instances and bridge stdio to the same newline-delimited JSON RPC as stdio mode. RPC serving is refactored so Unix connections share `serveRPCFrames` with a shared PTY hub.
> 
> **Desktop CLI** adds `cmux headless attach <destination> --id <instance>`: creates a remote workspace, passes `headless_instance_id` through `workspace.remote.configure`, and uses a headless-specific terminal startup path (`ssh-pty-attach` with a `headless-…` session id).
> 
> **App remote config** threads `headless_instance_id` through configure, snapshots, proxy-broker keys, and display targets (`host#id`). SSH batch daemon hello/transport runs `cmuxd-remote headless connect --id …` when an instance id is set; session restore treats headless like persistent PTY attach.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee0943a97ee38d4666f7ab7654a8c4c47c2a62a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces headless cmux instances and a desktop attach flow. This enables long‑lived remote PTY hubs discoverable via Unix sockets and attachable over SSH to reduce per‑workspace daemon processes.

- **New Features**
  - `cmuxd-remote serve --unix` runs a named headless instance with a shared PTY hub and writes to `~/.cmux/headless/instances`.
  - `cmuxd-remote headless list` and `headless connect` discover and bridge to Unix-socket instances using the same RPC as stdio.
  - `cmux headless attach <destination> --id <instance>` attaches the desktop workspace to an existing headless instance over SSH and keeps sessions alive after terminals close.
  - Remote config now includes `headless_instance_id`; when set, daemon RPC routes via `headless connect --id` instead of `serve --stdio`.

- **Migration**
  - On the remote: run `cmuxd-remote serve --unix --id work`.
  - On desktop: run `cmux headless attach user@host --id work`.

<sup>Written for commit ee0943a97ee38d4666f7ab7654a8c4c47c2a62a0. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4786?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `cmux headless attach` command to establish connections to remote instances with `--id` flag support
  * Added `headless list` and `headless connect` subcommands for managing persistent daemon instances
  * Introduced Unix socket-based daemon mode supporting long-running headless sessions with PTY preservation

* **Documentation**
  * Updated CLI documentation with headless command usage and Unix socket server details

* **Tests**
  * Added end-to-end tests for headless instance listing and RPC bridging

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4786?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->