### PR TITLE
Fix find field arrow keys

### DIFF
--- a/Sources/App/ShortcutRoutingSupport.swift
+++ b/Sources/App/ShortcutRoutingSupport.swift
@@ -191,6 +191,27 @@ func shouldDispatchTextBoxInputArrowViaFirstResponderKeyDown(
     }
 }
 
+func shouldDispatchFindTextFieldArrowViaFirstResponderKeyDown(
+    keyCode: UInt16,
+    firstResponderIsFindTextField: Bool,
+    firstResponderHasMarkedText: Bool = false,
+    flags: NSEvent.ModifierFlags
+) -> Bool {
+    guard firstResponderIsFindTextField else { return false }
+    guard !firstResponderHasMarkedText else { return false }
+    guard (123...126).contains(keyCode) else { return false }
+
+    let normalizedFlags = flags
+        .intersection(.deviceIndependentFlagsMask)
+        .subtracting([.numericPad, .function, .capsLock])
+    switch normalizedFlags {
+    case [], [.shift], [.option], [.option, .shift], [.command], [.command, .shift]:
+        return true
+    default:
+        return false
+    }
+}
+
 func shouldToggleMainWindowFullScreenForCommandControlFShortcut(
     flags: NSEvent.ModifierFlags,
     chars: String,

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -15325,6 +15325,7 @@ private var cmuxBrowserArrowForwardingDepth = 0
 private var cmuxBrowserOmnibarMarkedTextForwardingDepth = 0
 private var cmuxCommandPaletteArrowForwardingDepth = 0
 private var cmuxTextBoxInputArrowForwardingDepth = 0
+private var cmuxFindTextFieldArrowForwardingDepth = 0
 private var cmuxWindowFirstResponderBypassDepth = 0
 private var cmuxFieldEditorOwningWebViewAssociationKey: UInt8 = 0
 
@@ -16000,6 +16001,7 @@ private extension NSWindow {
         )
         let firstResponderOmnibarPanelId = browserOmnibarPanelId(for: self.firstResponder)
         let firstResponderIsTextBoxInput = self.firstResponder is TextBoxInputTextView
+        let firstResponderIsFindTextField = cmuxFindTextFieldOwner(for: self.firstResponder) != nil
         if ShortcutRecorderEventRouter.dispatchActiveRecordingEvent(event, preferredWindow: self) {
             return true
         }
@@ -16107,6 +16109,21 @@ private extension NSWindow {
             }
             cmuxCommandPaletteArrowForwardingDepth += 1
             defer { cmuxCommandPaletteArrowForwardingDepth = max(0, cmuxCommandPaletteArrowForwardingDepth - 1) }
+            self.firstResponder?.keyDown(with: event)
+            return true
+        }
+
+        if shouldDispatchFindTextFieldArrowViaFirstResponderKeyDown(
+            keyCode: event.keyCode,
+            firstResponderIsFindTextField: firstResponderIsFindTextField,
+            firstResponderHasMarkedText: firstResponderHasMarkedText,
+            flags: event.modifierFlags
+        ) {
+            if cmuxFindTextFieldArrowForwardingDepth > 0 {
+                return false
+            }
+            cmuxFindTextFieldArrowForwardingDepth += 1
+            defer { cmuxFindTextFieldArrowForwardingDepth = max(0, cmuxFindTextFieldArrowForwardingDepth - 1) }
             self.firstResponder?.keyDown(with: event)
             return true
         }

