### PR TITLE
Add React Doctor static-analysis gate for the web app

### DIFF
--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -1,0 +1,62 @@
+name: React Doctor
+
+# Static analysis for the Next.js web app (web/). react-doctor is a
+# deterministic React analyzer (Oxlint-based + dead-code detection). On pull
+# requests we scan only the files the PR changed (`--diff` against the base
+# branch), so the existing backlog never blocks a PR; only newly introduced
+# findings do. See https://react.doctor.
+#
+# We invoke the react-doctor CLI directly instead of the millionco/react-doctor
+# composite action: this org requires every action (including ones nested inside
+# a composite action) to be pinned to a full commit SHA, and that action's
+# internal steps reference actions/setup-node and actions/github-script by tag.
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/react-doctor.yml"
+      - "web/**"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  react-doctor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: "22"
+
+      - name: Scan changed web files
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          git fetch --no-tags origin "$BASE_REF"
+          # --diff scopes to files changed vs the PR base; only newly introduced
+          # findings can fail the job. Capture the exit code directly (a pipe
+          # would mask react-doctor's status behind sed's). react-doctor reports
+          # paths relative to the scanned directory (web/), so re-prefix `web/`
+          # on the emitted annotations so they anchor on the right file in the
+          # PR's Files tab.
+          set +e
+          npx -y react-doctor@0.2.14 web \
+            --diff "origin/$BASE_REF" \
+            --fail-on warning \
+            --annotations > rd.out 2>&1
+          status=$?
+          set -e
+          sed -E 's#^::(warning|error) file=#::\1 file=web/#' rd.out
+          echo "react-doctor exit: $status"
+          exit "$status"


### PR DESCRIPTION
Adds a `react-doctor` PR gate for the Next.js app under `web/`.

react-doctor is a deterministic React static analyzer (Oxlint-based + dead-code detection): 60+ rules across state/effects, performance, architecture, bundle size, security, correctness, accessibility, and framework-specific checks (it auto-detects Next.js 16 / React 19 / Tailwind 4 here). It is not just a diff viewer.

## How the gate works
On a PR touching `web/`, the workflow runs `react-doctor web --diff origin/<base>`, so it scans only the files that PR changed. The existing backlog (~124 findings, score 71/100) never blocks a PR; a PR fails only when it introduces a **new** finding. `--fail-on warning` means any new warning or error fails the check. Findings show up as inline annotations on the Files tab.

## Why the CLI instead of the official action
`millionco/react-doctor@<sha>` is a composite action whose internal steps use `actions/setup-node@v5` and `actions/github-script@v8` by tag. This org enforces "all actions must be pinned to a full commit SHA" transitively, so that action is rejected at job setup. This workflow calls the react-doctor CLI directly in SHA-pinned `checkout` + `setup-node` steps instead. `react-doctor` is pinned to `0.2.14`.

## Verification
Verified on this branch's own CI runs (the workflow self-triggers because the PR edits the workflow file):
- A throwaway probe (a `<button>` without `type`) added under `web/app/[locale]/...` made the check go **red** (`react-doctor exit: 1`), with the annotation correctly anchored to `web/app/[locale]/__react_doctor_probe.tsx:5` (`react-doctor/button-has-type`). This confirms it matches files under the literal `[locale]` route segment (nearly every file in the app) rather than glob-dropping the brackets.
- After removing the probe, the check is **green**.

The probe was removed before this PR was finalized; this is a clean single-file change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only addition with read-only repo permissions; no runtime or application code changes.
> 
> **Overview**
> Adds a **React Doctor** GitHub Actions workflow that runs on pull requests when `web/**` or the workflow file itself changes.
> 
> The job checks out full history, uses Node 22, fetches the PR base branch, and runs the pinned **`react-doctor@0.2.14`** CLI on `web/` with **`--diff`** against `origin/<base>` so only **new** findings in changed files can fail the check (existing backlog is ignored). **`--fail-on warning`** fails on new warnings or errors; annotations are rewritten to prefix **`web/`** so inline comments land on the correct paths in the Files tab. The official composite action is avoided because nested actions must be SHA-pinned in this org.
> 
> The shell step preserves react-doctor’s exit code (no pipe masking) and posts workflow annotations from captured output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20648360d29fbbbefd1a4fab47b2531ece9dc477. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated code quality checks that run on pull requests affecting the web directory. The workflow validates code and flags warnings to maintain code standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->