### PR TITLE
Migrate macOS CI/CD runners to Blacksmith

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,7 @@
+self-hosted-runner:
+  labels:
+    - blacksmith-6vcpu-macos-15
+    - blacksmith-6vcpu-macos-26
+    - blacksmith-6vcpu-macos-latest
+
+config-variables: null

--- a/.github/workflows/build-ghosttykit.yml
+++ b/.github/workflows/build-ghosttykit.yml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   build-ghosttykit:
-    runs-on: warp-macos-15-arm64-6x
+    runs-on: blacksmith-6vcpu-macos-15
     timeout-minutes: 20
     env:
       GHOSTTYKIT_CRASH_REPORT_SUBDIR: cmux/crash

--- a/.github/workflows/ci-macos-compat.yml
+++ b/.github/workflows/ci-macos-compat.yml
@@ -9,12 +9,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: warp-macos-15-arm64-6x
+          - os: blacksmith-6vcpu-macos-15
             timeout: 30
             startup_smoke: true
             virtual_display: true
             skip_zig: false
-          - os: warp-macos-26-arm64-6x
+          - os: blacksmith-6vcpu-macos-26
             timeout: 30
             startup_smoke: true
             virtual_display: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
           bun test tests/vm-db-read-model.test.ts
 
   tests:
-    runs-on: warp-macos-15-arm64-6x
+    runs-on: blacksmith-6vcpu-macos-15
     timeout-minutes: 75
     env:
       CMUX_SKIP_ZIG_BUILD: "1"
@@ -380,7 +380,7 @@ jobs:
     # Keep lag validation separate from UI regressions so functional UI failures
     # and performance regressions stay isolated. Broader interactive UI suites
     # still run via test-e2e.yml on GitHub-hosted runners.
-    runs-on: warp-macos-15-arm64-6x
+    runs-on: blacksmith-6vcpu-macos-15
     timeout-minutes: 20
     steps:
       - name: Checkout
@@ -568,7 +568,7 @@ jobs:
     # Compile the same unsigned universal Release app that nightly builds before
     # signing, notarization, and publishing. This catches DEBUG/Release boundary
     # mistakes before they reach main.
-    runs-on: warp-macos-26-arm64-6x
+    runs-on: blacksmith-6vcpu-macos-26
     timeout-minutes: 20
     steps:
       - name: Checkout
@@ -653,7 +653,7 @@ jobs:
             CODE_SIGNING_ALLOWED=NO ASSETCATALOG_COMPILER_APPICON_NAME=AppIcon-Nightly build
 
   ui-regressions:
-    runs-on: warp-macos-15-arm64-6x
+    runs-on: blacksmith-6vcpu-macos-15
     timeout-minutes: 25
     steps:
       - name: Checkout

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -100,7 +100,7 @@ jobs:
   build-sign-notarize-nightly:
     needs: decide
     if: needs.decide.outputs.should_build == 'true'
-    runs-on: warp-macos-26-arm64-6x
+    runs-on: blacksmith-6vcpu-macos-26
     timeout-minutes: 20
     steps:
       - name: Checkout build ref

