### PR TITLE
Fix restored browser split portal after Cmd-D

### DIFF
--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -12865,6 +12865,9 @@ final class Workspace: Identifiable, ObservableObject {
         if startupCommand != nil {
             var template = inheritedConfig ?? CmuxSurfaceConfigTemplate()
             template.waitAfterCommand = true
+            if usesRemoteTerminalStartupCommand {
+                template.workingDirectory = nil
+            }
             inheritedConfig = template
         }
 #if DEBUG
@@ -13044,6 +13047,9 @@ final class Workspace: Identifiable, ObservableObject {
         if startupCommand != nil {
             var template = inheritedConfig ?? CmuxSurfaceConfigTemplate()
             template.waitAfterCommand = true
+            if usesRemoteTerminalStartupCommand {
+                template.workingDirectory = nil
+            }
             inheritedConfig = template
         }
 

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -12855,6 +12855,7 @@ final class Workspace: Identifiable, ObservableObject {
         let requestedInitialCommand = initialCommand?.trimmingCharacters(in: .whitespacesAndNewlines)
         let explicitInitialCommand = (requestedInitialCommand?.isEmpty == false) ? requestedInitialCommand : nil
         let remoteTerminalStartupCommand = remoteTerminalStartupCommand()
+        let usesRemoteTerminalStartupCommand = explicitInitialCommand == nil && remoteTerminalStartupCommand != nil
         let startupCommand = explicitInitialCommand ?? remoteTerminalStartupCommand
         // Hold the pane open after the remote session ends so the user can read the
         // "ssh exited …" message the startup script prints. Otherwise Ghostty silently
@@ -12895,6 +12896,7 @@ final class Workspace: Identifiable, ObservableObject {
             let workspaceDirectory = currentDirectory.trimmingCharacters(in: .whitespacesAndNewlines)
             return workspaceDirectory.isEmpty ? nil : workspaceDirectory
         }()
+        let terminalWorkingDirectory = usesRemoteTerminalStartupCommand ? nil : splitWorkingDirectory
 #if DEBUG
         cmuxDebugLog(
             "split.cwd panelId=\(panelId.uuidString.prefix(5)) panelDir=\(panelDirectories[panelId] ?? "nil") requestedDir=\(terminalPanel(for: panelId)?.requestedWorkingDirectory ?? "nil") currentDir=\(currentDirectory) resolved=\(splitWorkingDirectory ?? "nil")"
@@ -12906,7 +12908,7 @@ final class Workspace: Identifiable, ObservableObject {
             workspaceId: id,
             context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
             configTemplate: inheritedConfig,
-            workingDirectory: splitWorkingDirectory,
+            workingDirectory: terminalWorkingDirectory,
             portOrdinal: portOrdinal,
             initialCommand: startupCommand,
             tmuxStartCommand: tmuxStartCommand,
@@ -12915,6 +12917,10 @@ final class Workspace: Identifiable, ObservableObject {
         configureTerminalPanel(newPanel)
         panels[newPanel.id] = newPanel
         panelTitles[newPanel.id] = newPanel.displayTitle
+        if usesRemoteTerminalStartupCommand,
+           let splitWorkingDirectory {
+            updatePanelDirectory(panelId: newPanel.id, directory: splitWorkingDirectory)
+        }
         let normalizedRemotePTYSessionID = normalizedRemotePTYSessionID(remotePTYSessionID)
         let tracksRemoteTerminalSurface = remoteTerminalStartupCommand != nil || normalizedRemotePTYSessionID != nil
         if let normalizedRemotePTYSessionID {
@@ -13030,6 +13036,7 @@ final class Workspace: Identifiable, ObservableObject {
         let requestedInitialCommand = initialCommand?.trimmingCharacters(in: .whitespacesAndNewlines)
         let explicitInitialCommand = (requestedInitialCommand?.isEmpty == false) ? requestedInitialCommand : nil
         let remoteTerminalStartupCommand = remoteTerminalStartupCommand()
+        let usesRemoteTerminalStartupCommand = explicitInitialCommand == nil && remoteTerminalStartupCommand != nil
         let startupCommand = explicitInitialCommand ?? remoteTerminalStartupCommand
         // See the comment at the other call site: hold the PTY open after the remote
         // command exits so the user sees the error rather than a silently-respawned
@@ -13045,7 +13052,7 @@ final class Workspace: Identifiable, ObservableObject {
             workspaceId: id,
             context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
             configTemplate: inheritedConfig,
-            workingDirectory: workingDirectory,
+            workingDirectory: usesRemoteTerminalStartupCommand ? nil : workingDirectory,
             portOrdinal: portOrdinal,
             initialCommand: startupCommand,
             tmuxStartCommand: tmuxStartCommand,
@@ -13055,6 +13062,10 @@ final class Workspace: Identifiable, ObservableObject {
         configureTerminalPanel(newPanel)
         panels[newPanel.id] = newPanel
         panelTitles[newPanel.id] = newPanel.displayTitle
+        if usesRemoteTerminalStartupCommand,
+           let workingDirectory {
+            updatePanelDirectory(panelId: newPanel.id, directory: workingDirectory)
+        }
         let normalizedRemotePTYSessionID = normalizedRemotePTYSessionID(remotePTYSessionID)
         let tracksRemoteTerminalSurface = remoteTerminalStartupCommand != nil || normalizedRemotePTYSessionID != nil
         if let normalizedRemotePTYSessionID {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -17170,9 +17170,19 @@ extension Workspace: BonsplitDelegate {
             "originalKinds=[\(paneKindSummary(originalPane))] newKinds=[\(paneKindSummary(newPane))]"
         )
 #endif
-        let rearmBrowserPortalHostReplacement: (PaneID, String) -> Void = { paneId, reason in
+        var rearmedBrowserPanelIds: Set<UUID> = []
+        for paneId in controller.allPaneIds {
+            let reason: String
+            if paneId == originalPane {
+                reason = "workspace.didSplit.original"
+            } else if paneId == newPane {
+                reason = "workspace.didSplit.new"
+            } else {
+                reason = "workspace.didSplit.topology"
+            }
             for tab in controller.tabs(inPane: paneId) {
                 guard let panelId = self.panelIdFromSurfaceId(tab.id),
+                      rearmedBrowserPanelIds.insert(panelId).inserted,
                       let browserPanel = self.browserPanel(for: panelId) else {
                     continue
                 }
@@ -17182,8 +17192,6 @@ extension Workspace: BonsplitDelegate {
                 )
             }
         }
-        rearmBrowserPortalHostReplacement(originalPane, "workspace.didSplit.original")
-        rearmBrowserPortalHostReplacement(newPane, "workspace.didSplit.new")
 
         // Only auto-create a terminal if the split came from bonsplit UI.
         // Programmatic splits via newTerminalSplit() set isProgrammaticSplit and handle their own panels.

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -12655,6 +12655,18 @@ final class Workspace: Identifiable, ObservableObject {
         lastTerminalConfigInheritanceFontPoints = fontPoints
     }
 
+    private func terminalConfigTemplateForStartupCommand(
+        _ configTemplate: CmuxSurfaceConfigTemplate?,
+        clearsWorkingDirectory: Bool
+    ) -> CmuxSurfaceConfigTemplate {
+        var template = configTemplate ?? CmuxSurfaceConfigTemplate()
+        template.waitAfterCommand = true
+        if clearsWorkingDirectory {
+            template.workingDirectory = nil
+        }
+        return template
+    }
+
     private func resolvedTerminalInheritanceFontPoints(
         for terminalPanel: TerminalPanel,
         sourceSurface: ghostty_surface_t,
@@ -12863,12 +12875,10 @@ final class Workspace: Identifiable, ObservableObject {
         // to $SHELL), and a dead VM looks identical to a healthy workspace with a
         // local prompt — which is what we saw during dogfood.
         if startupCommand != nil {
-            var template = inheritedConfig ?? CmuxSurfaceConfigTemplate()
-            template.waitAfterCommand = true
-            if usesRemoteTerminalStartupCommand {
-                template.workingDirectory = nil
-            }
-            inheritedConfig = template
+            inheritedConfig = terminalConfigTemplateForStartupCommand(
+                inheritedConfig,
+                clearsWorkingDirectory: usesRemoteTerminalStartupCommand
+            )
         }
 #if DEBUG
         dlog(
@@ -13046,12 +13056,10 @@ final class Workspace: Identifiable, ObservableObject {
         // command exits so the user sees the error rather than a silently-respawned
         // local login shell.
         if startupCommand != nil {
-            var template = inheritedConfig ?? CmuxSurfaceConfigTemplate()
-            template.waitAfterCommand = true
-            if usesRemoteTerminalStartupCommand {
-                template.workingDirectory = nil
-            }
-            inheritedConfig = template
+            inheritedConfig = terminalConfigTemplateForStartupCommand(
+                inheritedConfig,
+                clearsWorkingDirectory: usesRemoteTerminalStartupCommand
+            )
         }
 
         // Create new terminal panel
@@ -16039,10 +16047,10 @@ final class Workspace: Identifiable, ObservableObject {
         let requestedRemoteStartupCommand = remoteStartupCommand?.trimmingCharacters(in: .whitespacesAndNewlines)
         let startupCommand = requestedRemoteStartupCommand?.isEmpty == false ? requestedRemoteStartupCommand : nil
         if startupCommand != nil {
-            var template = inheritedConfig ?? CmuxSurfaceConfigTemplate()
-            template.waitAfterCommand = true
-            template.workingDirectory = nil
-            inheritedConfig = template
+            inheritedConfig = terminalConfigTemplateForStartupCommand(
+                inheritedConfig,
+                clearsWorkingDirectory: true
+            )
         }
         let terminalWorkingDirectory = startupCommand == nil ? workingDirectory : nil
 

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -12965,6 +12965,7 @@ final class Workspace: Identifiable, ObservableObject {
             panelTitles.removeValue(forKey: newPanel.id)
             remotePTYSessionIDsByPanelId.removeValue(forKey: newPanel.id)
             surfaceIdToPanelId.removeValue(forKey: newTab.id)
+            panelDirectories.removeValue(forKey: newPanel.id)
             if tracksRemoteTerminalSurface {
                 untrackRemoteTerminalSurface(newPanel.id)
             }
@@ -13094,6 +13095,7 @@ final class Workspace: Identifiable, ObservableObject {
             panels.removeValue(forKey: newPanel.id)
             panelTitles.removeValue(forKey: newPanel.id)
             remotePTYSessionIDsByPanelId.removeValue(forKey: newPanel.id)
+            panelDirectories.removeValue(forKey: newPanel.id)
             if tracksRemoteTerminalSurface {
                 untrackRemoteTerminalSurface(newPanel.id)
             }
@@ -16039,14 +16041,16 @@ final class Workspace: Identifiable, ObservableObject {
         if startupCommand != nil {
             var template = inheritedConfig ?? CmuxSurfaceConfigTemplate()
             template.waitAfterCommand = true
+            template.workingDirectory = nil
             inheritedConfig = template
         }
+        let terminalWorkingDirectory = startupCommand == nil ? workingDirectory : nil
 
         let newPanel = TerminalPanel(
             workspaceId: id,
             context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
             configTemplate: inheritedConfig,
-            workingDirectory: workingDirectory,
+            workingDirectory: terminalWorkingDirectory,
             portOrdinal: portOrdinal,
             initialCommand: startupCommand,
             initialInput: initialInput
@@ -16054,6 +16058,10 @@ final class Workspace: Identifiable, ObservableObject {
         configureTerminalPanel(newPanel)
         panels[newPanel.id] = newPanel
         panelTitles[newPanel.id] = newPanel.displayTitle
+        if startupCommand != nil,
+           let workingDirectory {
+            updatePanelDirectory(panelId: newPanel.id, directory: workingDirectory)
+        }
         if startupCommand != nil {
             trackRemoteTerminalSurface(newPanel.id)
         }
@@ -16074,6 +16082,7 @@ final class Workspace: Identifiable, ObservableObject {
             panels.removeValue(forKey: newPanel.id)
             panelTitles.removeValue(forKey: newPanel.id)
             surfaceIdToPanelId.removeValue(forKey: newTab.id)
+            panelDirectories.removeValue(forKey: newPanel.id)
             if startupCommand != nil {
                 untrackRemoteTerminalSurface(newPanel.id)
             }

--- a/cmuxTests/TabManagerSessionSnapshotTests.swift
+++ b/cmuxTests/TabManagerSessionSnapshotTests.swift
@@ -1574,6 +1574,34 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
         ))
     }
 
+    func testRestoredPersistentSSHCmdDSplitDoesNotPassLocalWorkingDirectoryToAttachCommand() throws {
+        let terminalPanelId = UUID()
+        let restoredWorkingDirectory = "/Users/lawrence/fun"
+        let snapshot = Self.persistentSSHWorkspaceSnapshot(
+            panel: Self.terminalPanelSnapshot(id: terminalPanelId),
+            focusedPanelId: terminalPanelId,
+            currentDirectory: restoredWorkingDirectory
+        )
+        let workspace = Workspace()
+        let restoredPanelIds = workspace.restoreSessionSnapshot(snapshot)
+        let restoredTerminalPanelId = try XCTUnwrap(restoredPanelIds[terminalPanelId])
+
+        workspace.focusPanel(restoredTerminalPanelId)
+        let splitPanel = try XCTUnwrap(workspace.newTerminalSplit(
+            from: restoredTerminalPanelId,
+            orientation: .horizontal,
+            focus: true
+        ))
+        let splitStartupCommand = try XCTUnwrap(splitPanel.surface.debugInitialCommand())
+
+        XCTAssertTrue(splitStartupCommand.contains("ssh-pty-attach"), splitStartupCommand)
+        XCTAssertNil(
+            splitPanel.requestedWorkingDirectory,
+            "Remote SSH attach scripts must not be passed to Ghostty with a local cwd; Ghostty treats inline scripts as relative executable paths."
+        )
+        XCTAssertEqual(workspace.panelDirectories[splitPanel.id], restoredWorkingDirectory)
+    }
+
     func testSessionSnapshotIncludesRemoteWorkspacesForRestore() throws {
         let manager = TabManager()
         let remoteWorkspace = manager.addWorkspace(select: true)
@@ -1969,7 +1997,8 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
 
     private static func persistentSSHWorkspaceSnapshot(
         panel: SessionPanelSnapshot,
-        focusedPanelId: UUID
+        focusedPanelId: UUID,
+        currentDirectory: String = NSHomeDirectory()
     ) -> SessionWorkspaceSnapshot {
         persistentSSHWorkspaceSnapshot(
             panels: [panel],
@@ -1977,14 +2006,16 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
                 panelIds: [focusedPanelId],
                 selectedPanelId: focusedPanelId
             )),
-            focusedPanelId: focusedPanelId
+            focusedPanelId: focusedPanelId,
+            currentDirectory: currentDirectory
         )
     }
 
     private static func persistentSSHWorkspaceSnapshot(
         panels: [SessionPanelSnapshot],
         layout: SessionWorkspaceLayoutSnapshot,
-        focusedPanelId: UUID
+        focusedPanelId: UUID,
+        currentDirectory: String = NSHomeDirectory()
     ) -> SessionWorkspaceSnapshot {
         SessionWorkspaceSnapshot(
             processTitle: "Persistent SSH",
@@ -1993,7 +2024,7 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
             customColor: nil,
             isPinned: false,
             terminalScrollBarHidden: nil,
-            currentDirectory: NSHomeDirectory(),
+            currentDirectory: currentDirectory,
             focusedPanelId: focusedPanelId,
             layout: layout,
             panels: panels,

--- a/cmuxTests/TabManagerSessionSnapshotTests.swift
+++ b/cmuxTests/TabManagerSessionSnapshotTests.swift
@@ -1,4 +1,5 @@
 import Darwin
+import CoreGraphics
 import XCTest
 
 #if canImport(cmux_DEV)
@@ -1515,6 +1516,64 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
         ))
     }
 
+    func testRestoredPersistentSSHBrowserSiblingAcceptsPortalHostAfterTerminalSplit() throws {
+        let terminalPanelId = UUID()
+        let browserPanelId = UUID()
+        let snapshot = Self.persistentSSHWorkspaceSnapshot(
+            panels: [
+                Self.terminalPanelSnapshot(id: terminalPanelId),
+                Self.browserPanelSnapshot(id: browserPanelId)
+            ],
+            layout: .split(SessionSplitLayoutSnapshot(
+                orientation: .horizontal,
+                dividerPosition: 0.5,
+                first: .pane(SessionPaneLayoutSnapshot(
+                    panelIds: [terminalPanelId],
+                    selectedPanelId: terminalPanelId
+                )),
+                second: .pane(SessionPaneLayoutSnapshot(
+                    panelIds: [browserPanelId],
+                    selectedPanelId: browserPanelId
+                ))
+            )),
+            focusedPanelId: terminalPanelId
+        )
+        let workspace = Workspace()
+        let restoredPanelIds = workspace.restoreSessionSnapshot(snapshot)
+        let restoredTerminalPanelId = try XCTUnwrap(restoredPanelIds[terminalPanelId])
+        let restoredBrowserPanelId = try XCTUnwrap(restoredPanelIds[browserPanelId])
+        let browserPanel = try XCTUnwrap(workspace.browserPanel(for: restoredBrowserPanelId))
+        let browserPaneId = try XCTUnwrap(workspace.paneId(forPanelId: restoredBrowserPanelId))
+        let initialHost = PortalHostClaimToken()
+        let replacementHost = PortalHostClaimToken()
+        let hostBounds = CGRect(x: 0, y: 0, width: 800, height: 600)
+
+        workspace.focusPanel(restoredTerminalPanelId)
+        XCTAssertTrue(browserPanel.claimPortalHost(
+            hostId: ObjectIdentifier(initialHost),
+            paneId: browserPaneId,
+            inWindow: true,
+            bounds: hostBounds,
+            reason: "test.initial"
+        ))
+
+        let splitPanel = try XCTUnwrap(workspace.newTerminalSplit(
+            from: restoredTerminalPanelId,
+            orientation: .horizontal,
+            focus: true
+        ))
+        XCTAssertNotEqual(workspace.paneId(forPanelId: splitPanel.id), browserPaneId)
+        XCTAssertEqual(workspace.paneId(forPanelId: restoredBrowserPanelId), browserPaneId)
+
+        XCTAssertTrue(browserPanel.claimPortalHost(
+            hostId: ObjectIdentifier(replacementHost),
+            paneId: browserPaneId,
+            inWindow: true,
+            bounds: hostBounds,
+            reason: "test.afterTerminalSplit"
+        ))
+    }
+
     func testSessionSnapshotIncludesRemoteWorkspacesForRestore() throws {
         let manager = TabManager()
         let remoteWorkspace = manager.addWorkspace(select: true)
@@ -1912,6 +1971,21 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
         panel: SessionPanelSnapshot,
         focusedPanelId: UUID
     ) -> SessionWorkspaceSnapshot {
+        persistentSSHWorkspaceSnapshot(
+            panels: [panel],
+            layout: .pane(SessionPaneLayoutSnapshot(
+                panelIds: [focusedPanelId],
+                selectedPanelId: focusedPanelId
+            )),
+            focusedPanelId: focusedPanelId
+        )
+    }
+
+    private static func persistentSSHWorkspaceSnapshot(
+        panels: [SessionPanelSnapshot],
+        layout: SessionWorkspaceLayoutSnapshot,
+        focusedPanelId: UUID
+    ) -> SessionWorkspaceSnapshot {
         SessionWorkspaceSnapshot(
             processTitle: "Persistent SSH",
             customTitle: "Persistent SSH",
@@ -1921,11 +1995,8 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
             terminalScrollBarHidden: nil,
             currentDirectory: NSHomeDirectory(),
             focusedPanelId: focusedPanelId,
-            layout: .pane(SessionPaneLayoutSnapshot(
-                panelIds: [focusedPanelId],
-                selectedPanelId: focusedPanelId
-            )),
-            panels: [panel],
+            layout: layout,
+            panels: panels,
             statusEntries: [],
             logEntries: [],
             progress: nil,
@@ -1988,3 +2059,5 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
         )
     }
 }
+
+private final class PortalHostClaimToken {}


### PR DESCRIPTION
## Summary
- add behavior coverage for a restored persistent SSH workspace with a left terminal pane and right browser pane
- rearm browser portal-host replacement across the whole workspace after split topology changes, not only the two panes directly involved in the split

## Verification
- Red: cloud Mac `xcodebuild -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination platform=macOS -derivedDataPath /tmp/cmux-4893-red test -only-testing:cmuxTests/TabManagerSessionSnapshotTests/testRestoredPersistentSSHBrowserSiblingAcceptsPortalHostAfterTerminalSplit` failed on commit `4ddcc80a6` at the post-split browser portal-host claim
- Green: same focused cloud Mac command passed on commit `88648bbfe`
- Local tagged reload: `./scripts/reload.sh --tag 4893-cmd-d-browser`

Closes https://github.com/manaflow-ai/cmux/issues/4893

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4908"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782515658&installation_id=133855650&pr_number=4908&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4908&signature=226f2017a0ed9c070a78cfde5666a6bd97ebedf2f9ae585c8dafe9e4f08611a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches split/restore paths for remote SSH terminals and browser portal claiming; behavior is covered by new session-restore tests but affects live split topology and Ghostty startup config.
> 
> **Overview**
> Fixes **Cmd‑D terminal splits** in restored persistent SSH workspaces so sibling **browser panes** can reclaim a portal host after topology changes, and so **remote attach/fork startup** does not send a **local cwd** into Ghostty (which mis-handles inline scripts as relative paths).
> 
> **Portal hosts:** After any split, browser panels across **all panes** are rearmed for the next distinct portal claim (deduped per panel), not only the two panes directly involved in the split.
> 
> **Remote terminal creation:** Shared `terminalConfigTemplateForStartupCommand` sets `waitAfterCommand` and clears inherited `workingDirectory` when the split uses the workspace’s remote startup command. The new surface gets `workingDirectory: nil` while the intended path is stored via `updatePanelDirectory`; failed splits/tabs also drop stale `panelDirectories` entries.
> 
> **Tests:** Restored terminal|browser layout accepts a replacement portal host after a terminal split; restored SSH Cmd‑D split keeps `ssh-pty-attach` without `requestedWorkingDirectory` but preserves cwd in `panelDirectories`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d8f8f322a3bd1e75fe169799ea525c086ff6d7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes browser portal reattachment after Cmd‑D splits in restored persistent SSH workspaces and prevents sending a local cwd to Ghostty for remote‑startup splits (attach and fork). Also consolidates remote‑startup config into a shared helper; portal rearming scans all panes (deduped), and SSH splits track cwd in panel state instead of Ghostty config (addresses #4893).

- **Bug Fixes**
  - Rearm browser portal-host replacement across the whole workspace after split topology changes; dedupe per browser panel.
  - For remote‑startup terminal splits (`ssh-pty-attach`, remote fork): clear inherited/surface cwd; record cwd via `updatePanelDirectory`; clean up `panelDirectories` on failure.
  - Tests: restored terminal|browser layout reclaims a portal host after a terminal split; restored SSH Cmd‑D split sets no local cwd.

<sup>Written for commit 0d8f8f322a3bd1e75fe169799ea525c086ff6d7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4908?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal splits and new terminals now correctly handle remote startup commands by avoiding unintended working-directory inheritance.
  * Panel directory updates are applied only when appropriate, reducing redundant updates.
  * Cleanup now removes stale panel directory metadata when terminal panel creation fails.
  * Improved browser portal handling during splits to prevent duplicate processing of browser panels.

* **Tests**
  * Added tests for persistent-SSH workspace restores, verifying terminal split behavior, directory handling, and browser portal claim consistency.
  * Test helpers updated to support restored workspace directories.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4908?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->