### PR TITLE
Optimize batch workspace sidebar actions

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -15385,13 +15385,20 @@ private struct TabItemView: View, Equatable {
     }
 
     private func toggleWorkspaceTerminalScrollBarHidden(targetIds: [UUID]) {
-        let currentlyHidden = !targetIds.isEmpty && targetIds.allSatisfy { targetId in
-            tabManager.tabs.first(where: { $0.id == targetId })?.terminalScrollBarHidden == true
+        let targetIdSet = Set(targetIds)
+        var liveTargetCount = 0
+        var hiddenTargetCount = 0
+        for workspace in tabManager.tabs where targetIdSet.contains(workspace.id) {
+            liveTargetCount += 1
+            if workspace.terminalScrollBarHidden {
+                hiddenTargetCount += 1
+            }
         }
+        let currentlyHidden = !targetIdSet.isEmpty &&
+            liveTargetCount == targetIdSet.count &&
+            hiddenTargetCount == liveTargetCount
         let hideScrollBar = !currentlyHidden
-        for targetId in targetIds {
-            tabManager.setWorkspaceTerminalScrollBarHidden(tabId: targetId, hidden: hideScrollBar)
-        }
+        tabManager.setWorkspaceTerminalScrollBarHidden(hidden: hideScrollBar, forWorkspaceIds: targetIds)
     }
 
     private func promptCustomColor(targetIds: [UUID]) {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -16095,6 +16095,38 @@ private struct SidebarBonsplitTabDropDelegate: DropDelegate {
 }
 
 @MainActor
+enum SidebarWorkspaceSelectionSyncPolicy {
+    static func reconciledSelection(
+        previousSelectionIds: Set<UUID>,
+        liveWorkspaceIds: [UUID],
+        fallbackSelectedWorkspaceId: UUID?
+    ) -> Set<UUID> {
+        let liveIdSet = Set(liveWorkspaceIds)
+        let liveSelectionIds = previousSelectionIds.filter { liveIdSet.contains($0) }
+        if !liveSelectionIds.isEmpty {
+            return liveSelectionIds
+        }
+        if let fallbackSelectedWorkspaceId, liveIdSet.contains(fallbackSelectedWorkspaceId) {
+            return [fallbackSelectedWorkspaceId]
+        }
+        return []
+    }
+
+    static func anchorIndex(
+        preferredWorkspaceId: UUID?,
+        selectedWorkspaceIds: Set<UUID>,
+        liveWorkspaceIds: [UUID]
+    ) -> Int? {
+        if let preferredWorkspaceId,
+           selectedWorkspaceIds.contains(preferredWorkspaceId),
+           let preferredIndex = liveWorkspaceIds.firstIndex(of: preferredWorkspaceId) {
+            return preferredIndex
+        }
+        return liveWorkspaceIds.firstIndex { selectedWorkspaceIds.contains($0) }
+    }
+}
+
+@MainActor
 private struct SidebarTabDropDelegate: DropDelegate {
     let targetTabId: UUID?
     let tabManager: TabManager
@@ -16191,14 +16223,9 @@ private struct SidebarTabDropDelegate: DropDelegate {
 #if DEBUG
         cmuxDebugLog("sidebar.drop.commit tab=\(draggedTabId.uuidString.prefix(5)) from=\(fromIndex) to=\(targetIndex)")
 #endif
+        let selectionBeforeReorder = selectedTabIds
         _ = tabManager.reorderWorkspace(tabId: draggedTabId, toIndex: targetIndex)
-        if let selectedId = tabManager.selectedTabId {
-            selectedTabIds = [selectedId]
-            syncSidebarSelection(preferredSelectedTabId: selectedId)
-        } else {
-            selectedTabIds = []
-            syncSidebarSelection()
-        }
+        syncSidebarSelection(preserving: selectionBeforeReorder)
         return true
     }
 
@@ -16224,6 +16251,21 @@ private struct SidebarTabDropDelegate: DropDelegate {
         } else {
             lastSidebarSelectionIndex = nil
         }
+    }
+
+    private func syncSidebarSelection(preserving previousSelectionIds: Set<UUID>) {
+        let liveWorkspaceIds = tabManager.tabs.map(\.id)
+        let nextSelectionIds = SidebarWorkspaceSelectionSyncPolicy.reconciledSelection(
+            previousSelectionIds: previousSelectionIds,
+            liveWorkspaceIds: liveWorkspaceIds,
+            fallbackSelectedWorkspaceId: tabManager.selectedTabId
+        )
+        selectedTabIds = nextSelectionIds
+        lastSidebarSelectionIndex = SidebarWorkspaceSelectionSyncPolicy.anchorIndex(
+            preferredWorkspaceId: tabManager.selectedTabId,
+            selectedWorkspaceIds: nextSelectionIds,
+            liveWorkspaceIds: liveWorkspaceIds
+        )
     }
 
     private func debugIndicator(_ indicator: SidebarDropIndicator?) -> String {

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -5693,8 +5693,9 @@ class TabManager: ObservableObject {
         if pinned {
             changedWorkspaces = changedIds.compactMap { workspacesById[$0] }
         } else {
-            // Match the existing repeated setPinned behavior: each unpinned item
-            // moves to the front of the unpinned segment as it is processed.
+            // Keep parity with reorderTabForPinnedState: each unpinned item
+            // is inserted at the front of the unpinned segment, so rebuilding a
+            // batch in one pass must reverse the changed input order.
             changedWorkspaces = changedIds.reversed().compactMap { workspacesById[$0] }
         }
 

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -5614,8 +5614,15 @@ class TabManager: ObservableObject {
     }
 
     func applyWorkspaceColor(_ color: String?, toWorkspaceIds workspaceIds: [UUID]) {
-        for workspaceId in workspaceIds {
+        guard !workspaceIds.isEmpty else { return }
+        if workspaceIds.count == 1, let workspaceId = workspaceIds.first {
             setTabColor(tabId: workspaceId, color: color)
+            return
+        }
+
+        let targetIds = Set(workspaceIds)
+        for tab in tabs where targetIds.contains(tab.id) {
+            tab.setCustomColor(color)
         }
     }
 
@@ -5629,6 +5636,19 @@ class TabManager: ObservableObject {
         tab.setTerminalScrollBarHidden(hidden)
     }
 
+    func setWorkspaceTerminalScrollBarHidden(hidden: Bool, forWorkspaceIds workspaceIds: [UUID]) {
+        guard !workspaceIds.isEmpty else { return }
+        if workspaceIds.count == 1, let workspaceId = workspaceIds.first {
+            setWorkspaceTerminalScrollBarHidden(tabId: workspaceId, hidden: hidden)
+            return
+        }
+
+        let targetIds = Set(workspaceIds)
+        for tab in tabs where targetIds.contains(tab.id) {
+            tab.setTerminalScrollBarHidden(hidden)
+        }
+    }
+
     func togglePin(tabId: UUID) {
         guard let index = tabs.firstIndex(where: { $0.id == tabId }) else { return }
         let tab = tabs[index]
@@ -5640,6 +5660,49 @@ class TabManager: ObservableObject {
         tab.isPinned = pinned
         reorderTabForPinnedState(tab)
         postWorkspaceOrderDidChange(movedWorkspaceIds: [tab.id])
+    }
+
+    @discardableResult
+    func setPinned(workspaceIds: [UUID], pinned: Bool) -> [UUID] {
+        guard !workspaceIds.isEmpty else { return [] }
+        if workspaceIds.count == 1,
+           let workspaceId = workspaceIds.first,
+           let tab = tabs.first(where: { $0.id == workspaceId }) {
+            let changed = tab.isPinned != pinned
+            setPinned(tab, pinned: pinned)
+            return changed ? [workspaceId] : []
+        }
+
+        var seen = Set<UUID>()
+        let orderedTargetIds = workspaceIds.filter { seen.insert($0).inserted }
+        let targetIds = Set(orderedTargetIds)
+        var workspacesById: [UUID: Workspace] = [:]
+        var changedIdSet = Set<UUID>()
+
+        for workspace in tabs {
+            workspacesById[workspace.id] = workspace
+            guard targetIds.contains(workspace.id), workspace.isPinned != pinned else { continue }
+            workspace.isPinned = pinned
+            changedIdSet.insert(workspace.id)
+        }
+
+        guard !changedIdSet.isEmpty else { return [] }
+        let changedIds = orderedTargetIds.filter { changedIdSet.contains($0) }
+
+        let changedWorkspaces: [Workspace]
+        if pinned {
+            changedWorkspaces = changedIds.compactMap { workspacesById[$0] }
+        } else {
+            // Match the existing repeated setPinned behavior: each unpinned item
+            // moves to the front of the unpinned segment as it is processed.
+            changedWorkspaces = changedIds.reversed().compactMap { workspacesById[$0] }
+        }
+
+        let remainingPinned = tabs.filter { $0.isPinned && !changedIdSet.contains($0.id) }
+        let remainingUnpinned = tabs.filter { !$0.isPinned && !changedIdSet.contains($0.id) }
+        tabs = remainingPinned + changedWorkspaces + remainingUnpinned
+        postWorkspaceOrderDidChange(movedWorkspaceIds: changedIds)
+        return changedIds
     }
 
     private func reorderTabForPinnedState(_ tab: Workspace) {

--- a/Sources/WorkspaceActionDispatcher.swift
+++ b/Sources/WorkspaceActionDispatcher.swift
@@ -32,14 +32,15 @@ enum WorkspaceActionDispatcher {
         in tabManager: TabManager,
         target: Target
     ) -> PinState? {
+        let workspacesById = Dictionary(uniqueKeysWithValues: tabManager.tabs.map { ($0.id, $0) })
         let targetWorkspaceIds = liveWorkspaceIds(in: tabManager, from: target.workspaceIds)
         guard !targetWorkspaceIds.isEmpty else { return nil }
 
         let anchorWorkspaceId = target.anchorWorkspaceId.flatMap { anchorId in
-            tabManager.tabs.contains { $0.id == anchorId } ? anchorId : nil
+            workspacesById[anchorId] == nil ? nil : anchorId
         } ?? targetWorkspaceIds[0]
 
-        guard let anchorWorkspace = tabManager.tabs.first(where: { $0.id == anchorWorkspaceId }) else {
+        guard let anchorWorkspace = workspacesById[anchorWorkspaceId] else {
             return nil
         }
 
@@ -67,16 +68,10 @@ enum WorkspaceActionDispatcher {
         in tabManager: TabManager
     ) -> PinResult {
         let targetWorkspaceIds = liveWorkspaceIds(in: tabManager, from: state.targetWorkspaceIds)
-        var changedWorkspaceIds: [UUID] = []
-
-        for workspaceId in targetWorkspaceIds {
-            guard let workspace = tabManager.tabs.first(where: { $0.id == workspaceId }) else { continue }
-            let wasPinned = workspace.isPinned
-            tabManager.setPinned(workspace, pinned: state.pinned)
-            if wasPinned != state.pinned {
-                changedWorkspaceIds.append(workspaceId)
-            }
-        }
+        let changedWorkspaceIds = tabManager.setPinned(
+            workspaceIds: targetWorkspaceIds,
+            pinned: state.pinned
+        )
 
         return PinResult(
             targetWorkspaceIds: targetWorkspaceIds,

--- a/cmuxTests/WorkspaceActionDispatcherTests.swift
+++ b/cmuxTests/WorkspaceActionDispatcherTests.swift
@@ -54,6 +54,31 @@ final class WorkspaceActionDispatcherTests: XCTestCase {
         XCTAssertEqual(manager.tabs.map(\.id), [second.id, third.id, first.id])
     }
 
+    func testPinActionUnpinsMultipleTargetsWithExistingOrdering() throws {
+        let manager = TabManager()
+        let first = try XCTUnwrap(manager.tabs.first)
+        let second = manager.addWorkspace()
+        let third = manager.addWorkspace()
+        manager.setPinned(first, pinned: true)
+        manager.setPinned(second, pinned: true)
+        manager.setPinned(third, pinned: true)
+        let target = WorkspaceActionDispatcher.Target(
+            workspaceIds: [second.id, third.id],
+            anchorWorkspaceId: second.id
+        )
+
+        let state = try XCTUnwrap(WorkspaceActionDispatcher.pinState(in: manager, target: target))
+        let result = WorkspaceActionDispatcher.performPinAction(state, in: manager)
+
+        XCTAssertFalse(state.pinned)
+        XCTAssertEqual(result.targetWorkspaceIds, [second.id, third.id])
+        XCTAssertEqual(result.changedWorkspaceIds, [second.id, third.id])
+        XCTAssertTrue(first.isPinned)
+        XCTAssertFalse(second.isPinned)
+        XCTAssertFalse(third.isPinned)
+        XCTAssertEqual(manager.tabs.map(\.id), [first.id, third.id, second.id])
+    }
+
     func testCapturedPinStateKeepsLabelAndActionConsistent() throws {
         let manager = TabManager()
         let workspace = try XCTUnwrap(manager.tabs.first)

--- a/cmuxTests/WorkspaceStressProfileTests.swift
+++ b/cmuxTests/WorkspaceStressProfileTests.swift
@@ -233,17 +233,21 @@ final class WorkspaceStressProfileTests: XCTestCase {
             timed("pass-\(label(for: pass))-color-apply", collectInto: &colorSamples) {
                 manager.applyWorkspaceColor("#1565C0", toWorkspaceIds: workspaceIds)
             }
+            XCTAssertTrue(manager.tabs.allSatisfy { $0.customColor == "#1565C0" })
             timed("pass-\(label(for: pass))-color-clear", collectInto: &colorSamples) {
                 manager.applyWorkspaceColor(nil, toWorkspaceIds: workspaceIds)
             }
+            XCTAssertTrue(manager.tabs.allSatisfy { $0.customColor == nil })
             timed("pass-\(label(for: pass))-scrollbar-hide", collectInto: &scrollBarSamples) {
                 manager.setWorkspaceTerminalScrollBarHidden(hidden: true, forWorkspaceIds: workspaceIds)
             }
+            XCTAssertTrue(manager.tabs.allSatisfy { $0.terminalScrollBarHidden })
             timed("pass-\(label(for: pass))-scrollbar-show", collectInto: &scrollBarSamples) {
                 manager.setWorkspaceTerminalScrollBarHidden(hidden: false, forWorkspaceIds: workspaceIds)
             }
-            timed("pass-\(label(for: pass))-pin", collectInto: &pinSamples) {
-                _ = WorkspaceActionDispatcher.performPinAction(
+            XCTAssertTrue(manager.tabs.allSatisfy { !$0.terminalScrollBarHidden })
+            let pinResult = timed("pass-\(label(for: pass))-pin", collectInto: &pinSamples) {
+                WorkspaceActionDispatcher.performPinAction(
                     WorkspaceActionDispatcher.PinState(
                         targetWorkspaceIds: workspaceIds,
                         anchorWorkspaceId: anchorWorkspaceId,
@@ -252,8 +256,10 @@ final class WorkspaceStressProfileTests: XCTestCase {
                     in: manager
                 )
             }
-            timed("pass-\(label(for: pass))-unpin", collectInto: &unpinSamples) {
-                _ = WorkspaceActionDispatcher.performPinAction(
+            XCTAssertFalse(pinResult.changedWorkspaceIds.isEmpty)
+            XCTAssertTrue(manager.tabs.allSatisfy { $0.isPinned })
+            let unpinResult = timed("pass-\(label(for: pass))-unpin", collectInto: &unpinSamples) {
+                WorkspaceActionDispatcher.performPinAction(
                     WorkspaceActionDispatcher.PinState(
                         targetWorkspaceIds: workspaceIds,
                         anchorWorkspaceId: anchorWorkspaceId,
@@ -262,6 +268,8 @@ final class WorkspaceStressProfileTests: XCTestCase {
                     in: manager
                 )
             }
+            XCTAssertFalse(unpinResult.changedWorkspaceIds.isEmpty)
+            XCTAssertTrue(manager.tabs.allSatisfy { !$0.isPinned })
         }
 
         XCTAssertEqual(manager.tabs.count, config.workspaceCount)

--- a/cmuxTests/WorkspaceStressProfileTests.swift
+++ b/cmuxTests/WorkspaceStressProfileTests.swift
@@ -200,6 +200,90 @@ final class WorkspaceStressProfileTests: XCTestCase {
         }
     }
 
+    func testWorkspaceBatchActionsStressProfile() {
+        let config = StressConfig.current()
+        let welcomeWasShown = UserDefaults.standard.object(forKey: WelcomeSettings.shownKey)
+        UserDefaults.standard.set(true, forKey: WelcomeSettings.shownKey)
+        defer {
+            if let welcomeWasShown {
+                UserDefaults.standard.set(welcomeWasShown, forKey: WelcomeSettings.shownKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: WelcomeSettings.shownKey)
+            }
+        }
+
+        let manager = TabManager(autoWelcomeIfNeeded: false)
+        for workspaceIndex in 1..<config.workspaceCount {
+            _ = manager.addWorkspace(
+                title: "Workspace \(label(for: workspaceIndex))",
+                select: false,
+                eagerLoadTerminal: false,
+                autoWelcomeIfNeeded: false
+            )
+        }
+
+        let workspaceIds = manager.tabs.map(\.id)
+        let anchorWorkspaceId = workspaceIds[0]
+        var colorSamples: [TimedSample] = []
+        var scrollBarSamples: [TimedSample] = []
+        var pinSamples: [TimedSample] = []
+        var unpinSamples: [TimedSample] = []
+
+        for pass in 0..<config.switchPasses {
+            timed("pass-\(label(for: pass))-color-apply", collectInto: &colorSamples) {
+                manager.applyWorkspaceColor("#1565C0", toWorkspaceIds: workspaceIds)
+            }
+            timed("pass-\(label(for: pass))-color-clear", collectInto: &colorSamples) {
+                manager.applyWorkspaceColor(nil, toWorkspaceIds: workspaceIds)
+            }
+            timed("pass-\(label(for: pass))-scrollbar-hide", collectInto: &scrollBarSamples) {
+                manager.setWorkspaceTerminalScrollBarHidden(hidden: true, forWorkspaceIds: workspaceIds)
+            }
+            timed("pass-\(label(for: pass))-scrollbar-show", collectInto: &scrollBarSamples) {
+                manager.setWorkspaceTerminalScrollBarHidden(hidden: false, forWorkspaceIds: workspaceIds)
+            }
+            timed("pass-\(label(for: pass))-pin", collectInto: &pinSamples) {
+                _ = WorkspaceActionDispatcher.performPinAction(
+                    WorkspaceActionDispatcher.PinState(
+                        targetWorkspaceIds: workspaceIds,
+                        anchorWorkspaceId: anchorWorkspaceId,
+                        pinned: true
+                    ),
+                    in: manager
+                )
+            }
+            timed("pass-\(label(for: pass))-unpin", collectInto: &unpinSamples) {
+                _ = WorkspaceActionDispatcher.performPinAction(
+                    WorkspaceActionDispatcher.PinState(
+                        targetWorkspaceIds: workspaceIds,
+                        anchorWorkspaceId: anchorWorkspaceId,
+                        pinned: false
+                    ),
+                    in: manager
+                )
+            }
+        }
+
+        XCTAssertEqual(manager.tabs.count, config.workspaceCount)
+        XCTAssertTrue(manager.tabs.allSatisfy { !$0.isPinned })
+        XCTAssertTrue(manager.tabs.allSatisfy { $0.customColor == nil })
+        XCTAssertTrue(manager.tabs.allSatisfy { !$0.terminalScrollBarHidden })
+
+        let report = [
+            "Workspace batch action stress config workspaces=\(config.workspaceCount) passes=\(config.switchPasses)",
+            reportLine(title: "color", summary: TimingSummary(samples: colorSamples), slowest: slowest(colorSamples)),
+            reportLine(title: "scrollbar", summary: TimingSummary(samples: scrollBarSamples), slowest: slowest(scrollBarSamples)),
+            reportLine(title: "pin", summary: TimingSummary(samples: pinSamples), slowest: slowest(pinSamples)),
+            reportLine(title: "unpin", summary: TimingSummary(samples: unpinSamples), slowest: slowest(unpinSamples))
+        ].joined(separator: "\n")
+
+        print(report)
+        let attachment = XCTAttachment(string: report)
+        attachment.name = "workspace-batch-actions-stress-profile"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+
     private func populate(workspace: Workspace, tabsPerWorkspace: Int) {
         guard tabsPerWorkspace > 0 else { return }
         while workspace.panels.count < tabsPerWorkspace {

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -228,6 +228,34 @@ final class SidebarSelectedWorkspaceColorTests: XCTestCase {
         XCTAssertEqual(background.color?.hexString(), "#C0392B")
         XCTAssertEqual(background.opacity, 0.7, accuracy: 0.001)
     }
+
+    @MainActor
+    func testBatchWorkspaceColorAppliesOnlyRequestedWorkspaces() {
+        let manager = TabManager()
+        let first = manager.tabs[0]
+        let second = manager.addWorkspace()
+        let third = manager.addWorkspace()
+
+        manager.applyWorkspaceColor("#1565C0", toWorkspaceIds: [first.id, third.id])
+
+        XCTAssertEqual(first.customColor, "#1565C0")
+        XCTAssertNil(second.customColor)
+        XCTAssertEqual(third.customColor, "#1565C0")
+    }
+
+    @MainActor
+    func testBatchWorkspaceTerminalScrollBarVisibilityAppliesOnlyRequestedWorkspaces() {
+        let manager = TabManager()
+        let first = manager.tabs[0]
+        let second = manager.addWorkspace()
+        let third = manager.addWorkspace()
+
+        manager.setWorkspaceTerminalScrollBarHidden(hidden: true, forWorkspaceIds: [first.id, third.id])
+
+        XCTAssertTrue(first.terminalScrollBarHidden)
+        XCTAssertFalse(second.terminalScrollBarHidden)
+        XCTAssertTrue(third.terminalScrollBarHidden)
+    }
 }
 
 

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -235,11 +235,12 @@ final class SidebarSelectedWorkspaceColorTests: XCTestCase {
         let first = manager.tabs[0]
         let second = manager.addWorkspace()
         let third = manager.addWorkspace()
+        manager.applyWorkspaceColor("#C0392B", toWorkspaceIds: [second.id])
 
         manager.applyWorkspaceColor("#1565C0", toWorkspaceIds: [first.id, third.id])
 
         XCTAssertEqual(first.customColor, "#1565C0")
-        XCTAssertNil(second.customColor)
+        XCTAssertEqual(second.customColor, "#C0392B")
         XCTAssertEqual(third.customColor, "#1565C0")
     }
 
@@ -249,12 +250,13 @@ final class SidebarSelectedWorkspaceColorTests: XCTestCase {
         let first = manager.tabs[0]
         let second = manager.addWorkspace()
         let third = manager.addWorkspace()
+        manager.setWorkspaceTerminalScrollBarHidden(hidden: true, forWorkspaceIds: [first.id, second.id, third.id])
 
-        manager.setWorkspaceTerminalScrollBarHidden(hidden: true, forWorkspaceIds: [first.id, third.id])
+        manager.setWorkspaceTerminalScrollBarHidden(hidden: false, forWorkspaceIds: [first.id, third.id])
 
-        XCTAssertTrue(first.terminalScrollBarHidden)
-        XCTAssertFalse(second.terminalScrollBarHidden)
-        XCTAssertTrue(third.terminalScrollBarHidden)
+        XCTAssertFalse(first.terminalScrollBarHidden)
+        XCTAssertTrue(second.terminalScrollBarHidden)
+        XCTAssertFalse(third.terminalScrollBarHidden)
     }
 }
 

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -3582,6 +3582,49 @@ final class SidebarWorkspaceAuxiliaryDetailVisibilityTests: XCTestCase {
 }
 
 
+final class SidebarWorkspaceSelectionSyncPolicyTests: XCTestCase {
+    @MainActor
+    func testReconciledSelectionPreservesMultiSelectionAfterReorder() {
+        let first = UUID()
+        let second = UUID()
+        let third = UUID()
+        let fourth = UUID()
+        let previousSelection: Set<UUID> = [second, third]
+
+        let result = SidebarWorkspaceSelectionSyncPolicy.reconciledSelection(
+            previousSelectionIds: previousSelection,
+            liveWorkspaceIds: [first, third, fourth, second],
+            fallbackSelectedWorkspaceId: second
+        )
+
+        XCTAssertEqual(result, previousSelection)
+        XCTAssertEqual(
+            SidebarWorkspaceSelectionSyncPolicy.anchorIndex(
+                preferredWorkspaceId: second,
+                selectedWorkspaceIds: result,
+                liveWorkspaceIds: [first, third, fourth, second]
+            ),
+            3
+        )
+    }
+
+    @MainActor
+    func testReconciledSelectionFallsBackToActiveWorkspaceWhenPreviousSelectionIsGone() {
+        let first = UUID()
+        let second = UUID()
+        let removed = UUID()
+
+        let result = SidebarWorkspaceSelectionSyncPolicy.reconciledSelection(
+            previousSelectionIds: [removed],
+            liveWorkspaceIds: [first, second],
+            fallbackSelectedWorkspaceId: second
+        )
+
+        XCTAssertEqual(result, [second])
+    }
+}
+
+
 final class WorkspaceReorderTests: XCTestCase {
     @MainActor
     func testReorderWorkspacePostsMovedWorkspaceId() {


### PR DESCRIPTION
Optimizes multi-workspace sidebar actions for large workspace counts.\n\n- Applies workspace colors and scrollbar visibility with one Set-backed pass instead of one full scan per selected workspace.\n- Pins and unpins selected workspaces with one batch reorder while preserving existing ordering behavior.\n- Adds batch-action coverage and a workspace batch action stress profile that can be run with CMUX_WORKSPACE_STRESS_WORKSPACES=1000.\n\nVerification:\n- ./scripts/reload.sh --tag wsbatch\n- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4865"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782458067&installation_id=133855650&pr_number=4865&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4865&signature=b14a4102c3812ac37397fb9cc78404b4205569dc5f2ff69f87a37094ea2f37f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches tab ordering and multi-select sidebar state; behavior is covered by new unit and stress tests but pin/unpin ordering parity is subtle.
> 
> **Overview**
> Improves **multi-workspace sidebar actions** when many workspaces are selected by batching work in `TabManager` and fixing selection behavior after drag-reorder.
> 
> **Batch mutations:** `applyWorkspaceColor`, terminal scrollbar visibility, and pin/unpin now walk `tabs` once with a `Set` of target IDs instead of per-ID lookups. Pin/unpin uses new `setPinned(workspaceIds:pinned:)` with a single list rebuild (including reversed order for batch unpin so ordering matches the old per-tab path). `WorkspaceActionDispatcher` calls that batch API.
> 
> **Sidebar UX:** Scrollbar hide/show for a selection uses one pass to detect “all hidden” and one batch update. After a drop reorder, `SidebarWorkspaceSelectionSyncPolicy` keeps multi-selection when those IDs still exist and picks a stable anchor index.
> 
> **Tests:** Unit tests for batch-only targets, selection reconciliation, multi unpin ordering, and a stress profile for color/scrollbar/pin at scale (`CMUX_WORKSPACE_STRESS_WORKSPACES`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29e24c6fc0ac827612e85cd348a4d66b1e160d17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up multi-select sidebar actions for large workspace sets. Batch updates cut UI lag and keep multi-selection after drag reorder.

- **Refactors**
  - Batch color and terminal-scrollbar updates with a single Set pass; adds `applyWorkspaceColor(_:toWorkspaceIds:)` and `setWorkspaceTerminalScrollBarHidden(hidden:forWorkspaceIds:)`. Sidebar toggle now checks “all hidden” only when all targets are live, then does one batch update.
  - Batch pin/unpin via `setPinned(workspaceIds:pinned:)`; preserves existing ordering (unpinned items move as before).
  - Preserve selection after drag reorder with `SidebarWorkspaceSelectionSyncPolicy`; keeps prior multi-selection, falls back to the active tab when needed, and maintains the anchor index.
  - `WorkspaceActionDispatcher` switches to the batched pin path and resolves anchors via an ID map. Tests harden coverage for batch-only updates, unpin ordering, selection reconciliation, and add a stress profile for color/scrollbar/pin/unpin.

<sup>Written for commit 29e24c6fc0ac827612e85cd348a4d66b1e160d17. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4865?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal scrollbar visibility behavior when managing multiple workspaces.
  * Enhanced workspace selection stability after reordering operations.
  * Optimized batch operations for pinning, unpinning, and color application across workspaces.

* **Tests**
  * Added comprehensive unit and stress tests for workspace batch operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4865?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->