### PR TITLE
Support RTL direction in native text composers

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -4486,6 +4486,7 @@ struct ContentView: View {
                 width: CGFloat.greatestFiniteMagnitude,
                 height: CGFloat.greatestFiniteMagnitude
             )
+            textView.configureCmuxNaturalWritingDirectionForComposedText()
             scrollView.documentView = textView
 
             placeholderField.translatesAutoresizingMaskIntoConstraints = false
@@ -4768,6 +4769,7 @@ struct ContentView: View {
             view.placeholder = placeholder
             view.maximumHeight = maxHeight
             view.textView.string = text
+            view.textView.applyCmuxNaturalWritingDirectionToComposedText()
             view.textView.delegate = context.coordinator
             view.textView.setAccessibilityLabel(accessibilityLabel)
             view.textView.setAccessibilityIdentifier(accessibilityIdentifier)
@@ -4803,6 +4805,7 @@ struct ContentView: View {
             if nsView.textView.string != text {
                 context.coordinator.isProgrammaticMutation = true
                 nsView.textView.string = text
+                nsView.textView.applyCmuxNaturalWritingDirectionToComposedText()
                 context.coordinator.isProgrammaticMutation = false
             }
             nsView.onMeasuredHeightChange = { [weak coordinator = context.coordinator] height in
@@ -12622,6 +12625,7 @@ private struct FeedbackComposerMessageEditor: NSViewRepresentable {
         let view = FeedbackComposerMessageEditorView()
         view.placeholder = placeholder
         view.textView.string = text
+        view.textView.applyCmuxNaturalWritingDirectionToComposedText()
         view.textView.delegate = context.coordinator
         view.textView.setAccessibilityLabel(accessibilityLabel)
         view.textView.setAccessibilityIdentifier(accessibilityIdentifier)
@@ -12632,6 +12636,7 @@ private struct FeedbackComposerMessageEditor: NSViewRepresentable {
     func updateNSView(_ nsView: FeedbackComposerMessageEditorView, context: Context) {
         if nsView.textView.string != text {
             nsView.textView.string = text
+            nsView.textView.applyCmuxNaturalWritingDirectionToComposedText()
             nsView.refreshTextLayout()
         }
         nsView.placeholder = placeholder
@@ -12730,6 +12735,7 @@ final class FeedbackComposerMessageEditorView: NSView {
             width: CGFloat.greatestFiniteMagnitude,
             height: CGFloat.greatestFiniteMagnitude
         )
+        textView.configureCmuxNaturalWritingDirectionForComposedText()
 
         scrollView.documentView = textView
         addSubview(scrollView)

--- a/Sources/Feed/FeedPanelView.swift
+++ b/Sources/Feed/FeedPanelView.swift
@@ -3257,6 +3257,7 @@ private final class FeedInlineTextEditorView: NSView {
             width: CGFloat.greatestFiniteMagnitude,
             height: CGFloat.greatestFiniteMagnitude
         )
+        textView.configureCmuxNaturalWritingDirectionForComposedText()
         addSubview(textView)
 
         placeholderField.textColor = .placeholderTextColor
@@ -3451,6 +3452,7 @@ private struct FeedInlineTextField: NSViewRepresentable {
         let view = FeedInlineTextEditorView(frame: .zero)
         view.textView.delegate = context.coordinator
         view.textView.string = text
+        view.textView.applyCmuxNaturalWritingDirectionToComposedText()
         view.textView.onActivate = { [weak coordinator = context.coordinator] in
             coordinator?.activateField()
         }
@@ -3478,6 +3480,7 @@ private struct FeedInlineTextField: NSViewRepresentable {
         if nsView.textView.string != text, !nsView.textView.hasMarkedText() {
             context.coordinator.isProgrammaticMutation = true
             nsView.textView.string = text
+            nsView.textView.applyCmuxNaturalWritingDirectionToComposedText()
             context.coordinator.isProgrammaticMutation = false
             nsView.refreshMetrics()
         }

--- a/Sources/NaturalTextCompositionDirection.swift
+++ b/Sources/NaturalTextCompositionDirection.swift
@@ -1,0 +1,33 @@
+import AppKit
+
+extension NSTextView {
+    func configureCmuxNaturalWritingDirectionForComposedText() {
+        baseWritingDirection = .natural
+        alignment = .natural
+
+        let paragraphStyle = cmuxNaturalComposedTextParagraphStyle()
+        defaultParagraphStyle = paragraphStyle
+
+        var attributes = typingAttributes
+        attributes[.paragraphStyle] = paragraphStyle
+        typingAttributes = attributes
+    }
+
+    func applyCmuxNaturalWritingDirectionToComposedText() {
+        configureCmuxNaturalWritingDirectionForComposedText()
+
+        let fullRange = NSRange(location: 0, length: (string as NSString).length)
+        guard fullRange.length > 0 else { return }
+
+        textStorage?.setAlignment(.natural, range: fullRange)
+        textStorage?.setBaseWritingDirection(.natural, range: fullRange)
+    }
+
+    func cmuxNaturalComposedTextParagraphStyle() -> NSParagraphStyle {
+        let paragraphStyle = (defaultParagraphStyle?.mutableCopy() as? NSMutableParagraphStyle)
+            ?? NSMutableParagraphStyle()
+        paragraphStyle.alignment = .natural
+        paragraphStyle.baseWritingDirection = .natural
+        return paragraphStyle.copy() as? NSParagraphStyle ?? paragraphStyle
+    }
+}

--- a/Sources/NaturalTextCompositionDirection.swift
+++ b/Sources/NaturalTextCompositionDirection.swift
@@ -28,6 +28,6 @@ extension NSTextView {
             ?? NSMutableParagraphStyle()
         paragraphStyle.alignment = .natural
         paragraphStyle.baseWritingDirection = .natural
-        return paragraphStyle.copy() as? NSParagraphStyle ?? paragraphStyle
+        return paragraphStyle.copy() as! NSParagraphStyle
     }
 }

--- a/Sources/TextBoxInput.swift
+++ b/Sources/TextBoxInput.swift
@@ -3690,7 +3690,6 @@ struct TextBoxInputView: NSViewRepresentable {
         textView.textContainerInset = TextBoxLayout.textInset
         textView.textContainer?.lineFragmentPadding = 0
         textView.registerForDraggedTypes([.fileURL])
-        textView.configureCmuxNaturalWritingDirectionForComposedText()
 
         let scrollView = NSScrollView()
         scrollView.drawsBackground = false
@@ -3752,7 +3751,6 @@ struct TextBoxInputView: NSViewRepresentable {
         textView.onInsertFileURLs = onInsertFileURLs
         textView.onChooseFiles = onChooseFiles
         textView.refreshInlineAttachmentCells(font: font, foregroundColor: foregroundColor)
-        textView.configureCmuxNaturalWritingDirectionForComposedText()
         textView.recenterSingleLineTextContainer()
         textView.wantsLayer = true
         textView.layer?.backgroundColor = NSColor.clear.cgColor

--- a/Sources/TextBoxInput.swift
+++ b/Sources/TextBoxInput.swift
@@ -3690,6 +3690,7 @@ struct TextBoxInputView: NSViewRepresentable {
         textView.textContainerInset = TextBoxLayout.textInset
         textView.textContainer?.lineFragmentPadding = 0
         textView.registerForDraggedTypes([.fileURL])
+        textView.configureCmuxNaturalWritingDirectionForComposedText()
 
         let scrollView = NSScrollView()
         scrollView.drawsBackground = false
@@ -3727,6 +3728,7 @@ struct TextBoxInputView: NSViewRepresentable {
         }
         if textView.inlineAttachments().isEmpty && textView.plainText() != text {
             textView.string = text
+            textView.applyCmuxNaturalWritingDirectionToComposedText()
         }
         updateTextView(textView, context: context)
     }
@@ -3750,6 +3752,7 @@ struct TextBoxInputView: NSViewRepresentable {
         textView.onInsertFileURLs = onInsertFileURLs
         textView.onChooseFiles = onChooseFiles
         textView.refreshInlineAttachmentCells(font: font, foregroundColor: foregroundColor)
+        textView.configureCmuxNaturalWritingDirectionForComposedText()
         textView.recenterSingleLineTextContainer()
         textView.wantsLayer = true
         textView.layer?.backgroundColor = NSColor.clear.cgColor
@@ -3886,6 +3889,16 @@ final class TextBoxInputTextView: NSTextView {
         attachmentPreviewPopover?.isShown == true
     }
 
+    override init(frame frameRect: NSRect, textContainer container: NSTextContainer?) {
+        super.init(frame: frameRect, textContainer: container)
+        configureCmuxNaturalWritingDirectionForComposedText()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
     deinit {
         dismissMentionCompletions()
         removeAttachmentKeyDownMonitor()
@@ -3997,6 +4010,7 @@ final class TextBoxInputTextView: NSTextView {
         dismissMentionCompletions()
         clearAttachmentFocus(dismissPreview: true)
         textStorage?.setAttributedString(NSAttributedString(string: ""))
+        configureCmuxNaturalWritingDirectionForComposedText()
         recenterSingleLineTextContainer()
         didChangeText()
     }
@@ -4019,6 +4033,7 @@ final class TextBoxInputTextView: NSTextView {
         dismissMentionCompletions()
         clearAttachmentFocus(dismissPreview: true)
         textStorage?.setAttributedString(content)
+        applyCmuxNaturalWritingDirectionToComposedText()
         refreshInlineAttachmentCells(
             font: font ?? NSFont.systemFont(ofSize: NSFont.systemFontSize),
             foregroundColor: textColor ?? .labelColor
@@ -5398,7 +5413,8 @@ final class TextBoxInputTextView: NSTextView {
         [
             .font: explicitFont ?? font ?? NSFont.systemFont(ofSize: NSFont.systemFontSize),
             .foregroundColor: explicitForegroundColor ?? textColor ?? .labelColor,
-            .baselineOffset: textBaselineOffsetForCurrentContent()
+            .baselineOffset: textBaselineOffsetForCurrentContent(),
+            .paragraphStyle: cmuxNaturalComposedTextParagraphStyle()
         ]
     }
 

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -315,6 +315,7 @@
 		E1000000A1B2C3D4E5F60718 /* MenuKeyEquivalentRoutingUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1000001A1B2C3D4E5F60718 /* MenuKeyEquivalentRoutingUITests.swift */; };
 		C0DE3150A00000000000001 /* MinimalModeSidebarControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE3150A00000000000002 /* MinimalModeSidebarControls.swift */; };
 		B9000015A1B2C3D4E5F60719 /* MultiWindowNotificationsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000016A1B2C3D4E5F60719 /* MultiWindowNotificationsUITests.swift */; };
+		C0DE50070000000000000001 /* NaturalTextCompositionDirection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE50070000000000000002 /* NaturalTextCompositionDirection.swift */; };
 		734F49D37E543DD01C2F4FEF /* NotificationAndMenuBarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C075029771815DD5DA1332 /* NotificationAndMenuBarTests.swift */; };
 		A5001094 /* NotificationsPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001091 /* NotificationsPage.swift */; };
 		4378399A7C0245EF8186F306 /* OmnibarAndToolsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B09C007F42697761B5F1A2AB /* OmnibarAndToolsTests.swift */; };
@@ -930,6 +931,7 @@
 		E1000001A1B2C3D4E5F60718 /* MenuKeyEquivalentRoutingUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuKeyEquivalentRoutingUITests.swift; sourceTree = "<group>"; };
 		C0DE3150A00000000000002 /* MinimalModeSidebarControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Update/MinimalModeSidebarControls.swift; sourceTree = "<group>"; };
 		B9000016A1B2C3D4E5F60719 /* MultiWindowNotificationsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiWindowNotificationsUITests.swift; sourceTree = "<group>"; };
+		C0DE50070000000000000002 /* NaturalTextCompositionDirection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NaturalTextCompositionDirection.swift; sourceTree = "<group>"; };
 		D2C075029771815DD5DA1332 /* NotificationAndMenuBarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationAndMenuBarTests.swift; sourceTree = "<group>"; };
 		A5001091 /* NotificationsPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsPage.swift; sourceTree = "<group>"; };
 		B09C007F42697761B5F1A2AB /* OmnibarAndToolsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OmnibarAndToolsTests.swift; sourceTree = "<group>"; };
@@ -1428,6 +1430,7 @@
 				C7934BB35B66491B1BCA8064 /* MenuBarExtraController.swift */,
 				2F0C07000000000000000001 /* CmuxMainWindow.swift */,
 				2F0C06000000000000000001 /* MainWindowVisibilityController.swift */,
+				C0DE50070000000000000002 /* NaturalTextCompositionDirection.swift */,
 				A500D011A1B2C3D4E5F60718 /* DebugLogging.swift */,
 				D35B71010000000000000002 /* StartupBreadcrumbLog.swift */,
 				A50016B0A1B2C3D4E5F60718 /* SessionSnapshotDebugBenchmark.swift */,
@@ -2319,6 +2322,7 @@
 				1A8BEE693C9E4C3190CB7F20 /* MenuBarExtraController.swift in Sources */,
 				3865A0033865A0033865A003 /* MenubarSearchPopover.swift in Sources */,
 				C0DE3150A00000000000001 /* MinimalModeSidebarControls.swift in Sources */,
+				C0DE50070000000000000001 /* NaturalTextCompositionDirection.swift in Sources */,
 					A5001094 /* NotificationsPage.swift in Sources */,
 				D0B1001CA1B2C3D4E5F60001 /* PaneDropRoutingSupport.swift in Sources */,
 				A5001400 /* Panel.swift in Sources */,


### PR DESCRIPTION
## Summary
- add a shared AppKit NSTextView setup for natural base writing direction and natural paragraph alignment
- apply it to the agent prompt text box and sibling cmux-owned native composition editors
- preserve natural writing direction when composer text is installed programmatically

## Scope
This PR delivers Part 1 of #5007: cmux native prompt/message composition uses natural writing direction so Hebrew/Arabic paragraphs can resolve RTL while Latin remains LTR.

Part 2 is intentionally out of scope: the terminal pane is Ghostty's cell grid, and BiDi reordering belongs upstream in Ghostty. This PR does not attempt to patch the embedded terminal grid.

## Verification
- Not run locally per task instruction: no local tests, no reload.sh, and no xcodebuild.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5008"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782708667&installation_id=133855650&pr_number=5008&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5008&signature=8040942fbdb49fdcb76b93806142c33bd239ddcd4e51a65bba8bf28826e94d0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized AppKit text-view configuration and call sites; no auth, data, or terminal rendering changes.
> 
> **Overview**
> Adds **`NaturalTextCompositionDirection.swift`**, an `NSTextView` extension that sets **natural** base writing direction, alignment, default paragraph style, and typing attributes, plus **`applyCmuxNaturalWritingDirectionToComposedText()`** to re-apply those settings across existing `textStorage` when text is set from SwiftUI.
> 
> That setup is wired into cmux-owned native composers: **command palette** and **feedback** editors in `ContentView.swift`, **feed inline** editors in `FeedPanelView.swift`, and the main **`TextBoxInput`** path (`TextBoxInputTextView` init, clear, draft install, sync, and `currentTextAttributes`). The Xcode project registers the new source file.
> 
> This is **Part 1 of #5007** (RTL/LTR in native composition); the embedded terminal grid is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3aa84a167e0a3341e96ecb7dc63c2bf9cd8f69b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable natural RTL/LTR composition in native text composers so Hebrew/Arabic render RTL while Latin stays LTR. Adds a shared `NSTextView` extension and applies it across the agent prompt, feedback editor, inline feed editor, and main input.

- **New Features**
  - Added `NaturalTextCompositionDirection.swift` with `NSTextView` helpers to set `.natural` base writing direction and alignment, update paragraph style/typing attributes, and reapply to existing text storage.
  - Applied on creation and after programmatic/binding updates in ContentView, FeedPanelView, and TextBoxInput; `TextBoxInputTextView` configures in `init`, on clear, and after `setContent`, and `currentTextAttributes` now includes the natural paragraph style so new typing inherits direction.
  - Delivers Part 1 of #5007; terminal pane unchanged (BiDi handled upstream).

<sup>Written for commit 3aa84a167e0a3341e96ecb7dc63c2bf9cd8f69b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5008?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Applied natural writing-direction handling to composed text across the command palette, feedback composer, feed panel, and text inputs.
  * Improved paragraph style and typing attributes so alignment and base writing direction remain consistent during editing, updates, and paste/insert operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/5008?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->