### PR TITLE
Match Claude Code project-dir dot encoding

### DIFF
--- a/Sources/SessionIndexStore.swift
+++ b/Sources/SessionIndexStore.swift
@@ -845,13 +845,18 @@ final class SessionIndexStore: ObservableObject {
     }
 
     nonisolated private static func decodeClaudeProjectDir(_ raw: String) -> String? {
-        // Claude encodes cwd by replacing "/" with "-" and prefixing "-"
-        // e.g. "-Users-lawrence-fun-cmuxterm-hq" -> "/Users/lawrence/fun/cmuxterm-hq".
-        // The encoding is lossy: a real path segment containing "-"
-        // (e.g. "my-cool-project") collapses to multiple segments
-        // ("/my/cool/project") on decode, which is wrong. Only return the
-        // candidate if it actually exists on disk; otherwise let the caller
-        // fall back to the JSONL `cwd` field.
+        // Claude encodes cwd by replacing both "/" and "." with "-" and
+        // prefixing "-", so "-Users-lawrence-fun-cmuxterm-hq" comes from
+        // "/Users/lawrence/fun/cmuxterm-hq" and "-Users-me--claude" comes from
+        // "/Users/me/.claude" (the "/." pair encodes to "--").
+        //
+        // The encoding is lossy in both directions: a real path segment
+        // containing "-" (e.g. "my-cool-project") collapses to multiple
+        // segments on decode, and "/" and "." map to the same character on
+        // encode. This routine only attempts the naive "-" -> "/"
+        // substitution and relies on the on-disk existence check below to
+        // discard wrong guesses; callers then fall back to the JSONL `cwd`
+        // field.
         guard !raw.isEmpty else { return nil }
         let stripped = raw.hasPrefix("-") ? String(raw.dropFirst()) : raw
         let candidate = "/" + stripped.replacingOccurrences(of: "-", with: "/")

--- a/cmuxTests/RestorableAgentSessionIndexTests.swift
+++ b/cmuxTests/RestorableAgentSessionIndexTests.swift
@@ -679,6 +679,37 @@ final class RestorableAgentSessionIndexTests: XCTestCase {
         )
     }
 
+    // Regression test for https://github.com/manaflow-ai/cmux/issues/4938:
+    // cmux's `encodeClaudeProjectDir` must produce the same folder name claude
+    // code itself uses when writing transcripts to `~/.claude/projects/`. Claude
+    // code replaces BOTH `/` and `.` with `-`. Empirically verified by
+    // inspecting real folder names: `/Users/me/.claude` becomes
+    // `-Users-me--claude` (double dash for `/.`), not `-Users-me-.claude`.
+    // Currently the encoder only replaces `/`, so this test fails until the
+    // accompanying fix lands.
+    func testEncodeClaudeProjectDirMatchesClaudeCodeEncoding() {
+        XCTAssertEqual(
+            RestorableAgentSessionIndex.encodeClaudeProjectDir("/Users/me/git/cmux"),
+            "-Users-me-git-cmux",
+            "Plain path with no dot components"
+        )
+        XCTAssertEqual(
+            RestorableAgentSessionIndex.encodeClaudeProjectDir("/Users/me/.claude"),
+            "-Users-me--claude",
+            "Home directory containing a dot-prefixed component"
+        )
+        XCTAssertEqual(
+            RestorableAgentSessionIndex.encodeClaudeProjectDir("/Users/me/git/repo/.claude/worktrees/feat-X"),
+            "-Users-me-git-repo--claude-worktrees-feat-X",
+            "Deeply nested worktree under .claude/worktrees"
+        )
+        XCTAssertEqual(
+            RestorableAgentSessionIndex.encodeClaudeProjectDir("/Users/me/git/repo/.worktrees/feat-x"),
+            "-Users-me-git-repo--worktrees-feat-x",
+            "Worktree under .worktrees alternative convention"
+        )
+    }
+
     /// Mirrors Claude's external project-directory naming rule ("/" and "." both become "-")
     /// independently of the production `encodeClaudeProjectDir`, so these regression tests fail if
     /// that helper regresses instead of masking it by sharing the same code path.

