### PR TITLE
[DO NOT MERGE] CI probe: red-state proof for closed-browser snapshot tests

### DIFF
--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -3147,7 +3147,7 @@ final class TabManagerReopenClosedBrowserFocusTests: XCTestCase {
         XCTAssertTrue(isFocusedPanelBrowser(in: workspace1))
     }
 
-    func testReopenFallsBackToCurrentWorkspaceAndFocusesBrowserWhenOriginalWorkspaceDeleted() {
+    func testReopenDoesNotRetargetUnrelatedWorkspaceWhenOriginalWorkspaceDeleted() {
         let manager = TabManager()
         guard let originalWorkspace = manager.selectedWorkspace,
               let closedBrowserId = manager.openBrowser(url: URL(string: "https://example.com/deleted-ws")) else {
@@ -3160,16 +3160,38 @@ final class TabManagerReopenClosedBrowserFocusTests: XCTestCase {
         drainMainQueue()
 
         let currentWorkspace = manager.addWorkspace()
+        let currentPanelCountBefore = currentWorkspace.panels.count
         manager.closeWorkspace(originalWorkspace, recordHistory: false)
 
         XCTAssertEqual(manager.selectedTabId, currentWorkspace.id)
         XCTAssertFalse(manager.tabs.contains(where: { $0.id == originalWorkspace.id }))
 
-        XCTAssertTrue(manager.reopenMostRecentlyClosedBrowserPanel())
+        XCTAssertFalse(manager.reopenMostRecentlyClosedBrowserPanel())
         drainMainQueue()
 
         XCTAssertEqual(manager.selectedTabId, currentWorkspace.id)
-        XCTAssertTrue(isFocusedPanelBrowser(in: currentWorkspace))
+        XCTAssertEqual(currentWorkspace.panels.count, currentPanelCountBefore)
+        XCTAssertFalse(isFocusedPanelBrowser(in: currentWorkspace))
+    }
+
+    func testClosingWorkspacePrunesItsBrowserSnapshotsFromLegacyStack() {
+        let manager = TabManager()
+        guard let originalWorkspace = manager.selectedWorkspace,
+              let closedBrowserId = manager.openBrowser(url: URL(string: "https://example.com/stack-leak")) else {
+            XCTFail("Expected initial workspace and browser panel")
+            return
+        }
+
+        drainMainQueue()
+        XCTAssertTrue(originalWorkspace.closePanel(closedBrowserId, force: true))
+        drainMainQueue()
+
+        XCTAssertNotNil(manager.mostRecentLegacyClosedBrowserPanelClosedAt())
+
+        _ = manager.addWorkspace()
+        manager.closeWorkspace(originalWorkspace, recordHistory: false)
+
+        XCTAssertNil(manager.mostRecentLegacyClosedBrowserPanelClosedAt())
     }
 
     func testReopenCollapsedSplitFromDifferentWorkspaceFocusesBrowser() {


### PR DESCRIPTION
Probe branch containing only the failing-test commit (228dd19c3) from PR #4961, so CI can record the red half of the two-commit red/green proof. Do not merge.

Expected: the `tests` job fails on:
- `TabManagerReopenClosedBrowserFocusTests/testReopenDoesNotRetargetUnrelatedWorkspaceWhenOriginalWorkspaceDeleted`
- `TabManagerReopenClosedBrowserFocusTests/testClosingWorkspacePrunesItsBrowserSnapshotsFromLegacyStack`

The fix lives in PR #4961.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4968"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782610846&installation_id=133855650&pr_number=4968&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4968&signature=f3998a0ed230fe924685ccec57ab27bb372b7bd62177dc3f5f4653868fb26a34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
CI probe that adds failing regression tests for closed-browser snapshot handling. Verifies that reopen does not retarget an unrelated workspace after the original is deleted, and that closing a workspace prunes its browser snapshots from the legacy stack.

<sup>Written for commit 228dd19c32a9d0975a8c60707a72f35af3524205. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4968?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

