### PR TITLE
Add secure cmux navigation links

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -19990,6 +19990,40 @@
         }
       }
     },
+    "command.copySurfaceLink.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy Surface Link"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サーフェスリンクをコピー"
+          }
+        }
+      }
+    },
+    "command.copyPaneLink.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy Pane Link"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ペインリンクをコピー"
+          }
+        }
+      }
+    },
     "command.copyWorkspaceIDAndRef.title": {
       "extractionState": "manual",
       "localizations": {
@@ -20009,6 +20043,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "워크스페이스 ID 및 참조 복사"
+          }
+        }
+      }
+    },
+    "command.copyWorkspaceLink.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy Workspace Link"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースリンクをコピー"
           }
         }
       }
@@ -36930,6 +36981,40 @@
           "stringUnit": {
             "state": "translated",
             "value": "워크스페이스 ID 복사"
+          }
+        }
+      }
+    },
+    "contextMenu.copyWorkspaceLink": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy Workspace Link"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースリンクをコピー"
+          }
+        }
+      }
+    },
+    "contextMenu.copyWorkspaceLinks": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy Workspace Links"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースリンクをコピー"
           }
         }
       }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -20004,6 +20004,114 @@
             "state": "translated",
             "value": "サーフェスリンクをコピー"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "复制界面链接"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "複製介面連結"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "서피스 링크 복사"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ចម្លងតំណភ្ជាប់ផ្ទៃ"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oberflächen-Link kopieren"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiar enlace de superficie"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copier le lien de la surface"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copia link superficie"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopiér overfladelink"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopiuj link powierzchni"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Копировать ссылку на поверхность"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopiraj link površine"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نسخ رابط السطح"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopier overflatelenke"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiar link da superfície"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "คัดลอกลิงก์เซอร์เฟซ"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yüzey bağlantısını kopyala"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Копіювати посилання на поверхню"
+          }
         }
       }
     },
@@ -20020,6 +20128,114 @@
           "stringUnit": {
             "state": "translated",
             "value": "ペインリンクをコピー"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "复制窗格链接"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "複製窗格連結"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "패널 링크 복사"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ចម្លងតំណភ្ជាប់ផ្ទាំង"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fensterbereich-Link kopieren"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiar enlace del panel"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copier le lien du volet"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copia link riquadro"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopiér panellink"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopiuj link panelu"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Копировать ссылку на панель"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopiraj link panela"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نسخ رابط الجزء"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopier panellenke"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiar link do painel"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "คัดลอกลิงก์พาเนล"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bölme bağlantısını kopyala"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Копіювати посилання на панель"
           }
         }
       }
@@ -20060,6 +20276,114 @@
           "stringUnit": {
             "state": "translated",
             "value": "ワークスペースリンクをコピー"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "复制工作区链接"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "複製工作區連結"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "워크스페이스 링크 복사"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ចម្លងតំណភ្ជាប់កន្លែងធ្វើការ"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arbeitsbereich-Link kopieren"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiar enlace de espacio de trabajo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copier le lien de l’espace de travail"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copia link area di lavoro"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopiér arbejdsområdelink"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopiuj link obszaru roboczego"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Копировать ссылку на рабочую область"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopiraj link radnog prostora"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نسخ رابط مساحة العمل"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopier arbeidsområdelenke"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiar link do espaço de trabalho"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "คัดลอกลิงก์เวิร์กสเปซ"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Çalışma alanı bağlantısını kopyala"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Копіювати посилання на робочий простір"
           }
         }
       }
@@ -36999,6 +37323,114 @@
             "state": "translated",
             "value": "ワークスペースリンクをコピー"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "复制工作区链接"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "複製工作區連結"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "워크스페이스 링크 복사"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ចម្លងតំណភ្ជាប់កន្លែងធ្វើការ"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arbeitsbereich-Link kopieren"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiar enlace de espacio de trabajo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copier le lien de l’espace de travail"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copia link area di lavoro"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopiér arbejdsområdelink"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopiuj link obszaru roboczego"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Копировать ссылку на рабочую область"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopiraj link radnog prostora"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نسخ رابط مساحة العمل"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopier arbeidsområdelenke"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiar link do espaço de trabalho"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "คัดลอกลิงก์เวิร์กสเปซ"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Çalışma alanı bağlantısını kopyala"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Копіювати посилання на робочий простір"
