### PR TITLE
Make session index backfill linear

### DIFF
--- a/Sources/SessionIndexStore.swift
+++ b/Sources/SessionIndexStore.swift
@@ -332,7 +332,9 @@ final class SessionIndexStore: ObservableObject {
         }
         guard !latestByPath.isEmpty else { return }
         let additions = latestByPath
-            .sorted { $0.value > $1.value }
+            .sorted { lhs, rhs in
+                lhs.value == rhs.value ? lhs.key < rhs.key : lhs.value > rhs.value
+            }
             .map(\.key)
         directoryOrder.append(contentsOf: additions)
     }
@@ -372,7 +374,11 @@ final class SessionIndexStore: ObservableObject {
             setAgentOrderIfPresentationChanged(nextOrder)
             return
         }
-        let additions = additionsByAgentId.values.sorted { $0.latest > $1.latest }
+        let additions = additionsByAgentId.values.sorted { lhs, rhs in
+            lhs.latest == rhs.latest
+                ? lhs.agent.rawValue < rhs.agent.rawValue
+                : lhs.latest > rhs.latest
+        }
         nextOrder.append(contentsOf: additions.map(\.agent))
         setAgentOrderIfPresentationChanged(nextOrder)
     }

--- a/Sources/SessionIndexStore.swift
+++ b/Sources/SessionIndexStore.swift
@@ -317,20 +317,24 @@ final class SessionIndexStore: ObservableObject {
     /// state and must only run in response to real data changes (new scan
     /// results, grouping switch) — not on every SwiftUI update tick.
     private func backfillDirectoryOrderFromEntries() {
-        var seen = Set(directoryOrder)
-        var additions: [(path: String, latest: Date)] = []
+        let knownPaths = Set(directoryOrder)
+        var latestByPath: [String: Date] = [:]
         for entry in entries {
             let path = entry.cwd ?? ""
-            if seen.insert(path).inserted {
-                additions.append((path, entry.modified))
-            } else if let idx = additions.firstIndex(where: { $0.path == path }),
-                      additions[idx].latest < entry.modified {
-                additions[idx].latest = entry.modified
+            guard !knownPaths.contains(path) else { continue }
+            if let latest = latestByPath[path] {
+                if latest < entry.modified {
+                    latestByPath[path] = entry.modified
+                }
+            } else {
+                latestByPath[path] = entry.modified
             }
         }
-        guard !additions.isEmpty else { return }
-        additions.sort { $0.latest > $1.latest }
-        directoryOrder.append(contentsOf: additions.map(\.path))
+        guard !latestByPath.isEmpty else { return }
+        let additions = latestByPath
+            .sorted { $0.value > $1.value }
+            .map(\.key)
+        directoryOrder.append(contentsOf: additions)
     }
 
     private func backfillAgentOrderFromEntries() {
@@ -351,21 +355,24 @@ final class SessionIndexStore: ObservableObject {
             }
             return .registered(refreshed)
         }
-        var seen = Set(nextOrder.map(\.rawValue))
-        var additions: [(agent: SessionAgent, latest: Date)] = []
+        let knownAgentIds = Set(nextOrder.map(\.rawValue))
+        var additionsByAgentId: [String: (agent: SessionAgent, latest: Date)] = [:]
         for entry in entries {
-            if seen.insert(entry.agent.rawValue).inserted {
-                additions.append((entry.agent, entry.modified))
-            } else if let idx = additions.firstIndex(where: { $0.agent.rawValue == entry.agent.rawValue }),
-                      additions[idx].latest < entry.modified {
-                additions[idx].latest = entry.modified
+            let agentId = entry.agent.rawValue
+            guard !knownAgentIds.contains(agentId) else { continue }
+            if let existing = additionsByAgentId[agentId] {
+                if existing.latest < entry.modified {
+                    additionsByAgentId[agentId] = (existing.agent, entry.modified)
+                }
+            } else {
+                additionsByAgentId[agentId] = (entry.agent, entry.modified)
             }
         }
-        if additions.isEmpty {
+        if additionsByAgentId.isEmpty {
             setAgentOrderIfPresentationChanged(nextOrder)
             return
         }
-        additions.sort { $0.latest > $1.latest }
+        let additions = additionsByAgentId.values.sorted { $0.latest > $1.latest }
         nextOrder.append(contentsOf: additions.map(\.agent))
         setAgentOrderIfPresentationChanged(nextOrder)
     }
@@ -521,6 +528,14 @@ final class SessionIndexStore: ObservableObject {
             }
         }
     }
+
+#if DEBUG
+    func replaceEntriesForTesting(_ entries: [SessionEntry]) {
+        self.entries = entries
+        backfillAgentOrderFromEntries()
+        backfillDirectoryOrderFromEntries()
+    }
+#endif
 
     // MARK: - Directory snapshot cache
 

--- a/cmuxTests/SessionIndexViewTests.swift
+++ b/cmuxTests/SessionIndexViewTests.swift
@@ -151,6 +151,38 @@ final class SessionIndexViewTests: XCTestCase {
         XCTAssertEqual(emittedValues, ["/foo"])
     }
 
+    func testDirectoryOrderBackfillUsesLatestModifiedForDuplicateDirectories() {
+        preservingSessionIndexDefaults {
+            let store = SessionIndexStore()
+            store.directoryOrder = ["/existing"]
+
+            store.replaceEntriesForTesting([
+                makeEntry(title: "old project", cwd: "/project-a", modified: Date(timeIntervalSince1970: 1)),
+                makeEntry(title: "new project", cwd: "/project-b", modified: Date(timeIntervalSince1970: 2)),
+                makeEntry(title: "newer project", cwd: "/project-a", modified: Date(timeIntervalSince1970: 3)),
+                makeEntry(title: "known project", cwd: "/existing", modified: Date(timeIntervalSince1970: 4))
+            ])
+
+            XCTAssertEqual(store.directoryOrder, ["/existing", "/project-a", "/project-b"])
+        }
+    }
+
+    func testAgentOrderBackfillUsesLatestModifiedForDuplicateAgents() {
+        preservingSessionIndexDefaults {
+            let store = SessionIndexStore()
+            store.agentOrder = [.claude]
+
+            store.replaceEntriesForTesting([
+                makeEntry(agent: .codex, title: "old codex", modified: Date(timeIntervalSince1970: 1)),
+                makeEntry(agent: .grok, title: "grok", modified: Date(timeIntervalSince1970: 2)),
+                makeEntry(agent: .codex, title: "newer codex", modified: Date(timeIntervalSince1970: 3)),
+                makeEntry(agent: .claude, title: "known claude", modified: Date(timeIntervalSince1970: 4))
+            ])
+
+            XCTAssertEqual(store.agentOrder.map(\.rawValue), ["claude", "codex", "grok"])
+        }
+    }
+
     func testCodexSQLSearchMatchesRolloutTranscriptContent() async throws {
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-session-index-\(UUID().uuidString)", isDirectory: true)
@@ -286,6 +318,8 @@ final class SessionIndexViewTests: XCTestCase {
         agent: SessionAgent = .claude,
         sessionId: String = UUID().uuidString,
         title: String,
+        cwd: String? = nil,
+        modified: Date = Date(timeIntervalSince1970: 0),
         fileURL: URL? = nil,
         specifics: AgentSpecifics? = nil,
         claudeConfigDirectoryForResume: String? = nil
@@ -295,10 +329,10 @@ final class SessionIndexViewTests: XCTestCase {
             agent: agent,
             sessionId: sessionId,
             title: title,
-            cwd: nil,
+            cwd: cwd,
             gitBranch: nil,
             pullRequest: nil,
-            modified: Date(timeIntervalSince1970: 0),
+            modified: modified,
             fileURL: fileURL,
             specifics: specifics ?? agent.defaultSpecificsForTesting(
                 claudeConfigDirectoryForResume: claudeConfigDirectoryForResume
@@ -308,6 +342,30 @@ final class SessionIndexViewTests: XCTestCase {
 
     private func pumpRunLoop() {
         RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+    }
+
+    private func preservingSessionIndexDefaults(_ body: () -> Void) {
+        let defaults = UserDefaults.standard
+        let keys = [
+            "sessionIndex.agentOrder",
+            "sessionIndex.directoryOrder",
+            "sessionIndex.grouping"
+        ]
+        let previousValues = keys.map { (key: $0, value: defaults.object(forKey: $0)) }
+        defer {
+            for previousValue in previousValues {
+                if let value = previousValue.value {
+                    defaults.set(value, forKey: previousValue.key)
+                } else {
+                    defaults.removeObject(forKey: previousValue.key)
+                }
+            }
+        }
+
+        for key in keys {
+            defaults.removeObject(forKey: key)
+        }
+        body()
     }
 
     private func makeCodexStateDatabase(

--- a/cmuxTests/SessionIndexViewTests.swift
+++ b/cmuxTests/SessionIndexViewTests.swift
@@ -202,6 +202,7 @@ final class SessionIndexViewTests: XCTestCase {
         preservingSessionIndexDefaults {
             let store = SessionIndexStore()
             let sameModified = Date(timeIntervalSince1970: 10)
+            store.agentOrder = []
 
             store.replaceEntriesForTesting([
                 makeEntry(agent: .grok, title: "grok", modified: sameModified),

--- a/cmuxTests/SessionIndexViewTests.swift
+++ b/cmuxTests/SessionIndexViewTests.swift
@@ -167,6 +167,21 @@ final class SessionIndexViewTests: XCTestCase {
         }
     }
 
+    func testDirectoryOrderBackfillUsesPathTieBreakForEqualModifiedDates() {
+        preservingSessionIndexDefaults {
+            let store = SessionIndexStore()
+            let sameModified = Date(timeIntervalSince1970: 10)
+
+            store.replaceEntriesForTesting([
+                makeEntry(title: "project b", cwd: "/project-b", modified: sameModified),
+                makeEntry(title: "project a", cwd: "/project-a", modified: sameModified),
+                makeEntry(title: "project c", cwd: "/project-c", modified: Date(timeIntervalSince1970: 1))
+            ])
+
+            XCTAssertEqual(store.directoryOrder, ["/project-a", "/project-b", "/project-c"])
+        }
+    }
+
     func testAgentOrderBackfillUsesLatestModifiedForDuplicateAgents() {
         preservingSessionIndexDefaults {
             let store = SessionIndexStore()
@@ -180,6 +195,21 @@ final class SessionIndexViewTests: XCTestCase {
             ])
 
             XCTAssertEqual(store.agentOrder.map(\.rawValue), ["claude", "codex", "grok"])
+        }
+    }
+
+    func testAgentOrderBackfillUsesAgentIdTieBreakForEqualModifiedDates() {
+        preservingSessionIndexDefaults {
+            let store = SessionIndexStore()
+            let sameModified = Date(timeIntervalSince1970: 10)
+
+            store.replaceEntriesForTesting([
+                makeEntry(agent: .grok, title: "grok", modified: sameModified),
+                makeEntry(agent: .codex, title: "codex", modified: sameModified),
+                makeEntry(agent: .claude, title: "claude", modified: Date(timeIntervalSince1970: 1))
+            ])
+
+            XCTAssertEqual(store.agentOrder.map(\.rawValue), ["codex", "grok", "claude"])
         }
     }
 


### PR DESCRIPTION
Optimizes session index section-order backfill for large session sets.\n\n- Replaces per-duplicate additions.firstIndex scans with keyed latest-modified aggregation for directory and agent ordering.\n- Preserves existing latest-modified ordering behavior.\n- Adds coverage for duplicate directory and agent entries.\n\nBenchmark shape:\n- 10k synthetic entries over 5k directories, 50 runs: old firstIndex backfill about 57s, dictionary backfill about 0.5s.\n\nVerification:\n- ./scripts/reload.sh --tag sessidx\n- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4868"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782459297&installation_id=133855650&pr_number=4868&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4868&signature=7869924a632d628d5645d98c30c331435dc3fbd5a79d2beaa1c5c94d5e563d70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local ordering/backfill performance and deterministic tie-breaks in the session index UI store; covered by unit tests with no auth or data-handling changes.
> 
> **Overview**
> **Session index** backfill for **directory** and **agent** section order no longer scans `additions` with `firstIndex` on every duplicate entry. It now aggregates **latest `modified`** per path or agent id in dictionaries, then sorts once—intended to make large session lists practical (e.g. ~57s → ~0.5s on cited 10k-entry benchmarks).
> 
> When timestamps tie, ordering is **deterministic**: **path** for folders, **agent id** for agents. A **DEBUG-only** `replaceEntriesForTesting` runs the same backfill path as reload without a full scan.
> 
> **Tests** cover duplicate cwd/agent rows, tie-breaks, and isolate `UserDefaults` for session index keys; `makeEntry` accepts **`cwd`** and **`modified`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84563c9cb8d481f3b7512075ceace8ba7ec909da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make session index backfill linear for directory and agent ordering by aggregating latest-modified per key. Keeps newest-first ordering and adds deterministic tie-breaks; cuts backfill time on large datasets.

- **Refactors**
  - Replace per-duplicate scans with keyed latest-modified aggregation for directories and agents; skip already-known items.
  - Stabilize equal-modified ordering with tie-breaks: path (directories) and agent id (agents). Add DEBUG `replaceEntriesForTesting` and tests for duplicates and tie-breaks, isolating `UserDefaults` via a helper.
  - Benchmark: 10k entries over 5k directories (50 runs) — ~57s → ~0.5s.

<sup>Written for commit 84563c9cb8d481f3b7512075ceace8ba7ec909da. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4868?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved directory and agent ordering to choose the most recently modified session per group and apply deterministic tie-breakers when timestamps match.
  * Ensures agent ordering is updated consistently even when no new agents are discovered.

* **Tests**
  * Added tests covering duplicate-directory and duplicate-agent ordering scenarios.
  * Added a debug-only helper to replace session entries for deterministic test setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4868?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->