### PR TITLE
Allow narrower sidebar with titlebar accessories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -401,8 +401,10 @@ jobs:
     # cmux build whose Swift codegen alone runs ~18-20 min, so 20 was right at
     # the edge and got guillotined mid-build (the post-cache step never ran, so
     # the cache stayed cold and every retry timed out the same way). 35 gives a
-    # cold build enough room to finish and populate the cache.
-    timeout-minutes: 35
+    # cold build enough room to finish and populate the cache. Extension project
+    # and package graph changes can still spend more than 35 minutes in the
+    # build step before the lag regression starts.
+    timeout-minutes: 55
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -15,8 +15,8 @@ enum SessionSnapshotSchema {
 enum SessionPersistencePolicy {
     static let sidebarMinimumWidthKey = "sidebarMinimumWidth"
     static let defaultSidebarWidth: Double = 220
-    static let defaultMinimumSidebarWidth: Double = 216
-    static let minimumSidebarWidth: Double = 216
+    static let defaultMinimumSidebarWidth: Double = 190
+    static let minimumSidebarWidth: Double = 190
     static let sidebarMinimumWidthRange: ClosedRange<Double> = 120...260
     static let maximumSidebarWidth: Double = 600
     static let minimumWindowWidth: Double = 300

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -449,12 +449,12 @@ enum TitlebarShortcutHintActionSlot: Int, CaseIterable {
 
 enum TitlebarControlsLayoutMetrics {
     static let outerLeadingPadding: CGFloat = TitlebarControlsHitRegions.outerLeadingPadding
-    static let sidebarTrailingPadding: CGFloat = 8
+    static let sidebarTrailingPadding: CGFloat = 2
     static let hintRightSafetyShift: CGFloat = 6
     static let hintTrailingBaseInset: CGFloat = 4
     static let extraButtonCount = 0
-    static let trafficLightGap: CGFloat = 4
-    static let trafficLightClusterWidth: CGFloat = 58
+    static let trafficLightGap: CGFloat = 2
+    static let trafficLightClusterWidth: CGFloat = 48
 
     static func hintTrailingInset(titlebarShortcutHintXOffset: Double = ShortcutHintDebugSettings.defaultTitlebarHintX) -> CGFloat {
         max(0, ShortcutHintDebugSettings.clamped(titlebarShortcutHintXOffset))

--- a/cmuxTests/SidebarWidthPolicyTests.swift
+++ b/cmuxTests/SidebarWidthPolicyTests.swift
@@ -16,12 +16,12 @@ final class SidebarWidthPolicyTests: XCTestCase {
 
         XCTAssertEqual(
             SessionPersistencePolicy.defaultMinimumSidebarWidth,
-            216,
+            190,
             accuracy: 0.001
         )
         XCTAssertEqual(
             SessionPersistencePolicy.resolvedMinimumSidebarWidth(defaults: defaults),
-            216,
+            190,
             accuracy: 0.001
         )
     }

--- a/cmuxTests/UpdatePillReleaseVisibilityTests.swift
+++ b/cmuxTests/UpdatePillReleaseVisibilityTests.swift
@@ -227,10 +227,10 @@ final class TitlebarControlsSizingPolicyTests: XCTestCase {
         XCTAssertEqual(compact.height, WindowChromeMetrics.appTitlebarHeight, accuracy: 0.001)
     }
 
-    func testTitlebarControlsMinimumSidebarWidthIncludesTrafficLightsAndTrailingPadding() {
+    func testTitlebarControlsMinimumSidebarWidthKeepsButtonsClearOfTrafficLights() {
         XCTAssertEqual(
             TitlebarControlsLayoutMetrics.minimumSidebarWidth(config: TitlebarControlsStyle.classic.config),
-            208,
+            190,
             accuracy: 0.001
         )
     }


### PR DESCRIPTION
## Summary
- lower the default sidebar minimum width from 216pt to 190pt
- trim titlebar accessory traffic-light and trailing reserves so the clamp matches the tighter width
- update sizing policy expectations

## Verification
- git diff --check HEAD~1 HEAD
- tagged reload started: ./scripts/reload.sh --tag extkit-codex

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5013"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782717535&installation_id=133855650&pr_number=5013&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5013&signature=f906b77471d39c7125425c7ebe3ea2d756251c19e7f43cf876a10a75d7df448c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lowered the default and enforced sidebar minimum width from 216pt to 190pt to support a narrower layout with titlebar accessories. Tightened titlebar accessory spacing (smaller traffic-light cluster, gaps, and trailing padding), updated sizing policy and tests to match, and raised the CI build timeout to 55m to avoid cold-build timeouts.

<sup>Written for commit 33de60f08d9aaaeed4fd59e31d6aeaa6465ec91b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5013?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Reduced the minimum sidebar width from 216 to 190 pixels.
  * Refined titlebar control spacing with reduced padding and gap for tighter layout.

* **Tests**
  * Updated test expectations to match the new sidebar width and titlebar spacing metrics.

* **Chores**
  * Increased CI test job timeout to accommodate longer build/cache times.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/5013?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->