### PR TITLE
Cover Ghostty split theme foreground override

### DIFF
--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -607,6 +607,70 @@ final class GhosttyConfigTests: XCTestCase {
         XCTAssertEqual(rgb255(darkConfig.backgroundColor), RGB(red: 0, green: 43, blue: 54))
     }
 
+    func testLoadHonorsPairedThemeAndTopLevelForegroundOverrideByColorScheme() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-ghostty-theme-pair-foreground-\(UUID().uuidString)")
+        let themesDir = root.appendingPathComponent("themes", isDirectory: true)
+        try fileManager.createDirectory(at: themesDir, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let originalFixedHome = getenv("CFFIXED_USER_HOME").map { String(cString: $0) }
+        let originalResourcesDir = getenv("GHOSTTY_RESOURCES_DIR").map { String(cString: $0) }
+        setenv("CFFIXED_USER_HOME", root.path, 1)
+        setenv("GHOSTTY_RESOURCES_DIR", root.path, 1)
+        defer {
+            if let originalFixedHome {
+                setenv("CFFIXED_USER_HOME", originalFixedHome, 1)
+            } else {
+                unsetenv("CFFIXED_USER_HOME")
+            }
+            if let originalResourcesDir {
+                setenv("GHOSTTY_RESOURCES_DIR", originalResourcesDir, 1)
+            } else {
+                unsetenv("GHOSTTY_RESOURCES_DIR")
+            }
+            GhosttyConfig.invalidateLoadCache()
+        }
+
+        try """
+        background = #fffcf0
+        foreground = #100f0f
+        """.write(
+            to: themesDir.appendingPathComponent("Flexoki Light", isDirectory: false),
+            atomically: true,
+            encoding: .utf8
+        )
+        try """
+        background = #100f0f
+        foreground = #cecdc3
+        """.write(
+            to: themesDir.appendingPathComponent("Flexoki Dark", isDirectory: false),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let ghosttyConfigDir = root.appendingPathComponent(".config/ghostty", isDirectory: true)
+        try fileManager.createDirectory(at: ghosttyConfigDir, withIntermediateDirectories: true)
+        try """
+        window-theme = auto
+        theme = light:Flexoki Light,dark:Flexoki Dark
+        foreground = #ff0000
+        """.write(
+            to: ghosttyConfigDir.appendingPathComponent("config", isDirectory: false),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let lightConfig = GhosttyConfig.load(preferredColorScheme: .light, useCache: false)
+        let darkConfig = GhosttyConfig.load(preferredColorScheme: .dark, useCache: false)
+
+        XCTAssertEqual(lightConfig.backgroundColor.hexString(), "#FFFCF0")
+        XCTAssertEqual(lightConfig.foregroundColor.hexString(), "#FF0000")
+        XCTAssertEqual(darkConfig.backgroundColor.hexString(), "#100F0F")
+        XCTAssertEqual(darkConfig.foregroundColor.hexString(), "#FF0000")
+    }
+
     func testParseBackgroundOpacityReadsConfigValue() {
         var config = GhosttyConfig()
         config.parse("background-opacity = 0.42")


### PR DESCRIPTION
## Summary
- Adds an issue-specific regression for Ghostty `theme = light:X,dark:Y` config loading.
- Covers the #2922 repro shape with `window-theme = auto` and a top-level `foreground` override after the paired theme directive.
- Verifies light and dark appearance loads select their matching theme backgrounds while preserving the explicit foreground override.

## Testing
- `git diff --check`
- Local builds/tests not run per issue instructions. CI should validate the XCTest.

## Notes
- I did not make a separate failing-test commit: this branch started from current `origin/main`, which already includes the later Ghostty runtime/theme fixes from #4278, #4567, and #4652, so the issue-specific regression is expected to pass on the base behavior.

Refs #2922

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4796"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782373770&installation_id=133855650&pr_number=4796&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4796&signature=a49a2e573bb44d8e309aabc8fa4fdb80cd311db45afe10ecb346b83707e10fd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no runtime or config-loader modifications; risk is limited to CI/test maintenance.
> 
> **Overview**
> Adds a **regression XCTest** in `GhosttyConfigTests` for Ghostty config loading when `theme` uses a **light/dark pair** together with **`window-theme = auto`** and a **top-level `foreground` override** listed after the theme directive.
> 
> The test builds temporary Flexoki Light/Dark theme files and a user `config`, then asserts that `GhosttyConfig.load` picks the **scheme-appropriate background** for light vs dark while keeping the **explicit `#FF0000` foreground** in both cases. There are **no production code changes** in this PR—coverage only, tied to **#2922**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c798117e8eff0193293860b339f4afa35eeab23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a test for Ghostty split themes to ensure backgrounds switch by appearance while a top-level `foreground` override is preserved in both light and dark modes. Covers the #2922 repro: `window-theme = auto` with `theme = light:Flexoki Light,dark:Flexoki Dark` and a global `foreground`.

<sup>Written for commit 4c798117e8eff0193293860b339f4afa35eeab23. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4796?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

