### PR TITLE
Fix blank Settings window on every open after the first

### DIFF
--- a/Sources/SettingsWindowContentVisibility.swift
+++ b/Sources/SettingsWindowContentVisibility.swift
@@ -50,6 +50,9 @@ struct SettingsWindowContentVisibility: Equatable {
     ///   - isSettingsWindow: Whether that window is the Settings window, used to
     ///     re-adopt it after a prior close cleared the reference.
     mutating func windowDidBecomeVisible(_ window: ObjectIdentifier, isSettingsWindow: Bool) {
+        if observedWindow == nil, isSettingsWindow {
+            observedWindow = window
+        }
         guard window == observedWindow else { return }
         shouldRenderContent = true
     }

--- a/Sources/SettingsWindowContentVisibility.swift
+++ b/Sources/SettingsWindowContentVisibility.swift
@@ -1,0 +1,63 @@
+/// Decides whether the Settings window renders its full content or a lightweight
+/// placeholder, based on the lifecycle of the underlying `NSWindow`.
+///
+/// SwiftUI reuses the Settings `Window` scene across close / reopen. The
+/// `WindowAccessor` that supplies the window dedupes by the reused `NSWindow`,
+/// so it does not fire again on the second open, and the scene's view state
+/// persists. Without re-adoption, a window that was forgotten on close (to stop
+/// observing it) can never flip back to rendering content — producing a blank
+/// window on every open after the first. This value type centralizes that
+/// state machine so the close → reopen path can be exercised in isolation.
+@MainActor
+struct SettingsWindowContentVisibility: Equatable {
+    /// Whether the settings content should render. When `false`, callers show a
+    /// cheap placeholder instead of the full settings hierarchy.
+    private(set) var shouldRenderContent: Bool
+
+    /// Identity of the window currently being observed, if any. Cleared on close.
+    private var observedWindow: ObjectIdentifier?
+
+    /// Creates a coordinator that renders content until a lifecycle event hides it.
+    init() {
+        shouldRenderContent = true
+        observedWindow = nil
+    }
+
+    /// Adopts the window the scene attached to.
+    ///
+    /// - Parameters:
+    ///   - window: Identity of the attached window.
+    ///   - isMiniaturized: Whether that window is currently miniaturized; content
+    ///     stays hidden while miniaturized to avoid wasted rendering.
+    mutating func windowConfigured(_ window: ObjectIdentifier, isMiniaturized: Bool) {
+        observedWindow = window
+        shouldRenderContent = !isMiniaturized
+    }
+
+    /// Hides content while the observed window is miniaturized.
+    mutating func windowDidMiniaturize(_ window: ObjectIdentifier) {
+        guard window == observedWindow else { return }
+        shouldRenderContent = false
+    }
+
+    /// Restores content when the window becomes visible again.
+    ///
+    /// Re-adopts the window when the previous observation was cleared on close
+    /// (the reused-scene case where `WindowAccessor` never fires a second time).
+    ///
+    /// - Parameters:
+    ///   - window: Identity of the window that became visible.
+    ///   - isSettingsWindow: Whether that window is the Settings window, used to
+    ///     re-adopt it after a prior close cleared the reference.
+    mutating func windowDidBecomeVisible(_ window: ObjectIdentifier, isSettingsWindow: Bool) {
+        guard window == observedWindow else { return }
+        shouldRenderContent = true
+    }
+
+    /// Hides content and forgets the window when it closes.
+    mutating func windowWillClose(_ window: ObjectIdentifier) {
+        guard window == observedWindow else { return }
+        shouldRenderContent = false
+        observedWindow = nil
+    }
+}

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -9008,12 +9008,11 @@ private struct GlobalHotkeySection: View {
 
 private struct SettingsWindowRootView: View {
     @State private var draftState = SettingsDraftState()
-    @State private var windowReference = WeakSettingsWindowReference()
-    @State private var shouldRenderSettingsContent = true
+    @State private var visibility = SettingsWindowContentVisibility()
 
     var body: some View {
         Group {
-            if shouldRenderSettingsContent {
+            if visibility.shouldRenderContent {
                 SettingsRootView(draftState: draftState)
             } else {
                 Color.clear
@@ -9024,52 +9023,39 @@ private struct SettingsWindowRootView: View {
             }
         }
         .background(WindowAccessor { window in
-            windowReference.window = window
             SettingsWindowPresenter.configure(window: window)
-            setContentVisibility(!window.isMiniaturized)
+            visibility.windowConfigured(ObjectIdentifier(window), isMiniaturized: window.isMiniaturized)
         })
         .onReceive(NotificationCenter.default.publisher(for: NSWindow.didMiniaturizeNotification)) { notification in
-            guard isObservedWindow(notification.object) else { return }
-            setContentVisibility(false)
+            guard let window = notification.object as? NSWindow else { return }
+            visibility.windowDidMiniaturize(ObjectIdentifier(window))
         }
         .onReceive(NotificationCenter.default.publisher(for: NSWindow.didDeminiaturizeNotification)) { notification in
-            guard isObservedWindow(notification.object) else { return }
-            setContentVisibility(true)
+            handleWindowDidBecomeVisible(notification.object)
         }
         .onReceive(NotificationCenter.default.publisher(for: NSWindow.didBecomeKeyNotification)) { notification in
-            guard isObservedWindow(notification.object) else { return }
-            setContentVisibility(true)
+            handleWindowDidBecomeVisible(notification.object)
         }
         .onReceive(NotificationCenter.default.publisher(for: NSWindow.didBecomeMainNotification)) { notification in
-            guard isObservedWindow(notification.object) else { return }
-            setContentVisibility(true)
+            handleWindowDidBecomeVisible(notification.object)
         }
         .onReceive(NotificationCenter.default.publisher(for: NSWindow.willCloseNotification)) { notification in
-            guard isObservedWindow(notification.object) else { return }
-            setContentVisibility(false)
-            windowReference.window = nil
+            guard let window = notification.object as? NSWindow else { return }
+            visibility.windowWillClose(ObjectIdentifier(window))
         }
     }
 
-    private func isObservedWindow(_ object: Any?) -> Bool {
-        guard
-            let notificationWindow = object as? NSWindow,
-            let window = windowReference.window
-        else {
-            return false
-        }
-        return notificationWindow === window
+    /// Forwards a "window became visible" notification to the visibility model,
+    /// re-adopting the Settings window by its stable identifier when a prior
+    /// close cleared the observed reference (the reused-scene case where
+    /// ``WindowAccessor`` does not fire again on the second open).
+    private func handleWindowDidBecomeVisible(_ object: Any?) {
+        guard let window = object as? NSWindow else { return }
+        visibility.windowDidBecomeVisible(
+            ObjectIdentifier(window),
+            isSettingsWindow: window.identifier?.rawValue == SettingsWindowPresenter.windowIdentifier
+        )
     }
-
-    private func setContentVisibility(_ isVisible: Bool) {
-        guard shouldRenderSettingsContent != isVisible else { return }
-        shouldRenderSettingsContent = isVisible
-    }
-}
-
-@MainActor
-private final class WeakSettingsWindowReference {
-    weak var window: NSWindow?
 }
 
 @MainActor

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -380,6 +380,8 @@
 		A50019A0 /* SettingsNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50019A1 /* SettingsNavigation.swift */; };
 		A50019B0 /* SettingsSearchAliases.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50019B1 /* SettingsSearchAliases.swift */; };
 		A50019B2 /* SettingsSearchIndexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50019B3 /* SettingsSearchIndexTests.swift */; };
+		A11EAB100000000000000000 /* SettingsWindowContentVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11EAB100000000000000001 /* SettingsWindowContentVisibility.swift */; };
+		A11EAB200000000000000000 /* SettingsWindowContentVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11EAB200000000000000001 /* SettingsWindowContentVisibilityTests.swift */; };
 		D36090010000000000000001 /* SettingsWindowPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36090010000000000000002 /* SettingsWindowPresenter.swift */; };
 		D36090010000000000000003 /* SettingsWindowPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36090010000000000000004 /* SettingsWindowPresenterTests.swift */; };
 		1521D55DC63D5E5FC4955E31 /* ShortcutAndCommandPaletteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6083A7DAD962E287FC2FFE94 /* ShortcutAndCommandPaletteTests.swift */; };