--- a/cmuxTests/RestorableAgentSessionIndexTests.swift
+++ b/cmuxTests/RestorableAgentSessionIndexTests.swift
@@ -1,5 +1,6 @@
 import CMUXAgentLaunch
 import Foundation
+import Darwin
 import XCTest
 
 #if canImport(cmux_DEV)
@@ -1035,6 +1036,54 @@ final class RestorableAgentSessionIndexTests: XCTestCase {
                 "source": "test",
             ],
         ]
+    }
+
+    func testSessionIndexStoreCwdFilterUsesClaudeCodeDotEncoding() async throws {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory
+            .appendingPathComponent("cmux-session-index-dot-encoding-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fm.removeItem(at: root) }
+
+        let configDir = root.appendingPathComponent("claude-config", isDirectory: true)
+        let projectsDir = configDir.appendingPathComponent("projects", isDirectory: true)
+        let cwd = root
+            .appendingPathComponent("repo", isDirectory: true)
+            .appendingPathComponent(".claude", isDirectory: true)
+            .appendingPathComponent("worktrees", isDirectory: true)
+            .appendingPathComponent("feat-X", isDirectory: true)
+        try fm.createDirectory(at: cwd, withIntermediateDirectories: true)
+
+        let projectDir = projectsDir.appendingPathComponent(
+            RestorableAgentSessionIndex.encodeClaudeProjectDir(cwd.path),
+            isDirectory: true
+        )
+        try fm.createDirectory(at: projectDir, withIntermediateDirectories: true)
+
+        let sessionId = "11111111-2222-3333-4444-555555555555"
+        try writeClaudeTranscript(sessionId: sessionId, cwd: cwd, projectsDir: projectsDir)
+
+        let originalClaudeConfigDir = getenv("CLAUDE_CONFIG_DIR").map { String(cString: $0) }
+        setenv("CLAUDE_CONFIG_DIR", configDir.path, 1)
+        defer {
+            if let originalClaudeConfigDir {
+                setenv("CLAUDE_CONFIG_DIR", originalClaudeConfigDir, 1)
+            } else {
+                unsetenv("CLAUDE_CONFIG_DIR")
+            }
+        }
+
+        let store = SessionIndexStore()
+        let outcome = await store.searchSessions(
+            query: "",
+            scope: .directory(cwd.path),
+            offset: 0,
+            limit: 10
+        )
+
+        XCTAssertTrue(
+            outcome.entries.contains { $0.agent == .claude && $0.sessionId == sessionId },
+            "SessionIndexStore should find the dot-containing cwd through Claude's encoded project dir"
+        )
     }
 
     private func hookRecord(

--- a/cmuxTests/RestorableAgentSessionIndexTests.swift
+++ b/cmuxTests/RestorableAgentSessionIndexTests.swift
@@ -1059,7 +1059,7 @@ final class RestorableAgentSessionIndexTests: XCTestCase {
         )
         try fm.createDirectory(at: projectDir, withIntermediateDirectories: true)
 
-        let sessionId = "11111111-2222-3333-4444-555555555555"
+        let sessionId = "session-dot-encoding"
         try writeClaudeTranscript(sessionId: sessionId, cwd: cwd, projectsDir: projectsDir)
 
         let originalClaudeConfigDir = getenv("CLAUDE_CONFIG_DIR").map { String(cString: $0) }


### PR DESCRIPTION
## Summary

- Addresses the Claude project-dir encoder fast path described in #4938.
- Match Claude Code's project folder naming by replacing both `/` and `.` with `-`.
- Keep the lossy decode path filesystem-gated and use it only as a fallback.

## Testing

- Two-commit red/green structure covers the encoder contract.
- Regression coverage exercises both restore lookup and the Sessions sidebar cwd-filter fast path.
- CI owns test execution.

## Demo Video

- Video URL or attachment: N/A, internal lookup behavior covered by regression tests.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [ ] I tested the change locally
- [x] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [x] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed session lookups for project paths containing dots (`.`) in directory names, now matching Claude's directory naming scheme

* **Tests**
  * Added regression tests to verify encoding compatibility across various path formats

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4939?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->