### PR TITLE
Move macOS CI/CD runners back to WarpBuild

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,7 +1,0 @@
-self-hosted-runner:
-  labels:
-    - blacksmith-6vcpu-macos-15
-    - blacksmith-6vcpu-macos-26
-    - blacksmith-6vcpu-macos-latest
-
-config-variables: null

--- a/.github/workflows/build-ghosttykit.yml
+++ b/.github/workflows/build-ghosttykit.yml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   build-ghosttykit:
-    runs-on: blacksmith-6vcpu-macos-15
+    runs-on: warp-macos-15-arm64-6x
     timeout-minutes: 20
     env:
       GHOSTTYKIT_CRASH_REPORT_SUBDIR: cmux/crash

--- a/.github/workflows/ci-macos-compat.yml
+++ b/.github/workflows/ci-macos-compat.yml
@@ -9,12 +9,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: blacksmith-6vcpu-macos-15
+          - os: warp-macos-15-arm64-6x
             timeout: 30
             startup_smoke: true
             virtual_display: true
             skip_zig: false
-          - os: blacksmith-6vcpu-macos-26
+          - os: warp-macos-26-arm64-6x
             timeout: 30
             startup_smoke: true
             virtual_display: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
           bun test tests/vm-db-read-model.test.ts
 
   tests:
-    runs-on: blacksmith-6vcpu-macos-15
+    runs-on: warp-macos-15-arm64-6x
     timeout-minutes: 75
     env:
       CMUX_SKIP_ZIG_BUILD: "1"
@@ -383,7 +383,7 @@ jobs:
     # Keep lag validation separate from UI regressions so functional UI failures
     # and performance regressions stay isolated. Broader interactive UI suites
     # still run via test-e2e.yml on GitHub-hosted runners.
-    runs-on: blacksmith-6vcpu-macos-15
+    runs-on: warp-macos-15-arm64-6x
     timeout-minutes: 20
     steps:
       - name: Checkout
@@ -571,7 +571,7 @@ jobs:
     # Compile the same unsigned universal Release app that nightly builds before
     # signing, notarization, and publishing. This catches DEBUG/Release boundary
     # mistakes before they reach main.
-    runs-on: blacksmith-6vcpu-macos-26
+    runs-on: warp-macos-26-arm64-6x
     timeout-minutes: 20
     steps:
       - name: Checkout
@@ -656,7 +656,7 @@ jobs:
             CODE_SIGNING_ALLOWED=NO ASSETCATALOG_COMPILER_APPICON_NAME=AppIcon-Nightly build
 
   ui-regressions:
-    runs-on: blacksmith-6vcpu-macos-15
+    runs-on: warp-macos-15-arm64-6x
     timeout-minutes: 25
     steps:
       - name: Checkout

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -100,7 +100,7 @@ jobs:
   build-sign-notarize-nightly:
     needs: decide
     if: needs.decide.outputs.should_build == 'true'
-    runs-on: blacksmith-6vcpu-macos-26
+    runs-on: warp-macos-26-arm64-6x
     timeout-minutes: 20
     steps:
       - name: Checkout build ref

--- a/.github/workflows/perf-activation.yml
+++ b/.github/workflows/perf-activation.yml
@@ -11,12 +11,11 @@ on:
       runner:
         description: macOS runner
         required: false
-        default: blacksmith-6vcpu-macos-15
+        default: warp-macos-15-arm64-6x
         type: choice
         options:
-          - blacksmith-6vcpu-macos-15
-          - blacksmith-6vcpu-macos-26
-          - blacksmith-6vcpu-macos-latest
+          - warp-macos-15-arm64-6x
+          - depot-macos-latest
       workspace_count:
         description: Fixture workspace count
         required: false
@@ -36,7 +35,7 @@ concurrency:
 
 jobs:
   activation-session:
