### PR TITLE
Fix CLI agent spawn startup commands

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -3761,30 +3761,51 @@ struct CMUXCLI {
             printV2Payload(payload, jsonOutput: jsonOutput, idFormat: idFormat, fallbackText: v2OKSummary(payload, idFormat: idFormat, kinds: ["pane", "workspace"]))
 
         case "new-pane":
-            let workspaceArg = workspaceFromArgsOrEnv(commandArgs, windowOverride: windowId)
-            let type = optionValue(commandArgs, name: "--type")
-            let direction = optionValue(commandArgs, name: "--direction") ?? "right"
-            let url = optionValue(commandArgs, name: "--url")
-            let focusOpt = optionValue(commandArgs, name: "--focus")
+            let (wsOpt, rem0) = parseOption(commandArgs, name: "--workspace")
+            let (type, rem1) = parseOption(rem0, name: "--type")
+            let (directionOpt, rem2) = parseOption(rem1, name: "--direction")
+            let (url, rem3) = parseOption(rem2, name: "--url")
+            let (focusOpt, rem4) = parseOption(rem3, name: "--focus")
+            let (windowOpt, rem5) = parseOption(rem4, name: "--window")
+            let (commandOpt, rem6) = parseOption(rem5, name: "--command")
+            let (cwdOpt, remaining) = parseOption(rem6, name: "--cwd")
+            let filteredRemaining = remaining.filter { $0 != "--" }
+            if let unexpected = filteredRemaining.first {
+                throw CLIError(message: "new-pane: unexpected argument '\(unexpected)'. Known flags: --type <terminal|browser>, --direction <left|right|up|down>, --workspace <id|ref|index>, --window <id|ref|index>, --url <url>, --command <text>, --cwd <path>, --focus <true|false>")
+            }
+            let direction = directionOpt ?? "right"
+            let windowRaw = windowOpt ?? windowId
+            let workspaceArg = wsOpt ?? (windowRaw == nil ? ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"] : nil)
             var params: [String: Any] = ["direction": direction]
-            let winId = try normalizeWindowHandle(windowFromArgsOrOverride(commandArgs, windowOverride: windowId), client: client)
+            let winId = try normalizeWindowHandle(windowRaw, client: client)
             if let winId { params["window_id"] = winId }
             let wsId = try normalizeWorkspaceHandle(workspaceArg, client: client, windowHandle: winId)
             if let wsId { params["workspace_id"] = wsId }
             if let type { params["type"] = type }
             if let url { params["url"] = url }
+            if let cwdOpt { params["working_directory"] = resolvePath(cwdOpt) }
+            if let commandOpt { params["initial_command"] = commandOpt }
             try applyFocusOption(focusOpt, defaultValue: false, to: &params)
             let payload = try client.sendV2(method: "pane.create", params: params)
             printV2Payload(payload, jsonOutput: jsonOutput, idFormat: idFormat, fallbackText: v2OKSummary(payload, idFormat: idFormat, kinds: ["surface", "pane", "workspace"]))
 
         case "new-surface":
-            let workspaceArg = workspaceFromArgsOrEnv(commandArgs, windowOverride: windowId)
-            let type = optionValue(commandArgs, name: "--type")
-            let paneRaw = optionValue(commandArgs, name: "--pane")
-            let url = optionValue(commandArgs, name: "--url")
-            let focusOpt = optionValue(commandArgs, name: "--focus")
+            let (wsOpt, rem0) = parseOption(commandArgs, name: "--workspace")
+            let (type, rem1) = parseOption(rem0, name: "--type")
+            let (paneRaw, rem2) = parseOption(rem1, name: "--pane")
+            let (url, rem3) = parseOption(rem2, name: "--url")
+            let (focusOpt, rem4) = parseOption(rem3, name: "--focus")
+            let (windowOpt, rem5) = parseOption(rem4, name: "--window")
+            let (commandOpt, rem6) = parseOption(rem5, name: "--command")
+            let (cwdOpt, remaining) = parseOption(rem6, name: "--cwd")
+            let filteredRemaining = remaining.filter { $0 != "--" }
+            if let unexpected = filteredRemaining.first {
+                throw CLIError(message: "new-surface: unexpected argument '\(unexpected)'. Known flags: --type <terminal|browser>, --pane <id|ref|index>, --workspace <id|ref|index>, --window <id|ref|index>, --url <url>, --command <text>, --cwd <path>, --focus <true|false>")
+            }
+            let windowRaw = windowOpt ?? windowId
+            let workspaceArg = wsOpt ?? (windowRaw == nil ? ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"] : nil)
             var params: [String: Any] = [:]
-            let winId = try normalizeWindowHandle(windowFromArgsOrOverride(commandArgs, windowOverride: windowId), client: client)
+            let winId = try normalizeWindowHandle(windowRaw, client: client)
             if let winId { params["window_id"] = winId }
             let wsId = try normalizeWorkspaceHandle(workspaceArg, client: client, windowHandle: winId)
             if let wsId { params["workspace_id"] = wsId }
@@ -3792,6 +3813,8 @@ struct CMUXCLI {
             if let paneId { params["pane_id"] = paneId }
             if let type { params["type"] = type }
             if let url { params["url"] = url }
+            if let cwdOpt { params["working_directory"] = resolvePath(cwdOpt) }
+            if let commandOpt { params["initial_command"] = commandOpt }
             try applyFocusOption(focusOpt, defaultValue: false, to: &params)
             let payload = try client.sendV2(method: "surface.create", params: params)
             printV2Payload(payload, jsonOutput: jsonOutput, idFormat: idFormat, fallbackText: v2OKSummary(payload, idFormat: idFormat, kinds: ["surface", "pane", "workspace"]))
@@ -12474,11 +12497,14 @@ struct CMUXCLI {
               --workspace <id|ref|index>          Target workspace (default: $CMUX_WORKSPACE_ID)
               --window <id|ref|index>             Window context for workspace refs and indexes
               --url <url>                         URL for browser panes
+              --cwd <path>                        Working directory for terminal panes
+              --command <text>                    Launch command for terminal panes
               --focus <true|false>                Focus the new pane (default: false)
 
             Example:
               cmux new-pane
               cmux new-pane --type browser --direction down --url https://example.com
+              cmux new-pane --command "npm test"
             """
         case "new-surface":
             return """
@@ -12492,11 +12518,14 @@ struct CMUXCLI {
               --workspace <id|ref|index>  Target workspace (default: $CMUX_WORKSPACE_ID)
               --window <id|ref|index>     Window context for workspace/pane refs and indexes
               --url <url>                 URL for browser surfaces
+              --cwd <path>                Working directory for terminal surfaces
+              --command <text>            Launch command for terminal surfaces
               --focus <true|false>        Focus the new surface (default: false)
 
             Example:
               cmux new-surface
               cmux new-surface --type browser --pane pane:1 --url https://example.com
+              cmux new-surface --command "npm test"
             """
         case "close-surface":
             return """
@@ -18335,9 +18364,12 @@ struct CMUXCLI {
                !cwd.isEmpty {
                 splitParams["working_directory"] = resolvePath(cwd)
             }
-            let startupScript = isOMXHud
-                ? tmuxStartupScript(commandTokens: parsed.positional, cwd: parsed.value("-c"))
-                : nil
+            // If tmux split-window includes a command, run it as the new terminal's
+            // startup command instead of typing into the pane after creation. Agent
+            // launchers often spawn a split and immediately exec their CLI; sending
+            // text after surface creation can race the shell startup and leave the
+            // new tab/pane blank.
+            let startupScript = tmuxStartupScript(commandTokens: parsed.positional, cwd: parsed.value("-c"))
             if let startupScript {
                 splitParams["initial_command"] = startupScript
             }

--- a/tests/test_cli_claude_teams_tmux_sequence.py
+++ b/tests/test_cli_claude_teams_tmux_sequence.py
@@ -188,6 +188,8 @@ class FakeCmuxState:
                 return {"ok": True}
             if method == "pane.resize":
                 return {"ok": True}
+            if method == "workspace.equalize_splits":
+                return {"ok": True}
             if method == "surface.send_text":
                 return {"ok": True}
             raise RuntimeError(f"Unsupported fake cmux method: {method}")

--- a/tests/test_cli_layout_focus_contract.py
+++ b/tests/test_cli_layout_focus_contract.py
@@ -244,11 +244,66 @@ def main() -> int:
                 {"workspace_id": WORKSPACE_ID, "direction": "down", "focus": False},
             )
 
+            command_cwd = str(Path(tmp).resolve())
+            run_cli(
+                cli,
+                socket_path,
+                [
+                    "new-pane",
+                    "--workspace",
+                    WORKSPACE_ID,
+                    "--direction",
+                    "down",
+                    "--cwd",
+                    command_cwd,
+                    "--command",
+                    "printf pane-ready",
+                ],
+            )
+            assert_last_call(
+                state,
+                "pane.create",
+                {
+                    "workspace_id": WORKSPACE_ID,
+                    "direction": "down",
+                    "working_directory": command_cwd,
+                    "initial_command": "printf pane-ready",
+                    "focus": False,
+                },
+            )
+
             run_cli(cli, socket_path, ["new-surface", "--workspace", WORKSPACE_ID, "--pane", PANE_ID])
             assert_last_call(
                 state,
                 "surface.create",
                 {"workspace_id": WORKSPACE_ID, "pane_id": PANE_ID, "focus": False},
+            )
+
+            run_cli(
+                cli,
+                socket_path,
+                [
+                    "new-surface",
+                    "--workspace",
+                    WORKSPACE_ID,
+                    "--pane",
+                    PANE_ID,
+                    "--cwd",
+                    command_cwd,
+                    "--command",
+                    "printf surface-ready",
+                ],
+            )
+            assert_last_call(
+                state,
+                "surface.create",
+                {
+                    "workspace_id": WORKSPACE_ID,
+                    "pane_id": PANE_ID,
+                    "working_directory": command_cwd,
+                    "initial_command": "printf surface-ready",
+                    "focus": False,
+                },
             )
 
             run_cli(cli, socket_path, ["reorder-surface", "--surface", SURFACE_ID, "--index", "0"])
@@ -284,6 +339,8 @@ def main() -> int:
             )
 
             assert_cli_fails(cli, socket_path, ["new-split", "--bogus"], "new-split requires a direction")
+            assert_cli_fails(cli, socket_path, ["new-pane", "--bogus"], "new-pane: unexpected argument")
+            assert_cli_fails(cli, socket_path, ["new-surface", "--bogus"], "new-surface: unexpected argument")
             assert_cli_fails(cli, socket_path, ["split-off", "--surface", SURFACE_ID, "--bogus"], "split-off requires a direction")
             assert_cli_fails(cli, socket_path, ["break-pane", "--focus", "true", "--no-focus"], "--focus and --no-focus cannot be used together")
             assert_cli_fails(cli, socket_path, ["move-surface", "--workspace", WORKSPACE_ID], "move-surface requires --surface")

--- a/tests/test_cli_omx_hud_tmux_split.py
+++ b/tests/test_cli_omx_hud_tmux_split.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from claude_teams_test_utils import resolve_cmux_cli
 
 WORKSPACE_ID = "11111111-1111-4111-8111-111111111111"
+WINDOW_ID = "22222222-2222-4222-8222-222222222222"
 PANE_ID = "33333333-3333-4333-8333-333333333333"
 SURFACE_ID = "44444444-4444-4444-8444-444444444444"
 HUD_PANE_ID = "66666666-6666-4666-8666-666666666666"
@@ -41,6 +42,17 @@ class FakeCmuxState:
                         "ref": "workspace:1",
                         "index": 1,
                         "title": "demo",
+                    }
+                ]
+            }
+        if method == "window.list":
+            return {
+                "windows": [
+                    {
+                        "id": WINDOW_ID,
+                        "ref": "window:1",
+                        "workspace_id": WORKSPACE_ID,
+                        "workspace_ref": "workspace:1",
                     }
                 ]
             }
@@ -267,6 +279,63 @@ def assert_omx_hud_splits_down_with_compact_size(
         raise AssertionError(f"expected HUD tmux start command metadata, got {split!r}")
     if state.sent_text:
         raise AssertionError(f"HUD command should not be typed into a shell: {state.sent_text!r}")
+
+
+def assert_regular_tmux_split_command_launches_as_initial_command(
+    cli_path: str,
+    socket_path: Path,
+    fake_home: Path,
+    cwd: Path,
+    state: FakeCmuxState,
+) -> None:
+    split_baseline = len(state.split_params)
+    sent_text_baseline = len(state.sent_text)
+    proc = run_cli(
+        cli_path,
+        socket_path,
+        fake_home,
+        [
+            "__tmux-compat",
+            "split-window",
+            "-h",
+            "-d",
+            "-c",
+            str(cwd),
+            "-P",
+            "-F",
+            "#{pane_id}",
+            "printf regular-agent-ready",
+        ],
+    )
+    if proc.returncode != 0:
+        raise AssertionError(
+            "regular split command returned non-zero\n"
+            f"stdout={proc.stdout.strip()}\n"
+            f"stderr={proc.stderr.strip()}"
+        )
+    if proc.stdout.strip() != f"%{HUD_PANE_ID}":
+        raise AssertionError(
+            f"expected split-window to print %{HUD_PANE_ID}, got {proc.stdout.strip()!r}"
+        )
+    new_splits = state.split_params[split_baseline:]
+    if len(new_splits) != 1:
+        raise AssertionError(f"expected one regular split command, got {new_splits!r}")
+    split = new_splits[0]
+    startup_script = split.get("initial_command")
+    if not isinstance(startup_script, str) or not startup_script:
+        raise AssertionError(f"expected regular tmux split command to launch as an initial command, got {split!r}")
+    startup_path = Path(startup_script)
+    if not startup_path.exists():
+        raise AssertionError(f"expected generated regular startup script to exist: {startup_script}")
+    startup_text = startup_path.read_text(encoding="utf-8")
+    if f"cd -- '{cwd}'" not in startup_text:
+        raise AssertionError(f"expected regular startup script to cd to project cwd, got {startup_text!r}")
+    if "printf regular-agent-ready" not in startup_text:
+        raise AssertionError(f"expected regular startup script to run the agent command, got {startup_text!r}")
+    if split.get("tmux_start_command") != "printf regular-agent-ready":
+        raise AssertionError(f"expected regular split start command metadata, got {split!r}")
+    if len(state.sent_text) != sent_text_baseline:
+        raise AssertionError(f"regular command should not be typed into a shell: {state.sent_text!r}")
 
 
 def assert_omx_hud_is_visible_to_tmux_pane_formats(
@@ -549,6 +618,13 @@ def main() -> int:
                     cli_path,
                     socket_path,
                     fake_home,
+                    state,
+                )
+                assert_regular_tmux_split_command_launches_as_initial_command(
+                    cli_path,
+                    socket_path,
+                    fake_home,
+                    cwd,
                     state,
                 )
             finally:


### PR DESCRIPTION
## Summary
- forward --command and --cwd from cmux new-pane/new-surface to initial_command and working_directory
- launch tmux split-window commands via initial_command startup scripts instead of racing surface.send_text
- add fake-socket regressions for direct CLI spawn and tmux agent split flows

## Validation
- xcodebuild -project cmux.xcodeproj -scheme cmux-cli -configuration Debug -destination 'platform=macOS' -derivedDataPath .derivedData-jcode-spawnfix build
- CMUX_CLI_BIN=.derivedData-jcode-spawnfix/Build/Products/Debug/cmux python3 tests/test_cli_layout_focus_contract.py
- CMUX_CLI_BIN=.derivedData-jcode-spawnfix/Build/Products/Debug/cmux python3 tests/test_cli_omx_hud_tmux_split.py
- CMUX_CLI_BIN=.derivedData-jcode-spawnfix/Build/Products/Debug/cmux python3 tests/test_cli_claude_teams_tmux_sequence.py
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4811"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782393471&installation_id=133855650&pr_number=4811&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4811&signature=8924fc4e24d5984d1d38834fe62acadc6f423097153609f1ceac24e55810ef7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CLI agent startup by forwarding --command/--cwd and by launching tmux splits via initial_command instead of typing into the shell, removing race conditions and blank panes. Also adds strict arg parsing with clear errors and updates CLI help.

- **Bug Fixes**
  - Forward `--command` to `initial_command` and `--cwd` to `working_directory` for `new-pane` and `new-surface`.
  - Execute tmux `split-window` commands via startup scripts (`initial_command`) instead of `surface.send_text`.
  - Add strict parsing for `new-pane`/`new-surface`; reject unexpected args with a helpful message.
  - Update help text and examples for `--command`/`--cwd`.
  - Add regression tests for direct CLI spawns and tmux split flows (including fake socket stubs for `window.list` and `workspace.equalize_splits`).

<sup>Written for commit c97c5316beb3a3a72044a6af1f0023a7271355ec. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4811?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--cwd` and `--command` flags to `new-pane` and `new-surface` commands, allowing users to specify working directory and initial command when creating new panes and surfaces.
  * Updated CLI help documentation with new examples demonstrating the flags.

* **Bug Fixes**
  * Improved tmux split behavior to reliably populate newly created panes and surfaces, preventing them from appearing blank.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4811?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->