### PR TITLE
Skip Cmd+Shift key forwarding test when Ghostty surface init fails

### DIFF
--- a/cmuxTests/GhosttyCommandShiftForwardingTests.swift
+++ b/cmuxTests/GhosttyCommandShiftForwardingTests.swift
@@ -67,6 +67,16 @@ final class GhosttyCommandShiftForwardingTests: XCTestCase {
         let surfaceView = hostedTerminal.surfaceView
         defer { window.orderOut(nil) }
 
+        // Headless CI runners can't initialize a Metal-backed Ghostty surface
+        // (embedded_window logs error.OutOfMemory). Skip rather than report a
+        // misleading key-forwarding failure; the same test still exercises
+        // the real path on developer machines and CI environments with a
+        // logged-in GUI session.
+        try XCTSkipUnless(
+            hostedTerminal.surface.hasLiveSurface,
+            "Ghostty surface failed to initialize on this host; Metal/embedded_window unavailable."
+        )
+
         XCTAssertTrue(window.makeFirstResponder(surfaceView), "Expected Ghostty surface view to accept first responder")
         XCTAssertNotNil(surfaceView.terminalSurface)
 


### PR DESCRIPTION
## Summary

- The tmux corpus \`terminal-nightly\` runner (\`warp-macos-15-arm64-6x\`) cannot initialize Metal-backed Ghostty surfaces. Every surface the unit test suite creates emits \`embedded_window: error initializing surface err=error.OutOfMemory\`, and \`ghostty_surface_new\` returns nil.
- \`testUnboundCommandShiftKeyAfterMenuMissForwardsToGhosttyKeyDown\` then fails \`XCTAssertTrue\` on \`performKeyEquivalentAfterMenuMiss\` because \`ensureSurfaceReadyForInput\` cannot return a live surface, which looks like a key-forwarding regression rather than the environment issue that it is. This has been the third failing test in tmux corpus since at least 2026-05-25.
- Adds \`XCTSkipUnless(hostedTerminal.surface.hasLiveSurface, ...)\` so the test skips cleanly when the runner can't init a Metal surface, while still running end-to-end on developer machines and on runners with a logged-in GUI session.

A separate follow-up should give the self-hosted runner a real GUI session (or move this test to a runner that has one) so we actually exercise the key-forwarding path in CI. Filing that as the next step rather than masking it further here.

## Test plan

- [ ] tmux corpus workflow_dispatch on this branch goes green (\`GhosttyCommandShiftForwardingTests\` skipped rather than failed)
- [ ] CI passes
- [ ] Sanity: on a workstation with Metal available, the test still runs and asserts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4871"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782464370&installation_id=133855650&pr_number=4871&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4871&signature=402f520627caedd4a169621360eedfeb5cb106edfbf8b66b8102b5e926e3c45a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only guard for CI environments without Metal/GUI; no production behavior changes.
> 
> **Overview**
> **`GhosttyCommandShiftForwardingTests`** now calls **`XCTSkipUnless(hostedTerminal.surface.hasLiveSurface, …)`** right after the hosted terminal is set up, before first-responder and key-forwarding assertions.
> 
> On runners where Metal / embedded Ghostty surfaces fail to initialize, the test **skips** with an explicit message instead of failing assertions that would look like a Cmd+Shift forwarding regression. The full key-forwarding path still runs wherever a live surface is available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01ee1b8258de1ea6292b1122322ba120e2fe7418. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip the Cmd+Shift key-forwarding test when Ghostty can’t create a Metal surface, preventing false failures on headless CI. Uses `XCTSkipUnless(hostedTerminal.surface.hasLiveSurface)` so the test still runs on machines with a GUI/Metal.

<sup>Written for commit 01ee1b8258de1ea6292b1122322ba120e2fe7418. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4871?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by conditionally skipping when graphics surface initialization is unavailable, preventing false failures in headless CI environments while maintaining validation in supported settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4871?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->