### PR TITLE
Fix browser pane tab drag routing

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -9348,6 +9348,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         guard env["CMUX_UI_TEST_BONSPLIT_TAB_DRAG_SETUP"] == "1" else { return }
         guard tabManager != nil else { return }
         let startWithHiddenSidebar = env["CMUX_UI_TEST_BONSPLIT_START_WITH_HIDDEN_SIDEBAR"] == "1"
+        let startWithTopBottomSplit = env["CMUX_UI_TEST_BONSPLIT_START_WITH_TOP_BOTTOM_SPLIT"] == "1"
+        let useBrowserPanels = env["CMUX_UI_TEST_BONSPLIT_USE_BROWSER_PANELS"] == "1"
         let showRightSidebar = env["CMUX_UI_TEST_BONSPLIT_SHOW_RIGHT_SIDEBAR"] == "1"
 
         let deadline = Date().addingTimeInterval(20.0)
@@ -9405,7 +9407,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             }
             let tabManager = context.tabManager
             guard let workspace = tabManager.selectedWorkspace ?? tabManager.tabs.first,
-                  let alphaPanelId = workspace.focusedPanelId else {
+                  let initialPanelId = workspace.focusedPanelId else {
                 self.writeBonsplitTabDragUITestData(["setupError": "Missing initial workspace or panel"])
                 return
             }
@@ -9413,16 +9415,80 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             let workspaceTitle = "UITest Workspace"
             let alphaTitle = "UITest Alpha"
             let betaTitle = "UITest Beta"
+            let gammaTitle = "UITest Gamma"
             tabManager.setCustomTitle(tabId: workspace.id, title: workspaceTitle)
-            workspace.setPanelCustomTitle(panelId: alphaPanelId, title: alphaTitle)
-            tabManager.newSurface()
+            let alphaPanelId: UUID
+            let betaPanelId: UUID
+            if useBrowserPanels {
+                guard let initialPaneId = workspace.paneId(forPanelId: initialPanelId),
+                      let alphaBrowser = workspace.newBrowserSurface(
+                        inPane: initialPaneId,
+                        url: URL(string: "about:blank"),
+                        focus: true,
+                        insertAtEnd: true
+                      ) else {
+                    self.writeBonsplitTabDragUITestData(["setupError": "Failed to create browser alpha surface"])
+                    return
+                }
+                alphaPanelId = alphaBrowser.id
+                workspace.setPanelCustomTitle(panelId: alphaPanelId, title: alphaTitle)
+                _ = workspace.closePanel(initialPanelId, force: true)
 
-            guard let betaPanelId = workspace.focusedPanelId, betaPanelId != alphaPanelId else {
-                self.writeBonsplitTabDragUITestData(["setupError": "Failed to create second surface"])
-                return
+                guard let topPaneId = workspace.paneId(forPanelId: alphaPanelId),
+                      let betaBrowser = workspace.newBrowserSurface(
+                        inPane: topPaneId,
+                        url: URL(string: "about:blank"),
+                        focus: true,
+                        insertAtEnd: true
+                      ) else {
+                    self.writeBonsplitTabDragUITestData(["setupError": "Failed to create browser beta surface"])
+                    return
+                }
+                betaPanelId = betaBrowser.id
+            } else {
+                alphaPanelId = initialPanelId
+                workspace.setPanelCustomTitle(panelId: alphaPanelId, title: alphaTitle)
+                tabManager.newSurface()
+
+                guard let createdBetaPanelId = workspace.focusedPanelId,
+                      createdBetaPanelId != alphaPanelId else {
+                    self.writeBonsplitTabDragUITestData(["setupError": "Failed to create second surface"])
+                    return
+                }
+                betaPanelId = createdBetaPanelId
             }
 
             workspace.setPanelCustomTitle(panelId: betaPanelId, title: betaTitle)
+            let gammaPanelId: UUID?
+            if startWithTopBottomSplit {
+                if useBrowserPanels {
+                    guard let gammaPanel = workspace.newBrowserSplit(
+                        from: alphaPanelId,
+                        orientation: .vertical,
+                        url: URL(string: "about:blank"),
+                        focus: false
+                    ) else {
+                        self.writeBonsplitTabDragUITestData(["setupError": "Failed to create top-bottom split"])
+                        return
+                    }
+                    workspace.setPanelCustomTitle(panelId: gammaPanel.id, title: gammaTitle)
+                    gammaPanelId = gammaPanel.id
+                } else {
+                    guard let gammaPanel = workspace.newTerminalSplit(
+                        from: alphaPanelId,
+                        orientation: .vertical,
+                        focus: false
+                    ) else {
+                        self.writeBonsplitTabDragUITestData(["setupError": "Failed to create top-bottom split"])
+                        return
+                    }
+                    workspace.setPanelCustomTitle(panelId: gammaPanel.id, title: gammaTitle)
+                    gammaPanelId = gammaPanel.id
+                }
+                workspace.focusPanel(alphaPanelId)
+            } else {
+                gammaPanelId = nil
+            }
             if let rawActionButtonCount = env["CMUX_UI_TEST_BONSPLIT_ACTION_BUTTON_COUNT"],
                let requestedActionButtonCount = Int(rawActionButtonCount),
                requestedActionButtonCount > 0 {
@@ -9473,13 +9539,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 "workspaceTitle": workspaceTitle,
                 "alphaTitle": alphaTitle,
                 "betaTitle": betaTitle,
+                "gammaTitle": gammaTitle,
                 "alphaPanelId": alphaPanelId.uuidString,
                 "betaPanelId": betaPanelId.uuidString,
+                "gammaPanelId": gammaPanelId?.uuidString ?? "",
+                "splitLayout": startWithTopBottomSplit ? "topBottom" : "none",
             ])
             self.startBonsplitTabDragUITestRecorder(
                 workspaceId: workspace.id,
                 alphaPanelId: alphaPanelId,
-                betaPanelId: betaPanelId
+                betaPanelId: betaPanelId,
+                trackedPanePanelId: alphaPanelId,
+                secondaryPanePanelId: gammaPanelId
             )
         }
 
