### PR TITLE
Enable Claude agent teams in normal sessions

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -15881,10 +15881,6 @@ struct CMUXCLI {
         workspaceId: String,
         client: SocketClient
     ) throws -> String {
-        if isUUID(handle) {
-            return handle
-        }
-
         let payload = try client.sendV2(method: "pane.list", params: ["workspace_id": workspaceId])
         let panes = payload["panes"] as? [[String: Any]] ?? []
         for pane in panes {
@@ -15895,12 +15891,20 @@ struct CMUXCLI {
             }
         }
 
+        if let paneId = try tmuxPaneIdForSurfaceHandle(handle, workspaceId: workspaceId, client: client) {
+            return paneId
+        }
+
         if let index = Int(handle) {
             for pane in panes where intFromAny(pane["index"]) == index {
                 if let id = pane["id"] as? String {
                     return id
                 }
             }
+        }
+
+        if isUUID(handle) {
+            return handle
         }
 
         throw CLIError(message: "Pane target not found")
@@ -15932,6 +15936,34 @@ struct CMUXCLI {
         throw CLIError(message: "Surface target not found")
     }
 
+    private func tmuxPaneIdForSurfaceHandle(
+        _ handle: String,
+        workspaceId: String,
+        client: SocketClient
+    ) throws -> String? {
+        guard isUUID(handle) || isHandleRef(handle) else {
+            return nil
+        }
+
+        let payload = try client.sendV2(method: "surface.list", params: ["workspace_id": workspaceId])
+        let surfaces = payload["surfaces"] as? [[String: Any]] ?? []
+        guard let surface = surfaces.first(where: {
+            ($0["id"] as? String) == handle || ($0["ref"] as? String) == handle
+        }) else {
+            return nil
+        }
+
+        if let paneId = surface["pane_id"] as? String,
+           !paneId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return paneId
+        }
+        if let paneRef = surface["pane_ref"] as? String,
+           !paneRef.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return try tmuxCanonicalPaneId(paneRef, workspaceId: workspaceId, client: client)
+        }
+        return nil
+    }
+
     private func tmuxWorkspaceIdForPaneHandle(_ handle: String, client: SocketClient) throws -> String? {
         guard isUUID(handle) || isHandleRef(handle) else {
             return nil
@@ -15944,6 +15976,12 @@ struct CMUXCLI {
             let panes = payload["panes"] as? [[String: Any]] ?? []
             if panes.contains(where: { ($0["id"] as? String) == handle || ($0["ref"] as? String) == handle }) {
                 return workspaceId
+            }
+            if let surfacesPayload = try? client.sendV2(method: "surface.list", params: ["workspace_id": workspaceId]) {
+                let surfaces = surfacesPayload["surfaces"] as? [[String: Any]] ?? []
+                if surfaces.contains(where: { ($0["id"] as? String) == handle || ($0["ref"] as? String) == handle }) {
+                    return workspaceId
+                }
             }
         }
 
@@ -29052,6 +29090,8 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                 return ("SessionEnd", false)
             case "Stop":
                 return ("Stop", false)
+            case "SubagentStart":
+                return ("SubagentStart", false)
             case "SubagentStop":
                 return ("SubagentStop", false)
             case "Notification":
@@ -29118,6 +29158,8 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
             return ("SessionEnd", false)
         case "Stop":
             return ("Stop", false)
+        case "SubagentStart":
+            return ("SubagentStart", false)
         case "SubagentStop":
             return ("SubagentStop", false)
         case "Notification":

--- a/Packages/CMUXWorkstream/Sources/CMUXWorkstream/WorkstreamEvent.swift
+++ b/Packages/CMUXWorkstream/Sources/CMUXWorkstream/WorkstreamEvent.swift
@@ -63,6 +63,7 @@ public struct WorkstreamEvent: Codable, Sendable, Equatable {
         case exitPlanMode = "ExitPlanMode"
         case todoWrite = "TodoWrite"
         case stop = "Stop"
+        case subagentStart = "SubagentStart"
         case subagentStop = "SubagentStop"
         case notification = "Notification"
     }

--- a/Packages/CMUXWorkstream/Sources/CMUXWorkstream/WorkstreamStore.swift
+++ b/Packages/CMUXWorkstream/Sources/CMUXWorkstream/WorkstreamStore.swift
@@ -307,7 +307,7 @@ public final class WorkstreamStore {
                 .userPrompt,
                 .userPrompt(text: prompt.isEmpty ? (event.context?.lastUserMessage ?? "") : prompt)
             )
-        case .sessionStart:
+        case .sessionStart, .subagentStart:
             return (.sessionStart, .sessionStart)
         case .sessionEnd:
             return (.sessionEnd, .sessionEnd)

--- a/Resources/bin/claude
+++ b/Resources/bin/claude
@@ -71,6 +71,77 @@ resolve_hook_cmux_bin() {
     printf '%s' "cmux"
 }
 
+cmux_env_truthy() {
+    case "${1:-}" in
+        1|true|TRUE|yes|YES|on|ON) return 0 ;;
+    esac
+    return 1
+}
+
+prepend_path_entry() {
+    local entry="$1"
+    [[ -n "$entry" ]] || return 0
+    case ":${PATH:-}:" in
+        *":$entry:"*) return 0 ;;
+    esac
+    export PATH="$entry${PATH:+:$PATH}"
+}
+
+ensure_claude_teams_tmux_shim() {
+    [[ -n "${HOME:-}" ]] || return 1
+
+    local shim_dir="$HOME/.cmuxterm/claude-teams-bin"
+    local shim_path="$shim_dir/tmux"
+    mkdir -p "$shim_dir" || return 1
+
+    local temp_path
+    temp_path="$(mktemp "$shim_dir/tmux.XXXXXX")" || return 1
+    cat >"$temp_path" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+exec "${CMUX_CLAUDE_TEAMS_CMUX_BIN:-cmux}" __tmux-compat "$@"
+EOF
+    chmod 0755 "$temp_path" || {
+        rm -f "$temp_path"
+        return 1
+    }
+    if [[ -f "$shim_path" ]] && cmp -s "$temp_path" "$shim_path"; then
+        rm -f "$temp_path" || return 1
+        chmod 0755 "$shim_path" || return 1
+    else
+        mv -f "$temp_path" "$shim_path" || {
+            rm -f "$temp_path"
+            return 1
+        }
+    fi
+
+    printf '%s' "$shim_dir"
+}
+
+configure_cmux_claude_agent_teams_environment() {
+    if cmux_env_truthy "${CMUX_CLAUDE_AGENT_TEAMS_DISABLED:-}" || cmux_env_truthy "${CMUX_CLAUDE_TEAMS_DISABLED:-}"; then
+        return 0
+    fi
+
+    local shim_dir
+    shim_dir="$(ensure_claude_teams_tmux_shim)" || return 0
+    prepend_path_entry "$shim_dir"
+    export CMUX_CLAUDE_TEAMS_CMUX_BIN="${CMUX_CLAUDE_TEAMS_CMUX_BIN:-${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}}"
+    if [[ -z "${CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS+x}" || -z "${CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS}" ]]; then
+        export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1
+    fi
+
+    [[ -n "${CMUX_WORKSPACE_ID:-}" && -n "${CMUX_SURFACE_ID:-}" ]] || return 0
+
+    local pane_token="${CMUX_PANE_ID:-$CMUX_SURFACE_ID}"
+    pane_token="${pane_token#%}"
+    local window_token="${CMUX_WINDOW_ID:-$CMUX_WORKSPACE_ID}"
+    export TMUX="/tmp/cmux-claude-teams/${CMUX_WORKSPACE_ID},${window_token},${pane_token}"
+    export TMUX_PANE="%$pane_token"
+    export TERM="${CMUX_CLAUDE_TEAMS_TERM:-screen-256color}"
+    unset TERM_PROGRAM
+}
+
 CLAUDE_AUTH_SELECTION_ENV_KEYS=(
     ANTHROPIC_API_KEY
     ANTHROPIC_MODEL
@@ -441,6 +512,7 @@ export CMUX_AGENT_LAUNCH_KIND="claude"
 export CMUX_AGENT_LAUNCH_EXECUTABLE="$REAL_CLAUDE"
 export CMUX_AGENT_LAUNCH_ARGV_B64="$(encode_launch_argv "$@")"
 export CMUX_AGENT_LAUNCH_CWD="$PWD"
+configure_cmux_claude_agent_teams_environment
 if GUARD_PATH="$(ensure_node_options_restore_module)"; then
     if [[ ${NODE_OPTIONS+x} ]]; then
         export CMUX_ORIGINAL_NODE_OPTIONS_PRESENT=1
@@ -466,9 +538,10 @@ fi
 #   This is Claude Code's native blocking decision hook. It covers
 #   permissions, ExitPlanMode, and AskUserQuestion without using
 #   PreToolUse denial as a side channel.
-# - SubagentStop: feed telemetry only. It must not run the visible Stop
-#   hook because a subagent finishing should not notify like the parent.
-HOOKS_JSON='{"preferredNotifChannel":"notifications_disabled","hooks":{"SessionStart":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude session-start","timeout":10}]}],"Stop":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude stop","timeout":10}]},{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks feed --source claude","timeout":10,"async":true}]}],"SubagentStop":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks feed --source claude","timeout":10,"async":true}]}],"SessionEnd":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude session-end","timeout":1}]}],"Notification":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude notification","timeout":10}]}],"UserPromptSubmit":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude prompt-submit","timeout":10}]}],"PreToolUse":[{"matcher":"CronCreate","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude cron-create-guard","timeout":5}]},{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude pre-tool-use","timeout":5,"async":true}]}],"PermissionRequest":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks feed --source claude","timeout":125}]}]}}'
+# - SubagentStart/SubagentStop: feed telemetry only. SubagentStop must not
+#   run the visible Stop hook because a subagent finishing should not notify
+#   like the parent.
+HOOKS_JSON='{"preferredNotifChannel":"notifications_disabled","hooks":{"SessionStart":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude session-start","timeout":10}]}],"Stop":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude stop","timeout":10}]},{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks feed --source claude","timeout":10,"async":true}]}],"SubagentStart":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks feed --source claude","timeout":10,"async":true}]}],"SubagentStop":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks feed --source claude","timeout":10,"async":true}]}],"SessionEnd":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude session-end","timeout":1}]}],"Notification":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude notification","timeout":10}]}],"UserPromptSubmit":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude prompt-submit","timeout":10}]}],"PreToolUse":[{"matcher":"CronCreate","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude cron-create-guard","timeout":5}]},{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude pre-tool-use","timeout":5,"async":true}]}],"PermissionRequest":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks feed --source claude","timeout":125}]}]}}'
 
 if [[ "$SKIP_SESSION_ID" == true ]]; then
     exec "$REAL_CLAUDE" --settings "$HOOKS_JSON" "$@"

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -328,6 +328,114 @@ exit 0
         return proc.returncode, observed_env, read_lines(args_log), proc.stderr.strip(), set(fingerprint_env)
 
 
+def run_wrapper_agent_teams_env_probe(
+    inherited_env: dict[str, str] | None = None,
+) -> tuple[int, dict[str, str], list[str], str]:
+    with tempfile.TemporaryDirectory(prefix="cmux-claude-wrapper-agent-teams-") as td:
+        tmp = Path(td)
+        wrapper_dir = tmp / "wrapper-bin"
+        real_dir = tmp / "real-bin"
+        bundled_dir = tmp / "bundled cli"
+        home_dir = tmp / "home"
+        wrapper_dir.mkdir(parents=True, exist_ok=True)
+        real_dir.mkdir(parents=True, exist_ok=True)
+        bundled_dir.mkdir(parents=True, exist_ok=True)
+        home_dir.mkdir(parents=True, exist_ok=True)
+
+        wrapper = wrapper_dir / "claude"
+        shutil.copy2(SOURCE_WRAPPER, wrapper)
+        wrapper.chmod(0o755)
+
+        env_log = tmp / "real-env.log"
+        args_log = tmp / "real-args.log"
+        socket_path = str(tmp / "cmux.sock")
+
+        make_executable(
+            real_dir / "claude",
+            """#!/usr/bin/env bash
+set -euo pipefail
+: > "$FAKE_REAL_ENV_LOG"
+: > "$FAKE_REAL_ARGS_LOG"
+keys=(
+  CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS
+  CMUX_CLAUDE_TEAMS_CMUX_BIN
+  TMUX
+  TMUX_PANE
+  TERM
+  TERM_PROGRAM
+)
+for key in "${keys[@]}"; do
+  if [[ ${!key+x} ]]; then
+    printf '%s=%s\\n' "$key" "${!key}" >> "$FAKE_REAL_ENV_LOG"
+  else
+    printf '%s=__UNSET__\\n' "$key" >> "$FAKE_REAL_ENV_LOG"
+  fi
+done
+printf 'tmux_path=%s\\n' "$(command -v tmux || true)" >> "$FAKE_REAL_ENV_LOG"
+for arg in "$@"; do
+  printf '%s\\n' "$arg" >> "$FAKE_REAL_ARGS_LOG"
+done
+""",
+        )
+
+        make_executable(
+            wrapper_dir / "cmux",
+            """#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "--socket" ]]; then
+  shift 2
+fi
+if [[ "${1:-}" == "ping" ]]; then
+  exit 0
+fi
+exit 0
+""",
+        )
+        bundled_cli_path = bundled_dir / "cmux"
+        make_executable(
+            bundled_cli_path,
+            """#!/usr/bin/env bash
+exit 0
+""",
+        )
+
+        test_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            test_socket.bind(socket_path)
+
+            env = os.environ.copy()
+            env["PATH"] = f"{wrapper_dir}:{real_dir}:{env.get('PATH', '/usr/bin:/bin')}"
+            env["HOME"] = str(home_dir)
+            env["CMUX_BUNDLED_CLI_PATH"] = str(bundled_cli_path)
+            env["CMUX_SOCKET_PATH"] = socket_path
+            env["CMUX_SURFACE_ID"] = "surface:test"
+            env["CMUX_WORKSPACE_ID"] = "workspace:test"
+            env["TERM"] = "xterm-256color"
+            env["TERM_PROGRAM"] = "Apple_Terminal"
+            env["FAKE_REAL_ENV_LOG"] = str(env_log)
+            env["FAKE_REAL_ARGS_LOG"] = str(args_log)
+            env.pop("CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS", None)
+            env.pop("CMUX_CLAUDE_TEAMS_CMUX_BIN", None)
+            env.pop("TMUX", None)
+            env.pop("TMUX_PANE", None)
+            if inherited_env:
+                env.update(inherited_env)
+
+            proc = subprocess.run(
+                [str(wrapper), "fan out to subagents"],
+                cwd=tmp,
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        finally:
+            test_socket.close()
+
+        observed_env = dict(line.split("=", 1) for line in read_lines(env_log))
+        return proc.returncode, observed_env, read_lines(args_log), proc.stderr.strip()
+
+
 def expect(condition: bool, message: str, failures: list[str]) -> None:
     if not condition:
         failures.append(message)
@@ -503,7 +611,7 @@ def test_live_socket_injects_supported_hooks_without_unlocking_bypass(failures: 
         failures,
     )
     hooks = settings.get("hooks", {})
-    expected_hooks = {"SessionStart", "Stop", "SubagentStop", "SessionEnd", "Notification", "UserPromptSubmit", "PreToolUse", "PermissionRequest"}
+    expected_hooks = {"SessionStart", "Stop", "SubagentStart", "SubagentStop", "SessionEnd", "Notification", "UserPromptSubmit", "PreToolUse", "PermissionRequest"}
     expect(set(hooks.keys()) == expected_hooks, f"unexpected hook keys: {hooks.keys()}, expected {expected_hooks}", failures)
     for hook_name, expected_subcommand in {
         "SessionStart": "session-start",
@@ -551,6 +659,16 @@ def test_live_socket_injects_supported_hooks_without_unlocking_bypass(failures: 
         f"PermissionRequest hook should call hooks feed, got {permission_request_hooks}",
         failures,
     )
+    subagent_start_hooks = hooks.get("SubagentStart", [{}])[0].get("hooks", [{}])
+    expect(
+        any(
+            h.get("command") == '"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}" hooks feed --source claude'
+            and h.get("async") is True
+            for h in subagent_start_hooks
+        ),
+        f"SubagentStart hook should call hooks feed asynchronously, got {subagent_start_hooks}",
+        failures,
+    )
     subagent_stop_hooks = hooks.get("SubagentStop", [{}])[0].get("hooks", [{}])
     expect(
         any(
@@ -573,6 +691,63 @@ def test_live_socket_injects_supported_hooks_without_unlocking_bypass(failures: 
         f"SessionEnd hook should have short timeout, got {session_end_hooks}",
         failures,
     )
+
+
+def test_live_socket_configures_native_claude_agent_teams(failures: list[str]) -> None:
+    code, observed_env, real_argv, stderr = run_wrapper_agent_teams_env_probe()
+    expect(code == 0, f"agent teams env: wrapper exited {code}: {stderr}", failures)
+    expect("--settings" in real_argv, f"agent teams env: expected hook settings, got {real_argv}", failures)
+    expect("--session-id" in real_argv, f"agent teams env: expected session id, got {real_argv}", failures)
+    expect("fan out to subagents" in real_argv, f"agent teams env: expected original prompt, got {real_argv}", failures)
+    expect(
+        "--teammate-mode" not in real_argv,
+        f"agent teams env: normal claude wrapper should not rewrite argv as claude-teams, got {real_argv}",
+        failures,
+    )
+    expect(
+        observed_env.get("CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS") == "1",
+        f"agent teams env: expected Claude native agent teams enabled, got {observed_env}",
+        failures,
+    )
+    expect(
+        observed_env.get("CMUX_CLAUDE_TEAMS_CMUX_BIN", "").endswith("/bundled cli/cmux"),
+        f"agent teams env: expected tmux shim pinned to bundled cmux, got {observed_env}",
+        failures,
+    )
+    expect(
+        observed_env.get("tmux_path", "").endswith("/.cmuxterm/claude-teams-bin/tmux"),
+        f"agent teams env: expected tmux shim first in PATH, got {observed_env}",
+        failures,
+    )
+    expect(
+        observed_env.get("TMUX") == "/tmp/cmux-claude-teams/workspace:test,workspace:test,surface:test",
+        f"agent teams env: expected fake TMUX value scoped to caller surface, got {observed_env}",
+        failures,
+    )
+    expect(
+        observed_env.get("TMUX_PANE") == "%surface:test",
+        f"agent teams env: expected fake TMUX_PANE to target caller surface, got {observed_env}",
+        failures,
+    )
+    expect(observed_env.get("TERM") == "screen-256color", f"agent teams env: expected tmux TERM, got {observed_env}", failures)
+    expect(observed_env.get("TERM_PROGRAM") == "__UNSET__", f"agent teams env: expected TERM_PROGRAM unset, got {observed_env}", failures)
+
+
+def test_live_socket_allows_native_claude_agent_teams_opt_out(failures: list[str]) -> None:
+    code, observed_env, real_argv, stderr = run_wrapper_agent_teams_env_probe({
+        "CMUX_CLAUDE_AGENT_TEAMS_DISABLED": "1",
+    })
+    expect(code == 0, f"agent teams opt-out: wrapper exited {code}: {stderr}", failures)
+    expect("--settings" in real_argv, f"agent teams opt-out: hook settings should still be injected, got {real_argv}", failures)
+    expect(
+        observed_env.get("CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS") == "__UNSET__",
+        f"agent teams opt-out: expected Claude agent teams env unset, got {observed_env}",
+        failures,
+    )
+    expect(observed_env.get("TMUX") == "__UNSET__", f"agent teams opt-out: expected TMUX unset, got {observed_env}", failures)
+    expect(observed_env.get("TMUX_PANE") == "__UNSET__", f"agent teams opt-out: expected TMUX_PANE unset, got {observed_env}", failures)
+    expect(observed_env.get("TERM") == "xterm-256color", f"agent teams opt-out: expected TERM preserved, got {observed_env}", failures)
+    expect(observed_env.get("TERM_PROGRAM") == "Apple_Terminal", f"agent teams opt-out: expected TERM_PROGRAM preserved, got {observed_env}", failures)
 
 
 def test_plain_claude_launch_argv_has_no_empty_argument(failures: list[str]) -> None:
@@ -1106,6 +1281,8 @@ def test_stale_socket_skips_hook_injection(failures: list[str]) -> None:
 def main() -> int:
     failures: list[str] = []
     test_live_socket_injects_supported_hooks_without_unlocking_bypass(failures)
+    test_live_socket_configures_native_claude_agent_teams(failures)
+    test_live_socket_allows_native_claude_agent_teams_opt_out(failures)
     test_plain_claude_launch_argv_has_no_empty_argument(failures)
     test_command_like_invocations_bypass_hook_injection(failures)
     test_passthrough_flags_bypass_hook_injection(failures)

--- a/tests/test_cli_tmux_compat_split_window_surface_ref.py
+++ b/tests/test_cli_tmux_compat_split_window_surface_ref.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from claude_teams_test_utils import resolve_cmux_cli
 
 WORKSPACE_ID = "11111111-1111-4111-8111-111111111111"
+WINDOW_ID = "22222222-2222-4222-8222-222222222222"
 PANE_ID = "33333333-3333-4333-8333-333333333333"
 SURFACE_ID = "44444444-4444-4444-8444-444444444444"
 NEW_PANE_ID = "66666666-6666-4666-8666-666666666666"
@@ -35,6 +36,18 @@ class FakeCmuxState:
                         "ref": "workspace:1",
                         "index": 1,
                         "title": "demo",
+                    }
+                ]
+            }
+        if method == "window.list":
+            return {
+                "windows": [
+                    {
+                        "id": WINDOW_ID,
+                        "ref": "window:1",
+                        "workspace_id": WORKSPACE_ID,
+                        "workspace_ref": "workspace:1",
+                        "index": 1,
                     }
                 ]
             }
@@ -100,7 +113,7 @@ class FakeCmuxState:
             }
         if method == "surface.close":
             target_surface = str(params.get("surface_id") or "")
-            if target_surface != NEW_SURFACE_ID:
+            if target_surface not in {NEW_SURFACE_ID, "surface:2"}:
                 raise RuntimeError(
                     f"expected close target {NEW_SURFACE_ID}, got {target_surface!r}"
                 )
@@ -152,12 +165,13 @@ def run_cli(
     socket_path: Path,
     fake_home: Path,
     args: list[str],
+    tmux_pane: str = "%pane:1",
 ) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
     env["CMUX_SOCKET_PATH"] = str(socket_path)
     env["CMUX_WORKSPACE_ID"] = "workspace:1"
     env["CMUX_SURFACE_ID"] = "surface:1"
-    env["TMUX_PANE"] = "%pane:1"
+    env["TMUX_PANE"] = tmux_pane
     env["HOME"] = str(fake_home)
     return subprocess.run(
         [cli_path, "--socket", str(socket_path), *args],
@@ -174,12 +188,14 @@ def assert_successful_split(
     socket_path: Path,
     fake_home: Path,
     label: str,
+    tmux_pane: str = "%pane:1",
 ) -> None:
     proc = run_cli(
         cli_path,
         socket_path,
         fake_home,
         ["__tmux-compat", "split-window", "-h", "-P", "-F", "#{pane_id}"],
+        tmux_pane=tmux_pane,
     )
     if proc.returncode != 0:
         raise AssertionError(
@@ -193,13 +209,12 @@ def assert_successful_split(
         )
 
 
-def assert_resplit_after_close(
+def close_teammate_surface(
     cli_path: str,
     socket_path: Path,
     fake_home: Path,
+    label: str,
 ) -> None:
-    assert_successful_split(cli_path, socket_path, fake_home, "initial split-window")
-
     closed = run_cli(
         cli_path,
         socket_path,
@@ -208,12 +223,45 @@ def assert_resplit_after_close(
     )
     if closed.returncode != 0:
         raise AssertionError(
-            "close-surface returned non-zero\n"
+            f"{label} returned non-zero\n"
             f"stdout={closed.stdout.strip()}\n"
             f"stderr={closed.stderr.strip()}"
         )
 
+
+def assert_resplit_after_close(
+    cli_path: str,
+    socket_path: Path,
+    fake_home: Path,
+) -> None:
+    assert_successful_split(cli_path, socket_path, fake_home, "initial split-window")
+
+    close_teammate_surface(cli_path, socket_path, fake_home, "close-surface")
     assert_successful_split(cli_path, socket_path, fake_home, "second split-window")
+    close_teammate_surface(cli_path, socket_path, fake_home, "final close-surface")
+
+
+def assert_split_from_surface_tmux_pane(
+    cli_path: str,
+    socket_path: Path,
+    fake_home: Path,
+) -> None:
+    assert_successful_split(
+        cli_path,
+        socket_path,
+        fake_home,
+        "surface-ref TMUX_PANE split-window",
+        tmux_pane="%surface:1",
+    )
+
+    close_teammate_surface(cli_path, socket_path, fake_home, "close-surface after surface-ref")
+    assert_successful_split(
+        cli_path,
+        socket_path,
+        fake_home,
+        "surface-id TMUX_PANE split-window",
+        tmux_pane=f"%{SURFACE_ID}",
+    )
 
 
 def main() -> int:
@@ -236,6 +284,7 @@ def main() -> int:
 
             try:
                 assert_resplit_after_close(cli_path, socket_path, fake_home)
+                assert_split_from_surface_tmux_pane(cli_path, socket_path, fake_home)
             finally:
                 server.shutdown()
                 server.server_close()

--- a/tests/test_codex_feed_hooks.py
+++ b/tests/test_codex_feed_hooks.py
@@ -2065,6 +2065,30 @@ def test_claude_subagent_stop_stays_distinct_feed_telemetry(cli_path: str, root:
         raise AssertionError(f"SubagentStop should stay distinct in Feed, got {event!r}")
 
 
+def test_claude_subagent_start_stays_distinct_feed_telemetry(cli_path: str, root: Path) -> None:
+    stdout, frame = run_feed_hook(
+        cli_path,
+        root / "cmux-claude-subagent-start.sock",
+        {
+            "session_id": "claude-session",
+            "cwd": "/tmp/project",
+            "hook_event_name": "SubagentStart",
+            "agent_id": "subagent-1",
+            "agent_type": "general-purpose",
+        },
+        None,
+        source="claude",
+    )
+    if stdout != {}:
+        raise AssertionError(f"SubagentStart telemetry should not emit a decision: {stdout!r}")
+    params = frame["params"]
+    if params.get("wait_timeout_seconds") != 0:
+        raise AssertionError(f"SubagentStart should not wait for Feed reply: {frame!r}")
+    event = params["event"]
+    if event.get("hook_event_name") != "SubagentStart" or event.get("_source") != "claude":
+        raise AssertionError(f"SubagentStart should stay distinct in Feed, got {event!r}")
+
+
 def main() -> int:
     try:
         cli_path = resolve_cmux_cli()
@@ -2110,6 +2134,7 @@ def main() -> int:
             test_permission_reply_uses_codex_permission_request_schema(cli_path, root)
             test_codex_persistent_permission_modes_degrade_to_once(cli_path, root)
             test_codex_pre_tool_use_is_telemetry_not_actionable(cli_path, root)
+            test_claude_subagent_start_stays_distinct_feed_telemetry(cli_path, root)
             test_claude_subagent_stop_stays_distinct_feed_telemetry(cli_path, root)
         except Exception as exc:
             print(f"FAIL: {exc}")


### PR DESCRIPTION
Summary:
- Auto-configure Claude native agent-team tmux env from the normal claude wrapper when running inside live cmux.
- Route Claude SubagentStart telemetry into Feed alongside SubagentStop.
- Let __tmux-compat resolve surface ids passed through TMUX_PANE back to their owning pane.

Docs checked:
- https://code.claude.com/docs/en/agents
- https://code.claude.com/docs/en/agent-teams
- https://code.claude.com/docs/en/hooks

Verification:
- ./scripts/reload.sh --tag cldteam
- bash -n Resources/bin/claude
- python3 tests/test_claude_wrapper_hooks.py
- python3 tests/test_cli_tmux_compat_split_window_surface_ref.py
- python3 tests/test_codex_feed_hooks.py
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4901"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782513636&installation_id=133855650&pr_number=4901&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4901&signature=3205ad78da723599ee606dd02466b30f52b1bc289675a4e99f630491e23123e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session launch env (PATH tmux shim, fake TMUX) and tmux-compat target resolution, which could affect split/teammate layout if mis-scoped; mitigated by opt-out flags and regression tests.
> 
> **Overview**
> **Normal Claude sessions in cmux** now opt into Claude’s experimental agent teams without a separate `claude-teams` entrypoint. The `claude` wrapper installs a `~/.cmuxterm/claude-teams-bin/tmux` shim ahead on `PATH` (delegating to `cmux __tmux-compat`), turns on `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` when unset, and when workspace/surface IDs are present sets scoped `TMUX` / `TMUX_PANE` and tmux-style `TERM`. Opt-out is via `CMUX_CLAUDE_AGENT_TEAMS_DISABLED` or `CMUX_CLAUDE_TEAMS_DISABLED`.
> 
> **Feed / workstream** gains **`SubagentStart`**: async `hooks feed` in injected Claude settings, CLI hook-name mapping, `WorkstreamEvent` + store handling (telemetry like session start), and tests that it stays distinct from `Stop`.
> 
> **`__tmux-compat`** resolves pane targets when the caller passes a **surface** id/ref (including via `TMUX_PANE`): lookup via `surface.list` → `pane_id` / `pane_ref`, workspace discovery also matches surfaces, and UUID pane ids are accepted only after list/index resolution fails. Split-window tests cover surface-ref/id `TMUX_PANE` and close/re-split flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca7657b0ecc9cbef055298297f2c12a3c8aaa40d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable Claude native agent teams in normal `claude` sessions when running inside live `cmux`, without switching binaries. Also send `SubagentStart` telemetry to Feed and make `__tmux-compat` resolve `TMUX_PANE` surface ids to their owning pane.

- New Features
  - Auto-configure agent-team tmux env from the `claude` wrapper: installs a tmux shim, prepends it to PATH, sets `TMUX`, `TMUX_PANE`, `TERM=screen-256color`, and enables `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`. Opt out via `CMUX_CLAUDE_AGENT_TEAMS_DISABLED` or `CMUX_CLAUDE_TEAMS_DISABLED`. Uses bundled `cmux` via `CMUX_CLAUDE_TEAMS_CMUX_BIN`.
  - Hook injection: add `SubagentStart` and route it to Feed asynchronously; keep `SubagentStop` as Feed-only.
  - Workstream: add `SubagentStart` event and handle it like `SessionStart`.
  - CLI tmux compat: resolve surface ids/refs (including from `TMUX_PANE`) to their owning pane; workspace resolution now also recognizes surface handles.

<sup>Written for commit ca7657b0ecc9cbef055298297f2c12a3c8aaa40d. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4901?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added native Agent Teams support with environment configuration and telemetry tracking for agent lifecycle events.
  * Users can opt out of Agent Teams functionality via environment flags.

* **Improvements**
  * Enhanced pane and surface reference resolution for team-based workflows.

* **Tests**
  * Added comprehensive test coverage for Agent Teams configuration, enablement, and opt-out scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4901?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->