### PR TITLE
Route Claude resume bindings through wrapper

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -23481,7 +23481,17 @@ struct CMUXCLI {
     ) -> [String]? {
         switch kind {
         case "claude":
-            return agentSurfaceResumeWithOption(kind: kind, launchCommand: launchCommand, fallbackExecutable: "claude", option: "--resume", sessionId: sessionId)
+            let stripped = launchCommand.map { record -> AgentHookLaunchCommandRecord in
+                var arguments = record.arguments
+                if !arguments.isEmpty {
+                    arguments[0] = "claude"
+                }
+                var updated = record
+                updated.executablePath = nil
+                updated.arguments = arguments
+                return updated
+            }
+            return agentSurfaceResumeWithOption(kind: kind, launchCommand: stripped, fallbackExecutable: "claude", option: "--resume", sessionId: sessionId)
         case "codex":
             let original = agentSurfaceResumeCommandParts(launchCommand: launchCommand, fallbackExecutable: "codex")
             return AgentLaunchSanitizer.preservedCodexForkArguments(args: original.tail).map {

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -247,6 +247,14 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         XCTAssertNil(environment["ANTHROPIC_BASE_URL"])
         XCTAssertNil(environment["ANTHROPIC_MODEL"])
         XCTAssertNil(environment["CLAUDE_CONFIG_DIR"])
+        XCTAssertEqual(
+            request["command"] as? String,
+            "cd '\(context.root.path)' && 'env' 'ANTHROPIC_BASE_URL=https://api.example.test' 'ANTHROPIC_MODEL=claude-sonnet-test' 'CLAUDE_CONFIG_DIR=\(context.root.path)/claude-config' 'CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV=1' 'CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV_KEYS=ANTHROPIC_BASE_URL,ANTHROPIC_MODEL,CLAUDE_CONFIG_DIR' 'claude' '--resume' '\(sessionId)' '--model' 'sonnet'"
+        )
+        XCTAssertFalse(
+            (request["command"] as? String)?.contains("/usr/local/bin/claude") ?? true,
+            "Claude resume binding must use bare claude so the cmux wrapper injects hooks."
+        )
     }
 
     func testClaudeSessionEndChecksConsumedWorkspaceBeforeClearingVisibleState() throws {


### PR DESCRIPTION
## Summary

Claude hook-published `surface.resume.set` bindings currently replay the captured Claude executable path, e.g. `/opt/homebrew/bin/claude --resume <session>`. That bypasses cmux's `claude` wrapper, so restored sessions do not get wrapper-injected `--settings` hooks and `SessionStart` / `UserPromptSubmit` hooks do not fire.

This PR makes the hook-published Claude resume path match the app restore path: discard the captured executable path and replay bare `claude --resume ...` so shell integration can resolve the cmux wrapper at execution time.

Related: #1984, #2754.

## Changes

- For Claude `surface.resume.set` commands, rewrite the saved launch command copy to `executablePath = nil` and `arguments[0] = "claude"` before building the resume command.
- Add a regression assertion that a captured `/usr/local/bin/claude` launch publishes a bare `claude --resume ...` command and does not leak the absolute executable into the resume binding.

## Testing

- `git diff --check HEAD~2..HEAD`

Unit tests were not run locally per repository guidance that tests run via CI/VM.

## Commit structure

- Commit 1 adds the failing regression test.
- Commit 2 applies the fix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4884"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782489604&installation_id=133855650&pr_number=4884&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4884&signature=aa8e8fa85102ac5b6c6730bd1013edbc7d818c2b927e0e6946e9af8df8c5a7f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `claude` resume bindings to go through the cmux wrapper so settings injection and session hooks run on restored sessions. Strips the captured executable path and replays a bare `claude --resume <session>` command.

- **Bug Fixes**
  - For `surface.resume.set` on `claude`, clear `executablePath` and set argv[0] to `claude` before building the resume command.
  - Add a regression test to assert a bare `claude --resume ...` and prevent leaking absolute paths.

<sup>Written for commit 457a0d020fdd7690911ccb8afe82a8072419796f. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4884?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
- Fixed Claude resume session functionality to properly handle command arguments and preserve authentication selection markers when resuming sessions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4884?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->