### PR TITLE
Move sidebar kind selection to titlebar menu

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -9987,17 +9987,9 @@ enum CmuxExtensionSidebarSelection {
             item.representedObject = descriptor.id
             item.target = CmuxExtensionSidebarMenuTarget.shared
             item.state = selectedProviderId == descriptor.id ? .on : .off
+            item.image = NSImage(systemSymbolName: descriptor.systemImageName, accessibilityDescription: nil)
             menu.addItem(item)
         }
-        menu.addItem(.separator())
-        let manageItem = NSMenuItem(
-            title: String(localized: "sidebar.extensions.manage", defaultValue: "Manage Sidebar Extensions..."),
-            action: #selector(CmuxExtensionSidebarMenuTarget.manageExtensions(_:)),
-            keyEquivalent: ""
-        )
-        manageItem.representedObject = anchorView
-        manageItem.target = CmuxExtensionSidebarMenuTarget.shared
-        menu.addItem(manageItem)
         menu.popUp(
             positioning: nil,
             at: NSPoint(x: 0, y: anchorView.bounds.maxY + 2),
@@ -10013,14 +10005,6 @@ private final class CmuxExtensionSidebarMenuTarget: NSObject {
     @objc func selectProvider(_ sender: NSMenuItem) {
         guard let providerId = sender.representedObject as? String else { return }
         CmuxExtensionSidebarSelection.setProviderId(providerId)
-    }
-
-    @objc func manageExtensions(_ sender: NSMenuItem) {
-        guard let anchorView = sender.representedObject as? NSView else { return }
-        AppDelegate.shared?.openSidebarExtensionBrowser(
-            from: anchorView,
-            title: String(localized: "sidebar.extensions.browser.title", defaultValue: "Sidebar Extensions")
-        )
     }
 }
 
@@ -13005,14 +12989,16 @@ private struct SidebarFooterButtons: View {
     @ObservedObject var updateViewModel: UpdateViewModel
     @ObservedObject var fileExplorerState: FileExplorerState
     let onSendFeedback: () -> Void
-    @State private var extensionMenuAnchorView: NSView?
+    @State private var extensionBrowserAnchorView: NSView?
 
     var body: some View {
         HStack(spacing: 4) {
             SidebarHelpMenuButton(onSendFeedback: onSendFeedback)
             Button {
-                guard let extensionMenuAnchorView else { return }
-                CmuxExtensionSidebarSelection.showMenu(anchorView: extensionMenuAnchorView, event: nil)
+                _ = AppDelegate.shared?.openSidebarExtensionBrowser(
+                    from: extensionBrowserAnchorView,
+                    title: String(localized: "sidebar.extensions.browser.title", defaultValue: "Sidebar Extensions")
+                )
             } label: {
                 Image(systemName: "puzzlepiece.extension")
                     .symbolRenderingMode(.monochrome)
@@ -13022,10 +13008,10 @@ private struct SidebarFooterButtons: View {
             }
             .buttonStyle(SidebarFooterIconButtonStyle())
             .frame(width: 22, height: 22, alignment: .center)
-            .safeHelp(String(localized: "command.switchExtensionSidebar.subtitle", defaultValue: "Choose Sidebar"))
-            .accessibilityLabel(String(localized: "command.switchExtensionSidebar.subtitle", defaultValue: "Choose Sidebar"))
+            .safeHelp(String(localized: "sidebar.extensions.browser.title", defaultValue: "Sidebar Extensions"))
+            .accessibilityLabel(String(localized: "sidebar.extensions.browser.title", defaultValue: "Sidebar Extensions"))
             .accessibilityIdentifier("SidebarExtensionMenuButton")
-            .background(TitlebarControlAnchorView { extensionMenuAnchorView = $0 })
+            .background(TitlebarControlAnchorView { extensionBrowserAnchorView = $0 })
             UpdatePill(model: updateViewModel)
         }
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/Sources/Update/MinimalModeSidebarControls.swift
+++ b/Sources/Update/MinimalModeSidebarControls.swift
@@ -194,13 +194,15 @@ final class MinimalModeSidebarControlActionView: NSView {
             return
         }
         switch slot {
+        case .toggleSidebar:
+            CmuxExtensionSidebarSelection.showMenu(anchorView: self, event: event)
         case .newTab:
             _ = AppDelegate.shared?.showNewWorkspaceContextMenu(anchorView: self, event: event)
         case .focusHistoryBack:
             _ = AppDelegate.shared?.showFocusHistoryContextMenu(anchorView: self, event: event, direction: .back)
         case .focusHistoryForward:
             _ = AppDelegate.shared?.showFocusHistoryContextMenu(anchorView: self, event: event, direction: .forward)
-        case .toggleSidebar, .showNotifications:
+        case .showNotifications:
             super.rightMouseDown(with: event)
         }
     }

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -866,7 +866,9 @@ struct TitlebarControlsView: View {
                 #endif
                 onToggleSidebar()
             },
-                rightClickAction: nil) {
+                rightClickAction: { anchorView, event in
+                    CmuxExtensionSidebarSelection.showMenu(anchorView: anchorView, event: event)
+                }) {
                 sidebarIconLabel(config: config, iconGeometryKeyPrefix: "titlebarControl_toggleSidebarIcon")
             }
             .safeHelp(KeyboardShortcutSettings.Action.toggleSidebar.tooltip(String(localized: "titlebar.sidebar.tooltip", defaultValue: "Show or hide the sidebar")))

--- a/Sources/WindowDragHandleView.swift
+++ b/Sources/WindowDragHandleView.swift
@@ -827,9 +827,9 @@ enum MinimalModeSidebarControlActionSlot: Int, CaseIterable {
 
     var acceptsContextMenu: Bool {
         switch self {
-        case .newTab, .focusHistoryBack, .focusHistoryForward:
+        case .toggleSidebar, .newTab, .focusHistoryBack, .focusHistoryForward:
             return true
-        case .toggleSidebar, .showNotifications:
+        case .showNotifications:
             return false
         }
     }


### PR DESCRIPTION
## Summary
- Add a right-click menu to the titlebar sidebar toggle for choosing the default workspace sidebar or extension-based sidebars.
- Keep left-click on the titlebar sidebar toggle as the normal show/hide sidebar action.
- Change the bottom sidebar puzzle button to open the Sidebar Extensions browser pane directly.

## Verification
- `./scripts/reload.sh --tag sbkind --swift-frontend-workaround --launch`

## Dogfood Checks
- Left-click the sidebar button next to the traffic lights. It should still toggle the sidebar open and closed.
- Right-click the same sidebar button. It should show only the sidebar type choices: default workspace sidebar and extension-based sidebars.
- Click the puzzle button near the bottom Help button. It should open the Sidebar Extensions browser pane directly, not the sidebar type chooser.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Sidebar extension picker now displays visual icons for better identification.
  * Added right-click context menu support to the sidebar toggle button for quick access to extensions.
  * Enhanced sidebar footer interaction for accessing the extensions browser.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->