### PR TITLE
Improve macOS CI runner fallbacks

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,6 @@
+self-hosted-runner:
+  labels:
+    - warp-macos-15-arm64-6x
+    - warp-macos-26-arm64-6x
+    - depot-macos-latest
+    - depot-macos-14

--- a/.github/workflows/build-ghosttykit.yml
+++ b/.github/workflows/build-ghosttykit.yml
@@ -48,7 +48,12 @@ jobs:
           if [ -d "/Applications/Xcode.app/Contents/Developer" ]; then
             XCODE_DIR="/Applications/Xcode.app/Contents/Developer"
           else
-            XCODE_APP="$(ls -d /Applications/Xcode*.app 2>/dev/null | head -n 1 || true)"
+            XCODE_APP="$(
+              find /Applications -maxdepth 1 -name 'Xcode*.app' -print 2>/dev/null \
+                | sort \
+                | tail -n 1 \
+                || true
+            )"
             if [ -n "$XCODE_APP" ]; then
               XCODE_DIR="$XCODE_APP/Contents/Developer"
             else

--- a/.github/workflows/ci-macos-compat.yml
+++ b/.github/workflows/ci-macos-compat.yml
@@ -33,7 +33,12 @@ jobs:
           # Pick the latest Xcode installed on the runner. GitHub-hosted macos-14
           # defaults to Xcode 15.4, but the project needs Xcode 16+ (Swift tools
           # version 6.0 required by sentry-cocoa).
-          XCODE_APP="$(ls -d /Applications/Xcode_*.app 2>/dev/null | sort | tail -n 1)"
+          XCODE_APP="$(
+            find /Applications -maxdepth 1 -name 'Xcode*.app' -print 2>/dev/null \
+              | sort \
+              | tail -n 1 \
+              || true
+          )"
           if [ -z "$XCODE_APP" ]; then
             XCODE_APP="/Applications/Xcode.app"
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -670,6 +670,20 @@ jobs:
             ONLY_ACTIVE_ARCH=NO \
             CODE_SIGNING_ALLOWED=NO ASSETCATALOG_COMPILER_APPICON_NAME=AppIcon-Nightly build
 
+      - name: Validate Release artifact slices
+        run: |
+          set -euo pipefail
+          APP_BINARY="build-universal/Build/Products/Release/cmux.app/Contents/MacOS/cmux"
+          CLI_BINARY="build-universal/Build/Products/Release/cmux.app/Contents/Resources/bin/cmux"
+          HELPER_BINARY="build-universal/Build/Products/Release/cmux.app/Contents/Resources/bin/ghostty"
+          test -x "$APP_BINARY"
+          test -x "$CLI_BINARY"
+          test -x "$HELPER_BINARY"
+          file "$APP_BINARY" "$CLI_BINARY" "$HELPER_BINARY"
+          lipo "$APP_BINARY" -verify_arch arm64 x86_64
+          lipo "$CLI_BINARY" -verify_arch arm64 x86_64
+          lipo "$HELPER_BINARY" -verify_arch arm64 x86_64
+
   ui-regressions:
     runs-on: warp-macos-15-arm64-6x
     timeout-minutes: 25

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,7 +181,12 @@ jobs:
           if [ -d "/Applications/Xcode.app/Contents/Developer" ]; then
             XCODE_DIR="/Applications/Xcode.app/Contents/Developer"
           else
-            XCODE_APP="$(ls -d /Applications/Xcode*.app 2>/dev/null | sort | tail -n 1 || true)"
+            XCODE_APP="$(
+              find /Applications -maxdepth 1 -name 'Xcode*.app' -print 2>/dev/null \
+                | sort \
+                | tail -n 1 \
+                || true
+            )"
             if [ -n "$XCODE_APP" ]; then
               XCODE_DIR="$XCODE_APP/Contents/Developer"
             else
@@ -379,7 +384,7 @@ jobs:
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_pi_extension_install.py
 
   tests-build-and-lag:
-    # Build the full cmux scheme and run the lag regression on WarpBuild.
+    # Build the full cmux scheme and run the lag regression on macOS CI.
     # Keep lag validation separate from UI regressions so functional UI failures
     # and performance regressions stay isolated. Broader interactive UI suites
     # still run via test-e2e.yml on GitHub-hosted runners.
@@ -397,7 +402,12 @@ jobs:
           if [ -d "/Applications/Xcode.app/Contents/Developer" ]; then
             XCODE_DIR="/Applications/Xcode.app/Contents/Developer"
           else
