### PR TITLE
Make bare cmux open the current directory

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -2702,6 +2702,39 @@ struct CMUXCLI {
         return true
     }
 
+    private func resolveSocketTarget(
+        explicitSocketPath: String?,
+        processEnv: [String: String],
+        cliBundleIdentifier: String?
+    ) throws -> (requestedPath: String, resolvedPath: String) {
+        let envSocketPath = explicitSocketPath == nil
+            ? try CLISocketEnvironment.socketPath(in: processEnv)
+            : CLISocketEnvironment.socketPathForTelemetry(in: processEnv)
+        let socketPath = explicitSocketPath ?? envSocketPath ?? CLISocketPathResolver.defaultSocketPath(
+            bundleIdentifier: cliBundleIdentifier,
+            environment: processEnv
+        )
+        let socketPathSource: CLISocketPathSource
+        if explicitSocketPath != nil {
+            socketPathSource = .explicitFlag
+        } else if let envSocketPath {
+            socketPathSource = CLISocketPathResolver.isImplicitDefaultPath(
+                envSocketPath,
+                bundleIdentifier: cliBundleIdentifier,
+                environment: processEnv
+            ) ? .implicitDefault : .environment
+        } else {
+            socketPathSource = .implicitDefault
+        }
+        let resolvedSocketPath = CLISocketPathResolver.resolve(
+            requestedPath: socketPath,
+            source: socketPathSource,
+            environment: processEnv,
+            bundleIdentifier: cliBundleIdentifier
+        )
+        return (socketPath, resolvedSocketPath)
+    }
+
     func run() throws {
         let processEnv = ProcessInfo.processInfo.environment
         let cliBundleIdentifier = CLISocketPathResolver.currentAppBundleIdentifier()
@@ -2762,11 +2795,14 @@ struct CMUXCLI {
             break
         }
 
-        guard index < args.count else {
-            throw CLIError(
-                message: "Missing command. Usage: cmux <path>|<command> [options]. Run 'cmux --help' for the full command list.",
-                exitCode: 2
+        if index >= args.count {
+            let socketTarget = try resolveSocketTarget(
+                explicitSocketPath: explicitSocketPath,
+                processEnv: processEnv,
+                cliBundleIdentifier: cliBundleIdentifier
             )
+            try openPath(".", socketPath: socketTarget.resolvedPath)
+            return
         }
 
         let command = args[index]
@@ -2829,36 +2865,18 @@ struct CMUXCLI {
             return
         }
 
-        let envSocketPath = explicitSocketPath == nil
-            ? try CLISocketEnvironment.socketPath(in: processEnv)
-            : CLISocketEnvironment.socketPathForTelemetry(in: processEnv)
-        let socketPath = explicitSocketPath ?? envSocketPath ?? CLISocketPathResolver.defaultSocketPath(
-            bundleIdentifier: cliBundleIdentifier,
-            environment: processEnv
+        let socketTarget = try resolveSocketTarget(
+            explicitSocketPath: explicitSocketPath,
+            processEnv: processEnv,
+            cliBundleIdentifier: cliBundleIdentifier
         )
-        let socketPathSource: CLISocketPathSource
-        if explicitSocketPath != nil {
-            socketPathSource = .explicitFlag
-        } else if let envSocketPath {
-            socketPathSource = CLISocketPathResolver.isImplicitDefaultPath(
-                envSocketPath,
-                bundleIdentifier: cliBundleIdentifier,
-                environment: processEnv
-            ) ? .implicitDefault : .environment
-        } else {
-            socketPathSource = .implicitDefault
-        }
+        let socketPath = socketTarget.requestedPath
+        let resolvedSocketPath = socketTarget.resolvedPath
         let cliTelemetry = CLISocketSentryTelemetry(
             command: command,
             commandArgs: commandArgs,
             socketPath: socketPath,
             processEnv: processEnv
-        )
-        let resolvedSocketPath = CLISocketPathResolver.resolve(
-            requestedPath: socketPath,
-            source: socketPathSource,
-            environment: processEnv,
-            bundleIdentifier: cliBundleIdentifier
         )
 
         // If the argument looks like a path (not a known command), open a workspace there.
@@ -29733,7 +29751,8 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
         cmux - control cmux via Unix socket
 
         Usage:
-          cmux <path>                Open a directory in a new workspace (launches cmux if needed)
+          cmux                       Open the current directory in a new workspace (launches cmux if needed)
+          cmux <path>                Open a directory or file parent in a new workspace
           cmux [global-options] <command> [options]
 
         Handle Inputs:


### PR DESCRIPTION
## Summary
- route bare `cmux` through the existing path-opening workspace flow with `.`
- share socket target resolution between bare/path and command dispatch
- update CLI usage to document the no-argument behavior

Closes https://github.com/manaflow-ai/cmux/issues/1448

## Verification
- `swiftc -parse CLI/*.swift`
- `git diff --check`
- `./scripts/reload.sh --tag opencwd`
- launched tagged `opencwd` app, ran the bundled CLI with no args from `/tmp/cmux-opencwd-smoke` against `/tmp/cmux-debug-opencwd.sock`, got `OK workspace:2`, and confirmed `list-workspaces --json` reported `current_directory` as `/private/tmp/cmux-opencwd-smoke/.`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4802"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782378402&installation_id=133855650&pr_number=4802&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4802&signature=12cfc328d3d28e38f6dd110030a96460f45e43922c7b9a3d38d2517a7d9d2561"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Reuses existing workspace-open and socket logic; no auth or data-model changes beyond CLI entry behavior.
> 
> **Overview**
> **Bare `cmux` now opens the current working directory** instead of exiting with a “missing command” error. When there are no arguments after global options, the CLI resolves the Unix socket the same way as other commands and calls the existing **`openPath(".", …)`** workspace flow (launching the app if needed).
> 
> Socket path resolution (**explicit flag → env → default**, plus **`CLISocketPathResolver.resolve`**) is moved into a new **`resolveSocketTarget`** helper so both the no-arg path and normal command dispatch share one code path. **`usage()`** documents `cmux` with no args and clarifies path vs command behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 712eac72fdcf1f585c69f56af7035047210b1250. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Running `cmux` with no arguments now opens the current directory in a new workspace (closes #1448). It also unifies socket target resolution across flows and updates the CLI usage.

- **New Features**
  - Bare `cmux` opens `.` in a new workspace (launches app if needed).
  - Usage text clarifies no-arg behavior and that `<path>` can be a directory or a file (parent is used).

- **Refactors**
  - Added `resolveSocketTarget(...)` to share socket path detection/resolution across open-path and command dispatch.
  - Keeps telemetry via `CLISocketSentryTelemetry` with requested and resolved socket paths.

<sup>Written for commit 712eac72fdcf1f585c69f56af7035047210b1250. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4802?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated help and usage text descriptions for path handling.

* **Chores**
  * Internal refactoring of socket path resolution logic to improve code organization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4802?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->