### PR TITLE
Fix sidebar hover drag-handle event dispatch

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -15579,6 +15579,10 @@ private extension NSWindow {
             CmuxTypingTiming.logEventDelay(path: "window.sendEvent", event: event)
         }
 #endif
+        let dragHandleDispatchToken = beginWindowDragHandleEventDispatch(window: self, event: event)
+        defer {
+            endWindowDragHandleEventDispatch(dragHandleDispatchToken)
+        }
         // recordTypingActivity must run in all builds so runSessionAutosaveTick
         // can honor the typing quiet period in release.
         if event.type == .keyDown, let app = AppDelegate.shared, cmuxCloseFocusedTerminalFindForEscape(event: event, appDelegate: app) { return }

--- a/Sources/WindowDragHandleView.swift
+++ b/Sources/WindowDragHandleView.swift
@@ -200,14 +200,17 @@ func beginWindowDragHandleEventDispatch(
     window: NSWindow,
     event: NSEvent
 ) -> WindowDragHandleEventDispatchToken {
+    dispatchPrecondition(condition: .onQueue(.main))
     WindowDragHandleEventDispatchState.begin(window: window, event: event)
 }
 
 func endWindowDragHandleEventDispatch(_ token: WindowDragHandleEventDispatchToken) {
+    dispatchPrecondition(condition: .onQueue(.main))
     WindowDragHandleEventDispatchState.end(token)
 }
 
 func windowDragHandleViewHitTestingAllowsCurrentEvent(_ event: NSEvent?) -> Bool {
+    dispatchPrecondition(condition: .onQueue(.main))
     guard let event, event.type == .leftMouseDown else {
         return false
     }

--- a/Sources/WindowDragHandleView.swift
+++ b/Sources/WindowDragHandleView.swift
@@ -201,7 +201,7 @@ func beginWindowDragHandleEventDispatch(
     event: NSEvent
 ) -> WindowDragHandleEventDispatchToken {
     dispatchPrecondition(condition: .onQueue(.main))
-    WindowDragHandleEventDispatchState.begin(window: window, event: event)
+    return WindowDragHandleEventDispatchState.begin(window: window, event: event)
 }
 
 func endWindowDragHandleEventDispatch(_ token: WindowDragHandleEventDispatchToken) {

--- a/Sources/WindowDragHandleView.swift
+++ b/Sources/WindowDragHandleView.swift
@@ -144,6 +144,76 @@ private func windowDragHandleShouldResolveActiveHitCapture(
     return eventWindow === dragHandleWindow
 }
 
+struct WindowDragHandleEventDispatchToken: Equatable {
+    fileprivate let id: Int
+}
+
+private struct WindowDragHandleEventDispatchFrame {
+    let token: WindowDragHandleEventDispatchToken
+    weak var window: NSWindow?
+    let windowNumber: Int
+    let eventType: NSEvent.EventType
+}
+
+private enum WindowDragHandleEventDispatchState {
+    // AppKit event dispatch is main-thread only. This stack lets drag-handle
+    // NSViews distinguish real event delivery from stale NSApp.currentEvent reads
+    // during SwiftUI/AppKit layout hit-testing.
+    private nonisolated(unsafe) static var nextTokenId = 0
+    private nonisolated(unsafe) static var frames: [WindowDragHandleEventDispatchFrame] = []
+
+    static func begin(window: NSWindow, event: NSEvent) -> WindowDragHandleEventDispatchToken {
+        nextTokenId += 1
+        let token = WindowDragHandleEventDispatchToken(id: nextTokenId)
+        frames.append(
+            WindowDragHandleEventDispatchFrame(
+                token: token,
+                window: window,
+                windowNumber: window.windowNumber,
+                eventType: event.type
+            )
+        )
+        return token
+    }
+
+    static func end(_ token: WindowDragHandleEventDispatchToken) {
+        if let index = frames.lastIndex(where: { $0.token == token }) {
+            frames.remove(at: index)
+        }
+    }
+
+    static func containsActiveDispatch(for event: NSEvent) -> Bool {
+        frames.contains { frame in
+            guard frame.eventType == event.type,
+                  frame.windowNumber == event.windowNumber else {
+                return false
+            }
+            if let eventWindow = event.window {
+                return frame.window === eventWindow
+            }
+            return true
+        }
+    }
+}
+
+func beginWindowDragHandleEventDispatch(
+    window: NSWindow,
+    event: NSEvent
+) -> WindowDragHandleEventDispatchToken {
+    WindowDragHandleEventDispatchState.begin(window: window, event: event)
+}
+
+func endWindowDragHandleEventDispatch(_ token: WindowDragHandleEventDispatchToken) {
+    WindowDragHandleEventDispatchState.end(token)
+}
+
+func windowDragHandleViewHitTestingAllowsCurrentEvent(_ event: NSEvent?) -> Bool {
+    guard let event, event.type == .leftMouseDown else {
+        return false
+    }
+    return WindowDragHandleEventDispatchState.containsActiveDispatch(for: event)
+}
+
 /// Runs the same action macOS titlebars use for double-click:
 /// zoom by default, or minimize when the user preference is set.
 enum StandardTitlebarDoubleClickAction: Equatable {
@@ -1180,11 +1250,7 @@ struct WindowDragHandleView: NSViewRepresentable {
 
         override func hitTest(_ point: NSPoint) -> NSView? {
             let currentEvent = NSApp.currentEvent
-            // Fast bail-out: only claim hits for left-mouse-down events.
-            // For mouseMoved / mouseEntered / etc., return nil immediately
-            // to avoid re-entering SwiftUI view state during layout passes,
-            // which causes exclusive-access crashes.
-            guard currentEvent?.type == .leftMouseDown else {
+            guard windowDragHandleViewHitTestingAllowsCurrentEvent(currentEvent) else {
                 return nil
             }
             let shouldCapture = windowDragHandleShouldCaptureHit(

--- a/cmuxTests/WindowAndDragTests.swift
+++ b/cmuxTests/WindowAndDragTests.swift
@@ -774,6 +774,27 @@ final class WindowDragHandleHitTests: XCTestCase {
         return nil
     }
 
+    private static func makeMouseEvent(
+        type: NSEvent.EventType,
+        location: NSPoint,
+        window: NSWindow
+    ) -> NSEvent {
+        guard let event = NSEvent.mouseEvent(
+            with: type,
+            location: location,
+            modifierFlags: [],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 1.0
+        ) else {
+            fatalError("Failed to create \(type) mouse event")
+        }
+        return event
+    }
+
     func testDragHandleCapturesHitWhenNoSiblingClaimsPoint() {
         let container = NSView(frame: NSRect(x: 0, y: 0, width: 220, height: 36))
         let dragHandle = NSView(frame: container.bounds)
@@ -973,6 +994,50 @@ final class WindowDragHandleHitTests: XCTestCase {
         XCTAssertFalse(windowDragHandleShouldCaptureHit(point, in: dragHandle, eventType: .cursorUpdate))
         XCTAssertFalse(windowDragHandleShouldCaptureHit(point, in: dragHandle, eventType: nil))
         XCTAssertTrue(windowDragHandleShouldCaptureHit(point, in: dragHandle, eventType: .leftMouseDown))
+    }
+
+    func testDragHandleViewHitTestingRequiresActiveWindowEventDispatch() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 220, height: 36),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+
+        let event = Self.makeMouseEvent(type: .leftMouseDown, location: NSPoint(x: 180, y: 18), window: window)
+
+        XCTAssertFalse(
+            windowDragHandleViewHitTestingAllowsCurrentEvent(event),
+            "A stale leftMouseDown in NSApp.currentEvent must not make layout/passive hit-testing enter the drag handle."
+        )
+
+        let token = beginWindowDragHandleEventDispatch(window: window, event: event)
+        defer { endWindowDragHandleEventDispatch(token) }
+
+        XCTAssertTrue(
+            windowDragHandleViewHitTestingAllowsCurrentEvent(event),
+            "A real leftMouseDown may resolve drag-handle hits while AppKit is dispatching that window event."
+        )
+    }
+
+    func testDragHandleViewHitTestingStillRejectsPassiveEventsDuringDispatch() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 220, height: 36),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+
+        let event = Self.makeMouseEvent(type: .mouseMoved, location: NSPoint(x: 180, y: 18), window: window)
+        let token = beginWindowDragHandleEventDispatch(window: window, event: event)
+        defer { endWindowDragHandleEventDispatch(token) }
+
+        XCTAssertFalse(
+            windowDragHandleViewHitTestingAllowsCurrentEvent(event),
+            "Hover dispatch must stay transparent to the titlebar drag handle."
+        )
     }
 
     func testDragHandleNeverCapturesRegisteredBonsplitPaneTab() {

--- a/cmuxTests/WindowAndDragTests.swift
+++ b/cmuxTests/WindowAndDragTests.swift
@@ -779,6 +779,14 @@ final class WindowDragHandleHitTests: XCTestCase {
         location: NSPoint,
         window: NSWindow
     ) -> NSEvent {
+        let isButtonEvent: Bool
+        switch type {
+        case .leftMouseDown, .leftMouseUp, .rightMouseDown, .rightMouseUp, .otherMouseDown, .otherMouseUp:
+            isButtonEvent = true
+        default:
+            isButtonEvent = false
+        }
+
         guard let event = NSEvent.mouseEvent(
             with: type,
             location: location,
@@ -787,8 +795,8 @@ final class WindowDragHandleHitTests: XCTestCase {
             windowNumber: window.windowNumber,
             context: nil,
             eventNumber: 0,
-            clickCount: 1,
-            pressure: 1.0
+            clickCount: isButtonEvent ? 1 : 0,
+            pressure: isButtonEvent ? 1.0 : 0.0
         ) else {
             fatalError("Failed to create \(type) mouse event")
         }


### PR DESCRIPTION
Fixes #750

## Summary
- Add regression coverage for stale titlebar drag-handle event dispatch before the source fix.
- Follow-up commit will make drag-handle view hit-testing depend on active NSWindow event dispatch, not stale NSApp.currentEvent.

## Test plan
- Not run locally per repository policy.
- CI should fail on the first test-only commit, then pass after the fix commit.

## Reproduction
- Existing issue report reproduces on cmux 0.61.0 / macOS 14.5 by hovering the sidebar top button group.
- PR #736 already documents reproduction on v0.61.0 and fixed-after verification for the direct hover path; this PR closes the remaining stale-currentEvent class around that same drag-handle route.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized AppKit event/hit-test plumbing for the titlebar drag handle with tests; no auth, data, or broad behavior changes beyond fixing stale-event drags.
> 
> **Overview**
> Fixes unintended titlebar/window drags when **sidebar hover** or layout hit-testing sees a **stale** `leftMouseDown` on `NSApp.currentEvent` (#750).
> 
> **Window event dispatch** is now bracketed in `sendEvent` with `beginWindowDragHandleEventDispatch` / `endWindowDragHandleEventDispatch`, maintaining a main-thread stack of active window + event type. **`WindowDragHandleView`** only participates in `hitTest` when that stack says a matching **`leftMouseDown`** is being delivered—not on passive events like `mouseMoved`.
> 
> Regression tests cover stale vs active dispatch and that hover stays transparent during dispatch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ec7079a3121a58ee22f94c04506fabd16fe7cf4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes unintended titlebar drags by scoping the drag-handle hit-test to active window event dispatch; fixes #750. Wraps `NSWindow.sendEvent` with begin/end tokens backed by a main-thread-asserted dispatch stack so only an in-flight `leftMouseDown` can capture; stale `NSApp.currentEvent` reads and hover/passive events are ignored, with tests for stale, active, and hover cases.

<sup>Written for commit 68f1924d3c0d3aca37939be9a60aa12b28de89c8. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4818?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4818"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782413140&installation_id=133855650&pr_number=4818&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4818&signature=fd3ecae4d26eefa830e3193c947d38f26a9dcaba254c791d53a9d221f475b0e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved window drag handle hit-testing so stale or unrelated mouse events no longer trigger unintended drags.
* **Tests**
  * Added coverage verifying drag-handle hit-testing rejects stale and passive events unless part of an active drag dispatch.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4818?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->