### PR TITLE
Add CEF runtime bridge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,11 @@ xcuserdata/
 GhosttyKit.xcframework
 GhosttyKit.xcframework.bak-*/
 
+# CEF binary runtime (downloaded by scripts/vendor-cef.sh)
+Vendor/cef-*/
+Vendor/cef-active
+Vendor/cmake/
+
 # Release artifacts
 cmux-*.zip
 cmux-macos.dmg

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -80,7 +80,7 @@
 		</dict>
 	</array>
 	<key>NSPrincipalClass</key>
-	<string>NSApplication</string>
+	<string>CMUXCEFApplication</string>
 	<key>NSAppleScriptEnabled</key>
 	<true/>
 	<key>OSAScriptingDefinition</key>

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -1231,6 +1231,23 @@
         }
       }
     },
+    "debug.cefBrowserDebug.runtimeUnavailable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CEF runtime unavailable."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CEF ランタイムを利用できません。"
+          }
+        }
+      }
+    },
     "debug.menu.browserProfilePopoverDebug": {
       "extractionState": "manual",
       "localizations": {
@@ -1256,6 +1273,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "브라우저 프로필 팝오버 디버그…"
+          }
+        }
+      }
+    },
+    "debug.menu.cefBrowserDebug": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CEF Browser Debug..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CEF ブラウザーデバッグ..."
           }
         }
       }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -930,6 +930,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     // Set to true when the user has already confirmed quit via the warning dialog,
     // so applicationShouldTerminate does not show a second alert.
     private var isQuitWarningConfirmed = false
+    private var isFlushingCEFBeforeTerminate = false
+    private var didFlushCEFBeforeTerminate = false
     private var didInstallLifecycleSnapshotObservers = false
     private var didDisableSuddenTermination = false
     private var commandPaletteVisibilityByWindowId: [UUID: Bool] = [:]
@@ -1615,6 +1617,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 reason = "policy"
             }
             StartupBreadcrumbLog.append("appDelegate.shouldTerminate.terminateNow", fields: ["reason": reason])
+            if flushCEFBeforeTerminateIfNeeded(sender: sender, completion: {
+                sender.reply(toApplicationShouldTerminate: true)
+            }) {
+                return .terminateLater
+            }
             return .terminateNow
         }
 
@@ -1640,6 +1647,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 self.isQuitWarningConfirmed = true
                 self.closeAllWebInspectorsBeforeAppTeardown()
                 StartupBreadcrumbLog.append("appDelegate.shouldTerminate.reply", fields: ["shouldQuit": "1"])
