### PR TITLE
fix: suppress false Needs Input on turn-end notifications

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -20182,6 +20182,22 @@ struct CMUXCLI {
             )
             let payload = notificationPayload(title: title, subtitle: summary.subtitle, body: summary.body)
 
+            // Only treat this notification as a genuine mid-task block requiring user action if:
+            // - it is not a task-completion signal ("Completed"), and
+            // - for "Waiting" signals, Claude was actively running (not just sitting at its idle prompt).
+            // Startup and post-task "waiting at prompt" notifications map to standby instead.
+            let currentLifecycle = mappedSession?.agentLifecycle ?? .unknown
+            let isGenuineBlock: Bool
+            switch summary.subtitle {
+            case "Completed":
+                isGenuineBlock = false
+            case "Waiting":
+                isGenuineBlock = currentLifecycle == .running
+            default:
+                isGenuineBlock = true
+            }
+            let notifLifecycle: AgentHibernationLifecycleState = isGenuineBlock ? .needsInput : .idle
+
             if let sessionId = parsedInput.sessionId {
                 try? sessionStore.upsert(
                     sessionId: sessionId,
@@ -20189,7 +20205,7 @@ struct CMUXCLI {
                     surfaceId: surfaceId,
                     cwd: parsedInput.cwd,
                     transcriptPath: parsedInput.transcriptPath,
-                    agentLifecycle: .needsInput,
+                    agentLifecycle: notifLifecycle,
                     lastSubtitle: summary.subtitle,
                     lastBody: summary.body
                 )
@@ -20198,18 +20214,29 @@ struct CMUXCLI {
             setAgentLifecycle(
                 client: client,
                 key: Self.claudeCodeStatusKey,
-                lifecycle: .needsInput,
+                lifecycle: notifLifecycle,
                 workspaceId: workspaceId,
                 surfaceId: surfaceId
             )
-            _ = try? setClaudeStatus(
-                client: client,
-                workspaceId: workspaceId,
-                surfaceId: surfaceId,
-                value: "Needs input",
-                icon: "bell.fill",
-                color: "#4C8DFF"
-            )
+            if isGenuineBlock {
+                _ = try? setClaudeStatus(
+                    client: client,
+                    workspaceId: workspaceId,
+                    surfaceId: surfaceId,
+                    value: "Needs input",
+                    icon: "bell.fill",
+                    color: "#4C8DFF"
+                )
+            } else {
+                _ = try? setClaudeStatus(
+                    client: client,
+                    workspaceId: workspaceId,
+                    surfaceId: surfaceId,
+                    value: "Standby",
+                    icon: "circle.fill",
+                    color: "#8E8E93"
+                )
+            }
             let response = try sendV1Command("notify_target_async \(workspaceId) \(surfaceId) \(payload)", client: client)
             print(response)
 

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -20182,20 +20182,19 @@ struct CMUXCLI {
             )
             let payload = notificationPayload(title: title, subtitle: summary.subtitle, body: summary.body)
 
-            // Only treat this notification as a genuine mid-task block requiring user action if:
-            // - it is not a task-completion signal ("Completed"), and
-            // - for "Waiting" signals, Claude was actively running (not just sitting at its idle prompt).
-            // Startup and post-task "waiting at prompt" notifications map to standby instead.
+            // Decide whether this notification is a genuine block requiring user action.
+            // Three paths to needsInput:
+            //   1. "Permission" or "Error" subtitle — explicit block regardless of session state.
+            //   2. Session is already .needsInput — pre-tool-use fired for AskUserQuestion first;
+            //      the notification hook follows immediately to display the question text.
+            // Everything else (Waiting, Completed, Attention at turn end) is a standby signal:
+            // the notification fires to report Claude is done and at its idle prompt, which is
+            // not an alert the user needs to act on.
             let currentLifecycle = mappedSession?.agentLifecycle ?? .unknown
-            let isGenuineBlock: Bool
-            switch summary.subtitle {
-            case "Completed":
-                isGenuineBlock = false
-            case "Waiting":
-                isGenuineBlock = currentLifecycle == .running
-            default:
-                isGenuineBlock = true
-            }
+            let isGenuineBlock =
+                summary.subtitle == "Permission"
+                || summary.subtitle == "Error"
+                || currentLifecycle == .needsInput
             let notifLifecycle: AgentHibernationLifecycleState = isGenuineBlock ? .needsInput : .idle
 
             if let sessionId = parsedInput.sessionId {
@@ -20211,14 +20210,17 @@ struct CMUXCLI {
                 )
             }
 
-            setAgentLifecycle(
-                client: client,
-                key: Self.claudeCodeStatusKey,
-                lifecycle: notifLifecycle,
-                workspaceId: workspaceId,
-                surfaceId: surfaceId
-            )
+            // Only push UI updates for genuine blocks. For turn-end notifications
+            // (Waiting, Completed, Attention), the stop hook fires immediately after
+            // and owns the idle transition — updating here causes a visible flicker.
             if isGenuineBlock {
+                setAgentLifecycle(
+                    client: client,
+                    key: Self.claudeCodeStatusKey,
+                    lifecycle: .needsInput,
+                    workspaceId: workspaceId,
+                    surfaceId: surfaceId
+                )
                 _ = try? setClaudeStatus(
                     client: client,
                     workspaceId: workspaceId,
@@ -20226,15 +20228,6 @@ struct CMUXCLI {
                     value: "Needs input",
                     icon: "bell.fill",
                     color: "#4C8DFF"
-                )
-            } else {
-                _ = try? setClaudeStatus(
-                    client: client,
-                    workspaceId: workspaceId,
-                    surfaceId: surfaceId,
-                    value: "Standby",
-                    icon: "circle.fill",
-                    color: "#8E8E93"
                 )
             }
             let response = try sendV1Command("notify_target_async \(workspaceId) \(surfaceId) \(payload)", client: client)

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -20163,6 +20163,11 @@ struct CMUXCLI {
                 print("OK")
                 return
             }
+            // Capture the raw incoming subtitle before body-substitution may overwrite it.
+            // isGenuineBlock must classify based on the original notification, not the
+            // display-text restoration that follows.
+            let rawSubtitle = summary.subtitle
+
             if let mappedSession,
                let savedBody = mappedSession.lastBody, !savedBody.isEmpty,
                summary.body.contains("needs your attention") || summary.body.contains("needs your input") {
@@ -20184,7 +20189,9 @@ struct CMUXCLI {
 
             // Decide whether this notification is a genuine block requiring user action.
             // Three paths to needsInput:
-            //   1. "Permission" or "Error" subtitle — explicit block regardless of session state.
+            //   1. "Permission" or "Error" raw subtitle — explicit block regardless of session state.
+            //      Uses rawSubtitle (pre-substitution) so a permission notification whose body
+            //      triggers body-substitution is not silently reclassified as idle.
             //   2. Session is already .needsInput — pre-tool-use fired for AskUserQuestion first;
             //      the notification hook follows immediately to display the question text.
             // Everything else (Waiting, Completed, Attention at turn end) is a standby signal:
@@ -20192,8 +20199,8 @@ struct CMUXCLI {
             // not an alert the user needs to act on.
             let currentLifecycle = mappedSession?.agentLifecycle ?? .unknown
             let isGenuineBlock =
-                summary.subtitle == "Permission"
-                || summary.subtitle == "Error"
+                rawSubtitle == "Permission"
+                || rawSubtitle == "Error"
                 || currentLifecycle == .needsInput
             let notifLifecycle: AgentHibernationLifecycleState = isGenuineBlock ? .needsInput : .idle
 

--- a/Resources/bin/claude
+++ b/Resources/bin/claude
@@ -28,7 +28,7 @@ find_real_claude() {
         if [[ -x "$d/claude" ]]; then
             # Skip other cmux claude wrappers to prevent shim loops when both
             # the debug build and release app bins are in PATH simultaneously.
-            head -3 "$d/claude" 2>/dev/null | grep -qF "cmux claude wrapper" && continue
+            head -3 "$d/claude" 2>/dev/null | grep -qF "cmux claude wrapper - injects hooks and session tracking" && continue
             printf '%s' "$d/claude" && return 0
         fi
     done

--- a/Resources/bin/claude
+++ b/Resources/bin/claude
@@ -25,7 +25,12 @@ find_real_claude() {
     local IFS=:
     for d in $PATH; do
         [[ "$d" == "$self_dir" ]] && continue
-        [[ -x "$d/claude" ]] && printf '%s' "$d/claude" && return 0
+        if [[ -x "$d/claude" ]]; then
+            # Skip other cmux claude wrappers to prevent shim loops when both
+            # the debug build and release app bins are in PATH simultaneously.
+            head -3 "$d/claude" 2>/dev/null | grep -qF "cmux claude wrapper" && continue
+            printf '%s' "$d/claude" && return 0
+        fi
     done
     return 1
 }

--- a/Resources/bin/claude
+++ b/Resources/bin/claude
@@ -28,7 +28,10 @@ find_real_claude() {
         if [[ -x "$d/claude" ]]; then
             # Skip other cmux claude wrappers to prevent shim loops when both
             # the debug build and release app bins are in PATH simultaneously.
-            head -3 "$d/claude" 2>/dev/null | grep -qF "cmux claude wrapper - injects hooks and session tracking" && continue
+            # Read only the first two lines (shebang + marker) using shell builtins
+            # to avoid spawning subprocesses on every PATH entry.
+            { IFS= read -r _cr_l1; IFS= read -r _cr_l2; } < "$d/claude" 2>/dev/null
+            [[ "$_cr_l1$_cr_l2" == *"cmux claude wrapper - injects hooks and session tracking"* ]] && continue
             printf '%s' "$d/claude" && return 0
         fi
     done

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -548,27 +548,19 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         XCTAssertEqual(record["agentLifecycle"] as? String, "idle")
     }
 
-    func testClaudeWaitingNotificationWhenRunningMapsToNeedsInput() throws {
-        // When Claude fires a "waiting for input" notification while actively running (mid-task),
-        // the lifecycle should be needsInput — Claude is genuinely blocked.
-        let context = try makeClaudeHookContext(name: "claude-waiting-running")
+    func testClaudePermissionNotificationAlwaysMapsToNeedsInput() throws {
+        // "Permission" type notifications are genuine blocks — Claude needs approval to continue.
+        // This must set needsInput regardless of current session lifecycle.
+        let context = try makeClaudeHookContext(name: "claude-permission-notif")
         defer { context.cleanup() }
 
-        let sessionId = "waiting-running-session"
-
-        let prompt = runClaudeHook(
-            context: context,
-            arguments: ["hooks", "claude", "prompt-submit"],
-            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"turn-1","cwd":"\#(context.root.path)","hook_event_name":"PromptSubmit"}"#
-        )
-        XCTAssertFalse(prompt.timedOut, prompt.stderr)
-        XCTAssertEqual(prompt.status, 0, prompt.stderr)
+        let sessionId = "permission-notif-session"
 
         let notifStart = context.state.commands.count
         let notification = runClaudeHook(
             context: context,
             arguments: ["hooks", "claude", "notification"],
-            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"turn-1","cwd":"\#(context.root.path)","hook_event_name":"Notification","message":"Claude is waiting for your input"}"#
+            standardInput: #"{"session_id":"\#(sessionId)","cwd":"\#(context.root.path)","hook_event_name":"Notification","message":"permission approval required"}"#
         )
         XCTAssertFalse(notification.timedOut, notification.stderr)
         XCTAssertEqual(notification.status, 0, notification.stderr)
@@ -579,11 +571,58 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
                 $0.hasPrefix("set_agent_lifecycle claude_code needsInput --tab=\(context.workspaceId)")
                     && $0.contains("--panel=\(context.surfaceId)")
             },
-            "Mid-task waiting notification must set needsInput, saw \(notifCommands)"
+            "Permission notification must set needsInput, saw \(notifCommands)"
         )
         XCTAssertTrue(
             notifCommands.contains { $0.hasPrefix("set_status claude_code Needs input") },
-            "Mid-task waiting notification must display 'Needs input', saw \(notifCommands)"
+            "Permission notification must display 'Needs input', saw \(notifCommands)"
+        )
+
+        let record = try readClaudeHookSession(sessionId, context: context)
+        XCTAssertEqual(record["agentLifecycle"] as? String, "needsInput")
+    }
+
+    func testClaudeAskUserQuestionPreToolUseFollowedByNotificationMapsToNeedsInput() throws {
+        // AskUserQuestion fires pre-tool-use (setting .needsInput in session store) and then
+        // the notification hook fires immediately after to display the question text.
+        // The notification handler must preserve needsInput when the session is already in that state.
+        let context = try makeClaudeHookContext(name: "claude-askuser-notif")
+        defer { context.cleanup() }
+
+        let sessionId = "askuser-notif-session"
+
+        let prompt = runClaudeHook(
+            context: context,
+            arguments: ["hooks", "claude", "prompt-submit"],
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"turn-1","cwd":"\#(context.root.path)","hook_event_name":"PromptSubmit"}"#
+        )
+        XCTAssertFalse(prompt.timedOut, prompt.stderr)
+        XCTAssertEqual(prompt.status, 0, prompt.stderr)
+
+        let preToolUse = runClaudeHook(
+            context: context,
+            arguments: ["hooks", "claude", "pre-tool-use"],
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"turn-1","cwd":"\#(context.root.path)","hook_event_name":"PreToolUse","tool_name":"AskUserQuestion","tool_input":{"question":"Should I proceed?"}}"#
+        )
+        XCTAssertFalse(preToolUse.timedOut, preToolUse.stderr)
+        XCTAssertEqual(preToolUse.status, 0, preToolUse.stderr)
+
+        let notifStart = context.state.commands.count
+        let notification = runClaudeHook(
+            context: context,
+            arguments: ["hooks", "claude", "notification"],
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"turn-1","cwd":"\#(context.root.path)","hook_event_name":"Notification","message":"Should I proceed?"}"#
+        )
+        XCTAssertFalse(notification.timedOut, notification.stderr)
+        XCTAssertEqual(notification.status, 0, notification.stderr)
+
+        let notifCommands = Array(context.state.commands.dropFirst(notifStart))
+        XCTAssertTrue(
+            notifCommands.contains {
+                $0.hasPrefix("set_agent_lifecycle claude_code needsInput --tab=\(context.workspaceId)")
+                    && $0.contains("--panel=\(context.surfaceId)")
+            },
+            "AskUserQuestion notification must preserve needsInput, saw \(notifCommands)"
         )
 
         let record = try readClaudeHookSession(sessionId, context: context)

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -508,6 +508,131 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         )
     }
 
+    // MARK: - Claude notification lifecycle classification
+
+    func testClaudeWaitingNotificationAtStartupMapsToStandby() throws {
+        // When Claude fires a "waiting for input" notification with no active running session
+        // (e.g., startup idle prompt), the lifecycle should be idle/Standby — not needsInput.
+        let context = try makeClaudeHookContext(name: "claude-standby-startup")
+        defer { context.cleanup() }
+
+        let sessionId = "standby-startup-session"
+        let notifStart = context.state.commands.count
+        let notification = runClaudeHook(
+            context: context,
+            arguments: ["hooks", "claude", "notification"],
+            standardInput: #"{"session_id":"\#(sessionId)","cwd":"\#(context.root.path)","hook_event_name":"Notification","message":"Claude is waiting for your input"}"#
+        )
+        XCTAssertFalse(notification.timedOut, notification.stderr)
+        XCTAssertEqual(notification.status, 0, notification.stderr)
+
+        let notifCommands = Array(context.state.commands.dropFirst(notifStart))
+        XCTAssertFalse(
+            notifCommands.contains { $0.hasPrefix("set_agent_lifecycle claude_code needsInput") },
+            "Startup idle notification must not set needsInput, saw \(notifCommands)"
+        )
+        XCTAssertTrue(
+            notifCommands.contains { $0.hasPrefix("set_agent_lifecycle claude_code idle") },
+            "Startup idle notification must set idle, saw \(notifCommands)"
+        )
+        XCTAssertFalse(
+            notifCommands.contains { $0.contains("Needs input") },
+            "Startup idle notification must not display 'Needs input', saw \(notifCommands)"
+        )
+        XCTAssertTrue(
+            notifCommands.contains { $0.hasPrefix("set_status claude_code Standby") },
+            "Startup idle notification must display 'Standby', saw \(notifCommands)"
+        )
+
+        let record = try readClaudeHookSession(sessionId, context: context)
+        XCTAssertEqual(record["agentLifecycle"] as? String, "idle")
+    }
+
+    func testClaudeWaitingNotificationWhenRunningMapsToNeedsInput() throws {
+        // When Claude fires a "waiting for input" notification while actively running (mid-task),
+        // the lifecycle should be needsInput — Claude is genuinely blocked.
+        let context = try makeClaudeHookContext(name: "claude-waiting-running")
+        defer { context.cleanup() }
+
+        let sessionId = "waiting-running-session"
+
+        let prompt = runClaudeHook(
+            context: context,
+            arguments: ["hooks", "claude", "prompt-submit"],
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"turn-1","cwd":"\#(context.root.path)","hook_event_name":"PromptSubmit"}"#
+        )
+        XCTAssertFalse(prompt.timedOut, prompt.stderr)
+        XCTAssertEqual(prompt.status, 0, prompt.stderr)
+
+        let notifStart = context.state.commands.count
+        let notification = runClaudeHook(
+            context: context,
+            arguments: ["hooks", "claude", "notification"],
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"turn-1","cwd":"\#(context.root.path)","hook_event_name":"Notification","message":"Claude is waiting for your input"}"#
+        )
+        XCTAssertFalse(notification.timedOut, notification.stderr)
+        XCTAssertEqual(notification.status, 0, notification.stderr)
+
+        let notifCommands = Array(context.state.commands.dropFirst(notifStart))
+        XCTAssertTrue(
+            notifCommands.contains {
+                $0.hasPrefix("set_agent_lifecycle claude_code needsInput --tab=\(context.workspaceId)")
+                    && $0.contains("--panel=\(context.surfaceId)")
+            },
+            "Mid-task waiting notification must set needsInput, saw \(notifCommands)"
+        )
+        XCTAssertTrue(
+            notifCommands.contains { $0.hasPrefix("set_status claude_code Needs input") },
+            "Mid-task waiting notification must display 'Needs input', saw \(notifCommands)"
+        )
+
+        let record = try readClaudeHookSession(sessionId, context: context)
+        XCTAssertEqual(record["agentLifecycle"] as? String, "needsInput")
+    }
+
+    func testClaudeCompletedNotificationDoesNotSetNeedsInput() throws {
+        // When Claude fires a "completed" notification (task done), the lifecycle should not
+        // be needsInput — the stop hook handles the final idle transition.
+        let context = try makeClaudeHookContext(name: "claude-completed-notif")
+        defer { context.cleanup() }
+
+        let sessionId = "completed-notif-session"
+
+        let prompt = runClaudeHook(
+            context: context,
+            arguments: ["hooks", "claude", "prompt-submit"],
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"turn-1","cwd":"\#(context.root.path)","hook_event_name":"PromptSubmit"}"#
+        )
+        XCTAssertFalse(prompt.timedOut, prompt.stderr)
+        XCTAssertEqual(prompt.status, 0, prompt.stderr)
+
+        let notifStart = context.state.commands.count
+        let notification = runClaudeHook(
+            context: context,
+            arguments: ["hooks", "claude", "notification"],
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"turn-1","cwd":"\#(context.root.path)","hook_event_name":"Notification","message":"task completed successfully"}"#
+        )
+        XCTAssertFalse(notification.timedOut, notification.stderr)
+        XCTAssertEqual(notification.status, 0, notification.stderr)
+
+        let notifCommands = Array(context.state.commands.dropFirst(notifStart))
+        XCTAssertFalse(
+            notifCommands.contains { $0.hasPrefix("set_agent_lifecycle claude_code needsInput") },
+            "Completed notification must not set needsInput, saw \(notifCommands)"
+        )
+        XCTAssertTrue(
+            notifCommands.contains { $0.hasPrefix("set_agent_lifecycle claude_code idle") },
+            "Completed notification must set idle, saw \(notifCommands)"
+        )
+        XCTAssertFalse(
+            notifCommands.contains { $0.contains("Needs input") },
+            "Completed notification must not display 'Needs input', saw \(notifCommands)"
+        )
+
+        let record = try readClaudeHookSession(sessionId, context: context)
+        XCTAssertEqual(record["agentLifecycle"] as? String, "idle")
+    }
+
     func testGenericAgentNotificationUpdatesLifecycleForNeedsInput() throws {
         let context = try makeClaudeHookContext(name: "codex-notification-lifecycle")
         defer { context.cleanup() }

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -527,21 +527,16 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         XCTAssertEqual(notification.status, 0, notification.stderr)
 
         let notifCommands = Array(context.state.commands.dropFirst(notifStart))
+        // Non-blocking notifications skip UI updates entirely; the stop hook fires immediately
+        // after and owns the idle transition. Only verify needsInput is NOT set and the
+        // session store reflects idle.
         XCTAssertFalse(
             notifCommands.contains { $0.hasPrefix("set_agent_lifecycle claude_code needsInput") },
             "Startup idle notification must not set needsInput, saw \(notifCommands)"
         )
-        XCTAssertTrue(
-            notifCommands.contains { $0.hasPrefix("set_agent_lifecycle claude_code idle") },
-            "Startup idle notification must set idle, saw \(notifCommands)"
-        )
         XCTAssertFalse(
             notifCommands.contains { $0.contains("Needs input") },
             "Startup idle notification must not display 'Needs input', saw \(notifCommands)"
-        )
-        XCTAssertTrue(
-            notifCommands.contains { $0.hasPrefix("set_status claude_code Standby") },
-            "Startup idle notification must display 'Standby', saw \(notifCommands)"
         )
 
         let record = try readClaudeHookSession(sessionId, context: context)
@@ -655,13 +650,12 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         XCTAssertEqual(notification.status, 0, notification.stderr)
 
         let notifCommands = Array(context.state.commands.dropFirst(notifStart))
+        // Non-blocking notifications skip UI updates entirely; the stop hook fires immediately
+        // after and owns the idle transition. Only verify needsInput is NOT set and the
+        // session store reflects idle.
         XCTAssertFalse(
             notifCommands.contains { $0.hasPrefix("set_agent_lifecycle claude_code needsInput") },
             "Completed notification must not set needsInput, saw \(notifCommands)"
-        )
-        XCTAssertTrue(
-            notifCommands.contains { $0.hasPrefix("set_agent_lifecycle claude_code idle") },
-            "Completed notification must set idle, saw \(notifCommands)"
         )
         XCTAssertFalse(
             notifCommands.contains { $0.contains("Needs input") },


### PR DESCRIPTION
## Problem

The Claude notification hook fires for both genuine mid-task blocks **and** for turn-end \"I\'m done\" signals (Waiting, Completed, Attention). Previously, all of these set `.needsInput`, so the sidebar flashed **Needs Input** every time Claude finished a task and returned to its idle prompt — even with no user action required.

This made \"Needs Input\" meaningless as a signal. Users couldn\'t distinguish \"Claude is genuinely waiting for guidance\" from \"Claude just finished and is sitting at its prompt.\"

## Solution

**`CLI/cmux.swift` — notification lifecycle classification**

Genuine blocks are now limited to two cases:
1. **Permission or Error subtitle** — explicit block, regardless of session state.
2. **Session already `.needsInput`** — the `pre-tool-use` hook fires first for `AskUserQuestion` and sets the session to `.needsInput`; the notification hook follows immediately to surface the question text, and must preserve that state.

Everything else (Waiting, Completed, Attention at turn end) skips UI updates entirely in the notification handler. The `stop` hook fires immediately after and owns the idle transition cleanly — no more Running → Needs-Input → Idle flicker on every task completion.

**`Resources/bin/claude` — shim loop fix**

When the debug build and release app bins are both in PATH (a common debug-testing setup), `find_real_claude` in one shim would find the other shim, which would then find the first one again, with each exec appending another `--settings <json>` (~1.5 KB) to `$@`. After ~660 hops the argument list hit `ARG_MAX` with `E2BIG`.

Fixed by detecting the `"cmux claude wrapper"` header marker already used by `isCmuxClaudeWrapper()` in the Swift codebase, and skipping any wrapper found in PATH to jump directly to the real Claude binary.

## Tests

Updated `CLINotifyProcessIntegrationRegressionTests`:
- `testClaudePermissionNotificationAlwaysMapsToNeedsInput` — Permission always sets needsInput
- `testClaudeAskUserQuestionPreToolUseFollowedByNotificationMapsToNeedsInput` — pre-tool-use + notification preserves needsInput
- `testClaudeWaitingNotificationAtStartupMapsToStandby` — turn-end Waiting skips UI update (stop owns it)
- `testClaudeCompletedNotificationDoesNotSetNeedsInput` — Completed skips UI update

## Test plan

- [ ] Open a workspace, start Claude — sidebar should show **Running**, then **Idle** after startup (not \"Needs Input\")
- [ ] Run a task to completion — sidebar goes Running → Idle, no \"Needs Input\" flash
- [ ] Trigger a permission request — sidebar shows **Needs Input** correctly
- [ ] Answer an `AskUserQuestion` prompt — sidebar shows **Needs Input** while waiting, clears on submit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4900"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782513350&installation_id=133855650&pr_number=4900&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4900&signature=d587f2369244f1de5f97a82ceb7f40614d5dab155f53ef6433f6535f34ebd9dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents false “Needs Input” flashes by treating turn-end notifications as idle and only marking genuine blocks. Also fixes the PATH shim loop and speeds up wrapper detection.

- **Bug Fixes**
  - Notification lifecycle: classify using the original subtitle (pre-body-substitution); only "Permission"/"Error" or when the session is already `.needsInput` set needs input; turn-end "Waiting"/"Completed" skip UI updates (stop hook sets idle).
  - Shim loop/perf: skip other cmux `claude` wrappers in PATH by matching the full "cmux claude wrapper - injects hooks and session tracking" marker and reading the first two lines with shell builtins (no subprocess), jumping to the real `claude` and avoiding `--settings` bloat and `E2BIG`.
  - Tests: regression tests for startup waiting→idle, permission→needs input, AskUserQuestion pre-tool-use→needs input, and completed→idle; non-blocking notifications assert no UI updates and idle in the session store.

<sup>Written for commit f08b29d70cc17ae74adfd6e82ad6e1260a723857. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4900?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed wrapper detection to avoid launching incorrect helper wrappers.
  * Improved notification handling to only mark sessions as needing input when truly required and to persist the correct session lifecycle.
  * Reduced UI flicker by suppressing unnecessary status/lifecycle updates for turn-end/standby notifications.

* **Tests**
  * Added integration tests validating notification-to-session lifecycle behavior and visible lifecycle updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4900?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->