--- a/Sources/Find/BrowserSearchOverlay.swift
+++ b/Sources/Find/BrowserSearchOverlay.swift
@@ -226,9 +226,9 @@ private struct BrowserSearchTextFieldRepresentable: NSViewRepresentable {
         }
 
         func focusField(_ field: BrowserSearchNativeTextField, in window: NSWindow, selectAll: Bool) {
+            let rememberedRange = cmuxStoredFindSelection(for: self.parent.selectionOwner) ?? field.cmuxLastSelectedRange ?? self.lastSelectedRange
             let alreadyFocused = cmuxTextFieldIsFirstResponder(field, in: window)
             guard alreadyFocused || window.makeFirstResponder(field) else { return }
-            let rememberedRange = field.cmuxLastSelectedRange ?? cmuxStoredFindSelection(for: self.parent.selectionOwner) ?? self.lastSelectedRange
             if let selection = cmuxApplyFindFocusSelection(field: field, selectAll: selectAll, alreadyFocused: alreadyFocused, rememberedRange: rememberedRange) { self.lastSelectedRange = selection; return }
             DispatchQueue.main.async { [weak field, weak self] in
                 guard let field, let self,
@@ -273,6 +273,16 @@ private struct BrowserSearchTextFieldRepresentable: NSViewRepresentable {
                 rememberSelection(from: textView)
                 let isShift = NSApp.currentEvent?.modifierFlags.contains(.shift) ?? false
                 parent.onReturn(isShift)
+                return true
+            case #selector(NSResponder.moveDown(_:)):
+                if textView.hasMarkedText() { return false }
+                rememberSelection(from: textView)
+                parent.onReturn(false)
+                return true
+            case #selector(NSResponder.moveUp(_:)):
+                if textView.hasMarkedText() { return false }
+                rememberSelection(from: textView)
+                parent.onReturn(true)
                 return true
             default:
                 if cmuxFindCommandMayChangeSelection(commandSelector) {

--- a/Sources/Find/FindTextFieldSupport.swift
+++ b/Sources/Find/FindTextFieldSupport.swift
@@ -119,7 +119,13 @@ func cmuxApplyFindFocusSelection(
         editor.setSelectedRange(selection)
         return selection
     }
-    guard !alreadyFocused, let rememberedRange else { return nil }
+    guard let rememberedRange else { return nil }
+    if alreadyFocused {
+        let currentSelection = editor.selectedRange()
+        guard currentSelection.location == 0,
+              currentSelection.length == 0,
+              rememberedRange.location != 0 || rememberedRange.length != 0 else { return nil }
+    }
     let selection = field.cmuxRememberSelection(rememberedRange, in: editor.string)
     editor.setSelectedRange(selection)
     return selection
@@ -164,6 +170,7 @@ class FindSelectionTrackingTextField: NSTextField {
     private var cmuxKeyMonitor: Any?
     private weak var cmuxObservedEditor: NSTextView?
     private weak var cmuxPreviousEditorNextResponder: NSResponder?
+    private var cmuxFocusTransitionRememberedSelection: NSRange?
 
     deinit {
         cmuxDetachSelectionObserver()
@@ -179,11 +186,16 @@ class FindSelectionTrackingTextField: NSTextField {
 
     override func textDidBeginEditing(_ notification: Notification) {
         super.textDidBeginEditing(notification)
+        let rememberedSelection = cmuxStoredFindSelection(for: cmuxSelectionOwner) ?? cmuxLastSelectedRange
+        cmuxFocusTransitionRememberedSelection = rememberedSelection
         cmuxAttachSelectionObserverIfNeeded()
         cmuxInstallKeyMonitorIfNeeded()
-        if cmuxLastSelectedRange == nil, cmuxStoredFindSelection(for: cmuxSelectionOwner) == nil {
+        if let rememberedSelection {
+            cmuxRestoreRememberedSelection(rememberedSelection)
+        } else if cmuxLastSelectedRange == nil {
             _ = cmuxRememberSelectionFromCurrentEditor()
         }
+        cmuxFocusTransitionRememberedSelection = nil
     }
 
     override func textDidChange(_ notification: Notification) {
@@ -192,7 +204,7 @@ class FindSelectionTrackingTextField: NSTextField {
     }
 
     override func textDidEndEditing(_ notification: Notification) {
-        _ = cmuxRememberSelectionFromCurrentEditor()
+        _ = cmuxRememberSelectionFromCurrentEditor(preservingStoredFocusTransitionSelection: true)
         cmuxRemoveKeyMonitor()
         cmuxDetachSelectionObserver()
         super.textDidEndEditing(notification)
@@ -216,8 +228,19 @@ class FindSelectionTrackingTextField: NSTextField {
         cmuxRememberSelection(textView.selectedRange(), in: textView.string)
     }
 
-    func cmuxRememberSelectionFromCurrentEditor() -> NSRange? {
+    func cmuxRememberSelectionFromCurrentEditor(preservingStoredFocusTransitionSelection: Bool = false) -> NSRange? {
         guard let editor = currentEditor() as? NSTextView else { return nil }
+        if preservingStoredFocusTransitionSelection {
+            let selection = cmuxClampedFindSelection(editor.selectedRange(), in: editor.string)
+            if selection.location == 0,
+               selection.length == 0,
+               let storedSelection = cmuxStoredFindSelection(for: cmuxSelectionOwner),
+               storedSelection.location != 0 || storedSelection.length != 0,
+               editor.string == stringValue {
+                cmuxLastSelectedRange = storedSelection
+                return storedSelection
+            }
+        }
         return cmuxRememberSelection(from: editor)
     }
 
@@ -235,6 +258,14 @@ class FindSelectionTrackingTextField: NSTextField {
         ) { [weak self] notification in
             guard let self,
                   let textView = notification.object as? NSTextView else { return }
+            let selection = cmuxClampedFindSelection(textView.selectedRange(), in: textView.string)
+            if selection.location == 0,
+               selection.length == 0,
+               let rememberedSelection = self.cmuxFocusTransitionRememberedSelection,
+               rememberedSelection.location != 0 || rememberedSelection.length != 0,
+               textView.string == self.stringValue {
+                return
+            }
             _ = self.cmuxRememberSelection(from: textView)
         }
     }
@@ -290,8 +321,9 @@ class FindSelectionTrackingTextField: NSTextField {
         }
     }
 
-    private func cmuxRestoreRememberedSelection() {
-        guard let rememberedSelection = cmuxStoredFindSelection(for: cmuxSelectionOwner) ?? cmuxLastSelectedRange else { return }
+    private func cmuxRestoreRememberedSelection(_ selection: NSRange? = nil) {
+        guard let rememberedSelection = selection ?? cmuxStoredFindSelection(for: cmuxSelectionOwner) ?? cmuxLastSelectedRange else { return }
+        guard rememberedSelection.location != 0 || rememberedSelection.length != 0 else { return }
         if let editor = currentEditor() as? NSTextView, !editor.hasMarkedText() {
             let selection = cmuxRememberSelection(rememberedSelection, in: editor.string)
             editor.setSelectedRange(selection)

--- a/Sources/Find/SurfaceSearchOverlay.swift
+++ b/Sources/Find/SurfaceSearchOverlay.swift
@@ -251,9 +251,9 @@ private struct SearchTextFieldRepresentable: NSViewRepresentable {
         }
 
         func focusField(_ field: SearchNativeTextField, in window: NSWindow, selectAll: Bool) {
+            let rememberedRange = cmuxStoredFindSelection(for: self.parent.selectionOwner) ?? field.cmuxLastSelectedRange ?? self.lastSelectedRange
             let alreadyFocused = cmuxTextFieldIsFirstResponder(field, in: window)
             guard alreadyFocused || window.makeFirstResponder(field) else { return }
-            let rememberedRange = field.cmuxLastSelectedRange ?? cmuxStoredFindSelection(for: self.parent.selectionOwner) ?? self.lastSelectedRange
             if let selection = cmuxApplyFindFocusSelection(field: field, selectAll: selectAll, alreadyFocused: alreadyFocused, rememberedRange: rememberedRange) { self.lastSelectedRange = selection; return }
             DispatchQueue.main.async { [weak field, weak self] in
                 guard let field, let self,
@@ -304,6 +304,16 @@ private struct SearchTextFieldRepresentable: NSViewRepresentable {
                 rememberSelection(from: textView)
                 let isShift = NSApp.currentEvent?.modifierFlags.contains(.shift) ?? false
                 parent.onReturn(isShift)
+                return true
+            case #selector(NSResponder.moveDown(_:)):
+                if textView.hasMarkedText() { return false }
+                rememberSelection(from: textView)
+                parent.onReturn(false)
+                return true
+            case #selector(NSResponder.moveUp(_:)):
+                if textView.hasMarkedText() { return false }
+                rememberSelection(from: textView)
+                parent.onReturn(true)
                 return true
             default:
                 if cmuxFindCommandMayChangeSelection(commandSelector) {

--- a/cmuxUITests/FindSelectionShortcutUITests.swift
+++ b/cmuxUITests/FindSelectionShortcutUITests.swift
@@ -4,6 +4,7 @@ import Foundation
 final class FindSelectionShortcutUITests: XCTestCase {
     private var dataPath = ""
     private var socketPath = ""
+    private var launchTag = ""
 
     override func setUp() {
         super.setUp()
@@ -12,13 +13,15 @@ final class FindSelectionShortcutUITests: XCTestCase {
         try? FileManager.default.removeItem(atPath: dataPath)
         socketPath = "/tmp/cmux-ui-test-socket-\(UUID().uuidString).sock"
         try? FileManager.default.removeItem(atPath: socketPath)
+        launchTag = "ui-tests-find-selection-\(UUID().uuidString.prefix(8))"
+
+        let cleanup = XCUIApplication()
+        cleanup.terminate()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.5))
     }
 
     func testRepeatedCmdFPreservesOpenTerminalAndBrowserFindCaretAndSelection() {
-        let app = XCUIApplication()
-        app.launchEnvironment["CMUX_SOCKET_PATH"] = socketPath
-        app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_RECORD_ONLY"] = "1"
-        app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_PATH"] = dataPath
+        let app = configuredApp()
         launchAndEnsureForeground(app)
 
         XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 10.0), "Expected main window")
@@ -40,10 +43,7 @@ final class FindSelectionShortcutUITests: XCTestCase {
     }
 
     func testEscapeClosesTerminalAndBrowserFindAfterQuery() {
-        let app = XCUIApplication()
-        app.launchEnvironment["CMUX_SOCKET_PATH"] = socketPath
-        app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_RECORD_ONLY"] = "1"
-        app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_PATH"] = dataPath
+        let app = configuredApp()
         launchAndEnsureForeground(app)
 
         XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 10.0), "Expected main window")
@@ -64,6 +64,102 @@ final class FindSelectionShortcutUITests: XCTestCase {
         assertFindRecoversAndCanReplace(app, pane: .browser, query: "browser", replacement: "b")
     }
 
+    func testFindFieldsKeepArrowKeyEditingWhileFocused() {
+        let app = configuredApp()
+        launchAndEnsureForeground(app)
+
+        XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 10.0), "Expected main window")
+
+        app.typeKey("d", modifierFlags: [.command])
+        XCTAssertTrue(
+            waitForDataMatch(timeout: 6.0) { data in
+                guard data["lastSplitDirection"] == "right" else { return false }
+                guard let paneCountAfterSplit = Int(data["paneCountAfterSplit"] ?? "") else { return false }
+                return paneCountAfterSplit >= 2
+            },
+            "Expected Cmd+D split before opening browser. data=\(String(describing: loadData()))"
+        )
+        openBrowserInRightPane(app)
+        assertFindArrowEditing(app, pane: .terminal)
+        assertFindArrowEditing(app, pane: .browser)
+    }
+
+    func testFindCaretPositionSurvivesCmdOptionPaneNavigation() {
+        let app = configuredApp()
+        launchAndEnsureForeground(app)
+
+        XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 10.0), "Expected main window")
+
+        app.typeKey("d", modifierFlags: [.command])
+        XCTAssertTrue(
+            waitForDataMatch(timeout: 6.0) { data in
+                guard data["lastSplitDirection"] == "right" else { return false }
+                guard let paneCountAfterSplit = Int(data["paneCountAfterSplit"] ?? "") else { return false }
+                return paneCountAfterSplit >= 2
+            },
+            "Expected Cmd+D split before opening browser. data=\(String(describing: loadData()))"
+        )
+        openBrowserInRightPane(app)
+        assertFindCaretSurvivesCmdOptionNavigation(app, pane: .terminal)
+        assertFindCaretSurvivesCmdOptionNavigation(app, pane: .browser)
+    }
+
+    func testBrowserFindUpDownArrowsNavigateMatchesWhileFocused() {
+        let app = configuredApp()
+        launchAndEnsureForeground(app)
+
+        XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 10.0), "Expected main window")
+
+        app.typeKey("d", modifierFlags: [.command])
+        XCTAssertTrue(
+            waitForDataMatch(timeout: 6.0) { data in
+                guard data["lastSplitDirection"] == "right" else { return false }
+                guard let paneCountAfterSplit = Int(data["paneCountAfterSplit"] ?? "") else { return false }
+                return paneCountAfterSplit >= 2
+            },
+            "Expected Cmd+D split before opening browser. data=\(String(describing: loadData()))"
+        )
+        openBrowserInRightPane(app, url: makeBrowserFindMatchesURL()) { omnibar in
+            self.waitForCondition(timeout: 8.0) {
+                ((omnibar.value as? String) ?? "").contains("data:text/html")
+            }
+        }
+
+        focusPane(.browser, app: app)
+        XCTAssertTrue(
+            waitForDataMatch(timeout: 6.0) { $0["focusedPanelKind"] == "browser" },
+            "Expected browser focus before opening find. data=\(String(describing: loadData()))"
+        )
+        app.typeKey("f", modifierFlags: [.command])
+        let findField = app.textFields[Pane.browser.findFieldId].firstMatch
+        XCTAssertTrue(
+            findField.waitForExistence(timeout: 6.0),
+            "Expected browser find field after Cmd+F. data=\(String(describing: loadData()))"
+        )
+        replaceFindText(app, with: "alpha")
+        XCTAssertTrue(
+            waitForDataMatch(timeout: 8.0) { data in
+                guard let total = Int(data["browserFindTotal"] ?? "") else { return false }
+                return data["browserFindNeedle"] == "alpha" &&
+                    data["browserFindSelected"] == "1" &&
+                    total >= 2
+            },
+            "Expected browser find to select the first match. data=\(String(describing: loadData()))"
+        )
+
+        app.typeKey(XCUIKeyboardKey.downArrow.rawValue, modifierFlags: [])
+        XCTAssertTrue(
+            waitForDataMatch(timeout: 6.0) { $0["browserFindSelected"] == "2" },
+            "Expected Down arrow in browser find to select the next match. data=\(String(describing: loadData()))"
+        )
+
+        app.typeKey(XCUIKeyboardKey.upArrow.rawValue, modifierFlags: [])
+        XCTAssertTrue(
+            waitForDataMatch(timeout: 6.0) { $0["browserFindSelected"] == "1" },
+            "Expected Up arrow in browser find to select the previous match. data=\(String(describing: loadData()))"
+        )
+    }
+
     private enum Pane {
         case terminal
         case browser
@@ -73,22 +169,31 @@ final class FindSelectionShortcutUITests: XCTestCase {
         var needleKey: String { self == .terminal ? "terminalFindNeedle" : "browserFindNeedle" }
         var visibleKey: String { self == .terminal ? "terminalFindVisible" : "browserFindVisible" }
         var findFieldId: String { self == .terminal ? "TerminalFindSearchTextField" : "BrowserFindSearchTextField" }
+        var findFieldOwnerType: String { self == .terminal ? "SearchNativeTextField" : "BrowserSearchNativeTextField" }
         var replacementMessage: String { self == .terminal ? "terminal find text" : "browser find text" }
         var arrowKey: String {
             self == .terminal ? XCUIKeyboardKey.leftArrow.rawValue : XCUIKeyboardKey.rightArrow.rawValue
         }
     }
 
-    private func openBrowserInRightPane(_ app: XCUIApplication) {
+    private func openBrowserInRightPane(
+        _ app: XCUIApplication,
+        url: String = "example.com",
+        waitForNavigation: ((XCUIElement) -> Bool)? = nil
+    ) {
         app.typeKey(XCUIKeyboardKey.rightArrow.rawValue, modifierFlags: [.command, .option])
         app.typeKey("l", modifierFlags: [.command, .shift])
         let omnibar = app.textFields["BrowserOmnibarTextField"].firstMatch
         XCTAssertTrue(omnibar.waitForExistence(timeout: 8.0), "Expected browser omnibar")
         app.typeKey("a", modifierFlags: [.command])
         app.typeKey(XCUIKeyboardKey.delete.rawValue, modifierFlags: [])
-        app.typeText("example.com")
+        app.typeText(url)
         app.typeKey(XCUIKeyboardKey.return.rawValue, modifierFlags: [])
-        XCTAssertTrue(waitForOmnibarToContainExampleDomain(omnibar, timeout: 8.0), "Expected browser navigation")
+        if let waitForNavigation {
+            XCTAssertTrue(waitForNavigation(omnibar), "Expected browser navigation")
+        } else {
+            XCTAssertTrue(waitForOmnibarToContainExampleDomain(omnibar, timeout: 8.0), "Expected browser navigation")
+        }
     }
 
     private func assertFindRefocusPreservesSelection(
@@ -268,6 +373,94 @@ final class FindSelectionShortcutUITests: XCTestCase {
         )
     }
 
+    private func assertFindArrowEditing(_ app: XCUIApplication, pane: Pane) {
+        focusPane(pane, app: app)
+        XCTAssertTrue(
+            waitForDataMatch(timeout: 6.0) { $0["focusedPanelKind"] == pane.focusKey },
+            "Expected \(pane.focusKey) focus before arrow editing. data=\(String(describing: loadData()))"
+        )
+        app.typeKey("f", modifierFlags: [.command])
+        let findField = app.textFields[pane.findFieldId].firstMatch
+        XCTAssertTrue(
+            findField.waitForExistence(timeout: 6.0),
+            "Expected \(pane.replacementMessage) field after Cmd+F. data=\(String(describing: loadData()))"
+        )
+        replaceFindText(app, with: "abcd")
+        app.typeKey(XCUIKeyboardKey.leftArrow.rawValue, modifierFlags: [.command])
+        app.typeText(">")
+        app.typeKey(XCUIKeyboardKey.rightArrow.rawValue, modifierFlags: [.command])
+        app.typeText("<")
+        app.typeKey(XCUIKeyboardKey.leftArrow.rawValue, modifierFlags: [])
+        app.typeText("!")
+        focusPane(pane.opposite, app: app)
+        XCTAssertTrue(
+            waitForDataMatch(timeout: 6.0) { data in
+                return data["focusedPanelKind"] == pane.opposite.focusKey &&
+                    data[pane.needleKey] == ">abcd!<"
+            },
+            "Expected arrow keys to edit \(pane.replacementMessage) while focused. data=\(String(describing: loadData()))"
+        )
+    }
+
+    private func assertFindCaretSurvivesCmdOptionNavigation(_ app: XCUIApplication, pane: Pane) {
+        focusPane(pane, app: app)
+        XCTAssertTrue(
+            waitForDataMatch(timeout: 6.0) { $0["focusedPanelKind"] == pane.focusKey },
+            "Expected \(pane.focusKey) focus before caret navigation. data=\(String(describing: loadData()))"
+        )
+        app.typeKey("f", modifierFlags: [.command])
+        let findField = app.textFields[pane.findFieldId].firstMatch
+        XCTAssertTrue(
+            findField.waitForExistence(timeout: 6.0),
+            "Expected \(pane.replacementMessage) field after Cmd+F. data=\(String(describing: loadData()))"
+        )
+        replaceFindText(app, with: "abcd")
+        app.typeKey(XCUIKeyboardKey.leftArrow.rawValue, modifierFlags: [])
+        app.typeKey(XCUIKeyboardKey.leftArrow.rawValue, modifierFlags: [])
+        XCTAssertTrue(
+            waitForDataMatch(timeout: 6.0) { data in
+                data["focusedPanelKind"] == pane.focusKey &&
+                    data[pane.needleKey] == "abcd" &&
+                    data["fieldEditorOwnerType"] == pane.findFieldOwnerType &&
+                    data["firstResponderSelectedRange"] == "{2, 0}"
+            },
+            "Expected \(pane.replacementMessage) caret at index 2 before Cmd+Option navigation. data=\(String(describing: loadData()))"
+        )
+
+        focusPane(pane.opposite, app: app)
+        XCTAssertTrue(
+            waitForDataMatch(timeout: 6.0) { data in
+                data["focusedPanelKind"] == pane.opposite.focusKey &&
+                    data[pane.needleKey] == "abcd"
+            },
+            "Expected Cmd+Option arrow to navigate away without changing \(pane.replacementMessage). data=\(String(describing: loadData()))"
+        )
+        focusPane(pane, app: app)
+        XCTAssertTrue(
+            waitForDataMatch(timeout: 6.0) { $0["focusedPanelKind"] == pane.focusKey },
+            "Expected Cmd+Option arrow to navigate back to \(pane.focusKey). data=\(String(describing: loadData()))"
+        )
+        XCTAssertTrue(
+            waitForDataMatch(timeout: 6.0) { data in
+                data["focusedPanelKind"] == pane.focusKey &&
+                    data[pane.needleKey] == "abcd" &&
+                    data["fieldEditorOwnerType"] == pane.findFieldOwnerType &&
+                    data["firstResponderSelectedRange"] == "{2, 0}"
+            },
+            "Expected Cmd+Option pane navigation to restore \(pane.replacementMessage) focus with caret at index 2. data=\(String(describing: loadData()))"
+        )
+
+        app.typeText("z")
+        focusPane(pane.opposite, app: app)
+        XCTAssertTrue(
+            waitForDataMatch(timeout: 6.0) { data in
+                data["focusedPanelKind"] == pane.opposite.focusKey &&
+                    data[pane.needleKey] == "abzcd"
+            },
+            "Expected insertion after Cmd+Option navigation to use restored \(pane.replacementMessage) caret. data=\(String(describing: loadData()))"
+        )
+    }
+
     private func focusPane(_ pane: Pane, app: XCUIApplication) {
         app.typeKey(pane.arrowKey, modifierFlags: [.command, .option])
     }
@@ -285,6 +478,21 @@ final class FindSelectionShortcutUITests: XCTestCase {
         }
     }
 
+    private func makeBrowserFindMatchesURL() -> String {
+        let html = "<!doctype html><meta charset=utf-8><body><p>alpha</p><p>alpha</p><p>alpha</p></body>"
+        let encoded = html.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? html
+        return "data:text/html;charset=utf-8,\(encoded)"
+    }
+
+    private func configuredApp() -> XCUIApplication {
+        let app = XCUIApplication()
+        app.launchEnvironment["CMUX_SOCKET_PATH"] = socketPath
+        app.launchEnvironment["CMUX_TAG"] = launchTag
+        app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_RECORD_ONLY"] = "1"
+        app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_PATH"] = dataPath
+        return app
+    }
+
     private func launchAndEnsureForeground(_ app: XCUIApplication) {
         let options = XCTExpectedFailure.Options()
         options.isStrict = false
@@ -292,8 +500,26 @@ final class FindSelectionShortcutUITests: XCTestCase {
             app.launch()
         }
 
-        if app.state == .runningForeground || app.state == .runningBackground { return }
-        XCTFail("App failed to start. state=\(app.state.rawValue)")
+        if app.state == .runningForeground { return }
+        if app.state == .runningBackground {
+            app.activate()
+            _ = app.wait(for: .runningForeground, timeout: 6.0)
+        }
+        XCTAssertTrue(
+            app.state == .runningForeground || app.state == .runningBackground,
+            "Expected app to start. state=\(app.state.rawValue)"
+        )
+        if app.state == .runningBackground {
+            XCTAssertTrue(
+                app.windows.firstMatch.waitForExistence(timeout: 6.0),
+                "Expected background-launched app to expose a window"
+            )
+            return
+        }
+        XCTAssertTrue(
+            app.wait(for: .runningForeground, timeout: 6.0),
+            "Expected app to launch in foreground. state=\(app.state.rawValue)"
+        )
     }
 
     private func waitForDataMatch(timeout: TimeInterval, predicate: @escaping ([String: String]) -> Bool) -> Bool {

--- a/cmuxUITests/FindSelectionShortcutUITests.swift
+++ b/cmuxUITests/FindSelectionShortcutUITests.swift
@@ -104,6 +104,67 @@ final class FindSelectionShortcutUITests: XCTestCase {
         assertFindCaretSurvivesCmdOptionNavigation(app, pane: .browser)
     }
 
+    func testFindCaretPositionSurvivesRapidCmdOptionPaneNavigationChurn() {
+        let app = configuredApp()
+        launchAndEnsureForeground(app)
+
+        XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 10.0), "Expected main window")
+
+        app.typeKey("d", modifierFlags: [.command])
+        XCTAssertTrue(
+            waitForDataMatch(timeout: 6.0) { data in
+                guard data["lastSplitDirection"] == "right" else { return false }
+                guard let paneCountAfterSplit = Int(data["paneCountAfterSplit"] ?? "") else { return false }
+                return paneCountAfterSplit >= 2
+            },
+            "Expected Cmd+D split before rapid caret churn. data=\(String(describing: loadData()))"
+        )
+        openBrowserInRightPane(app)
+
+        assertFindCaretSurvivesRapidCmdOptionNavigationChurn(app, pane: .terminal)
+        assertFindCaretSurvivesRapidCmdOptionNavigationChurn(app, pane: .browser)
+    }
+
+    func testTerminalFindSelectionEdgesSurviveCmdOptionPaneNavigationAndRepeatedCmdF() {
+        let app = configuredApp()
+        launchAndEnsureForeground(app)
+
+        XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 10.0), "Expected main window")
+
+        app.typeKey("d", modifierFlags: [.command])
+        XCTAssertTrue(
+            waitForDataMatch(timeout: 6.0) { data in
+                guard data["lastSplitDirection"] == "right" else { return false }
+                guard let paneCountAfterSplit = Int(data["paneCountAfterSplit"] ?? "") else { return false }
+                return paneCountAfterSplit >= 2
+            },
+            "Expected Cmd+D split before terminal edge checks. data=\(String(describing: loadData()))"
+        )
+        openBrowserInRightPane(app)
+
+        assertFindSelectionEdgeRangesSurviveCmdOptionNavigationAndRepeatedCmdF(app, pane: .terminal)
+    }
+
+    func testBrowserFindSelectionEdgesSurviveCmdOptionPaneNavigationAndRepeatedCmdF() {
+        let app = configuredApp()
+        launchAndEnsureForeground(app)
+
+        XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 10.0), "Expected main window")
+
+        app.typeKey("d", modifierFlags: [.command])
+        XCTAssertTrue(
+            waitForDataMatch(timeout: 6.0) { data in
+                guard data["lastSplitDirection"] == "right" else { return false }
+                guard let paneCountAfterSplit = Int(data["paneCountAfterSplit"] ?? "") else { return false }
+                return paneCountAfterSplit >= 2
+            },
+            "Expected Cmd+D split before browser edge checks. data=\(String(describing: loadData()))"
+        )
+        openBrowserInRightPane(app)
+
+        assertFindSelectionEdgeRangesSurviveCmdOptionNavigationAndRepeatedCmdF(app, pane: .browser)
+    }
+
     func testBrowserFindUpDownArrowsNavigateMatchesWhileFocused() {
         let app = configuredApp()
         launchAndEnsureForeground(app)
@@ -449,6 +510,19 @@ final class FindSelectionShortcutUITests: XCTestCase {
             },
             "Expected Cmd+Option pane navigation to restore \(pane.replacementMessage) focus with caret at index 2. data=\(String(describing: loadData()))"
         )
+        assertFindSelectionStable(pane: pane, expectedRange: "{2, 0}", label: "auto-refocused middle caret")
+
+        app.typeKey("f", modifierFlags: [.command])
+        XCTAssertTrue(
+            waitForDataMatch(timeout: 6.0) { data in
+                data["focusedPanelKind"] == pane.focusKey &&
+                    data[pane.needleKey] == "abcd" &&
+                    data["fieldEditorOwnerType"] == pane.findFieldOwnerType &&
+                    data["firstResponderSelectedRange"] == "{2, 0}"
+            },
+            "Expected repeated Cmd+F to keep \(pane.replacementMessage) caret at index 2. data=\(String(describing: loadData()))"
+        )
+        assertFindSelectionStable(pane: pane, expectedRange: "{2, 0}", label: "repeated Cmd+F middle caret")
 
         app.typeText("z")
         focusPane(pane.opposite, app: app)
@@ -459,6 +533,227 @@ final class FindSelectionShortcutUITests: XCTestCase {
             },
             "Expected insertion after Cmd+Option navigation to use restored \(pane.replacementMessage) caret. data=\(String(describing: loadData()))"
         )
+    }
+
+    private func assertFindCaretSurvivesRapidCmdOptionNavigationChurn(_ app: XCUIApplication, pane: Pane) {
+        focusPane(pane, app: app)
+        XCTAssertTrue(
+            waitForDataMatch(timeout: 6.0) { $0["focusedPanelKind"] == pane.focusKey },
+            "Expected \(pane.focusKey) focus before rapid caret churn. data=\(String(describing: loadData()))"
+        )
+        app.typeKey("f", modifierFlags: [.command])
+        let findField = app.textFields[pane.findFieldId].firstMatch
+        XCTAssertTrue(
+            findField.waitForExistence(timeout: 6.0),
+            "Expected \(pane.replacementMessage) field before rapid caret churn. data=\(String(describing: loadData()))"
+        )
+        replaceFindText(app, with: "abcd")
+        app.typeKey(XCUIKeyboardKey.leftArrow.rawValue, modifierFlags: [])
+        app.typeKey(XCUIKeyboardKey.leftArrow.rawValue, modifierFlags: [])
+        XCTAssertTrue(
+            waitForDataMatch(timeout: 6.0) { data in
+                data["focusedPanelKind"] == pane.focusKey &&
+                    data[pane.needleKey] == "abcd" &&
+                    data["fieldEditorOwnerType"] == pane.findFieldOwnerType &&
+                    data["firstResponderSelectedRange"] == "{2, 0}"
+            },
+            "Expected \(pane.replacementMessage) caret at index 2 before rapid Cmd+Option churn. data=\(String(describing: loadData()))"
+        )
+
+        for _ in 0..<6 {
+            focusPane(pane.opposite, app: app)
+            focusPane(pane, app: app)
+        }
+        XCTAssertTrue(
+            waitForDataMatch(timeout: 8.0) { data in
+                data["focusedPanelKind"] == pane.focusKey &&
+                    data[pane.needleKey] == "abcd" &&
+                    data["fieldEditorOwnerType"] == pane.findFieldOwnerType &&
+                    data["firstResponderSelectedRange"] == "{2, 0}"
+            },
+            "Expected rapid Cmd+Option pane navigation to restore \(pane.replacementMessage) caret. data=\(String(describing: loadData()))"
+        )
+        assertFindSelectionStable(pane: pane, expectedRange: "{2, 0}", label: "rapid Cmd+Option churn")
+
+        app.typeKey("f", modifierFlags: [.command])
+        XCTAssertTrue(
+            waitForDataMatch(timeout: 6.0) { data in
+                data["focusedPanelKind"] == pane.focusKey &&
+                    data[pane.needleKey] == "abcd" &&
+                    data["fieldEditorOwnerType"] == pane.findFieldOwnerType &&
+                    data["firstResponderSelectedRange"] == "{2, 0}"
+            },
+            "Expected repeated Cmd+F after rapid navigation to keep \(pane.replacementMessage) caret. data=\(String(describing: loadData()))"
+        )
+        assertFindSelectionStable(pane: pane, expectedRange: "{2, 0}", label: "repeated Cmd+F after rapid churn")
+
+        app.typeText("r")
+        focusPane(pane.opposite, app: app)
+        XCTAssertTrue(
+            waitForDataMatch(timeout: 6.0) { data in
+                data["focusedPanelKind"] == pane.opposite.focusKey &&
+                    data[pane.needleKey] == "abrcd"
+            },
+            "Expected insertion after rapid Cmd+Option navigation to use restored \(pane.replacementMessage) caret. data=\(String(describing: loadData()))"
+        )
+    }
+
+    private func assertFindSelectionEdgeRangesSurviveCmdOptionNavigationAndRepeatedCmdF(
+        _ app: XCUIApplication,
+        pane: Pane
+    ) {
+        assertFindSelectionRangeSurvivesCmdOptionNavigationAndRepeatedCmdF(
+            app,
+            pane: pane,
+            label: "caret at beginning",
+            expectedRange: "{0, 0}",
+            configureSelection: { app in
+                app.typeKey(XCUIKeyboardKey.leftArrow.rawValue, modifierFlags: [.command])
+            },
+            insertion: "^",
+            expectedNeedle: "^abcd"
+        )
+        assertFindSelectionRangeSurvivesCmdOptionNavigationAndRepeatedCmdF(
+            app,
+            pane: pane,
+            label: "caret in middle",
+            expectedRange: "{2, 0}",
+            configureSelection: { app in
+                app.typeKey(XCUIKeyboardKey.leftArrow.rawValue, modifierFlags: [])
+                app.typeKey(XCUIKeyboardKey.leftArrow.rawValue, modifierFlags: [])
+            },
+            insertion: "m",
+            expectedNeedle: "abmcd"
+        )
+        assertFindSelectionRangeSurvivesCmdOptionNavigationAndRepeatedCmdF(
+            app,
+            pane: pane,
+            label: "caret at end",
+            expectedRange: "{4, 0}",
+            configureSelection: { app in
+                app.typeKey(XCUIKeyboardKey.rightArrow.rawValue, modifierFlags: [.command])
+            },
+            insertion: "$",
+            expectedNeedle: "abcd$"
+        )
+        assertFindSelectionRangeSurvivesCmdOptionNavigationAndRepeatedCmdF(
+            app,
+            pane: pane,
+            label: "middle selection",
+            expectedRange: "{2, 1}",
+            configureSelection: { app in
+                app.typeKey(XCUIKeyboardKey.leftArrow.rawValue, modifierFlags: [])
+                app.typeKey(XCUIKeyboardKey.leftArrow.rawValue, modifierFlags: [])
+                app.typeKey(XCUIKeyboardKey.rightArrow.rawValue, modifierFlags: [.shift])
+            },
+            insertion: "X",
+            expectedNeedle: "abXd"
+        )
+        assertFindSelectionRangeSurvivesCmdOptionNavigationAndRepeatedCmdF(
+            app,
+            pane: pane,
+            label: "intentional full selection",
+            expectedRange: "{0, 4}",
+            configureSelection: { app in
+                app.typeKey("a", modifierFlags: [.command])
+            },
+            insertion: "F",
+            expectedNeedle: "F"
+        )
+    }
+
+    private func assertFindSelectionRangeSurvivesCmdOptionNavigationAndRepeatedCmdF(
+        _ app: XCUIApplication,
+        pane: Pane,
+        label: String,
+        expectedRange: String,
+        configureSelection: (XCUIApplication) -> Void,
+        insertion: String,
+        expectedNeedle: String
+    ) {
+        focusPane(pane, app: app)
+        XCTAssertTrue(
+            waitForDataMatch(timeout: 6.0) { $0["focusedPanelKind"] == pane.focusKey },
+            "Expected \(pane.focusKey) focus before \(label). data=\(String(describing: loadData()))"
+        )
+        app.typeKey("f", modifierFlags: [.command])
+        let findField = app.textFields[pane.findFieldId].firstMatch
+        XCTAssertTrue(
+            findField.waitForExistence(timeout: 6.0),
+            "Expected \(pane.replacementMessage) field before \(label). data=\(String(describing: loadData()))"
+        )
+        replaceFindText(app, with: "abcd")
+        configureSelection(app)
+        XCTAssertTrue(
+            waitForDataMatch(timeout: 6.0) { data in
+                data["focusedPanelKind"] == pane.focusKey &&
+                    data[pane.needleKey] == "abcd" &&
+                    data["fieldEditorOwnerType"] == pane.findFieldOwnerType &&
+                    data["firstResponderSelectedRange"] == expectedRange
+            },
+            "Expected \(pane.replacementMessage) \(label) before navigation. data=\(String(describing: loadData()))"
+        )
+        assertFindSelectionStable(pane: pane, expectedRange: expectedRange, label: "\(label) before navigation")
+
+        focusPane(pane.opposite, app: app)
+        XCTAssertTrue(
+            waitForDataMatch(timeout: 6.0) { data in
+                data["focusedPanelKind"] == pane.opposite.focusKey &&
+                    data[pane.needleKey] == "abcd"
+            },
+            "Expected Cmd+Option arrow to navigate away from \(pane.replacementMessage) \(label). data=\(String(describing: loadData()))"
+        )
+        focusPane(pane, app: app)
+        XCTAssertTrue(
+            waitForDataMatch(timeout: 6.0) { data in
+                data["focusedPanelKind"] == pane.focusKey &&
+                    data[pane.needleKey] == "abcd" &&
+                    data["fieldEditorOwnerType"] == pane.findFieldOwnerType &&
+                    data["firstResponderSelectedRange"] == expectedRange
+            },
+            "Expected Cmd+Option pane navigation to restore \(pane.replacementMessage) \(label). data=\(String(describing: loadData()))"
+        )
+        assertFindSelectionStable(pane: pane, expectedRange: expectedRange, label: "\(label) after navigation")
+
+        app.typeKey("f", modifierFlags: [.command])
+        XCTAssertTrue(
+            waitForDataMatch(timeout: 6.0) { data in
+                data["focusedPanelKind"] == pane.focusKey &&
+                    data[pane.needleKey] == "abcd" &&
+                    data["fieldEditorOwnerType"] == pane.findFieldOwnerType &&
+                    data["firstResponderSelectedRange"] == expectedRange
+            },
+            "Expected repeated Cmd+F to preserve \(pane.replacementMessage) \(label). data=\(String(describing: loadData()))"
+        )
+        assertFindSelectionStable(pane: pane, expectedRange: expectedRange, label: "\(label) after repeated Cmd+F")
+
+        app.typeText(insertion)
+        focusPane(pane.opposite, app: app)
+        XCTAssertTrue(
+            waitForDataMatch(timeout: 6.0) { data in
+                data["focusedPanelKind"] == pane.opposite.focusKey &&
+                    data[pane.needleKey] == expectedNeedle
+            },
+            "Expected insertion to use restored \(pane.replacementMessage) \(label). data=\(String(describing: loadData()))"
+        )
+    }
+
+    private func assertFindSelectionStable(
+        pane: Pane,
+        expectedRange: String,
+        label: String
+    ) {
+        let deadline = Date().addingTimeInterval(0.6)
+        var lastData: [String: String]?
+        while Date() < deadline {
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+            lastData = loadData()
+            guard let data = lastData else { continue }
+            XCTAssertEqual(data["focusedPanelKind"], pane.focusKey, "Expected \(pane.focusKey) focus while checking stable \(label). data=\(data)")
+            XCTAssertEqual(data["fieldEditorOwnerType"], pane.findFieldOwnerType, "Expected \(pane.replacementMessage) editor while checking stable \(label). data=\(data)")
+            XCTAssertEqual(data["firstResponderSelectedRange"], expectedRange, "Expected stable \(pane.replacementMessage) \(label). data=\(data)")
+        }
+        XCTAssertEqual(lastData?["firstResponderSelectedRange"], expectedRange, "Expected final stable \(pane.replacementMessage) \(label). data=\(String(describing: lastData))")
     }
 
     private func focusPane(_ pane: Pane, app: XCUIApplication) {


### PR DESCRIPTION
Summary
- Add XCUITest coverage that Cmd-F find fields keep in-field arrow-key editing while focused.
- Add XCUITest coverage that a find-field caret at `{2, 0}` survives Cmd+Option pane navigation away and back, then inserts at the restored cursor position.
- Route allowed find text-field arrow key equivalents to the focused field editor instead of AppKit menu handling.
- Preserve find-field selection across focus transitions and map Up/Down to match navigation in terminal and browser find overlays.

Regression proof
- Red test-only commit `54be61d9885828f114ab6dd9cd2753d5951908ae`: https://github.com/manaflow-ai/cmux/actions/runs/26503247523, artifact https://github.com/manaflow-ai/cmux-dev-artifacts/issues/1834. It fails because the caret is `{4, 0}` instead of `{2, 0}` after Left, Left in Cmd-F before Cmd+Option navigation.
- Green fixed commit `38437e9aa2bc407f7cd57f90284f669f607894af`: https://github.com/manaflow-ai/cmux/actions/runs/26503583583, artifact https://github.com/manaflow-ai/cmux-dev-artifacts/issues/1836. It passes `FindSelectionShortcutUITests/testFindCaretPositionSurvivesCmdOptionPaneNavigation`.

Verification
- `git diff --check`
- `./scripts/lint-pbxproj-test-wiring.sh`
- `./scripts/reload.sh --tag findarr`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches global key routing and find focus/selection state across terminal and browser; behavior is heavily covered by new UI tests but still affects a sensitive input path.
> 
> **Overview**
> Fixes **terminal and browser find** fields so arrow keys edit the query and navigate matches instead of being swallowed by global shortcut routing.
> 
> **Keyboard routing:** Adds `shouldDispatchFindTextFieldArrowViaFirstResponderKeyDown` and forwards allowed arrow keyDown events to the find field editor in `AppDelegate` (with reentry guard), matching omnibar/command-palette behavior.
> 
> **Find overlays:** Terminal and browser search delegates map **Up/Down** to previous/next match (like Return/Shift+Return). Focus logic prefers **stored** selection when refocusing.
> 
> **Selection persistence:** `FindTextFieldSupport` and `cmuxApplyFindFocusSelection` keep caret/selection across pane switches (Cmd+Option), repeated Cmd+F, and focus transitions—ignoring transient `{0,0}` resets during editing.
> 
> **Tests:** Expands `FindSelectionShortcutUITests` for in-field arrow editing, caret/edge ranges after pane navigation, browser Up/Down match navigation, and more stable launch handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d28b926b327d2be1a11a41397a08399f7835212. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->