### PR TITLE
Fix window movability regression

### DIFF
--- a/Resources/InfoPlist.xcstrings
+++ b/Resources/InfoPlist.xcstrings
@@ -16,6 +16,102 @@
             "state": "translated",
             "value": "cmux 内で実行中のプログラムが、パスキーとセキュリティキーを検出するために Bluetooth の使用を求めています。"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 cmux 中运行的程序想要使用蓝牙来发现通行密钥和安全密钥。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 cmux 中執行的程式想要使用藍牙來探索通行密鑰和安全密鑰。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux 내에서 실행 중인 프로그램이 패스키와 보안 키를 찾기 위해 Bluetooth를 사용하려고 합니다."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein in cmux ausgeführtes Programm möchte Bluetooth verwenden, um Passkeys und Sicherheitsschlüssel zu finden."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Un programa en ejecución dentro de cmux quiere usar Bluetooth para descubrir llaves de acceso y claves de seguridad."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Un programme s'exécutant dans cmux souhaite utiliser le Bluetooth pour détecter des clés d’accès et des clés de sécurité."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Un programma in esecuzione in cmux desidera usare il Bluetooth per rilevare passkey e chiavi di sicurezza."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Et program, der kører i cmux, vil gerne bruge Bluetooth til at finde adgangsnøgler og sikkerhedsnøgler."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Program działający w cmux chciałby użyć Bluetooth do wykrywania kluczy dostępu i kluczy zabezpieczeń."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Программа, запущенная в cmux, хотела бы использовать Bluetooth для обнаружения ключей доступа и ключей безопасности."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Program koji se izvršava unutar cmux želi koristiti Bluetooth za otkrivanje pristupnih ključeva i sigurnosnih ključeva."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يرغب برنامج يعمل داخل cmux في استخدام Bluetooth لاكتشاف مفاتيح المرور ومفاتيح الأمان."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Et program som kjører i cmux ønsker å bruke Bluetooth til å finne passnøkler og sikkerhetsnøkler."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Um programa em execução no cmux gostaria de usar Bluetooth para descobrir chaves de acesso e chaves de segurança."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "โปรแกรมที่ทำงานภายใน cmux ต้องการใช้ Bluetooth เพื่อค้นหาพาสคีย์และคีย์ความปลอดภัย"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux içinde çalışan bir program geçiş anahtarlarını ve güvenlik anahtarlarını bulmak için Bluetooth kullanmak istiyor."
+          }
         }
       }
     },
@@ -32,6 +128,102 @@
           "stringUnit": {
             "state": "translated",
             "value": "cmux 内で実行中のプログラムがカメラの使用を求めています。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 cmux 中运行的程序想要使用您的摄像头。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 cmux 中執行的程式想要使用您的相機。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux 내에서 실행 중인 프로그램이 카메라를 사용하려고 합니다."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein in cmux ausgeführtes Programm möchte Ihre Kamera verwenden."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Un programa en ejecución dentro de cmux desea usar tu cámara."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Un programme s'exécutant dans cmux souhaite utiliser votre caméra."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Un programma in esecuzione in cmux desidera utilizzare la fotocamera."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Et program, der kører i cmux, vil gerne bruge dit kamera."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Program działający w cmux chciałby użyć Twojej kamery."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Программа, запущенная в cmux, хотела бы использовать вашу камеру."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Program koji se izvršava unutar cmux želi koristiti vašu kameru."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يرغب برنامج يعمل داخل cmux في استخدام الكاميرا."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Et program som kjører i cmux ønsker å bruke kameraet ditt."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Um programa em execução no cmux gostaria de usar sua câmera."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "โปรแกรมที่ทำงานภายใน cmux ต้องการใช้กล้องของคุณ"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux içinde çalışan bir program kameranızı kullanmak istiyor."
           }
         }
       }

--- a/Sources/App/CmuxMainWindow.swift
+++ b/Sources/App/CmuxMainWindow.swift
@@ -29,9 +29,21 @@ final class MainWindowHostingView<Content: View>: NSHostingView<Content> {
 }
 
 @MainActor
