### PR TITLE
Deflake Grok notification CI coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,7 +286,6 @@ jobs:
               -disableAutomaticPackageResolution \
               -destination "platform=macOS" \
               CMUX_SKIP_ZIG_BUILD=1 \
-              -skip-testing:cmuxTests/CLINotifyProcessIntegrationRegressionTests/testGrokNotificationStillFiresOnRepeatedPromptWhenFeedTelemetryDoesNotReply \
               -skip-testing:cmuxTests/FileExplorerStoreTests/testRemoteWorkspaceRootRequestResolvesSSHHomeInsteadOfKeepingLocalPath \
               -skip-testing:cmuxTests/GhosttySurfaceOverlayTests \
               test 2>&1 &

--- a/cmuxTests/CLIGenericHookPersistenceTests.swift
+++ b/cmuxTests/CLIGenericHookPersistenceTests.swift
@@ -1481,7 +1481,7 @@ extension CLINotifyProcessIntegrationRegressionTests {
             "CMUX_CLI_SENTRY_DISABLED": "1",
         ]
 
-        func runGrokHook(_ subcommand: String, input: String, stallFeedTelemetry: Bool = false, timeout: TimeInterval = 5) -> ProcessRunResult {
+        func runGrokHook(_ subcommand: String, input: String, stallFeedTelemetry: Bool = false) -> ProcessRunResult {
             let serverHandled = startMockServerAllowingNoResponse(listenerFD: listenerFD, state: state) { line in
                 guard let payload = self.jsonObject(line) else {
                     return "OK"
@@ -1503,7 +1503,7 @@ extension CLINotifyProcessIntegrationRegressionTests {
                 arguments: ["hooks", "grok", subcommand],
                 environment: environment,
                 standardInput: input,
-                timeout: timeout
+                timeout: 5
             )
             wait(for: [serverHandled], timeout: 5)
             return result
@@ -1529,8 +1529,7 @@ extension CLINotifyProcessIntegrationRegressionTests {
             let notification = runGrokHook(
                 "notification",
                 input: #"{"sessionId":"\#(sessionId)","cwd":"\#(root.path)","hookEventName":"Notification","message":"\#(message)"}"#,
-                stallFeedTelemetry: index == 2,
-                timeout: 2
+                stallFeedTelemetry: index == 2
             )
 
             XCTAssertFalse(notification.timedOut, notification.stderr)


### PR DESCRIPTION
## Summary
- replace the Grok feed telemetry timeout test path with a deterministic dropped-reply socket path
- remove the stale CI skip for the Grok notification coverage

## Validation
- git diff --check
- xcodebuild -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-grok-notify build

Issue: https://github.com/manaflow-ai/cmux/issues/4524

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4903"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782514524&installation_id=133855650&pr_number=4903&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4903&signature=dd7ca48972125b9e4931e8933454060a40ef12bb3759859e192857edfaeae2d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and test-only timing changes; no production hook or notification logic in this diff.
> 
> **Overview**
> Re-enables the Grok integration test **`testGrokNotificationStillFiresOnRepeatedPromptWhenFeedTelemetryDoesNotReply`** in CI by dropping the **`-skip-testing`** entry from the unit-test **`xcodebuild`** invocation.
> 
> In **`CLIGenericHookPersistenceTests`**, the flaky path is tightened: **`runGrokHook`** no longer takes a per-call **`timeout`** (subprocess timeout is fixed at **5s**), and the second prompt’s notification case still uses **`stallFeedTelemetry: index == 2`** without a shorter **2s** timeout on that hook run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77cb689a3331a05ff22cfe063108705440b37383. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deflakes the Grok notification integration test by simulating a dropped socket and using a short, env-configurable feed telemetry timeout; re-enables the test in CI. Restores stable coverage and addresses #4524.

- **Bug Fixes**
  - Use a deterministic no-reply path: add `closeAfterNoResponse` to the mock server, switch `runGrokHook` to `closeFeedTelemetryBeforeReply`, and respect `CMUX_AGENT_HOOK_FEED_TELEMETRY_RESPONSE_TIMEOUT_SEC` (clamped to 0.75s; tests use 0.05s) with a hard 5s process timeout.
  - Remove CI skip for `cmuxTests/CLINotifyProcessIntegrationRegressionTests/testGrokNotificationStillFiresOnRepeatedPromptWhenFeedTelemetryDoesNotReply`.

<sup>Written for commit 77cb689a3331a05ff22cfe063108705440b37383. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4903?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Re-enabled integration regression test for notification behavior under repeated prompts to strengthen validation coverage.
  * Simplified test helper initialization by removing per-call timeout parameter overrides.

* **Chores**
  * Updated CI workflow to include previously excluded regression tests in the standard unit test execution suite.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4903?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->