### PR TITLE
Restore file preview text saving CI coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,7 +290,6 @@ jobs:
               -skip-testing:cmuxTests/CLINotifyProcessIntegrationRegressionTests/testNotificationCLIActionsMutateSocketStateAndListExtendedFields \
               -skip-testing:cmuxTests/CLINotifyProcessIntegrationRegressionTests/testGrokNotificationStillFiresOnRepeatedPromptWhenFeedTelemetryDoesNotReply \
               -skip-testing:cmuxTests/FileExplorerStoreTests/testRemoteWorkspaceRootRequestResolvesSSHHomeInsteadOfKeepingLocalPath \
-              -skip-testing:cmuxTests/FilePreviewPanelTextSavingTests \
               -skip-testing:cmuxTests/GhosttySurfaceOverlayTests \
               test 2>&1 &
             local xcodebuild_pid=$!

--- a/cmuxTests/WindowAndDragTests.swift
+++ b/cmuxTests/WindowAndDragTests.swift
@@ -2643,7 +2643,7 @@ final class FilePreviewDragPasteboardWriterTests: XCTestCase {
 
 @MainActor
 final class FilePreviewPanelTextSavingTests: XCTestCase {
-    func testNativePreviewSessionsDetachAndReuseViewsAcrossRecreation() throws {
+    func testNativePreviewSessionsDetachAndManageViewsAcrossRecreation() throws {
         let url = try temporaryTextFile(contents: "preview", encoding: .utf8)
         defer { try? FileManager.default.removeItem(at: url) }
 
@@ -2706,12 +2706,15 @@ final class FilePreviewPanelTextSavingTests: XCTestCase {
         ))
         XCTAssertNil(mediaView.superview)
 
-        XCTAssertTrue(quickLookView === sessions.quickLook.view(
+        let remountedQuickLookView = sessions.quickLook.view(
             panel: panel,
             isVisibleInUI: true,
             backgroundColor: NSColor.textBackgroundColor,
             drawsBackground: true
-        ))
+        )
+        XCTAssertFalse(quickLookView === remountedQuickLookView)
+        XCTAssertTrue(quickLookView.superview === host)
+        sessions.quickLook.dismantle(quickLookView)
         XCTAssertNil(quickLookView.superview)
     }
 
@@ -2720,6 +2723,7 @@ final class FilePreviewPanelTextSavingTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: url) }
 
         let panel = FilePreviewPanel(workspaceId: UUID(), filePath: url.path)
+        defer { panel.close() }
         await panel.loadTextContent().value
         let textView = NSTextView()
         textView.string = "edited from text view"
@@ -2740,6 +2744,7 @@ final class FilePreviewPanelTextSavingTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: url) }
 
         let panel = FilePreviewPanel(workspaceId: UUID(), filePath: url.path)
+        defer { panel.close() }
         await panel.loadTextContent().value
         panel.updateTextContent("first save")
 
@@ -2772,6 +2777,7 @@ final class FilePreviewPanelTextSavingTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: url) }
 
         let panel = FilePreviewPanel(workspaceId: UUID(), filePath: url.path)
+        defer { panel.close() }
         await panel.loadTextContent().value
 
         try "loaded after clean save".write(to: url, atomically: true, encoding: .utf8)
@@ -2798,6 +2804,7 @@ final class FilePreviewPanelTextSavingTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: url) }
 
         let panel = FilePreviewPanel(workspaceId: UUID(), filePath: url.path)
+        defer { panel.close() }
         await panel.loadTextContent().value
 
         let textView = SavingTextView()
@@ -2836,6 +2843,7 @@ final class FilePreviewPanelTextSavingTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: url) }
 
         let panel = FilePreviewPanel(workspaceId: UUID(), filePath: url.path)
+        defer { panel.close() }
         await panel.loadTextContent().value
 
         let textView = SavingTextView()
@@ -2865,6 +2873,7 @@ final class FilePreviewPanelTextSavingTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: url) }
 
         let panel = FilePreviewPanel(workspaceId: UUID(), filePath: url.path)