--- a/.github/workflows/perf-activation.yml
+++ b/.github/workflows/perf-activation.yml
@@ -86,8 +86,8 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: .ci-source-packages
-          key: spm-${{ hashFiles('cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
-          restore-keys: spm-
+          key: spm-${{ inputs.runner || 'blacksmith-6vcpu-macos-15' }}-${{ hashFiles('cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+          restore-keys: spm-${{ inputs.runner || 'blacksmith-6vcpu-macos-15' }}-
 
       - name: Resolve Swift packages
         run: |

--- a/.github/workflows/perf-activation.yml
+++ b/.github/workflows/perf-activation.yml
@@ -11,11 +11,12 @@ on:
       runner:
         description: macOS runner
         required: false
-        default: warp-macos-15-arm64-6x
+        default: blacksmith-6vcpu-macos-15
         type: choice
         options:
-          - warp-macos-15-arm64-6x
-          - depot-macos-latest
+          - blacksmith-6vcpu-macos-15
+          - blacksmith-6vcpu-macos-26
+          - blacksmith-6vcpu-macos-latest
       workspace_count:
         description: Fixture workspace count
         required: false
@@ -35,7 +36,7 @@ concurrency:
 
 jobs:
   activation-session:
-    runs-on: ${{ inputs.runner || 'warp-macos-15-arm64-6x' }}
+    runs-on: ${{ inputs.runner || 'blacksmith-6vcpu-macos-15' }}
     timeout-minutes: 45
     env:
       PERF_TAG: perfci

--- a/.github/workflows/perf-activation.yml
+++ b/.github/workflows/perf-activation.yml
@@ -130,6 +130,26 @@ jobs:
             --output perf-results/activation-session.json \
             --junit perf-results/activation-session.junit.xml
 
+      - name: Diagnose GUI session
+        run: |
+          set -uo pipefail
+          echo "job user: $(id -un) (uid $(id -u))"
+          CONSOLE_USER="$(stat -f %Su /dev/console 2>/dev/null || echo '?')"
+          echo "console user: $CONSOLE_USER"
+          if [ "$CONSOLE_USER" != "?" ] && [ "$CONSOLE_USER" != "root" ]; then
+            echo "console uid: $(id -u "$CONSOLE_USER" 2>/dev/null || echo '?')"
+          fi
+          echo "--- launchctl list (filtered for WindowServer/loginwindow) ---"
+          launchctl list 2>/dev/null | grep -iE 'windowserver|loginwindow|securityagent|coreaudio' || echo "(no matches)"
+          echo "--- WindowServer process ---"
+          pgrep -lf WindowServer || echo "(no WindowServer running)"
+          echo "--- loginwindow process ---"
+          pgrep -lf loginwindow || echo "(no loginwindow running)"
+          echo "--- ioreg display ---"
+          ioreg -lw0 | grep -i 'IODisplayConnect\|IOGraphics' | head -5 || true
+          echo "--- screencapture probe ---"
+          screencapture -x /tmp/probe.png 2>&1 && ls -la /tmp/probe.png || echo "(screencapture failed)"
+
       - name: Run Cmd-Tab activation benchmark
         run: |
           set -euo pipefail

--- a/.github/workflows/perf-activation.yml
+++ b/.github/workflows/perf-activation.yml
@@ -130,36 +130,21 @@ jobs:
             --output perf-results/activation-session.json \
             --junit perf-results/activation-session.junit.xml
 
-      - name: Diagnose GUI session
-        run: |
-          set -uo pipefail
-          echo "job user: $(id -un) (uid $(id -u))"
-          CONSOLE_USER="$(stat -f %Su /dev/console 2>/dev/null || echo '?')"
-          echo "console user: $CONSOLE_USER"
-          if [ "$CONSOLE_USER" != "?" ] && [ "$CONSOLE_USER" != "root" ]; then
-            echo "console uid: $(id -u "$CONSOLE_USER" 2>/dev/null || echo '?')"
-          fi
-          echo "--- launchctl list (filtered for WindowServer/loginwindow) ---"
-          launchctl list 2>/dev/null | grep -iE 'windowserver|loginwindow|securityagent|coreaudio' || echo "(no matches)"
-          echo "--- WindowServer process ---"
-          pgrep -lf WindowServer || echo "(no WindowServer running)"
-          echo "--- loginwindow process ---"
-          pgrep -lf loginwindow || echo "(no loginwindow running)"
-          echo "--- ioreg display ---"
-          ioreg -lw0 | grep -i 'IODisplayConnect\|IOGraphics' | head -5 || true
-          echo "--- screencapture probe ---"
-          screencapture -x /tmp/probe.png 2>&1 && ls -la /tmp/probe.png || echo "(screencapture failed)"
-
       - name: Run Cmd-Tab activation benchmark
         run: |
           set -euo pipefail
           APP_PATH="$HOME/Library/Developer/Xcode/DerivedData/cmux-$PERF_TAG/Build/Products/Debug/cmux DEV $PERF_TAG.app"
-          swift scripts/bench-window-visibility.swift \
-            "$APP_PATH" \
-            "com.cmuxterm.app.debug.$PERF_TAG" \
-            30 \
-            --cmd-tab-activation \
-            --cg-visibility \
+          # The GitHub Actions runner process runs in launchd's system
+          # bootstrap, not the console user's Aqua session, so windows
+          # created by apps launched via NSWorkspace.openApplication do
+          # not show up in CGWindowListCopyWindowInfo([.optionOnScreenOnly]).
+          # Re-enter the Aqua session via launchctl asuser before running
+          # the bench so visibility polling sees real on-screen windows.
+          CONSOLE_USER="$(stat -f %Su /dev/console)"
+          CONSOLE_UID="$(id -u "$CONSOLE_USER")"
+          sudo -n launchctl asuser "$CONSOLE_UID" sudo -n -u "$CONSOLE_USER" -E \
+            env PATH="$PATH" DEVELOPER_DIR="$DEVELOPER_DIR" \
+            bash -c "cd '$PWD' && swift scripts/bench-window-visibility.swift '$APP_PATH' 'com.cmuxterm.app.debug.$PERF_TAG' 30 --cmd-tab-activation --cg-visibility" \
             > perf-results/cmd-tab-activation.txt
           cat perf-results/cmd-tab-activation.txt
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   build-sign-notarize:
-    runs-on: warp-macos-26-arm64-6x
+    runs-on: blacksmith-6vcpu-macos-26
     timeout-minutes: 20
     steps:
       - name: Checkout

--- a/.github/workflows/test-depot.yml
+++ b/.github/workflows/test-depot.yml
@@ -28,7 +28,7 @@ on:
 
 jobs:
   tests:
-    runs-on: warp-macos-15-arm64-6x
+    runs-on: blacksmith-6vcpu-macos-15
     timeout-minutes: 20
     steps:
       - name: Checkout

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -20,17 +20,20 @@ on:
         default: true
         type: boolean
       runner:
-        description: "Runner OS (Depot runners for GUI activation support)"
+        description: "Runner OS"
         required: false
-        default: "depot-macos-latest"
+        default: "blacksmith-6vcpu-macos-latest"
         type: choice
         options:
+          - blacksmith-6vcpu-macos-latest
+          - blacksmith-6vcpu-macos-26
+          - blacksmith-6vcpu-macos-15
           - depot-macos-latest
           - depot-macos-14
 
 jobs:
   e2e:
-    runs-on: ${{ inputs.runner || 'depot-macos-latest' }}
+    runs-on: ${{ inputs.runner || 'blacksmith-6vcpu-macos-latest' }}
     timeout-minutes: 20
     env:
       TEST_REF: ${{ inputs.ref || github.ref }}
@@ -172,8 +175,8 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: .ci-source-packages
-          key: spm-${{ inputs.runner || 'depot-macos-latest' }}-${{ hashFiles('cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
-          restore-keys: spm-${{ inputs.runner || 'depot-macos-latest' }}-
+          key: spm-${{ inputs.runner || 'blacksmith-6vcpu-macos-latest' }}-${{ hashFiles('cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+          restore-keys: spm-${{ inputs.runner || 'blacksmith-6vcpu-macos-latest' }}-
 
       - name: Resolve Swift packages
         run: |

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -20,20 +20,20 @@ on:
         default: true
         type: boolean
       runner:
-        description: "Runner OS"
+        description: "Runner OS (macOS 15 default for GUI activation support)"
         required: false
-        default: "blacksmith-6vcpu-macos-latest"
+        default: "blacksmith-6vcpu-macos-15"
         type: choice
         options:
-          - blacksmith-6vcpu-macos-latest
-          - blacksmith-6vcpu-macos-26
           - blacksmith-6vcpu-macos-15
+          - blacksmith-6vcpu-macos-26
+          - blacksmith-6vcpu-macos-latest
           - depot-macos-latest
           - depot-macos-14
 
 jobs:
   e2e:
-    runs-on: ${{ inputs.runner || 'blacksmith-6vcpu-macos-latest' }}
+    runs-on: ${{ inputs.runner || 'blacksmith-6vcpu-macos-15' }}
     timeout-minutes: 20
     env:
       TEST_REF: ${{ inputs.ref || github.ref }}
@@ -175,8 +175,8 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: .ci-source-packages
-          key: spm-${{ inputs.runner || 'blacksmith-6vcpu-macos-latest' }}-${{ hashFiles('cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
-          restore-keys: spm-${{ inputs.runner || 'blacksmith-6vcpu-macos-latest' }}-
+          key: spm-${{ inputs.runner || 'blacksmith-6vcpu-macos-15' }}-${{ hashFiles('cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+          restore-keys: spm-${{ inputs.runner || 'blacksmith-6vcpu-macos-15' }}-
 
       - name: Resolve Swift packages
         run: |

--- a/.github/workflows/tmux-corpus.yml
+++ b/.github/workflows/tmux-corpus.yml
@@ -57,7 +57,7 @@ jobs:
 
   terminal-nightly:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    runs-on: [self-hosted, warp-macos-15-arm64-6x]
+    runs-on: blacksmith-6vcpu-macos-15
     timeout-minutes: 30
     steps:
       - name: Checkout

--- a/tests/test_ci_self_hosted_guard.sh
+++ b/tests/test_ci_self_hosted_guard.sh
@@ -14,15 +14,15 @@ check_blacksmith_runner() {
   local file="$1" job="$2"
   if ! awk -v job="$job" '
     $0 ~ "^  "job":" { in_job=1; next }
-    in_job && /^  [^[:space:]]/ { in_job=0 }
+    in_job && /^  [^[:space:]#][^:]*:[[:space:]]*(#.*)?$/ { in_job=0 }
     in_job && /runs-on:.*blacksmith-[0-9]+vcpu-macos-/ { saw=1 }
     in_job && /os: blacksmith-[0-9]+vcpu-macos-/ { saw=1 }
     END { exit !(saw) }
   ' "$file"; then
-    echo "FAIL: $job in $(basename "$file") must use a Blacksmith macOS runner"
+    echo "FAIL: $job in $(basename "$file") must use the expected macOS runner"
     exit 1
   fi
-  echo "PASS: $job Blacksmith runner is present"
+  echo "PASS: $job in $(basename "$file") uses the expected macOS runner"
 }
 
 # ci.yml jobs

--- a/tests/test_ci_self_hosted_guard.sh
+++ b/tests/test_ci_self_hosted_guard.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Regression test for https://github.com/manaflow-ai/cmux/issues/385.
-# Ensures paid CI jobs use WarpBuild runners.
+# Ensures paid CI jobs use Blacksmith macOS runners.
 # Fork PRs are gated by GitHub's built-in "Require approval for outside
 # collaborators" setting, so workflow-level fork guards are not needed.
 set -euo pipefail
@@ -10,29 +10,29 @@ CI_FILE="$ROOT_DIR/.github/workflows/ci.yml"
 GHOSTTYKIT_FILE="$ROOT_DIR/.github/workflows/build-ghosttykit.yml"
 COMPAT_FILE="$ROOT_DIR/.github/workflows/ci-macos-compat.yml"
 
-check_warp_runner() {
+check_blacksmith_runner() {
   local file="$1" job="$2"
   if ! awk -v job="$job" '
     $0 ~ "^  "job":" { in_job=1; next }
     in_job && /^  [^[:space:]]/ { in_job=0 }
-    in_job && /runs-on:.*warp-macos-.*-arm64/ { saw_warp=1 }
-    in_job && /os: warp-macos-.*-arm64/ { saw_warp=1 }
-    END { exit !(saw_warp) }
+    in_job && /runs-on:.*blacksmith-[0-9]+vcpu-macos-/ { saw=1 }
+    in_job && /os: blacksmith-[0-9]+vcpu-macos-/ { saw=1 }
+    END { exit !(saw) }
   ' "$file"; then
-    echo "FAIL: $job in $(basename "$file") must use a WarpBuild runner"
+    echo "FAIL: $job in $(basename "$file") must use a Blacksmith macOS runner"
     exit 1
   fi
-  echo "PASS: $job WarpBuild runner is present"
+  echo "PASS: $job Blacksmith runner is present"
 }
 
 # ci.yml jobs
-check_warp_runner "$CI_FILE" "tests"
-check_warp_runner "$CI_FILE" "tests-build-and-lag"
-check_warp_runner "$CI_FILE" "release-build"
-check_warp_runner "$CI_FILE" "ui-regressions"
+check_blacksmith_runner "$CI_FILE" "tests"
+check_blacksmith_runner "$CI_FILE" "tests-build-and-lag"
+check_blacksmith_runner "$CI_FILE" "release-build"
+check_blacksmith_runner "$CI_FILE" "ui-regressions"
 
 # build-ghosttykit.yml
-check_warp_runner "$GHOSTTYKIT_FILE" "build-ghosttykit"
+check_blacksmith_runner "$GHOSTTYKIT_FILE" "build-ghosttykit"
 
-# ci-macos-compat.yml (uses matrix.os with WarpBuild runners)
-check_warp_runner "$COMPAT_FILE" "compat-tests"
+# ci-macos-compat.yml (uses matrix.os with Blacksmith runners)
+check_blacksmith_runner "$COMPAT_FILE" "compat-tests"


### PR DESCRIPTION
## Summary

Switches every macOS CI job from WarpBuild (`warp-macos-*-arm64-6x`) and Depot (`depot-macos-latest`) to Blacksmith (`blacksmith-6vcpu-macos-{15,26,latest}`).

## Workflows touched

- `ci.yml` — tests, tests-build-and-lag, release-build, ui-regressions
- `build-ghosttykit.yml`
- `ci-macos-compat.yml` (matrix os values)
- `nightly.yml` (build-sign-notarize-nightly)
- `release.yml` (build-sign-notarize)
- `test-depot.yml`
- `perf-activation.yml` (default + choice options)
- `tmux-corpus.yml` (terminal-nightly; also drops the `self-hosted` label)
- `test-e2e.yml` (default `blacksmith-6vcpu-macos-latest`, keeps `depot-macos-{latest,14}` as fallback options on the workflow_dispatch input)

`tests/test_ci_self_hosted_guard.sh` updated to assert Blacksmith runners on the paid jobs from https://github.com/manaflow-ai/cmux/issues/385.

Size mapping is 1:1: every 6x WarpBuild job becomes a 6vcpu Blacksmith job. macOS 15 vs 26 preserved per job.

## Test plan

- [ ] Re-run `tests/test_ci_self_hosted_guard.sh` (passes locally)
- [ ] Manually trigger `ci-macos-compat.yml` to confirm both Blacksmith images boot
- [ ] Trigger `nightly.yml` with `force=true` and confirm sign+notarize completes
- [ ] Trigger `test-e2e.yml` with the new default runner
- [ ] Verify a `release.yml` dry run (or next real release) on `blacksmith-6vcpu-macos-26`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4902"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782513757&installation_id=133855650&pr_number=4902&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4902&signature=e30229a2cea6a4b53d2f9408873f64851776d80a9335b589429a47bf34953988"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches signing/notarization, release, and nightly pipelines plus GUI perf benchmarks; misconfigured runners or the Aqua-session workaround could break macOS CI or artifact publishing until validated on Blacksmith.
> 
> **Overview**
> Moves **macOS CI/CD** off WarpBuild (`warp-macos-*-arm64-6x`) and Depot defaults onto **Blacksmith** labels (`blacksmith-6vcpu-macos-15`, `-26`, `-latest`) across build, test, release, nightly, perf, e2e, and corpus workflows, with a 1:1 mapping from former 6x Warp jobs to 6vcpu Blacksmith jobs.
> 
> Adds **`.github/actionlint.yaml`** so actionlint accepts the new self-hosted runner labels. **`tests/test_ci_self_hosted_guard.sh`** now requires Blacksmith runners on the paid macOS jobs from issue #385 (including matrix `os` in compat).
> 
> **`perf-activation.yml`** changes defaults and `workflow_dispatch` runner choices to Blacksmith, scopes SwiftPM cache keys by runner, and runs the Cmd-Tab visibility bench inside the console user’s **Aqua** session via `launchctl asuser` so `CGWindowList` sees on-screen windows. **`test-e2e.yml`** defaults to Blacksmith while keeping Depot as optional dispatch choices; SPM cache keys follow the selected runner. **`tmux-corpus.yml`** `terminal-nightly` drops the `self-hosted` + Warp label pair in favor of a single Blacksmith runner.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a61c666ae2a7ee1f6c1eca6ae51eeaeae0701395. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized macOS runners to Blacksmith across CI/CD, nightly, release, build, perf, and E2E workflows.
  * Updated activation/performance and E2E workflow runner defaults and expanded available runner choices.
  * Adjusted Swift package caching and activation benchmark invocation to work with the new runner setup.
  * Added ActionLint config to recognize Blacksmith runner labels.

* **Tests**
  * Updated CI guard to enforce Blacksmith macOS runners for relevant workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4902?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->