### PR TITLE
Fix escape response leakage through insertText

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -14107,6 +14107,13 @@ extension GhosttyNSView: NSTextInputClient {
         guard let surface = surface else { return }
 #if DEBUG
         let typingTimingStart = CmuxTypingTiming.start()
+        defer {
+            CmuxTypingTiming.logDuration(
+                path: "terminal.sendTextToSurface",
+                startedAt: typingTimingStart,
+                extra: "textBytes=\(chars.utf8.count)"
+            )
+        }
 #endif
 #if DEBUG
         cmuxWriteChildExitProbe(
@@ -14184,13 +14191,6 @@ extension GhosttyNSView: NSTextInputClient {
             }
         }
         flushBufferedText()
-#if DEBUG
-        CmuxTypingTiming.logDuration(
-            path: "terminal.sendTextToSurface",
-            startedAt: typingTimingStart,
-            extra: "textBytes=\(chars.utf8.count)"
-        )
-#endif
     }
 
     private static func shouldSendAsRawTextPayload(_ text: String) -> Bool {
@@ -14204,7 +14204,9 @@ extension GhosttyNSView: NSTextInputClient {
         Self.debugGhosttySurfaceTextObserver?(data)
 #endif
         data.withUnsafeBytes { rawBuffer in
-            guard let baseAddress = rawBuffer.baseAddress?.assumingMemoryBound(to: CChar.self) else { return }
+            guard let baseAddress = rawBuffer.baseAddress?.assumingMemoryBound(to: CChar.self) else {
+                return
+            }
             ghostty_surface_text(surface, baseAddress, UInt(rawBuffer.count))
         }
     }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7410,6 +7410,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         return UserDefaults.standard.bool(forKey: "cmuxKeyLatencyProbe")
     }()
     @MainActor static var debugGhosttySurfaceKeyEventObserver: ((ghostty_input_key_s) -> Void)?
