### PR TITLE
Use transcript start cwd for Session Index Claude resume

### DIFF
--- a/Sources/SessionIndexModels.swift
+++ b/Sources/SessionIndexModels.swift
@@ -196,7 +196,12 @@ struct PullRequestLink: Hashable {
 
 /// Agent-specific fields used to build the resume command with appropriate flags.
 enum AgentSpecifics: Hashable {
-    case claude(model: String?, permissionMode: String?, configDirectoryForResume: String?)
+    case claude(
+        model: String?,
+        permissionMode: String?,
+        configDirectoryForResume: String?,
+        resumeWorkingDirectory: String?
+    )
     case codex(model: String?, approvalPolicy: String?, sandboxMode: String?, effort: String?)
     case grok(model: String?, permissionMode: String?, sandboxMode: String?, grokHome: String?)
     case opencode(providerModel: String?, agentName: String?)
@@ -266,6 +271,10 @@ struct SessionEntry: Identifiable, Hashable {
     let specifics: AgentSpecifics
 
     var resumeWorkingDirectory: String? {
+        if case let .claude(_, _, _, claudeResumeCwd) = specifics,
+           let claudeResumeCwd, !claudeResumeCwd.isEmpty {
+            return claudeResumeCwd
+        }
         guard let cwd, !cwd.isEmpty else { return nil }
         if case .registered(let registration) = specifics,
            registration.cwd == .ignore {
@@ -275,7 +284,7 @@ struct SessionEntry: Identifiable, Hashable {
     }
 
     func withClaudeConfigDirectoryForResume(_ configDirectory: String?) -> SessionEntry {
-        guard case let .claude(model, permissionMode, currentConfigDirectory) = specifics,
+        guard case let .claude(model, permissionMode, currentConfigDirectory, resumeWD) = specifics,
               currentConfigDirectory != configDirectory else {
             return self
         }
@@ -292,7 +301,8 @@ struct SessionEntry: Identifiable, Hashable {
             specifics: .claude(
                 model: model,
                 permissionMode: permissionMode,
-                configDirectoryForResume: configDirectory
+                configDirectoryForResume: configDirectory,
+                resumeWorkingDirectory: resumeWD
             )
         )
     }
@@ -314,7 +324,7 @@ struct SessionEntry: Identifiable, Hashable {
 
     private var resumeCommandWithoutWorkingDirectory: String? {
         switch specifics {
-        case let .claude(model, permissionMode, configDirectoryForResume):
+        case let .claude(model, permissionMode, configDirectoryForResume, _):
             // Route through the wrapper resolver token so a manually-resumed claude session
             // re-injects cmux hooks even when the command runs in a shell where the
             // integration's PATH shim / `claude()` function are not active (e.g. the

--- a/Sources/SessionIndexStore.swift
+++ b/Sources/SessionIndexStore.swift
@@ -862,7 +862,8 @@ final class SessionIndexStore: ObservableObject {
             out.model = String(m[..<bracket])
         }
         // The JSONL cwd is authoritative when present; project directory decoding is lossy.
-        out.resumeCwd = firstCwd ?? folderDecodedCwd ?? out.cwd
+        let transcriptCwd = parsedCwdFromTranscript ? out.cwd : nil
+        out.resumeCwd = firstCwd ?? transcriptCwd ?? folderDecodedCwd ?? out.cwd
         return out
     }
 

--- a/Sources/SessionIndexStore.swift
+++ b/Sources/SessionIndexStore.swift
@@ -665,6 +665,8 @@ final class SessionIndexStore: ObservableObject {
     private static let perAgentLimit = 30
     nonisolated static let headByteCap = 64 * 1024
     nonisolated static let tailByteCap = 32 * 1024
+    /// Bounded rescue scan for oversized first Claude JSONL records.
+    nonisolated static let firstCompleteClaudeCwdByteCap = 256 * 1024
     /// Hard cap on candidate files inspected per call to keep deep-page searches bounded.
     nonisolated static let searchMaxFiles = 1500
 
@@ -879,19 +881,30 @@ final class SessionIndexStore: ObservableObject {
         return cwd
     }
 
-    nonisolated private static func readFirstCompleteClaudeCwd(url: URL) -> String? {
+    nonisolated private static func readFirstCompleteClaudeCwd(
+        url: URL,
+        maxBytes: Int = firstCompleteClaudeCwdByteCap
+    ) -> String? {
+        guard maxBytes > 0 else { return nil }
         guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
         defer { try? handle.close() }
 
         var buffer = Data()
-        while true {
+        var bytesRead = 0
+        var reachedEOF = false
+        while bytesRead < maxBytes {
+            let readLimit = min(16 * 1024, maxBytes - bytesRead)
             let chunk: Data
             if #available(macOS 10.15.4, *) {
-                chunk = (try? handle.read(upToCount: 16 * 1024)) ?? Data()
+                chunk = (try? handle.read(upToCount: readLimit)) ?? Data()
             } else {
-                chunk = handle.readData(ofLength: 16 * 1024)
+                chunk = handle.readData(ofLength: readLimit)
             }
-            if chunk.isEmpty { break }
+            if chunk.isEmpty {
+                reachedEOF = true
+                break
+            }
+            bytesRead += chunk.count
             buffer.append(chunk)
 
             while let newlineIndex = buffer.firstIndex(of: 0x0A) {
@@ -905,7 +918,8 @@ final class SessionIndexStore: ObservableObject {
             }
         }
 
-        guard !buffer.isEmpty,
+        guard reachedEOF,
+              !buffer.isEmpty,
               let object = parseJSONLine(buffer),
               let cwd = claudeCwd(from: object) else {
             return nil

--- a/Sources/SessionIndexStore.swift
+++ b/Sources/SessionIndexStore.swift
@@ -842,7 +842,8 @@ final class SessionIndexStore: ObservableObject {
         if let m = out.model, let bracket = m.firstIndex(of: "[") {
             out.model = String(m[..<bracket])
         }
-        out.resumeCwd = folderDecodedCwd ?? firstCwd ?? out.cwd
+        // The JSONL cwd is authoritative when present; project directory decoding is lossy.
+        out.resumeCwd = firstCwd ?? folderDecodedCwd ?? out.cwd
         return out
     }
 

--- a/Sources/SessionIndexStore.swift
+++ b/Sources/SessionIndexStore.swift
@@ -1518,7 +1518,8 @@ final class SessionIndexStore: ObservableObject {
         offset: Int = 0,
         limit: Int = 100
     ) async -> [SessionEntry] {
-        // Test fixtures pass Claude's standard <configDir>/projects layout.
+        // Test fixtures pass Claude's standard <configDir>/projects layout; strip
+        // the trailing "projects" component to recover the config directory.
         let configDir = (projectsRoot as NSString).deletingLastPathComponent
         let root = ClaudeSessionRoot(configDir: configDir, resumeConfigDirectory: nil)
         return await loadClaudeEntries(

--- a/Sources/SessionIndexStore.swift
+++ b/Sources/SessionIndexStore.swift
@@ -1412,6 +1412,38 @@ final class SessionIndexStore: ObservableObject {
         needle: String, cwdFilter: String?, offset: Int, limit: Int
     ) async -> [SessionEntry] {
         let roots = claudeSessionRoots()
+        return await loadClaudeEntries(
+            roots: roots,
+            needle: needle,
+            cwdFilter: cwdFilter,
+            offset: offset,
+            limit: limit
+        )
+    }
+
+    #if DEBUG
+    nonisolated static func loadClaudeEntriesForTesting(
+        projectsRoot: String,
+        needle: String = "",
+        cwdFilter: String? = nil,
+        offset: Int = 0,
+        limit: Int = 100
+    ) async -> [SessionEntry] {
+        let configDir = (projectsRoot as NSString).deletingLastPathComponent
+        let root = ClaudeSessionRoot(configDir: configDir, resumeConfigDirectory: nil)
+        return await loadClaudeEntries(
+            roots: [root],
+            needle: needle,
+            cwdFilter: cwdFilter,
+            offset: offset,
+            limit: limit
+        )
+    }
+    #endif
+
+    nonisolated private static func loadClaudeEntries(
+        roots: [ClaudeSessionRoot], needle: String, cwdFilter: String?, offset: Int, limit: Int
+    ) async -> [SessionEntry] {
         guard !roots.isEmpty else { return [] }
         let fm = FileManager.default
 

--- a/Sources/SessionIndexStore.swift
+++ b/Sources/SessionIndexStore.swift
@@ -693,6 +693,7 @@ final class SessionIndexStore: ObservableObject {
         var pr: PullRequestLink?
         var model: String?
         var permissionMode: String?
+        var resumeCwd: String?
     }
 
     private struct ClaudeSessionRoot: Hashable {
@@ -768,13 +769,18 @@ final class SessionIndexStore: ObservableObject {
 
     nonisolated private static func extractClaudeMetadata(head: String, tail: String, projectDir: String) -> ClaudeParsed {
         var out = ClaudeParsed()
-        out.cwd = decodeClaudeProjectDir(projectDir)
+        let folderDecodedCwd = decodeClaudeProjectDir(projectDir)
+        out.cwd = folderDecodedCwd
+        var firstCwd: String?
 
         for line in head.split(separator: "\n", omittingEmptySubsequences: true) {
             guard let data = line.data(using: .utf8),
                   let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { continue }
             let isMeta = (obj["isMeta"] as? Bool) ?? false
             if let cwdField = obj["cwd"] as? String, !cwdField.isEmpty {
+                if firstCwd == nil {
+                    firstCwd = cwdField
+                }
                 out.cwd = cwdField
             }
             if let branchField = obj["gitBranch"] as? String, !branchField.isEmpty {
@@ -836,6 +842,7 @@ final class SessionIndexStore: ObservableObject {
         if let m = out.model, let bracket = m.firstIndex(of: "[") {
             out.model = String(m[..<bracket])
         }
+        out.resumeCwd = folderDecodedCwd ?? firstCwd ?? out.cwd
         return out
     }
 
@@ -1568,7 +1575,8 @@ final class SessionIndexStore: ObservableObject {
                         specifics: .claude(
                             model: parsed.model,
                             permissionMode: parsed.permissionMode,
-                            configDirectoryForResume: candidate.resumeConfigDirectory
+                            configDirectoryForResume: candidate.resumeConfigDirectory,
+                            resumeWorkingDirectory: parsed.resumeCwd
                         )
                     )
                     if needle.isEmpty {

--- a/Sources/SessionIndexStore.swift
+++ b/Sources/SessionIndexStore.swift
@@ -767,21 +767,27 @@ final class SessionIndexStore: ObservableObject {
         return roots
     }
 
-    nonisolated private static func extractClaudeMetadata(head: String, tail: String, projectDir: String) -> ClaudeParsed {
+    nonisolated private static func extractClaudeMetadata(
+        head: String,
+        tail: String,
+        projectDir: String,
+        transcriptURL: URL? = nil
+    ) -> ClaudeParsed {
         var out = ClaudeParsed()
         let folderDecodedCwd = decodeClaudeProjectDir(projectDir)
         out.cwd = folderDecodedCwd
         var firstCwd: String?
+        var parsedCwdFromTranscript = false
 
         for line in head.split(separator: "\n", omittingEmptySubsequences: true) {
-            guard let data = line.data(using: .utf8),
-                  let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { continue }
+            guard let obj = parseJSONLine(line) else { continue }
             let isMeta = (obj["isMeta"] as? Bool) ?? false
-            if let cwdField = obj["cwd"] as? String, !cwdField.isEmpty {
+            if let cwdField = claudeCwd(from: obj) {
                 if firstCwd == nil {
                     firstCwd = cwdField
                 }
                 out.cwd = cwdField
+                parsedCwdFromTranscript = true
             }
             if let branchField = obj["gitBranch"] as? String, !branchField.isEmpty {
                 out.branch = branchField
@@ -815,9 +821,12 @@ final class SessionIndexStore: ObservableObject {
         }
 
         for line in tail.split(separator: "\n", omittingEmptySubsequences: true) {
-            guard let data = line.data(using: .utf8),
-                  let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { continue }
+            guard let obj = parseJSONLine(line) else { continue }
             let type = obj["type"] as? String
+            if let cwdField = claudeCwd(from: obj) {
+                out.cwd = cwdField
+                parsedCwdFromTranscript = true
+            }
             if type == "pr-link", let number = obj["prNumber"] as? Int,
                let url = obj["prUrl"] as? String {
                 out.pr = PullRequestLink(
@@ -838,6 +847,14 @@ final class SessionIndexStore: ObservableObject {
                 out.model = model
             }
         }
+        if firstCwd == nil,
+           let transcriptURL,
+           let completeFirstCwd = readFirstCompleteClaudeCwd(url: transcriptURL) {
+            firstCwd = completeFirstCwd
+            if !parsedCwdFromTranscript {
+                out.cwd = completeFirstCwd
+            }
+        }
         // Strip the [1m] suffix some Claude internal model IDs carry (claude-opus-4-7[1m]).
         if let m = out.model, let bracket = m.firstIndex(of: "[") {
             out.model = String(m[..<bracket])
@@ -845,6 +862,55 @@ final class SessionIndexStore: ObservableObject {
         // The JSONL cwd is authoritative when present; project directory decoding is lossy.
         out.resumeCwd = firstCwd ?? folderDecodedCwd ?? out.cwd
         return out
+    }
+
+    nonisolated private static func parseJSONLine(_ line: Substring) -> [String: Any]? {
+        guard let data = line.data(using: .utf8) else { return nil }
+        return parseJSONLine(data)
+    }
+
+    nonisolated private static func parseJSONLine(_ data: Data) -> [String: Any]? {
+        guard !data.isEmpty else { return nil }
+        return (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+    }
+
+    nonisolated private static func claudeCwd(from object: [String: Any]) -> String? {
+        guard let cwd = object["cwd"] as? String, !cwd.isEmpty else { return nil }
+        return cwd
+    }
+
+    nonisolated private static func readFirstCompleteClaudeCwd(url: URL) -> String? {
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
+        defer { try? handle.close() }
+
+        var buffer = Data()
+        while true {
+            let chunk: Data
+            if #available(macOS 10.15.4, *) {
+                chunk = (try? handle.read(upToCount: 16 * 1024)) ?? Data()
+            } else {
+                chunk = handle.readData(ofLength: 16 * 1024)
+            }
+            if chunk.isEmpty { break }
+            buffer.append(chunk)
+
+            while let newlineIndex = buffer.firstIndex(of: 0x0A) {
+                let lineData = buffer.subdata(in: buffer.startIndex..<newlineIndex)
+                let afterNewline = buffer.index(after: newlineIndex)
+                buffer.removeSubrange(buffer.startIndex..<afterNewline)
+                if let object = parseJSONLine(lineData),
+                   let cwd = claudeCwd(from: object) {
+                    return cwd
+                }
+            }
+        }
+
+        guard !buffer.isEmpty,
+              let object = parseJSONLine(buffer),
+              let cwd = claudeCwd(from: object) else {
+            return nil
+        }
+        return cwd
     }
 
     /// Returns a usable user-prompt string from a Codex `user_message` /
@@ -1437,6 +1503,7 @@ final class SessionIndexStore: ObservableObject {
         offset: Int = 0,
         limit: Int = 100
     ) async -> [SessionEntry] {
+        // Test fixtures pass Claude's standard <configDir>/projects layout.
         let configDir = (projectsRoot as NSString).deletingLastPathComponent
         let root = ClaudeSessionRoot(configDir: configDir, resumeConfigDirectory: nil)
         return await loadClaudeEntries(
@@ -1560,7 +1627,12 @@ final class SessionIndexStore: ObservableObject {
                             true
                         )
                     }
-                    let parsed = extractClaudeMetadata(head: head, tail: tail, projectDir: candidate.dirName)
+                    let parsed = extractClaudeMetadata(
+                        head: head,
+                        tail: tail,
+                        projectDir: candidate.dirName,
+                        transcriptURL: candidate.url
+                    )
                     if let cwdFilter, parsed.cwd != cwdFilter { return (idx, nil, false) }
                     let sid = candidate.url.deletingPathExtension().lastPathComponent
                     let entry = SessionEntry(

--- a/cmuxTests/ClaudeConfigDirectoryPathTests.swift
+++ b/cmuxTests/ClaudeConfigDirectoryPathTests.swift
@@ -140,7 +140,8 @@ final class ClaudeConfigDirectoryPathTests: XCTestCase {
             specifics: .claude(
                 model: "claude-opus-4-7",
                 permissionMode: "default",
-                configDirectoryForResume: configDirectoryForResume
+                configDirectoryForResume: configDirectoryForResume,
+                resumeWorkingDirectory: nil
             )
         )
     }

--- a/cmuxTests/SessionIndexViewTests.swift
+++ b/cmuxTests/SessionIndexViewTests.swift
@@ -222,7 +222,8 @@ final class SessionIndexViewTests: XCTestCase {
         XCTAssertEqual(entry.cwd, laterCwd.path)
         XCTAssertEqual(
             entry.resumeCommandWithCwd,
-            "cd \(SessionEntry.shellQuote(startCwd.path)) && claude --resume \(sessionId)"
+            "cd \(SessionEntry.shellQuote(startCwd.path)) && "
+                + posixShWrappedForTest("\(AgentResumeArgv.claudeWrapperShellExecutableToken) --resume \(sessionId)")
         )
     }
 
@@ -253,7 +254,8 @@ final class SessionIndexViewTests: XCTestCase {
         XCTAssertEqual(entry.cwd, laterCwd.path)
         XCTAssertEqual(
             entry.resumeCommandWithCwd,
-            "cd \(SessionEntry.shellQuote(startCwd.path)) && claude --resume \(sessionId)"
+            "cd \(SessionEntry.shellQuote(startCwd.path)) && "
+                + posixShWrappedForTest("\(AgentResumeArgv.claudeWrapperShellExecutableToken) --resume \(sessionId)")
         )
     }
 
@@ -284,7 +286,8 @@ final class SessionIndexViewTests: XCTestCase {
         XCTAssertEqual(entry.cwd, laterCwd.path)
         XCTAssertEqual(
             entry.resumeCommandWithCwd,
-            "cd \(SessionEntry.shellQuote(laterCwd.path)) && claude --resume \(sessionId)"
+            "cd \(SessionEntry.shellQuote(laterCwd.path)) && "
+                + posixShWrappedForTest("\(AgentResumeArgv.claudeWrapperShellExecutableToken) --resume \(sessionId)")
         )
     }
 

--- a/cmuxTests/SessionIndexViewTests.swift
+++ b/cmuxTests/SessionIndexViewTests.swift
@@ -257,6 +257,37 @@ final class SessionIndexViewTests: XCTestCase {
         )
     }
 
+    func testClaudeResumeCommandUsesTranscriptCwdBeforeAmbiguousDecodeWhenInitialRecordExceedsRescueCap() async throws {
+        let fixture = try makeClaudeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let startCwd = fixture.root.appendingPathComponent("huge-start-project", isDirectory: true)
+        let laterCwd = startCwd.appendingPathComponent("featureworktree", isDirectory: true)
+        let slashDecodedAlternative = fixture.root
+            .appendingPathComponent("huge", isDirectory: true)
+            .appendingPathComponent("start", isDirectory: true)
+            .appendingPathComponent("project", isDirectory: true)
+        try FileManager.default.createDirectory(at: laterCwd, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: slashDecodedAlternative, withIntermediateDirectories: true)
+
+        let sessionId = "session-huge-initial-record"
+        try writeClaudeTranscript(
+            projectsRoot: fixture.projectsRoot,
+            sessionId: sessionId,
+            projectCwd: startCwd.path,
+            cwdLines: [startCwd.path, laterCwd.path],
+            firstContent: String(repeating: "x", count: SessionIndexStore.firstCompleteClaudeCwdByteCap + 1024)
+        )
+
+        let entry = try await loadSingleClaudeEntry(from: fixture.projectsRoot)
+
+        XCTAssertEqual(entry.cwd, laterCwd.path)
+        XCTAssertEqual(
+            entry.resumeCommandWithCwd,
+            "cd \(SessionEntry.shellQuote(laterCwd.path)) && claude --resume \(sessionId)"
+        )
+    }
+
     func testGrokResumeCommandPreservesSpecifics() {
         let entry = makeEntry(
             agent: .grok,

--- a/cmuxTests/SessionIndexViewTests.swift
+++ b/cmuxTests/SessionIndexViewTests.swift
@@ -141,7 +141,8 @@ final class SessionIndexViewTests: XCTestCase {
         XCTAssertEqual(entry.cwd, worktreeCwd.path)
         XCTAssertEqual(
             entry.resumeCommandWithCwd,
-            "cd \(SessionEntry.shellQuote(startCwd.path)) && claude --resume \(sessionId)"
+            "cd \(SessionEntry.shellQuote(startCwd.path)) && "
+                + posixShWrappedForTest("\(AgentResumeArgv.claudeWrapperShellExecutableToken) --resume \(sessionId)")
         )
     }
 
@@ -165,7 +166,8 @@ final class SessionIndexViewTests: XCTestCase {
         XCTAssertEqual(entry.cwd, startCwd.path)
         XCTAssertEqual(
             entry.resumeCommandWithCwd,
-            "cd \(SessionEntry.shellQuote(startCwd.path)) && claude --resume \(sessionId)"
+            "cd \(SessionEntry.shellQuote(startCwd.path)) && "
+                + posixShWrappedForTest("\(AgentResumeArgv.claudeWrapperShellExecutableToken) --resume \(sessionId)")
         )
     }
 
@@ -190,7 +192,8 @@ final class SessionIndexViewTests: XCTestCase {
         XCTAssertEqual(entry.cwd, laterCwd.path)
         XCTAssertEqual(
             entry.resumeCommandWithCwd,
-            "cd \(SessionEntry.shellQuote(startCwd.path)) && claude --resume \(sessionId)"
+            "cd \(SessionEntry.shellQuote(startCwd.path)) && "
+                + posixShWrappedForTest("\(AgentResumeArgv.claudeWrapperShellExecutableToken) --resume \(sessionId)")
         )
     }
 
@@ -764,7 +767,8 @@ private extension SessionAgent {
             return .claude(
                 model: nil,
                 permissionMode: nil,
-                configDirectoryForResume: claudeConfigDirectoryForResume
+                configDirectoryForResume: claudeConfigDirectoryForResume,
+                resumeWorkingDirectory: nil
             )
         case .codex:
             return .codex(model: nil, approvalPolicy: nil, sandboxMode: nil, effort: nil)

--- a/cmuxTests/SessionIndexViewTests.swift
+++ b/cmuxTests/SessionIndexViewTests.swift
@@ -197,6 +197,35 @@ final class SessionIndexViewTests: XCTestCase {
         )
     }
 
+    func testClaudeResumeCommandPrefersTranscriptCwdWhenDecodedProjectDirAlsoExists() async throws {
+        let fixture = try makeClaudeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let startCwd = fixture.root.appendingPathComponent("ambiguous-project", isDirectory: true)
+        let laterCwd = startCwd.appendingPathComponent("featureworktree", isDirectory: true)
+        let slashDecodedAlternative = fixture.root
+            .appendingPathComponent("ambiguous", isDirectory: true)
+            .appendingPathComponent("project", isDirectory: true)
+        try FileManager.default.createDirectory(at: laterCwd, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: slashDecodedAlternative, withIntermediateDirectories: true)
+
+        let sessionId = "session-ambiguous-cwd"
+        try writeClaudeTranscript(
+            projectsRoot: fixture.projectsRoot,
+            sessionId: sessionId,
+            projectCwd: startCwd.path,
+            cwdLines: [startCwd.path, laterCwd.path]
+        )
+
+        let entry = try await loadSingleClaudeEntry(from: fixture.projectsRoot)
+
+        XCTAssertEqual(entry.cwd, laterCwd.path)
+        XCTAssertEqual(
+            entry.resumeCommandWithCwd,
+            "cd \(SessionEntry.shellQuote(startCwd.path)) && claude --resume \(sessionId)"
+        )
+    }
+
     func testGrokResumeCommandPreservesSpecifics() {
         let entry = makeEntry(
             agent: .grok,
@@ -668,7 +697,6 @@ final class SessionIndexViewTests: XCTestCase {
     private func claudeProjectDirectoryName(for cwd: String) -> String {
         cwd
             .replacingOccurrences(of: "/", with: "-")
-            .replacingOccurrences(of: ".", with: "-")
     }
 
     private func loadSingleClaudeEntry(from projectsRoot: URL) async throws -> SessionEntry {

--- a/cmuxTests/SessionIndexViewTests.swift
+++ b/cmuxTests/SessionIndexViewTests.swift
@@ -118,6 +118,82 @@ final class SessionIndexViewTests: XCTestCase {
         )
     }
 
+    func testClaudeResumeCommandUsesTranscriptStartCwdWhenSessionCwdDrifts() async throws {
+        let fixture = try makeClaudeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let startCwd = fixture.root.appendingPathComponent("startcwd", isDirectory: true)
+        let worktreeCwd = startCwd
+            .appendingPathComponent("worktrees", isDirectory: true)
+            .appendingPathComponent("featx", isDirectory: true)
+        try FileManager.default.createDirectory(at: worktreeCwd, withIntermediateDirectories: true)
+
+        let sessionId = "session-cwd-drift"
+        try writeClaudeTranscript(
+            projectsRoot: fixture.projectsRoot,
+            sessionId: sessionId,
+            projectCwd: startCwd.path,
+            cwdLines: [startCwd.path, worktreeCwd.path]
+        )
+
+        let entry = try await loadSingleClaudeEntry(from: fixture.projectsRoot)
+
+        XCTAssertEqual(entry.cwd, worktreeCwd.path)
+        XCTAssertEqual(
+            entry.resumeCommandWithCwd,
+            "cd \(SessionEntry.shellQuote(startCwd.path)) && claude --resume \(sessionId)"
+        )
+    }
+
+    func testClaudeResumeCommandPreservesSameCwdSessions() async throws {
+        let fixture = try makeClaudeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let startCwd = fixture.root.appendingPathComponent("samecwd", isDirectory: true)
+        try FileManager.default.createDirectory(at: startCwd, withIntermediateDirectories: true)
+
+        let sessionId = "session-same-cwd"
+        try writeClaudeTranscript(
+            projectsRoot: fixture.projectsRoot,
+            sessionId: sessionId,
+            projectCwd: startCwd.path,
+            cwdLines: [startCwd.path, startCwd.path]
+        )
+
+        let entry = try await loadSingleClaudeEntry(from: fixture.projectsRoot)
+
+        XCTAssertEqual(entry.cwd, startCwd.path)
+        XCTAssertEqual(
+            entry.resumeCommandWithCwd,
+            "cd \(SessionEntry.shellQuote(startCwd.path)) && claude --resume \(sessionId)"
+        )
+    }
+
+    func testClaudeResumeCommandFallsBackToFirstCwdWhenProjectDirDecodeIsLossy() async throws {
+        let fixture = try makeClaudeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let startCwd = fixture.root.appendingPathComponent("my-cool-proj", isDirectory: true)
+        let laterCwd = startCwd.appendingPathComponent("featureworktree", isDirectory: true)
+        try FileManager.default.createDirectory(at: laterCwd, withIntermediateDirectories: true)
+
+        let sessionId = "session-lossy-cwd"
+        try writeClaudeTranscript(
+            projectsRoot: fixture.projectsRoot,
+            sessionId: sessionId,
+            projectCwd: startCwd.path,
+            cwdLines: [startCwd.path, laterCwd.path]
+        )
+
+        let entry = try await loadSingleClaudeEntry(from: fixture.projectsRoot)
+
+        XCTAssertEqual(entry.cwd, laterCwd.path)
+        XCTAssertEqual(
+            entry.resumeCommandWithCwd,
+            "cd \(SessionEntry.shellQuote(startCwd.path)) && claude --resume \(sessionId)"
+        )
+    }
+
     func testGrokResumeCommandPreservesSpecifics() {
         let entry = makeEntry(
             agent: .grok,
@@ -540,6 +616,64 @@ final class SessionIndexViewTests: XCTestCase {
         body()
     }
 
+    private func makeClaudeFixture() throws -> ClaudeFixture {
+        let suffix = UUID().uuidString.replacingOccurrences(of: "-", with: "")
+        let root = URL(fileURLWithPath: "/tmp", isDirectory: true)
+            .appendingPathComponent("cmuxsessionindex\(suffix)", isDirectory: true)
+        let configDir = root.appendingPathComponent("claudeconfig", isDirectory: true)
+        let projectsRoot = configDir.appendingPathComponent("projects", isDirectory: true)
+        try FileManager.default.createDirectory(at: projectsRoot, withIntermediateDirectories: true)
+        return ClaudeFixture(root: root, projectsRoot: projectsRoot)
+    }
+
+    private func writeClaudeTranscript(
+        projectsRoot: URL,
+        sessionId: String,
+        projectCwd: String,
+        cwdLines: [String]
+    ) throws {
+        let projectDir = projectsRoot.appendingPathComponent(
+            claudeProjectDirectoryName(for: projectCwd),
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: projectDir, withIntermediateDirectories: true)
+
+        let lines = try cwdLines.enumerated().map { index, cwd in
+            try claudeTranscriptLine(cwd: cwd, content: index == 0 ? "hi" : "continue")
+        }
+        let transcript = lines.joined(separator: "\n") + "\n"
+        try transcript.write(
+            to: projectDir.appendingPathComponent("\(sessionId).jsonl", isDirectory: false),
+            atomically: true,
+            encoding: .utf8
+        )
+    }
+
+    private func claudeTranscriptLine(cwd: String, content: String) throws -> String {
+        let object: [String: Any] = [
+            "type": "user",
+            "cwd": cwd,
+            "message": [
+                "role": "user",
+                "content": content
+            ]
+        ]
+        let data = try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+        return String(data: data, encoding: .utf8) ?? "{}"
+    }
+
+    private func claudeProjectDirectoryName(for cwd: String) -> String {
+        cwd
+            .replacingOccurrences(of: "/", with: "-")
+            .replacingOccurrences(of: ".", with: "-")
+    }
+
+    private func loadSingleClaudeEntry(from projectsRoot: URL) async throws -> SessionEntry {
+        let entries = await SessionIndexStore.loadClaudeEntriesForTesting(projectsRoot: projectsRoot.path)
+        XCTAssertEqual(entries.count, 1)
+        return try XCTUnwrap(entries.first)
+    }
+
     private func makeCodexStateDatabase(
         at url: URL,
         rolloutURL: URL,
@@ -656,6 +790,11 @@ private struct SessionPopoverHarness {
     let section: IndexSection
     let search: SessionSearchFn
     let loadSnapshot: DirectorySnapshotFn
+}
+
+private struct ClaudeFixture {
+    let root: URL
+    let projectsRoot: URL
 }
 
 private struct SQLiteTestError: Error {

--- a/cmuxTests/SessionIndexViewTests.swift
+++ b/cmuxTests/SessionIndexViewTests.swift
@@ -226,6 +226,37 @@ final class SessionIndexViewTests: XCTestCase {
         )
     }
 
+    func testClaudeResumeCommandReadsOversizedInitialRecordBeforeDecodeFallback() async throws {
+        let fixture = try makeClaudeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let startCwd = fixture.root.appendingPathComponent("oversized-start-project", isDirectory: true)
+        let laterCwd = startCwd.appendingPathComponent("featureworktree", isDirectory: true)
+        let slashDecodedAlternative = fixture.root
+            .appendingPathComponent("oversized", isDirectory: true)
+            .appendingPathComponent("start", isDirectory: true)
+            .appendingPathComponent("project", isDirectory: true)
+        try FileManager.default.createDirectory(at: laterCwd, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: slashDecodedAlternative, withIntermediateDirectories: true)
+
+        let sessionId = "session-oversized-initial-record"
+        try writeClaudeTranscript(
+            projectsRoot: fixture.projectsRoot,
+            sessionId: sessionId,
+            projectCwd: startCwd.path,
+            cwdLines: [startCwd.path, laterCwd.path],
+            firstContent: String(repeating: "x", count: SessionIndexStore.headByteCap + 1024)
+        )
+
+        let entry = try await loadSingleClaudeEntry(from: fixture.projectsRoot)
+
+        XCTAssertEqual(entry.cwd, laterCwd.path)
+        XCTAssertEqual(
+            entry.resumeCommandWithCwd,
+            "cd \(SessionEntry.shellQuote(startCwd.path)) && claude --resume \(sessionId)"
+        )
+    }
+
     func testGrokResumeCommandPreservesSpecifics() {
         let entry = makeEntry(
             agent: .grok,
@@ -662,7 +693,8 @@ final class SessionIndexViewTests: XCTestCase {
         projectsRoot: URL,
         sessionId: String,
         projectCwd: String,
-        cwdLines: [String]
+        cwdLines: [String],
+        firstContent: String = "hi"
     ) throws {
         let projectDir = projectsRoot.appendingPathComponent(
             claudeProjectDirectoryName(for: projectCwd),
@@ -671,7 +703,7 @@ final class SessionIndexViewTests: XCTestCase {
         try FileManager.default.createDirectory(at: projectDir, withIntermediateDirectories: true)
 
         let lines = try cwdLines.enumerated().map { index, cwd in
-            try claudeTranscriptLine(cwd: cwd, content: index == 0 ? "hi" : "continue")
+            try claudeTranscriptLine(cwd: cwd, content: index == 0 ? firstContent : "continue")
         }
         let transcript = lines.joined(separator: "\n") + "\n"
         try transcript.write(

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -2456,7 +2456,8 @@ final class SocketListenerAcceptPolicyTests: XCTestCase {
             specifics: .claude(
                 model: nil,
                 permissionMode: nil,
-                configDirectoryForResume: nil
+                configDirectoryForResume: nil,
+                resumeWorkingDirectory: nil
             )
         )
 
@@ -2489,7 +2490,8 @@ final class SocketListenerAcceptPolicyTests: XCTestCase {
             specifics: .claude(
                 model: "gpt-5.5",
                 permissionMode: "bypassPermissions",
-                configDirectoryForResume: nil
+                configDirectoryForResume: nil,
+                resumeWorkingDirectory: nil
             )
         )
 


### PR DESCRIPTION
## Summary

- Follow-up to #5154 for the Session Index resume path.
- #5154 fixes the restorable snapshot and fork/restore path; this PR covers `SessionEntry.resumeCommandWithCwd`, which is used by the Sessions sidebar resume and copy-resume actions.
- Keep the displayed cwd and cwd filtering on the latest transcript cwd, while storing a separate Claude resume cwd derived from the transcript start cwd.
- Related to #4963.

## Testing

- Adds Session Index coverage for cwd drift, unchanged cwd sessions, lossy or ambiguous project-dir decoding, and oversized initial transcript records.
- CI owns test execution.

## Demo Video

- N/A, command-generation behavior is covered by regression tests.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [ ] I tested the change locally
- [x] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved
