### PR TITLE
Fix #4995: route TypeScript previews away from QuickLook media

### DIFF
--- a/Sources/Panels/FilePreviewPanel.swift
+++ b/Sources/Panels/FilePreviewPanel.swift
@@ -717,7 +717,7 @@ enum FilePreviewKindResolver {
 
     private static func initialResolution(for url: URL) -> Resolution {
         let ext = url.pathExtension.lowercased()
-        if let textResolution = knownTextResolutionBeforeMedia(for: url) {
+        if let textResolution = knownTextResolutionBeforeMedia(for: url, sniffMediaCollisions: false) {
             return textResolution
         }
 
@@ -743,7 +743,7 @@ enum FilePreviewKindResolver {
             return .resolved(.quickLook)
         }
 
-        if let textResolution = knownTextResolutionBeforeMedia(for: url) {
+        if let textResolution = knownTextResolutionBeforeMedia(for: url, sniffMediaCollisions: true) {
             return textResolution
         }
 
@@ -809,7 +809,7 @@ enum FilePreviewKindResolver {
         return false
     }
 
-    private static func knownTextResolutionBeforeMedia(for url: URL) -> Resolution? {
+    private static func knownTextResolutionBeforeMedia(for url: URL, sniffMediaCollisions: Bool) -> Resolution? {
         let filename = url.lastPathComponent.lowercased()
         let ext = url.pathExtension.lowercased()
         guard ext != "plist",
@@ -825,7 +825,10 @@ enum FilePreviewKindResolver {
         }
 
         // Source extensions can collide with system audio/video UTIs (.ts, .mts).
-        // Decide from a small content sample before QuickLook can pick its movie generator.
+        // Initial routing stays extension-only; resolved routing sniffs off-main.
+        guard sniffMediaCollisions else {
+            return .resolved(.text)
+        }
         if sniffLooksLikeText(url: url) {
             return .resolved(.text)
         }

--- a/Sources/Panels/FilePreviewPanel.swift
+++ b/Sources/Panels/FilePreviewPanel.swift
@@ -1156,6 +1156,9 @@ final class FilePreviewPanel: Panel, ObservableObject, FilePreviewTextEditingPan
 
     private func applyResolvedPreviewMode(_ mode: FilePreviewMode) {
         guard previewMode != mode else { return }
+        if mode != .text {
+            textLoadGeneration += 1
+        }
         previewMode = mode
         displayIcon = FilePreviewKindResolver.iconName(for: mode)
         focusCoordinator.notePreferredIntent(Self.defaultFocusIntent(for: mode))
@@ -1165,13 +1168,18 @@ final class FilePreviewPanel: Panel, ObservableObject, FilePreviewTextEditingPan
 
     @discardableResult
     func loadTextContent(replacingDirtyContent: Bool = true) -> Task<Void, Never> {
+        guard previewMode == .text else {
+            return Task {}
+        }
         textLoadGeneration += 1
         let generation = textLoadGeneration
         let fileURL = fileURL
 
         return Task { [weak self, fileURL, generation, replacingDirtyContent] in
             let result = await FilePreviewTextLoader.load(url: fileURL)
-            guard let self, self.textLoadGeneration == generation else { return }
+            guard let self,
+                  self.textLoadGeneration == generation,
+                  self.previewMode == .text else { return }
             self.applyTextLoadResult(result, replacingDirtyContent: replacingDirtyContent)
         }
     }

--- a/Sources/Panels/FilePreviewPanel.swift
+++ b/Sources/Panels/FilePreviewPanel.swift
@@ -661,10 +661,10 @@ enum FilePreviewKindResolver {
     ]
 
     private static let textExtensions: Set<String> = [
-        "bash", "c", "cc", "cfg", "conf", "cpp", "cs", "css", "csv", "env",
+        "bash", "c", "cc", "cfg", "conf", "cpp", "cs", "css", "csv", "cts", "env",
         "fish", "go", "h", "hpp", "htm", "html", "ini", "java", "js", "json",
-        "jsx", "kt", "log", "m", "markdown", "md", "mdx", "mm", "plist", "py",
-        "rb", "rs", "sh", "sql", "swift", "toml", "ts", "tsx", "tsv", "txt",
+        "jsx", "kt", "log", "m", "markdown", "md", "mdx", "mm", "mts", "plist",
+        "py", "rb", "rs", "sh", "sql", "swift", "toml", "ts", "tsx", "tsv", "txt",
         "xml", "yaml", "yml", "zsh"
     ]
 
@@ -717,8 +717,8 @@ enum FilePreviewKindResolver {
 
     private static func initialResolution(for url: URL) -> Resolution {
         let ext = url.pathExtension.lowercased()
-        if needsSniffBeforeTextOrMedia(url: url) {
-            return .needsSniff
+        if let textResolution = knownTextResolutionBeforeMedia(for: url) {
+            return textResolution
         }
 
         if let type = UTType(filenameExtension: ext),
@@ -743,17 +743,8 @@ enum FilePreviewKindResolver {
             return .resolved(.quickLook)
         }
 
-        if needsSniffBeforeTextOrMedia(url: url) {
-            if sniffLooksLikeText(url: url) {
-                return .resolved(.text)
-            }
-            if looksLikeMPEGTransportStream(url: url) {
-                return .resolved(.media)
-            }
-            if let mediaMode = contentTypes(for: url).lazy.compactMap({ mediaMode(for: $0) }).first {
-                return .resolved(mediaMode)
-            }
-            return .needsSniff
+        if let textResolution = knownTextResolutionBeforeMedia(for: url) {
+            return textResolution
         }
 
         for type in contentTypes(for: url) {
@@ -818,20 +809,30 @@ enum FilePreviewKindResolver {
         return false
     }
 
-    private static func needsSniffBeforeTextOrMedia(url: URL) -> Bool {
+    private static func knownTextResolutionBeforeMedia(for url: URL) -> Resolution? {
         let filename = url.lastPathComponent.lowercased()
         let ext = url.pathExtension.lowercased()
-        if ext == "ts" {
-            return true
-        }
-        guard textFilenames.contains(filename) || textExtensions.contains(ext),
-              let type = UTType(filenameExtension: ext) else {
-            return false
+        guard ext != "plist",
+              textFilenames.contains(filename) || textExtensions.contains(ext) else {
+            return nil
         }
 
-        return mediaMode(for: type) != nil
-            && !type.conforms(to: .text)
-            && !type.conforms(to: .sourceCode)
+        guard let type = UTType(filenameExtension: ext),
+              let mediaMode = mediaMode(for: type),
+              !type.conforms(to: .text),
+              !type.conforms(to: .sourceCode) else {
+            return .resolved(.text)
+        }
+
+        // Source extensions can collide with system audio/video UTIs (.ts, .mts).
+        // Decide from a small content sample before QuickLook can pick its movie generator.
+        if sniffLooksLikeText(url: url) {
+            return .resolved(.text)
+        }
+        if looksLikeMPEGTransportStream(url: url) {
+            return .resolved(.media)
+        }
+        return .resolved(mediaMode)
     }
 
     private static func looksLikeBinaryPropertyList(url: URL) -> Bool {
@@ -842,8 +843,7 @@ enum FilePreviewKindResolver {
     }
 
     private static func looksLikeMPEGTransportStream(url: URL) -> Bool {
-        guard url.pathExtension.lowercased() == "ts",
-              let handle = try? FileHandle(forReadingFrom: url) else { return false }
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return false }
         defer { try? handle.close() }
 
         let data = (try? handle.read(upToCount: 4096)) ?? Data()

--- a/Sources/Panels/FilePreviewPanel.swift
+++ b/Sources/Panels/FilePreviewPanel.swift
@@ -993,16 +993,22 @@ final class FilePreviewPanel: Panel, ObservableObject, FilePreviewTextEditingPan
     private var activeSaveGeneration: Int?
     private weak var textView: NSTextView?
     private let focusCoordinator: FilePreviewFocusCoordinator
+    private let textLoader: @Sendable (URL) async -> FilePreviewTextLoader.Result
 
     var fileURL: URL {
         URL(fileURLWithPath: filePath)
     }
 
-    init(workspaceId: UUID, filePath: String) {
+    init(
+        workspaceId: UUID,
+        filePath: String,
+        textLoader: @escaping @Sendable (URL) async -> FilePreviewTextLoader.Result = FilePreviewTextLoader.load(url:)
+    ) {
         self.id = UUID()
         self.workspaceId = workspaceId
         self.filePath = filePath
         self.displayTitle = URL(fileURLWithPath: filePath).lastPathComponent
+        self.textLoader = textLoader
         let fileURL = URL(fileURLWithPath: filePath)
         let initialPreviewMode = FilePreviewKindResolver.initialMode(for: fileURL)
         self.previewMode = initialPreviewMode
@@ -1174,9 +1180,10 @@ final class FilePreviewPanel: Panel, ObservableObject, FilePreviewTextEditingPan
         textLoadGeneration += 1
         let generation = textLoadGeneration
         let fileURL = fileURL
+        let textLoader = textLoader
 
-        return Task { [weak self, fileURL, generation, replacingDirtyContent] in
-            let result = await FilePreviewTextLoader.load(url: fileURL)
+        return Task { [weak self, fileURL, generation, replacingDirtyContent, textLoader] in
+            let result = await textLoader(fileURL)
             guard let self,
                   self.textLoadGeneration == generation,
                   self.previewMode == .text else { return }

--- a/Sources/Panels/FilePreviewPanel.swift
+++ b/Sources/Panels/FilePreviewPanel.swift
@@ -1002,7 +1002,9 @@ final class FilePreviewPanel: Panel, ObservableObject, FilePreviewTextEditingPan
     init(
         workspaceId: UUID,
         filePath: String,
-        textLoader: @escaping @Sendable (URL) async -> FilePreviewTextLoader.Result = FilePreviewTextLoader.load(url:)
+        textLoader: @escaping @Sendable (URL) async -> FilePreviewTextLoader.Result = { url in
+            await FilePreviewTextLoader.load(url: url)
+        }
     ) {
         self.id = UUID()
         self.workspaceId = workspaceId

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -222,6 +222,7 @@
 		A5001441A5001441A5001441 /* FileOpenSocketSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001440A5001440A5001440 /* FileOpenSocketSupport.swift */; };
 		A5001432A5001432A5001432 /* FilePreviewFocusCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001431A5001431A5001431 /* FilePreviewFocusCoordinator.swift */; };
 		01EE5DC99896BA30240EF1B5 /* FilePreviewImageSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D1450569A797AA7937677D9 /* FilePreviewImageSession.swift */; };
+		C0DE49950000000000000001 /* FilePreviewKindResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE49950000000000000002 /* FilePreviewKindResolverTests.swift */; };
 		A5001447A5001447A5001447 /* FilePreviewMagnifyingPDFView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001446A5001446A5001446 /* FilePreviewMagnifyingPDFView.swift */; };
 		287C15EFC945CE9D560600E3 /* FilePreviewMediaSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64D7B3C5A409C0B3EDD002CE /* FilePreviewMediaSession.swift */; };
 		A5001443A5001443A5001443 /* FilePreviewModeSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001442A5001442A5001442 /* FilePreviewModeSupport.swift */; };
@@ -821,6 +822,7 @@
 		A5001440A5001440A5001440 /* FileOpenSocketSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileOpenSocketSupport.swift; sourceTree = "<group>"; };
 		A5001431A5001431A5001431 /* FilePreviewFocusCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/FilePreviewFocusCoordinator.swift; sourceTree = "<group>"; };
 		7D1450569A797AA7937677D9 /* FilePreviewImageSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/FilePreviewImageSession.swift; sourceTree = "<group>"; };
+		C0DE49950000000000000002 /* FilePreviewKindResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePreviewKindResolverTests.swift; sourceTree = "<group>"; };
 		A5001446A5001446A5001446 /* FilePreviewMagnifyingPDFView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/FilePreviewMagnifyingPDFView.swift; sourceTree = "<group>"; };
 		64D7B3C5A409C0B3EDD002CE /* FilePreviewMediaSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/FilePreviewMediaSession.swift; sourceTree = "<group>"; };
 		A5001442A5001442A5001442 /* FilePreviewModeSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/FilePreviewModeSupport.swift; sourceTree = "<group>"; };
@@ -1733,6 +1735,7 @@
 				BEE83F8394D90ACACD8E19DD /* WindowAndDragTests.swift */,
 				D0B10019A1B2C3D4E5F60001 /* FileDropOverlayViewTests.swift */,
 				2907A0042907A0042907A004 /* AppDelegateIssue2907RoutingTests.swift */,
+				C0DE49950000000000000002 /* FilePreviewKindResolverTests.swift */,
 				A5001435A5001435A5001435 /* FilePreviewPDFThumbnailSidebarTests.swift */,
 				D3664001D3664001D3664001 /* MarkdownPanelTests.swift */,
 				C0DE31390000000000000104 /* FilePreviewReviewFeedbackTests.swift */,
@@ -2532,6 +2535,7 @@
 				FE002101 /* FileExplorerRootResolverTests.swift in Sources */,
 				B37A0000000000000000000B /* FileExplorerStateModePersistenceTests.swift in Sources */,
 				FE002102 /* FileExplorerStoreTests.swift in Sources */,
+				C0DE49950000000000000001 /* FilePreviewKindResolverTests.swift in Sources */,
 				A5001436A5001436A5001436 /* FilePreviewPDFThumbnailSidebarTests.swift in Sources */,
 				C0DE31390000000000000103 /* FilePreviewReviewFeedbackTests.swift in Sources */,
 				FE002103 /* FileSearchRipgrepParserTests.swift in Sources */,

--- a/cmuxTests/FilePreviewKindResolverTests.swift
+++ b/cmuxTests/FilePreviewKindResolverTests.swift
@@ -40,11 +40,40 @@ struct FilePreviewKindResolverTests {
         }
     }
 
+    @Test("MTS binary transport streams keep media preview after sniffing")
+    func mtsBinaryTransportStreamsKeepMediaPreviewAfterSniffing() throws {
+        let url = try temporaryFile(
+            extension: "mts",
+            data: mpegTransportStreamData(packetSize: 192, syncOffset: 4)
+        )
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        #expect(FilePreviewKindResolver.initialMode(for: url) == .text)
+        #expect(FilePreviewKindResolver.mode(for: url) == .media)
+    }
+
     private func temporaryFile(extension fileExtension: String, contents: String) throws -> URL {
+        try temporaryFile(extension: fileExtension, data: Data(contents.utf8))
+    }
+
+    private func temporaryFile(extension fileExtension: String, data: Data) throws -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-file-preview-\(UUID().uuidString)")
             .appendingPathExtension(fileExtension)
-        try contents.write(to: url, atomically: true, encoding: .utf8)
+        try data.write(to: url, options: .atomic)
         return url
+    }
+
+    private func mpegTransportStreamData(packetSize: Int, syncOffset: Int) -> Data {
+        var data = Data(repeating: 0, count: syncOffset + packetSize * 2)
+        data[syncOffset] = 0x47
+        data[syncOffset + 1] = 0x40
+        data[syncOffset + 2] = 0x00
+        data[syncOffset + 3] = 0x10
+        data[syncOffset + packetSize] = 0x47
+        data[syncOffset + packetSize + 1] = 0x41
+        data[syncOffset + packetSize + 2] = 0x00
+        data[syncOffset + packetSize + 3] = 0x10
+        return data
     }
 }

--- a/cmuxTests/FilePreviewKindResolverTests.swift
+++ b/cmuxTests/FilePreviewKindResolverTests.swift
@@ -61,16 +61,23 @@ struct FilePreviewKindResolverTests {
             syncOffset: 4
         )
         defer { try? FileManager.default.removeItem(at: url) }
+        let loader = DeferredTextLoader(result: .unavailable)
 
-        let panel = FilePreviewPanel(workspaceId: UUID(), filePath: url.path)
+        let panel = FilePreviewPanel(
+            workspaceId: UUID(),
+            filePath: url.path,
+            textLoader: { url in await loader.load(url: url) }
+        )
         defer { panel.close() }
 
         #expect(panel.previewMode == .text)
+        await loader.waitUntilStarted()
         let resolvedAsMedia = await waitForPreviewMode(panel, .media)
         #expect(resolvedAsMedia)
         #expect(panel.isFileUnavailable == false)
 
-        await panel.loadTextContent().value
+        await loader.release()
+        await loader.waitUntilCompleted()
 
         #expect(panel.previewMode == .media)
         #expect(panel.isFileUnavailable == false)
@@ -127,5 +134,57 @@ struct FilePreviewKindResolverTests {
             await Task.yield()
         }
         return false
+    }
+}
+
+private actor DeferredTextLoader {
+    private let result: FilePreviewTextLoader.Result
+    private var didStart = false
+    private var didComplete = false
+    private var isReleased = false
+    private var startContinuations: [CheckedContinuation<Void, Never>] = []
+    private var releaseContinuations: [CheckedContinuation<Void, Never>] = []
+    private var completionContinuations: [CheckedContinuation<Void, Never>] = []
+
+    init(result: FilePreviewTextLoader.Result) {
+        self.result = result
+    }
+
+    func load(url: URL) async -> FilePreviewTextLoader.Result {
+        _ = url
+        didStart = true
+        startContinuations.forEach { $0.resume() }
+        startContinuations.removeAll()
+
+        if !isReleased {
+            await withCheckedContinuation { continuation in
+                releaseContinuations.append(continuation)
+            }
+        }
+
+        didComplete = true
+        completionContinuations.forEach { $0.resume() }
+        completionContinuations.removeAll()
+        return result
+    }
+
+    func waitUntilStarted() async {
+        guard !didStart else { return }
+        await withCheckedContinuation { continuation in
+            startContinuations.append(continuation)
+        }
+    }
+
+    func release() {
+        isReleased = true
+        releaseContinuations.forEach { $0.resume() }
+        releaseContinuations.removeAll()
+    }
+
+    func waitUntilCompleted() async {
+        guard !didComplete else { return }
+        await withCheckedContinuation { continuation in
+            completionContinuations.append(continuation)
+        }
     }
 }

--- a/cmuxTests/FilePreviewKindResolverTests.swift
+++ b/cmuxTests/FilePreviewKindResolverTests.swift
@@ -1,0 +1,50 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite("File preview kind resolver")
+struct FilePreviewKindResolverTests {
+    @Test("TypeScript-family source files route directly to text preview")
+    func typeScriptFamilySourceFilesRouteDirectlyToTextPreview() throws {
+        for fileExtension in ["ts", "tsx", "cts", "mts"] {
+            let url = try temporaryFile(
+                extension: fileExtension,
+                contents: "export const value: number = 42;\n"
+            )
+            defer { try? FileManager.default.removeItem(at: url) }
+
+            #expect(
+                FilePreviewKindResolver.initialMode(for: url) == .text,
+                "Expected .\(fileExtension) to avoid the QuickLook/media backend before async resolution."
+            )
+            #expect(FilePreviewKindResolver.mode(for: url) == .text)
+        }
+    }
+
+    @Test("Movie file extensions keep media preview")
+    func movieFileExtensionsKeepMediaPreview() throws {
+        for fileExtension in ["mov", "mp4"] {
+            let url = try temporaryFile(
+                extension: fileExtension,
+                contents: "not a source file\n"
+            )
+            defer { try? FileManager.default.removeItem(at: url) }
+
+            #expect(FilePreviewKindResolver.initialMode(for: url) == .media)
+            #expect(FilePreviewKindResolver.mode(for: url) == .media)
+        }
+    }
+
+    private func temporaryFile(extension fileExtension: String, contents: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-file-preview-\(UUID().uuidString)")
+            .appendingPathExtension(fileExtension)
+        try contents.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+}

--- a/cmuxTests/FilePreviewKindResolverTests.swift
+++ b/cmuxTests/FilePreviewKindResolverTests.swift
@@ -52,6 +52,31 @@ struct FilePreviewKindResolverTests {
         #expect(FilePreviewKindResolver.mode(for: url) == .media)
     }
 
+    @MainActor
+    @Test("Media previews ignore stale text-load completions")
+    func mediaPreviewsIgnoreStaleTextLoadCompletions() async throws {
+        let url = try temporaryOversizedMPEGTransportStream(
+            extension: "mts",
+            packetSize: 192,
+            syncOffset: 4
+        )
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let panel = FilePreviewPanel(workspaceId: UUID(), filePath: url.path)
+        defer { panel.close() }
+
+        #expect(panel.previewMode == .text)
+        let resolvedAsMedia = await waitForPreviewMode(panel, .media)
+        #expect(resolvedAsMedia)
+        #expect(panel.isFileUnavailable == false)
+
+        await panel.loadTextContent().value
+
+        #expect(panel.previewMode == .media)
+        #expect(panel.isFileUnavailable == false)
+        #expect(panel.textContent.isEmpty)
+    }
+
     private func temporaryFile(extension fileExtension: String, contents: String) throws -> URL {
         try temporaryFile(extension: fileExtension, data: Data(contents.utf8))
     }
@@ -61,6 +86,22 @@ struct FilePreviewKindResolverTests {
             .appendingPathComponent("cmux-file-preview-\(UUID().uuidString)")
             .appendingPathExtension(fileExtension)
         try data.write(to: url, options: .atomic)
+        return url
+    }
+
+    private func temporaryOversizedMPEGTransportStream(
+        extension fileExtension: String,
+        packetSize: Int,
+        syncOffset: Int
+    ) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-file-preview-\(UUID().uuidString)")
+            .appendingPathExtension(fileExtension)
+        _ = FileManager.default.createFile(atPath: url.path, contents: nil)
+        let handle = try FileHandle(forWritingTo: url)
+        defer { try? handle.close() }
+        try handle.write(contentsOf: mpegTransportStreamData(packetSize: packetSize, syncOffset: syncOffset))
+        try handle.truncate(atOffset: FilePreviewTextLoader.maximumLoadedTextBytes + 1)
         return url
     }
 
@@ -75,5 +116,16 @@ struct FilePreviewKindResolverTests {
         data[syncOffset + packetSize + 2] = 0x00
         data[syncOffset + packetSize + 3] = 0x10
         return data
+    }
+
+    @MainActor
+    private func waitForPreviewMode(_ panel: FilePreviewPanel, _ mode: FilePreviewMode) async -> Bool {
+        for _ in 0..<1000 {
+            if panel.previewMode == mode {
+                return true
+            }
+            await Task.yield()
+        }
+        return false
     }
 }

--- a/cmuxTests/FilePreviewReviewFeedbackTests.swift
+++ b/cmuxTests/FilePreviewReviewFeedbackTests.swift
@@ -117,7 +117,7 @@ final class FilePreviewReviewFeedbackTests: XCTestCase {
         data.append(contentsOf: [0x00, 0x00])
         try data.write(to: url, options: .atomic)
 
-        XCTAssertEqual(FilePreviewKindResolver.initialMode(for: url), .media)
+        XCTAssertEqual(FilePreviewKindResolver.initialMode(for: url), .text)
         XCTAssertNotEqual(FilePreviewKindResolver.mode(for: url), .text)
     }
 
@@ -155,7 +155,7 @@ final class FilePreviewReviewFeedbackTests: XCTestCase {
         data[191] = 0x10
         try data.write(to: url, options: .atomic)
 
-        XCTAssertEqual(FilePreviewKindResolver.initialMode(for: url), .media)
+        XCTAssertEqual(FilePreviewKindResolver.initialMode(for: url), .text)
         XCTAssertEqual(FilePreviewKindResolver.mode(for: url), .media)
     }
 
@@ -176,7 +176,7 @@ final class FilePreviewReviewFeedbackTests: XCTestCase {
         data[199] = 0x10
         try data.write(to: url, options: .atomic)
 
-        XCTAssertEqual(FilePreviewKindResolver.initialMode(for: url), .media)
+        XCTAssertEqual(FilePreviewKindResolver.initialMode(for: url), .text)
         XCTAssertEqual(FilePreviewKindResolver.mode(for: url), .media)
     }
 

--- a/cmuxTests/FilePreviewReviewFeedbackTests.swift
+++ b/cmuxTests/FilePreviewReviewFeedbackTests.swift
@@ -89,7 +89,7 @@ final class FilePreviewReviewFeedbackTests: XCTestCase {
         console.log(answer);
         """.write(to: url, atomically: true, encoding: .utf8)
 
-        XCTAssertEqual(FilePreviewKindResolver.initialMode(for: url), .quickLook)
+        XCTAssertEqual(FilePreviewKindResolver.initialMode(for: url), .text)
         XCTAssertEqual(FilePreviewKindResolver.mode(for: url), .text)
     }
 
@@ -103,7 +103,7 @@ final class FilePreviewReviewFeedbackTests: XCTestCase {
         data.append(Data("export const answer: number = 42;\n".utf8))
         try data.write(to: url, options: .atomic)
 
-        XCTAssertEqual(FilePreviewKindResolver.initialMode(for: url), .quickLook)
+        XCTAssertEqual(FilePreviewKindResolver.initialMode(for: url), .text)
         XCTAssertEqual(FilePreviewKindResolver.mode(for: url), .text)
     }
 
@@ -117,7 +117,7 @@ final class FilePreviewReviewFeedbackTests: XCTestCase {
         data.append(contentsOf: [0x00, 0x00])
         try data.write(to: url, options: .atomic)
 
-        XCTAssertEqual(FilePreviewKindResolver.initialMode(for: url), .quickLook)
+        XCTAssertEqual(FilePreviewKindResolver.initialMode(for: url), .media)
         XCTAssertNotEqual(FilePreviewKindResolver.mode(for: url), .text)
     }
 
@@ -134,7 +134,7 @@ final class FilePreviewReviewFeedbackTests: XCTestCase {
             + "\nexport const answer: number = 42;\n"
         try source.write(to: url, atomically: true, encoding: .utf8)
 
-        XCTAssertEqual(FilePreviewKindResolver.initialMode(for: url), .quickLook)
+        XCTAssertEqual(FilePreviewKindResolver.initialMode(for: url), .text)
         XCTAssertEqual(FilePreviewKindResolver.mode(for: url), .text)
     }
 
@@ -155,7 +155,7 @@ final class FilePreviewReviewFeedbackTests: XCTestCase {
         data[191] = 0x10
         try data.write(to: url, options: .atomic)
 
-        XCTAssertEqual(FilePreviewKindResolver.initialMode(for: url), .quickLook)
+        XCTAssertEqual(FilePreviewKindResolver.initialMode(for: url), .media)
         XCTAssertEqual(FilePreviewKindResolver.mode(for: url), .media)
     }
 
@@ -176,7 +176,7 @@ final class FilePreviewReviewFeedbackTests: XCTestCase {
         data[199] = 0x10
         try data.write(to: url, options: .atomic)
 
-        XCTAssertEqual(FilePreviewKindResolver.initialMode(for: url), .quickLook)
+        XCTAssertEqual(FilePreviewKindResolver.initialMode(for: url), .media)
         XCTAssertEqual(FilePreviewKindResolver.mode(for: url), .media)
     }
 


### PR DESCRIPTION
## Summary
- Adds focused routing coverage for TypeScript-family preview extensions.
- Routes known source/text extensions before UTType media delegation so .ts/.mts source files avoid QuickLook's movie generator.
- Keeps binary MPEG transport-stream samples and .mov/.mp4 previews on the media backend.

## Verification
- scripts/check-pbxproj.sh
- ./scripts/lint-pbxproj-test-wiring.sh
- git diff --check
- Local UTType repro confirmed .ts/.mts resolve to movie UTTypes on this machine.

Closes #4995

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/4997"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782670815&installation_id=133855650&pr_number=4997&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F4997&signature=50a48e86f77ba2b111da4c8f8b158eb3c91f4e40c4c9142a499cacbe36c41803"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches preview mode routing and async text-load lifecycle; behavior is localized to file preview but wrong sniffing could misclassify edge-case binaries as text or vice versa.
> 
> **Overview**
> Fixes file preview routing when **TypeScript-family** extensions (`.ts`, `.tsx`, `.cts`, `.mts`) collide with system **movie/transport-stream** UTTypes, so source files open in the **text** editor instead of QuickLook/media.
> 
> **`FilePreviewKindResolver`** now treats known text extensions **before** UTType media delegation: **initial** mode is extension-only (text for these collisions); **resolved** mode sniffs content so real MPEG-TS (including `.mts`) still lands on **media**. Adds `cts`/`mts` to the text extension set and broadens transport-stream detection beyond `.ts`-only paths.
> 
> **`FilePreviewPanel`** injects an optional async **text loader** (for tests), skips/cancels text loads when not in `.text`, bumps load generation when switching away from text, and ignores late text-load results after async resolution switches to media.
> 
> New **`FilePreviewKindResolverTests`** plus updated review feedback expectations; Xcode project wires the new test target.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbe4fb5d4c3742680619a4b7edfdf1fc0d9a88a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes TypeScript-family files to the text preview and away from QuickLook media using extension-only initial routing with deferred sniffing; real transport streams still go to media. Prevents stale text loads after switching to media. Fixes #4995.

- **Bug Fixes**
  - Route `.ts`, `.tsx`, `.cts`, `.mts` to text before UTType media; initial route is extension-only, async sniffing flips real MPEG-TS to media; `.mov`/`.mp4` stay on media; MPEG-TS detection no longer depends on a `.ts` extension.
  - Ignore stale text-load completions by bumping generation when leaving `.text` and guarding load/apply to only run in `.text`.
  - Inject a `@Sendable` text loader with a safe default to keep the preview loader seam warning-free; add `FilePreviewKindResolverTests` and a deterministic stale-load test; update review feedback tests.

<sup>Written for commit fbe4fb5d4c3742680619a4b7edfdf1fc0d9a88a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/4997?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable preview mode selection: TypeScript-like extensions now open as text initially, content sniffing can switch true media (including transport streams) to media, and stale/late text loads are prevented from reverting media previews.
* **Tests**
  * Added and updated tests covering initial vs. resolved preview modes and async text-load staleness with synthetic transport-stream fixtures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4997?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->