### PR TITLE
Unmask right sidebar chrome E2E tests

### DIFF
--- a/cmuxUITests/BonsplitTabDragUITests.swift
+++ b/cmuxUITests/BonsplitTabDragUITests.swift
@@ -160,11 +160,10 @@ final class BonsplitTabDragUITests: XCTestCase {
                 accuracy: 0.5,
                 "Expected \(presentationMode.rawValue)-mode right sidebar chrome metric to stay compact. geometry=\(geometry)"
             )
-            XCTAssertEqual(
-                modeBarHeight,
+            XCTAssertGreaterThanOrEqual(
                 alphaTab.frame.height,
-                accuracy: 2,
-                "Expected \(presentationMode.rawValue)-mode right sidebar mode bar to match Bonsplit pane tab height. geometry=\(geometry) alphaTab=\(alphaTab.frame)"
+                modeBarHeight,
+                "Expected \(presentationMode.rawValue)-mode Bonsplit pane tab hit target to cover the compact chrome lane. geometry=\(geometry) alphaTab=\(alphaTab.frame)"
             )
 
             if let referenceTopInset {

--- a/cmuxUITests/RightSidebarChromeHeightUITests.swift
+++ b/cmuxUITests/RightSidebarChromeHeightUITests.swift
@@ -47,7 +47,7 @@ final class RightSidebarChromeHeightUITests: XCTestCase {
         }
         XCTAssertEqual(secondaryBarHeight, modeBarHeight, accuracy: 0.5, "Expected secondary bar to match the right sidebar mode bar. geometry=\(geometry)")
         XCTAssertEqual(secondaryBarHeight, 28, accuracy: 0.5, "Expected right sidebar chrome to use the standard minimal-mode lane height. geometry=\(geometry)")
-        XCTAssertEqual(CGFloat(secondaryBarHeight), alphaTab.frame.height, accuracy: 2, "Expected secondary bar to match Bonsplit pane tab height. geometry=\(geometry) alphaTab=\(alphaTab.frame)")
+        XCTAssertGreaterThanOrEqual(alphaTab.frame.height, CGFloat(secondaryBarHeight), "Expected Bonsplit pane tab hit target to cover the compact chrome lane. geometry=\(geometry) alphaTab=\(alphaTab.frame)")
 
         let controlHeightKeys = [
             "rightSidebarModeControl_sessionsHeight",

--- a/cmuxUITests/RightSidebarChromeHeightUITests.swift
+++ b/cmuxUITests/RightSidebarChromeHeightUITests.swift
@@ -14,11 +14,7 @@ final class RightSidebarChromeHeightUITests: XCTestCase {
         app.launchEnvironment["CMUX_UI_TEST_BONSPLIT_TAB_DRAG_PATH"] = dataPath
         app.launchEnvironment["CMUX_UI_TEST_BONSPLIT_SHOW_RIGHT_SIDEBAR"] = "1"
         app.launchArguments += ["-workspacePresentationMode", "minimal"]
-        let options = XCTExpectedFailure.Options()
-        options.isStrict = false
-        XCTExpectFailure("App activation may fail on headless CI runners", options: options) {
-            app.launch()
-        }
+        app.launch()
         defer { app.terminate() }
 
         if app.state == .runningBackground {
@@ -109,11 +105,7 @@ final class RightSidebarChromeHeightUITests: XCTestCase {
             "-sidebarTintHexDark", "#FF0044",
             "-sidebarTintOpacity", "1.0",
         ]
-        let options = XCTExpectedFailure.Options()
-        options.isStrict = false
-        XCTExpectFailure("App activation may fail on headless CI runners", options: options) {
-            app.launch()
-        }
+        app.launch()
         defer { app.terminate() }
 
         if app.state == .runningBackground {


### PR DESCRIPTION
## Summary
- remove non-strict expected-failure launch wrappers from `RightSidebarChromeHeightUITests`
- update stale chrome assertions so visual 28 pt metrics are not compared to 48 pt accessibility hit targets
- cover the same stale assertion in `BonsplitTabDragUITests`

## Verification
- failing baseline: https://github.com/manaflow-ai/cmux/actions/runs/26576147383
- passing focused E2E: https://github.com/manaflow-ai/cmux/actions/runs/26576700096

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4949"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782566294&installation_id=133855650&pr_number=4949&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4949&signature=c67959738501466ad42f7afafdff502fe2452a181a8f54235355c09c1b6c270e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to XCTest expectations and launch handling; no production UI or app logic.
> 
> **Overview**
> **Unmasks** right-sidebar chrome E2E tests so launch failures surface on CI instead of being swallowed by non-strict `XCTExpectFailure` around `app.launch()` in `RightSidebarChromeHeightUITests`.
> 
> **Fixes** outdated height checks that compared **28 pt** in-app chrome metrics to **Bonsplit pane tab** frames from XCUITest. Those elements can be taller because of accessibility hit targets (~48 pt). Assertions now require the tab’s frame height to be **at least** the compact lane height, not equal to it—the same change in `BonsplitTabDragUITests` for the cross-presentation-mode mode-bar test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 527aca4181981956049494f0638b2a51b0e51243. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unmasked the right sidebar chrome UI tests and fixed hit-target assertions so we compare 28 pt chrome lanes against 48 pt tab targets. Improves reliability on CI and aligns tests with intended visual vs accessibility metrics.

- **Bug Fixes**
  - Removed non-strict expected-failure wrappers; launch app directly in `RightSidebarChromeHeightUITests`.
  - Replaced equality checks with greater-or-equal for tab hit target vs 28 pt chrome lane.
  - Added matching assertion coverage to `BonsplitTabDragUITests`.

<sup>Written for commit 527aca4181981956049494f0638b2a51b0e51243. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4949?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Improved test stability by removing app launch failure expectations on headless CI runners.
  * Enhanced UI height verification tests with more flexible assertions to ensure proper hit-target coverage for interface elements across different presentation modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4949?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->