+                if self.flushCEFBeforeTerminateIfNeeded(sender: sender, completion: {
+                    sender.reply(toApplicationShouldTerminate: true)
+                }) {
+                    return
+                }
             } else {
                 // Reset so that the next quit attempt can show the dialog again.
                 self.isTerminatingApp = false
@@ -1649,6 +1661,32 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
         StartupBreadcrumbLog.append("appDelegate.shouldTerminate.later")
         return .terminateLater
+    }
+
+    private func flushCEFBeforeTerminateIfNeeded(
+        sender _: NSApplication,
+        completion: @escaping () -> Void
+    ) -> Bool {
+        guard CMUXCEFIsInitialized(), !didFlushCEFBeforeTerminate else {
+            return false
+        }
+        guard !isFlushingCEFBeforeTerminate else {
+            return true
+        }
+
+        isFlushingCEFBeforeTerminate = true
+        StartupBreadcrumbLog.append("appDelegate.shouldTerminate.cefFlush.begin")
+        CMUXCEFFlushBrowserState { [weak self] in
+            guard let self else {
+                completion()
+                return
+            }
+            self.didFlushCEFBeforeTerminate = true
+            self.isFlushingCEFBeforeTerminate = false
+            StartupBreadcrumbLog.append("appDelegate.shouldTerminate.cefFlush.complete")
+            completion()
+        }
+        return true
     }
 
     private func hasQuitConfirmationDirtyWorkspaces() -> Bool {
@@ -1696,6 +1734,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         GhosttyPasteboardHelper.cleanupAllOwnedTemporaryImageFiles()
         VSCodeServeWebController.shared.stop()
         BrowserProfileStore.shared.flushPendingSaves()
+        if CMUXCEFIsInitialized() {
+            CMUXCEFShutdown()
+        }
         if TelemetrySettings.enabledForCurrentLaunch {
             PostHogAnalytics.shared.flush()
         }

--- a/Sources/CEF/CMUXCEFBridge.h
+++ b/Sources/CEF/CMUXCEFBridge.h
@@ -1,0 +1,60 @@
+#import <AppKit/AppKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+bool CMUXCEFPrepareApplication(void);
+bool CMUXCEFIsRuntimeAvailable(void);
+bool CMUXCEFIsInitialized(void);
+bool CMUXCEFInitialize(int argc, char* _Nullable argv[_Nonnull]);
+void CMUXCEFFlushBrowserState(void (^_Nullable completion)(void));
+void CMUXCEFShutdown(void);
+int CMUXCEFRemoteDebuggingPort(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+@interface CMUXCEFBrowserView : NSView
+
+@property(nonatomic, copy, nullable) void (^titleChangedHandler)(NSString* title);
+@property(nonatomic, copy, nullable) void (^urlChangedHandler)(NSString* url);
+@property(nonatomic, copy, nullable) void (^faviconURLChangedHandler)(NSString* faviconURL);
+@property(nonatomic, copy, nullable) void (^navigationStateChangedHandler)(BOOL canGoBack, BOOL canGoForward, BOOL isLoading);
+@property(nonatomic, copy, nullable) void (^consoleMessageHandler)(NSString* message, NSString* source, NSInteger line);
+@property(nonatomic, copy, nullable) void (^newWindowRequestedHandler)(NSString* url);
+@property(nonatomic, copy, nullable) void (^loadEventHandler)(
+  NSString* event,
+  NSString* url,
+  NSInteger httpStatusCode,
+  NSInteger errorCode,
+  NSString* errorText);
+
+- (instancetype)initWithFrame:(NSRect)frameRect
+                   initialURL:(NSString*)initialURL
+            profileIdentifier:(NSString*)profileIdentifier NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithFrame:(NSRect)frameRect NS_UNAVAILABLE;
+- (nullable instancetype)initWithCoder:(NSCoder*)coder NS_UNAVAILABLE;
+
+@property(nonatomic, readonly, nullable) NSString* currentURLString;
+@property(nonatomic, readonly, nullable) NSString* pageTitle;
+@property(nonatomic, readonly) NSInteger browserIdentifier;
+@property(nonatomic, readonly) BOOL canGoBack;
+@property(nonatomic, readonly) BOOL canGoForward;
+@property(nonatomic, readonly) BOOL isLoading;
+
+- (void)loadURLString:(NSString*)urlString;
+- (void)goBack;
+- (void)goForward;
+- (void)reload;
+- (void)stopLoading;
+- (void)executeJavaScript:(NSString*)javaScript;
+- (void)toggleDevTools;
+- (void)closeBrowser;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/CEF/CMUXCEFBridge.h
+++ b/Sources/CEF/CMUXCEFBridge.h
@@ -34,8 +34,7 @@ int CMUXCEFRemoteDebuggingPort(void);
   NSString* errorText);
 
 - (instancetype)initWithFrame:(NSRect)frameRect
-                   initialURL:(NSString*)initialURL
-            profileIdentifier:(NSString*)profileIdentifier NS_DESIGNATED_INITIALIZER;
+                   initialURL:(NSString*)initialURL NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithFrame:(NSRect)frameRect NS_UNAVAILABLE;
 - (nullable instancetype)initWithCoder:(NSCoder*)coder NS_UNAVAILABLE;
 

--- a/Sources/CEF/CMUXCEFBridge.mm
+++ b/Sources/CEF/CMUXCEFBridge.mm
@@ -1,0 +1,842 @@
+#import "CMUXCEFBridge.h"
+
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <atomic>
+#include <cmath>
+#include <cstring>
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "include/base/cef_logging.h"
+#include "include/cef_app.h"
+#include "include/cef_application_mac.h"
+#include "include/cef_browser.h"
+#include "include/cef_client.h"
+#include "include/cef_command_line.h"
+#include "include/cef_cookie.h"
+#include "include/cef_display_handler.h"
+#include "include/cef_life_span_handler.h"
+#include "include/cef_load_handler.h"
+#include "include/cef_request_context.h"
+#include "include/wrapper/cef_helpers.h"
+
+static int g_remoteDebuggingPort = 9433;
+static bool g_cefInitialized = false;
+static bool g_cefShuttingDown = false;
+static CefRefPtr<CefApp> g_cefApp;
+static CFRunLoopTimerRef g_messagePumpTimer = nullptr;
+static std::map<std::string, CefRefPtr<CefRequestContext>> g_persistentRequestContexts;
+static NSString* const CMUXCEFBuiltInDefaultProfileIdentifier = @"52B43C05-4A1D-45D3-8FD5-9EF94952E445";
+using CMUXCEFCompletionBlock = void (^)(void);
+
+struct CMUXCEFProfileFlushState {
+  explicit CMUXCEFProfileFlushState(CMUXCEFCompletionBlock completionBlock)
+      : completion([completionBlock copy]) {}
+
+  ~CMUXCEFProfileFlushState() {
+    completion = nil;
+  }
+
+  std::atomic<int> pending{0};
+  CMUXCEFCompletionBlock completion;
+};
+
+static NSString* CMUXNSStringFromCefString(const CefString& value) {
+  std::string stringValue = value.ToString();
+  return [NSString stringWithUTF8String:stringValue.c_str()] ?: @"";
+}
+
+static void CMUXCEFFinishProfileFlush(std::shared_ptr<CMUXCEFProfileFlushState> state) {
+  if (!state || state->pending.fetch_sub(1) != 1) {
+    return;
+  }
+  CMUXCEFCompletionBlock completion = [state->completion copy];
+  dispatch_async(dispatch_get_main_queue(), ^{
+    if (completion) {
+      completion();
+    }
+  });
+}
+
+class CMUXCEFCookieFlushCallback : public CefCompletionCallback {
+ public:
+  explicit CMUXCEFCookieFlushCallback(std::shared_ptr<CMUXCEFProfileFlushState> state)
+      : state_(std::move(state)) {}
+
+  void OnComplete() override {
+    CMUXCEFFinishProfileFlush(state_);
+  }
+
+ private:
+  std::shared_ptr<CMUXCEFProfileFlushState> state_;
+
+  IMPLEMENT_REFCOUNTING(CMUXCEFCookieFlushCallback);
+  DISALLOW_COPY_AND_ASSIGN(CMUXCEFCookieFlushCallback);
+};
+
+static bool CMUXCEFFlushCookieManager(CefRefPtr<CefCookieManager> manager,
+                                      std::shared_ptr<CMUXCEFProfileFlushState> state) {
+  if (!manager || !state) {
+    return false;
+  }
+  state->pending.fetch_add(1);
+  if (!manager->FlushStore(new CMUXCEFCookieFlushCallback(state))) {
+    CMUXCEFFinishProfileFlush(state);
+    return false;
+  }
+  return true;
+}
+
+static bool CMUXCEFIsPortAvailable(int port) {
+  int sock = socket(AF_INET, SOCK_STREAM, 0);
+  if (sock < 0) {
+    return false;
+  }
+  int opt = 1;
+  setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+
+  sockaddr_in addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  addr.sin_port = htons(static_cast<uint16_t>(port));
+
+  int result = bind(sock, reinterpret_cast<sockaddr*>(&addr), sizeof(addr));
+  close(sock);
+  return result == 0;
+}
+
+static int CMUXCEFFindAvailableRemoteDebuggingPort(void) {
+  for (int port = 9433; port <= 9443; ++port) {
+    if (CMUXCEFIsPortAvailable(port)) {
+      return port;
+    }
+  }
+  return 9433;
+}
+
+static NSString* CMUXCEFStorageNamespace(void) {
+  NSString* bundleIdentifier = [[NSBundle mainBundle] bundleIdentifier] ?: @"com.cmuxterm.app";
+  if ([bundleIdentifier hasPrefix:@"com.cmuxterm.app.debug."]) {
+    return @"com.cmuxterm.app.debug";
+  }
+  if ([bundleIdentifier hasPrefix:@"com.cmuxterm.app.staging."]) {
+    return @"com.cmuxterm.app.staging";
+  }
+  return bundleIdentifier;
+}
+
+static NSString* CMUXCEFStorageDirectory(void) {
+  NSArray<NSURL*>* appSupportURLs = [[NSFileManager defaultManager] URLsForDirectory:NSApplicationSupportDirectory
+                                                                           inDomains:NSUserDomainMask];
+  NSString* appSupportPath = appSupportURLs.firstObject.path;
+  if (appSupportPath.length == 0) {
+    appSupportPath = [NSHomeDirectory() stringByAppendingPathComponent:@"Library/Application Support"];
+  }
+  NSString* path = [[appSupportPath stringByAppendingPathComponent:CMUXCEFStorageNamespace()]
+    stringByAppendingPathComponent:@"cef"];
+  [[NSFileManager defaultManager] createDirectoryAtPath:path
+                            withIntermediateDirectories:YES
+                                             attributes:nil
+                                                  error:nil];
+  return path;
+}
+
+static CefRefPtr<CefRequestContext> CMUXCEFRequestContextForProfile(NSString* profileIdentifier) {
+  NSString* identifier = profileIdentifier.length > 0 ? profileIdentifier : @"default";
+  if ([identifier isEqualToString:@"default"] || [identifier isEqualToString:CMUXCEFBuiltInDefaultProfileIdentifier]) {
+    return CefRequestContext::GetGlobalContext();
+  }
+
+  std::string key([identifier UTF8String]);
+  auto existing = g_persistentRequestContexts.find(key);
+  if (existing != g_persistentRequestContexts.end()) {
+    return existing->second;
+  }
+
+  NSString* profilePath = [CMUXCEFStorageDirectory() stringByAppendingPathComponent:identifier];
+  [[NSFileManager defaultManager] createDirectoryAtPath:profilePath
+                            withIntermediateDirectories:YES
+                                             attributes:nil
+                                                  error:nil];
+
+  CefRequestContextSettings contextSettings;
+  contextSettings.persist_session_cookies = true;
+  CefString(&contextSettings.cache_path) = [profilePath UTF8String];
+  CefRefPtr<CefRequestContext> context = CefRequestContext::CreateContext(contextSettings, nullptr);
+  if (!context) {
+    NSLog(@"[CEF] Failed to create persistent request context for profile %@; using global context.", identifier);
+    return CefRequestContext::GetGlobalContext();
+  }
+  g_persistentRequestContexts[key] = context;
+  return context;
+}
+
+static NSString* CMUXCEFFrameworkExecutablePath(void) {
+  return [[[NSBundle mainBundle] privateFrameworksPath]
+    stringByAppendingPathComponent:@"Chromium Embedded Framework.framework/Chromium Embedded Framework"];
+}
+
+static NSString* CMUXCEFFrameworkBundlePath(void) {
+  return [[[NSBundle mainBundle] privateFrameworksPath]
+    stringByAppendingPathComponent:@"Chromium Embedded Framework.framework"];
+}
+
+static NSString* CMUXCEFHelperExecutablePath(void) {
+  return [[[NSBundle mainBundle] privateFrameworksPath]
+    stringByAppendingPathComponent:@"cmux Helper.app/Contents/MacOS/cmux Helper"];
+}
+
+static void CMUXCEFInvalidateMessagePumpTimer(void) {
+  if (!g_messagePumpTimer) {
+    return;
+  }
+  CFRunLoopTimerInvalidate(g_messagePumpTimer);
+  CFRelease(g_messagePumpTimer);
+  g_messagePumpTimer = nullptr;
+}
+
+static void CMUXCEFRunMessagePumpWork(void) {
+  if (!g_cefInitialized || g_cefShuttingDown) {
+    return;
+  }
+  CefDoMessageLoopWork();
+}
+
+static void CMUXCEFScheduleMessagePumpWork(int64_t delayMs) {
+  dispatch_async(dispatch_get_main_queue(), ^{
+    if (!g_cefInitialized || g_cefShuttingDown) {
+      return;
+    }
+    CMUXCEFInvalidateMessagePumpTimer();
+    if (delayMs <= 0) {
+      CMUXCEFRunMessagePumpWork();
+      return;
+    }
+
+    CFAbsoluteTime fireDate = CFAbsoluteTimeGetCurrent() + (static_cast<CFTimeInterval>(delayMs) / 1000.0);
+    g_messagePumpTimer = CFRunLoopTimerCreateWithHandler(kCFAllocatorDefault, fireDate, 0, 0, 0, ^(CFRunLoopTimerRef timer) {
+      if (g_messagePumpTimer == timer) {
+        CFRelease(g_messagePumpTimer);
+        g_messagePumpTimer = nullptr;
+      }
+      CMUXCEFRunMessagePumpWork();
+    });
+    CFRunLoopAddTimer(CFRunLoopGetMain(), g_messagePumpTimer, kCFRunLoopCommonModes);
+  });
+}
+
+@interface CMUXCEFApplication : NSApplication<CefAppProtocol> {
+ @private
+  BOOL handlingSendEvent_;
+}
+@end
+
+@implementation CMUXCEFApplication
+- (BOOL)isHandlingSendEvent {
+  return handlingSendEvent_;
+}
+
+- (void)setHandlingSendEvent:(BOOL)handlingSendEvent {
+  handlingSendEvent_ = handlingSendEvent;
+}
+
+- (void)sendEvent:(NSEvent*)event {
+  CefScopedSendingEvent sendingEventScoper;
+  [super sendEvent:event];
+}
+@end
+
+class CMUXCEFApp : public CefApp, public CefBrowserProcessHandler {
+ public:
+  CMUXCEFApp() = default;
+
+  CefRefPtr<CefBrowserProcessHandler> GetBrowserProcessHandler() override {
+    return this;
+  }
+
+  void OnBeforeCommandLineProcessing(const CefString& process_type, CefRefPtr<CefCommandLine> command_line) override {
+    command_line->AppendSwitch("use-mock-keychain");
+    command_line->AppendSwitch("enable-fullscreen");
+    command_line->AppendSwitch("allow-insecure-localhost");
+    command_line->AppendSwitchWithValue("remote-allow-origins", "*");
+  }
+
+  void OnBeforeChildProcessLaunch(CefRefPtr<CefCommandLine> command_line) override {
+    command_line->AppendSwitch("disable-background-mode");
+    command_line->AppendSwitch("disable-backgrounding-occluded-windows");
+  }
+
+  void OnScheduleMessagePumpWork(int64_t delay_ms) override {
+    CMUXCEFScheduleMessagePumpWork(delay_ms);
+  }
+
+ private:
+  IMPLEMENT_REFCOUNTING(CMUXCEFApp);
+  DISALLOW_COPY_AND_ASSIGN(CMUXCEFApp);
+};
+
+@class CMUXCEFBrowserView;
+
+class CMUXCEFBrowserClient : public CefClient,
+                             public CefDisplayHandler,
+                             public CefLoadHandler,
+                             public CefLifeSpanHandler {
+ public:
+  explicit CMUXCEFBrowserClient(CMUXCEFBrowserView* owner) : owner_(owner) {}
+
+  CefRefPtr<CefDisplayHandler> GetDisplayHandler() override { return this; }
+  CefRefPtr<CefLoadHandler> GetLoadHandler() override { return this; }
+  CefRefPtr<CefLifeSpanHandler> GetLifeSpanHandler() override { return this; }
+
+  void OnTitleChange(CefRefPtr<CefBrowser> browser, const CefString& title) override;
+  void OnAddressChange(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, const CefString& url) override;
+  void OnFaviconURLChange(CefRefPtr<CefBrowser> browser, const std::vector<CefString>& icon_urls) override;
+  void OnLoadStart(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, TransitionType transition_type) override;
+  void OnLoadEnd(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, int httpStatusCode) override;
+  void OnLoadError(CefRefPtr<CefBrowser> browser,
+                   CefRefPtr<CefFrame> frame,
+                   ErrorCode errorCode,
+                   const CefString& errorText,
+                   const CefString& failedUrl) override;
+  void OnLoadingStateChange(CefRefPtr<CefBrowser> browser, bool isLoading, bool canGoBack, bool canGoForward) override;
+  bool OnConsoleMessage(CefRefPtr<CefBrowser> browser,
+                        cef_log_severity_t level,
+                        const CefString& message,
+                        const CefString& source,
+                        int line) override;
+  bool OnBeforePopup(CefRefPtr<CefBrowser> browser,
+                     CefRefPtr<CefFrame> frame,
+                     int popup_id,
+                     const CefString& target_url,
+                     const CefString& target_frame_name,
+                     CefLifeSpanHandler::WindowOpenDisposition target_disposition,
+                     bool user_gesture,
+                     const CefPopupFeatures& popupFeatures,
+                     CefWindowInfo& windowInfo,
+                     CefRefPtr<CefClient>& client,
+                     CefBrowserSettings& settings,
+                     CefRefPtr<CefDictionaryValue>& extra_info,
+                     bool* no_javascript_access) override;
+  bool DoClose(CefRefPtr<CefBrowser> browser) override;
+  void MarkClosingFromCMUX();
+
+ private:
+  __weak CMUXCEFBrowserView* owner_;
+  bool closingFromCMUX_ = false;
+
+  IMPLEMENT_REFCOUNTING(CMUXCEFBrowserClient);
+  DISALLOW_COPY_AND_ASSIGN(CMUXCEFBrowserClient);
+};
+
+@interface CMUXCEFBrowserView () {
+ @private
+  NSString* initialURL_;
+  NSString* profileIdentifier_;
+  CefRefPtr<CefBrowser> browser_;
+  CefRefPtr<CMUXCEFBrowserClient> client_;
+  NSView* cefView_;
+  NSString* currentURLString_;
+  NSString* pageTitle_;
+  BOOL canGoBack_;
+  BOOL canGoForward_;
+  BOOL isLoading_;
+  BOOL didCreateBrowser_;
+}
+- (void)cmuxCEFSetTitle:(NSString*)title;
+- (void)cmuxCEFSetURL:(NSString*)url;
+- (void)cmuxCEFSetFaviconURL:(NSString*)url;
+- (void)cmuxCEFSetLoading:(BOOL)isLoading canGoBack:(BOOL)canGoBack canGoForward:(BOOL)canGoForward;
+- (void)cmuxCEFHandleLoadEvent:(NSString*)event
+                           url:(NSString*)url
+                httpStatusCode:(NSInteger)httpStatusCode
+                      errorCode:(NSInteger)errorCode
+                      errorText:(NSString*)errorText;
+- (void)cmuxCEFHandleConsoleMessage:(NSString*)message source:(NSString*)source line:(NSInteger)line;
+@end
+
+@implementation CMUXCEFBrowserView
+
+- (instancetype)initWithFrame:(NSRect)frameRect
+                   initialURL:(NSString*)initialURL
+            profileIdentifier:(NSString*)profileIdentifier {
+  self = [super initWithFrame:frameRect];
+  if (self) {
+    initialURL_ = [initialURL copy];
+    profileIdentifier_ = [profileIdentifier copy];
+    currentURLString_ = [initialURL copy];
+    self.wantsLayer = YES;
+    self.layer.backgroundColor = [NSColor colorWithCalibratedWhite:0.086 alpha:1].CGColor;
+    self.layer.masksToBounds = YES;
+  }
+  return self;
+}
+
+- (BOOL)isFlipped {
+  return YES;
+}
+
+- (BOOL)acceptsFirstResponder {
+  return YES;
+}
+
+- (BOOL)acceptsFirstMouse:(NSEvent*)event {
+  return YES;
+}
+
+- (NSView*)hitTest:(NSPoint)point {
+  if (!NSPointInRect(point, self.bounds)) {
+    return nil;
+  }
+  if (cefView_ && !cefView_.hidden && cefView_.alphaValue > 0.0) {
+    NSPoint cefPoint = [self convertPoint:point toView:cefView_];
+    if (NSPointInRect(cefPoint, cefView_.bounds)) {
+      NSView* hitView = [cefView_ hitTest:cefPoint];
+      return hitView ?: cefView_;
+    }
+  }
+  return [super hitTest:point];
+}
+
+- (BOOL)becomeFirstResponder {
+  if (cefView_ && self.window) {
+    [self.window makeFirstResponder:cefView_];
+  }
+  return [super becomeFirstResponder];
+}
+
+- (void)viewDidMoveToWindow {
+  [super viewDidMoveToWindow];
+  if (self.window && !didCreateBrowser_) {
+    [self createBrowserIfNeeded];
+  }
+}
+
+- (void)layout {
+  [super layout];
+  if (!cefView_) {
+    return;
+  }
+  NSRect targetFrame = self.bounds;
+  if (!NSEqualRects(cefView_.frame, targetFrame)) {
+    cefView_.frame = targetFrame;
+  }
+  if (!NSEqualPoints(cefView_.bounds.origin, NSZeroPoint)) {
+    [cefView_ setBoundsOrigin:NSZeroPoint];
+  }
+}
+
+- (NSString*)currentURLString {
+  return currentURLString_;
+}
+
+- (NSString*)pageTitle {
+  return pageTitle_;
+}
+
+- (NSInteger)browserIdentifier {
+  return browser_ ? browser_->GetIdentifier() : -1;
+}
+
+- (BOOL)canGoBack {
+  return canGoBack_;
+}
+
+- (BOOL)canGoForward {
+  return canGoForward_;
+}
+
+- (BOOL)isLoading {
+  return isLoading_;
+}
+
+- (void)createBrowserIfNeeded {
+  if (didCreateBrowser_ || !g_cefInitialized) {
+    return;
+  }
+  didCreateBrowser_ = YES;
+
+  CefWindowInfo windowInfo;
+  windowInfo.runtime_style = CEF_RUNTIME_STYLE_ALLOY;
+  CefRect rect(0, 0, static_cast<int>(MAX(1, self.bounds.size.width)), static_cast<int>(MAX(1, self.bounds.size.height)));
+  windowInfo.SetAsChild((__bridge void*)self, rect);
+
+  CefBrowserSettings browserSettings;
+  browserSettings.background_color = CefColorSetARGB(255, 22, 22, 22);
+  CefRefPtr<CefRequestContext> requestContext = CMUXCEFRequestContextForProfile(profileIdentifier_);
+
+  client_ = new CMUXCEFBrowserClient(self);
+  browser_ = CefBrowserHost::CreateBrowserSync(
+    windowInfo,
+    client_,
+    CefString("about:blank"),
+    browserSettings,
+    nullptr,
+    requestContext);
+  if (!browser_) {
+    return;
+  }
+
+  CefWindowHandle handle = browser_->GetHost()->GetWindowHandle();
+  cefView_ = (__bridge NSView*)handle;
+  cefView_.autoresizingMask = NSViewNotSizable;
+  cefView_.frame = self.bounds;
+  [self setNeedsLayout:YES];
+
+  if (initialURL_.length > 0) {
+    [self loadURLString:initialURL_];
+  }
+}
+
+- (void)loadURLString:(NSString*)urlString {
+  currentURLString_ = [urlString copy];
+  if (self.urlChangedHandler) {
+    self.urlChangedHandler(currentURLString_ ?: @"");
+  }
+  if (browser_ && urlString.length > 0) {
+    browser_->GetMainFrame()->LoadURL(CefString([urlString UTF8String]));
+  }
+}
+
+- (void)goBack {
+  if (browser_ && browser_->CanGoBack()) {
+    browser_->GoBack();
+  }
+}
+
+- (void)goForward {
+  if (browser_ && browser_->CanGoForward()) {
+    browser_->GoForward();
+  }
+}
+
+- (void)reload {
+  if (browser_) {
+    browser_->Reload();
+  }
+}
+
+- (void)stopLoading {
+  if (browser_) {
+    browser_->StopLoad();
+  }
+}
+
+- (void)executeJavaScript:(NSString*)javaScript {
+  if (!browser_ || javaScript.length == 0) {
+    return;
+  }
+  CefRefPtr<CefFrame> frame = browser_->GetMainFrame();
+  if (frame) {
+    frame->ExecuteJavaScript(CefString([javaScript UTF8String]), frame->GetURL(), 0);
+  }
+}
+
+- (void)toggleDevTools {
+  if (browser_) {
+    NSLog(@"[CEF] Remote debugging is available at http://127.0.0.1:%d", g_remoteDebuggingPort);
+  }
+}
+
+- (void)closeBrowser {
+  if (browser_) {
+    if (client_) {
+      client_->MarkClosingFromCMUX();
+    }
+    browser_->GetHost()->CloseBrowser(true);
+    browser_ = nullptr;
+  }
+  if (cefView_) {
+    [cefView_ removeFromSuperview];
+    cefView_ = nil;
+  }
+}
+
+- (void)dealloc {
+  [self closeBrowser];
+}
+
+- (void)cmuxCEFSetTitle:(NSString*)title {
+  pageTitle_ = [title copy];
+  if (self.titleChangedHandler) {
+    self.titleChangedHandler(pageTitle_ ?: @"");
+  }
+}
+
+- (void)cmuxCEFSetURL:(NSString*)url {
+  currentURLString_ = [url copy];
+  if (self.urlChangedHandler) {
+    self.urlChangedHandler(currentURLString_ ?: @"");
+  }
+}
+
+- (void)cmuxCEFSetFaviconURL:(NSString*)url {
+  if (self.faviconURLChangedHandler) {
+    self.faviconURLChangedHandler(url ?: @"");
+  }
+}
+
+- (void)cmuxCEFSetLoading:(BOOL)isLoading canGoBack:(BOOL)canGoBack canGoForward:(BOOL)canGoForward {
+  isLoading_ = isLoading;
+  canGoBack_ = canGoBack;
+  canGoForward_ = canGoForward;
+  if (self.navigationStateChangedHandler) {
+    self.navigationStateChangedHandler(canGoBack_, canGoForward_, isLoading_);
+  }
+}
+
+- (void)cmuxCEFHandleLoadEvent:(NSString*)event
+                           url:(NSString*)url
+                httpStatusCode:(NSInteger)httpStatusCode
+                      errorCode:(NSInteger)errorCode
+                      errorText:(NSString*)errorText {
+  if (self.loadEventHandler) {
+    self.loadEventHandler(event ?: @"", url ?: @"", httpStatusCode, errorCode, errorText ?: @"");
+  }
+}
+
+- (void)cmuxCEFHandleConsoleMessage:(NSString*)message source:(NSString*)source line:(NSInteger)line {
+  if (self.consoleMessageHandler) {
+    self.consoleMessageHandler(message ?: @"", source ?: @"", line);
+  }
+}
+
+@end
+
+void CMUXCEFBrowserClient::OnTitleChange(CefRefPtr<CefBrowser> browser, const CefString& title) {
+  CMUXCEFBrowserView* owner = owner_;
+  NSString* titleString = CMUXNSStringFromCefString(title);
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [owner cmuxCEFSetTitle:titleString];
+  });
+}
+
+void CMUXCEFBrowserClient::OnAddressChange(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, const CefString& url) {
+  if (!frame || !frame->IsMain()) {
+    return;
+  }
+  CMUXCEFBrowserView* owner = owner_;
+  NSString* urlString = CMUXNSStringFromCefString(url);
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [owner cmuxCEFSetURL:urlString];
+  });
+}
+
+void CMUXCEFBrowserClient::OnFaviconURLChange(CefRefPtr<CefBrowser> browser, const std::vector<CefString>& icon_urls) {
+  if (icon_urls.empty()) {
+    return;
+  }
+  CMUXCEFBrowserView* owner = owner_;
+  NSString* faviconURL = CMUXNSStringFromCefString(icon_urls.front());
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [owner cmuxCEFSetFaviconURL:faviconURL];
+  });
+}
+
+void CMUXCEFBrowserClient::OnLoadStart(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, TransitionType transition_type) {
+  if (!frame || !frame->IsMain()) {
+    return;
+  }
+  CMUXCEFBrowserView* owner = owner_;
+  NSString* urlString = CMUXNSStringFromCefString(frame->GetURL());
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [owner cmuxCEFHandleLoadEvent:@"loadStart" url:urlString httpStatusCode:0 errorCode:0 errorText:@""];
+  });
+}
+
+void CMUXCEFBrowserClient::OnLoadEnd(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, int httpStatusCode) {
+  if (!frame || !frame->IsMain()) {
+    return;
+  }
+  CMUXCEFBrowserView* owner = owner_;
+  NSString* urlString = CMUXNSStringFromCefString(frame->GetURL());
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [owner cmuxCEFHandleLoadEvent:@"loadEnd" url:urlString httpStatusCode:httpStatusCode errorCode:0 errorText:@""];
+  });
+}
+
+void CMUXCEFBrowserClient::OnLoadError(CefRefPtr<CefBrowser> browser,
+                                       CefRefPtr<CefFrame> frame,
+                                       ErrorCode errorCode,
+                                       const CefString& errorText,
+                                       const CefString& failedUrl) {
+  if (!frame || !frame->IsMain()) {
+    return;
+  }
+  CMUXCEFBrowserView* owner = owner_;
+  NSString* urlString = CMUXNSStringFromCefString(failedUrl);
+  NSString* errorTextString = CMUXNSStringFromCefString(errorText);
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [owner cmuxCEFHandleLoadEvent:@"loadError"
+                              url:urlString
+                   httpStatusCode:0
+                         errorCode:static_cast<NSInteger>(errorCode)
+                         errorText:errorTextString];
+  });
+}
+
+void CMUXCEFBrowserClient::OnLoadingStateChange(CefRefPtr<CefBrowser> browser, bool isLoading, bool canGoBack, bool canGoForward) {
+  CMUXCEFBrowserView* owner = owner_;
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [owner cmuxCEFSetLoading:isLoading canGoBack:canGoBack canGoForward:canGoForward];
+  });
+}
+
+bool CMUXCEFBrowserClient::OnConsoleMessage(CefRefPtr<CefBrowser> browser,
+                                            cef_log_severity_t level,
+                                            const CefString& message,
+                                            const CefString& source,
+                                            int line) {
+  CMUXCEFBrowserView* owner = owner_;
+  NSString* messageString = CMUXNSStringFromCefString(message);
+  NSString* sourceString = CMUXNSStringFromCefString(source);
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [owner cmuxCEFHandleConsoleMessage:messageString source:sourceString line:line];
+  });
+  return false;
+}
+
+bool CMUXCEFBrowserClient::OnBeforePopup(CefRefPtr<CefBrowser> browser,
+                                         CefRefPtr<CefFrame> frame,
+                                         int popup_id,
+                                         const CefString& target_url,
+                                         const CefString& target_frame_name,
+                                         CefLifeSpanHandler::WindowOpenDisposition target_disposition,
+                                         bool user_gesture,
+                                         const CefPopupFeatures& popupFeatures,
+                                         CefWindowInfo& windowInfo,
+                                         CefRefPtr<CefClient>& client,
+                                         CefBrowserSettings& settings,
+                                         CefRefPtr<CefDictionaryValue>& extra_info,
+                                         bool* no_javascript_access) {
+  std::string url = target_url.ToString();
+  CMUXCEFBrowserView* owner = owner_;
+  if (!url.empty() && owner.newWindowRequestedHandler) {
+    NSString* requestedURL = CMUXNSStringFromCefString(target_url);
+    dispatch_async(dispatch_get_main_queue(), ^{
+      if (owner.newWindowRequestedHandler) {
+        owner.newWindowRequestedHandler(requestedURL);
+      }
+    });
+    return true;
+  }
+  if (browser && !url.empty()) {
+    browser->GetMainFrame()->LoadURL(target_url);
+  }
+  return true;
+}
+
+bool CMUXCEFBrowserClient::DoClose(CefRefPtr<CefBrowser> browser) {
+  return closingFromCMUX_;
+}
+
+void CMUXCEFBrowserClient::MarkClosingFromCMUX() {
+  closingFromCMUX_ = true;
+}
+
+bool CMUXCEFPrepareApplication(void) {
+  [CMUXCEFApplication sharedApplication];
+  return [NSApp isKindOfClass:[CMUXCEFApplication class]];
+}
+
+bool CMUXCEFIsRuntimeAvailable(void) {
+  return [[NSFileManager defaultManager] fileExistsAtPath:CMUXCEFFrameworkExecutablePath()]
+    && [[NSFileManager defaultManager] fileExistsAtPath:CMUXCEFHelperExecutablePath()];
+}
+
+bool CMUXCEFIsInitialized(void) {
+  return g_cefInitialized;
+}
+
+bool CMUXCEFInitialize(int argc, char* _Nullable argv[]) {
+  if (g_cefInitialized) {
+    return true;
+  }
+  if (![NSApp isKindOfClass:[CMUXCEFApplication class]]) {
+    return false;
+  }
+  if (!CMUXCEFIsRuntimeAvailable()) {
+    NSLog(@"[CEF] Runtime not available. Missing framework or helper app.");
+    return false;
+  }
+
+  CefMainArgs mainArgs(argc, argv);
+  g_cefApp = new CMUXCEFApp();
+
+  CefSettings settings;
+  settings.no_sandbox = true;
+  settings.multi_threaded_message_loop = false;
+  settings.external_message_pump = true;
+  settings.windowless_rendering_enabled = false;
+  g_remoteDebuggingPort = CMUXCEFFindAvailableRemoteDebuggingPort();
+  settings.remote_debugging_port = g_remoteDebuggingPort;
+
+  NSString* bundlePath = [[NSBundle mainBundle] bundlePath];
+  if (bundlePath) {
+    CefString(&settings.main_bundle_path) = [bundlePath UTF8String];
+  }
+  CefString(&settings.framework_dir_path) = [CMUXCEFFrameworkBundlePath() UTF8String];
+  CefString(&settings.browser_subprocess_path) = [CMUXCEFHelperExecutablePath() UTF8String];
+
+  NSString* cachePath = CMUXCEFStorageDirectory();
+  CefString(&settings.cache_path) = [cachePath UTF8String];
+  CefString(&settings.root_cache_path) = [cachePath UTF8String];
+  settings.persist_session_cookies = true;
+  CefString(&settings.log_file) = [[cachePath stringByAppendingPathComponent:@"debug.log"] UTF8String];
+  settings.log_severity = LOGSEVERITY_ERROR;
+  CefString(&settings.accept_language_list) = "en-US,en";
+
+  if (!CefInitialize(mainArgs, settings, g_cefApp.get(), nullptr)) {
+    NSLog(@"[CEF] CefInitialize failed.");
+    return false;
+  }
+  g_cefInitialized = true;
+  g_cefShuttingDown = false;
+  CMUXCEFScheduleMessagePumpWork(0);
+  NSLog(@"[CEF] Initialized with remote debugging on 127.0.0.1:%d", g_remoteDebuggingPort);
+  return true;
+}
+
+void CMUXCEFFlushBrowserState(CMUXCEFCompletionBlock completion) {
+  auto state = std::make_shared<CMUXCEFProfileFlushState>(completion);
+  if (g_cefInitialized) {
+    CefRefPtr<CefRequestContext> globalContext = CefRequestContext::GetGlobalContext();
+    if (globalContext) {
+      CMUXCEFFlushCookieManager(globalContext->GetCookieManager(nullptr), state);
+    }
+    for (const auto& entry : g_persistentRequestContexts) {
+      if (entry.second) {
+        CMUXCEFFlushCookieManager(entry.second->GetCookieManager(nullptr), state);
+      }
+    }
+  }
+  if (state->pending.load() == 0 && completion) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+      completion();
+    });
+  }
+}
+
+void CMUXCEFShutdown(void) {
+  if (!g_cefInitialized) {
+    return;
+  }
+  g_cefShuttingDown = true;
+  CMUXCEFInvalidateMessagePumpTimer();
+  CefShutdown();
+  g_persistentRequestContexts.clear();
+  g_cefApp = nullptr;
+  g_cefInitialized = false;
+  g_cefShuttingDown = false;
+}
+
+int CMUXCEFRemoteDebuggingPort(void) {
+  return g_remoteDebuggingPort;
+}

