### PR TITLE
Restore AppDelegate Cmd-W CI coverage

### DIFF
--- a/.github/workflows/ci-macos-compat.yml
+++ b/.github/workflows/ci-macos-compat.yml
@@ -122,7 +122,6 @@ jobs:
               -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_DIR" \
               -disableAutomaticPackageResolution \
               -destination "platform=macOS" \
-              -skip-testing:cmuxTests/AppDelegateShortcutRoutingTests/testCmdWClosesWindowWhenClosingLastSurfaceInLastWorkspace \
               test 2>&1
           }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,7 +286,6 @@ jobs:
               -disableAutomaticPackageResolution \
               -destination "platform=macOS" \
               CMUX_SKIP_ZIG_BUILD=1 \
-              -skip-testing:cmuxTests/AppDelegateShortcutRoutingTests/testCmdWClosesWindowWhenClosingLastSurfaceInLastWorkspace \
               -skip-testing:cmuxTests/CLINotifyProcessIntegrationRegressionTests/testNotificationCLIActionsMutateSocketStateAndListExtendedFields \
               -skip-testing:cmuxTests/CLINotifyProcessIntegrationRegressionTests/testGrokNotificationStillFiresOnRepeatedPromptWhenFeedTelemetryDoesNotReply \
               -skip-testing:cmuxTests/FileExplorerStoreTests/testRemoteWorkspaceRootRequestResolvesSSHHomeInsteadOfKeepingLocalPath \

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -1864,10 +1864,6 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         )
     }
 
-    // NOTE: This test is skipped in CI via -skip-testing in ci.yml because closing
-    // the last Ghostty surface tears down the PTY/shell, which blocks indefinitely
-    // on headless runners. The xcodebuild test host doesn't inherit CI env vars,
-    // so XCTSkip can't detect CI from inside the test.
     func testCmdWClosesWindowWhenClosingLastSurfaceInLastWorkspace() {
         guard let appDelegate = AppDelegate.shared else {
             XCTFail("Expected AppDelegate.shared")
@@ -1876,18 +1872,37 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
 
         // Auto-confirm window close to avoid a modal dialog that blocks the RunLoop.
         appDelegate.debugCloseMainWindowConfirmationHandler = { _ in true }
+        defer { appDelegate.debugCloseMainWindowConfirmationHandler = nil }
 
-        let windowId = appDelegate.createMainWindow()
-        defer { closeWindow(withId: windowId) }
+        let defaults = UserDefaults.standard
+        let originalSetting = defaults.object(forKey: appDelegateLastSurfaceCloseShortcutDefaultsKey)
+        defaults.set(true, forKey: appDelegateLastSurfaceCloseShortcutDefaultsKey)
+        defer {
+            restoreDefaultsValue(originalSetting, forKey: appDelegateLastSurfaceCloseShortcutDefaultsKey, defaults: defaults)
+        }
 
-        guard let targetWindow = window(withId: windowId),
-              let manager = appDelegate.tabManagerFor(windowId: windowId) else {
-            XCTFail("Expected test window and manager")
+        let windowId = UUID()
+        let manager = TabManager(autoWelcomeIfNeeded: false)
+        let targetWindow = makeRegisteredShortcutRoutingWindow(id: windowId)
+        appDelegate.registerMainWindow(
+            targetWindow,
+            windowId: windowId,
+            tabManager: manager,
+            sidebarState: SidebarState(),
+            sidebarSelectionState: SidebarSelectionState()
+        )
+        defer { closeRegisteredShortcutRoutingWindow(targetWindow, id: windowId) }
+
+        guard let workspace = manager.selectedWorkspace else {
+            XCTFail("Expected test workspace")
             return
         }
 
         XCTAssertEqual(manager.tabs.count, 1)
-        XCTAssertEqual(manager.tabs[0].panels.count, 1)
+        XCTAssertEqual(workspace.panels.count, 1)
+
+        targetWindow.makeKeyAndOrderFront(nil)
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
 
         guard let event = makeKeyDownEvent(
             key: "w",
@@ -1905,10 +1920,12 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         XCTFail("debugHandleCustomShortcut is only available in DEBUG")
 #endif
 
-        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+        waitUntil(timeout: 1.0) {
+            self.window(withId: windowId)?.isVisible != true
+        }
 
-        XCTAssertNil(
-            self.window(withId: windowId),
+        XCTAssertFalse(
+            self.window(withId: windowId)?.isVisible == true,
             "Cmd+W on the last surface in the last workspace should close the window"
         )
     }


### PR DESCRIPTION
## Summary
- Move the Cmd-W last-surface shortcut test onto the lightweight registered-window fixture so CI does not create and tear down a real Ghostty PTY.
- Remove the AppDelegate Cmd-W skip from main CI and macOS compatibility CI.

Fixes part of https://github.com/manaflow-ai/cmux/issues/4524.

## Verification
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); YAML.load_file(".github/workflows/ci-macos-compat.yml"); puts "workflows parsed"'`\n- `xcodebuild -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-appcmdw build`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4894"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782509019&installation_id=133855650&pr_number=4894&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4894&signature=3ebb4cd45bc237f0df632c4f03f5e00306a05183ab3c9787e065d74cf887af6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and CI workflow changes only; no production shortcut or window-close behavior is modified.
> 
> **Overview**
> Re-enables **Cmd+W last-surface** shortcut coverage in main CI and macOS compatibility workflows by dropping the `-skip-testing` entry that had excluded `testCmdWClosesWindowWhenClosingLastSurfaceInLastWorkspace`.
> 
> The test is refactored to exercise the same **AppDelegate** shortcut path without `createMainWindow` / a real Ghostty surface: it registers a lightweight window with `TabManager(autoWelcomeIfNeeded: false)`, auto-confirms close, sets `closeWorkspaceOnLastSurfaceShortcut`, and waits for the window to become non-visible after **Cmd+W**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 061fc3ed0b16361dc5109c2bbe870e83b5516713. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores CI coverage for AppDelegate Cmd+W by moving the test to a lightweight registered-window fixture and re-enabling it in both CI workflows. Part of #4524.

- **Refactors**
  - Moved the last-surface Cmd+W test to a registered-window fixture to avoid real Ghostty PTY teardown on CI.
  - Removed -skip-testing for this test in `.github/workflows/ci.yml` and `.github/workflows/ci-macos-compat.yml`.
  - Hardened the test: registers a window with `TabManager`, auto-confirms close, toggles `appDelegateLastSurfaceCloseShortcutDefaultsKey`, brings the window to front, waits until it’s not visible after Cmd+W, and restores defaults/handler.

<sup>Written for commit 061fc3ed0b16361dc5109c2bbe870e83b5516713. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4894?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded unit test coverage for Cmd+W window-closing behavior, with more robust validation of last-surface/last-workspace scenarios and improved headless-runner reliability.
* **Chores**
  * CI configurations updated so the previously skipped macOS unit test now runs in standard and macOS-compatible workflows, strengthening test validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4894?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->