### PR TITLE
fix(git): avoid index.lock contention by using --no-optional-locks

### DIFF
--- a/Sources/FileExplorerStore.swift
+++ b/Sources/FileExplorerStore.swift
@@ -1186,7 +1186,7 @@ enum GitStatusProvider {
     static func fetchStatus(directory: String) -> [String: GitFileStatus] {
         guard let repoRoot = gitRepoRoot(for: directory) else { return [:] }
         return parseGitStatus(
-            output: runGit(in: repoRoot, arguments: ["status", "--porcelain"]),
+            output: runGit(in: repoRoot, arguments: ["status", "--no-optional-locks", "--porcelain"]),
             repoRoot: repoRoot,
             explorerRoot: directory
         )


### PR DESCRIPTION
## Problem

When cmux polls `git status` in the background (e.g. for sidebar file-explorer badges), it can create `index.lock` and interfere with user-initiated git operations such as `git rebase`, causing:

```
error: Unable to create '~/work/.git/index.lock': File exists.
Another git process seems to be running in this repository...
```

This is reproducible quite reliably when cmux's GitStatusProvider runs concurrently with user git commands.

## Root Cause

`GitStatusProvider.fetchStatus` invokes `git status --porcelain` without any lock-avoidance flags. Git may take optional locks during status, which contend with user operations.

## Fix

Add `--no-optional-locks` to the `git status` invocation:

```swift
runGit(in: repoRoot, arguments: ["status", "--no-optional-locks", "--porcelain"])
```

This makes the status check read-only and prevents it from taking any optional lock, giving user git operations priority over background polling.

## Verification

- [x] Single-line change, minimal scope
- [x] `--no-optional-locks` is supported in Git 2.15+ (cmux targets recent macOS)
- [x] No schema/lockfile changes

## References

Fixes #4779

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4805"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782378841&installation_id=133855650&pr_number=4805&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4805&signature=6cf3d2ea1112eddf776a39fa21ffb929985c7140873431163c8fa4681e803c95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run git status with --no-optional-locks to prevent background polling from creating index.lock and blocking user operations (e.g., rebase). This makes status checks read-only and avoids contention. Fixes #4779.

<sup>Written for commit 73b0bfd52adbc2af596f76dd47768aa1c86bd54a. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4805?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file status detection reliability in the file explorer by updating how the application queries repository information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4805?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->