### PR TITLE
[DO NOT MERGE] CI probe v2: tighter red-state proof

### DIFF
--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -3301,7 +3301,7 @@ final class TabManagerReopenClosedBrowserFocusTests: XCTestCase {
         XCTAssertTrue(isFocusedPanelBrowser(in: workspace1))
     }
 
-    func testReopenFallsBackToCurrentWorkspaceAndFocusesBrowserWhenOriginalWorkspaceDeleted() {
+    func testReopenDoesNotRetargetUnrelatedWorkspaceWhenOriginalWorkspaceDeleted() {
         let manager = TabManager()
         guard let originalWorkspace = manager.selectedWorkspace,
               let closedBrowserId = manager.openBrowser(url: URL(string: "https://example.com/deleted-ws")) else {
@@ -3314,16 +3314,38 @@ final class TabManagerReopenClosedBrowserFocusTests: XCTestCase {
         drainMainQueue()
 
         let currentWorkspace = manager.addWorkspace()
+        let currentPanelCountBefore = currentWorkspace.panels.count
         manager.closeWorkspace(originalWorkspace, recordHistory: false)
 
         XCTAssertEqual(manager.selectedTabId, currentWorkspace.id)
         XCTAssertFalse(manager.tabs.contains(where: { $0.id == originalWorkspace.id }))
 
-        XCTAssertTrue(manager.reopenMostRecentlyClosedBrowserPanel())
+        XCTAssertFalse(manager.reopenMostRecentlyClosedBrowserPanel())
         drainMainQueue()
 
         XCTAssertEqual(manager.selectedTabId, currentWorkspace.id)
-        XCTAssertTrue(isFocusedPanelBrowser(in: currentWorkspace))
+        XCTAssertEqual(currentWorkspace.panels.count, currentPanelCountBefore)
+        XCTAssertFalse(isFocusedPanelBrowser(in: currentWorkspace))
+    }
+
+    func testClosingWorkspacePrunesItsBrowserSnapshotsFromLegacyStack() {
+        let manager = TabManager()
+        guard let originalWorkspace = manager.selectedWorkspace,
+              let closedBrowserId = manager.openBrowser(url: URL(string: "https://example.com/stack-leak")) else {
+            XCTFail("Expected initial workspace and browser panel")
+            return
+        }
+
+        drainMainQueue()
+        XCTAssertTrue(originalWorkspace.closePanel(closedBrowserId, force: true))
+        drainMainQueue()
+
+        XCTAssertNotNil(manager.mostRecentLegacyClosedBrowserPanelClosedAt())
+
+        _ = manager.addWorkspace()
+        manager.closeWorkspace(originalWorkspace, recordHistory: false)
+
+        XCTAssertNil(manager.mostRecentLegacyClosedBrowserPanelClosedAt())
     }
 
     func testReopenCollapsedSplitFromDifferentWorkspaceFocusesBrowser() {

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -3301,6 +3301,10 @@ final class TabManagerReopenClosedBrowserFocusTests: XCTestCase {
         XCTAssertTrue(isFocusedPanelBrowser(in: workspace1))
     }
 
+    func testCanaryThisShouldAlwaysFailIfTestsAreRunning() {
+        XCTFail("canary: if you see this fail in CI, the test class IS executing; if you do not, the harness skipped it")
+    }
+
     func testReopenLegacyStackDropsSnapshotWhenOriginalWorkspaceIsGone() {
         let manager = TabManager()
         guard let workspace = manager.selectedWorkspace else {

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -3301,45 +3301,52 @@ final class TabManagerReopenClosedBrowserFocusTests: XCTestCase {
         XCTAssertTrue(isFocusedPanelBrowser(in: workspace1))
     }
 
-    func testReopenDoesNotRetargetUnrelatedWorkspaceWhenOriginalWorkspaceDeleted() {
+    func testReopenLegacyStackDropsSnapshotWhenOriginalWorkspaceIsGone() {
         let manager = TabManager()
-        guard let originalWorkspace = manager.selectedWorkspace,
-              let closedBrowserId = manager.openBrowser(url: URL(string: "https://example.com/deleted-ws")) else {
-            XCTFail("Expected initial workspace and browser panel")
+        guard let workspace = manager.selectedWorkspace else {
+            XCTFail("Expected initial workspace")
             return
         }
+        let panelsBefore = workspace.panels.count
 
+        let staleSnapshot = ClosedBrowserPanelRestoreSnapshot(
+            workspaceId: UUID(),
+            url: URL(string: "https://example.com/stale-from-deleted-workspace"),
+            profileID: nil,
+            originalPaneId: UUID(),
+            originalTabIndex: 0,
+            fallbackSplitOrientation: .horizontal,
+            fallbackSplitInsertFirst: false,
+            fallbackAnchorPaneId: UUID()
+        )
+        workspace.onClosedBrowserPanel?(staleSnapshot)
+        XCTAssertNotNil(manager.mostRecentLegacyClosedBrowserPanelClosedAt())
+
+        XCTAssertFalse(manager.reopenMostRecentlyClosedBrowserPanelFromLegacyStack())
         drainMainQueue()
-        XCTAssertTrue(originalWorkspace.closePanel(closedBrowserId, force: true))
-        drainMainQueue()
 
-        let currentWorkspace = manager.addWorkspace()
-        let currentPanelCountBefore = currentWorkspace.panels.count
-        manager.closeWorkspace(originalWorkspace, recordHistory: false)
-
-        XCTAssertEqual(manager.selectedTabId, currentWorkspace.id)
-        XCTAssertFalse(manager.tabs.contains(where: { $0.id == originalWorkspace.id }))
-
-        XCTAssertFalse(manager.reopenMostRecentlyClosedBrowserPanel())
-        drainMainQueue()
-
-        XCTAssertEqual(manager.selectedTabId, currentWorkspace.id)
-        XCTAssertEqual(currentWorkspace.panels.count, currentPanelCountBefore)
-        XCTAssertFalse(isFocusedPanelBrowser(in: currentWorkspace))
+        XCTAssertEqual(workspace.panels.count, panelsBefore)
+        XCTAssertNil(manager.mostRecentLegacyClosedBrowserPanelClosedAt())
     }
 
-    func testClosingWorkspacePrunesItsBrowserSnapshotsFromLegacyStack() {
+    func testCloseWorkspacePrunesLegacyStackSnapshotsForThatWorkspace() {
         let manager = TabManager()
-        guard let originalWorkspace = manager.selectedWorkspace,
-              let closedBrowserId = manager.openBrowser(url: URL(string: "https://example.com/stack-leak")) else {
-            XCTFail("Expected initial workspace and browser panel")
+        guard let originalWorkspace = manager.selectedWorkspace else {
+            XCTFail("Expected initial workspace")
             return
         }
 
-        drainMainQueue()
-        XCTAssertTrue(originalWorkspace.closePanel(closedBrowserId, force: true))
-        drainMainQueue()
-
+        let snapshot = ClosedBrowserPanelRestoreSnapshot(
+            workspaceId: originalWorkspace.id,
+            url: URL(string: "https://example.com/stack-leak"),
+            profileID: nil,
+            originalPaneId: UUID(),
+            originalTabIndex: 0,
+            fallbackSplitOrientation: .horizontal,
+            fallbackSplitInsertFirst: false,
+            fallbackAnchorPaneId: UUID()
+        )
+        originalWorkspace.onClosedBrowserPanel?(snapshot)
         XCTAssertNotNil(manager.mostRecentLegacyClosedBrowserPanelClosedAt())
 
         _ = manager.addWorkspace()


### PR DESCRIPTION
Probe v2 for PR #4961: tighter regression tests that directly exercise the legacy stack fallback via the wired onClosedBrowserPanel callback. Expected: tests job fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4969"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782614591&installation_id=133855650&pr_number=4969&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4969&signature=53f03d5da0ab8e3bce86026970f0b68a1fcb028fb01b59b8f57f99c79918af21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two focused regression tests that directly push legacy closed-browser snapshots and call the legacy reopen path to verify snapshots don’t retarget to the current workspace and are pruned when their workspace closes. Also adds a canary XCTFail to confirm test discovery; this CI probe is expected to fail on main until the fix lands.

<sup>Written for commit 4c51ec3abcbe3b52dcd3db515d512522cd0fa056. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4969?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

