### PR TITLE
Block hidden browser discard during media capture

### DIFF
--- a/Sources/Panels/BrowserHiddenWebViewDiscardManager.swift
+++ b/Sources/Panels/BrowserHiddenWebViewDiscardManager.swift
@@ -33,6 +33,7 @@ final class BrowserHiddenWebViewDiscardManager {
         let isElementFullscreenActive: Bool
         let isReactGrabActive: Bool
         let hasPopups: Bool
+        let isCapturingMedia: Bool
     }
 
     weak var delegate: BrowserHiddenWebViewDiscardManagerDelegate?
@@ -63,6 +64,7 @@ final class BrowserHiddenWebViewDiscardManager {
         if !snapshot.hasCurrentURL { blockers.append("no_url") }
         if snapshot.isLoading || snapshot.webViewIsLoading { blockers.append("loading") }
         if snapshot.isDownloading || snapshot.activeDownloadCount != 0 { blockers.append("download") }
+        if snapshot.isCapturingMedia { blockers.append("media_capture") }
         if snapshot.preferredDeveloperToolsVisible || snapshot.isDeveloperToolsVisible {
             blockers.append("developer_tools")
         }

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -4470,6 +4470,22 @@ final class BrowserPanel: Panel, ObservableObject {
         }
         webViewObservers.append(fullscreenObserver)
 
+        let cameraCaptureObserver = webView.observe(\.cameraCaptureState, options: [.new]) { [weak self] webView, _ in
+            Task { @MainActor in
+                guard let self, self.isCurrentWebView(webView, instanceID: observedWebViewInstanceID) else { return }
+                self.reevaluateHiddenWebViewDiscardScheduling(reason: "media_capture_changed")
+            }
+        }
+        webViewObservers.append(cameraCaptureObserver)
+
+        let microphoneCaptureObserver = webView.observe(\.microphoneCaptureState, options: [.new]) { [weak self] webView, _ in
+            Task { @MainActor in
+                guard let self, self.isCurrentWebView(webView, instanceID: observedWebViewInstanceID) else { return }
+                self.reevaluateHiddenWebViewDiscardScheduling(reason: "media_capture_changed")
+            }
+        }
+        webViewObservers.append(microphoneCaptureObserver)
+
         NotificationCenter.default.publisher(for: .ghosttyDefaultBackgroundDidChange)
             .sink { [weak self] notification in
                 guard let self else { return }
@@ -5357,7 +5373,8 @@ extension BrowserPanel: BrowserHiddenWebViewDiscardManagerDelegate {
             isDeveloperToolsVisible: isDeveloperToolsVisible(),
             isElementFullscreenActive: isElementFullscreenActive,
             isReactGrabActive: isReactGrabActive,
-            hasPopups: !popupControllers.isEmpty
+            hasPopups: !popupControllers.isEmpty,
+            isCapturingMedia: webView.cameraCaptureState != .none || webView.microphoneCaptureState != .none
         )
     }
 

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -45,6 +45,76 @@ private final class BrowserPanelTestNavigationDelegate: NSObject, WKNavigationDe
 }
 
 @MainActor