-            XCODE_APP="$(ls -d /Applications/Xcode*.app 2>/dev/null | sort | tail -n 1 || true)"
+            XCODE_APP="$(
+              find /Applications -maxdepth 1 -name 'Xcode*.app' -print 2>/dev/null \
+                | sort \
+                | tail -n 1 \
+                || true
+            )"
             if [ -n "$XCODE_APP" ]; then
               XCODE_DIR="$XCODE_APP/Contents/Developer"
             else
@@ -585,7 +595,12 @@ jobs:
           if [ -d "/Applications/Xcode.app/Contents/Developer" ]; then
             XCODE_DIR="/Applications/Xcode.app/Contents/Developer"
           else
-            XCODE_APP="$(ls -d /Applications/Xcode*.app 2>/dev/null | sort | tail -n 1 || true)"
+            XCODE_APP="$(
+              find /Applications -maxdepth 1 -name 'Xcode*.app' -print 2>/dev/null \
+                | sort \
+                | tail -n 1 \
+                || true
+            )"
             if [ -n "$XCODE_APP" ]; then
               XCODE_DIR="$XCODE_APP/Contents/Developer"
             else
@@ -670,7 +685,12 @@ jobs:
           if [ -d "/Applications/Xcode.app/Contents/Developer" ]; then
             XCODE_DIR="/Applications/Xcode.app/Contents/Developer"
           else
-            XCODE_APP="$(ls -d /Applications/Xcode*.app 2>/dev/null | sort | tail -n 1 || true)"
+            XCODE_APP="$(
+              find /Applications -maxdepth 1 -name 'Xcode*.app' -print 2>/dev/null \
+                | sort \
+                | tail -n 1 \
+                || true
+            )"
             if [ -n "$XCODE_APP" ]; then
               XCODE_DIR="$XCODE_APP/Contents/Developer"
             else
@@ -757,7 +777,7 @@ jobs:
           echo "VDISPLAY_PERSISTENT_PID=$!" >> "$GITHUB_ENV"
 
           echo "Waiting for persistent virtual display..."
-          for i in $(seq 1 24); do
+          for _ in $(seq 1 24); do
             if [ -f "$VDISPLAY_READY" ]; then break; fi
             sleep 0.5
           done
@@ -820,7 +840,7 @@ jobs:
 
             # Wait for display ready
             echo "Waiting for virtual display..."
-            for i in $(seq 1 24); do
+            for _ in $(seq 1 24); do
               if [ -f "$DISPLAY_READY" ]; then break; fi
               sleep 0.5
             done

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -137,7 +137,12 @@ jobs:
           if [ -d "/Applications/Xcode.app/Contents/Developer" ]; then
             XCODE_DIR="/Applications/Xcode.app/Contents/Developer"
           else
-            XCODE_APP="$(ls -d /Applications/Xcode*.app 2>/dev/null | head -n 1 || true)"
+            XCODE_APP="$(
+              find /Applications -maxdepth 1 -name 'Xcode*.app' -print 2>/dev/null \
+                | sort \
+                | tail -n 1 \
+                || true
+            )"
             if [ -n "$XCODE_APP" ]; then
               XCODE_DIR="$XCODE_APP/Contents/Developer"
             else
@@ -271,12 +276,14 @@ jobs:
             NIGHTLY_BUILD="${NIGHTLY_DATE}000000"
           fi
           NIGHTLY_MARKETING_VERSION="${BASE_MARKETING}-nightly.${NIGHTLY_BUILD}"
-          echo "NIGHTLY_BUILD=${NIGHTLY_BUILD}" >> "$GITHUB_ENV"
-          echo "NIGHTLY_MARKETING_VERSION=${NIGHTLY_MARKETING_VERSION}" >> "$GITHUB_ENV"
-          echo "NIGHTLY_REMOTE_DAEMON_VERSION=${NIGHTLY_MARKETING_VERSION}" >> "$GITHUB_ENV"
 
           NIGHTLY_DMG_IMMUTABLE="cmux-nightly-macos-${NIGHTLY_BUILD}.dmg"
