### PR TITLE
Improve OpenCode hook detail rendering

### DIFF
--- a/CLI/CMUXCLI+AgentHookDefinitions.swift
+++ b/CLI/CMUXCLI+AgentHookDefinitions.swift
@@ -155,7 +155,10 @@ extension CMUXCLI {
             configDir: ".config/opencode", configFile: "plugins/cmux-session.js", configDirEnvOverride: "OPENCODE_CONFIG_DIR",
             sessionStoreSuffix: "opencode", disableEnvVar: "CMUX_OPENCODE_HOOKS_DISABLED",
             hookMarker: "cmux hooks opencode", format: .flat,
-            events: []
+            events: [],
+            // OpenCode completion notifications are owned by cmux-feed.js.
+            // This session plugin only owns session restore and status.
+            publishesStopNotification: false
         ),
         AgentHookDef(
             name: "pi", displayName: "Pi", statusKey: "pi",

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -17527,6 +17527,7 @@ struct CMUXCLI {
     private static let omoPluginName = "oh-my-openagent"
     private static let legacyOmoPluginName = "oh-my-opencode"
     private static let openCodeSessionPluginConfigSpec = "./plugins/cmux-session.js"
+    private static let openCodeFeedPluginConfigSpec = "./plugins/cmux-feed.js"
 
     private func resolveExecutableInPath(_ name: String) -> String? {
         let entries = ProcessInfo.processInfo.environment["PATH"]?.split(separator: ":").map(String.init) ?? []
@@ -17709,10 +17710,10 @@ struct CMUXCLI {
         return UInt16(bigEndian: boundAddress.sin_port)
     }
 
-    private func omoResolvedPort(
+    private func omoConfiguredPort(
         commandArgs: [String],
         processEnvironment: [String: String]
-    ) -> String {
+    ) -> String? {
         if let requestedPort = omoRequestedPort(from: commandArgs) {
             return requestedPort
         }
@@ -17724,16 +17725,7 @@ struct CMUXCLI {
            omoBindableLoopbackPort(parsedEnvironmentPort) != nil {
             return environmentPort
         }
-
-        if let preferredPort = omoBindableLoopbackPort(4096) {
-            return String(preferredPort)
-        }
-
-        if let fallbackPort = omoBindableLoopbackPort(0) {
-            return String(fallbackPort)
-        }
-
-        return "4096"
+        return nil
     }
 
     /// Creates a shadow config directory that layers oh-my-openagent on top of the user's
@@ -17761,7 +17753,7 @@ struct CMUXCLI {
         }
 
         var plugins = Self.openCodePluginListNormalizingOMOPlugin(
-            Self.openCodePluginListRemovingSessionPlugin((config["plugin"] as? [Any]) ?? [])
+            Self.openCodePluginListRemovingCMUXPlugins((config["plugin"] as? [Any]) ?? [])
         )
         if !Self.openCodePluginListContains(plugins, spec: Self.omoPluginName, allowVersionSuffix: true) {
             plugins.append(Self.omoPluginName)
@@ -17915,8 +17907,14 @@ struct CMUXCLI {
         socketPath: String,
         explicitPassword: String?,
         focusedContext: TmuxCompatFocusedContext?,
-        openCodePort: String
+        openCodePort: String?
     ) {
+        var extraEnvVars: [(key: String, value: String)] = [
+            (key: "CMUX_OPENCODE_CMUX_BIN", value: executablePath),
+        ]
+        if let openCodePort {
+            extraEnvVars.append((key: "OPENCODE_PORT", value: openCodePort))
+        }
         configureTmuxCompatEnvironment(
             processEnvironment: processEnvironment,
             shimDirectory: shimDirectory,
@@ -17927,10 +17925,7 @@ struct CMUXCLI {
             tmuxPathPrefix: "cmux-omo",
             cmuxBinEnvVar: "CMUX_OMO_CMUX_BIN",
             termOverrideEnvVar: "CMUX_OMO_TERM",
-            extraEnvVars: [
-                (key: "OPENCODE_PORT", value: openCodePort),
-                (key: "CMUX_OPENCODE_CMUX_BIN", value: executablePath),
-            ]
+            extraEnvVars: extraEnvVars
         )
     }
 
@@ -17971,11 +17966,15 @@ struct CMUXCLI {
             processEnvironment: launcherEnvironment,
             explicitPassword: explicitPassword
         )
-        let openCodePort = omoResolvedPort(
+        let openCodePort = omoConfiguredPort(
             commandArgs: commandArgs,
             processEnvironment: launcherEnvironment
         )
-        launcherEnvironment["OPENCODE_PORT"] = openCodePort
+        if let openCodePort {
+            launcherEnvironment["OPENCODE_PORT"] = openCodePort
+        } else {
+            launcherEnvironment.removeValue(forKey: "OPENCODE_PORT")
+        }
         configureOMOEnvironment(
             processEnvironment: launcherEnvironment,
             shimDirectory: shimDirectory,
@@ -17987,11 +17986,10 @@ struct CMUXCLI {
         )
 
         let launchPath = openCodeExecutablePath ?? "opencode"
-        // oh-my-openagent needs the OpenCode API server running to attach
-        // subagent sessions to tmux panes. Prefer the historic default port
-        // when it is available, otherwise fall back to a free loopback port.
+        // Keep OpenCode on its random loopback port unless the caller supplied
+        // a port explicitly through args or OPENCODE_PORT.
         var effectiveArgs = commandArgs
-        if omoRequestedPort(from: commandArgs) == nil {
+        if let openCodePort, omoRequestedPort(from: commandArgs) == nil {
             effectiveArgs.append("--port")
             effectiveArgs.append(openCodePort)
         }
@@ -23704,10 +23702,18 @@ export default CMUXSessionRestore;
             guard let value else { return false }
             if value == spec { return true }
             if allowVersionSuffix, value.hasPrefix("\(spec)@") { return true }
+            let managedFileName: String?
             if spec == Self.openCodeSessionPluginConfigSpec {
-                return value == "./plugins/\(Self.openCodeSessionPluginFilename)"
-                    || value.hasSuffix("/plugins/\(Self.openCodeSessionPluginFilename)")
-                    || value.hasSuffix("/\(Self.openCodeSessionPluginFilename)")
+                managedFileName = Self.openCodeSessionPluginFilename
+            } else if spec == Self.openCodeFeedPluginConfigSpec {
+                managedFileName = Self.openCodePluginFileName
+            } else {
+                managedFileName = nil
+            }
+            if let managedFileName {
+                return value == "./plugins/\(managedFileName)"
+                    || value.hasSuffix("/plugins/\(managedFileName)")
+                    || value.hasSuffix("/\(managedFileName)")
             }
             return false
         }
@@ -23810,16 +23816,21 @@ export default CMUXSessionRestore;
         return normalized
     }
 
-    private static func openCodePluginListRemovingSessionPlugin(_ plugins: [Any]) -> [Any] {
-        plugins.filter { entry in
-            guard let value = (entry as? String) ?? ((entry as? [Any])?.first as? String) else {
+    private static func openCodePluginEntryIsManagedCMUXPlugin(_ entry: Any) -> Bool {
+        guard let value = (entry as? String) ?? ((entry as? [Any])?.first as? String) else {
+            return false
+        }
+        for spec in [openCodeSessionPluginConfigSpec, openCodeFeedPluginConfigSpec] {
+            if openCodePluginListContains([value], spec: spec) {
                 return true
             }
-            return value != Self.openCodeSessionPluginConfigSpec
-                && value != "cmux-session"
-                && value != "./plugins/\(Self.openCodeSessionPluginFilename)"
-                && !value.hasSuffix("/plugins/\(Self.openCodeSessionPluginFilename)")
-                && !value.hasSuffix("/\(Self.openCodeSessionPluginFilename)")
+        }
+        return value == "cmux-session" || value == "cmux-feed"
+    }
+
+    private static func openCodePluginListRemovingCMUXPlugins(_ plugins: [Any]) -> [Any] {
+        plugins.filter { entry in
+            !openCodePluginEntryIsManagedCMUXPlugin(entry)
         }
     }
 
@@ -23832,8 +23843,12 @@ export default CMUXSessionRestore;
         } else {
             config = [:]
         }
-        var plugins = Self.openCodePluginListRemovingSessionPlugin((config["plugin"] as? [Any]) ?? [])
-        if shouldInstall, !Self.openCodePluginListContains(plugins, spec: Self.openCodeSessionPluginConfigSpec) { plugins.append(Self.openCodeSessionPluginConfigSpec) }
+        var plugins = Self.openCodePluginListRemovingCMUXPlugins((config["plugin"] as? [Any]) ?? [])
+        if shouldInstall {
+            for spec in [Self.openCodeSessionPluginConfigSpec, Self.openCodeFeedPluginConfigSpec] where !Self.openCodePluginListContains(plugins, spec: spec) {
+                plugins.append(spec)
+            }
+        }
         config["plugin"] = plugins
         let output = try JSONSerialization.data(withJSONObject: config, options: [.prettyPrinted, .sortedKeys])
         if existingData == output { return false }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -113908,6 +113908,23 @@
         }
       }
     },
+    "feed.permission.doomLoop": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continue after repeated failures"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "繰り返し失敗しても続行"
+          }
+        }
+      }
+    },
     "feed.exitplan.bypass": {
       "extractionState": "manual",
       "localizations": {
@@ -114244,6 +114261,74 @@
           "stringUnit": {
             "state": "translated",
             "value": "Claudeへ送信"
+          }
+        }
+      }
+    },
+    "feed.stop.labelForSource": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ finished, reply to continue"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@が完了しました。続行するには返信してください"
+          }
+        }
+      }
+    },
+    "feed.stop.placeholderForSource": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reply to %@..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@への返信..."
+          }
+        }
+      }
+    },
+    "feed.stop.sendForSource": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Send to %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@へ送信"
+          }
+        }
+      }
+    },
+    "feed.source.opencode": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OpenCode"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OpenCode"
           }
         }
       }
