### PR TITLE
Add experimental paper layout mode for workspace panes

### DIFF
--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -9402,6 +9402,14 @@ struct PaperLayoutState: Codable, Equatable, Sendable {
     var focusedPaneId: UUID?
     var viewportOrigin: PaperPoint
 
+    var focusedPane: PaperPane? {
+        if let focusedPaneId,
+           let pane = panes.first(where: { $0.id == focusedPaneId }) {
+            return pane
+        }
+        return panes.first
+    }
+
     static func initial(paneId: PaneID, tabId: UUID, viewportSize: CGSize) -> PaperLayoutState {
         let frame = PaperRect(
             x: 0,
@@ -9421,6 +9429,54 @@ struct PaperLayoutState: Codable, Equatable, Sendable {
             focusedPaneId: pane.id,
             viewportOrigin: PaperPoint(x: 0, y: 0)
         )
+    }
+
+    func pane(containingTabId tabId: UUID) -> PaperPane? {
+        panes.first { $0.tabIds.contains(tabId) }
+    }
+
+    mutating func focusPane(containingTabId tabId: UUID) {
+        guard let paneIndex = panes.firstIndex(where: { $0.tabIds.contains(tabId) }) else { return }
+        focusedPaneId = panes[paneIndex].id
+        panes[paneIndex].selectedTabId = tabId
+    }
+
+    @discardableResult
+    mutating func insertPaneBesideFocused(
+        id: UUID,
+        tabId: UUID,
+        orientation: SplitOrientation,
+        gap: CGFloat = 24
+    ) -> PaperPane? {
+        guard let focusedPane = focusedPane else { return nil }
+        let frame: PaperRect
+        switch orientation {
+        case .horizontal:
+            frame = PaperRect(
+                x: focusedPane.frame.maxX + gap,
+                y: focusedPane.frame.minY,
+                width: focusedPane.frame.width,
+                height: focusedPane.frame.height
+            )
+        case .vertical:
+            frame = PaperRect(
+                x: focusedPane.frame.minX,
+                y: focusedPane.frame.maxY + gap,
+                width: focusedPane.frame.width,
+                height: focusedPane.frame.height
+            )
+        }
+
+        let pane = PaperPane(
+            id: id,
+            frame: frame,
+            tabIds: [tabId],
+            selectedTabId: tabId
+        )
+        panes.append(pane)
+        focusedPaneId = id
+        viewportOrigin = PaperPoint(x: frame.minX, y: frame.minY)
+        return pane
     }
 }
 
@@ -9541,6 +9597,11 @@ final class Workspace: Identifiable, ObservableObject {
 
     /// The currently focused pane's panel ID
     var focusedPanelId: UUID? {
+        if layoutMode == .paper,
+           let tabId = paperLayoutState?.focusedPane?.selectedTabId {
+            return panelIdFromSurfaceId(TabID(uuid: tabId))
+        }
+
         guard let paneId = bonsplitController.focusedPaneId,
               let tab = bonsplitController.selectedTab(inPane: paneId) else {
             return nil
@@ -9555,6 +9616,43 @@ final class Workspace: Identifiable, ObservableObject {
             return nil
         }
         return panel
+    }
+
+    @discardableResult
+    func ensurePaperLayoutState(viewportSize: CGSize = CGSize(width: 900, height: 600)) -> PaperLayoutState? {
+        if let paperLayoutState {
+            return paperLayoutState
+        }
+
+        guard let paneId = bonsplitController.focusedPaneId ?? bonsplitController.allPaneIds.first else {
+            return nil
+        }
+        guard let tabId = bonsplitController.selectedTab(inPane: paneId)?.id ??
+            bonsplitController.tabs(inPane: paneId).first?.id else {
+            return nil
+        }
+
+        let initialState = PaperLayoutState.initial(
+            paneId: paneId,
+            tabId: tabId.uuid,
+            viewportSize: viewportSize
+        )
+        paperLayoutState = initialState
+        return initialState
+    }
+
+    private func focusPaperPanel(tabId: TabID, panelId: UUID) {
+        guard layoutMode == .paper else { return }
+        if paperLayoutState == nil {
+            _ = ensurePaperLayoutState()
+        }
+        paperLayoutState?.focusPane(containingTabId: tabId.uuid)
+
+        if let terminalPanel = terminalPanel(for: panelId) {
+            terminalPanel.focus()
+        } else if let browserPanel = panels[panelId] as? BrowserPanel {
+            maybeAutoFocusBrowserAddressBarOnPanelFocus(browserPanel, trigger: .standard)
+        }
     }
 
     func representativePanelIdForWorkspaceManualUnread() -> UUID? {
@@ -12999,6 +13097,139 @@ final class Workspace: Identifiable, ObservableObject {
         return nil
     }
 
+    @discardableResult
+    func splitPaperPane(orientation: SplitOrientation) -> TerminalPanel? {
+        guard let panelId = focusedPanelId else { return nil }
+        return splitPaperPane(from: panelId, orientation: orientation)
+    }
+
+    @discardableResult
+    private func splitPaperPane(
+        from panelId: UUID,
+        orientation: SplitOrientation,
+        workingDirectory: String? = nil,
+        initialCommand: String? = nil,
+        tmuxStartCommand: String? = nil,
+        startupEnvironment: [String: String] = [:],
+        remotePTYSessionID: String? = nil,
+        focus: Bool = true
+    ) -> TerminalPanel? {
+        guard let sourceTabId = surfaceIdFromPanelId(panelId) else { return nil }
+        guard var paperState = ensurePaperLayoutState(),
+              paperState.pane(containingTabId: sourceTabId.uuid) != nil else {
+            return nil
+        }
+        paperState.focusPane(containingTabId: sourceTabId.uuid)
+        guard let sourcePaperPane = paperState.focusedPane else { return nil }
+
+        var inheritedConfig = inheritedTerminalConfig(preferredPanelId: panelId)
+        let requestedInitialCommand = initialCommand?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let explicitInitialCommand = (requestedInitialCommand?.isEmpty == false) ? requestedInitialCommand : nil
+        let remoteTerminalStartupCommand = remoteTerminalStartupCommand()
+        let startupCommand = explicitInitialCommand ?? remoteTerminalStartupCommand
+        if startupCommand != nil {
+            var template = inheritedConfig ?? CmuxSurfaceConfigTemplate()
+            template.waitAfterCommand = true
+            inheritedConfig = template
+        }
+
+        let splitWorkingDirectory: String? = {
+            if let workingDirectory = workingDirectory?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !workingDirectory.isEmpty {
+                return workingDirectory
+            }
+            if let panelDirectory = panelDirectories[panelId]?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !panelDirectory.isEmpty {
+                return panelDirectory
+            }
+            if let requestedWorkingDirectory = terminalPanel(for: panelId)?
+                .requestedWorkingDirectory?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+               !requestedWorkingDirectory.isEmpty {
+                return requestedWorkingDirectory
+            }
+            let workspaceDirectory = currentDirectory.trimmingCharacters(in: .whitespacesAndNewlines)
+            return workspaceDirectory.isEmpty ? nil : workspaceDirectory
+        }()
+
+        let newPanel = TerminalPanel(
+            workspaceId: id,
+            context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
+            configTemplate: inheritedConfig,
+            workingDirectory: splitWorkingDirectory,
+            portOrdinal: portOrdinal,
+            initialCommand: startupCommand,
+            tmuxStartCommand: tmuxStartCommand,
+            additionalEnvironment: startupEnvironment
+        )
+        configureTerminalPanel(newPanel)
+        panels[newPanel.id] = newPanel
+        panelTitles[newPanel.id] = newPanel.displayTitle
+        let normalizedRemotePTYSessionID = normalizedRemotePTYSessionID(remotePTYSessionID)
+        let tracksRemoteTerminalSurface = remoteTerminalStartupCommand != nil || normalizedRemotePTYSessionID != nil
+        if let normalizedRemotePTYSessionID {
+            remotePTYSessionIDsByPanelId[newPanel.id] = normalizedRemotePTYSessionID
+        }
+        if tracksRemoteTerminalSurface {
+            trackRemoteTerminalSurface(newPanel.id)
+        }
+        seedTerminalInheritanceFontPoints(panelId: newPanel.id, configTemplate: inheritedConfig)
+
+        let newTab = Bonsplit.Tab(
+            title: newPanel.displayTitle,
+            icon: newPanel.displayIcon,
+            kind: SurfaceKind.terminal,
+            isDirty: newPanel.isDirty,
+            isPinned: false
+        )
+        surfaceIdToPanelId[newTab.id] = newPanel.id
+
+        guard let newPaperPane = paperState.insertPaneBesideFocused(
+            id: UUID(),
+            tabId: newTab.id.uuid,
+            orientation: orientation
+        ) else {
+            panels.removeValue(forKey: newPanel.id)
+            panelTitles.removeValue(forKey: newPanel.id)
+            remotePTYSessionIDsByPanelId.removeValue(forKey: newPanel.id)
+            surfaceIdToPanelId.removeValue(forKey: newTab.id)
+            if tracksRemoteTerminalSurface {
+                untrackRemoteTerminalSurface(newPanel.id)
+            }
+            terminalInheritanceFontPointsByPanelId.removeValue(forKey: newPanel.id)
+            return nil
+        }
+        paperLayoutState = paperState
+
+        publishCmuxSplitCreated(
+            PaneID(id: newPaperPane.id),
+            sourcePaneId: PaneID(id: sourcePaperPane.id),
+            orientation: orientation,
+            surfaceId: newPanel.id,
+            kind: "terminal",
+            origin: "paper_terminal_split",
+            focused: focus
+        )
+#if DEBUG
+        cmuxDebugLog(
+            "paper.split.created workspace=\(id.uuidString.prefix(5)) " +
+            "sourcePane=\(sourcePaperPane.id.uuidString.prefix(5)) " +
+            "newPane=\(newPaperPane.id.uuidString.prefix(5)) orientation=\(orientation.rawValue)"
+        )
+#endif
+
+        if focus {
+            focusPanel(newPanel.id)
+        }
+        owningTabManager?.scheduleInitialWorkspaceGitMetadataRefreshIfPossible(
+            workspaceId: id,
+            panelId: newPanel.id,
+            reason: "paperSplitCreate"
+        )
+
+        return newPanel
+    }
+
     /// Create a new split with a terminal panel
     @discardableResult
     func newTerminalSplit(
@@ -13021,6 +13252,19 @@ final class Workspace: Identifiable, ObservableObject {
             "transport=\(splitTransport) stage=start elapsedMs=0.00"
         )
 #endif
+        if layoutMode == .paper {
+            return splitPaperPane(
+                from: panelId,
+                orientation: orientation,
+                workingDirectory: workingDirectory,
+                initialCommand: initialCommand,
+                tmuxStartCommand: tmuxStartCommand,
+                startupEnvironment: startupEnvironment,
+                remotePTYSessionID: remotePTYSessionID,
+                focus: focus
+            )
+        }
+
         // Find the pane containing the source panel
         guard let sourceTabId = surfaceIdFromPanelId(panelId) else { return nil }
         var sourcePaneId: PaneID?
@@ -14743,6 +14987,21 @@ final class Workspace: Identifiable, ObservableObject {
         )
 #endif
         guard let tabId = surfaceIdFromPanelId(panelId) else { return }
+        if layoutMode == .paper {
+            let previouslyFocusedPanelId = focusedPanelId
+            focusPaperPanel(tabId: tabId, panelId: panelId)
+            if previouslyFocusedPanelId != panelId {
+                syncUnreadBadgeStateForAllPanels()
+            }
+            if trigger == .terminalFirstResponder,
+               panels[panelId] is TerminalPanel {
+                beginEventDrivenLayoutFollowUp(
+                    reason: "workspace.focusPanel.paperTerminal",
+                    terminalFocusPanelId: panelId
+                )
+            }
+            return
+        }
         let currentlyFocusedPanelId = focusedPanelId
 
         // Capture the currently focused terminal view so we can explicitly move AppKit first

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -9402,6 +9402,11 @@ struct PaperLayoutState: Codable, Equatable, Sendable {
     var focusedPaneId: UUID?
     var viewportOrigin: PaperPoint
 
+    struct PaperColumn: Equatable, Sendable {
+        var x: CGFloat
+        var panes: [PaperPane]
+    }
+
     var focusedPane: PaperPane? {
         if let focusedPaneId,
            let pane = panes.first(where: { $0.id == focusedPaneId }) {
@@ -9450,100 +9455,126 @@ struct PaperLayoutState: Codable, Equatable, Sendable {
         }
     }
 
+    func columns(epsilon: CGFloat = 0.5) -> [PaperColumn] {
+        let sortedPanes = panes.sorted { lhs, rhs in
+            if abs(lhs.frame.minX - rhs.frame.minX) > epsilon {
+                return lhs.frame.minX < rhs.frame.minX
+            }
+            if abs(lhs.frame.minY - rhs.frame.minY) > epsilon {
+                return lhs.frame.minY < rhs.frame.minY
+            }
+            return lhs.id.uuidString < rhs.id.uuidString
+        }
+
+        var columns: [PaperColumn] = []
+        for pane in sortedPanes {
+            if let lastIndex = columns.indices.last,
+               abs(columns[lastIndex].x - pane.frame.minX) <= epsilon {
+                columns[lastIndex].panes.append(pane)
+            } else {
+                columns.append(PaperColumn(x: pane.frame.minX, panes: [pane]))
+            }
+        }
+
+        for index in columns.indices {
+            columns[index].panes.sort { lhs, rhs in
+                if abs(lhs.frame.minY - rhs.frame.minY) > epsilon {
+                    return lhs.frame.minY < rhs.frame.minY
+                }
+                return lhs.id.uuidString < rhs.id.uuidString
+            }
+        }
+
+        return columns
+    }
+
+    func visibleColumns(count rawCount: Int) -> [PaperColumn] {
+        let allColumns = columns()
+        guard !allColumns.isEmpty else { return [] }
+        guard let activePane = focusedPane ?? paneNearestViewportOrigin(),
+              let activeIndex = columnIndex(containing: activePane, in: allColumns) else {
+            return Array(allColumns.prefix(max(1, rawCount)))
+        }
+
+        let count = min(max(1, rawCount), allColumns.count)
+        let maxStartIndex = max(0, allColumns.count - count)
+        let startIndex = min(activeIndex, maxStartIndex)
+        return Array(allColumns[startIndex..<(startIndex + count)])
+    }
+
+    func visiblePanes(in column: PaperColumn, rowCount rawRowCount: Int) -> [PaperPane] {
+        guard !column.panes.isEmpty else { return [] }
+        let count = min(max(1, rawRowCount), column.panes.count)
+        guard let activePane = focusedPane ?? paneNearestViewportOrigin() else {
+            return Array(column.panes.prefix(count))
+        }
+
+        let activeRowIndex = column.panes.firstIndex { $0.id == activePane.id }
+            ?? column.panes.enumerated().min { lhs, rhs in
+                verticalScore(lhs.element, sourceCenterY: activePane.frame.midY) <
+                    verticalScore(rhs.element, sourceCenterY: activePane.frame.midY)
+            }?.offset
+            ?? 0
+        let maxStartIndex = max(0, column.panes.count - count)
+        let startIndex = min(activeRowIndex, maxStartIndex)
+        return Array(column.panes[startIndex..<(startIndex + count)])
+    }
+
     func paneInDirection(dx: CGFloat, dy: CGFloat) -> PaperPane? {
         guard let sourcePane = focusedPane ?? paneNearestViewportOrigin() else { return nil }
-        let sourceCenterX = sourcePane.frame.midX
         let sourceCenterY = sourcePane.frame.midY
-        let sourceColumnX = sourcePane.frame.minX
         let epsilon: CGFloat = 0.5
+        let allColumns = columns(epsilon: epsilon)
+        guard let sourceColumnIndex = columnIndex(containing: sourcePane, in: allColumns) else {
+            return nil
+        }
 
-        let candidates: [PaperPane]
         if abs(dx) >= abs(dy), dx > 0 {
-            candidates = panes.filter { $0.id != sourcePane.id && $0.frame.minX > sourceColumnX + epsilon }
-            guard let targetColumnX = candidates.map(\.frame.minX).min() else { return nil }
-            return candidates
-                .filter { abs($0.frame.minX - targetColumnX) <= epsilon }
-                .min {
-                    columnScore($0, sourceCenterY: sourceCenterY) <
-                        columnScore($1, sourceCenterY: sourceCenterY)
-                }
+            let targetIndex = sourceColumnIndex + 1
+            guard allColumns.indices.contains(targetIndex) else { return nil }
+            return pane(in: allColumns[targetIndex], closestToY: sourceCenterY)
         } else if abs(dx) >= abs(dy), dx < 0 {
-            candidates = panes.filter { $0.id != sourcePane.id && $0.frame.minX < sourceColumnX - epsilon }
-            guard let targetColumnX = candidates.map(\.frame.minX).max() else { return nil }
-            return candidates
-                .filter { abs($0.frame.minX - targetColumnX) <= epsilon }
-                .min {
-                    columnScore($0, sourceCenterY: sourceCenterY) <
-                        columnScore($1, sourceCenterY: sourceCenterY)
-                }
+            let targetIndex = sourceColumnIndex - 1
+            guard allColumns.indices.contains(targetIndex) else { return nil }
+            return pane(in: allColumns[targetIndex], closestToY: sourceCenterY)
         } else if dy > 0 {
-            let sameColumnCandidates = panes.filter {
-                $0.id != sourcePane.id &&
-                    abs($0.frame.minX - sourceColumnX) <= epsilon &&
-                    $0.frame.midY > sourceCenterY + epsilon
-            }
-            if let sameColumnPane = sameColumnCandidates.min(by: { lhs, rhs in
-                verticalScore(lhs, sourceCenterY: sourceCenterY) <
-                    verticalScore(rhs, sourceCenterY: sourceCenterY)
-            }) {
-                return sameColumnPane
-            }
-            candidates = panes.filter { $0.id != sourcePane.id && $0.frame.midY > sourceCenterY + epsilon }
-            return candidates.min {
-                directionalScore($0, sourceCenterX: sourceCenterX, sourceCenterY: sourceCenterY, horizontal: false) <
-                    directionalScore($1, sourceCenterX: sourceCenterX, sourceCenterY: sourceCenterY, horizontal: false)
-            }
+            return allColumns[sourceColumnIndex].panes
+                .filter { $0.id != sourcePane.id && $0.frame.midY > sourceCenterY + epsilon }
+                .min {
+                    verticalScore($0, sourceCenterY: sourceCenterY) <
+                        verticalScore($1, sourceCenterY: sourceCenterY)
+                }
         } else if dy < 0 {
-            let sameColumnCandidates = panes.filter {
-                $0.id != sourcePane.id &&
-                    abs($0.frame.minX - sourceColumnX) <= epsilon &&
-                    $0.frame.midY < sourceCenterY - epsilon
-            }
-            if let sameColumnPane = sameColumnCandidates.min(by: { lhs, rhs in
-                verticalScore(lhs, sourceCenterY: sourceCenterY) <
-                    verticalScore(rhs, sourceCenterY: sourceCenterY)
-            }) {
-                return sameColumnPane
-            }
-            candidates = panes.filter { $0.id != sourcePane.id && $0.frame.midY < sourceCenterY - epsilon }
-            return candidates.min {
-                directionalScore($0, sourceCenterX: sourceCenterX, sourceCenterY: sourceCenterY, horizontal: false) <
-                    directionalScore($1, sourceCenterX: sourceCenterX, sourceCenterY: sourceCenterY, horizontal: false)
-            }
+            return allColumns[sourceColumnIndex].panes
+                .filter { $0.id != sourcePane.id && $0.frame.midY < sourceCenterY - epsilon }
+                .min {
+                    verticalScore($0, sourceCenterY: sourceCenterY) <
+                        verticalScore($1, sourceCenterY: sourceCenterY)
+                }
         }
 
         return nil
     }
 
-    private func columnScore(_ pane: PaperPane, sourceCenterY: CGFloat) -> CGFloat {
-        (abs(pane.frame.midY - sourceCenterY) * 10_000) + pane.frame.minY
+    private func columnIndex(containing pane: PaperPane, in columns: [PaperColumn]) -> Int? {
+        columns.firstIndex { column in
+            column.panes.contains { $0.id == pane.id }
+        }
     }
 
-    private func verticalScore(_ pane: PaperPane, sourceCenterY: CGFloat) -> CGFloat {
-        abs(pane.frame.midY - sourceCenterY)
-    }
-
-    private func directionalScore(
-        _ pane: PaperPane,
-        sourceCenterX: CGFloat,
-        sourceCenterY: CGFloat,
-        horizontal: Bool
-    ) -> CGFloat {
-        let primary = horizontal
-            ? abs(pane.frame.midX - sourceCenterX)
-            : abs(pane.frame.midY - sourceCenterY)
-        let cross = horizontal
-            ? abs(pane.frame.midY - sourceCenterY)
-            : abs(pane.frame.midX - sourceCenterX)
-        return (primary * 10_000) + cross
-    }
-
-    private func verticallyOverlaps(_ lhs: PaperRect, _ rhs: PaperRect) -> Bool {
-        lhs.minY < rhs.maxY && rhs.minY < lhs.maxY
+    private func pane(in column: PaperColumn, closestToY sourceCenterY: CGFloat) -> PaperPane? {
+        column.panes.min {
+            verticalScore($0, sourceCenterY: sourceCenterY) <
+                verticalScore($1, sourceCenterY: sourceCenterY)
+        }
     }
 
     private func horizontallyOverlaps(_ lhs: PaperRect, _ rhs: PaperRect) -> Bool {
         lhs.minX < rhs.maxX && rhs.minX < lhs.maxX
+    }
+
+    private func verticalScore(_ pane: PaperPane, sourceCenterY: CGFloat) -> CGFloat {
+        abs(pane.frame.midY - sourceCenterY)
     }
 
     mutating func focusPane(containingTabId tabId: UUID) {
@@ -9739,6 +9770,20 @@ final class Workspace: Identifiable, ObservableObject {
     let bonsplitController: BonsplitController
     @Published var layoutMode: WorkspaceLayoutMode = .bonsplit
     @Published var paperLayoutState: PaperLayoutState?
+    @Published var paperVisibleColumnCount: Int = 1 {
+        didSet {
+            let clampedValue = min(4, max(1, paperVisibleColumnCount))
+            guard paperVisibleColumnCount != clampedValue else { return }
+            paperVisibleColumnCount = clampedValue
+        }
+    }
+    @Published var paperVisibleRowCount: Int = 1 {
+        didSet {
+            let clampedValue = min(4, max(1, paperVisibleRowCount))
+            guard paperVisibleRowCount != clampedValue else { return }
+            paperVisibleRowCount = clampedValue
+        }
+    }
 
     private struct SurfaceTabBarExecutableButton {
         let button: CmuxSurfaceTabBarButton
@@ -10076,6 +10121,38 @@ final class Workspace: Identifiable, ObservableObject {
             "tentative=(\(tentativeOrigin.x),\(tentativeOrigin.y)) " +
             "delta=(\(dx),\(dy)) " +
             "snappedPane=\(snappedPane?.id.uuidString.prefix(5) ?? "nil")"
+        )
+    }
+
+    func setPaperVisibleColumnCountForDebug(_ count: Int) {
+        guard layoutMode == .paper else {
+            cmuxDebugLog(
+                "paper.visibleColumns.set.skip workspace=\(id.uuidString.prefix(5)) " +
+                "reason=notPaper mode=\(layoutMode.rawValue) requested=\(count)"
+            )
+            return
+        }
+        let oldCount = paperVisibleColumnCount
+        paperVisibleColumnCount = count
+        cmuxDebugLog(
+            "paper.visibleColumns.set workspace=\(id.uuidString.prefix(5)) " +
+            "old=\(oldCount) new=\(paperVisibleColumnCount) requested=\(count)"
+        )
+    }
+
+    func setPaperVisibleRowCountForDebug(_ count: Int) {
+        guard layoutMode == .paper else {
+            cmuxDebugLog(
+                "paper.visibleRows.set.skip workspace=\(id.uuidString.prefix(5)) " +
+                "reason=notPaper mode=\(layoutMode.rawValue) requested=\(count)"
+            )
+            return
+        }
+        let oldCount = paperVisibleRowCount
+        paperVisibleRowCount = count
+        cmuxDebugLog(
+            "paper.visibleRows.set workspace=\(id.uuidString.prefix(5)) " +
+            "old=\(oldCount) new=\(paperVisibleRowCount) requested=\(count)"
         )
     }
 #endif

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -9478,6 +9478,49 @@ struct PaperLayoutState: Codable, Equatable, Sendable {
         viewportOrigin = PaperPoint(x: frame.minX, y: frame.minY)
         return pane
     }
+
+    @discardableResult
+    mutating func mirrorBonsplitSplit(
+        sourcePane: PaperPane,
+        newPaneId: PaneID,
+        tabId: UUID,
+        orientation: SplitOrientation,
+        gap: CGFloat = 24
+    ) -> PaperPane {
+        let sourceFrame = sourcePane.frame
+        let frame: PaperRect
+        switch orientation {
+        case .horizontal:
+            frame = PaperRect(
+                x: sourceFrame.maxX + gap,
+                y: sourceFrame.minY,
+                width: sourceFrame.width,
+                height: sourceFrame.height
+            )
+        case .vertical:
+            frame = PaperRect(
+                x: sourceFrame.minX,
+                y: sourceFrame.maxY + gap,
+                width: sourceFrame.width,
+                height: sourceFrame.height
+            )
+        }
+
+        let pane = PaperPane(
+            id: newPaneId.id,
+            frame: frame,
+            tabIds: [tabId],
+            selectedTabId: tabId
+        )
+        if let index = panes.firstIndex(where: { $0.id == newPaneId.id }) {
+            panes[index] = pane
+        } else {
+            panes.append(pane)
+        }
+        focusedPaneId = pane.id
+        viewportOrigin = PaperPoint(x: frame.minX, y: frame.minY)
+        return pane
+    }
 }
 
 struct PaperPane: Codable, Equatable, Identifiable, Sendable {
@@ -9557,6 +9600,7 @@ final class Workspace: Identifiable, ObservableObject {
     let bonsplitController: BonsplitController
     @Published var layoutMode: WorkspaceLayoutMode = .bonsplit
     @Published var paperLayoutState: PaperLayoutState?
+    private var isRunningBonsplitLifecycleForPaperSplit = false
 
     private struct SurfaceTabBarExecutableButton {
         let button: CmuxSurfaceTabBarButton
@@ -9598,6 +9642,7 @@ final class Workspace: Identifiable, ObservableObject {
     /// The currently focused pane's panel ID
     var focusedPanelId: UUID? {
         if layoutMode == .paper,
+           !isRunningBonsplitLifecycleForPaperSplit,
            let tabId = paperLayoutState?.focusedPane?.selectedTabId {
             return panelIdFromSurfaceId(TabID(uuid: tabId))
         }
@@ -13112,139 +13157,6 @@ final class Workspace: Identifiable, ObservableObject {
         return nil
     }
 
-    @discardableResult
-    func splitPaperPane(orientation: SplitOrientation) -> TerminalPanel? {
-        guard let panelId = focusedPanelId else { return nil }
-        return splitPaperPane(from: panelId, orientation: orientation)
-    }
-
-    @discardableResult
-    private func splitPaperPane(
-        from panelId: UUID,
-        orientation: SplitOrientation,
-        workingDirectory: String? = nil,
-        initialCommand: String? = nil,
-        tmuxStartCommand: String? = nil,
-        startupEnvironment: [String: String] = [:],
-        remotePTYSessionID: String? = nil,
-        focus: Bool = true
-    ) -> TerminalPanel? {
-        guard let sourceTabId = surfaceIdFromPanelId(panelId) else { return nil }
-        guard var paperState = ensurePaperLayoutState(),
-              paperState.pane(containingTabId: sourceTabId.uuid) != nil else {
-            return nil
-        }
-        paperState.focusPane(containingTabId: sourceTabId.uuid)
-        guard let sourcePaperPane = paperState.focusedPane else { return nil }
-
-        var inheritedConfig = inheritedTerminalConfig(preferredPanelId: panelId)
-        let requestedInitialCommand = initialCommand?.trimmingCharacters(in: .whitespacesAndNewlines)
-        let explicitInitialCommand = (requestedInitialCommand?.isEmpty == false) ? requestedInitialCommand : nil
-        let remoteTerminalStartupCommand = remoteTerminalStartupCommand()
-        let startupCommand = explicitInitialCommand ?? remoteTerminalStartupCommand
-        if startupCommand != nil {
-            var template = inheritedConfig ?? CmuxSurfaceConfigTemplate()
-            template.waitAfterCommand = true
-            inheritedConfig = template
-        }
-
-        let splitWorkingDirectory: String? = {
-            if let workingDirectory = workingDirectory?.trimmingCharacters(in: .whitespacesAndNewlines),
-               !workingDirectory.isEmpty {
-                return workingDirectory
-            }
-            if let panelDirectory = panelDirectories[panelId]?.trimmingCharacters(in: .whitespacesAndNewlines),
-               !panelDirectory.isEmpty {
-                return panelDirectory
-            }
-            if let requestedWorkingDirectory = terminalPanel(for: panelId)?
-                .requestedWorkingDirectory?
-                .trimmingCharacters(in: .whitespacesAndNewlines),
-               !requestedWorkingDirectory.isEmpty {
-                return requestedWorkingDirectory
-            }
-            let workspaceDirectory = currentDirectory.trimmingCharacters(in: .whitespacesAndNewlines)
-            return workspaceDirectory.isEmpty ? nil : workspaceDirectory
-        }()
-
-        let newPanel = TerminalPanel(
-            workspaceId: id,
-            context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
-            configTemplate: inheritedConfig,
-            workingDirectory: splitWorkingDirectory,
-            portOrdinal: portOrdinal,
-            initialCommand: startupCommand,
-            tmuxStartCommand: tmuxStartCommand,
-            additionalEnvironment: startupEnvironment
-        )
-        configureTerminalPanel(newPanel)
-        panels[newPanel.id] = newPanel
-        panelTitles[newPanel.id] = newPanel.displayTitle
-        let normalizedRemotePTYSessionID = normalizedRemotePTYSessionID(remotePTYSessionID)
-        let tracksRemoteTerminalSurface = remoteTerminalStartupCommand != nil || normalizedRemotePTYSessionID != nil
-        if let normalizedRemotePTYSessionID {
-            remotePTYSessionIDsByPanelId[newPanel.id] = normalizedRemotePTYSessionID
-        }
-        if tracksRemoteTerminalSurface {
-            trackRemoteTerminalSurface(newPanel.id)
-        }
-        seedTerminalInheritanceFontPoints(panelId: newPanel.id, configTemplate: inheritedConfig)
-
-        let newTab = Bonsplit.Tab(
-            title: newPanel.displayTitle,
-            icon: newPanel.displayIcon,
-            kind: SurfaceKind.terminal,
-            isDirty: newPanel.isDirty,
-            isPinned: false
-        )
-        surfaceIdToPanelId[newTab.id] = newPanel.id
-
-        guard let newPaperPane = paperState.insertPaneBesideFocused(
-            id: UUID(),
-            tabId: newTab.id.uuid,
-            orientation: orientation
-        ) else {
-            panels.removeValue(forKey: newPanel.id)
-            panelTitles.removeValue(forKey: newPanel.id)
-            remotePTYSessionIDsByPanelId.removeValue(forKey: newPanel.id)
-            surfaceIdToPanelId.removeValue(forKey: newTab.id)
-            if tracksRemoteTerminalSurface {
-                untrackRemoteTerminalSurface(newPanel.id)
-            }
-            terminalInheritanceFontPointsByPanelId.removeValue(forKey: newPanel.id)
-            return nil
-        }
-        paperLayoutState = paperState
-
-        publishCmuxSplitCreated(
-            PaneID(id: newPaperPane.id),
-            sourcePaneId: PaneID(id: sourcePaperPane.id),
-            orientation: orientation,
-            surfaceId: newPanel.id,
-            kind: "terminal",
-            origin: "paper_terminal_split",
-            focused: focus
-        )
-#if DEBUG
-        cmuxDebugLog(
-            "paper.split.created workspace=\(id.uuidString.prefix(5)) " +
-            "sourcePane=\(sourcePaperPane.id.uuidString.prefix(5)) " +
-            "newPane=\(newPaperPane.id.uuidString.prefix(5)) orientation=\(orientation.rawValue)"
-        )
-#endif
-
-        if focus {
-            focusPanel(newPanel.id)
-        }
-        owningTabManager?.scheduleInitialWorkspaceGitMetadataRefreshIfPossible(
-            workspaceId: id,
-            panelId: newPanel.id,
-            reason: "paperSplitCreate"
-        )
-
-        return newPanel
-    }
-
     /// Create a new split with a terminal panel
     @discardableResult
     func newTerminalSplit(
@@ -13267,19 +13179,6 @@ final class Workspace: Identifiable, ObservableObject {
             "transport=\(splitTransport) stage=start elapsedMs=0.00"
         )
 #endif
-        if layoutMode == .paper {
-            return splitPaperPane(
-                from: panelId,
-                orientation: orientation,
-                workingDirectory: workingDirectory,
-                initialCommand: initialCommand,
-                tmuxStartCommand: tmuxStartCommand,
-                startupEnvironment: startupEnvironment,
-                remotePTYSessionID: remotePTYSessionID,
-                focus: focus
-            )
-        }
-
         // Find the pane containing the source panel
         guard let sourceTabId = surfaceIdFromPanelId(panelId) else { return nil }
         var sourcePaneId: PaneID?
@@ -13292,6 +13191,23 @@ final class Workspace: Identifiable, ObservableObject {
         }
 
         guard let paneId = sourcePaneId else { return nil }
+
+        let shouldMirrorPaperSplit = layoutMode == .paper
+        var paperSplitSourcePane: PaperPane?
+        if shouldMirrorPaperSplit {
+            guard var paperState = ensurePaperLayoutState() else { return nil }
+            paperState.focusPane(containingTabId: sourceTabId.uuid)
+            guard let sourcePane = paperState.pane(containingTabId: sourceTabId.uuid) else { return nil }
+            paperLayoutState = paperState
+            paperSplitSourcePane = sourcePane
+            isRunningBonsplitLifecycleForPaperSplit = true
+        }
+        defer {
+            if shouldMirrorPaperSplit {
+                isRunningBonsplitLifecycleForPaperSplit = false
+            }
+        }
+
         var inheritedConfig = inheritedTerminalConfig(preferredPanelId: panelId, inPane: paneId)
         let requestedInitialCommand = initialCommand?.trimmingCharacters(in: .whitespacesAndNewlines)
         let explicitInitialCommand = (requestedInitialCommand?.isEmpty == false) ? requestedInitialCommand : nil
@@ -13405,6 +13321,35 @@ final class Workspace: Identifiable, ObservableObject {
         }
         applyInitialSplitDividerPosition(initialDividerPosition, sourcePaneId: paneId, newPaneId: newPaneId)
         publishCmuxSplitCreated(newPaneId, sourcePaneId: paneId, orientation: orientation, surfaceId: newPanel.id, kind: "terminal", origin: "terminal_split", focused: focus)
+
+        if shouldMirrorPaperSplit,
+           let paperSplitSourcePane {
+            var paperState = paperLayoutState ?? PaperLayoutState(
+                panes: [paperSplitSourcePane],
+                focusedPaneId: paperSplitSourcePane.id,
+                viewportOrigin: PaperPoint(x: paperSplitSourcePane.frame.minX, y: paperSplitSourcePane.frame.minY)
+            )
+            let newPaperPane = paperState.mirrorBonsplitSplit(
+                sourcePane: paperSplitSourcePane,
+                newPaneId: newPaneId,
+                tabId: newTab.id.uuid,
+                orientation: orientation
+            )
+            paperLayoutState = paperState
+#if DEBUG
+            cmuxDebugLog(
+                "paper.split.mirrored workspace=\(id.uuidString.prefix(5)) " +
+                "sourcePane=\(paperSplitSourcePane.id.uuidString.prefix(5)) " +
+                "bonsplitSourcePane=\(paneId.id.uuidString.prefix(5)) " +
+                "newPane=\(newPaneId.id.uuidString.prefix(5)) orientation=\(orientation.rawValue) " +
+                "sourceFrame=(\(paperSplitSourcePane.frame.x),\(paperSplitSourcePane.frame.y)," +
+                "\(paperSplitSourcePane.frame.width),\(paperSplitSourcePane.frame.height)) " +
+                "newFrame=(\(newPaperPane.frame.x),\(newPaperPane.frame.y)," +
+                "\(newPaperPane.frame.width),\(newPaperPane.frame.height)) " +
+                "viewport=(\(paperState.viewportOrigin.x),\(paperState.viewportOrigin.y))"
+            )
+#endif
+        }
 
 #if DEBUG
         cmuxDebugLog("split.created pane=\(paneId.id.uuidString.prefix(5)) orientation=\(orientation)")
@@ -15002,7 +14947,7 @@ final class Workspace: Identifiable, ObservableObject {
         )
 #endif
         guard let tabId = surfaceIdFromPanelId(panelId) else { return }
-        if layoutMode == .paper {
+        if layoutMode == .paper, !isRunningBonsplitLifecycleForPaperSplit {
             let previouslyFocusedPanelId = focusedPanelId
             focusPaperPanel(tabId: tabId, panelId: panelId)
             if previouslyFocusedPanelId != panelId {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -9788,10 +9788,17 @@ final class Workspace: Identifiable, ObservableObject {
 
     private func focusPaperPanel(tabId: TabID, panelId: UUID) {
         guard layoutMode == .paper else { return }
-        if paperLayoutState == nil {
-            _ = ensurePaperLayoutState()
+        guard var state = paperLayoutState ?? ensurePaperLayoutState() else {
+            return
         }
-        paperLayoutState?.focusPane(containingTabId: tabId.uuid)
+        state.focusPane(containingTabId: tabId.uuid)
+        if let focusedPane = state.focusedPane {
+            state.viewportOrigin = PaperPoint(
+                x: max(0, focusedPane.frame.minX),
+                y: max(0, focusedPane.frame.minY)
+            )
+        }
+        paperLayoutState = state
 
         if let terminalPanel = terminalPanel(for: panelId) {
             terminalPanel.focus()
@@ -13606,11 +13613,18 @@ final class Workspace: Identifiable, ObservableObject {
             isPinned: false
         )
         surfaceIdToPanelId[newTab.id] = newPanel.id
-        let previousFocusedPanelId = shouldMirrorPaperSplit ? panelId : focusedPanelId
+        let previousFocusedPanelId = focusedPanelId
+        let focusTransitionSourcePanelId: UUID? = shouldMirrorPaperSplit ? panelId : previousFocusedPanelId
 
         // Capture the source terminal's hosted view before bonsplit mutates focusedPaneId,
         // so we can hand it to focusPanel as the "move focus FROM" view.
-        let previousHostedView = terminalPanel(for: panelId)?.hostedView ?? focusedTerminalPanel?.hostedView
+        let previousHostedView = focusedTerminalPanel?.hostedView
+        let focusTransitionHostedView: GhosttySurfaceScrollView?
+        if shouldMirrorPaperSplit {
+            focusTransitionHostedView = terminalPanel(for: panelId)?.hostedView ?? previousHostedView
+        } else {
+            focusTransitionHostedView = previousHostedView
+        }
 
         // Create the split with the new tab already present in the new pane.
         isProgrammaticSplit = true
@@ -13672,14 +13686,14 @@ final class Workspace: Identifiable, ObservableObject {
         // stealing focus from the new panel and creating model/surface divergence.
         if focus {
             suppressReparentFocusUntilLayoutFollowUp(
-                previousHostedView,
+                focusTransitionHostedView,
                 reason: "workspace.terminalSplitReparent"
             )
             focusPanel(
                 newPanel.id,
-                previousHostedView: previousHostedView,
+                previousHostedView: focusTransitionHostedView,
                 forceBonsplitFocusPath: shouldMirrorPaperSplit,
-                currentlyFocusedPanelIdOverride: previousFocusedPanelId
+                currentlyFocusedPanelIdOverride: focusTransitionSourcePanelId
             )
         } else {
             preserveFocusAfterNonFocusSplit(

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -9392,6 +9392,66 @@ final class SharedLiveAgentIndex: ObservableObject {
     }
 }
 
+enum WorkspaceLayoutMode: String, Codable, Sendable {
+    case bonsplit
+    case paper
+}
+
+struct PaperLayoutState: Codable, Equatable, Sendable {
+    var panes: [PaperPane]
+    var focusedPaneId: UUID?
+    var viewportOrigin: PaperPoint
+
+    static func initial(paneId: PaneID, tabId: UUID, viewportSize: CGSize) -> PaperLayoutState {
+        let frame = PaperRect(
+            x: 0,
+            y: 0,
+            width: max(900, viewportSize.width),
+            height: max(600, viewportSize.height)
+        )
+        let pane = PaperPane(
+            id: paneId.id,
+            frame: frame,
+            tabIds: [tabId],
+            selectedTabId: tabId
+        )
+
+        return PaperLayoutState(
+            panes: [pane],
+            focusedPaneId: pane.id,
+            viewportOrigin: PaperPoint(x: 0, y: 0)
+        )
+    }
+}
+
+struct PaperPane: Codable, Equatable, Identifiable, Sendable {
+    var id: UUID
+    var frame: PaperRect
+    var tabIds: [UUID]
+    var selectedTabId: UUID?
+}
+
+struct PaperPoint: Codable, Equatable, Sendable {
+    var x: CGFloat
+    var y: CGFloat
+}
+
+struct PaperRect: Codable, Equatable, Sendable {
+    var x: CGFloat
+    var y: CGFloat
+    var width: CGFloat
+    var height: CGFloat
+
+    var cgRect: CGRect {
+        CGRect(x: x, y: y, width: width, height: height)
+    }
+
+    var minX: CGFloat { x }
+    var minY: CGFloat { y }
+    var maxX: CGFloat { x + width }
+    var maxY: CGFloat { y + height }
+}
+
 /// Workspace represents a sidebar tab.
 /// Each workspace contains one BonsplitController that manages split panes and nested surfaces.
 @MainActor
@@ -9439,6 +9499,9 @@ final class Workspace: Identifiable, ObservableObject {
 
     /// The bonsplit controller managing the split panes for this workspace
     let bonsplitController: BonsplitController
+    @Published var layoutMode: WorkspaceLayoutMode = .bonsplit
+    @Published var paperLayoutState: PaperLayoutState?
+
     private struct SurfaceTabBarExecutableButton {
         let button: CmuxSurfaceTabBarButton
         let builtInAction: CmuxSurfaceTabBarBuiltInAction?

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -9702,7 +9702,6 @@ final class Workspace: Identifiable, ObservableObject {
     let bonsplitController: BonsplitController
     @Published var layoutMode: WorkspaceLayoutMode = .bonsplit
     @Published var paperLayoutState: PaperLayoutState?
-    private var isRunningBonsplitLifecycleForPaperSplit = false
 
     private struct SurfaceTabBarExecutableButton {
         let button: CmuxSurfaceTabBarButton
@@ -9744,7 +9743,6 @@ final class Workspace: Identifiable, ObservableObject {
     /// The currently focused pane's panel ID
     var focusedPanelId: UUID? {
         if layoutMode == .paper,
-           !isRunningBonsplitLifecycleForPaperSplit,
            let tabId = paperLayoutState?.focusedPane?.selectedTabId {
             return panelIdFromSurfaceId(TabID(uuid: tabId))
         }
@@ -10015,7 +10013,6 @@ final class Workspace: Identifiable, ObservableObject {
             PaperPoint(x: max(0, $0.frame.minX), y: max(0, $0.frame.minY))
         } ?? tentativeOrigin
         paperState.viewportOrigin = newOrigin
-        objectWillChange.send()
         paperLayoutState = paperState
 
         cmuxDebugLog(
@@ -13516,12 +13513,6 @@ final class Workspace: Identifiable, ObservableObject {
             guard let sourcePane = paperState.pane(containingTabId: sourceTabId.uuid) else { return nil }
             paperLayoutState = paperState
             paperSplitSourcePane = sourcePane
-            isRunningBonsplitLifecycleForPaperSplit = true
-        }
-        defer {
-            if shouldMirrorPaperSplit {
-                isRunningBonsplitLifecycleForPaperSplit = false
-            }
         }
 
         var inheritedConfig = inheritedTerminalConfig(preferredPanelId: panelId, inPane: paneId)
@@ -13615,11 +13606,11 @@ final class Workspace: Identifiable, ObservableObject {
             isPinned: false
         )
         surfaceIdToPanelId[newTab.id] = newPanel.id
-        let previousFocusedPanelId = focusedPanelId
+        let previousFocusedPanelId = shouldMirrorPaperSplit ? panelId : focusedPanelId
 
         // Capture the source terminal's hosted view before bonsplit mutates focusedPaneId,
         // so we can hand it to focusPanel as the "move focus FROM" view.
-        let previousHostedView = focusedTerminalPanel?.hostedView
+        let previousHostedView = terminalPanel(for: panelId)?.hostedView ?? focusedTerminalPanel?.hostedView
 
         // Create the split with the new tab already present in the new pane.
         isProgrammaticSplit = true
@@ -13684,7 +13675,12 @@ final class Workspace: Identifiable, ObservableObject {
                 previousHostedView,
                 reason: "workspace.terminalSplitReparent"
             )
-            focusPanel(newPanel.id, previousHostedView: previousHostedView)
+            focusPanel(
+                newPanel.id,
+                previousHostedView: previousHostedView,
+                forceBonsplitFocusPath: shouldMirrorPaperSplit,
+                currentlyFocusedPanelIdOverride: previousFocusedPanelId
+            )
         } else {
             preserveFocusAfterNonFocusSplit(
                 preferredPanelId: previousFocusedPanelId,
@@ -15251,7 +15247,9 @@ final class Workspace: Identifiable, ObservableObject {
         _ panelId: UUID,
         previousHostedView: GhosttySurfaceScrollView? = nil,
         trigger: FocusPanelTrigger = .standard,
-        focusIntent: PanelFocusIntent? = nil
+        focusIntent: PanelFocusIntent? = nil,
+        forceBonsplitFocusPath: Bool = false,
+        currentlyFocusedPanelIdOverride: UUID? = nil
     ) {
         markExplicitFocusIntent(on: panelId)
 #if DEBUG
@@ -15263,7 +15261,7 @@ final class Workspace: Identifiable, ObservableObject {
         )
 #endif
         guard let tabId = surfaceIdFromPanelId(panelId) else { return }
-        if layoutMode == .paper, !isRunningBonsplitLifecycleForPaperSplit {
+        if layoutMode == .paper, !forceBonsplitFocusPath {
             let previouslyFocusedPanelId = focusedPanelId
             focusPaperPanel(tabId: tabId, panelId: panelId)
             if previouslyFocusedPanelId != panelId {
@@ -15278,7 +15276,7 @@ final class Workspace: Identifiable, ObservableObject {
             }
             return
         }
-        let currentlyFocusedPanelId = focusedPanelId
+        let currentlyFocusedPanelId = currentlyFocusedPanelIdOverride ?? focusedPanelId
 
         // Capture the currently focused terminal view so we can explicitly move AppKit first
         // responder when focusing another terminal (helps avoid "highlighted but typing goes to

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -9501,6 +9501,14 @@ struct PaperLayoutState: Codable, Equatable, Sendable {
         return (primary * 10_000) + cross
     }
 
+    private func verticallyOverlaps(_ lhs: PaperRect, _ rhs: PaperRect) -> Bool {
+        lhs.minY < rhs.maxY && rhs.minY < lhs.maxY
+    }
+
+    private func horizontallyOverlaps(_ lhs: PaperRect, _ rhs: PaperRect) -> Bool {
+        lhs.minX < rhs.maxX && rhs.minX < lhs.maxX
+    }
+
     mutating func focusPane(containingTabId tabId: UUID) {
         guard let paneIndex = panes.firstIndex(where: { $0.tabIds.contains(tabId) }) else { return }
         focusedPaneId = panes[paneIndex].id
@@ -9557,6 +9565,16 @@ struct PaperLayoutState: Codable, Equatable, Sendable {
         let frame: PaperRect
         switch orientation {
         case .horizontal:
+            let shift = sourceFrame.width + gap
+            for index in panes.indices {
+                guard panes[index].id != sourcePane.id,
+                      panes[index].id != newPaneId.id,
+                      panes[index].frame.midX > sourceFrame.midX,
+                      verticallyOverlaps(panes[index].frame, sourceFrame) else {
+                    continue
+                }
+                panes[index].frame.x += shift
+            }
             frame = PaperRect(
                 x: sourceFrame.maxX + gap,
                 y: sourceFrame.minY,
@@ -9564,6 +9582,16 @@ struct PaperLayoutState: Codable, Equatable, Sendable {
                 height: sourceFrame.height
             )
         case .vertical:
+            let shift = sourceFrame.height + gap
+            for index in panes.indices {
+                guard panes[index].id != sourcePane.id,
+                      panes[index].id != newPaneId.id,
+                      panes[index].frame.midY > sourceFrame.midY,
+                      horizontallyOverlaps(panes[index].frame, sourceFrame) else {
+                    continue
+                }
+                panes[index].frame.y += shift
+            }
             frame = PaperRect(
                 x: sourceFrame.minX,
                 y: sourceFrame.maxY + gap,
@@ -9775,11 +9803,18 @@ final class Workspace: Identifiable, ObservableObject {
     }
 
 #if DEBUG
+    private struct PaperPaneTreePlacement {
+        let paneIdString: String
+        let column: Int
+        let row: Int
+    }
+
     func togglePaperLayoutModeForDebug() {
         switch layoutMode {
         case .bonsplit:
+            paperLayoutState = nil
             layoutMode = .paper
-            _ = ensurePaperLayoutState()
+            rebuildPaperLayoutStateFromBonsplitForDebug()
         case .paper:
             layoutMode = .bonsplit
         }
@@ -9788,9 +9823,187 @@ final class Workspace: Identifiable, ObservableObject {
         )
     }
 
+    @discardableResult
+    func rebuildPaperLayoutStateFromBonsplitForDebug(
+        viewportSize: CGSize = CGSize(width: 900, height: 600)
+    ) -> PaperLayoutState? {
+        let width = max(900, viewportSize.width)
+        let height = max(600, viewportSize.height)
+        let gap: CGFloat = 24
+        paperLayoutState = nil
+        let bonsplitPaneIds = bonsplitController.allPaneIds
+        let focusedBonsplitPaneId = bonsplitController.focusedPaneId
+        let paneIdsByString = Dictionary(
+            uniqueKeysWithValues: bonsplitPaneIds.map { ($0.id.uuidString.lowercased(), $0) }
+        )
+        let treeSnapshot = bonsplitController.treeSnapshot()
+        let treePlacements = paperPaneTreePlacementsFromGeometry(in: treeSnapshot)
+        var seenPlacedPaneIds = Set<UUID>()
+        var placements: [(paneId: PaneID, column: Int, row: Int)] = treePlacements.compactMap { placement in
+            guard let paneId = paneIdsByString[placement.paneIdString.lowercased()],
+                  seenPlacedPaneIds.insert(paneId.id).inserted else {
+                return nil
+            }
+            return (paneId, placement.column, placement.row)
+        }
+        let fallbackPaneIds = bonsplitPaneIds.filter { seenPlacedPaneIds.insert($0.id).inserted }
+        if !fallbackPaneIds.isEmpty {
+            let columns = max(1, Int(ceil(sqrt(Double(fallbackPaneIds.count)))))
+            let fallbackStartColumn = (placements.map(\.column).max() ?? -1) + 1
+            placements.append(contentsOf: fallbackPaneIds.enumerated().map { offset, paneId in
+                (
+                    paneId,
+                    fallbackStartColumn + (offset % columns),
+                    offset / columns
+                )
+            })
+        }
+
+        cmuxDebugLog(
+            "paper.layout.rebuild.begin workspace=\(id.uuidString.prefix(5)) " +
+            "bonsplitPaneCount=\(bonsplitPaneIds.count) " +
+            "treePlacementCount=\(treePlacements.count) " +
+            "placedPaneCount=\(placements.count) " +
+            "focusedBonsplitPane=\(focusedBonsplitPaneId?.id.uuidString.prefix(5) ?? "nil") " +
+            "bonsplitPaneIds=\(bonsplitPaneIds.map { String($0.id.uuidString.prefix(5)) }.joined(separator: ",")) " +
+            "tree=\(paperTreeDescription(treeSnapshot))"
+        )
+
+        var paperPanes: [PaperPane] = []
+        for placement in placements {
+            let paneId = placement.paneId
+            let tabs = bonsplitController.tabs(inPane: paneId)
+            let selectedTab = bonsplitController.selectedTab(inPane: paneId).flatMap { selected in
+                tabs.first { $0.id == selected.id }
+            } ?? tabs.first
+            cmuxDebugLog(
+                "paper.layout.rebuild.bonsplitPane workspace=\(id.uuidString.prefix(5)) " +
+                "pane=\(paneId.id.uuidString.prefix(5)) " +
+                "tabCount=\(tabs.count) " +
+                "selectedTab=\(selectedTab?.id.uuid.uuidString.prefix(5) ?? "nil") " +
+                "selectedPanel=\(selectedTab.flatMap { panelIdFromSurfaceId($0.id) }?.uuidString.prefix(5) ?? "nil") " +
+                "tabIds=\(tabs.map { String($0.id.uuid.uuidString.prefix(5)) }.joined(separator: ","))"
+            )
+            guard let selectedTab else { continue }
+
+            let frame = PaperRect(
+                x: CGFloat(placement.column) * (width + gap),
+                y: CGFloat(placement.row) * (height + gap),
+                width: width,
+                height: height
+            )
+            paperPanes.append(
+                PaperPane(
+                    id: paneId.id,
+                    frame: frame,
+                    tabIds: tabs.map { $0.id.uuid },
+                    selectedTabId: selectedTab.id.uuid
+                )
+            )
+            cmuxDebugLog(
+                "paper.layout.rebuild.paperPane workspace=\(id.uuidString.prefix(5)) " +
+                "pane=\(paneId.id.uuidString.prefix(5)) " +
+                "selectedTab=\(selectedTab.id.uuid.uuidString.prefix(5)) " +
+                "grid=(\(placement.column),\(placement.row)) " +
+                "frame=(\(frame.x),\(frame.y),\(frame.width),\(frame.height))"
+            )
+        }
+
+        guard !paperPanes.isEmpty else {
+            paperLayoutState = nil
+            cmuxDebugLog(
+                "paper.layout.rebuild workspace=\(id.uuidString.prefix(5)) mirrored=0 focusedPane=nil viewport=(0,0)"
+            )
+            return nil
+        }
+
+        let focusedPaperPane = focusedBonsplitPaneId.flatMap { focusedPaneId in
+            paperPanes.first { $0.id == focusedPaneId.id }
+        } ?? paperPanes[0]
+        let state = PaperLayoutState(
+            panes: paperPanes,
+            focusedPaneId: focusedPaperPane.id,
+            viewportOrigin: PaperPoint(x: focusedPaperPane.frame.minX, y: focusedPaperPane.frame.minY)
+        )
+        paperLayoutState = state
+
+        cmuxDebugLog(
+            "paper.layout.rebuild workspace=\(id.uuidString.prefix(5)) " +
+            "mirrored=\(paperPanes.count) " +
+            "focusedPane=\(focusedPaperPane.id.uuidString.prefix(5)) " +
+            "viewport=(\(state.viewportOrigin.x),\(state.viewportOrigin.y)) " +
+            "paperPanes=\(paperPanes.map { pane in "\(pane.id.uuidString.prefix(5))@(\(pane.frame.x),\(pane.frame.y),\(pane.frame.width),\(pane.frame.height))" }.joined(separator: ","))"
+        )
+        return state
+    }
+
+    private func paperPaneTreePlacementsFromGeometry(in node: ExternalTreeNode) -> [PaperPaneTreePlacement] {
+        let panes = paperPaneNodes(in: node)
+        guard !panes.isEmpty else { return [] }
+
+        let xValues = uniqueSortedCoordinates(panes.map(\.frame.x))
+        let yValues = uniqueSortedCoordinates(panes.map(\.frame.y))
+
+        return panes.map { pane in
+            PaperPaneTreePlacement(
+                paneIdString: pane.id,
+                column: nearestCoordinateIndex(for: pane.frame.x, in: xValues),
+                row: nearestCoordinateIndex(for: pane.frame.y, in: yValues)
+            )
+        }
+    }
+
+    private func paperPaneNodes(in node: ExternalTreeNode) -> [ExternalPaneNode] {
+        switch node {
+        case .pane(let pane):
+            return [pane]
+        case .split(let split):
+            return paperPaneNodes(in: split.first) + paperPaneNodes(in: split.second)
+        }
+    }
+
+    private func uniqueSortedCoordinates(_ values: [Double]) -> [Double] {
+        let epsilon = 0.5
+        return values.sorted().reduce(into: []) { result, value in
+            guard result.last.map({ abs($0 - value) < epsilon }) != true else { return }
+            result.append(value)
+        }
+    }
+
+    private func nearestCoordinateIndex(for value: Double, in values: [Double]) -> Int {
+        values.enumerated().min { lhs, rhs in
+            abs(lhs.element - value) < abs(rhs.element - value)
+        }?.offset ?? 0
+    }
+
+    private func paperTreeDescription(_ node: ExternalTreeNode) -> String {
+        switch node {
+        case .pane(let pane):
+            return "pane(\(pane.id.prefix(5)))"
+        case .split(let split):
+            return "split(\(split.orientation),\(paperTreeDescription(split.first)),\(paperTreeDescription(split.second)))"
+        }
+    }
+
     func movePaperViewportForDebug(dx: CGFloat, dy: CGFloat) {
-        guard layoutMode == .paper else { return }
-        guard var paperState = ensurePaperLayoutState() else { return }
+        guard layoutMode == .paper else {
+            cmuxDebugLog(
+                "paper.viewport.move.skip workspace=\(id.uuidString.prefix(5)) reason=notPaper mode=\(layoutMode.rawValue) delta=(\(dx),\(dy))"
+            )
+            return
+        }
+        if paperLayoutState == nil {
+            _ = rebuildPaperLayoutStateFromBonsplitForDebug()
+        }
+        if paperLayoutState == nil {
+            _ = ensurePaperLayoutState()
+        }
+        guard var paperState = paperLayoutState else {
+            cmuxDebugLog(
+                "paper.viewport.move.skip workspace=\(id.uuidString.prefix(5)) reason=noPaperState delta=(\(dx),\(dy))"
+            )
+            return
+        }
 
         let oldOrigin = paperState.viewportOrigin
         let tentativeOrigin = PaperPoint(
@@ -9807,8 +10020,11 @@ final class Workspace: Identifiable, ObservableObject {
 
         cmuxDebugLog(
             "paper.viewport.move workspace=\(id.uuidString.prefix(5)) " +
+            "result=\(snappedPane == nil ? "noTarget" : "snapped") " +
+            "paneCount=\(paperState.panes.count) " +
             "old=(\(oldOrigin.x),\(oldOrigin.y)) " +
             "new=(\(newOrigin.x),\(newOrigin.y)) " +
+            "tentative=(\(tentativeOrigin.x),\(tentativeOrigin.y)) " +
             "delta=(\(dx),\(dy)) " +
             "snappedPane=\(snappedPane?.id.uuidString.prefix(5) ?? "nil")"
         )

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -9655,6 +9655,21 @@ final class Workspace: Identifiable, ObservableObject {
         }
     }
 
+#if DEBUG
+    func togglePaperLayoutModeForDebug() {
+        switch layoutMode {
+        case .bonsplit:
+            layoutMode = .paper
+            _ = ensurePaperLayoutState()
+        case .paper:
+            layoutMode = .bonsplit
+        }
+        cmuxDebugLog(
+            "paper.layout.toggle workspace=\(id.uuidString.prefix(5)) mode=\(layoutMode.rawValue)"
+        )
+    }
+#endif
+
     func representativePanelIdForWorkspaceManualUnread() -> UUID? {
         if let focusedPanelId, panels[focusedPanelId] != nil {
             return focusedPanelId

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -9451,31 +9451,60 @@ struct PaperLayoutState: Codable, Equatable, Sendable {
     }
 
     func paneInDirection(dx: CGFloat, dy: CGFloat) -> PaperPane? {
-        guard let sourcePane = paneNearestViewportOrigin() ?? focusedPane else { return nil }
+        guard let sourcePane = focusedPane ?? paneNearestViewportOrigin() else { return nil }
         let sourceCenterX = sourcePane.frame.midX
         let sourceCenterY = sourcePane.frame.midY
+        let sourceColumnX = sourcePane.frame.minX
         let epsilon: CGFloat = 0.5
 
         let candidates: [PaperPane]
         if abs(dx) >= abs(dy), dx > 0 {
-            candidates = panes.filter { $0.id != sourcePane.id && $0.frame.midX > sourceCenterX + epsilon }
-            return candidates.min {
-                directionalScore($0, sourceCenterX: sourceCenterX, sourceCenterY: sourceCenterY, horizontal: true) <
-                    directionalScore($1, sourceCenterX: sourceCenterX, sourceCenterY: sourceCenterY, horizontal: true)
-            }
+            candidates = panes.filter { $0.id != sourcePane.id && $0.frame.minX > sourceColumnX + epsilon }
+            guard let targetColumnX = candidates.map(\.frame.minX).min() else { return nil }
+            return candidates
+                .filter { abs($0.frame.minX - targetColumnX) <= epsilon }
+                .min {
+                    columnScore($0, sourceCenterY: sourceCenterY) <
+                        columnScore($1, sourceCenterY: sourceCenterY)
+                }
         } else if abs(dx) >= abs(dy), dx < 0 {
-            candidates = panes.filter { $0.id != sourcePane.id && $0.frame.midX < sourceCenterX - epsilon }
-            return candidates.min {
-                directionalScore($0, sourceCenterX: sourceCenterX, sourceCenterY: sourceCenterY, horizontal: true) <
-                    directionalScore($1, sourceCenterX: sourceCenterX, sourceCenterY: sourceCenterY, horizontal: true)
-            }
+            candidates = panes.filter { $0.id != sourcePane.id && $0.frame.minX < sourceColumnX - epsilon }
+            guard let targetColumnX = candidates.map(\.frame.minX).max() else { return nil }
+            return candidates
+                .filter { abs($0.frame.minX - targetColumnX) <= epsilon }
+                .min {
+                    columnScore($0, sourceCenterY: sourceCenterY) <
+                        columnScore($1, sourceCenterY: sourceCenterY)
+                }
         } else if dy > 0 {
+            let sameColumnCandidates = panes.filter {
+                $0.id != sourcePane.id &&
+                    abs($0.frame.minX - sourceColumnX) <= epsilon &&
+                    $0.frame.midY > sourceCenterY + epsilon
+            }
+            if let sameColumnPane = sameColumnCandidates.min(by: { lhs, rhs in
+                verticalScore(lhs, sourceCenterY: sourceCenterY) <
+                    verticalScore(rhs, sourceCenterY: sourceCenterY)
+            }) {
+                return sameColumnPane
+            }
             candidates = panes.filter { $0.id != sourcePane.id && $0.frame.midY > sourceCenterY + epsilon }
             return candidates.min {
                 directionalScore($0, sourceCenterX: sourceCenterX, sourceCenterY: sourceCenterY, horizontal: false) <
                     directionalScore($1, sourceCenterX: sourceCenterX, sourceCenterY: sourceCenterY, horizontal: false)
             }
         } else if dy < 0 {
+            let sameColumnCandidates = panes.filter {
+                $0.id != sourcePane.id &&
+                    abs($0.frame.minX - sourceColumnX) <= epsilon &&
+                    $0.frame.midY < sourceCenterY - epsilon
+            }
+            if let sameColumnPane = sameColumnCandidates.min(by: { lhs, rhs in
+                verticalScore(lhs, sourceCenterY: sourceCenterY) <
+                    verticalScore(rhs, sourceCenterY: sourceCenterY)
+            }) {
+                return sameColumnPane
+            }
             candidates = panes.filter { $0.id != sourcePane.id && $0.frame.midY < sourceCenterY - epsilon }
             return candidates.min {
                 directionalScore($0, sourceCenterX: sourceCenterX, sourceCenterY: sourceCenterY, horizontal: false) <
@@ -9484,6 +9513,14 @@ struct PaperLayoutState: Codable, Equatable, Sendable {
         }
 
         return nil
+    }
+
+    private func columnScore(_ pane: PaperPane, sourceCenterY: CGFloat) -> CGFloat {
+        (abs(pane.frame.midY - sourceCenterY) * 10_000) + pane.frame.minY
+    }
+
+    private func verticalScore(_ pane: PaperPane, sourceCenterY: CGFloat) -> CGFloat {
+        abs(pane.frame.midY - sourceCenterY)
     }
 
     private func directionalScore(
@@ -9566,11 +9603,11 @@ struct PaperLayoutState: Codable, Equatable, Sendable {
         switch orientation {
         case .horizontal:
             let shift = sourceFrame.width + gap
+            let epsilon: CGFloat = 0.5
             for index in panes.indices {
                 guard panes[index].id != sourcePane.id,
                       panes[index].id != newPaneId.id,
-                      panes[index].frame.midX > sourceFrame.midX,
-                      verticallyOverlaps(panes[index].frame, sourceFrame) else {
+                      panes[index].frame.minX > sourceFrame.minX + epsilon else {
                     continue
                 }
                 panes[index].frame.x += shift
@@ -10020,7 +10057,15 @@ final class Workspace: Identifiable, ObservableObject {
             PaperPoint(x: max(0, $0.frame.minX), y: max(0, $0.frame.minY))
         } ?? tentativeOrigin
         paperState.viewportOrigin = newOrigin
+        if let snappedPane {
+            paperState.focusedPaneId = snappedPane.id
+        }
         paperLayoutState = paperState
+        if let snappedPane,
+           let selectedTabId = snappedPane.selectedTabId ?? snappedPane.tabIds.first,
+           let panelId = panelIdFromSurfaceId(TabID(uuid: selectedTabId)) {
+            focusPaperPanel(tabId: TabID(uuid: selectedTabId), panelId: panelId)
+        }
 
         cmuxDebugLog(
             "paper.viewport.move workspace=\(id.uuidString.prefix(5)) " +

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -9435,6 +9435,72 @@ struct PaperLayoutState: Codable, Equatable, Sendable {
         panes.first { $0.tabIds.contains(tabId) }
     }
 
+    func paneNearestViewportOrigin() -> PaperPane? {
+        paneNearest(to: viewportOrigin)
+    }
+
+    func paneNearest(to point: PaperPoint) -> PaperPane? {
+        panes.min { lhs, rhs in
+            let lhsDistance = lhs.frame.originDistanceSquared(to: point)
+            let rhsDistance = rhs.frame.originDistanceSquared(to: point)
+            if lhsDistance == rhsDistance {
+                return lhs.id.uuidString < rhs.id.uuidString
+            }
+            return lhsDistance < rhsDistance
+        }
+    }
+
+    func paneInDirection(dx: CGFloat, dy: CGFloat) -> PaperPane? {
+        guard let sourcePane = paneNearestViewportOrigin() ?? focusedPane else { return nil }
+        let sourceCenterX = sourcePane.frame.midX
+        let sourceCenterY = sourcePane.frame.midY
+        let epsilon: CGFloat = 0.5
+
+        let candidates: [PaperPane]
+        if abs(dx) >= abs(dy), dx > 0 {
+            candidates = panes.filter { $0.id != sourcePane.id && $0.frame.midX > sourceCenterX + epsilon }
+            return candidates.min {
+                directionalScore($0, sourceCenterX: sourceCenterX, sourceCenterY: sourceCenterY, horizontal: true) <
+                    directionalScore($1, sourceCenterX: sourceCenterX, sourceCenterY: sourceCenterY, horizontal: true)
+            }
+        } else if abs(dx) >= abs(dy), dx < 0 {
+            candidates = panes.filter { $0.id != sourcePane.id && $0.frame.midX < sourceCenterX - epsilon }
+            return candidates.min {
+                directionalScore($0, sourceCenterX: sourceCenterX, sourceCenterY: sourceCenterY, horizontal: true) <
+                    directionalScore($1, sourceCenterX: sourceCenterX, sourceCenterY: sourceCenterY, horizontal: true)
+            }
+        } else if dy > 0 {
+            candidates = panes.filter { $0.id != sourcePane.id && $0.frame.midY > sourceCenterY + epsilon }
+            return candidates.min {
+                directionalScore($0, sourceCenterX: sourceCenterX, sourceCenterY: sourceCenterY, horizontal: false) <
+                    directionalScore($1, sourceCenterX: sourceCenterX, sourceCenterY: sourceCenterY, horizontal: false)
+            }
+        } else if dy < 0 {
+            candidates = panes.filter { $0.id != sourcePane.id && $0.frame.midY < sourceCenterY - epsilon }
+            return candidates.min {
+                directionalScore($0, sourceCenterX: sourceCenterX, sourceCenterY: sourceCenterY, horizontal: false) <
+                    directionalScore($1, sourceCenterX: sourceCenterX, sourceCenterY: sourceCenterY, horizontal: false)
+            }
+        }
+
+        return nil
+    }
+
+    private func directionalScore(
+        _ pane: PaperPane,
+        sourceCenterX: CGFloat,
+        sourceCenterY: CGFloat,
+        horizontal: Bool
+    ) -> CGFloat {
+        let primary = horizontal
+            ? abs(pane.frame.midX - sourceCenterX)
+            : abs(pane.frame.midY - sourceCenterY)
+        let cross = horizontal
+            ? abs(pane.frame.midY - sourceCenterY)
+            : abs(pane.frame.midX - sourceCenterX)
+        return (primary * 10_000) + cross
+    }
+
     mutating func focusPane(containingTabId tabId: UUID) {
         guard let paneIndex = panes.firstIndex(where: { $0.tabIds.contains(tabId) }) else { return }
         focusedPaneId = panes[paneIndex].id
@@ -9547,8 +9613,16 @@ struct PaperRect: Codable, Equatable, Sendable {
 
     var minX: CGFloat { x }
     var minY: CGFloat { y }
+    var midX: CGFloat { x + (width / 2) }
+    var midY: CGFloat { y + (height / 2) }
     var maxX: CGFloat { x + width }
     var maxY: CGFloat { y + height }
+
+    func originDistanceSquared(to point: PaperPoint) -> CGFloat {
+        let dx = x - point.x
+        let dy = y - point.y
+        return (dx * dx) + (dy * dy)
+    }
 }
 
 /// Workspace represents a sidebar tab.
@@ -9711,6 +9785,32 @@ final class Workspace: Identifiable, ObservableObject {
         }
         cmuxDebugLog(
             "paper.layout.toggle workspace=\(id.uuidString.prefix(5)) mode=\(layoutMode.rawValue)"
+        )
+    }
+
+    func movePaperViewportForDebug(dx: CGFloat, dy: CGFloat) {
+        guard layoutMode == .paper else { return }
+        guard var paperState = ensurePaperLayoutState() else { return }
+
+        let oldOrigin = paperState.viewportOrigin
+        let tentativeOrigin = PaperPoint(
+            x: max(0, oldOrigin.x + dx),
+            y: max(0, oldOrigin.y + dy)
+        )
+        let snappedPane = paperState.paneInDirection(dx: dx, dy: dy)
+        let newOrigin = snappedPane.map {
+            PaperPoint(x: max(0, $0.frame.minX), y: max(0, $0.frame.minY))
+        } ?? tentativeOrigin
+        paperState.viewportOrigin = newOrigin
+        objectWillChange.send()
+        paperLayoutState = paperState
+
+        cmuxDebugLog(
+            "paper.viewport.move workspace=\(id.uuidString.prefix(5)) " +
+            "old=(\(oldOrigin.x),\(oldOrigin.y)) " +
+            "new=(\(newOrigin.x),\(newOrigin.y)) " +
+            "delta=(\(dx),\(dy)) " +
+            "snappedPane=\(snappedPane?.id.uuidString.prefix(5) ?? "nil")"
         )
     }
 #endif

--- a/Sources/WorkspaceContentView.swift
+++ b/Sources/WorkspaceContentView.swift
@@ -298,6 +298,25 @@ struct WorkspaceContentView: View {
         // Recreate the Bonsplit subtree on zoom enter/exit so stale pre-zoom pane chrome
         // cannot remain stacked above portal-hosted browser content.
         .id(splitZoomRenderIdentity)
+
+        Group {
+            switch workspace.layoutMode {
+            case .bonsplit:
+                bonsplitView
+            case .paper:
+                PaperCanvasWorkspaceView(
+                    workspace: workspace,
+                    isWorkspaceVisible: isWorkspaceVisible,
+                    isWorkspaceInputActive: isWorkspaceInputActive,
+                    workspacePortalPriority: workspacePortalPriority,
+                    appearance: appearance,
+                    isSplit: isSplit,
+                    usesWorkspacePaneOverlay: usesWorkspacePaneOverlay,
+                    isWorkspaceManuallyUnread: isWorkspaceManuallyUnread,
+                    workspaceManualUnreadPanelId: workspaceManualUnreadPanelId
+                )
+            }
+        }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .onAppear {
             updateAgentHibernationPresentationVisibility()
@@ -355,26 +374,7 @@ struct WorkspaceContentView: View {
                 notificationPayloadHex: payloadHex
             )
         }
-
-        Group {
-            switch workspace.layoutMode {
-            case .bonsplit:
-                bonsplitView
-            case .paper:
-                PaperCanvasWorkspaceView(
-                    workspace: workspace,
-                    isWorkspaceVisible: isWorkspaceVisible,
-                    isWorkspaceInputActive: isWorkspaceInputActive,
-                    workspacePortalPriority: workspacePortalPriority,
-                    appearance: appearance,
-                    isSplit: isSplit,
-                    usesWorkspacePaneOverlay: usesWorkspacePaneOverlay,
-                    isWorkspaceManuallyUnread: isWorkspaceManuallyUnread,
-                    workspaceManualUnreadPanelId: workspaceManualUnreadPanelId
-                )
-            }
-        }
-            .ignoresSafeArea(.container, edges: (isMinimalMode && !isFullScreen) ? .top : [])
+        .ignoresSafeArea(.container, edges: (isMinimalMode && !isFullScreen) ? .top : [])
     }
 
     private func syncBonsplitNotificationBadges() {
@@ -807,17 +807,22 @@ struct PaperCanvasWorkspaceView: View {
     private func paperCanvasView(_ paperLayoutState: PaperLayoutState, viewportSize: CGSize) -> some View {
         let visibleColumns = paperLayoutState.visibleColumns(count: workspace.paperVisibleColumnCount)
         let visibleColumnCount = max(1, visibleColumns.count)
-        let requestedRowCount = min(4, max(1, workspace.paperVisibleRowCount))
+        let visibleRowCount = min(4, max(1, workspace.paperVisibleRowCount))
         let totalColumnSpacing = paperColumnSpacing * CGFloat(max(0, visibleColumnCount - 1))
-        let totalRowSpacing = paperRowSpacing * CGFloat(max(0, requestedRowCount - 1))
+        let totalRowSpacing = paperRowSpacing * CGFloat(max(0, visibleRowCount - 1))
         let paneSize = CGSize(
             width: max(1, (viewportSize.width - totalColumnSpacing) / CGFloat(visibleColumnCount)),
-            height: max(1, (viewportSize.height - totalRowSpacing) / CGFloat(requestedRowCount))
+            height: max(1, (viewportSize.height - totalRowSpacing) / CGFloat(visibleRowCount))
         )
 
         HStack(alignment: .top, spacing: paperColumnSpacing) {
             ForEach(visibleColumns, id: \.x) { column in
-                paperColumnView(column, paperLayoutState: paperLayoutState, paneSize: paneSize)
+                paperColumnView(
+                    column,
+                    paperLayoutState: paperLayoutState,
+                    visibleRowCount: visibleRowCount,
+                    paneSize: paneSize
+                )
             }
         }
         .frame(width: viewportSize.width, height: viewportSize.height, alignment: .topLeading)
@@ -827,10 +832,11 @@ struct PaperCanvasWorkspaceView: View {
     private func paperColumnView(
         _ column: PaperLayoutState.PaperColumn,
         paperLayoutState: PaperLayoutState,
+        visibleRowCount: Int,
         paneSize: CGSize
     ) -> some View {
         VStack(alignment: .leading, spacing: paperRowSpacing) {
-            ForEach(paperLayoutState.visiblePanes(in: column, rowCount: workspace.paperVisibleRowCount)) { pane in
+            ForEach(paperLayoutState.visiblePanes(in: column, rowCount: visibleRowCount)) { pane in
                 paperPaneView(pane, paneSize: paneSize)
             }
         }

--- a/Sources/WorkspaceContentView.swift
+++ b/Sources/WorkspaceContentView.swift
@@ -787,9 +787,7 @@ struct PaperCanvasWorkspaceView: View {
         GeometryReader { proxy in
             ZStack(alignment: .topLeading) {
                 if let paperLayoutState = workspace.paperLayoutState {
-                    ForEach(paperLayoutState.panes) { pane in
-                        paperPaneView(pane, viewportOrigin: paperLayoutState.viewportOrigin)
-                    }
+                    paperCanvasView(paperLayoutState, viewportSize: proxy.size)
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
@@ -804,7 +802,17 @@ struct PaperCanvasWorkspaceView: View {
     }
 
     @ViewBuilder
-    private func paperPaneView(_ pane: PaperPane, viewportOrigin: PaperPoint) -> some View {
+    private func paperCanvasView(_ paperLayoutState: PaperLayoutState, viewportSize: CGSize) -> some View {
+        ZStack(alignment: .topLeading) {
+            if let activePane = paperLayoutState.paneNearestViewportOrigin() {
+                paperPaneView(activePane)
+            }
+        }
+        .frame(width: viewportSize.width, height: viewportSize.height, alignment: .topLeading)
+    }
+
+    @ViewBuilder
+    private func paperPaneView(_ pane: PaperPane) -> some View {
         let paneId = PaneID(id: pane.id)
         let selectedTabId = pane.selectedTabId ?? pane.tabIds.first
         let panel = selectedTabId.flatMap { workspace.panel(for: TabID(uuid: $0)) }
@@ -827,60 +835,56 @@ struct PaperCanvasWorkspaceView: View {
                 isWorkspaceManualUnreadRepresentative: workspaceManualUnreadPanelId == panel.id
             )
 
-            PanelContentView(
-                panel: panel,
-                workspaceId: workspace.id,
-                paneId: paneId,
-                isFocused: isFocused,
-                isSelectedInPane: true,
-                isVisibleInUI: isVisibleInUI,
-                portalPriority: workspacePortalPriority,
-                isSplit: isSplit,
-                appearance: appearance,
-                hasUnreadNotification: showsNotificationRing && !usesWorkspacePaneOverlay,
-                terminalAgentContext: WorkspaceContentView.terminalAgentContext(panel: panel, workspace: workspace),
-                onFocus: {
-                    guard isWorkspaceInputActive else { return }
-                    guard workspace.panels[panel.id] != nil else { return }
-                    workspace.focusPanel(panel.id, trigger: .terminalFirstResponder)
-                },
-                onRequestPanelFocus: {
-                    guard isWorkspaceInputActive else { return }
-                    guard workspace.panels[panel.id] != nil else { return }
-                    AppDelegate.shared?.noteMainPanelKeyboardFocusIntent(
-                        workspaceId: workspace.id,
-                        panelId: panel.id,
-                        in: NSApp.keyWindow ?? NSApp.mainWindow
-                    )
-                    workspace.focusPanel(panel.id)
-                },
-                onResumeAgentHibernation: {
-                    guard isWorkspaceInputActive else { return }
-                    guard workspace.panels[panel.id] != nil else { return }
-                    workspace.resumeAgentHibernation(panelId: panel.id, focus: true)
-                },
-                onAutoResumeAgentHibernation: {
-                    guard isWorkspaceInputActive else { return }
-                    guard workspace.panels[panel.id] != nil else { return }
-                    workspace.resumeAgentHibernation(panelId: panel.id, focus: false)
-                },
-                onTriggerFlash: { workspace.triggerDebugFlash(panelId: panel.id) }
-            )
-            .frame(width: pane.frame.width, height: pane.frame.height)
-            .position(
-                x: pane.frame.minX - viewportOrigin.x + (pane.frame.width / 2),
-                y: pane.frame.minY - viewportOrigin.y + (pane.frame.height / 2)
-            )
-        } else {
-            EmptyPanelView(workspace: workspace, paneId: paneId)
-                .frame(width: pane.frame.width, height: pane.frame.height)
-                .position(
-                    x: pane.frame.minX - viewportOrigin.x + (pane.frame.width / 2),
-                    y: pane.frame.minY - viewportOrigin.y + (pane.frame.height / 2)
+            ZStack {
+                PanelContentView(
+                    panel: panel,
+                    workspaceId: workspace.id,
+                    paneId: paneId,
+                    isFocused: isFocused,
+                    isSelectedInPane: true,
+                    isVisibleInUI: isVisibleInUI,
+                    portalPriority: workspacePortalPriority,
+                    isSplit: isSplit,
+                    appearance: appearance,
+                    hasUnreadNotification: showsNotificationRing && !usesWorkspacePaneOverlay,
+                    terminalAgentContext: WorkspaceContentView.terminalAgentContext(panel: panel, workspace: workspace),
+                    onFocus: {
+                        guard isWorkspaceInputActive else { return }
+                        guard workspace.panels[panel.id] != nil else { return }
+                        workspace.focusPanel(panel.id, trigger: .terminalFirstResponder)
+                    },
+                    onRequestPanelFocus: {
+                        guard isWorkspaceInputActive else { return }
+                        guard workspace.panels[panel.id] != nil else { return }
+                        AppDelegate.shared?.noteMainPanelKeyboardFocusIntent(
+                            workspaceId: workspace.id,
+                            panelId: panel.id,
+                            in: NSApp.keyWindow ?? NSApp.mainWindow
+                        )
+                        workspace.focusPanel(panel.id)
+                    },
+                    onResumeAgentHibernation: {
+                        guard isWorkspaceInputActive else { return }
+                        guard workspace.panels[panel.id] != nil else { return }
+                        workspace.resumeAgentHibernation(panelId: panel.id, focus: true)
+                    },
+                    onAutoResumeAgentHibernation: {
+                        guard isWorkspaceInputActive else { return }
+                        guard workspace.panels[panel.id] != nil else { return }
+                        workspace.resumeAgentHibernation(panelId: panel.id, focus: false)
+                    },
+                    onTriggerFlash: { workspace.triggerDebugFlash(panelId: panel.id) }
                 )
-                .onTapGesture {
-                    workspace.bonsplitController.focusPane(paneId)
-                }
+            }
+            .frame(width: pane.frame.width, height: pane.frame.height)
+        } else {
+            ZStack {
+                EmptyPanelView(workspace: workspace, paneId: paneId)
+            }
+            .frame(width: pane.frame.width, height: pane.frame.height)
+            .onTapGesture {
+                workspace.bonsplitController.focusPane(paneId)
+            }
         }
     }
 

--- a/Sources/WorkspaceContentView.swift
+++ b/Sources/WorkspaceContentView.swift
@@ -871,9 +871,6 @@ struct PaperCanvasWorkspaceView: View {
                 x: pane.frame.minX - viewportOrigin.x + (pane.frame.width / 2),
                 y: pane.frame.minY - viewportOrigin.y + (pane.frame.height / 2)
             )
-            .onTapGesture {
-                workspace.focusPanel(panel.id)
-            }
         } else {
             EmptyPanelView(workspace: workspace, paneId: paneId)
                 .frame(width: pane.frame.width, height: pane.frame.height)

--- a/Sources/WorkspaceContentView.swift
+++ b/Sources/WorkspaceContentView.swift
@@ -872,10 +872,7 @@ struct PaperCanvasWorkspaceView: View {
                 y: pane.frame.minY - viewportOrigin.y + (pane.frame.height / 2)
             )
             .onTapGesture {
-                workspace.bonsplitController.focusPane(paneId)
-                if let selectedTabId {
-                    workspace.bonsplitController.selectTab(TabID(uuid: selectedTabId))
-                }
+                workspace.focusPanel(panel.id)
             }
         } else {
             EmptyPanelView(workspace: workspace, paneId: paneId)
@@ -891,17 +888,7 @@ struct PaperCanvasWorkspaceView: View {
     }
 
     private func initializePaperLayoutIfNeeded(viewportSize: CGSize) {
-        guard workspace.paperLayoutState == nil else { return }
-        let paneId = workspace.bonsplitController.focusedPaneId ?? workspace.bonsplitController.allPaneIds.first
-        guard let paneId else { return }
-        let tabId = workspace.bonsplitController.selectedTab(inPane: paneId)?.id ??
-            workspace.bonsplitController.tabs(inPane: paneId).first?.id
-        guard let tabId else { return }
-        workspace.paperLayoutState = PaperLayoutState.initial(
-            paneId: paneId,
-            tabId: tabId.uuid,
-            viewportSize: viewportSize
-        )
+        workspace.ensurePaperLayoutState(viewportSize: viewportSize)
     }
 }
 

--- a/Sources/WorkspaceContentView.swift
+++ b/Sources/WorkspaceContentView.swift
@@ -356,7 +356,24 @@ struct WorkspaceContentView: View {
             )
         }
 
-        bonsplitView
+        Group {
+            switch workspace.layoutMode {
+            case .bonsplit:
+                bonsplitView
+            case .paper:
+                PaperCanvasWorkspaceView(
+                    workspace: workspace,
+                    isWorkspaceVisible: isWorkspaceVisible,
+                    isWorkspaceInputActive: isWorkspaceInputActive,
+                    workspacePortalPriority: workspacePortalPriority,
+                    appearance: appearance,
+                    isSplit: isSplit,
+                    usesWorkspacePaneOverlay: usesWorkspacePaneOverlay,
+                    isWorkspaceManuallyUnread: isWorkspaceManuallyUnread,
+                    workspaceManualUnreadPanelId: workspaceManualUnreadPanelId
+                )
+            }
+        }
             .ignoresSafeArea(.container, edges: (isMinimalMode && !isFullScreen) ? .top : [])
     }
 
@@ -752,6 +769,140 @@ extension WorkspaceContentView {
         _ = workspace
     }
     #endif
+}
+
+struct PaperCanvasWorkspaceView: View {
+    @ObservedObject var workspace: Workspace
+    let isWorkspaceVisible: Bool
+    let isWorkspaceInputActive: Bool
+    let workspacePortalPriority: Int
+    let appearance: PanelAppearance
+    let isSplit: Bool
+    let usesWorkspacePaneOverlay: Bool
+    let isWorkspaceManuallyUnread: Bool
+    let workspaceManualUnreadPanelId: UUID?
+    @EnvironmentObject var notificationStore: TerminalNotificationStore
+
+    var body: some View {
+        GeometryReader { proxy in
+            ZStack(alignment: .topLeading) {
+                if let paperLayoutState = workspace.paperLayoutState {
+                    ForEach(paperLayoutState.panes) { pane in
+                        paperPaneView(pane, viewportOrigin: paperLayoutState.viewportOrigin)
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            .clipped()
+            .onAppear {
+                initializePaperLayoutIfNeeded(viewportSize: proxy.size)
+            }
+            .onChange(of: proxy.size) { _, viewportSize in
+                initializePaperLayoutIfNeeded(viewportSize: viewportSize)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func paperPaneView(_ pane: PaperPane, viewportOrigin: PaperPoint) -> some View {
+        let paneId = PaneID(id: pane.id)
+        let selectedTabId = pane.selectedTabId ?? pane.tabIds.first
+        let panel = selectedTabId.flatMap { workspace.panel(for: TabID(uuid: $0)) }
+
+        if let panel {
+            let isFocused = isWorkspaceInputActive && workspace.focusedPanelId == panel.id
+            let isVisibleInUI = WorkspaceContentView.panelVisibleInUI(
+                isWorkspaceVisible: isWorkspaceVisible,
+                isSelectedInPane: true,
+                isFocused: isFocused
+            )
+            let showsNotificationRing = Workspace.shouldShowUnreadIndicator(
+                hasUnreadNotification: notificationStore.hasVisibleNotificationIndicator(
+                    forTabId: workspace.id,
+                    surfaceId: panel.id
+                ),
+                hasPanelUnreadIndicator: workspace.manualUnreadPanelIds.contains(panel.id) ||
+                    workspace.restoredUnreadPanelIds.contains(panel.id),
+                isWorkspaceManuallyUnread: isWorkspaceManuallyUnread,
+                isWorkspaceManualUnreadRepresentative: workspaceManualUnreadPanelId == panel.id
+            )
+
+            PanelContentView(
+                panel: panel,
+                workspaceId: workspace.id,
+                paneId: paneId,
+                isFocused: isFocused,
+                isSelectedInPane: true,
+                isVisibleInUI: isVisibleInUI,
+                portalPriority: workspacePortalPriority,
+                isSplit: isSplit,
+                appearance: appearance,
+                hasUnreadNotification: showsNotificationRing && !usesWorkspacePaneOverlay,
+                terminalAgentContext: WorkspaceContentView.terminalAgentContext(panel: panel, workspace: workspace),
+                onFocus: {
+                    guard isWorkspaceInputActive else { return }
+                    guard workspace.panels[panel.id] != nil else { return }
+                    workspace.focusPanel(panel.id, trigger: .terminalFirstResponder)
+                },
+                onRequestPanelFocus: {
+                    guard isWorkspaceInputActive else { return }
+                    guard workspace.panels[panel.id] != nil else { return }
+                    AppDelegate.shared?.noteMainPanelKeyboardFocusIntent(
+                        workspaceId: workspace.id,
+                        panelId: panel.id,
+                        in: NSApp.keyWindow ?? NSApp.mainWindow
+                    )
+                    workspace.focusPanel(panel.id)
+                },
+                onResumeAgentHibernation: {
+                    guard isWorkspaceInputActive else { return }
+                    guard workspace.panels[panel.id] != nil else { return }
+                    workspace.resumeAgentHibernation(panelId: panel.id, focus: true)
+                },
+                onAutoResumeAgentHibernation: {
+                    guard isWorkspaceInputActive else { return }
+                    guard workspace.panels[panel.id] != nil else { return }
+                    workspace.resumeAgentHibernation(panelId: panel.id, focus: false)
+                },
+                onTriggerFlash: { workspace.triggerDebugFlash(panelId: panel.id) }
+            )
+            .frame(width: pane.frame.width, height: pane.frame.height)
+            .position(
+                x: pane.frame.minX - viewportOrigin.x + (pane.frame.width / 2),
+                y: pane.frame.minY - viewportOrigin.y + (pane.frame.height / 2)
+            )
+            .onTapGesture {
+                workspace.bonsplitController.focusPane(paneId)
+                if let selectedTabId {
+                    workspace.bonsplitController.selectTab(TabID(uuid: selectedTabId))
+                }
+            }
+        } else {
+            EmptyPanelView(workspace: workspace, paneId: paneId)
+                .frame(width: pane.frame.width, height: pane.frame.height)
+                .position(
+                    x: pane.frame.minX - viewportOrigin.x + (pane.frame.width / 2),
+                    y: pane.frame.minY - viewportOrigin.y + (pane.frame.height / 2)
+                )
+                .onTapGesture {
+                    workspace.bonsplitController.focusPane(paneId)
+                }
+        }
+    }
+
+    private func initializePaperLayoutIfNeeded(viewportSize: CGSize) {
+        guard workspace.paperLayoutState == nil else { return }
+        let paneId = workspace.bonsplitController.focusedPaneId ?? workspace.bonsplitController.allPaneIds.first
+        guard let paneId else { return }
+        let tabId = workspace.bonsplitController.selectedTab(inPane: paneId)?.id ??
+            workspace.bonsplitController.tabs(inPane: paneId).first?.id
+        guard let tabId else { return }
+        workspace.paperLayoutState = PaperLayoutState.initial(
+            paneId: paneId,
+            tabId: tabId.uuid,
+            viewportSize: viewportSize
+        )
+    }
 }
 
 /// View shown for empty panes

--- a/Sources/WorkspaceContentView.swift
+++ b/Sources/WorkspaceContentView.swift
@@ -772,6 +772,58 @@ extension WorkspaceContentView {
 }
 
 struct PaperCanvasWorkspaceView: View {
+    private struct RenderedPaperPane: Identifiable, Equatable {
+        let pane: PaperPane
+        let selectedTabId: UUID?
+        let panelId: UUID?
+
+        var id: String {
+            "\(pane.id.uuidString):\(selectedTabId?.uuidString ?? "nil")"
+        }
+
+        var shortDescription: String {
+            "\(pane.id.uuidString.prefix(5)):\(selectedTabId.map { String($0.uuidString.prefix(5)) } ?? "nil")"
+        }
+    }
+
+    private struct RenderedPaperColumn: Identifiable, Equatable {
+        let sourceX: CGFloat
+        let panes: [RenderedPaperPane]
+
+        var id: String {
+            panes.map(\.id).joined(separator: "|")
+        }
+    }
+
+    private struct PaperRenderPlan: Equatable {
+        let columns: [RenderedPaperColumn]
+        let duplicatePaneIds: [UUID]
+        let duplicateSelectedTabIds: [UUID]
+        let duplicatePanelIds: [UUID]
+        let missingPanels: [RenderedPaperPane]
+
+        var visibleColumnCount: Int {
+            max(1, columns.count)
+        }
+
+        var visiblePaneDescriptions: String {
+            columns
+                .flatMap(\.panes)
+                .map(\.shortDescription)
+                .joined(separator: ",")
+        }
+
+        var debugSignature: String {
+            [
+                "visible=\(visiblePaneDescriptions)",
+                "duplicatePanes=\(duplicatePaneIds.map { String($0.uuidString.prefix(5)) }.joined(separator: ","))",
+                "duplicateTabs=\(duplicateSelectedTabIds.map { String($0.uuidString.prefix(5)) }.joined(separator: ","))",
+                "duplicatePanels=\(duplicatePanelIds.map { String($0.uuidString.prefix(5)) }.joined(separator: ","))",
+                "missing=\(missingPanels.map(\.shortDescription).joined(separator: ","))"
+            ].joined(separator: " ")
+        }
+    }
+
     @ObservedObject var workspace: Workspace
     let isWorkspaceVisible: Bool
     let isWorkspaceInputActive: Bool
@@ -805,8 +857,8 @@ struct PaperCanvasWorkspaceView: View {
 
     @ViewBuilder
     private func paperCanvasView(_ paperLayoutState: PaperLayoutState, viewportSize: CGSize) -> some View {
-        let visibleColumns = paperLayoutState.visibleColumns(count: workspace.paperVisibleColumnCount)
-        let visibleColumnCount = max(1, visibleColumns.count)
+        let renderPlan = paperRenderPlan(paperLayoutState)
+        let visibleColumnCount = renderPlan.visibleColumnCount
         let visibleRowCount = min(4, max(1, workspace.paperVisibleRowCount))
         let totalColumnSpacing = paperColumnSpacing * CGFloat(max(0, visibleColumnCount - 1))
         let totalRowSpacing = paperRowSpacing * CGFloat(max(0, visibleRowCount - 1))
@@ -816,117 +868,211 @@ struct PaperCanvasWorkspaceView: View {
         )
 
         HStack(alignment: .top, spacing: paperColumnSpacing) {
-            ForEach(visibleColumns, id: \.x) { column in
-                paperColumnView(
-                    column,
-                    paperLayoutState: paperLayoutState,
-                    visibleRowCount: visibleRowCount,
-                    paneSize: paneSize
-                )
+            ForEach(renderPlan.columns) { column in
+                VStack(alignment: .leading, spacing: paperRowSpacing) {
+                    ForEach(column.panes) { renderedPane in
+                        paperPaneView(renderedPane, paneSize: paneSize)
+                    }
+                }
             }
         }
         .frame(width: viewportSize.width, height: viewportSize.height, alignment: .topLeading)
+#if DEBUG
+        .onAppear {
+            logPaperRenderPlan(renderPlan, visibleColumnCount: visibleColumnCount, visibleRowCount: visibleRowCount)
+        }
+        .onChange(of: renderPlan.debugSignature) { _, _ in
+            logPaperRenderPlan(renderPlan, visibleColumnCount: visibleColumnCount, visibleRowCount: visibleRowCount)
+        }
+#endif
     }
 
-    @ViewBuilder
-    private func paperColumnView(
-        _ column: PaperLayoutState.PaperColumn,
-        paperLayoutState: PaperLayoutState,
-        visibleRowCount: Int,
-        paneSize: CGSize
-    ) -> some View {
-        VStack(alignment: .leading, spacing: paperRowSpacing) {
-            ForEach(paperLayoutState.visiblePanes(in: column, rowCount: visibleRowCount)) { pane in
-                paperPaneView(pane, paneSize: paneSize)
-            }
+    private func paperRenderPlan(_ paperLayoutState: PaperLayoutState) -> PaperRenderPlan {
+        var seenPaneIds: Set<UUID> = []
+        var seenSelectedTabIds: Set<UUID> = []
+        var seenPanelIds: Set<UUID> = []
+        var duplicatePaneIds: [UUID] = []
+        var duplicateSelectedTabIds: [UUID] = []
+        var duplicatePanelIds: [UUID] = []
+        var missingPanels: [RenderedPaperPane] = []
+
+        let visibleColumns = paperLayoutState.visibleColumns(count: workspace.paperVisibleColumnCount)
+        let visibleRowCount = min(4, max(1, workspace.paperVisibleRowCount))
+
+        let renderedColumns = visibleColumns.compactMap { column -> RenderedPaperColumn? in
+            let renderedPanes = paperLayoutState
+                .visiblePanes(in: column, rowCount: visibleRowCount)
+                .compactMap { pane -> RenderedPaperPane? in
+                    guard seenPaneIds.insert(pane.id).inserted else {
+                        duplicatePaneIds.append(pane.id)
+                        return nil
+                    }
+
+                    let selectedTabId = pane.selectedTabId ?? pane.tabIds.first
+                    if let selectedTabId,
+                       !seenSelectedTabIds.insert(selectedTabId).inserted {
+                        duplicateSelectedTabIds.append(selectedTabId)
+                        return nil
+                    }
+
+                    let panelId = selectedTabId.flatMap { workspace.panel(for: TabID(uuid: $0))?.id }
+                    let renderedPane = RenderedPaperPane(
+                        pane: pane,
+                        selectedTabId: selectedTabId,
+                        panelId: panelId
+                    )
+                    if let selectedTabId, panelId == nil {
+                        missingPanels.append(renderedPane)
+                    }
+                    if let panelId,
+                       !seenPanelIds.insert(panelId).inserted {
+                        duplicatePanelIds.append(panelId)
+                        return nil
+                    }
+
+                    return renderedPane
+                }
+
+            guard !renderedPanes.isEmpty else { return nil }
+            return RenderedPaperColumn(sourceX: column.x, panes: renderedPanes)
+        }
+
+        return PaperRenderPlan(
+            columns: renderedColumns,
+            duplicatePaneIds: duplicatePaneIds,
+            duplicateSelectedTabIds: duplicateSelectedTabIds,
+            duplicatePanelIds: duplicatePanelIds,
+            missingPanels: missingPanels
+        )
+    }
+
+#if DEBUG
+    private func logPaperRenderPlan(
+        _ renderPlan: PaperRenderPlan,
+        visibleColumnCount: Int,
+        visibleRowCount: Int
+    ) {
+        cmuxDebugLog(
+            "paper.render.visible workspace=\(workspace.id.uuidString.prefix(5)) " +
+            "columns=\(visibleColumnCount) rows=\(visibleRowCount) panes=\(renderPlan.visiblePaneDescriptions)"
+        )
+
+        if !renderPlan.duplicatePaneIds.isEmpty ||
+            !renderPlan.duplicateSelectedTabIds.isEmpty ||
+            !renderPlan.duplicatePanelIds.isEmpty {
+            cmuxDebugLog(
+                "paper.render.duplicates workspace=\(workspace.id.uuidString.prefix(5)) " +
+                "paneIds=\(renderPlan.duplicatePaneIds.map { String($0.uuidString.prefix(5)) }.joined(separator: ",")) " +
+                "selectedTabIds=\(renderPlan.duplicateSelectedTabIds.map { String($0.uuidString.prefix(5)) }.joined(separator: ",")) " +
+                "panelIds=\(renderPlan.duplicatePanelIds.map { String($0.uuidString.prefix(5)) }.joined(separator: ","))"
+            )
+        }
+
+        for missingPanel in renderPlan.missingPanels {
+            cmuxDebugLog(
+                "paper.render.missingPanel workspace=\(workspace.id.uuidString.prefix(5)) " +
+                "pane=\(missingPanel.pane.id.uuidString.prefix(5)) " +
+                "selectedTab=\(missingPanel.selectedTabId.map { String($0.uuidString.prefix(5)) } ?? "nil") " +
+                "tabIds=\(missingPanel.pane.tabIds.map { String($0.uuidString.prefix(5)) }.joined(separator: ","))"
+            )
         }
     }
+#endif
 
     @ViewBuilder
-    private func paperPaneView(_ pane: PaperPane, paneSize: CGSize) -> some View {
+    private func paperPaneView(_ renderedPane: RenderedPaperPane, paneSize: CGSize) -> some View {
+        let pane = renderedPane.pane
         let paneId = PaneID(id: pane.id)
-        let selectedTabId = pane.selectedTabId ?? pane.tabIds.first
+        let selectedTabId = renderedPane.selectedTabId
         let panel = selectedTabId.flatMap { workspace.panel(for: TabID(uuid: $0)) }
 
-        if let panel {
-            let isFocused = isWorkspaceInputActive && workspace.focusedPanelId == panel.id
-            let isVisibleInUI = WorkspaceContentView.panelVisibleInUI(
-                isWorkspaceVisible: isWorkspaceVisible,
-                isSelectedInPane: true,
-                isFocused: isFocused
-            )
-            let showsNotificationRing = Workspace.shouldShowUnreadIndicator(
-                hasUnreadNotification: notificationStore.hasVisibleNotificationIndicator(
-                    forTabId: workspace.id,
-                    surfaceId: panel.id
-                ),
-                hasPanelUnreadIndicator: workspace.manualUnreadPanelIds.contains(panel.id) ||
-                    workspace.restoredUnreadPanelIds.contains(panel.id),
-                isWorkspaceManuallyUnread: isWorkspaceManuallyUnread,
-                isWorkspaceManualUnreadRepresentative: workspaceManualUnreadPanelId == panel.id
-            )
-
-            ZStack {
-                PanelContentView(
-                    panel: panel,
-                    workspaceId: workspace.id,
-                    paneId: paneId,
-                    isFocused: isFocused,
-                    isSelectedInPane: true,
-                    isVisibleInUI: isVisibleInUI,
-                    portalPriority: workspacePortalPriority,
-                    isSplit: isSplit,
-                    appearance: appearance,
-                    hasUnreadNotification: showsNotificationRing && !usesWorkspacePaneOverlay,
-                    terminalAgentContext: WorkspaceContentView.terminalAgentContext(panel: panel, workspace: workspace),
-                    onFocus: {
-                        guard isWorkspaceInputActive else { return }
-                        guard workspace.panels[panel.id] != nil else { return }
-                        workspace.focusPanel(panel.id, trigger: .terminalFirstResponder)
-                    },
-                    onRequestPanelFocus: {
-                        guard isWorkspaceInputActive else { return }
-                        guard workspace.panels[panel.id] != nil else { return }
-                        AppDelegate.shared?.noteMainPanelKeyboardFocusIntent(
-                            workspaceId: workspace.id,
-                            panelId: panel.id,
-                            in: NSApp.keyWindow ?? NSApp.mainWindow
-                        )
-                        workspace.focusPanel(panel.id)
-                    },
-                    onResumeAgentHibernation: {
-                        guard isWorkspaceInputActive else { return }
-                        guard workspace.panels[panel.id] != nil else { return }
-                        workspace.resumeAgentHibernation(panelId: panel.id, focus: true)
-                    },
-                    onAutoResumeAgentHibernation: {
-                        guard isWorkspaceInputActive else { return }
-                        guard workspace.panels[panel.id] != nil else { return }
-                        workspace.resumeAgentHibernation(panelId: panel.id, focus: false)
-                    },
-                    onTriggerFlash: { workspace.triggerDebugFlash(panelId: panel.id) }
-                )
-            }
-            .frame(width: paneSize.width, height: paneSize.height)
-        } else {
-            ZStack {
-                EmptyPanelView(workspace: workspace, paneId: paneId)
-            }
-            .frame(width: paneSize.width, height: paneSize.height)
+        Group {
+            if let panel {
+                paperPanelContentView(panel: panel, paneId: paneId, paneSize: paneSize)
+            } else {
+                ZStack {
+                    EmptyPanelView(workspace: workspace, paneId: paneId)
+                }
+                .frame(width: paneSize.width, height: paneSize.height)
 #if DEBUG
-            .onAppear {
-                let selectedTabDescription = selectedTabId.map { String($0.uuidString.prefix(5)) } ?? "nil"
-                cmuxDebugLog(
-                    "paper.render.missingPanel workspace=\(workspace.id.uuidString.prefix(5)) " +
-                    "pane=\(pane.id.uuidString.prefix(5)) selectedTab=\(selectedTabDescription) " +
-                    "tabIds=\(pane.tabIds.map { String($0.uuidString.prefix(5)) }.joined(separator: ","))"
-                )
-            }
+                .onAppear {
+                    let selectedTabDescription = selectedTabId.map { String($0.uuidString.prefix(5)) } ?? "nil"
+                    cmuxDebugLog(
+                        "paper.render.missingPanel workspace=\(workspace.id.uuidString.prefix(5)) " +
+                        "pane=\(pane.id.uuidString.prefix(5)) selectedTab=\(selectedTabDescription) " +
+                        "tabIds=\(pane.tabIds.map { String($0.uuidString.prefix(5)) }.joined(separator: ","))"
+                    )
+                }
 #endif
-            .onTapGesture {
-                workspace.bonsplitController.focusPane(paneId)
+                .onTapGesture {
+                    workspace.bonsplitController.focusPane(paneId)
+                }
             }
         }
+        .id(renderedPane.id)
+    }
+
+    @ViewBuilder
+    private func paperPanelContentView(panel: any Panel, paneId: PaneID, paneSize: CGSize) -> some View {
+        let isFocused = isWorkspaceInputActive && workspace.focusedPanelId == panel.id
+        let isVisibleInUI = WorkspaceContentView.panelVisibleInUI(
+            isWorkspaceVisible: isWorkspaceVisible,
+            isSelectedInPane: true,
+            isFocused: isFocused
+        )
+        let showsNotificationRing = Workspace.shouldShowUnreadIndicator(
+            hasUnreadNotification: notificationStore.hasVisibleNotificationIndicator(
+                forTabId: workspace.id,
+                surfaceId: panel.id
+            ),
+            hasPanelUnreadIndicator: workspace.manualUnreadPanelIds.contains(panel.id) ||
+                workspace.restoredUnreadPanelIds.contains(panel.id),
+            isWorkspaceManuallyUnread: isWorkspaceManuallyUnread,
+            isWorkspaceManualUnreadRepresentative: workspaceManualUnreadPanelId == panel.id
+        )
+
+        PanelContentView(
+            panel: panel,
+            workspaceId: workspace.id,
+            paneId: paneId,
+            isFocused: isFocused,
+            isSelectedInPane: true,
+            isVisibleInUI: isVisibleInUI,
+            portalPriority: workspacePortalPriority,
+            isSplit: isSplit,
+            appearance: appearance,
+            hasUnreadNotification: showsNotificationRing && !usesWorkspacePaneOverlay,
+            terminalAgentContext: WorkspaceContentView.terminalAgentContext(panel: panel, workspace: workspace),
+            onFocus: {
+                guard isWorkspaceInputActive else { return }
+                guard workspace.panels[panel.id] != nil else { return }
+                workspace.focusPanel(panel.id, trigger: .terminalFirstResponder)
+            },
+            onRequestPanelFocus: {
+                guard isWorkspaceInputActive else { return }
+                guard workspace.panels[panel.id] != nil else { return }
+                AppDelegate.shared?.noteMainPanelKeyboardFocusIntent(
+                    workspaceId: workspace.id,
+                    panelId: panel.id,
+                    in: NSApp.keyWindow ?? NSApp.mainWindow
+                )
+                workspace.focusPanel(panel.id)
+            },
+            onResumeAgentHibernation: {
+                guard isWorkspaceInputActive else { return }
+                guard workspace.panels[panel.id] != nil else { return }
+                workspace.resumeAgentHibernation(panelId: panel.id, focus: true)
+            },
+            onAutoResumeAgentHibernation: {
+                guard isWorkspaceInputActive else { return }
+                guard workspace.panels[panel.id] != nil else { return }
+                workspace.resumeAgentHibernation(panelId: panel.id, focus: false)
+            },
+            onTriggerFlash: {
+                workspace.triggerDebugFlash(panelId: panel.id)
+            }
+        )
+        .frame(width: paneSize.width, height: paneSize.height)
     }
 
     private func initializePaperLayoutIfNeeded(viewportSize: CGSize) {

--- a/Sources/WorkspaceContentView.swift
+++ b/Sources/WorkspaceContentView.swift
@@ -782,6 +782,8 @@ struct PaperCanvasWorkspaceView: View {
     let isWorkspaceManuallyUnread: Bool
     let workspaceManualUnreadPanelId: UUID?
     @EnvironmentObject var notificationStore: TerminalNotificationStore
+    private let paperColumnSpacing: CGFloat = 24
+    private let paperRowSpacing: CGFloat = 24
 
     var body: some View {
         GeometryReader { proxy in
@@ -803,16 +805,39 @@ struct PaperCanvasWorkspaceView: View {
 
     @ViewBuilder
     private func paperCanvasView(_ paperLayoutState: PaperLayoutState, viewportSize: CGSize) -> some View {
-        ZStack(alignment: .topLeading) {
-            if let activePane = paperLayoutState.paneNearestViewportOrigin() {
-                paperPaneView(activePane)
+        let visibleColumns = paperLayoutState.visibleColumns(count: workspace.paperVisibleColumnCount)
+        let visibleColumnCount = max(1, visibleColumns.count)
+        let requestedRowCount = min(4, max(1, workspace.paperVisibleRowCount))
+        let totalColumnSpacing = paperColumnSpacing * CGFloat(max(0, visibleColumnCount - 1))
+        let totalRowSpacing = paperRowSpacing * CGFloat(max(0, requestedRowCount - 1))
+        let paneSize = CGSize(
+            width: max(1, (viewportSize.width - totalColumnSpacing) / CGFloat(visibleColumnCount)),
+            height: max(1, (viewportSize.height - totalRowSpacing) / CGFloat(requestedRowCount))
+        )
+
+        HStack(alignment: .top, spacing: paperColumnSpacing) {
+            ForEach(visibleColumns, id: \.x) { column in
+                paperColumnView(column, paperLayoutState: paperLayoutState, paneSize: paneSize)
             }
         }
         .frame(width: viewportSize.width, height: viewportSize.height, alignment: .topLeading)
     }
 
     @ViewBuilder
-    private func paperPaneView(_ pane: PaperPane) -> some View {
+    private func paperColumnView(
+        _ column: PaperLayoutState.PaperColumn,
+        paperLayoutState: PaperLayoutState,
+        paneSize: CGSize
+    ) -> some View {
+        VStack(alignment: .leading, spacing: paperRowSpacing) {
+            ForEach(paperLayoutState.visiblePanes(in: column, rowCount: workspace.paperVisibleRowCount)) { pane in
+                paperPaneView(pane, paneSize: paneSize)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func paperPaneView(_ pane: PaperPane, paneSize: CGSize) -> some View {
         let paneId = PaneID(id: pane.id)
         let selectedTabId = pane.selectedTabId ?? pane.tabIds.first
         let panel = selectedTabId.flatMap { workspace.panel(for: TabID(uuid: $0)) }
@@ -876,12 +901,22 @@ struct PaperCanvasWorkspaceView: View {
                     onTriggerFlash: { workspace.triggerDebugFlash(panelId: panel.id) }
                 )
             }
-            .frame(width: pane.frame.width, height: pane.frame.height)
+            .frame(width: paneSize.width, height: paneSize.height)
         } else {
             ZStack {
                 EmptyPanelView(workspace: workspace, paneId: paneId)
             }
-            .frame(width: pane.frame.width, height: pane.frame.height)
+            .frame(width: paneSize.width, height: paneSize.height)
+#if DEBUG
+            .onAppear {
+                let selectedTabDescription = selectedTabId.map { String($0.uuidString.prefix(5)) } ?? "nil"
+                cmuxDebugLog(
+                    "paper.render.missingPanel workspace=\(workspace.id.uuidString.prefix(5)) " +
+                    "pane=\(pane.id.uuidString.prefix(5)) selectedTab=\(selectedTabDescription) " +
+                    "tabIds=\(pane.tabIds.map { String($0.uuidString.prefix(5)) }.joined(separator: ","))"
+                )
+            }
+#endif
             .onTapGesture {
                 workspace.bonsplitController.focusPane(paneId)
             }

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -360,6 +360,11 @@ struct cmuxApp: App {
                     appDelegate.openDebugStressWorkspacesWithLoadedSurfaces(nil)
                 }
 
+                Button("Toggle Selected Workspace Paper Layout") {
+                    activeTabManager.selectedWorkspace?.togglePaperLayoutModeForDebug()
+                }
+                .disabled(activeTabManager.selectedWorkspace == nil)
+
                 Divider()
                 Menu("Debug Windows") {
                     Button("Background Debug…") {

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -361,29 +361,24 @@ struct cmuxApp: App {
                 }
 
                 Button("Toggle Selected Workspace Paper Layout") {
-                    activeTabManager.selectedWorkspace?.togglePaperLayoutModeForDebug()
+                    debugPaperWorkspace(action: "toggle")?.togglePaperLayoutModeForDebug()
                 }
-                .disabled(activeTabManager.selectedWorkspace == nil)
 
                 Button("Paper View Left") {
-                    activeTabManager.selectedWorkspace?.movePaperViewportForDebug(dx: -1200, dy: 0)
+                    debugPaperWorkspace(action: "viewLeft")?.movePaperViewportForDebug(dx: -1200, dy: 0)
                 }
-                .disabled(activeTabManager.selectedWorkspace?.layoutMode != .paper)
 
                 Button("Paper View Right") {
-                    activeTabManager.selectedWorkspace?.movePaperViewportForDebug(dx: 1200, dy: 0)
+                    debugPaperWorkspace(action: "viewRight")?.movePaperViewportForDebug(dx: 1200, dy: 0)
                 }
-                .disabled(activeTabManager.selectedWorkspace?.layoutMode != .paper)
 
                 Button("Paper View Up") {
-                    activeTabManager.selectedWorkspace?.movePaperViewportForDebug(dx: 0, dy: -800)
+                    debugPaperWorkspace(action: "viewUp")?.movePaperViewportForDebug(dx: 0, dy: -800)
                 }
-                .disabled(activeTabManager.selectedWorkspace?.layoutMode != .paper)
 
                 Button("Paper View Down") {
-                    activeTabManager.selectedWorkspace?.movePaperViewportForDebug(dx: 0, dy: 800)
+                    debugPaperWorkspace(action: "viewDown")?.movePaperViewportForDebug(dx: 0, dy: 800)
                 }
-                .disabled(activeTabManager.selectedWorkspace?.layoutMode != .paper)
 
                 Divider()
                 Menu("Debug Windows") {
@@ -920,6 +915,46 @@ struct cmuxApp: App {
             preferredWindow: NSApp.keyWindow ?? NSApp.mainWindow
         ) ?? tabManager
     }
+
+#if DEBUG
+    private func debugPaperWorkspace(action: String) -> Workspace? {
+        debugPaperWorkspace(logAction: action)
+    }
+
+    private func debugPaperWorkspace(logAction action: String?) -> Workspace? {
+        let preferredWindow = debugPaperPreferredMainWindow()
+        let manager = AppDelegate.shared?.activeTabManagerForCommands(
+            preferredWindow: preferredWindow
+        ) ?? activeTabManager
+        let workspace = manager.selectedWorkspace
+        if let action {
+            cmuxDebugLog(
+                "paper.debugMenu action=\(action) " +
+                "window=\(preferredWindow?.windowNumber ?? -1) " +
+                "workspace=\(workspace?.id.uuidString.prefix(5) ?? "nil") " +
+                "mode=\(workspace?.layoutMode.rawValue ?? "nil")"
+            )
+        } else if workspace == nil {
+            cmuxDebugLog("paper.debugMenu action=nil workspace=nil")
+        }
+        return workspace
+    }
+
+    private func debugPaperPreferredMainWindow() -> NSWindow? {
+        guard let appDelegate = AppDelegate.shared else {
+            return NSApp.keyWindow ?? NSApp.mainWindow
+        }
+
+        let directCandidates = [NSApp.keyWindow, NSApp.mainWindow].compactMap { $0 }
+        if let directWindow = directCandidates.first(where: { appDelegate.mainWindowId(from: $0) != nil }) {
+            return directWindow
+        }
+
+        return NSApp.orderedWindows.first { window in
+            appDelegate.mainWindowId(from: window) != nil
+        } ?? NSApp.keyWindow ?? NSApp.mainWindow
+    }
+#endif
 
     private func notificationMenuItemTitle(for notification: TerminalNotification) -> String {
         let tabTitle = appDelegate.tabTitle(for: notification.tabId)

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -363,29 +363,72 @@ struct cmuxApp: App {
                 Button("Toggle Selected Workspace Paper Layout") {
                     debugPaperWorkspace(action: "toggle")?.togglePaperLayoutModeForDebug()
                 }
+                .keyboardShortcut("p", modifiers: [.command, .option])
 
                 Button("Paper Focus Left") {
                     debugPaperWorkspace(action: "focusLeft")?.movePaperViewportForDebug(dx: -1200, dy: 0)
                 }
+                .keyboardShortcut("h", modifiers: [.control, .option])
 
                 Button("Paper Focus Right") {
                     debugPaperWorkspace(action: "focusRight")?.movePaperViewportForDebug(dx: 1200, dy: 0)
                 }
+                .keyboardShortcut("l", modifiers: [.control, .option])
 
                 Button("Paper Focus Up") {
                     debugPaperWorkspace(action: "focusUp")?.movePaperViewportForDebug(dx: 0, dy: -800)
                 }
+                .keyboardShortcut("k", modifiers: [.control, .option])
 
                 Button("Paper Focus Down") {
                     debugPaperWorkspace(action: "focusDown")?.movePaperViewportForDebug(dx: 0, dy: 800)
                 }
+                .keyboardShortcut("j", modifiers: [.control, .option])
 
                 Button("Paper Workspace Up") {
                     debugMovePaperWorkspace(delta: -1, createIfNeeded: false, action: "workspaceUp")
                 }
+                .keyboardShortcut("u", modifiers: [.control, .option])
 
                 Button("Paper Workspace Down") {
                     debugMovePaperWorkspace(delta: 1, createIfNeeded: true, action: "workspaceDown")
+                }
+                .keyboardShortcut("d", modifiers: [.control, .option])
+
+                Menu("Paper Visible Columns") {
+                    Button("Paper Visible Columns: 1") {
+                        debugPaperWorkspace(action: "visibleColumns1")?.setPaperVisibleColumnCountForDebug(1)
+                    }
+
+                    Button("Paper Visible Columns: 2") {
+                        debugPaperWorkspace(action: "visibleColumns2")?.setPaperVisibleColumnCountForDebug(2)
+                    }
+
+                    Button("Paper Visible Columns: 3") {
+                        debugPaperWorkspace(action: "visibleColumns3")?.setPaperVisibleColumnCountForDebug(3)
+                    }
+
+                    Button("Paper Visible Columns: 4") {
+                        debugPaperWorkspace(action: "visibleColumns4")?.setPaperVisibleColumnCountForDebug(4)
+                    }
+                }
+
+                Menu("Paper Visible Rows") {
+                    Button("Paper Visible Rows: 1") {
+                        debugPaperWorkspace(action: "visibleRows1")?.setPaperVisibleRowCountForDebug(1)
+                    }
+
+                    Button("Paper Visible Rows: 2") {
+                        debugPaperWorkspace(action: "visibleRows2")?.setPaperVisibleRowCountForDebug(2)
+                    }
+
+                    Button("Paper Visible Rows: 3") {
+                        debugPaperWorkspace(action: "visibleRows3")?.setPaperVisibleRowCountForDebug(3)
+                    }
+
+                    Button("Paper Visible Rows: 4") {
+                        debugPaperWorkspace(action: "visibleRows4")?.setPaperVisibleRowCountForDebug(4)
+                    }
                 }
 
                 Divider()
@@ -968,11 +1011,19 @@ struct cmuxApp: App {
             cmuxDebugLog("paper.workspace.move action=\(action) result=noSelection")
             return
         }
+        guard workspace.layoutMode == .paper else {
+            cmuxDebugLog(
+                "paper.workspace.move action=\(action) result=notPaper " +
+                "workspace=\(workspace.id.uuidString.prefix(5)) mode=\(workspace.layoutMode.rawValue)"
+            )
+            return
+        }
 
         let targetIndex = currentIndex + delta
         if manager.tabs.indices.contains(targetIndex) {
             let targetWorkspace = manager.tabs[targetIndex]
             manager.selectWorkspace(targetWorkspace)
+            debugEnsurePaperWorkspaceMode(targetWorkspace, action: action)
             cmuxDebugLog(
                 "paper.workspace.move action=\(action) result=selected " +
                 "fromIndex=\(currentIndex) toIndex=\(targetIndex) " +
@@ -983,6 +1034,7 @@ struct cmuxApp: App {
 
         if createIfNeeded, delta > 0, targetIndex == manager.tabs.count {
             let newWorkspace = manager.addWorkspace(select: true)
+            debugEnsurePaperWorkspaceMode(newWorkspace, action: action)
             cmuxDebugLog(
                 "paper.workspace.move action=\(action) result=created " +
                 "fromIndex=\(currentIndex) toIndex=\(manager.tabs.count - 1) " +
@@ -994,6 +1046,16 @@ struct cmuxApp: App {
         cmuxDebugLog(
             "paper.workspace.move action=\(action) result=noTarget " +
             "fromIndex=\(currentIndex) targetIndex=\(targetIndex) workspaceCount=\(manager.tabs.count)"
+        )
+    }
+
+    private func debugEnsurePaperWorkspaceMode(_ workspace: Workspace, action: String) {
+        guard workspace.layoutMode != .paper else { return }
+        workspace.layoutMode = .paper
+        _ = workspace.rebuildPaperLayoutStateFromBonsplitForDebug()
+        cmuxDebugLog(
+            "paper.workspace.mode.ensure action=\(action) " +
+            "workspace=\(workspace.id.uuidString.prefix(5)) mode=paper"
         )
     }
 

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -365,6 +365,26 @@ struct cmuxApp: App {
                 }
                 .disabled(activeTabManager.selectedWorkspace == nil)
 
+                Button("Paper View Left") {
+                    activeTabManager.selectedWorkspace?.movePaperViewportForDebug(dx: -1200, dy: 0)
+                }
+                .disabled(activeTabManager.selectedWorkspace?.layoutMode != .paper)
+
+                Button("Paper View Right") {
+                    activeTabManager.selectedWorkspace?.movePaperViewportForDebug(dx: 1200, dy: 0)
+                }
+                .disabled(activeTabManager.selectedWorkspace?.layoutMode != .paper)
+
+                Button("Paper View Up") {
+                    activeTabManager.selectedWorkspace?.movePaperViewportForDebug(dx: 0, dy: -800)
+                }
+                .disabled(activeTabManager.selectedWorkspace?.layoutMode != .paper)
+
+                Button("Paper View Down") {
+                    activeTabManager.selectedWorkspace?.movePaperViewportForDebug(dx: 0, dy: 800)
+                }
+                .disabled(activeTabManager.selectedWorkspace?.layoutMode != .paper)
+
                 Divider()
                 Menu("Debug Windows") {
                     Button("Background Debug…") {

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -364,20 +364,28 @@ struct cmuxApp: App {
                     debugPaperWorkspace(action: "toggle")?.togglePaperLayoutModeForDebug()
                 }
 
-                Button("Paper View Left") {
-                    debugPaperWorkspace(action: "viewLeft")?.movePaperViewportForDebug(dx: -1200, dy: 0)
+                Button("Paper Focus Left") {
+                    debugPaperWorkspace(action: "focusLeft")?.movePaperViewportForDebug(dx: -1200, dy: 0)
                 }
 
-                Button("Paper View Right") {
-                    debugPaperWorkspace(action: "viewRight")?.movePaperViewportForDebug(dx: 1200, dy: 0)
+                Button("Paper Focus Right") {
+                    debugPaperWorkspace(action: "focusRight")?.movePaperViewportForDebug(dx: 1200, dy: 0)
                 }
 
-                Button("Paper View Up") {
-                    debugPaperWorkspace(action: "viewUp")?.movePaperViewportForDebug(dx: 0, dy: -800)
+                Button("Paper Focus Up") {
+                    debugPaperWorkspace(action: "focusUp")?.movePaperViewportForDebug(dx: 0, dy: -800)
                 }
 
-                Button("Paper View Down") {
-                    debugPaperWorkspace(action: "viewDown")?.movePaperViewportForDebug(dx: 0, dy: 800)
+                Button("Paper Focus Down") {
+                    debugPaperWorkspace(action: "focusDown")?.movePaperViewportForDebug(dx: 0, dy: 800)
+                }
+
+                Button("Paper Workspace Up") {
+                    debugMovePaperWorkspace(delta: -1, createIfNeeded: false, action: "workspaceUp")
+                }
+
+                Button("Paper Workspace Down") {
+                    debugMovePaperWorkspace(delta: 1, createIfNeeded: true, action: "workspaceDown")
                 }
 
                 Divider()
@@ -921,16 +929,28 @@ struct cmuxApp: App {
         debugPaperWorkspace(logAction: action)
     }
 
-    private func debugPaperWorkspace(logAction action: String?) -> Workspace? {
+    private func debugPaperTabManager(action: String) -> (manager: TabManager, preferredWindow: NSWindow?) {
         let preferredWindow = debugPaperPreferredMainWindow()
         let manager = AppDelegate.shared?.activeTabManagerForCommands(
             preferredWindow: preferredWindow
         ) ?? activeTabManager
+        cmuxDebugLog(
+            "paper.debugMenu action=\(action) " +
+            "window=\(preferredWindow?.windowNumber ?? -1) " +
+            "workspace=\(manager.selectedWorkspace?.id.uuidString.prefix(5) ?? "nil") " +
+            "workspaceCount=\(manager.tabs.count)"
+        )
+        return (manager, preferredWindow)
+    }
+
+    private func debugPaperWorkspace(logAction action: String?) -> Workspace? {
+        let context = debugPaperTabManager(action: action ?? "lookup")
+        let manager = context.manager
         let workspace = manager.selectedWorkspace
         if let action {
             cmuxDebugLog(
                 "paper.debugMenu action=\(action) " +
-                "window=\(preferredWindow?.windowNumber ?? -1) " +
+                "window=\(context.preferredWindow?.windowNumber ?? -1) " +
                 "workspace=\(workspace?.id.uuidString.prefix(5) ?? "nil") " +
                 "mode=\(workspace?.layoutMode.rawValue ?? "nil")"
             )
@@ -938,6 +958,43 @@ struct cmuxApp: App {
             cmuxDebugLog("paper.debugMenu action=nil workspace=nil")
         }
         return workspace
+    }
+
+    private func debugMovePaperWorkspace(delta: Int, createIfNeeded: Bool, action: String) {
+        let context = debugPaperTabManager(action: action)
+        let manager = context.manager
+        guard let workspace = manager.selectedWorkspace,
+              let currentIndex = selectedWorkspaceIndex(in: manager, workspaceId: workspace.id) else {
+            cmuxDebugLog("paper.workspace.move action=\(action) result=noSelection")
+            return
+        }
+
+        let targetIndex = currentIndex + delta
+        if manager.tabs.indices.contains(targetIndex) {
+            let targetWorkspace = manager.tabs[targetIndex]
+            manager.selectWorkspace(targetWorkspace)
+            cmuxDebugLog(
+                "paper.workspace.move action=\(action) result=selected " +
+                "fromIndex=\(currentIndex) toIndex=\(targetIndex) " +
+                "workspace=\(targetWorkspace.id.uuidString.prefix(5))"
+            )
+            return
+        }
+
+        if createIfNeeded, delta > 0, targetIndex == manager.tabs.count {
+            let newWorkspace = manager.addWorkspace(select: true)
+            cmuxDebugLog(
+                "paper.workspace.move action=\(action) result=created " +
+                "fromIndex=\(currentIndex) toIndex=\(manager.tabs.count - 1) " +
+                "workspace=\(newWorkspace.id.uuidString.prefix(5))"
+            )
+            return
+        }
+
+        cmuxDebugLog(
+            "paper.workspace.move action=\(action) result=noTarget " +
+            "fromIndex=\(currentIndex) targetIndex=\(targetIndex) workspaceCount=\(manager.tabs.count)"
+        )
     }
 
     private func debugPaperPreferredMainWindow() -> NSWindow? {


### PR DESCRIPTION
## Summary

Adds an experimental/debug paper layout mode for cmux workspaces inspired by Niri/PaperWM behavior.

In paper mode:
- Splitting right/down creates a new pane without shrinking existing panes.
- Terminal pane creation mirrors the normal Bonsplit lifecycle so terminal rendering and input continue to work.
- Paper panes are tracked in `PaperLayoutState`.
- Existing Bonsplit panes are mirrored into paper state when entering paper mode.
- Debug menu controls allow toggling paper mode and navigating the paper viewport.

## Testing

- Built and launched with `./scripts/reload.sh --tag mohit-paper-layout --launch`
- Verified normal Bonsplit mode still supports terminal input and normal splitting
- Verified paper mode split right/down keeps existing panes fixed-size
- Verified new paper panes render terminal content and accept input
- Verified existing Bonsplit panes can be mirrored into paper mode
- Verified Debug → Paper View Left/Right/Up/Down navigates between paper panes
- Verified toggling back to Bonsplit preserves normal behavior

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5014"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782719574&installation_id=133855650&pr_number=5014&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5014&signature=10d5353a895d4bb3631959c2c152bcea3c66a418a2303df3e9dad887fad453ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an experimental “paper” layout for workspace panes, rendering panes on a scrollable canvas with Niri-style column navigation. Also hardens rendering and focus so panes display reliably and splits/focus behave as expected.

- **New Features**
  - Added `WorkspaceLayoutMode.paper` with `PaperLayoutState`/`PaperPane`; column-aware viewport, directional snapping, and configurable visible columns/rows (1–4).
  - Introduced `PaperCanvasWorkspaceView` to render the nearest columns/rows around focus; initializes paper state on appear and viewport resize; routes focus and unread badges.
  - Paper mode mirrors the current Bonsplit tree into a grid; terminal splits mirror into paper state, shifting overlapping panes and snapping focus/viewport; Debug menu: Toggle Paper, Focus Left/Right/Up/Down, Workspace Up/Down, Visible Columns/Rows.

- **Bug Fixes**
  - Stabilized pane rendering with a render plan that dedupes panes/tabs/panels and skips missing panels to prevent flicker and view reuse glitches.
  - Tightened paper focus routing and terminal first-responder handoff; synced unread indicators; ensured canvas init on appear/resize to avoid blank or stale views.

<sup>Written for commit a057a434a1934f3a860e9fd181bcdf475891534a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5014?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New "Paper" workspace layout: canvas-style pane grid with viewport-aware positioning, directional navigation, and inserting panes beside the focused pane. Canvas view renders panes (or empty placeholders) and reinitializes on viewport/resize.

* **Bug Fixes / Improvements**
  * Focus routing and unread-badge syncing tightened in Paper mode; new splits mirror into the paper layout and preserve focus and viewport.

* **Chores (Debug)**
  * Debug commands to toggle Paper mode, nudge viewport, adjust visible rows/columns, and move between paper workspaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->