@@ -9502,7 +9573,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private func startBonsplitTabDragUITestRecorder(
         workspaceId: UUID,
         alphaPanelId: UUID,
-        betaPanelId: UUID
+        betaPanelId: UUID,
+        trackedPanePanelId: UUID? = nil,
+        secondaryPanePanelId: UUID? = nil
     ) {
         bonsplitTabDragUITestRecorder?.cancel()
         bonsplitTabDragUITestRecorder = nil
@@ -9513,7 +9586,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             self?.recordBonsplitTabDragUITestState(
                 workspaceId: workspaceId,
                 alphaPanelId: alphaPanelId,
-                betaPanelId: betaPanelId
+                betaPanelId: betaPanelId,
+                trackedPanePanelId: trackedPanePanelId,
+                secondaryPanePanelId: secondaryPanePanelId
             )
         }
         bonsplitTabDragUITestRecorder = timer
@@ -9523,14 +9598,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private func recordBonsplitTabDragUITestState(
         workspaceId: UUID,
         alphaPanelId: UUID,
-        betaPanelId: UUID
+        betaPanelId: UUID,
+        trackedPanePanelId: UUID? = nil,
+        secondaryPanePanelId: UUID? = nil
     ) {
         guard let tabManager else { return }
         guard let workspace = (tabManager.tabs.first { $0.id == workspaceId } ?? tabManager.selectedWorkspace ?? tabManager.tabs.first) else {
             return
         }
 
-        let trackedPaneId = workspace.paneId(forPanelId: alphaPanelId)
+        let trackedPaneId = trackedPanePanelId.flatMap { workspace.paneId(forPanelId: $0) }
+            ?? workspace.paneId(forPanelId: alphaPanelId)
             ?? workspace.paneId(forPanelId: betaPanelId)
             ?? workspace.bonsplitController.focusedPaneId
             ?? workspace.bonsplitController.allPaneIds.first
@@ -9543,12 +9621,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let selectedTitle = workspace.bonsplitController.selectedTab(inPane: trackedPaneId)
             .flatMap { workspace.panelIdFromSurfaceId($0.id) }
             .flatMap { workspace.panelTitle(panelId: $0) } ?? ""
+        let secondaryPaneId = secondaryPanePanelId.flatMap { workspace.paneId(forPanelId: $0) }
+        let secondaryTitles: [String] = secondaryPaneId.map { paneId in
+            workspace.bonsplitController.tabs(inPane: paneId).compactMap { tab in
+                guard let panelId = workspace.panelIdFromSurfaceId(tab.id) else { return nil }
+                return workspace.panelTitle(panelId: panelId)
+            }
+        } ?? []
 
         writeBonsplitTabDragUITestData([
             "trackedPaneId": trackedPaneId.description,
             "trackedPaneTabTitles": titles.joined(separator: "|"),
             "trackedPaneTabCount": String(titles.count),
             "trackedPaneSelectedTitle": selectedTitle,
+            "secondaryPaneId": secondaryPaneId?.description ?? "",
+            "secondaryPaneTabTitles": secondaryTitles.joined(separator: "|"),
+            "secondaryPaneTabCount": String(secondaryTitles.count),
         ])
     }
 

