### PR TITLE
Add cmux.xcworkspace with Packages visible alongside the project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 DerivedData/
 *.xcuserstate
 xcuserdata/
+*.xcworkspace/xcshareddata/
 
 # macOS
 .DS_Store

--- a/cmux.xcworkspace/contents.xcworkspacedata
+++ b/cmux.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:cmux.xcodeproj">
+   </FileRef>
+   <Group
+      location = "container:Packages"
+      name = "Packages">
+      <FileRef
+         location = "group:CMUXAgentLaunch">
+      </FileRef>
+      <FileRef
+         location = "group:CMUXAgentVault">
+      </FileRef>
+      <FileRef
+         location = "group:CMUXAuthCore">
+      </FileRef>
+      <FileRef
+         location = "group:CMUXDebugLog">
+      </FileRef>
+      <FileRef
+         location = "group:CmuxExtensionKit">
+      </FileRef>
+      <FileRef
+         location = "group:CMUXPasteboardFidelity">
+      </FileRef>
+      <FileRef
+         location = "group:CMUXSocketPathDomain">
+      </FileRef>
+      <FileRef
+         location = "group:CMUXWorkstream">
+      </FileRef>
+   </Group>
+</Workspace>


### PR DESCRIPTION
## Summary

- New `cmux.xcworkspace` references `cmux.xcodeproj` plus every `Packages/*` SPM package as siblings, so local packages are editable in the same window without nesting under the project node.
- Additive only. Existing `-project cmux.xcodeproj` flows (`scripts/reload.sh`, CI, `xcodebuild`) keep working unchanged.
- `.gitignore` adds `*.xcworkspace/xcshareddata/` so Xcode's auto-generated `WorkspaceSettings.xcsettings` and `IDEWorkspaceChecks.plist` churn does not leak into commits. Project-level `xcshareddata/xcschemes/` (the three shared schemes) is unaffected because the pattern only matches inside `.xcworkspace` directories.

## Test plan

- [ ] Open `cmux.xcworkspace` in Xcode. Navigator shows `cmux` (the project) and a `Packages` folder at the same indent level. Expanding `Packages` shows each of the 8 local packages.
- [ ] `./scripts/reload.sh --tag verify-workspace` still builds (driven by `-project`, unaffected).
- [ ] `git status` after a clean open shows no untracked / modified files inside `cmux.xcworkspace/xcshareddata/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4834"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782425072&installation_id=133855650&pr_number=4834&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4834&signature=b16c6b6fb1e34f468b0f19d66c464d82b38bb5e7010d52caf533b7a6a2688868"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `cmux.xcworkspace` that references `cmux.xcodeproj` plus all `Packages/*` SPM packages as siblings, so local packages are editable in the same window without nesting. Existing `-project` flows (`scripts/reload.sh`, CI, `xcodebuild`) stay unchanged, and `.gitignore` now ignores `*.xcworkspace/xcshareddata/` to prevent Xcode-generated churn.

<sup>Written for commit 0ba1c63a583f417e0ec007c2140e3dd7ca24c6d2. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4834?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development environment configuration for Xcode workspace setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4834?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->