### PR TITLE
Add scripts/cleanup-dev-builds.sh for safely reclaiming tagged DerivedData

### DIFF
--- a/.claude/commands/cleanup-builds.md
+++ b/.claude/commands/cleanup-builds.md
@@ -1,0 +1,29 @@
+# Cleanup Dev Builds
+
+Reclaim disk space taken by tagged dev artifacts produced by `./scripts/reload.sh --tag <tag>`. Each tagged build is multi-GB of DerivedData plus per-tag sockets and logs.
+
+## Steps
+
+1. **Preview first.**
+   ```bash
+   ./scripts/cleanup-dev-builds.sh
+   ```
+   Shows what would be deleted, what is skipped, and total reclaimable bytes. Dry-run by default; nothing is deleted yet.
+
+2. **Read the preview to the user.** Confirm the active tag and any tag they care about appears under `skipping:` (running, or most recent reload via `/tmp/cmux-last-cli-path`).
+
+3. **Ask the user before deleting.** Do not run `--apply` without explicit user confirmation. Surface any tags they may want to keep so they can add `--keep <tag>`.
+
+4. **Apply.** Once confirmed:
+   ```bash
+   ./scripts/cleanup-dev-builds.sh --apply
+   ```
+   Optional: `--keep <tag>` (repeatable) to protect specific tags, `--older-than <DAYS>` to skip anything touched recently.
+
+5. **Report.** Show the freed-bytes total from the script's final line.
+
+## Notes
+
+- Safety rules always on: skip running `cmux DEV <tag>` apps, skip the tag in `/tmp/cmux-last-cli-path` (most recent reload).
+- Worktrees existing under HQ are NOT a protection. Use `--keep` for explicit protection.
+- The script never touches `GhosttyKit.xcframework` symlinks, the GhosttyKit cache, or anything outside per-tag artifacts.

--- a/.claude/commands/cleanup-builds.md
+++ b/.claude/commands/cleanup-builds.md
@@ -5,9 +5,11 @@ Reclaim disk space taken by tagged dev artifacts produced by `./scripts/reload.s
 ## Steps
 
 1. **Preview first.**
+
    ```bash
    ./scripts/cleanup-dev-builds.sh
    ```
+
    Shows what would be deleted, what is skipped, and total reclaimable bytes. Dry-run by default; nothing is deleted yet.
 
 2. **Read the preview to the user.** Confirm the active tag and any tag they care about appears under `skipping:` (running, or most recent reload via `/tmp/cmux-last-cli-path`).
@@ -15,9 +17,11 @@ Reclaim disk space taken by tagged dev artifacts produced by `./scripts/reload.s
 3. **Ask the user before deleting.** Do not run `--apply` without explicit user confirmation. Surface any tags they may want to keep so they can add `--keep <tag>`.
 
 4. **Apply.** Once confirmed:
+
    ```bash
    ./scripts/cleanup-dev-builds.sh --apply
    ```
+
    Optional: `--keep <tag>` (repeatable) to protect specific tags, `--older-than <DAYS>` to skip anything touched recently.
 
 5. **Report.** Show the freed-bytes total from the script's final line.

