### PR TITLE
Require R2 appcast uploads

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -621,7 +621,6 @@ jobs:
 
       - name: Upload nightly appcast to R2
         if: needs.decide.outputs.should_publish == 'true' && steps.current_head_prebuild.outputs.still_current == 'true' && steps.current_head_postbuild.outputs.still_current == 'true'
-        continue-on-error: true
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.CF_R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.CF_R2_SECRET_ACCESS_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -416,7 +416,6 @@ jobs:
 
       - name: Upload release appcast to R2
         if: steps.guard_release_assets.outputs.skip_upload != 'true' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
-        continue-on-error: true
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.CF_R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.CF_R2_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
## Summary
- make nightly R2 appcast upload failures fail the workflow
- make stable release R2 appcast upload failures fail the workflow

## Validation
- rg -n "continue-on-error" .github/workflows
- git diff --check
- actionlint -oneline .github/workflows/nightly.yml .github/workflows/release.yml (only existing shellcheck warnings)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4918"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782526311&installation_id=133855650&pr_number=4918&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4918&signature=033a04e879379cd9273e339c3dd969214ba3d5f33f0ebc63938c4118f5822234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to workflow failure semantics for R2 uploads; no application runtime or auth logic is modified.
> 
> **Overview**
> **R2 Sparkle appcast uploads are now required to succeed** in both the nightly and stable release macOS workflows. The `continue-on-error: true` flag was removed from the **Upload nightly appcast to R2** and **Upload release appcast to R2** steps, so a failed Cloudflare R2 `aws s3 cp` (credentials, network, CLI install, etc.) will **fail the workflow** instead of leaving a green run with a stale or missing `files.cmux.com` appcast.
> 
> The upload steps themselves are unchanged: they still run after GitHub release publish, use the same R2 bucket paths (`nightly/appcast.xml` and `stable/appcast.xml`), and the release workflow still skips stable R2 upload when the tag is not the latest semver.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6cd8c37db66ebc7e0795e987f8d1408ee0125ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make R2 appcast uploads mandatory for nightly and release workflows. Removed continue-on-error so any R2 upload failure fails the job and blocks incomplete publishes.

<sup>Written for commit c6cd8c37db66ebc7e0795e987f8d1408ee0125ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4918?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated macOS nightly and release workflow configurations to improve release distribution reliability.
* Enhanced deployment error handling to ensure build failures properly stop execution instead of continuing.
* Refined release asset distribution logic for better version management and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4918?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->