-func configureCmuxMainWindowDragBehavior(_ window: NSWindow) {
+func configureCmuxMainWindowDragBehavior(
+    _ window: NSWindow,
+    defaults: UserDefaults = .standard
+) {
+    // Keep background dragging disabled so app content gestures and titlebar
+    // controls receive clicks. In standard mode, leave the OS-level movable bit
+    // enabled for macOS tiling and third-party window managers. In minimal mode,
+    // there is no native titlebar: app-owned chrome must explicitly call
+    // performDrag so Bonsplit pane tabs cannot be stolen by AppKit window moves.
     window.isMovableByWindowBackground = false
-    window.isMovable = false
+    if activeWindowMoveSuppressionSequenceReason(window: window) == nil {
+        window.isMovable = !WorkspacePresentationModeSettings.isMinimal(defaults: defaults)
+    } else {
+        ensureWindowMoveSuppressionSequenceIsImmovable(window: window)
+    }
 }
 
 @MainActor

--- a/Sources/App/CmuxMainWindow.swift
+++ b/Sources/App/CmuxMainWindow.swift
@@ -39,9 +39,14 @@ func configureCmuxMainWindowDragBehavior(
     // there is no native titlebar: app-owned chrome must explicitly call
     // performDrag so Bonsplit pane tabs cannot be stolen by AppKit window moves.
     window.isMovableByWindowBackground = false
+    let baselineIsMovable = !WorkspacePresentationModeSettings.isMinimal(defaults: defaults)
     if activeWindowMoveSuppressionSequenceReason(window: window) == nil {
-        window.isMovable = !WorkspacePresentationModeSettings.isMinimal(defaults: defaults)
+        window.isMovable = baselineIsMovable
     } else {
+        updateActiveWindowMoveSuppressionSequencePreviousMovableState(
+            window: window,
+            previousMovableState: baselineIsMovable
+        )
         ensureWindowMoveSuppressionSequenceIsImmovable(window: window)
     }
 }

--- a/Sources/App/CmuxMainWindow.swift
+++ b/Sources/App/CmuxMainWindow.swift
@@ -28,6 +28,14 @@ final class MainWindowHostingView<Content: View>: NSHostingView<Content> {
     }
 }
 