+          }
         }
       }
     },
@@ -37015,6 +37447,114 @@
           "stringUnit": {
             "state": "translated",
             "value": "ワークスペースリンクをコピー"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "复制工作区链接"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "複製工作區連結"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "워크스페이스 링크 복사"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ចម្លងតំណភ្ជាប់កន្លែងធ្វើការ"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arbeitsbereich-Links kopieren"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiar enlaces de espacios de trabajo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copier les liens des espaces de travail"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copia link aree di lavoro"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopiér arbejdsområdelinks"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopiuj linki obszarów roboczych"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Копировать ссылки на рабочие области"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopiraj linkove radnih prostora"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نسخ روابط مساحات العمل"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopier arbeidsområdelenker"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiar links dos espaços de trabalho"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "คัดลอกลิงก์เวิร์กสเปซ"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Çalışma alanı bağlantılarını kopyala"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Копіювати посилання на робочі простори"
           }
         }
       }

--- a/Sources/AppDelegate+CmuxSSHURL.swift
+++ b/Sources/AppDelegate+CmuxSSHURL.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Bonsplit
 import Foundation
 
 @MainActor
@@ -150,13 +151,124 @@ extension AppDelegate {
     }
 
     func claimAuthCallbackURLSchemes() {
-        // Pin the current build's callback scheme so auth and SSH deeplinks
+        // Pin the current build's callback scheme so auth, SSH, and navigation deeplinks
         // route back to this app instead of an unrelated LaunchServices entry.
         let bundleURL = Bundle.main.bundleURL
         NSWorkspace.shared.setDefaultApplication(
             at: bundleURL,
             toOpenURLsWithScheme: AuthEnvironment.callbackScheme
         ) { _ in }
+    }
+
+    @discardableResult
+    func handleCmuxNavigationURLs(from urls: [URL]) -> Bool {
+        var navigationRequests: [CmuxNavigationURLRequest] = []
+        var parseErrors: [(url: URL, error: CmuxNavigationURLParseError)] = []
+
+        for url in urls {
+            switch CmuxNavigationURLRequest.parse(url) {
+            case .success(.some(let request)):
+                navigationRequests.append(request)
+            case .success(nil):
+                break
+            case .failure(let error):
+                parseErrors.append((url, error))
+            }
+        }
+
+        let navigationIntentCount = navigationRequests.count + parseErrors.count
+        guard navigationIntentCount > 0 else { return false }
+
+        guard urls.count == 1, navigationIntentCount == 1 else {
+#if DEBUG
+            cmuxDebugLog("navigationURL.ignored reason=multipleLinks count=\(urls.count) intents=\(navigationIntentCount)")
+#endif
+            return true
+        }
+
+        if let parseError = parseErrors.first {
+#if DEBUG
+            cmuxDebugLog("navigationURL.blocked reason=\(parseError.error) url=\(parseError.url.absoluteString.prefix(160))")
+#endif
+            return true
+        }
+
+        if let request = navigationRequests.first {
+            _ = handleCmuxNavigationURLRequest(request)
+        }
+        return true
+    }
+
+    @discardableResult
+    private func handleCmuxNavigationURLRequest(_ request: CmuxNavigationURLRequest) -> Bool {
+        let workspaceId: UUID
+        switch request.target {
+        case .workspace(let id), .pane(let id, _), .surface(let id, _):
+            workspaceId = id
+        }
+
+        guard let context = mainWindowContexts.values.first(where: { context in
+            context.tabManager.tabs.contains(where: { $0.id == workspaceId })
+        }),
+              let workspace = context.tabManager.tabs.first(where: { $0.id == workspaceId }),
+              let window = context.window ?? windowForMainWindowId(context.windowId) else {
+#if DEBUG
+            cmuxDebugLog("navigationURL.notFound workspace=\(workspaceId.uuidString.prefix(8))")
+#endif
+            return false
+        }
+
+        let targetPanelId: UUID?
+        switch request.target {
+        case .workspace:
+            targetPanelId = nil
+        case .pane(_, let paneId):
+            guard let pane = workspace.bonsplitController.allPaneIds.first(where: { $0.id == paneId }) else {
+#if DEBUG
+                cmuxDebugLog(
+                    "navigationURL.notFound workspace=\(workspaceId.uuidString.prefix(8)) " +
+                    "pane=\(paneId.uuidString.prefix(8))"
+                )
+#endif
+                return false
+            }
+            let selectedTab = workspace.bonsplitController.selectedTab(inPane: pane)
+                ?? workspace.bonsplitController.tabs(inPane: pane).first
+            targetPanelId = selectedTab.flatMap { workspace.panelIdFromSurfaceId($0.id) }
+            if targetPanelId == nil {
+                workspace.bonsplitController.focusPane(pane)
+            }
+        case .surface(_, let surfaceId):
+            guard workspace.panels[surfaceId] != nil,
+                  workspace.surfaceIdFromPanelId(surfaceId) != nil else {
+#if DEBUG
+                cmuxDebugLog(
+                    "navigationURL.notFound workspace=\(workspaceId.uuidString.prefix(8)) " +
+                    "surface=\(surfaceId.uuidString.prefix(8))"
+                )
+#endif
+                return false
+            }
+            targetPanelId = surfaceId
+        }
+
+        prepareForExplicitOpenIntentAtStartup()
+        setActiveMainWindow(window)
+        _ = focusMainWindow(windowId: context.windowId)
+        context.tabManager.focusTab(
+            workspaceId,
+            surfaceId: targetPanelId,
+            suppressFlash: true
+        )
+
+#if DEBUG
+        let surface = targetPanelId.map { String($0.uuidString.prefix(8)) } ?? "nil"
+        cmuxDebugLog(
+            "navigationURL.focus workspace=\(workspaceId.uuidString.prefix(8)) " +
+            "surface=\(surface) window=\(context.windowId.uuidString.prefix(8))"
+        )
+#endif
+        return true
     }
 
     @discardableResult

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1008,6 +1008,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         if handleCmuxSSHURLs(from: urls) {
             return
         }
