### PR TITLE
Narrow AppDelegate CI quarantine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,7 +281,7 @@ jobs:
               -disableAutomaticPackageResolution \
               -destination "platform=macOS" \
               CMUX_SKIP_ZIG_BUILD=1 \
-              -skip-testing:cmuxTests/AppDelegateShortcutRoutingTests \
+              -skip-testing:cmuxTests/AppDelegateShortcutRoutingTests/testCmdWClosesWindowWhenClosingLastSurfaceInLastWorkspace \
               -skip-testing:cmuxTests/BrowserDeveloperToolsConfigurationTests \
               -skip-testing:cmuxTests/BrowserDeveloperToolsVisibilityPersistenceTests \
               -skip-testing:cmuxTests/BrowserPanelRemoteStoreTests \


### PR DESCRIPTION
Fixes part of https://github.com/manaflow-ai/cmux/issues/4524.

This restores the rest of `cmuxTests/AppDelegateShortcutRoutingTests` to the main CI unit-test job by replacing the class-level skip with the one known headless hang tracked at https://github.com/manaflow-ai/cmux/issues/1803.

Coverage remains active for the other AppDelegate shortcut routing tests. The known hanging method stays quarantined in both CI workflows until https://github.com/manaflow-ai/cmux/issues/1803 is fixed.

Verification:
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "ci.yml parsed"'`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4874"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782469217&installation_id=133855650&pr_number=4874&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4874&signature=714dd9616da9294f11f5a654d7995c1438b2a9afcbd902f64bfb28b518bb82c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that restores most AppDelegate shortcut tests in CI while keeping one known-flaky test skipped.
> 
> **Overview**
> Narrows CI quarantine for **AppDelegate** shortcut routing tests in `.github/workflows/ci.yml`.
> 
> The unit-test job no longer skips the entire `cmuxTests/AppDelegateShortcutRoutingTests` class. It now skips only **`testCmdWClosesWindowWhenClosingLastSurfaceInLastWorkspace`**, the method known to hang on headless macOS runners (issue #1803). Other tests in that class run again in the main `cmux-unit` job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e2ff3476e832793ab3a59f5e5cb73a83821be99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Narrows the CI quarantine to a single known-hanging test, restoring the rest of `cmuxTests/AppDelegateShortcutRoutingTests` to the main unit-test job. Addresses #4524 and keeps `testCmdWClosesWindowWhenClosingLastSurfaceInLastWorkspace` skipped until #1803 is fixed.

<sup>Written for commit 8e2ff3476e832793ab3a59f5e5cb73a83821be99. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4874?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated CI test configuration to refine which tests are executed during unit-test runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4874?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->