### PR TITLE
Fix bash "[N] Done" prompt spam (issue 1565)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,9 @@ jobs:
       - name: Validate pbxproj objectVersion pin and normalization
         run: ./scripts/check-pbxproj.sh
 
+      - name: Validate bash shell integration job-control suppression
+        run: python3 tests/test_bash_done_spam.py
+
       # Paused: stale-base merge races (two PRs each fitting the budget can
       # overshoot when merged back-to-back without rebasing). CodeRabbit and
       # Greptile already flag large-file growth on PRs. Re-enable by uncommenting

--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -51,9 +51,10 @@ _cmux_start_tracked_bg() {
     [[ "$1" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || return 1
     local __cmux_stb_var="$1"
     shift
-    # Empty argv would make `& ...` background nothing and leave $! pointing
-    # at a phantom slot. The caller would then kill an unrelated process if
-    # that PID got recycled. Refuse early.
+    # With empty argv, `"$@" & ...` backgrounds nothing and $! retains
+    # whatever the prior backgrounded PID was. The caller would then
+    # `kill -0` / `kill` an unrelated (possibly user-owned) process.
+    # Refuse early.
     (( $# >= 1 )) || {
         printf -v "$__cmux_stb_var" '%s' "" 2>/dev/null
         return 1

--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -44,23 +44,33 @@ _cmux_detach_bg() {
 # Same suppression as _cmux_detach_bg, but hands the background PID back to
 # the caller through a tempfile so timeout/cleanup logic can still
 # `kill -0`/`kill` the child. The inner `&` runs in a subshell so `$!` is
-# only visible there.
+# only visible there. Locals use a deliberately ugly prefix so they cannot
+# collide with whatever variable name the caller passes as $1 (bash uses
+# dynamic scoping, so a collision would shadow the outer var).
 _cmux_start_tracked_bg() {
-    local __cmux_pid_var="$1"
+    [[ "$1" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || return 1
+    local __cmux_stb_var="$1"
     shift
-    local __cmux_pid_file=""
-    __cmux_pid_file="$(mktemp "${TMPDIR:-/tmp}/cmux-bgpid.XXXXXX" 2>/dev/null)" || {
-        printf -v "$__cmux_pid_var" '%s' ""
+    # Empty argv would make `& ...` background nothing and leave $! pointing
+    # at a phantom slot. The caller would then kill an unrelated process if
+    # that PID got recycled. Refuse early.
+    (( $# >= 1 )) || {
+        printf -v "$__cmux_stb_var" '%s' "" 2>/dev/null
+        return 1
+    }
+    local __cmux_stb_file=""
+    __cmux_stb_file="$(mktemp "${TMPDIR:-/tmp}/cmux-bgpid.XXXXXX" 2>/dev/null)" || {
+        printf -v "$__cmux_stb_var" '%s' "" 2>/dev/null
         return 1
     }
     (
         "$@" >/dev/null 2>&1 &
-        printf '%s\n' "$!" > "$__cmux_pid_file"
+        printf '%s\n' "$!" > "$__cmux_stb_file"
     ) >/dev/null 2>&1
-    local __cmux_pid=""
-    IFS= read -r __cmux_pid < "$__cmux_pid_file" 2>/dev/null || __cmux_pid=""
-    /bin/rm -f -- "$__cmux_pid_file" >/dev/null 2>&1 || true
-    printf -v "$__cmux_pid_var" '%s' "$__cmux_pid"
+    local __cmux_stb_pid=""
+    IFS= read -r __cmux_stb_pid < "$__cmux_stb_file" 2>/dev/null || __cmux_stb_pid=""
+    /bin/rm -f -- "$__cmux_stb_file" >/dev/null 2>&1 || true
+    printf -v "$__cmux_stb_var" '%s' "$__cmux_stb_pid" 2>/dev/null
 }
 
 _cmux_socket_is_unix() {

--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -32,6 +32,37 @@ _cmux_send() {
     esac
 }
 
+# Fire-and-forget background dispatch. The outer subshell becomes a
+# synchronous foreground command from the interactive shell's perspective;
+# the inner `&` registers the real job in the subshell's own (non-monitoring)
+# job table, so the interactive shell never queues a `[N]+ Done` notification
+# regardless of how quickly the helper finishes. See issue 1565.
+_cmux_detach_bg() {
+    ( "$@" >/dev/null 2>&1 & ) >/dev/null 2>&1
+}
+
+# Same suppression as _cmux_detach_bg, but hands the background PID back to
+# the caller through a tempfile so timeout/cleanup logic can still
+# `kill -0`/`kill` the child. The inner `&` runs in a subshell so `$!` is
+# only visible there.
+_cmux_start_tracked_bg() {
+    local __cmux_pid_var="$1"
+    shift
+    local __cmux_pid_file=""
+    __cmux_pid_file="$(mktemp "${TMPDIR:-/tmp}/cmux-bgpid.XXXXXX" 2>/dev/null)" || {
+        printf -v "$__cmux_pid_var" '%s' ""
+        return 1
+    }
+    (
+        "$@" >/dev/null 2>&1 &
+        printf '%s\n' "$!" > "$__cmux_pid_file"
+    ) >/dev/null 2>&1
+    local __cmux_pid=""
+    IFS= read -r __cmux_pid < "$__cmux_pid_file" 2>/dev/null || __cmux_pid=""
+    /bin/rm -f -- "$__cmux_pid_file" >/dev/null 2>&1 || true
+    printf -v "$__cmux_pid_var" '%s' "$__cmux_pid"
+}
+
 _cmux_socket_is_unix() {
     [[ -n "$CMUX_SOCKET_PATH" && -S "$CMUX_SOCKET_PATH" ]]
 }
@@ -72,10 +103,7 @@ _cmux_relay_rpc_bg() {
     local relay_cli=""
     _cmux_socket_uses_remote_relay || return 1
     relay_cli="$(_cmux_relay_cli_path)" || return 1
-    {
-        "$relay_cli" rpc "$method" "$params" >/dev/null 2>&1 || true
-    } >/dev/null 2>&1 &
-    disown 2>/dev/null || true
+    _cmux_detach_bg "$relay_cli" rpc "$method" "$params"
 }
 
 _cmux_relay_rpc() {
@@ -378,6 +406,17 @@ _cmux_git_branch_for_path() {
     printf '%s\n' "${head_line#$prefix}"
 }
 
+_cmux_report_git_branch_for_path() {
+    local repo_path="$1"
+    local branch="" dirty_opt="--status=unknown"
+    branch="$(_cmux_git_branch_for_path "$repo_path" 2>/dev/null || true)"
+    if [[ -n "$branch" ]]; then
+        _cmux_send "report_git_branch $branch $dirty_opt --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
+    else
+        _cmux_send "clear_git_branch --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
+    fi
+}
+
 _cmux_report_tty_payload() {
     [[ -n "$CMUX_TAB_ID" ]] || return 0
     [[ -n "$_CMUX_TTY_NAME" ]] || return 0
@@ -402,9 +441,7 @@ _cmux_report_tty_once() {
         payload="$(_cmux_report_tty_payload)"
         [[ -n "$payload" ]] || return 0
         _CMUX_TTY_REPORTED=1
-        {
-            _cmux_send "$payload"
-        } >/dev/null 2>&1 & disown
+        _cmux_detach_bg _cmux_send "$payload"
     else
         [[ -n "$_CMUX_TTY_NAME" ]] || return 0
         # Keep the first relay TTY report synchronous so the server can resolve
@@ -422,9 +459,7 @@ _cmux_report_shell_activity_state() {
     [[ -n "$CMUX_PANEL_ID" ]] || return 0
     [[ "$_CMUX_SHELL_ACTIVITY_LAST" == "$state" ]] && return 0
     _CMUX_SHELL_ACTIVITY_LAST="$state"
-    {
-        _cmux_send "report_shell_state $state --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
-    } >/dev/null 2>&1 & disown
+    _cmux_detach_bg _cmux_send "report_shell_state $state --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
 }
 
 _cmux_reset_terminal_keyboard_protocols() {
@@ -445,9 +480,7 @@ _cmux_ports_kick() {
     fi
     _CMUX_PORTS_LAST_RUN="$(_cmux_now)"
     if _cmux_socket_is_unix; then
-        {
-            _cmux_send "ports_kick --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID --reason=$reason"
-        } >/dev/null 2>&1 & disown
+        _cmux_detach_bg _cmux_send "ports_kick --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID --reason=$reason"
     else
         _cmux_ports_kick_via_relay "$reason"
     fi
@@ -544,9 +577,7 @@ _cmux_emit_pr_command_hint() {
         local quoted_target="${_CMUX_LAST_PR_TARGET//\"/\\\"}"
         payload+=" --target=\"$quoted_target\""
     fi
-    {
-        _cmux_send "$payload"
-    } >/dev/null 2>&1 & disown
+    _cmux_detach_bg _cmux_send "$payload"
     _CMUX_LAST_PR_ACTION=""
     _CMUX_LAST_PR_TARGET=""
 }
@@ -1262,10 +1293,8 @@ _cmux_prompt_command() {
     # CWD: keep the app in sync with the actual shell directory.
     if [[ "$pwd" != "$_CMUX_PWD_LAST_PWD" ]]; then
         _CMUX_PWD_LAST_PWD="$pwd"
-        {
-            local qpwd="${pwd//\"/\\\"}"
-            _cmux_send "report_pwd \"${qpwd}\" --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
-        } >/dev/null 2>&1 & disown
+        local qpwd="${pwd//\"/\\\"}"
+        _cmux_detach_bg _cmux_send "report_pwd \"${qpwd}\" --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
     fi
 
     # Branch can change via aliases/tools while an older probe is still in flight.
@@ -1325,17 +1354,7 @@ _cmux_prompt_command() {
     if [[ "${CMUX_NO_GIT_WATCH:-}" != "1" ]] && { [[ -z "$_CMUX_GIT_JOB_PID" ]] || ! kill -0 "$_CMUX_GIT_JOB_PID" 2>/dev/null; }; then
         _CMUX_GIT_LAST_PWD="$pwd"
         _CMUX_GIT_LAST_RUN=$now
-        {
-            local branch dirty_opt="--status=unknown"
-            branch="$(_cmux_git_branch_for_path "$pwd" 2>/dev/null || true)"
-            if [[ -n "$branch" ]]; then
-                _cmux_send "report_git_branch $branch $dirty_opt --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
-            else
-                _cmux_send "clear_git_branch --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
-            fi
-        } >/dev/null 2>&1 &
-        _CMUX_GIT_JOB_PID=$!
-        disown
+        _cmux_start_tracked_bg _CMUX_GIT_JOB_PID _cmux_report_git_branch_for_path "$pwd"
         _CMUX_GIT_JOB_STARTED_AT=$now
     fi
 

--- a/tests/test_bash_done_spam.py
+++ b/tests/test_bash_done_spam.py
@@ -244,6 +244,21 @@ def test_bash_integration_no_done_spam() -> None:
                     bash.run("true")
                 bash.run(f"echo {marker}")
 
+                # Make sure the dispatch path actually fired. If the helpers
+                # silently no-oped (e.g. an environment guard regression
+                # short-circuited every reporter), the Done-line assertion
+                # below would pass trivially. Greptile flagged this in PR
+                # #4958 review; the check forces the test to fail loud if
+                # _cmux_send is never reached.
+                if not send_log.exists() or send_log.stat().st_size == 0:
+                    raise AssertionError(
+                        "expected at least one _cmux_send invocation but "
+                        f"{send_log} is empty. The reporter dispatch path "
+                        "appears to have been silently bypassed.\n\n"
+                        f"Bash: {bash_path}\n\n"
+                        f"Full PTY output:\n{bash.text}"
+                    )
+
                 done_lines = JOB_DONE_RE.findall(bash.text)
                 if done_lines:
                     raise AssertionError(

--- a/tests/test_bash_done_spam.py
+++ b/tests/test_bash_done_spam.py
@@ -85,11 +85,18 @@ class InteractiveBash:
     def __enter__(self) -> "InteractiveBash":
         pid, fd = pty.fork()
         if pid == 0:
-            os.execvpe(
-                self.bash_path,
-                [self.bash_path, "--noprofile", "--norc", "-i"],
-                self.env,
-            )
+            # If execvpe raises (e.g. resolved bash becomes non-executable
+            # between probe and fork), the exception would unwind back into
+            # the test harness inside the forked child and run framework
+            # code as a duplicate process. Hard-exit instead.
+            try:
+                os.execvpe(
+                    self.bash_path,
+                    [self.bash_path, "--noprofile", "--norc", "-i"],
+                    self.env,
+                )
+            except OSError:
+                os._exit(127)
         self.pid = pid
         self.fd = fd
         # Drain bash's startup banner before installing the sentinel PS1.

--- a/tests/test_bash_done_spam.py
+++ b/tests/test_bash_done_spam.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Regression test for https://github.com/manaflow-ai/cmux/issues/1565.
+
+cmux's bash integration fires background helpers (TTY report, shell-state
+report, port kick, CWD report, git-branch probe, PR-action hint) after every
+prompt. Until the fix, these used `{ cmd; } >/dev/null 2>&1 & disown`. The
+helpers complete in single-digit milliseconds, so the job often finishes
+before `disown` runs. Bash records the completion in its job table and prints
+`[N]+ Done ...` at the next prompt, producing a wall of notifications on
+bash 5.3 (where PS0 uses the no-fork `${ ...; }` valsub form so the helpers
+run directly in the interactive shell's job table).
+
+The fix wraps each fire-and-forget call in `( cmd & )` (inner `&`). The new
+process becomes a job in the throwaway subshell's job table, never in the
+interactive shell's, so no notification is ever queued.
+
+This test reproduces the failure with a PTY-driven interactive bash, real
+Unix socket so the reporters are not guarded out, and a stubbed `_cmux_send`
+that writes to a log. It asserts zero `[N] ... Done` lines after exercising
+the prompt path several times.
+"""
+
+from __future__ import annotations
+
+import os
+import pty
+import re
+import select
+import shlex
+import shutil
+import signal
+import socket
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+
+PROMPT = "__CMUX_TEST_PROMPT__ "
+JOB_DONE_RE = re.compile(r"^\[[0-9]+\][^\n\r]*\bDone\b", re.MULTILINE)
+
+
+def _find_modern_bash() -> str | None:
+    """Find a bash >= 5 binary. The Done-spam bug only reliably reproduces on
+    bash 5.x because pre-5.3 PS0 forks a throwaway subshell that hides the
+    leak, and Apple's system bash 3.2 predates several relevant changes."""
+    candidates = [
+        "/opt/homebrew/bin/bash",
+        "/usr/local/bin/bash",
+        shutil.which("bash"),
+    ]
+    for candidate in candidates:
+        if not candidate:
+            continue
+        if not os.path.exists(candidate):
+            continue
+        try:
+            import subprocess
+            result = subprocess.run(
+                [candidate, "-c", "echo $BASH_VERSION"],
+                capture_output=True,
+                text=True,
+                timeout=3,
+            )
+        except Exception:
+            continue
+        version = result.stdout.strip()
+        try:
+            major = int(version.split(".", 1)[0])
+        except (ValueError, IndexError):
+            continue
+        if major >= 5:
+            return candidate
+    return None
+
+
+class InteractiveBash:
+    def __init__(self, bash_path: str, env: dict[str, str]) -> None:
+        self.bash_path = bash_path
+        self.env = env
+        self.pid: int | None = None
+        self.fd: int | None = None
+        self.output = bytearray()
+
+    def __enter__(self) -> "InteractiveBash":
+        pid, fd = pty.fork()
+        if pid == 0:
+            os.execvpe(
+                self.bash_path,
+                [self.bash_path, "--noprofile", "--norc", "-i"],
+                self.env,
+            )
+        self.pid = pid
+        self.fd = fd
+        # Drain bash's startup banner before installing the sentinel PS1.
+        self._read_until(b"$", timeout=2)
+        self.run(f"PS1='{PROMPT}'")
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        if self.fd is not None:
+            try:
+                os.write(self.fd, b"exit\n")
+                self._read_until(b"exit", timeout=1)
+            except OSError:
+                pass
+            try:
+                os.close(self.fd)
+            except OSError:
+                pass
+        if self.pid is not None:
+            try:
+                os.kill(self.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+
+    def run(self, command: str, timeout: float = 5) -> None:
+        if self.fd is None:
+            raise RuntimeError("PTY is not open")
+        self._drain()
+        os.write(self.fd, command.encode("utf-8") + b"\n")
+        chunk = self._read_until(PROMPT.encode("utf-8"), timeout=timeout)
+        if PROMPT.encode("utf-8") not in chunk:
+            raise AssertionError(
+                f"timed out waiting for prompt after {command!r}\n\n"
+                f"Captured output:\n{self.text}"
+            )
+
+    def _read_until(self, marker: bytes, *, timeout: float) -> bytes:
+        if self.fd is None:
+            raise RuntimeError("PTY is not open")
+        deadline = time.time() + timeout
+        captured = bytearray()
+        while time.time() < deadline:
+            ready, _, _ = select.select([self.fd], [], [], 0.1)
+            if self.fd not in ready:
+                continue
+            try:
+                data = os.read(self.fd, 4096)
+            except OSError:
+                break
+            if not data:
+                break
+            captured.extend(data)
+            self.output.extend(data)
+            if marker in captured:
+                break
+        return bytes(captured)
+
+    def _drain(self) -> None:
+        if self.fd is None:
+            raise RuntimeError("PTY is not open")
+        while True:
+            ready, _, _ = select.select([self.fd], [], [], 0.05)
+            if self.fd not in ready:
+                return
+            try:
+                data = os.read(self.fd, 4096)
+            except OSError:
+                return
+            if not data:
+                return
+            self.output.extend(data)
+
+    @property
+    def text(self) -> str:
+        return self.output.decode("utf-8", errors="replace")
+
+
+def test_bash_integration_no_done_spam() -> None:
+    bash_path = _find_modern_bash()
+    if bash_path is None:
+        print("SKIP: no bash >= 5 found; the Done-spam bug only reproduces "
+              "on modern bash where PS0 uses the no-fork valsub form.")
+        return
+
+    repo_root = Path(__file__).resolve().parents[1]
+    integration_script = (
+        repo_root / "Resources/shell-integration/cmux-bash-integration.bash"
+    )
+    assert integration_script.exists(), integration_script
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        socket_path = tmp_path / "cmux.sock"
+        repo_path = tmp_path / "repo"
+        send_log = tmp_path / "send.log"
+
+        # Minimal git repo so the git-branch probe has something to report.
+        (repo_path / ".git").mkdir(parents=True)
+        (repo_path / ".git" / "HEAD").write_text(
+            "ref: refs/heads/feature/done-spam\n", encoding="utf-8"
+        )
+
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            sock.bind(str(socket_path))
+            sock.listen(1)
+
+            env = {
+                key: value
+                for key, value in os.environ.items()
+                if not key.startswith("CMUX")
+            }
+            env.update({
+                "LC_ALL": "C",
+                "LANG": "C",
+                "TERM": "xterm-256color",
+            })
+
+            with InteractiveBash(bash_path, env) as bash:
+                bash.run("set -m")  # explicit; default for interactive shells
+                bash.run(f"source {shlex.quote(str(integration_script))}")
+                # Stub the network write so we don't depend on ncat/socat/nc
+                # being installed, and so timing matches a fast (file I/O)
+                # path similar to a Unix-socket write.
+                bash.run(
+                    "_cmux_send() { printf '%s\\n' \"$1\" >> "
+                    f"{shlex.quote(str(send_log))}"
+                    "; }"
+                )
+                bash.run(f"export CMUX_SOCKET_PATH={shlex.quote(str(socket_path))}")
+                bash.run("export CMUX_TAB_ID=tab-test")
+                bash.run("export CMUX_PANEL_ID=panel-test")
+                bash.run("_CMUX_TTY_NAME=ttys-test")
+                bash.run(f"cd {shlex.quote(str(repo_path))}")
+
+                # Each `run` call triggers PS0 (preexec) and PROMPT_COMMAND,
+                # exercising the full reporter set.
+                marker = "__CMUX_DONE_CHECK__"
+                for _ in range(8):
+                    bash.run("true")
+                bash.run(f"echo {marker}")
+
+                done_lines = JOB_DONE_RE.findall(bash.text)
+                if done_lines:
+                    raise AssertionError(
+                        "bash integration emitted job-completion "
+                        f"notifications ({len(done_lines)} line(s)). "
+                        "Issue: https://github.com/manaflow-ai/cmux/issues/1565\n\n"
+                        f"Done lines:\n{chr(10).join(done_lines)}\n\n"
+                        f"Bash: {bash_path}\n\n"
+                        f"Full PTY output:\n{bash.text}"
+                    )
+        finally:
+            sock.close()
+
+
+if __name__ == "__main__":
+    try:
+        test_bash_integration_no_done_spam()
+    except AssertionError as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        sys.exit(1)
+    print("OK")

--- a/tests/test_bash_done_spam.py
+++ b/tests/test_bash_done_spam.py
@@ -113,6 +113,12 @@ class InteractiveBash:
                 os.kill(self.pid, signal.SIGKILL)
             except ProcessLookupError:
                 pass
+            # Reap the zombie so resources are returned promptly, especially
+            # when many tests run in sequence under pytest.
+            try:
+                os.waitpid(self.pid, 0)
+            except (ChildProcessError, OSError):
+                pass
 
     def run(self, command: str, timeout: float = 5) -> None:
         if self.fd is None:
@@ -170,8 +176,14 @@ class InteractiveBash:
 def test_bash_integration_no_done_spam() -> None:
     bash_path = _find_modern_bash()
     if bash_path is None:
-        print("SKIP: no bash >= 5 found; the Done-spam bug only reproduces "
-              "on modern bash where PS0 uses the no-fork valsub form.")
+        msg = ("no bash >= 5 found; the Done-spam bug only reproduces "
+               "on modern bash where the helpers fire from PROMPT_COMMAND "
+               "and PS0 valsub.")
+        # In CI we want a missing modern bash to be a loud configuration
+        # failure, not a silent skip that would let a regression land.
+        if os.environ.get("CI"):
+            raise RuntimeError(f"CI requires bash >= 5: {msg}")
+        print(f"SKIP: {msg}")
         return
 
     repo_root = Path(__file__).resolve().parents[1]


### PR DESCRIPTION
## Summary

Fixes https://github.com/manaflow-ai/cmux/issues/1565 — every command in a cmux bash terminal prints job-completion noise like:

```
[1]-  Done  { _cmux_send "report_shell_state ..."; } > /dev/null 2>&1
[2]+  Done  { _cmux_send "ports_kick ..."; } > /dev/null 2>&1
```

Root cause: `_cmux_send` is a Unix-socket write that completes in single-digit milliseconds, so the background job exits before `disown` runs. Bash has already recorded the completion in its job table and prints the notification at the next prompt. On bash 5.3, where PS0 uses the new no-fork `${ ...; }` valsub form, the leak is reliable (confirmed by the regression test: 12 lines per 8-prompt run on `main`).

The fix wraps each fire-and-forget call in `( cmd & ) >/dev/null 2>&1`. The outer subshell becomes a synchronous foreground command from the interactive shell's perspective; the inner `&` registers the job in the throwaway subshell's job table, so the interactive shell never tracks it and never queues a notification.

## Test plan

This PR uses the two-commit red/green structure (per `CLAUDE.md` policy):

- Commit 1 (`b6ab370b5`): adds `tests/test_bash_done_spam.py`, a PTY-driven regression test. Sources the unmodified integration in interactive bash 5.x, binds a Unix socket so reporters are not guarded out, stubs `_cmux_send` to a log file, runs 8 prompts, asserts zero `[N]...Done` lines. **Fails red on this commit (12 lines).**
- Commit 2 (`898123aec`): applies the fix. **Goes green.**

Local verification on bash 5.3.9 (Homebrew):

- [x] `bash -n Resources/shell-integration/cmux-bash-integration.bash` (syntax clean)
- [x] `python3 tests/test_bash_done_spam.py` x5 consecutive runs, all `OK`
- [x] No remaining `& disown` fire-and-forget sites; the only remaining `disown` is in `_cmux_start_pr_poll_loop`, which runs against an infinite `while` loop where the job is still alive when `disown` fires (no race)

## What changes

`Resources/shell-integration/cmux-bash-integration.bash`:

- Adds `_cmux_detach_bg` (subshell + inner `&`, no `[N] Done` ever queued).
- Adds `_cmux_start_tracked_bg` for the one site that needs `$!` (git-branch probe). Tempfile PID handoff.
- Extracts `_cmux_report_git_branch_for_path` so the probe can be invoked as a function call.
- Converts six fire-and-forget sites: `_cmux_relay_rpc_bg`, `_cmux_report_tty_once`, `_cmux_report_shell_activity_state`, `_cmux_ports_kick`, `_cmux_emit_pr_command_hint`, and the CWD report in `_cmux_prompt_command`.
- Converts the git-branch probe in `_cmux_prompt_command` to `_cmux_start_tracked_bg`.

Total: 50 insertions, 31 deletions in the integration; one new 255-line test file.

## Relationship to existing PRs

PR #4934 (by @lawrencecchen) covers the same bug plus several orthogonal bash 5.3 issues (PS0 `$BASH_COMMAND` corruption inside `${ ... }` valsub, PR-action-hint propagation across the legacy `$(...)` PS0 fork, preexec/prompt context branching). That PR is the comprehensive option.

This PR is the minimal alternative: scoped strictly to the `[N] Done` notification leak in issue 1565, no preexec/PS0 changes, no command-history reader, no PR-hint stash. If maintainers prefer the broader scope of #4934, close this PR.

Authors of prior work on this bug: @austinywang (#2804), @cedricvidal (inner-`&` analysis), @mol-george (initial fix proposal), @bartekurbanski (confirmation), @yegor256 (additional repro data), @psh4607 (#3700).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4958"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782593798&installation_id=133855650&pr_number=4958&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4958&signature=c9b4562fcfa183f272eb31f165bad776df203268b6b65e7303cba5f55dd9a1d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes bash “[N] Done” prompt spam (issue #1565) by detaching background reporters with an inner `&` in a subshell so the interactive shell never tracks them.

- **Bug Fixes**
  - Added `_cmux_detach_bg` to run helpers as `( cmd & ) >/dev/null 2>&1`.
  - Added `_cmux_start_tracked_bg` for the git-branch probe with PID handoff; validates var name, rejects empty argv, avoids dynamic-scope collisions, and silences `printf -v` errors.
  - Updated background calls in `_cmux_relay_rpc_bg`, `_cmux_report_tty_once`, `_cmux_report_shell_activity_state`, `_cmux_ports_kick`, `_cmux_emit_pr_command_hint`, and the CWD report in `_cmux_prompt_command`.
  - Extracted `_cmux_report_git_branch_for_path` for reuse.
  - Hardened the PTY regression test: guards `execvpe` failure in the forked child with `os._exit(127)`, asserts `_cmux_send` is invoked, reaps child processes, requires bash ≥5 in CI, and is wired into the workflow.

<sup>Written for commit 4cbcd22e127362122e7856bdb765aa6fd59e975f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4958?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Eliminated unwanted "Done" notifications in interactive shells by centralizing suppressed background dispatch.

* **New Features**
  * Added tracked background task handling for reliable PID/timeouts and improved git-branch reporting on directory changes.

* **Tests**
  * Added a regression test to prevent shell "Done" spam by exercising interactive shell prompts.

* **Chores**
  * CI now runs the new regression test as part of workflow validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4958?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->