### PR TITLE
Unmask help menu E2E launch

### DIFF
--- a/cmuxUITests/HelpMenuUITests.swift
+++ b/cmuxUITests/HelpMenuUITests.swift
@@ -119,11 +119,7 @@ final class HelpMenuUITests: XCTestCase {
     }
 
     private func launchAndActivate(_ app: XCUIApplication, activateTimeout: TimeInterval = 2.0) {
-        let options = XCTExpectedFailure.Options()
-        options.isStrict = false
-        XCTExpectFailure("Headless CI may launch the app without foreground activation", options: options) {
-            app.launch()
-        }
+        app.launch()
 
         XCTAssertTrue(
             helpMenuPollUntil(timeout: 10.0) {


### PR DESCRIPTION
Removes the non-strict expected-failure wrapper around the Help menu E2E app launch so hosted CI exercises the strict activation path.\n\nFocused proof will be the hosted test-e2e workflow for HelpMenuUITests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4951"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782568151&installation_id=133855650&pr_number=4951&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4951&signature=d1584bee5b305391deb1153b7cd7ffd4ac44c1c0cbfe0715b999e637ae838f13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change in Help menu E2E; no production auth, data, or app logic.
> 
> **Overview**
> **Help menu UI tests** now call `app.launch()` directly in `launchAndActivate` instead of wrapping launch in a non-strict `XCTExpectFailure` for headless CI activation issues.
> 
> The surrounding launch polling and foreground activation logic is unchanged; hosted E2E is expected to enforce the strict launch/activation path for `HelpMenuUITests`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86891060fb248659df7cb11732ded765b5ac0615. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unmasked the Help menu E2E app launch by removing the non-strict expected-failure wrapper. CI now exercises the strict activation path and will fail on activation regressions.

- **Refactors**
  - Removed `XCTExpectFailure` around `app.launch()` in `HelpMenuUITests`.
  - Hosted test-e2e will fail if the app doesn’t activate in the foreground.

<sup>Written for commit 86891060fb248659df7cb11732ded765b5ac0615. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4951?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Test helper now enforces stricter launch validation without suppressing failures in headless CI environments, ensuring more reliable test execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4951?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->