### PR TITLE
Build release app with macOS 26 SDK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Validate macOS runner guards
         run: ./tests/test_ci_self_hosted_guard.sh
 
+      - name: Validate release SDK build lane
+        run: ./tests/test_ci_release_sdk_lane.sh
+
       - name: Validate Python test harness syntax
         run: git ls-files 'tests/*.py' 'tests_v2/*.py' 'scripts/*.py' | xargs python3 -m py_compile
 
@@ -618,14 +621,47 @@ jobs:
           fi
           rm -f /tmp/create-virtual-display
 
+  release-ghostty-cli-helper:
+    runs-on: ${{ vars.MACOS_RUNNER_15 || 'warp-macos-15-arm64-6x' }}
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: recursive
+
+      - name: Install zig
+        run: ./scripts/install-zig-ci.sh
+
+      - name: Cache Zig packages
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/zig
+          key: zig-packages-${{ hashFiles('ghostty/build.zig.zon', 'ghostty/build.zig.zon.json') }}
+          restore-keys: zig-packages-
+
+      - name: Build universal Ghostty CLI helper
+        run: |
+          set -euo pipefail
+          mkdir -p ghostty-cli-helper
+          ./scripts/build-ghostty-cli-helper.sh --universal --output ghostty-cli-helper/ghostty
+          lipo ghostty-cli-helper/ghostty -verify_arch arm64 x86_64
+
+      - name: Upload universal Ghostty CLI helper
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: cmux-ghostty-cli-helper
+          path: ghostty-cli-helper/ghostty
+          if-no-files-found: error
+
   release-build:
+    needs: release-ghostty-cli-helper
     # Compile the same unsigned universal Release app that nightly builds before
     # signing, notarization, and publishing. This catches DEBUG/Release boundary
     # mistakes before they reach main.
-    # Keep this on macOS 15 until Zig can link the real universal Ghostty
-    # CLI helper on macOS 26 runners. The macOS 26 compatibility job still
-    # covers the app build path with CMUX_SKIP_ZIG_BUILD=1.
-    runs-on: ${{ vars.MACOS_RUNNER_15 || 'warp-macos-15-arm64-6x' }}
+    # Keep the app build on macOS 26 so SDK-gated SwiftUI Liquid Glass code
+    # compiles into the same artifact shape as nightly and stable releases.
+    runs-on: ${{ vars.MACOS_RUNNER_26 || 'warp-macos-26-arm64-6x' }}
     timeout-minutes: 20
     steps:
       - name: Checkout
@@ -674,20 +710,9 @@ jobs:
         run: |
           ./scripts/download-prebuilt-ghosttykit.sh
 
-      - name: Install zig
-        run: |
-          ./scripts/install-zig-ci.sh
-
       - name: Install Rust
         run: |
           ./scripts/install-rust-ci.sh
-
-      - name: Cache Zig packages
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/.cache/zig
-          key: zig-packages-${{ hashFiles('ghostty/build.zig.zon', 'ghostty/build.zig.zon.json') }}
-          restore-keys: zig-packages-
 
       - name: Cache DerivedData
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -714,6 +739,19 @@ jobs:
             ONLY_ACTIVE_ARCH=NO \
             CODE_SIGNING_ALLOWED=NO ASSETCATALOG_COMPILER_APPICON_NAME=AppIcon-Nightly build
 
+      - name: Download universal Ghostty CLI helper
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: cmux-ghostty-cli-helper
+          path: ghostty-cli-helper
+
+      - name: Install universal Ghostty CLI helper
+        run: |
+          set -euo pipefail
+          ./scripts/install-prebuilt-ghostty-cli-helper.sh \
+            ghostty-cli-helper/ghostty \
+            build-universal/Build/Products/Release/cmux.app
+
       - name: Validate Release artifact slices
         run: |
           set -euo pipefail
@@ -724,9 +762,12 @@ jobs:
           test -x "$CLI_BINARY"
           test -x "$HELPER_BINARY"
           file "$APP_BINARY" "$CLI_BINARY" "$HELPER_BINARY"
+          SDK_VERSION="$(otool -l "$APP_BINARY" | awk '/LC_BUILD_VERSION/ { in_version=1; next } in_version && /sdk / { print $2; exit }')"
+          echo "App SDK version: $SDK_VERSION"
           lipo "$APP_BINARY" -verify_arch arm64 x86_64
           lipo "$CLI_BINARY" -verify_arch arm64 x86_64
           lipo "$HELPER_BINARY" -verify_arch arm64 x86_64
