### PR TITLE
Keep detached workspace process titles updateable

### DIFF
--- a/Sources/AppDelegate+MoveTabToNewWorkspace.swift
+++ b/Sources/AppDelegate+MoveTabToNewWorkspace.swift
@@ -93,8 +93,10 @@ extension AppDelegate {
         }
 
         let targetManager = destinationManager ?? source.tabManager
+        let explicitTitle = title?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let pinnedTitle = explicitTitle?.isEmpty == false ? explicitTitle : nil
         let destinationTitle = titleForDetachedWorkspace(
-            explicitTitle: title,
+            explicitTitle: pinnedTitle,
             workspace: sourceWorkspace,
             panelId: panelId,
             panel: sourcePanel
@@ -110,7 +112,8 @@ extension AppDelegate {
             select: false,
             placementOverride: placementOverride,
             insertionIndexOverride: insertionIndexOverride,
-            focusIntent: activationIntent
+            focusIntent: activationIntent,
+            customTitle: pinnedTitle
         ) else {
             rollbackDetachedSurface(
                 detached,

--- a/Sources/AppDelegate+MoveTabToNewWorkspace.swift
+++ b/Sources/AppDelegate+MoveTabToNewWorkspace.swift
@@ -93,10 +93,9 @@ extension AppDelegate {
         }
 
         let targetManager = destinationManager ?? source.tabManager
-        let explicitTitle = title?.trimmingCharacters(in: .whitespacesAndNewlines)
-        let pinnedTitle = explicitTitle?.isEmpty == false ? explicitTitle : nil
+        let explicitTitle = normalizedDetachedWorkspaceTitle(title)
         let destinationTitle = titleForDetachedWorkspace(
-            explicitTitle: pinnedTitle,
+            explicitTitle: explicitTitle,
             workspace: sourceWorkspace,
             panelId: panelId,
             panel: sourcePanel
@@ -105,6 +104,7 @@ extension AppDelegate {
         let sourceIndex = sourceWorkspace.indexInPane(forPanelId: panelId)
         let activationIntent = focusIntentForNewWorkspaceMove(panel: sourcePanel)
         guard let detached = sourceWorkspace.detachSurface(panelId: panelId) else { return nil }
+        let destinationCustomTitle = explicitTitle ?? normalizedDetachedWorkspaceTitle(detached.customTitle)
 
         guard let destinationWorkspace = targetManager.addWorkspace(
             fromDetachedSurface: detached,
@@ -113,7 +113,7 @@ extension AppDelegate {
             placementOverride: placementOverride,
             insertionIndexOverride: insertionIndexOverride,
             focusIntent: activationIntent,
-            customTitle: pinnedTitle
+            customTitle: destinationCustomTitle
         ) else {
             rollbackDetachedSurface(
                 detached,
@@ -178,9 +178,8 @@ extension AppDelegate {
         panelId: UUID,
         panel: any Panel
     ) -> String {
-        let trimmedTitle = explicitTitle?.trimmingCharacters(in: .whitespacesAndNewlines)
-        if let trimmedTitle, !trimmedTitle.isEmpty {
-            return trimmedTitle
+        if let explicitTitle {
+            return explicitTitle
         }
 
         let fallbackTitle = workspace.panelTitle(panelId: panelId) ?? panel.displayTitle
@@ -190,5 +189,10 @@ extension AppDelegate {
         }
 
         return String(localized: "commandPalette.subtitle.tabFallback", defaultValue: "Tab")
+    }
+
+    private func normalizedDetachedWorkspaceTitle(_ title: String?) -> String? {
+        let trimmedTitle = title?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmedTitle.isEmpty ? nil : trimmedTitle
     }
 }

--- a/Sources/AppDelegate+MoveTabToNewWorkspace.swift
+++ b/Sources/AppDelegate+MoveTabToNewWorkspace.swift
@@ -93,6 +93,7 @@ extension AppDelegate {
         }
 
         let targetManager = destinationManager ?? source.tabManager
+        let hasCallerTitleArgument = title != nil
         let explicitTitle = normalizedDetachedWorkspaceTitle(title)
         let destinationTitle = titleForDetachedWorkspace(
             explicitTitle: explicitTitle,
@@ -104,7 +105,9 @@ extension AppDelegate {
         let sourceIndex = sourceWorkspace.indexInPane(forPanelId: panelId)
         let activationIntent = focusIntentForNewWorkspaceMove(panel: sourcePanel)
         guard let detached = sourceWorkspace.detachSurface(panelId: panelId) else { return nil }
-        let destinationCustomTitle = explicitTitle ?? normalizedDetachedWorkspaceTitle(detached.customTitle)
+        let destinationCustomTitle = hasCallerTitleArgument
+            ? explicitTitle
+            : normalizedDetachedWorkspaceTitle(detached.customTitle)
 
         guard let destinationWorkspace = targetManager.addWorkspace(
             fromDetachedSurface: detached,

--- a/Sources/TabManager+DetachedWorkspace.swift
+++ b/Sources/TabManager+DetachedWorkspace.swift
@@ -75,8 +75,8 @@ extension TabManager {
 
             applyCreationChromeInheritance(to: newWorkspace, from: sourceWorkspace ?? capturedTabs.first)
             newWorkspace.owningTabManager = self
-            // Only explicit caller-provided names pin `customTitle`. Panel-derived
-            // titles are just initial labels; pinning them would block OSC-driven
+            // Only intentional names pin `customTitle`. Process-derived titles
+            // are just initial labels; pinning them would block OSC-driven
             // `applyProcessTitle` updates from reaching the workspace row. See
             // https://github.com/manaflow-ai/cmux/issues/4946.
             if let customTitle, !customTitle.isEmpty {

--- a/Sources/TabManager+DetachedWorkspace.swift
+++ b/Sources/TabManager+DetachedWorkspace.swift
@@ -79,8 +79,10 @@ extension TabManager {
             // are just initial labels; pinning them would block OSC-driven
             // `applyProcessTitle` updates from reaching the workspace row. See
             // https://github.com/manaflow-ai/cmux/issues/4946.
-            if let customTitle, !customTitle.isEmpty {
-                newWorkspace.setCustomTitle(customTitle)
+            if let normalizedCustomTitle = customTitle?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+               !normalizedCustomTitle.isEmpty {
+                newWorkspace.setCustomTitle(normalizedCustomTitle)
             }
             wireClosedBrowserTracking(for: newWorkspace)
 

--- a/Sources/TabManager+DetachedWorkspace.swift
+++ b/Sources/TabManager+DetachedWorkspace.swift
@@ -28,7 +28,8 @@ extension TabManager {
         select: Bool = true,
         placementOverride: WorkspacePlacement? = nil,
         insertionIndexOverride: Int? = nil,
-        focusIntent: PanelFocusIntent? = nil
+        focusIntent: PanelFocusIntent? = nil,
+        customTitle: String? = nil
     ) -> Workspace? {
         let sourceWorkspace = selectedWorkspace
         let capturedTabs = tabs
@@ -74,11 +75,13 @@ extension TabManager {
 
             applyCreationChromeInheritance(to: newWorkspace, from: sourceWorkspace ?? capturedTabs.first)
             newWorkspace.owningTabManager = self
-            // Intentionally do NOT call `newWorkspace.setCustomTitle(title)` here.
-            // The ctor already seeded `self.title` with `title ?? detached.title`,
-            // and pinning `customTitle` would block OSC-driven `applyProcessTitle`
-            // updates (e.g. claude's `✳ <topic>` titles) from reaching the
-            // workspace row. See https://github.com/manaflow-ai/cmux/issues/4946.
+            // Only explicit caller-provided names pin `customTitle`. Panel-derived
+            // titles are just initial labels; pinning them would block OSC-driven
+            // `applyProcessTitle` updates from reaching the workspace row. See
+            // https://github.com/manaflow-ai/cmux/issues/4946.
+            if let customTitle, !customTitle.isEmpty {
+                newWorkspace.setCustomTitle(customTitle)
+            }
             wireClosedBrowserTracking(for: newWorkspace)
 
             var updatedTabs = tabs

--- a/Sources/TabManager+DetachedWorkspace.swift
+++ b/Sources/TabManager+DetachedWorkspace.swift
@@ -74,9 +74,11 @@ extension TabManager {
 
             applyCreationChromeInheritance(to: newWorkspace, from: sourceWorkspace ?? capturedTabs.first)
             newWorkspace.owningTabManager = self
-            if title != nil {
-                newWorkspace.setCustomTitle(title)
-            }
+            // Intentionally do NOT call `newWorkspace.setCustomTitle(title)` here.
+            // The ctor already seeded `self.title` with `title ?? detached.title`,
+            // and pinning `customTitle` would block OSC-driven `applyProcessTitle`
+            // updates (e.g. claude's `✳ <topic>` titles) from reaching the
+            // workspace row. See https://github.com/manaflow-ai/cmux/issues/4946.
             wireClosedBrowserTracking(for: newWorkspace)
 
             var updatedTabs = tabs

--- a/cmuxTests/AppDelegateMoveTabToNewWorkspaceTests.swift
+++ b/cmuxTests/AppDelegateMoveTabToNewWorkspaceTests.swift
@@ -1,4 +1,5 @@
-import XCTest
+import Foundation
+import Testing
 import CmuxTerminal
 
 #if canImport(cmux_DEV)
@@ -8,41 +9,44 @@ import CmuxTerminal
 #endif
 
 @MainActor
-final class AppDelegateMoveTabToNewWorkspaceTests: XCTestCase {
-    func testMoveSurfaceToNewWorkspaceCreatesSinglePanelWorkspaceFromPanelTitle() throws {
+@Suite("AppDelegate move tab to new workspace", .serialized)
+struct AppDelegateMoveTabToNewWorkspaceTests {
+    @Test("Move surface to new workspace creates single-panel workspace from panel title")
+    func moveSurfaceToNewWorkspaceCreatesSinglePanelWorkspaceFromPanelTitle() throws {
         let app = AppDelegate()
         let windowId = UUID()
         let manager = TabManager()
         app.registerMainWindowContextForTesting(windowId: windowId, tabManager: manager)
         defer { app.unregisterMainWindowContextForTesting(windowId: windowId) }
 
-        let sourceWorkspace = try XCTUnwrap(manager.selectedWorkspace)
-        let sourcePaneId = try XCTUnwrap(sourceWorkspace.bonsplitController.allPaneIds.first)
-        let remainingPanelId = try XCTUnwrap(sourceWorkspace.focusedTerminalPanel?.id)
-        let movedPanel = try XCTUnwrap(sourceWorkspace.newTerminalSurface(inPane: sourcePaneId, focus: false))
+        let sourceWorkspace = try #require(manager.selectedWorkspace)
+        let sourcePaneId = try #require(sourceWorkspace.bonsplitController.allPaneIds.first)
+        let remainingPanelId = try #require(sourceWorkspace.focusedTerminalPanel?.id)
+        let movedPanel = try #require(sourceWorkspace.newTerminalSurface(inPane: sourcePaneId, focus: false))
         sourceWorkspace.setPanelCustomTitle(panelId: movedPanel.id, title: "Build logs")
 
         let originalWorkspaceCount = manager.tabs.count
-        let result = try XCTUnwrap(app.moveSurfaceToNewWorkspace(
+        let result = try #require(app.moveSurfaceToNewWorkspace(
             panelId: movedPanel.id,
             focus: false,
             focusWindow: false
         ))
 
-        let destinationWorkspace = try XCTUnwrap(manager.tabs.first { $0.id == result.destinationWorkspaceId })
-        XCTAssertEqual(result.sourceWindowId, windowId)
-        XCTAssertEqual(result.sourceWorkspaceId, sourceWorkspace.id)
-        XCTAssertEqual(result.destinationWindowId, windowId)
-        XCTAssertEqual(manager.tabs.count, originalWorkspaceCount + 1)
-        XCTAssertEqual(destinationWorkspace.title, "Build logs")
-        XCTAssertEqual(destinationWorkspace.panels.count, 1)
-        XCTAssertNotNil(destinationWorkspace.panels[movedPanel.id])
-        XCTAssertNil(sourceWorkspace.panels[movedPanel.id])
-        XCTAssertNotNil(sourceWorkspace.panels[remainingPanelId])
-        XCTAssertEqual(result.paneId, destinationWorkspace.paneId(forPanelId: movedPanel.id)?.id)
+        let destinationWorkspace = try #require(manager.tabs.first { $0.id == result.destinationWorkspaceId })
+        #expect(result.sourceWindowId == windowId)
+        #expect(result.sourceWorkspaceId == sourceWorkspace.id)
+        #expect(result.destinationWindowId == windowId)
+        #expect(manager.tabs.count == originalWorkspaceCount + 1)
+        #expect(destinationWorkspace.title == "Build logs")
+        #expect(destinationWorkspace.panels.count == 1)
+        #expect(destinationWorkspace.panels[movedPanel.id] != nil)
+        #expect(sourceWorkspace.panels[movedPanel.id] == nil)
+        #expect(sourceWorkspace.panels[remainingPanelId] != nil)
+        #expect(result.paneId == destinationWorkspace.paneId(forPanelId: movedPanel.id)?.id)
     }
 
-    func testMoveSurfaceToNewWorkspacePreservesTerminalTextBoxStateWhenDefaultsEnabled() throws {
+    @Test("Move surface to new workspace preserves terminal text box state when defaults enabled")
+    func moveSurfaceToNewWorkspacePreservesTerminalTextBoxStateWhenDefaultsEnabled() throws {
         let defaults = UserDefaults.standard
         let showKey = TerminalTextBoxInputSettings.showOnNewTerminalsKey
         let focusKey = TerminalTextBoxInputSettings.focusOnNewTerminalsKey
@@ -70,103 +74,106 @@ final class AppDelegateMoveTabToNewWorkspaceTests: XCTestCase {
         app.registerMainWindowContextForTesting(windowId: windowId, tabManager: manager)
         defer { app.unregisterMainWindowContextForTesting(windowId: windowId) }
 
-        let sourceWorkspace = try XCTUnwrap(manager.selectedWorkspace)
-        let sourcePaneId = try XCTUnwrap(sourceWorkspace.bonsplitController.allPaneIds.first)
-        let movedPanel = try XCTUnwrap(sourceWorkspace.newTerminalSurface(inPane: sourcePaneId, focus: false))
-        XCTAssertFalse(movedPanel.isTextBoxActive)
+        let sourceWorkspace = try #require(manager.selectedWorkspace)
+        let sourcePaneId = try #require(sourceWorkspace.bonsplitController.allPaneIds.first)
+        let movedPanel = try #require(sourceWorkspace.newTerminalSurface(inPane: sourcePaneId, focus: false))
+        #expect(!movedPanel.isTextBoxActive)
 
         defaults.set(true, forKey: showKey)
         defaults.set(true, forKey: focusKey)
 
-        let result = try XCTUnwrap(app.moveSurfaceToNewWorkspace(
+        let result = try #require(app.moveSurfaceToNewWorkspace(
             panelId: movedPanel.id,
             focus: false,
             focusWindow: false
         ))
 
-        let destinationWorkspace = try XCTUnwrap(manager.tabs.first { $0.id == result.destinationWorkspaceId })
-        let destinationPanel = try XCTUnwrap(destinationWorkspace.panels[movedPanel.id] as? TerminalPanel)
-        XCTAssertFalse(destinationPanel.isTextBoxActive)
-        XCTAssertNotEqual(destinationPanel.preferredFocusIntentForActivation(), .terminal(.textBoxInput))
+        let destinationWorkspace = try #require(manager.tabs.first { $0.id == result.destinationWorkspaceId })
+        let destinationPanel = try #require(destinationWorkspace.panels[movedPanel.id] as? TerminalPanel)
+        #expect(!destinationPanel.isTextBoxActive)
+        #expect(destinationPanel.preferredFocusIntentForActivation() != .terminal(.textBoxInput))
     }
 
-    func testMoveBrowserBonsplitTabToNewWorkspaceRequestsAddressBarFocus() throws {
+    @Test("Move browser bonsplit tab to new workspace requests address bar focus")
+    func moveBrowserBonsplitTabToNewWorkspaceRequestsAddressBarFocus() throws {
         let app = AppDelegate()
         let windowId = UUID()
         let manager = TabManager()
         app.registerMainWindowContextForTesting(windowId: windowId, tabManager: manager)
         defer { app.unregisterMainWindowContextForTesting(windowId: windowId) }
 
-        let sourceWorkspace = try XCTUnwrap(manager.selectedWorkspace)
-        let sourcePaneId = try XCTUnwrap(sourceWorkspace.bonsplitController.allPaneIds.first)
-        let browserPanel = try XCTUnwrap(
+        let sourceWorkspace = try #require(manager.selectedWorkspace)
+        let sourcePaneId = try #require(sourceWorkspace.bonsplitController.allPaneIds.first)
+        let browserPanel = try #require(
             sourceWorkspace.newBrowserSurface(
                 inPane: sourcePaneId,
-                url: try XCTUnwrap(URL(string: "https://example.com")),
+                url: try #require(URL(string: "https://example.com")),
                 focus: false
             )
         )
-        let browserTabId = try XCTUnwrap(sourceWorkspace.surfaceIdFromPanelId(browserPanel.id)?.uuid)
+        let browserTabId = try #require(sourceWorkspace.surfaceIdFromPanelId(browserPanel.id)?.uuid)
         browserPanel.noteWebViewFocused()
-        XCTAssertEqual(browserPanel.preferredFocusIntentForActivation(), .browser(.webView))
+        #expect(browserPanel.preferredFocusIntentForActivation() == .browser(.webView))
 
-        let result = try XCTUnwrap(app.moveBonsplitTabToNewWorkspace(
+        let result = try #require(app.moveBonsplitTabToNewWorkspace(
             tabId: browserTabId,
             focus: true,
             focusWindow: false
         ))
 
-        let destinationWorkspace = try XCTUnwrap(manager.tabs.first { $0.id == result.destinationWorkspaceId })
-        let movedBrowserPanel = try XCTUnwrap(destinationWorkspace.panels[browserPanel.id] as? BrowserPanel)
-        XCTAssertEqual(destinationWorkspace.panels.count, 1)
-        XCTAssertFalse(destinationWorkspace.panels.values.contains { $0 is TerminalPanel })
-        XCTAssertEqual(destinationWorkspace.focusedPanelId, movedBrowserPanel.id)
-        XCTAssertEqual(movedBrowserPanel.preferredFocusIntentForActivation(), .browser(.addressBar))
+        let destinationWorkspace = try #require(manager.tabs.first { $0.id == result.destinationWorkspaceId })
+        let movedBrowserPanel = try #require(destinationWorkspace.panels[browserPanel.id] as? BrowserPanel)
+        #expect(destinationWorkspace.panels.count == 1)
+        #expect(!destinationWorkspace.panels.values.contains { $0 is TerminalPanel })
+        #expect(destinationWorkspace.focusedPanelId == movedBrowserPanel.id)
+        #expect(movedBrowserPanel.preferredFocusIntentForActivation() == .browser(.addressBar))
     }
 
-    func testMoveSurfaceToNewWorkspaceRejectsOnlyPanel() throws {
+    @Test("Move surface to new workspace rejects only panel")
+    func moveSurfaceToNewWorkspaceRejectsOnlyPanel() throws {
         let app = AppDelegate()
         let windowId = UUID()
         let manager = TabManager()
         app.registerMainWindowContextForTesting(windowId: windowId, tabManager: manager)
         defer { app.unregisterMainWindowContextForTesting(windowId: windowId) }
 
-        let sourceWorkspace = try XCTUnwrap(manager.selectedWorkspace)
-        let onlyPanelId = try XCTUnwrap(sourceWorkspace.focusedTerminalPanel?.id)
+        let sourceWorkspace = try #require(manager.selectedWorkspace)
+        let onlyPanelId = try #require(sourceWorkspace.focusedTerminalPanel?.id)
 
-        XCTAssertFalse(app.canMoveSurfaceToNewWorkspace(panelId: onlyPanelId))
-        XCTAssertNil(app.moveSurfaceToNewWorkspace(panelId: onlyPanelId, focus: false, focusWindow: false))
-        XCTAssertEqual(manager.tabs.count, 1)
-        XCTAssertNotNil(sourceWorkspace.panels[onlyPanelId])
+        #expect(!app.canMoveSurfaceToNewWorkspace(panelId: onlyPanelId))
+        #expect(app.moveSurfaceToNewWorkspace(panelId: onlyPanelId, focus: false, focusWindow: false) == nil)
+        #expect(manager.tabs.count == 1)
+        #expect(sourceWorkspace.panels[onlyPanelId] != nil)
     }
 
-    func testMoveTerminalBonsplitTabToExistingWorkspaceClosesEmptiedSourceWorkspace() throws {
+    @Test("Move terminal bonsplit tab to existing workspace closes emptied source workspace")
+    func moveTerminalBonsplitTabToExistingWorkspaceClosesEmptiedSourceWorkspace() throws {
         let app = AppDelegate()
         let windowId = UUID()
         let manager = TabManager()
         app.registerMainWindowContextForTesting(windowId: windowId, tabManager: manager)
         defer { app.unregisterMainWindowContextForTesting(windowId: windowId) }
 
-        let sourceWorkspace = try XCTUnwrap(manager.selectedWorkspace)
-        let movedPanelId = try XCTUnwrap(sourceWorkspace.focusedTerminalPanel?.id)
-        let movedBonsplitTabId = try XCTUnwrap(sourceWorkspace.surfaceIdFromPanelId(movedPanelId)?.uuid)
+        let sourceWorkspace = try #require(manager.selectedWorkspace)
+        let movedPanelId = try #require(sourceWorkspace.focusedTerminalPanel?.id)
+        let movedBonsplitTabId = try #require(sourceWorkspace.surfaceIdFromPanelId(movedPanelId)?.uuid)
         let destinationWorkspace = manager.addWorkspace(title: "Operations", select: false)
-        let destinationOriginalPanelId = try XCTUnwrap(destinationWorkspace.focusedTerminalPanel?.id)
+        let destinationOriginalPanelId = try #require(destinationWorkspace.focusedTerminalPanel?.id)
 
-        XCTAssertTrue(app.canMoveBonsplitTab(tabId: movedBonsplitTabId, toWorkspace: destinationWorkspace.id))
-        XCTAssertTrue(app.moveBonsplitTab(
+        #expect(app.canMoveBonsplitTab(tabId: movedBonsplitTabId, toWorkspace: destinationWorkspace.id))
+        #expect(app.moveBonsplitTab(
             tabId: movedBonsplitTabId,
             toWorkspace: destinationWorkspace.id,
             focus: false,
             focusWindow: false
         ))
 
-        XCTAssertFalse(manager.tabs.contains { $0.id == sourceWorkspace.id })
-        XCTAssertEqual(manager.tabs.map(\.id), [destinationWorkspace.id])
-        XCTAssertTrue(sourceWorkspace.panels.isEmpty)
-        XCTAssertNotNil(destinationWorkspace.panels[movedPanelId])
-        XCTAssertNotNil(destinationWorkspace.panels[destinationOriginalPanelId])
-        XCTAssertEqual(destinationWorkspace.panels.count, 2)
+        #expect(!manager.tabs.contains { $0.id == sourceWorkspace.id })
+        #expect(manager.tabs.map(\.id) == [destinationWorkspace.id])
+        #expect(sourceWorkspace.panels.isEmpty)
+        #expect(destinationWorkspace.panels[movedPanelId] != nil)
+        #expect(destinationWorkspace.panels[destinationOriginalPanelId] != nil)
+        #expect(destinationWorkspace.panels.count == 2)
     }
 
     /// Regression for https://github.com/manaflow-ai/cmux/issues/4946.
@@ -175,35 +182,36 @@ final class AppDelegateMoveTabToNewWorkspaceTests: XCTestCase {
     /// workspace's `customTitle`. Pinning blocks the OSC-driven
     /// `applyProcessTitle` pipeline, which is what feeds claude code's
     /// dynamic `✳ <topic>` titles into the workspace row.
-    func testMoveSurfaceToNewWorkspaceDoesNotPinCustomTitleAndAllowsLaterOSCUpdates() throws {
+    @Test("Move surface to new workspace does not pin custom title and allows later OSC updates")
+    func moveSurfaceToNewWorkspaceDoesNotPinCustomTitleAndAllowsLaterOSCUpdates() throws {
         let app = AppDelegate()
         let windowId = UUID()
         let manager = TabManager()
         app.registerMainWindowContextForTesting(windowId: windowId, tabManager: manager)
         defer { app.unregisterMainWindowContextForTesting(windowId: windowId) }
 
-        let sourceWorkspace = try XCTUnwrap(manager.selectedWorkspace)
-        let sourcePaneId = try XCTUnwrap(sourceWorkspace.bonsplitController.allPaneIds.first)
-        let movedPanel = try XCTUnwrap(sourceWorkspace.newTerminalSurface(inPane: sourcePaneId, focus: false))
+        let sourceWorkspace = try #require(manager.selectedWorkspace)
+        let sourcePaneId = try #require(sourceWorkspace.bonsplitController.allPaneIds.first)
+        let movedPanel = try #require(sourceWorkspace.newTerminalSurface(inPane: sourcePaneId, focus: false))
 
         // Seed the source panel's title with what a shell PROMPT_COMMAND
         // typically emits before the user starts claude. This is the value
         // the buggy code pins onto the detached workspace's `customTitle`.
         sourceWorkspace.setPanelCustomTitle(panelId: movedPanel.id, title: "user@host:~/git/repo")
 
-        let result = try XCTUnwrap(app.moveSurfaceToNewWorkspace(
+        let result = try #require(app.moveSurfaceToNewWorkspace(
             panelId: movedPanel.id,
             focus: false,
             focusWindow: false
         ))
-        let destinationWorkspace = try XCTUnwrap(manager.tabs.first { $0.id == result.destinationWorkspaceId })
+        let destinationWorkspace = try #require(manager.tabs.first { $0.id == result.destinationWorkspaceId })
 
         // 1. The destination workspace must not have its title pinned. A
         //    drag-created workspace should behave like one created via
         //    "New Workspace" — `customTitle` stays `nil` until the user
         //    renames it explicitly.
-        XCTAssertNil(
-            destinationWorkspace.customTitle,
+        #expect(
+            destinationWorkspace.customTitle == nil,
             "Detached workspace must not pin customTitle; pinning blocks OSC title updates."
         )
 
@@ -213,39 +221,39 @@ final class AppDelegateMoveTabToNewWorkspaceTests: XCTestCase {
         //    workspace title never moves off the shell prompt.
         let claudeTitle = "✳ Investigate workspace title bug"
         destinationWorkspace.applyProcessTitle(claudeTitle)
-        XCTAssertEqual(
-            destinationWorkspace.title,
-            claudeTitle,
+        #expect(
+            destinationWorkspace.title == claudeTitle,
             "applyProcessTitle must update self.title on a freshly detached workspace."
         )
     }
 
-    func testMoveSurfaceToExistingWorkspaceClosesEmptiedSourceWorkspaceAndFocusesDestination() throws {
+    @Test("Move surface to existing workspace closes emptied source workspace and focuses destination")
+    func moveSurfaceToExistingWorkspaceClosesEmptiedSourceWorkspaceAndFocusesDestination() throws {
         let app = AppDelegate()
         let windowId = UUID()
         let manager = TabManager()
         app.registerMainWindowContextForTesting(windowId: windowId, tabManager: manager)
         defer { app.unregisterMainWindowContextForTesting(windowId: windowId) }
 
-        let sourceWorkspace = try XCTUnwrap(manager.selectedWorkspace)
-        let movedPanelId = try XCTUnwrap(sourceWorkspace.focusedTerminalPanel?.id)
+        let sourceWorkspace = try #require(manager.selectedWorkspace)
+        let movedPanelId = try #require(sourceWorkspace.focusedTerminalPanel?.id)
         let destinationWorkspace = manager.addWorkspace(title: "Operations", select: false)
-        let destinationOriginalPanelId = try XCTUnwrap(destinationWorkspace.focusedTerminalPanel?.id)
+        let destinationOriginalPanelId = try #require(destinationWorkspace.focusedTerminalPanel?.id)
 
-        XCTAssertTrue(app.moveSurface(
+        #expect(app.moveSurface(
             panelId: movedPanelId,
             toWorkspace: destinationWorkspace.id,
             focus: true,
             focusWindow: false
         ))
 
-        XCTAssertFalse(manager.tabs.contains { $0.id == sourceWorkspace.id })
-        XCTAssertEqual(manager.tabs.map(\.id), [destinationWorkspace.id])
-        XCTAssertTrue(sourceWorkspace.panels.isEmpty)
-        XCTAssertNotNil(destinationWorkspace.panels[movedPanelId])
-        XCTAssertNotNil(destinationWorkspace.panels[destinationOriginalPanelId])
-        XCTAssertEqual(destinationWorkspace.panels.count, 2)
-        XCTAssertEqual(manager.selectedWorkspace?.id, destinationWorkspace.id)
-        XCTAssertEqual(destinationWorkspace.focusedPanelId, movedPanelId)
+        #expect(!manager.tabs.contains { $0.id == sourceWorkspace.id })
+        #expect(manager.tabs.map(\.id) == [destinationWorkspace.id])
+        #expect(sourceWorkspace.panels.isEmpty)
+        #expect(destinationWorkspace.panels[movedPanelId] != nil)
+        #expect(destinationWorkspace.panels[destinationOriginalPanelId] != nil)
+        #expect(destinationWorkspace.panels.count == 2)
+        #expect(manager.selectedWorkspace?.id == destinationWorkspace.id)
+        #expect(destinationWorkspace.focusedPanelId == movedPanelId)
     }
 }

--- a/cmuxTests/AppDelegateMoveTabToNewWorkspaceTests.swift
+++ b/cmuxTests/AppDelegateMoveTabToNewWorkspaceTests.swift
@@ -169,6 +169,57 @@ final class AppDelegateMoveTabToNewWorkspaceTests: XCTestCase {
         XCTAssertEqual(destinationWorkspace.panels.count, 2)
     }
 
+    /// Regression for https://github.com/manaflow-ai/cmux/issues/4946.
+    ///
+    /// Detaching a tab into a new workspace must not pin the destination
+    /// workspace's `customTitle`. Pinning blocks the OSC-driven
+    /// `applyProcessTitle` pipeline, which is what feeds claude code's
+    /// dynamic `✳ <topic>` titles into the workspace row.
+    func testMoveSurfaceToNewWorkspaceDoesNotPinCustomTitleAndAllowsLaterOSCUpdates() throws {
+        let app = AppDelegate()
+        let windowId = UUID()
+        let manager = TabManager()
+        app.registerMainWindowContextForTesting(windowId: windowId, tabManager: manager)
+        defer { app.unregisterMainWindowContextForTesting(windowId: windowId) }
+
+        let sourceWorkspace = try XCTUnwrap(manager.selectedWorkspace)
+        let sourcePaneId = try XCTUnwrap(sourceWorkspace.bonsplitController.allPaneIds.first)
+        let movedPanel = try XCTUnwrap(sourceWorkspace.newTerminalSurface(inPane: sourcePaneId, focus: false))
+
+        // Seed the source panel's title with what a shell PROMPT_COMMAND
+        // typically emits before the user starts claude. This is the value
+        // the buggy code pins onto the detached workspace's `customTitle`.
+        sourceWorkspace.setPanelCustomTitle(panelId: movedPanel.id, title: "user@host:~/git/repo")
+
+        let result = try XCTUnwrap(app.moveSurfaceToNewWorkspace(
+            panelId: movedPanel.id,
+            focus: false,
+            focusWindow: false
+        ))
+        let destinationWorkspace = try XCTUnwrap(manager.tabs.first { $0.id == result.destinationWorkspaceId })
+
+        // 1. The destination workspace must not have its title pinned. A
+        //    drag-created workspace should behave like one created via
+        //    "New Workspace" — `customTitle` stays `nil` until the user
+        //    renames it explicitly.
+        XCTAssertNil(
+            destinationWorkspace.customTitle,
+            "Detached workspace must not pin customTitle; pinning blocks OSC title updates."
+        )
+
+        // 2. Simulate the OSC SET_TITLE that claude emits once it starts
+        //    rendering its first message. With customTitle pinned, this
+        //    call short-circuits inside `applyProcessTitle` and the
+        //    workspace title never moves off the shell prompt.
+        let claudeTitle = "✳ Investigate workspace title bug"
+        destinationWorkspace.applyProcessTitle(claudeTitle)
+        XCTAssertEqual(
+            destinationWorkspace.title,
+            claudeTitle,
+            "applyProcessTitle must update self.title on a freshly detached workspace."
+        )
+    }
+
     func testMoveSurfaceToExistingWorkspaceClosesEmptiedSourceWorkspaceAndFocusesDestination() throws {
         let app = AppDelegate()
         let windowId = UUID()

--- a/cmuxTests/AppDelegateMoveTabToNewWorkspaceTests.swift
+++ b/cmuxTests/AppDelegateMoveTabToNewWorkspaceTests.swift
@@ -227,6 +227,37 @@ struct AppDelegateMoveTabToNewWorkspaceTests {
         )
     }
 
+    @Test("Move surface to new workspace pins explicit caller title")
+    func moveSurfaceToNewWorkspacePinsExplicitCallerTitle() throws {
+        let app = AppDelegate()
+        let windowId = UUID()
+        let manager = TabManager()
+        app.registerMainWindowContextForTesting(windowId: windowId, tabManager: manager)
+        defer { app.unregisterMainWindowContextForTesting(windowId: windowId) }
+
+        let sourceWorkspace = try #require(manager.selectedWorkspace)
+        let sourcePaneId = try #require(sourceWorkspace.bonsplitController.allPaneIds.first)
+        let movedPanel = try #require(sourceWorkspace.newTerminalSurface(inPane: sourcePaneId, focus: false))
+        sourceWorkspace.setPanelCustomTitle(panelId: movedPanel.id, title: "user@host:~/git/repo")
+
+        let result = try #require(app.moveSurfaceToNewWorkspace(
+            panelId: movedPanel.id,
+            title: "Deploy logs",
+            focus: false,
+            focusWindow: false
+        ))
+        let destinationWorkspace = try #require(manager.tabs.first { $0.id == result.destinationWorkspaceId })
+
+        #expect(destinationWorkspace.title == "Deploy logs")
+        #expect(destinationWorkspace.customTitle == "Deploy logs")
+
+        destinationWorkspace.applyProcessTitle("✳ Investigate workspace title bug")
+        #expect(
+            destinationWorkspace.title == "Deploy logs",
+            "Explicit caller title should remain pinned until the user or caller changes it."
+        )
+    }
+
     @Test("Move surface to existing workspace closes emptied source workspace and focuses destination")
     func moveSurfaceToExistingWorkspaceClosesEmptiedSourceWorkspaceAndFocusesDestination() throws {
         let app = AppDelegate()

--- a/cmuxTests/AppDelegateMoveTabToNewWorkspaceTests.swift
+++ b/cmuxTests/AppDelegateMoveTabToNewWorkspaceTests.swift
@@ -291,6 +291,36 @@ struct AppDelegateMoveTabToNewWorkspaceTests {
         )
     }
 
+    @Test("Move surface to new workspace ignores whitespace-only caller title pin")
+    func moveSurfaceToNewWorkspaceIgnoresWhitespaceOnlyCallerTitlePin() throws {
+        let app = AppDelegate()
+        let windowId = UUID()
+        let manager = TabManager()
+        app.registerMainWindowContextForTesting(windowId: windowId, tabManager: manager)
+        defer { app.unregisterMainWindowContextForTesting(windowId: windowId) }
+
+        let sourceWorkspace = try #require(manager.selectedWorkspace)
+        let sourcePaneId = try #require(sourceWorkspace.bonsplitController.allPaneIds.first)
+        let movedPanel = try #require(sourceWorkspace.newTerminalSurface(inPane: sourcePaneId, focus: false))
+        sourceWorkspace.setPanelCustomTitle(panelId: movedPanel.id, title: "user@host:~/git/repo")
+
+        let result = try #require(app.moveSurfaceToNewWorkspace(
+            panelId: movedPanel.id,
+            title: " \t\n ",
+            focus: false,
+            focusWindow: false
+        ))
+        let destinationWorkspace = try #require(manager.tabs.first { $0.id == result.destinationWorkspaceId })
+
+        #expect(destinationWorkspace.customTitle == nil)
+
+        destinationWorkspace.applyProcessTitle("claude investigation")
+        #expect(
+            destinationWorkspace.title == "claude investigation",
+            "Whitespace-only caller titles must not pin the workspace title."
+        )
+    }
+
     @Test("Move surface to existing workspace closes emptied source workspace and focuses destination")
     func moveSurfaceToExistingWorkspaceClosesEmptiedSourceWorkspaceAndFocusesDestination() throws {
         let app = AppDelegate()

--- a/cmuxTests/AppDelegateMoveTabToNewWorkspaceTests.swift
+++ b/cmuxTests/AppDelegateMoveTabToNewWorkspaceTests.swift
@@ -11,8 +11,8 @@ import CmuxTerminal
 @MainActor
 @Suite("AppDelegate move tab to new workspace", .serialized)
 struct AppDelegateMoveTabToNewWorkspaceTests {
-    @Test("Move surface to new workspace creates single-panel workspace from panel title")
-    func moveSurfaceToNewWorkspaceCreatesSinglePanelWorkspaceFromPanelTitle() throws {
+    @Test("Move surface to new workspace creates single-panel workspace from panel custom title")
+    func moveSurfaceToNewWorkspaceCreatesSinglePanelWorkspaceFromPanelCustomTitle() throws {
         let app = AppDelegate()
         let windowId = UUID()
         let manager = TabManager()
@@ -38,6 +38,7 @@ struct AppDelegateMoveTabToNewWorkspaceTests {
         #expect(result.destinationWindowId == windowId)
         #expect(manager.tabs.count == originalWorkspaceCount + 1)
         #expect(destinationWorkspace.title == "Build logs")
+        #expect(destinationWorkspace.customTitle == "Build logs")
         #expect(destinationWorkspace.panels.count == 1)
         #expect(destinationWorkspace.panels[movedPanel.id] != nil)
         #expect(sourceWorkspace.panels[movedPanel.id] == nil)
@@ -178,10 +179,10 @@ struct AppDelegateMoveTabToNewWorkspaceTests {
 
     /// Regression for https://github.com/manaflow-ai/cmux/issues/4946.
     ///
-    /// Detaching a tab into a new workspace must not pin the destination
-    /// workspace's `customTitle`. Pinning blocks the OSC-driven
-    /// `applyProcessTitle` pipeline, which is what feeds claude code's
-    /// dynamic `✳ <topic>` titles into the workspace row.
+    /// Detaching a tab with only a process-derived title into a new workspace
+    /// must not pin the destination workspace's `customTitle`. Pinning blocks
+    /// the OSC-driven `applyProcessTitle` pipeline, which is what feeds claude
+    /// code's dynamic `✳ <topic>` titles into the workspace row.
     @Test("Move surface to new workspace does not pin custom title and allows later OSC updates")
     func moveSurfaceToNewWorkspaceDoesNotPinCustomTitleAndAllowsLaterOSCUpdates() throws {
         let app = AppDelegate()
@@ -194,10 +195,11 @@ struct AppDelegateMoveTabToNewWorkspaceTests {
         let sourcePaneId = try #require(sourceWorkspace.bonsplitController.allPaneIds.first)
         let movedPanel = try #require(sourceWorkspace.newTerminalSurface(inPane: sourcePaneId, focus: false))
 
-        // Seed the source panel's title with what a shell PROMPT_COMMAND
-        // typically emits before the user starts claude. This is the value
-        // the buggy code pins onto the detached workspace's `customTitle`.
-        sourceWorkspace.setPanelCustomTitle(panelId: movedPanel.id, title: "user@host:~/git/repo")
+        // Seed the source panel's process-derived title with what a shell
+        // PROMPT_COMMAND typically emits before the user starts claude. This
+        // is the value the buggy code pins onto the detached workspace's
+        // `customTitle`.
+        #expect(sourceWorkspace.updatePanelTitle(panelId: movedPanel.id, title: "user@host:~/git/repo"))
 
         let result = try #require(app.moveSurfaceToNewWorkspace(
             panelId: movedPanel.id,
@@ -224,6 +226,37 @@ struct AppDelegateMoveTabToNewWorkspaceTests {
         #expect(
             destinationWorkspace.title == claudeTitle,
             "applyProcessTitle must update self.title on a freshly detached workspace."
+        )
+    }
+
+    @Test("Move surface to new workspace preserves manually renamed tab title")
+    func moveSurfaceToNewWorkspacePreservesManuallyRenamedTabTitle() throws {
+        let app = AppDelegate()
+        let windowId = UUID()
+        let manager = TabManager()
+        app.registerMainWindowContextForTesting(windowId: windowId, tabManager: manager)
+        defer { app.unregisterMainWindowContextForTesting(windowId: windowId) }
+
+        let sourceWorkspace = try #require(manager.selectedWorkspace)
+        let sourcePaneId = try #require(sourceWorkspace.bonsplitController.allPaneIds.first)
+        let movedPanel = try #require(sourceWorkspace.newTerminalSurface(inPane: sourcePaneId, focus: false))
+        #expect(sourceWorkspace.updatePanelTitle(panelId: movedPanel.id, title: "user@host:~/git/repo"))
+        sourceWorkspace.setPanelCustomTitle(panelId: movedPanel.id, title: "Deploy logs")
+
+        let result = try #require(app.moveSurfaceToNewWorkspace(
+            panelId: movedPanel.id,
+            focus: false,
+            focusWindow: false
+        ))
+        let destinationWorkspace = try #require(manager.tabs.first { $0.id == result.destinationWorkspaceId })
+
+        #expect(destinationWorkspace.title == "Deploy logs")
+        #expect(destinationWorkspace.customTitle == "Deploy logs")
+
+        destinationWorkspace.applyProcessTitle("claude investigation")
+        #expect(
+            destinationWorkspace.title == "Deploy logs",
+            "A manually renamed tab should stay pinned after it becomes a workspace."
         )
     }
 


### PR DESCRIPTION
## Summary

- Closes #4946.
- Leave process-derived detached workspace titles unpinned so later OSC title updates can still apply.
- Preserve manual tab renames and explicit caller titles as pinned custom titles when detaching.

## Testing

- Regression coverage verifies process-derived titles stay updateable after detach.
- Added coverage for manual tab renames and explicit caller titles.
- CI owns test execution.

## Demo Video

- Video URL or attachment: N/A, title behavior covered by regression tests.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [ ] I tested the change locally
- [x] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [x] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Workspaces created from moved panels no longer get accidentally pinned, allowing later terminal/process title updates to change the workspace title.
  * Explicit incoming titles are normalized (trimmed; blank treated as none) so empty/whitespace titles won’t be pinned.
  * Callers can now provide an explicit custom title that will be pinned only when non-empty.

* **Tests**
  * Added a regression test verifying unpinned workspaces accept later title updates and migrated move-tab tests to the new Swift testing framework.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->