### PR TITLE
Preserve stopped bash jobs in shell integration telemetry

### DIFF
--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -32,6 +32,97 @@ _cmux_send() {
     esac
 }
 
+_cmux_spawn_detached() {
+    # Bash 3.2 job control is global to the interactive shell. Starting cmux's
+    # prompt telemetry with plain `&` makes those helpers visible to `jobs`,
+    # and any later `disown` can delete the user's Ctrl-Z-stopped foreground
+    # job. Launch them from a subshell with job control disabled so they never
+    # enter the interactive shell's job table in the first place.
+    ( set +m; "$@" >/dev/null 2>&1 & )
+}
+
+_cmux_spawn_detached_capture_pid() {
+    local __var_name="$1"
+    shift
+
+    local pidfile=""
+    pidfile="$(mktemp "${TMPDIR:-/tmp}/cmux-bash-bgpid.XXXXXX" 2>/dev/null)" || return 1
+    (
+        set +m
+        "$@" >/dev/null 2>&1 &
+        printf '%s\n' "$!" > "$pidfile"
+    )
+
+    local spawned_pid=""
+    if [[ -r "$pidfile" ]]; then
+        IFS= read -r spawned_pid < "$pidfile" || spawned_pid=""
+    fi
+    /bin/rm -f -- "$pidfile" >/dev/null 2>&1 || true
+    printf -v "$__var_name" '%s' "$spawned_pid"
+    [[ -n "$spawned_pid" ]]
+}
+
+_cmux_send_payload() {
+    _cmux_send "$1"
+}
+
+_cmux_async_relay_rpc() {
+    local relay_cli="$1"
+    local method="$2"
+    local params="$3"
+    "$relay_cli" rpc "$method" "$params"
+}
+
+_cmux_async_report_pwd() {
+    local pwd="$1"
+    local qpwd="${pwd//\"/\\\"}"
+    _cmux_send "report_pwd \"${qpwd}\" --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
+}
+
+_cmux_probe_git_branch() {
+    # Skip git operations if not in a git repository to avoid TCC prompts.
+    git rev-parse --git-dir >/dev/null 2>&1 || return 0
+
+    local branch dirty_opt=""
+    branch=$(git branch --show-current 2>/dev/null)
+    if [[ -n "$branch" ]]; then
+        local first
+        first=$(git status --porcelain -uno 2>/dev/null | head -1)
+        [[ -n "$first" ]] && dirty_opt="--status=dirty"
+        _cmux_send "report_git_branch $branch $dirty_opt --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
+    else
+        _cmux_send "clear_git_branch --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
+    fi
+}
+
+_cmux_pr_poll_loop() {
+    local watch_pwd="$1"
+    local watch_shell_pid="$2"
+    local interval="$3"
+
+    local signal_path=""
+    signal_path="$(_cmux_pr_force_signal_path 2>/dev/null || true)"
+    while :; do
+        kill -0 "$watch_shell_pid" 2>/dev/null || break
+        local force_probe=0
+        if [[ -n "$signal_path" && -f "$signal_path" ]]; then
+            force_probe=1
+            /bin/rm -f -- "$signal_path" >/dev/null 2>&1 || true
+        fi
+        _cmux_run_pr_probe_with_timeout "$watch_pwd" "$force_probe" || true
+
+        local slept=0
+        while (( slept < interval )); do
+            kill -0 "$watch_shell_pid" 2>/dev/null || exit 0
+            if [[ -n "$signal_path" && -f "$signal_path" ]]; then
+                break
+            fi
+            sleep 1
+            slept=$(( slept + 1 ))
+        done
+    done
+}
+
 _cmux_socket_is_unix() {
     [[ -n "$CMUX_SOCKET_PATH" && -S "$CMUX_SOCKET_PATH" ]]
 }
