### PR TITLE
docs: add ADE workflow guide for sidebar and worktree setup

### DIFF
--- a/docs/ade-workflows.md
+++ b/docs/ade-workflows.md
@@ -1,0 +1,118 @@
+# Agent ADE Workflows with cmux
+
+This guide explains how to replicate the agent-driven engineering (ADE) workflow—used by tools like Claude Code, Codex, and OpenCode—inside cmux. The goal is a single primary checkout plus per-task worktrees, with each agent session organized in the sidebar.
+
+## Recommended repo layout
+
+```
+~/repos/my-project/          # primary checkout (bare or regular clone)
+├── main/                    # main worktree tracking origin/main
+├── task-42-fix-auth/        # worktree for authentication bugfix
+├── task-43-refactor-db/     # worktree for database refactor
+└── ...
+```
+
+Each worktree is an isolated working directory that shares the same `.git` object store, so branching, stashing, and history are cheap.
+
+## Creating a worktree and opening it in cmux
+
+1. Create the worktree from your primary checkout:
+
+   ```bash
+   cd ~/repos/my-project
+   git worktree add task-44-add-metrics origin/main
+   cd task-44-add-metrics
+   ```
+
+2. Open the directory in cmux:
+
+   ```bash
+   cmux new-workspace --name "my-project#44" --directory "$PWD"
+   ```
+
+   The workspace name appears in the sidebar. Use the `#<task>` suffix to keep the mapping obvious.
+
+3. Start your agent in that workspace:
+
+   ```bash
+   claude  # or codex, opencode, etc.
+   ```
+
+   The agent session runs in the worktree directory, and cmux sidebar shows the branch, working directory, and any notifications.
+
+## Organizing per-agent or per-task sessions in the sidebar
+
+Use cmux workspaces as the top-level unit of organization:
+
+- One workspace per task/worktree.
+- Name pattern: `<repo>#<issue>` or `<repo>-<brief-desc>`.
+- Use workspace colors (`cmux themes set --workspace <ref> --color <hex>`) to visually group related tasks.
+
+If you run multiple agents in parallel (e.g., Claude on one task and Codex on another), split the workspace (`Cmd+D`) and launch each agent in its own pane. Each pane gets its own sidebar metadata and notification ring.
+
+## Comparison with fully automated ADEs
+
+Fully automated ADEs (e.g., some cloud-based agent platforms) handle worktree provisioning for you:
+
+| Aspect | Fully automated ADE | cmux manual workflow |
+|--------|---------------------|----------------------|
+| Worktree creation | Automatic per task | `git worktree add` |
+| Session isolation | VM or container | cmux workspace + pane |
+| Sidebar metadata | Platform-specific UI | cmux native sidebar (branch, PR, cwd, ports) |
+| Notification routing | Platform-specific | cmux native notification rings |
+| Cleanup | Automatic on task close | Manual `git worktree remove` |
+
+The manual workflow trades one-click provisioning for full control: you choose when to branch, when to merge, and which tools to run.
+
+## Current manual steps versus future automation
+
+**Manual today:**
+1. `git worktree add <path> <branch>`
+2. `cmux new-workspace --name ... --directory ...`
+3. Start agent CLI manually.
+4. `git worktree remove <path>` when done.
+
+**Future automation (planned):**
+- Native `cmux worktree` commands to create/remove worktrees and workspaces in one step.
+- Agent hook auto-detection to spawn a new workspace when an agent session starts.
+- Vault integration to persist and resume agent sessions across worktrees.
+
+See related tracking issues:
+- [#3414](https://github.com/manaflow-ai/cmux/issues/3414)
+- [#4221](https://github.com/manaflow-ai/cmux/issues/4221)
+
+## Cleanup and recovery
+
+**Remove a stale worktree:**
+
+```bash
+cd ~/repos/my-project
+git worktree remove task-44-add-metrics
+```
+
+If the directory was deleted without `git worktree remove`, prune it:
+
+```bash
+git worktree prune
+```
+
+**Close the cmux workspace:**
+
+```bash
+cmux close-workspace --workspace workspace:<id>
+```
+
+Or use `Cmd+Shift+W` in the UI.
+
+**Recover a lost session:**
+
+If cmux crashed or was force-quit, use `File > Reopen Previous Session` (`Cmd+Shift+O`) to restore the last saved layout. Worktrees themselves are ordinary Git working directories and are unaffected by cmux state.
+
+## Quick-start checklist
+
+- [ ] Clone or initialize a primary repo checkout.
+- [ ] Create a worktree for the next task: `git worktree add ...`.
+- [ ] Open it in cmux: `cmux new-workspace --directory ...`.
+- [ ] Start the agent CLI in the workspace pane.
+- [ ] Observe sidebar metadata (branch, PR, cwd, ports).
+- [ ] Close and clean up when done: `git worktree remove ...` + `cmux close-workspace ...`.


### PR DESCRIPTION
﻿## Summary

- **What changed**: Added a new documentation page docs/ade-workflows.md that explains how to set up and use cmux for agent-driven engineering (ADE) workflows.
- **Why**: Users coming from agent ADEs expect documented guidance on opening a repo, creating per-task worktrees, and organizing each agent/session in the cmux sidebar. This page provides a clear mental model and copy-pasteable commands.

## Changes

- docs/ade-workflows.md (new file)
  - Recommended repo layout: primary checkout plus task worktrees
  - Step-by-step guide to create a worktree and open it in cmux
  - Sidebar organization tips (naming, colors, splits)
  - Comparison table: fully automated ADEs vs cmux manual workflow
  - Current manual steps vs planned future automation
  - Cleanup and recovery steps for stale worktrees or sessions
  - Quick-start checklist

## Testing

- Verified the Markdown renders correctly.
- All commands and paths were sanity-checked against cmux CLI conventions.

## Related Issue

Closes #4235

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4842"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782446266&installation_id=133855650&pr_number=4842&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4842&signature=f67b0628a00b67dea50594e6620220b95f5f322542d1a0b48dd5284d94f3aa89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `docs/ade-workflows.md`: a step-by-step guide to run ADE-style workflows in `cmux` using per-task Git worktrees and organized sidebar sessions.
Covers repo layout, commands to create/open worktrees in `cmux`, naming/color tips, cleanup and recovery, and a brief comparison to fully automated ADEs with notes on current manual steps vs planned automation.

<sup>Written for commit 000aa139da4c83243ebaa3ecbbdbea663aeb59ad. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4842?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive guide for implementing manual agent-driven engineering workflows with cmux and Git worktrees
  * Covers recommended repository layouts, workspace organization conventions, and step-by-step setup instructions
  * Includes procedures for cleanup and recovery, plus comparison with automated ADE platforms
  * Features a quick-start checklist for easy reference

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4842?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->