@@ -961,6 +963,8 @@
 		A50019A1 /* SettingsNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsNavigation.swift; sourceTree = "<group>"; };
 		A50019B1 /* SettingsSearchAliases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSearchAliases.swift; sourceTree = "<group>"; };
 		A50019B3 /* SettingsSearchIndexTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSearchIndexTests.swift; sourceTree = "<group>"; };
+		A11EAB100000000000000001 /* SettingsWindowContentVisibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsWindowContentVisibility.swift; sourceTree = "<group>"; };
+		A11EAB200000000000000001 /* SettingsWindowContentVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsWindowContentVisibilityTests.swift; sourceTree = "<group>"; };
 		D36090010000000000000002 /* SettingsWindowPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/SettingsWindowPresenter.swift; sourceTree = "<group>"; };
 		D36090010000000000000004 /* SettingsWindowPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsWindowPresenterTests.swift; sourceTree = "<group>"; };
 		6083A7DAD962E287FC2FFE94 /* ShortcutAndCommandPaletteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutAndCommandPaletteTests.swift; sourceTree = "<group>"; };
@@ -1276,6 +1280,7 @@
 				3023B1003023B1003023B100 /* ConfigSource.swift */,
 				3023B1013023B1013023B101 /* ConfigSettingsView.swift */,
 				A11EAB000000000000000001 /* AppearanceSettings.swift */,
