### PR TITLE
Gate visual screenshot harness failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Validate WarpBuild runner guards
+      - name: Validate macOS runner guards
         run: ./tests/test_ci_self_hosted_guard.sh
+
+      - name: Validate Python test harness syntax
+        run: git ls-files 'tests/*.py' 'tests_v2/*.py' 'scripts/*.py' | xargs python3 -m py_compile
 
       - name: Validate create-dmg version pinning
         run: ./tests/test_ci_create_dmg_pinned.sh

--- a/tests/test_visual_screenshots.py
+++ b/tests/test_visual_screenshots.py
@@ -1368,13 +1368,6 @@ def generate_html_report(changes: list[StateChange]) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _is_known_non_blocking_failure(change: StateChange) -> bool:
-    """Return True for known flaky VM-only visual failures we still report but do not gate on."""
-    if change.name == "Nested: Close Top of T-shape" and "VIEW_DETACHED" in (change.error or ""):
-        return True
-    return False
-
-
 def run_visual_tests():
     changes: list[StateChange] = []
 
@@ -1486,25 +1479,20 @@ def run_visual_tests():
     print("=" * 60)
     passed = sum(1 for c in changes if c.passed)
     failed_changes = [c for c in changes if not c.passed]
-    non_blocking_failed = [c for c in failed_changes if _is_known_non_blocking_failure(c)]
-    blocking_failed = [c for c in failed_changes if not _is_known_non_blocking_failure(c)]
 
     print(f"  Passed: {passed}")
     print(f"  Failed: {len(failed_changes)}")
-    if non_blocking_failed:
-        print(f"  Non-blocking failed: {len(non_blocking_failed)}")
     print(f"  Total:  {len(changes)}")
 
     if failed_changes:
         print()
         print("Failed tests:")
         for c in failed_changes:
-            marker = " (non-blocking)" if _is_known_non_blocking_failure(c) else ""
-            print(f"  - {c.name}{marker}: {c.error or 'unknown'}")
+            print(f"  - {c.name}: {c.error or 'unknown'}")
 
     print()
     print(f"Report: {HTML_REPORT}")
-    return 0 if len(blocking_failed) == 0 else 1
+    return 0 if len(failed_changes) == 0 else 1
 
 
 if __name__ == "__main__":

--- a/tests_v2/test_visual_screenshots.py
+++ b/tests_v2/test_visual_screenshots.py
@@ -27,7 +27,7 @@ import tempfile
 from pathlib import Path
 from datetime import datetime
 from dataclasses import dataclass
-from typing import Optional, List
+from typing import Optional, List, Union
 
 sys.path.insert(0, str(Path(__file__).parent))
 from cmux import cmux
@@ -383,7 +383,7 @@ def test_a3_split_down(client: cmux) -> StateChange:
     return change
 
 
