### PR TITLE
security(ci): gate self-hosted jobs to base-repo PRs only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,7 @@ jobs:
 
   tests:
     runs-on: warp-macos-15-arm64-6x
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 75
     env:
       CMUX_SKIP_ZIG_BUILD: "1"
@@ -387,6 +388,7 @@ jobs:
     # and performance regressions stay isolated. Broader interactive UI suites
     # still run via test-e2e.yml on GitHub-hosted runners.
     runs-on: warp-macos-15-arm64-6x
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 20
     steps:
       - name: Checkout
@@ -573,6 +575,7 @@ jobs:
     # signing, notarization, and publishing. This catches DEBUG/Release boundary
     # mistakes before they reach main.
     runs-on: warp-macos-26-arm64-6x
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 20
     steps:
       - name: Checkout
@@ -656,6 +659,7 @@ jobs:
 
   ui-regressions:
     runs-on: warp-macos-15-arm64-6x
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 25
     steps:
       - name: Checkout


### PR DESCRIPTION
﻿## Summary

- **What changed**: Added if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository guards to all four self-hosted (WarpBuild) jobs in .github/workflows/ci.yml (	ests, 	ests-build-and-lag, elease-build, ui-regressions).
- **Why**: Fork pull requests currently trigger these jobs on self-hosted macOS runners. An attacker could open a fork PR that modifies workflow steps or build scripts to execute arbitrary commands on the build machine, potentially accessing signing keys, credentials, or internal infrastructure. The guard skips these jobs when the PR originates from a fork, closing the attack surface while preserving CI for internal PRs.

## Testing

- Verified YAML syntax remains valid.
- Confirmed the if expression is placed immediately after uns-on in each affected job.
- Logic tested: non-PR triggers (push, workflow_dispatch) are unaffected; base-repo PRs continue to run; fork PRs are skipped.

## Demo Video

N/A — Infrastructure security fix with no UI or behavioral changes.

## Related Issue

Closes #385

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4841"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782445892&installation_id=133855650&pr_number=4841&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4841&signature=841752f2daabebd439755924889467bb07713a1709abfe53963bbbf123abba93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gated all self-hosted macOS CI jobs (tests, tests-build-and-lag, release-build, ui-regressions) to run only on base-repo PRs and non-PR events via an `if` check in `.github/workflows/ci.yml`. This blocks fork PRs from executing on our runners and protects secrets. Closes #385.

<sup>Written for commit 6f0a2af42dbe327652c85ce6586c8a0838b03459. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4841?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to optimize build processes and improve efficiency for different types of pull requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4841?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->