### PR TITLE
Avoid blocking quit on PostHog flush

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -930,7 +930,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     // Set to true when the user has already confirmed quit via the warning dialog,
     // so applicationShouldTerminate does not show a second alert.
     private var isQuitWarningConfirmed = false
-    private var didEnqueuePostHogTerminationFlush = false
     private var didInstallLifecycleSnapshotObservers = false
     private var didDisableSuddenTermination = false
     private var commandPaletteVisibilityByWindowId: [UUID: Bool] = [:]
@@ -1645,7 +1644,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             } else {
                 // Reset so that the next quit attempt can show the dialog again.
                 self.isTerminatingApp = false
-                self.didEnqueuePostHogTerminationFlush = false
                 StartupBreadcrumbLog.append("appDelegate.shouldTerminate.reply", fields: ["shouldQuit": "0"])
             }
             NSApp.reply(toApplicationShouldTerminate: shouldQuit)
@@ -1710,8 +1708,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     private func enqueuePostHogTerminationFlushIfNeeded(reason: String) {
         guard TelemetrySettings.enabledForCurrentLaunch else { return }
-        guard !didEnqueuePostHogTerminationFlush else { return }
-        didEnqueuePostHogTerminationFlush = true
         PostHogAnalytics.shared.flushForApplicationTermination(reason: reason)
     }
 

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -930,6 +930,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     // Set to true when the user has already confirmed quit via the warning dialog,
     // so applicationShouldTerminate does not show a second alert.
     private var isQuitWarningConfirmed = false
+    private var didEnqueuePostHogTerminationFlush = false
     private var didInstallLifecycleSnapshotObservers = false
     private var didDisableSuddenTermination = false
     private var commandPaletteVisibilityByWindowId: [UUID: Bool] = [:]
@@ -1596,6 +1597,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             ]
         )
         isTerminatingApp = true
+        enqueuePostHogTerminationFlushIfNeeded(reason: "applicationShouldTerminate")
         _ = saveSessionSnapshotIncludingProcessDetectedIndexes(includeScrollback: true, removeWhenEmpty: false)
 
         // If the user already confirmed via the Cmd+Q shortcut warning dialog,
@@ -1643,6 +1645,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             } else {
                 // Reset so that the next quit attempt can show the dialog again.
                 self.isTerminatingApp = false
+                self.didEnqueuePostHogTerminationFlush = false
                 StartupBreadcrumbLog.append("appDelegate.shouldTerminate.reply", fields: ["shouldQuit": "0"])
             }
             NSApp.reply(toApplicationShouldTerminate: shouldQuit)
@@ -1696,15 +1699,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         GhosttyPasteboardHelper.cleanupAllOwnedTemporaryImageFiles()
         VSCodeServeWebController.shared.stop()
         BrowserProfileStore.shared.flushPendingSaves()
-        if TelemetrySettings.enabledForCurrentLaunch {
-            PostHogAnalytics.shared.flushForApplicationTermination()
-        }
+        enqueuePostHogTerminationFlushIfNeeded(reason: "applicationWillTerminate")
         ghosttyCrashBreadcrumbTask?.cancel()
         ghosttyCrashBreadcrumbTask = nil
         notificationStore?.clearAll()
         GhosttyCrashBreadcrumb.markCleanExit()
         StartupBreadcrumbLog.append("appDelegate.willTerminate.complete")
         enableSuddenTerminationIfNeeded()
+    }
+
+    private func enqueuePostHogTerminationFlushIfNeeded(reason: String) {
+        guard TelemetrySettings.enabledForCurrentLaunch else { return }
+        guard !didEnqueuePostHogTerminationFlush else { return }
+        didEnqueuePostHogTerminationFlush = true
+        PostHogAnalytics.shared.flushForApplicationTermination(reason: reason)
     }
 
     func applicationWillResignActive(_ notification: Notification) {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1596,7 +1596,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             ]
         )
         isTerminatingApp = true
-        enqueuePostHogTerminationFlushIfNeeded(reason: "applicationShouldTerminate")
+        enqueuePostHogTerminationFlushIfNeeded(
+            reason: "applicationShouldTerminate",
+            preservePendingCaptures: true
+        )
         _ = saveSessionSnapshotIncludingProcessDetectedIndexes(includeScrollback: true, removeWhenEmpty: false)
 
         // If the user already confirmed via the Cmd+Q shortcut warning dialog,
@@ -1697,7 +1700,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         GhosttyPasteboardHelper.cleanupAllOwnedTemporaryImageFiles()
         VSCodeServeWebController.shared.stop()
         BrowserProfileStore.shared.flushPendingSaves()