+private final class BrowserHiddenWebViewDiscardTestDelegate: BrowserHiddenWebViewDiscardManagerDelegate {
+    var snapshot: BrowserHiddenWebViewDiscardManager.BlockerSnapshot
+    var hiddenAt: Date?
+    var webViewInstanceID = UUID()
+    var discardRequestCount = 0
+
+    init(snapshot: BrowserHiddenWebViewDiscardManager.BlockerSnapshot, hiddenAt: Date?) {
+        self.snapshot = snapshot
+        self.hiddenAt = hiddenAt
+    }
+
+    var hiddenWebViewDiscardSnapshot: BrowserHiddenWebViewDiscardManager.BlockerSnapshot {
+        snapshot
+    }
+
+    var hiddenWebViewDiscardHiddenAt: Date? {
+        hiddenAt
+    }
+
+    var hiddenWebViewDiscardWebViewInstanceID: UUID {
+        webViewInstanceID
+    }
+
+    func hiddenWebViewDiscardManagerDidRequestDiscard(
+        _ manager: BrowserHiddenWebViewDiscardManager,
+        reason: String
+    ) {
+        discardRequestCount += 1
+    }
+
+    func hiddenWebViewDiscardManagerPolicyDidChange(
+        _ manager: BrowserHiddenWebViewDiscardManager,
+        reason: String
+    ) {}
+}
+
+@MainActor
+final class BrowserHiddenWebViewDiscardManagerTests: XCTestCase {
+    func testActiveMediaCaptureBlocksHiddenWebViewDiscardScheduling() {
+        let snapshot = BrowserHiddenWebViewDiscardManager.BlockerSnapshot(
+            isClosing: false,
+            isVisibleInUI: false,
+            shouldRenderWebView: true,
+            hasPendingRemoteNavigation: false,
+            hasCurrentURL: true,
+            isLoading: false,
+            webViewIsLoading: false,
+            isDownloading: false,
+            activeDownloadCount: 0,
+            preferredDeveloperToolsVisible: false,
+            isDeveloperToolsVisible: false,
+            isElementFullscreenActive: false,
+            isReactGrabActive: false,
+            hasPopups: false,
+            isCapturingMedia: true
+        )
+        let manager = BrowserHiddenWebViewDiscardManager()
+        let delegate = BrowserHiddenWebViewDiscardTestDelegate(snapshot: snapshot, hiddenAt: Date())
+        manager.delegate = delegate
+
+        XCTAssertEqual(manager.blockers(for: snapshot), ["media_capture"])
+
+        manager.scheduleIfNeeded(reason: "test.hidden")
+
+        XCTAssertFalse(manager.hasScheduledDiscard)
+        XCTAssertEqual(delegate.discardRequestCount, 0)
+    }
+}
+
+@MainActor
 private func makeTemporaryBrowserPanelProfile(named prefix: String) throws -> BrowserProfileDefinition {
     try XCTUnwrap(
         BrowserProfileStore.shared.createProfile(

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -84,6 +84,17 @@ private final class BrowserHiddenWebViewDiscardTestDelegate: BrowserHiddenWebVie
 @MainActor
 final class BrowserHiddenWebViewDiscardManagerTests: XCTestCase {
     func testActiveMediaCaptureBlocksHiddenWebViewDiscardScheduling() {
+        let defaults = UserDefaults.standard
+        let previousEnabled = defaults.object(forKey: BrowserHiddenWebViewDiscardPolicy.enabledKey)
+        defaults.set(true, forKey: BrowserHiddenWebViewDiscardPolicy.enabledKey)
+        defer {
+            if let previousEnabled {
+                defaults.set(previousEnabled, forKey: BrowserHiddenWebViewDiscardPolicy.enabledKey)
+            } else {
+                defaults.removeObject(forKey: BrowserHiddenWebViewDiscardPolicy.enabledKey)
+            }
+        }
+
         let snapshot = BrowserHiddenWebViewDiscardManager.BlockerSnapshot(
             isClosing: false,
             isVisibleInUI: false,


### PR DESCRIPTION
## Summary
- add a media-capture blocker to hidden browser WebView discard eligibility
- observe WKWebView camera/microphone capture state and reevaluate pending discard scheduling on changes
- add a regression unit test for media_capture blocker behavior

Fixes #4909

## Testing
- Not run locally per repo policy; CI will run tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4912"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782517683&installation_id=133855650&pr_number=4912&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4912&signature=8a891771e896d00d342a185d7e2b0d6bc32c2e69dfb82c29b2c7788017c7ad16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized memory-management guard with KVO observers and a unit test; no auth, data, or payment paths touched.
> 
> **Overview**
> Hidden browser tabs are no longer eligible for **WebView discard** while the page is using the **camera or microphone**. A new `media_capture` blocker is added to the existing hidden-WebView discard policy, driven by `WKWebView` capture state in the panel snapshot.
> 
> **BrowserPanel** now **KVO-observes** `cameraCaptureState` and `microphoneCaptureState` and re-runs discard scheduling when capture starts or stops. A **unit test** asserts that active media capture prevents a discard timer from being scheduled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca5eb0db6dc43ab749db8f40660f5d9ec1093ab8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents hidden `WKWebView` discard while the camera or microphone is active to avoid dropped calls and recordings. Addresses #4909 by blocking discard during media capture and reevaluating timers when capture state changes.

- **Bug Fixes**
  - Observe `WKWebView.cameraCaptureState` and `WKWebView.microphoneCaptureState`; re-evaluate hidden discard scheduling on change.
  - Add `isCapturingMedia` to the discard snapshot and apply the `media_capture` blocker.
  - Add a unit test confirming active media capture blocks scheduling.

<sup>Written for commit ca5eb0db6dc43ab749db8f40660f5d9ec1093ab8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4912?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic detection for active media capture (camera and microphone) on web pages to intelligently prevent web views from being discarded while actively capturing media.

* **Tests**
  * Added comprehensive test coverage to verify that active media capture correctly blocks web view memory discard operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4912?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->