+        defer { panel.close() }
         await panel.loadTextContent().value
         panel.updateTextContent("edited")
         if let task = panel.saveTextContent() {
@@ -2891,6 +2900,7 @@ final class FilePreviewPanelTextSavingTests: XCTestCase {
         )
 
         let panel = FilePreviewPanel(workspaceId: UUID(), filePath: linkURL.path)
+        defer { panel.close() }
         await panel.loadTextContent().value
         panel.updateTextContent("edited through link")
         if let task = panel.saveTextContent() {
@@ -2911,6 +2921,7 @@ final class FilePreviewPanelTextSavingTests: XCTestCase {
         try FileManager.default.setAttributes([.posixPermissions: 0o400], ofItemAtPath: url.path)
 
         let panel = FilePreviewPanel(workspaceId: UUID(), filePath: url.path)
+        defer { panel.close() }
         await panel.loadTextContent().value
         if let task = panel.saveTextContent() {
             await task.value
@@ -2926,6 +2937,7 @@ final class FilePreviewPanelTextSavingTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: url) }
 
         let panel = FilePreviewPanel(workspaceId: UUID(), filePath: url.path)
+        defer { panel.close() }
         await panel.loadTextContent().value
         panel.updateTextContent("edited")
         try FileManager.default.removeItem(at: url)
@@ -2944,6 +2956,7 @@ final class FilePreviewPanelTextSavingTests: XCTestCase {
         textView.textContainer?.lineFragmentPadding = 5
 
         let firstWindow = windowHosting(textView)
+        defer { closeWindow(firstWindow) }
         XCTAssertEqual(textView.textContainerInset.width, FilePreviewTextEditorLayout.textContainerInset.width)
         XCTAssertEqual(textView.textContainerInset.height, FilePreviewTextEditorLayout.textContainerInset.height)
         XCTAssertEqual(textView.textContainer?.lineFragmentPadding, FilePreviewTextEditorLayout.lineFragmentPadding)
@@ -2952,6 +2965,7 @@ final class FilePreviewPanelTextSavingTests: XCTestCase {
         textView.textContainer?.lineFragmentPadding = 5
 
         let secondWindow = windowHosting(textView)
+        defer { closeWindow(secondWindow) }
         XCTAssertEqual(textView.textContainerInset.width, FilePreviewTextEditorLayout.textContainerInset.width)
         XCTAssertEqual(textView.textContainerInset.height, FilePreviewTextEditorLayout.textContainerInset.height)
         XCTAssertEqual(textView.textContainer?.lineFragmentPadding, FilePreviewTextEditorLayout.lineFragmentPadding)
@@ -3012,10 +3026,12 @@ final class FilePreviewPanelTextSavingTests: XCTestCase {
         let url = try temporaryTextFile(contents: "original", encoding: .utf8)
         defer { try? FileManager.default.removeItem(at: url) }
         let panel = FilePreviewPanel(workspaceId: UUID(), filePath: url.path)
+        defer { panel.close() }
         panel.focus()
 
         let textView = SavingTextView()
         let window = windowHosting(textView)
+        defer { closeWindow(window) }
         panel.attachTextView(textView)
 
         XCTAssertTrue(window.firstResponder === textView)
@@ -3052,6 +3068,7 @@ final class FilePreviewPanelTextSavingTests: XCTestCase {
         XCTAssertEqual(FilePreviewKindResolver.mode(for: url), .text)
 
         let panel = FilePreviewPanel(workspaceId: UUID(), filePath: url.path)
+        defer { panel.close() }
         await waitForPanelPreviewMode(panel, .text)
         await waitForPanelTextContent(panel, "extensionless text")
 
@@ -3273,6 +3290,11 @@ final class FilePreviewPanelTextSavingTests: XCTestCase {
             await Task.yield()
         }
         XCTFail("Timed out waiting for file preview text content", file: file, line: line)
+    }
+
+    private func closeWindow(_ window: NSWindow) {
+        window.contentView = nil
+        window.close()
     }
 
     private func windowHosting(_ textView: NSTextView) -> NSWindow {


### PR DESCRIPTION
## Summary

Restores `cmuxTests/FilePreviewPanelTextSavingTests` to the required macOS unit-test job.

Before restoring it, this updates the stale Quick Look assertion to match the current fresh-view lifecycle and adds explicit teardown for file-preview panels and test windows created by the suite.

This continues the quarantine reduction tracked by https://github.com/manaflow-ai/cmux/issues/4524.

## Verification

- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "ci.yml parsed"'`\n- Hosted PR checks will exercise the restored class.\n

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4885"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782491582&installation_id=133855650&pr_number=4885&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4885&signature=1e59c7cec82dd2f018058acad989519da482a0bc1493c70afc7ae793571d4564"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and test-only changes; no production file-preview logic is modified in this diff.
> 
> **Overview**
> **Re-enables** `FilePreviewPanelTextSavingTests` on the macOS unit-test job by removing its `-skip-testing` entry from `.github/workflows/ci.yml`, continuing quarantine reduction for file-preview coverage.
> 
> The suite is brought in line with current behavior and runner stability: the native-preview test now expects Quick Look to return a **new** view on remount (not pointer reuse), explicitly **dismantles** the old Quick Look view, and adds **`defer { panel.close() }`** (plus a `closeWindow` helper for test `NSWindow`s) so panels and windows tear down cleanly after each case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b46ae6e8f5f2151ef572e570f91a814d5e6be02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores `cmuxTests/FilePreviewPanelTextSavingTests` to the macOS CI job by updating Quick Look view assertions and adding explicit teardown for panels and windows. Re-enables coverage and reduces the file preview test quarantine (refs #4524).

- **Bug Fixes**
  - Unskipped `cmuxTests/FilePreviewPanelTextSavingTests` in `.github/workflows/ci.yml`.
  - Updated Quick Look view lifecycle: expect remount, verify host, and call `dismantle`.
  - Added `defer { panel.close() }` and a window `closeWindow` helper to prevent leaks and flakiness.

<sup>Written for commit 6b46ae6e8f5f2151ef572e570f91a814d5e6be02. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4885?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by enhancing cleanup behavior in preview panel lifecycle tests.
  * Updated test coverage to verify proper view remounting and resource management.
  * Adjusted CI workflow test execution to skip updated test cases for more accurate test results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4885?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->