### PR TITLE
Restore file preview review CI coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,7 +288,6 @@ jobs:
               -skip-testing:cmuxTests/CLINotifyProcessIntegrationRegressionTests/testGrokNotificationStillFiresOnRepeatedPromptWhenFeedTelemetryDoesNotReply \
               -skip-testing:cmuxTests/FileExplorerStoreTests/testRemoteWorkspaceRootRequestResolvesSSHHomeInsteadOfKeepingLocalPath \
               -skip-testing:cmuxTests/FilePreviewPanelTextSavingTests \
-              -skip-testing:cmuxTests/FilePreviewReviewFeedbackTests \
               -skip-testing:cmuxTests/GhosttySurfaceOverlayTests \
               test 2>&1 &
             local xcodebuild_pid=$!

--- a/cmuxTests/FilePreviewReviewFeedbackTests.swift
+++ b/cmuxTests/FilePreviewReviewFeedbackTests.swift
@@ -38,6 +38,7 @@ final class FilePreviewReviewFeedbackTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: url) }
 
         let panel = FilePreviewPanel(workspaceId: UUID(), filePath: url.path)
+        defer { panel.close() }
         await panel.loadTextContent().value
 
         let textView = SavingTextView()
@@ -72,6 +73,7 @@ final class FilePreviewReviewFeedbackTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: url) }
 
         let panel = FilePreviewPanel(workspaceId: UUID(), filePath: url.path)
+        defer { panel.close() }
         XCTAssertEqual(panel.previewMode, .quickLook)
 
         let view = panel.nativeViewSessions.quickLook.view(
@@ -102,6 +104,7 @@ final class FilePreviewReviewFeedbackTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: url) }
 
         let panel = FilePreviewPanel(workspaceId: UUID(), filePath: url.path)
+        defer { panel.close() }
         let retiredView = panel.nativeViewSessions.quickLook.view(
             panel: panel,
             isVisibleInUI: true,
@@ -191,6 +194,10 @@ final class FilePreviewReviewFeedbackTests: XCTestCase {
         XCTAssertFalse(coordinator.focus(.textEditor))
 
         let window = NSWindow(contentRect: textView.bounds, styleMask: [], backing: .buffered, defer: false)
+        defer {
+            window.contentView = nil
+            window.close()
+        }
         window.contentView = textView
         coordinator.fulfillPendingFocusIfNeeded()
 
@@ -208,6 +215,7 @@ final class FilePreviewReviewFeedbackTests: XCTestCase {
 
         let manager = TabManager()
         let workspace = manager.addWorkspace(select: true, eagerLoadTerminal: false)
+        defer { workspace.teardownAllPanels() }
         let firstPane = try XCTUnwrap(workspace.bonsplitController.allPaneIds.first)
         let existingPanel = try XCTUnwrap(workspace.newFilePreviewSurface(
             inPane: firstPane,


### PR DESCRIPTION
## Summary

Restores `cmuxTests/FilePreviewReviewFeedbackTests` to the required macOS unit-test job by removing the broad class-level skip from `.github/workflows/ci.yml`.

This continues the quarantine reduction tracked by https://github.com/manaflow-ai/cmux/issues/4524.

## Verification

- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "ci.yml parsed"'`\n- Hosted PR checks will exercise the restored class.\n

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4883"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782484224&installation_id=133855650&pr_number=4883&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4883&signature=ebf1020d38cb8fb0c830643643c06314a74a2c175e42607f9dac9afc4c35c51c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI skip removal and XCTest cleanup only; no app or auth/data-path changes.
> 
> **Overview**
> Re-enables **`FilePreviewReviewFeedbackTests`** on the macOS unit-test job by dropping the class-level **`-skip-testing`** entry from **`.github/workflows/ci.yml`**, continuing quarantine rollback for file-preview review coverage.
> 
> Tests in that class now **tear down UI state** so CI is less flaky: **`defer { panel.close() }`** on **`FilePreviewPanel`** fixtures, window cleanup in the focus-coordinator test, and **`workspace.teardownAllPanels()`** in the file-open pane test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cfc97ff7c57a24af2cb1cdfb51c6c34a846382e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores CI for `cmuxTests/FilePreviewReviewFeedbackTests` by removing its skip in `.github/workflows/ci.yml`, and hardens tests with `defer { panel.close() }`, window cleanup, and `workspace.teardownAllPanels()` to reduce flakiness. Continues the quarantine rollback in #4524.

<sup>Written for commit 2cfc97ff7c57a24af2cb1cdfb51c6c34a846382e. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4883?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI test configuration to change which unit tests are executed in the pipeline, altering the set of tests excluded from the main run.
* **Tests**
  * Improved unit tests to ensure UI and workspace resources are reliably cleaned up after each run, reducing flakiness and preventing lingering state between tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4883?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->