### PR TITLE
fix(antigravity): fail open when cmux socket is unreachable

### DIFF
--- a/CLI/CMUXCLI+AgentHookDefinitions.swift
+++ b/CLI/CMUXCLI+AgentHookDefinitions.swift
@@ -363,7 +363,7 @@ extension CMUXCLI {
                 routedArguments: routedArguments,
                 socketPath: socketPath
             )
-            dispatch = "if [ -x \(quotedCLIPath) ]; then \(primaryInvocation); elif command -v cmux >/dev/null 2>&1; then \(fallbackInvocation); else echo '{}'; fi"
+            dispatch = "if [ -x \(quotedCLIPath) ]; then \(primaryInvocation) || echo '{}'; elif command -v cmux >/dev/null 2>&1; then \(fallbackInvocation) || echo '{}'; else echo '{}'; fi"
         } else {
             dispatch = "command -v cmux >/dev/null 2>&1 && \(fallbackInvocation) || echo '{}'"
         }


### PR DESCRIPTION
## Problem

When cmux is not running, the Antigravity hook script propagates the non-zero exit code from the cmux socket call. Antigravity (and Gemini CLI) interprets non-zero exit on `PreToolUse` as `deny`, blocking every `agy` tool call with:

```
Tool call denied by jsonhook__cmux_PreToolUse_0_0
```

This makes `agy` unusable outside of cmux (e.g. from Terminal.app) because the hooks file persists across reboots.

## Root Cause

In `pinnedAgentHookShellCommand`, the dispatched cmux invocation had no fallback on failure:

```swift
dispatch = "... \(primaryInvocation); ... \(fallbackInvocation); ..."
```

When the socket is unreachable, the hook exits non-zero and the failure propagates.

## Fix

Add `|| echo '{}'` fallback to both primary and fallback cmux invocations:

```swift
dispatch = "... \(primaryInvocation) || echo '{}'; ... \(fallbackInvocation) || echo '{}'; ..."
```

A missing or unreachable socket now emits empty JSON and exits 0, allowing `agy` to continue normally when cmux is closed.

## Verification

- [x] Code review: single-line change, minimal scope
- [x] Logic verification: `|| echo '{}'` ensures exit 0 on socket failure
- [x] No lockfile/schema changes

## References

Fixes #4768

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4803"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782378567&installation_id=133855650&pr_number=4803&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4803&signature=4d79cf3adaaf33821809b86d23e8d4cb6b771ea3b2a40ba8adbb060dc0da2158"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail open in Antigravity when the `cmux` socket is unreachable by appending `|| echo '{}'` to both primary and fallback hook invocations, returning empty JSON with exit 0 instead of propagating an error. Prevents `agy` tool calls from being denied when `cmux` isn’t running (fixes #4768).

<sup>Written for commit 0ef03aecd5edcc5776b800628dd57a970eb1e587. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4803?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated error handling in shell dispatch logic to return empty responses on invocation failure instead of propagating errors for both primary and fallback scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4803?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->