### PR TITLE
Fix sidebar Project Worktrees + button: workspace tab exits immediately (#5032)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"9c9943de-bc79-4f2c-9b82-cbd58c3a1d51","pid":32319,"procStart":"Sun May 31 00:20:09 2026","acquiredAt":1780187614705}

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -11771,11 +11771,13 @@ struct VerticalTabsSidebar: View {
         Task {
             do {
                 let result = try await CmuxExtensionWorktreePrototype.createWorktree(projectRootPath: projectRootPath)
+                let spawnArgs = result.workspaceSpawnArgs()
                 tabManager.addWorkspace(
-                    title: result.workspaceTitle,
-                    workingDirectory: result.worktreePath,
-                    initialTerminalCommand: result.initialCommand,
-                    inheritWorkingDirectory: false,
+                    title: spawnArgs.title,
+                    workingDirectory: spawnArgs.workingDirectory,
+                    initialTerminalCommand: spawnArgs.initialTerminalCommand,
+                    initialTerminalInput: spawnArgs.initialTerminalInput,
+                    inheritWorkingDirectory: spawnArgs.inheritWorkingDirectory,
                     select: true,
                     eagerLoadTerminal: false
                 )

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -11775,11 +11775,11 @@ struct VerticalTabsSidebar: View {
                 tabManager.addWorkspace(
                     title: spawnArgs.title,
                     workingDirectory: spawnArgs.workingDirectory,
-                    initialTerminalCommand: spawnArgs.initialTerminalCommand,
                     initialTerminalInput: spawnArgs.initialTerminalInput,
                     inheritWorkingDirectory: spawnArgs.inheritWorkingDirectory,
                     select: true,
-                    eagerLoadTerminal: false
+                    eagerLoadTerminal: false,
+                    autoWelcomeIfNeeded: spawnArgs.initialTerminalInput == nil
                 )
             } catch {
                 NSSound.beep()

--- a/Sources/ExtensionWorktreePrototype.swift
+++ b/Sources/ExtensionWorktreePrototype.swift
@@ -13,17 +13,15 @@ struct CmuxExtensionWorktreeCreationResult: Sendable {
 ///
 /// A workspace closes the moment its main process exits, so the worktree
 /// `setupCommand` must be delivered as terminal *input* typed into the
-/// interactive login shell — never as `initialTerminalCommand` (the surface's
-/// primary process). Routing setup through `initialTerminalCommand` makes the
-/// tab flash and disappear the instant the setup command finishes or fails.
+/// interactive login shell — never as the surface's primary process. This type
+/// deliberately has **no** primary-command field: the workspace's main process
+/// is structurally always the login shell, so the "setup command became the
+/// main process and the tab died when it exited" bug cannot be expressed here.
 struct CmuxExtensionWorktreeWorkspaceSpawnArgs: Sendable, Equatable {
     let title: String
     let workingDirectory: String
-    /// The workspace's primary process. Always `nil` so the main process stays
-    /// the user's login shell and the tab survives setup completion.
-    let initialTerminalCommand: String?
     /// Setup command typed into the interactive shell after spawn (with a
-    /// trailing newline so it executes).
+    /// trailing newline so it executes), or `nil` when there is no setup.
     let initialTerminalInput: String?
     let inheritWorkingDirectory: Bool
 }
@@ -34,14 +32,12 @@ extension CmuxExtensionWorktreeCreationResult {
     /// The returned arguments always leave the workspace's main process as the
     /// login shell and deliver ``setupCommand`` as terminal input.
     func workspaceSpawnArgs() -> CmuxExtensionWorktreeWorkspaceSpawnArgs {
-        // The main process must stay the login shell so the tab survives setup
-        // completion. Worktree creation already ran as a pre-spawn step, so the
-        // setup command is delivered as interactive shell input (with a trailing
+        // Worktree creation already ran as a pre-spawn step, so the setup
+        // command is delivered as interactive shell input (with a trailing
         // newline so it executes) rather than as the surface's primary process.
         CmuxExtensionWorktreeWorkspaceSpawnArgs(
             title: workspaceTitle,
             workingDirectory: worktreePath,
-            initialTerminalCommand: nil,
             initialTerminalInput: setupCommand.isEmpty ? nil : setupCommand + "\n",
             inheritWorkingDirectory: false
         )

--- a/Sources/ExtensionWorktreePrototype.swift
+++ b/Sources/ExtensionWorktreePrototype.swift
@@ -34,14 +34,15 @@ extension CmuxExtensionWorktreeCreationResult {
     /// The returned arguments always leave the workspace's main process as the
     /// login shell and deliver ``setupCommand`` as terminal input.
     func workspaceSpawnArgs() -> CmuxExtensionWorktreeWorkspaceSpawnArgs {
-        // NOTE: this intentionally reproduces the original (buggy) behavior so
-        // the regression test can prove it fails; the fix follows in a separate
-        // commit.
+        // The main process must stay the login shell so the tab survives setup
+        // completion. Worktree creation already ran as a pre-spawn step, so the
+        // setup command is delivered as interactive shell input (with a trailing
+        // newline so it executes) rather than as the surface's primary process.
         CmuxExtensionWorktreeWorkspaceSpawnArgs(
             title: workspaceTitle,
             workingDirectory: worktreePath,
-            initialTerminalCommand: setupCommand.isEmpty ? nil : setupCommand,
-            initialTerminalInput: nil,
+            initialTerminalCommand: nil,
+            initialTerminalInput: setupCommand.isEmpty ? nil : setupCommand + "\n",
             inheritWorkingDirectory: false
         )
     }

--- a/Sources/ExtensionWorktreePrototype.swift
+++ b/Sources/ExtensionWorktreePrototype.swift
@@ -3,7 +3,48 @@ import Foundation
 struct CmuxExtensionWorktreeCreationResult: Sendable {
     let worktreePath: String
     let workspaceTitle: String
-    let initialCommand: String
+    /// A convenience command (e.g. a sample dev-server launcher) that should run
+    /// inside the new workspace's interactive shell. This is *setup*, never the
+    /// workspace's primary process.
+    let setupCommand: String
+}
+
+/// Arguments for spawning a workspace in a freshly created worktree.
+///
+/// A workspace closes the moment its main process exits, so the worktree
+/// `setupCommand` must be delivered as terminal *input* typed into the
+/// interactive login shell — never as `initialTerminalCommand` (the surface's
+/// primary process). Routing setup through `initialTerminalCommand` makes the
+/// tab flash and disappear the instant the setup command finishes or fails.
+struct CmuxExtensionWorktreeWorkspaceSpawnArgs: Sendable, Equatable {
+    let title: String
+    let workingDirectory: String
+    /// The workspace's primary process. Always `nil` so the main process stays
+    /// the user's login shell and the tab survives setup completion.
+    let initialTerminalCommand: String?
+    /// Setup command typed into the interactive shell after spawn (with a
+    /// trailing newline so it executes).
+    let initialTerminalInput: String?
+    let inheritWorkingDirectory: Bool
+}
+
+extension CmuxExtensionWorktreeCreationResult {
+    /// Builds the workspace spawn arguments for this worktree.
+    ///
+    /// The returned arguments always leave the workspace's main process as the
+    /// login shell and deliver ``setupCommand`` as terminal input.
+    func workspaceSpawnArgs() -> CmuxExtensionWorktreeWorkspaceSpawnArgs {
+        // NOTE: this intentionally reproduces the original (buggy) behavior so
+        // the regression test can prove it fails; the fix follows in a separate
+        // commit.
+        CmuxExtensionWorktreeWorkspaceSpawnArgs(
+            title: workspaceTitle,
+            workingDirectory: worktreePath,
+            initialTerminalCommand: setupCommand.isEmpty ? nil : setupCommand,
+            initialTerminalInput: nil,
+            inheritWorkingDirectory: false
+        )
+    }
 }
 
 final class CmuxExtensionProcessTermination: @unchecked Sendable {
@@ -66,7 +107,7 @@ enum CmuxExtensionWorktreePrototype {
             return CmuxExtensionWorktreeCreationResult(
                 worktreePath: worktree.path,
                 workspaceTitle: branchName,
-                initialCommand: "cd \(samplePath) && python3 -m http.server \(port)"
+                setupCommand: "cd \(samplePath) && python3 -m http.server \(port)"
             )
         }.value
     }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -203,6 +203,7 @@
 		D0B10014A1B2C3D4E5F60001 /* DragOverlayRoutingPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B10015A1B2C3D4E5F60001 /* DragOverlayRoutingPolicy.swift */; };
 		E4C001000000000000000001 /* ExtensionSidebarWorkspaceRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4C001000000000000000002 /* ExtensionSidebarWorkspaceRowView.swift */; };
 		E4C001000000000000000003 /* ExtensionWorktreePrototype.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4C001000000000000000004 /* ExtensionWorktreePrototype.swift */; };
+		E50320010000000000000001 /* ExtensionWorktreeSpawnArgsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E50320010000000000000002 /* ExtensionWorktreeSpawnArgsTests.swift */; };
 		FEED0A00000000000000F007 /* feed-tui in Resources */ = {isa = PBXBuildFile; fileRef = FEED0A00000000000000F006 /* feed-tui */; };
 		FEED0000000000000000F00D /* FeedButtonStyleDebugWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000F00C /* FeedButtonStyleDebugWindowController.swift */; };
 		FEED0000000000000000F002 /* FeedCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000F001 /* FeedCoordinator.swift */; };
@@ -834,6 +835,7 @@
 		D0B10015A1B2C3D4E5F60001 /* DragOverlayRoutingPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragOverlayRoutingPolicy.swift; sourceTree = "<group>"; };
 		E4C001000000000000000002 /* ExtensionSidebarWorkspaceRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionSidebarWorkspaceRowView.swift; sourceTree = "<group>"; };
 		E4C001000000000000000004 /* ExtensionWorktreePrototype.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionWorktreePrototype.swift; sourceTree = "<group>"; };
+		E50320010000000000000002 /* ExtensionWorktreeSpawnArgsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionWorktreeSpawnArgsTests.swift; sourceTree = "<group>"; };
 		FEED0A00000000000000F006 /* feed-tui */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder; path = "feed-tui"; sourceTree = "<group>"; };
 		FEED0000000000000000F00C /* FeedButtonStyleDebugWindowController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FeedButtonStyleDebugWindowController.swift; sourceTree = "<group>"; };
 		FEED0000000000000000F001 /* FeedCoordinator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FeedCoordinator.swift; sourceTree = "<group>"; };
@@ -1811,6 +1813,7 @@
 				BEE83F8394D90ACACD8E19DD /* WindowAndDragTests.swift */,
 				D0B10019A1B2C3D4E5F60001 /* FileDropOverlayViewTests.swift */,
 				2907A0042907A0042907A004 /* AppDelegateIssue2907RoutingTests.swift */,
+				E50320010000000000000002 /* ExtensionWorktreeSpawnArgsTests.swift */,
 				C0DE49950000000000000002 /* FilePreviewKindResolverTests.swift */,
 				A5001435A5001435A5001435 /* FilePreviewPDFThumbnailSidebarTests.swift */,
 				D3664001D3664001D3664001 /* MarkdownPanelTests.swift */,
@@ -2633,6 +2636,7 @@
 				A5008383 /* CommandPaletteSearchEngineTests.swift in Sources */,
 				C0DEF4120000000000000001 /* CommandPaletteSettingsToggleTests.swift in Sources */,
 					C1713006C1713006C1713006 /* CommandPaletteShortcutCustomizationTests.swift in Sources */,
+				E50320010000000000000001 /* ExtensionWorktreeSpawnArgsTests.swift in Sources */,
 				FEEDC0DEC0DEC0DEC0DE0001 /* FeedCoordinatorTests.swift in Sources */,
 				FEED49850000000000000001 /* FeedEventClassificationTests.swift in Sources */,
 				FEEDC1A50000000000000003 /* FeedEventClassifier.swift in Sources */,

--- a/cmuxTests/ExtensionWorktreeSpawnArgsTests.swift
+++ b/cmuxTests/ExtensionWorktreeSpawnArgsTests.swift
@@ -25,23 +25,17 @@ struct ExtensionWorktreeSpawnArgsTests {
         )
     }
 
-    @Test("setup command is never the workspace's primary process")
-    func setupCommandIsNeverPrimaryProcess() {
-        let args = makeResult(setupCommand: "cd '/tmp/sample' && python3 -m http.server 4100")
-            .workspaceSpawnArgs()
-
-        // A one-shot setup command as the primary process makes the tab die the
-        // moment that command exits. The main process must remain the shell.
-        #expect(args.initialTerminalCommand == nil)
-    }
-
     @Test("setup command runs as interactive shell input")
     func setupCommandRunsAsShellInput() {
         let setup = "cd '/tmp/sample' && python3 -m http.server 4100"
         let args = makeResult(setupCommand: setup).workspaceSpawnArgs()
 
-        // Delivered as input (with a trailing newline so it executes) into the
+        // The setup command must NOT become the workspace's primary process (a
+        // one-shot command there makes the tab die the moment it exits). It is
+        // delivered as input (with a trailing newline so it executes) into the
         // interactive shell, matching the `cmux new-workspace --cwd` contract.
+        // The spawn-args type has no primary-command field, so the original bug
+        // is structurally unrepresentable here.
         #expect(args.initialTerminalInput == setup + "\n")
     }
 
@@ -54,11 +48,10 @@ struct ExtensionWorktreeSpawnArgsTests {
         #expect(args.title == "cmux-sidebar-123")
     }
 
-    @Test("empty setup command yields no input and no command")
-    func emptySetupCommandYieldsNeither() {
+    @Test("empty setup command yields no input")
+    func emptySetupCommandYieldsNoInput() {
         let args = makeResult(setupCommand: "").workspaceSpawnArgs()
 
-        #expect(args.initialTerminalCommand == nil)
         #expect(args.initialTerminalInput == nil)
     }
 }

--- a/cmuxTests/ExtensionWorktreeSpawnArgsTests.swift
+++ b/cmuxTests/ExtensionWorktreeSpawnArgsTests.swift
@@ -1,0 +1,64 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Regression coverage for https://github.com/manaflow-ai/cmux/issues/5032.
+///
+/// The Project Worktrees sidebar `+` button created the worktree on disk but
+/// the workspace tab exited immediately, because the worktree setup command was
+/// passed as the workspace's primary process (`initialTerminalCommand`). A
+/// workspace closes the moment its main process exits, so the setup command
+/// finishing (or failing) killed the tab. The fix routes setup through
+/// `initialTerminalInput` so the workspace's main process stays the login shell.
+@Suite("Extension worktree workspace spawn args")
+struct ExtensionWorktreeSpawnArgsTests {
+    private func makeResult(setupCommand: String) -> CmuxExtensionWorktreeCreationResult {
+        CmuxExtensionWorktreeCreationResult(
+            worktreePath: "/tmp/project/.cmux/worktrees/cmux-sidebar-123",
+            workspaceTitle: "cmux-sidebar-123",
+            setupCommand: setupCommand
+        )
+    }
+
+    @Test("setup command is never the workspace's primary process")
+    func setupCommandIsNeverPrimaryProcess() {
+        let args = makeResult(setupCommand: "cd '/tmp/sample' && python3 -m http.server 4100")
+            .workspaceSpawnArgs()
+
+        // A one-shot setup command as the primary process makes the tab die the
+        // moment that command exits. The main process must remain the shell.
+        #expect(args.initialTerminalCommand == nil)
+    }
+
+    @Test("setup command runs as interactive shell input")
+    func setupCommandRunsAsShellInput() {
+        let setup = "cd '/tmp/sample' && python3 -m http.server 4100"
+        let args = makeResult(setupCommand: setup).workspaceSpawnArgs()
+
+        // Delivered as input (with a trailing newline so it executes) into the
+        // interactive shell, matching the `cmux new-workspace --cwd` contract.
+        #expect(args.initialTerminalInput == setup + "\n")
+    }
+
+    @Test("worktree path is the workspace working directory")
+    func worktreePathIsWorkingDirectory() {
+        let args = makeResult(setupCommand: "echo hi").workspaceSpawnArgs()
+
+        #expect(args.workingDirectory == "/tmp/project/.cmux/worktrees/cmux-sidebar-123")
+        #expect(args.inheritWorkingDirectory == false)
+        #expect(args.title == "cmux-sidebar-123")
+    }
+
+    @Test("empty setup command yields no input and no command")
+    func emptySetupCommandYieldsNeither() {
+        let args = makeResult(setupCommand: "").workspaceSpawnArgs()
+
+        #expect(args.initialTerminalCommand == nil)
+        #expect(args.initialTerminalInput == nil)
+    }
+}


### PR DESCRIPTION
## Problem

In the sidebar **Project Worktrees** view, clicking the **`+`** button to the right of a project header creates the git worktree on disk correctly, but the workspace tab exits **immediately** — it flashes in the sidebar and disappears, leaving no usable workspace.

## Root cause

A workspace closes the moment its main process exits. The sidebar `+` action (`createExtensionWorktreeWorkspace` in `Sources/ContentView.swift`) passed the worktree **setup command** — a sample dev-server launcher, `cd <sample> && python3 -m http.server <port>` — as the workspace's **primary process** via `initialTerminalCommand`. That string becomes `surfaceConfig.command` in `GhosttyTerminalView`, i.e. the surface's main process. The instant that command finishes or fails (e.g. `python3` missing), the PTY closes and the tab dies.

The working `cmux new-workspace --cwd <path>` CLI path never does this: its main process is the interactive login shell, and any command is typed into that shell as input.

## Fix (class, not symptom)

Treat worktree creation as a **pre-spawn step** (already awaited to completion), then spawn the workspace with the worktree path as `cwd` and **no foreground `--command`**. The setup command is delivered as `initialTerminalInput` (typed into the interactive shell with a trailing newline so it executes) instead of as the primary process — exactly matching the `new-workspace --cwd` contract.

This is encoded in a new, correct-by-construction seam, `CmuxExtensionWorktreeCreationResult.workspaceSpawnArgs()`, which always returns `initialTerminalCommand == nil`. That eliminates the entire class of "sidebar action spawned a workspace whose main process was the setup command" bugs, not just this one call site.

## Changes

- `Sources/ExtensionWorktreePrototype.swift`: rename the result's `initialCommand` → `setupCommand` (clarify intent), add `CmuxExtensionWorktreeWorkspaceSpawnArgs` + `workspaceSpawnArgs()` builder that routes setup through terminal input and keeps the main process as the login shell.
- `Sources/ContentView.swift`: the `+` handler spawns via the new args.
- `cmuxTests/ExtensionWorktreeSpawnArgsTests.swift`: Swift Testing regression coverage on the spawn-args seam.

## Test (two-commit red/green)

1. **Commit 1** extracts the spawn-args seam preserving the original buggy behavior (setup as primary process) and adds the test → CI **red**.
2. **Commit 2** flips the seam to route setup through `initialTerminalInput` → CI **green**.

The test asserts the sidebar `+` spawn args do **not** use a foreground one-shot command (`initialTerminalCommand == nil`), **do** use the worktree path as the working directory, and deliver setup as shell input.

No new user-facing strings.

Fixes #5032

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5035"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782779392&installation_id=133855650&pr_number=5035&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5035&signature=d97253bead2f9df297d5c1e26df57b5490c037aeaa27a35ee792061f01a7ca67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to extension sidebar workspace spawn wiring; no auth, data, or core terminal infrastructure changes beyond the existing addWorkspace API.
> 
> **Overview**
> Fixes **Project Worktrees** sidebar **`+`** workspaces that **closed immediately** after creation.
> 
> Worktree **setup** (sample dev server) is no longer passed as the workspace **primary process** via `initialTerminalCommand`. A new **`CmuxExtensionWorktreeWorkspaceSpawnArgs`** / **`workspaceSpawnArgs()`** seam always spawns with the **login shell** as the main process and sends setup as **`initialTerminalInput`** (with a trailing newline). **`ContentView`** uses those args when calling **`addWorkspace`**, including **`autoWelcomeIfNeeded`** when there is no setup input. **`initialCommand`** on the creation result is renamed to **`setupCommand`**.
> 
> Adds **`ExtensionWorktreeSpawnArgsTests`** regression tests and wires them into the Xcode project.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a81c836ae7e378cdf81fb630f51fcd5c61fbea92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the Project Worktrees sidebar + button so new workspace tabs no longer exit immediately by sending the setup command as terminal input, not as the main process. Workspaces now open in the worktree directory, skip the first-run welcome when seeding input, and match `cmux new-workspace --cwd`, fixing #5032.

- **Bug Fixes**
  - Treat setup as a pre-spawn step; spawn in the worktree cwd and deliver setup via `initialTerminalInput` (with newline).
  - Introduce `CmuxExtensionWorktreeWorkspaceSpawnArgs` and `workspaceSpawnArgs()`; make any foreground command unrepresentable; rename `initialCommand` → `setupCommand`.
  - Wire the sidebar `+` action in `ContentView` to pass `initialTerminalInput` and `autoWelcomeIfNeeded: initialTerminalInput == nil`.
  - Add regression tests in `cmuxTests/ExtensionWorktreeSpawnArgsTests.swift` for cwd, setup-as-input (+ newline), and empty-setup yielding no input.

<sup>Written for commit a81c836ae7e378cdf81fb630f51fcd5c61fbea92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5035?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Setup commands from extensions now run correctly in the new workspace’s interactive shell.
  * Workspace creation uses the correct working directory and inheritance settings.
  * New workspaces will show the welcome prompt only when appropriate.

* **Tests**
  * Added tests validating workspace spawn arguments, setup command routing, and working-directory behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->