### PR TITLE
Resolve TypeScript .ts files as text previews

### DIFF
--- a/Sources/Panels/FilePreviewPanel.swift
+++ b/Sources/Panels/FilePreviewPanel.swift
@@ -874,7 +874,7 @@ enum FilePreviewKindResolver {
         return sample.unicodeScalars.allSatisfy { scalar in
             let value = scalar.value
             return !CharacterSet.controlCharacters.contains(scalar)
-                || value == 0x09 || value == 0x0A || value == 0x0D
+                || value == 0x09 || value == 0x0A || value == 0x0D || value == 0xFEFF
         }
     }
 

--- a/Sources/Panels/FilePreviewPanel.swift
+++ b/Sources/Panels/FilePreviewPanel.swift
@@ -841,13 +841,20 @@ enum FilePreviewKindResolver {
         let data = (try? handle.read(upToCount: 4096)) ?? Data()
         guard data.count >= 376 else { return false }
 
-        for packetSize in [188, 192, 204] where data.count > packetSize {
-            var offset = 0
+        let syncCandidates = [
+            (packetSize: 188, syncOffset: 0),
+            (packetSize: 192, syncOffset: 0),
+            (packetSize: 192, syncOffset: 4),
+            (packetSize: 204, syncOffset: 0)
+        ]
+
+        for candidate in syncCandidates where data.count > candidate.syncOffset {
+            var offset = candidate.syncOffset
             var syncCount = 0
             while offset < data.count {
                 guard data[offset] == 0x47 else { break }
                 syncCount += 1
-                offset += packetSize
+                offset += candidate.packetSize
             }
             if syncCount >= 2 {
                 return true

--- a/Sources/Panels/FilePreviewPanel.swift
+++ b/Sources/Panels/FilePreviewPanel.swift
@@ -736,11 +736,11 @@ enum FilePreviewKindResolver {
         }
 
         if needsSniffBeforeTextOrMedia(url: url) {
-            if looksLikeMPEGTransportStream(url: url) {
-                return .resolved(.media)
-            }
             if sniffLooksLikeText(url: url) {
                 return .resolved(.text)
+            }
+            if looksLikeMPEGTransportStream(url: url) {
+                return .resolved(.media)
             }
             if let mediaMode = contentTypes(for: url).lazy.compactMap({ mediaMode(for: $0) }).first {
                 return .resolved(mediaMode)
@@ -868,10 +868,14 @@ enum FilePreviewKindResolver {
         if data.contains(0) {
             return false
         }
-        if String(data: data, encoding: .utf8) != nil {
-            return true
+        guard let sample = String(data: data, encoding: .utf8) else {
+            return false
         }
-        return false
+        return sample.unicodeScalars.allSatisfy { scalar in
+            let value = scalar.value
+            return !CharacterSet.controlCharacters.contains(scalar)
+                || value == 0x09 || value == 0x0A || value == 0x0D
+        }
     }
 
     private static func hasUTF16ByteOrderMark(_ data: Data) -> Bool {

--- a/Sources/Panels/FilePreviewPanel.swift
+++ b/Sources/Panels/FilePreviewPanel.swift
@@ -735,9 +735,14 @@ enum FilePreviewKindResolver {
             return .resolved(.quickLook)
         }
 
-        if knownTextFileNeedsSniffBeforeMedia(url: url),
-           sniffLooksLikeText(url: url) {
-            return .resolved(.text)
+        if knownTextFileNeedsSniffBeforeMedia(url: url) {
+            if looksLikeMPEGTransportStream(url: url),
+               let mediaMode = contentTypes(for: url).lazy.compactMap({ mediaMode(for: $0) }).first {
+                return .resolved(mediaMode)
+            }
+            if sniffLooksLikeText(url: url) {
+                return .resolved(.text)
+            }
         }
 
         for type in contentTypes(for: url) {
@@ -822,19 +827,43 @@ enum FilePreviewKindResolver {
         return String(data: data, encoding: .ascii) == "bplist00"
     }
 
+    private static func looksLikeMPEGTransportStream(url: URL) -> Bool {
+        guard url.pathExtension.lowercased() == "ts",
+              let handle = try? FileHandle(forReadingFrom: url) else { return false }
+        defer { try? handle.close() }
+
+        let data = (try? handle.read(upToCount: 4096)) ?? Data()
+        guard data.count >= 376 else { return false }
+
+        for packetSize in [188, 192, 204] where data.count > packetSize {
+            var offset = 0
+            var syncCount = 0
+            while offset < data.count {
+                guard data[offset] == 0x47 else { break }
+                syncCount += 1
+                offset += packetSize
+            }
+            if syncCount >= 2 {
+                return true
+            }
+        }
+
+        return false
+    }
+
     private static func sniffLooksLikeText(url: URL) -> Bool {
         guard let handle = try? FileHandle(forReadingFrom: url) else { return false }
         defer { try? handle.close() }
         let data = (try? handle.read(upToCount: 4096)) ?? Data()
         guard !data.isEmpty else { return true }
-        if String(data: data, encoding: .utf8) != nil {
-            return true
-        }
         if hasUTF16ByteOrderMark(data), String(data: data, encoding: .utf16) != nil {
             return true
         }
         if data.contains(0) {
             return false
+        }
+        if String(data: data, encoding: .utf8) != nil {
+            return true
         }
         return false
     }

--- a/Sources/Panels/FilePreviewPanel.swift
+++ b/Sources/Panels/FilePreviewPanel.swift
@@ -868,14 +868,7 @@ enum FilePreviewKindResolver {
         if data.contains(0) {
             return false
         }
-        guard let sample = String(data: data, encoding: .utf8) else {
-            return false
-        }
-        return sample.unicodeScalars.allSatisfy { scalar in
-            let value = scalar.value
-            return !CharacterSet.controlCharacters.contains(scalar)
-                || value == 0x09 || value == 0x0A || value == 0x0D || value == 0xFEFF
-        }
+        return String(data: data, encoding: .utf8) != nil
     }
 
     private static func hasUTF16ByteOrderMark(_ data: Data) -> Bool {

--- a/Sources/Panels/FilePreviewPanel.swift
+++ b/Sources/Panels/FilePreviewPanel.swift
@@ -709,6 +709,10 @@ enum FilePreviewKindResolver {
 
     private static func initialResolution(for url: URL) -> Resolution {
         let ext = url.pathExtension.lowercased()
+        if knownTextFileNeedsSniffBeforeMedia(url: url) {
+            return .needsSniff
+        }
+
         if let type = UTType(filenameExtension: ext),
            let mediaMode = mediaMode(for: type) {
             return .resolved(mediaMode)
@@ -729,6 +733,11 @@ enum FilePreviewKindResolver {
         let ext = url.pathExtension.lowercased()
         if ext == "plist", looksLikeBinaryPropertyList(url: url) {
             return .resolved(.quickLook)
+        }
+
+        if knownTextFileNeedsSniffBeforeMedia(url: url),
+           sniffLooksLikeText(url: url) {
+            return .resolved(.text)
         }
 
         for type in contentTypes(for: url) {
@@ -791,6 +800,19 @@ enum FilePreviewKindResolver {
             return true
         }
         return false
+    }
+
+    private static func knownTextFileNeedsSniffBeforeMedia(url: URL) -> Bool {
+        let filename = url.lastPathComponent.lowercased()
+        let ext = url.pathExtension.lowercased()
+        guard textFilenames.contains(filename) || textExtensions.contains(ext),
+              let type = UTType(filenameExtension: ext) else {
+            return false
+        }
+
+        return mediaMode(for: type) != nil
+            && !type.conforms(to: .text)
+            && !type.conforms(to: .sourceCode)
     }
 
     private static func looksLikeBinaryPropertyList(url: URL) -> Bool {

--- a/Sources/Panels/FilePreviewPanel.swift
+++ b/Sources/Panels/FilePreviewPanel.swift
@@ -709,7 +709,7 @@ enum FilePreviewKindResolver {
 
     private static func initialResolution(for url: URL) -> Resolution {
         let ext = url.pathExtension.lowercased()
-        if knownTextFileNeedsSniffBeforeMedia(url: url) {
+        if needsSniffBeforeTextOrMedia(url: url) {
             return .needsSniff
         }
 
@@ -735,14 +735,17 @@ enum FilePreviewKindResolver {
             return .resolved(.quickLook)
         }
 
-        if knownTextFileNeedsSniffBeforeMedia(url: url) {
-            if looksLikeMPEGTransportStream(url: url),
-               let mediaMode = contentTypes(for: url).lazy.compactMap({ mediaMode(for: $0) }).first {
-                return .resolved(mediaMode)
+        if needsSniffBeforeTextOrMedia(url: url) {
+            if looksLikeMPEGTransportStream(url: url) {
+                return .resolved(.media)
             }
             if sniffLooksLikeText(url: url) {
                 return .resolved(.text)
             }
+            if let mediaMode = contentTypes(for: url).lazy.compactMap({ mediaMode(for: $0) }).first {
+                return .resolved(mediaMode)
+            }
+            return .needsSniff
         }
 
         for type in contentTypes(for: url) {
@@ -807,9 +810,12 @@ enum FilePreviewKindResolver {
         return false
     }
 
-    private static func knownTextFileNeedsSniffBeforeMedia(url: URL) -> Bool {
+    private static func needsSniffBeforeTextOrMedia(url: URL) -> Bool {
         let filename = url.lastPathComponent.lowercased()
         let ext = url.pathExtension.lowercased()
+        if ext == "ts" {
+            return true
+        }
         guard textFilenames.contains(filename) || textExtensions.contains(ext),
               let type = UTType(filenameExtension: ext) else {
             return false

--- a/cmuxTests/FilePreviewReviewFeedbackTests.swift
+++ b/cmuxTests/FilePreviewReviewFeedbackTests.swift
@@ -68,6 +68,16 @@ final class FilePreviewReviewFeedbackTests: XCTestCase {
         XCTAssertEqual(FilePreviewKindResolver.mode(for: url), .text)
     }
 
+    func testExtensionlessANSITextResolvesAsTextAfterSniffing() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: url) }
+        try "\u{001B}[31mred\u{001B}[0m\n".write(to: url, atomically: true, encoding: .utf8)
+
+        XCTAssertEqual(FilePreviewKindResolver.initialMode(for: url), .quickLook)
+        XCTAssertEqual(FilePreviewKindResolver.mode(for: url), .text)
+    }
+
     func testTypeScriptFileResolvesAsTextInsteadOfTransportStreamMedia() throws {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString)

--- a/cmuxTests/FilePreviewReviewFeedbackTests.swift
+++ b/cmuxTests/FilePreviewReviewFeedbackTests.swift
@@ -68,6 +68,33 @@ final class FilePreviewReviewFeedbackTests: XCTestCase {
         XCTAssertEqual(FilePreviewKindResolver.mode(for: url), .text)
     }
 
+    func testTypeScriptFileResolvesAsTextInsteadOfTransportStreamMedia() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("ts")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        try """
+        export const answer: number = 42;
+        console.log(answer);
+        """.write(to: url, atomically: true, encoding: .utf8)
+
+        XCTAssertEqual(FilePreviewKindResolver.initialMode(for: url), .quickLook)
+        XCTAssertEqual(FilePreviewKindResolver.mode(for: url), .text)
+    }
+
+    func testBinaryTransportStreamFileKeepsMediaPreview() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("ts")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        try Data([0x47, 0x40, 0x00, 0x10, 0x00, 0x47, 0x41, 0x00, 0x10, 0x00])
+            .write(to: url, options: .atomic)
+
+        XCTAssertEqual(FilePreviewKindResolver.mode(for: url), .media)
+    }
+
     func testQuickLookSessionCloseDoesNotDeactivateMountedRepresentableView() throws {
         let url = try temporaryBinaryFile()
         defer { try? FileManager.default.removeItem(at: url) }

--- a/cmuxTests/FilePreviewReviewFeedbackTests.swift
+++ b/cmuxTests/FilePreviewReviewFeedbackTests.swift
@@ -89,9 +89,18 @@ final class FilePreviewReviewFeedbackTests: XCTestCase {
             .appendingPathExtension("ts")
         defer { try? FileManager.default.removeItem(at: url) }
 
-        try Data([0x47, 0x40, 0x00, 0x10, 0x00, 0x47, 0x41, 0x00, 0x10, 0x00])
-            .write(to: url, options: .atomic)
+        var data = Data(repeating: 0, count: 188 * 2)
+        data[0] = 0x47
+        data[1] = 0x40
+        data[2] = 0x00
+        data[3] = 0x10
+        data[188] = 0x47
+        data[189] = 0x41
+        data[190] = 0x00
+        data[191] = 0x10
+        try data.write(to: url, options: .atomic)
 
+        XCTAssertEqual(FilePreviewKindResolver.initialMode(for: url), .quickLook)
         XCTAssertEqual(FilePreviewKindResolver.mode(for: url), .media)
     }
 

--- a/cmuxTests/FilePreviewReviewFeedbackTests.swift
+++ b/cmuxTests/FilePreviewReviewFeedbackTests.swift
@@ -118,7 +118,7 @@ final class FilePreviewReviewFeedbackTests: XCTestCase {
         try data.write(to: url, options: .atomic)
 
         XCTAssertEqual(FilePreviewKindResolver.initialMode(for: url), .quickLook)
-        XCTAssertEqual(FilePreviewKindResolver.mode(for: url), .quickLook)
+        XCTAssertNotEqual(FilePreviewKindResolver.mode(for: url), .text)
     }
 
     func testTypeScriptTextWinsOverTransportStreamSyncBytePattern() throws {
@@ -153,6 +153,27 @@ final class FilePreviewReviewFeedbackTests: XCTestCase {
         data[189] = 0x41
         data[190] = 0x00
         data[191] = 0x10
+        try data.write(to: url, options: .atomic)
+
+        XCTAssertEqual(FilePreviewKindResolver.initialMode(for: url), .quickLook)
+        XCTAssertEqual(FilePreviewKindResolver.mode(for: url), .media)
+    }
+
+    func testM2TSTransportStreamFileKeepsMediaPreview() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("ts")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        var data = Data(repeating: 0, count: 192 * 2)
+        data[4] = 0x47
+        data[5] = 0x40
+        data[6] = 0x00
+        data[7] = 0x10
+        data[196] = 0x47
+        data[197] = 0x41
+        data[198] = 0x00
+        data[199] = 0x10
         try data.write(to: url, options: .atomic)
 
         XCTAssertEqual(FilePreviewKindResolver.initialMode(for: url), .quickLook)

--- a/cmuxTests/FilePreviewReviewFeedbackTests.swift
+++ b/cmuxTests/FilePreviewReviewFeedbackTests.swift
@@ -83,6 +83,20 @@ final class FilePreviewReviewFeedbackTests: XCTestCase {
         XCTAssertEqual(FilePreviewKindResolver.mode(for: url), .text)
     }
 
+    func testUTF8BOMTypeScriptFileResolvesAsText() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("ts")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        var data = Data([0xEF, 0xBB, 0xBF])
+        data.append(Data("export const answer: number = 42;\n".utf8))
+        try data.write(to: url, options: .atomic)
+
+        XCTAssertEqual(FilePreviewKindResolver.initialMode(for: url), .quickLook)
+        XCTAssertEqual(FilePreviewKindResolver.mode(for: url), .text)
+    }
+
     func testTypeScriptTextWinsOverTransportStreamSyncBytePattern() throws {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString)

--- a/cmuxTests/FilePreviewReviewFeedbackTests.swift
+++ b/cmuxTests/FilePreviewReviewFeedbackTests.swift
@@ -83,6 +83,23 @@ final class FilePreviewReviewFeedbackTests: XCTestCase {
         XCTAssertEqual(FilePreviewKindResolver.mode(for: url), .text)
     }
 
+    func testTypeScriptTextWinsOverTransportStreamSyncBytePattern() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("ts")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let source = "G"
+            + String(repeating: "a", count: 187)
+            + "G"
+            + String(repeating: "b", count: 187)
+            + "\nexport const answer: number = 42;\n"
+        try source.write(to: url, atomically: true, encoding: .utf8)
+
+        XCTAssertEqual(FilePreviewKindResolver.initialMode(for: url), .quickLook)
+        XCTAssertEqual(FilePreviewKindResolver.mode(for: url), .text)
+    }
+
     func testBinaryTransportStreamFileKeepsMediaPreview() throws {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString)

--- a/cmuxTests/FilePreviewReviewFeedbackTests.swift
+++ b/cmuxTests/FilePreviewReviewFeedbackTests.swift
@@ -107,6 +107,20 @@ final class FilePreviewReviewFeedbackTests: XCTestCase {
         XCTAssertEqual(FilePreviewKindResolver.mode(for: url), .text)
     }
 
+    func testTypeScriptFileWithNULBytesDoesNotResolveAsText() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("ts")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        var data = Data("export const answer = 42;".utf8)
+        data.append(contentsOf: [0x00, 0x00])
+        try data.write(to: url, options: .atomic)
+
+        XCTAssertEqual(FilePreviewKindResolver.initialMode(for: url), .quickLook)
+        XCTAssertEqual(FilePreviewKindResolver.mode(for: url), .quickLook)
+    }
+
     func testTypeScriptTextWinsOverTransportStreamSyncBytePattern() throws {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString)


### PR DESCRIPTION
## Summary
- Sniff ambiguous source/media extensions before routing file previews to media.
- Add regression coverage for textual .ts files and binary MPEG transport streams.

## Testing
- ./scripts/reload.sh --tag tsfiles (pass)

## Issues
- Task: ensure ts files open as TypeScript instead of video files

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4924"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782536504&installation_id=133855650&pr_number=4924&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4924&signature=c5898f4f6ba6b3bebff9dc047613176d1532162d74ffc861ab58796f527c23b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are isolated to file preview kind resolution with broad unit tests; wrong sniffing could mis-route rare `.ts` or other ambiguous extensions but does not touch auth or persistence.
> 
> **Overview**
> **File preview routing** now defers choosing text vs media when an extension is ambiguous—especially **`.ts`**, where macOS often classifies the file as MPEG transport stream instead of TypeScript.
> 
> `FilePreviewKindResolver` forces a **content sniff** up front for those cases (initial mode stays Quick Look, then async resolution). After sniffing, **text wins** if the bytes look like text; otherwise it checks for **real transport streams** via `0x47` sync-byte patterns (188/192/204-byte packets) before falling back to media. Text sniffing is stricter: **NUL bytes reject text**, UTF-16 BOM is handled explicitly, and valid UTF-8 is required for the plain-UTF-8 path.
> 
> Regression tests cover TypeScript `.ts` (including UTF-8 BOM and sync-byte-like ASCII), extensionless ANSI/UTF-16 text, and binary/M2TS `.ts` staying on **media** preview.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05f22dc59f84be254c5d2690b9ccad50f9b1899a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures `.ts` files open as TypeScript text instead of MPEG transport streams. Initial preview stays Quick Look; final resolves to text for source and to media for real transport streams.

- **Bug Fixes**
  - Sniff before choosing text vs media when a text-like extension maps to media (including `.ts`); text sniff rejects NUL bytes, allows ANSI, and accepts UTF‑16/UTF‑8 BOM; initial mode is Quick Look, then resolves to text if content is textual.
  - Detect real transport streams via sync-byte packet patterns (188/192/204); textual `.ts` with sync-like bytes still resolve to text; tests cover ANSI/extensionless text, UTF‑8 BOM, NUL‑byte `.ts`, plain textual `.ts`, and binary transport streams.

<sup>Written for commit db19dd1dfc07250c25ac5f765f29b9694bb5d2a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4924?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate preview mode for ambiguous file extensions by forcing content sniffing earlier, improving detection of text vs media (including transport-stream-like binaries and null-byte cases).

* **Tests**
  * Added tests verifying preview resolution for ambiguous extensions, covering text-encoded files, BOM/null-byte detection, and transport-stream-like binary vs text scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4924?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->