+        if handleCmuxNavigationURLs(from: urls) {
+            return
+        }
 
         let authCallbacks = urls.filter(AuthCallbackRouter.isAuthCallbackURL)
         for url in authCallbacks {

--- a/Sources/CmuxSSHURLRequest.swift
+++ b/Sources/CmuxSSHURLRequest.swift
@@ -357,3 +357,126 @@ struct CmuxSSHURLRequest: Equatable {
         return prefix.count == name.count ? name : "\(prefix)..."
     }
 }
+
+enum CmuxNavigationURLParseError: Error, Equatable {
+    case unsupportedURLShape
+    case invalidIdentifier(String)
+}
+
+struct CmuxNavigationURLRequest: Equatable {
+    enum Target: Equatable {
+        case workspace(UUID)
+        case pane(workspaceId: UUID, paneId: UUID)
+        case surface(workspaceId: UUID, surfaceId: UUID)
+    }
+
+    static var activeSupportedSchemes: Set<String> {
+        [AuthEnvironment.callbackScheme.lowercased()]
+    }
+
+    let originalURL: URL
+    let target: Target
+
+    static func parse(
+        _ url: URL,
+        supportedSchemes: Set<String> = activeSupportedSchemes
+    ) -> Result<CmuxNavigationURLRequest?, CmuxNavigationURLParseError> {
+        guard isSupportedScheme(url.scheme, supportedSchemes: supportedSchemes) else {
+            return .success(nil)
+        }
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            return .failure(.unsupportedURLShape)
+        }
+
+        let route = routeComponents(from: components)
+        guard route.first?.lowercased() == "workspace" else {
+            return .success(nil)
+        }
+
+        guard components.user == nil,
+              components.password == nil,
+              components.port == nil,
+              components.percentEncodedQuery == nil,
+              components.percentEncodedFragment == nil else {
+            return .failure(.unsupportedURLShape)
+        }
+
+        guard route.count == 2 || route.count == 4 else {
+            return .failure(.unsupportedURLShape)
+        }
+        guard let workspaceId = UUID(uuidString: route[1]) else {
+            return .failure(.invalidIdentifier("workspace"))
+        }
+        if route.count == 2 {
+            return .success(CmuxNavigationURLRequest(originalURL: url, target: .workspace(workspaceId)))
+        }
+
+        let childKind = route[2].lowercased()
+        guard let childId = UUID(uuidString: route[3]) else {
+            switch childKind {
+            case "pane":
+                return .failure(.invalidIdentifier("pane"))
+            case "surface", "panel":
+                return .failure(.invalidIdentifier("surface"))
+            default:
+                return .failure(.unsupportedURLShape)
+            }
+        }
+
+        switch childKind {
+        case "pane":
+            return .success(
+                CmuxNavigationURLRequest(
+                    originalURL: url,
+                    target: .pane(workspaceId: workspaceId, paneId: childId)
+                )
+            )
+        case "surface", "panel":
+            return .success(
+                CmuxNavigationURLRequest(
+                    originalURL: url,
+                    target: .surface(workspaceId: workspaceId, surfaceId: childId)
+                )
+            )
+        default:
+            return .failure(.unsupportedURLShape)
+        }
+    }
+
+    static func workspaceLink(workspaceId: UUID, scheme: String = AuthEnvironment.callbackScheme) -> String {
+        "\(scheme)://workspace/\(workspaceId.uuidString)"
+    }
+
+    static func paneLink(
+        workspaceId: UUID,
+        paneId: UUID,
+        scheme: String = AuthEnvironment.callbackScheme
+    ) -> String {
+        "\(scheme)://workspace/\(workspaceId.uuidString)/pane/\(paneId.uuidString)"
+    }
+
+    static func surfaceLink(
+        workspaceId: UUID,
+        surfaceId: UUID,
+        scheme: String = AuthEnvironment.callbackScheme
+    ) -> String {
+        "\(scheme)://workspace/\(workspaceId.uuidString)/surface/\(surfaceId.uuidString)"
+    }
+
+    private static func isSupportedScheme(_ scheme: String?, supportedSchemes: Set<String>) -> Bool {
+        guard let scheme = scheme?.lowercased() else { return false }
+        return supportedSchemes.contains(scheme)
+    }
+
+    private static func routeComponents(from components: URLComponents) -> [String] {
+        var route: [String] = []
+        if let host = components.host?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !host.isEmpty {
+            route.append(host)
+        }
+        route += components.path
+            .split(separator: "/", omittingEmptySubsequences: true)
+            .map(String.init)
+        return route
+    }
+}

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -13975,6 +13975,10 @@ private struct TabItemView: View, Equatable {
         WorkspaceSurfaceIdentifierClipboardText.copyWorkspaceIds(ids, includeRefs: includeRefs)
     }
 
