### PR TITLE
Add configurable file extension openers

### DIFF
--- a/Packages/CmuxSettings/Sources/CmuxSettings/Keys/AppCatalogSection.swift
+++ b/Packages/CmuxSettings/Sources/CmuxSettings/Keys/AppCatalogSection.swift
@@ -79,6 +79,12 @@ public struct AppCatalogSection: SettingCatalogSection {
         userDefaultsKey: "openMarkdownInCmuxViewer"
     )
 
+    public let fileExtensionOpeners = DefaultsKey<[String: FileExtensionOpenBehavior]>(
+        id: "app.fileExtensionOpeners",
+        defaultValue: FileExtensionOpenBehavior.defaultOpeners,
+        userDefaultsKey: "fileExtensionOpeners"
+    )
+
     public let iMessageMode = DefaultsKey<Bool>(
         id: "app.iMessageMode",
         defaultValue: false,

--- a/Packages/CmuxSettings/Sources/CmuxSettings/Stores/UserDefaultsSettingsStore.swift
+++ b/Packages/CmuxSettings/Sources/CmuxSettings/Stores/UserDefaultsSettingsStore.swift
@@ -61,6 +61,20 @@ public actor UserDefaultsSettingsStore {
         underlyingDefaults.set(value.encodeForUserDefaults(), forKey: key.userDefaultsKey)
     }
 
+    /// Returns the effective extension opener map, including built-in defaults.
+    public func fileExtensionOpeners() -> [String: FileExtensionOpenBehavior] {
+        FileExtensionOpenBehaviorSettings.openers(defaults: underlyingDefaults)
+    }
+
+    /// Writes extension openers through their specialized normalization rules.
+    public func setFileExtensionOpeners(_ value: [String: FileExtensionOpenBehavior]) {
+        FileExtensionOpenBehaviorSettings.setOpeners(
+            value,
+            defaults: underlyingDefaults,
+            notificationCenter: .default
+        )
+    }
+
     /// Removes the stored override for the key. After this call ``value(for:)``
     /// returns the key's default value until something writes a new override.
     public func reset<Value>(_ key: DefaultsKey<Value>) {

--- a/Packages/CmuxSettings/Sources/CmuxSettings/Values/FileExtensionOpenBehavior.swift
+++ b/Packages/CmuxSettings/Sources/CmuxSettings/Values/FileExtensionOpenBehavior.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+public enum FileExtensionOpenBehavior: String, CaseIterable, Identifiable, Sendable, SettingCodable {
+    case automatic
+    case cmuxPreview
+    case markdownViewer
+    case cmuxBrowser
+    case preferredEditor
+    case systemDefault
+
+    public var id: String { rawValue }
+
+    public static let defaultOpeners: [String: FileExtensionOpenBehavior] = [
+        "htm": .cmuxBrowser,
+        "html": .cmuxBrowser,
+    ]
+
+    public static func normalizedExtension(_ rawValue: String) -> String? {
+        var trimmed = rawValue
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        while trimmed.hasPrefix(".") {
+            trimmed.removeFirst()
+        }
+        guard !trimmed.isEmpty,
+              trimmed.allSatisfy({ character in
+                  character.isLetter || character.isNumber || character == "-" || character == "_" || character == "+"
+              }) else {
+            return nil
+        }
+        return trimmed
+    }
+}

--- a/Packages/CmuxSettings/Sources/CmuxSettings/Values/FileExtensionOpenBehavior.swift
+++ b/Packages/CmuxSettings/Sources/CmuxSettings/Values/FileExtensionOpenBehavior.swift
@@ -1,20 +1,33 @@
 import Foundation
 
+/// Per-extension destination used when Cmd-click opens a file path.
 public enum FileExtensionOpenBehavior: String, CaseIterable, Identifiable, Sendable, SettingCodable {
+    /// Defer to the legacy Markdown and supported-file routing settings.
     case automatic
+    /// Open the file in cmux's generic file preview surface.
     case cmuxPreview
+    /// Open the file in cmux's rendered Markdown viewer.
     case markdownViewer
+    /// Open the file URL in a cmux browser surface.
     case cmuxBrowser
+    /// Open the file with the configured preferred editor command.
     case preferredEditor
+    /// Hand the file to the operating system's default opener.
     case systemDefault
 
+    /// Stable identifier matching the raw config value.
     public var id: String { rawValue }
 
+    /// Built-in extension opener defaults applied before user overrides.
     public static let defaultOpeners: [String: FileExtensionOpenBehavior] = [
         "htm": .cmuxBrowser,
         "html": .cmuxBrowser,
     ]
 
+    /// Normalizes a user-entered extension key for storage and lookup.
+    ///
+    /// Leading dots are stripped, case is folded, and only simple extension
+    /// characters are accepted. Returns `nil` for empty or unsupported values.
     public static func normalizedExtension(_ rawValue: String) -> String? {
         var trimmed = rawValue
             .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -29,5 +42,13 @@ public enum FileExtensionOpenBehavior: String, CaseIterable, Identifiable, Senda
             return nil
         }
         return trimmed
+    }
+
+    /// Decodes stored opener behavior, treating unknown stored values as
+    /// ``automatic`` so one corrupt UserDefaults entry does not hide the rest
+    /// of the extension map in Settings.
+    public static func decodeFromUserDefaults(_ raw: Any?) -> Self? {
+        guard let rawValue = String.decodeFromUserDefaults(raw) else { return nil }
+        return Self(rawValue: rawValue) ?? .automatic
     }
 }

--- a/Packages/CmuxSettings/Sources/CmuxSettings/Values/FileExtensionOpenBehaviorSettings.swift
+++ b/Packages/CmuxSettings/Sources/CmuxSettings/Values/FileExtensionOpenBehaviorSettings.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+public enum FileExtensionOpenBehaviorSettings {
+    public static let key = "fileExtensionOpeners"
+    public static let didChangeNotification = Notification.Name("cmux.fileExtensionOpenersDidChange")
+    public static let defaultValue = FileExtensionOpenBehavior.defaultOpeners
+
+    public static func openers(defaults: UserDefaults = .standard) -> [String: FileExtensionOpenBehavior] {
+        guard defaults.object(forKey: key) != nil else { return defaultValue }
+        guard let stored = defaults.dictionary(forKey: key) else { return defaultValue }
+
+        var result: [String: FileExtensionOpenBehavior] = [:]
+        for (rawExtension, rawBehavior) in stored {
+            guard let normalizedExtension = FileExtensionOpenBehavior.normalizedExtension(rawExtension),
+                  let rawBehavior = rawBehavior as? String,
+                  let behavior = FileExtensionOpenBehavior(rawValue: rawBehavior) else {
+                continue
+            }
+            result[normalizedExtension] = behavior
+        }
+        return result
+    }
+
+    public static func behavior(forPath path: String, defaults: UserDefaults = .standard) -> FileExtensionOpenBehavior? {
+        let ext = (path as NSString).pathExtension
+        guard let normalizedExtension = FileExtensionOpenBehavior.normalizedExtension(ext) else {
+            return nil
+        }
+        return openers(defaults: defaults)[normalizedExtension]
+    }
+
+    public static func setOpeners(
+        _ openers: [String: FileExtensionOpenBehavior],
+        defaults: UserDefaults = .standard,
+        notificationCenter: NotificationCenter = .default
+    ) {
+        var normalized: [String: String] = [:]
+        for (rawExtension, behavior) in openers {
+            guard let normalizedExtension = FileExtensionOpenBehavior.normalizedExtension(rawExtension) else { continue }
+            normalized[normalizedExtension] = behavior.rawValue
+        }
+        defaults.set(normalized, forKey: key)
+        notifyDidChange(notificationCenter: notificationCenter)
+    }
+
+    public static func notifyDidChange(notificationCenter: NotificationCenter = .default) {
+        notificationCenter.post(name: didChangeNotification, object: nil)
+    }
+}

--- a/Packages/CmuxSettings/Sources/CmuxSettings/Values/FileExtensionOpenBehaviorSettings.swift
+++ b/Packages/CmuxSettings/Sources/CmuxSettings/Values/FileExtensionOpenBehaviorSettings.swift
@@ -1,15 +1,23 @@
 import Foundation
 
+/// UserDefaults-backed storage helpers for per-extension file opener behavior.
 public enum FileExtensionOpenBehaviorSettings {
+    /// UserDefaults key storing normalized extension-to-behavior raw values.
     public static let key = "fileExtensionOpeners"
+    /// Posted after this helper writes the opener map.
     public static let didChangeNotification = Notification.Name("cmux.fileExtensionOpenersDidChange")
+    /// Product defaults applied before user overrides.
     public static let defaultValue = FileExtensionOpenBehavior.defaultOpeners
 
-    public static func openers(defaults: UserDefaults = .standard) -> [String: FileExtensionOpenBehavior] {
+    /// Reads normalized opener mappings from `defaults`.
+    ///
+    /// Built-in defaults are preserved, and valid stored entries override them.
+    /// Invalid stored entries are skipped.
+    public static func openers(defaults: UserDefaults) -> [String: FileExtensionOpenBehavior] {
         guard defaults.object(forKey: key) != nil else { return defaultValue }
         guard let stored = defaults.dictionary(forKey: key) else { return defaultValue }
 
-        var result: [String: FileExtensionOpenBehavior] = [:]
+        var result = defaultValue
         for (rawExtension, rawBehavior) in stored {
             guard let normalizedExtension = FileExtensionOpenBehavior.normalizedExtension(rawExtension),
                   let rawBehavior = rawBehavior as? String,
@@ -21,7 +29,8 @@ public enum FileExtensionOpenBehaviorSettings {
         return result
     }
 
-    public static func behavior(forPath path: String, defaults: UserDefaults = .standard) -> FileExtensionOpenBehavior? {
+    /// Returns the opener behavior for `path`'s extension, if one is configured.
+    public static func behavior(forPath path: String, defaults: UserDefaults) -> FileExtensionOpenBehavior? {
         let ext = (path as NSString).pathExtension
         guard let normalizedExtension = FileExtensionOpenBehavior.normalizedExtension(ext) else {
             return nil
@@ -29,10 +38,11 @@ public enum FileExtensionOpenBehaviorSettings {
         return openers(defaults: defaults)[normalizedExtension]
     }
 
+    /// Writes normalized opener mappings and posts ``didChangeNotification``.
     public static func setOpeners(
         _ openers: [String: FileExtensionOpenBehavior],
-        defaults: UserDefaults = .standard,
-        notificationCenter: NotificationCenter = .default
+        defaults: UserDefaults,
+        notificationCenter: NotificationCenter
     ) {
         var normalized: [String: String] = [:]
         for (rawExtension, behavior) in openers {
@@ -43,7 +53,8 @@ public enum FileExtensionOpenBehaviorSettings {
         notifyDidChange(notificationCenter: notificationCenter)
     }
 
-    public static func notifyDidChange(notificationCenter: NotificationCenter = .default) {
+    /// Posts ``didChangeNotification`` on `notificationCenter`.
+    public static func notifyDidChange(notificationCenter: NotificationCenter) {
         notificationCenter.post(name: didChangeNotification, object: nil)
     }
 }

--- a/Packages/CmuxSettings/Sources/CmuxSettings/Values/FileExtensionOpenBehaviorSettings.swift
+++ b/Packages/CmuxSettings/Sources/CmuxSettings/Values/FileExtensionOpenBehaviorSettings.swift
@@ -17,16 +17,16 @@ public enum FileExtensionOpenBehaviorSettings {
         guard defaults.object(forKey: key) != nil else { return defaultValue }
         guard let stored = defaults.dictionary(forKey: key) else { return defaultValue }
 
-        var result = defaultValue
+        var storedOpeners: [String: FileExtensionOpenBehavior] = [:]
         for (rawExtension, rawBehavior) in stored {
             guard let normalizedExtension = FileExtensionOpenBehavior.normalizedExtension(rawExtension),
                   let rawBehavior = rawBehavior as? String,
                   let behavior = FileExtensionOpenBehavior(rawValue: rawBehavior) else {
                 continue
             }
-            result[normalizedExtension] = behavior
+            storedOpeners[normalizedExtension] = behavior
         }
-        return result
+        return effectiveOpeners(from: storedOpeners)
     }
 
     /// Returns the opener behavior for `path`'s extension, if one is configured.
@@ -39,6 +39,9 @@ public enum FileExtensionOpenBehaviorSettings {
     }
 
     /// Writes normalized opener mappings and posts ``didChangeNotification``.
+    ///
+    /// Entries matching built-in defaults are pruned. Store ``FileExtensionOpenBehavior/automatic``
+    /// for a built-in extension to explicitly opt out of that built-in route.
     public static func setOpeners(
         _ openers: [String: FileExtensionOpenBehavior],
         defaults: UserDefaults,
@@ -47,10 +50,23 @@ public enum FileExtensionOpenBehaviorSettings {
         var normalized: [String: String] = [:]
         for (rawExtension, behavior) in openers {
             guard let normalizedExtension = FileExtensionOpenBehavior.normalizedExtension(rawExtension) else { continue }
+            guard FileExtensionOpenBehavior.defaultOpeners[normalizedExtension] != behavior else { continue }
             normalized[normalizedExtension] = behavior.rawValue
         }
         defaults.set(normalized, forKey: key)
         notifyDidChange(notificationCenter: notificationCenter)
+    }
+
+    /// Normalizes `openers` and overlays them onto the built-in defaults.
+    public static func effectiveOpeners(
+        from openers: [String: FileExtensionOpenBehavior]
+    ) -> [String: FileExtensionOpenBehavior] {
+        var result = defaultValue
+        for (rawExtension, behavior) in openers {
+            guard let normalizedExtension = FileExtensionOpenBehavior.normalizedExtension(rawExtension) else { continue }
+            result[normalizedExtension] = behavior
+        }
+        return result
     }
 
     /// Posts ``didChangeNotification`` on `notificationCenter`.

--- a/Packages/CmuxSettings/Tests/CmuxSettingsTests/SettingCodableTests.swift
+++ b/Packages/CmuxSettings/Tests/CmuxSettingsTests/SettingCodableTests.swift
@@ -57,4 +57,26 @@ struct SettingCodableTests {
         #expect(openers["htm"] == .cmuxBrowser)
         #expect(openers["md"] == .markdownViewer)
     }
+
+    @Test func fileExtensionOpenersPruneDefaultsAndPreserveAutomaticOverrides() throws {
+        let suiteName = "cmux.fileExtensionOpeners.prune.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        FileExtensionOpenBehaviorSettings.setOpeners(
+            ["html": .automatic, "htm": .cmuxBrowser, "md": .markdownViewer],
+            defaults: defaults,
+            notificationCenter: .default
+        )
+
+        let stored = defaults.dictionary(forKey: FileExtensionOpenBehaviorSettings.key) as? [String: String]
+        #expect(stored?["html"] == "automatic")
+        #expect(stored?["htm"] == nil)
+        #expect(stored?["md"] == "markdownViewer")
+
+        let openers = FileExtensionOpenBehaviorSettings.openers(defaults: defaults)
+        #expect(openers["html"] == .automatic)
+        #expect(openers["htm"] == .cmuxBrowser)
+        #expect(openers["md"] == .markdownViewer)
+    }
 }

--- a/Packages/CmuxSettings/Tests/CmuxSettingsTests/SettingCodableTests.swift
+++ b/Packages/CmuxSettings/Tests/CmuxSettingsTests/SettingCodableTests.swift
@@ -37,4 +37,11 @@ struct SettingCodableTests {
         let encoded = value.encodeForJSON()
         #expect([String: Int].decodeFromJSON(encoded) == value)
     }
+
+    @Test func fileExtensionOpenBehaviorDictionaryRoundTrips() {
+        let value: [String: FileExtensionOpenBehavior] = ["html": .cmuxBrowser, "md": .markdownViewer]
+        let encoded = value.encodeForUserDefaults()
+        #expect([String: FileExtensionOpenBehavior].decodeFromUserDefaults(encoded) == value)
+        #expect([String: FileExtensionOpenBehavior].decodeFromJSON(encoded) == value)
+    }
 }

--- a/Packages/CmuxSettings/Tests/CmuxSettingsTests/SettingCodableTests.swift
+++ b/Packages/CmuxSettings/Tests/CmuxSettingsTests/SettingCodableTests.swift
@@ -44,4 +44,17 @@ struct SettingCodableTests {
         #expect([String: FileExtensionOpenBehavior].decodeFromUserDefaults(encoded) == value)
         #expect([String: FileExtensionOpenBehavior].decodeFromJSON(encoded) == value)
     }
+
+    @Test func fileExtensionOpenersPreserveDefaultsWithOverrides() throws {
+        let suiteName = "cmux.fileExtensionOpeners.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(["md": "markdownViewer"], forKey: FileExtensionOpenBehaviorSettings.key)
+
+        let openers = FileExtensionOpenBehaviorSettings.openers(defaults: defaults)
+        #expect(openers["html"] == .cmuxBrowser)
+        #expect(openers["htm"] == .cmuxBrowser)
+        #expect(openers["md"] == .markdownViewer)
+    }
 }

--- a/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Bindings/FileExtensionOpenersValueModel.swift
+++ b/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Bindings/FileExtensionOpenersValueModel.swift
@@ -32,7 +32,7 @@ final class FileExtensionOpenersValueModel {
     }
 
     private func observe(_ name: Notification.Name) {
-        Task { @MainActor [weak self] in
+        Task { [weak self] in
             for await _ in NotificationCenter.default.notifications(named: name) {
                 guard let self else { return }
                 await refresh()

--- a/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Bindings/FileExtensionOpenersValueModel.swift
+++ b/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Bindings/FileExtensionOpenersValueModel.swift
@@ -2,12 +2,27 @@ import CmuxSettings
 import Foundation
 import Observation
 
+private final class NotificationObserverBag {
+    private var observers: [NSObjectProtocol] = []
+
+    func append(_ observer: NSObjectProtocol) {
+        observers.append(observer)
+    }
+
+    deinit {
+        for observer in observers {
+            NotificationCenter.default.removeObserver(observer)
+        }
+    }
+}
+
 @MainActor
 @Observable
 final class FileExtensionOpenersValueModel {
     private(set) var current: [String: FileExtensionOpenBehavior]
 
     private let store: UserDefaultsSettingsStore
+    @ObservationIgnored private let observerBag = NotificationObserverBag()
 
     init(store: UserDefaultsSettingsStore) {
         self.store = store
@@ -32,12 +47,17 @@ final class FileExtensionOpenersValueModel {
     }
 
     private func observe(_ name: Notification.Name) {
-        Task { [weak self] in
-            for await _ in NotificationCenter.default.notifications(named: name) {
-                guard let self else { return }
-                await refresh()
+        observerBag.append(
+            NotificationCenter.default.addObserver(
+                forName: name,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                Task { @MainActor [weak self] in
+                    await self?.refresh()
+                }
             }
-        }
+        )
     }
 
     func refresh() async {

--- a/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Bindings/FileExtensionOpenersValueModel.swift
+++ b/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Bindings/FileExtensionOpenersValueModel.swift
@@ -1,0 +1,48 @@
+import CmuxSettings
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class FileExtensionOpenersValueModel {
+    private(set) var current: [String: FileExtensionOpenBehavior]
+
+    private let store: UserDefaultsSettingsStore
+
+    init(store: UserDefaultsSettingsStore) {
+        self.store = store
+        self.current = FileExtensionOpenBehaviorSettings.defaultValue
+        observe(FileExtensionOpenBehaviorSettings.didChangeNotification)
+        observe(UserDefaults.didChangeNotification)
+        Task { @MainActor [weak self] in
+            await self?.refresh()
+        }
+    }
+
+    func set(_ value: [String: FileExtensionOpenBehavior]) {
+        Task { @MainActor [weak self] in
+            await self?.setAndRefresh(value)
+        }
+    }
+
+    func setAndRefresh(_ value: [String: FileExtensionOpenBehavior]) async {
+        current = FileExtensionOpenBehaviorSettings.effectiveOpeners(from: value)
+        await store.setFileExtensionOpeners(value)
+        await refresh()
+    }
+
+    private func observe(_ name: Notification.Name) {
+        Task { @MainActor [weak self] in
+            for await _ in NotificationCenter.default.notifications(named: name) {
+                guard let self else { return }
+                await refresh()
+            }
+        }
+    }
+
+    func refresh() async {
+        let next = await store.fileExtensionOpeners()
+        guard next != current else { return }
+        current = next
+    }
+}

--- a/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/CuratedSettingEntry+Default.swift
+++ b/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/CuratedSettingEntry+Default.swift
@@ -57,11 +57,11 @@ extension Array where Element == CuratedSettingEntry {
             .init(section: .app, id: "desktop-notifications", title: "Desktop Notifications", synonyms: "desktop notifications permission authorize enable alerts banners send test notification center"),
 
             // File Opening
-            .init(section: .fileOpening, id: "file-drops", title: "File Drops", synonyms: "drag drop files finder path text terminal editor split preview shift"),
-            .init(section: .fileOpening, id: "preferred-editor", title: "Open Files With", synonyms: "app.preferredEditor editor open file code vscode visual studio zed sublime subl cursor"),
-            .init(section: .fileOpening, id: "file-extension-openers", title: "File Extension Openers", synonyms: "app.fileExtensionOpeners cmd click html htm browser preview markdown system default editor extension opener"),
-            .init(section: .fileOpening, id: "supported-file-previews", title: "Open Supported Files in cmux", synonyms: "app.openSupportedFilesInCmux cmd click file preview pdf image video audio quicklook quick look editor external"),
-            .init(section: .fileOpening, id: "markdown-viewer", title: "Open Markdown in cmux Viewer", synonyms: "app.openMarkdownInCmuxViewer md markdown mdx viewer preview readme"),
+            .init(section: .fileOpening, id: "file-drops", title: String(localized: "settings.app.fileDrop.defaultBehavior", defaultValue: "File Drops"), synonyms: "drag drop files finder path text terminal editor split preview shift"),
+            .init(section: .fileOpening, id: "preferred-editor", title: String(localized: "settings.app.preferredEditor", defaultValue: "Open Files With"), synonyms: "app.preferredEditor editor open file code vscode visual studio zed sublime subl cursor"),
+            .init(section: .fileOpening, id: "file-extension-openers", title: String(localized: "settings.app.fileExtensionOpeners", defaultValue: "File Extension Openers"), synonyms: "app.fileExtensionOpeners cmd click html htm browser preview markdown system default editor extension opener"),
+            .init(section: .fileOpening, id: "supported-file-previews", title: String(localized: "settings.app.openSupportedFilesInCmux", defaultValue: "Open Supported Files in cmux"), synonyms: "app.openSupportedFilesInCmux cmd click file preview pdf image video audio quicklook quick look editor external"),
+            .init(section: .fileOpening, id: "markdown-viewer", title: String(localized: "settings.app.openMarkdownInCmuxViewer", defaultValue: "Open Markdown in cmux Viewer"), synonyms: "app.openMarkdownInCmuxViewer md markdown mdx viewer preview readme"),
 
             // Terminal
             .init(section: .terminal, id: "scrollbar", title: "Show Terminal Scroll Bar", synonyms: "terminal.showScrollBar scrollback scrollbar scroll bar right edge alternate screen tui"),

--- a/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/CuratedSettingEntry+Default.swift
+++ b/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/CuratedSettingEntry+Default.swift
@@ -39,6 +39,7 @@ extension Array where Element == CuratedSettingEntry {
             .init(section: .app, id: "focus-pane-first-click", title: "Focus Pane on First Click", synonyms: "app.focusPaneOnFirstClick click to focus focus follows mouse first click mouse activation"),
             .init(section: .app, id: "file-drops", title: "File Drops", synonyms: "drag drop files finder path text terminal editor split preview shift"),
             .init(section: .app, id: "preferred-editor", title: "Open Files With", synonyms: "app.preferredEditor editor open file code vscode visual studio zed sublime subl cursor"),
+            .init(section: .app, id: "file-extension-openers", title: "File Extension Openers", synonyms: "app.fileExtensionOpeners cmd click html htm browser preview markdown system default editor extension opener"),
             .init(section: .app, id: "supported-file-previews", title: "Open Supported Files in cmux", synonyms: "app.openSupportedFilesInCmux cmd click file preview pdf image video audio quicklook quick look editor external"),
             .init(section: .app, id: "markdown-viewer", title: "Open Markdown in cmux Viewer", synonyms: "app.openMarkdownInCmuxViewer md markdown mdx viewer preview readme"),
             .init(section: .app, id: "terminal-config", title: "Terminal Config", synonyms: "ghostty config merged generated preview terminal configuration window open config"),

--- a/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/CuratedSettingEntry+Default.swift
+++ b/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/CuratedSettingEntry+Default.swift
@@ -37,11 +37,6 @@ extension Array where Element == CuratedSettingEntry {
             .init(section: .app, id: "minimal-mode", title: "Minimal Mode", synonyms: "app.minimalMode presentation compact chrome layout simple titlebar controls"),
             .init(section: .app, id: "keep-workspace-open", title: "Keep Workspace Open When Closing Last Surface", synonyms: "app.keepWorkspaceOpenWhenClosingLastSurface close last pane surface keep tab workspace"),
             .init(section: .app, id: "focus-pane-first-click", title: "Focus Pane on First Click", synonyms: "app.focusPaneOnFirstClick click to focus focus follows mouse first click mouse activation"),
-            .init(section: .app, id: "file-drops", title: "File Drops", synonyms: "drag drop files finder path text terminal editor split preview shift"),
-            .init(section: .app, id: "preferred-editor", title: "Open Files With", synonyms: "app.preferredEditor editor open file code vscode visual studio zed sublime subl cursor"),
-            .init(section: .app, id: "file-extension-openers", title: "File Extension Openers", synonyms: "app.fileExtensionOpeners cmd click html htm browser preview markdown system default editor extension opener"),
-            .init(section: .app, id: "supported-file-previews", title: "Open Supported Files in cmux", synonyms: "app.openSupportedFilesInCmux cmd click file preview pdf image video audio quicklook quick look editor external"),
-            .init(section: .app, id: "markdown-viewer", title: "Open Markdown in cmux Viewer", synonyms: "app.openMarkdownInCmuxViewer md markdown mdx viewer preview readme"),
             .init(section: .app, id: "terminal-config", title: "Terminal Config", synonyms: "ghostty config merged generated preview terminal configuration window open config"),
             .init(section: .app, id: "imessage-mode", title: "iMessage Mode", synonyms: "app.iMessageMode imessage message messages chat prompt prompts submitted texting reorder move workspace top agent send"),
             .init(section: .app, id: "reorder-notification", title: "Reorder on Notification", synonyms: "app.reorderOnNotification notification reorder move workspace top unread sort"),
@@ -60,6 +55,13 @@ extension Array where Element == CuratedSettingEntry {
             .init(section: .app, id: "notification-sound", title: "Notification Sound", synonyms: "notifications.sound sound audio alert chime beep custom file wav mp3 caf aiff"),
             .init(section: .app, id: "notification-command", title: "Notification Command", synonyms: "notifications.command shell command hook script env environment variable done agent"),
             .init(section: .app, id: "desktop-notifications", title: "Desktop Notifications", synonyms: "desktop notifications permission authorize enable alerts banners send test notification center"),
+
+            // File Opening
+            .init(section: .fileOpening, id: "file-drops", title: "File Drops", synonyms: "drag drop files finder path text terminal editor split preview shift"),
+            .init(section: .fileOpening, id: "preferred-editor", title: "Open Files With", synonyms: "app.preferredEditor editor open file code vscode visual studio zed sublime subl cursor"),
+            .init(section: .fileOpening, id: "file-extension-openers", title: "File Extension Openers", synonyms: "app.fileExtensionOpeners cmd click html htm browser preview markdown system default editor extension opener"),
+            .init(section: .fileOpening, id: "supported-file-previews", title: "Open Supported Files in cmux", synonyms: "app.openSupportedFilesInCmux cmd click file preview pdf image video audio quicklook quick look editor external"),
+            .init(section: .fileOpening, id: "markdown-viewer", title: "Open Markdown in cmux Viewer", synonyms: "app.openMarkdownInCmuxViewer md markdown mdx viewer preview readme"),
 
             // Terminal
             .init(section: .terminal, id: "scrollbar", title: "Show Terminal Scroll Bar", synonyms: "terminal.showScrollBar scrollback scrollbar scroll bar right edge alternate screen tui"),

--- a/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/SettingsSectionID.swift
+++ b/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/SettingsSectionID.swift
@@ -73,7 +73,7 @@ public enum SettingsSectionID: String, CaseIterable, Identifiable, Sendable, Has
     public var searchKeywords: String {
         switch self {
         case .account: return "sign in team sync user profile"
-        case .app: return "appearance language workspace notifications menu bar telemetry"
+        case .app: return "appearance language workspace notifications menu bar telemetry file extensions"
         case .terminal: return "scrollbar copy on select agent resume hibernation"
         case .textBox: return "textbox text box rich input prompt default new terminal workspace split tab focus show beta"
         case .sidebarAppearance: return "sidebar details branches material terminal background"

--- a/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/SettingsSectionID.swift
+++ b/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/SettingsSectionID.swift
@@ -12,6 +12,7 @@ import Foundation
 public enum SettingsSectionID: String, CaseIterable, Identifiable, Sendable, Hashable {
     case account
     case app
+    case fileOpening
     case terminal
     case textBox
     case sidebarAppearance
@@ -32,6 +33,7 @@ public enum SettingsSectionID: String, CaseIterable, Identifiable, Sendable, Has
         switch self {
         case .account: return "Account"
         case .app: return "App"
+        case .fileOpening: return String(localized: "settings.section.fileOpening", defaultValue: "File Opening")
         case .terminal: return "Terminal"
         case .textBox: return String(localized: "settings.section.textBox", defaultValue: "TextBox (Beta)")
         case .sidebarAppearance: return "Sidebar"
@@ -52,6 +54,7 @@ public enum SettingsSectionID: String, CaseIterable, Identifiable, Sendable, Has
         switch self {
         case .account: return "person.crop.circle"
         case .app: return "gearshape"
+        case .fileOpening: return "doc.badge.gearshape"
         case .terminal: return "terminal"
         case .textBox: return "textformat"
         case .sidebarAppearance: return "sidebar.left"
@@ -73,7 +76,8 @@ public enum SettingsSectionID: String, CaseIterable, Identifiable, Sendable, Has
     public var searchKeywords: String {
         switch self {
         case .account: return "sign in team sync user profile"
-        case .app: return "appearance language workspace notifications menu bar telemetry file extensions"
+        case .app: return "appearance language workspace notifications menu bar telemetry"
+        case .fileOpening: return "files paths cmd click html markdown preview editor drag drop extensions"
         case .terminal: return "scrollbar copy on select agent resume hibernation"
         case .textBox: return "textbox text box rich input prompt default new terminal workspace split tab focus show beta"
         case .sidebarAppearance: return "sidebar details branches material terminal background"

--- a/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Rows/FileExtensionOpenersEditor.swift
+++ b/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Rows/FileExtensionOpenersEditor.swift
@@ -6,15 +6,20 @@ public struct FileExtensionOpenersEditor: View {
     @Binding private var openers: [String: FileExtensionOpenBehavior]
     @State private var draftExtension = ""
     @State private var showsAllExtensions = false
+    @State private var normalizedOpenersCache: [String: FileExtensionOpenBehavior]
+    @State private var sortedExtensionCache: [String]
 
     private static let initiallyVisibleExtensionLimit = 32
 
     public init(openers: Binding<[String: FileExtensionOpenBehavior]>) {
+        let normalized = Self.normalizedOpeners(openers.wrappedValue)
         self._openers = openers
+        self._normalizedOpenersCache = State(initialValue: normalized)
+        self._sortedExtensionCache = State(initialValue: Self.sortedExtensions(from: normalized))
     }
 
     public var body: some View {
-        let extensions = sortedExtensions
+        let extensions = sortedExtensionCache
 
         VStack(alignment: .leading, spacing: 0) {
             SettingsCardRow(
@@ -56,11 +61,8 @@ public struct FileExtensionOpenersEditor: View {
                 }
             }
         }
-    }
-
-    private var sortedExtensions: [String] {
-        openers.keys.sorted { lhs, rhs in
-            lhs.localizedStandardCompare(rhs) == .orderedAscending
+        .onChange(of: openers) { _, newValue in
+            refreshCaches(for: newValue)
         }
     }
 
@@ -115,7 +117,7 @@ public struct FileExtensionOpenersEditor: View {
             Picker(
                 "",
                 selection: Binding(
-                    get: { openers[fileExtension] ?? .automatic },
+                    get: { normalizedOpenersCache[fileExtension] ?? .automatic },
                     set: { setBehavior($0, for: fileExtension) }
                 )
             ) {
@@ -144,27 +146,46 @@ public struct FileExtensionOpenersEditor: View {
 
     private func addDraftExtension() {
         guard let normalized = normalizedDraftExtension else { return }
-        var next = normalizedOpeners(openers)
+        var next = normalizedOpenersCache
         if next[normalized] == nil {
             next[normalized] = .cmuxPreview
         }
-        openers = next
+        applyOpeners(next)
         draftExtension = ""
     }
 
     private func setBehavior(_ behavior: FileExtensionOpenBehavior, for fileExtension: String) {
-        var next = normalizedOpeners(openers)
-        next[fileExtension] = behavior
-        openers = next
+        guard let normalized = FileExtensionOpenBehavior.normalizedExtension(fileExtension) else { return }
+        var next = normalizedOpenersCache
+        next[normalized] = behavior
+        applyOpeners(next)
     }
 
     private func remove(_ fileExtension: String) {
-        var next = normalizedOpeners(openers)
-        next.removeValue(forKey: fileExtension)
-        openers = next
+        guard let normalized = FileExtensionOpenBehavior.normalizedExtension(fileExtension) else { return }
+        var next = normalizedOpenersCache
+        next.removeValue(forKey: normalized)
+        applyOpeners(next)
     }
 
-    private func normalizedOpeners(_ value: [String: FileExtensionOpenBehavior]) -> [String: FileExtensionOpenBehavior] {
+    private func applyOpeners(_ value: [String: FileExtensionOpenBehavior]) {
+        refreshCaches(for: value)
+        openers = value
+    }
+
+    private func refreshCaches(for value: [String: FileExtensionOpenBehavior]) {
+        let normalized = Self.normalizedOpeners(value)
+        normalizedOpenersCache = normalized
+        sortedExtensionCache = Self.sortedExtensions(from: normalized)
+    }
+
+    private static func sortedExtensions(from value: [String: FileExtensionOpenBehavior]) -> [String] {
+        value.keys.sorted { lhs, rhs in
+            lhs.localizedStandardCompare(rhs) == .orderedAscending
+        }
+    }
+
+    private static func normalizedOpeners(_ value: [String: FileExtensionOpenBehavior]) -> [String: FileExtensionOpenBehavior] {
         var normalized: [String: FileExtensionOpenBehavior] = [:]
         for (rawExtension, behavior) in value {
             guard let normalizedExtension = FileExtensionOpenBehavior.normalizedExtension(rawExtension) else { continue }

--- a/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Rows/FileExtensionOpenersEditor.swift
+++ b/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Rows/FileExtensionOpenersEditor.swift
@@ -5,17 +5,22 @@ import SwiftUI
 public struct FileExtensionOpenersEditor: View {
     @Binding private var openers: [String: FileExtensionOpenBehavior]
     @State private var draftExtension = ""
+    @State private var showsAllExtensions = false
+
+    private static let initiallyVisibleExtensionLimit = 32
 
     public init(openers: Binding<[String: FileExtensionOpenBehavior]>) {
         self._openers = openers
     }
 
     public var body: some View {
+        let extensions = sortedExtensions
+
         VStack(alignment: .leading, spacing: 0) {
             SettingsCardRow(
                 configurationReview: .json("app.fileExtensionOpeners"),
                 String(localized: "settings.app.fileExtensionOpeners", defaultValue: "File Extension Openers"),
-                subtitle: String(localized: "settings.app.fileExtensionOpeners.subtitle", defaultValue: "Choose how Cmd-click opens specific file extensions. HTML opens in the cmux browser by default.")
+                subtitle: String(localized: "settings.app.fileExtensionOpeners.subtitle", defaultValue: "Add any file extension and choose whether Cmd-click opens it in preview, browser, Markdown viewer, preferred editor, or system default. HTML opens in the cmux browser by default.")
             ) {
                 HStack(spacing: 6) {
                     TextField(
@@ -36,13 +41,18 @@ public struct FileExtensionOpenersEditor: View {
                 }
             }
 
-            if sortedExtensions.isEmpty {
+            if extensions.isEmpty {
                 SettingsCardDivider()
                 SettingsCardNote(String(localized: "settings.app.fileExtensionOpeners.empty", defaultValue: "No extension overrides. Cmd-click falls back to the supported-file and Markdown settings."))
             } else {
-                ForEach(sortedExtensions, id: \.self) { fileExtension in
+                ForEach(visibleExtensions(from: extensions), id: \.self) { fileExtension in
                     SettingsCardDivider()
                     openerRow(fileExtension)
+                }
+
+                if shouldShowExtensionLimitToggle(for: extensions) {
+                    SettingsCardDivider()
+                    extensionLimitToggleRow()
                 }
             }
         }
@@ -56,6 +66,43 @@ public struct FileExtensionOpenersEditor: View {
 
     private var normalizedDraftExtension: String? {
         FileExtensionOpenBehavior.normalizedExtension(draftExtension)
+    }
+
+    private func visibleExtensions(from extensions: [String]) -> [String] {
+        guard !showsAllExtensions, extensions.count > Self.initiallyVisibleExtensionLimit else {
+            return extensions
+        }
+        return Array(extensions.prefix(Self.initiallyVisibleExtensionLimit))
+    }
+
+    private func shouldShowExtensionLimitToggle(for extensions: [String]) -> Bool {
+        extensions.count > Self.initiallyVisibleExtensionLimit
+    }
+
+    private func extensionLimitToggleRow() -> some View {
+        HStack(spacing: 12) {
+            Text(String(localized: "settings.app.fileExtensionOpeners.limitedNote", defaultValue: "Showing fewer rows keeps Settings responsive. Use cmux.json for bulk changes."))
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .lineLimit(2)
+
+            Spacer(minLength: 12)
+
+            Button {
+                showsAllExtensions.toggle()
+            } label: {
+                Text(
+                    showsAllExtensions
+                        ? String(localized: "settings.app.fileExtensionOpeners.showFewer", defaultValue: "Show Fewer")
+                        : String(localized: "settings.app.fileExtensionOpeners.showAll", defaultValue: "Show All")
+                )
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 8)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private func openerRow(_ fileExtension: String) -> some View {

--- a/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Rows/FileExtensionOpenersEditor.swift
+++ b/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Rows/FileExtensionOpenersEditor.swift
@@ -1,0 +1,145 @@
+import CmuxSettings
+import SwiftUI
+
+@MainActor
+public struct FileExtensionOpenersEditor: View {
+    @Binding private var openers: [String: FileExtensionOpenBehavior]
+    @State private var draftExtension = ""
+
+    public init(openers: Binding<[String: FileExtensionOpenBehavior]>) {
+        self._openers = openers
+    }
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            SettingsCardRow(
+                configurationReview: .json("app.fileExtensionOpeners"),
+                String(localized: "settings.app.fileExtensionOpeners", defaultValue: "File Extension Openers"),
+                subtitle: String(localized: "settings.app.fileExtensionOpeners.subtitle", defaultValue: "Choose how Cmd-click opens specific file extensions. HTML opens in the cmux browser by default.")
+            ) {
+                HStack(spacing: 6) {
+                    TextField(
+                        String(localized: "settings.app.fileExtensionOpeners.addPlaceholder", defaultValue: "html"),
+                        text: $draftExtension
+                    )
+                    .textFieldStyle(.roundedBorder)
+                    .frame(width: 78)
+
+                    Button {
+                        addDraftExtension()
+                    } label: {
+                        Label(String(localized: "settings.app.fileExtensionOpeners.add", defaultValue: "Add"), systemImage: "plus")
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .disabled(normalizedDraftExtension == nil)
+                }
+            }
+
+            if sortedExtensions.isEmpty {
+                SettingsCardDivider()
+                SettingsCardNote(String(localized: "settings.app.fileExtensionOpeners.empty", defaultValue: "No extension overrides. Cmd-click falls back to the supported-file and Markdown settings."))
+            } else {
+                ForEach(sortedExtensions, id: \.self) { fileExtension in
+                    SettingsCardDivider()
+                    openerRow(fileExtension)
+                }
+            }
+        }
+    }
+
+    private var sortedExtensions: [String] {
+        openers.keys.sorted { lhs, rhs in
+            lhs.localizedStandardCompare(rhs) == .orderedAscending
+        }
+    }
+
+    private var normalizedDraftExtension: String? {
+        FileExtensionOpenBehavior.normalizedExtension(draftExtension)
+    }
+
+    private func openerRow(_ fileExtension: String) -> some View {
+        HStack(spacing: 12) {
+            Text(".\(fileExtension)")
+                .font(.system(size: 13, weight: .medium, design: .monospaced))
+                .frame(width: 86, alignment: .leading)
+                .lineLimit(1)
+
+            Picker(
+                "",
+                selection: Binding(
+                    get: { openers[fileExtension] ?? .automatic },
+                    set: { setBehavior($0, for: fileExtension) }
+                )
+            ) {
+                ForEach(FileExtensionOpenBehavior.allCases) { behavior in
+                    Text(displayName(for: behavior)).tag(behavior)
+                }
+            }
+            .labelsHidden()
+            .pickerStyle(.menu)
+            .frame(width: 170, alignment: .trailing)
+
+            Button {
+                remove(fileExtension)
+            } label: {
+                Image(systemName: "minus.circle")
+            }
+            .buttonStyle(.plain)
+            .controlSize(.small)
+            .help(String(localized: "settings.app.fileExtensionOpeners.remove", defaultValue: "Remove extension opener"))
+            .accessibilityLabel(String(localized: "settings.app.fileExtensionOpeners.remove", defaultValue: "Remove extension opener"))
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func addDraftExtension() {
+        guard let normalized = normalizedDraftExtension else { return }
+        var next = normalizedOpeners(openers)
+        if next[normalized] == nil {
+            next[normalized] = .cmuxPreview
+        }
+        openers = next
+        draftExtension = ""
+    }
+
+    private func setBehavior(_ behavior: FileExtensionOpenBehavior, for fileExtension: String) {
+        var next = normalizedOpeners(openers)
+        next[fileExtension] = behavior
+        openers = next
+    }
+
+    private func remove(_ fileExtension: String) {
+        var next = normalizedOpeners(openers)
+        next.removeValue(forKey: fileExtension)
+        openers = next
+    }
+
+    private func normalizedOpeners(_ value: [String: FileExtensionOpenBehavior]) -> [String: FileExtensionOpenBehavior] {
+        var normalized: [String: FileExtensionOpenBehavior] = [:]
+        for (rawExtension, behavior) in value {
+            guard let normalizedExtension = FileExtensionOpenBehavior.normalizedExtension(rawExtension) else { continue }
+            normalized[normalizedExtension] = behavior
+        }
+        return normalized
+    }
+
+    private func displayName(for behavior: FileExtensionOpenBehavior) -> String {
+        switch behavior {
+        case .automatic:
+            return String(localized: "settings.app.fileExtensionOpeners.behavior.automatic", defaultValue: "Automatic")
+        case .cmuxPreview:
+            return String(localized: "settings.app.fileExtensionOpeners.behavior.cmuxPreview", defaultValue: "cmux Preview")
+        case .markdownViewer:
+            return String(localized: "settings.app.fileExtensionOpeners.behavior.markdownViewer", defaultValue: "Markdown Viewer")
+        case .cmuxBrowser:
+            return String(localized: "settings.app.fileExtensionOpeners.behavior.cmuxBrowser", defaultValue: "cmux Browser")
+        case .preferredEditor:
+            return String(localized: "settings.app.fileExtensionOpeners.behavior.preferredEditor", defaultValue: "Preferred Editor")
+        case .systemDefault:
+            return String(localized: "settings.app.fileExtensionOpeners.behavior.systemDefault", defaultValue: "System Default")
+        }
+    }
+}

--- a/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Rows/FileExtensionOpenersEditor.swift
+++ b/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Rows/FileExtensionOpenersEditor.swift
@@ -129,15 +129,27 @@ public struct FileExtensionOpenersEditor: View {
             .pickerStyle(.menu)
             .frame(width: 170, alignment: .trailing)
 
-            Button {
-                remove(fileExtension)
-            } label: {
-                Image(systemName: "minus.circle")
+            if let defaultBehavior = FileExtensionOpenBehavior.defaultOpeners[fileExtension] {
+                Button {
+                    setBehavior(defaultBehavior, for: fileExtension)
+                } label: {
+                    Image(systemName: "arrow.counterclockwise.circle")
+                }
+                .buttonStyle(.plain)
+                .controlSize(.small)
+                .help(String(localized: "settings.app.fileExtensionOpeners.restoreDefault", defaultValue: "Restore built-in opener"))
+                .accessibilityLabel(String(localized: "settings.app.fileExtensionOpeners.restoreDefault", defaultValue: "Restore built-in opener"))
+            } else {
+                Button {
+                    remove(fileExtension)
+                } label: {
+                    Image(systemName: "minus.circle")
+                }
+                .buttonStyle(.plain)
+                .controlSize(.small)
+                .help(String(localized: "settings.app.fileExtensionOpeners.remove", defaultValue: "Remove extension opener"))
+                .accessibilityLabel(String(localized: "settings.app.fileExtensionOpeners.remove", defaultValue: "Remove extension opener"))
             }
-            .buttonStyle(.plain)
-            .controlSize(.small)
-            .help(String(localized: "settings.app.fileExtensionOpeners.remove", defaultValue: "Remove extension opener"))
-            .accessibilityLabel(String(localized: "settings.app.fileExtensionOpeners.remove", defaultValue: "Remove extension opener"))
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 8)
@@ -148,7 +160,7 @@ public struct FileExtensionOpenersEditor: View {
         guard let normalized = normalizedDraftExtension else { return }
         var next = normalizedOpenersCache
         if next[normalized] == nil {
-            next[normalized] = .cmuxPreview
+            next[normalized] = FileExtensionOpenBehavior.defaultOpeners[normalized] ?? .cmuxPreview
         }
         applyOpeners(next)
         draftExtension = ""

--- a/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Scene/SettingsWindowScene.swift
+++ b/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Scene/SettingsWindowScene.swift
@@ -427,7 +427,7 @@ public struct SettingsWindowRoot: View {
     @ViewBuilder
     private var sectionStack: some View {
         // Order matches the legacy in-app SettingsView scroll order:
-        // Account, App, Terminal, TextBox, Sidebar, Beta Features,
+        // Account, App, File Opening, Terminal, TextBox, Sidebar, Beta Features,
         // Automation, Browser (with embedded Import), Global Hotkey,
         // Keyboard Shortcuts, Workspace Colors, cmux.json, Reset.
         AccountSection(
@@ -443,6 +443,9 @@ public struct SettingsWindowRoot: View {
             hostActions: hostActions
         )
         .id(anchorID(for: .app))
+
+        FileOpeningSection(defaultsStore: defaultsStore, catalog: catalog)
+            .id(anchorID(for: .fileOpening))
 
         TerminalSection(
             defaultsStore: defaultsStore,

--- a/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/AppSection.swift
+++ b/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/AppSection.swift
@@ -35,6 +35,7 @@ public struct AppSection: View {
     @State private var preferredEditor: DefaultsValueModel<String>
     @State private var openSupported: DefaultsValueModel<Bool>
     @State private var openMarkdown: DefaultsValueModel<Bool>
+    @State private var fileExtensionOpeners: DefaultsValueModel<[String: FileExtensionOpenBehavior]>
     @State private var iMessage: DefaultsValueModel<Bool>
     @State private var reorder: DefaultsValueModel<Bool>
     @State private var dockBadge: DefaultsValueModel<Bool>
@@ -75,6 +76,7 @@ public struct AppSection: View {
         _preferredEditor = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.app.preferredEditor))
         _openSupported = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.app.openSupportedFilesInCmux))
         _openMarkdown = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.app.openMarkdownInCmuxViewer))
+        _fileExtensionOpeners = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.app.fileExtensionOpeners))
         _iMessage = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.app.iMessageMode))
         _reorder = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.app.reorderOnNotification))
         _dockBadge = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.notifications.dockBadge))
@@ -269,6 +271,14 @@ public struct AppSection: View {
                 .textFieldStyle(.roundedBorder)
                 .frame(width: 200)
             }
+            SettingsCardDivider()
+
+            FileExtensionOpenersEditor(
+                openers: Binding(
+                    get: { fileExtensionOpeners.current },
+                    set: { fileExtensionOpeners.set($0) }
+                )
+            )
             SettingsCardDivider()
 
             // Open Supported Files in cmux

--- a/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/AppSection.swift
+++ b/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/AppSection.swift
@@ -7,14 +7,12 @@ import UniformTypeIdentifiers
 /// inside a single `SettingsCard`: Language, Appearance, App Icon,
 /// New Workspace Placement, Inherit Working Directory, Minimal Mode,
 /// Keep Workspace Open When Closing Last Surface, Focus Pane on
-/// First Click, File Drops, Open Files With, Open Supported Files in
-/// cmux, Terminal Config link, Open Markdown in cmux Viewer,
-/// iMessage Mode, Reorder on Notification, Dock Badge, Menu Bar
-/// Only, Show in Menu Bar, Unread Pane Ring, Pane Flash, Desktop
-/// Notifications, Notification Sound, Notification Command, Send
-/// anonymous telemetry, Warn Before Quit, Warn Before Closing Tab /
-/// X Button / Hide Tab Close Button, Rename Selects Existing Name,
-/// Command Palette Searches All Surfaces.
+/// First Click, Terminal Config link, iMessage Mode, Reorder on
+/// Notification, Dock Badge, Menu Bar Only, Show in Menu Bar,
+/// Unread Pane Ring, Pane Flash, Desktop Notifications, Notification
+/// Sound, Notification Command, Send anonymous telemetry, Warn Before
+/// Quit, Warn Before Closing Tab / X Button / Hide Tab Close Button,
+/// Rename Selects Existing Name, Command Palette Searches All Surfaces.
 @MainActor
 public struct AppSection: View {
     private let catalog: SettingCatalog
@@ -31,11 +29,6 @@ public struct AppSection: View {
     @State private var minimalMode: DefaultsValueModel<WorkspacePresentationMode>
     @State private var keepWorkspaceOpen: DefaultsValueModel<Bool>
     @State private var firstClick: DefaultsValueModel<Bool>
-    @State private var fileDrop: DefaultsValueModel<FileDropDefaultBehavior>
-    @State private var preferredEditor: DefaultsValueModel<String>
-    @State private var openSupported: DefaultsValueModel<Bool>
-    @State private var openMarkdown: DefaultsValueModel<Bool>
-    @State private var fileExtensionOpeners: DefaultsValueModel<[String: FileExtensionOpenBehavior]>
     @State private var iMessage: DefaultsValueModel<Bool>
     @State private var reorder: DefaultsValueModel<Bool>
     @State private var dockBadge: DefaultsValueModel<Bool>
@@ -72,11 +65,6 @@ public struct AppSection: View {
         _minimalMode = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.app.presentationMode))
         _keepWorkspaceOpen = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.app.keepWorkspaceOpenWhenClosingLastSurface))
         _firstClick = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.app.focusPaneOnFirstClick))
-        _fileDrop = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.app.fileDropDefaultBehavior))
-        _preferredEditor = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.app.preferredEditor))
-        _openSupported = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.app.openSupportedFilesInCmux))
-        _openMarkdown = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.app.openMarkdownInCmuxViewer))
-        _fileExtensionOpeners = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.app.fileExtensionOpeners))
         _iMessage = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.app.iMessageMode))
         _reorder = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.app.reorderOnNotification))
         _dockBadge = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.notifications.dockBadge))
@@ -241,58 +229,6 @@ public struct AppSection: View {
             }
             SettingsCardDivider()
 
-            // File Drops
-            SettingsCardRow(
-                configurationReview: .settingsOnly,
-                searchAnchorID: "setting:app:file-drops",
-                String(localized: "settings.app.fileDrop.defaultBehavior", defaultValue: "File Drops"),
-                subtitle: fileDropSubtitle(fileDrop.current),
-                controlWidth: Self.columnWidth
-            ) {
-                Picker("", selection: Binding(get: { fileDrop.current }, set: { fileDrop.set($0) })) {
-                    Text(String(localized: "settings.app.fileDrop.defaultBehavior.text", defaultValue: "Drop path text")).tag(FileDropDefaultBehavior.text)
-                    Text(String(localized: "settings.app.fileDrop.defaultBehavior.preview", defaultValue: "Open file preview")).tag(FileDropDefaultBehavior.preview)
-                }
-                .labelsHidden()
-                .pickerStyle(.menu)
-            }
-            SettingsCardDivider()
-
-            // Preferred Editor
-            SettingsCardRow(
-                configurationReview: .json("app.preferredEditor"),
-                String(localized: "settings.app.preferredEditor", defaultValue: "Open Files With"),
-                subtitle: String(localized: "settings.app.preferredEditor.subtitle", defaultValue: "Command used when Cmd-click file previews are disabled or a file is unsupported. Leave empty for system default.")
-            ) {
-                TextField(
-                    String(localized: "settings.app.preferredEditor.placeholder", defaultValue: "e.g. code, zed, subl"),
-                    text: Binding(get: { preferredEditor.current }, set: { preferredEditor.set($0) })
-                )
-                .textFieldStyle(.roundedBorder)
-                .frame(width: 200)
-            }
-            SettingsCardDivider()
-
-            FileExtensionOpenersEditor(
-                openers: Binding(
-                    get: { fileExtensionOpeners.current },
-                    set: { fileExtensionOpeners.set($0) }
-                )
-            )
-            SettingsCardDivider()
-
-            // Open Supported Files in cmux
-            SettingsCardRow(
-                configurationReview: .json("app.openSupportedFilesInCmux"),
-                String(localized: "settings.app.openSupportedFilesInCmux", defaultValue: "Open Supported Files in cmux"),
-                subtitle: String(localized: "settings.app.openSupportedFilesInCmux.subtitle", defaultValue: "Cmd-clicking readable files opens text, code, PDFs, images, audio, video, and Quick Look previews in cmux.")
-            ) {
-                Toggle("", isOn: Binding(get: { openSupported.current }, set: { openSupported.set($0) }))
-                    .labelsHidden()
-                    .controlSize(.small)
-            }
-            SettingsCardDivider()
-
             // Terminal Config (host action)
             SettingsCardRow(
                 configurationReview: .action,
@@ -306,18 +242,6 @@ public struct AppSection: View {
                 }
                 .buttonStyle(.bordered)
                 .controlSize(.small)
-            }
-            SettingsCardDivider()
-
-            // Open Markdown in cmux Viewer
-            SettingsCardRow(
-                configurationReview: .json("app.openMarkdownInCmuxViewer"),
-                String(localized: "settings.app.openMarkdownInCmuxViewer", defaultValue: "Open Markdown in cmux Viewer"),
-                subtitle: String(localized: "settings.app.openMarkdownInCmuxViewer.subtitle", defaultValue: "When supported file routing is on, Cmd-clicking Markdown files opens the rendered cmux markdown viewer instead of the generic file preview.")
-            ) {
-                Toggle("", isOn: Binding(get: { openMarkdown.current }, set: { openMarkdown.set($0) }))
-                    .labelsHidden()
-                    .controlSize(.small)
             }
             SettingsCardDivider()
 
@@ -706,21 +630,6 @@ public struct AppSection: View {
             return String(
                 localized: "workspace.placement.end.description",
                 defaultValue: "Append new workspaces to the bottom of the list."
-            )
-        }
-    }
-
-    private func fileDropSubtitle(_ behavior: FileDropDefaultBehavior) -> String {
-        switch behavior {
-        case .text:
-            return String(
-                localized: "settings.app.fileDrop.defaultBehavior.text.subtitle",
-                defaultValue: "Over terminals and editors, dragging files inserts shell-escaped paths. Hold Shift to open a file preview or split."
-            )
-        case .preview:
-            return String(
-                localized: "settings.app.fileDrop.defaultBehavior.preview.subtitle",
-                defaultValue: "Dragging files opens previews or split panes. Hold Shift over terminals and editors to insert path text."
             )
         }
     }

--- a/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/FileOpeningSection.swift
+++ b/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/FileOpeningSection.swift
@@ -1,0 +1,116 @@
+import CmuxSettings
+import SwiftUI
+
+@MainActor
+public struct FileOpeningSection: View {
+    @State private var fileDrop: DefaultsValueModel<FileDropDefaultBehavior>
+    @State private var preferredEditor: DefaultsValueModel<String>
+    @State private var fileExtensionOpeners: DefaultsValueModel<[String: FileExtensionOpenBehavior]>
+    @State private var openSupported: DefaultsValueModel<Bool>
+    @State private var openMarkdown: DefaultsValueModel<Bool>
+
+    public init(
+        defaultsStore: UserDefaultsSettingsStore,
+        catalog: SettingCatalog
+    ) {
+        _fileDrop = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.app.fileDropDefaultBehavior))
+        _preferredEditor = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.app.preferredEditor))
+        _fileExtensionOpeners = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.app.fileExtensionOpeners))
+        _openSupported = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.app.openSupportedFilesInCmux))
+        _openMarkdown = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.app.openMarkdownInCmuxViewer))
+    }
+
+    private static let columnWidth: CGFloat = 196
+
+    public var body: some View {
+        Group {
+            SettingsSectionHeader(
+                String(localized: "settings.section.fileOpening", defaultValue: "File Opening"),
+                section: .fileOpening
+            )
+            .accessibilityIdentifier("SettingsFileOpeningSection")
+
+            SettingsCard {
+                SettingsCardRow(
+                    configurationReview: .settingsOnly,
+                    searchAnchorID: "setting:fileOpening:file-drops",
+                    String(localized: "settings.app.fileDrop.defaultBehavior", defaultValue: "File Drops"),
+                    subtitle: fileDropSubtitle(fileDrop.current),
+                    controlWidth: Self.columnWidth
+                ) {
+                    Picker("", selection: Binding(get: { fileDrop.current }, set: { fileDrop.set($0) })) {
+                        Text(String(localized: "settings.app.fileDrop.defaultBehavior.text", defaultValue: "Drop path text"))
+                            .tag(FileDropDefaultBehavior.text)
+                        Text(String(localized: "settings.app.fileDrop.defaultBehavior.preview", defaultValue: "Open file preview"))
+                            .tag(FileDropDefaultBehavior.preview)
+                    }
+                    .labelsHidden()
+                    .pickerStyle(.menu)
+                }
+
+                SettingsCardDivider()
+
+                SettingsCardRow(
+                    configurationReview: .json("app.preferredEditor"),
+                    String(localized: "settings.app.preferredEditor", defaultValue: "Open Files With"),
+                    subtitle: String(localized: "settings.app.preferredEditor.subtitle", defaultValue: "Command used when Cmd-click file previews are disabled or a file is unsupported. Leave empty for system default.")
+                ) {
+                    TextField(
+                        String(localized: "settings.app.preferredEditor.placeholder", defaultValue: "e.g. code, zed, subl"),
+                        text: Binding(get: { preferredEditor.current }, set: { preferredEditor.set($0) })
+                    )
+                    .textFieldStyle(.roundedBorder)
+                    .frame(width: 200)
+                }
+
+                SettingsCardDivider()
+
+                FileExtensionOpenersEditor(
+                    openers: Binding(
+                        get: { fileExtensionOpeners.current },
+                        set: { fileExtensionOpeners.set($0) }
+                    )
+                )
+
+                SettingsCardDivider()
+
+                SettingsCardRow(
+                    configurationReview: .json("app.openSupportedFilesInCmux"),
+                    String(localized: "settings.app.openSupportedFilesInCmux", defaultValue: "Open Supported Files in cmux"),
+                    subtitle: String(localized: "settings.app.openSupportedFilesInCmux.subtitle", defaultValue: "Cmd-clicking readable files opens text, code, PDFs, images, audio, video, and Quick Look previews in cmux.")
+                ) {
+                    Toggle("", isOn: Binding(get: { openSupported.current }, set: { openSupported.set($0) }))
+                        .labelsHidden()
+                        .controlSize(.small)
+                }
+
+                SettingsCardDivider()
+
+                SettingsCardRow(
+                    configurationReview: .json("app.openMarkdownInCmuxViewer"),
+                    String(localized: "settings.app.openMarkdownInCmuxViewer", defaultValue: "Open Markdown in cmux Viewer"),
+                    subtitle: String(localized: "settings.app.openMarkdownInCmuxViewer.subtitle", defaultValue: "When supported file routing is on, Cmd-clicking Markdown files opens the rendered cmux markdown viewer instead of the generic file preview.")
+                ) {
+                    Toggle("", isOn: Binding(get: { openMarkdown.current }, set: { openMarkdown.set($0) }))
+                        .labelsHidden()
+                        .controlSize(.small)
+                }
+            }
+        }
+    }
+
+    private func fileDropSubtitle(_ behavior: FileDropDefaultBehavior) -> String {
+        switch behavior {
+        case .text:
+            return String(
+                localized: "settings.app.fileDrop.defaultBehavior.text.subtitle",
+                defaultValue: "Over terminals and editors, dragging files inserts shell-escaped paths. Hold Shift to open a file preview or split."
+            )
+        case .preview:
+            return String(
+                localized: "settings.app.fileDrop.defaultBehavior.preview.subtitle",
+                defaultValue: "Dragging files opens previews or split panes. Hold Shift over terminals and editors to insert path text."
+            )
+        }
+    }
+}

--- a/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/FileOpeningSection.swift
+++ b/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/FileOpeningSection.swift
@@ -53,7 +53,7 @@ public struct FileOpeningSection: View {
                 SettingsCardRow(
                     configurationReview: .json("app.preferredEditor"),
                     String(localized: "settings.app.preferredEditor", defaultValue: "Open Files With"),
-                    subtitle: String(localized: "settings.app.preferredEditor.subtitle", defaultValue: "Command used when Cmd-click file previews are disabled or a file is unsupported. Leave empty for system default.")
+                    subtitle: String(localized: "settings.app.preferredEditor.subtitle", defaultValue: "Command used when an extension is set to Preferred Editor, or when Cmd-click file previews are disabled or a file is unsupported. Leave empty for system default.")
                 ) {
                     TextField(
                         String(localized: "settings.app.preferredEditor.placeholder", defaultValue: "e.g. code, zed, subl"),

--- a/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/FileOpeningSection.swift
+++ b/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/FileOpeningSection.swift
@@ -1,6 +1,7 @@
 import CmuxSettings
 import SwiftUI
 
+/// Settings section for file drops, file editor fallback, and command-click file extension routing.
 @MainActor
 public struct FileOpeningSection: View {
     @State private var fileDrop: DefaultsValueModel<FileDropDefaultBehavior>
@@ -9,6 +10,7 @@ public struct FileOpeningSection: View {
     @State private var openSupported: DefaultsValueModel<Bool>
     @State private var openMarkdown: DefaultsValueModel<Bool>
 
+    /// Creates the file-opening settings section backed by the supplied defaults store and settings catalog.
     public init(
         defaultsStore: UserDefaultsSettingsStore,
         catalog: SettingCatalog
@@ -22,6 +24,7 @@ public struct FileOpeningSection: View {
 
     private static let columnWidth: CGFloat = 196
 
+    /// The SwiftUI content for the file-opening settings section.
     public var body: some View {
         Group {
             SettingsSectionHeader(

--- a/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/FileOpeningSection.swift
+++ b/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/FileOpeningSection.swift
@@ -5,7 +5,7 @@ import SwiftUI
 public struct FileOpeningSection: View {
     @State private var fileDrop: DefaultsValueModel<FileDropDefaultBehavior>
     @State private var preferredEditor: DefaultsValueModel<String>
-    @State private var fileExtensionOpeners: DefaultsValueModel<[String: FileExtensionOpenBehavior]>
+    @State private var fileExtensionOpeners: FileExtensionOpenersValueModel
     @State private var openSupported: DefaultsValueModel<Bool>
     @State private var openMarkdown: DefaultsValueModel<Bool>
 
@@ -15,7 +15,7 @@ public struct FileOpeningSection: View {
     ) {
         _fileDrop = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.app.fileDropDefaultBehavior))
         _preferredEditor = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.app.preferredEditor))
-        _fileExtensionOpeners = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.app.fileExtensionOpeners))
+        _fileExtensionOpeners = State(initialValue: FileExtensionOpenersValueModel(store: defaultsStore))
         _openSupported = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.app.openSupportedFilesInCmux))
         _openMarkdown = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.app.openMarkdownInCmuxViewer))
     }

--- a/Packages/CmuxSettingsUI/Tests/CmuxSettingsUITests/FileExtensionOpenersValueModelTests.swift
+++ b/Packages/CmuxSettingsUI/Tests/CmuxSettingsUITests/FileExtensionOpenersValueModelTests.swift
@@ -1,0 +1,38 @@
+import CmuxSettings
+import Foundation
+import Testing
+@testable import CmuxSettingsUI
+
+@Suite("FileExtensionOpenersValueModel")
+struct FileExtensionOpenersValueModelTests {
+    @Test func readsEffectiveOpenersFromPartialStoredMap() async throws {
+        let suiteName = "cmux.fileExtensionOpeners.ui.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { UserDefaults(suiteName: suiteName)?.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(["css": "cmuxPreview"], forKey: FileExtensionOpenBehaviorSettings.key)
+        let store = UserDefaultsSettingsStore(defaults: defaults)
+
+        let model = await FileExtensionOpenersValueModel(store: store)
+        await model.refresh()
+        let current = await model.current
+        #expect(current["html"] == .cmuxBrowser)
+        #expect(current["htm"] == .cmuxBrowser)
+        #expect(current["css"] == .cmuxPreview)
+    }
+
+    @Test func setPrunesDefaultValuesAndKeepsBuiltInAutomaticOverride() async throws {
+        let suiteName = "cmux.fileExtensionOpeners.ui.set.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { UserDefaults(suiteName: suiteName)?.removePersistentDomain(forName: suiteName) }
+        let store = UserDefaultsSettingsStore(defaults: defaults)
+
+        let model = await FileExtensionOpenersValueModel(store: store)
+        await model.setAndRefresh(["html": .automatic, "htm": .cmuxBrowser, "css": .cmuxBrowser])
+
+        let current = await model.current
+        #expect(current["html"] == .automatic)
+        #expect(current["htm"] == .cmuxBrowser)
+        #expect(current["css"] == .cmuxBrowser)
+    }
+}

--- a/Packages/CmuxSettingsUI/Tests/CmuxSettingsUITests/SettingsRowAnchorResolutionTests.swift
+++ b/Packages/CmuxSettingsUI/Tests/CmuxSettingsUITests/SettingsRowAnchorResolutionTests.swift
@@ -43,6 +43,7 @@ struct SettingsRowAnchorResolutionTests {
         "app.iMessageMode",
         "app.keepWorkspaceOpenWhenClosingLastSurface",
         "app.language",
+        "app.fileExtensionOpeners",
         "app.menuBarOnly",
         "app.minimalMode",
         "app.newWorkspacePlacement",

--- a/Packages/CmuxSettingsUI/Tests/CmuxSettingsUITests/SettingsRowAnchorResolutionTests.swift
+++ b/Packages/CmuxSettingsUI/Tests/CmuxSettingsUITests/SettingsRowAnchorResolutionTests.swift
@@ -121,7 +121,7 @@ struct SettingsRowAnchorResolutionTests {
     static let explicitlyAnchoredEntryIDs: Set<String> = [
         "setting:app:appearance",
         "setting:app:app-icon",
-        "setting:app:file-drops",
+        "setting:fileOpening:file-drops",
         "setting:app:terminal-config",
         "setting:app:desktop-notifications",
         "setting:account:account",

--- a/Sources/CmuxSettingsJSONPathSupport.swift
+++ b/Sources/CmuxSettingsJSONPathSupport.swift
@@ -71,6 +71,7 @@ extension CmuxSettingsFileStore {
         "app.keepWorkspaceOpenWhenClosingLastSurface",
         "app.focusPaneOnFirstClick",
         "app.preferredEditor",
+        "app.fileExtensionOpeners",
         "app.openSupportedFilesInCmux",
         "app.openMarkdownInCmuxViewer",
         "app.iMessageMode",

--- a/Sources/CommandClickFileOpenRouter.swift
+++ b/Sources/CommandClickFileOpenRouter.swift
@@ -49,9 +49,14 @@ enum CommandClickFileOpenRouter {
     }
 
     private nonisolated static func action(for path: String, defaults: UserDefaults) -> Action {
+        let normalizedExtension = normalizedExtension(forPath: path)
         if let behavior = FileExtensionOpenBehaviorSettings.behavior(forPath: path, defaults: defaults) {
             switch behavior {
             case .automatic:
+                if let normalizedExtension,
+                   FileExtensionOpenBehavior.defaultOpeners[normalizedExtension] != nil {
+                    return .unhandled
+                }
                 break
             case .cmuxPreview:
                 return CmdClickSupportedFileRouteSettings.isReadableRegularFile(path: path) ? .cmuxPreview : .unhandled
@@ -75,38 +80,43 @@ enum CommandClickFileOpenRouter {
         return .unhandled
     }
 
+    private nonisolated static func normalizedExtension(forPath path: String) -> String? {
+        FileExtensionOpenBehavior.normalizedExtension((path as NSString).pathExtension)
+    }
+
     @MainActor
     static func openCommandClickFile(
         workspace: Workspace,
         sourcePanelId: UUID,
         filePath: String,
+        fileURL: URL? = nil,
         fallback: Fallback
     ) -> Bool {
-        let fileURL = URL(fileURLWithPath: filePath)
+        let routedURL = fileURL ?? URL(fileURLWithPath: filePath)
         switch action(for: filePath, defaults: .standard) {
         case .markdownViewer:
             if workspace.openOrFocusMarkdownSplit(from: sourcePanelId, filePath: filePath) != nil {
                 return true
             }
-            fallback.open(fileURL)
+            fallback.open(routedURL)
             return true
         case .cmuxPreview:
             if workspace.openOrFocusFilePreviewSplit(from: sourcePanelId, filePath: filePath) != nil {
                 return true
             }
-            fallback.open(fileURL)
+            fallback.open(routedURL)
             return true
         case .cmuxBrowser:
-            if workspace.openOrFocusBrowserSplit(from: sourcePanelId, url: fileURL) != nil {
+            if workspace.openOrFocusBrowserSplit(from: sourcePanelId, url: routedURL) != nil {
                 return true
             }
-            fallback.open(fileURL)
+            fallback.open(routedURL)
             return true
         case .preferredEditor:
-            PreferredEditorSettings.open(fileURL)
+            PreferredEditorSettings.open(routedURL)
             return true
         case .systemDefault:
-            NSWorkspace.shared.open(fileURL)
+            NSWorkspace.shared.open(routedURL)
             return true
         case .unhandled:
             return false
@@ -149,24 +159,27 @@ enum CommandClickFileOpenRouter {
         preferredWorkspaceId: UUID,
         surfaceId: UUID,
         filePath: String,
+        fileURL: URL? = nil,
         fallback: Fallback
     ) {
         Task { @MainActor in
+            let routedURL = fileURL ?? URL(fileURLWithPath: filePath)
             let resolvedWorkspace = AppDelegate.shared?.workspaceContainingPanel(
                 panelId: surfaceId,
                 preferredWorkspaceId: preferredWorkspaceId
             )?.workspace ?? workspace
             guard !resolvedWorkspace.isRemoteTerminalSurface(surfaceId) else {
-                fallback.open(URL(fileURLWithPath: filePath))
+                fallback.open(routedURL)
                 return
             }
             guard openCommandClickFile(
                 workspace: resolvedWorkspace,
                 sourcePanelId: surfaceId,
                 filePath: filePath,
+                fileURL: routedURL,
                 fallback: fallback
             ) else {
-                fallback.open(URL(fileURLWithPath: filePath))
+                fallback.open(routedURL)
                 return
             }
         }

--- a/Sources/CommandClickFileOpenRouter.swift
+++ b/Sources/CommandClickFileOpenRouter.swift
@@ -1,10 +1,126 @@
 import AppKit
+import CmuxSettings
 import Foundation
 
+enum FileExtensionOpenBehaviorSettings {
+    static let key = "fileExtensionOpeners"
+    static let didChangeNotification = Notification.Name("cmux.fileExtensionOpenersDidChange")
+    static let defaultValue = FileExtensionOpenBehavior.defaultOpeners
+
+    static func openers(defaults: UserDefaults = .standard) -> [String: FileExtensionOpenBehavior] {
+        guard defaults.object(forKey: key) != nil else { return defaultValue }
+        guard let stored = defaults.dictionary(forKey: key) else { return defaultValue }
+
+        var result: [String: FileExtensionOpenBehavior] = [:]
+        for (rawExtension, rawBehavior) in stored {
+            guard let normalizedExtension = FileExtensionOpenBehavior.normalizedExtension(rawExtension),
+                  let rawBehavior = rawBehavior as? String,
+                  let behavior = FileExtensionOpenBehavior(rawValue: rawBehavior) else {
+                continue
+            }
+            result[normalizedExtension] = behavior
+        }
+        return result
+    }
+
+    static func behavior(forPath path: String, defaults: UserDefaults = .standard) -> FileExtensionOpenBehavior? {
+        let ext = (path as NSString).pathExtension
+        guard let normalizedExtension = FileExtensionOpenBehavior.normalizedExtension(ext) else {
+            return nil
+        }
+        return openers(defaults: defaults)[normalizedExtension]
+    }
+
+    static func setOpeners(
+        _ openers: [String: FileExtensionOpenBehavior],
+        defaults: UserDefaults = .standard,
+        notificationCenter: NotificationCenter = .default
+    ) {
+        var normalized: [String: String] = [:]
+        for (rawExtension, behavior) in openers {
+            guard let normalizedExtension = FileExtensionOpenBehavior.normalizedExtension(rawExtension) else { continue }
+            normalized[normalizedExtension] = behavior.rawValue
+        }
+        defaults.set(normalized, forKey: key)
+        notifyDidChange(notificationCenter: notificationCenter)
+    }
+
+    static func notifyDidChange(notificationCenter: NotificationCenter = .default) {
+        notificationCenter.post(name: didChangeNotification, object: nil)
+    }
+}
+
 enum CommandClickFileOpenRouter {
-    nonisolated static func shouldRouteInCmux(path: String) -> Bool {
-        CmdClickMarkdownRouteSettings.shouldRoute(path: path)
-            || CmdClickSupportedFileRouteSettings.shouldRoute(path: path)
+    enum Fallback {
+        case preferredEditor
+        case systemDefault
+
+        @MainActor
+        func open(_ url: URL) {
+            switch self {
+            case .preferredEditor:
+                PreferredEditorSettings.open(url)
+            case .systemDefault:
+                NSWorkspace.shared.open(url)
+            }
+        }
+    }
+
+    private enum Action {
+        case markdownViewer
+        case cmuxPreview
+        case cmuxBrowser
+        case preferredEditor
+        case systemDefault
+        case unhandled
+
+        var routesInCmux: Bool {
+            switch self {
+            case .markdownViewer, .cmuxPreview, .cmuxBrowser:
+                return true
+            case .preferredEditor, .systemDefault, .unhandled:
+                return false
+            }
+        }
+
+        var handlesCommandClick: Bool {
+            self != .unhandled
+        }
+    }
+
+    nonisolated static func shouldRouteInCmux(path: String, defaults: UserDefaults = .standard) -> Bool {
+        action(for: path, defaults: defaults).routesInCmux
+    }
+
+    nonisolated static func shouldHandleCommandClick(path: String, defaults: UserDefaults = .standard) -> Bool {
+        action(for: path, defaults: defaults).handlesCommandClick
+    }
+
+    private nonisolated static func action(for path: String, defaults: UserDefaults) -> Action {
+        if let behavior = FileExtensionOpenBehaviorSettings.behavior(forPath: path, defaults: defaults) {
+            switch behavior {
+            case .automatic:
+                break
+            case .cmuxPreview:
+                return CmdClickSupportedFileRouteSettings.isReadableRegularFile(path: path) ? .cmuxPreview : .unhandled
+            case .markdownViewer:
+                return CmdClickSupportedFileRouteSettings.isReadableRegularFile(path: path) ? .markdownViewer : .unhandled
+            case .cmuxBrowser:
+                return CmdClickSupportedFileRouteSettings.isReadableRegularFile(path: path) ? .cmuxBrowser : .unhandled
+            case .preferredEditor:
+                return .preferredEditor
+            case .systemDefault:
+                return .systemDefault
+            }
+        }
+
+        if CmdClickMarkdownRouteSettings.shouldRoute(path: path, defaults: defaults) {
+            return .markdownViewer
+        }
+        if CmdClickSupportedFileRouteSettings.shouldRoute(path: path, defaults: defaults) {
+            return .cmuxPreview
+        }
+        return .unhandled
     }
 
     @MainActor
@@ -13,15 +129,54 @@ enum CommandClickFileOpenRouter {
         sourcePanelId: UUID,
         filePath: String
     ) -> Bool {
-        if CmdClickMarkdownRouteSettings.shouldRoute(path: filePath),
-           workspace.openOrFocusMarkdownSplit(from: sourcePanelId, filePath: filePath) != nil {
-            return true
-        }
-
-        guard CmdClickSupportedFileRouteSettings.shouldRoute(path: filePath) else {
+        switch action(for: filePath, defaults: .standard) {
+        case .markdownViewer:
+            return workspace.openOrFocusMarkdownSplit(from: sourcePanelId, filePath: filePath) != nil
+        case .cmuxPreview:
+            return workspace.openOrFocusFilePreviewSplit(from: sourcePanelId, filePath: filePath) != nil
+        case .cmuxBrowser:
+            return workspace.openOrFocusBrowserSplit(from: sourcePanelId, url: URL(fileURLWithPath: filePath)) != nil
+        case .preferredEditor, .systemDefault, .unhandled:
             return false
         }
-        return workspace.openOrFocusFilePreviewSplit(from: sourcePanelId, filePath: filePath) != nil
+    }
+
+    @MainActor
+    static func openCommandClickFile(
+        workspace: Workspace,
+        sourcePanelId: UUID,
+        filePath: String,
+        fallback: Fallback
+    ) -> Bool {
+        let fileURL = URL(fileURLWithPath: filePath)
+        switch action(for: filePath, defaults: .standard) {
+        case .markdownViewer:
+            if workspace.openOrFocusMarkdownSplit(from: sourcePanelId, filePath: filePath) != nil {
+                return true
+            }
+            fallback.open(fileURL)
+            return true
+        case .cmuxPreview:
+            if workspace.openOrFocusFilePreviewSplit(from: sourcePanelId, filePath: filePath) != nil {
+                return true
+            }
+            fallback.open(fileURL)
+            return true
+        case .cmuxBrowser:
+            if workspace.openOrFocusBrowserSplit(from: sourcePanelId, url: fileURL) != nil {
+                return true
+            }
+            fallback.open(fileURL)
+            return true
+        case .preferredEditor:
+            PreferredEditorSettings.open(fileURL)
+            return true
+        case .systemDefault:
+            NSWorkspace.shared.open(fileURL)
+            return true
+        case .unhandled:
+            return false
+        }
     }
 
     /// Resolve the working directory for a terminal surface, preferring the
@@ -85,6 +240,35 @@ enum CommandClickFileOpenRouter {
                 return
             }
             fallback?()
+        }
+    }
+
+    @MainActor
+    static func deferredOpenCommandClickFile(
+        workspace: Workspace,
+        preferredWorkspaceId: UUID,
+        surfaceId: UUID,
+        filePath: String,
+        fallback: Fallback
+    ) {
+        DispatchQueue.main.async {
+            let resolvedWorkspace = AppDelegate.shared?.workspaceContainingPanel(
+                panelId: surfaceId,
+                preferredWorkspaceId: preferredWorkspaceId
+            )?.workspace ?? workspace
+            guard !resolvedWorkspace.isRemoteTerminalSurface(surfaceId) else {
+                fallback.open(URL(fileURLWithPath: filePath))
+                return
+            }
+            guard openCommandClickFile(
+                workspace: resolvedWorkspace,
+                sourcePanelId: surfaceId,
+                filePath: filePath,
+                fallback: fallback
+            ) else {
+                fallback.open(URL(fileURLWithPath: filePath))
+                return
+            }
         }
     }
 }

--- a/Sources/CommandClickFileOpenRouter.swift
+++ b/Sources/CommandClickFileOpenRouter.swift
@@ -2,54 +2,6 @@ import AppKit
 import CmuxSettings
 import Foundation
 
-enum FileExtensionOpenBehaviorSettings {
-    static let key = "fileExtensionOpeners"
-    static let didChangeNotification = Notification.Name("cmux.fileExtensionOpenersDidChange")
-    static let defaultValue = FileExtensionOpenBehavior.defaultOpeners
-
-    static func openers(defaults: UserDefaults = .standard) -> [String: FileExtensionOpenBehavior] {
-        guard defaults.object(forKey: key) != nil else { return defaultValue }
-        guard let stored = defaults.dictionary(forKey: key) else { return defaultValue }
-
-        var result: [String: FileExtensionOpenBehavior] = [:]
-        for (rawExtension, rawBehavior) in stored {
-            guard let normalizedExtension = FileExtensionOpenBehavior.normalizedExtension(rawExtension),
-                  let rawBehavior = rawBehavior as? String,
-                  let behavior = FileExtensionOpenBehavior(rawValue: rawBehavior) else {
-                continue
-            }
-            result[normalizedExtension] = behavior
-        }
-        return result
-    }
-
-    static func behavior(forPath path: String, defaults: UserDefaults = .standard) -> FileExtensionOpenBehavior? {
-        let ext = (path as NSString).pathExtension
-        guard let normalizedExtension = FileExtensionOpenBehavior.normalizedExtension(ext) else {
-            return nil
-        }
-        return openers(defaults: defaults)[normalizedExtension]
-    }
-
-    static func setOpeners(
-        _ openers: [String: FileExtensionOpenBehavior],
-        defaults: UserDefaults = .standard,
-        notificationCenter: NotificationCenter = .default
-    ) {
-        var normalized: [String: String] = [:]
-        for (rawExtension, behavior) in openers {
-            guard let normalizedExtension = FileExtensionOpenBehavior.normalizedExtension(rawExtension) else { continue }
-            normalized[normalizedExtension] = behavior.rawValue
-        }
-        defaults.set(normalized, forKey: key)
-        notifyDidChange(notificationCenter: notificationCenter)
-    }
-
-    static func notifyDidChange(notificationCenter: NotificationCenter = .default) {
-        notificationCenter.post(name: didChangeNotification, object: nil)
-    }
-}
-
 enum CommandClickFileOpenRouter {
     enum Fallback {
         case preferredEditor

--- a/Sources/CommandClickFileOpenRouter.swift
+++ b/Sources/CommandClickFileOpenRouter.swift
@@ -195,6 +195,11 @@ enum CommandClickFileOpenRouter {
         }
     }
 
+    /// Defers command-click routing until Ghostty's mouse callback has unwound.
+    ///
+    /// This mirrors `deferredOpenFileInCmux`, but routes through the full
+    /// extension-aware action model and falls back through `fallback` when cmux
+    /// does not handle the file.
     @MainActor
     static func deferredOpenCommandClickFile(
         workspace: Workspace,
@@ -203,7 +208,7 @@ enum CommandClickFileOpenRouter {
         filePath: String,
         fallback: Fallback
     ) {
-        DispatchQueue.main.async {
+        Task { @MainActor in
             let resolvedWorkspace = AppDelegate.shared?.workspaceContainingPanel(
                 panelId: surfaceId,
                 preferredWorkspaceId: preferredWorkspaceId

--- a/Sources/CommandClickFileOpenRouter.swift
+++ b/Sources/CommandClickFileOpenRouter.swift
@@ -76,24 +76,6 @@ enum CommandClickFileOpenRouter {
     }
 
     @MainActor
-    static func openInCmux(
-        workspace: Workspace,
-        sourcePanelId: UUID,
-        filePath: String
-    ) -> Bool {
-        switch action(for: filePath, defaults: .standard) {
-        case .markdownViewer:
-            return workspace.openOrFocusMarkdownSplit(from: sourcePanelId, filePath: filePath) != nil
-        case .cmuxPreview:
-            return workspace.openOrFocusFilePreviewSplit(from: sourcePanelId, filePath: filePath) != nil
-        case .cmuxBrowser:
-            return workspace.openOrFocusBrowserSplit(from: sourcePanelId, url: URL(fileURLWithPath: filePath)) != nil
-        case .preferredEditor, .systemDefault, .unhandled:
-            return false
-        }
-    }
-
-    @MainActor
     static func openCommandClickFile(
         workspace: Workspace,
         sourcePanelId: UUID,
@@ -155,51 +137,12 @@ enum CommandClickFileOpenRouter {
         return dir.isEmpty ? nil : dir
     }
 
-    /// Schedule a file open in cmux, deferred to the next runloop tick.
-    ///
-    /// Ghostty's `Surface.openUrl` holds an internal `os_unfair_lock` when it
-    /// dispatches into Swift; opening a new panel synchronously re-enters
-    /// Ghostty and deadlocks (#3370). This helper defers the split creation
-    /// via `DispatchQueue.main.async` and re-validates the workspace and path
-    /// at dispatch time (TOCTOU). When routing fails, `fallback` is called so
-    /// the caller can open the file externally.
-    @MainActor
-    static func deferredOpenFileInCmux(
-        workspace: Workspace,
-        preferredWorkspaceId: UUID,
-        surfaceId: UUID,
-        filePath: String,
-        fallback: (@MainActor @Sendable () -> Void)? = nil
-    ) {
-        DispatchQueue.main.async {
-            let resolvedWorkspace = AppDelegate.shared?.workspaceContainingPanel(
-                panelId: surfaceId,
-                preferredWorkspaceId: preferredWorkspaceId
-            )?.workspace ?? workspace
-            guard !resolvedWorkspace.isRemoteTerminalSurface(surfaceId) else {
-                fallback?()
-                return
-            }
-            guard shouldRouteInCmux(path: filePath) else {
-                fallback?()
-                return
-            }
-            if openInCmux(
-                workspace: resolvedWorkspace,
-                sourcePanelId: surfaceId,
-                filePath: filePath
-            ) {
-                return
-            }
-            fallback?()
-        }
-    }
-
     /// Defers command-click routing until Ghostty's mouse callback has unwound.
     ///
-    /// This mirrors `deferredOpenFileInCmux`, but routes through the full
-    /// extension-aware action model and falls back through `fallback` when cmux
-    /// does not handle the file.
+    /// Ghostty's `Surface.openUrl` holds an internal lock when it dispatches into
+    /// Swift; opening a new panel synchronously re-enters Ghostty and can
+    /// deadlock. The deferred task re-validates the workspace and falls back
+    /// externally when cmux does not handle the file.
     @MainActor
     static func deferredOpenCommandClickFile(
         workspace: Workspace,

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -4805,12 +4805,10 @@ class GhosttyApp {
                 return false
             }
             // Route local file URLs into cmux when the file-routing toggle is on.
-            // URL fragments/queries are stripped (the panel only needs the file
-            // path), so links emitted by tools like Claude Code (`foo.md#L42`)
-            // still route into the viewer. Anything else (toggle off, hosted
-            // file URL, remote workspace, unreadable file, split creation
-            // failure) falls through to the existing NSWorkspace path below so
-            // URL semantics are preserved.
+            // The file panel receives the path, while browser-routed extensions
+            // keep the original file URL so fragments and queries survive.
+            // Anything else falls through to the existing NSWorkspace path below
+            // so URL semantics are preserved.
             let fileURLHost = target.url.host
             if target.url.isFileURL,
                fileURLHost == nil || fileURLHost?.isEmpty == true || fileURLHost == "localhost" {
@@ -4827,6 +4825,7 @@ class GhosttyApp {
                         preferredWorkspaceId: workspace.id,
                         surfaceId: termSurface.id,
                         filePath: fileURL.path,
+                        fileURL: fileURL,
                         fallback: .systemDefault
                     )
                     return true

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -4775,21 +4775,19 @@ class GhosttyApp {
                     guard let resolvedPath = cmuxResolveTerminalOpenURLFilePath(trimmedUrlString, cwd: cwd) else {
                         return (false, nil)
                     }
-                    guard CommandClickFileOpenRouter.shouldRouteInCmux(path: resolvedPath) else {
+                    guard CommandClickFileOpenRouter.shouldHandleCommandClick(path: resolvedPath) else {
                         return (false, resolvedPath)
                     }
                     #if DEBUG
                     cmuxDebugLog("link.openURL resolvedAsFilePath=\(resolvedPath)")
                     #endif
-                    let fileURL = URL(fileURLWithPath: resolvedPath)
-                    CommandClickFileOpenRouter.deferredOpenFileInCmux(
+                    CommandClickFileOpenRouter.deferredOpenCommandClickFile(
                         workspace: workspace,
                         preferredWorkspaceId: workspace.id,
                         surfaceId: termSurface.id,
-                        filePath: resolvedPath
-                    ) {
-                        NSWorkspace.shared.open(fileURL)
-                    }
+                        filePath: resolvedPath,
+                        fallback: .systemDefault
+                    )
                     return (true, resolvedPath)
                 }
                 if let fallbackPath = filePathResolution.fallbackPath {
@@ -4821,17 +4819,16 @@ class GhosttyApp {
                     guard let termSurface = surfaceView.terminalSurface,
                           let workspace = termSurface.owningWorkspace(),
                           !workspace.isRemoteTerminalSurface(termSurface.id),
-                          CommandClickFileOpenRouter.shouldRouteInCmux(path: fileURL.path) else {
+                          CommandClickFileOpenRouter.shouldHandleCommandClick(path: fileURL.path) else {
                         return false
                     }
-                    CommandClickFileOpenRouter.deferredOpenFileInCmux(
+                    CommandClickFileOpenRouter.deferredOpenCommandClickFile(
                         workspace: workspace,
                         preferredWorkspaceId: workspace.id,
                         surfaceId: termSurface.id,
-                        filePath: fileURL.path
-                    ) {
-                        NSWorkspace.shared.open(fileURL)
-                    }
+                        filePath: fileURL.path,
+                        fallback: .systemDefault
+                    )
                     return true
                 }
                 if routed {
@@ -10236,10 +10233,11 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         if let termSurface = terminalSurface,
            let workspace = termSurface.owningWorkspace(),
            !workspace.isRemoteTerminalSurface(termSurface.id),
-           CommandClickFileOpenRouter.openInCmux(
+           CommandClickFileOpenRouter.openCommandClickFile(
                workspace: workspace,
                sourcePanelId: termSurface.id,
-               filePath: resolution.path
+               filePath: resolution.path,
+               fallback: .preferredEditor
            ) {
             return resolution
         }

--- a/Sources/KeyboardShortcutSettingsFileStore+Template.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore+Template.swift
@@ -1,3 +1,4 @@
+import CmuxSettings
 import Foundation
 
 extension CmuxSettingsFileStore {
@@ -67,6 +68,7 @@ extension CmuxSettingsFileStore {
                     "keepWorkspaceOpenWhenClosingLastSurface": !LastSurfaceCloseShortcutSettings.defaultValue,
                     "focusPaneOnFirstClick": PaneFirstClickFocusSettings.defaultEnabled,
                     "preferredEditor": "",
+                    "fileExtensionOpeners": FileExtensionOpenBehaviorSettings.defaultValue.mapValues(\.rawValue),
                     "openSupportedFilesInCmux": CmdClickSupportedFileRouteSettings.defaultValue,
                     "openMarkdownInCmuxViewer": CmdClickMarkdownRouteSettings.defaultValue,
                     "reorderOnNotification": WorkspaceAutoReorderSettings.defaultValue,

--- a/Sources/KeyboardShortcutSettingsFileStore.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore.swift
@@ -439,7 +439,7 @@ final class CmuxSettingsFileStore {
                 guard let normalizedExtension = FileExtensionOpenBehavior.normalizedExtension(rawExtension),
                       let behavior = FileExtensionOpenBehavior(rawValue: rawBehavior) else {
                     logInvalid("app.fileExtensionOpeners", sourcePath: sourcePath)
-                    return
+                    continue
                 }
                 normalized[normalizedExtension] = behavior.rawValue
             }

--- a/Sources/KeyboardShortcutSettingsFileStore.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore.swift
@@ -1,4 +1,5 @@
 import Combine
+import CmuxSettings
 import Foundation
 import os
 
@@ -431,6 +432,20 @@ final class CmuxSettingsFileStore {
         }
         if let value = jsonString(section["preferredEditor"]) {
             snapshot.managedUserDefaults[PreferredEditorSettings.key] = .string(value)
+        }
+        if let values = jsonStringDictionary(section["fileExtensionOpeners"]) {
+            var normalized: [String: String] = [:]
+            for (rawExtension, rawBehavior) in values {
+                guard let normalizedExtension = FileExtensionOpenBehavior.normalizedExtension(rawExtension),
+                      let behavior = FileExtensionOpenBehavior(rawValue: rawBehavior) else {
+                    logInvalid("app.fileExtensionOpeners", sourcePath: sourcePath)
+                    return
+                }
+                normalized[normalizedExtension] = behavior.rawValue
+            }
+            snapshot.managedUserDefaults[FileExtensionOpenBehaviorSettings.key] = .stringDictionary(normalized)
+        } else if section.keys.contains("fileExtensionOpeners") {
+            logInvalid("app.fileExtensionOpeners", sourcePath: sourcePath)
         }
         if let value = jsonBool(section["openSupportedFilesInCmux"]) {
             snapshot.managedUserDefaults[CmdClickSupportedFileRouteSettings.key] = .bool(value)
@@ -1607,6 +1622,17 @@ final class CmuxSettingsFileStore {
         for value in values {
             guard let string = value as? String else { return nil }
             strings.append(string)
+        }
+        return strings
+    }
+
+    private func jsonStringDictionary(_ rawValue: Any?) -> [String: String]? {
+        guard let values = rawValue as? [String: Any] else { return nil }
+        var strings: [String: String] = [:]
+        strings.reserveCapacity(values.count)
+        for (key, value) in values {
+            guard let string = value as? String else { return nil }
+            strings[key] = string
         }
         return strings
     }

--- a/Sources/KeyboardShortcutSettingsFileStore.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore.swift
@@ -433,9 +433,13 @@ final class CmuxSettingsFileStore {
         if let value = jsonString(section["preferredEditor"]) {
             snapshot.managedUserDefaults[PreferredEditorSettings.key] = .string(value)
         }
-        if let values = jsonStringDictionary(section["fileExtensionOpeners"]) {
+        if let values = section["fileExtensionOpeners"] as? [String: Any] {
             var normalized: [String: String] = [:]
-            for (rawExtension, rawBehavior) in values {
+            for (rawExtension, rawBehaviorValue) in values {
+                guard let rawBehavior = rawBehaviorValue as? String else {
+                    logInvalid("app.fileExtensionOpeners", sourcePath: sourcePath)
+                    continue
+                }
                 guard let normalizedExtension = FileExtensionOpenBehavior.normalizedExtension(rawExtension),
                       let behavior = FileExtensionOpenBehavior(rawValue: rawBehavior) else {
                     logInvalid("app.fileExtensionOpeners", sourcePath: sourcePath)
@@ -1622,17 +1626,6 @@ final class CmuxSettingsFileStore {
         for value in values {
             guard let string = value as? String else { return nil }
             strings.append(string)
-        }
-        return strings
-    }
-
-    private func jsonStringDictionary(_ rawValue: Any?) -> [String: String]? {
-        guard let values = rawValue as? [String: Any] else { return nil }
-        var strings: [String: String] = [:]
-        strings.reserveCapacity(values.count)
-        for (key, value) in values {
-            guard let string = value as? String else { return nil }
-            strings[key] = string
         }
         return strings
     }

--- a/Sources/SettingsNavigation.swift
+++ b/Sources/SettingsNavigation.swift
@@ -1,5 +1,6 @@
 import CmuxSettings
 import CmuxSettingsUI
+import Foundation
 import SwiftUI
 
 enum SettingsNavigationTarget: String, CaseIterable, Identifiable {
@@ -141,6 +142,9 @@ struct FileExtensionOpenersSettingsCard: View {
             )
         )
         .onReceive(NotificationCenter.default.publisher(for: FileExtensionOpenBehaviorSettings.didChangeNotification)) { _ in
+            openers = FileExtensionOpenBehaviorSettings.openers()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: UserDefaults.didChangeNotification)) { _ in
             openers = FileExtensionOpenBehaviorSettings.openers()
         }
     }

--- a/Sources/SettingsNavigation.swift
+++ b/Sources/SettingsNavigation.swift
@@ -1,3 +1,4 @@
+import CmuxSettingsUI
 import SwiftUI
 
 enum SettingsNavigationTarget: String, CaseIterable, Identifiable {
@@ -89,7 +90,7 @@ enum SettingsNavigationTarget: String, CaseIterable, Identifiable {
         case .account:
             return "\(title) sign in team sync"
         case .app:
-            return "\(title) appearance language workspace notifications menu bar telemetry default terminal"
+            return "\(title) appearance language workspace notifications menu bar telemetry default terminal file extensions"
         case .terminal:
             return "\(title) scrollbar auto resume restore reopen relaunch quit sessions agents claude codex opencode rovodev hibernation idle suspend commands approvals prefixes toggle"
         case .textBox:
@@ -114,6 +115,25 @@ enum SettingsNavigationTarget: String, CaseIterable, Identifiable {
             return "\(title) config file preferences editor documentation schema jsonc reload"
         case .reset:
             return "\(title) defaults"
+        }
+    }
+}
+
+struct FileExtensionOpenersSettingsCard: View {
+    @State private var openers = FileExtensionOpenBehaviorSettings.openers()
+
+    var body: some View {
+        FileExtensionOpenersEditor(
+            openers: Binding(
+                get: { openers },
+                set: { newValue in
+                    openers = newValue
+                    FileExtensionOpenBehaviorSettings.setOpeners(newValue)
+                }
+            )
+        )
+        .onReceive(NotificationCenter.default.publisher(for: FileExtensionOpenBehaviorSettings.didChangeNotification)) { _ in
+            openers = FileExtensionOpenBehaviorSettings.openers()
         }
     }
 }
@@ -308,6 +328,7 @@ enum SettingsSearchIndex {
         setting(.app, "focus-pane-first-click", String(localized: "settings.app.paneFirstClickFocus", defaultValue: "Focus Pane on First Click"), "mouse click focus"),
         setting(.app, "file-drops", String(localized: "settings.app.fileDrop.defaultBehavior", defaultValue: "File Drops"), "drag drop files finder path text terminal editor split preview shift"),
         setting(.app, "preferred-editor", String(localized: "settings.app.preferredEditor", defaultValue: "Open Files With"), "editor code zed subl cmd click file"),
+        setting(.app, "file-extension-openers", String(localized: "settings.app.fileExtensionOpeners", defaultValue: "File Extension Openers"), "cmd click html htm browser preview markdown system default editor extension opener"),
         setting(.app, "supported-file-previews", String(localized: "settings.app.openSupportedFilesInCmux", defaultValue: "Open Supported Files in cmux"), "cmd click file preview pdf image audio video quick look editor"),
         setting(.app, "terminal-config", String(localized: "settings.app.configWindow", defaultValue: "Terminal Config"), "ghostty config merged preview"),
         setting(.app, "markdown-viewer", String(localized: "settings.app.openMarkdownInCmuxViewer", defaultValue: "Open Markdown in cmux Viewer"), "md markdown viewer"),
@@ -427,6 +448,7 @@ enum SettingsSearchIndex {
         "fileDrop.defaultBehavior": settingID(for: .app, idSuffix: "file-drops"),
         "app.fileDropDefaultBehavior": settingID(for: .app, idSuffix: "file-drops"),
         "app.preferredEditor": settingID(for: .app, idSuffix: "preferred-editor"),
+        "app.fileExtensionOpeners": settingID(for: .app, idSuffix: "file-extension-openers"),
         "app.openSupportedFilesInCmux": settingID(for: .app, idSuffix: "supported-file-previews"),
         "app.openMarkdownInCmuxViewer": settingID(for: .app, idSuffix: "markdown-viewer"),
         "app.iMessageMode": settingID(for: .app, idSuffix: "imessage-mode"),

--- a/Sources/SettingsNavigation.swift
+++ b/Sources/SettingsNavigation.swift
@@ -129,7 +129,7 @@ enum SettingsNavigationTarget: String, CaseIterable, Identifiable {
 }
 
 struct FileExtensionOpenersSettingsCard: View {
-    @State private var openers = FileExtensionOpenBehaviorSettings.openers()
+    @State private var openers = FileExtensionOpenBehaviorSettings.openers(defaults: .standard)
 
     var body: some View {
         FileExtensionOpenersEditor(
@@ -137,15 +137,19 @@ struct FileExtensionOpenersSettingsCard: View {
                 get: { openers },
                 set: { newValue in
                     openers = newValue
-                    FileExtensionOpenBehaviorSettings.setOpeners(newValue)
+                    FileExtensionOpenBehaviorSettings.setOpeners(
+                        newValue,
+                        defaults: .standard,
+                        notificationCenter: .default
+                    )
                 }
             )
         )
         .onReceive(NotificationCenter.default.publisher(for: FileExtensionOpenBehaviorSettings.didChangeNotification)) { _ in
-            openers = FileExtensionOpenBehaviorSettings.openers()
+            openers = FileExtensionOpenBehaviorSettings.openers(defaults: .standard)
         }
         .onReceive(NotificationCenter.default.publisher(for: UserDefaults.didChangeNotification)) { _ in
-            openers = FileExtensionOpenBehaviorSettings.openers()
+            openers = FileExtensionOpenBehaviorSettings.openers(defaults: .standard)
         }
     }
 }

--- a/Sources/SettingsNavigation.swift
+++ b/Sources/SettingsNavigation.swift
@@ -1,9 +1,11 @@
+import CmuxSettings
 import CmuxSettingsUI
 import SwiftUI
 
 enum SettingsNavigationTarget: String, CaseIterable, Identifiable {
     case account
     case app
+    case fileOpening
     case terminal
     case textBox
     case sidebarAppearance
@@ -25,6 +27,8 @@ enum SettingsNavigationTarget: String, CaseIterable, Identifiable {
             return String(localized: "settings.section.account", defaultValue: "Account")
         case .app:
             return String(localized: "settings.section.app", defaultValue: "App")
+        case .fileOpening:
+            return String(localized: "settings.section.fileOpening", defaultValue: "File Opening")
         case .terminal:
             return String(localized: "settings.section.terminal", defaultValue: "Terminal")
         case .textBox:
@@ -58,6 +62,8 @@ enum SettingsNavigationTarget: String, CaseIterable, Identifiable {
             return "person.crop.circle"
         case .app:
             return "gearshape"
+        case .fileOpening:
+            return "doc.badge.gearshape"
         case .terminal:
             return "terminal"
         case .textBox:
@@ -90,7 +96,9 @@ enum SettingsNavigationTarget: String, CaseIterable, Identifiable {
         case .account:
             return "\(title) sign in team sync"
         case .app:
-            return "\(title) appearance language workspace notifications menu bar telemetry default terminal file extensions"
+            return "\(title) appearance language workspace notifications menu bar telemetry default terminal"
+        case .fileOpening:
+            return "\(title) files paths cmd click html markdown preview editor drag drop extensions"
         case .terminal:
             return "\(title) scrollbar auto resume restore reopen relaunch quit sessions agents claude codex opencode rovodev hibernation idle suspend commands approvals prefixes toggle"
         case .textBox:
@@ -326,12 +334,7 @@ enum SettingsSearchIndex {
         setting(.app, "minimal-mode", String(localized: "settings.app.minimalMode", defaultValue: "Minimal Mode"), "presentation compact chrome"),
         setting(.app, "keep-workspace-open", String(localized: "settings.app.closeWorkspaceOnLastSurfaceShortcut", defaultValue: "Keep Workspace Open When Closing Last Surface"), "close last surface shortcut"),
         setting(.app, "focus-pane-first-click", String(localized: "settings.app.paneFirstClickFocus", defaultValue: "Focus Pane on First Click"), "mouse click focus"),
-        setting(.app, "file-drops", String(localized: "settings.app.fileDrop.defaultBehavior", defaultValue: "File Drops"), "drag drop files finder path text terminal editor split preview shift"),
-        setting(.app, "preferred-editor", String(localized: "settings.app.preferredEditor", defaultValue: "Open Files With"), "editor code zed subl cmd click file"),
-        setting(.app, "file-extension-openers", String(localized: "settings.app.fileExtensionOpeners", defaultValue: "File Extension Openers"), "cmd click html htm browser preview markdown system default editor extension opener"),
-        setting(.app, "supported-file-previews", String(localized: "settings.app.openSupportedFilesInCmux", defaultValue: "Open Supported Files in cmux"), "cmd click file preview pdf image audio video quick look editor"),
         setting(.app, "terminal-config", String(localized: "settings.app.configWindow", defaultValue: "Terminal Config"), "ghostty config merged preview"),
-        setting(.app, "markdown-viewer", String(localized: "settings.app.openMarkdownInCmuxViewer", defaultValue: "Open Markdown in cmux Viewer"), "md markdown viewer"),
         setting(.app, "imessage-mode", String(localized: "settings.app.iMessageMode", defaultValue: "iMessage Mode"), "message messages imessage chat prompt prompts submitted message send agent workspace reorder move top"),
         setting(.app, "reorder-notification", String(localized: "settings.app.reorderOnNotification", defaultValue: "Reorder on Notification"), "workspace notification order"),
         setting(.app, "dock-badge", String(localized: "settings.app.dockBadge", defaultValue: "Dock Badge"), "unread count app icon"),
@@ -344,6 +347,11 @@ enum SettingsSearchIndex {
         setting(.app, "notification-command", String(localized: "settings.notifications.command", defaultValue: "Notification Command"), "shell command environment variables"),
         setting(.app, "telemetry", String(localized: "settings.app.telemetry", defaultValue: "Send anonymous telemetry"), "analytics crash usage"),
         setting(.app, "default-terminal", String(localized: "settings.app.defaultTerminal", defaultValue: "Default Terminal"), "ssh links command tool unix executable launch services handler registration system default"),
+        setting(.fileOpening, "file-drops", String(localized: "settings.app.fileDrop.defaultBehavior", defaultValue: "File Drops"), "drag drop files finder path text terminal editor split preview shift"),
+        setting(.fileOpening, "preferred-editor", String(localized: "settings.app.preferredEditor", defaultValue: "Open Files With"), "editor code zed subl cmd click file"),
+        setting(.fileOpening, "file-extension-openers", String(localized: "settings.app.fileExtensionOpeners", defaultValue: "File Extension Openers"), "cmd click html htm browser preview markdown system default editor extension opener"),
+        setting(.fileOpening, "supported-file-previews", String(localized: "settings.app.openSupportedFilesInCmux", defaultValue: "Open Supported Files in cmux"), "cmd click file preview pdf image audio video quick look editor"),
+        setting(.fileOpening, "markdown-viewer", String(localized: "settings.app.openMarkdownInCmuxViewer", defaultValue: "Open Markdown in cmux Viewer"), "md markdown viewer"),
         setting(.app, "warn-before-quit", String(localized: "settings.app.warnBeforeQuit", defaultValue: "Warn Before Quit"), "cmd q confirmation confirmQuit"),
         setting(.app, "warn-before-closing-tab", String(localized: "settings.app.warnBeforeClosingTab", defaultValue: "Warn Before Closing Tab"), "cmd w close tab confirmation"),
         setting(
@@ -445,12 +453,12 @@ enum SettingsSearchIndex {
         "app.minimalMode": settingID(for: .app, idSuffix: "minimal-mode"),
         "app.keepWorkspaceOpenWhenClosingLastSurface": settingID(for: .app, idSuffix: "keep-workspace-open"),
         "app.focusPaneOnFirstClick": settingID(for: .app, idSuffix: "focus-pane-first-click"),
-        "fileDrop.defaultBehavior": settingID(for: .app, idSuffix: "file-drops"),
-        "app.fileDropDefaultBehavior": settingID(for: .app, idSuffix: "file-drops"),
-        "app.preferredEditor": settingID(for: .app, idSuffix: "preferred-editor"),
-        "app.fileExtensionOpeners": settingID(for: .app, idSuffix: "file-extension-openers"),
-        "app.openSupportedFilesInCmux": settingID(for: .app, idSuffix: "supported-file-previews"),
-        "app.openMarkdownInCmuxViewer": settingID(for: .app, idSuffix: "markdown-viewer"),
+        "fileDrop.defaultBehavior": settingID(for: .fileOpening, idSuffix: "file-drops"),
+        "app.fileDropDefaultBehavior": settingID(for: .fileOpening, idSuffix: "file-drops"),
+        "app.preferredEditor": settingID(for: .fileOpening, idSuffix: "preferred-editor"),
+        "app.fileExtensionOpeners": settingID(for: .fileOpening, idSuffix: "file-extension-openers"),
+        "app.openSupportedFilesInCmux": settingID(for: .fileOpening, idSuffix: "supported-file-previews"),
+        "app.openMarkdownInCmuxViewer": settingID(for: .fileOpening, idSuffix: "markdown-viewer"),
         "app.iMessageMode": settingID(for: .app, idSuffix: "imessage-mode"),
         "app.reorderOnNotification": settingID(for: .app, idSuffix: "reorder-notification"),
         "notifications.dockBadge": settingID(for: .app, idSuffix: "dock-badge"),

--- a/Sources/SettingsSearchAliases.swift
+++ b/Sources/SettingsSearchAliases.swift
@@ -54,6 +54,7 @@ enum SettingsSearchAliasIndex {
         "app:keep-workspace-open": localized("settings.search.alias.setting.app.keep-workspace-open", defaultValue: "app.keepWorkspaceOpenWhenClosingLastSurface close last pane surface keep tab workspace"),
         "app:focus-pane-first-click": localized("settings.search.alias.setting.app.focus-pane-first-click", defaultValue: "app.focusPaneOnFirstClick click to focus focus follows mouse first click mouse activation"),
         "app:preferred-editor": localized("settings.search.alias.setting.app.preferred-editor", defaultValue: "app.preferredEditor editor open file code vscode visual studio zed sublime subl cursor"),
+        "app:file-extension-openers": localized("settings.search.alias.setting.app.file-extension-openers", defaultValue: "app.fileExtensionOpeners cmd click html htm browser preview markdown system default editor extension opener"),
         "app:supported-file-previews": localized("settings.search.alias.setting.app.supported-file-previews", defaultValue: "app.openSupportedFilesInCmux cmd click file preview pdf image video audio quicklook quick look editor external"),
         "app:terminal-config": localized("settings.search.alias.setting.app.terminal-config", defaultValue: "ghostty config configuration terminal settings preview merged file reload"),
         "app:markdown-viewer": localized("settings.search.alias.setting.app.markdown-viewer", defaultValue: "app.openMarkdownInCmuxViewer md markdown mdx viewer preview readme"),

--- a/Sources/SettingsSearchAliases.swift
+++ b/Sources/SettingsSearchAliases.swift
@@ -5,6 +5,8 @@ enum SettingsSearchAliasIndex {
             return localized("settings.search.alias.section.account", defaultValue: "auth authentication login logout sign in sign out email user profile team")
         case .app:
             return localized("settings.search.alias.section.app", defaultValue: "general preferences prefs behavior chrome dock menubar menu bar status notifications telemetry")
+        case .fileOpening:
+            return localized("settings.search.alias.section.fileOpening", defaultValue: "files file paths open with editor preview markdown html cmd click command click drag drop extensions")
         case .terminal:
             return localized("settings.search.alias.section.terminal", defaultValue: "shell scrollback scrollbar scroll bar ghostty tty pty")
         case .textBox:
@@ -53,11 +55,7 @@ enum SettingsSearchAliasIndex {
         "app:minimal-mode": localized("settings.search.alias.setting.app.minimal-mode", defaultValue: "app.minimalMode minimal layout simple chrome compact titlebar controls"),
         "app:keep-workspace-open": localized("settings.search.alias.setting.app.keep-workspace-open", defaultValue: "app.keepWorkspaceOpenWhenClosingLastSurface close last pane surface keep tab workspace"),
         "app:focus-pane-first-click": localized("settings.search.alias.setting.app.focus-pane-first-click", defaultValue: "app.focusPaneOnFirstClick click to focus focus follows mouse first click mouse activation"),
-        "app:preferred-editor": localized("settings.search.alias.setting.app.preferred-editor", defaultValue: "app.preferredEditor editor open file code vscode visual studio zed sublime subl cursor"),
-        "app:file-extension-openers": localized("settings.search.alias.setting.app.file-extension-openers", defaultValue: "app.fileExtensionOpeners cmd click html htm browser preview markdown system default editor extension opener"),
-        "app:supported-file-previews": localized("settings.search.alias.setting.app.supported-file-previews", defaultValue: "app.openSupportedFilesInCmux cmd click file preview pdf image video audio quicklook quick look editor external"),
         "app:terminal-config": localized("settings.search.alias.setting.app.terminal-config", defaultValue: "ghostty config configuration terminal settings preview merged file reload"),
-        "app:markdown-viewer": localized("settings.search.alias.setting.app.markdown-viewer", defaultValue: "app.openMarkdownInCmuxViewer md markdown mdx viewer preview readme"),
         "app:imessage-mode": localized("settings.search.alias.setting.app.imessage-mode", defaultValue: "app.iMessageMode imessage message messages chat prompt prompts submitted message texting reorder move workspace top agent send"),
         "app:reorder-notification": localized("settings.search.alias.setting.app.reorder-notification", defaultValue: "app.reorderOnNotification notification reorder move workspace top unread sort"),
         "app:dock-badge": localized("settings.search.alias.setting.app.dock-badge", defaultValue: "notifications.dockBadge badge dock unread count icon notifications red bubble"),
@@ -81,6 +79,10 @@ enum SettingsSearchAliasIndex {
         ),
         "app:rename-selects-name": localized("settings.search.alias.setting.app.rename-selects-name", defaultValue: "app.renameSelectsExistingName rename select all existing title command palette workspace name"),
         "app:palette-search-all": localized("settings.search.alias.setting.app.palette-search-all", defaultValue: "app.commandPaletteSearchesAllSurfaces command palette search all surfaces cmd-p terminal browser markdown"),
+        "fileOpening:preferred-editor": localized("settings.search.alias.setting.app.preferred-editor", defaultValue: "app.preferredEditor editor open file code vscode visual studio zed sublime subl cursor"),
+        "fileOpening:file-extension-openers": localized("settings.search.alias.setting.app.file-extension-openers", defaultValue: "app.fileExtensionOpeners cmd click html htm browser preview markdown system default editor extension opener"),
+        "fileOpening:supported-file-previews": localized("settings.search.alias.setting.app.supported-file-previews", defaultValue: "app.openSupportedFilesInCmux cmd click file preview pdf image video audio quicklook quick look editor external"),
+        "fileOpening:markdown-viewer": localized("settings.search.alias.setting.app.markdown-viewer", defaultValue: "app.openMarkdownInCmuxViewer md markdown mdx viewer preview readme"),
         "terminal:scrollbar": localized("settings.search.alias.setting.terminal.scrollbar", defaultValue: "terminal.showScrollBar scrollback scrollbar scroll bar right edge alternate screen tui"),
         "terminal:copy-on-select": localized("settings.search.alias.setting.terminal.copy-on-select", defaultValue: "terminal.copyOnSelect copy on selection select clipboard mouse double click triple click iterm"),
         "terminal:resume-commands": localized("settings.search.alias.setting.terminal.resume-commands", defaultValue: "surface resume commands approvals command prefixes auto restore ask manual tmux hibernation sticky process"),

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -14158,6 +14158,39 @@ final class Workspace: Identifiable, ObservableObject {
     }
 
     @discardableResult
+    func openOrFocusBrowserSplit(
+        from panelId: UUID,
+        url: URL
+    ) -> BrowserPanel? {
+        guard BrowserAvailabilitySettings.isEnabled() else {
+            return nil
+        }
+
+        let targetURLString = url.standardizedFileURL.absoluteString
+        for (existingId, panel) in panels {
+            guard let browser = panel as? BrowserPanel,
+                  browser.preferredURLStringForOmnibar() == targetURLString else {
+                continue
+            }
+            focusPanel(existingId)
+            return browser
+        }
+
+        if let targetPane = preferredRightSideTargetPane(fromPanelId: panelId) {
+            return newBrowserSurface(inPane: targetPane, url: url, focus: true)
+        }
+
+        guard let sourcePaneId = paneId(forPanelId: panelId) else { return nil }
+        return newBrowserSplit(
+            from: panelId,
+            orientation: .horizontal,
+            url: url,
+            focus: true,
+            initialDividerPosition: nil
+        ) ?? newBrowserSurface(inPane: sourcePaneId, url: url, focus: true)
+    }
+
+    @discardableResult
     func newFilePreviewSurface(
         inPane paneId: PaneID,
         filePath: String,

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -5061,6 +5061,16 @@ enum CmdClickSupportedFileRouteSettings {
     }
 
     static func shouldRoute(path: String, defaults: UserDefaults = .standard) -> Bool {
+        if let behavior = FileExtensionOpenBehaviorSettings.behavior(forPath: path, defaults: defaults) {
+            switch behavior {
+            case .automatic:
+                break
+            case .cmuxPreview:
+                return isReadableRegularFile(path: path)
+            case .markdownViewer, .cmuxBrowser, .preferredEditor, .systemDefault:
+                return false
+            }
+        }
         guard isEnabled(defaults: defaults) else { return false }
         return isReadableRegularFile(path: path)
     }
@@ -6572,6 +6582,11 @@ struct SettingsView: View {
                             .textFieldStyle(.roundedBorder)
                             .frame(width: 200)
                         }
+
+                        SettingsCardDivider()
+
+                        FileExtensionOpenersSettingsCard()
+                            .settingsSearchAnchor(SettingsSearchIndex.settingID(for: .app, idSuffix: "file-extension-openers"))
 
                         SettingsCardDivider()
 
@@ -8395,6 +8410,7 @@ struct SettingsView: View {
         openSupportedFilesInCmux = CmdClickSupportedFileRouteSettings.defaultValue
         CmdClickMarkdownRouteSettings.setEnabled(CmdClickMarkdownRouteSettings.defaultValue)
         openMarkdownInCmuxViewer = CmdClickMarkdownRouteSettings.defaultValue
+        FileExtensionOpenBehaviorSettings.setOpeners(FileExtensionOpenBehaviorSettings.defaultValue)
         browserSearchEngine = BrowserSearchSettings.defaultSearchEngine.rawValue
         browserCustomSearchEngineName = BrowserSearchSettings.defaultCustomSearchEngineName
         browserCustomSearchEngineURLTemplate = BrowserSearchSettings.defaultCustomSearchEngineURLTemplate

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -6918,7 +6918,7 @@ struct SettingsView: View {
                         SettingsCardRow(
                             configurationReview: .json("app.preferredEditor"),
                             String(localized: "settings.app.preferredEditor", defaultValue: "Open Files With"),
-                            subtitle: String(localized: "settings.app.preferredEditor.subtitle", defaultValue: "Command used when Cmd-click file previews are disabled or a file is unsupported. Leave empty for system default.")
+                            subtitle: String(localized: "settings.app.preferredEditor.subtitle", defaultValue: "Command used when an extension is set to Preferred Editor, or when Cmd-click file previews are disabled or a file is unsupported. Leave empty for system default.")
                         ) {
                             TextField(
                                 String(localized: "settings.app.preferredEditor.placeholder", defaultValue: "e.g. code, zed, subl"),
@@ -8412,7 +8412,11 @@ struct SettingsView: View {
         openSupportedFilesInCmux = CmdClickSupportedFileRouteSettings.defaultValue
         CmdClickMarkdownRouteSettings.setEnabled(CmdClickMarkdownRouteSettings.defaultValue)
         openMarkdownInCmuxViewer = CmdClickMarkdownRouteSettings.defaultValue
-        FileExtensionOpenBehaviorSettings.setOpeners(FileExtensionOpenBehaviorSettings.defaultValue)
+        FileExtensionOpenBehaviorSettings.setOpeners(
+            FileExtensionOpenBehaviorSettings.defaultValue,
+            defaults: .standard,
+            notificationCenter: .default
+        )
         browserSearchEngine = BrowserSearchSettings.defaultSearchEngine.rawValue
         browserCustomSearchEngineName = BrowserSearchSettings.defaultCustomSearchEngineName
         browserCustomSearchEngineURLTemplate = BrowserSearchSettings.defaultCustomSearchEngineURLTemplate

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -5061,9 +5061,14 @@ enum CmdClickSupportedFileRouteSettings {
     }
 
     static func shouldRoute(path: String, defaults: UserDefaults = .standard) -> Bool {
+        let normalizedExtension = FileExtensionOpenBehavior.normalizedExtension((path as NSString).pathExtension)
         if let behavior = FileExtensionOpenBehaviorSettings.behavior(forPath: path, defaults: defaults) {
             switch behavior {
             case .automatic:
+                if let normalizedExtension,
+                   FileExtensionOpenBehavior.defaultOpeners[normalizedExtension] != nil {
+                    return false
+                }
                 break
             case .cmuxPreview:
                 return isReadableRegularFile(path: path)

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -6555,56 +6555,6 @@ struct SettingsView: View {
 
                         SettingsCardDivider()
 
-                        SettingsPickerRow(
-                            configurationReview: .settingsOnly,
-                            String(localized: "settings.app.fileDrop.defaultBehavior", defaultValue: "File Drops"),
-                            subtitle: selectedFileDropDefaultBehavior.settingsSubtitle,
-                            controlWidth: pickerColumnWidth,
-                            selection: fileDropDefaultBehaviorSelection
-                        ) {
-                            ForEach(FileDropDefaultBehavior.allCases) { behavior in
-                                Text(behavior.displayName).tag(behavior.rawValue)
-                            }
-                        }
-                        .settingsSearchAnchor(SettingsSearchIndex.settingID(for: .app, idSuffix: "file-drops"))
-
-                        SettingsCardDivider()
-
-                        SettingsCardRow(
-                            configurationReview: .json("app.preferredEditor"),
-                            String(localized: "settings.app.preferredEditor", defaultValue: "Open Files With"),
-                            subtitle: String(localized: "settings.app.preferredEditor.subtitle", defaultValue: "Command used when Cmd-click file previews are disabled or a file is unsupported. Leave empty for system default.")
-                        ) {
-                            TextField(
-                                String(localized: "settings.app.preferredEditor.placeholder", defaultValue: "e.g. code, zed, subl"),
-                                text: $preferredEditorCommand
-                            )
-                            .textFieldStyle(.roundedBorder)
-                            .frame(width: 200)
-                        }
-
-                        SettingsCardDivider()
-
-                        FileExtensionOpenersSettingsCard()
-                            .settingsSearchAnchor(SettingsSearchIndex.settingID(for: .app, idSuffix: "file-extension-openers"))
-
-                        SettingsCardDivider()
-
-                        SettingsCardRow(
-                            configurationReview: .json("app.openSupportedFilesInCmux"),
-                            String(localized: "settings.app.openSupportedFilesInCmux", defaultValue: "Open Supported Files in cmux"),
-                            subtitle: String(localized: "settings.app.openSupportedFilesInCmux.subtitle", defaultValue: "Cmd-clicking readable files opens text, code, PDFs, images, audio, video, and Quick Look previews in cmux.")
-                        ) {
-                            Toggle("", isOn: supportedFileRoutingBinding)
-                                .labelsHidden()
-                                .controlSize(.small)
-                                .accessibilityLabel(
-                                    String(localized: "settings.app.openSupportedFilesInCmux", defaultValue: "Open Supported Files in cmux")
-                                )
-                        }
-
-                        SettingsCardDivider()
-
                         SettingsCardRow(
                             configurationReview: .action,
                             String(localized: "settings.app.configWindow", defaultValue: "Terminal Config"),
@@ -6623,21 +6573,6 @@ struct SettingsView: View {
                             }
                             .buttonStyle(.bordered)
                             .controlSize(.small)
-                        }
-
-                        SettingsCardDivider()
-
-                        SettingsCardRow(
-                            configurationReview: .json("app.openMarkdownInCmuxViewer"),
-                            String(localized: "settings.app.openMarkdownInCmuxViewer", defaultValue: "Open Markdown in cmux Viewer"),
-                            subtitle: String(localized: "settings.app.openMarkdownInCmuxViewer.subtitle", defaultValue: "Cmd-clicking Markdown files opens the rendered cmux markdown viewer instead of the generic file preview.")
-                        ) {
-                            Toggle("", isOn: markdownRoutingBinding)
-                                .labelsHidden()
-                                .controlSize(.small)
-                                .accessibilityLabel(
-                                    String(localized: "settings.app.openMarkdownInCmuxViewer", defaultValue: "Open Markdown in cmux Viewer")
-                                )
                         }
 
                         SettingsCardDivider()
@@ -6960,6 +6895,73 @@ struct SettingsView: View {
                                 )
                         }
 
+                    }
+
+                    SettingsSectionHeader(title: String(localized: "settings.section.fileOpening", defaultValue: "File Opening"))
+                        .settingsSearchAnchor(SettingsSearchIndex.sectionID(for: .fileOpening))
+                    SettingsCard {
+                        SettingsPickerRow(
+                            configurationReview: .settingsOnly,
+                            String(localized: "settings.app.fileDrop.defaultBehavior", defaultValue: "File Drops"),
+                            subtitle: selectedFileDropDefaultBehavior.settingsSubtitle,
+                            controlWidth: pickerColumnWidth,
+                            selection: fileDropDefaultBehaviorSelection
+                        ) {
+                            ForEach(FileDropDefaultBehavior.allCases) { behavior in
+                                Text(behavior.displayName).tag(behavior.rawValue)
+                            }
+                        }
+                        .settingsSearchAnchor(SettingsSearchIndex.settingID(for: .fileOpening, idSuffix: "file-drops"))
+
+                        SettingsCardDivider()
+
+                        SettingsCardRow(
+                            configurationReview: .json("app.preferredEditor"),
+                            String(localized: "settings.app.preferredEditor", defaultValue: "Open Files With"),
+                            subtitle: String(localized: "settings.app.preferredEditor.subtitle", defaultValue: "Command used when Cmd-click file previews are disabled or a file is unsupported. Leave empty for system default.")
+                        ) {
+                            TextField(
+                                String(localized: "settings.app.preferredEditor.placeholder", defaultValue: "e.g. code, zed, subl"),
+                                text: $preferredEditorCommand
+                            )
+                            .textFieldStyle(.roundedBorder)
+                            .frame(width: 200)
+                        }
+
+                        SettingsCardDivider()
+
+                        FileExtensionOpenersSettingsCard()
+                            .settingsSearchAnchor(SettingsSearchIndex.settingID(for: .fileOpening, idSuffix: "file-extension-openers"))
+
+                        SettingsCardDivider()
+
+                        SettingsCardRow(
+                            configurationReview: .json("app.openSupportedFilesInCmux"),
+                            String(localized: "settings.app.openSupportedFilesInCmux", defaultValue: "Open Supported Files in cmux"),
+                            subtitle: String(localized: "settings.app.openSupportedFilesInCmux.subtitle", defaultValue: "Cmd-clicking readable files opens text, code, PDFs, images, audio, video, and Quick Look previews in cmux.")
+                        ) {
+                            Toggle("", isOn: supportedFileRoutingBinding)
+                                .labelsHidden()
+                                .controlSize(.small)
+                                .accessibilityLabel(
+                                    String(localized: "settings.app.openSupportedFilesInCmux", defaultValue: "Open Supported Files in cmux")
+                                )
+                        }
+
+                        SettingsCardDivider()
+
+                        SettingsCardRow(
+                            configurationReview: .json("app.openMarkdownInCmuxViewer"),
+                            String(localized: "settings.app.openMarkdownInCmuxViewer", defaultValue: "Open Markdown in cmux Viewer"),
+                            subtitle: String(localized: "settings.app.openMarkdownInCmuxViewer.subtitle", defaultValue: "Cmd-clicking Markdown files opens the rendered cmux markdown viewer instead of the generic file preview.")
+                        ) {
+                            Toggle("", isOn: markdownRoutingBinding)
+                                .labelsHidden()
+                                .controlSize(.small)
+                                .accessibilityLabel(
+                                    String(localized: "settings.app.openMarkdownInCmuxViewer", defaultValue: "Open Markdown in cmux Viewer")
+                                )
+                        }
                     }
 
                     SettingsSectionHeader(title: String(localized: "settings.section.terminal", defaultValue: "Terminal"))

--- a/cmuxTests/WindowAndDragTests.swift
+++ b/cmuxTests/WindowAndDragTests.swift
@@ -3289,7 +3289,11 @@ final class FilePreviewPanelTextSavingTests: XCTestCase {
         let fileURL = try temporaryTextFile(contents: "<!doctype html>", encoding: .utf8, pathExtension: "html")
         defer { try? FileManager.default.removeItem(at: fileURL) }
 
-        FileExtensionOpenBehaviorSettings.setOpeners(["html": .cmuxPreview], defaults: defaults)
+        FileExtensionOpenBehaviorSettings.setOpeners(
+            ["html": .cmuxPreview],
+            defaults: defaults,
+            notificationCenter: .default
+        )
 
         XCTAssertEqual(FileExtensionOpenBehaviorSettings.behavior(forPath: fileURL.path, defaults: defaults), .cmuxPreview)
         XCTAssertTrue(CmdClickSupportedFileRouteSettings.shouldRoute(path: fileURL.path, defaults: defaults))
@@ -3304,7 +3308,11 @@ final class FilePreviewPanelTextSavingTests: XCTestCase {
         let fileURL = try temporaryTextFile(contents: "notes", encoding: .utf8, pathExtension: "txt")
         defer { try? FileManager.default.removeItem(at: fileURL) }
 
-        FileExtensionOpenBehaviorSettings.setOpeners(["txt": .preferredEditor], defaults: defaults)
+        FileExtensionOpenBehaviorSettings.setOpeners(
+            ["txt": .preferredEditor],
+            defaults: defaults,
+            notificationCenter: .default
+        )
 
         XCTAssertFalse(CommandClickFileOpenRouter.shouldRouteInCmux(path: fileURL.path, defaults: defaults))
         XCTAssertTrue(CommandClickFileOpenRouter.shouldHandleCommandClick(path: fileURL.path, defaults: defaults))

--- a/cmuxTests/WindowAndDragTests.swift
+++ b/cmuxTests/WindowAndDragTests.swift
@@ -3318,6 +3318,74 @@ final class FilePreviewPanelTextSavingTests: XCTestCase {
         XCTAssertTrue(CommandClickFileOpenRouter.shouldHandleCommandClick(path: fileURL.path, defaults: defaults))
     }
 
+    func testSettingsFileStoreAppliesFileExtensionOpenersFromSettingsJSON() throws {
+        let defaults = UserDefaults.standard
+        let openersKey = FileExtensionOpenBehaviorSettings.key
+        let settingsFileBackupsKey = "cmux.settingsFile.backups.v1"
+        let previousOpeners = defaults.object(forKey: openersKey)
+        let previousSupportedRouting = defaults.object(forKey: CmdClickSupportedFileRouteSettings.key)
+        let previousBackups = defaults.data(forKey: settingsFileBackupsKey)
+        defer {
+            if let previousOpeners {
+                defaults.set(previousOpeners, forKey: openersKey)
+            } else {
+                defaults.removeObject(forKey: openersKey)
+            }
+
+            if let previousSupportedRouting {
+                defaults.set(previousSupportedRouting, forKey: CmdClickSupportedFileRouteSettings.key)
+            } else {
+                defaults.removeObject(forKey: CmdClickSupportedFileRouteSettings.key)
+            }
+
+            if let previousBackups {
+                defaults.set(previousBackups, forKey: settingsFileBackupsKey)
+            } else {
+                defaults.removeObject(forKey: settingsFileBackupsKey)
+            }
+        }
+
+        defaults.removeObject(forKey: openersKey)
+        defaults.removeObject(forKey: CmdClickSupportedFileRouteSettings.key)
+        defaults.removeObject(forKey: settingsFileBackupsKey)
+
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let settingsFileURL = directoryURL.appendingPathComponent("cmux.json", isDirectory: false)
+        try """
+        {
+          "app": {
+            "fileExtensionOpeners": {
+              ".CSS": "cmuxBrowser",
+              "json": "systemDefault",
+              "tsx": "preferredEditor",
+              "bad": "notARealBehavior"
+            },
+            "openSupportedFilesInCmux": false
+          }
+        }
+        """.write(to: settingsFileURL, atomically: true, encoding: .utf8)
+
+        _ = KeyboardShortcutSettingsFileStore(
+            primaryPath: settingsFileURL.path,
+            fallbackPath: nil,
+            startWatching: false
+        )
+
+        let stored = defaults.dictionary(forKey: openersKey) as? [String: String]
+        XCTAssertEqual(stored?["css"], "cmuxBrowser")
+        XCTAssertEqual(stored?["json"], "systemDefault")
+        XCTAssertEqual(stored?["tsx"], "preferredEditor")
+        XCTAssertNil(stored?["bad"])
+        XCTAssertEqual(FileExtensionOpenBehaviorSettings.behavior(forPath: "/tmp/styles.css", defaults: defaults), .cmuxBrowser)
+        XCTAssertEqual(FileExtensionOpenBehaviorSettings.behavior(forPath: "/tmp/package.json", defaults: defaults), .systemDefault)
+        XCTAssertEqual(FileExtensionOpenBehaviorSettings.behavior(forPath: "/tmp/component.tsx", defaults: defaults), .preferredEditor)
+        XCTAssertEqual(defaults.object(forKey: CmdClickSupportedFileRouteSettings.key) as? Bool, false)
+    }
+
     func testCmdClickMarkdownRoutingDoesNotRequireSupportedFileRoutingSetting() throws {
         let suiteName = "cmux.markdown-preview-routing.\(UUID().uuidString)"
         let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))

--- a/cmuxTests/WindowAndDragTests.swift
+++ b/cmuxTests/WindowAndDragTests.swift
@@ -3300,6 +3300,25 @@ final class FilePreviewPanelTextSavingTests: XCTestCase {
         XCTAssertTrue(CommandClickFileOpenRouter.shouldRouteInCmux(path: fileURL.path, defaults: defaults))
     }
 
+    func testCmdClickFileExtensionOpenersCanDisableBuiltInHTMLDefault() throws {
+        let suiteName = "cmux.html-automatic-routing.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let fileURL = try temporaryTextFile(contents: "<!doctype html>", encoding: .utf8, pathExtension: "html")
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        FileExtensionOpenBehaviorSettings.setOpeners(
+            ["html": .automatic],
+            defaults: defaults,
+            notificationCenter: .default
+        )
+
+        XCTAssertEqual(FileExtensionOpenBehaviorSettings.behavior(forPath: fileURL.path, defaults: defaults), .automatic)
+        XCTAssertFalse(CommandClickFileOpenRouter.shouldRouteInCmux(path: fileURL.path, defaults: defaults))
+        XCTAssertFalse(CommandClickFileOpenRouter.shouldHandleCommandClick(path: fileURL.path, defaults: defaults))
+    }
+
     func testCmdClickFileExtensionOpenersCanUsePreferredEditorWithoutCmuxRoute() throws {
         let suiteName = "cmux.preferred-editor-routing.\(UUID().uuidString)"
         let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))

--- a/cmuxTests/WindowAndDragTests.swift
+++ b/cmuxTests/WindowAndDragTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 import AppKit
 import Carbon.HIToolbox
+import CmuxSettings
 import Darwin
 import PDFKit
 import SwiftUI
@@ -3265,6 +3266,48 @@ final class FilePreviewPanelTextSavingTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: fileURL) }
 
         XCTAssertFalse(CmdClickSupportedFileRouteSettings.shouldRoute(path: fileURL.path, defaults: defaults))
+    }
+
+    func testCmdClickFileExtensionOpenersDefaultHTMLToBrowser() throws {
+        let suiteName = "cmux.html-browser-routing.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let fileURL = try temporaryTextFile(contents: "<!doctype html>", encoding: .utf8, pathExtension: "html")
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        XCTAssertEqual(FileExtensionOpenBehaviorSettings.behavior(forPath: fileURL.path, defaults: defaults), .cmuxBrowser)
+        XCTAssertTrue(CommandClickFileOpenRouter.shouldRouteInCmux(path: fileURL.path, defaults: defaults))
+        XCTAssertTrue(CommandClickFileOpenRouter.shouldHandleCommandClick(path: fileURL.path, defaults: defaults))
+    }
+
+    func testCmdClickFileExtensionOpenersCanOverrideHTMLToPreview() throws {
+        let suiteName = "cmux.html-preview-routing.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let fileURL = try temporaryTextFile(contents: "<!doctype html>", encoding: .utf8, pathExtension: "html")
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        FileExtensionOpenBehaviorSettings.setOpeners(["html": .cmuxPreview], defaults: defaults)
+
+        XCTAssertEqual(FileExtensionOpenBehaviorSettings.behavior(forPath: fileURL.path, defaults: defaults), .cmuxPreview)
+        XCTAssertTrue(CmdClickSupportedFileRouteSettings.shouldRoute(path: fileURL.path, defaults: defaults))
+        XCTAssertTrue(CommandClickFileOpenRouter.shouldRouteInCmux(path: fileURL.path, defaults: defaults))
+    }
+
+    func testCmdClickFileExtensionOpenersCanUsePreferredEditorWithoutCmuxRoute() throws {
+        let suiteName = "cmux.preferred-editor-routing.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let fileURL = try temporaryTextFile(contents: "notes", encoding: .utf8, pathExtension: "txt")
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        FileExtensionOpenBehaviorSettings.setOpeners(["txt": .preferredEditor], defaults: defaults)
+
+        XCTAssertFalse(CommandClickFileOpenRouter.shouldRouteInCmux(path: fileURL.path, defaults: defaults))
+        XCTAssertTrue(CommandClickFileOpenRouter.shouldHandleCommandClick(path: fileURL.path, defaults: defaults))
     }
 
     func testCmdClickMarkdownRoutingDoesNotRequireSupportedFileRoutingSetting() throws {

--- a/cmuxTests/WindowAndDragTests.swift
+++ b/cmuxTests/WindowAndDragTests.swift
@@ -3315,6 +3315,7 @@ final class FilePreviewPanelTextSavingTests: XCTestCase {
         )
 
         XCTAssertEqual(FileExtensionOpenBehaviorSettings.behavior(forPath: fileURL.path, defaults: defaults), .automatic)
+        XCTAssertFalse(CmdClickSupportedFileRouteSettings.shouldRoute(path: fileURL.path, defaults: defaults))
         XCTAssertFalse(CommandClickFileOpenRouter.shouldRouteInCmux(path: fileURL.path, defaults: defaults))
         XCTAssertFalse(CommandClickFileOpenRouter.shouldHandleCommandClick(path: fileURL.path, defaults: defaults))
     }
@@ -3381,6 +3382,7 @@ final class FilePreviewPanelTextSavingTests: XCTestCase {
               ".CSS": "cmuxBrowser",
               "json": "systemDefault",
               "tsx": "preferredEditor",
+              "pdf": 123,
               "bad": "notARealBehavior"
             },
             "openSupportedFilesInCmux": false
@@ -3398,6 +3400,7 @@ final class FilePreviewPanelTextSavingTests: XCTestCase {
         XCTAssertEqual(stored?["css"], "cmuxBrowser")
         XCTAssertEqual(stored?["json"], "systemDefault")
         XCTAssertEqual(stored?["tsx"], "preferredEditor")
+        XCTAssertNil(stored?["pdf"])
         XCTAssertNil(stored?["bad"])
         XCTAssertEqual(FileExtensionOpenBehaviorSettings.behavior(forPath: "/tmp/styles.css", defaults: defaults), .cmuxBrowser)
         XCTAssertEqual(FileExtensionOpenBehaviorSettings.behavior(forPath: "/tmp/package.json", defaults: defaults), .systemDefault)

--- a/cmuxTests/WindowAndDragTests.swift
+++ b/cmuxTests/WindowAndDragTests.swift
@@ -3256,6 +3256,17 @@ final class FilePreviewPanelTextSavingTests: XCTestCase {
         XCTAssertFalse(CmdClickSupportedFileRouteSettings.shouldRoute(path: fileURL.path, defaults: defaults))
     }
 
+    func testCmdClickSupportedFileRoutingDoesNotPreviewHTMLByDefault() throws {
+        let suiteName = "cmux.html-file-preview-routing.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let fileURL = try temporaryTextFile(contents: "<!doctype html>", encoding: .utf8, pathExtension: "html")
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        XCTAssertFalse(CmdClickSupportedFileRouteSettings.shouldRoute(path: fileURL.path, defaults: defaults))
+    }
+
     func testCmdClickMarkdownRoutingDoesNotRequireSupportedFileRoutingSetting() throws {
         let suiteName = "cmux.markdown-preview-routing.\(UUID().uuidString)"
         let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -1,6 +1,5 @@
 import XCTest
 import AppKit
-import CmuxSettings
 import SwiftUI
 import UniformTypeIdentifiers
 import WebKit
@@ -1926,73 +1925,6 @@ final class KeyboardShortcutSettingsFileStoreTests: XCTestCase {
 
         XCTAssertEqual(defaults.object(forKey: managedKey) as? Bool, false)
         XCTAssertNil(defaults.data(forKey: settingsFileBackupsDefaultsKey))
-    }
-
-    func testSettingsFileStoreAppliesFileExtensionOpenersFromSettingsJSON() throws {
-        let defaults = UserDefaults.standard
-        let managedKey = FileExtensionOpenBehaviorSettings.key
-        let previousValue = defaults.object(forKey: managedKey)
-        let previousSupportedRouting = defaults.object(forKey: CmdClickSupportedFileRouteSettings.key)
-        let previousBackups = defaults.data(forKey: settingsFileBackupsDefaultsKey)
-        defer {
-            if let previousValue {
-                defaults.set(previousValue, forKey: managedKey)
-            } else {
-                defaults.removeObject(forKey: managedKey)
-            }
-
-            if let previousSupportedRouting {
-                defaults.set(previousSupportedRouting, forKey: CmdClickSupportedFileRouteSettings.key)
-            } else {
-                defaults.removeObject(forKey: CmdClickSupportedFileRouteSettings.key)
-            }
-
-            if let previousBackups {
-                defaults.set(previousBackups, forKey: settingsFileBackupsDefaultsKey)
-            } else {
-                defaults.removeObject(forKey: settingsFileBackupsDefaultsKey)
-            }
-        }
-
-        defaults.removeObject(forKey: managedKey)
-        defaults.removeObject(forKey: CmdClickSupportedFileRouteSettings.key)
-        defaults.removeObject(forKey: settingsFileBackupsDefaultsKey)
-
-        let directoryURL = try makeTemporaryDirectory()
-        defer { try? FileManager.default.removeItem(at: directoryURL) }
-
-        let settingsFileURL = directoryURL.appendingPathComponent("cmux.json", isDirectory: false)
-        try writeSettingsFile(
-            """
-            {
-              "app": {
-                "fileExtensionOpeners": {
-                  ".CSS": "cmuxBrowser",
-                  "json": "systemDefault",
-                  "tsx": "preferredEditor",
-                  "bad": "notARealBehavior"
-                },
-                "openSupportedFilesInCmux": false
-              }
-            }
-            """,
-            to: settingsFileURL
-        )
-
-        _ = KeyboardShortcutSettingsFileStore(
-            primaryPath: settingsFileURL.path,
-            fallbackPath: nil,
-            startWatching: false
-        )
-
-        let stored = defaults.dictionary(forKey: managedKey) as? [String: String]
-        XCTAssertEqual(stored?["css"], "cmuxBrowser")
-        XCTAssertEqual(stored?["json"], "systemDefault")
-        XCTAssertEqual(stored?["tsx"], "preferredEditor")
-        XCTAssertEqual(FileExtensionOpenBehaviorSettings.behavior(forPath: "/tmp/styles.css", defaults: defaults), .cmuxBrowser)
-        XCTAssertEqual(FileExtensionOpenBehaviorSettings.behavior(forPath: "/tmp/package.json", defaults: defaults), .systemDefault)
-        XCTAssertEqual(FileExtensionOpenBehaviorSettings.behavior(forPath: "/tmp/component.tsx", defaults: defaults), .preferredEditor)
-        XCTAssertEqual(defaults.object(forKey: CmdClickSupportedFileRouteSettings.key) as? Bool, false)
     }
 
     func testSettingsFileStoreAppliesWorkspaceColorDictionaryAndAllowsRemovingDefaults() throws {

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -1932,12 +1932,19 @@ final class KeyboardShortcutSettingsFileStoreTests: XCTestCase {
         let defaults = UserDefaults.standard
         let managedKey = FileExtensionOpenBehaviorSettings.key
         let previousValue = defaults.object(forKey: managedKey)
+        let previousSupportedRouting = defaults.object(forKey: CmdClickSupportedFileRouteSettings.key)
         let previousBackups = defaults.data(forKey: settingsFileBackupsDefaultsKey)
         defer {
             if let previousValue {
                 defaults.set(previousValue, forKey: managedKey)
             } else {
                 defaults.removeObject(forKey: managedKey)
+            }
+
+            if let previousSupportedRouting {
+                defaults.set(previousSupportedRouting, forKey: CmdClickSupportedFileRouteSettings.key)
+            } else {
+                defaults.removeObject(forKey: CmdClickSupportedFileRouteSettings.key)
             }
 
             if let previousBackups {
@@ -1948,6 +1955,7 @@ final class KeyboardShortcutSettingsFileStoreTests: XCTestCase {
         }
 
         defaults.removeObject(forKey: managedKey)
+        defaults.removeObject(forKey: CmdClickSupportedFileRouteSettings.key)
         defaults.removeObject(forKey: settingsFileBackupsDefaultsKey)
 
         let directoryURL = try makeTemporaryDirectory()
@@ -1961,8 +1969,10 @@ final class KeyboardShortcutSettingsFileStoreTests: XCTestCase {
                 "fileExtensionOpeners": {
                   ".CSS": "cmuxBrowser",
                   "json": "systemDefault",
-                  "tsx": "preferredEditor"
-                }
+                  "tsx": "preferredEditor",
+                  "bad": "notARealBehavior"
+                },
+                "openSupportedFilesInCmux": false
               }
             }
             """,
@@ -1979,9 +1989,10 @@ final class KeyboardShortcutSettingsFileStoreTests: XCTestCase {
         XCTAssertEqual(stored?["css"], "cmuxBrowser")
         XCTAssertEqual(stored?["json"], "systemDefault")
         XCTAssertEqual(stored?["tsx"], "preferredEditor")
-        XCTAssertEqual(FileExtensionOpenBehaviorSettings.behavior(forPath: "/tmp/styles.css"), .cmuxBrowser)
-        XCTAssertEqual(FileExtensionOpenBehaviorSettings.behavior(forPath: "/tmp/package.json"), .systemDefault)
-        XCTAssertEqual(FileExtensionOpenBehaviorSettings.behavior(forPath: "/tmp/component.tsx"), .preferredEditor)
+        XCTAssertEqual(FileExtensionOpenBehaviorSettings.behavior(forPath: "/tmp/styles.css", defaults: defaults), .cmuxBrowser)
+        XCTAssertEqual(FileExtensionOpenBehaviorSettings.behavior(forPath: "/tmp/package.json", defaults: defaults), .systemDefault)
+        XCTAssertEqual(FileExtensionOpenBehaviorSettings.behavior(forPath: "/tmp/component.tsx", defaults: defaults), .preferredEditor)
+        XCTAssertEqual(defaults.object(forKey: CmdClickSupportedFileRouteSettings.key) as? Bool, false)
     }
 
     func testSettingsFileStoreAppliesWorkspaceColorDictionaryAndAllowsRemovingDefaults() throws {

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import AppKit
+import CmuxSettings
 import SwiftUI
 import UniformTypeIdentifiers
 import WebKit
@@ -1925,6 +1926,62 @@ final class KeyboardShortcutSettingsFileStoreTests: XCTestCase {
 
         XCTAssertEqual(defaults.object(forKey: managedKey) as? Bool, false)
         XCTAssertNil(defaults.data(forKey: settingsFileBackupsDefaultsKey))
+    }
+
+    func testSettingsFileStoreAppliesFileExtensionOpenersFromSettingsJSON() throws {
+        let defaults = UserDefaults.standard
+        let managedKey = FileExtensionOpenBehaviorSettings.key
+        let previousValue = defaults.object(forKey: managedKey)
+        let previousBackups = defaults.data(forKey: settingsFileBackupsDefaultsKey)
+        defer {
+            if let previousValue {
+                defaults.set(previousValue, forKey: managedKey)
+            } else {
+                defaults.removeObject(forKey: managedKey)
+            }
+
+            if let previousBackups {
+                defaults.set(previousBackups, forKey: settingsFileBackupsDefaultsKey)
+            } else {
+                defaults.removeObject(forKey: settingsFileBackupsDefaultsKey)
+            }
+        }
+
+        defaults.removeObject(forKey: managedKey)
+        defaults.removeObject(forKey: settingsFileBackupsDefaultsKey)
+
+        let directoryURL = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let settingsFileURL = directoryURL.appendingPathComponent("cmux.json", isDirectory: false)
+        try writeSettingsFile(
+            """
+            {
+              "app": {
+                "fileExtensionOpeners": {
+                  ".CSS": "cmuxBrowser",
+                  "json": "systemDefault",
+                  "tsx": "preferredEditor"
+                }
+              }
+            }
+            """,
+            to: settingsFileURL
+        )
+
+        _ = KeyboardShortcutSettingsFileStore(
+            primaryPath: settingsFileURL.path,
+            fallbackPath: nil,
+            startWatching: false
+        )
+
+        let stored = defaults.dictionary(forKey: managedKey) as? [String: String]
+        XCTAssertEqual(stored?["css"], "cmuxBrowser")
+        XCTAssertEqual(stored?["json"], "systemDefault")
+        XCTAssertEqual(stored?["tsx"], "preferredEditor")
+        XCTAssertEqual(FileExtensionOpenBehaviorSettings.behavior(forPath: "/tmp/styles.css"), .cmuxBrowser)
+        XCTAssertEqual(FileExtensionOpenBehaviorSettings.behavior(forPath: "/tmp/package.json"), .systemDefault)
+        XCTAssertEqual(FileExtensionOpenBehaviorSettings.behavior(forPath: "/tmp/component.tsx"), .preferredEditor)
     }
 
     func testSettingsFileStoreAppliesWorkspaceColorDictionaryAndAllowsRemovingDefaults() throws {

--- a/web/app/[locale]/docs/configuration/page.tsx
+++ b/web/app/[locale]/docs/configuration/page.tsx
@@ -61,7 +61,7 @@ const settingsFileExample = `{
   //   "newWorkspacePlacement": "afterCurrent",
   //   "confirmQuit": "always",
   //   "openSupportedFilesInCmux": true,
-  //   "fileExtensionOpeners": { "html": "cmuxBrowser", "md": "markdownViewer" },
+  //   "fileExtensionOpeners": { "html": "cmuxBrowser", "md": "markdownViewer", "tsx": "preferredEditor" },
   //   "workspaceInheritWorkingDirectory": true,
   //   "iMessageMode": true
   // },

--- a/web/app/[locale]/docs/configuration/page.tsx
+++ b/web/app/[locale]/docs/configuration/page.tsx
@@ -61,6 +61,7 @@ const settingsFileExample = `{
   //   "newWorkspacePlacement": "afterCurrent",
   //   "confirmQuit": "always",
   //   "openSupportedFilesInCmux": true,
+  //   "fileExtensionOpeners": { "html": "cmuxBrowser", "md": "markdownViewer" },
   //   "workspaceInheritWorkingDirectory": true,
   //   "iMessageMode": true
   // },

--- a/web/data/cmux.schema.json
+++ b/web/data/cmux.schema.json
@@ -332,7 +332,7 @@
             "type": "string",
             "enum": ["automatic", "cmuxPreview", "markdownViewer", "cmuxBrowser", "preferredEditor", "systemDefault"]
           },
-          "description": "Map file extensions to their Cmd-click opener. Values are automatic, cmuxPreview, markdownViewer, cmuxBrowser, preferredEditor, and systemDefault. Keys may include or omit the leading dot."
+          "description": "Map file extensions to their Cmd-click opener. Values are automatic, cmuxPreview, markdownViewer, cmuxBrowser, preferredEditor, and systemDefault. Keys may include or omit the leading dot. Built-in defaults are merged with this map; set a built-in extension to automatic to opt out."
         },
         "reorderOnNotification": {
           "type": "boolean",

--- a/web/data/cmux.schema.json
+++ b/web/data/cmux.schema.json
@@ -319,6 +319,21 @@
           "default": true,
           "description": "When enabled, Cmd-clicking .md/.markdown/.mkd/.mdx files opens the rendered cmux markdown viewer panel (with live reload) instead of the generic file preview."
         },
+        "fileExtensionOpeners": {
+          "type": "object",
+          "default": {
+            "htm": "cmuxBrowser",
+            "html": "cmuxBrowser"
+          },
+          "propertyNames": {
+            "pattern": "^\\.?[A-Za-z0-9][A-Za-z0-9_+-]*$"
+          },
+          "additionalProperties": {
+            "type": "string",
+            "enum": ["automatic", "cmuxPreview", "markdownViewer", "cmuxBrowser", "preferredEditor", "systemDefault"]
+          },
+          "description": "Map file extensions to their Cmd-click opener. Values are automatic, cmuxPreview, markdownViewer, cmuxBrowser, preferredEditor, and systemDefault. Keys may include or omit the leading dot."
+        },
         "reorderOnNotification": {
           "type": "boolean",
           "default": true,


### PR DESCRIPTION
## Summary
- Route Cmd-clicked `.html` and `.htm` paths to the cmux browser by default instead of the file preview editor.
- Add per-extension opener settings in Settings and `cmux.json`, with browser, preview, Markdown, preferred editor, system default, and automatic behaviors.
- Document the new `app.fileExtensionOpeners` config schema.

## Testing
- `swift test --package-path Packages/CmuxSettings --filter SettingCodable`
- `swift test --package-path Packages/CmuxSettingsUI`
- `bun test` in `web/`
- `bun run lint` in `web/` (passes with existing warnings)
- `./scripts/reload.sh --tag fileopen --swift-frontend-workaround`

Note: full `swift test --package-path Packages/CmuxSettings` still hits the existing `SettingCatalogTests.userDefaultsStorageKeysAreUnique` failure on `main` (115 keys vs 106 unique keys on `main`; 116 vs 107 with this branch).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5040"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782780954&installation_id=133855650&pr_number=5040&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5040&signature=fc3a86411c59f297ff5d8ad4b183a6b1305bb70b648c433c9b2fe374304d9364"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default Cmd-click behavior for HTML and centralizes file-open routing; scope is settings and UX rather than auth or data, with tests covering overrides and JSON loading.
> 
> **Overview**
> Adds **per-extension Cmd-click routing** via `app.fileExtensionOpeners`, with a dedicated **File Opening** settings section and `cmux.json` support.
> 
> **Defaults and behavior:** `.html` / `.htm` now open in the **cmux browser** instead of the generic file preview. Each extension can be set to automatic (legacy Markdown/supported-file toggles), cmux preview, Markdown viewer, browser, preferred editor, or system default. Built-in defaults merge with user overrides; storing `automatic` on a built-in extension opts out of that default.
> 
> **Routing:** `CommandClickFileOpenRouter` resolves extension rules first, then existing settings. Terminal link handling uses deferred opens with fallbacks; browser routes keep URL fragments when opening local files.
> 
> **UI / config:** File drops, preferred editor, extension editor (add/remove, show-all cap), and related toggles move out of **App** into **File Opening**. Search anchors, localization, schema docs, and tests cover storage, JSON import, and HTML routing regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42975165904517c4d9f3da97c55aa37a77a2aa56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cmd-click on `.html`/`.htm` now opens in the cmux browser by default. File opening is configurable per extension via Settings and `cmux.json`, with a new “File Opening” section and a router that falls back to your preferred editor or the system default.

- **New Features**
  - New setting: `app.fileExtensionOpeners` maps extensions to behaviors: automatic, cmuxPreview, markdownViewer, cmuxBrowser, preferredEditor, systemDefault. Defaults `.html`/`.htm` → `cmuxBrowser`; keys may include or omit a leading dot; values are normalized; built-in defaults are merged and can be overridden. Changes post a notification and the Settings UI uses observer tokens to stay in sync.
  - Routing: Centralized `shouldHandleCommandClick` resolves extension rules first, then legacy Markdown/supported-file toggles. “automatic” respects built‑in defaults (so HTML won’t route to preview). Opens/focuses a browser split for local HTML, and falls back to preferred editor or system default if in‑app open fails; terminal link handling uses this path.
  - Settings UI: New “File Opening” section with File Drops, Preferred Editor, and a File Extension Openers editor (add/remove, “Show All/Fewer”). Search, navigation, and localization updated. `cmux.json` schema/loader validate, normalize, and merge openers with defaults; the template seeds defaults; tests cover defaults, overrides, JSON parsing, routing, and an HTML preview regression. Configuration docs now include the File Opening section and an example for `fileExtensionOpeners`.

- **Migration**
  - Behavior change: HTML opens in the cmux browser on Cmd-click.
  - To keep previous behavior, set in Settings → File Opening or in `cmux.json`, for example:
    - cmux preview: `"fileExtensionOpeners": { "html": "cmuxPreview" }`
    - system default: `"fileExtensionOpeners": { "html": "systemDefault" }`
    - preferred editor: `"fileExtensionOpeners": { "html": "preferredEditor" }`

<sup>Written for commit 42975165904517c4d9f3da97c55aa37a77a2aa56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5040?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File Opening settings section now available for configuring command-click behavior by file extension
  * Set extensions to open via: automatic, cmux preview, markdown viewer, cmux browser, preferred editor, or system default

* **Documentation**
  * Configuration documentation and schema updated with file extension opener reference
<!-- end of auto-generated comment: release notes by coderabbit.ai -->