### PR TITLE
Fix right Option as Alt handling

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7330,6 +7330,10 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     ])
     private static let tabTransferPasteboardType = NSPasteboard.PasteboardType("com.splittabbar.tabtransfer")
     private static let sidebarTabReorderPasteboardType = NSPasteboard.PasteboardType("com.cmux.sidebar-tab-reorder")
+    private static let rightShiftModifierFlag = NSEvent.ModifierFlags(rawValue: UInt(NX_DEVICERSHIFTKEYMASK))
+    private static let rightControlModifierFlag = NSEvent.ModifierFlags(rawValue: UInt(NX_DEVICERCTLKEYMASK))
+    private static let rightOptionModifierFlag = NSEvent.ModifierFlags(rawValue: UInt(NX_DEVICERALTKEYMASK))
+    private static let rightCommandModifierFlag = NSEvent.ModifierFlags(rawValue: UInt(NX_DEVICERCMDKEYMASK))
 
     private enum WordPathResolutionSource: String {
         case quicklook
@@ -8979,27 +8983,10 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
         // Translate mods to respect Ghostty config (e.g., macos-option-as-alt)
         let translationModsGhostty = ghostty_surface_key_translation_mods(surface, modsFromEvent(event))
-        var translationMods = event.modifierFlags
-        for flag in [NSEvent.ModifierFlags.shift, .control, .option, .command] {
-            let hasFlag: Bool
-            switch flag {
-            case .shift:
-                hasFlag = (translationModsGhostty.rawValue & GHOSTTY_MODS_SHIFT.rawValue) != 0
-            case .control:
-                hasFlag = (translationModsGhostty.rawValue & GHOSTTY_MODS_CTRL.rawValue) != 0
-            case .option:
-                hasFlag = (translationModsGhostty.rawValue & GHOSTTY_MODS_ALT.rawValue) != 0
-            case .command:
-                hasFlag = (translationModsGhostty.rawValue & GHOSTTY_MODS_SUPER.rawValue) != 0
-            default:
-                hasFlag = translationMods.contains(flag)
-            }
-            if hasFlag {
-                translationMods.insert(flag)
-            } else {
-                translationMods.remove(flag)
-            }
-        }
+        let translationMods = translatedModifierFlags(
+            from: translationModsGhostty,
+            fallback: event.modifierFlags
+        )
 
         let translationEvent: NSEvent
         if translationMods == event.modifierFlags {
@@ -9424,11 +9411,16 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     }
 
     private func modsFromFlags(_ flags: NSEvent.ModifierFlags) -> ghostty_input_mods_e {
+        let rawFlags = flags.rawValue
         var mods = GHOSTTY_MODS_NONE.rawValue
         if flags.contains(.shift) { mods |= GHOSTTY_MODS_SHIFT.rawValue }
         if flags.contains(.control) { mods |= GHOSTTY_MODS_CTRL.rawValue }
         if flags.contains(.option) { mods |= GHOSTTY_MODS_ALT.rawValue }
         if flags.contains(.command) { mods |= GHOSTTY_MODS_SUPER.rawValue }
+        if rawFlags & Self.rightShiftModifierFlag.rawValue != 0 { mods |= GHOSTTY_MODS_SHIFT_RIGHT.rawValue }
+        if rawFlags & Self.rightControlModifierFlag.rawValue != 0 { mods |= GHOSTTY_MODS_CTRL_RIGHT.rawValue }
+        if rawFlags & Self.rightOptionModifierFlag.rawValue != 0 { mods |= GHOSTTY_MODS_ALT_RIGHT.rawValue }
+        if rawFlags & Self.rightCommandModifierFlag.rawValue != 0 { mods |= GHOSTTY_MODS_SUPER_RIGHT.rawValue }
         return ghostty_input_mods_e(rawValue: mods)
     }
 
@@ -9439,9 +9431,45 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         var mods = GHOSTTY_MODS_NONE.rawValue
         // Only include Shift and Option as potentially consumed
         // Control and Command are never consumed for text translation
-        if flags.contains(.shift) { mods |= GHOSTTY_MODS_SHIFT.rawValue }
-        if flags.contains(.option) { mods |= GHOSTTY_MODS_ALT.rawValue }
+        if flags.contains(.shift) {
+            mods |= GHOSTTY_MODS_SHIFT.rawValue
+            if flags.rawValue & Self.rightShiftModifierFlag.rawValue != 0 {
+                mods |= GHOSTTY_MODS_SHIFT_RIGHT.rawValue
+            }
+        }
+        if flags.contains(.option) {
+            mods |= GHOSTTY_MODS_ALT.rawValue
+            if flags.rawValue & Self.rightOptionModifierFlag.rawValue != 0 {
+                mods |= GHOSTTY_MODS_ALT_RIGHT.rawValue
+            }
+        }
         return ghostty_input_mods_e(rawValue: mods)
+    }
+
+    private func translatedModifierFlags(
+        from ghosttyMods: ghostty_input_mods_e,
+        fallback: NSEvent.ModifierFlags
+    ) -> NSEvent.ModifierFlags {
+        var flags = fallback
+
+        func set(_ appKitFlag: NSEvent.ModifierFlags, when ghosttyFlag: ghostty_input_mods_e) {
+            if ghosttyMods.rawValue & ghosttyFlag.rawValue != 0 {
+                flags.insert(appKitFlag)
+            } else {
+                flags.remove(appKitFlag)
+            }
+        }
+
+        set(.shift, when: GHOSTTY_MODS_SHIFT)
+        set(.control, when: GHOSTTY_MODS_CTRL)
+        set(.option, when: GHOSTTY_MODS_ALT)
+        set(.command, when: GHOSTTY_MODS_SUPER)
+        set(Self.rightShiftModifierFlag, when: GHOSTTY_MODS_SHIFT_RIGHT)
+        set(Self.rightControlModifierFlag, when: GHOSTTY_MODS_CTRL_RIGHT)
+        set(Self.rightOptionModifierFlag, when: GHOSTTY_MODS_ALT_RIGHT)
+        set(Self.rightCommandModifierFlag, when: GHOSTTY_MODS_SUPER_RIGHT)
+
+        return flags
     }
 
     func beginFindEscapeSuppression() {
@@ -9533,27 +9561,10 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
         // Translate mods to respect Ghostty config (e.g., macos-option-as-alt).
         let translationModsGhostty = ghostty_surface_key_translation_mods(surface, modsFromEvent(event))
-        var translationMods = event.modifierFlags
-        for flag in [NSEvent.ModifierFlags.shift, .control, .option, .command] {
-            let hasFlag: Bool
-            switch flag {
-            case .shift:
-                hasFlag = (translationModsGhostty.rawValue & GHOSTTY_MODS_SHIFT.rawValue) != 0
-            case .control:
-                hasFlag = (translationModsGhostty.rawValue & GHOSTTY_MODS_CTRL.rawValue) != 0
-            case .option:
-                hasFlag = (translationModsGhostty.rawValue & GHOSTTY_MODS_ALT.rawValue) != 0
-            case .command:
-                hasFlag = (translationModsGhostty.rawValue & GHOSTTY_MODS_SUPER.rawValue) != 0
-            default:
-                hasFlag = translationMods.contains(flag)
-            }
-            if hasFlag {
-                translationMods.insert(flag)
-            } else {
-                translationMods.remove(flag)
-            }
-        }
+        let translationMods = translatedModifierFlags(
+            from: translationModsGhostty,
+            fallback: event.modifierFlags
+        )
 
         keyEvent.consumed_mods = consumedModsFromFlags(translationMods)
         keyEvent.text = nil

--- a/cmuxTests/CJKIMEInputTests.swift
+++ b/cmuxTests/CJKIMEInputTests.swift
@@ -2353,5 +2353,11 @@ final class GhosttyOptionDeleteRegressionTests: XCTestCase {
             GHOSTTY_MODS_ALT_RIGHT.rawValue,
             "Right Option+Delete should include AltRight"
         )
+        XCTAssertEqual(
+            pressEvent.consumed_mods.rawValue,
+            GHOSTTY_MODS_NONE.rawValue,
+            "Right Option+Delete should not consume Option as text input"
+        )
+        XCTAssertNil(pressEvent.text, "Right Option+Delete should be encoded as a key event, not forwarded as DEL text")
     }
 }

