### PR TITLE
docs(readme): document Claude wrapper behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,25 @@ Grok, OpenCode, Pi, Amp, Cursor CLI, Gemini, Rovo Dev, Copilot, CodeBuddy,
 Factory, and Qoder. Claude Code is handled by the cmux Claude wrapper when Claude
 integration is enabled in Settings.
 
+### Claude Code wrapper
+
+When you run `claude` inside a cmux terminal, cmux's PATH wrapper (`Resources/bin/claude`) automatically intercepts the invocation to inject session hooks and a generated `--session-id`. This provides zero-config integration for notifications, sidebar status, and session resume.
+
+Injected hooks:
+- `SessionStart`, `Stop`, `SessionEnd` — lifecycle tracking
+- `Notification` — forward Claude notifications to cmux
+- `UserPromptSubmit` — update sidebar status to "Running"
+- `PreToolUse` — guard unsupported cron requests and capture status
+- `PermissionRequest` — Feed approval bridge
+
+To disable the wrapper and run the real `claude` binary directly:
+
+```bash
+CMUX_CLAUDE_HOOKS_DISABLED=1 claude
+```
+
+Outside cmux terminals, the wrapper passes through to the real binary unchanged.
+
 Advanced users and integrations can attach a custom resume command to the
 current terminal surface. This is useful for tools with their own durable state,
 such as tmux sessions or custom agent CLIs:


### PR DESCRIPTION
﻿## Summary

- **What changed**: Added a "Claude Code wrapper" subsection to the README under "Session restore".
- **Why**: The wrapper automatically intercepts claude invocations inside cmux terminals, but this behavior was not documented in the README. Users should understand the transparent layer and how to disable it.

## Changes

- README.md
  - Added "Claude Code wrapper" subsection explaining automatic hook injection
  - Listed the injected hooks (SessionStart, Stop, SessionEnd, Notification, UserPromptSubmit, PreToolUse, PermissionRequest)
  - Documented how to disable the wrapper (CMUX_CLAUDE_HOOKS_DISABLED=1)
  - Clarified that outside cmux terminals the wrapper passes through unchanged

## Related Issue

Refs #2140

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4846"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782446799&installation_id=133855650&pr_number=4846&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4846&signature=5f5d64ab5c4bc2813c2e5f65e168bbe7b66efdb64d35a565b4b82aae26beb3d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented the `claude` PATH wrapper in the README: how it injects session hooks and a generated `--session-id` in `cmux` terminals for zero-config notifications/status/resume, and how to disable via `CMUX_CLAUDE_HOOKS_DISABLED=1`. Clarifies that outside `cmux` terminals the wrapper passes through to the real binary. Refs #2140.

<sup>Written for commit e4164f503a2f8a102919ecf5d63220254238ff51. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4846?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added detailed documentation for the Claude Code wrapper, explaining how it intercepts and enhances command execution within terminal sessions by injecting session hooks. Includes information about available hook types and how to disable the wrapper using an environment variable to run the standard binary directly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4846?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->