### PR TITLE
Fix restore previous launch crash and preserve current work

### DIFF
--- a/Sources/AppDelegate+ClosedItemHistory.swift
+++ b/Sources/AppDelegate+ClosedItemHistory.swift
@@ -152,10 +152,6 @@ extension AppDelegate {
                 originalWorkspaceIds: originalWorkspaceIdsByIndex,
                 restoredPanelIdsByWorkspaceIndex: restoredPanelIdsByWorkspaceIndex
             )
-            if let originalWindowId {
-                ClosedItemHistoryStore.shared.remapWorkspaceWindowIds(from: originalWindowId, to: windowId)
-                ClosedItemHistoryStore.shared.flushPendingSaves()
-            }
             return true
         }
     }

--- a/Sources/AppDelegate+ClosedItemHistory.swift
+++ b/Sources/AppDelegate+ClosedItemHistory.swift
@@ -118,6 +118,7 @@ extension AppDelegate {
                 sessionWindowSnapshot: windowEntry.snapshot,
                 shouldActivate: shouldActivate,
                 closedWindowHistoryWorkspaceIds: windowEntry.workspaceIds,
+                remapClosedWorkspaceWindowIdsFromSnapshot: false,
                 restoredSessionSnapshotHandler: { panelIdsByWorkspaceIndex, tabManager in
                     restoredPanelIdsByWorkspaceIndex = panelIdsByWorkspaceIndex
                     restoredTabManager = tabManager

--- a/Sources/AppDelegate+ClosedItemHistory.swift
+++ b/Sources/AppDelegate+ClosedItemHistory.swift
@@ -119,10 +119,17 @@ extension AppDelegate {
                 windowSnapshot.windowId = windowEntry.windowId
             }
             let originalWindowId = windowSnapshot.windowId
+            let originalWorkspaceIdsByIndex = windowSnapshot.tabManager.workspaces.enumerated().map { index, workspaceSnapshot -> UUID? in
+                if let workspaceId = workspaceSnapshot.workspaceId {
+                    return workspaceId
+                }
+                guard windowEntry.workspaceIds.indices.contains(index) else { return nil }
+                return windowEntry.workspaceIds[index]
+            }
             let windowId = createMainWindow(
                 sessionWindowSnapshot: windowSnapshot,
                 shouldActivate: shouldActivate,
-                closedWindowHistoryWorkspaceIds: windowEntry.workspaceIds,
+                remapClosedPanelHistoryFromSessionSnapshot: false,
                 restoredSessionSnapshotHandler: { panelIdsByWorkspaceIndex, tabManager in
                     restoredPanelIdsByWorkspaceIndex = panelIdsByWorkspaceIndex
                     restoredTabManager = tabManager
@@ -141,6 +148,10 @@ extension AppDelegate {
                 discardMainWindowWithoutClosedHistory(windowId: windowId)
                 return false
             }
+            restoredTabManager?.remapClosedPanelHistoryAfterSessionRestore(
+                originalWorkspaceIds: originalWorkspaceIdsByIndex,
+                restoredPanelIdsByWorkspaceIndex: restoredPanelIdsByWorkspaceIndex
+            )
             if let originalWindowId {
                 ClosedItemHistoryStore.shared.remapWorkspaceWindowIds(from: originalWindowId, to: windowId)
                 ClosedItemHistoryStore.shared.flushPendingSaves()

--- a/Sources/AppDelegate+ClosedItemHistory.swift
+++ b/Sources/AppDelegate+ClosedItemHistory.swift
@@ -114,11 +114,15 @@ extension AppDelegate {
         case .window(let windowEntry):
             var restoredPanelIdsByWorkspaceIndex: [[UUID: UUID]] = []
             var restoredTabManager: TabManager?
+            var windowSnapshot = windowEntry.snapshot
+            if windowSnapshot.windowId == nil {
+                windowSnapshot.windowId = windowEntry.windowId
+            }
+            let originalWindowId = windowSnapshot.windowId
             let windowId = createMainWindow(
-                sessionWindowSnapshot: windowEntry.snapshot,
+                sessionWindowSnapshot: windowSnapshot,
                 shouldActivate: shouldActivate,
                 closedWindowHistoryWorkspaceIds: windowEntry.workspaceIds,
-                remapClosedWorkspaceWindowIdsFromSnapshot: false,
                 restoredSessionSnapshotHandler: { panelIdsByWorkspaceIndex, tabManager in
                     restoredPanelIdsByWorkspaceIndex = panelIdsByWorkspaceIndex
                     restoredTabManager = tabManager
@@ -130,11 +134,16 @@ extension AppDelegate {
                 restoredPanelIdsByWorkspaceIndex: restoredPanelIdsByWorkspaceIndex,
                 hasLivePanels: hasLivePanels
             ) else {
+                if let originalWindowId {
+                    ClosedItemHistoryStore.shared.remapWorkspaceWindowIds(from: windowId, to: originalWindowId)
+                    ClosedItemHistoryStore.shared.flushPendingSaves()
+                }
                 discardMainWindowWithoutClosedHistory(windowId: windowId)
                 return false
             }
-            if let oldWindowId = windowEntry.windowId {
-                ClosedItemHistoryStore.shared.remapWorkspaceWindowIds(from: oldWindowId, to: windowId)
+            if let originalWindowId {
+                ClosedItemHistoryStore.shared.remapWorkspaceWindowIds(from: originalWindowId, to: windowId)
+                ClosedItemHistoryStore.shared.flushPendingSaves()
             }
             return true
         }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -3031,6 +3031,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         )
 #endif
         context.tabManager.restoreSessionSnapshot(snapshot.tabManager)
+        if let originalWindowId = snapshot.windowId {
+            ClosedItemHistoryStore.shared.remapWorkspaceWindowIds(from: originalWindowId, to: context.windowId)
+        }
         context.sidebarState.isVisible = snapshot.sidebar.isVisible
         context.sidebarState.persistedWidth = CGFloat(
             SessionPersistencePolicy.sanitizedSidebarWidth(snapshot.sidebar.width)
@@ -4045,6 +4048,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         let window = context.window ?? windowForMainWindowId(context.windowId)
         return SessionWindowSnapshot(
+            windowId: context.windowId,
             frame: window.map { SessionRectSnapshot($0.frame) },
             display: displaySnapshot(for: window),
             tabManager: tabManagerSnapshot,
@@ -7538,6 +7542,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                     originalWorkspaceIds: closedWindowHistoryWorkspaceIds,
                     restoredPanelIdsByWorkspaceIndex: restoredPanelIdsByWorkspaceIndex
                 )
+            }
+            if let originalWindowId = sessionWindowSnapshot.windowId {
+                ClosedItemHistoryStore.shared.remapWorkspaceWindowIds(from: originalWindowId, to: windowId)
             }
             restoredSessionSnapshotHandler?(restoredPanelIdsByWorkspaceIndex, tabManager)
         }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2973,55 +2973,37 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         guard let snapshot = SessionPersistenceStore.loadReopenSessionSnapshot() else {
             return false
         }
+        return restorePreviousSessionSnapshot(snapshot, shouldActivate: shouldActivate)
+    }
 
+    @discardableResult
+    func restorePreviousSessionSnapshot(
+        _ snapshot: AppSessionSnapshot,
+        shouldActivate: Bool = true
+    ) -> Bool {
         let snapshotWindows = Array(
             snapshot.windows.prefix(SessionPersistencePolicy.maxWindowsPerSnapshot)
         )
         guard !snapshotWindows.isEmpty else { return false }
 
-        let existingContexts = sortedMainWindowContextsForSessionSnapshot()
         isApplyingSessionRestore = true
         startupSessionSnapshot = nil
         didAttemptStartupSessionRestore = true
+        var createdWindowIds: [UUID] = []
 
-        if existingContexts.isEmpty {
-            for windowSnapshot in snapshotWindows {
-                _ = createMainWindow(
-                    sessionWindowSnapshot: windowSnapshot,
-                    shouldActivate: shouldActivate
-                )
-            }
-        } else {
-            for (context, windowSnapshot) in zip(existingContexts, snapshotWindows) {
-                applySessionWindowSnapshot(
-                    windowSnapshot,
-                    to: context,
-                    window: context.window ?? windowForMainWindowId(context.windowId)
-                )
-            }
-
-            if snapshotWindows.count > existingContexts.count {
-                for windowSnapshot in snapshotWindows.dropFirst(existingContexts.count) {
-                    _ = createMainWindow(
-                        sessionWindowSnapshot: windowSnapshot,
-                        shouldActivate: shouldActivate
-                    )
-                }
-            }
-
-            if existingContexts.count > snapshotWindows.count {
-                for context in existingContexts.dropFirst(snapshotWindows.count) {
-                    _ = closeMainWindow(windowId: context.windowId, recordHistory: false)
-                }
-            }
+        for windowSnapshot in snapshotWindows {
+            let windowId = createMainWindow(
+                sessionWindowSnapshot: windowSnapshot,
+                shouldActivate: false
+            )
+            createdWindowIds.append(windowId)
         }
 
         completeSessionRestoreOperation(isManualReopen: true)
 
         if shouldActivate,
-           let primaryWindow = sortedMainWindowContextsForSessionSnapshot()
-            .compactMap({ $0.window ?? windowForMainWindowId($0.windowId) })
-            .first {
+           let primaryWindowId = createdWindowIds.first,
+           let primaryWindow = mainWindow(for: primaryWindowId) {
             primaryWindow.makeKeyAndOrderFront(nil)
             setActiveMainWindow(primaryWindow)
             NSRunningApplication.current.activate(

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -3031,8 +3031,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         )
 #endif
         context.tabManager.restoreSessionSnapshot(snapshot.tabManager)
-        if let originalWindowId = snapshot.windowId {
+        if let originalWindowId = snapshot.windowId,
+           originalWindowId != context.windowId {
             ClosedItemHistoryStore.shared.remapWorkspaceWindowIds(from: originalWindowId, to: context.windowId)
+            ClosedItemHistoryStore.shared.flushPendingSaves()
         }
         context.sidebarState.isVisible = snapshot.sidebar.isVisible
         context.sidebarState.persistedWidth = CGFloat(
@@ -7525,7 +7527,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         shouldActivate: Bool = true,
         sourceWindow preferredSourceWindow: NSWindow? = nil,
         closedWindowHistoryWorkspaceIds: [UUID] = [],
-        remapClosedWorkspaceWindowIdsFromSnapshot: Bool = true,
         restoredSessionSnapshotHandler: (([[UUID: UUID]], TabManager) -> Void)? = nil
     ) -> UUID {
         reserveInitialSocketPathIfNeeded()
@@ -7544,9 +7545,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                     restoredPanelIdsByWorkspaceIndex: restoredPanelIdsByWorkspaceIndex
                 )
             }
-            if remapClosedWorkspaceWindowIdsFromSnapshot,
-               let originalWindowId = sessionWindowSnapshot.windowId {
+            if let originalWindowId = sessionWindowSnapshot.windowId,
+               originalWindowId != windowId {
                 ClosedItemHistoryStore.shared.remapWorkspaceWindowIds(from: originalWindowId, to: windowId)
+                ClosedItemHistoryStore.shared.flushPendingSaves()
             }
             restoredSessionSnapshotHandler?(restoredPanelIdsByWorkspaceIndex, tabManager)
         }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -7604,7 +7604,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         sessionWindowSnapshot: SessionWindowSnapshot? = nil,
         shouldActivate: Bool = true,
         sourceWindow preferredSourceWindow: NSWindow? = nil,
-        closedWindowHistoryWorkspaceIds: [UUID] = [],
+        remapClosedPanelHistoryFromSessionSnapshot: Bool = true,
         restoredSessionSnapshotHandler: (([[UUID: UUID]], TabManager) -> Void)? = nil
     ) -> UUID {
         reserveInitialSocketPathIfNeeded()
@@ -7616,13 +7616,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             autoWelcomeIfNeeded: initialTerminalInput == nil
         )
         if let sessionWindowSnapshot {
-            let restoredPanelIdsByWorkspaceIndex = tabManager.restoreSessionSnapshot(sessionWindowSnapshot.tabManager)
-            if !closedWindowHistoryWorkspaceIds.isEmpty {
-                tabManager.remapClosedPanelHistoryAfterWindowRestore(
-                    originalWorkspaceIds: closedWindowHistoryWorkspaceIds,
-                    restoredPanelIdsByWorkspaceIndex: restoredPanelIdsByWorkspaceIndex
-                )
-            }
+            let restoredPanelIdsByWorkspaceIndex = tabManager.restoreSessionSnapshot(
+                sessionWindowSnapshot.tabManager,
+                remapClosedPanelHistory: remapClosedPanelHistoryFromSessionSnapshot
+            )
             if let originalWindowId = sessionWindowSnapshot.windowId,
                originalWindowId != windowId {
                 ClosedItemHistoryStore.shared.remapWorkspaceWindowIds(from: originalWindowId, to: windowId)

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -7525,6 +7525,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         shouldActivate: Bool = true,
         sourceWindow preferredSourceWindow: NSWindow? = nil,
         closedWindowHistoryWorkspaceIds: [UUID] = [],
+        remapClosedWorkspaceWindowIdsFromSnapshot: Bool = true,
         restoredSessionSnapshotHandler: (([[UUID: UUID]], TabManager) -> Void)? = nil
     ) -> UUID {
         reserveInitialSocketPathIfNeeded()
@@ -7543,7 +7544,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                     restoredPanelIdsByWorkspaceIndex: restoredPanelIdsByWorkspaceIndex
                 )
             }
-            if let originalWindowId = sessionWindowSnapshot.windowId {
+            if remapClosedWorkspaceWindowIdsFromSnapshot,
+               let originalWindowId = sessionWindowSnapshot.windowId {
                 ClosedItemHistoryStore.shared.remapWorkspaceWindowIds(from: originalWindowId, to: windowId)
             }
             restoredSessionSnapshotHandler?(restoredPanelIdsByWorkspaceIndex, tabManager)

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1594,6 +1594,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         )
         isTerminatingApp = true
         _ = saveSessionSnapshotIncludingProcessDetectedIndexes(includeScrollback: true, removeWhenEmpty: false)
+        ClosedItemHistoryStore.shared.flushPendingSaves()
 
         // If the user already confirmed via the Cmd+Q shortcut warning dialog,
         // or policy skips the warning, avoid a second alert.
@@ -1686,6 +1687,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         isTerminatingApp = true
         closeAllWebInspectorsBeforeAppTeardown()
         _ = saveSessionSnapshotIncludingProcessDetectedIndexes(includeScrollback: true, removeWhenEmpty: false)
+        ClosedItemHistoryStore.shared.flushPendingSaves()
         stopSessionAutosaveTimer()
         CloudVMActionLauncher.shared.terminateAll()
         CmuxSSHURLProcessLauncher.shared.terminateAll()
@@ -1715,6 +1717,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     func persistSessionForUpdateRelaunch() {
         isTerminatingApp = true
         _ = saveSessionSnapshotIncludingProcessDetectedIndexes(includeScrollback: true, removeWhenEmpty: false)
+        ClosedItemHistoryStore.shared.flushPendingSaves()
     }
 
     func configure(tabManager: TabManager, notificationStore: TerminalNotificationStore, sidebarState: SidebarState) {
@@ -3433,6 +3436,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 guard let self else { return }
                 self.isTerminatingApp = true
                 _ = self.saveSessionSnapshotIncludingProcessDetectedIndexes(includeScrollback: true, removeWhenEmpty: false)
+                ClosedItemHistoryStore.shared.flushPendingSaves()
             }
         }
         lifecycleSnapshotObservers.append(powerOffObserver)
@@ -3446,6 +3450,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 guard let self else { return }
                 if self.isTerminatingApp {
                     _ = self.saveSessionSnapshotIncludingProcessDetectedIndexes(includeScrollback: true, removeWhenEmpty: false)
+                    ClosedItemHistoryStore.shared.flushPendingSaves()
                 } else {
                     self.saveSessionSnapshotAfterLoadingProcessDetectedIndexes(includeScrollback: false)
                 }

--- a/Sources/ClosedItemHistory.swift
+++ b/Sources/ClosedItemHistory.swift
@@ -2,13 +2,13 @@ import Foundation
 import Combine
 import Bonsplit
 
-struct ClosedPanelSplitPlacement {
+struct ClosedPanelSplitPlacement: Codable {
     let orientation: SplitOrientation
     let insertFirst: Bool
     let anchorPanelId: UUID?
 }
 
-struct ClosedPanelHistoryEntry {
+struct ClosedPanelHistoryEntry: Codable {
     let workspaceId: UUID
     let paneId: UUID
     let paneAnchorPanelId: UUID?
@@ -36,14 +36,14 @@ struct ClosedPanelHistoryEntry {
     }
 }
 
-struct ClosedWorkspaceHistoryEntry {
+struct ClosedWorkspaceHistoryEntry: Codable {
     let workspaceId: UUID
     let windowId: UUID?
     let workspaceIndex: Int
     let snapshot: SessionWorkspaceSnapshot
 }
 
-struct ClosedWindowHistoryEntry {
+struct ClosedWindowHistoryEntry: Codable {
     let windowId: UUID?
     let snapshot: SessionWindowSnapshot
 
@@ -56,13 +56,13 @@ struct ClosedWindowHistoryEntry {
     }
 }
 
-enum ClosedItemHistoryEntry {
+enum ClosedItemHistoryEntry: Codable {
     case panel(ClosedPanelHistoryEntry)
     case workspace(ClosedWorkspaceHistoryEntry)
     case window(ClosedWindowHistoryEntry)
 }
 
-struct ClosedItemHistoryRecord: Identifiable {
+struct ClosedItemHistoryRecord: Identifiable, Codable {
     let id: UUID
     let closedAt: Date
     var entry: ClosedItemHistoryEntry
@@ -120,14 +120,23 @@ enum ClosedWindowRestoreValidation {
 
 @MainActor
 final class ClosedItemHistoryStore: ObservableObject {
-    static let shared = ClosedItemHistoryStore(capacity: 50)
+    static let shared = ClosedItemHistoryStore(
+        capacity: nil,
+        fileURL: defaultHistoryFileURL()
+    )
 
     @Published private(set) var revision: UInt64 = 0
     @Published private var records: [ClosedItemHistoryRecord] = []
-    private let capacity: Int
+    private let capacity: Int?
+    private let fileURL: URL?
 
-    init(capacity: Int) {
-        self.capacity = max(1, capacity)
+    init(capacity: Int? = nil, fileURL: URL? = nil, loadPersisted: Bool = true) {
+        self.capacity = capacity.map { max(1, $0) }
+        self.fileURL = fileURL
+        if loadPersisted, let fileURL {
+            records = Self.loadRecords(fileURL: fileURL)
+            trimToCapacityIfNeeded()
+        }
     }
 
     var canReopen: Bool {
@@ -140,10 +149,9 @@ final class ClosedItemHistoryStore: ObservableObject {
 
     func push(_ record: ClosedItemHistoryRecord) {
         records.append(record)
-        if records.count > capacity {
-            records.removeFirst(records.count - capacity)
-        }
+        trimToCapacityIfNeeded()
         revision &+= 1
+        persistRecords()
     }
 
     @discardableResult
@@ -179,6 +187,7 @@ final class ClosedItemHistoryStore: ObservableObject {
             if let index = records.firstIndex(where: { $0.id == candidate.id }) {
                 records.remove(at: index)
                 revision &+= 1
+                persistRecords()
             }
             return true
         }
@@ -191,12 +200,13 @@ final class ClosedItemHistoryStore: ObservableObject {
         }
         let record = records.remove(at: index)
         revision &+= 1
+        persistRecords()
         return (record, index)
     }
 
     func insert(_ record: ClosedItemHistoryRecord, at index: Int) {
         records.insert(record, at: min(max(0, index), records.count))
-        if records.count > capacity {
+        if let capacity, records.count > capacity {
             let protectedRecordId = record.id
             let overflow = records.count - capacity
             for _ in 0..<overflow {
@@ -208,6 +218,7 @@ final class ClosedItemHistoryStore: ObservableObject {
             }
         }
         revision &+= 1
+        persistRecords()
     }
 
     func menuSnapshot(maxItemCount: Int? = nil) -> ClosedItemHistoryMenuSnapshot {
@@ -264,6 +275,7 @@ final class ClosedItemHistoryStore: ObservableObject {
         if didUpdate {
             records = remappedRecords
             revision &+= 1
+            persistRecords()
         }
     }
 
@@ -302,6 +314,7 @@ final class ClosedItemHistoryStore: ObservableObject {
         if didUpdate {
             records = remappedRecords
             revision &+= 1
+            persistRecords()
         }
     }
 
@@ -324,6 +337,7 @@ final class ClosedItemHistoryStore: ObservableObject {
         if didUpdate {
             records = remappedRecords
             revision &+= 1
+            persistRecords()
         }
     }
 
@@ -336,6 +350,7 @@ final class ClosedItemHistoryStore: ObservableObject {
         }
         if records.count != originalCount {
             revision &+= 1
+            persistRecords()
         }
     }
 
@@ -343,6 +358,82 @@ final class ClosedItemHistoryStore: ObservableObject {
         guard !records.isEmpty else { return }
         records.removeAll(keepingCapacity: false)
         revision &+= 1
+        persistRecords()
+    }
+
+    private func trimToCapacityIfNeeded() {
+        guard let capacity, records.count > capacity else { return }
+        records.removeFirst(records.count - capacity)
+    }
+
+    private func persistRecords() {
+        guard let fileURL else { return }
+        Self.saveRecords(records, fileURL: fileURL)
+    }
+
+    nonisolated private static func loadRecords(fileURL: URL) -> [ClosedItemHistoryRecord] {
+        guard let data = try? Data(contentsOf: fileURL) else { return [] }
+        let decoder = JSONDecoder()
+        if let snapshot = try? decoder.decode(ClosedItemHistoryPersistenceSnapshot.self, from: data),
+           snapshot.version == ClosedItemHistoryPersistenceSnapshot.currentVersion {
+            return snapshot.records
+        }
+        return (try? decoder.decode([ClosedItemHistoryRecord].self, from: data)) ?? []
+    }
+
+    nonisolated private static func saveRecords(_ records: [ClosedItemHistoryRecord], fileURL: URL) {
+        guard !records.isEmpty else {
+            try? FileManager.default.removeItem(at: fileURL)
+            return
+        }
+        let directory = fileURL.deletingLastPathComponent()
+        do {
+            try FileManager.default.createDirectory(
+                at: directory,
+                withIntermediateDirectories: true,
+                attributes: nil
+            )
+            let snapshot = ClosedItemHistoryPersistenceSnapshot(records: records)
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.sortedKeys]
+            let data = try encoder.encode(snapshot)
+            if let existingData = try? Data(contentsOf: fileURL), existingData == data {
+                return
+            }
+            try data.write(to: fileURL, options: .atomic)
+        } catch {
+            return
+        }
+    }
+
+    nonisolated private static func defaultHistoryFileURL(
+        bundleIdentifier: String? = Bundle.main.bundleIdentifier,
+        appSupportDirectory: URL? = nil,
+        isRunningUnderAutomatedTests: Bool = SessionRestorePolicy.isRunningUnderAutomatedTests()
+    ) -> URL? {
+        guard !isRunningUnderAutomatedTests else { return nil }
+        let resolvedAppSupport: URL
+        if let appSupportDirectory {
+            resolvedAppSupport = appSupportDirectory
+        } else if let discovered = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first {
+            resolvedAppSupport = discovered
+        } else {
+            return nil
+        }
+        let bundleId = (bundleIdentifier?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false)
+            ? bundleIdentifier!
+            : "com.cmuxterm.app"
+        let safeBundleId = bundleId.replacingOccurrences(
+            of: "[^A-Za-z0-9._-]",
+            with: "_",
+            options: .regularExpression
+        )
+        return resolvedAppSupport
+            .appendingPathComponent("cmux", isDirectory: true)
+            .appendingPathComponent("closed-item-history-\(safeBundleId).json", isDirectory: false)
     }
 
     private static func menuItem(for record: ClosedItemHistoryRecord) -> ClosedItemHistoryMenuItem {
@@ -436,4 +527,11 @@ final class ClosedItemHistoryStore: ObservableObject {
             count
         )
     }
+}
+
+private struct ClosedItemHistoryPersistenceSnapshot: Codable {
+    static let currentVersion = 1
+
+    var version: Int = currentVersion
+    var records: [ClosedItemHistoryRecord]
 }

--- a/Sources/ClosedItemHistory.swift
+++ b/Sources/ClosedItemHistory.swift
@@ -139,6 +139,18 @@ final class ClosedItemHistoryStore: ObservableObject {
     private var didFinishPersistedRecordsLoad: Bool
     private var needsPersistenceAfterPersistedRecordsLoad = false
     private var shouldDiscardPersistedRecordsOnLoad = false
+    private var pendingPersistedRecordMutations: [PendingPersistedRecordMutation] = []
+
+    private enum PendingPersistedRecordMutation {
+        case remapPanelWorkspaceIds(
+            oldWorkspaceId: UUID,
+            newWorkspaceId: UUID,
+            panelIdMap: [UUID: UUID]
+        )
+        case remapPanelAnchorIds(oldPanelId: UUID, newPanelId: UUID)
+        case remapWorkspaceWindowIds(oldWindowId: UUID, newWindowId: UUID)
+        case removePanelRecords(workspaceIds: Set<UUID>)
+    }
 
     init(
         capacity: Int? = nil,
@@ -267,36 +279,19 @@ final class ClosedItemHistoryStore: ObservableObject {
         panelIdMap: [UUID: UUID] = [:]
     ) {
         guard oldWorkspaceId != newWorkspaceId else { return }
-        func remapAnchor(_ panelId: UUID?) -> UUID? {
-            guard let panelId else { return nil }
-            return panelIdMap[panelId] ?? panelId
-        }
-        var didUpdate = false
-        let remappedRecords = records.map { record in
-            guard case .panel(let panelEntry) = record.entry,
-                  panelEntry.workspaceId == oldWorkspaceId else {
-                return record
-            }
-            didUpdate = true
-            let fallbackSplitPlacement = panelEntry.fallbackSplitPlacement.map {
-                ClosedPanelSplitPlacement(
-                    orientation: $0.orientation,
-                    insertFirst: $0.insertFirst,
-                    anchorPanelId: remapAnchor($0.anchorPanelId)
-                )
-            }
-            return ClosedItemHistoryRecord(id: record.id, closedAt: record.closedAt, entry: .panel(ClosedPanelHistoryEntry(
-                workspaceId: newWorkspaceId,
-                paneId: panelEntry.paneId,
-                paneAnchorPanelId: remapAnchor(panelEntry.paneAnchorPanelId),
-                restoreInOriginalPane: false,
-                tabIndex: panelEntry.tabIndex,
-                snapshot: panelEntry.snapshot,
-                fallbackSplitPlacement: fallbackSplitPlacement
-            )))
-        }
-        if didUpdate {
-            records = remappedRecords
+        queuePersistedRecordMutationIfLoading(.remapPanelWorkspaceIds(
+            oldWorkspaceId: oldWorkspaceId,
+            newWorkspaceId: newWorkspaceId,
+            panelIdMap: panelIdMap
+        ))
+        let result = Self.recordsByRemappingPanelWorkspaceIds(
+            records,
+            from: oldWorkspaceId,
+            to: newWorkspaceId,
+            panelIdMap: panelIdMap
+        )
+        if result.didUpdate {
+            records = result.records
             revision &+= 1
             persistRecords()
         }
@@ -304,38 +299,13 @@ final class ClosedItemHistoryStore: ObservableObject {
 
     func remapPanelAnchorIds(from oldPanelId: UUID, to newPanelId: UUID) {
         guard oldPanelId != newPanelId else { return }
-        var didUpdate = false
-        let remappedRecords = records.map { record in
-            guard case .panel(let panelEntry) = record.entry else { return record }
-            let paneAnchorPanelId = panelEntry.paneAnchorPanelId == oldPanelId
-                ? newPanelId
-                : panelEntry.paneAnchorPanelId
-            let fallbackSplitPlacement = panelEntry.fallbackSplitPlacement.map { placement in
-                let anchorPanelId = placement.anchorPanelId == oldPanelId
-                    ? newPanelId
-                    : placement.anchorPanelId
-                return ClosedPanelSplitPlacement(
-                    orientation: placement.orientation,
-                    insertFirst: placement.insertFirst,
-                    anchorPanelId: anchorPanelId
-                )
-            }
-            if paneAnchorPanelId != panelEntry.paneAnchorPanelId ||
-                fallbackSplitPlacement?.anchorPanelId != panelEntry.fallbackSplitPlacement?.anchorPanelId {
-                didUpdate = true
-            }
-            return ClosedItemHistoryRecord(id: record.id, closedAt: record.closedAt, entry: .panel(ClosedPanelHistoryEntry(
-                workspaceId: panelEntry.workspaceId,
-                paneId: panelEntry.paneId,
-                paneAnchorPanelId: paneAnchorPanelId,
-                restoreInOriginalPane: panelEntry.restoreInOriginalPane,
-                tabIndex: panelEntry.tabIndex,
-                snapshot: panelEntry.snapshot,
-                fallbackSplitPlacement: fallbackSplitPlacement
-            )))
-        }
-        if didUpdate {
-            records = remappedRecords
+        queuePersistedRecordMutationIfLoading(.remapPanelAnchorIds(
+            oldPanelId: oldPanelId,
+            newPanelId: newPanelId
+        ))
+        let result = Self.recordsByRemappingPanelAnchorIds(records, from: oldPanelId, to: newPanelId)
+        if result.didUpdate {
+            records = result.records
             revision &+= 1
             persistRecords()
         }
@@ -343,22 +313,13 @@ final class ClosedItemHistoryStore: ObservableObject {
 
     func remapWorkspaceWindowIds(from oldWindowId: UUID, to newWindowId: UUID) {
         guard oldWindowId != newWindowId else { return }
-        var didUpdate = false
-        let remappedRecords = records.map { record in
-            guard case .workspace(let workspaceEntry) = record.entry,
-                  workspaceEntry.windowId == oldWindowId else {
-                return record
-            }
-            didUpdate = true
-            return ClosedItemHistoryRecord(id: record.id, closedAt: record.closedAt, entry: .workspace(ClosedWorkspaceHistoryEntry(
-                workspaceId: workspaceEntry.workspaceId,
-                windowId: newWindowId,
-                workspaceIndex: workspaceEntry.workspaceIndex,
-                snapshot: workspaceEntry.snapshot
-            )))
-        }
-        if didUpdate {
-            records = remappedRecords
+        queuePersistedRecordMutationIfLoading(.remapWorkspaceWindowIds(
+            oldWindowId: oldWindowId,
+            newWindowId: newWindowId
+        ))
+        let result = Self.recordsByRemappingWorkspaceWindowIds(records, from: oldWindowId, to: newWindowId)
+        if result.didUpdate {
+            records = result.records
             revision &+= 1
             persistRecords()
         }
@@ -366,12 +327,10 @@ final class ClosedItemHistoryStore: ObservableObject {
 
     func removePanelRecords(forWorkspaceIds workspaceIds: Set<UUID>) {
         guard !workspaceIds.isEmpty else { return }
-        let originalCount = records.count
-        records.removeAll { record in
-            guard case .panel(let panelEntry) = record.entry else { return false }
-            return workspaceIds.contains(panelEntry.workspaceId)
-        }
-        if records.count != originalCount {
+        queuePersistedRecordMutationIfLoading(.removePanelRecords(workspaceIds: workspaceIds))
+        let result = Self.recordsByRemovingPanelRecords(records, forWorkspaceIds: workspaceIds)
+        if result.didUpdate {
+            records = result.records
             revision &+= 1
             persistRecords()
         }
@@ -418,7 +377,14 @@ final class ClosedItemHistoryStore: ObservableObject {
             let loadedRecords = await ClosedItemHistoryPersistenceActor.shared.load(fileURL: fileURL)
             guard let self else { return }
             if !shouldDiscardPersistedRecordsOnLoad {
+                var loadedRecords = loadedRecords
+                let didMutateLoadedRecords = applyPendingPersistedRecordMutations(to: &loadedRecords)
                 mergeLoadedPersistedRecords(loadedRecords)
+                if didMutateLoadedRecords {
+                    needsPersistenceAfterPersistedRecordsLoad = true
+                }
+            } else {
+                pendingPersistedRecordMutations.removeAll(keepingCapacity: false)
             }
             didFinishPersistedRecordsLoad = true
             shouldDiscardPersistedRecordsOnLoad = false
@@ -427,6 +393,153 @@ final class ClosedItemHistoryStore: ObservableObject {
                 persistRecords()
             }
         }
+    }
+
+    private func queuePersistedRecordMutationIfLoading(_ mutation: PendingPersistedRecordMutation) {
+        guard !didFinishPersistedRecordsLoad else { return }
+        pendingPersistedRecordMutations.append(mutation)
+    }
+
+    @discardableResult
+    private func applyPendingPersistedRecordMutations(to loadedRecords: inout [ClosedItemHistoryRecord]) -> Bool {
+        guard !pendingPersistedRecordMutations.isEmpty else { return false }
+        var didUpdate = false
+        for mutation in pendingPersistedRecordMutations {
+            let result = Self.recordsByApplying(mutation, to: loadedRecords)
+            loadedRecords = result.records
+            didUpdate = didUpdate || result.didUpdate
+        }
+        pendingPersistedRecordMutations.removeAll(keepingCapacity: false)
+        return didUpdate
+    }
+
+    private static func recordsByApplying(
+        _ mutation: PendingPersistedRecordMutation,
+        to records: [ClosedItemHistoryRecord]
+    ) -> (records: [ClosedItemHistoryRecord], didUpdate: Bool) {
+        switch mutation {
+        case .remapPanelWorkspaceIds(let oldWorkspaceId, let newWorkspaceId, let panelIdMap):
+            return recordsByRemappingPanelWorkspaceIds(
+                records,
+                from: oldWorkspaceId,
+                to: newWorkspaceId,
+                panelIdMap: panelIdMap
+            )
+        case .remapPanelAnchorIds(let oldPanelId, let newPanelId):
+            return recordsByRemappingPanelAnchorIds(records, from: oldPanelId, to: newPanelId)
+        case .remapWorkspaceWindowIds(let oldWindowId, let newWindowId):
+            return recordsByRemappingWorkspaceWindowIds(records, from: oldWindowId, to: newWindowId)
+        case .removePanelRecords(let workspaceIds):
+            return recordsByRemovingPanelRecords(records, forWorkspaceIds: workspaceIds)
+        }
+    }
+
+    private static func recordsByRemappingPanelWorkspaceIds(
+        _ records: [ClosedItemHistoryRecord],
+        from oldWorkspaceId: UUID,
+        to newWorkspaceId: UUID,
+        panelIdMap: [UUID: UUID]
+    ) -> (records: [ClosedItemHistoryRecord], didUpdate: Bool) {
+        func remapAnchor(_ panelId: UUID?) -> UUID? {
+            guard let panelId else { return nil }
+            return panelIdMap[panelId] ?? panelId
+        }
+        var didUpdate = false
+        let remappedRecords = records.map { record in
+            guard case .panel(let panelEntry) = record.entry,
+                  panelEntry.workspaceId == oldWorkspaceId else {
+                return record
+            }
+            didUpdate = true
+            let fallbackSplitPlacement = panelEntry.fallbackSplitPlacement.map {
+                ClosedPanelSplitPlacement(
+                    orientation: $0.orientation,
+                    insertFirst: $0.insertFirst,
+                    anchorPanelId: remapAnchor($0.anchorPanelId)
+                )
+            }
+            return ClosedItemHistoryRecord(id: record.id, closedAt: record.closedAt, entry: .panel(ClosedPanelHistoryEntry(
+                workspaceId: newWorkspaceId,
+                paneId: panelEntry.paneId,
+                paneAnchorPanelId: remapAnchor(panelEntry.paneAnchorPanelId),
+                restoreInOriginalPane: false,
+                tabIndex: panelEntry.tabIndex,
+                snapshot: panelEntry.snapshot,
+                fallbackSplitPlacement: fallbackSplitPlacement
+            )))
+        }
+        return (remappedRecords, didUpdate)
+    }
+
+    private static func recordsByRemappingPanelAnchorIds(
+        _ records: [ClosedItemHistoryRecord],
+        from oldPanelId: UUID,
+        to newPanelId: UUID
+    ) -> (records: [ClosedItemHistoryRecord], didUpdate: Bool) {
+        var didUpdate = false
+        let remappedRecords = records.map { record in
+            guard case .panel(let panelEntry) = record.entry else { return record }
+            let paneAnchorPanelId = panelEntry.paneAnchorPanelId == oldPanelId
+                ? newPanelId
+                : panelEntry.paneAnchorPanelId
+            let fallbackSplitPlacement = panelEntry.fallbackSplitPlacement.map { placement in
+                let anchorPanelId = placement.anchorPanelId == oldPanelId
+                    ? newPanelId
+                    : placement.anchorPanelId
+                return ClosedPanelSplitPlacement(
+                    orientation: placement.orientation,
+                    insertFirst: placement.insertFirst,
+                    anchorPanelId: anchorPanelId
+                )
+            }
+            if paneAnchorPanelId != panelEntry.paneAnchorPanelId ||
+                fallbackSplitPlacement?.anchorPanelId != panelEntry.fallbackSplitPlacement?.anchorPanelId {
+                didUpdate = true
+            }
+            return ClosedItemHistoryRecord(id: record.id, closedAt: record.closedAt, entry: .panel(ClosedPanelHistoryEntry(
+                workspaceId: panelEntry.workspaceId,
+                paneId: panelEntry.paneId,
+                paneAnchorPanelId: paneAnchorPanelId,
+                restoreInOriginalPane: panelEntry.restoreInOriginalPane,
+                tabIndex: panelEntry.tabIndex,
+                snapshot: panelEntry.snapshot,
+                fallbackSplitPlacement: fallbackSplitPlacement
+            )))
+        }
+        return (remappedRecords, didUpdate)
+    }
+
+    private static func recordsByRemappingWorkspaceWindowIds(
+        _ records: [ClosedItemHistoryRecord],
+        from oldWindowId: UUID,
+        to newWindowId: UUID
+    ) -> (records: [ClosedItemHistoryRecord], didUpdate: Bool) {
+        var didUpdate = false
+        let remappedRecords = records.map { record in
+            guard case .workspace(let workspaceEntry) = record.entry,
+                  workspaceEntry.windowId == oldWindowId else {
+                return record
+            }
+            didUpdate = true
+            return ClosedItemHistoryRecord(id: record.id, closedAt: record.closedAt, entry: .workspace(ClosedWorkspaceHistoryEntry(
+                workspaceId: workspaceEntry.workspaceId,
+                windowId: newWindowId,
+                workspaceIndex: workspaceEntry.workspaceIndex,
+                snapshot: workspaceEntry.snapshot
+            )))
+        }
+        return (remappedRecords, didUpdate)
+    }
+
+    private static func recordsByRemovingPanelRecords(
+        _ records: [ClosedItemHistoryRecord],
+        forWorkspaceIds workspaceIds: Set<UUID>
+    ) -> (records: [ClosedItemHistoryRecord], didUpdate: Bool) {
+        let filteredRecords = records.filter { record in
+            guard case .panel(let panelEntry) = record.entry else { return true }
+            return !workspaceIds.contains(panelEntry.workspaceId)
+        }
+        return (filteredRecords, filteredRecords.count != records.count)
     }
 
     private func mergeLoadedPersistedRecords(_ loadedRecords: [ClosedItemHistoryRecord]) {

--- a/Sources/ClosedItemHistory.swift
+++ b/Sources/ClosedItemHistory.swift
@@ -372,27 +372,56 @@ final class ClosedItemHistoryStore: ObservableObject {
         }
     }
 
+    func flushPendingSaves() {
+        guard let fileURL else { return }
+        if !didFinishPersistedRecordsLoad {
+            finishPersistedRecordsLoad(Self.loadRecords(fileURL: fileURL))
+        }
+        needsPersistenceAfterPersistedRecordsLoad = false
+        let recordsSnapshot = records
+        let revisionSnapshot = revision
+        if persistsRecordsSynchronously {
+            Self.saveRecords(recordsSnapshot, fileURL: fileURL)
+            return
+        }
+        let semaphore = DispatchSemaphore(value: 0)
+        Task.detached(priority: .userInitiated) {
+            await ClosedItemHistoryPersistenceActor.shared.save(
+                recordsSnapshot,
+                fileURL: fileURL,
+                revision: revisionSnapshot
+            )
+            semaphore.signal()
+        }
+        semaphore.wait()
+    }
+
     private func loadPersistedRecordsAsync(from fileURL: URL) {
         Task { @MainActor [weak self] in
             let loadedRecords = await ClosedItemHistoryPersistenceActor.shared.load(fileURL: fileURL)
-            guard let self else { return }
-            if !shouldDiscardPersistedRecordsOnLoad {
-                var loadedRecords = loadedRecords
-                let didMutateLoadedRecords = applyPendingPersistedRecordMutations(to: &loadedRecords)
-                mergeLoadedPersistedRecords(loadedRecords)
-                if didMutateLoadedRecords {
-                    needsPersistenceAfterPersistedRecordsLoad = true
-                }
-            } else {
-                pendingPersistedRecordMutations.removeAll(keepingCapacity: false)
-            }
-            didFinishPersistedRecordsLoad = true
-            shouldDiscardPersistedRecordsOnLoad = false
+            guard let self, !didFinishPersistedRecordsLoad else { return }
+            finishPersistedRecordsLoad(loadedRecords)
             if needsPersistenceAfterPersistedRecordsLoad {
                 needsPersistenceAfterPersistedRecordsLoad = false
                 persistRecords()
             }
         }
+    }
+
+    private func finishPersistedRecordsLoad(_ loadedRecords: [ClosedItemHistoryRecord]) {
+        guard !didFinishPersistedRecordsLoad else { return }
+        if !shouldDiscardPersistedRecordsOnLoad {
+            var loadedRecords = loadedRecords
+            let didMutateLoadedRecords = applyPendingPersistedRecordMutations(to: &loadedRecords)
+            mergeLoadedPersistedRecords(loadedRecords)
+            if didMutateLoadedRecords {
+                needsPersistenceAfterPersistedRecordsLoad = true
+            }
+        } else {
+            pendingPersistedRecordMutations.removeAll(keepingCapacity: false)
+        }
+        didFinishPersistedRecordsLoad = true
+        shouldDiscardPersistedRecordsOnLoad = false
     }
 
     private func queuePersistedRecordMutationIfLoading(_ mutation: PendingPersistedRecordMutation) {

--- a/Sources/ClosedItemHistory.swift
+++ b/Sources/ClosedItemHistory.swift
@@ -136,6 +136,9 @@ final class ClosedItemHistoryStore: ObservableObject {
     private let capacity: Int?
     private let fileURL: URL?
     private let persistsRecordsSynchronously: Bool
+    private var didFinishPersistedRecordsLoad: Bool
+    private var needsPersistenceAfterPersistedRecordsLoad = false
+    private var shouldDiscardPersistedRecordsOnLoad = false
 
     init(
         capacity: Int? = nil,
@@ -147,12 +150,14 @@ final class ClosedItemHistoryStore: ObservableObject {
         self.capacity = capacity.map { max(1, $0) }
         self.fileURL = fileURL
         self.persistsRecordsSynchronously = persistsRecordsSynchronously
+        self.didFinishPersistedRecordsLoad = !loadPersisted || fileURL == nil
         if loadPersisted, let fileURL {
             if loadsPersistedRecordsSynchronously {
                 records = Self.loadRecords(fileURL: fileURL)
                 trimToCapacityIfNeeded()
+                didFinishPersistedRecordsLoad = true
             } else {
-                loadPersistedRecordsAsync(from: fileURL, expectedRevision: revision)
+                loadPersistedRecordsAsync(from: fileURL)
             }
         }
     }
@@ -373,7 +378,10 @@ final class ClosedItemHistoryStore: ObservableObject {
     }
 
     func removeAll() {
-        guard !records.isEmpty else { return }
+        guard !records.isEmpty || !didFinishPersistedRecordsLoad else { return }
+        if !didFinishPersistedRecordsLoad {
+            shouldDiscardPersistedRecordsOnLoad = true
+        }
         records.removeAll(keepingCapacity: false)
         revision &+= 1
         persistRecords()
@@ -386,6 +394,10 @@ final class ClosedItemHistoryStore: ObservableObject {
 
     private func persistRecords() {
         guard let fileURL else { return }
+        guard didFinishPersistedRecordsLoad else {
+            needsPersistenceAfterPersistedRecordsLoad = true
+            return
+        }
         let recordsSnapshot = records
         let revisionSnapshot = revision
         if persistsRecordsSynchronously {
@@ -401,15 +413,34 @@ final class ClosedItemHistoryStore: ObservableObject {
         }
     }
 
-    private func loadPersistedRecordsAsync(from fileURL: URL, expectedRevision: UInt64) {
+    private func loadPersistedRecordsAsync(from fileURL: URL) {
         Task { @MainActor [weak self] in
             let loadedRecords = await ClosedItemHistoryPersistenceActor.shared.load(fileURL: fileURL)
-            guard let self, self.revision == expectedRevision else { return }
-            guard !loadedRecords.isEmpty else { return }
-            records = loadedRecords
-            trimToCapacityIfNeeded()
-            revision &+= 1
+            guard let self else { return }
+            if !shouldDiscardPersistedRecordsOnLoad {
+                mergeLoadedPersistedRecords(loadedRecords)
+            }
+            didFinishPersistedRecordsLoad = true
+            shouldDiscardPersistedRecordsOnLoad = false
+            if needsPersistenceAfterPersistedRecordsLoad {
+                needsPersistenceAfterPersistedRecordsLoad = false
+                persistRecords()
+            }
         }
+    }
+
+    private func mergeLoadedPersistedRecords(_ loadedRecords: [ClosedItemHistoryRecord]) {
+        guard !loadedRecords.isEmpty else { return }
+        if records.isEmpty {
+            records = loadedRecords
+        } else {
+            var seenRecordIds = Set(records.map(\.id))
+            let missingLoadedRecords = loadedRecords.filter { seenRecordIds.insert($0.id).inserted }
+            guard !missingLoadedRecords.isEmpty else { return }
+            records = missingLoadedRecords + records
+        }
+        trimToCapacityIfNeeded()
+        revision &+= 1
     }
 
     nonisolated fileprivate static func loadRecords(fileURL: URL) -> [ClosedItemHistoryRecord] {

--- a/Sources/ClosedItemHistory.swift
+++ b/Sources/ClosedItemHistory.swift
@@ -1,6 +1,12 @@
 import Foundation
 import Combine
 import Bonsplit
+import OSLog
+
+private let closedItemHistoryLogger = Logger(
+    subsystem: "com.cmuxterm.app",
+    category: "ClosedItemHistory"
+)
 
 struct ClosedPanelSplitPlacement: Codable {
     let orientation: SplitOrientation
@@ -129,13 +135,25 @@ final class ClosedItemHistoryStore: ObservableObject {
     @Published private var records: [ClosedItemHistoryRecord] = []
     private let capacity: Int?
     private let fileURL: URL?
+    private let persistsRecordsSynchronously: Bool
 
-    init(capacity: Int? = nil, fileURL: URL? = nil, loadPersisted: Bool = true) {
+    init(
+        capacity: Int? = nil,
+        fileURL: URL? = nil,
+        loadPersisted: Bool = true,
+        loadsPersistedRecordsSynchronously: Bool = false,
+        persistsRecordsSynchronously: Bool = false
+    ) {
         self.capacity = capacity.map { max(1, $0) }
         self.fileURL = fileURL
+        self.persistsRecordsSynchronously = persistsRecordsSynchronously
         if loadPersisted, let fileURL {
-            records = Self.loadRecords(fileURL: fileURL)
-            trimToCapacityIfNeeded()
+            if loadsPersistedRecordsSynchronously {
+                records = Self.loadRecords(fileURL: fileURL)
+                trimToCapacityIfNeeded()
+            } else {
+                loadPersistedRecordsAsync(from: fileURL, expectedRevision: revision)
+            }
         }
     }
 
@@ -368,10 +386,33 @@ final class ClosedItemHistoryStore: ObservableObject {
 
     private func persistRecords() {
         guard let fileURL else { return }
-        Self.saveRecords(records, fileURL: fileURL)
+        let recordsSnapshot = records
+        let revisionSnapshot = revision
+        if persistsRecordsSynchronously {
+            Self.saveRecords(recordsSnapshot, fileURL: fileURL)
+        } else {
+            Task {
+                await ClosedItemHistoryPersistenceActor.shared.save(
+                    recordsSnapshot,
+                    fileURL: fileURL,
+                    revision: revisionSnapshot
+                )
+            }
+        }
     }
 
-    nonisolated private static func loadRecords(fileURL: URL) -> [ClosedItemHistoryRecord] {
+    private func loadPersistedRecordsAsync(from fileURL: URL, expectedRevision: UInt64) {
+        Task { @MainActor [weak self] in
+            let loadedRecords = await ClosedItemHistoryPersistenceActor.shared.load(fileURL: fileURL)
+            guard let self, self.revision == expectedRevision else { return }
+            guard !loadedRecords.isEmpty else { return }
+            records = loadedRecords
+            trimToCapacityIfNeeded()
+            revision &+= 1
+        }
+    }
+
+    nonisolated fileprivate static func loadRecords(fileURL: URL) -> [ClosedItemHistoryRecord] {
         guard let data = try? Data(contentsOf: fileURL) else { return [] }
         let decoder = JSONDecoder()
         if let snapshot = try? decoder.decode(ClosedItemHistoryPersistenceSnapshot.self, from: data),
@@ -381,9 +422,17 @@ final class ClosedItemHistoryStore: ObservableObject {
         return (try? decoder.decode([ClosedItemHistoryRecord].self, from: data)) ?? []
     }
 
-    nonisolated private static func saveRecords(_ records: [ClosedItemHistoryRecord], fileURL: URL) {
+    nonisolated fileprivate static func saveRecords(_ records: [ClosedItemHistoryRecord], fileURL: URL) {
         guard !records.isEmpty else {
-            try? FileManager.default.removeItem(at: fileURL)
+            do {
+                try FileManager.default.removeItem(at: fileURL)
+            } catch {
+                if FileManager.default.fileExists(atPath: fileURL.path) {
+                    closedItemHistoryLogger.debug(
+                        "closedItemHistory.remove.failed file=\(fileURL.path, privacy: .public) error=\(error.localizedDescription, privacy: .public)"
+                    )
+                }
+            }
             return
         }
         let directory = fileURL.deletingLastPathComponent()
@@ -402,6 +451,9 @@ final class ClosedItemHistoryStore: ObservableObject {
             }
             try data.write(to: fileURL, options: .atomic)
         } catch {
+            closedItemHistoryLogger.debug(
+                "closedItemHistory.save.failed file=\(fileURL.path, privacy: .public) records=\(records.count) error=\(error.localizedDescription, privacy: .public)"
+            )
             return
         }
     }
@@ -534,4 +586,23 @@ private struct ClosedItemHistoryPersistenceSnapshot: Codable {
 
     var version: Int = currentVersion
     var records: [ClosedItemHistoryRecord]
+}
+
+private actor ClosedItemHistoryPersistenceActor {
+    static let shared = ClosedItemHistoryPersistenceActor()
+
+    private var latestRevisionByPath: [String: UInt64] = [:]
+
+    func load(fileURL: URL) -> [ClosedItemHistoryRecord] {
+        ClosedItemHistoryStore.loadRecords(fileURL: fileURL)
+    }
+
+    func save(_ records: [ClosedItemHistoryRecord], fileURL: URL, revision: UInt64) {
+        let path = fileURL.standardizedFileURL.path
+        if let latestRevision = latestRevisionByPath[path], revision < latestRevision {
+            return
+        }
+        latestRevisionByPath[path] = revision
+        ClosedItemHistoryStore.saveRecords(records, fileURL: fileURL)
+    }
 }

--- a/Sources/CmuxEventPublishing.swift
+++ b/Sources/CmuxEventPublishing.swift
@@ -291,13 +291,18 @@ extension CmuxEventBus {
     }
 
     func publishNotificationChanges(oldValue: [TerminalNotification], newValue: [TerminalNotification]) {
-        let oldById = Dictionary(uniqueKeysWithValues: oldValue.map { ($0.id, $0) })
+        var oldById: [UUID: TerminalNotification] = [:]
+        for notification in oldValue {
+            oldById[notification.id] = notification
+        }
         let newIds = Set(newValue.map(\.id))
         let removed = oldValue.filter { !newIds.contains($0.id) }
         for notification in removed {
             publishNotificationRemoved(notification)
         }
+        var seenNewIds = Set<UUID>()
         for notification in newValue {
+            guard seenNewIds.insert(notification.id).inserted else { continue }
             if let old = oldById[notification.id] {
                 if !old.isRead, notification.isRead {
                     publishNotificationRead(

--- a/Sources/CmuxEventPublishing.swift
+++ b/Sources/CmuxEventPublishing.swift
@@ -305,7 +305,11 @@ extension CmuxEventBus {
             oldById[notification.id] = notification
         }
         let newIds = Set(newValue.map(\.id))
-        let removed = oldValue.filter { !newIds.contains($0.id) }
+        var removedIds = Set<UUID>()
+        let removed = oldValue.filter { notification in
+            guard !newIds.contains(notification.id) else { return false }
+            return removedIds.insert(notification.id).inserted
+        }
         for notification in removed {
             publishNotificationRemoved(notification)
         }

--- a/Sources/CmuxEventPublishing.swift
+++ b/Sources/CmuxEventPublishing.swift
@@ -293,6 +293,15 @@ extension CmuxEventBus {
     func publishNotificationChanges(oldValue: [TerminalNotification], newValue: [TerminalNotification]) {
         var oldById: [UUID: TerminalNotification] = [:]
         for notification in oldValue {
+#if DEBUG
+            if oldById[notification.id] != nil {
+                cmuxDebugLog(
+                    "notification.changes.duplicateOldId function=publishNotificationChanges " +
+                        "id=\(notification.id.uuidString) source=oldById " +
+                        "expectedUniqueBy=TerminalNotificationStore.restoreSessionNotifications.notificationWithUniqueId"
+                )
+            }
+#endif
             oldById[notification.id] = notification
         }
         let newIds = Set(newValue.map(\.id))

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -1679,6 +1679,7 @@ indirect enum SessionWorkspaceLayoutSnapshot: Codable, Sendable {
 }
 
 struct SessionWorkspaceSnapshot: Codable, Sendable {
+    var workspaceId: UUID? = nil
     var processTitle: String
     var customTitle: String?
     var customDescription: String?

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -1679,6 +1679,9 @@ indirect enum SessionWorkspaceLayoutSnapshot: Codable, Sendable {
 }
 
 struct SessionWorkspaceSnapshot: Codable, Sendable {
+    /// Original workspace ID captured when the snapshot comes from a live workspace.
+    /// Restore uses this to remap closed-panel history onto the new workspace IDs;
+    /// legacy or externally-created snapshots can leave it nil.
     var workspaceId: UUID? = nil
     var processTitle: String
     var customTitle: String?

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -1721,6 +1721,7 @@ struct SessionTabManagerSnapshot: Codable, Sendable {
 }
 
 struct SessionWindowSnapshot: Codable, Sendable {
+    var windowId: UUID? = nil
     var frame: SessionRectSnapshot?
     var display: SessionDisplaySnapshot?
     var tabManager: SessionTabManagerSnapshot

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -10098,11 +10098,13 @@ extension TabManager {
     ) {
         let count = min(originalWorkspaceIds.count, tabs.count)
         guard count > 0 else { return }
+        var didRequestHistoryRemap = false
         for index in 0..<count {
             guard let originalWorkspaceId = originalWorkspaceIds[index],
                   originalWorkspaceId != tabs[index].id else {
                 continue
             }
+            didRequestHistoryRemap = true
             let panelIdMap = restoredPanelIdsByWorkspaceIndex.indices.contains(index)
                 ? restoredPanelIdsByWorkspaceIndex[index]
                 : [:]
@@ -10111,6 +10113,9 @@ extension TabManager {
                 to: tabs[index].id,
                 panelIdMap: panelIdMap
             )
+        }
+        if didRequestHistoryRemap {
+            ClosedItemHistoryStore.shared.flushPendingSaves()
         }
     }
 
@@ -10121,7 +10126,9 @@ extension TabManager {
         guard !originalWorkspaceIds.isEmpty else { return }
         let count = min(originalWorkspaceIds.count, tabs.count)
         guard count > 0 else { return }
+        var didRequestHistoryRemap = false
         for index in 0..<count {
+            didRequestHistoryRemap = true
             let panelIdMap = restoredPanelIdsByWorkspaceIndex.indices.contains(index)
                 ? restoredPanelIdsByWorkspaceIndex[index]
                 : [:]
@@ -10130,6 +10137,9 @@ extension TabManager {
                 to: tabs[index].id,
                 panelIdMap: panelIdMap
             )
+        }
+        if didRequestHistoryRemap {
+            ClosedItemHistoryStore.shared.flushPendingSaves()
         }
     }
 }

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -11054,7 +11054,10 @@ extension TabManager {
     }
 
     @discardableResult
-    func restoreSessionSnapshot(_ snapshot: SessionTabManagerSnapshot) -> [[UUID: UUID]] {
+    func restoreSessionSnapshot(
+        _ snapshot: SessionTabManagerSnapshot,
+        remapClosedPanelHistory: Bool = true
+    ) -> [[UUID: UUID]] {
         isRestoringSessionSnapshot = true
         defer { isRestoringSessionSnapshot = false }
         let previousTabs = tabs
@@ -11197,10 +11200,12 @@ extension TabManager {
                 )
             }
         }
-        remapClosedPanelHistoryAfterSessionRestore(
-            originalWorkspaceIds: restoredOriginalWorkspaceIds,
-            restoredPanelIdsByWorkspaceIndex: restoredPanelIdsByWorkspaceIndex
-        )
+        if remapClosedPanelHistory {
+            remapClosedPanelHistoryAfterSessionRestore(
+                originalWorkspaceIds: restoredOriginalWorkspaceIds,
+                restoredPanelIdsByWorkspaceIndex: restoredPanelIdsByWorkspaceIndex
+            )
+        }
 
         if let selectedTabId {
             NotificationCenter.default.post(
@@ -11212,7 +11217,7 @@ extension TabManager {
         return restoredPanelIdsByWorkspaceIndex
     }
 
-    private func remapClosedPanelHistoryAfterSessionRestore(
+    func remapClosedPanelHistoryAfterSessionRestore(
         originalWorkspaceIds: [UUID?],
         restoredPanelIdsByWorkspaceIndex: [[UUID: UUID]]
     ) {

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -10023,6 +10023,7 @@ extension TabManager {
         var restoredPanelIdsByWorkspaceIndex: [[UUID: UUID]] = []
         let workspaceSnapshots = snapshot.workspaces
             .prefix(SessionPersistencePolicy.maxWorkspacesPerWindow)
+        var restoredOriginalWorkspaceIds: [UUID?] = []
         for workspaceSnapshot in workspaceSnapshots {
             let ordinal = Self.nextPortOrdinal
             Self.nextPortOrdinal += 1
@@ -10036,6 +10037,7 @@ extension TabManager {
             wireClosedBrowserTracking(for: workspace)
             newTabs.append(workspace)
             restoredPanelIdsByWorkspaceIndex.append(restoredPanelIds)
+            restoredOriginalWorkspaceIds.append(workspaceSnapshot.workspaceId)
         }
 
         if newTabs.isEmpty {
@@ -10075,6 +10077,10 @@ extension TabManager {
                 )
             }
         }
+        remapClosedPanelHistoryAfterSessionRestore(
+            originalWorkspaceIds: restoredOriginalWorkspaceIds,
+            restoredPanelIdsByWorkspaceIndex: restoredPanelIdsByWorkspaceIndex
+        )
 
         if let selectedTabId {
             NotificationCenter.default.post(
@@ -10084,6 +10090,28 @@ extension TabManager {
             )
         }
         return restoredPanelIdsByWorkspaceIndex
+    }
+
+    private func remapClosedPanelHistoryAfterSessionRestore(
+        originalWorkspaceIds: [UUID?],
+        restoredPanelIdsByWorkspaceIndex: [[UUID: UUID]]
+    ) {
+        let count = min(originalWorkspaceIds.count, tabs.count)
+        guard count > 0 else { return }
+        for index in 0..<count {
+            guard let originalWorkspaceId = originalWorkspaceIds[index],
+                  originalWorkspaceId != tabs[index].id else {
+                continue
+            }
+            let panelIdMap = restoredPanelIdsByWorkspaceIndex.indices.contains(index)
+                ? restoredPanelIdsByWorkspaceIndex[index]
+                : [:]
+            ClosedItemHistoryStore.shared.remapPanelWorkspaceIds(
+                from: originalWorkspaceId,
+                to: tabs[index].id,
+                panelIdMap: panelIdMap
+            )
+        }
     }
 
     func remapClosedPanelHistoryAfterWindowRestore(

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -1723,9 +1723,11 @@ final class TerminalNotificationStore: ObservableObject {
         let removedIds = notifications
             .filter { $0.tabId == tabId }
             .map { $0.id.uuidString }
+        var usedNotificationIds = Set(notifications.filter { $0.tabId != tabId }.map(\.id))
         let restoredForTab = restoredNotifications
             .filter { $0.tabId == tabId }
             .sorted(by: Self.notificationSortPrecedes)
+            .map { Self.notificationWithUniqueId($0, usedIds: &usedNotificationIds) }
         let keptNotifications = notifications.filter { $0.tabId != tabId }
         let nextNotifications = (restoredForTab + keptNotifications).sorted(by: Self.notificationSortPrecedes)
 
@@ -1739,6 +1741,34 @@ final class TerminalNotificationStore: ObservableObject {
             center.removeDeliveredNotificationsOffMain(withIdentifiers: removedIds)
             center.removePendingNotificationRequestsOffMain(withIdentifiers: removedIds)
         }
+    }
+
+    private static func notificationWithUniqueId(
+        _ notification: TerminalNotification,
+        usedIds: inout Set<UUID>
+    ) -> TerminalNotification {
+        if usedIds.insert(notification.id).inserted {
+            return notification
+        }
+
+        var replacementId = UUID()
+        while !usedIds.insert(replacementId).inserted {
+            replacementId = UUID()
+        }
+
+        return TerminalNotification(
+            id: replacementId,
+            tabId: notification.tabId,
+            surfaceId: notification.surfaceId,
+            panelId: notification.panelId,
+            title: notification.title,
+            subtitle: notification.subtitle,
+            body: notification.body,
+            createdAt: notification.createdAt,
+            isRead: notification.isRead,
+            paneFlash: notification.paneFlash,
+            clickAction: notification.clickAction
+        )
     }
 
     private func replaceNotificationsForClear(_ next: [TerminalNotification]) { suppressNotificationDiffPublishing = true; notifications = next; suppressNotificationDiffPublishing = false }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -233,6 +233,7 @@ extension Workspace {
         let workspaceNotificationSnapshots = notificationSnapshots(surfaceId: nil)
 
         return SessionWorkspaceSnapshot(
+            workspaceId: id,
             processTitle: processTitle,
             customTitle: customTitle,
             customDescription: customDescription,

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -1312,6 +1312,90 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         XCTAssertFalse(liveManager.tabs.contains { $0.customTitle == "Closed Previous Workspace" })
     }
 
+    func testFailedClosedWindowRestoreDoesNotRemapClosedPanelHistoryToDiscardedWindow() throws {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        ClosedItemHistoryStore.shared.removeAll()
+        defer { ClosedItemHistoryStore.shared.removeAll() }
+
+        let baselineWindowIds = mainWindowIds()
+        defer {
+            for windowId in mainWindowIds().subtracting(baselineWindowIds) {
+                closeWindow(withId: windowId)
+            }
+        }
+
+        let sourceManager = TabManager(autoWelcomeIfNeeded: false)
+        let sourceWorkspace = try XCTUnwrap(sourceManager.selectedWorkspace)
+        let originalWorkspaceId = sourceWorkspace.id
+        var closedPanelSnapshot = try XCTUnwrap(sourceWorkspace.sessionSnapshot(includeScrollback: false).panels.first)
+        closedPanelSnapshot.customTitle = "Panel From Failed Window"
+        let closedPanelRecordId = UUID()
+        ClosedItemHistoryStore.shared.push(ClosedItemHistoryRecord(
+            id: closedPanelRecordId,
+            closedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            entry: .panel(ClosedPanelHistoryEntry(
+                workspaceId: originalWorkspaceId,
+                paneId: UUID(),
+                tabIndex: 0,
+                snapshot: closedPanelSnapshot
+            ))
+        ))
+
+        var invalidWorkspaceSnapshot = sourceWorkspace.sessionSnapshot(includeScrollback: false)
+        var invalidPanelSnapshot = try XCTUnwrap(invalidWorkspaceSnapshot.panels.first)
+        invalidPanelSnapshot.type = .markdown
+        invalidPanelSnapshot.title = "Broken Markdown"
+        invalidPanelSnapshot.customTitle = "Broken Markdown"
+        invalidPanelSnapshot.terminal = nil
+        invalidPanelSnapshot.browser = nil
+        invalidPanelSnapshot.markdown = nil
+        invalidPanelSnapshot.filePreview = nil
+        invalidPanelSnapshot.rightSidebarTool = nil
+        invalidWorkspaceSnapshot.panels = [invalidPanelSnapshot]
+        invalidWorkspaceSnapshot.layout = .pane(SessionPaneLayoutSnapshot(
+            panelIds: [invalidPanelSnapshot.id],
+            selectedPanelId: invalidPanelSnapshot.id
+        ))
+
+        let originalWindowId = UUID()
+        let failedWindowRecordId = UUID()
+        let failedWindowSnapshot = SessionWindowSnapshot(
+            windowId: originalWindowId,
+            frame: nil,
+            display: nil,
+            tabManager: SessionTabManagerSnapshot(
+                selectedWorkspaceIndex: 0,
+                workspaces: [invalidWorkspaceSnapshot]
+            ),
+            sidebar: SessionSidebarSnapshot(isVisible: true, selection: .tabs, width: nil)
+        )
+        ClosedItemHistoryStore.shared.push(ClosedItemHistoryRecord(
+            id: failedWindowRecordId,
+            closedAt: Date(timeIntervalSince1970: 1_700_000_001),
+            entry: .window(ClosedWindowHistoryEntry(
+                windowId: originalWindowId,
+                snapshot: failedWindowSnapshot,
+                workspaceIds: [originalWorkspaceId]
+            ))
+        ))
+
+        XCTAssertFalse(appDelegate.reopenClosedHistoryItem(
+            id: failedWindowRecordId,
+            shouldActivate: false
+        ))
+
+        let record = try XCTUnwrap(ClosedItemHistoryStore.shared.removeRecord(id: closedPanelRecordId)?.record)
+        guard case .panel(let panelEntry) = record.entry else {
+            return XCTFail("Expected closed panel history")
+        }
+        XCTAssertEqual(panelEntry.workspaceId, originalWorkspaceId)
+        XCTAssertTrue(panelEntry.restoreInOriginalPane)
+    }
+
     func testCmdShiftNCreatesWindowFromEventWindowWithoutAddingWorkspace() {
         guard let appDelegate = AppDelegate.shared else {
             XCTFail("Expected AppDelegate.shared")

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -1312,51 +1312,6 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         XCTAssertFalse(liveManager.tabs.contains { $0.customTitle == "Closed Previous Workspace" })
     }
 
-    func testCreateMainWindowCanDeferClosedWorkspaceWindowIdRemap() throws {
-        guard let appDelegate = AppDelegate.shared else {
-            XCTFail("Expected AppDelegate.shared")
-            return
-        }
-
-        ClosedItemHistoryStore.shared.removeAll()
-        defer { ClosedItemHistoryStore.shared.removeAll() }
-
-        let baselineWindowIds = mainWindowIds()
-        defer {
-            for windowId in mainWindowIds().subtracting(baselineWindowIds) {
-                closeWindow(withId: windowId)
-            }
-        }
-
-        let oldWindowId = UUID()
-        let restoredManager = TabManager(autoWelcomeIfNeeded: false)
-        let closedWorkspaceManager = TabManager(autoWelcomeIfNeeded: false)
-        let closedWorkspace = try XCTUnwrap(closedWorkspaceManager.selectedWorkspace)
-        let closedRecordId = UUID()
-        ClosedItemHistoryStore.shared.push(ClosedItemHistoryRecord(
-            id: closedRecordId,
-            closedAt: Date(timeIntervalSince1970: 1_700_000_002),
-            entry: .workspace(ClosedWorkspaceHistoryEntry(
-                workspaceId: closedWorkspace.id,
-                windowId: oldWindowId,
-                workspaceIndex: 0,
-                snapshot: closedWorkspace.sessionSnapshot(includeScrollback: false)
-            ))
-        ))
-
-        _ = appDelegate.createMainWindow(
-            sessionWindowSnapshot: sessionWindowSnapshot(tabManager: restoredManager, windowId: oldWindowId),
-            shouldActivate: false,
-            remapClosedWorkspaceWindowIdsFromSnapshot: false
-        )
-
-        let record = try XCTUnwrap(ClosedItemHistoryStore.shared.removeRecord(id: closedRecordId)?.record)
-        guard case .workspace(let entry) = record.entry else {
-            return XCTFail("Expected workspace history")
-        }
-        XCTAssertEqual(entry.windowId, oldWindowId)
-    }
-
     func testCmdShiftNCreatesWindowFromEventWindowWithoutAddingWorkspace() {
         guard let appDelegate = AppDelegate.shared else {
             XCTFail("Expected AppDelegate.shared")

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -1312,6 +1312,51 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         XCTAssertFalse(liveManager.tabs.contains { $0.customTitle == "Closed Previous Workspace" })
     }
 
+    func testCreateMainWindowCanDeferClosedWorkspaceWindowIdRemap() throws {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        ClosedItemHistoryStore.shared.removeAll()
+        defer { ClosedItemHistoryStore.shared.removeAll() }
+
+        let baselineWindowIds = mainWindowIds()
+        defer {
+            for windowId in mainWindowIds().subtracting(baselineWindowIds) {
+                closeWindow(withId: windowId)
+            }
+        }
+
+        let oldWindowId = UUID()
+        let restoredManager = TabManager(autoWelcomeIfNeeded: false)
+        let closedWorkspaceManager = TabManager(autoWelcomeIfNeeded: false)
+        let closedWorkspace = try XCTUnwrap(closedWorkspaceManager.selectedWorkspace)
+        let closedRecordId = UUID()
+        ClosedItemHistoryStore.shared.push(ClosedItemHistoryRecord(
+            id: closedRecordId,
+            closedAt: Date(timeIntervalSince1970: 1_700_000_002),
+            entry: .workspace(ClosedWorkspaceHistoryEntry(
+                workspaceId: closedWorkspace.id,
+                windowId: oldWindowId,
+                workspaceIndex: 0,
+                snapshot: closedWorkspace.sessionSnapshot(includeScrollback: false)
+            ))
+        ))
+
+        _ = appDelegate.createMainWindow(
+            sessionWindowSnapshot: sessionWindowSnapshot(tabManager: restoredManager, windowId: oldWindowId),
+            shouldActivate: false,
+            remapClosedWorkspaceWindowIdsFromSnapshot: false
+        )
+
+        let record = try XCTUnwrap(ClosedItemHistoryStore.shared.removeRecord(id: closedRecordId)?.record)
+        guard case .workspace(let entry) = record.entry else {
+            return XCTFail("Expected workspace history")
+        }
+        XCTAssertEqual(entry.windowId, oldWindowId)
+    }
+
     func testCmdShiftNCreatesWindowFromEventWindowWithoutAddingWorkspace() {
         guard let appDelegate = AppDelegate.shared else {
             XCTFail("Expected AppDelegate.shared")

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -1248,6 +1248,70 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         XCTAssertEqual(restoredWindowManager.selectedWorkspace?.customTitle, "Previous Work")
     }
 
+    func testRestorePreviousSessionSnapshotRemapsClosedWorkspaceWindowIds() throws {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        ClosedItemHistoryStore.shared.removeAll()
+        defer { ClosedItemHistoryStore.shared.removeAll() }
+
+        let baselineWindowIds = mainWindowIds()
+        let liveWindowId = appDelegate.createMainWindow(shouldActivate: false)
+        defer {
+            for windowId in mainWindowIds().subtracting(baselineWindowIds) {
+                closeWindow(withId: windowId)
+            }
+        }
+
+        let liveManager = try XCTUnwrap(appDelegate.tabManagerFor(windowId: liveWindowId))
+        let oldRestoredWindowId = UUID()
+
+        let restoredManager = TabManager(autoWelcomeIfNeeded: false)
+        let restoredWorkspace = try XCTUnwrap(restoredManager.selectedWorkspace)
+        restoredWorkspace.setCustomTitle("Previous Work")
+
+        let closedWorkspaceManager = TabManager(autoWelcomeIfNeeded: false)
+        let closedWorkspace = try XCTUnwrap(closedWorkspaceManager.selectedWorkspace)
+        closedWorkspace.setCustomTitle("Closed Previous Workspace")
+        let closedRecordId = UUID()
+        ClosedItemHistoryStore.shared.push(ClosedItemHistoryRecord(
+            id: closedRecordId,
+            closedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            entry: .workspace(ClosedWorkspaceHistoryEntry(
+                workspaceId: closedWorkspace.id,
+                windowId: oldRestoredWindowId,
+                workspaceIndex: 1,
+                snapshot: closedWorkspace.sessionSnapshot(includeScrollback: false)
+            ))
+        ))
+
+        let snapshot = AppSessionSnapshot(
+            version: SessionSnapshotSchema.currentVersion,
+            createdAt: 1_700_000_001,
+            windows: [sessionWindowSnapshot(tabManager: restoredManager, windowId: oldRestoredWindowId)]
+        )
+
+        XCTAssertTrue(appDelegate.restorePreviousSessionSnapshot(snapshot, shouldActivate: false))
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+
+        let restoredWindowIds = mainWindowIds().subtracting(baselineWindowIds).subtracting([liveWindowId])
+        XCTAssertEqual(restoredWindowIds.count, 1)
+        let restoredWindowId = try XCTUnwrap(restoredWindowIds.first)
+        let restoredWindowManager = try XCTUnwrap(appDelegate.tabManagerFor(windowId: restoredWindowId))
+
+        XCTAssertTrue(
+            appDelegate.reopenClosedHistoryItem(
+                id: closedRecordId,
+                preferredTabManager: liveManager,
+                shouldActivate: false
+            )
+        )
+        XCTAssertTrue(restoredWindowManager.tabs.contains { $0.customTitle == "Closed Previous Workspace" })
+        XCTAssertFalse(liveManager.tabs.contains { $0.customTitle == "Closed Previous Workspace" })
+    }
+
     func testCmdShiftNCreatesWindowFromEventWindowWithoutAddingWorkspace() {
         guard let appDelegate = AppDelegate.shared else {
             XCTFail("Expected AppDelegate.shared")
@@ -10634,8 +10698,9 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         }
     }
 
-    private func sessionWindowSnapshot(tabManager: TabManager) -> SessionWindowSnapshot {
+    private func sessionWindowSnapshot(tabManager: TabManager, windowId: UUID? = nil) -> SessionWindowSnapshot {
         SessionWindowSnapshot(
+            windowId: windowId,
             frame: nil,
             display: nil,
             tabManager: tabManager.sessionSnapshot(includeScrollback: false),

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -1203,6 +1203,51 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         createdWindowId = newWindowIds.first
     }
 
+    func testRestorePreviousSessionSnapshotCreatesNewWindowWithoutClosingCurrentWindows() throws {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let baselineWindowIds = mainWindowIds()
+        let liveWindowId = appDelegate.createMainWindow(shouldActivate: false)
+        defer {
+            for windowId in mainWindowIds().subtracting(baselineWindowIds) {
+                closeWindow(withId: windowId)
+            }
+        }
+
+        guard let liveManager = appDelegate.tabManagerFor(windowId: liveWindowId),
+              let liveWorkspace = liveManager.selectedWorkspace else {
+            XCTFail("Expected live window manager and workspace")
+            return
+        }
+        liveWorkspace.setCustomTitle("Current Work")
+        let windowIdsAfterLiveWindow = mainWindowIds()
+
+        let restoredManager = TabManager(autoWelcomeIfNeeded: false)
+        let restoredWorkspace = try XCTUnwrap(restoredManager.selectedWorkspace)
+        restoredWorkspace.setCustomTitle("Previous Work")
+        let snapshot = AppSessionSnapshot(
+            version: SessionSnapshotSchema.currentVersion,
+            createdAt: 1_700_000_000,
+            windows: [sessionWindowSnapshot(tabManager: restoredManager)]
+        )
+
+        XCTAssertTrue(appDelegate.restorePreviousSessionSnapshot(snapshot, shouldActivate: false))
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+
+        let finalWindowIds = mainWindowIds()
+        XCTAssertTrue(finalWindowIds.contains(liveWindowId))
+        XCTAssertEqual(liveManager.selectedWorkspace?.customTitle, "Current Work")
+
+        let createdWindowIds = finalWindowIds.subtracting(windowIdsAfterLiveWindow)
+        XCTAssertEqual(createdWindowIds.count, 1)
+        let restoredWindowId = try XCTUnwrap(createdWindowIds.first)
+        let restoredWindowManager = try XCTUnwrap(appDelegate.tabManagerFor(windowId: restoredWindowId))
+        XCTAssertEqual(restoredWindowManager.selectedWorkspace?.customTitle, "Previous Work")
+    }
+
     func testCmdShiftNCreatesWindowFromEventWindowWithoutAddingWorkspace() {
         guard let appDelegate = AppDelegate.shared else {
             XCTFail("Expected AppDelegate.shared")

--- a/cmuxTests/CmuxEventBusTests.swift
+++ b/cmuxTests/CmuxEventBusTests.swift
@@ -263,6 +263,43 @@ final class CmuxEventBusTests: XCTestCase {
         XCTAssertEqual(replacedIds, [oldNotification.id.uuidString])
     }
 
+    func testNotificationRemovalDeduplicatesDuplicateOldIds() throws {
+        let bus = CmuxEventBus(retainedEventLimit: 8)
+        let workspaceId = UUID()
+        let surfaceId = UUID()
+        let notificationId = UUID()
+        let firstNotification = TerminalNotification(
+            id: notificationId,
+            tabId: workspaceId,
+            surfaceId: surfaceId,
+            title: "First",
+            subtitle: "",
+            body: "Done",
+            createdAt: Date(),
+            isRead: false
+        )
+        let duplicateNotification = TerminalNotification(
+            id: notificationId,
+            tabId: workspaceId,
+            surfaceId: surfaceId,
+            title: "Duplicate",
+            subtitle: "",
+            body: "Done",
+            createdAt: Date(),
+            isRead: false
+        )
+
+        bus.publishNotificationChanges(
+            oldValue: [firstNotification, duplicateNotification],
+            newValue: []
+        )
+
+        XCTAssertEqual(
+            bus.retainedSnapshot().compactMap { $0["name"] as? String },
+            ["notification.removed"]
+        )
+    }
+
     @MainActor
     func testBulkNotificationClearPublishesClearedWithoutRemovedDuplicates() throws {
         let store = TerminalNotificationStore.shared

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -126,6 +126,45 @@ final class SessionPersistenceTests: XCTestCase {
         XCTAssertTrue(store.notificationMenuSnapshot.hasUnreadNotifications)
     }
 
+    @MainActor
+    func testRestoreSessionNotificationsKeepsNotificationIdsUniqueWhenSnapshotIsDuplicated() throws {
+        let store = TerminalNotificationStore.shared
+        store.replaceNotificationsForTesting([])
+        defer { store.replaceNotificationsForTesting([]) }
+
+        let duplicateId = UUID()
+        let liveWorkspaceId = UUID()
+        let restoredWorkspaceId = UUID()
+        let existing = TerminalNotification(
+            id: duplicateId,
+            tabId: liveWorkspaceId,
+            surfaceId: nil,
+            title: "Existing",
+            subtitle: "codex",
+            body: "Already in the running app",
+            createdAt: Date(timeIntervalSince1970: 1_700_000_000),
+            isRead: false
+        )
+        let restored = TerminalNotification(
+            id: duplicateId,
+            tabId: restoredWorkspaceId,
+            surfaceId: nil,
+            title: "Restored",
+            subtitle: "codex",
+            body: "From the previous launch snapshot",
+            createdAt: Date(timeIntervalSince1970: 1_700_000_001),
+            isRead: false
+        )
+
+        store.replaceNotificationsForTesting([existing])
+        store.restoreSessionNotifications([restored], forTabId: restoredWorkspaceId)
+
+        XCTAssertEqual(store.notifications.count, 2)
+        XCTAssertEqual(Set(store.notifications.map(\.id)).count, 2)
+        XCTAssertTrue(store.notifications.contains { $0.tabId == liveWorkspaceId && $0.id == duplicateId })
+        XCTAssertTrue(store.notifications.contains { $0.tabId == restoredWorkspaceId && $0.id != duplicateId })
+    }
+
     func testSaveAndLoadRoundTripWithCustomSnapshotPath() throws {
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-session-tests-\(UUID().uuidString)", isDirectory: true)

--- a/cmuxTests/TabManagerSessionSnapshotTests.swift
+++ b/cmuxTests/TabManagerSessionSnapshotTests.swift
@@ -1057,7 +1057,12 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
         let historyURL = tempDir.appendingPathComponent("history.json", isDirectory: false)
         let manager = TabManager()
         let workspace = try XCTUnwrap(manager.selectedWorkspace)
-        let store = ClosedItemHistoryStore(capacity: nil, fileURL: historyURL)
+        let store = ClosedItemHistoryStore(
+            capacity: nil,
+            fileURL: historyURL,
+            loadsPersistedRecordsSynchronously: true,
+            persistsRecordsSynchronously: true
+        )
 
         for index in 0..<3 {
             var workspaceSnapshot = workspace.sessionSnapshot(includeScrollback: false)
@@ -1073,7 +1078,12 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
             ))
         }
 
-        let restoredStore = ClosedItemHistoryStore(capacity: nil, fileURL: historyURL)
+        let restoredStore = ClosedItemHistoryStore(
+            capacity: nil,
+            fileURL: historyURL,
+            loadsPersistedRecordsSynchronously: true,
+            persistsRecordsSynchronously: true
+        )
         let snapshot = restoredStore.menuSnapshot()
 
         XCTAssertEqual(snapshot.totalItemCount, 3)

--- a/cmuxTests/TabManagerSessionSnapshotTests.swift
+++ b/cmuxTests/TabManagerSessionSnapshotTests.swift
@@ -1048,6 +1048,46 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
         XCTAssertTrue(snapshot.items.allSatisfy { $0.menuSubtitle.contains("Closed") })
     }
 
+    func testClosedItemHistoryPersistsRecordsWithoutSharedCapacityLimit() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-closed-history-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let historyURL = tempDir.appendingPathComponent("history.json", isDirectory: false)
+        let manager = TabManager()
+        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let store = ClosedItemHistoryStore(capacity: nil, fileURL: historyURL)
+
+        for index in 0..<3 {
+            var workspaceSnapshot = workspace.sessionSnapshot(includeScrollback: false)
+            workspaceSnapshot.customTitle = "Closed Workspace \(index)"
+            store.push(ClosedItemHistoryRecord(
+                closedAt: Date(timeIntervalSince1970: TimeInterval(index)),
+                entry: .workspace(ClosedWorkspaceHistoryEntry(
+                    workspaceId: UUID(),
+                    windowId: nil,
+                    workspaceIndex: index,
+                    snapshot: workspaceSnapshot
+                ))
+            ))
+        }
+
+        let restoredStore = ClosedItemHistoryStore(capacity: nil, fileURL: historyURL)
+        let snapshot = restoredStore.menuSnapshot()
+
+        XCTAssertEqual(snapshot.totalItemCount, 3)
+        XCTAssertFalse(snapshot.isLimited)
+        XCTAssertEqual(snapshot.items.map(\.title), [
+            "Closed Workspace 2",
+            "Closed Workspace 1",
+            "Closed Workspace 0"
+        ])
+
+        restoredStore.removeAll()
+        XCTAssertFalse(FileManager.default.fileExists(atPath: historyURL.path))
+    }
+
     func testRecentlyClosedWorkspaceTitleIgnoresDotDirectoryFallback() throws {
         let manager = TabManager()
         let workspace = try XCTUnwrap(manager.selectedWorkspace)

--- a/cmuxTests/TabManagerSessionSnapshotTests.swift
+++ b/cmuxTests/TabManagerSessionSnapshotTests.swift
@@ -1151,6 +1151,69 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
         ])
     }
 
+    func testClosedItemHistoryAsyncLoadReplaysQueuedPanelWorkspaceRemap() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-closed-history-remap-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let historyURL = tempDir.appendingPathComponent("history.json", isDirectory: false)
+        let manager = TabManager()
+        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        var panelSnapshot = try XCTUnwrap(workspace.sessionSnapshot(includeScrollback: false).panels.first)
+        panelSnapshot.customTitle = "Persisted Closed Tab"
+        let oldWorkspaceId = workspace.id
+        let newWorkspaceId = UUID()
+        let oldPanelId = panelSnapshot.id
+        let newPanelId = UUID()
+        let recordId = UUID()
+        let seedStore = ClosedItemHistoryStore(
+            capacity: nil,
+            fileURL: historyURL,
+            loadsPersistedRecordsSynchronously: true,
+            persistsRecordsSynchronously: true
+        )
+        seedStore.push(ClosedItemHistoryRecord(
+            id: recordId,
+            closedAt: Date(timeIntervalSince1970: 1),
+            entry: .panel(ClosedPanelHistoryEntry(
+                workspaceId: oldWorkspaceId,
+                paneId: UUID(),
+                paneAnchorPanelId: oldPanelId,
+                tabIndex: 0,
+                snapshot: panelSnapshot,
+                fallbackSplitPlacement: ClosedPanelSplitPlacement(
+                    orientation: .horizontal,
+                    insertFirst: false,
+                    anchorPanelId: oldPanelId
+                )
+            ))
+        ))
+
+        let loadingStore = ClosedItemHistoryStore(
+            capacity: nil,
+            fileURL: historyURL,
+            loadsPersistedRecordsSynchronously: false,
+            persistsRecordsSynchronously: true
+        )
+        loadingStore.remapPanelWorkspaceIds(
+            from: oldWorkspaceId,
+            to: newWorkspaceId,
+            panelIdMap: [oldPanelId: newPanelId]
+        )
+
+        waitForClosedHistoryCount(1, in: loadingStore)
+
+        let remappedRecord = try XCTUnwrap(loadingStore.removeRecord(id: recordId)?.record)
+        guard case .panel(let entry) = remappedRecord.entry else {
+            return XCTFail("Expected persisted panel record")
+        }
+        XCTAssertEqual(entry.workspaceId, newWorkspaceId)
+        XCTAssertEqual(entry.paneAnchorPanelId, newPanelId)
+        XCTAssertEqual(entry.fallbackSplitPlacement?.anchorPanelId, newPanelId)
+        XCTAssertFalse(entry.restoreInOriginalPane)
+    }
+
     func testSessionRestoreRemapsPersistedClosedPanelWorkspaceIds() throws {
         let originalAppDelegate = AppDelegate.shared
         AppDelegate.shared = nil

--- a/cmuxTests/TabManagerSessionSnapshotTests.swift
+++ b/cmuxTests/TabManagerSessionSnapshotTests.swift
@@ -1151,6 +1151,43 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
         ])
     }
 
+    func testClosedItemHistoryFlushPendingSavesPersistsLatestRecords() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-closed-history-flush-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let historyURL = tempDir.appendingPathComponent("history.json", isDirectory: false)
+        let manager = TabManager()
+        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let store = ClosedItemHistoryStore(
+            capacity: nil,
+            fileURL: historyURL,
+            loadPersisted: false
+        )
+        var workspaceSnapshot = workspace.sessionSnapshot(includeScrollback: false)
+        workspaceSnapshot.customTitle = "Flushed Workspace"
+        store.push(ClosedItemHistoryRecord(
+            closedAt: Date(timeIntervalSince1970: 1),
+            entry: .workspace(ClosedWorkspaceHistoryEntry(
+                workspaceId: workspace.id,
+                windowId: nil,
+                workspaceIndex: 0,
+                snapshot: workspaceSnapshot
+            ))
+        ))
+
+        store.flushPendingSaves()
+
+        let restoredStore = ClosedItemHistoryStore(
+            capacity: nil,
+            fileURL: historyURL,
+            loadsPersistedRecordsSynchronously: true,
+            persistsRecordsSynchronously: true
+        )
+        XCTAssertEqual(restoredStore.menuSnapshot().items.map(\.title), ["Flushed Workspace"])
+    }
+
     func testClosedItemHistoryAsyncLoadReplaysQueuedPanelWorkspaceRemap() throws {
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-closed-history-remap-\(UUID().uuidString)", isDirectory: true)

--- a/cmuxTests/TabManagerSessionSnapshotTests.swift
+++ b/cmuxTests/TabManagerSessionSnapshotTests.swift
@@ -1098,6 +1098,93 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: historyURL.path))
     }
 
+    func testClosedItemHistoryAsyncLoadMergesEarlyMutation() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-closed-history-merge-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let historyURL = tempDir.appendingPathComponent("history.json", isDirectory: false)
+        let manager = TabManager()
+        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let seedStore = ClosedItemHistoryStore(
+            capacity: nil,
+            fileURL: historyURL,
+            loadsPersistedRecordsSynchronously: true,
+            persistsRecordsSynchronously: true
+        )
+        var persistedSnapshot = workspace.sessionSnapshot(includeScrollback: false)
+        persistedSnapshot.customTitle = "Persisted Workspace"
+        seedStore.push(ClosedItemHistoryRecord(
+            closedAt: Date(timeIntervalSince1970: 1),
+            entry: .workspace(ClosedWorkspaceHistoryEntry(
+                workspaceId: UUID(),
+                windowId: nil,
+                workspaceIndex: 0,
+                snapshot: persistedSnapshot
+            ))
+        ))
+
+        let loadingStore = ClosedItemHistoryStore(
+            capacity: nil,
+            fileURL: historyURL,
+            loadsPersistedRecordsSynchronously: false,
+            persistsRecordsSynchronously: true
+        )
+        var earlySnapshot = workspace.sessionSnapshot(includeScrollback: false)
+        earlySnapshot.customTitle = "Early Workspace"
+        loadingStore.push(ClosedItemHistoryRecord(
+            closedAt: Date(timeIntervalSince1970: 2),
+            entry: .workspace(ClosedWorkspaceHistoryEntry(
+                workspaceId: UUID(),
+                windowId: nil,
+                workspaceIndex: 1,
+                snapshot: earlySnapshot
+            ))
+        ))
+
+        waitForClosedHistoryCount(2, in: loadingStore)
+
+        XCTAssertEqual(loadingStore.menuSnapshot().items.map(\.title), [
+            "Early Workspace",
+            "Persisted Workspace"
+        ])
+    }
+
+    func testSessionRestoreRemapsPersistedClosedPanelWorkspaceIds() throws {
+        let originalAppDelegate = AppDelegate.shared
+        AppDelegate.shared = nil
+        defer {
+            AppDelegate.shared = originalAppDelegate
+        }
+
+        let sourceManager = TabManager()
+        let sourceWorkspace = try XCTUnwrap(sourceManager.selectedWorkspace)
+        sourceWorkspace.setCustomTitle("Restored Parent")
+        let pane = try XCTUnwrap(sourceWorkspace.bonsplitController.allPaneIds.first)
+        let panelId = try XCTUnwrap(sourceWorkspace.newTerminalSurface(inPane: pane, focus: true)?.id)
+        sourceWorkspace.setPanelCustomTitle(panelId: panelId, title: "Persisted Closed Tab")
+        let sourceSnapshot = sourceManager.sessionSnapshot(includeScrollback: false)
+        let panelSnapshot = try XCTUnwrap(
+            sourceWorkspace.sessionSnapshot(includeScrollback: false).panels.first { $0.id == panelId }
+        )
+
+        ClosedItemHistoryStore.shared.push(.panel(ClosedPanelHistoryEntry(
+            workspaceId: sourceWorkspace.id,
+            paneId: UUID(),
+            tabIndex: 0,
+            snapshot: panelSnapshot
+        )))
+
+        let restoreManager = TabManager()
+        _ = restoreManager.restoreSessionSnapshot(sourceSnapshot)
+        let restoredWorkspace = try XCTUnwrap(restoreManager.tabs.first { $0.customTitle == "Restored Parent" })
+        XCTAssertNotEqual(restoredWorkspace.id, sourceWorkspace.id)
+
+        XCTAssertTrue(restoreManager.reopenMostRecentlyClosedItem())
+        XCTAssertTrue(restoredWorkspace.panelCustomTitles.values.contains("Persisted Closed Tab"))
+    }
+
     func testRecentlyClosedWorkspaceTitleIgnoresDotDirectoryFallback() throws {
         let manager = TabManager()
         let workspace = try XCTUnwrap(manager.selectedWorkspace)
@@ -2008,6 +2095,21 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
                 skipDaemonBootstrap: nil
             )
         )
+    }
+
+    private func waitForClosedHistoryCount(
+        _ expectedCount: Int,
+        in store: ClosedItemHistoryStore,
+        timeout: TimeInterval = 2
+    ) {
+        let deadline = Date(timeIntervalSinceNow: timeout)
+        while Date() < deadline {
+            if store.menuSnapshot().totalItemCount == expectedCount {
+                return
+            }
+            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.02))
+        }
+        XCTAssertEqual(store.menuSnapshot().totalItemCount, expectedCount)
     }
 
     private static func browserPanelSnapshot(id: UUID) -> SessionPanelSnapshot {


### PR DESCRIPTION
## Summary
- Restore Previous Launch now opens restored windows alongside current windows instead of replacing or closing live work.
- Restored notifications get fresh IDs when duplicated snapshots collide with live notifications, and notification event publishing no longer traps on duplicate old IDs.
- Recently closed tab, workspace, and window history now persists to disk without the shared 50-item cap.

## Testing
- Passed: ./scripts/setup.sh
- Passed: ./scripts/reload.sh --tag rprev
- Added regression coverage for duplicate restored notification IDs, non-destructive previous-launch restore, and closed history persistence. Local xcodebuild test execution was intentionally not run on this Mac per repo policy.

## Issues
- Task: restore previous launch crash, make Cmd-Shift-O non-destructive, and persist workspace history forever.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore Previous Launch now creates new windows for snapshots instead of touching existing ones, fixing the crash and keeping current work open. Closed-item history is persisted to disk; remaps are applied immediately and survive restore, save, and shutdown.

- **Bug Fixes**
  - Restore is additive: snapshots open in new windows; only the first restored window is activated.
  - Closed-history remaps: window IDs remap only when different, deferred until a valid window exists, and rolled back on failed restore; panel remap happens after restore using captured original IDs; failed closed-window restores do not remap panel history.
  - Notifications: tolerate duplicate old IDs and dedupe change events; restored notifications get unique IDs.

- **New Features**
  - Recently closed tabs/workspaces/windows persist to a versioned JSON file under Application Support with optional per-store capacity; the file is removed when history is cleared.
  - Persisted history loads on launch, merges early changes, replays queued remaps/removals after async load, and flushes on quit/relaunch/power-off/session events; snapshots now include optional `windowId` and `workspaceId` for precise remapping.

<sup>Written for commit 85cbd50e4db4197e2f411e0f6b9c39201cd37491. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4982?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Closed panels/windows history can persist to disk with configurable persistence and stable ordering; workspace snapshots may include original workspace IDs.

* **Bug Fixes**
  * Session restore now reopens restored windows without closing existing ones and respects activation behavior.
  * Notification handling deduplicates IDs and ensures restored notifications get unique IDs.
  * Shutdown/restore flows flush pending history saves to ensure persistence.

* **Tests**
  * Added tests for session restore, notification-ID uniqueness, and history persistence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4982?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session restore, window lifecycle, and on-disk history persistence with ID remapping across quit/restore paths; behavior is well-covered by new tests but spans core app state.
> 
> **Overview**
> **Restore Previous Launch** no longer replaces or closes live windows: it always opens snapshot windows as **new** main windows and only activates the first when requested (`restorePreviousSessionSnapshot`).
> 
> **Recently closed** tabs, workspaces, and windows are **persisted to disk** (versioned JSON, no default 50-item cap on the shared store). Saves are **flushed** on quit, relaunch, power-off, and session resign; async load **merges** in-memory changes and **replays** queued remaps/removals before merge.
> 
> **Session snapshots** now carry optional **`windowId`** and **`workspaceId`** so restore can **remap** closed-history window, workspace, and panel IDs onto new UUIDs. Failed **closed-window** reopen discards the temp window and **reverts** window-ID remap without poisoning panel history; successful paths defer panel remap until content validates.
> 
> **Notifications**: restored session notifications get **new IDs** when they collide with live ones; event publishing **deduplicates** duplicate old/new IDs so removal/diff logic cannot trap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85cbd50e4db4197e2f411e0f6b9c39201cd37491. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->