--- a/cmuxTests/CJKIMEInputTests.swift
+++ b/cmuxTests/CJKIMEInputTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import AppKit
+import Carbon.HIToolbox
 import ObjectiveC.runtime
 
 #if canImport(cmux_DEV)
@@ -2254,7 +2255,13 @@ final class DeadKeyCompositionRegressionTests: XCTestCase {
 
 @MainActor
 final class GhosttyOptionDeleteRegressionTests: XCTestCase {
-    func testOptionDeletePreservesAltAsModifierForWordDelete() {
+    private static let rightOptionModifierFlag = NSEvent.ModifierFlags(rawValue: UInt(NX_DEVICERALTKEYMASK))
+
+    private func captureOptionDeletePressEvent(
+        modifierFlags: NSEvent.ModifierFlags,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> ghostty_input_key_s? {
         _ = NSApplication.shared
 
         let surface = TerminalSurface(
@@ -2277,8 +2284,8 @@ final class GhosttyOptionDeleteRegressionTests: XCTestCase {
         }
 
         guard let contentView = window.contentView else {
-            XCTFail("Expected content view")
-            return
+            XCTFail("Expected content view", file: file, line: line)
+            return nil
         }
         hostedView.frame = contentView.bounds
         hostedView.autoresizingMask = [.width, .height]
@@ -2301,11 +2308,14 @@ final class GhosttyOptionDeleteRegressionTests: XCTestCase {
             characters: "\u{7F}",
             charactersIgnoringModifiers: "\u{7F}",
             keyCode: 51,
-            modifierFlags: [.option]
+            modifierFlags: modifierFlags
         )
-        XCTAssertTrue(sent, "Expected synthetic Option+Delete event to be dispatched")
+        XCTAssertTrue(sent, "Expected synthetic Option+Delete event to be dispatched", file: file, line: line)
+        return pressEvent
+    }
 
-        guard let pressEvent else {
+    func testOptionDeletePreservesAltAsModifierForWordDelete() {
+        guard let pressEvent = captureOptionDeletePressEvent(modifierFlags: [.option]) else {
             XCTFail("Expected to capture Option+Delete key event")
             return
         }
@@ -2323,5 +2333,25 @@ final class GhosttyOptionDeleteRegressionTests: XCTestCase {
             "Non-printing delete should not consume Option as text input"
         )
         XCTAssertNil(pressEvent.text, "Delete should be encoded as a key event, not forwarded as DEL text")
+    }
+
+    func testRightOptionDeleteSetsAltRightModifier() {
+        guard let pressEvent = captureOptionDeletePressEvent(
+            modifierFlags: [.option, Self.rightOptionModifierFlag]
+        ) else {
+            XCTFail("Expected to capture Right Option+Delete key event")
+            return
+        }
+
+        XCTAssertEqual(
+            pressEvent.mods.rawValue & GHOSTTY_MODS_ALT.rawValue,
+            GHOSTTY_MODS_ALT.rawValue,
+            "Right Option+Delete should include Alt"
+        )
+        XCTAssertEqual(
+            pressEvent.mods.rawValue & GHOSTTY_MODS_ALT_RIGHT.rawValue,
+            GHOSTTY_MODS_ALT_RIGHT.rawValue,
+            "Right Option+Delete should include AltRight"
+        )
     }
 }


### PR DESCRIPTION
## Summary
- Preserve Ghostty right-side modifier bits from AppKit key events, including `GHOSTTY_MODS_ALT_RIGHT` for right Option.
- Reuse one modifier-translation helper for keyDown/keyUp so Ghostty's `macos-option-as-alt = right` can strip Option for text translation while keeping the raw terminal modifier.
- Add regression coverage for synthetic Right Option+Delete carrying the AltRight modifier bit and remaining a non-text key event.

Fixes #2369.

## Testing
- Not run locally per workspace policy.
- Pushed the regression test first as its own commit (`f36663bd2`), then the fix commit (`5c21a374a`), then review-feedback coverage (`29a480b6d`).
- The test-only PR run was left pending for the broad `tests` job for an extended wait; CI's unit-test wrapper appears to treat normal XCTest assertion failures as pass when the summary reports `0 unexpected`, so I proceeded with the fix commit rather than leaving the PR stuck.