+				A11EAB100000000000000001 /* SettingsWindowContentVisibility.swift */,
 				A11EAC000000000000000001 /* GhosttyTerminalAppearance.swift */,
 				A11EAD000000000000000001 /* WorkspaceAppearanceResolution.swift */,
 				A5001011 /* cmuxApp.swift */,
@@ -1704,6 +1709,7 @@
 				D7AB00000000000000000010 /* AppDelegateMoveTabToNewWorkspaceTests.swift */,
 				17C9F5BA0DD14EDC8C3E5002 /* MainWindowVisibilityControllerTests.swift */,
 				A11EAA000000000000000001 /* AppearanceSettingsTests.swift */,
+				A11EAB200000000000000001 /* SettingsWindowContentVisibilityTests.swift */,
 				6083A7DAD962E287FC2FFE94 /* ShortcutAndCommandPaletteTests.swift */,
 				C3408A000000000000000004 /* RightSidebarCommandPaletteTests.swift */,
 				C0DEF4120000000000000002 /* CommandPaletteSettingsToggleTests.swift */,
@@ -2260,6 +2266,7 @@
 				D9CCF002D9CCF002D9CCF002 /* SettingsLazyLoadHelpers.swift in Sources */,
 				A50019A0 /* SettingsNavigation.swift in Sources */,
 				A50019B0 /* SettingsSearchAliases.swift in Sources */,
+				A11EAB100000000000000000 /* SettingsWindowContentVisibility.swift in Sources */,
 				D36090010000000000000001 /* SettingsWindowPresenter.swift in Sources */,
 				76027A12C93B4538BF22C71E /* ShortcutBareStartRouting.swift in Sources */,
 				125BAEF2FE3B454547B964D1 /* ShortcutHintPill.swift in Sources */,
@@ -2527,6 +2534,7 @@
 				8A3392FE64E0605D942213D1 /* SessionIndexViewTests.swift in Sources */,
 					F5000000A1B2C3D4E5F60718 /* SessionPersistenceTests.swift in Sources */,
 				A50019B2 /* SettingsSearchIndexTests.swift in Sources */,
+				A11EAB200000000000000000 /* SettingsWindowContentVisibilityTests.swift in Sources */,
 				D36090010000000000000003 /* SettingsWindowPresenterTests.swift in Sources */,
 				1521D55DC63D5E5FC4955E31 /* ShortcutAndCommandPaletteTests.swift in Sources */,
 				F6001000A1B2C3D4E5F60718 /* ShortcutUnbindingTests.swift in Sources */,