--- a/Sources/CEF/CMUXCEFBridge.mm
+++ b/Sources/CEF/CMUXCEFBridge.mm
@@ -31,10 +31,10 @@
 static int g_remoteDebuggingPort = 9433;
 static bool g_cefInitialized = false;
 static bool g_cefShuttingDown = false;
+static bool g_cefContextInitialized = false;
 static bool g_cefMessageLoopEnabled = false;
 static bool g_messagePumpActive = false;
 static bool g_messagePumpReentrancyDetected = false;
-static int g_cefLiveBrowserCount = 0;
 static CefRefPtr<CefApp> g_cefApp;
 static NSTimer* g_messagePumpTimer = nil;
 static std::map<std::string, CefRefPtr<CefRequestContext>> g_persistentRequestContexts;
@@ -210,6 +210,7 @@ static void CMUXCEFInvalidateMessagePumpTimer(void) {
 }
 
 static void CMUXCEFScheduleMessagePumpWork(int64_t delayMs);
+static void CMUXCEFNotifyContextInitialized(void);
 
 static bool CMUXCEFPerformMessagePumpWork(void) {
   if (!g_cefMessageLoopEnabled || g_cefShuttingDown) {
@@ -234,7 +235,7 @@ static void CMUXCEFRunMessagePumpWork(void) {
   bool wasReentrant = CMUXCEFPerformMessagePumpWork();
   if (wasReentrant) {
     CMUXCEFScheduleMessagePumpWork(0);
-  } else if (!g_messagePumpTimer && g_cefLiveBrowserCount > 0) {
+  } else if (!g_messagePumpTimer) {
     CMUXCEFScheduleMessagePumpWork(CMUXCEFMessagePumpTimerDelayPlaceholder);
   }
 }
@@ -312,12 +313,33 @@ class CMUXCEFApp : public CefApp, public CefBrowserProcessHandler {
     CMUXCEFScheduleMessagePumpWork(delay_ms);
   }
 
+  void OnContextInitialized() override {
+    g_cefContextInitialized = true;
+    CMUXCEFNotifyContextInitialized();
+  }
+
  private:
   IMPLEMENT_REFCOUNTING(CMUXCEFApp);
   DISALLOW_COPY_AND_ASSIGN(CMUXCEFApp);
 };
 
 @class CMUXCEFBrowserView;
+
+static NSHashTable<CMUXCEFBrowserView*>* CMUXCEFPendingBrowserViews(void) {
+  static NSHashTable<CMUXCEFBrowserView*>* pendingViews = nil;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    pendingViews = [NSHashTable weakObjectsHashTable];
+  });
+  return pendingViews;
+}
+
+static void CMUXCEFRegisterPendingBrowserView(CMUXCEFBrowserView* view) {
+  if (!view) {
+    return;
+  }
+  [CMUXCEFPendingBrowserViews() addObject:view];
+}
 
 class CMUXCEFBrowserClient : public CefClient,
                              public CefDisplayHandler,
