### PR TITLE
Fix Claude restore cwd after subagent metadata

### DIFF
--- a/Sources/SessionIndexStore.swift
+++ b/Sources/SessionIndexStore.swift
@@ -752,13 +752,15 @@ final class SessionIndexStore: ObservableObject {
     nonisolated private static func extractClaudeMetadata(head: String, tail: String, projectDir: String) -> ClaudeParsed {
         var out = ClaudeParsed()
         out.cwd = decodeClaudeProjectDir(projectDir)
+        var didReadTranscriptCwd = false
 
         for line in head.split(separator: "\n", omittingEmptySubsequences: true) {
             guard let data = line.data(using: .utf8),
                   let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { continue }
             let isMeta = (obj["isMeta"] as? Bool) ?? false
-            if let cwdField = obj["cwd"] as? String, !cwdField.isEmpty {
+            if !didReadTranscriptCwd, let cwdField = obj["cwd"] as? String, !cwdField.isEmpty {
                 out.cwd = cwdField
+                didReadTranscriptCwd = true
             }
             if let branchField = obj["gitBranch"] as? String, !branchField.isEmpty {
                 out.branch = branchField

--- a/cmuxTests/SessionIndexViewTests.swift
+++ b/cmuxTests/SessionIndexViewTests.swift
@@ -137,6 +137,51 @@ final class SessionIndexViewTests: XCTestCase {
         )
     }
 
+    func testClaudeDirectorySnapshotKeepsProjectCwdWhenSubagentCwdAppears() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-claude-subagent-cwd-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let configDir = root.appendingPathComponent("claude-config", isDirectory: true)
+        let parentCwd = root.appendingPathComponent("parent repo", isDirectory: true)
+        let subagentCwd = root.appendingPathComponent("subagent scratch", isDirectory: true)
+        try FileManager.default.createDirectory(at: parentCwd, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: subagentCwd, withIntermediateDirectories: true)
+
+        let transcriptURL = configDir
+            .appendingPathComponent("projects", isDirectory: true)
+            .appendingPathComponent(RestorableAgentSessionIndex.encodeClaudeProjectDir(parentCwd.path), isDirectory: true)
+            .appendingPathComponent("claude-parent-session.jsonl", isDirectory: false)
+        try FileManager.default.createDirectory(
+            at: transcriptURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try [
+            #"{"type":"user","cwd":"\#(parentCwd.path)","message":{"role":"user","content":"restore parent repo"}}"#,
+            #"{"type":"assistant","message":{"model":"claude-sonnet-4-5"}}"#,
+            #"{"type":"user","isMeta":true,"cwd":"\#(subagentCwd.path)","message":{"role":"user","content":"subagent bookkeeping"}}"#,
+        ].joined(separator: "\n").write(to: transcriptURL, atomically: true, encoding: .utf8)
+
+        let previousClaudeConfigDir = getenv("CLAUDE_CONFIG_DIR").map { String(cString: $0) }
+        setenv("CLAUDE_CONFIG_DIR", configDir.path, 1)
+        defer {
+            if let previousClaudeConfigDir {
+                setenv("CLAUDE_CONFIG_DIR", previousClaudeConfigDir, 1)
+            } else {
+                unsetenv("CLAUDE_CONFIG_DIR")
+            }
+        }
+
+        let snapshot = await SessionIndexStore().loadDirectorySnapshot(cwd: parentCwd.path)
+        let entry = try XCTUnwrap(snapshot.entries.first { $0.sessionId == "claude-parent-session" })
+
+        XCTAssertEqual(entry.cwd, parentCwd.path)
+        XCTAssertEqual(
+            entry.resumeCommand,
+            "cd '\(parentCwd.path)' && claude --resume claude-parent-session"
+        )
+    }
+
     func testCurrentDirectorySetterDoesNotPublishEqualValue() {
         let store = SessionIndexStore()
         var emittedValues: [String?] = []


### PR DESCRIPTION
## Summary

- Preserve the first `cwd` parsed from a Claude transcript so later subagent metadata cannot move the parent session into another directory.
- Add a regression test that seeds a Claude transcript with a parent `cwd`, then a subagent `cwd`, and verifies the directory snapshot plus `claude --resume` command still use the parent folder.

## Red failure

At commit `2ed6ac65f`, the focused AWS `cmux-unit` run failed for the intended reason:

```text
SessionIndexViewTests.testClaudeDirectorySnapshotKeepsProjectCwdWhenSubagentCwdAppears
XCTUnwrap failed: expected non-nil value of type "SessionEntry"
```

The session disappeared from the parent directory snapshot because the later subagent `cwd` overwrote the parent `cwd`.

## Green pass

At commit `4b235c269`, the same focused AWS `cmux-unit` run passed with exit code 0:

```text
xcodebuild -project cmux.xcodeproj -scheme cmux-unit ... -only-testing:cmuxTests/SessionIndexViewTests/testClaudeDirectorySnapshotKeepsProjectCwdWhenSubagentCwdAppears test
```

## Tagged build

`./scripts/reload.sh --tag claude-cwd` succeeded and built `cmux DEV claude-cwd.app`.

## Proof notes

Cloud bootstrap artifacts are under `/Users/lawrence/fun/cmuxterm-hq/cmux-assets/issue-claude-restore-wrong-folder-after-subagent/auto-issue/20260528-232909`. The accepted proof for this fix is the red/green behavior test because it exercises the restore command source directly. The initial cloud recording was only a CUA bootstrap smoke check and did not reproduce the Claude restore path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to Claude metadata parsing plus a unit test; no auth, persistence, or broad indexing refactors.
> 
> **Overview**
> Claude session indexing now keeps only the **first** `cwd` found while scanning a transcript’s head, so later lines (including subagent `isMeta` bookkeeping with a different folder) no longer replace the parent session’s working directory.
> 
> That fixes wrong **directory snapshots** and **`claude --resume`** commands that previously `cd`’d into a subagent scratch path and could hide the session from the parent repo’s index. A regression test builds a transcript with parent then subagent `cwd` and asserts snapshot `cwd` and resume command stay on the parent folder.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b235c2690e20ad30befd886d130407162d80267. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4979"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782629230&installation_id=133855650&pr_number=4979&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4979&signature=86fc755ed7e0c37a26295db3a79a90d5d04842b3298f06f3fd9079456be16bb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Claude restore picking the wrong folder when subagent metadata includes a different cwd. We now lock to the first cwd in the transcript so directory snapshots and `claude --resume` stay in the project root.

- Bug Fixes
  - Parse the first non-empty cwd only; ignore later cwd values from meta/subagent lines.
  - Add a regression test that seeds parent and subagent cwds and asserts the snapshot and resume command use the parent folder.

<sup>Written for commit 4b235c2690e20ad30befd886d130407162d80267. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4979?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where project directory context could be overwritten when processing transcripts containing multiple directory references. The correct project directory is now preserved throughout session operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4979?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->