-def _close_and_verify(client: cmux, change: StateChange, close_idx: int,
+def _close_and_verify(client: cmux, change: StateChange, close_idx: Union[int, str],
                       expected: int, before_label: str, after_label: str) -> StateChange:
     """Shared logic: close a surface, verify count, verify responsiveness, capture after."""
     change.before, change.before_state = capture(client, before_label)
@@ -394,10 +394,22 @@ def _close_and_verify(client: cmux, change: StateChange, close_idx: int,
             change.error = f"Expected {expected} surface(s), got {surface_count(client)}"
             change.passed = False
         else:
-            # Functional blank-detection: verify every remaining terminal responds
-            blank_err = verify_all_responsive(client, after_label)
-            if blank_err:
-                change.error = f"BLANK: {blank_err}"
+            # Functional blank-detection can be transient while split-tree views settle.
+            last_blank_err = None
+            for verify_attempt in range(3):
+                blank_err = verify_all_responsive(client, after_label)
+                if not blank_err:
+                    last_blank_err = None
+                    break
+                last_blank_err = blank_err
+                if verify_attempt < 2:
+                    try:
+                        client.refresh_surfaces()
+                    except Exception:
+                        pass
+                    time.sleep(0.8 + (0.4 * verify_attempt))
+            if last_blank_err:
+                change.error = f"BLANK: {last_blank_err}"
                 change.passed = False
     except Exception as e:
         change.error = str(e)
@@ -532,19 +544,26 @@ def test_d11_nested_close_bottomright(client: cmux) -> StateChange:
 
 
 def test_d12_nested_close_top(client: cmux) -> StateChange:
-    """D12: Split down, split bottom right → close top pane."""
+    """D12: Split down, split bottom right → close original top pane."""
     change = StateChange(
         name="Nested: Close Top of T-shape", group="D",
-        description="Split down → split bottom right → close top (surface 0)",
-        command="split down; focus 1; split right; close 0",
+        description="Split down → split bottom right → close the original top surface by ID",
+        command="capture top-id; split down; focus 1; split right; close <top-id>",
     )
+    surfaces = client.list_surfaces()
+    if not surfaces:
+        change.passed = False
+        change.error = "No initial surface"
+        return change
+    top_surface_id = surfaces[0][1]
+
     client.new_split("down")
     time.sleep(SPLIT_WAIT)
     client.focus_surface(1)
     time.sleep(SHORT_WAIT)
     client.new_split("right")
     time.sleep(SPLIT_WAIT)
-    return _close_and_verify(client, change, 0, 2, "d12_before", "d12_after")
+    return _close_and_verify(client, change, top_surface_id, 2, "d12_before", "d12_after")
 
 
 def test_d13_4pane_close_second(client: cmux) -> StateChange:
@@ -1310,13 +1329,6 @@ def generate_html_report(changes: list[StateChange]) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _is_known_non_blocking_failure(change: StateChange) -> bool:
-    """Return True for known flaky VM-only visual failures we still report but do not gate on."""
-    if change.name == "Nested: Close Top of T-shape" and "VIEW_DETACHED" in (change.error or ""):
-        return True
-    return False
-
-
 def run_visual_tests():
     changes: list[StateChange] = []
 
@@ -1428,25 +1440,20 @@ def run_visual_tests():
     print("=" * 60)
     passed = sum(1 for c in changes if c.passed)
     failed_changes = [c for c in changes if not c.passed]
-    non_blocking_failed = [c for c in failed_changes if _is_known_non_blocking_failure(c)]
-    blocking_failed = [c for c in failed_changes if not _is_known_non_blocking_failure(c)]
 
     print(f"  Passed: {passed}")
     print(f"  Failed: {len(failed_changes)}")
-    if non_blocking_failed:
-        print(f"  Non-blocking failed: {len(non_blocking_failed)}")
     print(f"  Total:  {len(changes)}")
 
     if failed_changes:
         print()
         print("Failed tests:")
         for c in failed_changes:
-            marker = " (non-blocking)" if _is_known_non_blocking_failure(c) else ""
-            print(f"  - {c.name}{marker}: {c.error or 'unknown'}")
+            print(f"  - {c.name}: {c.error or 'unknown'}")
 
     print()
     print(f"Report: {HTML_REPORT}")
-    return 0 if len(blocking_failed) == 0 else 1
+    return 0 if len(failed_changes) == 0 else 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- remove the visual screenshot harness non-blocking failure allowlist
- make the v2 D12 close-top scenario close the captured surface ID and retry responsiveness while the split tree settles
- add Python harness byte-compilation to workflow guard CI

## Validation
- ./tests/test_ci_self_hosted_guard.sh
- git ls-files 'tests/*.py' 'tests_v2/*.py' 'scripts/*.py' | xargs python3 -m py_compile\n- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4915"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782524572&installation_id=133855650&pr_number=4915&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4915&signature=ceb65efc883eaeebba70003b5acb4a8dc7f3d65bcdcc417a1594b1e88c56ea73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 88085ecb344b73d15291ca2efdaac56abb78d74a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make visual screenshot harness failures block CI by removing the non-blocking allowlist, and stabilize the D12 “close top” scenario to reduce flakiness. Also add Python byte-compilation in CI to catch syntax errors early.

- **Bug Fixes**
  - D12: close the original top surface by ID and retry responsiveness (with surface refresh) while the split tree settles.

- **Migration**
  - Visual screenshot failures now fail CI; fix tests instead of relying on the old allowlist.

<sup>Written for commit 88085ecb344b73d15291ca2efdaac56abb78d74a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4915?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  - Updated CI workflow to validate macOS runner guards and Python syntax compliance.

* **Tests**
  - Enhanced visual screenshot test stability with improved terminal detection and pane identification.
  - Simplified test failure reporting to consistently treat all failures as blocking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4915?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->