+    @MainActor static var debugGhosttySurfaceTextObserver: ((Data) -> Void)?
     @MainActor static var debugTextInputEventHandler: ((GhosttyNSView, NSEvent) -> Bool)?
 #endif
     private var eventMonitor: Any?

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -14100,7 +14100,9 @@ extension GhosttyNSView: NSTextInputClient {
     /// Deliver committed text using typed-input semantics so shells and editors
     /// keep their normal interactive behaviors (autosuggestions, Return
     /// execution, etc.). Programmatic callers can preserve literal ESC bytes so
-    /// automation payloads remain byte-for-byte stable.
+    /// automation payloads remain byte-for-byte stable. Programmatic escape
+    /// sequence payloads use Ghostty's raw text path so the control introducer
+    /// stays attached to the bytes that follow it.
     fileprivate func sendTextToSurface(_ chars: String, preserveLiteralEscape: Bool) {
         guard let surface = surface else { return }
 #if DEBUG
@@ -14115,6 +14117,11 @@ extension GhosttyNSView: NSTextInputClient {
             increments: ["probeInsertTextCount": 1]
         )
 #endif
+
+        if preserveLiteralEscape, Self.shouldSendAsRawTextPayload(chars) {
+            sendRawTextPayload(chars, to: surface)
+            return
+        }
 
         var bufferedText = ""
         var previousWasCR = false
@@ -14184,6 +14191,22 @@ extension GhosttyNSView: NSTextInputClient {
             extra: "textBytes=\(chars.utf8.count)"
         )
 #endif
+    }
+
+    private static func shouldSendAsRawTextPayload(_ text: String) -> Bool {
+        guard let first = text.unicodeScalars.first else { return false }
+        return first.value == 0x1B || first.value == 0x9B
+    }
+
+    private func sendRawTextPayload(_ text: String, to surface: ghostty_surface_t) {
+        guard let data = text.data(using: .utf8), !data.isEmpty else { return }
+#if DEBUG
+        Self.debugGhosttySurfaceTextObserver?(data)
+#endif
+        data.withUnsafeBytes { rawBuffer in
+            guard let baseAddress = rawBuffer.baseAddress?.assumingMemoryBound(to: CChar.self) else { return }
+            ghostty_surface_text(surface, baseAddress, UInt(rawBuffer.count))
+        }
     }
 
     /// External accessibility/dictation tools should commit plain text, but

--- a/cmuxTests/CJKIMEInputTests.swift
+++ b/cmuxTests/CJKIMEInputTests.swift
@@ -1355,7 +1355,7 @@ final class AccessibilityInsertTextRegressionTests: XCTestCase {
         XCTAssertEqual(pressedKeycodes, [36], "Trailing newline should be delivered as Return, not pasted text")
     }
 
-    func testDirectInsertTextPreservesLeadingEscapeForAutomation() {
+    func testDirectInsertTextRoutesLeadingEscapeThroughRawTextPath() {
         _ = NSApplication.shared
 
         let surface = TerminalSurface(
@@ -1374,6 +1374,7 @@ final class AccessibilityInsertTextRegressionTests: XCTestCase {
         )
         defer {
             GhosttyNSView.debugGhosttySurfaceKeyEventObserver = nil
+            GhosttyNSView.debugGhosttySurfaceTextObserver = nil
             window.orderOut(nil)
         }
 
@@ -1400,6 +1401,7 @@ final class AccessibilityInsertTextRegressionTests: XCTestCase {
 
         var pressedText: [String] = []
         var pressedKeycodes: [UInt32] = []
+        var rawText: [Data] = []
         GhosttyNSView.debugGhosttySurfaceKeyEventObserver = { keyEvent in
             guard keyEvent.action == GHOSTTY_ACTION_PRESS else { return }
             if let text = keyEvent.text {
@@ -1408,11 +1410,15 @@ final class AccessibilityInsertTextRegressionTests: XCTestCase {
                 pressedKeycodes.append(keyEvent.keycode)
             }
         }
+        GhosttyNSView.debugGhosttySurfaceTextObserver = { data in
+            rawText.append(data)
+        }
 
         view.insertText("\u{1B}[A", replacementRange: NSRange(location: NSNotFound, length: 0))
 
-        XCTAssertEqual(pressedText, ["\u{1B}[A"])
-        XCTAssertEqual(pressedKeycodes, [], "Direct NSTextInputClient insertText should preserve raw ESC bytes")
+        XCTAssertEqual(rawText, [Data("\u{1B}[A".utf8)])
+        XCTAssertEqual(pressedText, [], "Automation escape payloads should bypass key-event text encoding")
+        XCTAssertEqual(pressedKeycodes, [], "Automation escape payloads should preserve ESC as raw PTY bytes, not Escape key events")
     }
 
     func testAccessibilityValueSanitizesLeadingEscapeSequence() {

--- a/cmuxTests/CJKIMEInputTests.swift
+++ b/cmuxTests/CJKIMEInputTests.swift
@@ -1415,8 +1415,9 @@ final class AccessibilityInsertTextRegressionTests: XCTestCase {
         }
 
         view.insertText("\u{1B}[A", replacementRange: NSRange(location: NSNotFound, length: 0))
+        view.insertText("\u{9B}A", replacementRange: NSRange(location: NSNotFound, length: 0))
 
-        XCTAssertEqual(rawText, [Data("\u{1B}[A".utf8)])
+        XCTAssertEqual(rawText, [Data("\u{1B}[A".utf8), Data("\u{9B}A".utf8)])
         XCTAssertEqual(pressedText, [], "Automation escape payloads should bypass key-event text encoding")
         XCTAssertEqual(pressedKeycodes, [], "Automation escape payloads should preserve ESC as raw PTY bytes, not Escape key events")
     }


### PR DESCRIPTION
## Summary
- add a regression test that captures direct `insertText` payloads starting with ESC routing through Ghostty's raw text path
- route preserved ESC/C1-leading committed text through `ghostty_surface_text` instead of per-scalar key events
- keep accessibility/dictation sanitization on the existing external committed-text path

## Reproduction / evidence
- Issue #2636 reports Claude Code DECRPM/DSR response bytes like `?997;1n` leaking into shell input.
- The Ghostty submodule no longer has the older unsolicited `report_color_scheme` mode-enable send, so this change targets the remaining Swift committed-text routing path described in the issue discussion.
- The first commit is a failing regression test only; the second commit applies the fix.

## Testing
- Not run locally per workspace instruction. HQ should run the dev build with:
  `CMUX_SKIP_ZIG_BUILD=1 ./scripts/reload.sh --tag issue-2636-decrpm-response-leaks-into-shell-input --launch`

Closes #2636

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4819"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782413777&installation_id=133855650&pr_number=4819&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4819&signature=20aa3005d62eed86e050f41d3b58df1b1e8d3822446de956098c8c5b2d500bd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes committed-text routing in the terminal input path; wrong branching could affect automation, IME, or accessibility, but scope is narrow and covered by a targeted regression test.
> 
> **Overview**
> Fixes **terminal response bytes leaking into shell input** when tools call `insertText` with escape-prefixed payloads (e.g. DECRPM/DSR fragments like `?997;1n` from issue #2636).
> 
> Committed text that **starts with ESC (`0x1B`) or C1 CSI (`0x9B`)** and uses the programmatic `preserveLiteralEscape` path now goes through **`ghostty_surface_text`** as a single raw PTY write instead of being split into per-scalar key events (which could surface response bodies as typed characters). **Accessibility/dictation** still use the external path that **strips** leading escape sequences before send.
> 
> A regression test asserts both `\u{1B}[A` and `\u{9B}A` hit the raw-text observer with **no** synthetic key events. DEBUG typing timing for `sendTextToSurface` is logged via **`defer`** so early returns on the raw path are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 600c2de301d0e9ca57ec429860bf0b6877522208. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes DECRPM/DSR response bytes (e.g., `?997;1n`) leaking into shell input by routing ESC/C1-leading `insertText` payloads through Ghostty’s raw text path. Closes #2636.

- **Bug Fixes**
  - Send preserved ESC/C1-leading committed text via `ghostty_surface_text` (raw text), not per-scalar key events; accessibility/dictation sanitization remains to strip injected escapes.
  - Add regression tests for ESC (`0x1B`) and C1 CSI (`0x9B`) to ensure `insertText` is delivered as raw PTY bytes with no key events.

<sup>Written for commit 600c2de301d0e9ca57ec429860bf0b6877522208. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4819?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved text input handling for escape sequences to ensure proper byte transmission in automation scenarios.

* **Tests**
  * Added regression test to verify correct handling of escape sequences during text input operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4819?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->