### PR TITLE
tmux-compat: implement #{session_attached} format placeholder

### DIFF
--- a/CLI/CMUXCLI+TmuxCompatSupport.swift
+++ b/CLI/CMUXCLI+TmuxCompatSupport.swift
@@ -135,6 +135,35 @@ extension CMUXCLI {
         return format.contains("#{pane_start_command}") || format.contains("#{pane_current_command}")
     }
 
+    func tmuxFormatRequestsSessionAttached(_ format: String?) -> Bool {
+        guard let format else { return false }
+        return format.contains("#{session_attached}")
+    }
+
+    func tmuxSessionAttachedValue(workspaceId: String, windows: [[String: Any]]) -> String {
+        // tmux reports #{session_attached} as the number of attached clients.
+        // cmux has no one-to-one client attach model, so the compatibility
+        // layer maps the count to whether this workspace is selected in a
+        // visible cmux window. That is the closest signal that rendering a
+        // pane-targeted prompt will be visible to the user.
+        let isVisibleSelectedWorkspace = windows.contains { window in
+            guard (window["visible"] as? Bool) == true else { return false }
+            return (window["selected_workspace_id"] as? String) == workspaceId
+        }
+        return isVisibleSelectedWorkspace ? "1" : "0"
+    }
+
+    func tmuxWindowListForSessionAttached(client: SocketClient) -> [[String: Any]] {
+        do {
+            let payload = try client.sendV2(method: "window.list")
+            return payload["windows"] as? [[String: Any]] ?? []
+        } catch {
+            // Keep callers integer-shaped on lookup failure by returning an
+            // empty list, which maps any workspace to session_attached=0.
+            return []
+        }
+    }
+
     func tmuxLegacyOMXHudStartCommand(
         workspaceId: String,
         surfaceId: String,

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -16177,6 +16177,7 @@ struct CMUXCLI {
         workspaceId: String,
         paneId: String? = nil,
         surfaceId: String? = nil,
+        sessionAttachedWindows: [[String: Any]]? = nil,
         client: SocketClient
     ) throws -> [String: String] {
         let canonicalWorkspaceId = try resolveWorkspaceId(workspaceId, client: client)
@@ -16185,6 +16186,12 @@ struct CMUXCLI {
             "window_id": "@\(canonicalWorkspaceId)",
             "window_uuid": canonicalWorkspaceId
         ]
+        if let sessionAttachedWindows {
+            context["session_attached"] = tmuxSessionAttachedValue(
+                workspaceId: canonicalWorkspaceId,
+                windows: sessionAttachedWindows
+            )
+        }
 
         let workspaceItems = try tmuxWorkspaceItems(client: client)
         if let workspace = workspaceItems.first(where: {
@@ -18635,8 +18642,16 @@ struct CMUXCLI {
                 ])
             }
             if parsed.hasFlag("-P") {
-                let context = try tmuxFormatContext(workspaceId: workspaceId, client: client)
-                print(tmuxRenderFormat(parsed.value("-F"), context: context, fallback: "@\(workspaceId)"))
+                let format = parsed.value("-F")
+                let sessionAttachedWindows = tmuxFormatRequestsSessionAttached(format)
+                    ? tmuxWindowListForSessionAttached(client: client)
+                    : nil
+                let context = try tmuxFormatContext(
+                    workspaceId: workspaceId,
+                    sessionAttachedWindows: sessionAttachedWindows,
+                    client: client
+                )
+                print(tmuxRenderFormat(format, context: context, fallback: "@\(workspaceId)"))
             }
 
         case "new-window", "neww":
@@ -18672,8 +18687,16 @@ struct CMUXCLI {
                 ])
             }
             if parsed.hasFlag("-P") {
-                let context = try tmuxFormatContext(workspaceId: workspaceId, client: client)
-                print(tmuxRenderFormat(parsed.value("-F"), context: context, fallback: "@\(workspaceId)"))
+                let format = parsed.value("-F")
+                let sessionAttachedWindows = tmuxFormatRequestsSessionAttached(format)
+                    ? tmuxWindowListForSessionAttached(client: client)
+                    : nil
+                let context = try tmuxFormatContext(
+                    workspaceId: workspaceId,
+                    sessionAttachedWindows: sessionAttachedWindows,
+                    client: client
+                )
+                print(tmuxRenderFormat(format, context: context, fallback: "@\(workspaceId)"))
             }
 
         case "split-window", "splitw":
