### PR TITLE
docs(wrappers): document Claude wrapper and add activation notice

### DIFF
--- a/Resources/bin/claude
+++ b/Resources/bin/claude
@@ -421,6 +421,8 @@ fi
 unset CLAUDECODE
 clear_inherited_claude_auth_selection_env
 
+echo "[cmux] Using Claude wrapper with session hooks — disable with CMUX_CLAUDE_HOOKS_DISABLED=1" >&2
+
 # Check if the user already specified a session/resume flag.
 # If so, don't inject our own --session-id (it would conflict).
 SKIP_SESSION_ID=false

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -113,7 +113,24 @@ Global hooks from `~/.config/cmux/cmux.json` run first. Project hooks from paren
 
 ### Claude Code
 
-See the [Claude Code documentation](https://docs.anthropic.com/en/docs/claude-code) for hook configuration.
+When you run `claude` inside a cmux terminal, cmux automatically intercepts the invocation via a PATH wrapper (`Resources/bin/claude`). The wrapper injects `--settings` with hooks for session lifecycle and notification events, and generates a `--session-id` so cmux can track and resume the session.
+
+Hooks injected automatically:
+- `SessionStart`, `Stop`, `SessionEnd` — lifecycle tracking
+- `Notification` — forward Claude notifications to cmux
+- `UserPromptSubmit` — update sidebar status to "Running"
+- `PreToolUse` — guard unsupported cron requests and capture status
+- `PermissionRequest` — Feed approval bridge
+
+To disable the wrapper and run the real `claude` binary directly:
+
+```bash
+CMUX_CLAUDE_HOOKS_DISABLED=1 claude
+```
+
+Outside cmux terminals, the wrapper passes through to the real binary unchanged.
+
+See the [Claude Code documentation](https://docs.anthropic.com/en/docs/claude-code) for additional hook configuration.
 
 ### GitHub Copilot CLI
 


### PR DESCRIPTION
﻿## Summary

- **What changed**: Documented the cmux Claude wrapper behavior and added a visible activation notice.
- **Why**: The wrapper automatically intercepts claude invocations inside cmux terminals to inject session hooks and --session-id, but this behavior was previously undocumented. Users should know that a transparent layer sits between their shell and the official Claude binary.

## Changes

- Resources/bin/claude
  - Added stderr notice when the wrapper activates: [cmux] Using Claude wrapper with session hooks — disable with CMUX_CLAUDE_HOOKS_DISABLED=1
- docs/notifications.md
  - Expanded the "Claude Code" section to explain automatic hook injection
  - Listed the injected hooks (SessionStart, Stop, SessionEnd, Notification, UserPromptSubmit, PreToolUse, PermissionRequest)
  - Documented how to disable the wrapper (CMUX_CLAUDE_HOOKS_DISABLED=1)
  - Clarified that outside cmux terminals the wrapper passes through unchanged

## Testing

- Verified the wrapper script syntax remains valid bash.
- Confirmed the notice is emitted to stderr so it does not interfere with stdout pipelines.

## Related Issue

Closes #2140

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4844"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782446493&installation_id=133855650&pr_number=4844&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4844&signature=5a0460de240052e788fbd8c5c215c28ca7e32fc0680c232f17c8a31cd32161ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an activation notice to the `claude` wrapper inside `cmux` terminals and documents the wrapper’s automatic hook injection. The notice is printed to stderr; docs explain injected hooks and `--session-id`, how to disable with `CMUX_CLAUDE_HOOKS_DISABLED=1`, and that outside `cmux` terminals it passes through.

<sup>Written for commit e7bb4f60b40bb052e1f065f6fa07c4e1689e0a62. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4844?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stderr notification when Claude session hooks are enabled, with instructions to disable via `CMUX_CLAUDE_HOOKS_DISABLED=1` environment variable.

* **Documentation**
  * Enhanced Claude Code integration documentation with details on session lifecycle management, hook injection, and bypass options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4844?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->