### PR TITLE
Fix zsh hook errors when job table is saturated

### DIFF
--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -13,10 +13,8 @@ typeset -g _CMUX_HAS_ZSH_JOBSTATES=0
 if zmodload zsh/parameter 2>/dev/null && (( ${+jobstates} )); then
     _CMUX_HAS_ZSH_JOBSTATES=1
 fi
-typeset -g _CMUX_ZSH_JOB_TABLE_SATURATED=0
 
 _cmux_zsh_job_table_saturated() {
-    (( _CMUX_ZSH_JOB_TABLE_SATURATED )) && return 0
     (( _CMUX_HAS_ZSH_JOBSTATES )) || return 1
 
     local limit="${CMUX_ZSH_JOB_TABLE_SOFT_LIMIT:-900}"
@@ -27,11 +25,6 @@ _cmux_zsh_job_table_saturated() {
 
     local job_count=${#jobstates}
     (( job_count >= limit ))
-    local saturated=$?
-    if (( saturated == 0 )); then
-        _CMUX_ZSH_JOB_TABLE_SATURATED=1
-    fi
-    return "$saturated"
 }
 
 _cmux_restore_status() {
@@ -1296,16 +1289,13 @@ _cmux_run_pr_probe_with_timeout() {
 }
 
 _cmux_halt_pr_poll_loop() {
-    local saturated=0
-    _cmux_zsh_job_table_saturated && saturated=1
-
     # Process-group kill: background jobs are process-group leaders, so
     # negative PID kills the loop + all descendants (gh, sleep) without
     # the synchronous /bin/ps + awk of tree-kill (~5-13ms).
-    [[ -z "$_CMUX_PR_POLL_PID" || "$saturated" == "1" ]] || kill -KILL -- -"$_CMUX_PR_POLL_PID" 2>/dev/null || true
+    [[ -z "$_CMUX_PR_POLL_PID" ]] || kill -KILL -- -"$_CMUX_PR_POLL_PID" 2>/dev/null || true
     local signal_path=""
     [[ -n "$CMUX_PANEL_ID" ]] && signal_path="/tmp/cmux-pr-force-${CMUX_PANEL_ID}"
-    [[ -z "$signal_path" || "$saturated" == "1" ]] || /bin/rm -f -- "$signal_path" >/dev/null 2>&1 || true
+    [[ -z "$signal_path" ]] || /bin/rm -f -- "$signal_path" >/dev/null 2>&1 || true
     _CMUX_PR_POLL_PID=""
     _CMUX_PR_POLL_PWD=""
 }
@@ -1367,10 +1357,7 @@ _cmux_start_pr_poll_loop() {
 
 _cmux_stop_git_head_watch() {
     [[ -n "$_CMUX_GIT_HEAD_WATCH_PID" ]] || return 0
-
-    _cmux_zsh_job_table_saturated
-    local saturated=$?
-    (( saturated == 0 )) || kill "$_CMUX_GIT_HEAD_WATCH_PID" >/dev/null 2>&1 || true
+    kill "$_CMUX_GIT_HEAD_WATCH_PID" >/dev/null 2>&1 || true
     _CMUX_GIT_HEAD_WATCH_PID=""
 }
 
@@ -1394,9 +1381,11 @@ _cmux_start_git_head_watch() {
     _CMUX_GIT_HEAD_SIGNATURE="$watch_head_signature"
 
     _cmux_stop_git_head_watch
+    local watch_shell_pid="$$"
     {
         local last_signature="$watch_head_signature"
         while true; do
+            kill -0 "$watch_shell_pid" >/dev/null 2>&1 || break
             sleep 1
 
             local signature

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -9,6 +9,23 @@ if zmodload zsh/net/unix 2>/dev/null; then
     _CMUX_HAS_ZSOCKET=1
 fi
 
+typeset -g _CMUX_HAS_ZSH_JOBSTATES=0
+if zmodload zsh/parameter 2>/dev/null && (( ${+jobstates} )); then
+    _CMUX_HAS_ZSH_JOBSTATES=1
+fi
+
+_cmux_zsh_job_table_saturated() {
+    (( _CMUX_HAS_ZSH_JOBSTATES )) || return 1
+
+    local limit="${CMUX_ZSH_JOB_TABLE_SOFT_LIMIT:-900}"
+    case "$limit" in
+        ''|*[!0-9]*) limit=900 ;;
+    esac
+    (( limit > 0 )) || limit=900
+
+    (( ${#jobstates} >= limit ))
+}
+
 _cmux_send() {
     local payload="$1"
     if (( _CMUX_HAS_ZSOCKET )); then
@@ -38,6 +55,7 @@ _cmux_send_bg() {
     if (( _CMUX_HAS_ZSOCKET )); then
         _cmux_send "$1"
     else
+        _cmux_zsh_job_table_saturated && return 0
         { _cmux_send "$1" } >/dev/null 2>&1 &!
     fi
 }
@@ -80,6 +98,7 @@ _cmux_relay_rpc_bg() {
     local method="$1"
     local params="$2"
     local relay_cli=""
+    _cmux_zsh_job_table_saturated && return 1
     _cmux_socket_uses_remote_relay || return 1
     relay_cli="$(_cmux_relay_cli_path)" || return 1
     { "$relay_cli" rpc "$method" "$params" >/dev/null 2>&1 || true } >/dev/null 2>&1 &!
@@ -407,6 +426,48 @@ _cmux_patch_ghostty_semantic_redraw() {
     _cmux_ensure_ghostty_preexec_strips_both_marks _ghostty_preexec
 }
 _cmux_patch_ghostty_semantic_redraw
+
+_cmux_prepend_job_table_guard_to_function() {
+    local fn_name="$1"
+    (( $+functions[$fn_name] )) || return 0
+    [[ "${functions[$fn_name]}" == *"_cmux_zsh_job_table_saturated"* ]] && return 0
+
+    functions[$fn_name]=$'_cmux_zsh_job_table_saturated && builtin return 0\n'"${functions[$fn_name]}"
+}
+
+_cmux_insert_job_table_guard_after() {
+    local fn_name="$1"
+    local needle="$2"
+    local guard="$3"
+    (( $+functions[$fn_name] )) || return 0
+
+    local body="${functions[$fn_name]}"
+    [[ "$body" == *"$guard"* ]] && return 0
+    [[ "$body" == *"$needle"* ]] || return 0
+
+    functions[$fn_name]="${body/$needle/$needle
+$guard}"
+}
+
+_cmux_patch_ghostty_job_table_guard() {
+    local guard4=$'        _cmux_zsh_job_table_saturated && builtin return 0'
+    local guard6=$'          _cmux_zsh_job_table_saturated && builtin return 0'
+
+    # Patch deferred definitions before Ghostty's first precmd installs and
+    # invokes its live hook functions.
+    if (( $+functions[_ghostty_deferred_init] )); then
+        _cmux_insert_job_table_guard_after _ghostty_deferred_init $'    _ghostty_precmd() {' "$guard4"
+        _cmux_insert_job_table_guard_after _ghostty_deferred_init $'    _ghostty_preexec() {' "$guard4"
+        _cmux_insert_job_table_guard_after _ghostty_deferred_init $'      _ghostty_zle_line_init _ghostty_zle_line_finish _ghostty_zle_keymap_select() {' "$guard6"
+    fi
+
+    _cmux_prepend_job_table_guard_to_function _ghostty_precmd
+    _cmux_prepend_job_table_guard_to_function _ghostty_preexec
+    _cmux_prepend_job_table_guard_to_function _ghostty_zle_line_init
+    _cmux_prepend_job_table_guard_to_function _ghostty_zle_line_finish
+    _cmux_prepend_job_table_guard_to_function _ghostty_zle_keymap_select
+}
+_cmux_patch_ghostty_job_table_guard
 
 _cmux_prompt_wrap_guard() {
     local cmd_start="$1"
@@ -1157,6 +1218,8 @@ _cmux_run_pr_probe_with_timeout() {
     local started_at="${EPOCHSECONDS:-$SECONDS}"
     local now=$started_at
 
+    _cmux_zsh_job_table_saturated && return 1
+
     (
         _cmux_report_pr_for_path "$repo_path" "$force_probe"
     ) &
@@ -1206,6 +1269,7 @@ _cmux_start_pr_poll_loop() {
     [[ -S "$CMUX_SOCKET_PATH" ]] || return 0
     [[ -n "$CMUX_TAB_ID" ]] || return 0
     [[ -n "$CMUX_PANEL_ID" ]] || return 0
+    _cmux_zsh_job_table_saturated && return 0
 
     local watch_pwd="${1:-$PWD}"
     local force_restart="${2:-0}"
@@ -1262,6 +1326,7 @@ _cmux_start_git_head_watch() {
     [[ -S "$CMUX_SOCKET_PATH" ]] || return 0
     [[ -n "$CMUX_TAB_ID" ]] || return 0
     [[ -n "$CMUX_PANEL_ID" ]] || return 0
+    _cmux_zsh_job_table_saturated && return 0
 
     local watch_pwd="$PWD"
     local watch_head_path
@@ -1345,6 +1410,8 @@ _cmux_command_starts_nested_shell() {
 }
 
 _cmux_preexec() {
+    _cmux_zsh_job_table_saturated && return 0
+
     _cmux_normalize_claude_config_dir
     if (( ! _CMUX_DELAY_TERM_RESTORE_UNTIL_FIRST_PROMPT )); then
         _cmux_restore_terminal_identity_after_startup
@@ -1383,6 +1450,8 @@ _cmux_preexec() {
 
 _cmux_precmd() {
     local last_status=$?
+    _cmux_zsh_job_table_saturated && return 0
+
     _cmux_normalize_claude_config_dir
     if (( _CMUX_DELAY_TERM_RESTORE_UNTIL_FIRST_PROMPT )); then
         _CMUX_DELAY_TERM_RESTORE_UNTIL_FIRST_PROMPT=0
@@ -1400,6 +1469,7 @@ _cmux_precmd() {
     fi
 
     # Handle cases where Ghostty integration initializes after this file.
+    _cmux_patch_ghostty_job_table_guard
     (( _CMUX_GHOSTTY_SEMANTIC_PATCHED )) || _cmux_patch_ghostty_semantic_redraw
 
     if [[ -z "$_CMUX_TTY_NAME" ]]; then

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -13,8 +13,10 @@ typeset -g _CMUX_HAS_ZSH_JOBSTATES=0
 if zmodload zsh/parameter 2>/dev/null && (( ${+jobstates} )); then
     _CMUX_HAS_ZSH_JOBSTATES=1
 fi
+typeset -g _CMUX_ZSH_JOB_TABLE_SATURATED=0
 
 _cmux_zsh_job_table_saturated() {
+    (( _CMUX_ZSH_JOB_TABLE_SATURATED )) && return 0
     (( _CMUX_HAS_ZSH_JOBSTATES )) || return 1
 
     local limit="${CMUX_ZSH_JOB_TABLE_SOFT_LIMIT:-900}"
@@ -23,7 +25,17 @@ _cmux_zsh_job_table_saturated() {
     esac
     (( limit > 0 )) || limit=900
 
-    (( ${#jobstates} >= limit ))
+    local job_count=${#jobstates}
+    (( job_count >= limit ))
+    local saturated=$?
+    if (( saturated == 0 )); then
+        _CMUX_ZSH_JOB_TABLE_SATURATED=1
+    fi
+    return "$saturated"
+}
+
+_cmux_restore_status() {
+    builtin return "$1"
 }
 
 _cmux_send() {
@@ -430,35 +442,73 @@ _cmux_patch_ghostty_semantic_redraw
 _cmux_prepend_job_table_guard_to_function() {
     local fn_name="$1"
     (( $+functions[$fn_name] )) || return 0
-    [[ "${functions[$fn_name]}" == *"_cmux_zsh_job_table_saturated"* ]] && return 0
+    local saved_var="__cmux_${fn_name}_saved_status"
+    [[ "${functions[$fn_name]}" == *"$saved_var"* ]] && return 0
 
-    functions[$fn_name]=$'_cmux_zsh_job_table_saturated && builtin return 0\n'"${functions[$fn_name]}"
+    functions[$fn_name]="builtin local ${saved_var}=\$?
+_cmux_zsh_job_table_saturated && builtin return 0
+_cmux_restore_status \"\$${saved_var}\"
+${functions[$fn_name]}"
 }
 
-_cmux_insert_job_table_guard_after() {
+_cmux_insert_job_table_guard_after_declaration() {
+    builtin emulate -L zsh -o extended_glob -o no_aliases
+
     local fn_name="$1"
-    local needle="$2"
+    local target_name="$2"
     local guard="$3"
     (( $+functions[$fn_name] )) || return 0
 
     local body="${functions[$fn_name]}"
     [[ "$body" == *"$guard"* ]] && return 0
-    [[ "$body" == *"$needle"* ]] || return 0
 
-    functions[$fn_name]="${body/$needle/$needle
-$guard}"
+    local -a lines patched_lines declaration_names
+    lines=("${(@f)body}")
+    local line trimmed declaration candidate
+    local inserted=0
+
+    for line in "${lines[@]}"; do
+        patched_lines+=("$line")
+        (( inserted )) && continue
+
+        trimmed="${line##[[:space:]]#}"
+        [[ "$trimmed" == *"{"* ]] || continue
+
+        declaration="${trimmed%%\{}"
+        declaration="${declaration//\(\)/ }"
+        if [[ "$declaration" == function[[:space:]]* ]]; then
+            declaration="${declaration#function}"
+        fi
+        declaration_names=("${(@z)declaration}")
+
+        for candidate in "${declaration_names[@]}"; do
+            if [[ "$candidate" == "$target_name" ]]; then
+                patched_lines+=("${(@f)guard}")
+                inserted=1
+                break
+            fi
+        done
+    done
+
+    (( inserted )) || return 0
+    functions[$fn_name]="${(F)patched_lines}"
 }
 
 _cmux_patch_ghostty_job_table_guard() {
-    local guard4=$'        _cmux_zsh_job_table_saturated && builtin return 0'
-    local guard6=$'          _cmux_zsh_job_table_saturated && builtin return 0'
+    local guard_precmd=$'        builtin local __cmux__ghostty_precmd_saved_status=$?\n        _cmux_zsh_job_table_saturated && builtin return 0\n        _cmux_restore_status "$__cmux__ghostty_precmd_saved_status"'
+    local guard_preexec=$'        builtin local __cmux__ghostty_preexec_saved_status=$?\n        _cmux_zsh_job_table_saturated && builtin return 0\n        _cmux_restore_status "$__cmux__ghostty_preexec_saved_status"'
+    local guard_zle_init=$'          builtin local __cmux__ghostty_zle_line_init_saved_status=$?\n          _cmux_zsh_job_table_saturated && builtin return 0\n          _cmux_restore_status "$__cmux__ghostty_zle_line_init_saved_status"'
+    local guard_zle_finish=$'          builtin local __cmux__ghostty_zle_line_finish_saved_status=$?\n          _cmux_zsh_job_table_saturated && builtin return 0\n          _cmux_restore_status "$__cmux__ghostty_zle_line_finish_saved_status"'
+    local guard_zle_keymap=$'          builtin local __cmux__ghostty_zle_keymap_select_saved_status=$?\n          _cmux_zsh_job_table_saturated && builtin return 0\n          _cmux_restore_status "$__cmux__ghostty_zle_keymap_select_saved_status"'
 
     # Patch deferred definitions before Ghostty's first precmd installs and
     # invokes its live hook functions.
     if (( $+functions[_ghostty_deferred_init] )); then
-        _cmux_insert_job_table_guard_after _ghostty_deferred_init $'    _ghostty_precmd() {' "$guard4"
-        _cmux_insert_job_table_guard_after _ghostty_deferred_init $'    _ghostty_preexec() {' "$guard4"
-        _cmux_insert_job_table_guard_after _ghostty_deferred_init $'      _ghostty_zle_line_init _ghostty_zle_line_finish _ghostty_zle_keymap_select() {' "$guard6"
+        _cmux_insert_job_table_guard_after_declaration _ghostty_deferred_init _ghostty_precmd "$guard_precmd"
+        _cmux_insert_job_table_guard_after_declaration _ghostty_deferred_init _ghostty_preexec "$guard_preexec"
+        _cmux_insert_job_table_guard_after_declaration _ghostty_deferred_init _ghostty_zle_line_init "$guard_zle_init"
+        _cmux_insert_job_table_guard_after_declaration _ghostty_deferred_init _ghostty_zle_line_finish "$guard_zle_finish"
+        _cmux_insert_job_table_guard_after_declaration _ghostty_deferred_init _ghostty_zle_keymap_select "$guard_zle_keymap"
     fi
 
     _cmux_prepend_job_table_guard_to_function _ghostty_precmd
@@ -1246,15 +1296,16 @@ _cmux_run_pr_probe_with_timeout() {
 }
 
 _cmux_halt_pr_poll_loop() {
-    if [[ -n "$_CMUX_PR_POLL_PID" ]]; then
-        # Process-group kill: background jobs are process-group leaders, so
-        # negative PID kills the loop + all descendants (gh, sleep) without
-        # the synchronous /bin/ps + awk of tree-kill (~5-13ms).
-        kill -KILL -- -"$_CMUX_PR_POLL_PID" 2>/dev/null || true
-    fi
+    local saturated=0
+    _cmux_zsh_job_table_saturated && saturated=1
+
+    # Process-group kill: background jobs are process-group leaders, so
+    # negative PID kills the loop + all descendants (gh, sleep) without
+    # the synchronous /bin/ps + awk of tree-kill (~5-13ms).
+    [[ -z "$_CMUX_PR_POLL_PID" || "$saturated" == "1" ]] || kill -KILL -- -"$_CMUX_PR_POLL_PID" 2>/dev/null || true
     local signal_path=""
-    signal_path="$(_cmux_pr_force_signal_path 2>/dev/null || true)"
-    [[ -n "$signal_path" ]] && /bin/rm -f -- "$signal_path" >/dev/null 2>&1 || true
+    [[ -n "$CMUX_PANEL_ID" ]] && signal_path="/tmp/cmux-pr-force-${CMUX_PANEL_ID}"
+    [[ -z "$signal_path" || "$saturated" == "1" ]] || /bin/rm -f -- "$signal_path" >/dev/null 2>&1 || true
     _CMUX_PR_POLL_PID=""
     _CMUX_PR_POLL_PWD=""
 }
@@ -1315,10 +1366,12 @@ _cmux_start_pr_poll_loop() {
 }
 
 _cmux_stop_git_head_watch() {
-    if [[ -n "$_CMUX_GIT_HEAD_WATCH_PID" ]]; then
-        kill "$_CMUX_GIT_HEAD_WATCH_PID" >/dev/null 2>&1 || true
-        _CMUX_GIT_HEAD_WATCH_PID=""
-    fi
+    [[ -n "$_CMUX_GIT_HEAD_WATCH_PID" ]] || return 0
+
+    _cmux_zsh_job_table_saturated
+    local saturated=$?
+    (( saturated == 0 )) || kill "$_CMUX_GIT_HEAD_WATCH_PID" >/dev/null 2>&1 || true
+    _CMUX_GIT_HEAD_WATCH_PID=""
 }
 
 _cmux_start_git_head_watch() {
@@ -1410,6 +1463,9 @@ _cmux_command_starts_nested_shell() {
 }
 
 _cmux_preexec() {
+    local cmd="${1## }"
+    _cmux_halt_pr_poll_loop
+    _cmux_stop_git_head_watch
     _cmux_zsh_job_table_saturated && return 0
 
     _cmux_normalize_claude_config_dir
@@ -1417,7 +1473,6 @@ _cmux_preexec() {
         _cmux_restore_terminal_identity_after_startup
     fi
     _cmux_tmux_sync_cmux_environment
-    local cmd="${1## }"
 
     if [[ -z "$_CMUX_TTY_NAME" ]]; then
         local t
@@ -1440,8 +1495,6 @@ _cmux_preexec() {
     # Register TTY + kick batched port scan for foreground commands (servers).
     _cmux_report_tty_once
     _cmux_ports_kick command
-    _cmux_halt_pr_poll_loop
-    _cmux_stop_git_head_watch
     if _cmux_command_starts_nested_shell "$cmd"; then
         return 0
     fi
@@ -1450,13 +1503,17 @@ _cmux_preexec() {
 
 _cmux_precmd() {
     local last_status=$?
+    # Handle cases where Ghostty integration initializes after this file. This
+    # is pure function-body patching, so it remains safe under job saturation.
+    _cmux_patch_ghostty_job_table_guard
+    (( _CMUX_GHOSTTY_SEMANTIC_PATCHED )) || _cmux_patch_ghostty_semantic_redraw
+    _cmux_stop_git_head_watch
     _cmux_zsh_job_table_saturated && return 0
 
     _cmux_normalize_claude_config_dir
     if (( _CMUX_DELAY_TERM_RESTORE_UNTIL_FIRST_PROMPT )); then
         _CMUX_DELAY_TERM_RESTORE_UNTIL_FIRST_PROMPT=0
     fi
-    _cmux_stop_git_head_watch
     _cmux_tmux_sync_cmux_environment
 
     local cmux_has_unix_socket=0
@@ -1467,10 +1524,6 @@ _cmux_precmd() {
         _cmux_reset_terminal_keyboard_protocols
         _cmux_report_shell_activity_state prompt
     fi
-
-    # Handle cases where Ghostty integration initializes after this file.
-    _cmux_patch_ghostty_job_table_guard
-    (( _CMUX_GHOSTTY_SEMANTIC_PATCHED )) || _cmux_patch_ghostty_semantic_redraw
 
     if [[ -z "$_CMUX_TTY_NAME" ]]; then
         local t

--- a/tests/test_ghostty_zsh_job_table_saturation_guard.py
+++ b/tests/test_ghostty_zsh_job_table_saturation_guard.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""
+Regression: zsh integration hooks should degrade quietly when the job table is full.
+
+The zsh job table has a fixed maximum size. Once user jobs or prompt plugins fill
+it, cmux's injected Ghostty zsh integration must not keep surfacing hook errors on
+every prompt redraw.
+"""
+
+from __future__ import annotations
+
+import os
+import pty
+import select
+import shutil
+import signal
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+
+ERROR_NEEDLE = b"job table full or recursion limit exceeded"
+
+
+def _read_available(master: int, output: bytearray, deadline: float) -> None:
+    while time.time() < deadline:
+        readable, _, _ = select.select([master], [], [], 0.05)
+        if master not in readable:
+            continue
+        try:
+            chunk = os.read(master, 4096)
+        except OSError:
+            return
+        if not chunk:
+            return
+        output.extend(chunk)
+
+
+def _send(master: int, text: str) -> None:
+    os.write(master, text.encode("utf-8"))
+
+
+def _capture_saturated_session(env: dict[str, str], zsh_path: str) -> bytes:
+    master, slave = pty.openpty()
+    proc = subprocess.Popen(
+        [zsh_path, "-d", "-i"],
+        stdin=slave,
+        stdout=slave,
+        stderr=slave,
+        env=env,
+        start_new_session=True,
+        close_fds=True,
+    )
+    os.close(slave)
+
+    output = bytearray()
+    try:
+        _read_available(master, output, time.time() + 0.75)
+        _send(master, "print __CMUX_READY__\n")
+        _read_available(master, output, time.time() + 1.0)
+        _send(master, "for i in {1..1100}; do sleep 600 & done\n")
+        _read_available(master, output, time.time() + 8.0)
+        _send(master, "print __CMUX_AFTER_FILL__\n")
+        _read_available(master, output, time.time() + 1.0)
+        for _ in range(3):
+            _send(master, "\n")
+            _read_available(master, output, time.time() + 0.5)
+    finally:
+        try:
+            os.killpg(proc.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        finally:
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+            os.close(master)
+
+    return bytes(output)
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parents[1]
+    cmux_wrapper_dir = root / "Resources" / "shell-integration"
+    ghostty_resources_dir = root / "ghostty" / "src"
+    if not (cmux_wrapper_dir / ".zshenv").exists():
+        print(f"SKIP: missing cmux zsh wrapper at {cmux_wrapper_dir}")
+        return 0
+    if not (ghostty_resources_dir / "shell-integration" / "zsh" / "ghostty-integration").exists():
+        print(f"SKIP: missing Ghostty zsh integration at {ghostty_resources_dir}")
+        return 0
+
+    zsh_path = shutil.which("zsh")
+    if zsh_path is None:
+        print("SKIP: zsh not installed")
+        return 0
+
+    base = Path(tempfile.mkdtemp(prefix="cmux_ghostty_zsh_jobs_"))
+    try:
+        home = base / "home"
+        home.mkdir(parents=True, exist_ok=True)
+        for filename in (".zshenv", ".zprofile", ".zshrc"):
+            (home / filename).write_text("", encoding="utf-8")
+
+        env = dict(os.environ)
+        env["HOME"] = str(home)
+        env["ZDOTDIR"] = str(cmux_wrapper_dir)
+        env["CMUX_ZSH_ZDOTDIR"] = str(home)
+        env["CMUX_SHELL_INTEGRATION"] = "1"
+        env["CMUX_SHELL_INTEGRATION_DIR"] = str(cmux_wrapper_dir)
+        env["CMUX_LOAD_GHOSTTY_ZSH_INTEGRATION"] = "1"
+        env["GHOSTTY_RESOURCES_DIR"] = str(ghostty_resources_dir)
+        env["GHOSTTY_SHELL_FEATURES"] = "cursor,title"
+        env.pop("GHOSTTY_BIN_DIR", None)
+
+        output = _capture_saturated_session(env, zsh_path)
+        if b"__CMUX_AFTER_FILL__" not in output:
+            print("FAIL: saturated zsh session did not reach the post-fill prompt")
+            print(output.decode("utf-8", "replace")[-4000:])
+            return 1
+        if ERROR_NEEDLE in output:
+            print("FAIL: zsh integration hooks emitted job-table saturation errors")
+            print(output.decode("utf-8", "replace")[-4000:])
+            return 1
+
+        print("PASS: zsh integration hooks stay quiet when the job table is saturated")
+        return 0
+    finally:
+        shutil.rmtree(base, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ghostty_zsh_job_table_saturation_guard.py
+++ b/tests/test_ghostty_zsh_job_table_saturation_guard.py
@@ -18,8 +18,10 @@ import subprocess
 import tempfile
 import time
 from pathlib import Path
+from typing import Callable
 
 
+BACKGROUND_SLEEP_SECONDS = 30
 ERROR_NEEDLE = b"job table full or recursion limit exceeded"
 EXIT_42_MARKER = b"\x1b]133;D;42\x07"
 
@@ -42,7 +44,11 @@ def _send(master: int, text: str) -> None:
     os.write(master, text.encode("utf-8"))
 
 
-def _capture_saturated_session(env: dict[str, str], zsh_path: str) -> bytes:
+def _run_pty_session(
+    env: dict[str, str],
+    zsh_path: str,
+    interact: Callable[[int, bytearray], None],
+) -> bytes:
     master, slave = pty.openpty()
     proc = subprocess.Popen(
         [zsh_path, "-d", "-i"],
@@ -57,95 +63,54 @@ def _capture_saturated_session(env: dict[str, str], zsh_path: str) -> bytes:
 
     output = bytearray()
     try:
+        interact(master, output)
+    finally:
+        try:
+            os.killpg(proc.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        finally:
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+            os.close(master)
+
+    return bytes(output)
+
+
+def _capture_saturated_session(env: dict[str, str], zsh_path: str) -> bytes:
+    def interact(master: int, output: bytearray) -> None:
         _read_available(master, output, time.time() + 0.75)
         _send(master, "print __CMUX_READY__\n")
         _read_available(master, output, time.time() + 1.0)
-        _send(master, "for i in {1..1100}; do sleep 600 & done\n")
+        _send(master, f"for i in {{1..1100}}; do sleep {BACKGROUND_SLEEP_SECONDS} & done\n")
         _read_available(master, output, time.time() + 8.0)
         _send(master, "print __CMUX_AFTER_FILL__\n")
         _read_available(master, output, time.time() + 1.0)
         for _ in range(3):
             _send(master, "\n")
             _read_available(master, output, time.time() + 0.5)
-    finally:
-        try:
-            os.killpg(proc.pid, signal.SIGKILL)
-        except ProcessLookupError:
-            pass
-        finally:
-            try:
-                proc.wait(timeout=5)
-            except subprocess.TimeoutExpired:
-                proc.kill()
-            os.close(master)
 
-    return bytes(output)
+    return _run_pty_session(env, zsh_path, interact)
 
 
 def _capture_status_marker_session(env: dict[str, str], zsh_path: str) -> bytes:
-    master, slave = pty.openpty()
-    proc = subprocess.Popen(
-        [zsh_path, "-d", "-i"],
-        stdin=slave,
-        stdout=slave,
-        stderr=slave,
-        env=env,
-        start_new_session=True,
-        close_fds=True,
-    )
-    os.close(slave)
-
-    output = bytearray()
-    try:
+    def interact(master: int, output: bytearray) -> None:
         _read_available(master, output, time.time() + 1.0)
         _send(master, "/bin/sh -c 'exit 42'\n")
         _read_available(master, output, time.time() + 1.5)
-    finally:
-        try:
-            os.killpg(proc.pid, signal.SIGKILL)
-        except ProcessLookupError:
-            pass
-        finally:
-            try:
-                proc.wait(timeout=5)
-            except subprocess.TimeoutExpired:
-                proc.kill()
-            os.close(master)
 
-    return bytes(output)
+    return _run_pty_session(env, zsh_path, interact)
 
 
 def _capture_initial_prompt(env: dict[str, str], zsh_path: str) -> bytes:
-    master, slave = pty.openpty()
-    proc = subprocess.Popen(
-        [zsh_path, "-d", "-i"],
-        stdin=slave,
-        stdout=slave,
-        stderr=slave,
-        env=env,
-        start_new_session=True,
-        close_fds=True,
-    )
-    os.close(slave)
-
-    output = bytearray()
-    try:
+    def interact(master: int, output: bytearray) -> None:
         _read_available(master, output, time.time() + 1.0)
         _send(master, "print __CMUX_READY__\n")
         _read_available(master, output, time.time() + 1.0)
-    finally:
-        try:
-            os.killpg(proc.pid, signal.SIGKILL)
-        except ProcessLookupError:
-            pass
-        finally:
-            try:
-                proc.wait(timeout=5)
-            except subprocess.TimeoutExpired:
-                proc.kill()
-            os.close(master)
 
-    return bytes(output)
+    return _run_pty_session(env, zsh_path, interact)
 
 
 def _prepare_home(home: Path, zshrc: str = "") -> None:
@@ -194,7 +159,7 @@ def main() -> int:
             return 1
 
         initial_home = base / "initially_saturated_home"
-        _prepare_home(initial_home, "sleep 600 &\n")
+        _prepare_home(initial_home, f"sleep {BACKGROUND_SLEEP_SECONDS} &\n")
         initial_env = dict(env)
         initial_env["HOME"] = str(initial_home)
         initial_env["CMUX_ZSH_ZDOTDIR"] = str(initial_home)

--- a/tests/test_ghostty_zsh_job_table_saturation_guard.py
+++ b/tests/test_ghostty_zsh_job_table_saturation_guard.py
@@ -21,6 +21,7 @@ from pathlib import Path
 
 
 ERROR_NEEDLE = b"job table full or recursion limit exceeded"
+EXIT_42_MARKER = b"\x1b]133;D;42\x07"
 
 
 def _read_available(master: int, output: bytearray, deadline: float) -> None:
@@ -81,6 +82,79 @@ def _capture_saturated_session(env: dict[str, str], zsh_path: str) -> bytes:
     return bytes(output)
 
 
+def _capture_status_marker_session(env: dict[str, str], zsh_path: str) -> bytes:
+    master, slave = pty.openpty()
+    proc = subprocess.Popen(
+        [zsh_path, "-d", "-i"],
+        stdin=slave,
+        stdout=slave,
+        stderr=slave,
+        env=env,
+        start_new_session=True,
+        close_fds=True,
+    )
+    os.close(slave)
+
+    output = bytearray()
+    try:
+        _read_available(master, output, time.time() + 1.0)
+        _send(master, "/bin/sh -c 'exit 42'\n")
+        _read_available(master, output, time.time() + 1.5)
+    finally:
+        try:
+            os.killpg(proc.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        finally:
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+            os.close(master)
+
+    return bytes(output)
+
+
+def _capture_initial_prompt(env: dict[str, str], zsh_path: str) -> bytes:
+    master, slave = pty.openpty()
+    proc = subprocess.Popen(
+        [zsh_path, "-d", "-i"],
+        stdin=slave,
+        stdout=slave,
+        stderr=slave,
+        env=env,
+        start_new_session=True,
+        close_fds=True,
+    )
+    os.close(slave)
+
+    output = bytearray()
+    try:
+        _read_available(master, output, time.time() + 1.0)
+        _send(master, "print __CMUX_READY__\n")
+        _read_available(master, output, time.time() + 1.0)
+    finally:
+        try:
+            os.killpg(proc.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        finally:
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+            os.close(master)
+
+    return bytes(output)
+
+
+def _prepare_home(home: Path, zshrc: str = "") -> None:
+    home.mkdir(parents=True, exist_ok=True)
+    (home / ".zshenv").write_text("", encoding="utf-8")
+    (home / ".zprofile").write_text("", encoding="utf-8")
+    (home / ".zshrc").write_text(zshrc, encoding="utf-8")
+
+
 def main() -> int:
     root = Path(__file__).resolve().parents[1]
     cmux_wrapper_dir = root / "Resources" / "shell-integration"
@@ -100,9 +174,7 @@ def main() -> int:
     base = Path(tempfile.mkdtemp(prefix="cmux_ghostty_zsh_jobs_"))
     try:
         home = base / "home"
-        home.mkdir(parents=True, exist_ok=True)
-        for filename in (".zshenv", ".zprofile", ".zshrc"):
-            (home / filename).write_text("", encoding="utf-8")
+        _prepare_home(home)
 
         env = dict(os.environ)
         env["HOME"] = str(home)
@@ -114,6 +186,28 @@ def main() -> int:
         env["GHOSTTY_RESOURCES_DIR"] = str(ghostty_resources_dir)
         env["GHOSTTY_SHELL_FEATURES"] = "cursor,title"
         env.pop("GHOSTTY_BIN_DIR", None)
+
+        status_output = _capture_status_marker_session(env, zsh_path)
+        if EXIT_42_MARKER not in status_output:
+            print("FAIL: Ghostty prompt marker did not preserve exit status 42")
+            print(status_output.decode("utf-8", "replace")[-4000:])
+            return 1
+
+        initial_home = base / "initially_saturated_home"
+        _prepare_home(initial_home, "sleep 600 &\n")
+        initial_env = dict(env)
+        initial_env["HOME"] = str(initial_home)
+        initial_env["CMUX_ZSH_ZDOTDIR"] = str(initial_home)
+        initial_env["CMUX_ZSH_JOB_TABLE_SOFT_LIMIT"] = "1"
+        initial_output = _capture_initial_prompt(initial_env, zsh_path)
+        if b"__CMUX_READY__" not in initial_output:
+            print("FAIL: initially saturated zsh session did not reach the prompt")
+            print(initial_output.decode("utf-8", "replace")[-4000:])
+            return 1
+        if ERROR_NEEDLE in initial_output:
+            print("FAIL: deferred Ghostty hook emitted job-table saturation errors")
+            print(initial_output.decode("utf-8", "replace")[-4000:])
+            return 1
 
         output = _capture_saturated_session(env, zsh_path)
         if b"__CMUX_AFTER_FILL__" not in output:


### PR DESCRIPTION
Fixes #4957.

## Observed

In an isolated local zsh/PTY repro, after filling the child shell job table with background jobs, every prompt redraw emitted hook errors such as:

```text
_ghostty_precmd:7: job table full or recursion limit exceeded
```

The user-reported symptom names `_ghostty_zle_line_finish`, but the audited risk is broader: any Ghostty or cmux zsh hook that keeps calling ZLE or launching background work after the fixed-size job table is saturated can surface the same repeated zsh error.

## Expected

A long-running cmux zsh session should degrade quietly when the shell is already near the zsh job-table limit. Shell integration telemetry and prompt markers may pause, but the prompt should not print repeated `job table full or recursion limit exceeded` errors on every Enter/redraw.

## Root Cause

Upstream Ghostty search did not show a ready-made `job table full` fix to bump. In cmux, Ghostty's zsh integration is loaded through the cmux wrapper, and cmux already runtime-patches Ghostty hook definitions for embedder behavior. The missing invariant was a shared no-fork guard across the injected Ghostty hooks and cmux's own precmd/preexec background-probe paths.

## Fix

- Add a zsh-only saturation guard using `zsh/parameter`'s `jobstates` parameter, with a conservative soft limit of 900 jobs.
- Runtime-patch Ghostty's deferred and live `_ghostty_precmd`, `_ghostty_preexec`, `_ghostty_zle_line_init`, `_ghostty_zle_line_finish`, and `_ghostty_zle_keymap_select` functions so they return before touching ZLE or writing prompt state when the table is saturated.
- Guard cmux's zsh precmd/preexec and background launch paths so cmux does not add more async jobs or fork-capable socket fallbacks under saturation.

## Regression Coverage

The first commit adds a failing regression test that drives an interactive zsh through a PTY, fills only that child shell's job table, and asserts the cmux-injected Ghostty integration does not emit `job table full or recursion limit exceeded` after saturation.

## Validation

- Reproduced locally before the fix with synthetic child zsh job-table saturation.
- Re-ran the isolated repro after the fix: it reached the post-fill prompt and reported `HAS_RECURSION_ERROR=False`.
- Did not run local test suites or local builds, per repo/task constraints.

## Current Workarounds

- `exec zsh` recycles the job table temporarily.
- `~/Library/Application Support/com.cmuxterm.app/config` can set `shell-integration = none` or `shell-integration-features = no-cursor,no-sudo,no-title`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4959"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782593963&installation_id=133855650&pr_number=4959&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4959&signature=515200eb5b6a969e46bd1a5033627e2cb09d495b2dfa949d8bd682434ad7cf6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shell hook behavior and suppresses background integration work under load, which could briefly pause git/PR/port telemetry but avoids worse prompt breakage; patching is invasive but scoped to zsh saturation.
> 
> **Overview**
> Fixes repeated **`job table full or recursion limit exceeded`** noise when cmux’s injected **Ghostty** zsh hooks and cmux’s own **precmd/preexec** work keep running after the shell’s fixed job table is nearly full.
> 
> The integration now detects saturation via **`zsh/parameter`**’s **`jobstates`** (default soft limit **900**, overridable with **`CMUX_ZSH_JOB_TABLE_SOFT_LIMIT`**) and **runtime-patches** Ghostty’s deferred and live **`_ghostty_*`** hooks (precmd, preexec, ZLE line init/finish, keymap select) to **early-return** while preserving **`$?`**. cmux also **skips spawning** more background jobs when saturated—socket fallbacks, relay RPC, PR probes/poll loops, and git HEAD watches—so prompts stay usable even if some telemetry pauses.
> 
> A new **PTY regression test** fills a child zsh’s job table and asserts hooks stay quiet and Ghostty’s exit-status marker still works.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2c6a3b231b453796c024612ac8a955973501e27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents zsh hook errors when the job table is full by adding a saturation guard and making Ghostty/cmux zsh hooks no-op under overload. This stops repeated “job table full or recursion limit exceeded” messages, keeps the prompt quiet, preserves exit status, and safely halts watchers.

- **Bug Fixes**
  - Added `_cmux_zsh_job_table_saturated` using `jobstates` with a soft limit of 900 (override with `CMUX_ZSH_JOB_TABLE_SOFT_LIMIT`).
  - Patched Ghostty hooks (`_ghostty_precmd`, `_ghostty_preexec`, `_ghostty_zle_line_init`, `_ghostty_zle_line_finish`, `_ghostty_zle_keymap_select`) to early-return and restore `$?`; covers deferred and live definitions.
  - cmux paths respect saturation: `precmd`/`preexec`, PR probe/loop, git head watch, socket relays skip forks; watchers are halted early, won’t restart when saturated, and exit if the parent shell dies; cleanup uses process‑group kill and safe rm.
  - Regression test fills a child zsh’s job table, covers initially saturated startup, and asserts Ghostty’s prompt marker preserves exit code (e.g., 42).

<sup>Written for commit f2c6a3b231b453796c024612ac8a955973501e27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4959?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * zsh integration now detects job-table saturation and suppresses extra background jobs, polling loops, and watchers to prevent saturation errors and keep prompts responsive.

* **New Features**
  * Ghostty hooks are wrapped to early-return when the shell is saturated, avoiding additional background work and preserving prompt behavior.

* **Tests**
  * Added a regression test that verifies Ghostty/zsh remain quiet and stable when the job table is saturated.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4959?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->