--- a/cmuxTests/SettingsWindowContentVisibilityTests.swift
+++ b/cmuxTests/SettingsWindowContentVisibilityTests.swift
@@ -1,0 +1,97 @@
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Regression coverage for the Settings window rendering a blank placeholder on
+/// every open after the first within a session.
+///
+/// SwiftUI reuses the Settings `Window` scene across close / reopen, so the
+/// scene's content-visibility state persists and the `WindowAccessor` that
+/// supplies the window does not fire a second time. The original implementation
+/// cleared the observed window on close and then rejected every subsequent
+/// "became visible" notification, leaving the body stuck on the placeholder.
+@MainActor
+@Suite struct SettingsWindowContentVisibilityTests {
+    /// Distinct object identities standing in for `NSWindow` instances.
+    private final class WindowToken {}
+
+    @Test func rendersContentOnFirstConfigure() {
+        var visibility = SettingsWindowContentVisibility()
+        let window = WindowToken()
+
+        visibility.windowConfigured(ObjectIdentifier(window), isMiniaturized: false)
+
+        #expect(visibility.shouldRenderContent)
+    }
+
+    @Test func hidesContentWhileMiniaturizedAndRestoresOnDeminiaturize() {
+        var visibility = SettingsWindowContentVisibility()
+        let window = WindowToken()
+        let id = ObjectIdentifier(window)
+        visibility.windowConfigured(id, isMiniaturized: false)
+
+        visibility.windowDidMiniaturize(id)
+        #expect(!visibility.shouldRenderContent)
+
+        visibility.windowDidBecomeVisible(id, isSettingsWindow: true)
+        #expect(visibility.shouldRenderContent)
+    }
+
+    /// The core regression: close then reopen the reused window. Because the
+    /// reopen arrives only as a "became visible" notification (the accessor does
+    /// not fire again), the model must re-adopt the Settings window and restore
+    /// content. Before the fix this stayed `false` — a permanently blank window.
+    @Test func restoresContentWhenReusedWindowReopensAfterClose() {
+        var visibility = SettingsWindowContentVisibility()
+        let window = WindowToken()
+        let id = ObjectIdentifier(window)
+        visibility.windowConfigured(id, isMiniaturized: false)
+
+        visibility.windowWillClose(id)
+        #expect(!visibility.shouldRenderContent)
+
+        // Reopen: same reused NSWindow, only a become-visible notification.
+        visibility.windowDidBecomeVisible(id, isSettingsWindow: true)
+        #expect(visibility.shouldRenderContent)
+    }
+
+    @Test func survivesRepeatedCloseReopenCycles() {
+        var visibility = SettingsWindowContentVisibility()
+        let window = WindowToken()
+        let id = ObjectIdentifier(window)
+        visibility.windowConfigured(id, isMiniaturized: false)
+
+        for _ in 0..<5 {
+            visibility.windowWillClose(id)
+            #expect(!visibility.shouldRenderContent)
+            visibility.windowDidBecomeVisible(id, isSettingsWindow: true)
+            #expect(visibility.shouldRenderContent)
+        }
+    }
+
+    @Test func ignoresUnrelatedWindowsAfterClose() {
+        var visibility = SettingsWindowContentVisibility()
+        let settingsWindow = WindowToken()
+        let otherWindow = WindowToken()
+        visibility.windowConfigured(ObjectIdentifier(settingsWindow), isMiniaturized: false)
+        visibility.windowWillClose(ObjectIdentifier(settingsWindow))
+
+        // A non-settings window becoming key must not flip content back on.
+        visibility.windowDidBecomeVisible(ObjectIdentifier(otherWindow), isSettingsWindow: false)
+        #expect(!visibility.shouldRenderContent)
+    }
+
+    @Test func miniaturizeNotificationForUnrelatedWindowIsIgnored() {
+        var visibility = SettingsWindowContentVisibility()
+        let settingsWindow = WindowToken()
+        let otherWindow = WindowToken()
+        visibility.windowConfigured(ObjectIdentifier(settingsWindow), isMiniaturized: false)
+
+        visibility.windowDidMiniaturize(ObjectIdentifier(otherWindow))
+        #expect(visibility.shouldRenderContent)
+    }
+}


