### PR TITLE
Fix notification ring corner radius

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -633,6 +633,7 @@ private final class WindowTmuxWorkspacePaneOverlayController: NSObject {
     private var installConstraints: [NSLayoutConstraint] = []
     private weak var installedReferenceView: NSView?
     private var lastRenderState: TmuxWorkspacePaneOverlayRenderState?
+    private var lastWindowCornerRadius: CGFloat?
 
     init(window: NSWindow) {
         self.window = window
@@ -641,7 +642,8 @@ private final class WindowTmuxWorkspacePaneOverlayController: NSObject {
                 unreadRects: [],
                 flashRect: nil,
                 flashStartedAt: nil,
-                flashReason: nil
+                flashReason: nil,
+                windowCornerRadius: WindowGlassEffect.windowCornerRadius(for: window)
             )
         )
         super.init()
@@ -690,12 +692,19 @@ private final class WindowTmuxWorkspacePaneOverlayController: NSObject {
     func update(state: TmuxWorkspacePaneOverlayRenderState?) {
         guard ensureInstalled() else { return }
 
-        if state == nil, lastRenderState == nil, containerView.isHidden {
+        let windowCornerRadius = currentWindowCornerRadius()
+        if state == nil,
+           lastRenderState == nil,
+           containerView.isHidden,
+           lastWindowCornerRadius == windowCornerRadius {
             return
         }
-        if let state, state == lastRenderState {
+        if let state,
+           state == lastRenderState,
+           lastWindowCornerRadius == windowCornerRadius {
             return
         }
+        lastWindowCornerRadius = windowCornerRadius
 
         if let state {
             lastRenderState = state
@@ -704,7 +713,8 @@ private final class WindowTmuxWorkspacePaneOverlayController: NSObject {
                 unreadRects: model.unreadRects,
                 flashRect: model.flashRect,
                 flashStartedAt: model.flashStartedAt,
-                flashReason: model.flashReason
+                flashReason: model.flashReason,
+                windowCornerRadius: windowCornerRadius
             )
             containerView.alphaValue = 1
             containerView.isHidden = false
@@ -715,11 +725,17 @@ private final class WindowTmuxWorkspacePaneOverlayController: NSObject {
                 unreadRects: [],
                 flashRect: nil,
                 flashStartedAt: nil,
-                flashReason: nil
+                flashReason: nil,
+                windowCornerRadius: windowCornerRadius
             )
             containerView.alphaValue = 0
             containerView.isHidden = true
         }
+    }
+
+    private func currentWindowCornerRadius() -> CGFloat? {
+        guard let window else { return nil }
+        return WindowGlassEffect.windowCornerRadius(for: window)
     }
 }
 

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -3251,6 +3251,11 @@ struct ContentView: View {
             }
         })
 
+        view = AnyView(view.environment(
+            \.cmuxWindowCornerRadius,
+            observedWindow.flatMap { WindowGlassEffect.windowCornerRadius(for: $0) }
+        ))
+
         view = AnyView(view.ignoresSafeArea())
         view = AnyView(view.sheet(isPresented: $isFeedbackComposerPresented) {
             SidebarFeedbackComposerSheet()

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -11030,7 +11030,6 @@ final class GhosttySurfaceScrollView: NSView {
 
     private enum NotificationRingMetrics {
         static let inset = PanelOverlayRingMetrics.inset
-        static let cornerRadius = PanelOverlayRingMetrics.cornerRadius
         static let lineWidth = PanelOverlayRingMetrics.lineWidth
     }
 
@@ -13924,7 +13923,7 @@ final class GhosttySurfaceScrollView: NSView {
             layer: notificationRingLayer,
             bounds: notificationRingOverlayView.bounds,
             inset: NotificationRingMetrics.inset,
-            radius: NotificationRingMetrics.cornerRadius
+            radius: overlayRingCornerRadius()
         )
     }
 
@@ -13934,7 +13933,7 @@ final class GhosttySurfaceScrollView: NSView {
         switch style {
         case .navigation, .notification:
             inset = NotificationRingMetrics.inset
-            radius = NotificationRingMetrics.cornerRadius
+            radius = overlayRingCornerRadius()
         }
         updateOverlayRingPath(
             layer: flashLayer,
@@ -13942,6 +13941,11 @@ final class GhosttySurfaceScrollView: NSView {
             inset: inset,
             radius: radius
         )
+    }
+
+    private func overlayRingCornerRadius() -> CGFloat {
+        let windowCornerRadius = uiWindow.flatMap { WindowGlassEffect.windowCornerRadius(for: $0) }
+        return PanelOverlayRingMetrics.cornerRadius(forWindowCornerRadius: windowCornerRadius)
     }
 
     private func updateFlashAppearance(style: FlashStyle) {

--- a/Sources/Panels/Panel.swift
+++ b/Sources/Panels/Panel.swift
@@ -211,7 +211,6 @@ enum FocusFlashPattern {
     static let duration: TimeInterval = 0.9
     static let curves: [FocusFlashCurve] = [.easeOut, .easeIn, .easeOut, .easeIn]
     static let ringInset: Double = Double(PanelOverlayRingMetrics.inset)
-    static let ringCornerRadius: Double = Double(PanelOverlayRingMetrics.cornerRadius)
 
     static var segments: [FocusFlashSegment] {
         let stepCount = min(curves.count, values.count - 1, keyTimes.count - 1)

--- a/Sources/Panels/Panel.swift
+++ b/Sources/Panels/Panel.swift
@@ -166,6 +166,11 @@ enum PanelOverlayRingMetrics {
     static let cornerRadius: CGFloat = 6
     static let lineWidth: CGFloat = 2.5
 
+    static func cornerRadius(forWindowCornerRadius windowCornerRadius: CGFloat?) -> CGFloat {
+        guard let windowCornerRadius else { return cornerRadius }
+        return max(0, windowCornerRadius - inset)
+    }
+
     static func pathRect(in bounds: CGRect) -> CGRect {
         bounds.insetBy(dx: inset, dy: inset)
     }

--- a/Sources/Panels/WorkspaceAttentionFlashRingView.swift
+++ b/Sources/Panels/WorkspaceAttentionFlashRingView.swift
@@ -4,12 +4,15 @@ import SwiftUI
 struct WorkspaceAttentionFlashRingView: View {
     let opacity: Double
     var reason: WorkspaceAttentionFlashReason = .navigation
-    @State private var windowCornerRadius: CGFloat?
+    var windowCornerRadius: CGFloat?
+    @Environment(\.cmuxWindowCornerRadius) private var environmentWindowCornerRadius
 
     var body: some View {
         let presentation = WorkspaceAttentionCoordinator.flashStyle(for: reason)
         let color = Color(nsColor: presentation.accent.strokeColor)
-        let cornerRadius = PanelOverlayRingMetrics.cornerRadius(forWindowCornerRadius: windowCornerRadius)
+        let cornerRadius = PanelOverlayRingMetrics.cornerRadius(
+            forWindowCornerRadius: windowCornerRadius ?? environmentWindowCornerRadius
+        )
 
         RoundedRectangle(cornerRadius: cornerRadius)
             .stroke(color.opacity(opacity), lineWidth: PanelOverlayRingMetrics.lineWidth)
@@ -19,14 +22,16 @@ struct WorkspaceAttentionFlashRingView: View {
             )
             .padding(CGFloat(FocusFlashPattern.ringInset))
             .allowsHitTesting(false)
-            .background(WindowAccessor(dedupeByWindow: false) { window in
-                updateWindowCornerRadius(from: window)
-            })
     }
+}
 
-    private func updateWindowCornerRadius(from window: NSWindow) {
-        let radius = WindowGlassEffect.windowCornerRadius(for: window)
-        guard windowCornerRadius != radius else { return }
-        windowCornerRadius = radius
+private struct CmuxWindowCornerRadiusEnvironmentKey: EnvironmentKey {
+    static let defaultValue: CGFloat? = nil
+}
+
+extension EnvironmentValues {
+    var cmuxWindowCornerRadius: CGFloat? {
+        get { self[CmuxWindowCornerRadiusEnvironmentKey.self] }
+        set { self[CmuxWindowCornerRadiusEnvironmentKey.self] = newValue }
     }
 }

--- a/Sources/Panels/WorkspaceAttentionFlashRingView.swift
+++ b/Sources/Panels/WorkspaceAttentionFlashRingView.swift
@@ -1,14 +1,17 @@
+import AppKit
 import SwiftUI
 
 struct WorkspaceAttentionFlashRingView: View {
     let opacity: Double
     var reason: WorkspaceAttentionFlashReason = .navigation
+    @State private var windowCornerRadius: CGFloat?
 
     var body: some View {
         let presentation = WorkspaceAttentionCoordinator.flashStyle(for: reason)
         let color = Color(nsColor: presentation.accent.strokeColor)
+        let cornerRadius = PanelOverlayRingMetrics.cornerRadius(forWindowCornerRadius: windowCornerRadius)
 
-        RoundedRectangle(cornerRadius: CGFloat(FocusFlashPattern.ringCornerRadius))
+        RoundedRectangle(cornerRadius: cornerRadius)
             .stroke(color.opacity(opacity), lineWidth: PanelOverlayRingMetrics.lineWidth)
             .shadow(
                 color: color.opacity(opacity * presentation.glowOpacity),
@@ -16,5 +19,14 @@ struct WorkspaceAttentionFlashRingView: View {
             )
             .padding(CGFloat(FocusFlashPattern.ringInset))
             .allowsHitTesting(false)
+            .background(WindowAccessor(dedupeByWindow: false) { window in
+                updateWindowCornerRadius(from: window)
+            })
+    }
+
+    private func updateWindowCornerRadius(from window: NSWindow) {
+        let radius = WindowGlassEffect.windowCornerRadius(for: window)
+        guard windowCornerRadius != radius else { return }
+        windowCornerRadius = radius
     }
 }

--- a/Sources/TmuxWorkspacePaneOverlayView.swift
+++ b/Sources/TmuxWorkspacePaneOverlayView.swift
@@ -5,6 +5,7 @@ struct TmuxWorkspacePaneOverlayView: View {
     let flashRect: CGRect?
     let flashStartedAt: Date?
     let flashReason: WorkspaceAttentionFlashReason?
+    let windowCornerRadius: CGFloat?
     @State private var completedFlashStartedAt: Date?
 
     var body: some View {
@@ -108,7 +109,9 @@ struct TmuxWorkspacePaneOverlayView: View {
               rect.height > PanelOverlayRingMetrics.inset * 2 else { return nil }
         return Path(
             roundedRect: PanelOverlayRingMetrics.pathRect(in: rect),
-            cornerRadius: PanelOverlayRingMetrics.cornerRadius
+            cornerRadius: PanelOverlayRingMetrics.cornerRadius(
+                forWindowCornerRadius: windowCornerRadius
+            )
         )
     }
 }

--- a/Sources/Windowing/WindowGlassEffect.swift
+++ b/Sources/Windowing/WindowGlassEffect.swift
@@ -478,7 +478,7 @@ enum WindowGlassEffect {
         return -max(0, themeFrame.safeAreaInsets.top)
     }
 
-    private static func windowCornerRadius(for window: NSWindow) -> CGFloat? {
+    static func windowCornerRadius(for window: NSWindow) -> CGFloat? {
         guard window.responds(to: Selector(("_cornerRadius"))) else {
             return nil
         }

--- a/cmuxTests/WindowAndDragTests.swift
+++ b/cmuxTests/WindowAndDragTests.swift
@@ -518,7 +518,6 @@ final class FocusFlashPatternTests: XCTestCase {
         XCTAssertEqual(FocusFlashPattern.duration, 0.9, accuracy: 0.0001)
         XCTAssertEqual(FocusFlashPattern.curves, [.easeOut, .easeIn, .easeOut, .easeIn])
         XCTAssertEqual(FocusFlashPattern.ringInset, Double(PanelOverlayRingMetrics.inset), accuracy: 0.0001)
-        XCTAssertEqual(FocusFlashPattern.ringCornerRadius, Double(PanelOverlayRingMetrics.cornerRadius), accuracy: 0.0001)
     }
 
     func testFocusFlashPatternSegmentsCoverFullDoublePulseTimeline() {

--- a/cmuxTests/WindowAndDragTests.swift
+++ b/cmuxTests/WindowAndDragTests.swift
@@ -495,19 +495,24 @@ final class AppDelegateLaunchServicesRegistrationTests: XCTestCase {
 
 final class FocusFlashPatternTests: XCTestCase {
     func testPanelOverlayRingRadiusTracksInsetWindowCornerRadius() {
+        let radiusBeyondInset: CGFloat = 10
+        let windowRadiusLargerThanInset = PanelOverlayRingMetrics.inset + radiusBeyondInset
         XCTAssertEqual(
-            PanelOverlayRingMetrics.cornerRadius(forWindowCornerRadius: 12),
-            10,
+            PanelOverlayRingMetrics.cornerRadius(forWindowCornerRadius: windowRadiusLargerThanInset),
+            radiusBeyondInset,
             accuracy: 0.0001
         )
+
+        let windowRadiusEqualToInset = PanelOverlayRingMetrics.inset
         XCTAssertEqual(
-            PanelOverlayRingMetrics.cornerRadius(forWindowCornerRadius: 2),
+            PanelOverlayRingMetrics.cornerRadius(forWindowCornerRadius: windowRadiusEqualToInset),
             0,
             accuracy: 0.0001
         )
+
         XCTAssertEqual(
             PanelOverlayRingMetrics.cornerRadius(forWindowCornerRadius: nil),
-            6,
+            PanelOverlayRingMetrics.cornerRadius,
             accuracy: 0.0001
         )
     }

--- a/cmuxTests/WindowAndDragTests.swift
+++ b/cmuxTests/WindowAndDragTests.swift
@@ -494,6 +494,24 @@ final class AppDelegateLaunchServicesRegistrationTests: XCTestCase {
 
 
 final class FocusFlashPatternTests: XCTestCase {
+    func testPanelOverlayRingRadiusTracksInsetWindowCornerRadius() {
+        XCTAssertEqual(
+            PanelOverlayRingMetrics.cornerRadius(forWindowCornerRadius: 12),
+            10,
+            accuracy: 0.0001
+        )
+        XCTAssertEqual(
+            PanelOverlayRingMetrics.cornerRadius(forWindowCornerRadius: 2),
+            0,
+            accuracy: 0.0001
+        )
+        XCTAssertEqual(
+            PanelOverlayRingMetrics.cornerRadius(forWindowCornerRadius: nil),
+            6,
+            accuracy: 0.0001
+        )
+    }
+
     func testFocusFlashPatternMatchesTerminalDoublePulseShape() {
         XCTAssertEqual(FocusFlashPattern.values, [0, 1, 0, 1, 0])
         XCTAssertEqual(FocusFlashPattern.keyTimes, [0, 0.25, 0.5, 0.75, 1])


### PR DESCRIPTION
## Summary
- derive terminal unread notification/flash ring radius from the actual NSWindow corner radius minus the ring inset
- keep the existing 6pt fallback when the window radius is unavailable
- expose the existing window-radius lookup instead of duplicating private KVC access

Fixes #4813

## Testing
- Added regression coverage in a test-only commit before the fix commit, per policy.
- Not run locally per task instructions; CI should run the suite.

## Reproduction
- Reproduced from the failing code path: the terminal ring used the hardcoded 6pt PanelOverlayRingMetrics.cornerRadius while WindowGlassEffect already reads the real NSWindow radius. No cloud Mac video attached because building/launching the app was explicitly reserved for HQ in this task.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4835"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782429362&installation_id=133855650&pr_number=4835&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4835&signature=e9c44e48f8cf6265576f906f8f0cc981d848c4a1cb59a30217a2c62d545553d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized SwiftUI presentation change with a nil fallback to existing ring metrics; no auth, data, or core terminal logic touched in this diff.
> 
> **Overview**
> Fixes workspace attention flash rings not matching the host window’s rounded corners by **threading the real `NSWindow` corner radius** into SwiftUI instead of discovering it per overlay.
> 
> `ContentView` now sets a **`cmuxWindowCornerRadius` environment value** from `WindowGlassEffect.windowCornerRadius(for:)` when the observed window is known. **`WorkspaceAttentionFlashRingView`** uses that value (or an explicit override) with `PanelOverlayRingMetrics.cornerRadius(forWindowCornerRadius:)`, and **drops the `WindowAccessor` + `@State` path** that previously updated radius locally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 610fb88e73f7f68c01910f7cd6fc4ebd4d8b4a21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Derives the notification/flash ring radius from the actual window corner radius minus the ring inset so rings match rounded windows. Keeps the 6pt fallback, passes the radius through environment/overlay state to avoid stateful lookups, and only re-renders when it changes (fixes #4813).

- **Bug Fixes**
  - Compute ring radius via `PanelOverlayRingMetrics.cornerRadius(forWindowCornerRadius:)`, subtracting the inset and clamping at 0.
  - Flow the window corner radius via `EnvironmentValues.cmuxWindowCornerRadius` and overlay render state: `ContentView` sets it, `WorkspaceAttentionFlashRingView` and `TmuxWorkspacePaneOverlayView` consume it; the overlay controller caches `lastWindowCornerRadius` to skip redundant updates.
  - Expose `WindowGlassEffect.windowCornerRadius(for:)` and replace hardcoded 6pt usage in `GhosttyTerminalView`; remove `FocusFlashPattern.ringCornerRadius`. Add tests covering derivation, clamp-to-zero at inset, and the 6pt fallback.

<sup>Written for commit 610fb88e73f7f68c01910f7cd6fc4ebd4d8b4a21. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4835?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Notification, flash, and panel overlay corner radii now adapt dynamically to each window's corner radius for smoother, more consistent visuals.
* **Bug Fixes**
  * Overlay updates now account for changes in window corner radius and avoid unnecessary redraws when nothing else changed, reducing flicker.
* **Tests**
  * New unit tests validate overlay ring radius behavior across varied window corner sizes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4835?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->