### PR TITLE
Add "Send Ctrl-F to Terminal" passthrough action (force-stop Claude Code agents) (#4993)

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -12666,6 +12666,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return handled
         }
 
+        if matchConfiguredShortcut(event: event, action: .sendCtrlFToTerminal) {
+            let routedManager = preferredMainWindowContextForShortcutRouting(event: event)?.tabManager ?? tabManager
+            let handled = routedManager?.sendCtrlFToFocusedTerminal() ?? false
+#if DEBUG
+            cmuxDebugLog(
+                "shortcut.action name=sendCtrlFToTerminal handled=\(handled ? 1 : 0) " +
+                "\(debugShortcutRouteSnapshot(event: event))"
+            )
+#endif
+            // Only consume when a focused terminal actually received the chord.
+            return handled
+        }
+
         // Workspace navigation: Cmd+Ctrl+] / Cmd+Ctrl+[
         if matchConfiguredShortcut(event: event, action: .nextSidebarTab) {
 #if DEBUG

--- a/Sources/ContentView+RightSidebarCommandPalette.swift
+++ b/Sources/ContentView+RightSidebarCommandPalette.swift
@@ -77,6 +77,8 @@ extension ContentView {
             return .focusTextBoxInput
         case "palette.terminalAttachTextBoxFile":
             return .attachTextBoxFile
+        case "palette.terminalSendCtrlF":
+            return .sendCtrlFToTerminal
         case "palette.toggleSplitZoom":
             return .toggleSplitZoom
         case "palette.equalizeSplits":

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -7404,6 +7404,18 @@ struct ContentView: View {
         )
         contributions.append(
             CommandPaletteCommandContribution(
+                commandId: "palette.terminalSendCtrlF",
+                title: constant(String(localized: "command.terminalSendCtrlF.title", defaultValue: "Send Ctrl-F to Terminal")),
+                subtitle: terminalPanelSubtitle,
+                keywords: [
+                    "terminal", "ctrl", "control", "f", "send", "key", "passthrough",
+                    "force", "stop", "agent", "agents", "claude", "code", "hung", "background", "watchdog", "kill",
+                ],
+                when: { $0.bool(CommandPaletteContextKeys.panelIsTerminal) }
+            )
+        )
+        contributions.append(
+            CommandPaletteCommandContribution(
                 commandId: "palette.terminalSplitRight",
                 title: constant(String(localized: "command.terminalSplitRight.title", defaultValue: "Split Right")),
                 subtitle: constant(String(localized: "command.terminalSplitRight.subtitle", defaultValue: "Terminal Layout")),
@@ -8104,6 +8116,11 @@ struct ContentView: View {
         }
         registry.register(commandId: "palette.terminalAttachTextBoxFile") {
             if !tabManager.attachFileToFocusedTerminalTextBoxInput() {
+                NSSound.beep()
+            }
+        }
+        registry.register(commandId: "palette.terminalSendCtrlF") {
+            if !tabManager.sendCtrlFToFocusedTerminal() {
                 NSSound.beep()
             }
         }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5236,6 +5236,17 @@ final class TerminalSurface: Identifiable, ObservableObject {
         case inputQueueFull
         case surfaceUnavailable
         case processExited
+
+        /// Whether the named key was delivered to the surface or queued for an
+        /// imminently-started surface. `false` means the key never reached the PTY.
+        var accepted: Bool {
+            switch self {
+            case .sent, .queued:
+                return true
+            case .unknownKey, .inputQueueFull, .surfaceUnavailable, .processExited:
+                return false
+            }
+        }
     }
 
     enum InputSendResult: Equatable {
@@ -7081,6 +7092,9 @@ final class TerminalSurface: Identifiable, ObservableObject {
             return PendingKeyEvent(keycode: UInt32(kVK_ANSI_C), mods: GHOSTTY_MODS_CTRL, label: normalized)
         case "ctrl-d", "ctrl+d", "eof":
             return PendingKeyEvent(keycode: UInt32(kVK_ANSI_D), mods: GHOSTTY_MODS_CTRL, label: normalized)
+        case "ctrl-f", "ctrl+f":
+            // Force-stop chord for embedded TUIs (e.g. Claude Code's "Ctrl-F twice").
+            return PendingKeyEvent(keycode: UInt32(kVK_ANSI_F), mods: GHOSTTY_MODS_CTRL, label: normalized)
         case "ctrl-z", "ctrl+z", "sigtstp":
             return PendingKeyEvent(keycode: UInt32(kVK_ANSI_Z), mods: GHOSTTY_MODS_CTRL, label: normalized)
         case "ctrl-\\", "ctrl+\\", "sigquit":

--- a/Sources/KeyboardShortcutContext.swift
+++ b/Sources/KeyboardShortcutContext.swift
@@ -51,7 +51,7 @@ extension KeyboardShortcutSettings.Action {
         switch self {
         case .switchRightSidebarToFiles, .switchRightSidebarToFind, .switchRightSidebarToSessions, .switchRightSidebarToFeed, .switchRightSidebarToDock:
             return .rightSidebarFocus
-        case .renameTab, .renameWorkspace:
+        case .renameTab, .renameWorkspace, .sendCtrlFToTerminal:
             return .nonBrowserPanel
         case .browserBack, .browserForward, .browserReload, .toggleBrowserDeveloperTools, .showBrowserJavaScriptConsole,
              .browserZoomIn, .browserZoomOut, .browserZoomReset:

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -112,6 +112,7 @@ enum KeyboardShortcutSettings {
         case toggleTerminalCopyMode
         case focusTextBoxInput
         case attachTextBoxFile
+        case sendCtrlFToTerminal
 
         // Panes / splits
         case focusLeft
@@ -201,6 +202,7 @@ enum KeyboardShortcutSettings {
             case .toggleTerminalCopyMode: return String(localized: "shortcut.toggleTerminalCopyMode.label", defaultValue: "Toggle Terminal Copy Mode")
             case .focusTextBoxInput: return String(localized: "shortcut.focusTextBoxInput.label", defaultValue: "Focus TextBox Input")
             case .attachTextBoxFile: return String(localized: "shortcut.attachTextBoxFile.label", defaultValue: "Attach File to TextBox Input")
+            case .sendCtrlFToTerminal: return String(localized: "shortcut.sendCtrlFToTerminal.label", defaultValue: "Send Ctrl-F to Terminal")
             case .focusLeft: return String(localized: "shortcut.focusPaneLeft.label", defaultValue: "Focus Pane Left")
             case .focusRight: return String(localized: "shortcut.focusPaneRight.label", defaultValue: "Focus Pane Right")
             case .focusUp: return String(localized: "shortcut.focusPaneUp.label", defaultValue: "Focus Pane Up")
@@ -377,6 +379,13 @@ enum KeyboardShortcutSettings {
                 return StoredShortcut(key: "a", command: true, shift: true, option: false, control: false)
             case .attachTextBoxFile:
                 return StoredShortcut(key: "a", command: true, shift: true, option: true, control: false)
+            case .sendCtrlFToTerminal:
+                // Unbound by default: this is a deliberate escape hatch for forwarding a
+                // control chord (e.g. Claude Code's Ctrl-F force-stop) to the focused
+                // terminal. Binding it to plain Ctrl-F would be self-referential, so users
+                // opt in via Settings; it stays reachable through the command palette and
+                // the `send_key ctrl-f` socket command.
+                return .unbound
             case .selectWorkspaceByNumber:
                 return StoredShortcut(key: "1", command: true, shift: false, option: false, control: false)
             case .toggleRightSidebar:

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -2543,6 +2543,33 @@ class TabManager: ObservableObject {
         return panel.surface.toggleKeyboardCopyMode()
     }
 
+    /// Forwards a single Ctrl-F (`^F`) key press to the focused terminal surface,
+    /// faithfully encoded through Ghostty so it matches whatever the running TUI
+    /// would receive from a real keystroke.
+    ///
+    /// This is the non-keyboard escape hatch for control chords that a focused TUI
+    /// reads off the raw tty. The motivating case is Claude Code's force-stop, which
+    /// is only exposed as "press Ctrl-F twice"; invoke this action twice to deliver
+    /// it. Delivery bypasses cmux's shortcut/menu/responder layers entirely.
+    ///
+    /// - Returns: `true` when the chord was sent or queued for the focused terminal,
+    ///   `false` when no terminal panel is focused.
+    @discardableResult
+    func sendCtrlFToFocusedTerminal() -> Bool {
+        guard let panel = selectedTerminalPanel else { return false }
+        let result = panel.sendNamedKeyResult("ctrl-f")
+        if result == .sent {
+            panel.surface.forceRefresh(reason: "tabManager.sendCtrlFToFocusedTerminal")
+        }
+#if DEBUG
+        cmuxDebugLog(
+            "terminal.sendCtrlF workspace=\(panel.workspaceId.uuidString.prefix(5)) " +
+            "panel=\(panel.id.uuidString.prefix(5)) result=\(result)"
+        )
+#endif
+        return result.accepted
+    }
+
     @discardableResult
     func toggleFocusedTerminalTextBox() -> Bool {
         guard let panel = selectedTerminalPanel else { return false }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -17002,7 +17002,7 @@ class TerminalController {
 
         Input commands:
           send <text>                     - Send text to current terminal
-          send_key <key>                  - Send special key (ctrl-c, ctrl-d, enter, tab, escape)
+          send_key <key>                  - Send special key (ctrl-c, ctrl-d, ctrl-f, enter, tab, escape)
           send_surface <id|idx> <text>    - Send text to a specific terminal
           send_key_surface <id|idx> <key> - Send special key to a specific terminal
           read_screen [id|idx] [--scrollback] [--lines N] - Read terminal text (plain text)

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -664,6 +664,18 @@ struct cmuxApp: App {
                         activeTabManager.searchSelection()
                     }
                     .disabled(!(activeTabManager.canUseSelectionForFind))
+
+                    Divider()
+
+                    splitCommandButton(title: String(localized: "menu.find.sendCtrlFToTerminal", defaultValue: "Send Ctrl-F to Terminal"), shortcut: menuShortcut(for: .sendCtrlFToTerminal)) {
+                        // Restore focus to the terminal if the right sidebar grabbed it, then
+                        // forward a faithfully-encoded Ctrl-F (e.g. Claude Code force-stop).
+                        restoreFindTargetFocus()
+                        if !activeTabManager.sendCtrlFToFocusedTerminal() {
+                            NSSound.beep()
+                        }
+                    }
+                    .disabled(activeTabManager.selectedTerminalPanel == nil)
                 }
             }
 

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -1145,6 +1145,44 @@ final class TerminalOffscreenStartupTests: XCTestCase {
         XCTAssertEqual(pending.bytes, 0)
     }
 
+    func testSendNamedKeyRecognizesCtrlFForceStopChord() {
+        // Claude Code (and other raw-tty TUIs) only expose force-stop as a Ctrl-F
+        // keybinding. cmux must be able to deliver that chord to the focused terminal
+        // via a non-keyboard path, so the named-key layer has to recognize "ctrl-f".
+        // A recognized-but-undeliverable key returns `.surfaceUnavailable` on a closed
+        // surface, whereas an unrecognized key returns `.unknownKey`.
+        let panel = TerminalPanel(workspaceId: UUID())
+        panel.surface.releaseSurfaceForTesting()
+        panel.surface.beginPortalCloseLifecycle(reason: "test.closed")
+
+        XCTAssertEqual(
+            panel.surface.sendNamedKey("ctrl-f"),
+            .surfaceUnavailable,
+            "ctrl-f must be a recognized control chord so it can be forwarded to the focused terminal."
+        )
+        XCTAssertEqual(
+            panel.surface.sendNamedKey("ctrl+f"),
+            .surfaceUnavailable,
+            "The ctrl+f alias must resolve identically to ctrl-f."
+        )
+        XCTAssertEqual(
+            panel.surface.sendNamedKey("ctrl-thisisnotakey"),
+            .unknownKey,
+            "An unrecognized chord must surface as .unknownKey, proving the ctrl-f result is meaningful."
+        )
+    }
+
+    func testNamedKeySendResultAcceptedReflectsDelivery() {
+        // `sendCtrlFToFocusedTerminal()` reports success from this flag, so delivery and
+        // failure cases must map correctly.
+        XCTAssertTrue(TerminalSurface.NamedKeySendResult.sent.accepted)
+        XCTAssertTrue(TerminalSurface.NamedKeySendResult.queued.accepted)
+        XCTAssertFalse(TerminalSurface.NamedKeySendResult.unknownKey.accepted)
+        XCTAssertFalse(TerminalSurface.NamedKeySendResult.inputQueueFull.accepted)
+        XCTAssertFalse(TerminalSurface.NamedKeySendResult.surfaceUnavailable.accepted)
+        XCTAssertFalse(TerminalSurface.NamedKeySendResult.processExited.accepted)
+    }
+
     func testDaemonSendWorkspaceQueuesColdControlInputInsteadOfReportingDroppedOK() throws {
         let previousManager = TerminalController.shared.activeTabManagerForCallerNotification()
         let manager = TabManager()

--- a/web/data/cmux-shortcuts.ts
+++ b/web/data/cmux-shortcuts.ts
@@ -135,6 +135,15 @@ export const shortcutCategories: ShortcutCategory[] = [
       { id: "focusTextBoxInput", combos: [["⌘", "⇧", "A"]], description: { en: "Switch focus between terminal and TextBox input", ja: "ターミナルとTextBox入力のフォーカスを切り替え" } },
       { id: "attachTextBoxFile", combos: [["⌥", "⌘", "⇧", "A"]], description: { en: "Attach file to TextBox input", ja: "TextBox入力にファイルを添付" } },
       {
+        id: "sendCtrlFToTerminal",
+        combos: [],
+        description: { en: "Send Ctrl-F to terminal", ja: "ターミナルにCtrl-Fを送信" },
+        note: {
+          en: "unbound by default; forwards Ctrl-F to the focused terminal (Claude Code: invoke twice to force-stop hung background agents)",
+          ja: "デフォルトでは未割り当て。フォーカス中のターミナルにCtrl-Fを転送（Claude Code: 2回実行で停止しないバックグラウンドエージェントを強制停止）",
+        },
+      },
+      {
         id: "saveFilePreview",
         combos: [["⌘", "S"]],
         description: { en: "Save file preview", ja: "ファイルプレビューを保存" },


### PR DESCRIPTION
Fixes #4993.

## Problem

Inside a cmux-managed Claude Code (CC) session, force-stopping a hung background agent is only exposed by CC as a TUI keybinding — its watchdog instructs "press Ctrl-F twice." Because that chord is read off the raw tty, it inherits every keystroke-capture layer between the window and the PTY, and there is no non-keyboard way to deliver it. `/clear` does not help (CC preserves background agents by design), so a hung agent can't be cleared short of killing the session.

The maintainer comment on the issue states the durable framing: *"any ctrl-chord CC reads off the raw tty is one keystroke-capture handler away from being swallowed … the durable fix is a non-keyboard stop path."*

## Investigation (what actually swallows plain Ctrl-F today)

Tracing cmux's key-routing path on current `main` with default settings, **plain Ctrl-F is _not_ captured by cmux** and already reaches the PTY:
- Not bound to any cmux action — `find`=⌘F, `toggleFullScreen`=⌘⌃F, `switchRightSidebarToFind`=⌃2.
- Not a Ghostty default keybind, not a menu key-equivalent.
- The window `performKeyEquivalent` swizzle returns `false` for non-⌘ chords, so the event flows to `GhosttyTerminalView.keyDown`'s control fast path and is encoded to the PTY as `^F` (the only thing that intercepts `^F` is keyboard copy-mode, which the user must explicitly toggle on).

So the literal "cmux grabs Ctrl-F" does not reproduce in code. The real, durable gap — and what this PR delivers — is a **non-keyboard affordance** to deliver the chord, so force-stop works regardless of how fragile keystroke routing is for any given TUI chord.

## Fix — one shared passthrough action, wired through every surface

A single shared model path, `TabManager.sendCtrlFToFocusedTerminal()`, delivers a faithfully Ghostty-encoded Ctrl-F to the focused terminal's PTY via the existing named-key path (`sendNamedKey("ctrl-f")`), so it respects the surface's current keyboard-encoding mode and matches a real keystroke. It bypasses cmux's shortcut/menu/responder layers entirely. Invoke twice to force-stop.

Entrypoints (per the repo's shared-behavior policy):
- **Customizable shortcut** — new `KeyboardShortcutSettings.Action.sendCtrlFToTerminal`, editable in Settings, **unbound by default** (binding plain Ctrl-F would be self-referential; users opt in).
- **Command palette** — `palette.terminalSendCtrlF`, searchable by "force stop / agent / claude / ctrl f / hung".
- **Menu** — Find menu item, disabled when no terminal is focused.
- **CLI / socket** — `send_key ctrl-f` (already worked via the generic parser; now an explicit named case + help text).
- **cmux.json** — `shortcuts.bindings.sendCtrlFToTerminal` (auto-derived from the action).
- **Docs** — keyboard-shortcuts + configuration pages derive from the single `web/data/cmux-shortcuts.ts` source.
- **Localization** — en + ja strings added.

### Altitude (why Ctrl-F specifically in the GUI, not an arbitrary-key picker)
The general raw-key passthrough already exists on the CLI (`send_key <key>`). A key-picker is the wrong ergonomics for a quick GUI force-stop, so the GUI surfaces expose the concrete Ctrl-F chord (the issue's documented need) while the socket command stays general. This eliminates the class — *a structured action has no keystroke left to intercept* — without special-casing a keycode in the routing layer.

## Tests
Behavioral guards (added to the already-wired `TerminalAndGhosttyTests`):
- `testSendNamedKeyRecognizesCtrlFForceStopChord` — `ctrl-f`/`ctrl+f` resolve to a recognized, deliverable chord (`.surfaceUnavailable` on a closed surface vs `.unknownKey` for garbage), locking the encoding the affordance depends on.
- `testNamedKeySendResultAcceptedReflectsDelivery` — the new `NamedKeySendResult.accepted` maps delivery vs failure correctly.

**On red-first:** a red-first regression test does not apply here. The byte-level chord encoding already worked generically on `main`; the defect was the *absence of a non-keyboard affordance*, which is GUI/menu/palette wiring exercised only at integration level, not a unit-reproducible capture bug. Stated plainly rather than faking a red/green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5011"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782711193&installation_id=133855650&pr_number=5011&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5011&signature=e684c98fc59f3b56eacbbee19092e10d59222b88a213636f223142ef5c89d895"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and input-forwarding only; no auth, persistence, or security-sensitive paths; default shortcut is unbound and delivery is gated on a focused terminal.
> 
> **Overview**
> Adds a **Send Ctrl-F to Terminal** action so users can deliver a Ghostty-encoded `^F` to the focused PTY without relying on keyboard routing—aimed at TUIs (e.g. Claude Code) that require **Ctrl-F twice** to force-stop hung background agents.
> 
> `TabManager.sendCtrlFToFocusedTerminal()` calls `sendNamedKey("ctrl-f")`, refreshes the surface on success, and reports delivery via new `NamedKeySendResult.accepted`. The named-key parser now maps `ctrl-f` / `ctrl+f`.
> 
> The action is wired through **Settings** (`sendCtrlFToTerminal`, **unbound** by default), **command palette**, **Find** menu (with focus restore), **AppDelegate** shortcut handling (event consumed only when delivery succeeds), socket help for `send_key ctrl-f`, **web** shortcut docs, and **localization**. Unit tests lock `ctrl-f` recognition and the `accepted` flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb798df6c13ec3e909572f19e5bbd0da71c49a3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a non-keyboard action to send Ctrl‑F to the focused terminal, giving a reliable way to force‑stop hung Claude Code agents even when keystrokes are intercepted. Invoke it twice to trigger the stop.

- **New Features**
  - Adds `TabManager.sendCtrlFToFocusedTerminal()` which forwards a Ghostty‑encoded Ctrl‑F via `sendNamedKey("ctrl-f")`; extends the named‑key map to recognize `ctrl-f`/`ctrl+f` and adds `NamedKeySendResult.accepted` to report delivery.
  - Exposed via: command palette (“Send Ctrl‑F to Terminal”), Find menu item, configurable shortcut (`sendCtrlFToTerminal`, unbound by default), and CLI/socket `send_key ctrl-f` (help text updated).
  - Behavior: only runs when a terminal is focused, respects current keyboard encoding, and beeps on failure.
  - Localization: adds strings for all catalog locales (en/ja translated; others seeded with English for review).

<sup>Written for commit fb798df6c13ec3e909572f19e5bbd0da71c49a3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5011?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Send Ctrl‑F to Terminal" command accessible from the Find menu, command palette, and shortcut settings; forwards Ctrl‑F to the focused terminal (unbound by default) and signals failure with a system beep.

* **Documentation**
  * Added localized strings (English, Japanese translated; other locales marked for review) and updated help text/descriptions across UI and web shortcut listing.

* **Tests**
  * Added regression tests for Ctrl‑F delivery and delivery-state reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/5011?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->