### PR TITLE
Wait for E2E virtual display readiness

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -125,10 +125,36 @@ jobs:
           echo ""
           clang -framework Foundation -framework CoreGraphics \
             -o /tmp/create-virtual-display scripts/create-virtual-display.m
-          /tmp/create-virtual-display &
+          VDISPLAY_READY="$RUNNER_TEMP/cmux-virtual-display.ready"
+          VDISPLAY_ID_PATH="$RUNNER_TEMP/cmux-virtual-display.id"
+          VDISPLAY_LOG="$RUNNER_TEMP/cmux-virtual-display.log"
+          rm -f "$VDISPLAY_READY" "$VDISPLAY_ID_PATH" "$VDISPLAY_LOG"
+
+          /tmp/create-virtual-display \
+            --ready-path "$VDISPLAY_READY" \
+            --display-id-path "$VDISPLAY_ID_PATH" \
+            >"$VDISPLAY_LOG" 2>&1 &
           VDISPLAY_PID=$!
           echo "VDISPLAY_PID=$VDISPLAY_PID" >> "$GITHUB_ENV"
-          sleep 3
+
+          for _ in $(seq 1 100); do
+            if [ -s "$VDISPLAY_READY" ] && [ -s "$VDISPLAY_ID_PATH" ]; then
+              break
+            fi
+            if ! kill -0 "$VDISPLAY_PID" 2>/dev/null; then
+              echo "Virtual display helper exited before readiness" >&2
+              cat "$VDISPLAY_LOG" >&2 || true
+              exit 1
+            fi
+            sleep 0.1
+          done
+          if [ ! -s "$VDISPLAY_READY" ] || [ ! -s "$VDISPLAY_ID_PATH" ]; then
+            echo "Timed out waiting for virtual display readiness" >&2
+            cat "$VDISPLAY_LOG" >&2 || true
+            exit 1
+          fi
+          echo "Virtual display ready: $(tr -d '\n' < "$VDISPLAY_ID_PATH")"
+          cat "$VDISPLAY_LOG"
           echo "=== Display after ==="
           system_profiler SPDisplaysDataType 2>/dev/null || echo "(none)"
 


### PR DESCRIPTION
Replaces the fixed virtual-display sleep in hosted E2E with the helper readiness and display-id markers. The workflow now fails with the helper log if readiness never arrives or the helper exits early.

I tried removing several non-strict UI-test launch expected-failure masks, but the current runner still fails at `app.launch()` for CommandPalette, UpdatePill, and FeedSidebar. Those masks stay in place. This PR keeps the deterministic CI timing fix only.

Validation:

- `git diff --check`
- `actionlint -oneline .github/workflows/test-e2e.yml`
- `./tests/test_ci_self_hosted_guard.sh`
- PR checks pending on final commit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow timing change; no app runtime, auth, or data-path impact.
> 
> **Overview**
> Hosted E2E no longer assumes a **3 second** delay after starting `create-virtual-display`. The workflow passes **`--ready-path`** and **`--display-id-path`**, polls until both marker files exist (or the helper exits), and **fails the job** with the helper log on timeout or early exit.
> 
> That ties test startup to the helper’s real “display created” signal instead of a fixed sleep, which should reduce flaky races when the virtual display is slow or fast to come up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0eace8295f9f6e8685e1182b6b046d6d66f7a8ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->