### PR TITLE
security(ci): fix script injection in update-homebrew.yml workflow

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -25,12 +25,16 @@ jobs:
     steps:
       - name: Get version
         id: version
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [ -n "${{ github.event.inputs.version }}" ]; then
-            VERSION="${{ github.event.inputs.version }}"
+          if [ -n "${INPUT_VERSION}" ]; then
+            VERSION="${INPUT_VERSION}"
           else
             # workflow_run: extract tag from the triggering workflow's head branch
-            VERSION="${{ github.event.workflow_run.head_branch }}"
+            VERSION="${HEAD_BRANCH}"
           fi
           VERSION="${VERSION#v}"
           if [ -z "$VERSION" ]; then
@@ -38,7 +42,7 @@ jobs:
             exit 1
           fi
           if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
               echo "Invalid version: ${VERSION}" >&2
               exit 1
             fi


### PR DESCRIPTION
﻿## Summary

- **What changed**: Moved GitHub Actions expression interpolations (${{ github.event.inputs.version }}, ${{ github.event.workflow_run.head_branch }}, ${{ github.event_name }}) from the shell un: block into the step's env: variables in .github/workflows/update-homebrew.yml.
- **Why**: The previous pattern directly interpolated user-controlled workflow_dispatch inputs into shell commands, creating a script injection vulnerability. Any collaborator with workflow_dispatch trigger permission could supply a crafted version string that executes arbitrary shell commands in the Actions runner with access to repository secrets. By moving the expressions to env:, the shell receives plain variable references instead of template-substituted strings, eliminating the injection vector.

## Testing

- Verified the YAML syntax remains valid.
- Confirmed the env: variables are referenced correctly in the un: block.
- The workflow logic is unchanged; only the data flow is hardened.

## Demo Video

N/A — Infrastructure security fix with no UI or behavioral changes.

## Related Issue

Closes #386

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4840"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782445412&installation_id=133855650&pr_number=4840&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4840&signature=4e6ab8d497ba1b2a7ac2b4aac73bd60e3d67f13a56d47584d25afa5183f7f68e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent script injection in `.github/workflows/update-homebrew.yml` by moving `${{ ... }}` expressions into step `env` vars (`INPUT_VERSION`, `HEAD_BRANCH`, `EVENT_NAME`) and using those in the `run` script. Blocks command execution via `workflow_dispatch` inputs without changing behavior; closes #386.

<sup>Written for commit e446355c757f90874c391066924a8ef402ca5a49. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4840?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Homebrew release automation to better handle version extraction and validation during the macOS app release process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4840?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->