### PR TITLE
Restore browser remote store CI coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,7 +283,6 @@ jobs:
               CMUX_SKIP_ZIG_BUILD=1 \
               -skip-testing:cmuxTests/AppDelegateShortcutRoutingTests/testCmdWClosesWindowWhenClosingLastSurfaceInLastWorkspace \
               -skip-testing:cmuxTests/BrowserDeveloperToolsVisibilityPersistenceTests \
-              -skip-testing:cmuxTests/BrowserPanelRemoteStoreTests \
               -skip-testing:cmuxTests/BrowserPanelWebViewLifecycleTests \
               -skip-testing:cmuxTests/BrowserSessionHistoryRestoreTests \
               -skip-testing:cmuxTests/CLINotifyProcessIntegrationRegressionTests/testNotificationCLIActionsMutateSocketStateAndListExtendedFields \


### PR DESCRIPTION
## Summary

Restores `cmuxTests/BrowserPanelRemoteStoreTests` to the required macOS unit-test job by removing the broad class-level skip from `.github/workflows/ci.yml`.

This continues the quarantine reduction tracked by https://github.com/manaflow-ai/cmux/issues/4524.

## Verification

- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "ci.yml parsed"'`\n- Hosted PR checks will exercise the restored class.\n

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4878"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782478243&installation_id=133855650&pr_number=4878&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4878&signature=33e317619a4ecd0a799504e8f716957727253f3e890f6edbf5c149ed6bccb8ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore `cmuxTests/BrowserPanelRemoteStoreTests` in the macOS unit-test CI by removing its skip in `.github/workflows/ci.yml`. This re-enables browser remote store coverage and continues the quarantine reduction tracked in #4524.

<sup>Written for commit 44dc2044635baa1309b4be44e8814c1b8d4fcfa6. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4878?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated CI testing configuration for macOS unit test execution.

*Note: This is an internal testing infrastructure change with no end-user visible impact.*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4878?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change; may surface flaky or failing remote-store tests on CI but does not alter app code.
> 
> **Overview**
> Re-enables **`cmuxTests/BrowserPanelRemoteStoreTests`** on the macOS unit-test job by removing its class-level `-skip-testing` entry from **`.github/workflows/ci.yml`**, so those tests run again with the rest of the quarantined suite reduction (issue #4524).
> 
> No product or test source changes—only CI wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44dc2044635baa1309b4be44e8814c1b8d4fcfa6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->