@@ -114996,6 +115081,210 @@
         }
       }
     },
+    "feed.notification.permission.bash": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shell command"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "シェルコマンド"
+          }
+        }
+      }
+    },
+    "feed.notification.permission.edit": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edit file"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ファイルを編集"
+          }
+        }
+      }
+    },
+    "feed.notification.permission.write": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Write file"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ファイルを書き込み"
+          }
+        }
+      }
+    },
+    "feed.notification.permission.patch": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Patch file"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ファイルにパッチを適用"
+          }
+        }
+      }
+    },
+    "feed.notification.permission.read": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Read file"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ファイルを読み取り"
+          }
+        }
+      }
+    },
+    "feed.notification.permission.searchFiles": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search files"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ファイルを検索"
+          }
+        }
+      }
+    },
+    "feed.notification.permission.list": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "List directory"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ディレクトリを一覧表示"
+          }
+        }
+      }
+    },
+    "feed.notification.permission.task": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Task request"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タスクのリクエスト"
+          }
+        }
+      }
+    },
+    "feed.notification.permission.webfetch": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fetch URL"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URLを取得"
+          }
+        }
+      }
+    },
+    "feed.notification.permission.websearch": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Web search"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Web検索"
+          }
+        }
+      }
+    },
+    "feed.notification.permission.lsp": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Language server request"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "言語サーバーのリクエスト"
+          }
+        }
+      }
+    },
+    "feed.notification.permission.externalDirectory": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Access external directory"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "外部ディレクトリにアクセス"
+          }
+        }
+      }
+    },
     "feed.notification.decisionNeeded": {
       "extractionState": "manual",
       "localizations": {
@@ -115077,6 +115366,57 @@
           "stringUnit": {
             "state": "translated",
             "value": "エージェントが質問しています"
+          }
+        }
+      }
+    },
+    "feed.notification.stop.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ completed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@が完了しました"
+          }
+        }
+      }
+    },
+    "feed.notification.stop.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Completed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完了"
+          }
+        }
+      }
+    },
+    "feed.notification.stop.body": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ session completed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@のセッションが完了しました"
           }
         }
       }

--- a/Resources/opencode-plugin.js
+++ b/Resources/opencode-plugin.js
@@ -12,12 +12,23 @@ const DEFAULT_SOCKET = `${os.homedir()}/.config/cmux/cmux.sock`;
 const SOCKET_PATH = process.env.CMUX_SOCKET_PATH || DEFAULT_SOCKET;
 const REPLY_TIMEOUT_MS = 120_000;
 const MAX_PLAN_BYTES = 128 * 1024;
