### PR TITLE
Guard E2E Depot runner identity

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -40,6 +40,25 @@ jobs:
     env:
       TEST_REF: ${{ inputs.ref || github.ref }}
     steps:
+      - name: Validate Depot runner identity
+        if: ${{ startsWith(inputs.runner || 'depot-macos-latest', 'depot-macos-') }}
+        env:
+          REQUESTED_RUNNER: ${{ inputs.runner || 'depot-macos-latest' }}
+          RUNNER_CONTEXT_NAME: ${{ runner.name }}
+        run: |
+          set -euo pipefail
+          echo "Requested runner: $REQUESTED_RUNNER"
+          case "$RUNNER_CONTEXT_NAME" in
+            depot-*)
+              echo "Resolved runner matches depot-*? yes"
+              ;;
+            *)
+              echo "Resolved runner matches depot-*? no"
+              echo "::error::$REQUESTED_RUNNER resolved outside Depot. Remove $REQUESTED_RUNNER from non-Depot self-hosted runners or choose an explicit runner."
+              exit 1
+              ;;
+          esac
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/tests/test_ci_self_hosted_guard.sh
+++ b/tests/test_ci_self_hosted_guard.sh
@@ -53,12 +53,43 @@ check_e2e_runner_fallbacks() {
     fi
   done
 
+  if ! grep -Fq 'RUNNER_CONTEXT_NAME: ${{ runner.name }}' "$E2E_FILE"; then
+    echo "FAIL: test-e2e.yml must inspect the actual runner name for Depot runs"
+    exit 1
+  fi
+
+  if ! grep -Fq "startsWith(inputs.runner || 'depot-macos-latest', 'depot-macos-')" "$E2E_FILE"; then
+    echo "FAIL: test-e2e.yml must validate all Depot macOS runner choices"
+    exit 1
+  fi
+
+  if ! awk '
+    /^[[:space:]]*\*\)$/ {
+      in_reject = 1
+      saw_error = 0
+      saw_exit = 0
+      next
+    }
+    in_reject && /echo "::error::\$REQUESTED_RUNNER resolved outside Depot/ { saw_error = 1 }
+    in_reject && /^[[:space:]]*exit 1$/ { saw_exit = 1 }
+    in_reject && /^[[:space:]]*;;$/ {
+      if (saw_error && saw_exit) {
+        found = 1
+      }
+      in_reject = 0
+    }
+    END { exit(found ? 0 : 1) }
+  ' "$E2E_FILE"; then
+    echo "FAIL: test-e2e.yml must fail fast and explain runner label misrouting clearly"
+    exit 1
+  fi
+
   if grep -Eq "^[[:space:]]*continue-on-error:" "$E2E_FILE"; then
     echo "FAIL: test-e2e.yml must not mask E2E setup or test failures with continue-on-error"
     exit 1
   fi
 
-  echo "PASS: test-e2e.yml exposes Depot runner choices and duplicate-queue cancellation"
+  echo "PASS: test-e2e.yml exposes Depot runner choices, identity guard, and duplicate-queue cancellation"
 }
 
 check_xcode_selection() {


### PR DESCRIPTION
## Summary
- Fail the manual E2E workflow early when the default `depot-macos-latest` label resolves to a non-Depot runner.
- Extend the existing workflow guard script so the identity check stays wired.

## Why
The strict activation proof in https://github.com/manaflow-ai/cmux/actions/runs/26570108351 silently routed `depot-macos-latest` to an AWS self-hosted runner named `cmux-aws-m4pro-5`, then failed with a misleading app activation error. After removing that accidental external label, https://github.com/manaflow-ai/cmux/actions/runs/26571172281 resolved to a true Depot runner named `depot-w8l2gw3nfv`. This PR makes that runner-class invariant explicit in the workflow.

## Testing
- `actionlint -oneline .github/workflows/test-e2e.yml`
- `./tests/test_ci_self_hosted_guard.sh`
- `git diff --check`

@coderabbitai review

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4944"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782559734&installation_id=133855650&pr_number=4944&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4944&signature=3f3bc623b6dff94cd17b2f39ea653d98d43ee0fa5005191647bf6acb23ee2bd1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only guard and test assertions; no application runtime, auth, or data-path changes.
> 
> **Overview**
> Adds an early **Validate Depot runner identity** step to the manual E2E workflow when the selected label is `depot-macos-*`. It compares the requested runner to `${{ runner.name }}` and **fails fast** with a clear `::error::` if the job did not land on a `depot-*` host (avoiding misleading GUI/activation failures on mislabeled self-hosted runners).
> 
> Extends `tests/test_ci_self_hosted_guard.sh` so CI asserts that guard stays wired: `runner.name` is set, all Depot macOS choices are gated, and misrouting triggers the documented error plus `exit 1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29176a0198349f0f5e1326a803aea396f29c1ac9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an identity guard to the E2E workflow so jobs requesting `depot-macos-*` fail fast if routed to a non-Depot runner. This prevents misleading activation failures and makes the runner class explicit.

- **Bug Fixes**
  - Added a conditional "Validate Depot runner identity" step in `.github/workflows/test-e2e.yml` for any `depot-macos-*` (default `depot-macos-latest`) that echoes the requested label, checks `runner.name` starts with `depot-`, and fails with a clear message if not.
  - Extended `tests/test_ci_self_hosted_guard.sh` to assert the `runner.name` inspection, the `startsWith(inputs.runner || 'depot-macos-latest', 'depot-macos-')` gate, the misrouting `::error::` plus `exit 1`, and that no `continue-on-error` is used.

<sup>Written for commit 29176a0198349f0f5e1326a803aea396f29c1ac9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4944?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added CI checks to validate macOS runner identity, fail fast on misrouted runners, and emit clear diagnostic guidance for corrective action.
  * Expanded end-to-end test guardrails to assert runner identity is captured, detect misrouting and duplicate-queue scenarios, and update success messaging to reflect the broader coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4944?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->