### PR TITLE
Stop stale closed-browser snapshots from reappearing in unrelated workspaces

### DIFF
--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -779,6 +779,10 @@ struct RecentlyClosedBrowserStack {
     mutating func pop() -> ClosedBrowserPanelRestoreSnapshot? {
         entries.popLast()
     }
+
+    mutating func removeSnapshots(forWorkspaceId workspaceId: UUID) {
+        entries.removeAll { $0.workspaceId == workspaceId }
+    }
 }
 
 #if DEBUG
@@ -5949,6 +5953,7 @@ class TabManager: ObservableObject {
         }
         workspace.teardownRemoteConnection()
         unwireClosedBrowserTracking(for: workspace)
+        recentlyClosedBrowsers.removeSnapshots(forWorkspaceId: workspace.id)
         workspace.owningTabManager = nil
 
         if let index = tabs.firstIndex(where: { $0.id == workspace.id }) {
@@ -5976,6 +5981,7 @@ class TabManager: ObservableObject {
 
         let removed = tabs.remove(at: index)
         unwireClosedBrowserTracking(for: removed)
+        recentlyClosedBrowsers.removeSnapshots(forWorkspaceId: removed.id)
         removed.owningTabManager = nil
         lastFocusedPanelByTab.removeValue(forKey: removed.id)
 
@@ -8167,11 +8173,12 @@ class TabManager: ObservableObject {
         guard BrowserAvailabilitySettings.isEnabled() else { return false }
 
         while let snapshot = recentlyClosedBrowsers.pop() {
-            guard let targetWorkspace =
-                tabs.first(where: { $0.id == snapshot.workspaceId })
-                ?? selectedWorkspace
-                ?? tabs.first else {
-                return false
+            // The legacy stack must restore into the workspace that originally owned the
+            // browser. If that workspace is gone, the snapshot is stale and we drop it
+            // instead of barging into whatever workspace happens to be selected now
+            // (which surfaced yesterday's browser inside today's unrelated workspaces).
+            guard let targetWorkspace = tabs.first(where: { $0.id == snapshot.workspaceId }) else {
+                continue
             }
             let preReopenFocusedPanelId = focusedPanelId(for: targetWorkspace.id)
 

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -2747,9 +2747,25 @@ final class RecentlyClosedBrowserStackTests: XCTestCase {
         XCTAssertNil(stack.pop())
     }
 
-    private func makeSnapshot(index: Int) -> ClosedBrowserPanelRestoreSnapshot {
+    func testRemoveSnapshotsDropsOnlyEntriesForGivenWorkspaceId() {
+        let workspaceA = UUID()
+        let workspaceB = UUID()
+        var stack = RecentlyClosedBrowserStack(capacity: 20)
+        stack.push(makeSnapshot(index: 1, workspaceId: workspaceA))
+        stack.push(makeSnapshot(index: 2, workspaceId: workspaceB))
+        stack.push(makeSnapshot(index: 3, workspaceId: workspaceA))
+        stack.push(makeSnapshot(index: 4, workspaceId: workspaceB))
+
+        stack.removeSnapshots(forWorkspaceId: workspaceA)
+
+        XCTAssertEqual(stack.pop()?.originalTabIndex, 4)
+        XCTAssertEqual(stack.pop()?.originalTabIndex, 2)
+        XCTAssertNil(stack.pop())
+    }
+
+    private func makeSnapshot(index: Int, workspaceId: UUID = UUID()) -> ClosedBrowserPanelRestoreSnapshot {
         ClosedBrowserPanelRestoreSnapshot(
-            workspaceId: UUID(),
+            workspaceId: workspaceId,
             url: URL(string: "https://example.com/\(index)"),
             profileID: nil,
             originalPaneId: UUID(),

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -3301,7 +3301,7 @@ final class TabManagerReopenClosedBrowserFocusTests: XCTestCase {
         XCTAssertTrue(isFocusedPanelBrowser(in: workspace1))
     }
 
-    func testReopenFallsBackToCurrentWorkspaceAndFocusesBrowserWhenOriginalWorkspaceDeleted() {
+    func testReopenDropsBrowserSnapshotWhenOriginalWorkspaceDeleted() {
         let manager = TabManager()
         guard let originalWorkspace = manager.selectedWorkspace,
               let closedBrowserId = manager.openBrowser(url: URL(string: "https://example.com/deleted-ws")) else {
@@ -3314,16 +3314,18 @@ final class TabManagerReopenClosedBrowserFocusTests: XCTestCase {
         drainMainQueue()
 
         let currentWorkspace = manager.addWorkspace()
+        let currentPanelCountBefore = currentWorkspace.panels.count
         manager.closeWorkspace(originalWorkspace, recordHistory: false)
 
         XCTAssertEqual(manager.selectedTabId, currentWorkspace.id)
         XCTAssertFalse(manager.tabs.contains(where: { $0.id == originalWorkspace.id }))
 
-        XCTAssertTrue(manager.reopenMostRecentlyClosedBrowserPanel())
+        XCTAssertFalse(manager.reopenMostRecentlyClosedBrowserPanel())
         drainMainQueue()
 
         XCTAssertEqual(manager.selectedTabId, currentWorkspace.id)
-        XCTAssertTrue(isFocusedPanelBrowser(in: currentWorkspace))
+        XCTAssertEqual(currentWorkspace.panels.count, currentPanelCountBefore)
+        XCTAssertFalse(isFocusedPanelBrowser(in: currentWorkspace))
     }
 
     func testReopenCollapsedSplitFromDifferentWorkspaceFocusesBrowser() {

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -3301,58 +3301,29 @@ final class TabManagerReopenClosedBrowserFocusTests: XCTestCase {
         XCTAssertTrue(isFocusedPanelBrowser(in: workspace1))
     }
 
-    func testReopenLegacyStackDropsSnapshotWhenOriginalWorkspaceIsGone() {
+    func testReopenFallsBackToCurrentWorkspaceAndFocusesBrowserWhenOriginalWorkspaceDeleted() {
         let manager = TabManager()
-        guard let workspace = manager.selectedWorkspace else {
-            XCTFail("Expected initial workspace")
+        guard let originalWorkspace = manager.selectedWorkspace,
+              let closedBrowserId = manager.openBrowser(url: URL(string: "https://example.com/deleted-ws")) else {
+            XCTFail("Expected initial workspace and browser panel")
             return
         }
-        let panelsBefore = workspace.panels.count
 
-        let staleSnapshot = ClosedBrowserPanelRestoreSnapshot(
-            workspaceId: UUID(),
-            url: URL(string: "https://example.com/stale-from-deleted-workspace"),
-            profileID: nil,
-            originalPaneId: UUID(),
-            originalTabIndex: 0,
-            fallbackSplitOrientation: .horizontal,
-            fallbackSplitInsertFirst: false,
-            fallbackAnchorPaneId: UUID()
-        )
-        workspace.onClosedBrowserPanel?(staleSnapshot)
-        XCTAssertNotNil(manager.mostRecentLegacyClosedBrowserPanelClosedAt())
-
-        XCTAssertFalse(manager.reopenMostRecentlyClosedBrowserPanelFromLegacyStack())
+        drainMainQueue()
+        XCTAssertTrue(originalWorkspace.closePanel(closedBrowserId, force: true))
         drainMainQueue()
 
-        XCTAssertEqual(workspace.panels.count, panelsBefore)
-        XCTAssertNil(manager.mostRecentLegacyClosedBrowserPanelClosedAt())
-    }
-
-    func testCloseWorkspacePrunesLegacyStackSnapshotsForThatWorkspace() {
-        let manager = TabManager()
-        guard let originalWorkspace = manager.selectedWorkspace else {
-            XCTFail("Expected initial workspace")
-            return
-        }
-
-        let snapshot = ClosedBrowserPanelRestoreSnapshot(
-            workspaceId: originalWorkspace.id,
-            url: URL(string: "https://example.com/stack-leak"),
-            profileID: nil,
-            originalPaneId: UUID(),
-            originalTabIndex: 0,
-            fallbackSplitOrientation: .horizontal,
-            fallbackSplitInsertFirst: false,
-            fallbackAnchorPaneId: UUID()
-        )
-        originalWorkspace.onClosedBrowserPanel?(snapshot)
-        XCTAssertNotNil(manager.mostRecentLegacyClosedBrowserPanelClosedAt())
-
-        _ = manager.addWorkspace()
+        let currentWorkspace = manager.addWorkspace()
         manager.closeWorkspace(originalWorkspace, recordHistory: false)
 
-        XCTAssertNil(manager.mostRecentLegacyClosedBrowserPanelClosedAt())
+        XCTAssertEqual(manager.selectedTabId, currentWorkspace.id)
+        XCTAssertFalse(manager.tabs.contains(where: { $0.id == originalWorkspace.id }))
+
+        XCTAssertTrue(manager.reopenMostRecentlyClosedBrowserPanel())
+        drainMainQueue()
+
+        XCTAssertEqual(manager.selectedTabId, currentWorkspace.id)
+        XCTAssertTrue(isFocusedPanelBrowser(in: currentWorkspace))
     }
 
     func testReopenCollapsedSplitFromDifferentWorkspaceFocusesBrowser() {

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -3147,45 +3147,52 @@ final class TabManagerReopenClosedBrowserFocusTests: XCTestCase {
         XCTAssertTrue(isFocusedPanelBrowser(in: workspace1))
     }
 
-    func testReopenDoesNotRetargetUnrelatedWorkspaceWhenOriginalWorkspaceDeleted() {
+    func testReopenLegacyStackDropsSnapshotWhenOriginalWorkspaceIsGone() {
         let manager = TabManager()
-        guard let originalWorkspace = manager.selectedWorkspace,
-              let closedBrowserId = manager.openBrowser(url: URL(string: "https://example.com/deleted-ws")) else {
-            XCTFail("Expected initial workspace and browser panel")
+        guard let workspace = manager.selectedWorkspace else {
+            XCTFail("Expected initial workspace")
             return
         }
+        let panelsBefore = workspace.panels.count
 
+        let staleSnapshot = ClosedBrowserPanelRestoreSnapshot(
+            workspaceId: UUID(),
+            url: URL(string: "https://example.com/stale-from-deleted-workspace"),
+            profileID: nil,
+            originalPaneId: UUID(),
+            originalTabIndex: 0,
+            fallbackSplitOrientation: .horizontal,
+            fallbackSplitInsertFirst: false,
+            fallbackAnchorPaneId: UUID()
+        )
+        workspace.onClosedBrowserPanel?(staleSnapshot)
+        XCTAssertNotNil(manager.mostRecentLegacyClosedBrowserPanelClosedAt())
+
+        XCTAssertFalse(manager.reopenMostRecentlyClosedBrowserPanelFromLegacyStack())
         drainMainQueue()
-        XCTAssertTrue(originalWorkspace.closePanel(closedBrowserId, force: true))
-        drainMainQueue()
 
-        let currentWorkspace = manager.addWorkspace()
-        let currentPanelCountBefore = currentWorkspace.panels.count
-        manager.closeWorkspace(originalWorkspace, recordHistory: false)
-
-        XCTAssertEqual(manager.selectedTabId, currentWorkspace.id)
-        XCTAssertFalse(manager.tabs.contains(where: { $0.id == originalWorkspace.id }))
-
-        XCTAssertFalse(manager.reopenMostRecentlyClosedBrowserPanel())
-        drainMainQueue()
-
-        XCTAssertEqual(manager.selectedTabId, currentWorkspace.id)
-        XCTAssertEqual(currentWorkspace.panels.count, currentPanelCountBefore)
-        XCTAssertFalse(isFocusedPanelBrowser(in: currentWorkspace))
+        XCTAssertEqual(workspace.panels.count, panelsBefore)
+        XCTAssertNil(manager.mostRecentLegacyClosedBrowserPanelClosedAt())
     }
 
-    func testClosingWorkspacePrunesItsBrowserSnapshotsFromLegacyStack() {
+    func testCloseWorkspacePrunesLegacyStackSnapshotsForThatWorkspace() {
         let manager = TabManager()
-        guard let originalWorkspace = manager.selectedWorkspace,
-              let closedBrowserId = manager.openBrowser(url: URL(string: "https://example.com/stack-leak")) else {
-            XCTFail("Expected initial workspace and browser panel")
+        guard let originalWorkspace = manager.selectedWorkspace else {
+            XCTFail("Expected initial workspace")
             return
         }
 
-        drainMainQueue()
-        XCTAssertTrue(originalWorkspace.closePanel(closedBrowserId, force: true))
-        drainMainQueue()
-
+        let snapshot = ClosedBrowserPanelRestoreSnapshot(
+            workspaceId: originalWorkspace.id,
+            url: URL(string: "https://example.com/stack-leak"),
+            profileID: nil,
+            originalPaneId: UUID(),
+            originalTabIndex: 0,
+            fallbackSplitOrientation: .horizontal,
+            fallbackSplitInsertFirst: false,
+            fallbackAnchorPaneId: UUID()
+        )
+        originalWorkspace.onClosedBrowserPanel?(snapshot)
         XCTAssertNotNil(manager.mostRecentLegacyClosedBrowserPanelClosedAt())
 
         _ = manager.addWorkspace()

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -3147,7 +3147,7 @@ final class TabManagerReopenClosedBrowserFocusTests: XCTestCase {
         XCTAssertTrue(isFocusedPanelBrowser(in: workspace1))
     }
 
-    func testReopenFallsBackToCurrentWorkspaceAndFocusesBrowserWhenOriginalWorkspaceDeleted() {
+    func testReopenDoesNotRetargetUnrelatedWorkspaceWhenOriginalWorkspaceDeleted() {
         let manager = TabManager()
         guard let originalWorkspace = manager.selectedWorkspace,
               let closedBrowserId = manager.openBrowser(url: URL(string: "https://example.com/deleted-ws")) else {
@@ -3160,16 +3160,38 @@ final class TabManagerReopenClosedBrowserFocusTests: XCTestCase {
         drainMainQueue()
 
         let currentWorkspace = manager.addWorkspace()
+        let currentPanelCountBefore = currentWorkspace.panels.count
         manager.closeWorkspace(originalWorkspace, recordHistory: false)
 
         XCTAssertEqual(manager.selectedTabId, currentWorkspace.id)
         XCTAssertFalse(manager.tabs.contains(where: { $0.id == originalWorkspace.id }))
 
-        XCTAssertTrue(manager.reopenMostRecentlyClosedBrowserPanel())
+        XCTAssertFalse(manager.reopenMostRecentlyClosedBrowserPanel())
         drainMainQueue()
 
         XCTAssertEqual(manager.selectedTabId, currentWorkspace.id)
-        XCTAssertTrue(isFocusedPanelBrowser(in: currentWorkspace))
+        XCTAssertEqual(currentWorkspace.panels.count, currentPanelCountBefore)
+        XCTAssertFalse(isFocusedPanelBrowser(in: currentWorkspace))
+    }
+
+    func testClosingWorkspacePrunesItsBrowserSnapshotsFromLegacyStack() {
+        let manager = TabManager()
+        guard let originalWorkspace = manager.selectedWorkspace,
+              let closedBrowserId = manager.openBrowser(url: URL(string: "https://example.com/stack-leak")) else {
+            XCTFail("Expected initial workspace and browser panel")
+            return
+        }
+
+        drainMainQueue()
+        XCTAssertTrue(originalWorkspace.closePanel(closedBrowserId, force: true))
+        drainMainQueue()
+
+        XCTAssertNotNil(manager.mostRecentLegacyClosedBrowserPanelClosedAt())
+
+        _ = manager.addWorkspace()
+        manager.closeWorkspace(originalWorkspace, recordHistory: false)
+
+        XCTAssertNil(manager.mostRecentLegacyClosedBrowserPanelClosedAt())
     }
 
     func testReopenCollapsedSplitFromDifferentWorkspaceFocusesBrowser() {


### PR DESCRIPTION
## Summary
- Old browser panes were resurfacing in unrelated workspaces hours or days after being closed. Closing a browser via Cmd+W or the X button pushed a snapshot into `RecentlyClosedBrowserStack`. That snapshot stayed in memory after its source workspace was gone, and `reopenMostRecentlyClosedBrowserPanelFromLegacyStack` silently retargeted it via `selectedWorkspace ?? tabs.first` — opening yesterday's URL inside today's new workspace.
- `closeWorkspace` and `detachWorkspace` now prune the legacy stack for the removed workspace's id, and the legacy reopen path drops a snapshot whose workspace is gone instead of replaying it on an unrelated one.
- Updated the existing test that codified the buggy retarget behavior and added a coverage test for the stack-leak path.

## Test plan
- [ ] `cmuxTests/TabManagerUnitTests/TabManagerReopenClosedBrowserFocusTests/testReopenDoesNotRetargetUnrelatedWorkspaceWhenOriginalWorkspaceDeleted`
- [ ] `cmuxTests/TabManagerUnitTests/TabManagerReopenClosedBrowserFocusTests/testClosingWorkspacePrunesItsBrowserSnapshotsFromLegacyStack`
- [ ] Dogfood: open browser via CLI in a workspace, close it with Cmd+W, close the workspace, create a new workspace, press Cmd+Shift+T — no stale browser should appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4961"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782601604&installation_id=133855650&pr_number=4961&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4961&signature=c17f70abc7578bbf46e6b8d8452d476bbd7fd1309cce40e7960297cfe9d61b4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents stale closed-browser snapshots from reopening in unrelated workspaces. We now prune the legacy stack on workspace removal and restore only into the original workspace, dropping orphaned entries.

- **Bug Fixes**
  - Added `removeSnapshots(forWorkspaceId:)` to `RecentlyClosedBrowserStack`; called from `closeWorkspace` and `detachWorkspace`.
  - `reopenMostRecentlyClosedBrowserPanelFromLegacyStack` restores only if the original workspace exists; otherwise drops the snapshot and continues.
  - Updated tests: added `RecentlyClosedBrowserStackTests.testRemoveSnapshotsDropsOnlyEntriesForGivenWorkspaceId` and revised the deleted-workspace reopen test to assert the new no-fallback behavior.

<sup>Written for commit 2ad6d9aa08b3043c671cea2a018ff3181c53e38e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4961?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Browser restore snapshots are now removed when their associated workspace is closed.
  * Reopening a recently closed browser strictly requires the original workspace to still exist; no fallback to other workspaces.

* **Tests**
  * Added/updated unit tests to verify snapshot removal is workspace-scoped and that reopen is blocked when the original workspace is gone.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4961?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->