### PR TITLE
Fix JSONC comment skipper for CRLF line endings

### DIFF
--- a/.github/workflows/tmux-corpus.yml
+++ b/.github/workflows/tmux-corpus.yml
@@ -56,7 +56,7 @@ jobs:
           done
 
   terminal-nightly:
-    if: github.event_name == 'schedule'
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: [self-hosted, warp-macos-15-arm64-6x]
     timeout-minutes: 30
     steps:

--- a/Sources/JSONCParser.swift
+++ b/Sources/JSONCParser.swift
@@ -77,6 +77,14 @@ enum JSONCParser {
         }
     }
 
+    static func isLineTerminator(_ character: Character) -> Bool {
+        // Swift treats "\r\n" as a single extended grapheme cluster, so comparing
+        // against "\n" alone misses CRLF line endings and would let line comments
+        // run to end-of-file. Match any character whose first scalar is CR or LF.
+        guard let scalar = character.unicodeScalars.first else { return false }
+        return scalar == "\n" || scalar == "\r"
+    }
+
     private static func stripComments(from source: String) throws -> String {
         var result = ""
         var index = source.startIndex
@@ -112,7 +120,7 @@ enum JSONCParser {
                     let next = source[nextIndex]
                     if next == "/" {
                         index = source.index(after: nextIndex)
-                        while index < source.endIndex && source[index] != "\n" {
+                        while index < source.endIndex && !JSONCParser.isLineTerminator(source[index]) {
                             index = source.index(after: index)
                         }
                         continue
@@ -355,7 +363,7 @@ enum JSONCObjectEditor {
                 let next = source.index(after: index)
                 if next < source.endIndex, source[next] == "/" {
                     index = source.index(after: next)
-                    while index < source.endIndex, source[index] != "\n" {
+                    while index < source.endIndex, !JSONCParser.isLineTerminator(source[index]) {
                         index = source.index(after: index)
                     }
                     continue
@@ -452,7 +460,7 @@ enum JSONCObjectEditor {
                 let next = source.index(after: index)
                 if next < source.endIndex, source[next] == "/" {
                     index = source.index(after: next)
-                    while index < source.endIndex, source[index] != "\n" {
+                    while index < source.endIndex, !JSONCParser.isLineTerminator(source[index]) {
                         index = source.index(after: index)
                     }
                     continue

--- a/Sources/JSONCParser.swift
+++ b/Sources/JSONCParser.swift
@@ -491,7 +491,7 @@ enum JSONCObjectEditor {
         var lineStart = index
         while lineStart > source.startIndex {
             let previous = source.index(before: lineStart)
-            if source[previous] == "\n" || source[previous] == "\r" {
+            if JSONCParser.isLineTerminator(source[previous]) {
                 break
             }
             lineStart = previous


### PR DESCRIPTION
## Summary

- Swift treats `\r\n` as a single extended grapheme cluster, so the `//` comment skippers in `JSONCParser.swift` (3 sites) compared `source[index] != \"\n\"` and walked past CRLF line endings, stripping everything after the first line comment.
- On a CRLF cmux.json, `preprocess()` returned truncated JSON and `loadCmuxSettingsRoot()` / `jsonObject()` threw `Unexpected end of file`, which is why the nightly tmux corpus terminal-nightly job has been failing on `testSurfaceResumeApprovalWritesRecordsIntoCmuxJSON` since 2026-05-23.
- Adds a small helper `isLineTerminator(_:)` that matches any character whose first scalar is CR or LF, and uses it in all three call sites.
- Also enables `workflow_dispatch` to run the macOS `terminal-nightly` job so the same tests can be re-run on demand against PRs (instead of waiting for the next schedule).

Repro of the underlying bug:

```swift
let s = "// comment\r\nrest\r\n"
var i = s.startIndex
while i < s.endIndex && s[i] != "\n" { i = s.index(after: i) }
// i is now s.endIndex — the loop ate the rest of the file
```

## Test plan

- [ ] `tmux corpus` workflow_dispatch on this branch goes green (specifically `cmuxTests/SessionPersistenceTests/testSurfaceResumeApprovalWritesRecordsIntoCmuxJSON` and `testRestoreDoesNotRunUntrustedSurfaceResumeBindingByDefault`)
- [ ] CI passes
- [ ] Sanity: existing tests that use LF cmux.json still work (unchanged path; terminator check is a superset of `\n`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow parsing fix for JSONC comment/line boundaries plus a CI trigger change; no auth, security, or broad API surface changes.
> 
> **Overview**
> Fixes **JSONC** `//` line-comment handling when config text uses **CRLF** line endings. Swift treats `\r\n` as one character, so loops that stopped only on `\n` could consume the rest of the file, truncate preprocessed JSON, and break **cmux.json** load paths (including session persistence tests on macOS).
> 
> Adds **`JSONCParser.isLineTerminator(_:)`** (CR or LF on the first scalar) and uses it everywhere line comments and “start of line” scanning used to compare against `\n` alone.
> 
> Also lets the **tmux corpus** **`terminal-nightly`** job run on **`workflow_dispatch`**, not only on schedule, so the same macOS terminal corpus can be re-run from a branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7ef5d6e51b46cb7db1e694e0022bd9cd4fcdd98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4869"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782461500&installation_id=133855650&pr_number=4869&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4869&signature=a6483f2f2598b1741e552bfe63857ca584d973cd9679e2044ebd480b4e353282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes JSONC `//` comment parsing and indentation detection for CRLF files to prevent truncation and misaligned inserts, restoring tmux corpus stability. Also enables manual runs of the macOS `terminal-nightly` workflow.

- **Bug Fixes**
  - Added `isLineTerminator(_:)` and used it in three `//` comment loops to stop at CR, LF, or CRLF and avoid truncating files.
  - Used the same helper when scanning to the start of a line to fix indent detection on CRLF, keeping inserted properties aligned.

- **New Features**
  - Enabled `workflow_dispatch` for the `terminal-nightly` job to re-run tmux corpus tests on demand.

<sup>Written for commit a7ef5d6e51b46cb7db1e694e0022bd9cd4fcdd98. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4869?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of JSON-with-comments files to correctly recognize all common line endings (LF, CR, CRLF). This prevents comment text from spilling into following lines, preserves correct indentation detection, and fixes parsing errors or misformatting when files use different platform line endings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4869?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->