--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -543,13 +543,17 @@ final class WindowBrowserHostView: NSView {
             return nil
         }
         // Mirror terminal portal routing: while tab-reorder drags are active,
-        // pass through to SwiftUI drop targets behind the portal host.
+        // keep native pane drop targets reachable before passing through to
+        // SwiftUI drop targets behind the portal host.
         // Browser hover routing also arrives as cursor/enter events and may not
         // report a pressed-button state, so include that path here.
         if Self.shouldPassThroughToDragTargets(
             pasteboardTypes: dragPasteboardTypes,
             eventType: eventType
         ) {
+            if let paneDropTarget = browserPaneDropTarget(at: point) {
+                return paneDropTarget
+            }
             return nil
         }
 
@@ -725,6 +729,20 @@ final class WindowBrowserHostView: NSView {
             eventType: eventType
         ) else { return false }
         return decision.result
+    }
+
+    private func browserPaneDropTarget(at point: NSPoint) -> BrowserPaneDropTargetView? {
+        for subview in subviews.reversed() {
+            guard let slot = subview as? WindowBrowserSlotView,
+                  !slot.isHidden,
+                  slot.alphaValue > 0,
+                  slot.frame.contains(point) else { continue }
+            let pointInSlot = slot.convert(point, from: self)
+            if let paneDropTarget = slot.paneDropTargetForDrop(at: pointInSlot) {
+                return paneDropTarget
+            }
+        }
+        return nil
     }
 
     private func shouldPassThroughToSidebarResizer(at point: NSPoint) -> Bool {

--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -468,11 +468,19 @@ final class WindowBrowserHostView: NSView {
     }
 
     override func hitTest(_ point: NSPoint) -> NSView? {
+        performHitTest(at: point, currentEvent: NSApp.currentEvent)
+    }
+
+    func performHitTest(
+        at point: NSPoint,
+        currentEvent: NSEvent?,
+        dragPasteboardTypes: [NSPasteboard.PasteboardType]? = NSPasteboard(name: .drag).types
+    ) -> NSView? {
         let dividerHit = splitDividerHit(at: point)
         let hostedInspectorHit = dividerHit == nil ? hostedInspectorDividerHit(at: point) : nil
         updateDividerCursor(at: point, dividerHit: dividerHit, hostedInspectorHit: hostedInspectorHit)
 
-        let eventType = NSApp.currentEvent?.type
+        let eventType = currentEvent?.type
         let titlebarPassThrough = shouldPassThroughToTitlebar(at: point)
         let tabStripPassThrough = shouldPassThroughToPaneTabBar(at: point, eventType: eventType)
         let sidebarPassThrough = shouldPassThroughToSidebarResizer(
@@ -539,8 +547,8 @@ final class WindowBrowserHostView: NSView {
         // Browser hover routing also arrives as cursor/enter events and may not
         // report a pressed-button state, so include that path here.
         if Self.shouldPassThroughToDragTargets(
-            pasteboardTypes: NSPasteboard(name: .drag).types,
-            eventType: NSApp.currentEvent?.type
+            pasteboardTypes: dragPasteboardTypes,
+            eventType: eventType
         ) {
             return nil
         }

--- a/cmuxTests/PortalTabDragRoutingTests.swift
+++ b/cmuxTests/PortalTabDragRoutingTests.swift
@@ -321,6 +321,50 @@ final class PortalTabDragRoutingTests: XCTestCase {
         XCTAssertTrue(BonsplitTabBarPassThrough.isPassThroughPointerEvent(.periodic))
     }
 
+    func testBrowserPortalReturnsPaneDropTargetDuringBonsplitTabDrag() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 420, height: 260),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer {
+            window.orderOut(nil)
+        }
+        guard let contentView = window.contentView else {
+            XCTFail("Expected window content view")
+            return
+        }
+
+        let host = WindowBrowserHostView(frame: contentView.bounds)
+        host.autoresizingMask = [.width, .height]
+        contentView.addSubview(host)
+
+        let slot = WindowBrowserSlotView(frame: host.bounds.insetBy(dx: 32, dy: 40))
+        slot.autoresizingMask = [.width, .height]
+        slot.setPaneDropContext(BrowserPaneDropContext(
+            workspaceId: UUID(),
+            panelId: UUID(),
+            paneId: PaneID(id: UUID())
+        ))
+        host.addSubview(slot)
+        host.layoutSubtreeIfNeeded()
+
+        let pointInSlot = NSPoint(x: slot.bounds.midX, y: slot.bounds.midY)
+        let pointInWindow = slot.convert(pointInSlot, to: nil)
+        let pointInHost = host.convert(pointInWindow, from: nil)
+        let event = makeMouseEvent(type: .leftMouseDragged, at: pointInWindow, window: window)
+
+        XCTAssertTrue(
+            host.performHitTest(
+                at: pointInHost,
+                currentEvent: event,
+                dragPasteboardTypes: [DragOverlayRoutingPolicy.bonsplitTabTransferType]
+            ) is BrowserPaneDropTargetView,
+            "Browser portal-hosted panes must keep their pane drop target reachable during Bonsplit tab drags"
+        )
+    }
+
     func testTerminalPaneDropTargetDefersToUnderlyingTabStrip() {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 420, height: 260),

--- a/cmuxUITests/BonsplitTabDragUITests.swift
+++ b/cmuxUITests/BonsplitTabDragUITests.swift
@@ -65,6 +65,124 @@ final class BonsplitTabDragUITests: XCTestCase {
         XCTAssertEqual(window.frame.origin.y, windowFrameBeforeDrag.origin.y, accuracy: 2.0, "Expected tab drag not to move the window vertically")
     }
 
+    func testMinimalModeTopPaneTabReorderWorksWhenWorkspaceIsSplit() {
+        let (app, dataPath) = launchConfiguredApp(startWithTopBottomSplit: true)
+
+        XCTAssertTrue(
+            ensureForegroundAfterLaunch(app, timeout: launchTimeout),
+            "Expected app to launch for split-workspace top-pane Bonsplit tab drag UI test. state=\(app.state.rawValue)"
+        )
+        XCTAssertTrue(waitForAnyJSON(atPath: dataPath, timeout: setupTimeout), "Expected tab-drag setup data at \(dataPath)")
+        guard let ready = waitForJSONKey("ready", equals: "1", atPath: dataPath, timeout: setupTimeout) else {
+            XCTFail("Timed out waiting for ready=1. data=\(loadJSON(atPath: dataPath) ?? [:])")
+            return
+        }
+
+        if let setupError = ready["setupError"], !setupError.isEmpty {
+            XCTFail("Setup failed: \(setupError)")
+            return
+        }
+
+        XCTAssertEqual(ready["splitLayout"], "topBottom", "Expected split setup for this regression test. data=\(ready)")
+
+        let alphaTitle = ready["alphaTitle"] ?? "UITest Alpha"
+        let betaTitle = ready["betaTitle"] ?? "UITest Beta"
+        let gammaTitle = ready["gammaTitle"] ?? "UITest Gamma"
+        let window = app.windows.element(boundBy: 0)
+        let alphaTab = app.buttons[alphaTitle]
+        let betaTab = app.buttons[betaTitle]
+        let gammaTab = app.buttons[gammaTitle]
+        let initialOrder = "\(alphaTitle)|\(betaTitle)"
+        let reorderedOrder = "\(betaTitle)|\(alphaTitle)"
+
+        XCTAssertTrue(window.waitForExistence(timeout: 5.0), "Expected main window to exist")
+        XCTAssertTrue(alphaTab.waitForExistence(timeout: 5.0), "Expected alpha tab to exist")
+        XCTAssertTrue(betaTab.waitForExistence(timeout: 5.0), "Expected beta tab to exist")
+        XCTAssertTrue(gammaTab.waitForExistence(timeout: 5.0), "Expected lower-pane gamma tab to exist")
+        XCTAssertLessThan(alphaTab.frame.maxY, gammaTab.frame.minY, "Expected alpha/beta to be in the top pane and gamma to be in the lower pane. alpha=\(alphaTab.frame) gamma=\(gammaTab.frame)")
+        XCTAssertTrue(
+            waitForJSONKey("trackedPaneTabTitles", equals: initialOrder, atPath: dataPath, timeout: 5.0) != nil,
+            "Expected initial top-pane tab order to be \(initialOrder). data=\(loadJSON(atPath: dataPath) ?? [:])"
+        )
+        XCTAssertLessThan(alphaTab.frame.minX, betaTab.frame.minX, "Expected beta tab to start to the right of alpha")
+        let windowFrameBeforeDrag = window.frame
+
+        dragTab(betaTab, before: alphaTab)
+
+        XCTAssertTrue(
+            waitForJSONKey("trackedPaneTabTitles", equals: reorderedOrder, atPath: dataPath, timeout: 5.0) != nil,
+            "Expected top-pane tab order to become \(reorderedOrder). data=\(loadJSON(atPath: dataPath) ?? [:])"
+        )
+        XCTAssertTrue(
+            waitForCondition(timeout: 5.0) { betaTab.frame.minX < alphaTab.frame.minX },
+            "Expected dragging beta onto alpha in the top pane to reorder tab frames. alpha=\(alphaTab.frame) beta=\(betaTab.frame)"
+        )
+        XCTAssertEqual(window.frame.origin.x, windowFrameBeforeDrag.origin.x, accuracy: 2.0, "Expected top-pane tab drag not to move the window horizontally")
+        XCTAssertEqual(window.frame.origin.y, windowFrameBeforeDrag.origin.y, accuracy: 2.0, "Expected top-pane tab drag not to move the window vertically")
+    }
+
+    func testMinimalModeTopPaneTabCanMoveToLowerPane() {
+        let (app, dataPath) = launchConfiguredApp(
+            startWithTopBottomSplit: true,
+            useBrowserPanels: true
+        )
+
+        XCTAssertTrue(
+            ensureForegroundAfterLaunch(app, timeout: launchTimeout),
+            "Expected app to launch for split-workspace top-pane tab move UI test. state=\(app.state.rawValue)"
+        )
+        XCTAssertTrue(waitForAnyJSON(atPath: dataPath, timeout: setupTimeout), "Expected tab-drag setup data at \(dataPath)")
+        guard let ready = waitForJSONKey("ready", equals: "1", atPath: dataPath, timeout: setupTimeout) else {
+            XCTFail("Timed out waiting for ready=1. data=\(loadJSON(atPath: dataPath) ?? [:])")
+            return
+        }
+
+        if let setupError = ready["setupError"], !setupError.isEmpty {
+            XCTFail("Setup failed: \(setupError)")
+            return
+        }
+
+        XCTAssertEqual(ready["splitLayout"], "topBottom", "Expected split setup for this regression test. data=\(ready)")
+
+        let alphaTitle = ready["alphaTitle"] ?? "UITest Alpha"
+        let betaTitle = ready["betaTitle"] ?? "UITest Beta"
+        let gammaTitle = ready["gammaTitle"] ?? "UITest Gamma"
+        let window = app.windows.element(boundBy: 0)
+        let alphaTab = app.buttons[alphaTitle]
+        let betaTab = app.buttons[betaTitle]
+        let gammaTab = app.buttons[gammaTitle]
+
+        XCTAssertTrue(window.waitForExistence(timeout: 5.0), "Expected main window to exist")
+        XCTAssertTrue(alphaTab.waitForExistence(timeout: 5.0), "Expected alpha tab to exist")
+        XCTAssertTrue(betaTab.waitForExistence(timeout: 5.0), "Expected beta tab to exist")
+        XCTAssertTrue(gammaTab.waitForExistence(timeout: 5.0), "Expected lower-pane gamma tab to exist")
+        XCTAssertLessThan(alphaTab.frame.maxY, gammaTab.frame.minY, "Expected alpha/beta to be in the top pane and gamma to be in the lower pane. alpha=\(alphaTab.frame) gamma=\(gammaTab.frame)")
+
+        dragTab(
+            betaTab,
+            toWindowPoint: CGPoint(
+                x: gammaTab.frame.midX,
+                y: min(
+                    window.frame.maxY - 90,
+                    gammaTab.frame.maxY + max(120, (window.frame.maxY - gammaTab.frame.maxY) * 0.5)
+                )
+            ),
+            in: window
+        )
+
+        XCTAssertTrue(
+            waitForJSONKey("trackedPaneTabTitles", equals: alphaTitle, atPath: dataPath, timeout: 5.0) != nil,
+            "Expected dragging the top-pane beta tab to remove it from the top pane. data=\(loadJSON(atPath: dataPath) ?? [:])"
+        )
+        XCTAssertTrue(
+            waitForCondition(timeout: 5.0) {
+                guard let titles = loadJSON(atPath: dataPath)?["secondaryPaneTabTitles"] else { return false }
+                return titles.contains(betaTitle) && titles.contains(gammaTitle)
+            },
+            "Expected lower pane to contain the moved beta tab and original gamma tab. data=\(loadJSON(atPath: dataPath) ?? [:])"
+        )
+    }
+
     func testMinimalModePlacesPaneTabBarAtTopEdge() {
         let (app, dataPath) = launchConfiguredApp()
 
@@ -836,11 +954,13 @@ final class BonsplitTabDragUITests: XCTestCase {
 
     private func launchConfiguredApp(
         startWithHiddenSidebar: Bool = false,
+        startWithTopBottomSplit: Bool = false,
         presentationMode: WorkspacePresentationMode = .minimal,
         showRightSidebar: Bool = false,
         alwaysShowShortcutHints: Bool = false,
         windowSize: String? = nil,
-        actionButtonCount: Int? = nil
+        actionButtonCount: Int? = nil,
+        useBrowserPanels: Bool = false
     ) -> (XCUIApplication, String) {
         let app = XCUIApplication()
         let dataPath = "/tmp/cmux-ui-test-bonsplit-tab-drag-\(UUID().uuidString).json"
@@ -851,6 +971,12 @@ final class BonsplitTabDragUITests: XCTestCase {
         app.launchEnvironment["CMUX_UI_TEST_BONSPLIT_TAB_DRAG_PATH"] = dataPath
         if startWithHiddenSidebar {
             app.launchEnvironment["CMUX_UI_TEST_BONSPLIT_START_WITH_HIDDEN_SIDEBAR"] = "1"
+        }
+        if startWithTopBottomSplit {
+            app.launchEnvironment["CMUX_UI_TEST_BONSPLIT_START_WITH_TOP_BOTTOM_SPLIT"] = "1"
+        }
+        if useBrowserPanels {
+            app.launchEnvironment["CMUX_UI_TEST_BONSPLIT_USE_BROWSER_PANELS"] = "1"
         }
         if let windowSize {
             app.launchEnvironment["CMUX_UI_TEST_BONSPLIT_WINDOW_SIZE"] = windowSize
@@ -1016,6 +1142,17 @@ final class BonsplitTabDragUITests: XCTestCase {
     private func dragTab(_ sourceTab: XCUIElement, before targetTab: XCUIElement) {
         let source = sourceTab.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
         let target = targetTab.coordinate(withNormalizedOffset: CGVector(dx: 0.1, dy: 0.5))
+        source.press(forDuration: 0.25, thenDragTo: target)
+    }
+
+    private func dragTab(_ sourceTab: XCUIElement, toWindowPoint point: CGPoint, in window: XCUIElement) {
+        let source = sourceTab.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
+        let target = window.coordinate(withNormalizedOffset: .zero).withOffset(
+            CGVector(
+                dx: point.x - window.frame.minX,
+                dy: point.y - window.frame.minY
+            )
+        )
         source.press(forDuration: 0.25, thenDragTo: target)
     }
 }


### PR DESCRIPTION
Summary:
- Add split-workspace pane-tab drag regressions for the top pane.
- Add Browser portal unit coverage for Bonsplit tab drags reaching pane drop targets.
- Route browser portal tab drags to native pane drop targets before passing through to lower SwiftUI layers.

Testing:
- ./scripts/reload.sh --tag topdrag
- CI: https://github.com/manaflow-ai/cmux/actions/runs/26515797700
- Targeted E2E: https://github.com/manaflow-ai/cmux/actions/runs/26516005929

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4879"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782478328&installation_id=133855650&pr_number=4879&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4879&signature=5aad74027f4b6af020da771ecd42875780052318976d389f63ff92bc1b0a948f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes browser portal hit testing so Bonsplit tab drags in the top pane hit native pane drop targets before SwiftUI. Restores tab reorder and cross-pane moves in split workspaces and prevents window drags.

- **Bug Fixes**
  - Route drags with `DragOverlayRoutingPolicy.bonsplitTabTransferType` to `BrowserPaneDropTargetView` via `WindowBrowserHostView.performHitTest`, scanning visible `WindowBrowserSlotView`s with `browserPaneDropTarget(at:)`, then pass through if none.
  - Parameterize `performHitTest` with `currentEvent` and drag pasteboard types; used by tests.
  - Add unit test asserting the portal returns a pane drop target during Bonsplit tab drags.
  - Add UI tests: top-pane reorder in a top/bottom split, and moving a top-pane tab to the lower pane (using browser panels).
  - Extend UI harness: `CMUX_UI_TEST_BONSPLIT_START_WITH_TOP_BOTTOM_SPLIT=1` and `CMUX_UI_TEST_BONSPLIT_USE_BROWSER_PANELS=1`; recorder now outputs tracked/secondary pane IDs and tab titles/counts.

<sup>Written for commit 99a987e17bfff48cdba429e096ddcfec0287137e. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4879?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pointer routing during drags in split workspaces (browser portal layer); risk is localized but affects tab reorder and cross-pane moves.
> 
> **Overview**
> Fixes **browser portal hit-testing** so **Bonsplit tab drags** still reach **native pane drop targets** instead of only passing through to SwiftUI behind the host.
> 
> `WindowBrowserHostView` now routes through **`performHitTest`** (injectable event and drag pasteboard types). When a tab-reorder drag is active, it resolves a **`BrowserPaneDropTargetView`** via **`browserPaneDropTarget(at:)`** on visible **`WindowBrowserSlotView`** instances before returning `nil` for pass-through.
> 
> **Tests:** a unit test asserts the portal returns a pane drop target during Bonsplit tab drags; UI-test setup gains **top/bottom split** and **browser panel** launch flags plus **secondary-pane** recorder fields; new UI tests cover **top-pane tab reorder** in a split workspace and **moving a tab into the lower pane** with browser panels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99a987e17bfff48cdba429e096ddcfec0287137e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Top/bottom split workspace support for dual-pane layouts.
  * Enhanced tab dragging to move and reorder tabs across split panes.

* **Bug Fixes / Reliability**
  * Improved drag-and-drop targeting so pane drop targets remain reachable during tab drags.

* **Tests**
  * Added UI and unit tests validating tab reordering, cross-pane moves, and drop-target routing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4879?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