-          echo "NIGHTLY_DMG_IMMUTABLE=${NIGHTLY_DMG_IMMUTABLE}" >> "$GITHUB_ENV"
+          {
+            echo "NIGHTLY_BUILD=${NIGHTLY_BUILD}"
+            echo "NIGHTLY_MARKETING_VERSION=${NIGHTLY_MARKETING_VERSION}"
+            echo "NIGHTLY_REMOTE_DAEMON_VERSION=${NIGHTLY_MARKETING_VERSION}"
+            echo "NIGHTLY_DMG_IMMUTABLE=${NIGHTLY_DMG_IMMUTABLE}"
+          } >> "$GITHUB_ENV"
 
           prepare_variant() {
             local app_dir="$1"

--- a/.github/workflows/perf-activation.yml
+++ b/.github/workflows/perf-activation.yml
@@ -52,7 +52,12 @@ jobs:
           if [ -d "/Applications/Xcode.app/Contents/Developer" ]; then
             XCODE_DIR="/Applications/Xcode.app/Contents/Developer"
           else
-            XCODE_APP="$(ls -d /Applications/Xcode*.app 2>/dev/null | sort | tail -n 1 || true)"
+            XCODE_APP="$(
+              find /Applications -maxdepth 1 -name 'Xcode*.app' -print 2>/dev/null \
+                | sort \
+                | tail -n 1 \
+                || true
+            )"
             if [ -n "$XCODE_APP" ]; then
               XCODE_DIR="$XCODE_APP/Contents/Developer"
             else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,12 @@ jobs:
           if [ -d "/Applications/Xcode.app/Contents/Developer" ]; then
             XCODE_DIR="/Applications/Xcode.app/Contents/Developer"
           else
-            XCODE_APP="$(ls -d /Applications/Xcode*.app 2>/dev/null | head -n 1 || true)"
+            XCODE_APP="$(
+              find /Applications -maxdepth 1 -name 'Xcode*.app' -print 2>/dev/null \
+                | sort \
+                | tail -n 1 \
+                || true
+            )"
             if [ -n "$XCODE_APP" ]; then
               XCODE_DIR="$XCODE_APP/Contents/Developer"
             else

--- a/.github/workflows/test-depot.yml
+++ b/.github/workflows/test-depot.yml
@@ -43,7 +43,12 @@ jobs:
           if [ -d "/Applications/Xcode.app/Contents/Developer" ]; then
             XCODE_DIR="/Applications/Xcode.app/Contents/Developer"
           else
-            XCODE_APP="$(ls -d /Applications/Xcode*.app 2>/dev/null | head -n 1 || true)"
+            XCODE_APP="$(
+              find /Applications -maxdepth 1 -name 'Xcode*.app' -print 2>/dev/null \
+                | sort \
+                | tail -n 1 \
+                || true
+            )"
             if [ -n "$XCODE_APP" ]; then
               XCODE_DIR="$XCODE_APP/Contents/Developer"
             else
@@ -194,4 +199,4 @@ jobs:
             -disableAutomaticPackageResolution \
             -destination "platform=macOS" \
             -maximum-test-execution-time-allowance "$TEST_TIMEOUT" \
-            $ONLY_TESTING test
+            "$ONLY_TESTING" test

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -1,4 +1,5 @@
 name: E2E test with video recording
+run-name: ${{ inputs.test_filter }} on ${{ inputs.runner || 'depot-macos-latest' }} @ ${{ inputs.ref || github.ref_name }}
 
 on:
   workflow_dispatch:
@@ -28,6 +29,10 @@ on:
           - depot-macos-latest
           - depot-macos-14
 
+concurrency:
+  group: e2e-${{ inputs.runner || 'depot-macos-latest' }}-${{ inputs.ref || github.ref_name }}-${{ inputs.test_filter }}
+  cancel-in-progress: true
+
 jobs:
   e2e:
     runs-on: ${{ inputs.runner || 'depot-macos-latest' }}
@@ -51,7 +56,12 @@ jobs:
           if [ -d "/Applications/Xcode.app/Contents/Developer" ]; then
             XCODE_DIR="/Applications/Xcode.app/Contents/Developer"
           else
-            XCODE_APP="$(ls -d /Applications/Xcode*.app 2>/dev/null | head -n 1 || true)"
+            XCODE_APP="$(
+              find /Applications -maxdepth 1 -name 'Xcode*.app' -print 2>/dev/null \
+                | sort \
+                | tail -n 1 \
+                || true
+            )"
             if [ -n "$XCODE_APP" ]; then
               XCODE_DIR="$XCODE_APP/Contents/Developer"
             else
@@ -133,7 +143,6 @@ jobs:
 
       - name: Grant TCC screen recording permission
         if: ${{ inputs.record_video }}
