### PR TITLE
Prioritize command palette title phrase matches

### DIFF
--- a/Native/CommandPaletteNucleoFFI/src/lib.rs
+++ b/Native/CommandPaletteNucleoFFI/src/lib.rs
@@ -26,6 +26,7 @@ pub struct CmuxNucleoMatch {
 
 struct Candidate {
     title: String,
+    title_lowercase: String,
     search_text: String,
     search_lines: Vec<String>,
     rank: i32,
@@ -125,6 +126,7 @@ pub unsafe extern "C" fn cmux_nucleo_index_create(
             return std::ptr::null_mut();
         };
         let ascii_prefilter_safe = title.is_ascii() && search_text.is_ascii();
+        let title_lowercase = title.to_lowercase();
         let (title_low, title_high) = ascii_mask(title);
         let (search_low, search_high) = ascii_mask(search_text);
         let title_initials = title_word_initials(title);
@@ -132,6 +134,7 @@ pub unsafe extern "C" fn cmux_nucleo_index_create(
         let search_lines = search_text.lines().map(str::to_owned).collect();
         candidates.push(Candidate {
             title: title.to_owned(),
+            title_lowercase,
             search_text: search_text.to_owned(),
             search_lines,
             rank: span.rank,
@@ -262,6 +265,7 @@ unsafe fn cmux_nucleo_index_search_impl(
     } else {
         let query_mask = ascii_mask_query(&normalized_query);
         let search_tokens = search_tokens(&normalized_query);
+        let normalized_query_lowercase = normalized_query.to_lowercase();
         let mut best_matches = BinaryHeap::with_capacity(output_limit);
 
         SEARCH_STATE.with(|state| {
@@ -277,9 +281,13 @@ unsafe fn cmux_nucleo_index_search_impl(
                     }
                 }
 
-                let Some(score) =
-                    weighted_query_score(&mut state, &normalized_query, &search_tokens, candidate)
-                else {
+                let Some(score) = weighted_query_score(
+                    &mut state,
+                    &normalized_query,
+                    &normalized_query_lowercase,
+                    &search_tokens,
+                    candidate,
+                ) else {
                     continue;
                 };
                 append_scored_candidate(
@@ -373,20 +381,25 @@ fn search_tokens(query: &str) -> Vec<SearchToken> {
 fn weighted_query_score(
     state: &mut SearchState,
     query: &str,
+    query_lowercase: &str,
     tokens: &[SearchToken],
     candidate: &Candidate,
 ) -> Option<f64> {
-    if tokens.len() == 1 {
-        return weighted_token_score(state, &tokens[0], candidate);
-    }
-
-    let mut total_score = 0.0;
-    for token in tokens {
-        total_score += weighted_token_score(state, token, candidate)?;
-    }
+    let mut total_score = if tokens.len() == 1 {
+        weighted_token_score(state, &tokens[0], candidate)?
+    } else {
+        let mut score = 0.0;
+        for token in tokens {
+            score += weighted_token_score(state, token, candidate)?;
+        }
+        score
+    };
 
     if let Some(exact_query_line_score) = exact_search_text_line_score(candidate, query) {
         total_score = total_score.max(exact_query_line_score);
+    }
+    if let Some(title_phrase_score) = title_phrase_score(candidate, query_lowercase, tokens.len()) {
+        total_score = total_score.max(title_phrase_score);
     }
     Some(total_score)
 }
@@ -480,6 +493,59 @@ fn keyword_exact_line_score(query_char_count: usize) -> f64 {
         return 30_000.0 + f64::from(query_char_count as u32) * 10.0;
     }
     1_800.0 + f64::from(query_char_count as u32) * 10.0
+}
+
+fn title_phrase_score(
+    candidate: &Candidate,
+    query_lowercase: &str,
+    query_token_count: usize,
+) -> Option<f64> {
+    if query_lowercase.is_empty() {
+        return None;
+    }
+
+    let title = &candidate.title_lowercase;
+    let Some(start_byte) = title.find(query_lowercase) else {
+        return None;
+    };
+    let end_byte = start_byte + query_lowercase.len();
+    let query_char_count = query_lowercase.chars().count();
+    let query_token_count = query_token_count.max(1);
+
+    if title == query_lowercase {
+        return Some(
+            80_000.0 * query_token_count as f64 + f64::from(query_char_count as u32) * 20.0,
+        );
+    }
+
+    let starts_on_boundary = start_byte == 0
+        || title[..start_byte]
+            .chars()
+            .last()
+            .is_some_and(is_title_word_boundary);
+    let ends_on_boundary = end_byte == title.len()
+        || title[end_byte..]
+            .chars()
+            .next()
+            .is_some_and(is_title_word_boundary);
+    if !starts_on_boundary || !ends_on_boundary {
+        return None;
+    }
+
+    let trailing_penalty = candidate.title_char_count.saturating_sub(query_char_count) as f64 * 6.0;
+    if start_byte == 0 {
+        return Some(
+            70_000.0 * query_token_count as f64 + f64::from(query_char_count as u32) * 20.0
+                - trailing_penalty,
+        );
+    }
+
+    let start_char_count = title[..start_byte].chars().count();
+    Some(
+        60_000.0 * query_token_count as f64 + f64::from(query_char_count as u32) * 20.0
+            - start_char_count as f64 * 30.0
+            - trailing_penalty,
+    )
 }
 
 fn initialism_query(query: &str) -> Option<InitialismQuery> {
@@ -611,6 +677,7 @@ mod tests {
         let (search_low, search_high) = ascii_mask(&search_text);
         Candidate {
             title: title.to_owned(),
+            title_lowercase: title.to_lowercase(),
             search_text: search_text.clone(),
             search_lines: search_text.lines().map(str::to_owned).collect(),
             rank,
@@ -645,7 +712,9 @@ mod tests {
                 query.as_ptr(),
                 query.len(),
                 limit,
-                boosts.map(|values| values.as_ptr()).unwrap_or(std::ptr::null()),
+                boosts
+                    .map(|values| values.as_ptr())
+                    .unwrap_or(std::ptr::null()),
                 boosts.map(|values| values.len()).unwrap_or(0),
                 matches.as_mut_ptr(),
                 matches.len(),

--- a/Native/CommandPaletteNucleoFFI/src/lib.rs
+++ b/Native/CommandPaletteNucleoFFI/src/lib.rs
@@ -599,3 +599,95 @@ fn set_ascii_mask_bit(byte: u8, low: &mut u64, high: &mut u64) {
         *high |= 1_u64 << u64::from(byte - 64);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_candidate(title: &str, search_lines: &[&str], rank: i32) -> Candidate {
+        let search_text = search_lines.join("\n");
+        let ascii_prefilter_safe = title.is_ascii() && search_text.is_ascii();
+        let (title_low, title_high) = ascii_mask(title);
+        let (search_low, search_high) = ascii_mask(&search_text);
+        Candidate {
+            title: title.to_owned(),
+            search_text: search_text.clone(),
+            search_lines: search_text.lines().map(str::to_owned).collect(),
+            rank,
+            ascii_prefilter_safe,
+            ascii_mask_low: title_low | search_low,
+            ascii_mask_high: title_high | search_high,
+            title_initials: title_word_initials(title),
+            title_char_count: title.chars().count(),
+        }
+    }
+
+    fn search_candidate_indices(
+        candidates: Vec<Candidate>,
+        query: &str,
+        limit: usize,
+        boosts: Option<&[i32]>,
+    ) -> Vec<usize> {
+        let mut index = CmuxNucleoIndex { candidates };
+        let mut matches = vec![
+            CmuxNucleoMatch {
+                index: 0,
+                score: 0.0,
+                rank: 0,
+            };
+            limit
+        ];
+        let mut out_count = 0;
+
+        let status = unsafe {
+            cmux_nucleo_index_search_impl(
+                &mut index,
+                query.as_ptr(),
+                query.len(),
+                limit,
+                boosts.map(|values| values.as_ptr()).unwrap_or(std::ptr::null()),
+                boosts.map(|values| values.len()).unwrap_or(0),
+                matches.as_mut_ptr(),
+                matches.len(),
+                &mut out_count,
+            )
+        };
+
+        assert_eq!(status, 0);
+        matches.truncate(out_count);
+        matches.into_iter().map(|result| result.index).collect()
+    }
+
+    #[test]
+    fn title_phrase_prefix_beats_description_phrase_match() {
+        let matches = search_candidate_indices(
+            vec![
+                test_candidate(
+                    "owl browser engine",
+                    &[
+                        "owl browser engine",
+                        "Workspace",
+                        "workspace",
+                        "switch",
+                        "go",
+                        "open",
+                        "Use Owl 2 pieces that are ready: generated Mojo transports, Swift-owned pipe handles, and resize verification gates.",
+                        "owl",
+                        "2",
+                    ],
+                    0,
+                ),
+                test_candidate(
+                    "owl 2 aws",
+                    &["owl 2 aws", "Workspace", "workspace", "switch", "go", "open"],
+                    6,
+                ),
+            ],
+            "owl 2",
+            5,
+            None,
+        );
+
+        assert_eq!(matches.first(), Some(&1));
+    }
+}

--- a/Sources/CommandPalette/CommandPaletteSearch.swift
+++ b/Sources/CommandPalette/CommandPaletteSearch.swift
@@ -135,7 +135,7 @@ enum CommandPaletteSwitcherSearchIndexer {
 }
 
 enum CommandPaletteFuzzyMatcher {
-    private static let tokenBoundaryChars: Set<Character> = [" ", "-", "_", "/", ".", ":"]
+    private static let tokenBoundaryChars: Set<Character> = [" ", "-", "_", "/", "\\", ".", ":"]
 
     struct WordSegment: Hashable, Sendable {
         let start: Int
@@ -397,6 +397,38 @@ enum CommandPaletteFuzzyMatcher {
             }
         }
         return scores
+    }
+
+    static func titlePhraseScore(
+        preparedQuery: PreparedQuery,
+        preparedTitle: PreparedCandidateText
+    ) -> Int? {
+        let queryText = preparedQuery.normalizedText
+        guard !queryText.isEmpty else { return nil }
+
+        let titleText = preparedTitle.normalizedText
+        let titleChars = preparedTitle.characters
+        let queryLength = queryText.count
+        let queryTokenCount = max(1, preparedQuery.tokens.count)
+        guard queryLength <= titleChars.count else { return nil }
+
+        if titleText == queryText {
+            return (80_000 * queryTokenCount) + (queryLength * 20)
+        }
+
+        guard let range = titleText.range(of: queryText) else { return nil }
+        let start = titleText.distance(from: titleText.startIndex, to: range.lowerBound)
+        let end = start + queryLength
+        let startsOnBoundary = start == 0 || tokenBoundaryChars.contains(titleChars[start - 1])
+        let endsOnBoundary = end == titleChars.count || tokenBoundaryChars.contains(titleChars[end])
+        guard startsOnBoundary, endsOnBoundary else { return nil }
+
+        let trailingPenalty = max(0, titleChars.count - queryLength) * 6
+        if start == 0 {
+            return (70_000 * queryTokenCount) + (queryLength * 20) - trailingPenalty
+        }
+
+        return (60_000 * queryTokenCount) + (queryLength * 20) - (start * 30) - trailingPenalty
     }
 
     static func matchCharacterIndices(query: String, candidate: String) -> Set<Int> {
@@ -1397,14 +1429,24 @@ enum CommandPaletteSearchEngine {
         ) else {
             return nil
         }
-        if let preparedTitle = entry.preparedTitle,
-           preparedQuery.tokens.allSatisfy({ $0.couldMatch(preparedTitle) }),
-           let titleScore = CommandPaletteFuzzyMatcher.score(
-                preparedQuery: preparedQuery,
-                preparedCandidate: preparedTitle
-            ) {
-            return max(fuzzyScore, titleScore + titleMatchBonus)
+        var bestScore = fuzzyScore
+        if let preparedTitle = entry.preparedTitle {
+            bestScore = max(
+                bestScore,
+                CommandPaletteFuzzyMatcher.titlePhraseScore(
+                    preparedQuery: preparedQuery,
+                    preparedTitle: preparedTitle
+                ) ?? Int.min
+            )
+
+            if preparedQuery.tokens.allSatisfy({ $0.couldMatch(preparedTitle) }),
+               let titleScore = CommandPaletteFuzzyMatcher.score(
+                   preparedQuery: preparedQuery,
+                   preparedCandidate: preparedTitle
+               ) {
+                bestScore = max(bestScore, titleScore + titleMatchBonus)
+            }
         }
-        return fuzzyScore
+        return bestScore
     }
 }

--- a/cmuxTests/CommandPaletteSearchEngineTests.swift
+++ b/cmuxTests/CommandPaletteSearchEngineTests.swift
@@ -536,6 +536,18 @@ final class CommandPaletteSearchEngineTests: XCTestCase {
         )
     }
 
+    func testTitlePhraseScoreTreatsBackslashAsBoundary() throws {
+        let preparedQuery = CommandPaletteFuzzyMatcher.preparedQuery("project")
+        let preparedTitle = try XCTUnwrap(CommandPaletteFuzzyMatcher.prepareCandidateText("org\\project"))
+
+        XCTAssertNotNil(
+            CommandPaletteFuzzyMatcher.titlePhraseScore(
+                preparedQuery: preparedQuery,
+                preparedTitle: preparedTitle
+            )
+        )
+    }
+
     func testForkableAgentCacheKeepsPanelVisibleWithoutFallbackSnapshot() {
         let workspaceId = UUID()
         let panelId = UUID()

--- a/cmuxTests/CommandPaletteSearchEngineTests.swift
+++ b/cmuxTests/CommandPaletteSearchEngineTests.swift
@@ -504,6 +504,38 @@ final class CommandPaletteSearchEngineTests: XCTestCase {
         XCTAssertEqual(results.map(\.payload).first, "palette.forkAgentConversationRight")
     }
 
+    func testTitlePhrasePrefixBeatsDescriptionExactTokens() {
+        let entries = [
+            FixtureEntry(
+                id: "workspace.owlBrowserEngine",
+                rank: 0,
+                title: "owl browser engine",
+                searchableTexts: [
+                    "owl browser engine",
+                    "Workspace",
+                    "workspace",
+                    "switch",
+                    "go",
+                    "open",
+                    "Use Owl 2 pieces that are ready: generated Mojo transports.",
+                    "owl",
+                    "2",
+                ]
+            ),
+            FixtureEntry(
+                id: "workspace.owl2Aws",
+                rank: 6,
+                title: "owl 2 aws",
+                searchableTexts: ["owl 2 aws", "Workspace", "workspace", "switch", "go", "open"]
+            ),
+        ]
+
+        XCTAssertEqual(
+            optimizedResults(entries: entries, query: "owl 2").first?.id,
+            "workspace.owl2Aws"
+        )
+    }
+
     func testForkableAgentCacheKeepsPanelVisibleWithoutFallbackSnapshot() {
         let workspaceId = UUID()
         let panelId = UUID()


### PR DESCRIPTION
Summary:
- Prioritize phrase matches in command palette titles over exact tokens from descriptions and metadata.
- Apply the same title phrase scoring to the Swift fallback searcher and the Rust Nucleo FFI searcher.
- Add regression coverage for the reported "owl 2" ordering case.

Red test:
- Commit e5d84a750: `cargo test title_phrase_prefix_beats_description_phrase_match -- --nocapture` failed before the fix with `left: Some(0)`, `right: Some(1)`.

Green checks:
- `cargo test -- --nocapture` in `Native/CommandPaletteNucleoFFI` passed.
- `swiftc -typecheck Sources/CommandPalette/CommandPaletteSearch.swift` passed.
- `./scripts/reload.sh --tag owl2ord` passed after rebase.

Dogfood:
- Tag: `owl2ord`
- Check Cmd+P with `owl 2`. Expected top workspace is `owl 2 aws`, not metadata-heavy entries like `chromium readonly design` or `owl browser engine`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4880"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782478721&installation_id=133855650&pr_number=4880&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4880&signature=d40f5f8fab432ba2bfe644f25215f5eb6834498d9c6dd92b13c9b7fd21fe1cda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Search ranking and scoring only; no auth, persistence, or network changes. Risk is limited to Cmd+P result ordering regressions elsewhere.
> 
> **Overview**
> Command palette ranking now **boosts boundary-aligned phrase matches in item titles** (exact title, title prefix, or in-title phrase) so a query like `owl 2` prefers **`owl 2 aws`** over entries that only match `owl` / `2` in descriptions or metadata.
> 
> The same scoring is applied in **`CommandPaletteFuzzyMatcher`** / **`CommandPaletteSearchEngine`** and in **`CommandPaletteNucleoFFI`** (including cached lowercase titles for phrase lookup). **`\\`** is treated as a word boundary in Swift phrase detection. Regression tests cover the **`owl 2`** ordering case and backslash boundaries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49110c878f41dcd91c67eff66321611acbad545f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prioritize phrase matches in command palette titles over description/metadata tokens to improve result ordering, and treat backslash as a boundary in Swift. Fixes the “owl 2” case so “owl 2 aws” ranks first in both Swift and Rust searchers.

- **Bug Fixes**
  - Add title phrase scoring (exact full title, title prefix, boundary-aligned substring) into the overall score using max with fuzzy/line scores.
  - Mirror the logic in the Swift fallback and Rust Nucleo FFI searchers, and cache `title_lowercase` in Rust for cheap phrase lookups.
  - Add regression tests for the “owl 2” ordering and backslash-boundary cases.

<sup>Written for commit 49110c878f41dcd91c67eff66321611acbad545f. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4880?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Ranking now favors exact or boundary-aligned title-phrase matches (including prefix and exact-title boosts), so results whose titles contain the full query rank higher than matches spread across descriptions.
  * Matching normalization lowercases queries/titles once and treats additional characters (e.g., backslash) as token boundaries to improve phrase detection and scoring.

* **Tests**
  * Added a regression test ensuring title-phrase prefix matches outrank description-only matches.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4880?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->