+/// Applies the main-window AppKit movability baseline for the active presentation mode.
+///
+/// Standard mode keeps native OS-level window movability enabled for macOS
+/// tiling and third-party window managers. Minimal mode disables native
+/// movability so cmux-owned chrome can decide exactly when to call
+/// `performDrag`. If a protected drag suppression sequence is active, the
+/// window remains immovable and only the post-suppression restore baseline is
+/// updated.
 @MainActor
 func configureCmuxMainWindowDragBehavior(
     _ window: NSWindow,

--- a/Sources/App/ShortcutRoutingSupport.swift
+++ b/Sources/App/ShortcutRoutingSupport.swift
@@ -789,6 +789,7 @@ enum WindowMoveSuppressionReason: String {
     case bonsplitPaneTabDrag
 }
 
+@MainActor
 func shouldSuppressWindowMoveForBonsplitPaneTabDrag(window: NSWindow, event: NSEvent) -> Bool {
     guard event.type == .leftMouseDown else {
         return false
@@ -797,6 +798,7 @@ func shouldSuppressWindowMoveForBonsplitPaneTabDrag(window: NSWindow, event: NSE
     return BonsplitTabItemHitRegionRegistry.containsWindowPoint(event.locationInWindow, in: window)
 }
 
+@MainActor
 func windowMoveSuppressionReason(window: NSWindow, event: NSEvent) -> WindowMoveSuppressionReason? {
     if shouldSuppressWindowMoveForFolderDrag(window: window, event: event) {
         return .folderDrag
@@ -807,6 +809,7 @@ func windowMoveSuppressionReason(window: NSWindow, event: NSEvent) -> WindowMove
     return nil
 }
 
+@MainActor
 func beginOrContinueWindowMoveSuppressionSequenceForEvent(
     window: NSWindow,
     event: NSEvent,
@@ -829,6 +832,7 @@ func beginOrContinueWindowMoveSuppressionSequenceForEvent(
     return beginWindowMoveSuppressionSequence(window: window, reason: reason)
 }
 
+@MainActor
 func shouldFinishWindowMoveSuppressionSequenceAfterDispatch(window: NSWindow, event: NSEvent) -> Bool {
     activeWindowMoveSuppressionSequenceReason(window: window) != nil && event.type == .leftMouseUp
 }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -3205,6 +3205,7 @@ struct ContentView: View {
 
         view = AnyView(view.onChange(of: isMinimalMode) { _, _ in
             if let observedWindow {
+                configureCmuxMainWindowDragBehavior(observedWindow)
                 setTitlebarControlsHidden(isFullScreen, in: observedWindow)
                 AppDelegate.shared?.applyWindowDecorations(to: observedWindow)
                 refreshWindowChromeMetrics(for: observedWindow)
@@ -3256,9 +3257,11 @@ struct ContentView: View {
             window.isRestorable = false
             setMinimalModeSidebarTitlebarControlsAvailable(sidebarState.isVisible, in: window)
             window.titlebarAppearsTransparent = true
-            // Native AppKit titlebar dragging steals pane-tab drags in minimal
-            // mode. Keep the main window immovable by default; explicit chrome
-            // drag zones temporarily enable performDrag for real app moves.
+            // Keep background dragging disabled so app content gestures and
+            // titlebar controls receive clicks. Standard mode keeps AppKit
+            // movability for macOS tiling/window managers; minimal mode keeps
+            // the native movable bit off so Bonsplit tabs cannot become window
+            // drags. Explicit cmux drag zones call performDrag when needed.
             configureCmuxMainWindowDragBehavior(window)
             window.styleMask.insert(.fullSizeContentView)
 

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -3205,7 +3205,6 @@ struct ContentView: View {
 
         view = AnyView(view.onChange(of: isMinimalMode) { _, _ in
             if let observedWindow {
-                configureCmuxMainWindowDragBehavior(observedWindow)
                 setTitlebarControlsHidden(isFullScreen, in: observedWindow)
                 AppDelegate.shared?.applyWindowDecorations(to: observedWindow)
                 refreshWindowChromeMetrics(for: observedWindow)

--- a/Sources/DetachedFolderDragIcon.swift
+++ b/Sources/DetachedFolderDragIcon.swift
@@ -83,6 +83,7 @@ final class DraggableFolderNSView: NSView, NSDraggingSource {
     }
 
     func draggingSession(_ session: NSDraggingSession, endedAt screenPoint: NSPoint, operation: NSDragOperation) {
+        finishWindowMoveSuppressionSequence(window: window, matching: .folderDrag)
         #if DEBUG
         let nowMovable = window.map { String($0.isMovable) } ?? "nil"
         let windowOrigin = window.map { formatPoint($0.frame.origin) } ?? "nil"
@@ -142,6 +143,7 @@ final class DraggableFolderNSView: NSView, NSDraggingSource {
 
     override func mouseUp(with event: NSEvent) {
         clearPendingDrag()
+        finishWindowMoveSuppressionSequence(window: window, matching: .folderDrag)
         super.mouseUp(with: event)
     }
 

--- a/Sources/WindowDecorationsController.swift
+++ b/Sources/WindowDecorationsController.swift
@@ -1,5 +1,6 @@
 import AppKit
 
+@MainActor
 final class WindowDecorationsController {
     private var observers: [NSObjectProtocol] = []
     private var didStart = false
@@ -36,7 +37,11 @@ final class WindowDecorationsController {
     }
 
     func apply(to window: NSWindow) {
-        if isMainWorkspaceWindow(window), WorkspacePresentationModeSettings.isMinimal() {
+        let isMainWindow = isMainWorkspaceWindow(window)
+        if isMainWindow {
+            configureCmuxMainWindowDragBehavior(window)
+        }
+        if isMainWindow, WorkspacePresentationModeSettings.isMinimal() {
             WindowMouseMovedEventsCoordinator.enable(for: window, owner: self)
         } else {
             WindowMouseMovedEventsCoordinator.disable(for: window, owner: self)

--- a/Sources/WindowDragHandleView.swift
+++ b/Sources/WindowDragHandleView.swift
@@ -240,7 +240,7 @@ private enum WindowDragHandleAssociatedObjectKeys {
 // main-thread mouse-event dispatch path.
 private final class WindowMoveSuppressionSequenceState: @unchecked Sendable {
     let reason: WindowMoveSuppressionReason
-    let previousMovableState: Bool
+    var previousMovableState: Bool
 
     init(reason: WindowMoveSuppressionReason, previousMovableState: Bool) {
         self.reason = reason
@@ -334,6 +334,20 @@ func beginWindowMoveSuppressionSequence(
         .OBJC_ASSOCIATION_RETAIN_NONATOMIC
     )
     return reason
+}
+
+func updateActiveWindowMoveSuppressionSequencePreviousMovableState(
+    window: NSWindow?,
+    previousMovableState: Bool
+) {
+    guard let window,
+          let state = objc_getAssociatedObject(
+            window,
+            WindowDragHandleAssociatedObjectKeys.moveSuppressionSequence
+          ) as? WindowMoveSuppressionSequenceState else {
+        return
+    }
+    state.previousMovableState = previousMovableState
 }
 
 func ensureWindowMoveSuppressionSequenceIsImmovable(window: NSWindow?) {

--- a/Sources/WindowDragHandleView.swift
+++ b/Sources/WindowDragHandleView.swift
@@ -366,6 +366,17 @@ func finishWindowMoveSuppressionSequence(window: NSWindow?) -> WindowMoveSuppres
     return state.reason
 }
 
+@discardableResult
+func finishWindowMoveSuppressionSequence(
+    window: NSWindow?,
+    matching reason: WindowMoveSuppressionReason
+) -> WindowMoveSuppressionReason? {
+    guard activeWindowMoveSuppressionSequenceReason(window: window) == reason else {
+        return nil
+    }
+    return finishWindowMoveSuppressionSequence(window: window)
+}
+
 func restoreWindowDragging(window: NSWindow?, previousMovableState: Bool?) {
     guard let window,
           let previousMovableState else { return }

--- a/Sources/WindowDragHandleView.swift
+++ b/Sources/WindowDragHandleView.swift
@@ -303,6 +303,8 @@ func isWindowDragSuppressed(window: NSWindow?) -> Bool {
     windowDragSuppressionDepth(window: window) > 0
 }
 
+/// Returns the reason for the active window-move suppression sequence, if one exists.
+@MainActor
 func activeWindowMoveSuppressionSequenceReason(window: NSWindow?) -> WindowMoveSuppressionReason? {
     guard let window,
           let state = objc_getAssociatedObject(
@@ -314,6 +316,8 @@ func activeWindowMoveSuppressionSequenceReason(window: NSWindow?) -> WindowMoveS
     return state.reason
 }
 
+/// Starts a window-move suppression sequence and records the window's restore baseline.
+@MainActor
 @discardableResult
 func beginWindowMoveSuppressionSequence(
     window: NSWindow?,
@@ -372,6 +376,8 @@ func updateActiveWindowMoveSuppressionSequencePreviousMovableState(
     )
 }
 
+/// Keeps a window immovable while its move-suppression sequence is active.
+@MainActor
 func ensureWindowMoveSuppressionSequenceIsImmovable(window: NSWindow?) {
     guard let window,
           activeWindowMoveSuppressionSequenceReason(window: window) != nil,
@@ -381,6 +387,8 @@ func ensureWindowMoveSuppressionSequenceIsImmovable(window: NSWindow?) {
     window.isMovable = false
 }
 
+/// Finishes the active move-suppression sequence and restores the recorded baseline.
+@MainActor
 @discardableResult
 func finishWindowMoveSuppressionSequence(window: NSWindow?) -> WindowMoveSuppressionReason? {
     guard let window,
@@ -406,6 +414,7 @@ func finishWindowMoveSuppressionSequence(window: NSWindow?) -> WindowMoveSuppres
 ///
 /// This lets a specific drag source clean up after itself without accidentally
 /// ending another source's still-active suppression sequence.
+@MainActor
 @discardableResult
 func finishWindowMoveSuppressionSequence(
     window: NSWindow?,
@@ -417,6 +426,8 @@ func finishWindowMoveSuppressionSequence(
     return finishWindowMoveSuppressionSequence(window: window)
 }
 
+/// Restores AppKit window dragging to a previously captured value.
+@MainActor
 func restoreWindowDragging(window: NSWindow?, previousMovableState: Bool?) {
     guard let window,
           let previousMovableState else { return }
@@ -425,6 +436,8 @@ func restoreWindowDragging(window: NSWindow?, previousMovableState: Bool?) {
     }
 }
 
+/// Clears all drag-suppression state attached to a window.
+@MainActor
 @discardableResult
 func clearWindowDragSuppression(window: NSWindow?) -> Int {
     guard let window else { return 0 }
@@ -1118,6 +1131,7 @@ private func windowDragHandleSiblingHitResolutionScope(
 /// Returns whether the titlebar drag handle should capture a hit at `point`.
 /// We only claim the hit when no sibling view already handles it, so interactive
 /// controls layered in the titlebar (e.g. proxy folder icon) keep their gestures.
+@MainActor
 func windowDragHandleShouldCaptureHit(
     _ point: NSPoint,
     in dragHandleView: NSView,

--- a/Sources/WindowDragHandleView.swift
+++ b/Sources/WindowDragHandleView.swift
@@ -9,6 +9,10 @@ enum WindowMouseMovedEventsCoordinator {
         var owners: Set<ObjectIdentifier>
     }
 
+    // NSLock is used instead of actor isolation because these static reference
+    // counts are read and restored synchronously from AppKit event-monitor and
+    // deinit paths that cannot suspend or hop while preserving the prior
+    // `acceptsMouseMovedEvents` value.
     private nonisolated(unsafe) static var records: [ObjectIdentifier: Record] = [:]
     private nonisolated static let lock = NSLock()
 
@@ -73,6 +77,9 @@ private func windowDragHandleEventTypeDescription(_ eventType: NSEvent.EventType
 }
 
 private enum WindowDragHandleBreadcrumbLimiter {
+    // NSLock keeps this debug breadcrumb limiter synchronous and allocation-light
+    // from AppKit mouse-event paths; an actor hop would reorder or defer logging
+    // decisions relative to the event currently being handled.
     private static let lock = NSLock()
     private static var lastEmissionByKey: [String: CFAbsoluteTime] = [:]
 
@@ -240,7 +247,7 @@ private enum WindowDragHandleAssociatedObjectKeys {
 // main-thread mouse-event dispatch path.
 private final class WindowMoveSuppressionSequenceState: @unchecked Sendable {
     let reason: WindowMoveSuppressionReason
-    var previousMovableState: Bool
+    let previousMovableState: Bool
 
     init(reason: WindowMoveSuppressionReason, previousMovableState: Bool) {
         self.reason = reason
@@ -336,6 +343,12 @@ func beginWindowMoveSuppressionSequence(
     return reason
 }
 
+/// Updates the restore baseline for an active move-suppression sequence.
+///
+/// Presentation mode can change while a protected drag is in progress. The
+/// window must stay immovable until the drag finishes, but the post-drag
+/// restore value needs to track the current presentation-mode baseline.
+@MainActor
 func updateActiveWindowMoveSuppressionSequencePreviousMovableState(
     window: NSWindow?,
     previousMovableState: Bool
@@ -347,7 +360,16 @@ func updateActiveWindowMoveSuppressionSequencePreviousMovableState(
           ) as? WindowMoveSuppressionSequenceState else {
         return
     }
-    state.previousMovableState = previousMovableState
+    let updatedState = WindowMoveSuppressionSequenceState(
+        reason: state.reason,
+        previousMovableState: previousMovableState
+    )
+    objc_setAssociatedObject(
+        window,
+        WindowDragHandleAssociatedObjectKeys.moveSuppressionSequence,
+        updatedState,
+        .OBJC_ASSOCIATION_RETAIN_NONATOMIC
+    )
 }
 
 func ensureWindowMoveSuppressionSequenceIsImmovable(window: NSWindow?) {
@@ -380,6 +402,10 @@ func finishWindowMoveSuppressionSequence(window: NSWindow?) -> WindowMoveSuppres
     return state.reason
 }
 
+/// Finishes the active move-suppression sequence only when its reason matches.
+///
+/// This lets a specific drag source clean up after itself without accidentally
+/// ending another source's still-active suppression sequence.
 @discardableResult
 func finishWindowMoveSuppressionSequence(
     window: NSWindow?,
@@ -459,6 +485,10 @@ protocol MinimalModeSidebarControlActionHitRegionProviding: MinimalModeTitlebarC
 }
 
 enum MinimalModeTitlebarControlHitRegionRegistry {
+    // NSLock protects the weak view table because AppKit can register/unregister
+    // representable-backed views during layout while hit-testing reads snapshots
+    // from event dispatch; actor isolation would add a hop to pointer paths and
+    // cannot guard NSHashTable's synchronous mutation semantics.
     private static let lock = NSLock()
     private static let registeredViews = NSHashTable<NSView>.weakObjects()
 

--- a/cmuxTests/WindowAndDragTests.swift
+++ b/cmuxTests/WindowAndDragTests.swift
@@ -1862,7 +1862,38 @@ final class TitlebarLeadingInsetPassthroughViewTests: XCTestCase {
         )
     }
 
-    func testMainWindowDragBehaviorRequiresExplicitDragZones() {
+    func testMainWindowDragBehaviorKeepsOSMovabilityWithoutBackgroundDraggingInStandardMode() {
+        let suiteName = "cmuxTests.standardDragBehavior.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.set(WorkspacePresentationModeSettings.Mode.standard.rawValue, forKey: WorkspacePresentationModeSettings.modeKey)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let window = CmuxMainWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 180),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        window.isMovable = false
+        window.isMovableByWindowBackground = true
+
+        configureCmuxMainWindowDragBehavior(window, defaults: defaults)
+
+        XCTAssertTrue(
+            window.isMovable,
+            "Standard main windows must keep AppKit movability enabled for macOS tiling and third-party window managers"
+        )
+        XCTAssertFalse(
+            window.isMovableByWindowBackground,
+            "App content gestures and titlebar controls must not become implicit AppKit background-drag regions"
+        )
+    }
+
+    func testMainWindowDragBehaviorDisablesNativeMovabilityInMinimalMode() {
+        let suiteName = "cmuxTests.minimalDragBehavior.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.set(WorkspacePresentationModeSettings.Mode.minimal.rawValue, forKey: WorkspacePresentationModeSettings.modeKey)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
         let window = CmuxMainWindow(
             contentRect: NSRect(x: 0, y: 0, width: 320, height: 180),
             styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
@@ -1873,23 +1904,44 @@ final class TitlebarLeadingInsetPassthroughViewTests: XCTestCase {
         window.isMovable = true
         window.isMovableByWindowBackground = true
 
-        configureCmuxMainWindowDragBehavior(window)
+        configureCmuxMainWindowDragBehavior(window, defaults: defaults)
 
         XCTAssertFalse(
             window.isMovable,
-            "Main windows must not use native AppKit titlebar dragging because pane tabs live in the titlebar band"
+            "Minimal mode has no native titlebar; explicit cmux drag zones must own window movement so Bonsplit tabs cannot move the window"
         )
         XCTAssertFalse(window.isMovableByWindowBackground)
+    }
 
-        let previous = withTemporaryWindowMovableEnabled(window: window) {
-            XCTAssertTrue(window.isMovable)
-        }
+    func testMainWindowDragBehaviorDoesNotReenableActiveSuppressionSequence() {
+        let suiteName = "cmuxTests.suppressedDragBehavior.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.set(WorkspacePresentationModeSettings.Mode.standard.rawValue, forKey: WorkspacePresentationModeSettings.modeKey)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let window = CmuxMainWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 180),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        configureCmuxMainWindowDragBehavior(window, defaults: defaults)
+        XCTAssertTrue(window.isMovable)
 
-        XCTAssertEqual(previous, false)
+        XCTAssertEqual(
+            beginWindowMoveSuppressionSequence(window: window, reason: .bonsplitPaneTabDrag),
+            .bonsplitPaneTabDrag
+        )
+        XCTAssertFalse(window.isMovable)
+
+        configureCmuxMainWindowDragBehavior(window, defaults: defaults)
+
         XCTAssertFalse(
             window.isMovable,
-            "Explicit chrome drag zones may temporarily enable movement, but the main window must return to pane-tab-safe immovable state"
+            "Re-applying window configuration during a tab drag must not re-enable native AppKit movement"
         )
+        XCTAssertEqual(finishWindowMoveSuppressionSequence(window: window), .bonsplitPaneTabDrag)
+        XCTAssertTrue(window.isMovable)
     }
 }
 
@@ -1971,6 +2023,23 @@ final class FolderWindowMoveSuppressionTests: XCTestCase {
         XCTAssertEqual(windowDragSuppressionDepth(window: window), 0)
         XCTAssertFalse(isWindowDragSuppressed(window: window))
         XCTAssertTrue(window.isMovable)
+    }
+
+    func testFinishingMatchingSuppressionRestoresMovableWindow() {
+        let window = makeWindow()
+        window.isMovable = true
+
+        XCTAssertEqual(
+            beginWindowMoveSuppressionSequence(window: window, reason: .folderDrag),
+            .folderDrag
+        )
+        XCTAssertFalse(window.isMovable)
+        XCTAssertNil(finishWindowMoveSuppressionSequence(window: window, matching: .bonsplitPaneTabDrag))
+        XCTAssertFalse(window.isMovable)
+
+        XCTAssertEqual(finishWindowMoveSuppressionSequence(window: window, matching: .folderDrag), .folderDrag)
+        XCTAssertTrue(window.isMovable)
+        XCTAssertNil(activeWindowMoveSuppressionSequenceReason(window: window))
     }
 
     func testWindowDragSuppressionDepthLifecycle() {

--- a/cmuxTests/WindowAndDragTests.swift
+++ b/cmuxTests/WindowAndDragTests.swift
@@ -1943,6 +1943,70 @@ final class TitlebarLeadingInsetPassthroughViewTests: XCTestCase {
         XCTAssertEqual(finishWindowMoveSuppressionSequence(window: window), .bonsplitPaneTabDrag)
         XCTAssertTrue(window.isMovable)
     }
+
+    func testMainWindowDragBehaviorRestoresMinimalBaselineAfterModeChangeDuringSuppression() {
+        let suiteName = "cmuxTests.suppressedDragBehavior.standardToMinimal.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.set(WorkspacePresentationModeSettings.Mode.standard.rawValue, forKey: WorkspacePresentationModeSettings.modeKey)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let window = CmuxMainWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 180),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        configureCmuxMainWindowDragBehavior(window, defaults: defaults)
+        XCTAssertTrue(window.isMovable)
+
+        XCTAssertEqual(
+            beginWindowMoveSuppressionSequence(window: window, reason: .bonsplitPaneTabDrag),
+            .bonsplitPaneTabDrag
+        )
+        XCTAssertFalse(window.isMovable)
+
+        defaults.set(WorkspacePresentationModeSettings.Mode.minimal.rawValue, forKey: WorkspacePresentationModeSettings.modeKey)
+        configureCmuxMainWindowDragBehavior(window, defaults: defaults)
+
+        XCTAssertFalse(window.isMovable)
+        XCTAssertEqual(finishWindowMoveSuppressionSequence(window: window), .bonsplitPaneTabDrag)
+        XCTAssertFalse(
+            window.isMovable,
+            "A mode change during suppression must update the post-drag baseline instead of restoring stale standard-mode movability"
+        )
+    }
+
+    func testMainWindowDragBehaviorRestoresStandardBaselineAfterModeChangeDuringSuppression() {
+        let suiteName = "cmuxTests.suppressedDragBehavior.minimalToStandard.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.set(WorkspacePresentationModeSettings.Mode.minimal.rawValue, forKey: WorkspacePresentationModeSettings.modeKey)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let window = CmuxMainWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 180),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        configureCmuxMainWindowDragBehavior(window, defaults: defaults)
+        XCTAssertFalse(window.isMovable)
+
+        XCTAssertEqual(
+            beginWindowMoveSuppressionSequence(window: window, reason: .bonsplitPaneTabDrag),
+            .bonsplitPaneTabDrag
+        )
+        XCTAssertFalse(window.isMovable)
+
+        defaults.set(WorkspacePresentationModeSettings.Mode.standard.rawValue, forKey: WorkspacePresentationModeSettings.modeKey)
+        configureCmuxMainWindowDragBehavior(window, defaults: defaults)
+
+        XCTAssertFalse(window.isMovable)
+        XCTAssertEqual(finishWindowMoveSuppressionSequence(window: window), .bonsplitPaneTabDrag)
+        XCTAssertTrue(
+            window.isMovable,
+            "A mode change during suppression must restore the current standard-mode baseline once the protected drag ends"
+        )
+    }
 }
 
 


### PR DESCRIPTION
## Summary

- Restore standard-mode main window `isMovable` so macOS tiling and third-party window managers can move cmux windows again.
- Keep `isMovableByWindowBackground` disabled so app content, titlebar controls, folder proxy icon drags, and Bonsplit tab gestures do not become implicit background window drags.
- Keep minimal mode native movability disabled; explicit cmux chrome drag handles still opt into `performDrag` when they intentionally move the window.
- Preserve active window-move suppression while a protected drag sequence is in progress, and finish folder-drag suppression only when the active suppression reason matches.
- Does not update `vendor/bonsplit`; this PR only addresses the cmux-side regression.

## Testing

- `CMUX_NUCLEO_FFI_REQUIRE_CARGO=0 CMUX_SKIP_ZIG_BUILD=1 ./scripts/test-unit.sh test -only-testing:cmuxTests/TitlebarLeadingInsetPassthroughViewTests -only-testing:cmuxTests/FolderWindowMoveSuppressionTests -only-testing:cmuxTests/WindowMoveSuppressionHitPathTests`
- `CMUX_SKIP_ZIG_BUILD=1 CMUX_NUCLEO_FFI_REQUIRE_CARGO=0 ./scripts/reload.sh --tag window-movable-regression`
- Manually verified the built tagged Debug app path was produced for QA.
- Docs/changelog not updated: this is a narrow window-drag regression fix with no docs-facing behavior change.

## Demo Video

For UI or behavior changes, include a short demo video (GitHub upload, Loom, or other direct link).

- Video URL or attachment: Not included per request.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed (N/A)
- [x] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [x] All code review bot comments are resolved
- [x] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4983"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782633259&installation_id=133855650&pr_number=4983&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4983&signature=27598fd78e6f2085f9f1b99660179d48329aba62ae613ccad2fdfc83f94fb2f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores OS-level movability for the main window in standard mode while keeping background drags off; minimal mode stays immovable and uses explicit chrome drags. Preserves suppression state across mode changes and aligns suppression helpers to the main thread for safe UI updates.

- **Bug Fixes**
  - Set `isMovable` by presentation mode: enabled in standard, disabled in minimal; keep `isMovableByWindowBackground = false`.
  - Do not re-enable movability during an active suppression; update the restore baseline on mode changes and keep the window immovable until suppression ends.
  - Finish folder-drag suppression on mouseUp/session end only when the reason matches via `finishWindowMoveSuppressionSequence(...)`.
  - Re-apply window drag config when decorations apply to the main window and on mode changes, without breaking active suppressions.
  - Marked suppression and routing helpers `@MainActor`; used lightweight locks where needed to keep AppKit event paths synchronous and avoid cross-actor issues.
  - Expanded tests for standard/minimal baselines, no re-enable during suppression, mode-switch restoration, and folder-drag matching finish.

- **New Features**
  - Added localized strings for Bluetooth and camera permission prompts in `InfoPlist.xcstrings` (zh-Hans/zh-Hant/ko/de/es/fr/it/da/pl/ru/bs/ar/nb/pt-BR/th/tr).

<sup>Written for commit 2ebd19682ac85c82b2ea09432735e7c94138b807. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4983?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Main-window drag behavior now respects presentation mode and active suppression sequences; background dragging stays disabled and prior movability is preserved/restored correctly.

* **Tests**
  * Added extensive tests covering mode changes, suppression lifecycles, and folder-drag suppression behavior.

* **Localization**
  * Added translations for permission usage strings across many additional locales.

* **Refactor**
  * Improved main-thread safety and drag-handling coordination.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4983?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->