### PR TITLE
Add sidebar position toggle

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -55255,6 +55255,23 @@
         }
       }
     },
+    "settings.app.workspacesOnRight": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workspaces on Right"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースを右側に表示"
+          }
+        }
+      }
+    },
     "settings.app.commandPaletteSearchAllSurfaces.subtitleOff": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -11099,6 +11099,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         titlebarAccessoryController.attach(to: window)
     }
 
+    func titlebarControlsWorkspaceSidebarWidth(preferredWindow: NSWindow?) -> CGFloat? {
+        guard SidebarPositionSettings.workspacesOnRight(),
+              let context = contextForMainWindow(preferredWindow),
+              context.sidebarState.isVisible else {
+            return nil
+        }
+        return CGFloat(
+            SessionPersistencePolicy.sanitizedSidebarWidth(
+                Double(context.sidebarState.persistedWidth)
+            )
+        )
+    }
+
     func applyWindowDecorations(to window: NSWindow) {
         windowDecorationsController.apply(to: window)
     }

--- a/Sources/CommandPalette/CommandPaletteSettingsToggle.swift
+++ b/Sources/CommandPalette/CommandPaletteSettingsToggle.swift
@@ -386,6 +386,31 @@ enum CommandPaletteSettingsToggleCommands {
                 defaultsKey: CommandPaletteSwitcherSearchSettings.searchAllSurfacesKey
             ),
             CommandPaletteSettingToggleDescriptor(
+                commandId: commandIdPrefix + "workspacesOnRight",
+                settingsKey: SidebarPositionSettings.workspacesOnRightKey,
+                title: {
+                    String(localized: "settings.app.workspacesOnRight", defaultValue: "Workspaces on Right")
+                },
+                sectionTitle: sidebar,
+                keywords: [
+                    "sidebar.workspacesOnRight",
+                    "sidebar",
+                    "position",
+                    "layout",
+                    "swap",
+                    "right",
+                    "left",
+                    "workspace",
+                    "workspaces",
+                    "vscode",
+                    "primary",
+                    "side",
+                    "bar",
+                ],
+                defaultValue: SidebarPositionSettings.defaultWorkspacesOnRight,
+                defaultsKey: SidebarPositionSettings.workspacesOnRightKey
+            ),
+            CommandPaletteSettingToggleDescriptor(
                 commandId: commandIdPrefix + "terminalShowScrollBar",
                 settingsKey: "terminal.showScrollBar",
                 title: {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1057,6 +1057,8 @@ struct ContentView: View {
     @EnvironmentObject var fileExplorerState: FileExplorerState
     @Environment(\.colorScheme) private var colorScheme
     @AppStorage("titlebarControlsStyle") private var titlebarControlsStyleRawValue = TitlebarControlsStyle.classic.rawValue
+    @AppStorage(SidebarPositionSettings.workspacesOnRightKey)
+    private var workspacesOnRight = SidebarPositionSettings.defaultWorkspacesOnRight
     @AppStorage(SessionPersistencePolicy.sidebarMinimumWidthKey) private var sidebarMinimumWidthSetting = SessionPersistencePolicy.defaultMinimumSidebarWidth
     @AppStorage(MinimalModeTitlebarDebugSettings.leftControlsLeadingInsetKey) private var titlebarLeftControlsLeadingInset = MinimalModeTitlebarDebugSettings.defaultLeftControlsLeadingInset
     @AppStorage(MinimalModeTitlebarDebugSettings.leftControlsTopInsetKey) private var titlebarLeftControlsTopInset = MinimalModeTitlebarDebugSettings.defaultLeftControlsTopInset
@@ -1580,6 +1582,20 @@ struct ContentView: View {
         CGFloat(SessionPersistencePolicy.sanitizedMinimumSidebarWidth(sidebarMinimumWidthSetting))
     }
 
+    private var primarySidebarOnTrailingEdge: Bool {
+        workspacesOnRight
+    }
+
+    private var toolsSidebarOnLeadingEdge: Bool {
+        primarySidebarOnTrailingEdge
+    }
+
+    private var terminalContentTouchesWindowLeadingEdge: Bool {
+        let primaryOccupiesLeadingEdge = sidebarState.isVisible && !primarySidebarOnTrailingEdge
+        let toolsOccupyLeadingEdge = rightSidebarVisible && toolsSidebarOnLeadingEdge
+        return !primaryOccupiesLeadingEdge && !toolsOccupyLeadingEdge
+    }
+
     private enum SidebarResizerHandle: Hashable {
         case divider
         case explorerDivider
@@ -1599,8 +1615,9 @@ struct ContentView: View {
                 captureStart: { sidebarDragStartWidth = sidebarWidth },
                 updateWidth: { translation in
                     let startWidth = sidebarDragStartWidth ?? sidebarWidth
+                    let signedTranslation = primarySidebarOnTrailingEdge ? -translation : translation
                     let nextWidth = Self.clampedSidebarWidth(
-                        startWidth + translation,
+                        startWidth + signedTranslation,
                         maximumWidth: maxSidebarWidth(availableWidth: availableWidth),
                         minimumWidth: minimumSidebarWidth
                     )
@@ -1616,8 +1633,9 @@ struct ContentView: View {
                 captureStart: { fileExplorerDragStartWidth = fileExplorerWidth },
                 updateWidth: { translation in
                     let startWidth = fileExplorerDragStartWidth ?? fileExplorerWidth
+                    let signedTranslation = toolsSidebarOnLeadingEdge ? translation : -translation
                     let nextWidth = Self.clampedRightSidebarWidth(
-                        startWidth - translation,
+                        startWidth + signedTranslation,
                         availableWidth: availableWidth
                     )
                     withTransaction(Transaction(animation: nil)) {
@@ -1769,14 +1787,22 @@ struct ContentView: View {
 
     private func dividerBandContains(pointInContent point: NSPoint, contentBounds: NSRect) -> Bool {
         guard point.y >= contentBounds.minY, point.y <= contentBounds.maxY else { return false }
-        if sidebarState.isVisible,
-           SidebarResizeInteraction.Edge.leading.hitRange(dividerX: sidebarWidth).contains(point.x) {
-            return true
+        if sidebarState.isVisible {
+            let primaryEdge: SidebarResizeInteraction.Edge = primarySidebarOnTrailingEdge ? .trailing : .leading
+            let primaryDividerX = primarySidebarOnTrailingEdge
+                ? contentBounds.maxX - sidebarWidth
+                : sidebarWidth
+            if primaryEdge.hitRange(dividerX: primaryDividerX).contains(point.x) {
+                return true
+            }
         }
 
-        let rightDividerX = contentBounds.maxX - rightSidebarWidth
-        return rightSidebarVisible &&
-            SidebarResizeInteraction.Edge.trailing.hitRange(dividerX: rightDividerX).contains(point.x)
+        guard rightSidebarVisible else { return false }
+        let toolsEdge: SidebarResizeInteraction.Edge = toolsSidebarOnLeadingEdge ? .leading : .trailing
+        let toolsDividerX = toolsSidebarOnLeadingEdge
+            ? rightSidebarWidth
+            : contentBounds.maxX - rightSidebarWidth
+        return toolsEdge.hitRange(dividerX: toolsDividerX).contains(point.x)
     }
 
     private func updateSidebarResizerBandState(using _: NSEvent? = nil) {
@@ -1979,18 +2005,24 @@ struct ContentView: View {
     private var sidebarResizerOverlay: some View {
         placedSidebarResizerOverlay(
             handle: .divider,
-            edge: .leading,
+            edge: primarySidebarOnTrailingEdge ? .trailing : .leading,
             accessibilityIdentifier: "SidebarResizer",
-            dividerX: { totalWidth in min(max(sidebarWidth, 0), totalWidth) }
+            dividerX: { totalWidth in
+                primarySidebarOnTrailingEdge
+                    ? totalWidth - min(max(sidebarWidth, 0), totalWidth)
+                    : min(max(sidebarWidth, 0), totalWidth)
+            }
         )
     }
 
     private var rightSidebarResizerOverlay: some View {
         placedSidebarResizerOverlay(
             handle: .explorerDivider,
-            edge: .trailing,
+            edge: toolsSidebarOnLeadingEdge ? .leading : .trailing,
             accessibilityIdentifier: "RightSidebarResizer",
-            dividerX: { totalWidth in totalWidth - rightSidebarWidth }
+            dividerX: { totalWidth in
+                toolsSidebarOnLeadingEdge ? rightSidebarWidth : totalWidth - rightSidebarWidth
+            }
         )
     }
 
@@ -2008,6 +2040,9 @@ struct ContentView: View {
                 )
             },
             observedWindow: observedWindow,
+            showsMinimalTitlebarControls: true,
+            minimalTitlebarControlsPlacement: minimalModeSidebarTitlebarControlsPlacement,
+            borderAlignment: primarySidebarOnTrailingEdge ? .leading : .trailing,
             selection: $sidebarSelectionState.selection,
             selectedTabIds: $selectedTabIds,
             lastSidebarSelectionIndex: $lastSidebarSelectionIndex
@@ -2027,6 +2062,14 @@ struct ContentView: View {
 
     private var isMinimalMode: Bool {
         WorkspacePresentationModeSettings.mode(for: workspacePresentationMode) == .minimal
+    }
+
+    private var minimalModeSidebarTitlebarControlsAvailable: Bool {
+        sidebarState.isVisible
+    }
+
+    private var minimalModeSidebarTitlebarControlsPlacement: MinimalModeSidebarTitlebarControlsPlacement {
+        primarySidebarOnTrailingEdge ? .trailing : .leading
     }
 
     private var effectiveTitlebarPadding: CGFloat {
@@ -2137,6 +2180,14 @@ struct ContentView: View {
         rightSidebarVisible ? fileExplorerWidth : 0
     }
 
+    private var leadingToolSidebarTitlebarReserve: CGFloat {
+        guard toolsSidebarOnLeadingEdge, !isFullScreen else { return 0 }
+        return max(
+            titlebarLeadingInset,
+            TitlebarLeadingInsetPolicy.fallbackTrafficLightReserve
+        )
+    }
+
     private func sidebarBackdropLayer(
         width: CGFloat,
         role: WindowBackdropRole,
@@ -2166,16 +2217,27 @@ struct ContentView: View {
     }
 
     private func sidebarPanelWithBackdrop(appearance: WindowAppearanceSnapshot) -> some View {
-        sidebarPanelContainer(width: sidebarWidth, alignment: .leading, role: .leftSidebar, appearance: appearance) {
+        sidebarPanelContainer(
+            width: sidebarWidth,
+            alignment: primarySidebarOnTrailingEdge ? .trailing : .leading,
+            role: .leftSidebar,
+            appearance: appearance
+        ) {
             sidebarView
         }
     }
 
     private func rightSidebarPanelWithBackdrop(appearance: WindowAppearanceSnapshot) -> some View {
-        let panel = sidebarPanelContainer(width: rightSidebarWidth, alignment: .trailing, role: .rightSidebar, appearance: appearance) {
+        let borderAlignment: Alignment = toolsSidebarOnLeadingEdge ? .trailing : .leading
+        let panel = sidebarPanelContainer(
+            width: rightSidebarWidth,
+            alignment: toolsSidebarOnLeadingEdge ? .leading : .trailing,
+            role: .rightSidebar,
+            appearance: appearance
+        ) {
             rightSidebarPanel
         }
-        .overlay(alignment: .leading) {
+        .overlay(alignment: borderAlignment) {
             if rightSidebarVisible {
                 WindowChromeBorder(orientation: .vertical)
             }
@@ -2191,6 +2253,7 @@ struct ContentView: View {
             fileExplorerState: fileExplorerState,
             sessionIndexStore: sessionIndexStore,
             titlebarHeight: RightSidebarChromeMetrics.titlebarHeight,
+            titlebarLeadingReserve: leadingToolSidebarTitlebarReserve,
             workspaceId: tabManager.selectedTabId,
             onResumeSession: { entry in
                 resumeSession(entry: entry)
@@ -2208,7 +2271,10 @@ struct ContentView: View {
                 _ = AppDelegate.shared?.closeRightSidebarInActiveMainWindow(preferredWindow: observedWindow)
             }
         )
-        .frame(width: rightSidebarWidth)
+        .frame(
+            width: rightSidebarWidth,
+            alignment: toolsSidebarOnLeadingEdge ? .leading : .trailing
+        )
         .clipped()
         .allowsHitTesting(rightSidebarVisible)
         .accessibilityHidden(!rightSidebarVisible)
@@ -2338,6 +2404,12 @@ struct ContentView: View {
 
     private func customTitlebar(appearance: WindowAppearanceSnapshot) -> some View {
         let titlebarContentHeight = max(1, WindowChromeMetrics.appTitlebarHeight - 2)
+        let titlebarLeadingPadding: CGFloat = {
+            if isFullScreen && terminalContentTouchesWindowLeadingEdge {
+                return 8
+            }
+            return terminalContentTouchesWindowLeadingEdge ? titlebarLeadingInset : 12
+        }()
         return ZStack {
             // Enable window dragging from the titlebar strip without making the entire content
             // view draggable (which breaks drag gestures like tab reordering).
@@ -2369,7 +2441,7 @@ struct ContentView: View {
             }
             .frame(height: titlebarContentHeight)
             .padding(.top, 2)
-            .padding(.leading, (isFullScreen && !sidebarState.isVisible) ? 8 : (sidebarState.isVisible ? 12 : titlebarLeadingInset))
+            .padding(.leading, titlebarLeadingPadding)
             .padding(.trailing, 8)
         }
         .frame(height: WindowChromeMetrics.appTitlebarHeight)
@@ -2382,7 +2454,7 @@ struct ContentView: View {
     }
 
     private func syncTrafficLightInset() {
-        let inset: CGFloat = (isMinimalMode && !sidebarState.isVisible && !isFullScreen)
+        let inset: CGFloat = (isMinimalMode && terminalContentTouchesWindowLeadingEdge && !isFullScreen)
             ? CGFloat(titlebarDebugChromeSnapshot.trafficLightTabBarLeadingInset)
             : 0
         tabManager.syncWorkspaceTabBarLeadingInset(inset)
@@ -2599,33 +2671,62 @@ struct ContentView: View {
         let useWithinWindow = sidebarBlendMode == SidebarBlendModeOption.withinWindow.rawValue
             && !sidebarMatchTerminalBackground
         if useWithinWindow {
-            // Overlay mode keeps the left sidebar on top, but the right
-            // sidebar stays in an HStack so terminal rows are clipped before
-            // the sidebar backdrop samples the window.
-            layout = AnyView(
-                ZStack(alignment: .leading) {
-                    HStack(spacing: 0) {
-                        terminalContentWithSidebarDropOverlay(appearance: appearance)
-                            .padding(.leading, sidebarState.isVisible ? sidebarWidth : 0)
-                            .frame(maxWidth: .infinity, maxHeight: .infinity)
-                            .layoutPriority(1)
-                        rightSidebarPanelWithBackdrop(appearance: appearance)
+            if primarySidebarOnTrailingEdge {
+                layout = AnyView(
+                    ZStack(alignment: .trailing) {
+                        HStack(spacing: 0) {
+                            rightSidebarPanelWithBackdrop(appearance: appearance)
+                            terminalContentWithSidebarDropOverlay(appearance: appearance)
+                                .padding(.trailing, sidebarState.isVisible ? sidebarWidth : 0)
+                                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                                .layoutPriority(1)
+                        }
+                        if sidebarState.isVisible {
+                            sidebarPanelWithBackdrop(appearance: appearance)
+                        }
                     }
-                    if sidebarState.isVisible {
-                        sidebarPanelWithBackdrop(appearance: appearance)
+                )
+            } else {
+                // Overlay mode keeps the workspace sidebar on top, but the tools
+                // sidebar stays in an HStack so terminal rows are clipped before
+                // the sidebar backdrop samples the window.
+                layout = AnyView(
+                    ZStack(alignment: .leading) {
+                        HStack(spacing: 0) {
+                            terminalContentWithSidebarDropOverlay(appearance: appearance)
+                                .padding(.leading, sidebarState.isVisible ? sidebarWidth : 0)
+                                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                                .layoutPriority(1)
+                            rightSidebarPanelWithBackdrop(appearance: appearance)
+                        }
+                        if sidebarState.isVisible {
+                            sidebarPanelWithBackdrop(appearance: appearance)
+                        }
                     }
-                }
-            )
+                )
+            }
         } else {
             // Standard HStack mode for behindWindow blur
-            layout = AnyView(
-                HStack(spacing: 0) {
-                    if sidebarState.isVisible {
-                        sidebarPanelWithBackdrop(appearance: appearance)
+            if primarySidebarOnTrailingEdge {
+                layout = AnyView(
+                    HStack(spacing: 0) {
+                        rightSidebarPanelWithBackdrop(appearance: appearance)
+                        terminalContentWithSidebarDropOverlay(appearance: appearance)
+                        if sidebarState.isVisible {
+                            sidebarPanelWithBackdrop(appearance: appearance)
+                        }
                     }
-                    terminalContentWithRightSidebarPanel(appearance: appearance)
-                }
-            )
+                )
+            } else {
+                layout = AnyView(
+                    HStack(spacing: 0) {
+                        if sidebarState.isVisible {
+                            sidebarPanelWithBackdrop(appearance: appearance)
+                        }
+                        terminalContentWithRightSidebarPanel(appearance: appearance)
+                    }
+                )
+            }
         }
 
         return AnyView(
@@ -2656,11 +2757,12 @@ struct ContentView: View {
                 contentAndSidebarLayout(appearance: appearance)
             }
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-                .overlay(alignment: .topLeading) {
+                .overlay(alignment: primarySidebarOnTrailingEdge ? .topTrailing : .topLeading) {
                     if isFullScreen && sidebarState.isVisible && !isMinimalMode {
                         fullscreenControls
                             .environment(\.colorScheme, appearance.sidebarContentColorScheme)
-                            .padding(.leading, 10)
+                            .padding(.leading, primarySidebarOnTrailingEdge ? 0 : 10)
+                            .padding(.trailing, primarySidebarOnTrailingEdge ? 10 : 0)
                             .padding(.top, 4)
                     }
                 }
@@ -3166,6 +3268,9 @@ struct ContentView: View {
             // terminals and browsers need an explicit post-layout geometry resync.
             schedulePortalGeometrySynchronize()
             updateSidebarResizerBandState()
+            if let observedWindow {
+                AppDelegate.shared?.attachUpdateAccessory(to: observedWindow)
+            }
         })
 
         view = AnyView(view.onChange(of: sidebarMinimumWidthSetting) { _ in
@@ -3173,10 +3278,30 @@ struct ContentView: View {
             updateSidebarResizerBandState()
         })
 
-        view = AnyView(view.onChange(of: sidebarState.isVisible) { isVisible in
-            setMinimalModeSidebarTitlebarControlsAvailable(isVisible, in: observedWindow)
+        view = AnyView(view.onChange(of: sidebarState.isVisible) { _ in
+            setMinimalModeSidebarTitlebarControlsAvailable(
+                minimalModeSidebarTitlebarControlsAvailable,
+                placement: minimalModeSidebarTitlebarControlsPlacement,
+                in: observedWindow
+            )
             if let observedWindow {
                 AppDelegate.shared?.applyWindowDecorations(to: observedWindow)
+                AppDelegate.shared?.attachUpdateAccessory(to: observedWindow)
+            }
+            schedulePortalGeometrySynchronize()
+            updateSidebarResizerBandState()
+            syncTrafficLightInset()
+        })
+
+        view = AnyView(view.onChange(of: workspacesOnRight) { _, _ in
+            if let observedWindow {
+                setMinimalModeSidebarTitlebarControlsAvailable(
+                    minimalModeSidebarTitlebarControlsAvailable,
+                    placement: minimalModeSidebarTitlebarControlsPlacement,
+                    in: observedWindow
+                )
+                AppDelegate.shared?.applyWindowDecorations(to: observedWindow)
+                AppDelegate.shared?.attachUpdateAccessory(to: observedWindow)
             }
             schedulePortalGeometrySynchronize()
             updateSidebarResizerBandState()
@@ -3192,6 +3317,7 @@ struct ContentView: View {
             } else {
                 TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronizeForAllWindows()
             }
+            syncTrafficLightInset()
         })
 
         view = AnyView(view.onChange(of: sidebarMatchTerminalBackground) { _ in
@@ -3252,7 +3378,11 @@ struct ContentView: View {
         view = AnyView(view.background(WindowAccessor(refreshID: appearance.appKitWindowMutationID) { [appearance] window in
             window.identifier = NSUserInterfaceItemIdentifier(windowIdentifier)
             window.isRestorable = false
-            setMinimalModeSidebarTitlebarControlsAvailable(sidebarState.isVisible, in: window)
+            setMinimalModeSidebarTitlebarControlsAvailable(
+                minimalModeSidebarTitlebarControlsAvailable,
+                placement: minimalModeSidebarTitlebarControlsPlacement,
+                in: window
+            )
             window.titlebarAppearsTransparent = true
             // Native AppKit titlebar dragging steals pane-tab drags in minimal
             // mode. Keep the main window immovable by default; explicit chrome
@@ -9746,6 +9876,9 @@ struct VerticalTabsSidebar: View {
     let onToggleSidebar: () -> Void
     let onNewTab: () -> Void
     let observedWindow: NSWindow?
+    let showsMinimalTitlebarControls: Bool
+    let minimalTitlebarControlsPlacement: MinimalModeSidebarTitlebarControlsPlacement
+    let borderAlignment: Alignment
     @EnvironmentObject var tabManager: TabManager
     @EnvironmentObject var notificationStore: TerminalNotificationStore
     @Binding var selection: SidebarSelection
@@ -9865,6 +9998,52 @@ struct VerticalTabsSidebar: View {
             return MinimalModeSidebarTitlebarControlsMetrics.topInset
         }
         return minimalModeSidebarTitlebarControlsTopInset(in: observedWindow)
+    }
+
+    private var minimalModeSidebarTitlebarControlsAlignment: Alignment {
+        minimalTitlebarControlsPlacement == .trailing ? .topTrailing : .topLeading
+    }
+
+    private var minimalModeSidebarTitlebarControlsHorizontalEdge: Edge.Set {
+        minimalTitlebarControlsPlacement == .trailing ? .trailing : .leading
+    }
+
+    private var minimalModeSidebarTitlebarControlsHorizontalPadding: CGFloat {
+        minimalTitlebarControlsPlacement == .trailing
+            ? MinimalModeSidebarTitlebarControlsMetrics.trailingInset
+            : CGFloat(titlebarDebugChromeSnapshot.leftControlsLeadingInset)
+    }
+
+    private var minimalModeSidebarTitlebarControls: some View {
+        HiddenTitlebarSidebarControlsView(
+            notificationStore: notificationStore,
+            onToggleSidebar: onToggleSidebar,
+            onToggleNotifications: { anchorView in
+                AppDelegate.shared?.toggleNotificationsPopover(
+                    animated: true,
+                    anchorView: anchorView
+                )
+            },
+            onNewTab: onNewTab,
+            onFocusHistoryBack: {
+                if !tabManager.navigateBack() {
+                    NSSound.beep()
+                }
+            },
+            onFocusHistoryForward: {
+                if !tabManager.navigateForward() {
+                    NSSound.beep()
+                }
+            }
+        )
+        .padding(
+            minimalModeSidebarTitlebarControlsHorizontalEdge,
+            minimalModeSidebarTitlebarControlsHorizontalPadding
+        )
+        .padding(
+            .top,
+            minimalModeSidebarTitlebarControlsTopPadding
+        )
     }
 
     private var showsSidebarNotificationMessage: Bool {
@@ -9990,7 +10169,7 @@ struct VerticalTabsSidebar: View {
         }
         .accessibilityIdentifier("Sidebar")
         .ignoresSafeArea()
-        .overlay(alignment: .trailing) {
+        .overlay(alignment: borderAlignment) {
             SidebarTrailingBorder()
         }
         .background(
@@ -10144,37 +10323,9 @@ struct VerticalTabsSidebar: View {
                             ))
                     }
                 }
-                .overlay(alignment: .topLeading) {
-                    if isMinimalMode {
-                        HiddenTitlebarSidebarControlsView(
-                            notificationStore: notificationStore,
-                            onToggleSidebar: onToggleSidebar,
-                            onToggleNotifications: { anchorView in
-                                AppDelegate.shared?.toggleNotificationsPopover(
-                                    animated: true,
-                                    anchorView: anchorView
-                                )
-                            },
-                            onNewTab: onNewTab,
-                            onFocusHistoryBack: {
-                                if !tabManager.navigateBack() {
-                                    NSSound.beep()
-                                }
-                            },
-                            onFocusHistoryForward: {
-                                if !tabManager.navigateForward() {
-                                    NSSound.beep()
-                                }
-                            }
-                        )
-                            .padding(
-                                .leading,
-                                CGFloat(titlebarDebugChromeSnapshot.leftControlsLeadingInset)
-                            )
-                            .padding(
-                                .top,
-                                minimalModeSidebarTitlebarControlsTopPadding
-                            )
+                .overlay(alignment: minimalModeSidebarTitlebarControlsAlignment) {
+                    if isMinimalMode && showsMinimalTitlebarControls {
+                        minimalModeSidebarTitlebarControls
                     }
                 }
                 .background(Color.clear)
@@ -10285,37 +10436,9 @@ struct VerticalTabsSidebar: View {
                     .frame(height: sidebarTitlebarInteractionHeight)
                     .background(TitlebarDoubleClickMonitorView())
             }
-            .overlay(alignment: .topLeading) {
-                if isMinimalMode {
-                    HiddenTitlebarSidebarControlsView(
-                        notificationStore: notificationStore,
-                        onToggleSidebar: onToggleSidebar,
-                        onToggleNotifications: { anchorView in
-                            AppDelegate.shared?.toggleNotificationsPopover(
-                                animated: true,
-                                anchorView: anchorView
-                            )
-                        },
-                        onNewTab: onNewTab,
-                        onFocusHistoryBack: {
-                            if !tabManager.navigateBack() {
-                                NSSound.beep()
-                            }
-                        },
-                        onFocusHistoryForward: {
-                            if !tabManager.navigateForward() {
-                                NSSound.beep()
-                            }
-                        }
-                    )
-                    .padding(
-                        .leading,
-                        CGFloat(titlebarDebugChromeSnapshot.leftControlsLeadingInset)
-                    )
-                    .padding(
-                        .top,
-                        minimalModeSidebarTitlebarControlsTopPadding
-                    )
+            .overlay(alignment: minimalModeSidebarTitlebarControlsAlignment) {
+                if isMinimalMode && showsMinimalTitlebarControls {
+                    minimalModeSidebarTitlebarControls
                 }
             }
             .background(Color.clear)
@@ -16694,6 +16817,63 @@ private struct SidebarVisualEffectBackground: NSViewRepresentable {
 }
 
 /// Reads the leading inset required to clear traffic lights + left titlebar accessories.
+enum TitlebarLeadingInsetPolicy {
+    static let trafficLightTrailingMargin: CGFloat = 10
+    static let minimumTrafficLightReserve: CGFloat = 150
+
+    static var fallbackTrafficLightReserve: CGFloat {
+        max(
+            minimumTrafficLightReserve,
+            MinimalModeTitlebarDebugSettings.trafficLightTitlebarLeadingInset()
+        )
+    }
+
+    static func reserve(
+        trafficLightFrames: [NSRect],
+        leftAccessoryWidths: [CGFloat],
+        fallbackTrafficLightReserve: CGFloat = Self.fallbackTrafficLightReserve
+    ) -> CGFloat {
+        let measuredTrafficLightReserve = trafficLightFrames
+            .map(\.maxX)
+            .max()
+            .map { $0 + trafficLightTrailingMargin } ?? 0
+        let trafficLightReserve = max(fallbackTrafficLightReserve, measuredTrafficLightReserve)
+        let accessoryReserve = leftAccessoryWidths.reduce(CGFloat.zero) { partial, width in
+            partial + max(0, width)
+        }
+        return trafficLightReserve + accessoryReserve
+    }
+
+    static func reserve(in window: NSWindow) -> CGFloat {
+        let contentView = window.contentView
+        let trafficLightFrames = [
+            NSWindow.ButtonType.closeButton,
+            .miniaturizeButton,
+            .zoomButton
+        ].compactMap { buttonType -> NSRect? in
+            guard let button = window.standardWindowButton(buttonType),
+                  !button.isHidden,
+                  button.alphaValue > 0 else {
+                return nil
+            }
+            guard let contentView else {
+                return button.frame
+            }
+            return button.convert(button.bounds, to: contentView)
+        }
+        let leftAccessoryWidths = window.titlebarAccessoryViewControllers.compactMap { accessory -> CGFloat? in
+            guard accessory.layoutAttribute == .leading || accessory.layoutAttribute == .left else {
+                return nil
+            }
+            return accessory.view.frame.width
+        }
+        return reserve(
+            trafficLightFrames: trafficLightFrames,
+            leftAccessoryWidths: leftAccessoryWidths
+        )
+    }
+}
+
 final class TitlebarLeadingInsetPassthroughView: NSView {
     override var mouseDownCanMoveWindow: Bool { false }
     override func hitTest(_ point: NSPoint) -> NSView? { nil }
@@ -16711,13 +16891,7 @@ private struct TitlebarLeadingInsetReader: NSViewRepresentable {
     func updateNSView(_ nsView: NSView, context: Context) {
         DispatchQueue.main.async {
             guard let window = nsView.window else { return }
-            // Start past the traffic lights
-            var leading = MinimalModeTitlebarDebugSettings.trafficLightTitlebarLeadingInset()
-            // Add width of all left-aligned titlebar accessories
-            for accessory in window.titlebarAccessoryViewControllers
-                where accessory.layoutAttribute == .leading || accessory.layoutAttribute == .left {
-                leading += accessory.view.frame.width
-            }
+            let leading = TitlebarLeadingInsetPolicy.reserve(in: window)
             if leading != inset {
                 inset = leading
             }

--- a/Sources/RightSidebarPanelView.swift
+++ b/Sources/RightSidebarPanelView.swift
@@ -160,6 +160,7 @@ struct RightSidebarPanelView: View {
     @ObservedObject var fileExplorerState: FileExplorerState
     @ObservedObject var sessionIndexStore: SessionIndexStore
     let titlebarHeight: CGFloat
+    let titlebarLeadingReserve: CGFloat
     let workspaceId: UUID?
     let onResumeSession: ((SessionEntry) -> Void)?
     let onOpenFilePreview: (String) -> Void
@@ -269,7 +270,7 @@ struct RightSidebarPanelView: View {
                 closeButton
             }
         }
-        .rightSidebarChromeBar(leadingPadding: 4, trailingPadding: 6, height: titlebarHeight)
+        .rightSidebarChromeBar(leadingPadding: max(4, titlebarLeadingReserve), trailingPadding: 6, height: titlebarHeight)
         .overlay(alignment: .topLeading) {
             focusShortcutHintOverlay
         }
@@ -376,7 +377,7 @@ struct RightSidebarPanelView: View {
                 fontSize: 9,
                 emphasis: 1.05
             )
-                .padding(.leading, 6)
+                .padding(.leading, max(6, titlebarLeadingReserve + 2))
                 .padding(.top, 5)
                 .offset(
                     x: CGFloat(ShortcutHintDebugSettings.clamped(focusShortcutHintXOffset)),

--- a/Sources/Sidebar/SidebarState.swift
+++ b/Sources/Sidebar/SidebarState.swift
@@ -1,5 +1,6 @@
 import Combine
 import CoreGraphics
+import Foundation
 
 final class SidebarState: ObservableObject {
     @Published var isVisible: Bool
@@ -13,6 +14,15 @@ final class SidebarState: ObservableObject {
 
     func toggle() {
         isVisible.toggle()
+    }
+}
+
+enum SidebarPositionSettings {
+    static let workspacesOnRightKey = "sidebar.workspacesOnRight"
+    static let defaultWorkspacesOnRight = false
+
+    static func workspacesOnRight(defaults: UserDefaults = .standard) -> Bool {
+        defaults.object(forKey: workspacesOnRightKey) as? Bool ?? defaultWorkspacesOnRight
     }
 }
 

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -1792,6 +1792,11 @@ enum TitlebarWindowGeometryNotifications {
 }
 
 final class TitlebarControlsAccessoryViewController: NSTitlebarAccessoryViewController, NSPopoverDelegate {
+    private enum TrailingWorkspaceAlignment {
+        static let leadingInset: CGFloat = 10
+        static let trailingInset: CGFloat = 8
+    }
+
     private let hostingView: NonDraggableHostingView<TitlebarControlsView>
     private let containerView: NSView
     private let notificationStore: TerminalNotificationStore
@@ -1898,6 +1903,11 @@ final class TitlebarControlsAccessoryViewController: NSTitlebarAccessoryViewCont
         scheduleSizeUpdate(invalidateIntrinsicSize: true, invalidateLayout: observedWindowChanged)
     }
 
+    func refreshLayoutForSidebarPlacement() {
+        lastAppliedLayoutSnapshot = nil
+        scheduleSizeUpdate(invalidateIntrinsicSize: true, invalidateLayout: true)
+    }
+
     @discardableResult
     private func updateObservedWindowIfNeeded() -> Bool {
         let currentWindow = view.window
@@ -1971,19 +1981,40 @@ final class TitlebarControlsAccessoryViewController: NSTitlebarAccessoryViewCont
             titlebarHeight: titlebarHeight
         )
         let debugSnapshot = MinimalModeTitlebarDebugSettings.snapshot()
-        let xOffset = MinimalModeTitlebarDebugSettings.leftControlsXOffset(
-            leadingInset: debugSnapshot.leftControlsLeadingInset
+        let preferredLayoutAttribute = UpdateTitlebarAccessoryController.preferredControlsLayoutAttribute()
+        let workspaceSidebarWidth = AppDelegate.shared?.titlebarControlsWorkspaceSidebarWidth(
+            preferredWindow: view.window
         )
+        let alignsToTrailingWorkspaceSidebar = preferredLayoutAttribute == .right && workspaceSidebarWidth != nil
+        let xOffset = alignsToTrailingWorkspaceSidebar
+            ? 0
+            : MinimalModeTitlebarDebugSettings.leftControlsXOffset(
+                leadingInset: debugSnapshot.leftControlsLeadingInset
+            )
         let yOffset = TitlebarControlsLayoutMetrics.yOffset(
             contentHeight: contentSize.height,
             containerHeight: containerHeight,
             trafficLightFrame: trafficLightFrame,
             debugSnapshot: debugSnapshot
         )
+        let containerWidth: CGFloat
+        let hostingX: CGFloat
+        if let workspaceSidebarWidth, preferredLayoutAttribute == .right {
+            let minimumWidthForContent = contentSize.width
+                + TrailingWorkspaceAlignment.leadingInset
+                + TrailingWorkspaceAlignment.trailingInset
+            containerWidth = max(workspaceSidebarWidth, minimumWidthForContent)
+            hostingX = containerWidth == workspaceSidebarWidth
+                ? TrailingWorkspaceAlignment.leadingInset
+                : containerWidth - minimumWidthForContent + TrailingWorkspaceAlignment.leadingInset
+        } else {
+            containerWidth = contentSize.width + abs(xOffset)
+            hostingX = xOffset
+        }
         let nextLayoutSnapshot = TitlebarControlsLayoutSnapshot(
             contentSize: contentSize,
             containerHeight: containerHeight,
-            xOffset: xOffset,
+            xOffset: hostingX,
             yOffset: yOffset
         )
         guard titlebarControlsShouldApplyLayout(
@@ -1993,10 +2024,9 @@ final class TitlebarControlsAccessoryViewController: NSTitlebarAccessoryViewCont
             return
         }
         lastAppliedLayoutSnapshot = nextLayoutSnapshot
-        let containerWidth = contentSize.width + abs(xOffset)
         preferredContentSize = NSSize(width: containerWidth, height: containerHeight)
         containerView.setFrameSize(NSSize(width: containerWidth, height: containerHeight))
-        hostingView.frame = NSRect(x: xOffset, y: yOffset, width: contentSize.width, height: contentSize.height)
+        hostingView.frame = NSRect(x: hostingX, y: yOffset, width: contentSize.width, height: contentSize.height)
     }
 
     private func applyWorkspaceTitlebarVisibility() {
@@ -2725,6 +2755,8 @@ final class UpdateTitlebarAccessoryController {
     private let controlsIdentifier = NSUserInterfaceItemIdentifier("cmux.titlebarControls")
     private let controlsControllers = NSHashTable<TitlebarControlsAccessoryViewController>.weakObjects()
     private var lastKnownPresentationMode: WorkspacePresentationModeSettings.Mode = WorkspacePresentationModeSettings.mode()
+    private var lastKnownControlsLayoutAttribute: NSLayoutConstraint.Attribute =
+        UpdateTitlebarAccessoryController.preferredControlsLayoutAttribute()
     private var detachedNotificationsPopover: NSPopover?
     private var detachedNotificationsPopoverDelegate: DetachedNotificationsPopoverDelegate?
 
@@ -2784,7 +2816,7 @@ final class UpdateTitlebarAccessoryController {
             queue: .main
         ) { [weak self] _ in
             Task { @MainActor [weak self] in
-                self?.reattachIfPresentationModeChanged()
+                self?.applyUserDefaultsDrivenAccessoryState()
             }
         })
 
@@ -2792,18 +2824,27 @@ final class UpdateTitlebarAccessoryController {
         // AppKit does not provide a stable cross-SDK API for this. Startup scans handle this case.
     }
 
-    private func reattachIfPresentationModeChanged() {
-
+    private func applyUserDefaultsDrivenAccessoryState() {
         let currentMode = WorkspacePresentationModeSettings.mode()
-        guard currentMode != lastKnownPresentationMode else { return }
+        let currentLayoutAttribute = Self.preferredControlsLayoutAttribute()
+        guard currentMode != lastKnownPresentationMode
+                || currentLayoutAttribute != lastKnownControlsLayoutAttribute else {
+            return
+        }
         lastKnownPresentationMode = currentMode
+        lastKnownControlsLayoutAttribute = currentLayoutAttribute
 
         if currentMode == .standard {
             attachToExistingWindows()
         }
         for window in attachedWindows.allObjects {
+            applyControlsPlacement(for: window)
             applyAccessoryVisibility(for: window)
         }
+    }
+
+    fileprivate static func preferredControlsLayoutAttribute() -> NSLayoutConstraint.Attribute {
+        SidebarPositionSettings.workspacesOnRight() ? .right : .left
     }
 
     private func attachToExistingWindows() {
@@ -2868,6 +2909,7 @@ final class UpdateTitlebarAccessoryController {
 
         // Don't re-attach controls if already attached.
         guard !attachedWindows.contains(window) else {
+            applyControlsPlacement(for: window)
             applyAccessoryVisibility(for: window)
             return
         }
@@ -2876,13 +2918,14 @@ final class UpdateTitlebarAccessoryController {
             let controls = TitlebarControlsAccessoryViewController(
                 notificationStore: TerminalNotificationStore.shared
             )
-            controls.layoutAttribute = .left
+            controls.layoutAttribute = Self.preferredControlsLayoutAttribute()
             controls.view.identifier = controlsIdentifier
             window.addTitlebarAccessoryViewController(controls)
             controlsControllers.add(controls)
         }
 
         attachedWindows.add(window)
+        applyControlsPlacement(for: window)
         applyAccessoryVisibility(for: window)
 
 #if DEBUG
@@ -2908,6 +2951,21 @@ final class UpdateTitlebarAccessoryController {
             accessory.view.isHidden = shouldHide
             accessory.view.alphaValue = shouldHide ? 0 : 1
         }
+    }
+
+    private func applyControlsPlacement(for window: NSWindow) {
+        guard canAccessTitlebarAccessories(on: window) else { return }
+        let layoutAttribute = Self.preferredControlsLayoutAttribute()
+        for accessory in window.titlebarAccessoryViewControllers
+            where accessory.view.identifier == controlsIdentifier {
+            accessory.layoutAttribute = layoutAttribute
+            if let controls = accessory as? TitlebarControlsAccessoryViewController {
+                controls.refreshLayoutForSidebarPlacement()
+            }
+        }
+        window.contentView?.superview?.needsLayout = true
+        window.contentView?.layoutSubtreeIfNeeded()
+        window.contentView?.superview?.layoutSubtreeIfNeeded()
     }
 
     private func removeAccessoryIfPresent(from window: NSWindow) {

--- a/Sources/WindowDecorationsController.swift
+++ b/Sources/WindowDecorationsController.swift
@@ -391,12 +391,15 @@ final class WindowDecorationsController {
             return
         }
 
+        let placement = minimalModeSidebarTitlebarControlsPlacement(in: window)
         let target = minimalModeSidebarTitlebarClickTargets.object(forKey: window) ?? {
             let view = MinimalModeSidebarControlActionView()
-            view.autoresizingMask = [.maxXMargin, .minYMargin]
             minimalModeSidebarTitlebarClickTargets.setObject(view, forKey: window)
             return view
         }()
+        target.autoresizingMask = placement == .trailing
+            ? [.minXMargin, .minYMargin]
+            : [.maxXMargin, .minYMargin]
         target.config = (TitlebarControlsStyle(rawValue: UserDefaults.standard.integer(forKey: "titlebarControlsStyle")) ?? .classic).config
         target.isEnabled = true
         target.requiresRevealedState = true
@@ -430,7 +433,8 @@ final class WindowDecorationsController {
                 ? 0
                 : MinimalModeSidebarTitlebarControlsMetrics.titlebarControlsOpticalYOffset(
                     backingScaleFactor: window.backingScaleFactor
-                )
+                ),
+            placement: placement
         )
 
         #if DEBUG

--- a/Sources/WindowDragHandleView.swift
+++ b/Sources/WindowDragHandleView.swift
@@ -662,6 +662,11 @@ struct MinimalModeTitlebarDebugSnapshot: Equatable {
     let trafficLightTitlebarLeadingInset: Double
 }
 
+enum MinimalModeSidebarTitlebarControlsPlacement {
+    case leading
+    case trailing
+}
+
 enum MinimalModeSidebarTitlebarControlsMetrics {
     static var leadingInset: CGFloat {
         leadingInset()
@@ -682,6 +687,29 @@ enum MinimalModeSidebarTitlebarControlsMetrics {
     static let hostWidth: CGFloat = 164
     static let hostHeight: CGFloat = 28
     static let singleButtonHostWidth: CGFloat = hostHeight
+    static let trailingInset: CGFloat = 10
+
+    static func originX(
+        contentBounds: NSRect,
+        placement: MinimalModeSidebarTitlebarControlsPlacement,
+        defaults: UserDefaults = .standard
+    ) -> CGFloat {
+        switch placement {
+        case .leading:
+            return contentBounds.minX + leadingInset(defaults: defaults)
+        case .trailing:
+            return max(contentBounds.minX, contentBounds.maxX - hostWidth - trailingInset)
+        }
+    }
+
+    static func horizontalRange(
+        contentBounds: NSRect,
+        placement: MinimalModeSidebarTitlebarControlsPlacement,
+        defaults: UserDefaults = .standard
+    ) -> ClosedRange<CGFloat> {
+        let minX = originX(contentBounds: contentBounds, placement: placement, defaults: defaults)
+        return minX...(minX + hostWidth)
+    }
 
     static func titlebarControlsOpticalYOffset(backingScaleFactor: CGFloat?) -> CGFloat {
         let scale = max(1.0, backingScaleFactor ?? 1.0)
@@ -716,6 +744,7 @@ func minimalModeSidebarTitlebarControlsFrame(
         visualDownwardAdjustment: trafficLightFrameInContent == nil
             ? 0
             : MinimalModeSidebarTitlebarControlsMetrics.titlebarControlsOpticalYOffset(in: window),
+        placement: minimalModeSidebarTitlebarControlsPlacement(in: window),
         defaults: defaults
     )
 }
@@ -740,6 +769,7 @@ func minimalModeSidebarTitlebarControlsFrame(
     contentViewIsFlipped: Bool,
     trafficLightFrameInContent: NSRect?,
     visualDownwardAdjustment: CGFloat = 0,
+    placement: MinimalModeSidebarTitlebarControlsPlacement = .leading,
     defaults: UserDefaults = .standard
 ) -> NSRect {
     let hostHeight = MinimalModeSidebarTitlebarControlsMetrics.hostHeight
@@ -756,7 +786,11 @@ func minimalModeSidebarTitlebarControlsFrame(
             : max(0, contentBounds.maxY - hostHeight - topInset)
     }
     return NSRect(
-        x: MinimalModeSidebarTitlebarControlsMetrics.leadingInset(defaults: defaults),
+        x: MinimalModeSidebarTitlebarControlsMetrics.originX(
+            contentBounds: contentBounds,
+            placement: placement,
+            defaults: defaults
+        ),
         y: targetY,
         width: MinimalModeSidebarTitlebarControlsMetrics.hostWidth,
         height: hostHeight
@@ -867,16 +901,28 @@ final class MinimalModeSidebarChromeHoverState: ObservableObject {
 
 private enum MinimalModeSidebarTitlebarControlAssociatedKeys {
     private static let sidebarVisibleToken = NSObject()
+    private static let placementToken = NSObject()
 
     static let sidebarVisible = UnsafeRawPointer(Unmanaged.passUnretained(sidebarVisibleToken).toOpaque())
+    static let placement = UnsafeRawPointer(Unmanaged.passUnretained(placementToken).toOpaque())
 }
 
-func setMinimalModeSidebarTitlebarControlsAvailable(_ isAvailable: Bool, in window: NSWindow?) {
+func setMinimalModeSidebarTitlebarControlsAvailable(
+    _ isAvailable: Bool,
+    placement: MinimalModeSidebarTitlebarControlsPlacement = .leading,
+    in window: NSWindow?
+) {
     guard let window else { return }
     objc_setAssociatedObject(
         window,
         MinimalModeSidebarTitlebarControlAssociatedKeys.sidebarVisible,
         NSNumber(value: isAvailable),
+        .OBJC_ASSOCIATION_RETAIN_NONATOMIC
+    )
+    objc_setAssociatedObject(
+        window,
+        MinimalModeSidebarTitlebarControlAssociatedKeys.placement,
+        NSNumber(value: placement == .trailing),
         .OBJC_ASSOCIATION_RETAIN_NONATOMIC
     )
 }
@@ -889,6 +935,16 @@ func minimalModeSidebarTitlebarControlsAreAvailable(in window: NSWindow) -> Bool
         return true
     }
     return value.boolValue
+}
+
+func minimalModeSidebarTitlebarControlsPlacement(in window: NSWindow) -> MinimalModeSidebarTitlebarControlsPlacement {
+    guard let value = objc_getAssociatedObject(
+        window,
+        MinimalModeSidebarTitlebarControlAssociatedKeys.placement
+    ) as? NSNumber else {
+        return .leading
+    }
+    return value.boolValue ? .trailing : .leading
 }
 
 func isMinimalModeSidebarChromeHoverCandidate(
@@ -926,9 +982,13 @@ func isMinimalModeSidebarChromeHoverCandidate(
         topStripHeight: MinimalModeChromeMetrics.titlebarHeight
     ) else { return false }
 
-    let minX = MinimalModeSidebarTitlebarControlsMetrics.leadingInset(defaults: defaults)
-    let maxX = minX + MinimalModeSidebarTitlebarControlsMetrics.hostWidth
-    return locationInWindow.x >= minX && locationInWindow.x <= maxX
+    let placement = minimalModeSidebarTitlebarControlsPlacement(in: window)
+    let xRange = MinimalModeSidebarTitlebarControlsMetrics.horizontalRange(
+        contentBounds: contentBounds,
+        placement: placement,
+        defaults: defaults
+    )
+    return xRange.contains(locationInWindow.x)
 }
 
 private func titlebarControlsStyleConfig(defaults: UserDefaults) -> TitlebarControlsStyleConfig {
@@ -971,9 +1031,14 @@ func minimalModeSidebarControlActionSlot(
         topStripHeight: MinimalModeChromeMetrics.titlebarHeight
     ) else { return nil }
 
-    let leadingInset = MinimalModeSidebarTitlebarControlsMetrics.leadingInset(defaults: defaults)
+    let placement = minimalModeSidebarTitlebarControlsPlacement(in: window)
+    let xRange = MinimalModeSidebarTitlebarControlsMetrics.horizontalRange(
+        contentBounds: contentBounds,
+        placement: placement,
+        defaults: defaults
+    )
     let localPoint = NSPoint(
-        x: locationInWindow.x - leadingInset,
+        x: locationInWindow.x - xRange.lowerBound,
         y: MinimalModeSidebarTitlebarControlsMetrics.hostHeight / 2
     )
     return TitlebarControlsHitRegions.sidebarActionSlot(
@@ -1017,9 +1082,13 @@ func recordMinimalModeSidebarChromeHoverForUITest(
         contentBounds: contentBounds,
         titlebarBandHeight: MinimalModeChromeMetrics.titlebarHeight
     )
-    let minX = MinimalModeSidebarTitlebarControlsMetrics.leadingInset
-    let maxX = minX + MinimalModeSidebarTitlebarControlsMetrics.hostWidth
-    let inXRange = (locationInWindow.x >= minX && locationInWindow.x <= maxX)
+    let placement = minimalModeSidebarTitlebarControlsPlacement(in: window)
+    let xRange = MinimalModeSidebarTitlebarControlsMetrics.horizontalRange(
+        contentBounds: contentBounds,
+        placement: placement,
+        defaults: defaults
+    )
+    let inXRange = xRange.contains(locationInWindow.x)
         || MinimalModeTitlebarControlHitRegionRegistry.containsSidebarControlHostWindowPoint(
             locationInWindow,
             in: window
@@ -1035,6 +1104,7 @@ func recordMinimalModeSidebarChromeHoverForUITest(
         payload["minimalSidebarHoverIsFullScreen"] = String(isFullScreen)
         payload["minimalSidebarHoverIsMainWindow"] = String(isMainWindow)
         payload["minimalSidebarHoverSidebarControlsAvailable"] = String(sidebarControlsAvailable)
+        payload["minimalSidebarHoverPlacement"] = placement == .trailing ? "trailing" : "leading"
         payload["minimalSidebarHoverInTitlebarBand"] = String(inTitlebarBand)
         payload["minimalSidebarHoverInXRange"] = String(inXRange)
         payload["minimalSidebarHoverContentBounds"] = NSStringFromRect(contentBounds)

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -5339,6 +5339,8 @@ struct SettingsView: View {
     @AppStorage("sidebarTintHexDark") private var sidebarTintHexDark: String?
     @AppStorage("sidebarTintOpacity") private var sidebarTintOpacity = SidebarTintDefaults.opacity
     @AppStorage("sidebarMatchTerminalBackground") private var sidebarMatchTerminalBackground = false
+    @AppStorage(SidebarPositionSettings.workspacesOnRightKey)
+    private var workspacesOnRight = SidebarPositionSettings.defaultWorkspacesOnRight
     @AppStorage(RightSidebarBetaFeatureSettings.dockEnabledKey)
     private var rightSidebarDockEnabled = RightSidebarBetaFeatureSettings.defaultDockEnabled
 
@@ -8154,6 +8156,7 @@ struct SettingsView: View {
         sidebarTintHexDark = nil
         sidebarTintOpacity = SidebarTintDefaults.opacity
         sidebarMatchTerminalBackground = false
+        workspacesOnRight = SidebarPositionSettings.defaultWorkspacesOnRight
         showOpenAccessConfirmation = false
         pendingOpenAccessMode = nil
         draftState.socketPasswordDraft = ""

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -2717,6 +2717,83 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         XCTAssertEqual(minimalAccessory.view.alphaValue, 0, accuracy: 0.01)
     }
 
+    func testAttachUpdateAccessoryMovesTitlebarAccessoryWithWorkspaceSidebarSide() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let defaults = UserDefaults.standard
+        let savedMode = defaults.object(forKey: WorkspacePresentationModeSettings.modeKey)
+        let savedLegacyTitlebar = defaults.object(forKey: WorkspaceTitlebarSettings.showTitlebarKey)
+        let savedWorkspacesOnRight = defaults.object(forKey: SidebarPositionSettings.workspacesOnRightKey)
+        defaults.set(WorkspacePresentationModeSettings.Mode.standard.rawValue, forKey: WorkspacePresentationModeSettings.modeKey)
+        defaults.removeObject(forKey: WorkspaceTitlebarSettings.showTitlebarKey)
+        defaults.set(false, forKey: SidebarPositionSettings.workspacesOnRightKey)
+        defer {
+            restoreDefaultsValue(savedMode, forKey: WorkspacePresentationModeSettings.modeKey, defaults: defaults)
+            restoreDefaultsValue(savedLegacyTitlebar, forKey: WorkspaceTitlebarSettings.showTitlebarKey, defaults: defaults)
+            restoreDefaultsValue(savedWorkspacesOnRight, forKey: SidebarPositionSettings.workspacesOnRightKey, defaults: defaults)
+        }
+
+        let windowId = appDelegate.createMainWindow()
+        defer { closeWindow(withId: windowId) }
+
+        guard let window = window(withId: windowId) else {
+            XCTFail("Expected main window")
+            return
+        }
+
+        let titlebarAccessory: () -> NSTitlebarAccessoryViewController? = {
+            window.titlebarAccessoryViewControllers.first {
+                $0.view.identifier?.rawValue == "cmux.titlebarControls"
+            }
+        }
+
+        appDelegate.attachUpdateAccessory(to: window)
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+
+        guard let leadingAccessory = titlebarAccessory() else {
+            XCTFail("Expected titlebar accessory")
+            return
+        }
+        XCTAssertEqual(leadingAccessory.layoutAttribute, .left)
+
+        defaults.set(true, forKey: SidebarPositionSettings.workspacesOnRightKey)
+        appDelegate.attachUpdateAccessory(to: window)
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+
+        guard let trailingAccessory = titlebarAccessory() else {
+            XCTFail("Expected titlebar accessory")
+            return
+        }
+        XCTAssertEqual(trailingAccessory.layoutAttribute, .right)
+        if let context = appDelegate.contextForMainWindow(window) {
+            XCTAssertGreaterThanOrEqual(
+                trailingAccessory.preferredContentSize.width,
+                context.sidebarState.persistedWidth - 0.5
+            )
+        }
+    }
+
+    func testTitlebarLeadingInsetPolicyUsesMeasuredTrafficLightFrames() {
+        let reserve = TitlebarLeadingInsetPolicy.reserve(
+            trafficLightFrames: [
+                NSRect(x: 14, y: 0, width: 28, height: 28),
+                NSRect(x: 62, y: 0, width: 28, height: 28),
+                NSRect(x: 110, y: 0, width: 28, height: 28)
+            ],
+            leftAccessoryWidths: [24],
+            fallbackTrafficLightReserve: 78
+        )
+
+        XCTAssertEqual(
+            reserve,
+            110 + 28 + TitlebarLeadingInsetPolicy.trafficLightTrailingMargin + 24,
+            accuracy: 0.001
+        )
+    }
+
     func testWorkspaceButtonFadeModeDefaultsOffWhenTitlebarVisible() {
         let defaults = UserDefaults.standard
         let savedMode = defaults.object(forKey: WorkspaceButtonFadeSettings.modeKey)

--- a/cmuxTests/WindowAndDragTests.swift
+++ b/cmuxTests/WindowAndDragTests.swift
@@ -1370,6 +1370,79 @@ final class WindowDragHandleHitTests: XCTestCase {
         )
     }
 
+    func testMinimalModeSidebarTitlebarControlsFrameCanUseTrailingPlacement() {
+        let contentBounds = NSRect(x: 0, y: 0, width: 500, height: 120)
+
+        let frame = minimalModeSidebarTitlebarControlsFrame(
+            contentBounds: contentBounds,
+            contentViewIsFlipped: false,
+            trafficLightFrameInContent: nil,
+            placement: .trailing
+        )
+
+        XCTAssertEqual(
+            frame.minX,
+            contentBounds.maxX
+                - MinimalModeSidebarTitlebarControlsMetrics.hostWidth
+                - MinimalModeSidebarTitlebarControlsMetrics.trailingInset,
+            accuracy: 0.001
+        )
+        XCTAssertEqual(frame.width, MinimalModeSidebarTitlebarControlsMetrics.hostWidth, accuracy: 0.001)
+    }
+
+    func testMinimalModeSidebarFallbackActionSlotUsesTrailingPlacement() {
+        let suiteName = "WindowDragHandleHitTests.sidebarTrailingPlacement.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.set(WorkspacePresentationModeSettings.Mode.minimal.rawValue, forKey: WorkspacePresentationModeSettings.modeKey)
+        defaults.set(TitlebarControlsStyle.classic.rawValue, forKey: "titlebarControlsStyle")
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 500, height: 120),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        window.identifier = NSUserInterfaceItemIdentifier("cmux.main.test")
+        setMinimalModeSidebarTitlebarControlsAvailable(true, placement: .trailing, in: window)
+        defer { window.orderOut(nil) }
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        let xRange = MinimalModeSidebarTitlebarControlsMetrics.horizontalRange(
+            contentBounds: contentView.bounds,
+            placement: .trailing,
+            defaults: defaults
+        )
+        let buttonRanges = TitlebarControlsHitRegions.buttonXRanges(config: TitlebarControlsStyle.classic.config)
+        let point = NSPoint(
+            x: xRange.lowerBound + buttonRanges[MinimalModeSidebarControlActionSlot.showNotifications.rawValue].lowerBound + 1,
+            y: contentView.bounds.maxY - 10
+        )
+
+        XCTAssertEqual(
+            minimalModeSidebarControlActionSlot(window: window, locationInWindow: point, defaults: defaults),
+            .showNotifications
+        )
+        XCTAssertTrue(
+            isMinimalModeSidebarChromeHoverCandidate(window: window, locationInWindow: point, defaults: defaults),
+            "Hover reveal should follow the right-aligned titlebar control frame."
+        )
+
+        let oldLeadingPoint = NSPoint(
+            x: MinimalModeSidebarTitlebarControlsMetrics.leadingInset(defaults: defaults)
+                + buttonRanges[MinimalModeSidebarControlActionSlot.showNotifications.rawValue].lowerBound
+                + 1,
+            y: point.y
+        )
+        XCTAssertNil(
+            minimalModeSidebarControlActionSlot(window: window, locationInWindow: oldLeadingPoint, defaults: defaults),
+            "Right-aligned controls should not leave an active fallback hit target on the left."
+        )
+    }
+
     func testSuppressedTitlebarDoubleClickConsumesWithoutWindowAction() {
         XCTAssertEqual(
             handleTitlebarDoubleClick(window: nil, behavior: .suppress),
@@ -1760,6 +1833,7 @@ final class WindowDragHandleHitTests: XCTestCase {
             fileExplorerState: FileExplorerState(),
             sessionIndexStore: SessionIndexStore(),
             titlebarHeight: 36,
+            titlebarLeadingReserve: 0,
             workspaceId: nil,
             onResumeSession: nil,
             onOpenFilePreview: { _ in },


### PR DESCRIPTION
## Summary
- Add a command-palette settings toggle for `Workspaces on Right`
- Swap the workspace sidebar to the right edge and the tools sidebar to the left edge
- Move the visible titlebar controls to the right and align them to the leading edge of the right workspace sidebar
- Keep traffic-light spacing, tools-sidebar header spacing, explorer body reachability, resize hit regions, portal sync, and minimal-mode titlebar hit testing aligned with the selected sidebar side

## Verification
- `git diff --check`
- `jq empty Resources/Localizable.xcstrings`
- `./scripts/reload.sh --tag sidebar-pos`
- Launched `sidebar-pos` and verified the left tools header clears the traffic lights, explorer content remains reachable, and the right titlebar controls align with the right workspace sidebar

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core window layout, titlebar accessories, minimal-mode hit regions, and portal geometry sync across many code paths; behavior is covered by new tests but regressions in edge layouts are plausible.
> 
> **Overview**
> Adds a **Workspaces on Right** preference (`sidebar.workspacesOnRight`) exposed via the command palette and settings reset, with localized strings.
> 
> When enabled, the main window **swaps sidebar sides**: the workspace list moves to the trailing edge and the tools (right) sidebar to the leading edge. `ContentView` drives HStack/ZStack order, resize dividers, overlay placement, titlebar padding, traffic-light/tab-bar insets, portal geometry refresh, and minimal-mode chrome from that flag.
> 
> **Titlebar controls** follow the workspace sidebar: standard mode moves the accessory to `.right` and sizes/positions it to the sidebar width; minimal mode places sidebar controls on the matching edge with updated hit-testing and click targets. **Leading inset** for tools headers uses measured traffic lights via `TitlebarLeadingInsetPolicy`.
> 
> Tests cover accessory side changes, inset math, and trailing minimal-mode control frames.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89169bc31ea113c5af61bb3dfabef6d12d6a7e12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->