### PR DESCRIPTION
## Summary

- **What changed?** The Settings window (⌘,) was blank on every open after the first within an app session — titlebar only, empty content — in any appearance mode. This fixes it so reopening always renders the full settings UI.
- **Why?** `SettingsWindowRootView` (`Sources/cmuxApp.swift`) chooses between the real settings content and a `Color.clear` placeholder via a `@State` flag plus a weak observed-window reference (the CPU optimization from #4661). On `willClose` it both hid content and cleared `windowReference.window`. SwiftUI **reuses** the Settings `Window` scene across close/reopen, so the `@State` placeholder flag persists and the `WindowAccessor` (which dedupes by the reused `NSWindow`) never fires again. On reopen, `didBecomeKey`/`didBecomeMain` fire but are gated by `isObservedWindow(...)`, which returns `false` because the reference was cleared — so content visibility never flips back on. Result: a permanently blank Settings window until app restart.

Fixes #4964.

### Approach

- Extracted the window-lifecycle decision into a small, pure, unit-testable `SettingsWindowContentVisibility` model (`Sources/SettingsWindowContentVisibility.swift`).
- When the window becomes visible again, the model **re-adopts** the Settings window by its stable identifier (`cmux.settings`) if a prior close cleared the reference — the only signal available, since the accessor doesn't re-fire for the reused scene.
- Rewired `SettingsWindowRootView` to delegate to the model.

## Testing

- **Reproduced** on a Debug build (`reload.sh`): open Settings → ⌘W → reopen → blank window (titlebar only, empty content area).
- **Verified the fix** on the same build: 4 consecutive close→reopen cycles all render the full settings UI (sidebar + detail).
- **Added `cmuxTests/SettingsWindowContentVisibilityTests.swift`** (6 Swift Testing cases) covering the exact close→reopen repro, miniaturize/deminiaturize, repeated cycles, and unrelated-window guards. Wired into `project.pbxproj`; passes `scripts/lint-pbxproj-test-wiring.sh` and `scripts/check-pbxproj.sh`.
- Ran `xcodebuild -scheme cmux-unit -only-testing:cmuxTests/SettingsWindowContentVisibilityTests test` → **TEST SUCCEEDED** (6/6).
- **Two-commit red/green:** the first commit lands the test + seam in the bug-reproducing state (`restoresContentWhenReusedWindowReopensAfterClose` and `survivesRepeatedCloseReopenCycles` fail); the second commit adds the fix and turns them green — so the Commits tab proves the test catches the bug.

## Demo Video

### Before

https://github.com/user-attachments/assets/1071103e-e3d2-4064-9feb-f8d6c501b0db

### After

https://github.com/user-attachments/assets/4392d6a7-17fa-4bf9-a2d2-b17848e0df90



## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed (N/A — internal bug fix, no user-facing API/docs change)
- [x] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4965"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782603701&installation_id=133855650&pr_number=4965&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4965&signature=cf47faa5c7e071eb9eeda44654ffc8b69501af23f0b6a75281309285e14968c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #4964 by re-adopting the reused Settings window so reopening always shows the full Settings UI. Centralizes window lifecycle logic to prevent the blank window after the first open.

- **Bug Fixes**
  - Introduced `SettingsWindowContentVisibility` to control content rendering based on window lifecycle.
  - Re-adopts the Settings window by stable id `cmux.settings` on become-visible when the scene is reused.
  - Replaced weak-window logic in `SettingsWindowRootView` with the model; simplified event handling.
  - Added unit tests covering close→reopen, miniaturize/deminiaturize, and repeated cycles.

<sup>Written for commit 9dd49a7126c112f89c02ee4de710517e712f3515. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4965?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Settings window content rendering during miniaturization and restoration.
  * Fixed issue where Settings window content would not properly display after reopening.

* **Tests**
  * Added comprehensive test suite for Settings window visibility handling across various window state transitions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4965?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->