### PR TITLE
Fix cmux ssh window resize not reaching the remote PTY

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -9653,7 +9653,32 @@ struct CMUXCLI {
                 params["surface_id"] = surfaceID
                 params["allow_moved_surface"] = true
             }
-            _ = try? client.sendV2(method: "workspace.remote.pty_resize", params: params)
+            // The cmux control socket serves a single request per connection (the
+            // server closes the connection once it has replied), so by the time the
+            // next SIGWINCH arrives the long-lived `client` connection is usually
+            // gone. Reusing it made every resize after the first fail silently ("Not
+            // connected"/broken pipe), freezing the remote PTY at its initial width.
+            // A closed connection is the expected steady state here rather than an
+            // error, so re-establish it before sending whenever it is no longer
+            // open. If the send still throws — poll can briefly miss a peer close,
+            // and this socket closes after every reply — reconnect and retry once
+            // so a single SIGWINCH isn't dropped; pty_resize is idempotent, so the
+            // redundant resend is safe.
+            do {
+                if !client.connectionAppearsOpen() {
+                    client.close()
+                    try client.connect()
+                }
+                do {
+                    _ = try client.sendV2(method: "workspace.remote.pty_resize", params: params)
+                } catch {
+                    client.close()
+                    try client.connect()
+                    _ = try client.sendV2(method: "workspace.remote.pty_resize", params: params)
+                }
+            } catch {
+                self.cliDebugLog("ssh-pty-attach: failed to propagate terminal resize (\(size.cols)x\(size.rows)): \(error)")
+            }
         }
         source.resume()
         return source

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -3337,6 +3337,173 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         ])
     }
 