+    private func copyWorkspaceLinksToPasteboard(_ ids: [UUID]) {
+        WorkspaceSurfaceIdentifierClipboardText.copyWorkspaceLinks(ids)
+    }
+
     private var visibleAuxiliaryDetails: SidebarWorkspaceAuxiliaryDetailVisibility {
         settings.visibleAuxiliaryDetails
     }
@@ -14518,6 +14522,10 @@ private struct TabItemView: View, Equatable {
             multi: String(localized: "contextMenu.copyWorkspaceIDs", defaultValue: "Copy Workspace IDs"),
             single: String(localized: "contextMenu.copyWorkspaceID", defaultValue: "Copy Workspace ID"),
             isMulti: isMulti)
+        let copyWorkspaceLinkLabel = contextMenuLabel(
+            multi: String(localized: "contextMenu.copyWorkspaceLinks", defaultValue: "Copy Workspace Links"),
+            single: String(localized: "contextMenu.copyWorkspaceLink", defaultValue: "Copy Workspace Link"),
+            isMulti: isMulti)
         let renameWorkspaceShortcut = KeyboardShortcutSettings.shortcut(for: .renameWorkspace)
         let editWorkspaceDescriptionShortcut = KeyboardShortcutSettings.shortcut(for: .editWorkspaceDescription)
         let closeWorkspaceShortcut = KeyboardShortcutSettings.shortcut(for: .closeWorkspace)