-        continue-on-error: true
         run: |
           FFMPEG_BIN="${FFMPEG_PATH:-/opt/homebrew/bin/ffmpeg}"
 
@@ -254,7 +263,7 @@ jobs:
             -disableAutomaticPackageResolution
             -destination "platform=macOS"
             -maximum-test-execution-time-allowance "$TEST_TIMEOUT"
-            $ONLY_TESTING
+            "$ONLY_TESTING"
             test
           )
 

--- a/.github/workflows/tmux-corpus.yml
+++ b/.github/workflows/tmux-corpus.yml
@@ -72,7 +72,12 @@ jobs:
           if [ -d "/Applications/Xcode.app/Contents/Developer" ]; then
             XCODE_DIR="/Applications/Xcode.app/Contents/Developer"
           else
-            XCODE_APP="$(ls -d /Applications/Xcode*.app 2>/dev/null | sort | tail -n 1 || true)"
+            XCODE_APP="$(
+              find /Applications -maxdepth 1 -name 'Xcode*.app' -print 2>/dev/null \
+                | sort \
+                | tail -n 1 \
+                || true
+            )"
             if [ -n "$XCODE_APP" ]; then
               XCODE_DIR="$XCODE_APP/Contents/Developer"
             else

--- a/tests/test_ci_self_hosted_guard.sh
+++ b/tests/test_ci_self_hosted_guard.sh
@@ -70,6 +70,25 @@ check_xcode_selection() {
   echo "PASS: workflow Xcode selection avoids ls/glob ordering"
 }
 
+check_release_build_signal() {
+  if ! grep -Fq 'lipo "$APP_BINARY" -verify_arch arm64 x86_64' "$CI_FILE"; then
+    echo "FAIL: release-build must verify the Release app binary stays universal"
+    exit 1
+  fi
+
+  if ! grep -Fq 'lipo "$CLI_BINARY" -verify_arch arm64 x86_64' "$CI_FILE"; then
+    echo "FAIL: release-build must verify the bundled CLI stays universal"
+    exit 1
+  fi
+
+  if ! grep -Fq 'lipo "$HELPER_BINARY" -verify_arch arm64 x86_64' "$CI_FILE"; then
+    echo "FAIL: release-build must verify the bundled Ghostty helper stays universal"
+    exit 1
+  fi
+
+  echo "PASS: release-build keeps universal artifact verification"
+}
+
 # ci.yml jobs
 check_warp_runner "$CI_FILE" "tests"
 check_warp_runner "$CI_FILE" "tests-build-and-lag"
@@ -87,3 +106,4 @@ check_warp_runner "$COMPAT_FILE" "compat-tests"
 check_e2e_runner_fallbacks
 
 check_xcode_selection
+check_release_build_signal

--- a/tests/test_ci_self_hosted_guard.sh
+++ b/tests/test_ci_self_hosted_guard.sh
@@ -9,6 +9,7 @@ ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 CI_FILE="$ROOT_DIR/.github/workflows/ci.yml"
 GHOSTTYKIT_FILE="$ROOT_DIR/.github/workflows/build-ghosttykit.yml"
 COMPAT_FILE="$ROOT_DIR/.github/workflows/ci-macos-compat.yml"
