### PR TITLE
Restore browser devtools config CI coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,7 +282,6 @@ jobs:
               -destination "platform=macOS" \
               CMUX_SKIP_ZIG_BUILD=1 \
               -skip-testing:cmuxTests/AppDelegateShortcutRoutingTests/testCmdWClosesWindowWhenClosingLastSurfaceInLastWorkspace \
-              -skip-testing:cmuxTests/BrowserDeveloperToolsConfigurationTests \
               -skip-testing:cmuxTests/BrowserDeveloperToolsVisibilityPersistenceTests \
               -skip-testing:cmuxTests/BrowserPanelRemoteStoreTests \
               -skip-testing:cmuxTests/BrowserPanelWebViewLifecycleTests \


### PR DESCRIPTION
## Summary

Restores `cmuxTests/BrowserDeveloperToolsConfigurationTests` to the required macOS unit-test job by removing the broad class-level skip from `.github/workflows/ci.yml`.

This continues the quarantine reduction tracked by https://github.com/manaflow-ai/cmux/issues/4524.

## Verification

- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "ci.yml parsed"'`\n- Hosted PR checks will exercise the restored class.\n

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4876"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782475034&installation_id=133855650&pr_number=4876&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4876&signature=eb6fe992e7b3cf2bfbbaf60f73ffb11e28ff0943c2a50b9cce42935b1b0b114a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-enables cmuxTests/BrowserDeveloperToolsConfigurationTests in the required macOS unit-test CI by removing the skip entry from .github/workflows/ci.yml. Continues the test quarantine reduction tracked in #4524.

<sup>Written for commit 553e8f91212a2a193eaac2ce8899595fa2e76366. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4876?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change; main risk is longer or flakier macOS unit runs if the class was skipped for stability reasons.
> 
> **Overview**
> Re-enables **`BrowserDeveloperToolsConfigurationTests`** on the WarpBuild macOS **Run unit tests** job by dropping the class-wide `-skip-testing:cmuxTests/BrowserDeveloperToolsConfigurationTests` flag from `.github/workflows/ci.yml`.
> 
> That continues shrinking the XCTest quarantine list (issue #4524): devtools **configuration** coverage runs again in CI, while related suites such as **`BrowserDeveloperToolsVisibilityPersistenceTests`** stay skipped for flaky app-host/WebKit behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 553e8f91212a2a193eaac2ce8899595fa2e76366. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->