+    /// Regression: the cmux control socket serves a single request per connection
+    /// (it closes the connection once it has replied). `ssh-pty-attach` reused one
+    /// long-lived SocketClient for every SIGWINCH-driven resize, so after the first
+    /// resize the connection was dead and all later resizes failed silently — the
+    /// remote PTY froze at its initial width. Drive several SIGWINCH signals against
+    /// a one-request-per-connection server and assert each is delivered as its own
+    /// resize RPC (i.e. the handler reconnects). Pre-fix this server would receive
+    /// only the bridge request and zero resizes.
+    func testSSHPTYAttachReconnectsResizeForEachSIGWINCH() throws {
+        let cliPath = try bundledCLIPath()
+        let socketPath = makeSocketPath("sshptyresizereconnect")
+        let listenerFD = try bindUnixSocket(at: socketPath)
+        let bridge = try bindLoopbackTCP()
+        let state = MockSocketServerState()
+        let workspaceId = "44444444-4444-4444-4444-444444444444"
+        let surfaceId = "55555555-5555-5555-5555-555555555555"
+        let sessionId = "ssh-\(workspaceId)-\(surfaceId)"
+        let token = "bridge-token"
+        let bridgeReady = DispatchSemaphore(value: 0)
+        let closeBridge = DispatchSemaphore(value: 0)
+
+        defer {
+            Darwin.close(listenerFD)
+            Darwin.close(bridge.fd)
+            unlink(socketPath)
+        }
+
+        // One request per connection: accept, answer a single request, then close —
+        // mirroring the real cmux control socket. The accept loop ends when the
+        // listener is closed in `defer`.
+        DispatchQueue.global(qos: .userInitiated).async {
+            while true {
+                var clientAddr = sockaddr_un()
+                var clientAddrLen = socklen_t(MemoryLayout<sockaddr_un>.size)
+                let clientFD = withUnsafeMutablePointer(to: &clientAddr) { ptr in
+                    ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
+                        Darwin.accept(listenerFD, sockaddrPtr, &clientAddrLen)
+                    }
+                }
+                if clientFD < 0 { return }
+                var pending = Data()
+                var buffer = [UInt8](repeating: 0, count: 4096)
+                var answered = false
+                while !answered {
+                    let count = Darwin.read(clientFD, &buffer, buffer.count)
+                    if count <= 0 { break }
+                    pending.append(buffer, count: count)
+                    guard let newlineRange = pending.firstRange(of: Data([0x0A])) else { continue }
+                    let lineData = pending.subdata(in: 0..<newlineRange.lowerBound)
+                    guard let line = String(data: lineData, encoding: .utf8) else { break }
+                    state.append(line)
+                    let response: String
+                    if let payload = self.jsonObject(line),
+                       let id = payload["id"] as? String,
+                       let method = payload["method"] as? String {
+                        switch method {
+                        case "workspace.remote.pty_bridge":
+                            response = self.v2Response(
+                                id: id,
+                                ok: true,
+                                result: [
+                                    "host": "127.0.0.1",
+                                    "port": bridge.port,
+                                    "token": token,
+                                    "session_id": sessionId,
+                                    "attachment_id": surfaceId,
+                                ]
+                            )
+                        default:
+                            response = self.v2Response(id: id, ok: true, result: [:])
+                        }
+                    } else {
+                        response = self.malformedRequestResponse(raw: line)
+                    }
+                    _ = (response + "\n").withCString { Darwin.write(clientFD, $0, strlen($0)) }
+                    answered = true
+                }
+                Darwin.close(clientFD)
+            }
+        }
+
+        // Bridge loopback: complete the attach handshake and hand back the token.
+        DispatchQueue.global(qos: .userInitiated).async {
+            var clientAddr = sockaddr_in()
+            var clientAddrLen = socklen_t(MemoryLayout<sockaddr_in>.size)
+            let clientFD = withUnsafeMutablePointer(to: &clientAddr) { ptr in
+                ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
+                    Darwin.accept(bridge.fd, sockaddrPtr, &clientAddrLen)
+                }
+            }
+            guard clientFD >= 0 else { return }
+            defer { Darwin.close(clientFD) }
+            var pending = Data()
+            var buffer = [UInt8](repeating: 0, count: 1024)
+            while !pending.contains(0x0A) {
+                let count = Darwin.read(clientFD, &buffer, buffer.count)
+                if count < 0 { if errno == EINTR { continue }; return }
+                if count == 0 { return }
+                pending.append(buffer, count: count)
+            }
+            let ready = #"{"type":"ready","attachment_token":"attach-token"}"# + "\n"
+            _ = ready.withCString { Darwin.write(clientFD, $0, strlen($0)) }
+            bridgeReady.signal()
+            _ = closeBridge.wait(timeout: .now() + 10)
+        }
+
+        let process = Process()
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.executableURL = URL(fileURLWithPath: cliPath)
+        process.arguments = [
+            "ssh-pty-attach",
+            "--workspace", workspaceId,
+            "--session-id", sessionId,
+            "--attachment-id", surfaceId,
+        ]
+        var environment = ProcessInfo.processInfo.environment
+        environment["CMUX_SOCKET_PATH"] = socketPath
+        environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
+        process.environment = environment
+        process.standardInput = FileHandle.nullDevice
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        try process.run()
+        defer {
+            if process.isRunning { process.terminate() }
+        }
+        XCTAssertEqual(bridgeReady.wait(timeout: .now() + 5), .success)
+
+        // Count only resizes that carry the full attach context the remote PTY
+        // requires; a resize that drops workspace/session/attachment ids or the
+        // token would be rejected by the real daemon, so it must not count here.
+        func resizeCount() -> Int {
+            state.snapshot()
+                .compactMap { self.jsonObject($0) }
+                .filter { ($0["method"] as? String) == "workspace.remote.pty_resize" }
+                .filter { request in
+                    guard let params = request["params"] as? [String: Any] else { return false }
+                    return params["workspace_id"] as? String == workspaceId
+                        && params["session_id"] as? String == sessionId
+                        && params["attachment_id"] as? String == surfaceId
+                        && params["attachment_token"] as? String == "attach-token"
+                        && params["cols"] as? Int != nil
+                        && params["rows"] as? Int != nil
+                }
+                .count
+        }
+
+        // Each SIGWINCH must reconnect and deliver its own resize RPC. Pre-fix the
+        // first dead-connection resize would abort the chain at zero.
+        let targetResizes = 3
+        let deadline = Date().addingTimeInterval(10)
+        while resizeCount() < targetResizes, Date() < deadline {
+            Darwin.kill(process.processIdentifier, SIGWINCH)
+            usleep(200_000)
+        }
+        let delivered = resizeCount()
+        closeBridge.signal()
+
+        XCTAssertGreaterThanOrEqual(
+            delivered,
+            targetResizes,
+            "Each SIGWINCH must reconnect and issue a resize RPC; reusing one connection froze resizes after the first (delivered=\(delivered))"
+        )
+    }
+
     func testSSHSessionAttachCreatesSurfaceWithPersistedPTYSessionID() throws {
         let cliPath = try bundledCLIPath()
         let socketPath = makeSocketPath("sshattach")


### PR DESCRIPTION
## Summary

- **What changed?** `cmux ssh` froze the remote terminal at its initial width — resizing the cmux window never reflowed the remote shell, while a plain `ssh` inside a cmux terminal resized fine. The SIGWINCH-driven resize handler now checks whether its cached control-socket connection is still open (`connectionAppearsOpen()`) and re-establishes it *before* each resize — a closed connection is the expected steady state for this socket, not an error. If the send still throws (poll can briefly miss a peer close), it reconnects and retries exactly once (`pty_resize` is idempotent, so the redundant resend is safe), and logs any final failure instead of silently discarding it.
- **Why?** The persistent SSH PTY path (added in #4323, shipping in v0.64.10) forwards local `SIGWINCH` events to the remote PTY via `workspace.remote.pty_resize` over the cmux control socket. That socket serves a single request per connection (it closes the connection after replying), but the resize handler reused one long-lived `SocketClient`. By the next `SIGWINCH` the cached connection was dead, so every resize after the first failed and was swallowed by `_ = try? client.sendV2(...)`. The local PTY reflowed (ghostty resizes it) while the remote PTY stayed frozen at its attach-time width.

## Testing

- **Structured as two commits per the repo's regression policy:** commit 1 adds the failing test only (CI **red**), commit 2 adds the fix (CI **green**), so the Commits tab proves the test catches the bug.
- **Added regression test** `testSSHPTYAttachReconnectsResizeForEachSIGWINCH` (`cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift`): drives several `SIGWINCH` signals against a one-request-per-connection server and asserts each is delivered as its own resize RPC.
  - Against the unfixed handler (commit 1) it **fails with `delivered=0`**; with the fix (commit 2) it **passes**.
  - Existing `testSSHPTYAttachSerializesResizeBeforeEOFLocalCleanup` still passes unchanged (no test-mock changes needed).
  - `xcodebuild test -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS,arch=arm64' -only-testing:cmuxTests/CLINotifyProcessIntegrationRegressionTests/testSSHPTYAttachReconnectsResizeForEachSIGWINCH -only-testing:cmuxTests/CLINotifyProcessIntegrationRegressionTests/testSSHPTYAttachSerializesResizeBeforeEOFLocalCleanup` → **TEST SUCCEEDED** (2 tests, 0 failures)
- **Manual, Debug build against a real remote** (`cmux ssh`): five consecutive window resizes each propagated to the remote PTY. Read both ends' `TIOCGWINSZ` after each resize:

  | resize | local PTY | remote PTY | match |
  |--------|-----------|------------|-------|
  | A | 98×41 | 98×41 | ✓ |
  | B | 34×17 | 34×17 | ✓ |
  | C | 98×38 | 98×38 | ✓ |
  | D | 62×25 | 62×25 | ✓ |
  | E | 98×41 | 98×41 | ✓ |

  Zero resize errors logged. Pre-fix, the remote PTY stayed at the initial size after the first resize (`Broken pipe` / `Not connected` on the reused connection).

## Demo Video

Behavior is terminal-only (remote shell reflow on window resize); captured as the before/after `TIOCGWINSZ` table above rather than a screen recording. Happy to add a screen capture if preferred.

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed (no changelog entry required)
- [x] I requested bot reviews after my latest commit
- [x] All code review bot comments are addressed (Greptile's 3 P2 notes replied to inline)
- [ ] All human review comments are resolved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal resize reliability for long-lived remote sessions: the client now detects broken control connections, reconnects, and retries resize requests so terminal dimensions are applied consistently instead of silently stopping after a single failure.

* **Tests**
  * Added a regression test that simulates one-request-per-connection behavior and verifies resize requests continue to be delivered across reconnects.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4960?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
