### PR TITLE
Fix equalize split span weighting

### DIFF
--- a/Sources/SplitEqualizer.swift
+++ b/Sources/SplitEqualizer.swift
@@ -19,7 +19,7 @@ enum SplitEqualizer {
     ) -> Result {
         var foundSplit = false
         var allSucceeded = true
-        _ = equalize(
+        equalize(
             node,
             controller: controller,
             orientationFilter: orientationFilter,
@@ -29,26 +29,25 @@ enum SplitEqualizer {
         return Result(foundSplit: foundSplit, allSucceeded: allSucceeded)
     }
 
-    @discardableResult
     private static func equalize(
         _ node: ExternalTreeNode,
         controller: BonsplitController,
         orientationFilter: String?,
         foundSplit: inout Bool,
         allSucceeded: inout Bool
-    ) -> Int {
+    ) {
         switch node {
         case .pane:
-            return 1
+            return
         case .split(let splitNode):
-            let firstLeafCount = equalize(
+            equalize(
                 splitNode.first,
                 controller: controller,
                 orientationFilter: orientationFilter,
                 foundSplit: &foundSplit,
                 allSucceeded: &allSucceeded
             )
-            let secondLeafCount = equalize(
+            equalize(
                 splitNode.second,
                 controller: controller,
                 orientationFilter: orientationFilter,
@@ -59,8 +58,10 @@ enum SplitEqualizer {
             if orientationFilter == nil || splitNode.orientation == orientationFilter {
                 foundSplit = true
                 if let splitId = UUID(uuidString: splitNode.id) {
-                    let totalLeafCount = firstLeafCount + secondLeafCount
-                    let position = CGFloat(firstLeafCount) / CGFloat(totalLeafCount)
+                    let firstSpanCount = spanCount(in: splitNode.first, along: splitNode.orientation)
+                    let secondSpanCount = spanCount(in: splitNode.second, along: splitNode.orientation)
+                    let totalSpanCount = firstSpanCount + secondSpanCount
+                    let position = CGFloat(firstSpanCount) / CGFloat(totalSpanCount)
                     if !controller.setDividerPosition(position, forSplit: splitId, fromExternal: true) {
                         allSucceeded = false
                     }
@@ -68,8 +69,20 @@ enum SplitEqualizer {
                     allSucceeded = false
                 }
             }
+        }
+    }
 
-            return firstLeafCount + secondLeafCount
+    private static func spanCount(in node: ExternalTreeNode, along orientation: String) -> Int {
+        switch node {
+        case .pane:
+            return 1
+        case .split(let splitNode):
+            let firstSpanCount = spanCount(in: splitNode.first, along: orientation)
+            let secondSpanCount = spanCount(in: splitNode.second, along: orientation)
+            if splitNode.orientation == orientation {
+                return firstSpanCount + secondSpanCount
+            }
+            return max(firstSpanCount, secondSpanCount)
         }
     }
 }

--- a/Sources/SplitEqualizer.swift
+++ b/Sources/SplitEqualizer.swift
@@ -77,12 +77,12 @@ enum SplitEqualizer {
         case .pane:
             return 1
         case .split(let splitNode):
+            guard splitNode.orientation == orientation else {
+                return 1
+            }
             let firstSpanCount = spanCount(in: splitNode.first, along: orientation)
             let secondSpanCount = spanCount(in: splitNode.second, along: orientation)
-            if splitNode.orientation == orientation {
-                return firstSpanCount + secondSpanCount
-            }
-            return max(firstSpanCount, secondSpanCount)
+            return firstSpanCount + secondSpanCount
         }
     }
 }

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -2351,37 +2351,134 @@ final class TabManagerSurfaceCreationTests: XCTestCase {
 
 @MainActor
 final class TabManagerEqualizeSplitsTests: XCTestCase {
-    func testEqualizeSplitsUsesLeafProportionsForAsymmetricTree() {
+    func testEqualizeSplitsKeepsMultiTabPaneAndBrowserAtHalfWidth() {
         let manager = TabManager()
-        guard let workspace = manager.selectedWorkspace,
-              let leftPanelId = workspace.focusedPanelId,
-              let rightPanel = workspace.newTerminalSplit(from: leftPanelId, orientation: .horizontal),
-              workspace.newTerminalSplit(from: rightPanel.id, orientation: .horizontal) != nil else {
-            XCTFail("Expected asymmetric horizontal split setup to succeed")
+        guard let workspace = manager.selectedWorkspace else {
+            XCTFail("Expected selected workspace")
             return
         }
 
-        let initialSplits = splitNodes(in: workspace.bonsplitController.treeSnapshot())
-        XCTAssertGreaterThanOrEqual(initialSplits.count, 2, "Expected at least two split nodes in nested layout")
-
-        for (index, split) in initialSplits.enumerated() {
-            guard let splitId = UUID(uuidString: split.id) else {
-                XCTFail("Expected split ID to be a UUID")
-                return
-            }
-            let targetPosition: CGFloat = index.isMultiple(of: 2) ? 0.2 : 0.8
-            XCTAssertTrue(
-                workspace.bonsplitController.setDividerPosition(targetPosition, forSplit: splitId),
-                "Expected to seed divider position for split \(splitId)"
-            )
-        }
+        workspace.applyCustomLayout(
+            .split(CmuxSplitDefinition(
+                direction: .horizontal,
+                split: 0.2,
+                children: [
+                    .pane(CmuxPaneDefinition(surfaces: [
+                        CmuxSurfaceDefinition(type: .terminal, name: "Terminal A"),
+                        CmuxSurfaceDefinition(type: .terminal, name: "Terminal B")
+                    ])),
+                    .pane(CmuxPaneDefinition(surfaces: [
+                        CmuxSurfaceDefinition(type: .browser, name: "Browser", url: "https://example.com")
+                    ]))
+                ]
+            )),
+            baseCwd: NSTemporaryDirectory()
+        )
 
         XCTAssertTrue(manager.equalizeSplits(tabId: workspace.id), "Expected equalize splits command to succeed")
 
-        let equalizedSplits = splitNodes(in: workspace.bonsplitController.treeSnapshot())
-        XCTAssertEqual(equalizedSplits.count, initialSplits.count)
-        let equalizedLeafCount = assertProportionalEqualizedSplitTree(workspace.bonsplitController.treeSnapshot())
-        XCTAssertEqual(equalizedLeafCount, 3)
+        guard case .split(let root) = workspace.bonsplitController.treeSnapshot() else {
+            XCTFail("Expected horizontal root split")
+            return
+        }
+        XCTAssertEqual(root.orientation, "horizontal")
+        XCTAssertEqual(root.dividerPosition, 0.5, accuracy: 0.000_1)
+
+        guard case .pane(let terminalPane) = root.first else {
+            XCTFail("Expected first child to remain one pane containing multiple tabs")
+            return
+        }
+        XCTAssertEqual(terminalPane.tabs.count, 2)
+    }
+
+    func testEqualizeSplitsBalancesThreeSameAxisSiblingPanesIntoThirds() {
+        let manager = TabManager()
+        guard let workspace = manager.selectedWorkspace else {
+            XCTFail("Expected selected workspace")
+            return
+        }
+
+        workspace.applyCustomLayout(
+            .split(CmuxSplitDefinition(
+                direction: .horizontal,
+                split: 0.2,
+                children: [
+                    .pane(CmuxPaneDefinition(surfaces: [
+                        CmuxSurfaceDefinition(type: .terminal, name: "Left")
+                    ])),
+                    .split(CmuxSplitDefinition(
+                        direction: .horizontal,
+                        split: 0.8,
+                        children: [
+                            .pane(CmuxPaneDefinition(surfaces: [
+                                CmuxSurfaceDefinition(type: .terminal, name: "Middle")
+                            ])),
+                            .pane(CmuxPaneDefinition(surfaces: [
+                                CmuxSurfaceDefinition(type: .browser, name: "Right", url: "https://example.com")
+                            ]))
+                        ]
+                    ))
+                ]
+            )),
+            baseCwd: NSTemporaryDirectory()
+        )
+
+        XCTAssertTrue(manager.equalizeSplits(tabId: workspace.id), "Expected equalize splits command to succeed")
+
+        guard case .split(let root) = workspace.bonsplitController.treeSnapshot(),
+              case .split(let rightColumn) = root.second else {
+            XCTFail("Expected three-pane same-axis split tree")
+            return
+        }
+        XCTAssertEqual(root.orientation, "horizontal")
+        XCTAssertEqual(root.dividerPosition, 1.0 / 3.0, accuracy: 0.000_1)
+        XCTAssertEqual(rightColumn.orientation, "horizontal")
+        XCTAssertEqual(rightColumn.dividerPosition, 0.5, accuracy: 0.000_1)
+    }
+
+    func testEqualizeSplitsCountsCrossAxisSubtreeAsOneSpan() {
+        let manager = TabManager()
+        guard let workspace = manager.selectedWorkspace else {
+            XCTFail("Expected selected workspace")
+            return
+        }
+
+        workspace.applyCustomLayout(
+            .split(CmuxSplitDefinition(
+                direction: .horizontal,
+                split: 0.2,
+                children: [
+                    .split(CmuxSplitDefinition(
+                        direction: .vertical,
+                        split: 0.8,
+                        children: [
+                            .pane(CmuxPaneDefinition(surfaces: [
+                                CmuxSurfaceDefinition(type: .terminal, name: "Top Terminal")
+                            ])),
+                            .pane(CmuxPaneDefinition(surfaces: [
+                                CmuxSurfaceDefinition(type: .terminal, name: "Bottom Terminal")
+                            ]))
+                        ]
+                    )),
+                    .pane(CmuxPaneDefinition(surfaces: [
+                        CmuxSurfaceDefinition(type: .browser, name: "Browser", url: "https://example.com")
+                    ]))
+                ]
+            )),
+            baseCwd: NSTemporaryDirectory()
+        )
+
+        XCTAssertTrue(manager.equalizeSplits(tabId: workspace.id), "Expected equalize splits command to succeed")
+
+        guard case .split(let root) = workspace.bonsplitController.treeSnapshot(),
+              case .split(let leftStack) = root.first else {
+            XCTFail("Expected browser beside a vertically stacked terminal subtree")
+            return
+        }
+        XCTAssertEqual(root.orientation, "horizontal")
+        XCTAssertEqual(root.dividerPosition, 0.5, accuracy: 0.000_1)
+        XCTAssertEqual(leftStack.orientation, "vertical")
+        XCTAssertEqual(leftStack.dividerPosition, 0.5, accuracy: 0.000_1)
     }
 }
 

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -2480,6 +2480,63 @@ final class TabManagerEqualizeSplitsTests: XCTestCase {
         XCTAssertEqual(leftStack.orientation, "vertical")
         XCTAssertEqual(leftStack.dividerPosition, 0.5, accuracy: 0.000_1)
     }
+
+    func testEqualizeSplitsDoesNotPropagateSameAxisSpansThroughCrossAxisBoundary() {
+        let manager = TabManager()
+        guard let workspace = manager.selectedWorkspace else {
+            XCTFail("Expected selected workspace")
+            return
+        }
+
+        workspace.applyCustomLayout(
+            .split(CmuxSplitDefinition(
+                direction: .horizontal,
+                split: 0.2,
+                children: [
+                    .split(CmuxSplitDefinition(
+                        direction: .vertical,
+                        split: 0.8,
+                        children: [
+                            .split(CmuxSplitDefinition(
+                                direction: .horizontal,
+                                split: 0.8,
+                                children: [
+                                    .pane(CmuxPaneDefinition(surfaces: [
+                                        CmuxSurfaceDefinition(type: .terminal, name: "Top Left")
+                                    ])),
+                                    .pane(CmuxPaneDefinition(surfaces: [
+                                        CmuxSurfaceDefinition(type: .terminal, name: "Top Right")
+                                    ]))
+                                ]
+                            )),
+                            .pane(CmuxPaneDefinition(surfaces: [
+                                CmuxSurfaceDefinition(type: .terminal, name: "Bottom")
+                            ]))
+                        ]
+                    )),
+                    .pane(CmuxPaneDefinition(surfaces: [
+                        CmuxSurfaceDefinition(type: .browser, name: "Browser", url: "https://example.com")
+                    ]))
+                ]
+            )),
+            baseCwd: NSTemporaryDirectory()
+        )
+
+        XCTAssertTrue(manager.equalizeSplits(tabId: workspace.id), "Expected equalize splits command to succeed")
+
+        guard case .split(let root) = workspace.bonsplitController.treeSnapshot(),
+              case .split(let leftStack) = root.first,
+              case .split(let topRow) = leftStack.first else {
+            XCTFail("Expected browser beside a mixed nested terminal subtree")
+            return
+        }
+        XCTAssertEqual(root.orientation, "horizontal")
+        XCTAssertEqual(root.dividerPosition, 0.5, accuracy: 0.000_1)
+        XCTAssertEqual(leftStack.orientation, "vertical")
+        XCTAssertEqual(leftStack.dividerPosition, 0.5, accuracy: 0.000_1)
+        XCTAssertEqual(topRow.orientation, "horizontal")
+        XCTAssertEqual(topRow.dividerPosition, 0.5, accuracy: 0.000_1)
+    }
 }
 
 @MainActor


### PR DESCRIPTION
Fixes #4783.

## Summary

- Changes Equalize Splits from total leaf-count weighting to axis-span weighting.
- Same-axis nested splits add spans, so three horizontal sibling panes still equalize to thirds.
- Perpendicular nested splits are a span boundary: the entire cross-axis subtree contributes one span to the parent split, so a vertical terminal stack beside a browser no longer makes the terminal column count as two horizontal panes.
- Adds regression coverage for multi-tab panes, three same-axis panes, the nested cross-axis repro, and a deeper mixed-orientation boundary.

## Repro / Tree Evidence

Captured before changing code with live cmux v2 CLI throwaway workspaces under `/tmp/issue-4783-live-tree`.

### Multi-tab pane next to browser

Input split tree:

```text
horizontal split
|-- pane: 2 terminal tabs
`-- pane: 1 browser tab
```

After current equalize, the panes remained equal width:

```text
container width: 1236.62109375
terminal pane width: 618.310546875 (surface_count=2)
browser pane width: 618.310546875 (surface_count=1)
inferred root divider: 0.5
```

This rules out tab/surface count leaking into the equalize math.

### Nested cross-axis repro

Input split tree:

```text
horizontal split
|-- vertical split        leaf count = 2, horizontal span count = 1
|   |-- pane: terminal
|   `-- pane: terminal
`-- pane: browser         leaf count = 1, horizontal span count = 1
```

Before equalize, the root was 50/50. After current equalize on main, the terminal column became 2/3 and the browser became 1/3:

```text
container width: 1236.62109375
terminal top width: 824.4140625
terminal bottom width: 824.4140625
browser width: 412.20703125
inferred root divider: 0.6667
inner vertical divider: 0.5
```

Mechanism: the existing algorithm counts leaves in the perpendicular vertical stack, so the left column gets weight 2 while the browser gets weight 1. The issue is not tab count.

## Chosen Semantics

Equalize should divide each split by visible spans along that split's axis:

- A pane contributes one span.
- A nested split with the same orientation contributes the sum of its child spans.
- A nested split with the perpendicular orientation contributes exactly one span to the parent axis, because that subtree is one visible region along the parent split. Its internal splits are equalized independently when the recursive walk reaches them.

This preserves thirds for three same-axis panes while making terminal/browser regions equal when the terminal side is a perpendicular stack.

## Verification

- Not run locally per repo policy; unit tests run in CI.
- Regression commits are split test-first, then fix.