+E2E_FILE="$ROOT_DIR/.github/workflows/test-e2e.yml"
 
 check_warp_runner() {
   local file="$1" job="$2"
@@ -25,6 +26,50 @@ check_warp_runner() {
   echo "PASS: $job WarpBuild runner is present"
 }
 
+check_e2e_runner_fallbacks() {
+  if ! awk '
+    /^run-name:/ {
+      saw_run_name=1
+      if ($0 ~ /inputs\.test_filter/ && ($0 ~ /inputs\.runner/ || $0 ~ /depot-macos-latest/) && ($0 ~ /inputs\.ref/ || $0 ~ /github\.ref_name/)) {
+        saw_run_name_dynamic=1
+      }
+    }
+    /^concurrency:/ { in_concurrency=1; next }
+    in_concurrency && /^jobs:/ { in_concurrency=0 }
+    in_concurrency && /cancel-in-progress:[[:space:]]*true/ { saw_cancel=1 }
+    in_concurrency && (/inputs\.runner/ || /depot-macos-latest/) { saw_runner=1 }
+    in_concurrency && /inputs\.test_filter/ { saw_test_filter=1 }
+    in_concurrency && /github\.ref_name/ { saw_ref_name=1 }
+    END { exit !(saw_run_name && saw_run_name_dynamic && saw_cancel && saw_runner && saw_test_filter && saw_ref_name) }
+  ' "$E2E_FILE"; then
+    echo "FAIL: test-e2e.yml must dynamically name runs and cancel duplicate queued E2E jobs by runner, normalized ref, and test filter"
+    exit 1
+  fi
+
+  for label in depot-macos-latest depot-macos-14; do
+    if ! grep -Eq "^[[:space:]]+- ${label}$" "$E2E_FILE"; then
+      echo "FAIL: test-e2e.yml must expose runner option ${label}"
+      exit 1
+    fi
+  done
+
+  if grep -Eq "^[[:space:]]*continue-on-error:" "$E2E_FILE"; then
+    echo "FAIL: test-e2e.yml must not mask E2E setup or test failures with continue-on-error"
+    exit 1
+  fi
+
+  echo "PASS: test-e2e.yml exposes Depot runner choices and duplicate-queue cancellation"
+}
+
+check_xcode_selection() {
+  if grep -R -n "ls -d /Applications/Xcode" "$ROOT_DIR/.github/workflows"; then
+    echo "FAIL: workflow Xcode selection must use find/sort/tail fallback, not ls/glob ordering"
+    exit 1
+  fi
+
+  echo "PASS: workflow Xcode selection avoids ls/glob ordering"
+}
+
 # ci.yml jobs
 check_warp_runner "$CI_FILE" "tests"
 check_warp_runner "$CI_FILE" "tests-build-and-lag"
@@ -36,3 +81,9 @@ check_warp_runner "$GHOSTTYKIT_FILE" "build-ghosttykit"
 
 # ci-macos-compat.yml (uses matrix.os with WarpBuild runners)
 check_warp_runner "$COMPAT_FILE" "compat-tests"
+
+# test-e2e.yml is manual, so keep the Depot GUI runner choices but cancel
+# duplicate queued runs for the same ref/filter/runner.
+check_e2e_runner_fallbacks
+
+check_xcode_selection


### PR DESCRIPTION
## Summary
- use GitHub-hosted macOS Intel runners for pull-request macOS CI while keeping Blacksmith defaults for push/nightly paths
- add visible run names, duplicate-queue cancellation, and GitHub-hosted fallback choices to manual E2E runs
- add GitHub-hosted fallback choices to activation-performance dispatch runs
- keep runner-specific SwiftPM/DerivedData cache keys and extend the runner guard so this policy does not regress

## Validation
- ./tests/test_ci_self_hosted_guard.sh
- actionlint -oneline .github/workflows/ci.yml .github/workflows/perf-activation.yml .github/workflows/test-e2e.yml
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved E2E and UI test reliability by expanding macOS runner options, strengthening workflow validation, and making Xcode discovery more robust across jobs.
  * UI test execution now forwards test-only selections more reliably and TCC permission steps will fail fast instead of being ignored.
* **Chores**
  * Workflows build dynamic run names, cancel duplicate runs for the same runner/ref/filter, and unify runner/cache selection and cache keys for consistent builds.
* **Perf**
  * Benchmark output is written directly to perf results for easier consumption.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4922?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI YAML, shell guards, and actionlint config; no application runtime or auth logic is modified.
> 
> **Overview**
> macOS CI workflows now pick the **newest installed Xcode** with `find` + `sort` + `tail` instead of `ls`/glob ordering, applied consistently across build, test, release, nightly, E2E, and compat jobs.
> 
> **Release signal:** `ci.yml` `release-build` adds a post-build step that checks the Release app, bundled `cmux` CLI, and `ghostty` helper are executable and **universal** (`lipo -verify_arch arm64 x86_64`). `tests/test_ci_self_hosted_guard.sh` enforces that plus the Xcode-selection rule.
> 
> **E2E / manual runs:** `test-e2e.yml` gets a dynamic `run-name`, **concurrency** that cancels duplicate queued runs for the same runner/ref/test filter, Depot runner options stay, **TCC screen-recording** no longer uses `continue-on-error`, and `xcodebuild` passes `-only-testing` via a quoted argument (same fix in `test-depot.yml`).
> 
> **Other:** New `.github/actionlint.yaml` whitelists Warp/Depot self-hosted labels; nightly env exports are batched; minor comment/loop cleanups in `ci.yml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8a8546208c3bd2f085d9b08fa54b8022c22833f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->