@@ -394,7 +416,18 @@ class CMUXCEFBrowserClient : public CefClient,
                       errorCode:(NSInteger)errorCode
                       errorText:(NSString*)errorText;
 - (void)cmuxCEFHandleConsoleMessage:(NSString*)message source:(NSString*)source line:(NSInteger)line;
+- (void)cmuxCEFContextInitialized;
 @end
+
+static void CMUXCEFNotifyContextInitialized(void) {
+  dispatch_async(dispatch_get_main_queue(), ^{
+    NSArray<CMUXCEFBrowserView*>* views = CMUXCEFPendingBrowserViews().allObjects;
+    [CMUXCEFPendingBrowserViews() removeAllObjects];
+    for (CMUXCEFBrowserView* view in views) {
+      [view cmuxCEFContextInitialized];
+    }
+  });
+}
 
 @implementation CMUXCEFBrowserView
 
@@ -491,7 +524,18 @@ class CMUXCEFBrowserClient : public CefClient,
 }
 
 - (void)createBrowserIfNeeded {
-  if (didCreateBrowser_ || !g_cefInitialized || !self.window) {
+  if (didCreateBrowser_) {
+    return;
+  }
+  if (!g_cefInitialized) {
+    return;
+  }
+  if (!g_cefContextInitialized) {
+    CMUXCEFRegisterPendingBrowserView(self);
+    CMUXCEFScheduleMessagePumpWork(0);
+    return;
+  }
+  if (!self.window) {
     return;
   }
   if (self.bounds.size.width < 1 || self.bounds.size.height < 1) {
@@ -506,16 +550,16 @@ class CMUXCEFBrowserClient : public CefClient,
 
   CefBrowserSettings browserSettings;
   browserSettings.background_color = CefColorSetARGB(255, 22, 22, 22);
-  CefRefPtr<CefRequestContext> requestContext = CMUXCEFRequestContextForProfile(profileIdentifier_);
+  std::string initialURL = initialURL_.length > 0 ? [initialURL_ UTF8String] : "about:blank";
 
   client_ = new CMUXCEFBrowserClient(self);
   browser_ = CefBrowserHost::CreateBrowserSync(
     windowInfo,
     client_,
-    CefString("about:blank"),
+    CefString(initialURL),
     browserSettings,
     nullptr,
-    requestContext);
+    nullptr);
   if (!browser_) {
     didCreateBrowser_ = NO;
     NSLog(@"[CEF] Failed to create browser for %@", initialURL_);
@@ -534,15 +578,10 @@ class CMUXCEFBrowserClient : public CefClient,
   if (!cefView_.superview) {
     [self addSubview:cefView_];
   }
-  g_cefLiveBrowserCount += 1;
   CMUXCEFScheduleMessagePumpWork(0);
   cefView_.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
   cefView_.frame = self.bounds;
   [self setNeedsLayout:YES];
-
-  if (initialURL_.length > 0) {
-    [self loadURLString:initialURL_];
-  }
 }
 
 - (void)loadURLString:(NSString*)urlString {
@@ -602,7 +641,6 @@ class CMUXCEFBrowserClient : public CefClient,
     }
     browser_->GetHost()->CloseBrowser(true);
     browser_ = nullptr;
-    g_cefLiveBrowserCount = std::max(0, g_cefLiveBrowserCount - 1);
   }
   if (cefView_) {
     [cefView_ removeFromSuperview];
@@ -657,6 +695,10 @@ class CMUXCEFBrowserClient : public CefClient,
   if (self.consoleMessageHandler) {
     self.consoleMessageHandler(message ?: @"", source ?: @"", line);
   }
+}
+
+- (void)cmuxCEFContextInitialized {
+  [self createBrowserIfNeeded];
 }
 
 @end
@@ -798,8 +840,9 @@ bool CMUXCEFPrepareApplication(void) {
 }
 
 bool CMUXCEFIsRuntimeAvailable(void) {
-  return [[NSFileManager defaultManager] fileExistsAtPath:CMUXCEFFrameworkExecutablePath()]
-    && [[NSFileManager defaultManager] fileExistsAtPath:CMUXCEFHelperExecutablePath()];
+  bool frameworkAvailable = [[NSFileManager defaultManager] fileExistsAtPath:CMUXCEFFrameworkExecutablePath()];
+  bool helperAvailable = [[NSFileManager defaultManager] fileExistsAtPath:CMUXCEFHelperExecutablePath()];
+  return frameworkAvailable && helperAvailable;
 }
 
 bool CMUXCEFIsInitialized(void) {
@@ -826,6 +869,7 @@ bool CMUXCEFInitialize(int argc, char* _Nullable argv[]) {
   settings.multi_threaded_message_loop = false;
   settings.external_message_pump = true;
   settings.windowless_rendering_enabled = false;
+  g_cefContextInitialized = false;
   g_remoteDebuggingPort = CMUXCEFFindAvailableRemoteDebuggingPort();
   settings.remote_debugging_port = g_remoteDebuggingPort;
 
@@ -891,6 +935,7 @@ void CMUXCEFShutdown(void) {
   g_persistentRequestContexts.clear();
   g_cefApp = nullptr;
   g_cefInitialized = false;
+  g_cefContextInitialized = false;
   g_cefShuttingDown = false;
 }
 

--- a/Sources/CEF/CMUXCEFBridge.mm
+++ b/Sources/CEF/CMUXCEFBridge.mm
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <climits>
 #include <cmath>
 #include <cstring>
 #include <map>
@@ -30,10 +31,16 @@
 static int g_remoteDebuggingPort = 9433;
 static bool g_cefInitialized = false;
 static bool g_cefShuttingDown = false;
+static bool g_cefMessageLoopEnabled = false;
+static bool g_messagePumpActive = false;
+static bool g_messagePumpReentrancyDetected = false;
+static int g_cefLiveBrowserCount = 0;
 static CefRefPtr<CefApp> g_cefApp;
-static CFRunLoopTimerRef g_messagePumpTimer = nullptr;
+static NSTimer* g_messagePumpTimer = nil;
 static std::map<std::string, CefRefPtr<CefRequestContext>> g_persistentRequestContexts;
 static NSString* const CMUXCEFBuiltInDefaultProfileIdentifier = @"52B43C05-4A1D-45D3-8FD5-9EF94952E445";
+static const int32_t CMUXCEFMessagePumpTimerDelayPlaceholder = INT_MAX;
+static const int64_t CMUXCEFMaxMessagePumpDelayMs = 1000 / 30;
 using CMUXCEFCompletionBlock = void (^)(void);
 
 struct CMUXCEFProfileFlushState {
@@ -198,21 +205,46 @@ static void CMUXCEFInvalidateMessagePumpTimer(void) {
   if (!g_messagePumpTimer) {
     return;
   }
-  CFRunLoopTimerInvalidate(g_messagePumpTimer);
-  CFRelease(g_messagePumpTimer);
-  g_messagePumpTimer = nullptr;
+  [g_messagePumpTimer invalidate];
+  g_messagePumpTimer = nil;
+}
+
+static void CMUXCEFScheduleMessagePumpWork(int64_t delayMs);
+
+static bool CMUXCEFPerformMessagePumpWork(void) {
+  if (!g_cefMessageLoopEnabled || g_cefShuttingDown) {
+    return false;
+  }
+  if (g_messagePumpActive) {
+    g_messagePumpReentrancyDetected = true;
+    return false;
+  }
+
+  g_messagePumpReentrancyDetected = false;
+  g_messagePumpActive = true;
+  CefDoMessageLoopWork();
+  g_messagePumpActive = false;
+  return g_messagePumpReentrancyDetected;
 }
 
 static void CMUXCEFRunMessagePumpWork(void) {
-  if (!g_cefInitialized || g_cefShuttingDown) {
+  if (!g_cefMessageLoopEnabled || g_cefShuttingDown) {
     return;
   }
-  CefDoMessageLoopWork();
+  bool wasReentrant = CMUXCEFPerformMessagePumpWork();
+  if (wasReentrant) {
+    CMUXCEFScheduleMessagePumpWork(0);
+  } else if (!g_messagePumpTimer && g_cefLiveBrowserCount > 0) {
+    CMUXCEFScheduleMessagePumpWork(CMUXCEFMessagePumpTimerDelayPlaceholder);
+  }
 }
 
 static void CMUXCEFScheduleMessagePumpWork(int64_t delayMs) {
   dispatch_async(dispatch_get_main_queue(), ^{
-    if (!g_cefInitialized || g_cefShuttingDown) {
+    if (!g_cefMessageLoopEnabled || g_cefShuttingDown) {
+      return;
+    }
+    if (delayMs == CMUXCEFMessagePumpTimerDelayPlaceholder && g_messagePumpTimer) {
       return;
     }
     CMUXCEFInvalidateMessagePumpTimer();
@@ -221,15 +253,17 @@ static void CMUXCEFScheduleMessagePumpWork(int64_t delayMs) {
       return;
     }
 
-    CFAbsoluteTime fireDate = CFAbsoluteTimeGetCurrent() + (static_cast<CFTimeInterval>(delayMs) / 1000.0);
-    g_messagePumpTimer = CFRunLoopTimerCreateWithHandler(kCFAllocatorDefault, fireDate, 0, 0, 0, ^(CFRunLoopTimerRef timer) {
+    int64_t boundedDelayMs = std::min(delayMs, CMUXCEFMaxMessagePumpDelayMs);
+    g_messagePumpTimer = [NSTimer timerWithTimeInterval:static_cast<NSTimeInterval>(boundedDelayMs) / 1000.0
+                                                 repeats:NO
+                                                   block:^(NSTimer* timer) {
       if (g_messagePumpTimer == timer) {
-        CFRelease(g_messagePumpTimer);
-        g_messagePumpTimer = nullptr;
+        g_messagePumpTimer = nil;
       }
       CMUXCEFRunMessagePumpWork();
-    });
-    CFRunLoopAddTimer(CFRunLoopGetMain(), g_messagePumpTimer, kCFRunLoopCommonModes);
+    }];
+    [[NSRunLoop mainRunLoop] addTimer:g_messagePumpTimer forMode:NSRunLoopCommonModes];
+    [[NSRunLoop mainRunLoop] addTimer:g_messagePumpTimer forMode:NSEventTrackingRunLoopMode];
   });
 }
 
@@ -414,14 +448,13 @@ class CMUXCEFBrowserClient : public CefClient,
 
 - (void)viewDidMoveToWindow {
   [super viewDidMoveToWindow];
-  if (self.window && !didCreateBrowser_) {
-    [self createBrowserIfNeeded];
-  }
+  [self createBrowserIfNeeded];
 }
 
 - (void)layout {
   [super layout];
   if (!cefView_) {
+    [self createBrowserIfNeeded];
     return;
   }
   NSRect targetFrame = self.bounds;
@@ -458,7 +491,10 @@ class CMUXCEFBrowserClient : public CefClient,
 }
 
 - (void)createBrowserIfNeeded {
-  if (didCreateBrowser_ || !g_cefInitialized) {
+  if (didCreateBrowser_ || !g_cefInitialized || !self.window) {
+    return;
+  }
+  if (self.bounds.size.width < 1 || self.bounds.size.height < 1) {
     return;
   }
   didCreateBrowser_ = YES;
@@ -481,12 +517,26 @@ class CMUXCEFBrowserClient : public CefClient,
     nullptr,
     requestContext);
   if (!browser_) {
+    didCreateBrowser_ = NO;
+    NSLog(@"[CEF] Failed to create browser for %@", initialURL_);
     return;
   }
 
   CefWindowHandle handle = browser_->GetHost()->GetWindowHandle();
   cefView_ = (__bridge NSView*)handle;
-  cefView_.autoresizingMask = NSViewNotSizable;
+  if (!cefView_) {
+    didCreateBrowser_ = NO;
+    browser_->GetHost()->CloseBrowser(true);
+    browser_ = nullptr;
+    NSLog(@"[CEF] Browser created without a host view for %@", initialURL_);
+    return;
+  }
+  if (!cefView_.superview) {
+    [self addSubview:cefView_];
+  }
+  g_cefLiveBrowserCount += 1;
+  CMUXCEFScheduleMessagePumpWork(0);
+  cefView_.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
   cefView_.frame = self.bounds;
   [self setNeedsLayout:YES];
 
@@ -552,6 +602,7 @@ class CMUXCEFBrowserClient : public CefClient,
     }
     browser_->GetHost()->CloseBrowser(true);
     browser_ = nullptr;
+    g_cefLiveBrowserCount = std::max(0, g_cefLiveBrowserCount - 1);
   }
   if (cefView_) {
     [cefView_ removeFromSuperview];
@@ -799,6 +850,9 @@ bool CMUXCEFInitialize(int argc, char* _Nullable argv[]) {
   }
   g_cefInitialized = true;
   g_cefShuttingDown = false;
+  g_cefMessageLoopEnabled = true;
+  g_messagePumpActive = false;
+  g_messagePumpReentrancyDetected = false;
   CMUXCEFScheduleMessagePumpWork(0);
   NSLog(@"[CEF] Initialized with remote debugging on 127.0.0.1:%d", g_remoteDebuggingPort);
   return true;
@@ -829,7 +883,10 @@ void CMUXCEFShutdown(void) {
     return;
   }
   g_cefShuttingDown = true;
+  g_cefMessageLoopEnabled = false;
   CMUXCEFInvalidateMessagePumpTimer();
+  g_messagePumpActive = false;
+  g_messagePumpReentrancyDetected = false;
   CefShutdown();
   g_persistentRequestContexts.clear();
   g_cefApp = nullptr;

--- a/Sources/CEF/CMUXCEFBridge.mm
+++ b/Sources/CEF/CMUXCEFBridge.mm
@@ -9,7 +9,6 @@
 #include <climits>
 #include <cmath>
 #include <cstring>
-#include <map>
 #include <memory>
 #include <string>
 #include <utility>
@@ -37,8 +36,6 @@ static bool g_messagePumpActive = false;
 static bool g_messagePumpReentrancyDetected = false;
 static CefRefPtr<CefApp> g_cefApp;
 static NSTimer* g_messagePumpTimer = nil;
-static std::map<std::string, CefRefPtr<CefRequestContext>> g_persistentRequestContexts;
-static NSString* const CMUXCEFBuiltInDefaultProfileIdentifier = @"52B43C05-4A1D-45D3-8FD5-9EF94952E445";
 static const int32_t CMUXCEFMessagePumpTimerDelayPlaceholder = INT_MAX;
 static const int64_t CMUXCEFMaxMessagePumpDelayMs = 1000 / 30;
 using CMUXCEFCompletionBlock = void (^)(void);
@@ -154,36 +151,6 @@ static NSString* CMUXCEFStorageDirectory(void) {
                                              attributes:nil
                                                   error:nil];
   return path;
-}
-
-static CefRefPtr<CefRequestContext> CMUXCEFRequestContextForProfile(NSString* profileIdentifier) {
-  NSString* identifier = profileIdentifier.length > 0 ? profileIdentifier : @"default";
-  if ([identifier isEqualToString:@"default"] || [identifier isEqualToString:CMUXCEFBuiltInDefaultProfileIdentifier]) {
-    return CefRequestContext::GetGlobalContext();
-  }
-
-  std::string key([identifier UTF8String]);
-  auto existing = g_persistentRequestContexts.find(key);
-  if (existing != g_persistentRequestContexts.end()) {
-    return existing->second;
-  }
-
-  NSString* profilePath = [CMUXCEFStorageDirectory() stringByAppendingPathComponent:identifier];
-  [[NSFileManager defaultManager] createDirectoryAtPath:profilePath
-                            withIntermediateDirectories:YES
-                                             attributes:nil
-                                                  error:nil];
-
-  CefRequestContextSettings contextSettings;
-  contextSettings.persist_session_cookies = true;
-  CefString(&contextSettings.cache_path) = [profilePath UTF8String];
-  CefRefPtr<CefRequestContext> context = CefRequestContext::CreateContext(contextSettings, nullptr);
-  if (!context) {
-    NSLog(@"[CEF] Failed to create persistent request context for profile %@; using global context.", identifier);
-    return CefRequestContext::GetGlobalContext();
-  }
-  g_persistentRequestContexts[key] = context;
-  return context;
 }
 
 static NSString* CMUXCEFFrameworkExecutablePath(void) {
@@ -395,7 +362,6 @@ class CMUXCEFBrowserClient : public CefClient,
 @interface CMUXCEFBrowserView () {
  @private
   NSString* initialURL_;
-  NSString* profileIdentifier_;
   CefRefPtr<CefBrowser> browser_;
   CefRefPtr<CMUXCEFBrowserClient> client_;
   NSView* cefView_;
@@ -432,12 +398,10 @@ static void CMUXCEFNotifyContextInitialized(void) {
 @implementation CMUXCEFBrowserView
 
 - (instancetype)initWithFrame:(NSRect)frameRect
-                   initialURL:(NSString*)initialURL
-            profileIdentifier:(NSString*)profileIdentifier {
+                   initialURL:(NSString*)initialURL {
   self = [super initWithFrame:frameRect];
   if (self) {
     initialURL_ = [initialURL copy];
-    profileIdentifier_ = [profileIdentifier copy];
     currentURLString_ = [initialURL copy];
     self.wantsLayer = YES;
     self.layer.backgroundColor = [NSColor colorWithCalibratedWhite:0.086 alpha:1].CGColor;
@@ -909,11 +873,6 @@ void CMUXCEFFlushBrowserState(CMUXCEFCompletionBlock completion) {
     if (globalContext) {
       CMUXCEFFlushCookieManager(globalContext->GetCookieManager(nullptr), state);
     }
-    for (const auto& entry : g_persistentRequestContexts) {
-      if (entry.second) {
-        CMUXCEFFlushCookieManager(entry.second->GetCookieManager(nullptr), state);
-      }
-    }
   }
   if (state->pending.load() == 0 && completion) {
     dispatch_async(dispatch_get_main_queue(), ^{
@@ -932,7 +891,6 @@ void CMUXCEFShutdown(void) {
   g_messagePumpActive = false;
   g_messagePumpReentrancyDetected = false;
   CefShutdown();
-  g_persistentRequestContexts.clear();
   g_cefApp = nullptr;
   g_cefInitialized = false;
   g_cefContextInitialized = false;

--- a/Sources/CEF/CMUXCEFBrowserDebugWindow.swift
+++ b/Sources/CEF/CMUXCEFBrowserDebugWindow.swift
@@ -70,8 +70,7 @@ private struct CMUXCEFBrowserDebugRepresentable: NSViewRepresentable {
 
         return CMUXCEFBrowserView(
             frame: .zero,
-            initialURL: "https://example.com",
-            profileIdentifier: "cef-debug"
+            initialURL: "https://example.com"
         )
     }
 

--- a/Sources/CEF/CMUXCEFBrowserDebugWindow.swift
+++ b/Sources/CEF/CMUXCEFBrowserDebugWindow.swift
@@ -1,0 +1,83 @@
+import AppKit
+import SwiftUI
+
+final class CMUXCEFBrowserDebugWindowController: NSWindowController, NSWindowDelegate {
+    static let shared = CMUXCEFBrowserDebugWindowController()
+
+    private init() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 960, height: 680),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = String(localized: "debug.menu.cefBrowserDebug", defaultValue: "CEF Browser Debug...")
+        window.identifier = NSUserInterfaceItemIdentifier("cmux.cefBrowserDebug")
+        window.contentView = NSHostingView(rootView: CMUXCEFBrowserDebugContentView())
+        window.center()
+        super.init(window: window)
+        window.delegate = self
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    func show() {
+        showWindow(nil)
+        window?.makeKeyAndOrderFront(nil)
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        window?.contentView = NSHostingView(rootView: CMUXCEFBrowserDebugContentView())
+    }
+}
+
+private struct CMUXCEFBrowserDebugContentView: View {
+    var body: some View {
+        CMUXCEFBrowserDebugRepresentable()
+            .frame(minWidth: 640, minHeight: 420)
+            .ignoresSafeArea()
+    }
+}
+
+private struct CMUXCEFBrowserDebugRepresentable: NSViewRepresentable {
+    func makeNSView(context: Context) -> NSView {
+        guard CMUXCEFPrepareApplication(),
+              CMUXCEFIsRuntimeAvailable(),
+              CMUXCEFInitialize(Int32(CommandLine.argc), CommandLine.unsafeArgv) else {
+            let label = NSTextField(
+                wrappingLabelWithString: String(
+                    localized: "debug.cefBrowserDebug.runtimeUnavailable",
+                    defaultValue: "CEF runtime unavailable."
+                )
+            )
+            label.alignment = .center
+            label.textColor = .secondaryLabelColor
+            let container = NSView(frame: .zero)
+            container.wantsLayer = true
+            container.layer?.backgroundColor = NSColor.windowBackgroundColor.cgColor
+            label.translatesAutoresizingMaskIntoConstraints = false
+            container.addSubview(label)
+            NSLayoutConstraint.activate([
+                label.centerXAnchor.constraint(equalTo: container.centerXAnchor),
+                label.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+                label.widthAnchor.constraint(lessThanOrEqualTo: container.widthAnchor, constant: -48)
+            ])
+            return container
+        }
+
+        return CMUXCEFBrowserView(
+            frame: .zero,
+            initialURL: "https://example.com",
+            profileIdentifier: "cef-debug"
+        )
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {}
+
+    static func dismantleNSView(_ nsView: NSView, coordinator: ()) {
+        (nsView as? CMUXCEFBrowserView)?.closeBrowser()
+    }
+}

--- a/Sources/CEF/CMUXCEFProcessHelper.cc
+++ b/Sources/CEF/CMUXCEFProcessHelper.cc
@@ -1,0 +1,29 @@
+#include "include/cef_app.h"
+#include "include/wrapper/cef_library_loader.h"
+
+#if defined(CEF_USE_SANDBOX)
+#include "include/cef_sandbox_mac.h"
+#endif
+
+class CMUXCEFHelperApp : public CefApp {
+ private:
+  IMPLEMENT_REFCOUNTING(CMUXCEFHelperApp);
+};
+
+int main(int argc, char* argv[]) {
+#if defined(CEF_USE_SANDBOX)
+  CefScopedSandboxContext sandbox_context;
+  if (!sandbox_context.Initialize(argc, argv)) {
+    return 1;
+  }
+#endif
+
+  CefScopedLibraryLoader library_loader;
+  if (!library_loader.LoadInHelper()) {
+    return 1;
+  }
+
+  CefMainArgs main_args(argc, argv);
+  CefRefPtr<CefApp> app(new CMUXCEFHelperApp);
+  return CefExecuteProcess(main_args, app, nullptr);
+}

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -3740,6 +3740,8 @@ class TerminalController {
             return v2Result(id: id, self.v2DebugTextBoxInteract(params: params))
         case "debug.app.activate":
             return v2Result(id: id, self.v2DebugActivateApp())
+        case "debug.cef_browser.open":
+            return v2Result(id: id, self.v2DebugOpenCEFBrowserDebugWindow())
         case "debug.command_palette.toggle":
             return v2Result(id: id, self.v2DebugToggleCommandPalette(params: params))
         case "debug.command_palette.rename_tab.open":
@@ -4015,6 +4017,7 @@ class TerminalController {
             "debug.textbox.inline_fixture",
             "debug.textbox.interact",
             "debug.app.activate",
+            "debug.cef_browser.open",
             "debug.command_palette.toggle",
             "debug.command_palette.rename_tab.open",
             "debug.command_palette.visible",
@@ -15134,6 +15137,13 @@ class TerminalController {
     private func v2DebugActivateApp() -> V2CallResult {
         let resp = activateApp()
         return resp == "OK" ? .ok([:]) : .err(code: "internal_error", message: resp, data: nil)
+    }
+
+    private func v2DebugOpenCEFBrowserDebugWindow() -> V2CallResult {
+        v2MainSync {
+            CMUXCEFBrowserDebugWindowController.shared.show()
+        }
+        return .ok([:])
     }
 
     private func v2DebugToggleCommandPalette(params: [String: Any]) -> V2CallResult {

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -1179,6 +1179,7 @@ struct cmuxApp: App {
         FeedTextEditorDebugWindowController.shared.show()
         FeedButtonStyleDebugWindowController.shared.show()
         BonsplitTabBarDebugWindowController.shared.show()
+        CMUXCEFBrowserDebugWindowController.shared.show()
     }
 #endif
 }

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -48,12 +48,11 @@ struct cmuxApp: App {
             Self.terminateForMissingLaunchTag()
         }
 
-        let initializedCEF = preparedCEFApplication && CMUXCEFInitialize(CommandLine.argc, CommandLine.unsafeArgv)
+        let cefRuntimeAvailable = preparedCEFApplication && CMUXCEFIsRuntimeAvailable()
         StartupBreadcrumbLog.append(
-            "app.init.cef.initialized",
+            "app.init.cefRuntime.available",
             fields: [
-                "initialized": initializedCEF ? "1" : "0",
-                "remoteDebuggingPort": String(CMUXCEFRemoteDebuggingPort())
+                "available": cefRuntimeAvailable ? "1" : "0"
             ]
         )
 

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -1207,6 +1207,7 @@ private let cmuxAuxiliaryWindowIdentifiers: Set<String> = [
     "cmux.licenses",
     "cmux.browser-popup",
     "cmux.browserProfilePopoverDebug",
+    "cmux.cefBrowserDebug",
     "cmux.configEditor",
     "cmux.feedButtonStyleDebug",
     "cmux.feedPreview",

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -35,6 +35,11 @@ struct cmuxApp: App {
         CLIForwardingLaunchRouter.forwardToBundledCLIIfNeeded()
 
         StartupBreadcrumbLog.append("app.init.begin")
+        let preparedCEFApplication = CMUXCEFPrepareApplication()
+        StartupBreadcrumbLog.append(
+            "app.init.cefApplication.prepared",
+            fields: ["prepared": preparedCEFApplication ? "1" : "0"]
+        )
         UITestLaunchManifest.applyIfPresent()
         StartupBreadcrumbLog.append("app.init.uiTestManifest.applied")
 
@@ -42,6 +47,15 @@ struct cmuxApp: App {
             StartupBreadcrumbLog.append("app.init.blockUntaggedDebugLaunch")
             Self.terminateForMissingLaunchTag()
         }
+
+        let initializedCEF = preparedCEFApplication && CMUXCEFInitialize(CommandLine.argc, CommandLine.unsafeArgv)
+        StartupBreadcrumbLog.append(
+            "app.init.cef.initialized",
+            fields: [
+                "initialized": initializedCEF ? "1" : "0",
+                "remoteDebuggingPort": String(CMUXCEFRemoteDebuggingPort())
+            ]
+        )
 
         Self.configureGhosttyEnvironment()
         StartupBreadcrumbLog.append("app.init.ghosttyEnvironment.configured")
@@ -432,6 +446,14 @@ struct cmuxApp: App {
                         )
                     ) {
                         TitlebarLayoutDebugWindowController.shared.show()
+                    }
+                    Button(
+                        String(
+                            localized: "debug.menu.cefBrowserDebug",
+                            defaultValue: "CEF Browser Debug..."
+                        )
+                    ) {
+                        CMUXCEFBrowserDebugWindowController.shared.show()
                     }
                     Button("Sidebar Debug…") {
                         SidebarDebugWindowController.shared.show()

--- a/cmux-Bridging-Header.h
+++ b/cmux-Bridging-Header.h
@@ -1,1 +1,2 @@
 @import GhosttyKit;
+#import "Sources/CEF/CMUXCEFBridge.h"

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -30,6 +30,8 @@
 		3865A0063865A0063865A006 /* AppDelegate+GlobalSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3865B0063865B0063865B006 /* AppDelegate+GlobalSearch.swift */; };
 		3865A0073865A0073865A007 /* GlobalSearchDocuments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3865B0073865B0073865B007 /* GlobalSearchDocuments.swift */; };
 		3865A0083865A0083865A008 /* GlobalSearchPanelCaptureManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3865B0083865B0083865B008 /* GlobalSearchPanelCaptureManager.swift */; };
+		CEF000000000000000000001 /* CMUXCEFBridge.mm in Sources */ = {isa = PBXBuildFile; fileRef = CEF000000000000000000101 /* CMUXCEFBridge.mm */; };
+		CEF000000000000000000002 /* CMUXCEFBrowserDebugWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF000000000000000000102 /* CMUXCEFBrowserDebugWindow.swift */; };
 		C2B6A97D1F2E4C71A8B9D001 /* BrowserOmnibarPerformanceSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2B6A97D1F2E4C71A8B9D002 /* BrowserOmnibarPerformanceSupportTests.swift */; };
 		3023A1003023A1003023A100 /* ConfigSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3023B1003023B1003023B100 /* ConfigSource.swift */; };
 		3023A1013023A1013023A101 /* ConfigSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3023B1013023B1013023B101 /* ConfigSettingsView.swift */; };
@@ -785,6 +787,10 @@
 		A5001016 /* GhosttyKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = GhosttyKit.xcframework; sourceTree = "<group>"; };
 		A5001017 /* ghostty.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ghostty.h; sourceTree = "<group>"; };
 		A5001018 /* cmux-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "cmux-Bridging-Header.h"; sourceTree = "<group>"; };
+		CEF000000000000000000101 /* CMUXCEFBridge.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CMUXCEFBridge.mm; sourceTree = "<group>"; };
+		CEF000000000000000000102 /* CMUXCEFBrowserDebugWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMUXCEFBrowserDebugWindow.swift; sourceTree = "<group>"; };
+		CEF000000000000000000103 /* CMUXCEFBridge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CMUXCEFBridge.h; sourceTree = "<group>"; };
+		CEF000000000000000000104 /* CMUXCEFProcessHelper.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CMUXCEFProcessHelper.cc; sourceTree = "<group>"; };
 		A5001019 /* TerminalController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalController.swift; sourceTree = "<group>"; };
 		E7E000000000000000000006 /* CmuxEventBus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxEventBus.swift; sourceTree = "<group>"; };
 		E7E00000000000000000000E /* CmuxEventLogWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxEventLogWriter.swift; sourceTree = "<group>"; };
@@ -1246,6 +1252,18 @@
 			path = Cloud;
 			sourceTree = "<group>";
 		};
+		CEF000000000000000000100 /* CEF */ = {
+			isa = PBXGroup;
+			children = (
+				CEF000000000000000000101 /* CMUXCEFBridge.mm */,
+				CEF000000000000000000102 /* CMUXCEFBrowserDebugWindow.swift */,
+				CEF000000000000000000103 /* CMUXCEFBridge.h */,
+				CEF000000000000000000104 /* CMUXCEFProcessHelper.cc */,
+			);
+			name = CEF;
+			path = CEF;
+			sourceTree = "<group>";
+		};
 		A5001040 = {
 			isa = PBXGroup;
 			children = (
@@ -1288,6 +1306,7 @@
 				B37A00000000000000000008 /* SettingsCardNote.swift */,
 				C0DE35860000000000000002 /* BackgroundWorkspacePrimeCoordinator.swift */,
 				A5001012 /* ContentView.swift */,
+				CEF000000000000000000100 /* CEF */,
 				E4C001000000000000000002 /* ExtensionSidebarWorkspaceRowView.swift */,
 				E4C001000000000000000004 /* ExtensionWorktreePrototype.swift */,
 				C0DE36230000000000000002 /* WorkspaceFinderDirectoryResolver.swift */,
@@ -1751,12 +1770,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = A5001060 /* Build configuration list for PBXNativeTarget "cmux" */;
 			buildPhases = (
+				CEF000000000000000000010 /* Vendor CEF Runtime */,
 				A5001051 /* Sources */,
 				A5001030 /* Frameworks */,
 				A5001102 /* Resources */,
 				D3664003D3664003D3664003 /* Compress Markdown Viewer Assets */,
 				D1320AA0D1320AA0D1320AA6 /* Copy Dock Tile Plugin */,
 				A5001020 /* Embed Frameworks */,
+				CEF000000000000000000011 /* Copy CEF Runtime */,
 				B900000AA1B2C3D4E5F60719 /* Copy CLI */,
 				C0DEFF100000000000000003 /* Build Command Palette Nucleo FFI */,
 				A5001300A1B2C3D4E5F60719 /* ShellScript */,
@@ -1971,6 +1992,44 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		CEF000000000000000000010 /* Vendor CEF Runtime */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Vendor CEF Runtime";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -euo pipefail\n\"${SRCROOT}/scripts/vendor-cef.sh\" --archs \"${ARCHS:-}\" --link-root \"${CEF_ROOT:-${SRCROOT}/Vendor/cef-active}\" >/dev/null\n";
+		};
+		CEF000000000000000000011 /* Copy CEF Runtime */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Copy CEF Runtime";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -euo pipefail\n\"${SRCROOT}/scripts/copy-cef-runtime.sh\"\n";
+		};
 		D3664003D3664003D3664003 /* Compress Markdown Viewer Assets */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -2061,6 +2120,8 @@
 				B37A00000000000000000007 /* SettingsCardNote.swift in Sources */,
 				C0DE35860000000000000001 /* BackgroundWorkspacePrimeCoordinator.swift in Sources */,
 				A5001002 /* ContentView.swift in Sources */,
+				CEF000000000000000000001 /* CMUXCEFBridge.mm in Sources */,
+				CEF000000000000000000002 /* CMUXCEFBrowserDebugWindow.swift in Sources */,
 				E4C001000000000000000001 /* ExtensionSidebarWorkspaceRowView.swift in Sources */,
 				E4C001000000000000000003 /* ExtensionWorktreePrototype.swift in Sources */,
 				C0DE36230000000000000001 /* WorkspaceFinderDirectoryResolver.swift in Sources */,
@@ -2666,6 +2727,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "AppIcon-Debug";
+				CEF_ROOT = "$(SRCROOT)/Vendor/cef-active";
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_ENABLE_OBJC_ARC = YES;
 				CMUX_AUTH_CALLBACK_SCHEME = "cmux-dev";
 				CODE_SIGN_ENTITLEMENTS = "";
 				CODE_SIGN_STYLE = Automatic;
@@ -2673,11 +2737,23 @@
 				CURRENT_PROJECT_VERSION = 90;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = NO;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(CEF_ROOT)/Release",
+				);
 				GENERATE_INFOPLIST_FILE = NO;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(CEF_ROOT)",
+				);
 				INFOPLIST_FILE = Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(CEF_ROOT)/build/libcef_dll_wrapper",
 				);
 				MARKETING_VERSION = 0.64.10;
 				OTHER_LDFLAGS = (
@@ -2692,6 +2768,8 @@
 					UniformTypeIdentifiers,
 					"-framework",
 					Carbon,
+					"-Wl,-weak_framework,Chromium\\ Embedded\\ Framework",
+					"-lcef_dll_wrapper",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.cmuxterm.app.debug;
 				PRODUCT_NAME = "cmux DEV";
@@ -2706,6 +2784,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CEF_ROOT = "$(SRCROOT)/Vendor/cef-active";
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_ENABLE_OBJC_ARC = YES;
 				CMUX_AUTH_CALLBACK_SCHEME = cmux;
 				CODE_SIGN_ENTITLEMENTS = Resources/cmux.entitlements;
 				CODE_SIGN_STYLE = Automatic;
@@ -2713,11 +2794,23 @@
 				CURRENT_PROJECT_VERSION = 90;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = NO;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(CEF_ROOT)/Release",
+				);
 				GENERATE_INFOPLIST_FILE = NO;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(CEF_ROOT)",
+				);
 				INFOPLIST_FILE = Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(CEF_ROOT)/build/libcef_dll_wrapper",
 				);
 				MARKETING_VERSION = 0.64.10;
 				ONLY_ACTIVE_ARCH = NO;
@@ -2733,6 +2826,8 @@
 					UniformTypeIdentifiers,
 					"-framework",
 					Carbon,
+					"-Wl,-weak_framework,Chromium\\ Embedded\\ Framework",
+					"-lcef_dll_wrapper",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.cmuxterm.app;
 				PRODUCT_NAME = cmux;

--- a/scripts/copy-cef-runtime.sh
+++ b/scripts/copy-cef-runtime.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${CEF_ROOT:-}" ]]; then
+  echo "error: CEF_ROOT is not set" >&2
+  exit 1
+fi
+if [[ -z "${TARGET_BUILD_DIR:-}" || -z "${FRAMEWORKS_FOLDER_PATH:-}" || -z "${INFOPLIST_PATH:-}" ]]; then
+  echo "error: Xcode build environment is incomplete" >&2
+  exit 1
+fi
+
+FRAMEWORKS_DIR="$TARGET_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH"
+INFO_PLIST="$TARGET_BUILD_DIR/$INFOPLIST_PATH"
+HELPER_SOURCE="$CEF_ROOT/build/cmux-cef-helper"
+CEF_FRAMEWORK_SOURCE="$CEF_ROOT/Release/Chromium Embedded Framework.framework"
+
+if [[ ! -d "$CEF_FRAMEWORK_SOURCE" ]]; then
+  echo "error: missing CEF framework at $CEF_FRAMEWORK_SOURCE" >&2
+  exit 1
+fi
+if [[ ! -x "$HELPER_SOURCE" ]]; then
+  echo "error: missing CEF helper executable at $HELPER_SOURCE" >&2
+  exit 1
+fi
+if [[ ! -f "$INFO_PLIST" ]]; then
+  echo "error: missing app Info.plist at $INFO_PLIST" >&2
+  exit 1
+fi
+
+mkdir -p "$FRAMEWORKS_DIR"
+rsync -a --delete "$CEF_FRAMEWORK_SOURCE" "$FRAMEWORKS_DIR/"
+CEF_FRAMEWORK_DEST="$FRAMEWORKS_DIR/Chromium Embedded Framework.framework"
+CEF_FRAMEWORK_VERSION_DIR="$CEF_FRAMEWORK_DEST/Versions/A"
+if [[ ! -d "$CEF_FRAMEWORK_VERSION_DIR" ]]; then
+  versioned_dest="$CEF_FRAMEWORK_DEST.versioned.$$"
+  rm -rf "$versioned_dest"
+  mkdir -p "$versioned_dest/Versions/A"
+  rsync -a "$CEF_FRAMEWORK_DEST/" "$versioned_dest/Versions/A/"
+  ln -s A "$versioned_dest/Versions/Current"
+  ln -s "Versions/Current/Chromium Embedded Framework" "$versioned_dest/Chromium Embedded Framework"
+  ln -s "Versions/Current/Resources" "$versioned_dest/Resources"
+  if [[ -d "$versioned_dest/Versions/A/Libraries" ]]; then
+    ln -s "Versions/Current/Libraries" "$versioned_dest/Libraries"
+  fi
+  rm -rf "$CEF_FRAMEWORK_DEST"
+  mv "$versioned_dest" "$CEF_FRAMEWORK_DEST"
+fi
+CEF_FRAMEWORK_LIBRARIES="$CEF_FRAMEWORK_DEST/Versions/Current/Libraries"
+
+BUNDLE_ID="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$INFO_PLIST")"
+MARKETING_VERSION="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$INFO_PLIST" 2>/dev/null || printf '1')"
+BUNDLE_VERSION="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$INFO_PLIST" 2>/dev/null || printf '1')"
+HELPER_NAMES=(
+  "cmux Helper"
+  "cmux Helper (Alerts)"
+  "cmux Helper (GPU)"
+  "cmux Helper (Plugin)"
+  "cmux Helper (Renderer)"
+)
+
+helper_bundle_suffix() {
+  case "$1" in
+    "cmux Helper") printf 'helper' ;;
+    "cmux Helper (Alerts)") printf 'helper.alerts' ;;
+    "cmux Helper (GPU)") printf 'helper.gpu' ;;
+    "cmux Helper (Plugin)") printf 'helper.plugin' ;;
+    "cmux Helper (Renderer)") printf 'helper.renderer' ;;
+    *) printf '%s' "$1" | tr '[:upper:] ()' '[:lower:]---' | tr -cs '[:alnum:].-' '-' ;;
+  esac
+}
+
+for helper_name in "${HELPER_NAMES[@]}"; do
+  helper_app="$FRAMEWORKS_DIR/$helper_name.app"
+  helper_macos="$helper_app/Contents/MacOS"
+  mkdir -p "$helper_macos"
+  cp "$HELPER_SOURCE" "$helper_macos/$helper_name"
+  chmod 755 "$helper_macos/$helper_name"
+  helper_id="$BUNDLE_ID.$(helper_bundle_suffix "$helper_name")"
+  cat >"$helper_app/Contents/Info.plist" <<EOF_HELPER
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleExecutable</key>
+	<string>$helper_name</string>
+	<key>CFBundleIdentifier</key>
+	<string>$helper_id</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$helper_name</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$MARKETING_VERSION</string>
+	<key>CFBundleVersion</key>
+	<string>$BUNDLE_VERSION</string>
+	<key>LSBackgroundOnly</key>
+	<true/>
+</dict>
+</plist>
+EOF_HELPER
+done
+
+sign_cef_runtime_if_requested() {
+  if [[ "${CODE_SIGNING_ALLOWED:-YES}" == "NO" ]]; then
+    return
+  fi
+  local identity="${EXPANDED_CODE_SIGN_IDENTITY:-}"
+  if [[ -z "$identity" ]]; then
+    return
+  fi
+
+  local common=(--force --sign "$identity" --timestamp=none)
+  if [[ "${ENABLE_HARDENED_RUNTIME:-NO}" == "YES" ]]; then
+    common+=(--options runtime)
+  fi
+
+  local entitlements="${CMUX_HELPER_ENTITLEMENTS:-${SRCROOT:-}/cmux-helper.entitlements}"
+  local entitlement_args=()
+  if [[ -f "$entitlements" ]]; then
+    entitlement_args=(--entitlements "$entitlements")
+  fi
+
+  if [[ -d "$CEF_FRAMEWORK_LIBRARIES" ]]; then
+    while IFS= read -r -d '' library; do
+      /usr/bin/codesign "${common[@]}" "${entitlement_args[@]}" "$library"
+    done < <(find "$CEF_FRAMEWORK_LIBRARIES" -type f -name "*.dylib" -print0)
+  fi
+
+  /usr/bin/codesign "${common[@]}" "${entitlement_args[@]}" "$CEF_FRAMEWORK_DEST"
+  for helper_name in "${HELPER_NAMES[@]}"; do
+    /usr/bin/codesign "${common[@]}" "${entitlement_args[@]}" "$FRAMEWORKS_DIR/$helper_name.app"
+  done
+}
+
+sign_cef_runtime_if_requested