--- a/scripts/cleanup-dev-builds.sh
+++ b/scripts/cleanup-dev-builds.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+# Clean up tagged dev-build artifacts created by scripts/reload.sh.
+#
+# Each `./scripts/reload.sh --tag <tag>` produces:
+#   ~/Library/Developer/Xcode/DerivedData/cmux-<tag>/      (multi-GB)
+#   /tmp/cmux-<tag>/                                       (build scratch)
+#   /tmp/cmux-debug-<tag>.sock                             (control socket)
+#   /tmp/cmux-debug-<tag>.log                              (debug log)
+#   /tmp/cmux-reload-<tag>.log                             (build log)
+#   ~/Library/Application Support/cmux/cmuxd-dev-<tag>.sock (cmuxd socket)
+#
+# This script removes those artifacts for tags that are safe to clean.
+# Safety rules (always on):
+#   - Skip any tag whose `cmux DEV <tag>` app is currently running.
+#   - Skip the tag pointed at by /tmp/cmux-last-cli-path (most recent reload).
+#   - Skip any tag still tied to a git worktree under
+#     cmuxterm-hq/worktrees/<tag>/ (assumes default HQ layout; we look at
+#     `git worktree list` from this checkout's parent repo).
+#
+# Defaults to dry-run. Pass --apply to actually delete.
+#
+# Filters:
+#   --older-than <DAYS>   Only touch tags whose DerivedData mtime is at
+#                         least DAYS days old.
+#   --keep <TAG>          Protect a tag (repeatable).
+#   --apply               Delete instead of preview.
+#
+# Examples:
+#   ./scripts/cleanup-dev-builds.sh
+#   ./scripts/cleanup-dev-builds.sh --older-than 7
+#   ./scripts/cleanup-dev-builds.sh --keep sidebar-lazy --keep txtbox --apply
+
+set -euo pipefail
+
+DERIVED_DATA_ROOT="$HOME/Library/Developer/Xcode/DerivedData"
+APP_SUPPORT_DIR="$HOME/Library/Application Support/cmux"
+LAST_CLI_PATH_FILE="/tmp/cmux-last-cli-path"
+
+apply=0
+older_than_days=0
+keep_tags=()
+
+usage() {
+    awk '/^# / && !/^#!/ {sub(/^# ?/, ""); print; next} /^set -euo/ {exit}' "$0"
+    exit "${1:-0}"
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --apply) apply=1; shift ;;
+        --older-than)
+            older_than_days="${2:?--older-than requires DAYS}"
+            shift 2
+            ;;
+        --keep)
+            keep_tags+=("${2:?--keep requires TAG}")
+            shift 2
+            ;;
+        -h|--help) usage 0 ;;
+        *) echo "unknown arg: $1" >&2; usage 2 ;;
+    esac
+done
+
+# ---- discovery --------------------------------------------------------------
+
+# Tags come from DerivedData dirs named cmux-<tag>. Authoritative because
+# reload.sh always creates one there.
+discover_tags() {
+    [[ -d "$DERIVED_DATA_ROOT" ]] || return 0
+    find "$DERIVED_DATA_ROOT" -maxdepth 1 -type d -name 'cmux-*' -print0 \
+        | xargs -0 -n1 basename \
+        | sed 's/^cmux-//'
+}
+
+artifact_paths_for_tag() {
+    local tag="$1"
+    printf '%s\n' \
+        "$DERIVED_DATA_ROOT/cmux-${tag}" \
+        "/tmp/cmux-${tag}" \
+        "/tmp/cmux-${tag}.tar" \
+        "/tmp/cmux-debug-${tag}.sock" \
+        "/tmp/cmux-debug-${tag}.log" \
+        "/tmp/cmux-reload-${tag}.log" \
+        "$APP_SUPPORT_DIR/cmuxd-dev-${tag}.sock"
+}
+
+bytes_in_path() {
+    local p="$1"
+    [[ -e "$p" || -L "$p" ]] || { echo 0; return; }
+    # du -sk reports KB, portable across macOS and Linux. Convert to bytes.
+    local kb
+    kb="$(du -sk "$p" 2>/dev/null | awk '{print $1}')"
+    [[ -n "$kb" ]] || kb=0
+    echo "$((kb * 1024))"
+}
+
+human_bytes() {
+    local b="$1"
+    awk -v b="$b" 'BEGIN {
+        split("B KB MB GB TB", u);
+        for (i = 1; b >= 1024 && i < 5; i++) b /= 1024;
+        printf "%.1f %s", b, u[i];
+    }'
+}
+
+derived_data_mtime_days() {
+    local p="$1"
+    [[ -e "$p" ]] || { echo -1; return; }
+    local mtime
+    mtime="$(stat -f %m "$p" 2>/dev/null || stat -c %Y "$p" 2>/dev/null)"
+    local now
+    now="$(date +%s)"
+    echo $(( (now - mtime) / 86400 ))
+}
+
+# ---- safety probes ----------------------------------------------------------
+
+# Active tag (most recent reload) per the CLI symlink target.
+active_tag=""
+if [[ -r "$LAST_CLI_PATH_FILE" ]]; then
+    last_path="$(cat "$LAST_CLI_PATH_FILE" 2>/dev/null || true)"
+    if [[ "$last_path" == "$DERIVED_DATA_ROOT/cmux-"* ]]; then
+        rest="${last_path#$DERIVED_DATA_ROOT/cmux-}"
+        active_tag="${rest%%/*}"
+    fi
+fi
+
+# Tags that have a live git worktree. Look from any cmux checkout we can find.
+worktree_tags=()
+worktree_repo=""
+if worktree_repo="$(git -C "$(dirname "$0")/.." rev-parse --show-toplevel 2>/dev/null)"; then
+    while IFS= read -r line; do
+        # `git worktree list --porcelain` lines look like: `worktree /path/to/dir`
+        case "$line" in
+            "worktree "*)
+                p="${line#worktree }"
+                base="$(basename "$p")"
+                # Convention: HQ worktrees live at <root>/worktrees/<branch-slug>.
+                # The branch slug is the same as the reload --tag for slices that
+                # follow the HQ convention. Tags that don't follow are still safe
+                # because we only treat them as protections, not deletions.
+                worktree_tags+=("$base")
+                ;;
+        esac
+    done < <(git -C "$worktree_repo" worktree list --porcelain 2>/dev/null || true)
+fi
+
+# Running cmux DEV processes by tag (the app name embeds the tag).
+running_tags=()
+while IFS= read -r line; do
+    # Match "cmux DEV <tag>" (with or without .app suffix).
+    if [[ "$line" =~ cmux\ DEV\ ([A-Za-z0-9._-]+) ]]; then
+        running_tags+=("${BASH_REMATCH[1]}")
+    fi
+done < <(pgrep -fl "cmux DEV " 2>/dev/null || true)
+
+# ---- planning ---------------------------------------------------------------
+
+contains() {
+    local needle="$1"; shift
+    for x in "$@"; do
+        [[ "$x" == "$needle" ]] && return 0
+    done
+    return 1
+}
+
+declare -a plan_delete=()
+declare -a plan_skip=()
+total_bytes=0
+
+while IFS= read -r tag; do
+    [[ -n "$tag" ]] || continue
+    reasons=()
+
+    if [[ "$tag" == "$active_tag" ]]; then
+        reasons+=("active (most recent reload)")
+    fi
+    if contains "$tag" ${running_tags[@]+"${running_tags[@]}"}; then
+        reasons+=("app running")
+    fi
+    if contains "$tag" ${worktree_tags[@]+"${worktree_tags[@]}"}; then
+        reasons+=("worktree exists")
+    fi
+    if contains "$tag" ${keep_tags[@]+"${keep_tags[@]}"}; then
+        reasons+=("--keep")
+    fi
+    if (( older_than_days > 0 )); then
+        age="$(derived_data_mtime_days "$DERIVED_DATA_ROOT/cmux-${tag}")"
+        if (( age < older_than_days )); then
+            reasons+=("age ${age}d < ${older_than_days}d")
+        fi
+    fi
+
+    tag_bytes=0
+    while IFS= read -r p; do
+        tag_bytes=$(( tag_bytes + $(bytes_in_path "$p") ))
+    done < <(artifact_paths_for_tag "$tag")
+
+    if (( ${#reasons[@]} == 0 )); then
+        plan_delete+=("$tag|$tag_bytes")
+        total_bytes=$(( total_bytes + tag_bytes ))
+    else
+        IFS=, ; reason_str="${reasons[*]}" ; IFS=$' \t\n'
+        plan_skip+=("$tag|$tag_bytes|$reason_str")
+    fi
+done < <(discover_tags | sort)
+
+# ---- output -----------------------------------------------------------------
+
+printf 'cleanup-dev-builds  (mode: %s)\n\n' "$([[ $apply -eq 1 ]] && echo APPLY || echo DRY-RUN)"
+
+if (( ${#plan_skip[@]} > 0 )); then
+    printf 'skipping:\n'
+    for entry in "${plan_skip[@]}"; do
+        IFS='|' read -r tag bytes reason <<< "$entry"
+        printf '  %-40s %10s  (%s)\n' "$tag" "$(human_bytes "$bytes")" "$reason"
+    done
+    echo
+fi
+
+if (( ${#plan_delete[@]} == 0 )); then
+    printf 'nothing to clean.\n'
+    exit 0
+fi
+
+printf 'would delete:\n'
+for entry in "${plan_delete[@]}"; do
+    IFS='|' read -r tag bytes <<< "$entry"
+    printf '  %-40s %10s\n' "$tag" "$(human_bytes "$bytes")"
+done
+printf '\ntotal reclaimable: %s across %d tag(s)\n' "$(human_bytes "$total_bytes")" "${#plan_delete[@]}"
+
+if (( apply == 0 )); then
+    printf '\nDry run. Re-run with --apply to delete.\n'
+    exit 0
+fi
+
+echo
+echo 'applying...'
+for entry in "${plan_delete[@]}"; do
+    IFS='|' read -r tag _ <<< "$entry"
+    while IFS= read -r p; do
+        if [[ -e "$p" || -L "$p" ]]; then
+            rm -rf -- "$p"
+        fi
+    done < <(artifact_paths_for_tag "$tag")
+    printf '  removed: %s\n' "$tag"
+done
+printf '\nfreed: %s\n' "$(human_bytes "$total_bytes")"

--- a/scripts/cleanup-dev-builds.sh
+++ b/scripts/cleanup-dev-builds.sh
@@ -68,9 +68,14 @@ done
 # reload.sh always creates one there.
 discover_tags() {
     [[ -d "$DERIVED_DATA_ROOT" ]] || return 0
-    find "$DERIVED_DATA_ROOT" -maxdepth 1 -type d -name 'cmux-*' -print0 \
-        | xargs -0 -n1 basename \
-        | sed 's/^cmux-//'
+    local d name
+    for d in "$DERIVED_DATA_ROOT"/cmux-*/; do
+        # The glob leaves the literal pattern if no matches exist on macOS.
+        [[ -d "$d" ]] || continue
+        name="${d%/}"
+        name="${name##*/}"
+        printf '%s\n' "${name#cmux-}"
+    done
 }
 
 artifact_paths_for_tag() {
@@ -116,13 +121,14 @@ derived_data_mtime_days() {
 
 # ---- safety probes ----------------------------------------------------------
 
-# Active tag (most recent reload) per the CLI symlink target.
+# Active tag (most recent reload) per the CLI symlink target. Match
+# `/cmux-<tag>/` anywhere in the path so we cover paths under DerivedData,
+# /tmp, or other locations reload.sh may emit.
 active_tag=""
 if [[ -r "$LAST_CLI_PATH_FILE" ]]; then
     last_path="$(cat "$LAST_CLI_PATH_FILE" 2>/dev/null || true)"
-    if [[ "$last_path" == "$DERIVED_DATA_ROOT/cmux-"* ]]; then
-        rest="${last_path#$DERIVED_DATA_ROOT/cmux-}"
-        active_tag="${rest%%/*}"
+    if [[ "$last_path" =~ /cmux-([A-Za-z0-9._-]+)/ ]]; then
+        active_tag="${BASH_REMATCH[1]}"
     fi
 fi
 
@@ -164,7 +170,11 @@ while IFS= read -r tag; do
     fi
     if (( older_than_days > 0 )); then
         age="$(derived_data_mtime_days "$DERIVED_DATA_ROOT/cmux-${tag}")"
-        if (( age < older_than_days )); then
+        # age == -1 means the DerivedData dir is gone (e.g., manually
+        # deleted while orphan sockets/logs remain). Treat as "no age
+        # signal, age filter does not apply" so the residue still gets
+        # cleaned. Otherwise apply the threshold normally.
+        if (( age >= 0 && age < older_than_days )); then
             reasons+=("age ${age}d < ${older_than_days}d")
         fi
     fi
@@ -224,4 +234,8 @@ for entry in "${plan_delete[@]}"; do
     done < <(artifact_paths_for_tag "$tag")
     printf '  removed: %s\n' "$tag"
 done
-printf '\nfreed: %s\n' "$(human_bytes "$total_bytes")"
+# Estimated because total_bytes was measured during planning. If a
+# concurrent process (e.g., Xcode's "Delete Derived Data") removed a
+# planned path between then and now, rm -rf skips it but the byte
+# count still includes those bytes.
+printf '\nfreed (estimated): %s\n' "$(human_bytes "$total_bytes")"

--- a/scripts/cleanup-dev-builds.sh
+++ b/scripts/cleanup-dev-builds.sh
@@ -13,9 +13,10 @@
 # Safety rules (always on):
 #   - Skip any tag whose `cmux DEV <tag>` app is currently running.
 #   - Skip the tag pointed at by /tmp/cmux-last-cli-path (most recent reload).
-#   - Skip any tag still tied to a git worktree under
-#     cmuxterm-hq/worktrees/<tag>/ (assumes default HQ layout; we look at
-#     `git worktree list` from this checkout's parent repo).
+# A worktree merely existing on the same name is not treated as a
+# protection. Use --keep TAG when you want to preserve a build whose
+# worktree you still have around, or --older-than DAYS to skip anything
+# you have touched recently.
 #
 # Defaults to dry-run. Pass --apply to actually delete.
 #
@@ -125,26 +126,6 @@ if [[ -r "$LAST_CLI_PATH_FILE" ]]; then
     fi
 fi
 
-# Tags that have a live git worktree. Look from any cmux checkout we can find.
-worktree_tags=()
-worktree_repo=""
-if worktree_repo="$(git -C "$(dirname "$0")/.." rev-parse --show-toplevel 2>/dev/null)"; then
-    while IFS= read -r line; do
-        # `git worktree list --porcelain` lines look like: `worktree /path/to/dir`
-        case "$line" in
-            "worktree "*)
-                p="${line#worktree }"
-                base="$(basename "$p")"
-                # Convention: HQ worktrees live at <root>/worktrees/<branch-slug>.
-                # The branch slug is the same as the reload --tag for slices that
-                # follow the HQ convention. Tags that don't follow are still safe
-                # because we only treat them as protections, not deletions.
-                worktree_tags+=("$base")
-                ;;
-        esac
-    done < <(git -C "$worktree_repo" worktree list --porcelain 2>/dev/null || true)
-fi
-
 # Running cmux DEV processes by tag (the app name embeds the tag).
 running_tags=()
 while IFS= read -r line; do
@@ -177,9 +158,6 @@ while IFS= read -r tag; do
     fi
     if contains "$tag" ${running_tags[@]+"${running_tags[@]}"}; then
         reasons+=("app running")
-    fi
-    if contains "$tag" ${worktree_tags[@]+"${worktree_tags[@]}"}; then
-        reasons+=("worktree exists")
     fi
     if contains "$tag" ${keep_tags[@]+"${keep_tags[@]}"}; then
         reasons+=("--keep")


### PR DESCRIPTION
## Summary

`./scripts/reload.sh --tag <tag>` produces a multi-GB `DerivedData/cmux-<tag>/` plus per-tag sockets and logs. Across many slices these accumulate fast. On my machine right now: **34.3 GB across 11 tags** safely reclaimable.

This script removes those artifacts for tags the user has explicitly marked done.

## Behavior

Defaults to dry-run. Pass `--apply` to delete.

Cleans for each tag:
- `~/Library/Developer/Xcode/DerivedData/cmux-<tag>/`
- `/tmp/cmux-<tag>/` (build scratch)
- `/tmp/cmux-debug-<tag>.{sock,log}`
- `/tmp/cmux-reload-<tag>.log`
- `~/Library/Application Support/cmux/cmuxd-dev-<tag>.sock`

## Safety rules (always on)

- Skip any tag whose `cmux DEV <tag>` app is currently running
- Skip the tag pointed at by `/tmp/cmux-last-cli-path` (the most recent reload, what `cmux-dev` resolves to)
- Skip any tag tied to a live git worktree (via `git worktree list`)

## Filters

- `--older-than DAYS` (mtime-based)
- `--keep TAG` (repeatable)
- `--apply` (default off; previews otherwise)

## Test plan

- [ ] `./scripts/cleanup-dev-builds.sh` prints a sized preview and exits without changing anything.
- [ ] Currently-running `cmux DEV <tag>` is listed under `skipping:` with reason `app running`.
- [ ] The tag matching `/tmp/cmux-last-cli-path` is listed under `skipping:` with reason `active (most recent reload)`.
- [ ] `--keep <tag>` protects that tag.
- [ ] `--older-than N` only marks tags older than N days for deletion.
- [ ] `--apply` actually deletes and the freed-bytes report matches `du` before/after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4837"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782437398&installation_id=133855650&pr_number=4837&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4837&signature=88c91c636679aed135b80513f652ed9c38469d0f78904a39050e4db026836852"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a safe cleanup script to reclaim disk space from tagged dev builds, plus a `/cleanup-builds` command for guided preview → confirm → apply. It shows reclaimable space, protects active tags, and also cleans orphaned sockets/logs.

- **New Features**
  - Added `scripts/cleanup-dev-builds.sh` to remove per-tag artifacts from `scripts/reload.sh --tag` (e.g., `DerivedData/cmux-<tag>/`, `/tmp/cmux-<tag>/`, per-tag sockets/logs).
  - Defaults to dry-run; use `--apply` to delete. Reports total reclaimable bytes and final "freed (estimated)".
  - Safety: skips running `cmux DEV <tag>` and the tag in `/tmp/cmux-last-cli-path`. Worktrees are not a protection; use `--keep`.
  - Filters: `--older-than DAYS`, `--keep TAG` (repeatable). Orphan sockets/logs are still cleaned even if `DerivedData` was already removed.

<sup>Written for commit 47a6265c3937d10ae3f61aa8c7629431f2d69656. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4837?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a safe cleanup utility for development build artifacts and temporary caches. Runs in dry‑run by default, supports an apply mode, explicit keep rules, and age‑based pruning; skips active or running builds and reports per‑tag reclaimable and freed disk space.
* **Documentation**
  * Added guidance describing the preview→confirm→apply workflow, safety checks, and recommended usage for reclaiming multi‑GB dev artifacts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4837?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->