-        enqueuePostHogTerminationFlushIfNeeded(reason: "applicationWillTerminate")
+        enqueuePostHogTerminationFlushIfNeeded(
+            reason: "applicationWillTerminate",
+            preservePendingCaptures: false
+        )
         ghosttyCrashBreadcrumbTask?.cancel()
         ghosttyCrashBreadcrumbTask = nil
         notificationStore?.clearAll()
@@ -1706,9 +1712,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         enableSuddenTerminationIfNeeded()
     }
 
-    private func enqueuePostHogTerminationFlushIfNeeded(reason: String) {
+    private func enqueuePostHogTerminationFlushIfNeeded(reason: String, preservePendingCaptures: Bool) {
         guard TelemetrySettings.enabledForCurrentLaunch else { return }
-        PostHogAnalytics.shared.flushForApplicationTermination(reason: reason)
+        PostHogAnalytics.shared.flushForApplicationTermination(
+            reason: reason,
+            preservePendingCaptures: preservePendingCaptures
+        )
     }
 
     func applicationWillResignActive(_ notification: Notification) {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1694,7 +1694,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         VSCodeServeWebController.shared.stop()
         BrowserProfileStore.shared.flushPendingSaves()
         if TelemetrySettings.enabledForCurrentLaunch {
-            PostHogAnalytics.shared.flush()
+            PostHogAnalytics.shared.flushForApplicationTermination()
         }
         ghosttyCrashBreadcrumbTask?.cancel()
         ghosttyCrashBreadcrumbTask = nil

--- a/Sources/PostHogAnalytics.swift
+++ b/Sources/PostHogAnalytics.swift
@@ -22,6 +22,7 @@ final class PostHogAnalytics {
     private let lastActiveHourUTCKey = "posthog.lastActiveHourUTC"
 
     private let workQueue: DispatchQueue
+    private let terminationFlushQueue: DispatchQueue
     private let workQueueSpecificKey = DispatchSpecificKey<Void>()
     private let utcHourFormatter: DateFormatter
     private let utcDayFormatter: DateFormatter
@@ -33,10 +34,12 @@ final class PostHogAnalytics {
     // Internal so @testable regression tests can inject a busy queue and stub flush.
     internal init(
         workQueue: DispatchQueue = DispatchQueue(label: "com.cmux.posthog.analytics", qos: .utility),
+        terminationFlushQueue: DispatchQueue = DispatchQueue(label: "com.cmux.posthog.analytics.terminationFlush", qos: .utility),
         didStart: Bool = false,
         sdkFlush: @escaping () -> Void = { PostHogSDK.shared.flush() }
     ) {
         self.workQueue = workQueue
+        self.terminationFlushQueue = terminationFlushQueue
         self.sdkFlush = sdkFlush
         self.didStart = didStart
         utcHourFormatter = Self.makeUTCFormatter("yyyy-MM-dd'T'HH")
@@ -90,7 +93,7 @@ final class PostHogAnalytics {
     }
 
     func flushForApplicationTermination(reason: String = "applicationWillTerminate") {
-        enqueueFlush(reason: reason)
+        enqueueTerminationFlush(reason: reason)
     }
 
     private func startIfNeededOnWorkQueue() {
@@ -222,6 +225,18 @@ final class PostHogAnalytics {
         workQueue.async(execute: workItem)
     }
 
+    private func enqueueTerminationFlush(reason: String) {
+        postHogAnalyticsLogger.debug("posthog.flush.termination.enqueue reason=\(reason, privacy: .public)")
+#if DEBUG
+        cmuxDebugLog("posthog.flush.termination.enqueue reason=\(reason)")
+#endif
+
+        let workItem = DispatchWorkItem { [sdkFlush] in
+            Self.performSDKFlush(reason: reason, sdkFlush: sdkFlush)
+        }
+        terminationFlushQueue.async(execute: workItem)
+    }
+
     private func flushOnWorkQueue(reason: String) {
         guard didStart else {
             postHogAnalyticsLogger.debug("posthog.flush.skip reason=\(reason, privacy: .public) started=0")
@@ -231,6 +246,10 @@ final class PostHogAnalytics {
             return
         }
 
+        Self.performSDKFlush(reason: reason, sdkFlush: sdkFlush)
+    }
+
+    private nonisolated static func performSDKFlush(reason: String, sdkFlush: () -> Void) {
         let signpostID = postHogAnalyticsSignposter.makeSignpostID()
         let signpostState = postHogAnalyticsSignposter.beginInterval(
             "PostHog Flush",

--- a/Sources/PostHogAnalytics.swift
+++ b/Sources/PostHogAnalytics.swift
@@ -89,8 +89,8 @@ final class PostHogAnalytics {
         flushSynchronously(reason: "manual")
     }
 
-    func flushForApplicationTermination() {
-        enqueueFlush(reason: "applicationWillTerminate")
+    func flushForApplicationTermination(reason: String = "applicationWillTerminate") {
+        enqueueFlush(reason: reason)
     }
 
     private func startIfNeededOnWorkQueue() {

--- a/Sources/PostHogAnalytics.swift
+++ b/Sources/PostHogAnalytics.swift
@@ -21,12 +21,19 @@ final class PostHogAnalytics {
     private let workQueueSpecificKey = DispatchSpecificKey<Void>()
     private let utcHourFormatter: DateFormatter
     private let utcDayFormatter: DateFormatter
+    private let sdkFlush: () -> Void
 
     private var didStart = false
     private var activeCheckTimer: Timer?
 
-    private init() {
-        workQueue = DispatchQueue(label: "com.cmux.posthog.analytics", qos: .utility)
+    init(
+        workQueue: DispatchQueue = DispatchQueue(label: "com.cmux.posthog.analytics", qos: .utility),
+        didStart: Bool = false,
+        sdkFlush: @escaping () -> Void = { PostHogSDK.shared.flush() }
+    ) {
+        self.workQueue = workQueue
+        self.sdkFlush = sdkFlush
+        self.didStart = didStart
         utcHourFormatter = Self.makeUTCFormatter("yyyy-MM-dd'T'HH")
         utcDayFormatter = Self.makeUTCFormatter("yyyy-MM-dd")
         workQueue.setSpecific(key: workQueueSpecificKey, value: ())
@@ -56,7 +63,7 @@ final class PostHogAnalytics {
             let didCaptureHourly = self.trackHourlyActiveOnWorkQueue(reason: reason, flush: false)
             if didCaptureDaily || didCaptureHourly {
                 // On app focus we can capture both events; flush once to reduce extra work.
-                PostHogSDK.shared.flush()
+                self.flushOnWorkQueue()
             }
         }
     }
@@ -75,9 +82,12 @@ final class PostHogAnalytics {
 
     func flush() {
         dispatchSyncOnWorkQueue {
-            guard didStart else { return }
-            PostHogSDK.shared.flush()
+            flushOnWorkQueue()
         }
+    }
+
+    func flushForApplicationTermination() {
+        flush()
     }
 
     private func startIfNeededOnWorkQueue() {
@@ -144,7 +154,7 @@ final class PostHogAnalytics {
 
         if flush && Self.shouldFlushAfterCapture(event: event) {
             // For active metrics we care more about delivery than batching.
-            PostHogSDK.shared.flush()
+            flushOnWorkQueue()
         }
 
         return true
@@ -176,10 +186,15 @@ final class PostHogAnalytics {
 
         if flush && Self.shouldFlushAfterCapture(event: event) {
             // Keep hourly freshness and avoid losing a deduped hour on abrupt exits.
-            PostHogSDK.shared.flush()
+            flushOnWorkQueue()
         }
 
         return true
+    }
+
+    private func flushOnWorkQueue() {
+        guard didStart else { return }
+        sdkFlush()
     }
 
     private func dispatchAsyncOnWorkQueue(_ block: @escaping () -> Void) {

--- a/Sources/PostHogAnalytics.swift
+++ b/Sources/PostHogAnalytics.swift
@@ -30,7 +30,8 @@ final class PostHogAnalytics {
     private var didStart = false
     private var activeCheckTimer: Timer?
 
-    init(
+    // Internal so @testable regression tests can inject a busy queue and stub flush.
+    internal init(
         workQueue: DispatchQueue = DispatchQueue(label: "com.cmux.posthog.analytics", qos: .utility),
         didStart: Bool = false,
         sdkFlush: @escaping () -> Void = { PostHogSDK.shared.flush() }
@@ -88,8 +89,8 @@ final class PostHogAnalytics {
         flushSynchronously(reason: "manual")
     }
 
-    func flushForApplicationTermination() {
-        enqueueFlush(reason: "applicationWillTerminate")
+    func flushForApplicationTermination(maximumWait: DispatchTimeInterval = .milliseconds(250)) {
+        flushWithDeadline(reason: "applicationWillTerminate", maximumWait: maximumWait)
     }
 
     private func startIfNeededOnWorkQueue() {
@@ -204,13 +205,35 @@ final class PostHogAnalytics {
         }
     }
 
-    private func enqueueFlush(reason: String) {
-        postHogAnalyticsLogger.debug("posthog.flush.enqueue reason=\(reason, privacy: .public)")
+    private func flushWithDeadline(reason: String, maximumWait: DispatchTimeInterval) {
+        postHogAnalyticsLogger.debug("posthog.flush.deadline.request reason=\(reason, privacy: .public)")
 #if DEBUG
-        cmuxDebugLog("posthog.flush.enqueue reason=\(reason)")
+        cmuxDebugLog("posthog.flush.deadline.request reason=\(reason)")
 #endif
-        dispatchAsyncOnWorkQueue { [weak self] in
-            self?.flushOnWorkQueue(reason: reason)
+
+        if DispatchQueue.getSpecific(key: workQueueSpecificKey) != nil {
+            flushOnWorkQueue(reason: reason)
+            return
+        }
+
+        let group = DispatchGroup()
+        group.enter()
+        workQueue.async { [self] in
+            defer { group.leave() }
+            flushOnWorkQueue(reason: reason)
+        }
+
+        switch group.wait(timeout: .now() + maximumWait) {
+        case .success:
+            postHogAnalyticsLogger.debug("posthog.flush.deadline.completed reason=\(reason, privacy: .public)")
+#if DEBUG
+            cmuxDebugLog("posthog.flush.deadline.completed reason=\(reason)")
+#endif
+        case .timedOut:
+            postHogAnalyticsLogger.notice("posthog.flush.deadline.timeout reason=\(reason, privacy: .public)")
+#if DEBUG
+            cmuxDebugLog("posthog.flush.deadline.timeout reason=\(reason)")
+#endif
         }
     }
 

--- a/Sources/PostHogAnalytics.swift
+++ b/Sources/PostHogAnalytics.swift
@@ -89,8 +89,8 @@ final class PostHogAnalytics {
         flushSynchronously(reason: "manual")
     }
 
-    func flushForApplicationTermination(maximumWait: DispatchTimeInterval = .milliseconds(250)) {
-        flushWithDeadline(reason: "applicationWillTerminate", maximumWait: maximumWait)
+    func flushForApplicationTermination() {
+        enqueueFlush(reason: "applicationWillTerminate")
     }
 
     private func startIfNeededOnWorkQueue() {
@@ -205,10 +205,10 @@ final class PostHogAnalytics {
         }
     }
 
-    private func flushWithDeadline(reason: String, maximumWait: DispatchTimeInterval) {
-        postHogAnalyticsLogger.debug("posthog.flush.deadline.request reason=\(reason, privacy: .public)")
+    private func enqueueFlush(reason: String) {
+        postHogAnalyticsLogger.debug("posthog.flush.enqueue reason=\(reason, privacy: .public)")
 #if DEBUG
-        cmuxDebugLog("posthog.flush.deadline.request reason=\(reason)")
+        cmuxDebugLog("posthog.flush.enqueue reason=\(reason)")
 #endif
 
         if DispatchQueue.getSpecific(key: workQueueSpecificKey) != nil {
@@ -216,25 +216,10 @@ final class PostHogAnalytics {
             return
         }
 
-        let group = DispatchGroup()
-        group.enter()
-        workQueue.async { [self] in
-            defer { group.leave() }
+        let workItem = DispatchWorkItem { [self] in
             flushOnWorkQueue(reason: reason)
         }
-
-        switch group.wait(timeout: .now() + maximumWait) {
-        case .success:
-            postHogAnalyticsLogger.debug("posthog.flush.deadline.completed reason=\(reason, privacy: .public)")
-#if DEBUG
-            cmuxDebugLog("posthog.flush.deadline.completed reason=\(reason)")
-#endif
-        case .timedOut:
-            postHogAnalyticsLogger.notice("posthog.flush.deadline.timeout reason=\(reason, privacy: .public)")
-#if DEBUG
-            cmuxDebugLog("posthog.flush.deadline.timeout reason=\(reason)")
-#endif
-        }
+        workQueue.async(execute: workItem)
     }
 
     private func flushOnWorkQueue(reason: String) {

--- a/Sources/PostHogAnalytics.swift
+++ b/Sources/PostHogAnalytics.swift
@@ -92,8 +92,15 @@ final class PostHogAnalytics {
         flushSynchronously(reason: "manual")
     }
 
-    func flushForApplicationTermination(reason: String = "applicationWillTerminate") {
-        enqueueTerminationFlush(reason: reason)
+    func flushForApplicationTermination(
+        reason: String = "applicationWillTerminate",
+        preservePendingCaptures: Bool = false
+    ) {
+        if preservePendingCaptures {
+            enqueueFlush(reason: reason)
+        } else {
+            enqueueTerminationFlush(reason: reason)
+        }
     }
 
     private func startIfNeededOnWorkQueue() {

--- a/Sources/PostHogAnalytics.swift
+++ b/Sources/PostHogAnalytics.swift
@@ -1,6 +1,10 @@
 import AppKit
 import Foundation
+import OSLog
 import PostHog
+
+nonisolated private let postHogAnalyticsLogger = Logger(subsystem: "com.cmuxterm.app", category: "PostHogAnalytics")
+nonisolated private let postHogAnalyticsSignposter = OSSignposter(logger: postHogAnalyticsLogger)
 
 final class PostHogAnalytics {
     static let shared = PostHogAnalytics()
@@ -63,7 +67,7 @@ final class PostHogAnalytics {
             let didCaptureHourly = self.trackHourlyActiveOnWorkQueue(reason: reason, flush: false)
             if didCaptureDaily || didCaptureHourly {
                 // On app focus we can capture both events; flush once to reduce extra work.
-                self.flushOnWorkQueue()
+                self.flushOnWorkQueue(reason: "trackActive")
             }
         }
     }
@@ -81,13 +85,11 @@ final class PostHogAnalytics {
     }
 
     func flush() {
-        dispatchSyncOnWorkQueue {
-            flushOnWorkQueue()
-        }
+        flushSynchronously(reason: "manual")
     }
 
     func flushForApplicationTermination() {
-        flush()
+        enqueueFlush(reason: "applicationWillTerminate")
     }
 
     private func startIfNeededOnWorkQueue() {
@@ -154,7 +156,7 @@ final class PostHogAnalytics {
 
         if flush && Self.shouldFlushAfterCapture(event: event) {
             // For active metrics we care more about delivery than batching.
-            flushOnWorkQueue()
+            flushOnWorkQueue(reason: "trackDailyActive")
         }
 
         return true
@@ -186,15 +188,59 @@ final class PostHogAnalytics {
 
         if flush && Self.shouldFlushAfterCapture(event: event) {
             // Keep hourly freshness and avoid losing a deduped hour on abrupt exits.
-            flushOnWorkQueue()
+            flushOnWorkQueue(reason: "trackHourlyActive")
         }
 
         return true
     }
 
-    private func flushOnWorkQueue() {
-        guard didStart else { return }
+    private func flushSynchronously(reason: String) {
+        postHogAnalyticsLogger.debug("posthog.flush.sync.request reason=\(reason, privacy: .public)")
+#if DEBUG
+        cmuxDebugLog("posthog.flush.sync.request reason=\(reason)")
+#endif
+        dispatchSyncOnWorkQueue { [self] in
+            flushOnWorkQueue(reason: reason)
+        }
+    }
+
+    private func enqueueFlush(reason: String) {
+        postHogAnalyticsLogger.debug("posthog.flush.enqueue reason=\(reason, privacy: .public)")
+#if DEBUG
+        cmuxDebugLog("posthog.flush.enqueue reason=\(reason)")
+#endif
+        dispatchAsyncOnWorkQueue { [weak self] in
+            self?.flushOnWorkQueue(reason: reason)
+        }
+    }
+
+    private func flushOnWorkQueue(reason: String) {
+        guard didStart else {
+            postHogAnalyticsLogger.debug("posthog.flush.skip reason=\(reason, privacy: .public) started=0")
+#if DEBUG
+            cmuxDebugLog("posthog.flush.skip reason=\(reason) started=0")
+#endif
+            return
+        }
+
+        let signpostID = postHogAnalyticsSignposter.makeSignpostID()
+        let signpostState = postHogAnalyticsSignposter.beginInterval(
+            "PostHog Flush",
+            id: signpostID,
+            "reason=\(reason, privacy: .public)"
+        )
+        let start = DispatchTime.now().uptimeNanoseconds
+        postHogAnalyticsLogger.debug("posthog.flush.begin reason=\(reason, privacy: .public)")
+#if DEBUG
+        cmuxDebugLog("posthog.flush.begin reason=\(reason)")
+#endif
         sdkFlush()
+        let elapsedMilliseconds = Double(DispatchTime.now().uptimeNanoseconds - start) / 1_000_000
+        postHogAnalyticsLogger.info("posthog.flush.end reason=\(reason, privacy: .public) elapsedMs=\(elapsedMilliseconds, privacy: .public)")
+#if DEBUG
+        cmuxDebugLog("posthog.flush.end reason=\(reason) elapsedMs=\(String(format: "%.1f", elapsedMilliseconds))")
+#endif
+        postHogAnalyticsSignposter.endInterval("PostHog Flush", signpostState)
     }
 
     private func dispatchAsyncOnWorkQueue(_ block: @escaping () -> Void) {

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -3447,8 +3447,7 @@ final class PostHogAnalyticsPropertiesTests: XCTestCase {
         let queue = DispatchQueue(label: "com.cmux.posthog.analytics.test")
         let blockerStarted = DispatchSemaphore(value: 0)
         let releaseBlocker = DispatchSemaphore(value: 0)
-        let returned = expectation(description: "termination flush returned")
-        let flushed = expectation(description: "queued flush eventually ran")
+        let flushed = DispatchSemaphore(value: 0)
 
         queue.async {
             blockerStarted.signal()
@@ -3460,23 +3459,39 @@ final class PostHogAnalyticsPropertiesTests: XCTestCase {
             workQueue: queue,
             didStart: true,
             sdkFlush: {
-                flushed.fulfill()
+                flushed.signal()
             }
         )
 
-        DispatchQueue.global(qos: .userInitiated).async {
-            analytics.flushForApplicationTermination()
-            returned.fulfill()
-        }
+        let start = DispatchTime.now().uptimeNanoseconds
+        analytics.flushForApplicationTermination(maximumWait: .milliseconds(20))
+        let elapsedMilliseconds = Double(DispatchTime.now().uptimeNanoseconds - start) / 1_000_000
 
-        XCTAssertEqual(
-            XCTWaiter.wait(for: [returned], timeout: 1),
-            .completed,
-            "Termination flush must not synchronously wait on the analytics queue"
+        XCTAssertLessThan(
+            elapsedMilliseconds,
+            500,
+            "Termination flush must use a bounded wait instead of synchronously waiting on the analytics queue"
         )
+        XCTAssertEqual(flushed.wait(timeout: .now() + 0.05), .timedOut)
 
         releaseBlocker.signal()
-        XCTAssertEqual(XCTWaiter.wait(for: [flushed], timeout: 1), .completed)
+        XCTAssertEqual(flushed.wait(timeout: .now() + 1), .success)
+    }
+
+    func testTerminationFlushRunsBeforeReturningWhenAnalyticsQueueIsAvailable() {
+        let queue = DispatchQueue(label: "com.cmux.posthog.analytics.test.idle")
+        let flushed = DispatchSemaphore(value: 0)
+        let analytics = PostHogAnalytics(
+            workQueue: queue,
+            didStart: true,
+            sdkFlush: {
+                flushed.signal()
+            }
+        )
+
+        analytics.flushForApplicationTermination(maximumWait: .seconds(1))
+
+        XCTAssertEqual(flushed.wait(timeout: .now() + 0.1), .success)
     }
 }
 

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -3464,7 +3464,7 @@ final class PostHogAnalyticsPropertiesTests: XCTestCase {
         )
 
         let start = DispatchTime.now().uptimeNanoseconds
-        analytics.flushForApplicationTermination()
+        analytics.flushForApplicationTermination(preservePendingCaptures: false)
         let elapsedMilliseconds = Double(DispatchTime.now().uptimeNanoseconds - start) / 1_000_000
 
         XCTAssertLessThan(
@@ -3481,6 +3481,33 @@ final class PostHogAnalyticsPropertiesTests: XCTestCase {
         releaseBlocker.signal()
     }
 
+    func testTerminationFlushCanPreservePendingAnalyticsQueueCaptures() {
+        let queue = DispatchQueue(label: "com.cmux.posthog.analytics.test.ordered")
+        let blockerStarted = DispatchSemaphore(value: 0)
+        let releaseBlocker = DispatchSemaphore(value: 0)
+        let flushed = DispatchSemaphore(value: 0)
+
+        queue.async {
+            blockerStarted.signal()
+            releaseBlocker.wait()
+        }
+        XCTAssertEqual(blockerStarted.wait(timeout: .now() + 1), .success)
+
+        let analytics = PostHogAnalytics(
+            workQueue: queue,
+            didStart: true,
+            sdkFlush: {
+                flushed.signal()
+            }
+        )
+
+        analytics.flushForApplicationTermination(preservePendingCaptures: true)
+
+        XCTAssertEqual(flushed.wait(timeout: .now() + 0.05), .timedOut)
+        releaseBlocker.signal()
+        XCTAssertEqual(flushed.wait(timeout: .now() + 1), .success)
+    }
+
     func testTerminationFlushEventuallyRunsWhenAnalyticsQueueIsAvailable() {
         let queue = DispatchQueue(label: "com.cmux.posthog.analytics.test.idle")
         let flushed = DispatchSemaphore(value: 0)
@@ -3492,7 +3519,7 @@ final class PostHogAnalyticsPropertiesTests: XCTestCase {
             }
         )
 
-        analytics.flushForApplicationTermination()
+        analytics.flushForApplicationTermination(preservePendingCaptures: false)
 
         XCTAssertEqual(flushed.wait(timeout: .now() + 1), .success)
     }

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -3469,7 +3469,7 @@ final class PostHogAnalyticsPropertiesTests: XCTestCase {
 
         XCTAssertLessThan(
             elapsedMilliseconds,
-            500,
+            100,
             "Termination flush must use a bounded wait instead of synchronously waiting on the analytics queue"
         )
         XCTAssertEqual(flushed.wait(timeout: .now() + 0.05), .timedOut)
@@ -3491,7 +3491,7 @@ final class PostHogAnalyticsPropertiesTests: XCTestCase {
 
         analytics.flushForApplicationTermination(maximumWait: .seconds(1))
 
-        XCTAssertEqual(flushed.wait(timeout: .now() + 0.1), .success)
+        XCTAssertEqual(flushed.wait(timeout: .now()), .success)
     }
 }
 

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -3442,6 +3442,42 @@ final class PostHogAnalyticsPropertiesTests: XCTestCase {
         XCTAssertTrue(PostHogAnalytics.shouldFlushAfterCapture(event: "cmux_hourly_active"))
         XCTAssertFalse(PostHogAnalytics.shouldFlushAfterCapture(event: "cmux_other_event"))
     }
+
+    func testTerminationFlushReturnsWhileAnalyticsQueueIsBusy() {
+        let queue = DispatchQueue(label: "com.cmux.posthog.analytics.test")
+        let blockerStarted = DispatchSemaphore(value: 0)
+        let releaseBlocker = DispatchSemaphore(value: 0)
+        let returned = expectation(description: "termination flush returned")
+        let flushed = expectation(description: "queued flush eventually ran")
+
+        queue.async {
+            blockerStarted.signal()
+            releaseBlocker.wait()
+        }
+        XCTAssertEqual(blockerStarted.wait(timeout: .now() + 1), .success)
+
+        let analytics = PostHogAnalytics(
+            workQueue: queue,
+            didStart: true,
+            sdkFlush: {
+                flushed.fulfill()
+            }
+        )
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            analytics.flushForApplicationTermination()
+            returned.fulfill()
+        }
+
+        XCTAssertEqual(
+            XCTWaiter.wait(for: [returned], timeout: 1),
+            .completed,
+            "Termination flush must not synchronously wait on the analytics queue"
+        )
+
+        releaseBlocker.signal()
+        XCTAssertEqual(XCTWaiter.wait(for: [flushed], timeout: 1), .completed)
+    }
 }
 
 final class GhosttyMouseFocusTests: XCTestCase {

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -3464,13 +3464,13 @@ final class PostHogAnalyticsPropertiesTests: XCTestCase {
         )
 
         let start = DispatchTime.now().uptimeNanoseconds
-        analytics.flushForApplicationTermination(maximumWait: .milliseconds(20))
+        analytics.flushForApplicationTermination()
         let elapsedMilliseconds = Double(DispatchTime.now().uptimeNanoseconds - start) / 1_000_000
 
         XCTAssertLessThan(
             elapsedMilliseconds,
             100,
-            "Termination flush must use a bounded wait instead of synchronously waiting on the analytics queue"
+            "Termination flush must return without waiting on the analytics queue"
         )
         XCTAssertEqual(flushed.wait(timeout: .now() + 0.05), .timedOut)
 
@@ -3478,7 +3478,7 @@ final class PostHogAnalyticsPropertiesTests: XCTestCase {
         XCTAssertEqual(flushed.wait(timeout: .now() + 1), .success)
     }
 
-    func testTerminationFlushRunsBeforeReturningWhenAnalyticsQueueIsAvailable() {
+    func testTerminationFlushEventuallyRunsWhenAnalyticsQueueIsAvailable() {
         let queue = DispatchQueue(label: "com.cmux.posthog.analytics.test.idle")
         let flushed = DispatchSemaphore(value: 0)
         let analytics = PostHogAnalytics(
@@ -3489,9 +3489,9 @@ final class PostHogAnalyticsPropertiesTests: XCTestCase {
             }
         )
 
-        analytics.flushForApplicationTermination(maximumWait: .seconds(1))
+        analytics.flushForApplicationTermination()
 
-        XCTAssertEqual(flushed.wait(timeout: .now()), .success)
+        XCTAssertEqual(flushed.wait(timeout: .now() + 1), .success)
     }
 }
 

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -3472,10 +3472,13 @@ final class PostHogAnalyticsPropertiesTests: XCTestCase {
             100,
             "Termination flush must return without waiting on the analytics queue"
         )
-        XCTAssertEqual(flushed.wait(timeout: .now() + 0.05), .timedOut)
+        XCTAssertEqual(
+            flushed.wait(timeout: .now() + 1),
+            .success,
+            "Termination flush should not wait behind the busy analytics queue"
+        )
 
         releaseBlocker.signal()
-        XCTAssertEqual(flushed.wait(timeout: .now() + 1), .success)
     }
 
     func testTerminationFlushEventuallyRunsWhenAnalyticsQueueIsAvailable() {


### PR DESCRIPTION
## Summary
- Make the app termination PostHog flush best-effort async so quit does not block on the analytics serial queue.
- Add OSLog signposts, unified logs, and DEBUG log breadcrumbs for PostHog flush enqueue/begin/end/skip phases.
- Add a regression test that holds the analytics queue busy and verifies termination flush returns before the queue drains.

## Audit
- NIGHTLY PID 2774: 609.8 MB physical footprint, 811.1 MB peak. Main thread was blocked in `AppDelegate.applicationWillTerminate(_:)` -> `PostHogAnalytics.flush()` -> `_dispatch_sync_f_slow`.
- The PostHog analytics queue was simultaneously inside `trackActive(reason:)` / `trackHourlyActiveOnWorkQueue`, waiting in NotificationCenter/NSOperation. That makes synchronous quit flushing a main-thread deadlock risk.
- Separate local `/Applications/cmux.app` PID 23781 was at 8.3 GB physical footprint and high CPU in SwiftUI/AppKit layout. This PR fixes the NIGHTLY quit hang path; that layout/memory issue should be tracked separately if still reproducible.

## Testing
- PASS: `./scripts/reload.sh --tag phflush`
- BLOCKED: AWS targeted unit test could not run because the runner data volume was full while extracting Sentry binary artifacts.
- Triggered Depot unit workflow for hosted verification.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4862"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782456512&installation_id=133855650&pr_number=4862&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4862&signature=206ab186b9c4e21006ea6f9440bc5424d8432eb743424f03b2c5a57dff61a65a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry-only shutdown path change; manual flush behavior is unchanged and the fix removes a documented main-thread hang risk on quit.
> 
> **Overview**
> **Quit no longer blocks on PostHog.** Termination used a synchronous `flush()` on the main thread that could wait forever behind a busy analytics serial queue (e.g. during `trackActive`). That path is replaced with `flushForApplicationTermination`, which returns immediately.
> 
> `AppDelegate` now calls a shared helper from **`applicationShouldTerminate`** (`preservePendingCaptures: true` — flush is queued on the normal analytics work queue so in-flight captures can finish first) and **`applicationWillTerminate`** (`preservePendingCaptures: false` — SDK flush runs on a **separate** termination queue so the main thread never `dispatch_sync`s onto the analytics queue). Manual `flush()` stays synchronous for callers that need it.
> 
> `PostHogAnalytics` centralizes flushes through `flushOnWorkQueue` / `performSDKFlush`, adds **OSLog** and signpost timing, and exposes an injectable `init` for tests. New unit tests assert termination flush returns in under ~100ms while the analytics queue is blocked, and cover preserve-vs-fast paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36468e07f077f44d770b2d2ef0dd507668c8e36b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Quit no longer blocks on analytics. We start a best-effort `PostHogSDK` flush earlier and run it on a dedicated termination queue, with an option to preserve pending captures.

- **Bug Fixes**
  - Replaced blocking quit `flush()` with `flushForApplicationTermination()` that enqueues asynchronously; manual `flush()` stays synchronous.
  - Call from both `applicationShouldTerminate` (preserve pending captures) and `applicationWillTerminate` (bypass analytics queue); removed the inline synchronous flush in `applicationWillTerminate`.
  - Centralized flush via `flushOnWorkQueue`/`performSDKFlush` with OSLog signposts and DEBUG breadcrumbs; tests cover quick return while the analytics queue is busy, preserving pending captures, and running when idle.

<sup>Written for commit 36468e07f077f44d770b2d2ef0dd507668c8e36b. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4862?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * App termination no longer blocks on analytics; shutdown returns promptly while pending analytics work continues asynchronously.
  * Manual analytics flush remains immediate; termination flush is enqueued safely, avoiding duplicate enqueues and is canceled if quit is aborted.
  * Added diagnostics and timing for analytics flushes to improve observability and reliability.
* **Tests**
  * New tests validate termination-flush behavior when the analytics queue is busy and when it is idle.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4862?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->