### PR TITLE
Make "Open Folder in VS Code (Inline)" bindable as a keyboard shortcut

### DIFF
--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -72,6 +72,7 @@ enum KeyboardShortcutSettings {
         case toggleSidebar
         case newTab
         case openFolder
+        case openFolderInVSCodeInline
         case reopenPreviousSession
         case goToWorkspace
         case commandPalette
@@ -160,6 +161,7 @@ enum KeyboardShortcutSettings {
             case .toggleSidebar: return String(localized: "shortcut.toggleLeftSidebar.label", defaultValue: "Toggle Left Sidebar")
             case .newTab: return String(localized: "shortcut.newWorkspace.label", defaultValue: "New Workspace")
             case .openFolder: return String(localized: "shortcut.openFolder.label", defaultValue: "Open Folder")
+            case .openFolderInVSCodeInline: return String(localized: "menu.file.openFolderInVSCodeInline", defaultValue: "Open Folder in VS Code (Inline)…")
             case .reopenPreviousSession: return String(localized: "shortcut.reopenPreviousSession.label", defaultValue: "Restore Previous App Launch")
             case .goToWorkspace: return String(localized: "menu.file.goToWorkspace", defaultValue: "Go to Workspace…")
             case .commandPalette: return String(localized: "menu.file.commandPalette", defaultValue: "Command Palette…")
@@ -272,6 +274,8 @@ enum KeyboardShortcutSettings {
                 return StoredShortcut(key: "n", command: true, shift: false, option: false, control: false)
             case .openFolder:
                 return StoredShortcut(key: "o", command: true, shift: false, option: false, control: false)
+            case .openFolderInVSCodeInline:
+                return .unbound
             case .reopenPreviousSession:
                 return StoredShortcut(key: "o", command: true, shift: true, option: false, control: false)
             case .goToWorkspace:

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -537,11 +537,12 @@ struct cmuxApp: App {
                     AppDelegate.shared?.showOpenFolderPanel()
                 }
 
-                Button(
-                    String(
+                splitCommandButton(
+                    title: String(
                         localized: "menu.file.openFolderInVSCodeInline",
                         defaultValue: "Open Folder in VS Code (Inline)…"
-                    )
+                    ),
+                    shortcut: menuShortcut(for: .openFolderInVSCodeInline)
                 ) {
                     AppDelegate.shared?.showOpenFolderInInlineVSCodePanel()
                 }

--- a/web/data/cmux-shortcuts.ts
+++ b/web/data/cmux-shortcuts.ts
@@ -77,6 +77,12 @@ export const shortcutCategories: ShortcutCategory[] = [
       { id: "newTab", combos: [["⌘", "N"]], description: { en: "New workspace", ja: "新規ワークスペース" } },
       { id: "openFolder", combos: [["⌘", "O"]], description: { en: "Open folder", ja: "フォルダを開く" } },
       {
+        id: "openFolderInVSCodeInline",
+        combos: [],
+        description: { en: "Open folder in VS Code (Inline)", ja: "VS Code（インライン）でフォルダを開く" },
+        note: { en: "unbound by default", ja: "デフォルトでは未割り当て" },
+      },
+      {
         id: "goToWorkspace",
         combos: [["⌘", "P"]],
         description: { en: "Go to workspace", ja: "ワークスペースへ移動" },


### PR DESCRIPTION
Closes #4923

## Summary

Makes **"Open Folder in VS Code (Inline)"** bindable as a keyboard shortcut. Previously this File-menu action (and command-palette entry `palette.openFolderInVSCodeInline`) had no entry in `KeyboardShortcutSettings.Action`, so it could not be assigned a hotkey in Settings or `~/.config/cmux/cmux.json` — contrary to the shortcut policy in `CLAUDE.md`.

## Changes

- **`Sources/KeyboardShortcutSettings.swift`** — add `openFolderInVSCodeInline` action. Default is `.unbound` (no key) so it does not collide with Open Folder (⌘O); the label reuses the existing `menu.file.openFolderInVSCodeInline` string.
- **`Sources/cmuxApp.swift`** — the File-menu item now routes through `splitCommandButton(... shortcut: menuShortcut(for: .openFolderInVSCodeInline))`, so a user-assigned shortcut applies (and the `.disabled` availability check is preserved).
- **`web/data/cmux-shortcuts.ts`** — document the shortcut (unbound by default), mirroring how `sendFeedback` is listed.

Because the action is public and unbound, it automatically appears in Settings → Keyboard Shortcuts (`settingsVisibleActions`) and in the generated `cmux.json` template (`publicShortcutActions`), with no per-action plumbing required.

## Scope note (desktop variant)

The linked issue mentioned the desktop variant too. There is currently **no "Open Folder in VS Code" (desktop) flow** — `TerminalDirectoryOpenTarget.vscode` only exists as the terminal-context "Open Current Directory in VS Code" command, not as a folder-picker action like the inline one (`showOpenFolderInInlineVSCodePanel`). Adding a bindable desktop equivalent would mean building a new open-folder flow, so it is intentionally left out of this PR. Happy to follow up if maintainers want it.

## Test plan

- [ ] Build (I could not compile locally — opening as **Draft** for maintainer verification).
- [ ] Settings → Keyboard Shortcuts shows "Open Folder in VS Code (Inline)…", unbound by default; recording a shortcut works and conflict detection applies.
- [ ] Bound shortcut opens the inline VS Code folder picker; File-menu item shows the assigned key.
- [ ] Setting `shortcut.openFolderInVSCodeInline` in `~/.config/cmux/cmux.json` is honored.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4925"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782536872&installation_id=133855650&pr_number=4925&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4925&signature=6770297e9a152f8e458d6e2637d4ce9604ccf17c8763a3b9ce399e54904f86a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes “Open Folder in VS Code (Inline)” assignable to a keyboard shortcut, so users can open the inline VS Code folder picker via a hotkey. The action is unbound by default, appears in Settings and `~/.config/cmux/cmux.json`, and the File menu shows and uses the chosen key.

- New Features
  - Added `openFolderInVSCodeInline` to `KeyboardShortcutSettings` (label `menu.file.openFolderInVSCodeInline`), default `.unbound` to avoid colliding with ⌘O.
  - Routed the File menu item through `splitCommandButton(..., shortcut: menuShortcut(for: .openFolderInVSCodeInline))` while preserving the disabled state.
  - Documented the shortcut in `web/data/cmux-shortcuts.ts` (listed unbound by default).

<sup>Written for commit 0f097882c728717620c1a4b6e27e0b10d5831812. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4925?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new keyboard shortcut option to open folders in VS Code inline. This shortcut is unbound by default, allowing you to assign your preferred key combination.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4925?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->