--- a/scripts/sign-cmux-bundle.sh
+++ b/scripts/sign-cmux-bundle.sh
@@ -18,9 +18,10 @@
 #   1. CLI helpers under Contents/Resources/bin/* with minimal
 #      hardened-runtime entitlements (no application-identifier).
 #   2. Each nested plugin under Contents/PlugIns/* with --deep.
-#   3. Each nested framework under Contents/Frameworks/* with --deep
+#   3. CEF dylibs/frameworks/helper apps with Chromium JIT entitlements.
+#   4. Each remaining nested framework under Contents/Frameworks/* with --deep
 #      (covers Sparkle's XPCServices and Updater.app).
-#   4. The main app bundle with the provided app-level entitlements,
+#   5. The main app bundle with the provided app-level entitlements,
 #      WITHOUT --deep. --deep here would overwrite helper/plugin
 #      signatures and re-introduce the app-id mismatch that amfi on
 #      notarized macOS 26 Tahoe rejects with errno 163.
@@ -58,6 +59,7 @@ else
 fi
 
 COMMON=(--force --options runtime "${TS_FLAG[@]}" --sign "$IDENTITY")
+FRAMEWORKS_PATH="$APP_PATH/Contents/Frameworks"
 
 # 1. CLI helpers
 for helper in "$APP_PATH/Contents/Resources/bin"/*; do
@@ -74,15 +76,52 @@ if [[ -d "$APP_PATH/Contents/PlugIns" ]]; then
   done < <(find "$APP_PATH/Contents/PlugIns" -mindepth 1 -maxdepth 1 -print0)
 fi
 
-# 3. Frameworks
-if [[ -d "$APP_PATH/Contents/Frameworks" ]]; then
-  while IFS= read -r -d '' framework; do
-    echo "==> signing framework $(basename "$framework")"
-    /usr/bin/codesign "${COMMON[@]}" --deep "$framework"
-  done < <(find "$APP_PATH/Contents/Frameworks" -mindepth 1 -maxdepth 1 -print0)
+# 3. CEF runtime
+if [[ -d "$FRAMEWORKS_PATH/Chromium Embedded Framework.framework" ]]; then
+  find "$FRAMEWORKS_PATH/Chromium Embedded Framework.framework/Libraries" \
+    -name '*.dylib' \
+    -type f \
+    -print0 2>/dev/null |
+    while IFS= read -r -d '' dylib_path; do
+      echo "==> signing CEF dylib $(basename "$dylib_path")"
+      /usr/bin/codesign "${COMMON[@]}" --entitlements "$HELPER_ENTITLEMENTS" "$dylib_path"
+    done
+
+  echo "==> signing CEF framework"
+  /usr/bin/codesign "${COMMON[@]}" --entitlements "$HELPER_ENTITLEMENTS" "$FRAMEWORKS_PATH/Chromium Embedded Framework.framework"
+
+  find "$FRAMEWORKS_PATH" \
+    -mindepth 1 \
+    -maxdepth 1 \
+    -name 'cmux Helper*.app' \
+    -type d \
+    -print0 |
+    while IFS= read -r -d '' helper_app; do
+      helper_name="$(basename "$helper_app" .app)"
+      helper_executable="$helper_app/Contents/MacOS/$helper_name"
+      if [[ -x "$helper_executable" ]]; then
+        echo "==> signing CEF helper executable $helper_name"
+        /usr/bin/codesign "${COMMON[@]}" --entitlements "$HELPER_ENTITLEMENTS" "$helper_executable"
+      fi
+      echo "==> signing CEF helper app $helper_name"
+      /usr/bin/codesign "${COMMON[@]}" --entitlements "$HELPER_ENTITLEMENTS" "$helper_app"
+    done
 fi
 
-# 4. Main app bundle (no --deep).
+# 4. Frameworks
+if [[ -d "$FRAMEWORKS_PATH" ]]; then
+  while IFS= read -r -d '' framework; do
+    case "$(basename "$framework")" in
+      "Chromium Embedded Framework.framework"|cmux\ Helper*.app)
+        continue
+        ;;
+    esac
+    echo "==> signing framework $(basename "$framework")"
+    /usr/bin/codesign "${COMMON[@]}" --deep "$framework"
+  done < <(find "$FRAMEWORKS_PATH" -mindepth 1 -maxdepth 1 -print0)
+fi
+
+# 5. Main app bundle (no --deep).
 echo "==> signing main bundle"
 /usr/bin/codesign "${COMMON[@]}" --entitlements "$APP_ENTITLEMENTS" "$APP_PATH"
 
@@ -114,5 +153,15 @@ for helper in "$APP_PATH/Contents/Resources/bin"/*; do
     exit 1
   fi
 done
+while IFS= read -r -d '' helper_app; do
+  helper_name="$(basename "$helper_app" .app)"
+  helper_executable="$helper_app/Contents/MacOS/$helper_name"
+  [[ -f "$helper_executable" && -x "$helper_executable" ]] || continue
+  if /usr/bin/codesign -d --entitlements :- "$helper_executable" 2>&1 \
+       | grep -q "application-identifier"; then
+    echo "error: CEF helper $helper_name unexpectedly carries application-identifier" >&2
+    exit 1
+  fi
+done < <(find "$FRAMEWORKS_PATH" -maxdepth 1 -type d -name "cmux Helper*.app" -print0 2>/dev/null || true)
 
 echo "==> signing OK: $APP_PATH"

--- a/scripts/vendor-cef.sh
+++ b/scripts/vendor-cef.sh
@@ -1,0 +1,294 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CEF_VERSION="${CMUX_CEF_VERSION:-147.0.10+gd58e84d}"
+CHROMIUM_VERSION="${CMUX_CHROMIUM_VERSION:-147.0.7727.118}"
+CMAKE_BIN="${CMAKE_BIN:-cmake}"
+VENDOR_DIR="${CMUX_CEF_VENDOR_DIR:-$REPO_ROOT/Vendor}"
+LINK_ROOT="${CMUX_CEF_LINK_ROOT:-$VENDOR_DIR/cef-active}"
+REQUESTED_ARCHS="${CMUX_CEF_ARCHS:-${ARCHS:-$(uname -m)}}"
+
+usage() {
+  cat >&2 <<'EOF'
+usage: scripts/vendor-cef.sh [--archs "arm64 x86_64"] [--link-root <path>]
+
+Downloads the pinned CEF binary distribution, builds libcef_dll_wrapper and the
+cmux CEF helper executable, and points Vendor/cef-active at the selected root.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --archs)
+      REQUESTED_ARCHS="${2:-}"
+      shift 2
+      ;;
+    --link-root)
+      LINK_ROOT="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+normalize_arch() {
+  case "$1" in
+    arm64|aarch64)
+      printf 'arm64\n'
+      ;;
+    x86_64|x64|amd64)
+      printf 'x86_64\n'
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+selected_arches() {
+  local raw=" $REQUESTED_ARCHS "
+  local has_arm64=0
+  local has_x86_64=0
+  case "$raw" in
+    *" arm64 "*|*" aarch64 "*) has_arm64=1 ;;
+  esac
+  case "$raw" in
+    *" x86_64 "*|*" x64 "*|*" amd64 "*) has_x86_64=1 ;;
+  esac
+  if [[ "$has_arm64" -eq 1 ]]; then
+    printf 'arm64\n'
+  fi
+  if [[ "$has_x86_64" -eq 1 ]]; then
+    printf 'x86_64\n'
+  fi
+  if [[ "$has_arm64" -eq 0 && "$has_x86_64" -eq 0 ]]; then
+    normalize_arch "$(uname -m)"
+  fi
+}
+
+cef_archive_arch() {
+  case "$1" in
+    arm64) printf 'macosarm64\n' ;;
+    x86_64) printf 'macosx64\n' ;;
+  esac
+}
+
+cmake_project_arch() {
+  case "$1" in
+    arm64) printf 'arm64\n' ;;
+    x86_64) printf 'x86_64\n' ;;
+  esac
+}
+
+cef_root_for_arch() {
+  printf '%s/cef-%s\n' "$VENDOR_DIR" "$1"
+}
+
+expected_version_for_arch() {
+  printf '%s+chromium-%s+%s\n' "$CEF_VERSION" "$CHROMIUM_VERSION" "$1"
+}
+
+ensure_cmake() {
+  if command -v "$CMAKE_BIN" >/dev/null 2>&1; then
+    return
+  fi
+
+  local vendored="$VENDOR_DIR/cmake/CMake.app/Contents/bin/cmake"
+  if [[ -x "$vendored" ]]; then
+    CMAKE_BIN="$vendored"
+    return
+  fi
+
+  local version="3.30.2"
+  local temp="$VENDOR_DIR/cmake-temp.tar.gz"
+  mkdir -p "$VENDOR_DIR"
+  curl -L "https://github.com/Kitware/CMake/releases/download/v${version}/cmake-${version}-macos-universal.tar.gz" -o "$temp"
+  rm -rf "$VENDOR_DIR/cmake" "$VENDOR_DIR/cmake-${version}-macos-universal"
+  tar -xzf "$temp" -C "$VENDOR_DIR"
+  mv "$VENDOR_DIR/cmake-${version}-macos-universal" "$VENDOR_DIR/cmake"
+  rm -f "$temp"
+  CMAKE_BIN="$vendored"
+}
+
+download_cef_arch() {
+  local arch="$1"
+  local cef_arch
+  cef_arch="$(cef_archive_arch "$arch")"
+  local root
+  root="$(cef_root_for_arch "$arch")"
+  local expected
+  expected="$(expected_version_for_arch "$arch")"
+  if [[ -d "$root" && -f "$root/.cef-version" && "$(cat "$root/.cef-version")" == "$expected" ]]; then
+    return
+  fi
+
+  rm -rf "$root"
+  mkdir -p "$(dirname "$root")" "$root"
+  local temp="$VENDOR_DIR/cef-${arch}-temp.tar.bz2"
+  local url="https://cef-builds.spotifycdn.com/cef_binary_${CEF_VERSION}+chromium-${CHROMIUM_VERSION}_${cef_arch}_minimal.tar.bz2"
+  curl -L "$url" -o "$temp"
+  local size
+  size="$(stat -f%z "$temp")"
+  if [[ "$size" -lt 50000000 ]]; then
+    rm -f "$temp"
+    echo "error: CEF download was unexpectedly small: $size bytes" >&2
+    exit 1
+  fi
+  tar -xjf "$temp" --strip-components=1 -C "$root"
+  rm -f "$temp"
+  echo "$expected" > "$root/.cef-version"
+}
+
+build_cef_arch() {
+  local arch="$1"
+  local root
+  root="$(cef_root_for_arch "$arch")"
+  local cmake_arch
+  cmake_arch="$(cmake_project_arch "$arch")"
+  ensure_cmake
+
+  if [[ ! -f "$root/build/libcef_dll_wrapper/libcef_dll_wrapper.a" ]]; then
+    rm -rf "$root/build"
+    mkdir -p "$root/build"
+    (
+      cd "$root/build"
+      "$CMAKE_BIN" -DPROJECT_ARCH="$cmake_arch" -DCMAKE_BUILD_TYPE=Release .. >&2
+      make -j"$(sysctl -n hw.ncpu)" libcef_dll_wrapper >&2
+    )
+  fi
+  lipo -archs "$root/Release/Chromium Embedded Framework.framework/Chromium Embedded Framework" | grep -Fx "$arch" >&2
+
+  local helper="$root/build/cmux-cef-helper"
+  if [[ -x "$helper" ]] && lipo -archs "$helper" | grep -Fx "$arch" >&2; then
+    return
+  fi
+
+  xcrun --sdk macosx clang++ \
+    -arch "$arch" \
+    -mmacosx-version-min=14.0 \
+    -std=c++20 \
+    -ObjC++ \
+    -fobjc-arc \
+    -I"$root" \
+    -c "$REPO_ROOT/Sources/CEF/CMUXCEFProcessHelper.cc" \
+    -o "$root/build/CMUXCEFProcessHelper.o"
+
+  xcrun --sdk macosx clang++ \
+    -arch "$arch" \
+    -mmacosx-version-min=14.0 \
+    -std=c++20 \
+    "$root/build/CMUXCEFProcessHelper.o" \
+    -o "$helper" \
+    -framework Cocoa \
+    -F"$root/Release" \
+    -framework "Chromium Embedded Framework" \
+    -L"$root/build/libcef_dll_wrapper" \
+    -lcef_dll_wrapper \
+    -stdlib=libc++
+
+  install_name_tool \
+    -change "@executable_path/../Frameworks/Chromium Embedded Framework.framework/Chromium Embedded Framework" \
+    "@executable_path/../../../../Frameworks/Chromium Embedded Framework.framework/Chromium Embedded Framework" \
+    "$helper"
+  lipo -archs "$helper" | grep -Fx "$arch" >&2
+}
+
+file_has_macho_arch() {
+  local file_path="$1"
+  local arch="$2"
+  lipo -archs "$file_path" 2>/dev/null | grep -Fx "$arch" >/dev/null
+}
+
+lipo_matching_macho_files() {
+  local arm_root="$1"
+  local x86_root="$2"
+  local out_root="$3"
+  local rel
+  (
+    cd "$arm_root"
+    find . -type f -print0
+  ) | while IFS= read -r -d '' rel; do
+    rel="${rel#./}"
+    local arm_file="$arm_root/$rel"
+    local x86_file="$x86_root/$rel"
+    local out_file="$out_root/$rel"
+    [[ -f "$x86_file" ]] || continue
+    if file_has_macho_arch "$arm_file" arm64 && file_has_macho_arch "$x86_file" x86_64; then
+      lipo -create "$arm_file" "$x86_file" -output "$out_file"
+    fi
+  done
+}
+
+build_universal_root() {
+  local arm_root
+  arm_root="$(cef_root_for_arch arm64)"
+  local x86_root
+  x86_root="$(cef_root_for_arch x86_64)"
+  local universal_root="$VENDOR_DIR/cef-universal"
+  local expected="$CEF_VERSION+chromium-$CHROMIUM_VERSION+universal"
+
+  if [[ -d "$universal_root" && -f "$universal_root/.cef-version" && "$(cat "$universal_root/.cef-version")" == "$expected" ]] \
+    && file_has_macho_arch "$universal_root/Release/Chromium Embedded Framework.framework/Chromium Embedded Framework" arm64 \
+    && file_has_macho_arch "$universal_root/Release/Chromium Embedded Framework.framework/Chromium Embedded Framework" x86_64 \
+    && file_has_macho_arch "$universal_root/build/cmux-cef-helper" arm64 \
+    && file_has_macho_arch "$universal_root/build/cmux-cef-helper" x86_64; then
+    printf '%s\n' "$universal_root"
+    return
+  fi
+
+  rm -rf "$universal_root"
+  mkdir -p "$universal_root"
+  rsync -a --delete "$arm_root/" "$universal_root/"
+  lipo_matching_macho_files \
+    "$arm_root/Release/Chromium Embedded Framework.framework" \
+    "$x86_root/Release/Chromium Embedded Framework.framework" \
+    "$universal_root/Release/Chromium Embedded Framework.framework"
+
+  mkdir -p "$universal_root/build/libcef_dll_wrapper"
+  lipo -create \
+    "$arm_root/build/libcef_dll_wrapper/libcef_dll_wrapper.a" \
+    "$x86_root/build/libcef_dll_wrapper/libcef_dll_wrapper.a" \
+    -output "$universal_root/build/libcef_dll_wrapper/libcef_dll_wrapper.a"
+  lipo -create \
+    "$arm_root/build/cmux-cef-helper" \
+    "$x86_root/build/cmux-cef-helper" \
+    -output "$universal_root/build/cmux-cef-helper"
+  chmod +x "$universal_root/build/cmux-cef-helper"
+  echo "$expected" > "$universal_root/.cef-version"
+  printf '%s\n' "$universal_root"
+}
+
+ARCHES=()
+while IFS= read -r arch; do
+  [[ -n "$arch" ]] && ARCHES+=("$arch")
+done < <(selected_arches)
+if [[ "${#ARCHES[@]}" -eq 0 ]]; then
+  echo "error: no supported CEF architecture found in: $REQUESTED_ARCHS" >&2
+  exit 1
+fi
+
+for arch in "${ARCHES[@]}"; do
+  download_cef_arch "$arch"
+  build_cef_arch "$arch"
+done
+
+if [[ "${#ARCHES[@]}" -gt 1 ]]; then
+  CEF_ROOT="$(build_universal_root)"
+else
+  CEF_ROOT="$(cef_root_for_arch "${ARCHES[0]}")"
+fi
+
+mkdir -p "$(dirname "$LINK_ROOT")"
+rm -rf "$LINK_ROOT"
+ln -s "$CEF_ROOT" "$LINK_ROOT"
+printf '%s\n' "$CEF_ROOT"


### PR DESCRIPTION
## Summary
- add pinned CEF vendoring and runtime packaging for cmux builds
- add a native Objective-C++ CEF bridge with helper app bundles and lifecycle flush/shutdown hooks
- add Debug > Debug Windows > CEF Browser Debug... as the first CEF verification surface

## Verification
- bash -n scripts/vendor-cef.sh scripts/copy-cef-runtime.sh scripts/sign-cmux-bundle.sh
- plutil -lint cmux.xcodeproj/project.pbxproj Resources/Info.plist cmux-helper.entitlements
- python3 -m json.tool Resources/Localizable.xcstrings >/dev/null
- git diff --cached --check
- ./scripts/reload.sh --tag cef
- codesign --verify --deep --strict --verbose=2 "/Users/lawrence/Library/Developer/Xcode/DerivedData/cmux-cef/Build/Products/Debug/cmux DEV cef.app"

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4872"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782466742&installation_id=133855650&pr_number=4872&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4872&signature=eae68465734ba884796c12cf8ecb8fd38ae7b6fd8a975882f2fc2bc61398bf1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large new native runtime (subprocesses, codesigning, app principal class, async quit) affects app lifecycle and packaging; production browser panels still use WebKit, but mistakes in init/shutdown or signing can break launches or quit.
> 
> **Overview**
> Integrates **Chromium Embedded Framework (CEF)** as a new macOS browser runtime: vendoring/packaging scripts, Xcode build phases, C++20/weak-linked framework wiring, and ignored `Vendor/cef-*` artifacts.
> 
> Adds an Objective-C++ **`CMUXCEFBridge`** with `CMUXCEFApplication` as `NSPrincipalClass`, external message-pump scheduling, `CMUXCEFBrowserView`, helper subprocess entrypoint, cookie flush on quit, and `CMUXCEFShutdown` during teardown.
> 
> **Quit flow** now returns `.terminateLater` while `CMUXCEFFlushBrowserState` runs when CEF was initialized.
> 
> First verification surface: **Debug → CEF Browser Debug…** (SwiftUI window, localized fallback if runtime missing) plus `debug.cef_browser.open` on the terminal socket API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08c639355acb437db25dda1ffa53bc0c46a6c41a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Chromium Embedded Framework (CEF) runtime with a native Objective‑C++ bridge, lazy init, a “CEF Browser Debug…” window, an external message pump, and clean quit with cookie flush and shutdown. Removes an unused profile context path; cookie flush now uses the global context.

- **New Features**
  - Objective‑C++ bridge `CMUXCEFBridge` with prepare/isAvailable/isInitialized/init/flush/shutdown APIs and an `NSView` browser (`CMUXCEFBrowserView`); external timer/pump keeps the CEF loop responsive.
  - App lifecycle: `NSPrincipalClass` set to `CMUXCEFApplication`; prepare at launch, initialize CEF on first use, flush cookies via `CMUXCEFFlushBrowserState` before quit, then `CMUXCEFShutdown`.
  - Debug menu: “Debug > Debug Windows > CEF Browser Debug…” uses a CEF view; localized fallback when runtime is unavailable; registered as an auxiliary window so Cmd‑W works. Remote debugging binds to 127.0.0.1 on an available port 9433–9443 (`CMUXCEFRemoteDebuggingPort()`).
  - Socket API: `debug.cef_browser.open` opens the debug window.
  - Rendering fix: the CEF debug window reliably displays and resizes the browser view.

- **Dependencies**
  - Vendoring/packaging via `scripts/vendor-cef.sh` and `scripts/copy-cef-runtime.sh`; builds `libcef_dll_wrapper` and a helper subprocess (`CMUXCEFProcessHelper.cc`).
  - Xcode: C++20, header/library search paths, weak‑links “Chromium Embedded Framework”, links `-lcef_dll_wrapper`, and adds “Vendor CEF Runtime”/“Copy CEF Runtime” build phases.
  - Codesigning (`scripts/sign-cmux-bundle.sh`): signs CEF framework/dylibs and `cmux Helper*.app` with helper entitlements; ensures helpers have no application‑identifier.

<sup>Written for commit 08c639355acb437db25dda1ffa53bc0c46a6c41a. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4872?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Built-in CEF browser debug window, debug-menu item, and a debug command to open it.

* **Improvements**
  * App quit now waits to flush embedded-browser state for cleaner shutdown.
  * Integrated embedded-browser runtime support with remote debugging.

* **Localization**
  * Added English and Japanese messages for "CEF runtime unavailable" and the debug menu label.

* **Chores**
  * Added tooling, vendoring/signing scripts, and .gitignore entries for the embedded-browser runtime.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4872?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->