### PR TITLE
Add pir hook integration

### DIFF
--- a/CLI/CMUXCLI+AgentHookDefinitions.swift
+++ b/CLI/CMUXCLI+AgentHookDefinitions.swift
@@ -1,3 +1,4 @@
+import CMUXAgentLaunch
 import Foundation
 
 extension CMUXCLI {
@@ -16,7 +17,7 @@ extension CMUXCLI {
         let sessionStoreSuffix: String // e.g. "cursor" -> ~/.cmuxterm/cursor-hook-sessions.json
         let disableEnvVar: String   // e.g. "CMUX_CURSOR_HOOKS_DISABLED"
         let hookMarker: String      // Marker in commands: "cmux hooks cursor"
-        let binaryName: String
+        let binaryNames: [String]
         let format: HookFormat
         let events: [HookEvent]
         let aliases: Set<String>
@@ -28,6 +29,7 @@ extension CMUXCLI {
         /// approve/deny a permission / plan / question.
         let feedHookEvents: [String]
         let postInstallAction: PostInstallAction?
+        var binaryName: String { binaryNames.first ?? name }
 
         enum HookFormat {
             case flat       // Cursor: {"hooks": {"event": [{"command": "..."}]}, "version": 1}
@@ -65,7 +67,10 @@ extension CMUXCLI {
                    !subpath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                     url.appendPathComponent(subpath, isDirectory: true)
                 }
-                return url.path
+                let path = url.path
+                return envKey == "PI_CODING_AGENT_DIR"
+                    ? PiConfigDirectoryPath.preferredPath(path, homeDirectory: home)
+                    : path
             }
             return URL(fileURLWithPath: home, isDirectory: true)
                 .appendingPathComponent(configDir, isDirectory: true)
@@ -77,6 +82,7 @@ extension CMUXCLI {
              configDirEnvOverrideSubpath: String? = nil,
              createConfigDirIfMissing: Bool = false,
              binaryName: String? = nil,
+             binaryNames: [String] = [],
              sessionStoreSuffix: String, disableEnvVar: String, hookMarker: String,
              format: HookFormat, events: [HookEvent],
              aliases: Set<String> = [],
@@ -88,7 +94,14 @@ extension CMUXCLI {
             self.configDirEnvOverride = configDirEnvOverride
             self.configDirEnvOverrideSubpath = configDirEnvOverrideSubpath
             self.createConfigDirIfMissing = createConfigDirIfMissing
-            self.binaryName = binaryName ?? name
+            var seenBinaryNames = Set<String>()
+            var normalizedBinaryNames: [String] = []
+            for candidate in [binaryName ?? name] + binaryNames {
+                let normalized = candidate.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !normalized.isEmpty, seenBinaryNames.insert(normalized).inserted else { continue }
+                normalizedBinaryNames.append(normalized)
+            }
+            self.binaryNames = normalizedBinaryNames.isEmpty ? [name] : normalizedBinaryNames
             self.sessionStoreSuffix = sessionStoreSuffix; self.disableEnvVar = disableEnvVar
             self.hookMarker = hookMarker; self.format = format; self.events = events
             self.publishesStopNotification = publishesStopNotification
@@ -160,9 +173,11 @@ extension CMUXCLI {
         AgentHookDef(
             name: "pi", displayName: "Pi", statusKey: "pi",
             configDir: ".pi/agent", configFile: "extensions/cmux-session.ts", configDirEnvOverride: "PI_CODING_AGENT_DIR",
+            binaryName: "pir", binaryNames: ["pi", "pi-rust", "pi-coding-agent"],
             sessionStoreSuffix: "pi", disableEnvVar: "CMUX_PI_HOOKS_DISABLED",
             hookMarker: "cmux hooks pi", format: .flat,
-            events: []
+            events: [],
+            aliases: ["pir", "pi-rust"]
         ),
         AgentHookDef(
             name: "amp", displayName: "Amp", statusKey: "amp",

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -11847,7 +11847,7 @@ struct CMUXCLI {
             agent. Claude Code hooks are injected automatically by the cmux Claude wrapper.
 
             Agents:
-              codex, grok, opencode, pi, amp, cursor, gemini, antigravity (alias: agy), rovodev (alias: rovo), hermes-agent, copilot, codebuddy, factory, qoder
+              codex, grok, opencode, pi (alias: pir), amp, cursor, gemini, antigravity (alias: agy), rovodev (alias: rovo), hermes-agent, copilot, codebuddy, factory, qoder
 
             Hook targets:
               setup              Install hooks for all supported agents on PATH
@@ -11867,6 +11867,7 @@ struct CMUXCLI {
             Examples:
               cmux hooks setup
               cmux hooks setup --agent codex
+              cmux hooks setup pir
               cmux hooks setup rovo
               cmux hooks uninstall rovo
               cmux hooks codex install
@@ -23889,15 +23890,17 @@ export default CMUXSessionRestore;
     private static let piExtensionMarker = "cmux-pi-session-extension-marker"
     private static let piExtensionFilename = "cmux-session.ts"
     private static let piExtensionSource = #"""
-// cmux-pi-session-extension-marker v1
+// cmux-pi-session-extension-marker v2
 // Bridges Pi session lifecycle events into cmux's restorable session store.
-// Installed by `cmux hooks pi install` or `cmux hooks setup`.
+// Installed by `cmux hooks pi install`, `cmux hooks pir install`, or `cmux hooks setup`.
 // DO NOT EDIT MANUALLY. cmux upgrades this file in place.
 
 import { spawnSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { AgentEndEvent, ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+
+const PI_EXECUTABLE_CANDIDATES = ["pir", "pi-rust", "pi"];
 
 function firstString(...values: unknown[]): string | null {
   for (const value of values) {
@@ -23919,9 +23922,17 @@ function resolveExecutable(name: string): string {
   return name;
 }
 
+function resolvePreferredPiExecutable(): string {
+  for (const name of PI_EXECUTABLE_CANDIDATES) {
+    const resolved = resolveExecutable(name);
+    if (resolved !== name) return resolved;
+  }
+  return resolveExecutable("pi");
+}
+
 function looksLikePiExecutable(value: string): boolean {
   const base = path.basename(value).toLowerCase();
-  return base === "pi" || base === "pi-coding-agent";
+  return base === "pir" || base === "pi-rust" || base === "pi" || base === "pi-coding-agent";
 }
 
 function looksLikePiScript(value: string): boolean {
@@ -23937,12 +23948,13 @@ function looksLikePiScript(value: string): boolean {
 
 function normalizedLaunchArgv(): string[] {
   const raw = Array.isArray(process.argv) ? process.argv.map((value) => String(value)) : [];
-  if (raw.length === 0) return [resolveExecutable("pi")];
+  const fallback = resolvePreferredPiExecutable();
+  if (raw.length === 0) return [fallback];
   if (looksLikePiExecutable(raw[0])) return raw;
   if (raw.length > 1 && looksLikePiScript(raw[1])) {
-    return [resolveExecutable("pi"), ...raw.slice(2)];
+    return [fallback, ...raw.slice(2)];
   }
-  return [resolveExecutable("pi"), ...raw.slice(1)];
+  return [fallback, ...raw.slice(1)];
 }
 
 function base64NulSeparated(values: string[]): string {
@@ -23960,7 +23972,7 @@ function hookEnvironment(cwd: string): NodeJS.ProcessEnv {
   if (!env.CMUX_AGENT_LAUNCH_ARGV_B64) {
     const argv = normalizedLaunchArgv();
     env.CMUX_AGENT_LAUNCH_KIND = "pi";
-    env.CMUX_AGENT_LAUNCH_EXECUTABLE = argv[0] || resolveExecutable("pi");
+    env.CMUX_AGENT_LAUNCH_EXECUTABLE = argv[0] || resolvePreferredPiExecutable();
     env.CMUX_AGENT_LAUNCH_ARGV_B64 = base64NulSeparated(argv);
     env.CMUX_AGENT_LAUNCH_CWD = cwd || process.cwd();
   }
@@ -24019,7 +24031,7 @@ function sendHook(subcommand: string, ctx: ExtensionContext, extra: Record<strin
     event: eventName(subcommand),
     ...extra,
   };
-  const cmux = process.env.CMUX_PI_CMUX_BIN || "cmux";
+  const cmux = process.env.CMUX_PI_CMUX_BIN || process.env.CMUX_BUNDLED_CLI_PATH || "cmux";
   try {
     spawnSync(cmux, ["hooks", "pi", subcommand], {
       input: JSON.stringify(payload),
@@ -29422,7 +29434,7 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
             // On install, also skip agents whose binary isn't on PATH.
             // On uninstall, always proceed so stale configs can be
             // cleaned up regardless of whether the binary still exists.
-            if !isUninstall && !Self.isBinaryOnPath(def.binaryName) {
+            if !isUninstall && !Self.isAnyBinaryOnPath(def.binaryNames) {
                 print("  \(def.name): skipped (binary not found on PATH)")
                 skipped += 1
                 skippedNoBinary.append(def.name)
@@ -29445,6 +29457,10 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
     }
 
     /// Cross-platform `command -v <name>` for the install gate.
+    private static func isAnyBinaryOnPath(_ names: [String]) -> Bool {
+        names.contains { isBinaryOnPath($0) }
+    }
+
     private static func isBinaryOnPath(_ name: String) -> Bool {
         let process = Process()
         process.launchPath = "/bin/sh"

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -24016,11 +24016,11 @@ function lastAssistantMessage(event: AgentEndEvent): string | undefined {
   return undefined;
 }
 
-function sendHook(subcommand: string, ctx: ExtensionContext, extra: Record<string, unknown> = {}): void {
+async function sendHook(subcommand: string, ctx: ExtensionContext, extra: Record<string, unknown> = {}): Promise<void> {
   if (process.env.CMUX_PI_HOOKS_DISABLED === "1") return;
   if (!process.env.CMUX_SURFACE_ID) return;
 
-  const sessionId = firstString(ctx.sessionManager.getSessionId());
+  const sessionId = firstString(await Promise.resolve(ctx.sessionManager.getSessionId()));
   if (!sessionId) return;
 
   const cwd = firstString(ctx.cwd, process.cwd()) || process.cwd();
@@ -24045,15 +24045,15 @@ function sendHook(subcommand: string, ctx: ExtensionContext, extra: Record<strin
 
 export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
   pi.on("session_start", async (_event, ctx) => {
-    sendHook("session-start", ctx);
+    await sendHook("session-start", ctx);
   });
 
   pi.on("before_agent_start", async (event, ctx) => {
-    sendHook("prompt-submit", ctx, { prompt: event.prompt });
+    await sendHook("prompt-submit", ctx, { prompt: event.prompt });
   });
 
   pi.on("agent_end", async (event, ctx) => {
-    sendHook("stop", ctx, { last_assistant_message: lastAssistantMessage(event) });
+    await sendHook("stop", ctx, { last_assistant_message: lastAssistantMessage(event) });
   });
 }
 """#

--- a/Packages/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchEnvironmentPolicy.swift
+++ b/Packages/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchEnvironmentPolicy.swift
@@ -1,25 +1,68 @@
 import Foundation
 
+public enum SubrouterConfigDirectoryPath {
+    public static func preferredPath(
+        _ rawPath: String,
+        agentDirectoryName: String,
+        fileManager: FileManager = .default,
+        homeDirectory: String = NSHomeDirectory()
+    ) -> String {
+        let trimmed = rawPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return rawPath }
+        let agentName = agentDirectoryName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !agentName.isEmpty else { return rawPath }
+
+        let standardized = ((trimmed as NSString).expandingTildeInPath as NSString).standardizingPath
+        let aliasHome = (homeDirectory as NSString).expandingTildeInPath
+        let home = ((homeDirectory as NSString).expandingTildeInPath as NSString).standardizingPath
+        let legacyRoot = ((home as NSString)
+            .appendingPathComponent(".subrouter/codex/\(agentName)") as NSString)
+            .standardizingPath
+        guard standardized == legacyRoot || standardized.hasPrefix(legacyRoot + "/") else { return standardized }
+
+        let accountContainer = (aliasHome as NSString).appendingPathComponent(".codex-accounts")
+        let accountRoot = (accountContainer as NSString).appendingPathComponent(agentName)
+        let candidate = accountRoot + String(standardized.dropFirst(legacyRoot.count))
+        var isDirectory: ObjCBool = false
+        if fileManager.fileExists(atPath: candidate, isDirectory: &isDirectory) && isDirectory.boolValue {
+            return candidate
+        }
+        if (try? fileManager.destinationOfSymbolicLink(atPath: accountContainer)) != nil,
+           fileManager.fileExists(atPath: standardized, isDirectory: &isDirectory),
+           isDirectory.boolValue {
+            return candidate
+        }
+        return standardized
+    }
+}
+
 public enum ClaudeConfigDirectoryPath {
     public static func preferredPath(
         _ rawPath: String,
         fileManager: FileManager = .default,
         homeDirectory: String = NSHomeDirectory()
     ) -> String {
-        let trimmed = rawPath.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return rawPath }
+        SubrouterConfigDirectoryPath.preferredPath(
+            rawPath,
+            agentDirectoryName: "claude",
+            fileManager: fileManager,
+            homeDirectory: homeDirectory
+        )
+    }
+}
 
-        let standardized = ((trimmed as NSString).expandingTildeInPath as NSString).standardizingPath
-        let home = ((homeDirectory as NSString).expandingTildeInPath as NSString).standardizingPath
-        let legacyRoot = ((home as NSString).appendingPathComponent(".subrouter/codex/claude") as NSString).standardizingPath
-        guard standardized == legacyRoot || standardized.hasPrefix(legacyRoot + "/") else { return standardized }
-
-        let accountRoot = ((home as NSString).appendingPathComponent(".codex-accounts/claude") as NSString).standardizingPath
-        let candidate = accountRoot + String(standardized.dropFirst(legacyRoot.count))
-        var isDirectory: ObjCBool = false
-        return fileManager.fileExists(atPath: candidate, isDirectory: &isDirectory) && isDirectory.boolValue
-            ? candidate
-            : standardized
+public enum PiConfigDirectoryPath {
+    public static func preferredPath(
+        _ rawPath: String,
+        fileManager: FileManager = .default,
+        homeDirectory: String = NSHomeDirectory()
+    ) -> String {
+        SubrouterConfigDirectoryPath.preferredPath(
+            rawPath,
+            agentDirectoryName: "pi",
+            fileManager: fileManager,
+            homeDirectory: homeDirectory
+        )
     }
 }
 
@@ -71,10 +114,13 @@ public enum AgentLaunchEnvironmentPolicy {
         "USE_BUILTIN_RIPGREP"
     ]
 
-    public static func selectedEnvironment(from env: [String: String]) -> [String: String] {
+    public static func selectedEnvironment(
+        from env: [String: String],
+        homeDirectory: String = NSHomeDirectory()
+    ) -> [String: String] {
         var result: [String: String] = [:]
         for key in safeEnvironmentKeys.sorted() where key != "NODE_OPTIONS" {
-            guard let value = sanitizedValue(key: key, value: env[key]) else { continue }
+            guard let value = sanitizedValue(key: key, value: env[key], homeDirectory: homeDirectory) else { continue }
             result[key] = value
         }
         if let nodeOptions = selectedNodeOptions(from: env) {
@@ -83,11 +129,17 @@ public enum AgentLaunchEnvironmentPolicy {
         return result
     }
 
-    public static func sanitizedValue(key: String, value: String?) -> String? {
+    public static func sanitizedValue(
+        key: String,
+        value: String?,
+        homeDirectory: String = NSHomeDirectory()
+    ) -> String? {
         guard safeEnvironmentKeys.contains(key) else { return nil }
         switch key {
         case "CLAUDE_CONFIG_DIR":
-            return value.map { ClaudeConfigDirectoryPath.preferredPath($0) }
+            return value.map { ClaudeConfigDirectoryPath.preferredPath($0, homeDirectory: homeDirectory) }
+        case "PI_CODING_AGENT_DIR":
+            return value.map { PiConfigDirectoryPath.preferredPath($0, homeDirectory: homeDirectory) }
         case "NODE_OPTIONS":
             return sanitizedNodeOptions(value)
         default:

--- a/Packages/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchEnvironmentPolicyTests.swift
+++ b/Packages/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchEnvironmentPolicyTests.swift
@@ -1,0 +1,55 @@
+import CMUXAgentLaunch
+import Foundation
+import Testing
+
+@Suite("AgentLaunchEnvironmentPolicy")
+struct AgentLaunchEnvironmentPolicyTests {
+    @Test("Normalizes Pi Subrouter config directory aliases")
+    func normalizesPiSubrouterConfigDirectoryAliases() throws {
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-pi-subrouter-home-\(UUID().uuidString)", isDirectory: true)
+        let legacyConfig = home
+            .appendingPathComponent(".subrouter", isDirectory: true)
+            .appendingPathComponent("codex", isDirectory: true)
+            .appendingPathComponent("pi", isDirectory: true)
+            .appendingPathComponent("_p1775010019397", isDirectory: true)
+        try FileManager.default.createDirectory(at: legacyConfig, withIntermediateDirectories: true)
+        try FileManager.default.createSymbolicLink(
+            at: home.appendingPathComponent(".codex-accounts", isDirectory: true),
+            withDestinationURL: home.appendingPathComponent(".subrouter", isDirectory: true)
+                .appendingPathComponent("codex", isDirectory: true)
+        )
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        let selected = AgentLaunchEnvironmentPolicy.selectedEnvironment(from: [
+            "PI_CODING_AGENT_DIR": legacyConfig.path,
+            "OPENAI_API_KEY": "secret",
+        ], homeDirectory: home.path)
+
+        #expect(
+            selected["PI_CODING_AGENT_DIR"] == home
+                .appendingPathComponent(".codex-accounts", isDirectory: true)
+                .appendingPathComponent("pi", isDirectory: true)
+                .appendingPathComponent("_p1775010019397", isDirectory: true)
+                .path
+        )
+        #expect(selected["OPENAI_API_KEY"] == nil)
+    }
+
+    @Test("Keeps legacy Pi Subrouter path when no alias exists")
+    func keepsLegacyPiSubrouterPathWithoutAlias() throws {
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-pi-subrouter-legacy-home-\(UUID().uuidString)", isDirectory: true)
+        let legacyConfig = home
+            .appendingPathComponent(".subrouter", isDirectory: true)
+            .appendingPathComponent("codex", isDirectory: true)
+            .appendingPathComponent("pi", isDirectory: true)
+            .appendingPathComponent("_p1775010019397", isDirectory: true)
+        try FileManager.default.createDirectory(at: legacyConfig, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        #expect(
+            PiConfigDirectoryPath.preferredPath(legacyConfig.path, homeDirectory: home.path) == legacyConfig.path
+        )
+    }
+}

--- a/Packages/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchSanitizerTests.swift
+++ b/Packages/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchSanitizerTests.swift
@@ -486,6 +486,16 @@ struct AgentLaunchSanitizerTests {
                 fallbackKind: "pi"
             ) == ["pi", "--model", "anthropic/claude-sonnet-4-5", "--thinking", "high"]
         )
+        #expect(
+            AgentLaunchSanitizer.sanitizedLaunchArguments(
+                [
+                    "pir", "--session", "old-session", "--model", "anthropic/claude-sonnet-4-5",
+                    "--thinking", "high", "implement this",
+                ],
+                launcher: "pi",
+                fallbackKind: "pi"
+            ) == ["pir", "--model", "anthropic/claude-sonnet-4-5", "--thinking", "high"]
+        )
     }
 
     @Test("Preserves repeated Pi extension and skill flags without replaying prompt")

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -6155,6 +6155,10 @@ final class TerminalSurface: Identifiable, ObservableObject {
            !inheritedClaudeConfigDir.isEmpty {
             env["CLAUDE_CONFIG_DIR"] = ClaudeConfigDirectoryPath.preferredPath(inheritedClaudeConfigDir)
         }
+        if let inheritedPiConfigDir = ProcessInfo.processInfo.environment["PI_CODING_AGENT_DIR"],
+           !inheritedPiConfigDir.isEmpty {
+            env["PI_CODING_AGENT_DIR"] = PiConfigDirectoryPath.preferredPath(inheritedPiConfigDir)
+        }
         if let bundledCLIURL = Bundle.main.resourceURL?.appendingPathComponent("bin/cmux"),
            FileManager.default.isExecutableFile(atPath: bundledCLIURL.path) {
             setManagedEnvironmentValue("CMUX_BUNDLED_CLI_PATH", bundledCLIURL.path)

--- a/Sources/TerminalStartupEnvironment.swift
+++ b/Sources/TerminalStartupEnvironment.swift
@@ -80,6 +80,9 @@ extension TerminalSurface {
         if let claudeConfigDir = merged["CLAUDE_CONFIG_DIR"], !claudeConfigDir.isEmpty {
             merged["CLAUDE_CONFIG_DIR"] = ClaudeConfigDirectoryPath.preferredPath(claudeConfigDir)
         }
+        if let piConfigDir = merged["PI_CODING_AGENT_DIR"], !piConfigDir.isEmpty {
+            merged["PI_CODING_AGENT_DIR"] = PiConfigDirectoryPath.preferredPath(piConfigDir)
+        }
         return merged
     }
 }

--- a/Sources/VaultAgentRegistry.swift
+++ b/Sources/VaultAgentRegistry.swift
@@ -118,7 +118,10 @@ struct CmuxVaultAgentRegistration: Codable, Hashable, Sendable {
             id: "pi",
             name: "Pi",
             iconAssetName: "AgentIcons/Pi",
-            detect: CmuxVaultAgentDetectRule(processName: "pi", argvContains: ["pi"]),
+            detect: CmuxVaultAgentDetectRule(
+                processNames: ["pir", "pi-rust", "pi", "pi-coding-agent"],
+                argvContains: ["pi"]
+            ),
             sessionIdSource: .piSessionFile,
             resumeCommand: "{{executable}} --session {{sessionId}}",
             cwd: .preserve,

--- a/cmuxTests/CLIGenericHookPersistenceTests.swift
+++ b/cmuxTests/CLIGenericHookPersistenceTests.swift
@@ -132,6 +132,34 @@ extension CLINotifyProcessIntegrationRegressionTests {
                 expectedEnvironment: ["GROK_HOME": "/tmp/grok home"]
             ),
             GenericHookPersistenceScenario(
+                agent: "pi",
+                subcommand: "session-start",
+                sessionId: "pi-session-123",
+                executable: "/Users/example/.local/bin/pir",
+                launchArguments: [
+                    "/Users/example/.local/bin/pir",
+                    "--model",
+                    "anthropic/claude-sonnet-4-5",
+                    "--session",
+                    "old-session",
+                    "--thinking",
+                    "high",
+                    "initial prompt should not persist"
+                ],
+                extraEnvironment: [
+                    "PI_CODING_AGENT_DIR": "/tmp/pi home",
+                    "OPENAI_API_KEY": "secret"
+                ],
+                expectedArguments: [
+                    "/Users/example/.local/bin/pir",
+                    "--model",
+                    "anthropic/claude-sonnet-4-5",
+                    "--thinking",
+                    "high"
+                ],
+                expectedEnvironment: ["PI_CODING_AGENT_DIR": "/tmp/pi home"]
+            ),
+            GenericHookPersistenceScenario(
                 agent: "copilot",
                 subcommand: "session-start",
                 sessionId: "copilot-session-123",
@@ -2413,6 +2441,50 @@ extension CLINotifyProcessIntegrationRegressionTests {
         var isDirectory: ObjCBool = true
         XCTAssertTrue(FileManager.default.fileExists(atPath: hooksPath.path, isDirectory: &isDirectory))
         XCTAssertFalse(isDirectory.boolValue)
+    }
+
+    func testPirAliasSetupInstallsPiExtensionWhenOnlyPirIsOnPath() throws {
+        let cliPath = try bundledCLIPath()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-pir-hook-setup-\(UUID().uuidString)", isDirectory: true)
+        let binDir = root.appendingPathComponent("bin", isDirectory: true)
+        let pirURL = binDir.appendingPathComponent("pir", isDirectory: false)
+        try FileManager.default.createDirectory(at: binDir, withIntermediateDirectories: true)
+        try "#!/bin/sh\nexit 0\n".write(to: pirURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: pirURL.path)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let environment: [String: String] = [
+            "HOME": root.path,
+            "PATH": "\(binDir.path):/usr/bin:/bin:/usr/sbin:/sbin",
+            "CMUX_CLI_SENTRY_DISABLED": "1",
+        ]
+        let setupResult = runProcess(
+            executablePath: cliPath,
+            arguments: ["hooks", "setup", "pir", "--yes"],
+            environment: environment,
+            timeout: 5
+        )
+
+        XCTAssertFalse(setupResult.timedOut, setupResult.stderr)
+        XCTAssertEqual(setupResult.status, 0, setupResult.stderr)
+        XCTAssertTrue(setupResult.stdout.contains("pi:"), setupResult.stdout)
+        XCTAssertTrue(setupResult.stdout.contains("Pi hooks installed"), setupResult.stdout)
+
+        let extensionURL = root
+            .appendingPathComponent(".pi/agent/extensions/cmux-session.ts", isDirectory: false)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: extensionURL.path))
+
+        let reinstallResult = runProcess(
+            executablePath: cliPath,
+            arguments: ["hooks", "pir", "install", "--yes"],
+            environment: environment,
+            timeout: 5
+        )
+
+        XCTAssertFalse(reinstallResult.timedOut, reinstallResult.stderr)
+        XCTAssertEqual(reinstallResult.status, 0, reinstallResult.stderr)
+        XCTAssertTrue(reinstallResult.stdout.contains("Pi hooks already up to date"), reinstallResult.stdout)
     }
 
     func runGenericHookPersistenceScenario(_ scenario: GenericHookPersistenceScenario) throws {

--- a/cmuxTests/PiVaultAgentPersistenceTests.swift
+++ b/cmuxTests/PiVaultAgentPersistenceTests.swift
@@ -66,6 +66,8 @@ final class PiVaultAgentPersistenceTests: XCTestCase {
 
         XCTAssertEqual(agent.iconAssetName, "AgentIcons/Pi")
         XCTAssertEqual(SessionAgent.registered(agent).assetName, "AgentIcons/Pi")
+        XCTAssertEqual(CmuxVaultAgentRegistration.builtInPi.detect.processNames, ["pir", "pi-rust", "pi", "pi-coding-agent"])
+        XCTAssertEqual(CmuxVaultAgentRegistration.builtInPi.detect.argvContains, ["pi"])
     }
 
     func testBuiltInAntigravityRegistrationUsesBrandedIconAsset() {

--- a/cmuxTests/RestorableAgentHookProviderResumeTests.swift
+++ b/cmuxTests/RestorableAgentHookProviderResumeTests.swift
@@ -306,8 +306,8 @@ extension SocketListenerAcceptPolicyTests {
         let pi = SessionRestorableAgentSnapshot(
             kind: .pi, sessionId: "pi-session-123", workingDirectory: "/tmp/pi repo",
             launchCommand: AgentLaunchCommandSnapshot(
-                launcher: "pi", executablePath: "/Users/example/.bun/bin/pi",
-                arguments: ["/Users/example/.bun/bin/pi", "--model", "anthropic/claude-sonnet-4-5", "--session", "old-session", "--thinking", "high", "initial prompt should not replay"],
+                launcher: "pi", executablePath: "/Users/example/.local/bin/pir",
+                arguments: ["/Users/example/.local/bin/pir", "--model", "anthropic/claude-sonnet-4-5", "--session", "old-session", "--thinking", "high", "initial prompt should not replay"],
                 workingDirectory: "/tmp/pi repo", environment: ["PI_CODING_AGENT_DIR": "/tmp/pi home", "OPENAI_API_KEY": "secret"], capturedAt: 123, source: "process"
             )
         )
@@ -361,7 +361,7 @@ extension SocketListenerAcceptPolicyTests {
             grok.resumeCommand,
             "cd '/tmp/grok repo' && 'env' 'GROK_HOME=/tmp/grok home' '/Users/example/.grok/bin/grok' '-r' 'grok-session-123' '--model' 'grok-4' '--permission-mode' 'auto' '--cwd' '/tmp/grok repo'"
         )
-        XCTAssertEqual(pi.resumeCommand, "cd '/tmp/pi repo' && 'env' 'PI_CODING_AGENT_DIR=/tmp/pi home' '/Users/example/.bun/bin/pi' '--session' 'pi-session-123' '--model' 'anthropic/claude-sonnet-4-5' '--thinking' 'high'")
+        XCTAssertEqual(pi.resumeCommand, "cd '/tmp/pi repo' && 'env' 'PI_CODING_AGENT_DIR=/tmp/pi home' '/Users/example/.local/bin/pir' '--session' 'pi-session-123' '--model' 'anthropic/claude-sonnet-4-5' '--thinking' 'high'")
         XCTAssertEqual(
             amp.resumeCommand,
             "cd '/tmp/amp repo' && 'env' 'AMP_SETTINGS_FILE=/tmp/amp-settings.json' '/Users/example/.local/bin/amp' 'threads' 'continue' '--mode' 'smart' '--effort' 'high' 'T-019e032c-c31a-77a9-ad87-8298ec47029f'"

--- a/docs/agent-hooks.md
+++ b/docs/agent-hooks.md
@@ -11,7 +11,7 @@ cmux hooks setup --agent <agent>
 cmux hooks uninstall <agent>
 ```
 
-Supported agent names are `codex`, `grok`, `opencode`, `pi`, `amp`, `cursor`, `gemini`, `rovodev` (or `rovo`), `copilot`, `codebuddy`, `factory`, and `qoder`. `cmux hooks setup` skips agents whose binary is not on `PATH` and prints a summary.
+Supported agent names are `codex`, `grok`, `opencode`, `pi` (or `pir` for the Rust CLI), `amp`, `cursor`, `gemini`, `rovodev` (or `rovo`), `copilot`, `codebuddy`, `factory`, and `qoder`. `cmux hooks setup` skips agents whose binary is not on `PATH` and prints a summary.
 
 ## Integrations
 
@@ -21,7 +21,7 @@ Supported agent names are `codex`, `grok`, `opencode`, `pi`, `amp`, `cursor`, `g
 | Codex | `codex` | `~/.codex/hooks.json`, `~/.codex/config.toml` | `codex resume <id>` | PreToolUse, PermissionRequest |
 | Grok | `grok` | `~/.grok/hooks/cmux-session.json` | `grok -r <id>` | PreToolUse |
 | OpenCode | `opencode` | `~/.config/opencode/plugins/cmux-session.js`, `~/.config/opencode/plugins/cmux-feed.js` | `opencode --session <id>` | plugin event bus |
-| Pi | `pi` | `~/.pi/agent/extensions/cmux-session.ts` | `pi --session <id>` | none |
+| Pi | `pir`, `pi-rust`, or `pi` | `~/.pi/agent/extensions/cmux-session.ts` | `pir --session <id>` or `pi --session <id>` | none |
 | Amp | `amp` | `~/.config/amp/plugins/cmux-session.ts` | `amp threads continue <id>` | none |
 | Cursor CLI | `cursor-agent` | `~/.cursor/hooks.json` | `cursor-agent --resume <id>` | beforeShellExecution |
 | Gemini | `gemini` | `~/.gemini/settings.json` | `gemini --resume <id>` | PreToolUse |
@@ -46,6 +46,8 @@ Session hooks write `~/.cmuxterm/<agent>-hook-sessions.json`. Each entry stores 
 The sanitizer preserves model, sandbox, config, and cwd-related flags. It drops prompts, credentials, old session selectors, and noninteractive commands so relaunch resumes the session instead of starting a new task or leaking secrets.
 
 Grok uses its `Notification` hook for user-facing completion messages. cmux records `Stop` as idle state, but leaves the visible notification text to the `Notification` payload so repeated turns keep Grok's own message instead of a generic completion fallback.
+
+Pi sends `session_start`, `before_agent_start`, and `agent_end` through the installed extension. On completion, cmux includes the last assistant message in the native notification when Pi provides it.
 
 ## Agent Hibernation
 
@@ -122,7 +124,9 @@ and browser state. Restored agent terminals stay idle until you resume them manu
 | Factory | none | `CMUX_FACTORY_HOOKS_DISABLED=1` |
 | Qoder | `QODER_CONFIG_DIR` | `CMUX_QODER_HOOKS_DISABLED=1` |
 
-Pi uses Pi's extension system, not the legacy Pi hooks API. The installed extension is auto-discovered from `~/.pi/agent/extensions/` or `$PI_CODING_AGENT_DIR/extensions/`.
+Pi uses Pi's extension system, not the legacy Pi hooks API. The installed extension is auto-discovered from `~/.pi/agent/extensions/` or `$PI_CODING_AGENT_DIR/extensions/`. Rust Pi installs can use `cmux hooks pir install --yes`; cmux stores the session under the shared `pi` session store and resumes with the captured executable.
+
+When Subrouter points `PI_CODING_AGENT_DIR` at `~/.subrouter/codex/pi/...`, cmux prefers the matching `~/.codex-accounts/pi/...` alias when it exists. The same normalization is applied to hook installation, terminal startup, and saved resume commands.
 
 ## Troubleshooting
 

--- a/docs/agent-hooks.md
+++ b/docs/agent-hooks.md
@@ -128,6 +128,25 @@ Pi uses Pi's extension system, not the legacy Pi hooks API. The installed extens
 
 When Subrouter points `PI_CODING_AGENT_DIR` at `~/.subrouter/codex/pi/...`, cmux prefers the matching `~/.codex-accounts/pi/...` alias when it exists. The same normalization is applied to hook installation, terminal startup, and saved resume commands.
 
+For Subrouter account routing, Pi also needs its Codex provider URL pointed at the Subrouter backend. `PI_CODING_AGENT_DIR` controls which Pi config directory is read, but it does not change the OpenAI Codex endpoint by itself. Add this to `~/.pi/agent/models.json` or the active `$PI_CODING_AGENT_DIR/models.json`, replacing the host with the selected Subrouter server when needed:
+
+```json
+{
+  "providers": {
+    "openai-codex": {
+      "baseUrl": "http://subrouter-team:31415/backend-api",
+      "api": "openai-codex-responses",
+      "headers": {
+        "X-Subrouter-Agent": "pi",
+        "X-Subrouter-Session": "!printf 'pir-%s-%s\\n' \"${CMUX_WORKSPACE_ID:-standalone}\" \"${CMUX_SURFACE_ID:-$PPID}\""
+      }
+    }
+  }
+}
+```
+
+Pi normalizes the `backend-api` URL to the Codex responses endpoint. The session header keeps all turns from the same cmux pane on the same Subrouter account while still allowing standalone `pir` runs to get their own session key.
+
 ## Troubleshooting
 
 Run `cmux hooks <agent> install --yes` to reinstall one integration. Run `cmux hooks <agent> uninstall --yes` before editing generated files by hand.

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -278,14 +278,14 @@ Hook subcommands:
 
 | Command | Contract |
 | --- | --- |
-| `hooks setup` | Install hooks for all supported agents whose binaries are on `PATH`. Supports `--agent <name>`, positional agent filters such as `cmux hooks setup rovo`, and `--yes`. |
+| `hooks setup` | Install hooks for all supported agents whose binaries are on `PATH`. Supports `--agent <name>`, positional agent filters such as `cmux hooks setup pir` or `cmux hooks setup rovo`, and `--yes`. |
 | `hooks uninstall` | Remove hooks for all supported agents. Supports `--agent <name>`, positional agent filters such as `cmux hooks uninstall rovo`, and `--yes`. |
 | `hooks <agent> install` | Install hooks for one supported agent. `opencode` also supports `--project` for the project-local Feed plugin. |
 | `hooks <agent> uninstall` | Remove hooks for one supported agent. |
 | `hooks claude <event>` | Handle Claude Code hook events. `claude-hook <event>` remains as the main-compatibility alias. |
 | `hooks codex <event>` | Handle Codex hook events. `codex install-hooks` remains as the main-compatibility installer alias. |
 | `hooks feed --source <agent>` | Convert agent hook events into Feed context. |
-| `hooks <agent> <event>` | Generic hook surface for `grok`, `opencode`, `pi`, `amp`, `cursor`, `gemini`, `rovodev`, `copilot`, `codebuddy`, `factory`, and `qoder`. |
+| `hooks <agent> <event>` | Generic hook surface for `grok`, `opencode`, `pi`/`pir`, `amp`, `cursor`, `gemini`, `rovodev`, `copilot`, `codebuddy`, `factory`, and `qoder`. |
 
 Right sidebar commands:
 

--- a/docs/feed.md
+++ b/docs/feed.md
@@ -84,7 +84,7 @@ Installs supported agent hooks whose binaries are on `PATH`. See [Agent hook int
 | CodeBuddy    | `~/.codebuddy/settings.json`              | PreToolUse               |
 | Factory      | `~/.factory/settings.json`                | PreToolUse               |
 | Qoder        | `~/.qoder/settings.json`                  | PreToolUse               |
-| Pi           | `~/.pi/agent/extensions/cmux-session.ts`  | lifecycle only           |
+| Pi (`pir` or `pi`) | `~/.pi/agent/extensions/cmux-session.ts` | lifecycle only           |
 | Rovo Dev     | `~/.rovodev/config.yml`                   | lifecycle only           |
 
 Individual agents:
@@ -96,7 +96,7 @@ cmux hooks opencode install --project     # .opencode/plugins/cmux-feed.js in cw
 cmux hooks <agent> uninstall
 ```
 
-Agents without a binary on `PATH` are skipped at install time, and `cmux hooks setup` prints a summary line naming the ones it skipped. Use `cmux hooks setup --agent <name>` or `cmux hooks setup <name>` to install one integration, and `cmux hooks uninstall --agent <name>` or `cmux hooks uninstall <name>` to remove one. Rovo Dev accepts either `rovodev` or `rovo`.
+Agents without a binary on `PATH` are skipped at install time, and `cmux hooks setup` prints a summary line naming the ones it skipped. Use `cmux hooks setup --agent <name>` or `cmux hooks setup <name>` to install one integration, and `cmux hooks uninstall --agent <name>` or `cmux hooks uninstall <name>` to remove one. Pi accepts either `pi` or `pir`; Rovo Dev accepts either `rovodev` or `rovo`.
 
 ## Decision semantics
 


### PR DESCRIPTION
## Summary
- add `pir` and `pi-rust` as Pi hook aliases while preserving existing `pi` support
- make the Pi extension capture `pir` launch argv, use the bundled cmux CLI when available, and keep completion notification text
- normalize Subrouter `PI_CODING_AGENT_DIR` paths to `~/.codex-accounts/pi/...` for hook install, terminal startup, and saved resume commands
- document Rust Pi setup and Subrouter behavior

## Verification
- `swift test --package-path Packages/CMUXAgentLaunch`
- `./scripts/reload.sh --tag pir-agent`
- installed `pir` v0.1.16 while leaving existing `pi` v0.73.1 in place
- installed user Pi hooks with the tagged cmux CLI
- verified a temp Subrouter-style `PI_CODING_AGENT_DIR` installs hooks at `~/.codex-accounts/pi/...`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4856"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782453432&installation_id=133855650&pr_number=4856&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4856&signature=7a96811f7757eb3d36eddec821a596af25067f8b3f1645658a70fc23e83db1b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session restore paths, hook install gates, and config-directory resolution across CLI, app startup, and saved launch metadata—incorrect aliasing could break Pi resume or hook placement for Subrouter users.
> 
> **Overview**
> Adds **Rust Pi (`pir`)** as a first-class Pi hook target alongside existing `pi` support, without splitting session storage.
> 
> **Hooks & CLI:** Pi hook definitions now accept multiple on-PATH binaries (`pir`, `pi-rust`, `pi`, `pi-coding-agent`) and CLI aliases `pir` / `pi-rust`. `cmux hooks setup pir` installs the same Pi integration; setup skips Pi only when none of those binaries are found.
> 
> **Pi extension (v2):** The generated `cmux-session.ts` prefers `pir` when present, records launch argv for resume, uses the bundled `cmux` when available, and awaits session IDs from Pi’s extension API so lifecycle hooks stay reliable.
> 
> **Subrouter config paths:** Shared `SubrouterConfigDirectoryPath` logic maps legacy `~/.subrouter/codex/pi/...` `PI_CODING_AGENT_DIR` values to `~/.codex-accounts/pi/...` when that alias exists—applied during hook install, terminal startup, and sanitized launch environment (mirroring Claude).
> 
> **Vault & restore:** Built-in Pi detection and launch sanitization treat `pir` like `pi` while preserving the captured executable in resume commands.
> 
> Docs cover `pir` setup and Subrouter `models.json` provider headers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 998a9f54e65f23f8a31abc9b08327ce9c86a02bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->