### PR TITLE
feat(cli): add --json flag to new-workspace for structured output

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -3650,7 +3650,24 @@ struct CMUXCLI {
             try applyFocusOption(focusOpt, defaultValue: false, to: &params)
             let response = try client.sendV2(method: "workspace.create", params: params)
             let wsId = (response["workspace_ref"] as? String) ?? (response["workspace_id"] as? String) ?? ""
-            print("OK \(wsId)")
+            if jsonOutput {
+                var jsonResponse: [String: Any] = [:]
+                if let workspaceId = response["workspace_id"] as? String {
+                    jsonResponse["workspace_id"] = workspaceId
+                }
+                if let workspaceRef = response["workspace_ref"] as? String {
+                    jsonResponse["workspace_ref"] = workspaceRef
+                }
+                if let initialSurfaceId = response["initial_surface_id"] as? String {
+                    jsonResponse["initial_surface_id"] = initialSurfaceId
+                }
+                if let initialSurfaceRef = response["initial_surface_ref"] as? String {
+                    jsonResponse["initial_surface_ref"] = initialSurfaceRef
+                }
+                print(jsonString(jsonResponse))
+            } else {
+                print("OK \(wsId)")
+            }
             if layoutOpt == nil, let commandText = commandOpt, !wsId.isEmpty {
                 let text = unescapeSendText(commandText + "\\n")
                 let sendParams: [String: Any] = ["text": text, "workspace_id": wsId]
@@ -12201,7 +12218,7 @@ struct CMUXCLI {
             """
         case "new-workspace":
             return """
-            Usage: cmux new-workspace [--name <title>] [--description <text>] [--cwd <path>] [--command <text>] [--layout <json>] [--window <id|ref|index>] [--focus <true|false>]
+            Usage: cmux new-workspace [--name <title>] [--description <text>] [--cwd <path>] [--command <text>] [--layout <json>] [--window <id|ref|index>] [--focus <true|false>] [--json]
 
             Create a new workspace in the caller's window.
 
@@ -12216,6 +12233,7 @@ struct CMUXCLI {
               --window <id|ref|index>
                                    Target window (default: caller's window from $CMUX_WORKSPACE_ID/$CMUX_SURFACE_ID)
               --focus <true|false> Focus the new workspace (default: false)
+              --json               Output workspace and surface refs as JSON instead of OK line
 
             Example:
               cmux new-workspace


### PR DESCRIPTION
## Problem

When scripting workspace creation (e.g. in CI or automation), consumers need programmatic access to the created workspace and initial surface references. The current plain `OK <workspace_id>` line is hard to parse reliably and requires string splitting.

## Proposed Solution

Add `--json` flag to `cmux new-workspace` that emits structured JSON output containing:
- `workspace_id`
- `workspace_ref`
- `initial_surface_id`
- `initial_surface_ref`

## Implementation

- When `--json` is passed, output a JSON object with the fields above instead of the `OK` line
- Existing behavior (plain `OK` line) is preserved when `--json` is not passed
- Updated help text to document the new flag

## Example

```bash
$ cmux new-workspace --name "Build" --json
{"workspace_id":"ws:123","workspace_ref":"workspace:123","initial_surface_id":"sf:456","initial_surface_ref":"surface:456"}
```

## Verification

- [x] Code review: single file change, follows existing jsonOutput pattern
- [x] Help text updated
- [x] No schema/lockfile changes

## References

Fixes #4668

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4806"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782379180&installation_id=133855650&pr_number=4806&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4806&signature=a6c071aa8c033f5bb68c52ed02e7d82da6fd64af724424d4314f858314709f70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `--json` flag to `cmux new-workspace` to return structured JSON for scripts and CI instead of the plain OK line. The JSON includes workspace_id, workspace_ref, initial_surface_id, and initial_surface_ref; default output is unchanged when `--json` is omitted.

<sup>Written for commit c1a88f60c0b0e2425cbf23941933bede9b571d52. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4806?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--json` flag to the `new-workspace` command to output workspace and surface reference information in JSON format instead of plain text.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4806?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->