### PR TITLE
fix: keep main windows movable for Swish

### DIFF
--- a/Sources/App/CmuxMainWindow.swift
+++ b/Sources/App/CmuxMainWindow.swift
@@ -30,8 +30,13 @@ final class MainWindowHostingView<Content: View>: NSHostingView<Content> {
 
 @MainActor
 func configureCmuxMainWindowDragBehavior(_ window: NSWindow) {
+    // Keep the window movable so macOS Accessibility-based window managers
+    // (notably Swish) can identify cmux as a normal movable window and attach
+    // titlebar gestures. Content/background drags are still opt-in: cmux only
+    // starts AppKit window drags from explicit titlebar drag handles, and tab /
+    // folder drag interactions temporarily suppress movability while active.
     window.isMovableByWindowBackground = false
-    window.isMovable = false
+    window.isMovable = true
 }
 
 @MainActor

--- a/cmuxTests/WindowAndDragTests.swift
+++ b/cmuxTests/WindowAndDragTests.swift
@@ -1862,7 +1862,7 @@ final class TitlebarLeadingInsetPassthroughViewTests: XCTestCase {
         )
     }
 
-    func testMainWindowDragBehaviorRequiresExplicitDragZones() {
+    func testMainWindowDragBehaviorKeepsWindowManagerCompatibility() {
         let window = CmuxMainWindow(
             contentRect: NSRect(x: 0, y: 0, width: 320, height: 180),
             styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
@@ -1870,25 +1870,28 @@ final class TitlebarLeadingInsetPassthroughViewTests: XCTestCase {
             defer: false
         )
         defer { window.orderOut(nil) }
-        window.isMovable = true
+        window.isMovable = false
         window.isMovableByWindowBackground = true
 
         configureCmuxMainWindowDragBehavior(window)
 
-        XCTAssertFalse(
+        XCTAssertTrue(
             window.isMovable,
-            "Main windows must not use native AppKit titlebar dragging because pane tabs live in the titlebar band"
+            "Main windows must remain movable so Accessibility-based window managers such as Swish can attach titlebar gestures"
         )
-        XCTAssertFalse(window.isMovableByWindowBackground)
+        XCTAssertFalse(
+            window.isMovableByWindowBackground,
+            "Main content must not become an implicit AppKit background-drag region; explicit titlebar chrome owns app-window dragging"
+        )
 
         let previous = withTemporaryWindowMovableEnabled(window: window) {
             XCTAssertTrue(window.isMovable)
         }
 
-        XCTAssertEqual(previous, false)
-        XCTAssertFalse(
+        XCTAssertEqual(previous, true)
+        XCTAssertTrue(
             window.isMovable,
-            "Explicit chrome drag zones may temporarily enable movement, but the main window must return to pane-tab-safe immovable state"
+            "Explicit chrome drag zones should preserve the window-manager-compatible movable state"
         )
     }
 }


### PR DESCRIPTION
## Summary
- keep cmux main windows `isMovable` so Accessibility-based window managers like Swish can attach titlebar gestures
- keep `isMovableByWindowBackground = false` so app content does not become an implicit drag region
- update the drag behavior unit test to preserve this compatibility

Fixes #1383.

## Testing
- Not run: local machine only has Command Line Tools selected, so `xcodebuild` fails with `tool 'xcodebuild' requires Xcode, but active developer directory '/Library/Developer/CommandLineTools' is a command line tools instance`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5001"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782678684&installation_id=133855650&pr_number=5001&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5001&signature=02d3d25169667198dedf5a225e16d8747036d6e2d9c58b1393f9f191738f658c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep main windows movable so Swish and other Accessibility-based window managers can attach titlebar gestures. Background drags stay disabled; only explicit titlebar zones start drags. Fixes #1383.

- **Bug Fixes**
  - Set `isMovable = true` and keep `isMovableByWindowBackground = false` in main window config.
  - Updated drag behavior test to expect a movable window while preserving explicit drag zones and temporary overrides.

<sup>Written for commit 79effca35f53a8db896bf3c02a49d2577b778b56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5001?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed window drag behavior: windows are now properly movable while maintaining correct dragging for interactive elements like tabs and folders.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/5001?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->