@@ -72,10 +163,7 @@ _cmux_relay_rpc_bg() {
     local relay_cli=""
     _cmux_socket_uses_remote_relay || return 1
     relay_cli="$(_cmux_relay_cli_path)" || return 1
-    {
-        "$relay_cli" rpc "$method" "$params" >/dev/null 2>&1 || true
-    } >/dev/null 2>&1 &
-    disown 2>/dev/null || true
+    _cmux_spawn_detached _cmux_async_relay_rpc "$relay_cli" "$method" "$params"
 }
 
 _cmux_relay_rpc() {
@@ -402,9 +490,7 @@ _cmux_report_tty_once() {
         payload="$(_cmux_report_tty_payload)"
         [[ -n "$payload" ]] || return 0
         _CMUX_TTY_REPORTED=1
-        {
-            _cmux_send "$payload"
-        } >/dev/null 2>&1 & disown
+        _cmux_spawn_detached _cmux_send_payload "$payload"
     else
         [[ -n "$_CMUX_TTY_NAME" ]] || return 0
         # Keep the first relay TTY report synchronous so the server can resolve
@@ -422,9 +508,7 @@ _cmux_report_shell_activity_state() {
     [[ -n "$CMUX_PANEL_ID" ]] || return 0
     [[ "$_CMUX_SHELL_ACTIVITY_LAST" == "$state" ]] && return 0
     _CMUX_SHELL_ACTIVITY_LAST="$state"
-    {
-        _cmux_send "report_shell_state $state --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
-    } >/dev/null 2>&1 & disown
+    _cmux_spawn_detached _cmux_send_payload "report_shell_state $state --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
 }
 
 _cmux_reset_terminal_keyboard_protocols() {
@@ -445,9 +529,7 @@ _cmux_ports_kick() {
     fi
     _CMUX_PORTS_LAST_RUN="$(_cmux_now)"
     if _cmux_socket_is_unix; then
-        {
-            _cmux_send "ports_kick --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID --reason=$reason"
-        } >/dev/null 2>&1 & disown
+        _cmux_spawn_detached _cmux_send_payload "ports_kick --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID --reason=$reason"
     else
         _cmux_ports_kick_via_relay "$reason"
     fi
@@ -544,9 +626,7 @@ _cmux_emit_pr_command_hint() {
         local quoted_target="${_CMUX_LAST_PR_TARGET//\"/\\\"}"
         payload+=" --target=\"$quoted_target\""
     fi
-    {
-        _cmux_send "$payload"
-    } >/dev/null 2>&1 & disown
+    _cmux_spawn_detached _cmux_send_payload "$payload"
     _CMUX_LAST_PR_ACTION=""
     _CMUX_LAST_PR_TARGET=""
 }
@@ -1092,31 +1172,9 @@ _cmux_start_pr_poll_loop() {
     fi
     _CMUX_PR_POLL_PWD="$watch_pwd"
 
-    {
-        local signal_path=""
-        signal_path="$(_cmux_pr_force_signal_path 2>/dev/null || true)"
-        while :; do
-            kill -0 "$watch_shell_pid" 2>/dev/null || break
-            local force_probe=0
-            if [[ -n "$signal_path" && -f "$signal_path" ]]; then
-                force_probe=1
-                /bin/rm -f -- "$signal_path" >/dev/null 2>&1 || true
-            fi
-            _cmux_run_pr_probe_with_timeout "$watch_pwd" "$force_probe" || true
-
-            local slept=0
-            while (( slept < interval )); do
-                kill -0 "$watch_shell_pid" 2>/dev/null || exit 0
-                if [[ -n "$signal_path" && -f "$signal_path" ]]; then
-                    break
-                fi
-                sleep 1
-                slept=$(( slept + 1 ))
-            done
-        done
-    } >/dev/null 2>&1 &
-    _CMUX_PR_POLL_PID=$!
-    disown "$_CMUX_PR_POLL_PID" 2>/dev/null || disown
+    if ! _cmux_spawn_detached_capture_pid _CMUX_PR_POLL_PID _cmux_pr_poll_loop "$watch_pwd" "$watch_shell_pid" "$interval"; then
+        _CMUX_PR_POLL_PID=""
+    fi
 }
 
 _cmux_bash_cleanup() {
@@ -1262,10 +1320,7 @@ _cmux_prompt_command() {
     # CWD: keep the app in sync with the actual shell directory.
     if [[ "$pwd" != "$_CMUX_PWD_LAST_PWD" ]]; then
         _CMUX_PWD_LAST_PWD="$pwd"
-        {
-            local qpwd="${pwd//\"/\\\"}"
-            _cmux_send "report_pwd \"${qpwd}\" --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
-        } >/dev/null 2>&1 & disown
+        _cmux_spawn_detached _cmux_async_report_pwd "$pwd"
     fi
 
     # Branch can change via aliases/tools while an older probe is still in flight.
@@ -1325,18 +1380,12 @@ _cmux_prompt_command() {
     if [[ "${CMUX_NO_GIT_WATCH:-}" != "1" ]] && { [[ -z "$_CMUX_GIT_JOB_PID" ]] || ! kill -0 "$_CMUX_GIT_JOB_PID" 2>/dev/null; }; then
         _CMUX_GIT_LAST_PWD="$pwd"
         _CMUX_GIT_LAST_RUN=$now
-        {
-            local branch dirty_opt="--status=unknown"
-            branch="$(_cmux_git_branch_for_path "$pwd" 2>/dev/null || true)"
-            if [[ -n "$branch" ]]; then
-                _cmux_send "report_git_branch $branch $dirty_opt --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
-            else
-                _cmux_send "clear_git_branch --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
-            fi
-        } >/dev/null 2>&1 &
-        _CMUX_GIT_JOB_PID=$!
-        disown
-        _CMUX_GIT_JOB_STARTED_AT=$now
+        if _cmux_spawn_detached_capture_pid _CMUX_GIT_JOB_PID _cmux_probe_git_branch; then
+            _CMUX_GIT_JOB_STARTED_AT=$now
+        else
+            _CMUX_GIT_JOB_PID=""
+            _CMUX_GIT_JOB_STARTED_AT=0
+        fi
     fi
 
     if [[ "$git_head_changed" == "1" ]]; then

--- a/tests/test_bash_shell_integration_ctrl_z_job_control.py
+++ b/tests/test_bash_shell_integration_ctrl_z_job_control.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""
+Regression: cmux bash integration must not remove user-stopped jobs from the
+interactive shell job table when its prompt hook launches background telemetry.
+
+Previously the integration used bare `disown`, which in bash 3.2 removes all
+active jobs. After Ctrl-Z stopped a foreground process, the next prompt hook
+could delete that job while detaching cmux's own async git probe, breaking `fg`.
+"""
+
+from __future__ import annotations
+
+import os
+import pty
+import select
+import subprocess
+import tempfile
+import textwrap
+import time
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "Resources" / "shell-integration" / "cmux-bash-integration.bash"
+
+
+def _write_executable(path: Path, contents: str) -> None:
+    path.write_text(contents, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _read_until(fd: int, needles: list[str], timeout: float) -> str:
+    deadline = time.time() + timeout
+    chunks: list[str] = []
+    while time.time() < deadline:
+        remaining = deadline - time.time()
+        ready, _, _ = select.select([fd], [], [], max(0.05, remaining))
+        if not ready:
+            continue
+        data = os.read(fd, 4096).decode("utf-8", errors="replace")
+        if not data:
+            break
+        chunks.append(data)
+        joined = "".join(chunks)
+        if any(needle in joined for needle in needles):
+            return joined
+    return "".join(chunks)
+
+
+def main() -> int:
+    failures: list[str] = []
+
+    with tempfile.TemporaryDirectory(prefix="cmux-bash-ctrlz-job-control-") as td:
+        tmp = Path(td)
+        bindir = tmp / "bin"
+        repo = tmp / "repo"
+        repo_git = repo / ".git"
+        socket_path = tmp / "cmux.sock"
+        send_log = tmp / "send.log"
+        bindir.mkdir(parents=True, exist_ok=True)
+        repo_git.mkdir(parents=True, exist_ok=True)
+        (repo_git / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
+
+        _write_executable(
+            bindir / "git",
+            textwrap.dedent(
+                """\
+                #!/bin/sh
+                if [ "$1" = "rev-parse" ] && [ "$2" = "--git-dir" ]; then
+                  printf '%s/.git\\n' "$PWD"
+                  exit 0
+                fi
+                if [ "$1" = "branch" ] && [ "$2" = "--show-current" ]; then
+                  printf 'main\\n'
+                  exit 0
+                fi
+                if [ "$1" = "status" ] && [ "$2" = "--porcelain" ] && [ "$3" = "-uno" ]; then
+                  exit 0
+                fi
+                printf 'unexpected git args: %s\\n' "$*" >&2
+                exit 1
+                """
+            ),
+        )
+
+        env = dict(os.environ)
+        env.update(
+            {
+                "PATH": f"{bindir}:/usr/bin:/bin:/usr/sbin:/sbin",
+                "CMUX_SOCKET_PATH": str(socket_path),
+                "CMUX_TAB_ID": "11111111-1111-1111-1111-111111111111",
+                "CMUX_PANEL_ID": "22222222-2222-2222-2222-222222222222",
+                "CMUX_TEST_SEND_LOG": str(send_log),
+                "PS1": "cmux-test$ ",
+            }
+        )
+
+        server = subprocess.Popen(
+            [
+                "/usr/bin/python3",
+                "-c",
+                textwrap.dedent(
+                    """\
+                    import os, socket
+                    path = os.environ["CMUX_SOCKET_PATH"]
+                    try:
+                        os.unlink(path)
+                    except FileNotFoundError:
+                        pass
+                    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                    sock.bind(path)
+                    sock.listen(8)
+                    try:
+                        while True:
+                            conn, _ = sock.accept()
+                            conn.recv(4096)
+                            conn.close()
+                    except KeyboardInterrupt:
+                        pass
+                    finally:
+                        sock.close()
+                    """
+                ),
+            ],
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+        try:
+            time.sleep(0.2)
+            master_fd, slave_fd = pty.openpty()
+            proc = subprocess.Popen(
+                ["/bin/bash", "--noprofile", "--norc", "-i"],
+                stdin=slave_fd,
+                stdout=slave_fd,
+                stderr=slave_fd,
+                cwd=repo,
+                env=env,
+                close_fds=True,
+            )
+            os.close(slave_fd)
+
+            try:
+                bootstrap = textwrap.dedent(
+                    f"""\
+                    source "{SCRIPT}"
+                    _cmux_send() {{ printf '%s\\n' "$1" >> "$CMUX_TEST_SEND_LOG"; }}
+                    cd "{repo}"
+                    export PS1='cmux-test$ '
+                    """
+                )
+                os.write(master_fd, bootstrap.encode("utf-8"))
+                initial = _read_until(master_fd, ["cmux-test$ "], 5.0)
+                if "cmux-test$ " not in initial:
+                    failures.append(f"bash shell did not reach prompt after bootstrap: {initial!r}")
+                else:
+                    os.write(master_fd, b"sleep 30\n")
+                    running = _read_until(master_fd, ["sleep 30"], 2.0)
+                    if "sleep 30" not in running:
+                        failures.append(f"sleep command did not start as expected: {running!r}")
+
+                    os.write(master_fd, b"\x1a")
+                    stopped = _read_until(master_fd, ["Stopped", "cmux-test$ "], 5.0)
+                    os.write(master_fd, b"jobs\n")
+                    jobs_output = _read_until(master_fd, ["cmux-test$ "], 5.0)
+
+                    combined = stopped + jobs_output
+                    if "Stopped" not in combined:
+                        failures.append(f"expected Ctrl-Z to stop foreground job, got: {combined!r}")
+                    if "sleep 30" not in combined:
+                        failures.append(f"expected stopped job to remain in job table, got: {combined!r}")
+                    if "deleting stopped job" in combined:
+                        failures.append(f"prompt hook deleted stopped job: {combined!r}")
+
+                os.write(master_fd, b"exit\n")
+                proc.wait(timeout=5)
+            finally:
+                os.close(master_fd)
+                if proc.poll() is None:
+                    proc.terminate()
+                    try:
+                        proc.wait(timeout=3)
+                    except subprocess.TimeoutExpired:
+                        proc.kill()
+                        proc.wait(timeout=3)
+        finally:
+            server.terminate()
+            try:
+                server.wait(timeout=3)
+            except subprocess.TimeoutExpired:
+                server.kill()
+                server.wait(timeout=3)
+
+    if failures:
+        print("FAIL: bash shell integration Ctrl-Z regression")
+        for failure in failures:
+            print(failure)
+        return 1
+
+    print("PASS: bash shell integration preserves stopped jobs across prompt telemetry")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- launch bash prompt telemetry helpers from detached subshells so they do not enter the interactive job table
- reuse the detached helper path for git branch probes, PR polling, pwd reporting, and relay RPC kicks
- add a Ctrl-Z regression test covering stopped jobs across prompt-driven telemetry

## Why
A fast background git branch probe can show up as a completed shell job (`Done ...`) on the next prompt, and the older `disown` path can also interfere with `fg`/`bg` after Ctrl-Z. This keeps cmux telemetry out of the interactive shell job table entirely.

## Validation
- `bash -n Resources/shell-integration/cmux-bash-integration.bash`
- `git diff --check`
- identity audit on `origin/main..HEAD` with deny fragments for local name, email, and home path
- interactive detached-helper smoke checks in bash (`jobs -l` stays empty after short-lived telemetry helpers)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4970"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782615544&installation_id=133855650&pr_number=4970&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4970&signature=6f78f0ac36b93485aea3d03266fd9fbc47151c9c630d1937c757fda1c15e7f8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run bash telemetry helpers from detached subshells with job control disabled to keep them out of the interactive job table and preserve Ctrl-Z stopped jobs. This removes stray “Done …” messages and avoids breaking fg/bg.

- **Bug Fixes**
  - Launch all prompt telemetry from a detached subshell (replace `disown`); add PID capture where needed and move PR polling into its own loop, keeping telemetry out of `jobs`.
  - Skip git probe outside repos to avoid TCC prompts; add a Ctrl-Z regression test confirming stopped jobs persist and no telemetry appears as shell jobs.

<sup>Written for commit 2657e057e394d832eb9244b099d0253237b79221. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4970?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where stopped background jobs (created with Ctrl-Z) could be inadvertently deleted by shell integration prompt hooks and telemetry operations.

* **Improvements**
  * Enhanced shell integration job control and asynchronous payload handling mechanisms for improved reliability during shell operations.

* **Tests**
  * Added regression test to verify stopped background jobs remain intact during shell integration telemetry operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4970?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->