### PR TITLE
Avoid macOS 15 DevTools attach crash and analytics quit hang

### DIFF
--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -39,6 +39,33 @@ struct BrowserRemoteWorkspaceStatus: Equatable {
     let lastHeartbeatAt: Date?
 }
 
+enum BrowserDeveloperToolsAttachmentPolicy {
+#if DEBUG
+    private nonisolated(unsafe) static var attachedInspectorAllowedOverrideForTesting: Bool?
+
+    static func withAttachedInspectorAllowedForTesting<T>(
+        _ allowed: Bool?,
+        _ body: () throws -> T
+    ) rethrows -> T {
+        let previous = attachedInspectorAllowedOverrideForTesting
+        attachedInspectorAllowedOverrideForTesting = allowed
+        defer { attachedInspectorAllowedOverrideForTesting = previous }
+        return try body()
+    }
+#endif
+
+    static func allowsAttachedInspector(
+        osVersion: OperatingSystemVersion = ProcessInfo.processInfo.operatingSystemVersion
+    ) -> Bool {
+#if DEBUG
+        if let attachedInspectorAllowedOverrideForTesting {
+            return attachedInspectorAllowedOverrideForTesting
+        }
+#endif
+        return true
+    }
+}
+
 enum GhosttyBackgroundTheme {
     static func clampedOpacity(_ opacity: Double) -> CGFloat {
         WindowAppearanceSnapshot.clampedOpacity(opacity)

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -40,6 +40,8 @@ struct BrowserRemoteWorkspaceStatus: Equatable {
 }
 
 enum BrowserDeveloperToolsAttachmentPolicy {
+    private static let firstStableAttachedInspectorMajorVersion = 26
+
 #if DEBUG
     private nonisolated(unsafe) static var attachedInspectorAllowedOverrideForTesting: Bool?
 
@@ -62,7 +64,8 @@ enum BrowserDeveloperToolsAttachmentPolicy {
             return attachedInspectorAllowedOverrideForTesting
         }
 #endif
-        return true
+        // macOS 15 WebKit 20621 crashes inside WebInspectorUIProxy::platformAttach.
+        return osVersion.majorVersion >= firstStableAttachedInspectorMajorVersion
     }
 }
 
@@ -6327,6 +6330,10 @@ extension BrowserPanel {
     }
 
     private func prepareDeveloperToolsForRevealIfNeeded(_ inspector: NSObject) {
+        guard BrowserDeveloperToolsAttachmentPolicy.allowsAttachedInspector() else {
+            setPreferredDeveloperToolsPresentation(.detached)
+            return
+        }
         if preferredDeveloperToolsPresentation != .unknown {
             guard preferredDeveloperToolsPresentation == .attached else { return }
             guard webView.superview != nil, webView.window != nil else { return }

--- a/Sources/PostHogAnalytics.swift
+++ b/Sources/PostHogAnalytics.swift
@@ -21,16 +21,45 @@ final class PostHogAnalytics {
     private let workQueueSpecificKey = DispatchSpecificKey<Void>()
     private let utcHourFormatter: DateFormatter
     private let utcDayFormatter: DateFormatter
+    private let flushImplementation: () -> Void
 
     private var didStart = false
     private var activeCheckTimer: Timer?
 
     private init() {
-        workQueue = DispatchQueue(label: "com.cmux.posthog.analytics", qos: .utility)
-        utcHourFormatter = Self.makeUTCFormatter("yyyy-MM-dd'T'HH")
-        utcDayFormatter = Self.makeUTCFormatter("yyyy-MM-dd")
+        self.workQueue = DispatchQueue(label: "com.cmux.posthog.analytics", qos: .utility)
+        self.utcHourFormatter = Self.makeUTCFormatter("yyyy-MM-dd'T'HH")
+        self.utcDayFormatter = Self.makeUTCFormatter("yyyy-MM-dd")
+        self.flushImplementation = { PostHogSDK.shared.flush() }
         workQueue.setSpecific(key: workQueueSpecificKey, value: ())
     }
+
+    private init(
+        workQueue: DispatchQueue,
+        didStart: Bool,
+        flushImplementation: @escaping () -> Void
+    ) {
+        self.workQueue = workQueue
+        self.utcHourFormatter = Self.makeUTCFormatter("yyyy-MM-dd'T'HH")
+        self.utcDayFormatter = Self.makeUTCFormatter("yyyy-MM-dd")
+        self.flushImplementation = flushImplementation
+        self.didStart = didStart
+        workQueue.setSpecific(key: workQueueSpecificKey, value: ())
+    }
+
+#if DEBUG
+    static func makeForTesting(
+        workQueue: DispatchQueue,
+        didStart: Bool,
+        flushImplementation: @escaping () -> Void
+    ) -> PostHogAnalytics {
+        PostHogAnalytics(
+            workQueue: workQueue,
+            didStart: didStart,
+            flushImplementation: flushImplementation
+        )
+    }
+#endif
 
     private var isEnabled: Bool {
         guard TelemetrySettings.enabledForCurrentLaunch else { return false }
@@ -56,7 +85,7 @@ final class PostHogAnalytics {
             let didCaptureHourly = self.trackHourlyActiveOnWorkQueue(reason: reason, flush: false)
             if didCaptureDaily || didCaptureHourly {
                 // On app focus we can capture both events; flush once to reduce extra work.
-                PostHogSDK.shared.flush()
+                self.flushImplementation()
             }
         }
     }
@@ -76,7 +105,7 @@ final class PostHogAnalytics {
     func flush() {
         dispatchSyncOnWorkQueue {
             guard didStart else { return }
-            PostHogSDK.shared.flush()
+            flushImplementation()
         }
     }
 
@@ -144,7 +173,7 @@ final class PostHogAnalytics {
 
         if flush && Self.shouldFlushAfterCapture(event: event) {
             // For active metrics we care more about delivery than batching.
-            PostHogSDK.shared.flush()
+            flushImplementation()
         }
 
         return true
@@ -176,7 +205,7 @@ final class PostHogAnalytics {
 
         if flush && Self.shouldFlushAfterCapture(event: event) {
             // Keep hourly freshness and avoid losing a deduped hour on abrupt exits.
-            PostHogSDK.shared.flush()
+            flushImplementation()
         }
 
         return true

--- a/Sources/PostHogAnalytics.swift
+++ b/Sources/PostHogAnalytics.swift
@@ -103,9 +103,9 @@ final class PostHogAnalytics {
     }
 
     func flush() {
-        dispatchSyncOnWorkQueue {
-            guard didStart else { return }
-            flushImplementation()
+        dispatchAsyncOnWorkQueue { [weak self] in
+            guard let self, self.didStart else { return }
+            self.flushImplementation()
         }
     }
 
@@ -217,14 +217,6 @@ final class PostHogAnalytics {
             return
         }
         workQueue.async(execute: block)
-    }
-
-    private func dispatchSyncOnWorkQueue(_ block: () -> Void) {
-        if DispatchQueue.getSpecific(key: workQueueSpecificKey) != nil {
-            block()
-            return
-        }
-        workQueue.sync(execute: block)
     }
 
     private func utcHourString(_ date: Date) -> String {

--- a/cmuxTests/BrowserConfigTests.swift
+++ b/cmuxTests/BrowserConfigTests.swift
@@ -1833,6 +1833,23 @@ final class BrowserDeveloperToolsConfigurationTests: XCTestCase {
         }
     }
 
+    func testAttachedWebInspectorIsDisabledOnMacOS15() {
+        XCTAssertFalse(
+            BrowserDeveloperToolsAttachmentPolicy.allowsAttachedInspector(
+                osVersion: OperatingSystemVersion(majorVersion: 15, minorVersion: 7, patchVersion: 5)
+            ),
+            "The crash report is WebKit::WebInspectorUIProxy::platformAttach on macOS 15.7.5; cmux should not force side-attached Web Inspector there."
+        )
+    }
+
+    func testAttachedWebInspectorRemainsEnabledOnMacOS26() {
+        XCTAssertTrue(
+            BrowserDeveloperToolsAttachmentPolicy.allowsAttachedInspector(
+                osVersion: OperatingSystemVersion(majorVersion: 26, minorVersion: 0, patchVersion: 0)
+            )
+        )
+    }
+
     func testBrowserPanelRefreshesUnderPageBackgroundColorWhenGhosttyBackgroundChanges() {
         let panel = BrowserPanel(workspaceId: UUID())
         let updatedColor = NSColor(srgbRed: 0.18, green: 0.29, blue: 0.44, alpha: 1.0)
@@ -3621,6 +3638,23 @@ final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
         )
         XCTAssertTrue(panel.isDeveloperToolsVisible())
         XCTAssertEqual(inspector.attachCount, 2)
+    }
+
+    func testShowDeveloperToolsSkipsAttachWhenAttachmentPolicyDisallowsIt() throws {
+        let (panel, inspector) = makePanelWithInspector()
+        defer { closeBrowserPanel(panel) }
+
+        try BrowserDeveloperToolsAttachmentPolicy.withAttachedInspectorAllowedForTesting(false) {
+            XCTAssertTrue(panel.showDeveloperTools())
+        }
+
+        XCTAssertTrue(panel.isDeveloperToolsVisible())
+        XCTAssertEqual(
+            inspector.attachCount,
+            0,
+            "macOS versions with unstable WebKit side attach should open DevTools without calling the private attach selector."
+        )
+        XCTAssertEqual(inspector.showCount, 1)
     }
 
     func testSyncRespectsManualCloseAndPreventsUnexpectedRestore() {

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -3362,6 +3362,36 @@ final class UITestLaunchManifestTests: XCTestCase {
 }
 
 final class PostHogAnalyticsPropertiesTests: XCTestCase {
+    func testFlushReturnsWithoutWaitingForBusyAnalyticsQueue() {
+        let queue = DispatchQueue(label: "com.cmux.posthog.analytics.test")
+        let queuedWorkStarted = DispatchSemaphore(value: 0)
+        let releaseQueuedWork = DispatchSemaphore(value: 0)
+        queue.async {
+            queuedWorkStarted.signal()
+            _ = releaseQueuedWork.wait(timeout: .now() + 5)
+        }
+        XCTAssertEqual(queuedWorkStarted.wait(timeout: .now() + 1), .success)
+
+        let analytics = PostHogAnalytics.makeForTesting(
+            workQueue: queue,
+            didStart: true,
+            flushImplementation: {}
+        )
+        let flushReturned = expectation(description: "flush returned")
+        DispatchQueue.global(qos: .userInitiated).async {
+            analytics.flush()
+            flushReturned.fulfill()
+        }
+
+        let result = XCTWaiter().wait(for: [flushReturned], timeout: 0.2)
+        releaseQueuedWork.signal()
+        XCTAssertEqual(
+            result,
+            .completed,
+            "PostHogAnalytics.flush must not synchronously wait for the analytics queue while the main thread is terminating."
+        )
+    }
+
     func testDailyActivePropertiesIncludeVersionAndBuild() {
         let properties = PostHogAnalytics.dailyActiveProperties(
             dayUTC: "2026-02-21",


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4981"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782630763&installation_id=133855650&pr_number=4981&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4981&signature=a27cc4c1173a2ca94e545b89d60901912b3aaa48fe8223b9d73421b5e3a8db39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted workarounds for a known WebKit crash and analytics shutdown blocking; behavior changes are version-gated and limited to DevTools presentation and flush timing.
> 
> **Overview**
> Adds a **macOS version gate** so Web Inspector is not side-attached on macOS 15 (WebKit `platformAttach` crash); those systems prefer **detached** DevTools and skip the private `attach` call when revealing tools.
> 
> **PostHog** `flush()` is now **async** on the analytics queue (no `sync` wait), with an injectable flush hook and DEBUG test factory so shutdown does not block on a busy queue.
> 
> Tests cover the attach policy (15 vs 26), DevTools show without attach when disallowed, and non-blocking flush.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ccac7848460ca6554b1a77e2f7e27eab8c10773. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a crash when opening DevTools on macOS 15 by avoiding side-attached Web Inspector, and fixes a quit hang by making analytics flushing non-blocking. Adds tests to cover both behaviors.

- **Bug Fixes**
  - Developer Tools: Introduced BrowserDeveloperToolsAttachmentPolicy to block attached inspector on macOS 15 and open DevTools detached instead.
  - Analytics: Made PostHogAnalytics.flush asynchronous (no sync wait on the analytics queue) and routed all flushes through an injectable implementation to avoid hangs during app termination.
  - Tests: Added unit tests for the attachment policy and for non-blocking flush behavior.

<sup>Written for commit 1ccac7848460ca6554b1a77e2f7e27eab8c10773. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4981?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced developer tools attachment policy with OS version detection and override capabilities for testing.

* **Bug Fixes**
  * Added WebKit crash workaround for affected macOS versions by preventing attached Web Inspector usage on unstable builds.

* **Refactor**
  * Updated analytics flushing to use non-blocking asynchronous dispatch for improved responsiveness.

* **Tests**
  * Added comprehensive test coverage for developer tools attachment policies and analytics flush behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4981?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->