-    runs-on: ${{ inputs.runner || 'blacksmith-6vcpu-macos-15' }}
+    runs-on: ${{ inputs.runner || 'warp-macos-15-arm64-6x' }}
     timeout-minutes: 45
     env:
       PERF_TAG: perfci
@@ -86,8 +85,8 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: .ci-source-packages
-          key: spm-${{ inputs.runner || 'blacksmith-6vcpu-macos-15' }}-${{ hashFiles('cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
-          restore-keys: spm-${{ inputs.runner || 'blacksmith-6vcpu-macos-15' }}-
+          key: spm-${{ hashFiles('cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+          restore-keys: spm-
 
       - name: Resolve Swift packages
         run: |
@@ -134,17 +133,12 @@ jobs:
         run: |
           set -euo pipefail
           APP_PATH="$HOME/Library/Developer/Xcode/DerivedData/cmux-$PERF_TAG/Build/Products/Debug/cmux DEV $PERF_TAG.app"
-          # The GitHub Actions runner process runs in launchd's system
-          # bootstrap, not the console user's Aqua session, so windows
-          # created by apps launched via NSWorkspace.openApplication do
-          # not show up in CGWindowListCopyWindowInfo([.optionOnScreenOnly]).
-          # Re-enter the Aqua session via launchctl asuser before running
-          # the bench so visibility polling sees real on-screen windows.
-          CONSOLE_USER="$(stat -f %Su /dev/console)"
-          CONSOLE_UID="$(id -u "$CONSOLE_USER")"
-          sudo -n launchctl asuser "$CONSOLE_UID" sudo -n -u "$CONSOLE_USER" -E \
-            env PATH="$PATH" DEVELOPER_DIR="$DEVELOPER_DIR" \
-            bash -c "cd '$PWD' && swift scripts/bench-window-visibility.swift '$APP_PATH' 'com.cmuxterm.app.debug.$PERF_TAG' 30 --cmd-tab-activation --cg-visibility" \
+          swift scripts/bench-window-visibility.swift \
+            "$APP_PATH" \
+            "com.cmuxterm.app.debug.$PERF_TAG" \
+            30 \
+            --cmd-tab-activation \
+            --cg-visibility \
             > perf-results/cmd-tab-activation.txt
           cat perf-results/cmd-tab-activation.txt
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   build-sign-notarize:
-    runs-on: blacksmith-6vcpu-macos-26
+    runs-on: warp-macos-26-arm64-6x
     timeout-minutes: 20
     steps:
       - name: Checkout

--- a/.github/workflows/test-depot.yml
+++ b/.github/workflows/test-depot.yml
@@ -28,7 +28,7 @@ on:
 
 jobs:
   tests:
-    runs-on: blacksmith-6vcpu-macos-15
+    runs-on: warp-macos-15-arm64-6x
     timeout-minutes: 20
     steps:
       - name: Checkout

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -20,20 +20,17 @@ on:
         default: true
         type: boolean
       runner:
-        description: "Runner OS (macOS 15 default for GUI activation support)"
+        description: "Runner OS (Depot runners for GUI activation support)"
         required: false
-        default: "blacksmith-6vcpu-macos-15"
+        default: "depot-macos-latest"
         type: choice
         options:
-          - blacksmith-6vcpu-macos-15
-          - blacksmith-6vcpu-macos-26
-          - blacksmith-6vcpu-macos-latest
           - depot-macos-latest
           - depot-macos-14
 
 jobs:
   e2e:
-    runs-on: ${{ inputs.runner || 'blacksmith-6vcpu-macos-15' }}
+    runs-on: ${{ inputs.runner || 'depot-macos-latest' }}
     timeout-minutes: 20
     env:
       TEST_REF: ${{ inputs.ref || github.ref }}
@@ -175,8 +172,8 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: .ci-source-packages
-          key: spm-${{ inputs.runner || 'blacksmith-6vcpu-macos-15' }}-${{ hashFiles('cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
-          restore-keys: spm-${{ inputs.runner || 'blacksmith-6vcpu-macos-15' }}-
+          key: spm-${{ inputs.runner || 'depot-macos-latest' }}-${{ hashFiles('cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+          restore-keys: spm-${{ inputs.runner || 'depot-macos-latest' }}-
 
       - name: Resolve Swift packages
         run: |

--- a/.github/workflows/tmux-corpus.yml
+++ b/.github/workflows/tmux-corpus.yml
@@ -57,7 +57,7 @@ jobs:
 
   terminal-nightly:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    runs-on: blacksmith-6vcpu-macos-15
+    runs-on: [self-hosted, warp-macos-15-arm64-6x]
     timeout-minutes: 30
     steps:
       - name: Checkout

--- a/tests/test_ci_self_hosted_guard.sh
+++ b/tests/test_ci_self_hosted_guard.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Regression test for https://github.com/manaflow-ai/cmux/issues/385.
-# Ensures paid CI jobs use Blacksmith macOS runners.
+# Ensures paid CI jobs use WarpBuild runners.
 # Fork PRs are gated by GitHub's built-in "Require approval for outside
 # collaborators" setting, so workflow-level fork guards are not needed.
 set -euo pipefail
@@ -10,29 +10,29 @@ CI_FILE="$ROOT_DIR/.github/workflows/ci.yml"
 GHOSTTYKIT_FILE="$ROOT_DIR/.github/workflows/build-ghosttykit.yml"
 COMPAT_FILE="$ROOT_DIR/.github/workflows/ci-macos-compat.yml"
 
-check_blacksmith_runner() {
+check_warp_runner() {
   local file="$1" job="$2"
   if ! awk -v job="$job" '
     $0 ~ "^  "job":" { in_job=1; next }
-    in_job && /^  [^[:space:]#][^:]*:[[:space:]]*(#.*)?$/ { in_job=0 }
-    in_job && /runs-on:.*blacksmith-[0-9]+vcpu-macos-/ { saw=1 }
-    in_job && /os: blacksmith-[0-9]+vcpu-macos-/ { saw=1 }
-    END { exit !(saw) }
+    in_job && /^  [^[:space:]]/ { in_job=0 }
+    in_job && /runs-on:.*warp-macos-.*-arm64/ { saw_warp=1 }
+    in_job && /os: warp-macos-.*-arm64/ { saw_warp=1 }
+    END { exit !(saw_warp) }
   ' "$file"; then
-    echo "FAIL: $job in $(basename "$file") must use the expected macOS runner"
+    echo "FAIL: $job in $(basename "$file") must use a WarpBuild runner"
     exit 1
   fi
-  echo "PASS: $job in $(basename "$file") uses the expected macOS runner"
+  echo "PASS: $job WarpBuild runner is present"
 }
 
 # ci.yml jobs
-check_blacksmith_runner "$CI_FILE" "tests"
-check_blacksmith_runner "$CI_FILE" "tests-build-and-lag"
-check_blacksmith_runner "$CI_FILE" "release-build"
-check_blacksmith_runner "$CI_FILE" "ui-regressions"
+check_warp_runner "$CI_FILE" "tests"
+check_warp_runner "$CI_FILE" "tests-build-and-lag"
+check_warp_runner "$CI_FILE" "release-build"
+check_warp_runner "$CI_FILE" "ui-regressions"
 
 # build-ghosttykit.yml
-check_blacksmith_runner "$GHOSTTYKIT_FILE" "build-ghosttykit"
+check_warp_runner "$GHOSTTYKIT_FILE" "build-ghosttykit"
 
-# ci-macos-compat.yml (uses matrix.os with Blacksmith runners)
-check_blacksmith_runner "$COMPAT_FILE" "compat-tests"
+# ci-macos-compat.yml (uses matrix.os with WarpBuild runners)
+check_warp_runner "$COMPAT_FILE" "compat-tests"


### PR DESCRIPTION
## Summary
- Revert PR #4902 (Migrate macOS CI/CD runners to Blacksmith). Blacksmith macOS capacity is effectively zero right now: every Blacksmith macOS SKU (2/4/6/8/12 vcpu × macos-15/-26) sat queued for 8m+ in a diagnostic probe and 65m+ on the live main CI run for `21b9fdca`, while GitHub-hosted macOS runners picked up in under 10s. Every cmux main push since the Blacksmith migration landed has had CI marked CANCELLED for the same reason.
- Restores `warp-macos-15-arm64-6x` / `warp-macos-26-arm64-6x` on the paid jobs (`tests`, `tests-build-and-lag`, `release-build`, `ui-regressions`, plus nightly, release, build-ghosttykit, test-depot, tmux-corpus, ci-macos-compat, perf-activation, test-e2e).
- Reverts the Blacksmith-specific `launchctl asuser` wrapper around the Cmd-Tab activation bench in perf-activation (Warp runs in the console Aqua session, so the simple `swift` invocation is enough).
- Updates `tests/test_ci_self_hosted_guard.sh` back to the WarpBuild assertion.

## Test plan
- [x] `./tests/test_ci_self_hosted_guard.sh` passes against the reverted tree.
- [ ] CI on this branch goes green on Warp runners.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4926"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782539441&installation_id=133855650&pr_number=4926&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4926&signature=41b6ab29fe44e61aee4ed8eebb2fcd7757020846f674bc7da4a0f28cf3b79416"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to workflow YAML and a CI guard script; no app runtime or auth logic. Risk is mainly CI queue time and benchmark behavior if Warp/Depot sessions differ from Blacksmith.
> 
> **Overview**
> Moves **macOS CI/CD** off Blacksmith and back onto **WarpBuild** (`warp-macos-15-arm64-6x` / `warp-macos-26-arm64-6x`) for paid jobs in `ci.yml`, nightly, release, GhosttyKit build, compat matrix, perf activation, test-depot, and related workflows.
> 
> Removes **Blacksmith-specific** pieces: `.github/actionlint.yaml` self-hosted label allowlist, Blacksmith runner choices in dispatch inputs, and the **`launchctl asuser`** wrapper around the Cmd-Tab visibility bench in `perf-activation.yml` (direct `swift` again). **E2E** defaults shift to **Depot** (`depot-macos-latest`); **perf** can pick Warp or Depot. **SPM cache** keys in perf-activation drop runner-specific prefixes. **`tests/test_ci_self_hosted_guard.sh`** again enforces Warp runners on guarded jobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4130f27fd659bf2badbbf493f8c7aaef90d8ca51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch macOS CI/CD back from Blacksmith to WarpBuild to restore capacity and stop long queues. This unblocks paid macOS jobs and stabilizes main.

- **Bug Fixes**
  - Replaced all Blacksmith labels with WarpBuild: `warp-macos-15-arm64-6x` and `warp-macos-26-arm64-6x` across `tests`, `tests-build-and-lag`, `release-build`, `ui-regressions`, nightly/release signing, `build-ghosttykit`, `test-depot`, `ci-macos-compat`, and `tmux-corpus`.
  - Perf activation: default runner set to `warp-macos-15-arm64-6x`, removed the Blacksmith-specific `launchctl asuser` wrapper, and simplified SPM cache keys.
  - E2E: default runner set to `depot-macos-latest` for GUI activation support; updated SPM cache keys.
  - Deleted `.github/actionlint.yaml` that enforced Blacksmith labels.
  - Updated `tests/test_ci_self_hosted_guard.sh` to assert WarpBuild runners.

<sup>Written for commit 4130f27fd659bf2badbbf493f8c7aaef90d8ca51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4926?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows to migrate build and test jobs to new macOS runners for improved CI/CD infrastructure.
  * Updated CI verification scripts to validate the updated runner configuration.
  * Optimized Swift package dependency caching strategy in performance activation workflow.
  * Removed legacy runner configuration from workflow settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4926?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->