+const MAX_SESSION_STATES = 300;
+const MAX_TELEMETRY_OUTBOX = 128;
+const MAX_REPLY_OUTBOX = 32;
+const TELEMETRY_RECONNECT_MS = 250;
 
 export const CMUXFeed = async (ctx) => {
   let client = null;
+  let clientReady = false;
+  let lastTelemetryConnectAttempt = 0;
   let buffered = "";
+  const telemetryOutbox = [];
+  const replyOutbox = [];
   const pending = new Map();
   const messageRoles = new Map();
+  const messagePartText = new Map();
+  const messagePartTypes = new Map();
+  const messageText = new Map();
   const sessions = new Map();
 
   const isObject = (value) => value && typeof value === "object" && !Array.isArray(value);
@@ -36,16 +47,175 @@ export const CMUXFeed = async (ctx) => {
     return normalized.length > max ? `${normalized.slice(0, max - 3)}...` : normalized;
   };
 
+  const stringList = (value) => {
+    if (!Array.isArray(value)) return [];
+    return value
+      .map((item) => typeof item === "string" ? item.trim() : "")
+      .filter(Boolean);
+  };
+
+  const pathWithoutWildcardTail = (value) => {
+    const text = firstString(value) || "";
+    const wildcard = text.search(/[*?{[]/);
+    return (wildcard >= 0 ? text.slice(0, wildcard) : text).replace(/[\\/]+$/, "");
+  };
+
+  const permissionPayloadInfo = (permission, input, metadata, patterns) => {
+    const name = String(permission || "").toLowerCase();
+    switch (name) {
+      case "bash": {
+        const command = firstString(input.command, input.cmd);
+        return { action: "run_command", command, description: firstString(input.description, input.title) };
+      }
+      case "edit":
+      case "write":
+      case "multiedit":
+      case "apply_patch": {
+        const file = firstString(input.filePath, input.file_path, input.filepath, input.path, patterns[0]) || "";
+        return {
+          action: name === "write" ? "write_file" : name === "apply_patch" ? "patch_file" : "edit_file",
+          resource: file,
+          diff: firstString(metadata.diff, input.diff),
+          file,
+          description: firstString(input.description),
+        };
+      }
+      case "read": {
+        const file = firstString(input.filePath, input.file_path, input.filepath, input.path, patterns[0]) || "";
+        return { action: "read_file", resource: file, file };
+      }
+      case "glob": {
+        const pattern = firstString(input.pattern, patterns[0]) || "";
+        return { action: "glob", pattern, resource: pattern };
+      }
+      case "grep": {
+        const pattern = firstString(input.pattern, patterns[0]) || "";
+        return { action: "grep", pattern, resource: pattern };
+      }
+      case "list": {
+        const dir = firstString(input.path, input.directory, patterns[0]) || "";
+        return { action: "list_directory", resource: dir, path: dir };
+      }
+      case "task": {
+        const type = firstString(input.subagent_type, input.subagentType) || "general";
+        const description = firstString(input.description, input.prompt);
+        return { action: "task", subagent_type: type, description };
+      }
+      case "webfetch": {
+        const url = firstString(input.url, patterns[0]) || "";
+        return { action: "webfetch", url, resource: url };
+      }
+      case "websearch": {
+        const query = firstString(input.query, patterns[0]) || "";
+        return { action: "websearch", query, resource: query };
+      }
+      case "lsp": {
+        const file = firstString(input.filePath, input.file_path, input.path) || "";
+        const operation = firstString(input.operation) || "request";
+        const line = typeof input.line === "number" ? input.line : null;
+        const character = typeof input.character === "number" ? input.character : null;
+        return {
+          action: "lsp",
+          operation,
+          resource: file,
+          file,
+          position: line !== null && character !== null ? { line, character } : undefined,
+        };
+      }
+      case "external_directory": {
+        const raw = firstString(metadata.parentDir, metadata.filepath, input.path, patterns[0]) || "";
+        const dir = pathWithoutWildcardTail(raw);
+        return { action: "external_directory", resource: dir, path: dir };
+      }
+      case "doom_loop":
+        return { action: "doom_loop" };
+      default:
+        return { action: "tool_call", resource: permission || "permission" };
+    }
+  };
+
+  const permissionToolInput = (props, permission) => {
+    const metadata = isObject(props.metadata) ? props.metadata : {};
+    const input = isObject(metadata.input) ? metadata.input : {};
+    const patterns = stringList(props.patterns);
+    const always = stringList(props.always);
+    const payloadInfo = permissionPayloadInfo(permission, input, metadata, patterns);
+    const toolInput = {
+      ...metadata,
+      ...input,
+      permission,
+      patterns,
+      always,
+      metadata,
+      action: payloadInfo.action,
+    };
+    if (props.tool) toolInput.tool = props.tool;
+    if (payloadInfo.description) toolInput.description = payloadInfo.description;
+    if (payloadInfo.resource) toolInput.resource = payloadInfo.resource;
+    if (payloadInfo.operation) toolInput.operation = payloadInfo.operation;
+    if (payloadInfo.pattern) toolInput.pattern = payloadInfo.pattern;
+    if (payloadInfo.position) toolInput.position = payloadInfo.position;
+    if (payloadInfo.diff) toolInput.diff = payloadInfo.diff;
+    if (payloadInfo.subagent_type) toolInput.subagent_type = payloadInfo.subagent_type;
+    if (payloadInfo.command) toolInput.command = payloadInfo.command;
+    if (payloadInfo.url) toolInput.url = payloadInfo.url;
+    if (payloadInfo.query) toolInput.query = payloadInfo.query;
+    if (payloadInfo.path) toolInput.path = payloadInfo.path;
+    if (payloadInfo.file) {
+      toolInput.filePath = payloadInfo.file;
+      toolInput.file_path = payloadInfo.file;
+    }
+    return toolInput;
+  };
+
+  const trimMap = (map, max = 300) => {
+    while (map.size > max) {
+      map.delete(map.keys().next().value);
+    }
+  };
+
   const sessionState = (sessionId) => {
     const key = sessionId || "unknown";
-    if (!sessions.has(key)) {
-      sessions.set(key, {
+    let state = sessions.get(key);
+    if (!state) {
+      state = {
         lastUserMessage: null,
         assistantPreamble: null,
         cwd: null,
-      });
+      };
+    } else {
+      sessions.delete(key);
     }
-    return sessions.get(key);
+    sessions.set(key, state);
+    trimMap(sessions, MAX_SESSION_STATES);
+    return state;
+  };
+
+  const messagePartKey = (messageId, partId) => `${messageId || "unknown"}:${partId || "unknown"}`;
+
+  const recordMessageText = (sessionId, messageId, role, text) => {
+    const normalized = normalizeText(text);
+    if (!sessionId || !normalized) return;
+    if (messageId) {
+      messageText.set(messageId, { sessionId, text: normalized });
+      trimMap(messageText);
+    }
+    const state = sessionState(sessionId);
+    if (role === "user") {
+      state.lastUserMessage = normalized;
+    } else if (role === "assistant") {
+      state.assistantPreamble = normalized;
+    }
+  };
+
+  const stopToolInput = (state) => {
+    const message = normalizeText(state.assistantPreamble, 2000);
+    if (!message) return {};
+    return {
+      reason: message,
+      last_assistant_message: message,
+      assistant_preamble: message,
+    };
   };
 
   const contextForSession = (sessionId) => {
@@ -347,10 +517,58 @@ export const CMUXFeed = async (ctx) => {
     buffered = "";
   };
 
-  const connect = () => {
+  const resetConnection = () => {
+    client = null;
+    clientReady = false;
+    telemetryOutbox.splice(0);
+    replyOutbox.splice(0);
+    failPending();
+  };
+
+  const writeConnected = (frame) => {
+    if (!client || !clientReady || client.destroyed || !client.writable) return false;
+    try {
+      client.write(JSON.stringify(frame) + "\n");
+      return true;
+    } catch (e) {
+      resetConnection();
+      return false;
+    }
+  };
+
+  const flushOutboxQueue = (queue) => {
+    while (queue.length > 0) {
+      const item = queue.shift();
+      if (!writeConnected(item.frame)) {
+        if (item.requestId) resolvePending(item.requestId, { status: "timed_out" });
+        return false;
+      }
+    }
+    return true;
+  };
+
+  const flushOutboxes = () => {
+    if (!flushOutboxQueue(telemetryOutbox)) return false;
+    return flushOutboxQueue(replyOutbox);
+  };
+
+  const connect = ({ immediate = false } = {}) => {
+    if (client) return client;
+    if (!immediate) {
+      const now = Date.now();
+      if (now - lastTelemetryConnectAttempt < TELEMETRY_RECONNECT_MS) return null;
+      lastTelemetryConnectAttempt = now;
+    }
     try {
       const conn = net.createConnection(SOCKET_PATH);
+      client = conn;
+      clientReady = false;
       conn.setEncoding("utf8");
+      conn.unref?.();
+      conn.on("connect", () => {
+        clientReady = true;
+        flushOutboxes();
+      });
       conn.on("data", (chunk) => {
         buffered += chunk;
         let idx;
@@ -375,30 +593,29 @@ export const CMUXFeed = async (ctx) => {
         }
       });
       conn.on("close", () => {
-        client = null;
-        failPending();
+        resetConnection();
       });
       conn.on("error", () => {
-        client = null;
-        failPending();
+        resetConnection();
       });
       return conn;
     } catch (e) {
-      failPending();
+      resetConnection();
       return null;
     }
   };
 
-  const write = (frame) => {
-    if (!client) client = connect();
-    if (!client) return false;
-    try {
-      client.write(JSON.stringify(frame) + "\n");
-      return true;
-    } catch (e) {
-      failPending();
-      return false;
+  const write = (frame, { requiresReply = false, requestId = null } = {}) => {
+    if (writeConnected(frame)) return true;
+    if (!connect({ immediate: requiresReply })) return false;
+    const queue = requiresReply ? replyOutbox : telemetryOutbox;
+    const max = requiresReply ? MAX_REPLY_OUTBOX : MAX_TELEMETRY_OUTBOX;
+    if (queue.length >= max) {
+      const dropped = queue.shift();
+      if (dropped?.requestId) resolvePending(dropped.requestId, { status: "timed_out" });
     }
+    queue.push({ frame, requestId });
+    return true;
   };
 
   const base = (sessionId, extra) => {
@@ -408,6 +625,10 @@ export const CMUXFeed = async (ctx) => {
       typeof process.env.CMUX_WORKSPACE_ID === "string" && process.env.CMUX_WORKSPACE_ID.trim()
         ? process.env.CMUX_WORKSPACE_ID.trim()
         : null;
+    const surfaceId =
+      typeof process.env.CMUX_SURFACE_ID === "string" && process.env.CMUX_SURFACE_ID.trim()
+        ? process.env.CMUX_SURFACE_ID.trim()
+        : null;
     const event = {
       session_id: `opencode-${sessionId}`,
       _source: "opencode",
@@ -416,6 +637,7 @@ export const CMUXFeed = async (ctx) => {
       ...extra,
     };
     if (workspaceId) event.workspace_id = workspaceId;
+    if (surfaceId) event.surface_id = surfaceId;
     if (context) event.context = context;
     return event;
   };
@@ -427,44 +649,75 @@ export const CMUXFeed = async (ctx) => {
       const messageId = info.id || props.messageID;
       const sessionId = info.sessionID || props.sessionID;
       const role = info.role || props.role;
-      if (messageId && sessionId && role) {
-        messageRoles.set(messageId, { sessionId, role });
-        if (messageRoles.size > 300) {
-          messageRoles.delete(messageRoles.keys().next().value);
+      if (messageId && sessionId) {
+        const previous = messageRoles.get(messageId);
+        messageRoles.set(messageId, { sessionId, role: role || previous?.role });
+        trimMap(messageRoles);
+        const pendingText = messageText.get(messageId);
+        if (role && pendingText) {
+          recordMessageText(sessionId, messageId, role, pendingText.text);
         }
+      }
+      return null;
+    }
+
+    if (event.type === "message.part.delta") {
+      if (props.field !== "text" || !props.partID || !props.messageID) return null;
+      const meta = messageRoles.get(props.messageID);
+      const sessionId = meta?.sessionId || props.sessionID;
+      const key = messagePartKey(props.messageID, props.partID);
+      const text = `${messagePartText.get(key) || ""}${props.delta || ""}`;
+      messagePartText.set(key, text);
+      trimMap(messagePartText);
+      if (messagePartTypes.get(key) === "text") {
+        recordMessageText(sessionId, props.messageID, meta?.role || "assistant", text);
       }
       return null;
     }
 
     if (event.type !== "message.part.updated") return null;
     const part = props.part || {};
+    const key = messagePartKey(part.messageID, part.id);
+    if (part.id) {
+      messagePartTypes.set(key, part.type);
+      trimMap(messagePartTypes);
+    }
     if (part.type !== "text" || !part.messageID) return null;
     const meta = messageRoles.get(part.messageID);
-    if (!meta) return null;
+    const sessionId = part.sessionID || props.sessionID || meta?.sessionId;
     const text = normalizeText(part.text || part.textDelta || part.content);
     if (!text) return null;
-    const state = sessionState(meta.sessionId);
-    if (meta.role === "user") {
-      state.lastUserMessage = text;
-      return base(meta.sessionId, {
+    if (part.id) {
+      messagePartText.set(key, part.text || part.textDelta || part.content || "");
+      trimMap(messagePartText);
+    }
+    const role = meta?.role;
+    recordMessageText(sessionId, part.messageID, role, text);
+    if (role === "user") {
+      return base(sessionId, {
         hook_event_name: "UserPromptSubmit",
         tool_input: { prompt: text },
         context: { lastUserMessage: text },
       });
     }
-    if (meta.role === "assistant") {
-      state.assistantPreamble = text;
-    }
     return null;
   };
 
   const pushBlocking = (event, requestId) => {
+    let timeoutId = null;
     const reply = new Promise((resolve) => {
-      pending.set(requestId, resolve);
-      setTimeout(() => {
+      const finish = (value) => {
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+          timeoutId = null;
+        }
+        resolve(value);
+      };
+      pending.set(requestId, finish);
+      timeoutId = setTimeout(() => {
         if (pending.has(requestId)) {
           pending.delete(requestId);
-          resolve({ status: "timed_out" });
+          finish({ status: "timed_out" });
         }
       }, REPLY_TIMEOUT_MS);
     });
@@ -472,7 +725,7 @@ export const CMUXFeed = async (ctx) => {
       id: `opencode-${requestId}`,
       method: "feed.push",
       params: { event, wait_timeout_seconds: REPLY_TIMEOUT_MS / 1000 },
-    });
+    }, { requiresReply: true, requestId });
     if (!wrote) {
       resolvePending(requestId, { status: "timed_out" });
     }
@@ -508,8 +761,10 @@ export const CMUXFeed = async (ctx) => {
         case "session.idle": {
           const sid = event.properties?.sessionID;
           if (!sid) break;
+          const state = sessionState(sid);
           pushTelemetry(base(sid, {
             hook_event_name: "Stop",
+            tool_input: stopToolInput(state),
           }));
           break;
         }
@@ -537,18 +792,12 @@ export const CMUXFeed = async (ctx) => {
           if (!requestId) break;
           const sid = props.sessionID || "unknown";
           const permission = firstString(props.permission, props.tool?.name) || "permission";
-          const metadata = isObject(props.metadata) ? props.metadata : {};
+          const toolInput = permissionToolInput(props, permission);
           const frame = base(sid, {
             hook_event_name: "PermissionRequest",
             _opencode_request_id: requestId,
             tool_name: permission,
-            tool_input: {
-              permission,
-              patterns: Array.isArray(props.patterns) ? props.patterns : [],
-              always: Array.isArray(props.always) ? props.always : [],
-              metadata,
-              tool: props.tool,
-            },
+            tool_input: toolInput,
             context: {
               ...(contextForSession(sid) || {}),
               permissionMode: "opencode",

--- a/Sources/Feed/FeedCoordinator.swift
+++ b/Sources/Feed/FeedCoordinator.swift
@@ -92,6 +92,7 @@ final class FeedCoordinator: @unchecked Sendable {
                     if let ppid = event.ppid, ppid > 0 {
                         FeedCoordinator.shared.armPidWatcher(ppid: ppid)
                     }
+                    FeedCoordinator.shared.postTelemetryNotificationIfNeeded(event: event)
                 }
             }
             return .acknowledged(itemId: nil)
@@ -343,6 +344,11 @@ enum FeedJumpResolver {
         return (agent, sessionId)
     }
 
+    static func lookupTarget(workstreamId: String) -> Target? {
+        guard let parsed = parse(workstreamId) else { return nil }
+        return lookup(agent: parsed.agent, sessionId: parsed.sessionId)
+    }
+
     static func lookup(agent: String, sessionId: String) -> Target? {
         let home = FileManager.default.homeDirectoryForCurrentUser
         let file = home
@@ -408,6 +414,260 @@ extension Notification.Name {
 // MARK: - Native notification banner
 
 private extension FeedCoordinator {
+    static func notificationBody(for event: WorkstreamEvent) -> String? {
+        switch event.hookEventName {
+        case .permissionRequest:
+            return permissionNotificationBody(for: event)
+        case .exitPlanMode:
+            return exitPlanNotificationBody(for: event)
+        case .askUserQuestion:
+            return questionNotificationBody(for: event)
+        case .stop:
+            return stopNotificationBody(for: event)
+        default:
+            return nil
+        }
+    }
+
+    private static func permissionNotificationBody(for event: WorkstreamEvent) -> String? {
+        let dict = effectiveToolInput(from: jsonDictionary(event.toolInputJSON))
+        let permission = firstString(
+            dict["permission"],
+            dict["toolName"],
+            dict["tool_name"],
+            event.toolName
+        )?.lowercased()
+
+        return compactNotificationText([
+            permissionNotificationSummary(permission: permission, toolName: event.toolName),
+        ])
+    }
+
+    private static func permissionNotificationSummary(permission: String?, toolName: String?) -> String {
+        switch permission ?? "" {
+        case "bash":
+            return String(localized: "feed.notification.permission.bash", defaultValue: "Shell command")
+        case "edit", "multiedit":
+            return String(localized: "feed.notification.permission.edit", defaultValue: "Edit file")
+        case "write":
+            return String(localized: "feed.notification.permission.write", defaultValue: "Write file")
+        case "apply_patch":
+            return String(localized: "feed.notification.permission.patch", defaultValue: "Patch file")
+        case "read":
+            return String(localized: "feed.notification.permission.read", defaultValue: "Read file")
+        case "glob", "grep":
+            return String(localized: "feed.notification.permission.searchFiles", defaultValue: "Search files")
+        case "list":
+            return String(localized: "feed.notification.permission.list", defaultValue: "List directory")
+        case "task":
+            return String(localized: "feed.notification.permission.task", defaultValue: "Task request")
+        case "webfetch":
+            return String(localized: "feed.notification.permission.webfetch", defaultValue: "Fetch URL")
+        case "websearch":
+            return String(localized: "feed.notification.permission.websearch", defaultValue: "Web search")
+        case "lsp":
+            return String(localized: "feed.notification.permission.lsp", defaultValue: "Language server request")
+        case "external_directory":
+            return String(localized: "feed.notification.permission.externalDirectory", defaultValue: "Access external directory")
+        case "doom_loop":
+            return String(localized: "feed.permission.doomLoop", defaultValue: "Continue after repeated failures")
+        default:
+            if let toolName = firstString(toolName) {
+                return String.localizedStringWithFormat(
+                    String(localized: "feed.notification.permission.body", defaultValue: "%@ needs approval"),
+                    toolName
+                )
+            }
+            return String(localized: "feed.notification.decisionNeeded", defaultValue: "Decision needed")
+        }
+    }
+
+    private static func exitPlanNotificationBody(for event: WorkstreamEvent) -> String? {
+        let rawPlan = event.toolInputJSON ?? ""
+        let preview = WorkstreamExitPlanPreview(rawPlan: rawPlan)
+        if let summary = preview.summary {
+            return compactNotificationText([summary])
+        }
+        return firstMarkdownContentLine(preview.planText).flatMap { compactNotificationText([$0]) }
+    }
+
+    private static func questionNotificationBody(for event: WorkstreamEvent) -> String? {
+        let dict = jsonDictionary(event.toolInputJSON)
+        let firstQuestion: [String: Any]?
+        if let questions = dict["questions"] as? [[String: Any]] {
+            firstQuestion = questions.first
+        } else {
+            firstQuestion = dict.isEmpty ? nil : dict
+        }
+        guard let firstQuestion else { return nil }
+        let prompt = firstString(firstQuestion["question"], firstQuestion["prompt"])
+        let options = (firstQuestion["options"] as? [Any])?
+            .prefix(3)
+            .compactMap { option -> String? in
+                if let text = option as? String { return firstString(text) }
+                guard let dict = option as? [String: Any] else { return nil }
+                return firstString(dict["label"], dict["title"])
+            }
+            .map { "- \($0)" } ?? []
+        return compactNotificationText([prompt] + options.map(Optional.some))
+    }
+
+    private static func stopNotificationBody(for event: WorkstreamEvent) -> String? {
+        let dict = jsonDictionary(event.toolInputJSON)
+        guard let message = event.assistantFinalMessage ?? firstString(dict["reason"], dict["message"], dict["cause"]) else {
+            return nil
+        }
+        return compactNotificationText([
+            message,
+        ])
+    }
+
+    private static func jsonDictionary(_ json: String?) -> [String: Any] {
+        guard let json,
+              let data = json.data(using: .utf8),
+              let dict = try? JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed]) as? [String: Any]
+        else { return [:] }
+        return dict
+    }
+
+    private static func effectiveToolInput(from dict: [String: Any]) -> [String: Any] {
+        var out: [String: Any] = [:]
+        if let metadata = dict["metadata"] as? [String: Any] {
+            out.merge(metadata) { _, new in new }
+            if let input = metadata["input"] as? [String: Any] {
+                out.merge(input) { _, new in new }
+            }
+        }
+        out.merge(dict) { _, new in new }
+        return out
+    }
+
+    private static func firstString(_ values: Any?...) -> String? {
+        for value in values {
+            if let text = value as? String {
+                let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !trimmed.isEmpty { return trimmed }
+            }
+        }
+        return nil
+    }
+
+    private static func stringArray(_ value: Any?) -> [String] {
+        guard let values = value as? [Any] else { return [] }
+        return values.compactMap { item in
+            guard let text = item as? String else { return nil }
+            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        }
+    }
+
+    private static func firstMarkdownContentLine(_ text: String) -> String? {
+        for rawLine in text.split(separator: "\n", omittingEmptySubsequences: false) {
+            var line = String(rawLine).trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !line.isEmpty else { continue }
+            if line.hasPrefix("#") {
+                line = line.trimmingCharacters(in: CharacterSet(charactersIn: "# "))
+            } else if line.hasPrefix("- ") || line.hasPrefix("* ") {
+                line = String(line.dropFirst(2)).trimmingCharacters(in: .whitespacesAndNewlines)
+            }
+            if !line.isEmpty { return line }
+        }
+        return nil
+    }
+
+    private static func compactNotificationText(_ pieces: [String], limit: Int = 240) -> String? {
+        compactNotificationText(pieces.map(Optional.some), limit: limit)
+    }
+
+    private static func compactNotificationText(_ pieces: [String?], limit: Int = 240) -> String? {
+        let text = pieces
+            .compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: "\n")
+        guard !text.isEmpty else { return nil }
+        if text.count <= limit { return text }
+        let end = text.index(text.startIndex, offsetBy: max(limit - 3, 0))
+        return String(text[..<end]) + "..."
+    }
+
+    private struct BasicNotificationContent {
+        let title: String
+        let subtitle: String
+        let body: String
+        let cooldownKey: String
+    }
+
+    private struct BasicNotificationTarget {
+        let tabId: UUID
+        let surfaceId: UUID?
+    }
+
+    private static func basicStopNotificationContent(for event: WorkstreamEvent) -> BasicNotificationContent? {
+        guard event.hookEventName == .stop,
+              event.source == WorkstreamSource.opencode.rawValue
+        else { return nil }
+
+        let displayName = sourceDisplayName(event.source)
+        let title = String.localizedStringWithFormat(
+            String(
+                localized: "feed.notification.stop.title",
+                defaultValue: "%@ completed"
+            ),
+            displayName
+        )
+        let subtitle = String(localized: "feed.notification.stop.subtitle", defaultValue: "Completed")
+        let body = stopNotificationBody(for: event) ?? ""
+        return BasicNotificationContent(
+            title: title,
+            subtitle: subtitle,
+            body: body,
+            cooldownKey: "feed.stop.\(event.sessionId)"
+        )
+    }
+
+    private static func sourceDisplayName(_ source: String) -> String {
+        switch source {
+        case WorkstreamSource.opencode.rawValue:
+            return String(localized: "feed.source.opencode", defaultValue: "OpenCode")
+        default:
+            return source.capitalized
+        }
+    }
+
+    private static func basicNotificationTarget(for event: WorkstreamEvent) -> BasicNotificationTarget? {
+        let extra = jsonDictionary(event.extraFieldsJSON)
+        if let workspaceId = event.workspaceId.flatMap(UUID.init(uuidString:)) {
+            let surfaceId = firstString(extra["surface_id"], extra["surfaceId"])
+                .flatMap(UUID.init(uuidString:))
+            return BasicNotificationTarget(tabId: workspaceId, surfaceId: surfaceId)
+        }
+
+        guard let target = FeedJumpResolver.lookupTarget(workstreamId: event.sessionId),
+              let workspaceId = UUID(uuidString: target.workspaceId)
+        else { return nil }
+        return BasicNotificationTarget(
+            tabId: workspaceId,
+            surfaceId: UUID(uuidString: target.surfaceId)
+        )
+    }
+
+    @MainActor
+    func postTelemetryNotificationIfNeeded(event: WorkstreamEvent) {
+        guard let content = Self.basicStopNotificationContent(for: event),
+              let target = Self.basicNotificationTarget(for: event)
+        else { return }
+
+        TerminalNotificationStore.shared.addNotification(
+            tabId: target.tabId,
+            surfaceId: target.surfaceId,
+            title: content.title,
+            subtitle: content.subtitle,
+            body: content.body,
+            cooldownKey: content.cooldownKey,
+            cooldownInterval: 10
+        )
+    }
+
     /// Posts a UNUserNotificationCenter banner with inline action buttons
     /// for the given Feed event after optional notification policy hooks run.
     /// Notification eligibility is derived only from the waiter table so
@@ -447,7 +707,7 @@ private extension FeedCoordinator {
                     localized: "feed.notification.permission.title",
                     defaultValue: "\(event.source.capitalized) permission"
                 )
-                body = event.toolName.map {
+                body = Self.notificationBody(for: event) ?? event.toolName.map {
                     String(
                         localized: "feed.notification.permission.body",
                         defaultValue: "\($0) needs approval"
@@ -462,7 +722,7 @@ private extension FeedCoordinator {
                     localized: "feed.notification.exitPlan.title",
                     defaultValue: "\(event.source.capitalized) plan ready"
                 )
-                body = String(
+                body = Self.notificationBody(for: event) ?? String(
                     localized: "feed.notification.exitPlan.body",
                     defaultValue: "Review and approve the plan"
                 )
@@ -472,7 +732,7 @@ private extension FeedCoordinator {
                     localized: "feed.notification.question.title",
                     defaultValue: "\(event.source.capitalized) question"
                 )
-                body = String(
+                body = Self.notificationBody(for: event) ?? String(
                     localized: "feed.notification.question.body",
                     defaultValue: "Agent is asking a question"
                 )
@@ -690,6 +950,21 @@ private extension FeedCoordinator {
         let center = UNUserNotificationCenter.current()
         center.removePendingNotificationRequestsOffMain(withIdentifiers: [identifier])
         center.removeDeliveredNotificationsOffMain(withIdentifiers: [identifier])
+    }
+}
+
+extension FeedCoordinator {
+    static func notificationBodyForTesting(event: WorkstreamEvent) -> String? {
+        notificationBody(for: event)
+    }
+
+    static func basicStopNotificationForTesting(event: WorkstreamEvent) -> (
+        title: String,
+        subtitle: String,
+        body: String
+    )? {
+        guard let content = basicStopNotificationContent(for: event) else { return nil }
+        return (content.title, content.subtitle, content.body)
     }
 }
 

--- a/Sources/Feed/FeedPanelView.swift
+++ b/Sources/Feed/FeedPanelView.swift
@@ -42,6 +42,27 @@ private extension WorkstreamExitPlanMode {
         }
     }
 }
+
+private extension WorkstreamSource {
+    var feedDisplayName: String {
+        switch self {
+        case .opencode:
+            return String(localized: "feed.source.opencode", defaultValue: "OpenCode")
+        default:
+            return rawValue.capitalized
+        }
+    }
+
+    var rendersFeedMarkdown: Bool {
+        switch self {
+        case .claude, .opencode:
+            return true
+        default:
+            return false
+        }
+    }
+}
+
 /// Right-sidebar Feed view. Matches the Sessions page visual language:
 /// compact rows with SF Symbol + 13pt title + secondary metadata,
 /// full-width hover backgrounds, and control-bar pill buttons styled
@@ -1273,6 +1294,7 @@ struct FeedItemRow: View, Equatable {
             StopActionArea(
                 draft: $stopDraft,
                 focusRequest: $stopFocusRequest,
+                source: snapshot.source,
                 onFocusRow: onControlFocus,
                 onActionRow: onControlAction,
                 onBlurRow: onControlBlur,
@@ -1377,7 +1399,7 @@ private struct FeedContextBlock: View {
                     text: preamble,
                     labelColor: .secondary,
                     textColor: .secondary,
-                    rendersMarkdown: source == .claude
+                    rendersMarkdown: source.rendersFeedMarkdown
                 )
             }
             if let plan = context.planSummary {
@@ -1386,7 +1408,7 @@ private struct FeedContextBlock: View {
                     text: plan,
                     labelColor: Color.purple.opacity(0.85),
                     textColor: .secondary,
-                    rendersMarkdown: source == .claude
+                    rendersMarkdown: source.rendersFeedMarkdown
                 )
             }
         }
@@ -1555,31 +1577,157 @@ private struct PermissionInputPreview {
         let dict = (try? JSONSerialization.jsonObject(
             with: Data(toolInputJSON.utf8)
         )) as? [String: Any] ?? [:]
+        let effective = Self.effectiveInput(from: dict)
+        let name = (Self.firstString(
+            effective["permission"],
+            effective["toolName"],
+            effective["tool_name"],
+            toolName
+        ) ?? toolName).lowercased()
+        let summary = Self.firstString(effective["summary"], effective["title"])
+        let detailLines = Self.stringArray(effective["lines"])
+        let patterns = Self.stringArray(effective["patterns"])
 
-        switch toolName.lowercased() {
+        switch name {
         case "bash":
             self.sigil = "$"
-            self.primary = (dict["command"] as? String) ?? toolInputJSON
-            self.secondary = (dict["description"] as? String)
-        case "write", "edit", "multiedit":
+            let primary = Self.firstString(effective["command"], effective["cmd"], detailLines.first) ?? toolInputJSON
+            self.primary = primary
+            self.secondary = Self.secondaryText(
+                preferred: Self.firstString(effective["description"], summary),
+                excluding: primary,
+                fallbackLines: Array(detailLines.dropFirst())
+            )
+        case "write", "edit", "multiedit", "apply_patch":
             self.sigil = nil
-            self.primary = (dict["file_path"] as? String) ?? toolInputJSON
-            if toolName.lowercased() == "write" {
-                let content = (dict["content"] as? String) ?? ""
+            let primary = Self.firstString(
+                effective["filePath"],
+                effective["file_path"],
+                effective["filepath"],
+                effective["path"],
+                patterns.first,
+                summary
+            ) ?? (toolInputJSON == "{}" ? nil : toolInputJSON)
+            self.primary = primary
+            if name == "write" {
+                let content = Self.firstString(effective["content"]) ?? ""
                 let preview = content.split(separator: "\n").first.map(String.init) ?? ""
-                self.secondary = preview.isEmpty ? nil : preview
+                self.secondary = Self.secondaryText(
+                    preferred: preview.isEmpty ? nil : preview,
+                    excluding: primary,
+                    fallbackLines: detailLines
+                )
             } else {
-                self.secondary = nil
+                self.secondary = Self.secondaryText(
+                    preferred: Self.firstString(effective["description"]),
+                    excluding: primary,
+                    fallbackLines: detailLines
+                )
             }
         case "read":
             self.sigil = nil
-            self.primary = (dict["file_path"] as? String) ?? toolInputJSON
-            self.secondary = nil
+            let primary = Self.firstString(
+                effective["filePath"],
+                effective["file_path"],
+                effective["filepath"],
+                effective["path"],
+                patterns.first,
+                summary
+            ) ?? (toolInputJSON == "{}" ? nil : toolInputJSON)
+            self.primary = primary
+            self.secondary = Self.secondaryText(excluding: primary, fallbackLines: detailLines)
+        case "glob", "grep":
+            self.sigil = nil
+            let primary = Self.firstString(effective["pattern"], patterns.first, summary) ?? (toolInputJSON == "{}" ? nil : toolInputJSON)
+            self.primary = primary
+            self.secondary = Self.secondaryText(excluding: primary, fallbackLines: detailLines)
+        case "list":
+            self.sigil = nil
+            let primary = Self.firstString(effective["path"], effective["directory"], patterns.first, summary) ?? (toolInputJSON == "{}" ? nil : toolInputJSON)
+            self.primary = primary
+            self.secondary = Self.secondaryText(excluding: primary, fallbackLines: detailLines)
+        case "task":
+            self.sigil = "*"
+            let primary = Self.firstString(effective["description"], effective["prompt"], summary) ?? (toolInputJSON == "{}" ? nil : toolInputJSON)
+            self.primary = primary
+            self.secondary = Self.secondaryText(excluding: primary, fallbackLines: detailLines)
+        case "webfetch":
+            self.sigil = "%"
+            let primary = Self.firstString(effective["url"], patterns.first, summary) ?? (toolInputJSON == "{}" ? nil : toolInputJSON)
+            self.primary = primary
+            self.secondary = Self.secondaryText(excluding: primary, fallbackLines: detailLines)
+        case "websearch":
+            self.sigil = "*"
+            let primary = Self.firstString(effective["query"], patterns.first, summary) ?? (toolInputJSON == "{}" ? nil : toolInputJSON)
+            self.primary = primary
+            self.secondary = Self.secondaryText(excluding: primary, fallbackLines: detailLines)
+        case "lsp":
+            self.sigil = nil
+            let primary = Self.firstString(summary, effective["operation"], effective["filePath"], effective["file_path"]) ?? (toolInputJSON == "{}" ? nil : toolInputJSON)
+            self.primary = primary
+            self.secondary = Self.secondaryText(excluding: primary, fallbackLines: detailLines)
+        case "external_directory":
+            self.sigil = "<"
+            let primary = summary ?? Self.firstString(patterns.first) ?? (toolInputJSON == "{}" ? nil : toolInputJSON)
+            self.primary = primary
+            self.secondary = Self.secondaryText(excluding: primary, fallbackLines: detailLines.isEmpty ? patterns : detailLines)
+        case "doom_loop":
+            self.sigil = "~"
+            let primary = summary ?? String(localized: "feed.permission.doomLoop", defaultValue: "Continue after repeated failures")
+            self.primary = primary
+            self.secondary = Self.secondaryText(excluding: primary, fallbackLines: detailLines)
         default:
             self.sigil = nil
-            self.primary = toolInputJSON == "{}" ? nil : toolInputJSON
-            self.secondary = nil
+            let primary = summary ?? (toolInputJSON == "{}" ? nil : toolInputJSON)
+            self.primary = primary
+            self.secondary = Self.secondaryText(excluding: primary, fallbackLines: detailLines)
         }
+    }
+
+    private static func effectiveInput(from dict: [String: Any]) -> [String: Any] {
+        var out: [String: Any] = [:]
+        if let metadata = dict["metadata"] as? [String: Any] {
+            out.merge(metadata) { _, new in new }
+            if let input = metadata["input"] as? [String: Any] {
+                out.merge(input) { _, new in new }
+            }
+        }
+        out.merge(dict) { _, new in new }
+        return out
+    }
+
+    private static func firstString(_ values: Any?...) -> String? {
+        for value in values {
+            if let text = value as? String {
+                let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !trimmed.isEmpty { return trimmed }
+            }
+        }
+        return nil
+    }
+
+    private static func stringArray(_ value: Any?) -> [String] {
+        guard let values = value as? [Any] else { return [] }
+        return values.compactMap { item in
+            guard let text = item as? String else { return nil }
+            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        }
+    }
+
+    private static func secondaryText(
+        preferred: String? = nil,
+        excluding primary: String?,
+        fallbackLines: [String]
+    ) -> String? {
+        if let preferred,
+           !preferred.isEmpty,
+           preferred != primary {
+            return preferred
+        }
+        let lines = fallbackLines.filter { !$0.isEmpty && $0 != primary }
+        guard !lines.isEmpty else { return nil }
+        return lines.joined(separator: "\n")
     }
 }
 
@@ -2228,7 +2376,7 @@ private struct ExitPlanActionArea: View {
         VStack(alignment: .leading, spacing: 10) {
             PlanBodyView(
                 plan: preview.planText,
-                rendersMarkdown: source == .claude
+                rendersMarkdown: source.rendersFeedMarkdown
             )
             if !preview.allowedPrompts.isEmpty {
                 ExitPlanAllowedPromptsView(prompts: preview.allowedPrompts)
@@ -3633,19 +3781,21 @@ private struct FlowLayout: Layout {
     }
 }
 
-/// Renders a Stop event (Claude finished a turn and is waiting for
+/// Renders a Stop event (an agent finished a turn and is waiting for
 /// the next user prompt). Shows a text field + Send button that
 /// types the reply into the agent's terminal surface and presses
-/// Return — so the user can reply without switching focus.
+/// Return, so the user can reply without switching focus.
 private struct StopActionArea: View {
     @Binding var draft: FeedStopDraft
     @Binding var focusRequest: Int
 
+    let source: WorkstreamSource
     let onFocusRow: () -> Void
     let onActionRow: () -> Void
     let onBlurRow: () -> Void
     let onSend: (String) -> Void
 
+    private var sourceName: String { source.feedDisplayName }
     private var trimmed: String {
         draft.reply.trimmingCharacters(in: .whitespacesAndNewlines)
     }
@@ -3664,14 +3814,26 @@ private struct StopActionArea: View {
                 Image(systemName: "checkmark.circle")
                     .font(.system(size: 10))
                     .foregroundColor(.secondary)
-                Text(String(localized: "feed.stop.label", defaultValue: "Claude finished — reply to continue"))
+                Text(String.localizedStringWithFormat(
+                    String(
+                        localized: "feed.stop.labelForSource",
+                        defaultValue: "%@ finished, reply to continue"
+                    ),
+                    sourceName
+                ))
                     .font(.system(size: 11, weight: .medium))
                     .foregroundColor(.secondary)
             }
             FeedInlineTextField(
                 text: replyBinding,
                 focusRequest: focusRequest == 0 ? nil : focusRequest,
-                placeholder: String(localized: "feed.stop.placeholder", defaultValue: "Reply to Claude…"),
+                placeholder: String.localizedStringWithFormat(
+                    String(
+                        localized: "feed.stop.placeholderForSource",
+                        defaultValue: "Reply to %@..."
+                    ),
+                    sourceName
+                ),
                 isEnabled: true,
                 font: replyFont,
                 onFocus: onFocusRow,
@@ -3700,7 +3862,10 @@ private struct StopActionArea: View {
                 requestReplyFocus()
             }
             FeedButton(
-                label: String(localized: "feed.stop.send", defaultValue: "Send to Claude"),
+                label: String.localizedStringWithFormat(
+                    String(localized: "feed.stop.sendForSource", defaultValue: "Send to %@"),
+                    sourceName
+                ),
                 leadingIcon: "arrow.up.circle.fill",
                 kind: canSend ? .primary : .soft,
                 size: .medium,
@@ -3732,7 +3897,7 @@ private struct TelemetryActionArea: View {
         if case .todos(let todos) = snapshot.payload {
             TodoListBody(todos: todos)
         } else if case .assistantMessage(let text) = snapshot.payload,
-                  snapshot.source == .claude {
+                  snapshot.source.rendersFeedMarkdown {
             FeedMarkdownInlineText(
                 text: text,
                 fontSize: 11,

--- a/cmuxTests/CLIGenericHookPersistenceTests.swift
+++ b/cmuxTests/CLIGenericHookPersistenceTests.swift
@@ -696,6 +696,108 @@ extension CLINotifyProcessIntegrationRegressionTests {
         XCTAssertEqual(events.compactMap { $0["_ppid"] as? Int }, [424242, 424242, 424242])
     }
 
+    func testOpenCodeSessionStopDoesNotPublishGenericNotification() throws {
+        let cliPath = try bundledCLIPath()
+        let socketPath = makeSocketPath("opencode-stop")
+        let listenerFD = try bindUnixSocket(at: socketPath)
+        let state = MockSocketServerState()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-opencode-stop-\(UUID().uuidString)", isDirectory: true)
+        let workspaceId = "11111111-1111-1111-1111-111111111111"
+        let surfaceId = "22222222-2222-2222-2222-222222222222"
+        let sessionId = "opencode-session-123"
+        let openCodeConfigDir = root.appendingPathComponent("opencode", isDirectory: true)
+
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer {
+            Darwin.close(listenerFD)
+            unlink(socketPath)
+            try? FileManager.default.removeItem(at: root)
+        }
+
+        let environment: [String: String] = [
+            "HOME": root.path,
+            "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+            "PWD": root.path,
+            "CMUX_SOCKET_PATH": socketPath,
+            "CMUX_WORKSPACE_ID": workspaceId,
+            "CMUX_SURFACE_ID": surfaceId,
+            "CMUX_AGENT_HOOK_STATE_DIR": root.path,
+            "CMUX_CLI_SENTRY_DISABLED": "1",
+            "OPENCODE_CONFIG_DIR": openCodeConfigDir.path,
+        ]
+
+        func runOpenCodeHook(_ subcommand: String, input: String) -> ProcessRunResult {
+            let serverHandled = startMockServer(listenerFD: listenerFD, state: state) { line in
+                guard let payload = self.jsonObject(line) else {
+                    return "OK"
+                }
+                guard let id = payload["id"] as? String, let method = payload["method"] as? String else {
+                    return self.malformedRequestResponse(id: payload["id"] as? String, raw: line)
+                }
+                switch method {
+                case "surface.list":
+                    return self.surfaceListResponse(id: id, surfaceId: surfaceId)
+                case "feed.push":
+                    return self.v2Response(id: id, ok: true, result: ["status": "acknowledged"])
+                case "surface.resume.set":
+                    return self.v2Response(id: id, ok: true, result: ["resume_binding": [:]])
+                default:
+                    return self.v2Response(id: id, ok: false, error: ["code": "unrecognized_method", "message": "unexpected method: \(method)"])
+                }
+            }
+            let result = runProcess(
+                executablePath: cliPath,
+                arguments: ["hooks", "opencode", subcommand],
+                environment: environment,
+                standardInput: input,
+                timeout: 5
+            )
+            wait(for: [serverHandled], timeout: 5)
+            return result
+        }
+
+        let start = runOpenCodeHook(
+            "session-start",
+            input: #"{"session_id":"\#(sessionId)","cwd":"\#(root.path)","hook_event_name":"SessionStart"}"#
+        )
+        XCTAssertFalse(start.timedOut, start.stderr)
+        XCTAssertEqual(start.status, 0, start.stderr)
+        XCTAssertEqual(start.stdout, "{}\n")
+
+        let stopCommandStart = state.commands.count
+        let stop = runOpenCodeHook(
+            "stop",
+            input: #"{"session_id":"\#(sessionId)","cwd":"\#(root.path)","hook_event_name":"Stop"}"#
+        )
+        XCTAssertFalse(stop.timedOut, stop.stderr)
+        XCTAssertEqual(stop.status, 0, stop.stderr)
+        XCTAssertEqual(stop.stdout, "{}\n")
+
+        let stopCommands = Array(state.commands.dropFirst(stopCommandStart))
+        XCTAssertFalse(
+            stopCommands.contains { $0.hasPrefix("notify_target_async ") },
+            "OpenCode session hooks must not publish generic completion notifications; Feed owns OpenCode stop notifications. Saw \(stopCommands)"
+        )
+        XCTAssertTrue(
+            stopCommands.contains { $0.contains("set_status opencode Idle") },
+            "Expected OpenCode Stop to keep task-manager status idle, saw \(stopCommands)"
+        )
+        XCTAssertTrue(
+            stopCommands.contains {
+                guard let payload = self.jsonObject($0),
+                      payload["method"] as? String == "feed.push",
+                      let params = payload["params"] as? [String: Any],
+                      let event = params["event"] as? [String: Any] else {
+                    return false
+                }
+                return event["hook_event_name"] as? String == "Stop"
+                    && event["_source"] as? String == "opencode"
+            },
+            "Expected OpenCode Stop to still emit Feed telemetry, saw \(stopCommands)"
+        )
+    }
+
     func testGrokNotificationHookUsesPayloadMessageAndStopDoesNotSendGenericNotification() throws {
         let cliPath = try bundledCLIPath()
         let socketPath = makeSocketPath("grok-notification")

--- a/cmuxTests/FeedCoordinatorTests.swift
+++ b/cmuxTests/FeedCoordinatorTests.swift
@@ -135,6 +135,84 @@ final class FeedCoordinatorTests: XCTestCase {
         )
     }
 
+    func testOpenCodePermissionNotificationBodyUsesSafeSummary() {
+        let event = WorkstreamEvent(
+            sessionId: "opencode-notification-permission",
+            hookEventName: .permissionRequest,
+            source: "opencode",
+            toolName: "bash",
+            toolInputJSON: #"{"permission":"bash","action":"run_command","metadata":{"input":{"command":"deploy --token super-secret"}}}"#,
+            requestId: "per-opencode-rich"
+        )
+
+        XCTAssertEqual(
+            FeedCoordinator.notificationBodyForTesting(event: event),
+            "Shell command"
+        )
+    }
+
+    func testOpenCodePlanAndQuestionNotificationBodiesUsePayloadDetails() {
+        let planEvent = WorkstreamEvent(
+            sessionId: "opencode-notification-plan",
+            hookEventName: .exitPlanMode,
+            source: "opencode",
+            toolName: "plan_exit",
+            toolInputJSON: ###"{"plan":"## Demo plan\n\n- Wire richer OpenCode hooks\n- Verify with a plugin harness"}"###,
+            requestId: "que-opencode-plan"
+        )
+        XCTAssertEqual(
+            FeedCoordinator.notificationBodyForTesting(event: planEvent),
+            "Wire richer OpenCode hooks"
+        )
+
+        let questionEvent = WorkstreamEvent(
+            sessionId: "opencode-notification-question",
+            hookEventName: .askUserQuestion,
+            source: "opencode",
+            toolName: "question",
+            toolInputJSON: #"{"questions":[{"question":"Which detail should cmux show?","options":[{"label":"Command","description":"Show the shell command"},{"label":"Path","description":"Show the file path"}]}]}"#,
+            requestId: "que-opencode-rich"
+        )
+        XCTAssertEqual(
+            FeedCoordinator.notificationBodyForTesting(event: questionEvent),
+            "Which detail should cmux show?\n- Command\n- Path"
+        )
+    }
+
+    func testOpenCodeStopNotificationUsesStopDetails() {
+        let event = WorkstreamEvent(
+            sessionId: "opencode-stop-notification",
+            hookEventName: .stop,
+            source: "opencode",
+            toolInputJSON: #"{"reason":"Implemented the hook rendering update"}"#,
+            extraFieldsJSON: #"{"surface_id":"11111111-1111-1111-1111-111111111111"}"#
+        )
+
+        XCTAssertEqual(
+            FeedCoordinator.notificationBodyForTesting(event: event),
+            "Implemented the hook rendering update"
+        )
+        let content = FeedCoordinator.basicStopNotificationForTesting(event: event)
+        XCTAssertEqual(content?.title, "OpenCode completed")
+        XCTAssertEqual(content?.subtitle, "Completed")
+        XCTAssertEqual(content?.body, "Implemented the hook rendering update")
+    }
+
+    func testOpenCodeStopNotificationWithoutAssistantTextUsesTitleOnly() {
+        let event = WorkstreamEvent(
+            sessionId: "opencode-stop-notification-basic",
+            hookEventName: .stop,
+            source: "opencode",
+            extraFieldsJSON: #"{"surface_id":"11111111-1111-1111-1111-111111111111"}"#
+        )
+
+        XCTAssertNil(FeedCoordinator.notificationBodyForTesting(event: event))
+        let content = FeedCoordinator.basicStopNotificationForTesting(event: event)
+        XCTAssertEqual(content?.title, "OpenCode completed")
+        XCTAssertEqual(content?.subtitle, "Completed")
+        XCTAssertEqual(content?.body, "")
+    }
+
     private static func resetFeedCoordinatorTestHooks() {
         let reset: @Sendable () -> Void = {
             MainActor.assumeIsolated {

--- a/cmuxTests/OpenCodeHookRegressionTests.swift
+++ b/cmuxTests/OpenCodeHookRegressionTests.swift
@@ -19,7 +19,7 @@ final class OpenCodeHookRegressionTests: XCTestCase {
         try FileManager.default.createDirectory(at: binDir, withIntermediateDirectories: true)
 
         let configURL = configDir.appendingPathComponent("opencode.json", isDirectory: false)
-        try #"{"plugin":["other-plugin","./plugins/cmux-session.js"]}"#.write(to: configURL, atomically: true, encoding: .utf8)
+        try #"{"plugin":["other-plugin","./plugins/cmux-session.js","cmux-feed"]}"#.write(to: configURL, atomically: true, encoding: .utf8)
         let fakeOpenCodeURL = binDir.appendingPathComponent("opencode", isDirectory: false)
         try "#!/bin/sh\nexit 0\n".write(to: fakeOpenCodeURL, atomically: true, encoding: .utf8)
         chmod(fakeOpenCodeURL.path, 0o755)
@@ -45,7 +45,7 @@ final class OpenCodeHookRegressionTests: XCTestCase {
         XCTAssertTrue(try String(contentsOf: configDir.appendingPathComponent("plugins/cmux-feed.js"), encoding: .utf8).contains("cmux-feed-plugin-marker"))
 
         let json = try XCTUnwrap(JSONSerialization.jsonObject(with: try Data(contentsOf: configURL), options: []) as? [String: Any])
-        XCTAssertEqual(try XCTUnwrap(json["plugin"] as? [String]), ["other-plugin", "./plugins/cmux-session.js"])
+        XCTAssertEqual(try XCTUnwrap(json["plugin"] as? [String]), ["other-plugin", "./plugins/cmux-session.js", "./plugins/cmux-feed.js"])
     }
 
     func testLegacyHookAliasesAreHiddenFromHelp() throws {

--- a/tests/test_opencode_plugin_install.py
+++ b/tests/test_opencode_plugin_install.py
@@ -45,7 +45,9 @@ def main() -> int:
                         "oh-my-opencode",
                         ["existing-plugin", {"enabled": True}],
                         "cmux-session",
+                        "cmux-feed",
                         "./plugins/cmux-session.js",
+                        "./plugins/cmux-feed.js",
                     ]
                 }
             ),
@@ -90,17 +92,19 @@ def main() -> int:
         if not isinstance(plugins, list):
             print(f"FAIL: expected plugin list in opencode.json, got {plugins!r}")
             return 1
-        stale = [
-            entry
-            for entry in plugins
-            if (entry if isinstance(entry, str) else entry[0] if isinstance(entry, list) and entry else "")
-            == "cmux-session"
-        ]
+        stale = []
+        for entry in plugins:
+            name = entry if isinstance(entry, str) else entry[0] if isinstance(entry, list) and entry else ""
+            if name in {"cmux-session", "cmux-feed"}:
+                stale.append(entry)
         if stale:
             print(f"FAIL: expected stale cmux plugin registrations removed, got {plugins!r}")
             return 1
-        if "./plugins/cmux-session.js" not in plugins:
-            print(f"FAIL: expected local cmux session plugin registration, got {plugins!r}")
+        if plugins.count("./plugins/cmux-session.js") != 1:
+            print(f"FAIL: expected one local cmux session plugin registration, got {plugins!r}")
+            return 1
+        if plugins.count("./plugins/cmux-feed.js") != 1:
+            print(f"FAIL: expected one local cmux feed plugin registration, got {plugins!r}")
             return 1
         if "oh-my-opencode" not in plugins or ["existing-plugin", {"enabled": True}] not in plugins:
             print(f"FAIL: installer did not preserve existing plugin entries: {plugins!r}")
@@ -130,6 +134,10 @@ def main() -> int:
                 print("FAIL: opencode did not auto-load cmux session plugin file")
                 print(debug_output[-4000:])
                 return 1
+            if f"file://{feed_plugin_path}" not in debug_output:
+                print("FAIL: opencode did not auto-load cmux feed plugin file")
+                print(debug_output[-4000:])
+                return 1
 
         fake_cmux = root / "fake-cmux"
         fake_args_log = root / "fake-cmux-args.log"
@@ -155,6 +163,8 @@ printf '\\n---\\n' >> "$FAKE_CMUX_STDIN_LOG"
         check_env = env.copy()
         check_env["CMUX_TEST_OPENCODE_PLUGIN_PATH"] = str(plugin_path)
         check_env["CMUX_TEST_OPENCODE_PLUGIN_COPY_PATH"] = str(plugin_copy_path)
+        check_env["CMUX_TEST_OPENCODE_FEED_PLUGIN_PATH"] = str(feed_plugin_path)
+        check_env["CMUX_SOCKET_PATH"] = f"/tmp/cmux-opencode-feed-{os.getpid()}.sock"
         check_env["CMUX_SURFACE_ID"] = "surface-opencode-test"
         check_env["CMUX_OPENCODE_CMUX_BIN"] = str(fake_cmux)
         check_env["FAKE_CMUX_ARGS_LOG"] = str(fake_args_log)
@@ -213,6 +223,145 @@ await hooks.event({
             print(f"exit={check.returncode}")
             print(f"stdout={check.stdout.strip()}")
             print(f"stderr={check.stderr.strip()}")
+            return 1
+
+        feed_check_source = """
+const net = await import("node:net");
+const fs = await import("node:fs");
+const pluginPath = process.env.CMUX_TEST_OPENCODE_FEED_PLUGIN_PATH;
+const socketPath = process.env.CMUX_SOCKET_PATH;
+try { fs.unlinkSync(socketPath); } catch (_) {}
+const frames = [];
+const sockets = new Set();
+const server = net.createServer((socket) => {
+  sockets.add(socket);
+  socket.on("close", () => sockets.delete(socket));
+  socket.setEncoding("utf8");
+  let buffered = "";
+  socket.on("data", (chunk) => {
+    buffered += chunk;
+    let idx;
+    while ((idx = buffered.indexOf("\\n")) >= 0) {
+      const line = buffered.slice(0, idx);
+      buffered = buffered.slice(idx + 1);
+      if (!line) continue;
+      const msg = JSON.parse(line);
+      frames.push(msg);
+      if (msg.id && msg.params?.event?.hook_event_name === "PermissionRequest") {
+        socket.write(JSON.stringify({ id: msg.id, result: { status: "timed_out" } }) + "\\n");
+      }
+    }
+  });
+});
+await new Promise((resolve) => server.listen(socketPath, resolve));
+const mod = await import(pluginPath);
+if (typeof mod.CMUXFeed !== "function") {
+  throw new Error("missing CMUXFeed export");
+}
+const hooks = await mod.CMUXFeed({ directory: "/tmp/opencode-project" });
+await hooks.event({
+  event: {
+    type: "permission.asked",
+    properties: {
+      id: "permission-rich",
+      sessionID: "ses-rich-stop",
+      permission: "bash",
+      metadata: {
+        input: {
+          command: "deploy --token super-secret",
+          description: "Deploy production"
+        }
+      },
+      patterns: ["deploy *"]
+    }
+  }
+});
+await hooks.event({
+  event: {
+    type: "message.updated",
+    properties: { info: { id: "msg-user", sessionID: "ses-rich-stop", role: "user" } },
+  },
+});
+await hooks.event({
+  event: {
+    type: "message.part.updated",
+    properties: {
+      part: {
+        id: "part-user",
+        sessionID: "ses-rich-stop",
+        messageID: "msg-user",
+        type: "text",
+        text: "meaning of life",
+      },
+    },
+  },
+});
+await hooks.event({
+  event: {
+    type: "message.updated",
+    properties: { info: { id: "msg-assistant", sessionID: "ses-rich-stop", role: "assistant" } },
+  },
+});
+await hooks.event({
+  event: {
+    type: "message.part.updated",
+    properties: {
+      part: {
+        id: "part-assistant",
+        sessionID: "ses-rich-stop",
+        messageID: "msg-assistant",
+        type: "text",
+        text: "42. Use cmux notifications.",
+      },
+    },
+  },
+});
+await hooks.event({ event: { type: "session.idle", properties: { sessionID: "ses-rich-stop" } } });
+await new Promise((resolve) => setTimeout(resolve, 100));
+sockets.forEach((socket) => socket.destroy());
+await new Promise((resolve) => server.close(resolve));
+try { fs.unlinkSync(socketPath); } catch (_) {}
+const stop = frames.find((frame) => frame.params?.event?.hook_event_name === "Stop");
+if (!stop) {
+  throw new Error(`missing Stop frame: ${JSON.stringify(frames)}`);
+}
+const event = stop.params.event;
+if (event.tool_input?.reason !== "42. Use cmux notifications.") {
+  throw new Error(`missing Stop reason: ${JSON.stringify(event)}`);
+}
+if (event.tool_input?.last_assistant_message !== "42. Use cmux notifications.") {
+  throw new Error(`missing Stop last_assistant_message: ${JSON.stringify(event)}`);
+}
+if (event.context?.assistantPreamble !== "42. Use cmux notifications.") {
+  throw new Error(`missing Stop context assistantPreamble: ${JSON.stringify(event)}`);
+}
+const permission = frames.find((frame) => frame.params?.event?.hook_event_name === "PermissionRequest")?.params?.event;
+if (!permission) {
+  throw new Error(`missing PermissionRequest frame: ${JSON.stringify(frames)}`);
+}
+if (permission.tool_input?.action !== "run_command") {
+  throw new Error(`missing canonical permission action: ${JSON.stringify(permission)}`);
+}
+for (const presentationKey of ["summary", "title", "lines", "icon"]) {
+  if (Object.prototype.hasOwnProperty.call(permission.tool_input || {}, presentationKey)) {
+    throw new Error(`permission payload leaked presentation key ${presentationKey}: ${JSON.stringify(permission)}`);
+  }
+}
+"""
+        feed_check = subprocess.run(
+            [bun, "--eval", feed_check_source],
+            cwd=root,
+            capture_output=True,
+            text=True,
+            check=False,
+            env=check_env,
+            timeout=20,
+        )
+        if feed_check.returncode != 0:
+            print("FAIL: generated OpenCode feed plugin did not emit rich Stop details")
+            print(f"exit={feed_check.returncode}")
+            print(f"stdout={feed_check.stdout.strip()}")
+            print(f"stderr={feed_check.stderr.strip()}")
             return 1
 
         args_log = fake_args_log.read_text(encoding="utf-8") if fake_args_log.exists() else ""


### PR DESCRIPTION
## Summary
- Enrich OpenCode feed hooks with structured permission, plan, question, and Stop payloads based on current OpenCode event shapes.
- Make `cmux-feed.js` the single OpenCode completion notification owner; `cmux-session.js` only owns restore/status.
- Stop notifications now use assistant completion text captured from OpenCode message events. When OpenCode has no assistant text, the notification is title-only (`OpenCode completed`).
- Keep permission payloads canonical in JS and render localized, privacy-safe native notification summaries in Swift.

## Upstream reference
- Reviewed `anomalyco/opencode` locally to match current hook payload shapes.

## Testing
- `./scripts/reload.sh --tag ocrich`
- `CMUX_CLI_BIN='/Users/lawrence/Library/Developer/Xcode/DerivedData/cmux-ocrich/Build/Products/Debug/cmux DEV ocrich.app/Contents/Resources/bin/cmux' python3 tests/test_opencode_plugin_install.py`
- Source Bun harness: PermissionRequest emits canonical `action` without `summary` / `title` / `lines` / `icon`, and Stop emits assistant text in `tool_input.reason`.
- `node --check Resources/opencode-plugin.js`
- `jq empty Resources/Localizable.xcstrings`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added English/Japanese localized strings for stop UI, notification text, and a “continue after repeated failures” option.
  * Notifications now show richer, source-aware bodies and include more detailed stop/context info.
  * Stop UI placeholders and “Send to …” labels adjust based on content source.

* **Bug Fixes**
  * Prevented redundant generic completion notifications for the OpenCode workflow.

* **Tests**
  * Added tests for notification body generation and feed plugin socket/frame behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4847?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent hook install, OpenCode launch port behavior, and notification/permission paths where regressions could affect approvals or duplicate/missed alerts; mitigated by focused tests and explicit notification ownership split.
> 
> **Overview**
> This PR splits **OpenCode** integration so **`cmux-feed.js`** owns Feed events (permissions, plans, questions, **Stop**) and completion-style notifications, while **`cmux-session.js`** stays limited to session restore and status—session hooks no longer emit generic stop notifications.
> 
> The feed plugin now maps OpenCode events into **canonical `tool_input`** (including permission kinds like bash/edit/doom loop), tracks assistant text from message parts/deltas for **Stop** payloads, and hardens the cmux socket client with outboxes and reconnect behavior. CLI install/OMO shadow config registers **both** managed plugins and only sets **`OPENCODE_PORT`** when the user or env explicitly provides a port (no more implicit default/fallback binding).
> 
> On the app side, **Feed** shows richer OpenCode permission/plan previews, **source-aware Stop** reply UI and markdown where appropriate, and **privacy-safe** localized notification summaries. **OpenCode Stop** telemetry can post a tab notification (title-only when there is no assistant text). New **en/ja** strings back the UI and notification copy.
> 
> Tests cover plugin registration idempotency, feed plugin socket/Stop/permission shape, and notification body generation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b3642d5708befed250d6e5843615c9d08cd6e33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->