@@ -18795,14 +18818,19 @@ struct CMUXCLI {
                 ])
             }
             if parsed.hasFlag("-P") {
+                let format = parsed.value("-F")
+                let sessionAttachedWindows = tmuxFormatRequestsSessionAttached(format)
+                    ? tmuxWindowListForSessionAttached(client: client)
+                    : nil
                 let context = try tmuxFormatContext(
                     workspaceId: target.workspaceId,
                     paneId: paneId,
                     surfaceId: surfaceId,
+                    sessionAttachedWindows: sessionAttachedWindows,
                     client: client
                 )
                 let fallback = context["pane_id"] ?? surfaceId
-                print(tmuxRenderFormat(parsed.value("-F"), context: context, fallback: fallback))
+                print(tmuxRenderFormat(format, context: context, fallback: fallback))
             }
 
         case "select-window", "selectw":
@@ -18885,10 +18913,15 @@ struct CMUXCLI {
         case "display-message", "display", "displayp":
             let parsed = try parseTmuxArguments(rawArgs, valueFlags: ["-F", "-t"], boolFlags: ["-p"])
             let target = try tmuxResolveSurfaceTarget(parsed.value("-t"), client: client)
+            let format = parsed.positional.isEmpty ? parsed.value("-F") : parsed.positional.joined(separator: " ")
+            let sessionAttachedWindows = tmuxFormatRequestsSessionAttached(format)
+                ? tmuxWindowListForSessionAttached(client: client)
+                : nil
             var context = try tmuxFormatContext(
                 workspaceId: target.workspaceId,
                 paneId: target.paneId,
                 surfaceId: target.surfaceId,
+                sessionAttachedWindows: sessionAttachedWindows,
                 client: client
             )
             // Enrich with geometry for format strings like #{pane_width},#{window_width}
@@ -18901,7 +18934,6 @@ struct CMUXCLI {
             } else if let firstPane = panesList.first(where: { ($0["focused"] as? Bool) == true }) ?? panesList.first {
                 tmuxEnrichContextWithGeometry(&context, pane: firstPane, containerFrame: containerFrame)
             }
-            let format = parsed.positional.isEmpty ? parsed.value("-F") : parsed.positional.joined(separator: " ")
             let rendered = tmuxRenderFormat(format, context: context, fallback: "")
             if parsed.hasFlag("-p") || !rendered.isEmpty {
                 print(rendered)
@@ -18909,19 +18941,31 @@ struct CMUXCLI {
 
         case "list-windows", "lsw":
             let parsed = try parseTmuxArguments(rawArgs, valueFlags: ["-F", "-t"], boolFlags: [])
+            let format = parsed.value("-F")
+            let sessionAttachedWindows = tmuxFormatRequestsSessionAttached(format)
+                ? tmuxWindowListForSessionAttached(client: client)
+                : nil
             let items = try tmuxWorkspaceItems(client: client)
             for item in items {
                 guard let workspaceId = item["id"] as? String else { continue }
-                let context = try tmuxFormatContext(workspaceId: workspaceId, client: client)
+                let context = try tmuxFormatContext(
+                    workspaceId: workspaceId,
+                    sessionAttachedWindows: sessionAttachedWindows,
+                    client: client
+                )
                 let fallback = [
                     context["window_index"] ?? "?",
                     context["window_name"] ?? workspaceId
                 ].joined(separator: " ")
-                print(tmuxRenderFormat(parsed.value("-F"), context: context, fallback: fallback))
+                print(tmuxRenderFormat(format, context: context, fallback: fallback))
             }
 
         case "list-panes", "lsp":
             let parsed = try parseTmuxArguments(rawArgs, valueFlags: ["-F", "-t"], boolFlags: [])
+            let format = parsed.value("-F")
+            let sessionAttachedWindows = tmuxFormatRequestsSessionAttached(format)
+                ? tmuxWindowListForSessionAttached(client: client)
+                : nil
             // Resolve target: can be a pane (%uuid) or workspace. In tmux,
             // list-panes -t %<pane> lists all panes in the window containing that pane.
             let workspaceId: String
@@ -18936,9 +18980,14 @@ struct CMUXCLI {
             let containerFrame = payload["container_frame"] as? [String: Any]
             for pane in panes {
                 guard let paneId = pane["id"] as? String else { continue }
-                var context = try tmuxFormatContext(workspaceId: workspaceId, paneId: paneId, client: client)
+                var context = try tmuxFormatContext(
+                    workspaceId: workspaceId,
+                    paneId: paneId,
+                    sessionAttachedWindows: sessionAttachedWindows,
+                    client: client
+                )
                 tmuxEnrichContextWithGeometry(&context, pane: pane, containerFrame: containerFrame)
-                if tmuxFormatRequestsPaneCommand(parsed.value("-F")),
+                if tmuxFormatRequestsPaneCommand(format),
                    context["pane_start_command"] == nil,
                    let surfaceId = context["surface_id"],
                    let legacyHudStartCommand = tmuxLegacyOMXHudStartCommand(
@@ -18950,7 +18999,7 @@ struct CMUXCLI {
                     context["pane_current_command"] = tmuxCurrentCommandName(from: legacyHudStartCommand)
                 }
                 let fallback = context["pane_id"] ?? paneId
-                print(tmuxRenderFormat(parsed.value("-F"), context: context, fallback: fallback))
+                print(tmuxRenderFormat(format, context: context, fallback: fallback))
             }
 
         case "rename-window", "renamew":

--- a/tests_v2/test_tmux_compat_geometry.py
+++ b/tests_v2/test_tmux_compat_geometry.py
@@ -158,6 +158,25 @@ def test_display_geometry_format(cli: str) -> None:
     print("PASS")
 
 
+def test_display_session_attached_format(cli: str, c: cmux) -> None:
+    """display -p renders session_attached as a parseInt-compatible tmux count."""
+    print("  test_display_session_attached_format ... ", end="", flush=True)
+    c.select_workspace(c.current_workspace())
+    proc = _run_tmux_compat(cli, ["display-message", "-p", "#{session_attached}"])
+    _must(proc.returncode == 0, f"display-message failed: {proc.stderr}")
+
+    value = proc.stdout.rstrip("\n")
+    _must(proc.stdout == f"{value}\n", f"Expected exactly one trailing newline, got: {proc.stdout!r}")
+    _must(value == proc.stdout.strip(), f"session_attached should not include spaces: {proc.stdout!r}")
+    _must(value.isdigit(), f"session_attached should be a non-empty integer string, got: {value!r}")
+    _must(int(value) == 1, f"visible selected workspace should report attached count 1, got: {value!r}")
+
+    wrapped = _run_tmux_compat(cli, ["display-message", "-p", "x#{session_attached}x"])
+    _must(wrapped.returncode == 0, f"wrapped display-message failed: {wrapped.stderr}")
+    _must(wrapped.stdout.strip() == "x1x", f"session_attached should not render empty inside text: {wrapped.stdout!r}")
+    print("PASS")
+
+
 def test_multi_pane_geometry(cli: str, c: cmux) -> None:
     """After splitting, two panes have different pane_left values and halved widths."""
     print("  test_multi_pane_geometry ... ", end="", flush=True)
@@ -222,6 +241,7 @@ def main() -> int:
             ("test_list_panes_geometry_format", lambda: test_list_panes_geometry_format(cli)),
             ("test_list_panes_pane_target", lambda: test_list_panes_pane_target(cli, c)),
             ("test_display_geometry_format", lambda: test_display_geometry_format(cli)),
+            ("test_display_session_attached_format", lambda: test_display_session_attached_format(cli, c)),
             ("test_multi_pane_geometry", lambda: test_multi_pane_geometry(cli, c)),
         ]
 


### PR DESCRIPTION
## Summary
`__tmux-compat` currently returns an empty string for `#{session_attached}`, which breaks tooling that follows the standard tmux contract of returning an integer attached-client count for this placeholder. This PR implements the placeholder to return `"1"` when the target workspace is selected in a visible cmux window and `"0"` otherwise.

## Motivation
Real-world impact: `oh-my-codex` (`omx question` / `$deep-interview`) uses `#{session_attached}` to detect whether a question pane can be rendered to an attached user. It evaluates `parseInt(value) > 0`. Empty string → `NaN > 0` → `false` → OMX fails closed and falls back to plain-text input even though the user is actively viewing the cmux pane.

## Repro (before this PR)
```console
$ ~/.cmuxterm/omx-bin/tmux display-message -p '#{pane_id}|#{session_name}|#{session_attached}'
%XXX|cmux|              # session_attached is empty

$ ~/.cmuxterm/omx-bin/tmux display-message -p 'x#{session_attached}x'
xx                       # confirms substitution to empty
```

Expected (real tmux):
```console
$ tmux display-message -p '#{session_attached}'
1
```

## Behavior after this PR
- Returns `"1"` when the target workspace is currently selected in a visible cmux window.
- Returns `"0"` otherwise, including visibility lookup failure.
- This is the closest semantic match to tmux's "number of attached clients" — cmux does not have a multi-client attach model, so visible selected workspace is the natural proxy.
- The value is always integer-shaped, preserving `parseInt(value) > 0` compatibility.

## Related
- Follows #221 / #153 by filling in a tmux-compat format placeholder under the same compatibility surface.

## Tests
- `xcodebuild -project cmux.xcodeproj -scheme cmux-cli -configuration Debug -quiet build`
- `python3 tests_v2/test_tmux_compat_geometry.py`
- `python3 -m py_compile tests_v2/test_tmux_compat_geometry.py`
- `git diff --check`

## Not tested
- Full app build / `./scripts/reload.sh --tag <feature>`: local checkout is missing `GhosttyKit.xcframework`; `./scripts/setup.sh` attempted but stopped because `zig` is not installed.

## Out of scope
- PATH injection of `~/.cmuxterm/omx-bin` into spawned child processes — separate concern from this placeholder parity fix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4967"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782610153&installation_id=133855650&pr_number=4967&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4967&signature=caafac1b900af7e75b917c5085c212f9cd0c2cf68dcd41dd2257718c4637d6f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements `#{session_attached}` in the tmux-compat layer. Returns "1" when the selected workspace is visible and "0" otherwise, restoring tmux-compatible integer output and fixing `oh-my-codex`/`omx` detection.

- **Bug Fixes**
  - Map `session_attached` to the visible selected workspace and inject into format context so `display-message -p` and friends return "1"/"0".
  - Always return an integer-shaped value, including on lookup errors, preserving `parseInt(value) > 0` behavior.

- **Performance**
  - Compute `session_attached` only when requested in the format and reuse a single `window.list` result across batch renders (e.g., `display-message`, `list-windows`, `list-panes`).

<sup>Written for commit e0410ee72e460971ddc30866315a42b8fbbe241b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4967?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a tmux-accessible session_attached variable that returns "1" when a workspace is selected and visible in tmux, and "0" otherwise; usable in display-message and format strings for workspace visibility checks.

* **Tests**
  * Added an integration test validating display-message -p "#{session_attached}" yields the expected value and interpolates correctly in surrounding text.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4967?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->