### PR TITLE
Fix nightly publishing runner selection

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -100,7 +100,10 @@ jobs:
   build-sign-notarize-nightly:
     needs: decide
     if: needs.decide.outputs.should_build == 'true'
-    runs-on: ${{ vars.MACOS_RUNNER_26 || 'warp-macos-26-arm64-6x' }}
+    # Keep publishing builds on macOS 15 until Zig can link the real universal
+    # Ghostty CLI helper on macOS 26. ci-macos-compat.yml covers macOS 26 with
+    # CMUX_SKIP_ZIG_BUILD=1, but nightly needs the real universal helper.
+    runs-on: ${{ vars.MACOS_RUNNER_15 || 'warp-macos-15-arm64-6x' }}
     timeout-minutes: 20
     steps:
       - name: Checkout build ref

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,10 @@ env:
 
 jobs:
   build-sign-notarize:
-    runs-on: ${{ vars.MACOS_RUNNER_26 || 'warp-macos-26-arm64-6x' }}
+    # Keep publishing builds on macOS 15 until Zig can link the real universal
+    # Ghostty CLI helper on macOS 26. ci-macos-compat.yml covers macOS 26 with
+    # CMUX_SKIP_ZIG_BUILD=1, but release needs the real universal helper.
+    runs-on: ${{ vars.MACOS_RUNNER_15 || 'warp-macos-15-arm64-6x' }}
     timeout-minutes: 20
     steps:
       - name: Checkout

--- a/docs/macos-ci-runners.md
+++ b/docs/macos-ci-runners.md
@@ -2,10 +2,12 @@
 
 All paid macOS CI/CD jobs pick their runner from two repository variables instead of a hardcoded label:
 
-- `MACOS_RUNNER_15` for macOS 15 jobs (most jobs, plus the e2e/perf defaults)
-- `MACOS_RUNNER_26` for macOS 26 jobs (release, nightly, the `release-build` job, compat)
+- `MACOS_RUNNER_15` for jobs that build the real universal Release app, including nightly, stable release, `release-build`, and the e2e/perf defaults.
+- `MACOS_RUNNER_26` for macOS 26 compatibility coverage and jobs that do not need Zig to build the real universal Ghostty CLI helper.
 
 Workflows reference them as `runs-on: ${{ vars.MACOS_RUNNER_15 || 'warp-macos-15-arm64-6x' }}`. If a variable is unset, the job falls back to WarpBuild, so CI is never broken by a missing variable.
+
+Nightly and stable release stay on macOS 15 until Zig can link the real universal Ghostty CLI helper on macOS 26. `ci-macos-compat.yml` still covers macOS 26 by setting `CMUX_SKIP_ZIG_BUILD=1`, but publishing workflows cannot use that stub because the signed artifacts must include the real helper.
 
 ## Switch Blacksmith <-> WarpBuild
 


### PR DESCRIPTION
## Summary
- Move nightly and stable release publishing workflows back to the macOS 15 runner variable so the real universal Ghostty CLI helper builds on the supported lane.
- Document that macOS 26 remains compatibility coverage with CMUX_SKIP_ZIG_BUILD=1, while publishing artifacts need the real helper.

## Testing
- ./tests/test_ci_self_hosted_guard.sh
- actionlint .github/workflows/nightly.yml .github/workflows/release.yml .github/workflows/ci.yml .github/workflows/ci-macos-compat.yml
- git diff --check

## Issues
- Related: https://github.com/manaflow-ai/cmux/actions/runs/26681115918

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5022"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782730978&installation_id=133855650&pr_number=5022&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5022&signature=2637ed1d40f746a732830419d7c049932f3865cd999266177c398efcd2f89546"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow runner label and documentation only; no app code, signing, or release logic changes.
> 
> **Overview**
> **Nightly** and **stable release** publishing jobs now use `MACOS_RUNNER_15` (with Warp macOS 15 fallback) instead of `MACOS_RUNNER_26`, so CI builds the real universal **Ghostty** CLI helper via Zig on a supported lane.
> 
> Inline workflow comments and `docs/macos-ci-runners.md` clarify the split: macOS 15 for artifact-producing Release builds; macOS 26 for compat jobs that can set `CMUX_SKIP_ZIG_BUILD=1` but cannot ship signed releases with a stub helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11414be1798697d94470e53a5a0527defc1d2ac4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch nightly and stable publishing to macOS 15 runners so Zig can link the real universal Ghostty CLI helper and produce valid signed artifacts. macOS 26 stays for compatibility-only CI.

- **Bug Fixes**
  - Set `runs-on` in `nightly.yml` and `release.yml` to `${{ vars.MACOS_RUNNER_15 || 'warp-macos-15-arm64-6x' }}`.
  - Updated `docs/macos-ci-runners.md` to clarify runner roles and that `ci-macos-compat.yml` covers macOS 26 using `CMUX_SKIP_ZIG_BUILD=1` (publishing cannot use this stub).

<sup>Written for commit 11414be1798697d94470e53a5a0527defc1d2ac4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5022?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS nightly and release build runners to macOS 15.
  * Added documentation for CI/CD runner configuration management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/5022?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->