+          [[ "$SDK_VERSION" == 26.* ]]
 
   ui-regressions:
     runs-on: ${{ vars.MACOS_RUNNER_15 || 'warp-macos-15-arm64-6x' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,11 +15,45 @@ env:
   CREATE_DMG_VERSION: 8.0.0
 
 jobs:
-  build-sign-notarize:
-    # Keep publishing builds on macOS 15 until Zig can link the real universal
-    # Ghostty CLI helper on macOS 26. ci-macos-compat.yml covers macOS 26 with
-    # CMUX_SKIP_ZIG_BUILD=1, but release needs the real universal helper.
+  build-ghostty-cli-helper:
     runs-on: ${{ vars.MACOS_RUNNER_15 || 'warp-macos-15-arm64-6x' }}
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: recursive
+
+      - name: Install zig
+        run: ./scripts/install-zig-ci.sh
+
+      - name: Cache Zig packages
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/zig
+          key: zig-packages-${{ hashFiles('ghostty/build.zig.zon', 'ghostty/build.zig.zon.json') }}
+          restore-keys: zig-packages-
+
+      - name: Build universal Ghostty CLI helper
+        run: |
+          set -euo pipefail
+          mkdir -p ghostty-cli-helper
+          ./scripts/build-ghostty-cli-helper.sh --universal --output ghostty-cli-helper/ghostty
+          lipo ghostty-cli-helper/ghostty -verify_arch arm64 x86_64
+
+      - name: Upload universal Ghostty CLI helper
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: cmux-ghostty-cli-helper
+          path: ghostty-cli-helper/ghostty
+          if-no-files-found: error
+
+  build-sign-notarize:
+    needs: build-ghostty-cli-helper
+    # Build the app on macOS 26 so SDK-gated SwiftUI Liquid Glass code compiles
+    # into stable releases. The real universal Ghostty CLI helper is built on
+    # macOS 15 above because Zig 0.15.2 cannot link it on macOS 26.
+    runs-on: ${{ vars.MACOS_RUNNER_26 || 'warp-macos-26-arm64-6x' }}
     timeout-minutes: 20
     steps:
       - name: Checkout
@@ -132,7 +166,6 @@ jobs:
             rustup default stable
           fi
           rustup target add aarch64-apple-darwin x86_64-apple-darwin
-          ./scripts/install-zig-ci.sh
           npm install --global "create-dmg@${CREATE_DMG_VERSION}"
 
       - name: Download pre-built GhosttyKit.xcframework
@@ -171,12 +204,27 @@ jobs:
       - name: Build universal app (Release)
         if: steps.guard_release_assets.outputs.skip_all != 'true'
         run: |
-          xcodebuild -scheme cmux -configuration Release -derivedDataPath build-universal \
+          CMUX_SKIP_ZIG_BUILD=1 xcodebuild -scheme cmux -configuration Release -derivedDataPath build-universal \
             -destination 'generic/platform=macOS' \
             -clonedSourcePackagesDirPath .spm-cache \
             ARCHS="arm64 x86_64" \
             ONLY_ACTIVE_ARCH=NO \
             CODE_SIGNING_ALLOWED=NO build
+
+      - name: Download universal Ghostty CLI helper
+        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: cmux-ghostty-cli-helper
+          path: ghostty-cli-helper
+
+      - name: Install universal Ghostty CLI helper
+        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        run: |
+          set -euo pipefail
+          ./scripts/install-prebuilt-ghostty-cli-helper.sh \
+            ghostty-cli-helper/ghostty \
+            build-universal/Build/Products/Release/cmux.app
 
       - name: Verify binary architectures
         if: steps.guard_release_assets.outputs.skip_all != 'true'
@@ -188,12 +236,15 @@ jobs:
           APP_ARCHS="$(lipo -archs "$APP_BINARY")"
           CLI_ARCHS="$(lipo -archs "$CLI_BINARY")"
           HELPER_ARCHS="$(lipo -archs "$HELPER_BINARY")"
+          SDK_VERSION="$(otool -l "$APP_BINARY" | awk '/LC_BUILD_VERSION/ { in_version=1; next } in_version && /sdk / { print $2; exit }')"
           echo "App binary architectures: $APP_ARCHS"
           echo "CLI binary architectures: $CLI_ARCHS"
           echo "Ghostty helper architectures: $HELPER_ARCHS"
+          echo "App SDK version: $SDK_VERSION"
           [[ "$APP_ARCHS" == *arm64* && "$APP_ARCHS" == *x86_64* ]]
           [[ "$CLI_ARCHS" == *arm64* && "$CLI_ARCHS" == *x86_64* ]]
           [[ "$HELPER_ARCHS" == *arm64* && "$HELPER_ARCHS" == *x86_64* ]]
+          [[ "$SDK_VERSION" == 26.* ]]
 
       - name: Build remote daemon release assets and inject manifest
         if: steps.guard_release_assets.outputs.skip_all != 'true'

--- a/scripts/install-prebuilt-ghostty-cli-helper.sh
+++ b/scripts/install-prebuilt-ghostty-cli-helper.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+usage: scripts/install-prebuilt-ghostty-cli-helper.sh <helper-path> <app-path>
+EOF
+}
+
+if [[ $# -ne 2 ]]; then
+  usage >&2
+  exit 1
+fi
+
+HELPER_PATH="$1"
+APP_PATH="$2"
+DEST_PATH="$APP_PATH/Contents/Resources/bin/ghostty"
+
+if [[ ! -f "$HELPER_PATH" ]]; then
+  echo "error: Ghostty CLI helper not found at $HELPER_PATH" >&2
+  exit 1
+fi
+
+if [[ ! -d "$APP_PATH/Contents" ]]; then
+  echo "error: app bundle not found at $APP_PATH" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$DEST_PATH")"
+install -m 755 "$HELPER_PATH" "$DEST_PATH"
+
+lipo "$DEST_PATH" -verify_arch arm64 x86_64
+echo "Installed universal Ghostty CLI helper at $DEST_PATH"

--- a/tests/test_ci_release_sdk_lane.sh
+++ b/tests/test_ci_release_sdk_lane.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+CI_FILE="$ROOT_DIR/.github/workflows/ci.yml"
+RELEASE_FILE="$ROOT_DIR/.github/workflows/release.yml"
+
+# nightly.yml is intentionally not covered here. It builds the macOS 26 SDK app
+# with its own inline helper-build model (PR #5077) and self-guards via its
+# "Select Xcode" loud-fail and "Verify nightly binary architectures" steps.
+# This lane guards the release/CI artifact-download model added by this change.
+
+job_section() {
+  local file="$1" job="$2"
+  awk -v job="$job" '
+    $0 ~ "^  "job":" { in_job=1; next }
+    in_job && /^  [^[:space:]#][^:]*:[[:space:]]*(#.*)?$/ { exit }
+    in_job { print }
+  ' "$file"
+}
+
+require_job_contains() {
+  local file="$1" job="$2" needle="$3" message="$4"
+  local section
+  section="$(job_section "$file" "$job")"
+  if [[ "$section" != *"$needle"* ]]; then
+    echo "FAIL: $message" >&2
+    exit 1
+  fi
+}
+
+require_job_contains \
+  "$RELEASE_FILE" \
+  "build-ghostty-cli-helper" \
+  'runs-on: ${{ vars.MACOS_RUNNER_15 || '\''warp-macos-15-arm64-6x'\'' }}' \
+  "release must build the real Ghostty CLI helper on macOS 15"
+
+require_job_contains \
+  "$RELEASE_FILE" \
+  "build-sign-notarize" \
+  'runs-on: ${{ vars.MACOS_RUNNER_26 || '\''warp-macos-26-arm64-6x'\'' }}' \
+  "release must build the app on macOS 26"
+
+require_job_contains \
+  "$CI_FILE" \
+  "release-ghostty-cli-helper" \
+  'runs-on: ${{ vars.MACOS_RUNNER_15 || '\''warp-macos-15-arm64-6x'\'' }}' \
+  "CI must build the real Ghostty CLI helper on macOS 15"
+
+require_job_contains \
+  "$CI_FILE" \
+  "release-build" \
+  'runs-on: ${{ vars.MACOS_RUNNER_26 || '\''warp-macos-26-arm64-6x'\'' }}' \
+  "CI release-build must compile the app on macOS 26"
+
+for workflow in "$CI_FILE" "$RELEASE_FILE"; do
+  if ! grep -Fq "CMUX_SKIP_ZIG_BUILD=1 xcodebuild" "$workflow"; then
+    echo "FAIL: $(basename "$workflow") must skip the in-build Zig helper on macOS 26" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq "actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0" "$workflow"; then
+    echo "FAIL: $(basename "$workflow") must download the macOS 15-built helper artifact" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq "./scripts/install-prebuilt-ghostty-cli-helper.sh" "$workflow"; then
+    echo "FAIL: $(basename "$workflow") must install the prebuilt Ghostty CLI helper into the app" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq '[[ "$SDK_VERSION" == 26.* ]]' "$workflow"; then
+    echo "FAIL: $(basename "$workflow") must verify the app binary was built with a macOS 26 SDK" >&2
+    exit 1
+  fi
+done
+
+echo "PASS: release and CI app builds use macOS 26 SDK with a macOS 15-built Ghostty CLI helper"