@@ -14738,6 +14746,11 @@ private struct TabItemView: View, Equatable {
 
         Button(copyWorkspaceIDLabel) {
             copyWorkspaceIdsToPasteboard(targetIds)
+        }
+        .disabled(targetIds.isEmpty)
+
+        Button(copyWorkspaceLinkLabel) {
+            copyWorkspaceLinksToPasteboard(targetIds)
         }
         .disabled(targetIds.isEmpty)
 

--- a/Sources/ContentViewIdentifierCopyCommands.swift
+++ b/Sources/ContentViewIdentifierCopyCommands.swift
@@ -22,6 +22,11 @@ extension ContentView {
                 String(localized: "command.copyWorkspaceIDAndRef.title", defaultValue: "Copy Workspace ID and Ref"),
                 ["copy", "workspace", "id", "identifier", "ref", "reference"]
             ),
+            (
+                "palette.copyWorkspaceLink",
+                String(localized: "command.copyWorkspaceLink.title", defaultValue: "Copy Workspace Link"),
+                ["copy", "workspace", "link", "url", "deeplink", "deep link"]
+            ),
         ]
         contributions += workspaceCommands.map { command in
             CommandPaletteCommandContribution(
@@ -41,9 +46,21 @@ extension ContentView {
                 true
             ),
             (
+                "palette.copyPaneLink",
+                String(localized: "command.copyPaneLink.title", defaultValue: "Copy Pane Link"),
+                ["copy", "pane", "split", "link", "url", "deeplink", "deep link"],
+                true
+            ),
+            (
                 "palette.copySurfaceID",
                 String(localized: "command.copySurfaceID.title", defaultValue: "Copy Surface ID"),
                 ["copy", "surface", "tab", "id", "identifier"],
+                false
+            ),
+            (
+                "palette.copySurfaceLink",
+                String(localized: "command.copySurfaceLink.title", defaultValue: "Copy Surface Link"),
+                ["copy", "surface", "tab", "link", "url", "deeplink", "deep link"],
                 false
             ),
             (
@@ -71,8 +88,11 @@ extension ContentView {
     func registerIdentifierCopyCommandHandlers(_ registry: inout CommandPaletteHandlerRegistry) {
         registry.register(commandId: "palette.copyWorkspaceID") { copySelectedWorkspaceIdentifiers(includeRefs: false) }
         registry.register(commandId: "palette.copyWorkspaceIDAndRef") { copySelectedWorkspaceIdentifiers(includeRefs: true) }
+        registry.register(commandId: "palette.copyWorkspaceLink") { copySelectedWorkspaceLink() }
         registry.register(commandId: "palette.copyPaneID") { copyFocusedPaneIdentifier() }
+        registry.register(commandId: "palette.copyPaneLink") { copyFocusedPaneLink() }
         registry.register(commandId: "palette.copySurfaceID") { copyFocusedSurfaceIdentifier() }
+        registry.register(commandId: "palette.copySurfaceLink") { copyFocusedSurfaceLink() }
         registry.register(commandId: "palette.copyIdentifiers") { copyFocusedWorkspacePaneSurfaceIdentifiers() }
     }
 
@@ -82,6 +102,16 @@ extension ContentView {
             return
         }
         WorkspaceSurfaceIdentifierClipboardText.copyWorkspaceIds([workspaceId], includeRefs: includeRefs)
+    }
+
+    private func copySelectedWorkspaceLink() {
+        guard let workspaceId = tabManager.selectedWorkspace?.id else {
+            NSSound.beep()
+            return
+        }
+        WorkspaceSurfaceIdentifierClipboardText.copy(
+            WorkspaceSurfaceIdentifierClipboardText.makeWorkspaceLink(workspaceId: workspaceId)
+        )
     }
 
     private func focusedPanelIdentifierContext() -> (workspaceId: UUID, paneId: UUID?, surfaceId: UUID)? {
@@ -101,12 +131,39 @@ extension ContentView {
         WorkspaceSurfaceIdentifierClipboardText.copy(WorkspaceSurfaceIdentifierClipboardText.makePane(paneId: paneId))
     }
 
+    private func copyFocusedPaneLink() {
+        guard let context = focusedPanelIdentifierContext(),
+              let paneId = context.paneId else {
+            NSSound.beep()
+            return
+        }
+        WorkspaceSurfaceIdentifierClipboardText.copy(
+            WorkspaceSurfaceIdentifierClipboardText.makePaneLink(
+                workspaceId: context.workspaceId,
+                paneId: paneId
+            )
+        )
+    }
+
     private func copyFocusedSurfaceIdentifier() {
         guard let context = focusedPanelIdentifierContext() else {
             NSSound.beep()
             return
         }
         WorkspaceSurfaceIdentifierClipboardText.copy(WorkspaceSurfaceIdentifierClipboardText.makeSurface(surfaceId: context.surfaceId))
+    }
+
+    private func copyFocusedSurfaceLink() {
+        guard let context = focusedPanelIdentifierContext() else {
+            NSSound.beep()
+            return
+        }
+        WorkspaceSurfaceIdentifierClipboardText.copy(
+            WorkspaceSurfaceIdentifierClipboardText.makeSurfaceLink(
+                workspaceId: context.workspaceId,
+                surfaceId: context.surfaceId
+            )
+        )
     }
 
     private func copyFocusedWorkspacePaneSurfaceIdentifiers() {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -8334,6 +8334,16 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         )
     }
 
+    @IBAction func copyCurrentSurfaceLink(_ sender: Any?) {
+        guard let terminalSurface else { return }
+        WorkspaceSurfaceIdentifierClipboardText.copy(
+            WorkspaceSurfaceIdentifierClipboardText.makeSurfaceLink(
+                workspaceId: terminalSurface.tabId,
+                surfaceId: terminalSurface.id
+            )
+        )
+    }
+
     private func recordDirectAgentHibernationTerminalInput() {
         guard let terminalSurface else { return }
         recordAgentHibernationTerminalInput(
@@ -10400,6 +10410,12 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                 keyEquivalent: ""
             )
             identifiersItem.target = self
+            let linkItem = menu.addItem(
+                withTitle: String(localized: "command.copySurfaceLink.title", defaultValue: "Copy Surface Link"),
+                action: #selector(copyCurrentSurfaceLink(_:)),
+                keyEquivalent: ""
+            )
+            linkItem.target = self
         }
         return menu
     }

--- a/Sources/WorkspaceSurfaceIdentifierClipboardText.swift
+++ b/Sources/WorkspaceSurfaceIdentifierClipboardText.swift
@@ -14,6 +14,11 @@ enum WorkspaceSurfaceIdentifierClipboardText {
     }
 
     @MainActor
+    static func copyWorkspaceLinks(_ ids: [UUID]) {
+        copy(makeWorkspaceLinks(ids))
+    }
+
+    @MainActor
     static func makeWorkspaceIds(_ ids: [UUID], includeRefs: Bool) -> String {
         let refs = includeRefs ? TerminalController.shared.v2WorkspaceRefs(for: ids) : [:]
         return make(workspaces: ids.map { (id: $0, ref: refs[$0]) })
@@ -35,6 +40,22 @@ enum WorkspaceSurfaceIdentifierClipboardText {
         }
         lines.append("surface_id=\(surfaceId.uuidString)")
         return lines.joined(separator: "\n")
+    }
+
+    static func makeWorkspaceLink(workspaceId: UUID) -> String {
+        CmuxNavigationURLRequest.workspaceLink(workspaceId: workspaceId)
+    }
+
+    static func makeWorkspaceLinks(_ ids: [UUID]) -> String {
+        ids.map { makeWorkspaceLink(workspaceId: $0) }.joined(separator: "\n")
+    }
+
+    static func makePaneLink(workspaceId: UUID, paneId: UUID) -> String {
+        CmuxNavigationURLRequest.paneLink(workspaceId: workspaceId, paneId: paneId)
+    }
+
+    static func makeSurfaceLink(workspaceId: UUID, surfaceId: UUID) -> String {
+        CmuxNavigationURLRequest.surfaceLink(workspaceId: workspaceId, surfaceId: surfaceId)
     }
 
     @MainActor

--- a/cmuxTests/CmuxSSHURLRequestTests.swift
+++ b/cmuxTests/CmuxSSHURLRequestTests.swift
@@ -546,3 +546,94 @@ final class CmuxSSHURLRequestTests: XCTestCase {
         return components.url
     }
 }
+
+final class CmuxNavigationURLRequestTests: XCTestCase {
+    private let supportedScheme = "cmux-test"
+    private let workspaceId = UUID(uuidString: "11111111-1111-1111-1111-111111111111")!
+    private let paneId = UUID(uuidString: "22222222-2222-2222-2222-222222222222")!
+    private let surfaceId = UUID(uuidString: "33333333-3333-3333-3333-333333333333")!
+
+    func testParsesWorkspacePaneAndSurfaceLinks() throws {
+        let workspaceURL = try XCTUnwrap(URL(string: "\(supportedScheme)://workspace/\(workspaceId.uuidString)"))
+        let paneURL = try XCTUnwrap(URL(string: "\(supportedScheme)://workspace/\(workspaceId.uuidString)/pane/\(paneId.uuidString)"))
+        let surfaceURL = try XCTUnwrap(URL(string: "\(supportedScheme)://workspace/\(workspaceId.uuidString)/surface/\(surfaceId.uuidString)"))
+        let panelAliasURL = try XCTUnwrap(URL(string: "\(supportedScheme)://workspace/\(workspaceId.uuidString)/panel/\(surfaceId.uuidString)"))
+
+        XCTAssertEqual(try parsedTarget(workspaceURL), .workspace(workspaceId))
+        XCTAssertEqual(try parsedTarget(paneURL), .pane(workspaceId: workspaceId, paneId: paneId))
+        XCTAssertEqual(try parsedTarget(surfaceURL), .surface(workspaceId: workspaceId, surfaceId: surfaceId))
+        XCTAssertEqual(try parsedTarget(panelAliasURL), .surface(workspaceId: workspaceId, surfaceId: surfaceId))
+    }
+
+    func testGeneratedLinksRoundTrip() throws {
+        let workspaceURL = try XCTUnwrap(URL(string: CmuxNavigationURLRequest.workspaceLink(workspaceId: workspaceId, scheme: supportedScheme)))
+        let paneURL = try XCTUnwrap(URL(string: CmuxNavigationURLRequest.paneLink(workspaceId: workspaceId, paneId: paneId, scheme: supportedScheme)))
+        let surfaceURL = try XCTUnwrap(URL(string: CmuxNavigationURLRequest.surfaceLink(workspaceId: workspaceId, surfaceId: surfaceId, scheme: supportedScheme)))
+
+        XCTAssertEqual(try parsedTarget(workspaceURL), .workspace(workspaceId))
+        XCTAssertEqual(try parsedTarget(paneURL), .pane(workspaceId: workspaceId, paneId: paneId))
+        XCTAssertEqual(try parsedTarget(surfaceURL), .surface(workspaceId: workspaceId, surfaceId: surfaceId))
+    }
+
+    func testIgnoresOtherCmuxRoutesAndInactiveSchemes() throws {
+        let sshURL = try XCTUnwrap(URL(string: "\(supportedScheme)://ssh?host=dev.example.com"))
+        let authURL = try XCTUnwrap(URL(string: "\(supportedScheme)://auth-callback?stack_refresh=abc"))
+        let inactiveURL = try XCTUnwrap(URL(string: "cmux-other://workspace/\(workspaceId.uuidString)"))
+
+        XCTAssertNil(try parsedOptional(sshURL))
+        XCTAssertNil(try parsedOptional(authURL))
+        XCTAssertNil(try parsedOptional(inactiveURL))
+    }
+
+    func testRejectsQueryFragmentAuthorityAndExtraPathComponents() throws {
+        let cases = [
+            "\(supportedScheme)://workspace/\(workspaceId.uuidString)?command=id",
+            "\(supportedScheme)://workspace/\(workspaceId.uuidString)#fragment",
+            "\(supportedScheme)://user@workspace/\(workspaceId.uuidString)",
+            "\(supportedScheme)://workspace:123/\(workspaceId.uuidString)",
+            "\(supportedScheme)://workspace/\(workspaceId.uuidString)/surface/\(surfaceId.uuidString)/run"
+        ]
+
+        for rawURL in cases {
+            let url = try XCTUnwrap(URL(string: rawURL))
+            switch CmuxNavigationURLRequest.parse(url, supportedSchemes: [supportedScheme]) {
+            case .failure(.unsupportedURLShape):
+                break
+            default:
+                XCTFail("Expected unsupported URL shape rejection for \(rawURL)")
+            }
+        }
+    }
+
+    func testRejectsNonUUIDIdentifiersAndRelativeRefs() throws {
+        let cases = [
+            ("\(supportedScheme)://workspace/workspace:1", "workspace"),
+            ("\(supportedScheme)://workspace/\(workspaceId.uuidString)/pane/pane:1", "pane"),
+            ("\(supportedScheme)://workspace/\(workspaceId.uuidString)/surface/surface:1", "surface")
+        ]
+
+        for (rawURL, component) in cases {
+            let url = try XCTUnwrap(URL(string: rawURL))
+            switch CmuxNavigationURLRequest.parse(url, supportedSchemes: [supportedScheme]) {
+            case .failure(.invalidIdentifier(component)):
+                break
+            default:
+                XCTFail("Expected invalid \(component) rejection for \(rawURL)")
+            }
+        }
+    }
+
+    private func parsedOptional(_ url: URL) throws -> CmuxNavigationURLRequest? {
+        switch CmuxNavigationURLRequest.parse(url, supportedSchemes: [supportedScheme]) {
+        case .success(let request):
+            return request
+        case .failure(let error):
+            throw error
+        }
+    }
+
+    private func parsedTarget(_ url: URL) throws -> CmuxNavigationURLRequest.Target {
+        let request = try XCTUnwrap(parsedOptional(url))
+        return request.target
+    }
+}


### PR DESCRIPTION
## Summary
- Add selector-only cmux navigation deeplinks for live workspaces, panes, and surfaces.
- Add copy-link commands in the command palette, workspace context menu, and terminal context menu.
- Reject query strings, fragments, auth components, non-UUID identifiers, refs, indexes, and unsupported routes.

## Testing
- `jq empty Resources/Localizable.xcstrings`
- `git diff --check`
- `./scripts/lint-pbxproj-test-wiring.sh`
- `./scripts/reload.sh --tag deeplink`

## Issues
- Related: user request for secure cmux navigation deeplinks to already-open workspaces and panes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4857"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782454351&installation_id=133855650&pr_number=4857&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4857&signature=97c5e0a4711037c52c12c0de75a2c9aa01252add0b50763d8b792239794f586b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New URL open handling affects window focus and tab selection; parsing is constrained but wrong focus behavior or edge cases in multi-window setups are the main review concern—not remote code execution.
> 
> **Overview**
> Adds **selector-only navigation deeplinks** on the app’s callback URL scheme so opening a link can focus an **already-open** workspace, pane, or surface (`workspace/{uuid}`, `.../pane/{uuid}`, `.../surface|panel/{uuid}`). Parsing is strict: **UUID paths only**, no query, fragment, user/password/port, or extra path segments; non-navigation cmux URLs are ignored.
> 
> **Inbound handling** runs after SSH URL handling in `application(_:open:)`, accepts a **single** navigation intent (multiple links are ignored), resolves the workspace across main windows, then activates the window and calls `focusTab` (pane links map to the selected tab’s panel when possible).
> 
> **Copy link** is wired through clipboard helpers, command palette commands, sidebar workspace context menu (including multi-select), and a terminal context menu item for the current surface. New **localizable** strings cover command and context menu titles.
> 
> **Tests** cover parse/generate round-trips, `panel` as a surface alias, and rejection cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdd0ea6eb3b200760e40677e654f6038e3ee3172. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds secure cmux navigation deeplinks that focus already-open workspaces, panes, or surfaces, plus “Copy … Link” commands to quickly share selector-only links. Links are strict: UUID-only, no query/fragment/auth, and unsupported routes are blocked.

- **New Features**
  - Navigation URL parser/handler using the current callback scheme; focuses an existing window/tab/pane/surface; single-link only; supports `workspace/{id}`, `workspace/{id}/pane/{id}`, and `workspace/{id}/surface|panel/{id}`.
  - Copy-link commands: workspace/pane/surface in the command palette; workspace link in the sidebar context menu (multi-select); surface link in the terminal context menu.
  - Clipboard helpers generate canonical links; labels localized across 20+ languages.
  - Strict validation: rejects non-UUID ids, extra path segments, queries, fragments, and any URL with user/password/port; ignores inactive schemes and unrelated routes.
  - Tests cover parsing, link generation, aliasing (`panel`→`surface`), and all rejection cases.

<sup>Written for commit fdd0ea6eb3b200760e40677e654f6038e3ee3172. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4857?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

