### PR TITLE
fix(agent-resume): resume from launch directory, not drifted cwd

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -24320,7 +24320,7 @@ struct CMUXCLI {
             "command": command,
             "auto_resume": true
         ]
-        if let cwd = normalizedHookValue(cwd) ?? normalizedHookValue(launchCommand?.workingDirectory) {
+        if let cwd = normalizedHookValue(launchCommand?.workingDirectory) ?? normalizedHookValue(cwd) {
             params["cwd"] = cwd
         }
         if let resumeEnvironment, !resumeEnvironment.isEmpty {
@@ -24402,7 +24402,7 @@ struct CMUXCLI {
         guard let argv, !argv.isEmpty else { return nil }
         return agentSurfaceResumeShellCommand(
             argv: argv,
-            workingDirectory: workingDirectory ?? launchCommand?.workingDirectory,
+            workingDirectory: launchCommand?.workingDirectory ?? workingDirectory,
             kind: kind,
             environment: environment
         )

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -362,7 +362,7 @@ enum AgentResumeCommandBuilder {
 
         let cwd = !includeWorkingDirectoryPrefix || customRegistration?.cwd == .ignore
             ? nil
-            : normalized(workingDirectory ?? launchCommand?.workingDirectory)
+            : normalized(launchCommand?.workingDirectory ?? workingDirectory)
         let sanitizedCommandParts = customRegistration == nil
             ? AgentLaunchSanitizer.removingSavedWorkingDirectoryOptions(
                 from: commandParts,
@@ -670,7 +670,7 @@ enum AgentResumeCommandBuilder {
             "sessionId": sessionId,
             "sessionPath": sessionId,
             "executable": original.executable,
-            "cwd": normalized(workingDirectory ?? launchCommand?.workingDirectory) ?? "",
+            "cwd": normalized(launchCommand?.workingDirectory ?? workingDirectory) ?? "",
             "sessionDir": sessionDirectory ?? "",
         ]
         var resolved: [String] = []

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -666,11 +666,14 @@ enum AgentResumeCommandBuilder {
         let sessionDirectory = normalized(registration.sessionDirectory).map {
             ($0 as NSString).expandingTildeInPath
         }
+        let resolvedCwd = registration.cwd == .ignore
+            ? nil
+            : normalized(launchCommand?.workingDirectory ?? workingDirectory)
         let replacements: [String: String] = [
             "sessionId": sessionId,
             "sessionPath": sessionId,
             "executable": original.executable,
-            "cwd": normalized(launchCommand?.workingDirectory ?? workingDirectory) ?? "",
+            "cwd": resolvedCwd ?? "",
             "sessionDir": sessionDirectory ?? "",
         ]
         var resolved: [String] = []

--- a/cmuxTests/RestorableAgentHookProviderResumeTests.swift
+++ b/cmuxTests/RestorableAgentHookProviderResumeTests.swift
@@ -1,4 +1,5 @@
 import CMUXAgentLaunch
+import Testing
 import XCTest
 
 #if canImport(cmux_DEV)
@@ -640,8 +641,12 @@ extension SocketListenerAcceptPolicyTests {
             ]
         )
     }
+}
 
-    func testClaudeResumeCommandChangesToLaunchDirectoryNotDriftedCwd() {
+@Suite
+struct RestorableAgentResumeWorkingDirectoryTests {
+    @Test
+    func claudeResumeCommandChangesToLaunchDirectoryNotDriftedCwd() {
         let snapshot = SessionRestorableAgentSnapshot(
             kind: .claude,
             sessionId: "59729506-e83c-4bfe-a730-1d50d10cc396",
@@ -657,9 +662,70 @@ extension SocketListenerAcceptPolicyTests {
             )
         )
 
-        XCTAssertEqual(
-            snapshot.resumeCommand,
-            "{ cd -- '/tmp/claude repo' 2>/dev/null || [ ! -d '/tmp/claude repo' ]; } && '/Users/example/.local/bin/claude' '--resume' '59729506-e83c-4bfe-a730-1d50d10cc396'"
+        #expect(
+            snapshot.resumeCommand
+                == "{ cd -- '/tmp/claude repo' 2>/dev/null || [ ! -d '/tmp/claude repo' ]; } && '/Users/example/.local/bin/claude' '--resume' '59729506-e83c-4bfe-a730-1d50d10cc396'"
         )
+    }
+
+    @Test
+    func customVaultResumeTemplateUsesLaunchDirectoryNotDriftedCwd() throws {
+        let snapshot = SessionRestorableAgentSnapshot(
+            kind: .custom("vault-tool"),
+            sessionId: "session-123",
+            workingDirectory: "/tmp/vault-drifted",
+            launchCommand: AgentLaunchCommandSnapshot(
+                launcher: "vault-tool",
+                executablePath: "/usr/local/bin/vault-tool",
+                arguments: ["/usr/local/bin/vault-tool"],
+                workingDirectory: "/tmp/vault-launch",
+                environment: nil,
+                capturedAt: 123,
+                source: "process"
+            ),
+            registration: CmuxVaultAgentRegistration(
+                id: "vault-tool",
+                name: "Vault Tool",
+                detect: CmuxVaultAgentDetectRule(processName: "vault-tool"),
+                sessionIdSource: .argvOption("--resume"),
+                resumeCommand: "{{executable}} --resume {{sessionId}} --dir {{cwd}}",
+                cwd: .preserve
+            )
+        )
+
+        let command = try #require(snapshot.resumeCommand)
+        #expect(command.contains("/tmp/vault-launch"))
+        #expect(!command.contains("/tmp/vault-drifted"))
+    }
+
+    @Test
+    func customVaultResumeTemplateSuppressesCwdWhenIgnored() {
+        let snapshot = SessionRestorableAgentSnapshot(
+            kind: .custom("vault-tool"),
+            sessionId: "session-123",
+            workingDirectory: "/tmp/vault-drifted",
+            launchCommand: AgentLaunchCommandSnapshot(
+                launcher: "vault-tool",
+                executablePath: "/usr/local/bin/vault-tool",
+                arguments: ["/usr/local/bin/vault-tool"],
+                workingDirectory: "/tmp/vault-launch",
+                environment: nil,
+                capturedAt: 123,
+                source: "process"
+            ),
+            registration: CmuxVaultAgentRegistration(
+                id: "vault-tool",
+                name: "Vault Tool",
+                detect: CmuxVaultAgentDetectRule(processName: "vault-tool"),
+                sessionIdSource: .argvOption("--resume"),
+                resumeCommand: "{{executable}} --resume {{sessionId}} --dir {{cwd}}",
+                cwd: .ignore
+            )
+        )
+
+        // cwd: .ignore must keep the launch dir out of the resolved command entirely.
+        let command = snapshot.resumeCommand ?? ""
+        #expect(!command.contains("/tmp/vault-launch"))
+        #expect(!command.contains("/tmp/vault-drifted"))
     }
 }

--- a/cmuxTests/RestorableAgentHookProviderResumeTests.swift
+++ b/cmuxTests/RestorableAgentHookProviderResumeTests.swift
@@ -640,4 +640,26 @@ extension SocketListenerAcceptPolicyTests {
             ]
         )
     }
+
+    func testClaudeResumeCommandChangesToLaunchDirectoryNotDriftedCwd() {
+        let snapshot = SessionRestorableAgentSnapshot(
+            kind: .claude,
+            sessionId: "59729506-e83c-4bfe-a730-1d50d10cc396",
+            workingDirectory: "/tmp/claude repo/nested",
+            launchCommand: AgentLaunchCommandSnapshot(
+                launcher: "claude",
+                executablePath: "/Users/example/.local/bin/claude",
+                arguments: ["/Users/example/.local/bin/claude"],
+                workingDirectory: "/tmp/claude repo",
+                environment: nil,
+                capturedAt: 123,
+                source: "process"
+            )
+        )
+
+        XCTAssertEqual(
+            snapshot.resumeCommand,
+            "{ cd -- '/tmp/claude repo' 2>/dev/null || [ ! -d '/tmp/claude repo' ]; } && '/Users/example/.local/bin/claude' '--resume' '59729506-e83c-4bfe-a730-1d50d10cc396'"
+        )
+    }
 }


### PR DESCRIPTION
## Summary

When the cmux app is closed and reopened, it restores agent sessions by generating a shell command like:

```
cd '/Users/you/project/subdir' && '/Users/you/.local/bin/claude' '--resume' '<session-id>'
```

The `cd` target was the agent's **drifted current working directory**, not the directory the agent was **launched** in. Claude Code keys its session transcript to the launch directory, so resuming from a drifted cwd fails hard:

```
No conversation found with session ID: <session-id>
```

This PR makes resume (and fork) `cd` back to the **launch directory**.

## Root cause

Both resume-command builders resolved the working directory as `workingDirectory ?? launchCommand?.workingDirectory` — i.e. they **preferred the drifted cwd** and only fell back to the launch dir:

- `workingDirectory` = the agent's hook-reported **current** cwd (can drift mid-session).
- `launchCommand?.workingDirectory` = `CMUX_AGENT_LAUNCH_CWD` = the dir the agent was **launched** in (set by the `claude` wrapper to `$PWD`).

For Claude this is fatal because `claude --resume <id>` only finds the session in the project directory it was created in (the launch dir). The fork-probe path (`AgentForkSupport.openCodeProbeWorkingDirectory`) already used the correct precedence — the resume builders were the inconsistent ones.

## The fix

Flip the precedence to `launchCommand?.workingDirectory ?? workingDirectory` in:

| File | Location | Covers |
|---|---|---|
| `Sources/RestorableAgentSession.swift` | `AgentResumeCommandBuilder.shellCommand` (used by both `resumeShellCommand` **and** `forkShellCommand`) | resume + fork, all agent kinds |
| `Sources/RestorableAgentSession.swift` | `customResumeArguments` `{{cwd}}` template | custom/registered (vault) agents |
| `cli/cmux.swift` | `agentSurfaceResumeCommand` (the `cd` in the auto-resume binding) | all kinds, hook-driven auto-resume |
| `cli/cmux.swift` | `publishAgentSurfaceResumeBinding` `params["cwd"]` metadata | all kinds (binding/display cwd) |

## Scope / blast radius

- **Code:** all agent kinds (resume + fork + custom template + CLI auto-resume binding). Not Claude-specific.
- **Observable behavior:** changes **only** when the agent's recorded cwd diverges from its launch dir (cwd drift).
  - No drift (common case): `launchCommand.workingDirectory == workingDirectory` → byte-identical output, **zero change**. This is why all existing resume tests (gemini/cursor/copilot/codex/…), which set both values equal, pass unchanged.
  - `launchCommand` absent (older snapshots / process-scan snapshots): falls back to `workingDirectory` → **identical to old behavior**, no regression.
- **Direction:** strictly toward "resume where you launched," which is correct for every agent — Claude *requires* it; codex/gemini/cursor/copilot/etc. all want the project dir they started in rather than a drifted one.

## Tests

- Commit 1 adds a failing regression test (`testClaudeResumeCommandChangesToLaunchDirectoryNotDriftedCwd`) that reproduces the bug (launch dir `≠` drifted cwd) and asserts the resume command `cd`s to the launch dir.
- Commit 2 applies the fix, making the test pass.

Verified locally with Xcode 26.5:

```
Test Case '...testClaudeResumeCommandChangesToLaunchDirectoryNotDriftedCwd' passed (0.002s)
Executed 1 test, with 0 failures
** TEST SUCCEEDED **
```

(Two-commit red/green structure per the repo's regression-test policy.)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5029"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782771828&installation_id=133855650&pr_number=5029&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5029&signature=384454aee69851716640c5d148729e7ff1db5ea764c29d4d75f25f298a76e126"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resuming and forking now cd into the agent’s launch directory instead of a drifted cwd, fixing failed resumes (e.g., Claude Code “No conversation found”). Custom resume templates also honor `cwd: .ignore` by omitting the cwd.

- **Bug Fixes**
  - Prefer `launchCommand.workingDirectory` over drifted `workingDirectory` in resume/fork builders and the `{{cwd}}` template.
  - Update CLI auto-resume to `cd` into the launch dir and publish that as `cwd` metadata.
  - Suppress `{{cwd}}` when a custom registration sets `cwd: .ignore`.
  - Applies to all agent kinds; changes only under cwd drift or when templates set `cwd: .ignore`.

- **Tests**
  - Added `claudeResumeCommandChangesToLaunchDirectoryNotDriftedCwd`.
  - Added vault template tests for launch-dir precedence and `cwd: .ignore`, moved into a Swift Testing suite.

<sup>Written for commit 511cdaec320f411fb6cbcd91f8220b5ef51c4ca6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5029?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected working-directory resolution for session restore so resume commands prefer the launch directory when available, and omit cwd when instructed to ignore it.

* **Tests**
  * Added tests validating resume-command working-directory precedence, including preserved launch-directory behavior and suppressed cwd when ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->