--- a/tests/test_ci_self_hosted_guard.sh
+++ b/tests/test_ci_self_hosted_guard.sh
@@ -126,6 +126,7 @@ check_release_build_signal() {
 # ci.yml jobs
 check_macos_runner "$CI_FILE" "tests"
 check_macos_runner "$CI_FILE" "tests-build-and-lag"
+check_macos_runner "$CI_FILE" "release-ghostty-cli-helper"
 check_macos_runner "$CI_FILE" "release-build"
 check_macos_runner "$CI_FILE" "ui-regressions"
 


### PR DESCRIPTION
## Summary

- Restores the released-main TextBox rendering path by keeping the SDK 26 Liquid Glass branch intact.
- Builds the real universal Ghostty CLI helper on macOS 15, then builds the app bundle on macOS 26 and installs that helper before verification/signing.
- Keeps only the requested TextBox button nudge: left button 1 px farther left, right button 1 px farther right.

## Root Cause

Released stable `0.64.10` was built from `fafa50702` with SDK `26.2`, so `TextBoxInputGlassPillBackground` compiled the `.glassEffect(.regular.interactive(true), in:)` branch.

The bad nightly was built from `99a4c71` with SDK `15.5` after https://github.com/manaflow-ai/cmux/pull/5022 moved publishing to macOS 15 runners. That meant the SDK-gated Liquid Glass branch did not compile into the nightly artifact even though `Sources/TextBoxInput.swift` had no visual diff.

## Verification

- `./tests/test_ci_release_sdk_lane.sh`
- `./tests/test_ci_self_hosted_guard.sh`
- `actionlint .github/workflows/ci.yml .github/workflows/nightly.yml .github/workflows/release.yml`
- `bash -n scripts/install-prebuilt-ghostty-cli-helper.sh tests/test_ci_release_sdk_lane.sh tests/test_ci_self_hosted_guard.sh`
- `scripts/install-prebuilt-ghostty-cli-helper.sh` against the installed stable helper in a temporary app bundle

Local tagged reload was attempted with `./scripts/reload.sh --tag textbox-sdk`, but the local Swift compiler sat in the same large current-main batch for about 12 minutes and the log ended with `BUILD INTERRUPTED`, so there is no valid local dogfood tag from this run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release and CI artifact shape and runner split; misconfiguration could ship wrong SDK or a missing/bad helper, but new workflow guards and binary checks reduce that risk.
> 
> **Overview**
> CI and release workflows now use a **two-runner split**: a dedicated job on **macOS 15** builds the universal Ghostty CLI helper with Zig and uploads it as an artifact; the **Release app** job runs on **macOS 26**, builds with `CMUX_SKIP_ZIG_BUILD=1`, downloads that artifact, and installs it into the app bundle before verification/signing.
> 
> This restores **macOS 26 SDK** compilation for SDK-gated SwiftUI (e.g. Liquid Glass) in shipped artifacts, while still shipping a real universal `ghostty` helper built where Zig can link. New `scripts/install-prebuilt-ghostty-cli-helper.sh` copies the helper into `Contents/Resources/bin/ghostty` and checks arm64/x86_64. **Release and CI** both assert the main app binary’s SDK is `26.*` via `otool`, in addition to existing universal `lipo` checks.
> 
> **Guardrails**: `workflow-guard-tests` runs `tests/test_ci_release_sdk_lane.sh`; `tests/test_ci_self_hosted_guard.sh` covers the new `release-ghostty-cli-helper` job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ec9c31beb06211a48acbb6e06c259148010fa90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->