### PR TITLE
Fix transient double-selection flash in sidebar on workspace switch

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -14544,7 +14544,10 @@ struct TabItemView: View, Equatable {
     @State private var workspaceFinderDirectoryOpenRequest: WorkspaceFinderDirectoryOpenRequest?
 
     var isMultiSelected: Bool {
-        selectedTabIds.contains(tab.id)
+        sidebarWorkspaceRowShowsMultiSelectHighlight(
+            tabId: tab.id,
+            selectedTabIds: selectedTabIds
+        )
     }
 
     private var sidebarShortcutHintXOffset: Double {

--- a/Sources/Sidebar/SidebarAppearanceSupport.swift
+++ b/Sources/Sidebar/SidebarAppearanceSupport.swift
@@ -316,3 +316,22 @@ func sidebarWorkspaceRowBackgroundStyle(
         return .clear
     }
 }
+
+// Whether a sidebar workspace row should paint the secondary (faint)
+// multi-selection background.
+//
+// The faint accent denotes an *additional* member of a multi-selection, so it
+// only applies when more than one workspace is selected. A single selected id is
+// always the active workspace, which paints the full-strength `isActive`
+// background instead, so a lone id must never paint faint. Gating on count > 1
+// also removes a one-frame "two rows selected" flash when the active workspace
+// changes (Cmd+N, workspace switch, CLI select): the sidebar's `selectedTabIds`
+// set is re-synced to the new active id one render later via `onChange`, and the
+// stale single-element set would otherwise paint the previously-active row faint
+// blue for the frame where its `isActive` drops to false.
+func sidebarWorkspaceRowShowsMultiSelectHighlight(
+    tabId: UUID,
+    selectedTabIds: Set<UUID>
+) -> Bool {
+    selectedTabIds.count > 1 && selectedTabIds.contains(tabId)
+}

--- a/Sources/Sidebar/SidebarAppearanceSupport.swift
+++ b/Sources/Sidebar/SidebarAppearanceSupport.swift
@@ -321,14 +321,19 @@ func sidebarWorkspaceRowBackgroundStyle(
 // multi-selection background.
 //
 // The faint accent denotes an *additional* member of a multi-selection, so it
-// only applies when more than one workspace is selected. A single selected id is
-// always the active workspace, which paints the full-strength `isActive`
-// background instead, so a lone id must never paint faint. Gating on count > 1
-// also removes a one-frame "two rows selected" flash when the active workspace
-// changes (Cmd+N, workspace switch, CLI select): the sidebar's `selectedTabIds`
-// set is re-synced to the new active id one render later via `onChange`, and the
-// stale single-element set would otherwise paint the previously-active row faint
-// blue for the frame where its `isActive` drops to false.
+// only applies when more than one workspace is selected. A lone selected id
+// never warrants it: in steady state that id is the active workspace, already
+// painted full-strength via `isActive`; during a selection change it is a stale
+// value left over from the previously-active workspace.
+//
+// Gating on count > 1 removes a one-frame "two rows selected" flash when the
+// active workspace changes (Cmd+N, Cmd+number, next/prev, CLI select). The
+// sidebar's `selectedTabIds` set re-syncs to the new active id one render later
+// via `onChange(of: selectedTabId)`, so for the frame where the old row's
+// `isActive` drops to false, `selectedTabIds` is still {old}. The fix works not
+// because the lone id is guaranteed to be the active one, but because both the
+// stale {old} set and the settled {new} set have count <= 1, so neither paints
+// faint and the outcome is identical regardless of the lag.
 func sidebarWorkspaceRowShowsMultiSelectHighlight(
     tabId: UUID,
     selectedTabIds: Set<UUID>

--- a/cmuxTests/SidebarWidthPolicyTests.swift
+++ b/cmuxTests/SidebarWidthPolicyTests.swift
@@ -326,3 +326,90 @@ final class SidebarWorkspaceSelectionColorTests: XCTestCase {
         )
     }
 }
+
+// Guards the predicate that decides when a sidebar row paints the faint
+// secondary "also-selected" background. The user-visible bug it protects against
+// is the transient "two workspaces look selected (one half blue)" flash on
+// Cmd+N / workspace switch: the active selection moves immediately but the
+// sidebar's `selectedTabIds` set lags one render, so a stale single-element set
+// must not paint a second faint row. (The one-frame flash itself is a SwiftUI
+// render-timing artifact and is verified by dogfood, not here; this test pins
+// the rule that makes the stale frame paint identically to the settled one.)
+final class SidebarWorkspaceMultiSelectHighlightTests: XCTestCase {
+    func testLoneSelectedIdNeverPaintsSecondaryHighlight() {
+        let onlySelected = UUID()
+        XCTAssertFalse(
+            sidebarWorkspaceRowShowsMultiSelectHighlight(
+                tabId: onlySelected,
+                selectedTabIds: [onlySelected]
+            ),
+            "A single selected id is the active workspace and must not also paint the faint multi-select background"
+        )
+
+        // The non-active row of a stale single-element selection must look
+        // identical to an unselected row (clear), not a faint second selection.
+        let style = sidebarWorkspaceRowBackgroundStyle(
+            activeTabIndicatorStyle: .solidFill,
+            isActive: false,
+            isMultiSelected: sidebarWorkspaceRowShowsMultiSelectHighlight(
+                tabId: onlySelected,
+                selectedTabIds: [onlySelected]
+            ),
+            customColorHex: nil,
+            colorScheme: .dark,
+            sidebarSelectionColorHex: nil
+        )
+        XCTAssertNil(style.color)
+        XCTAssertEqual(style.opacity, 0, accuracy: 0.001)
+    }
+
+    func testGenuineMultiSelectionStillPaintsFaintAccentOnNonActiveMembers() {
+        let active = UUID()
+        let other = UUID()
+        let selection: Set<UUID> = [active, other]
+
+        XCTAssertTrue(
+            sidebarWorkspaceRowShowsMultiSelectHighlight(
+                tabId: other,
+                selectedTabIds: selection
+            )
+        )
+
+        let style = sidebarWorkspaceRowBackgroundStyle(
+            activeTabIndicatorStyle: .solidFill,
+            isActive: false,
+            isMultiSelected: sidebarWorkspaceRowShowsMultiSelectHighlight(
+                tabId: other,
+                selectedTabIds: selection
+            ),
+            customColorHex: nil,
+            colorScheme: .dark,
+            sidebarSelectionColorHex: nil
+        )
+        XCTAssertNotNil(style.color)
+        XCTAssertEqual(style.opacity, 0.25, accuracy: 0.001)
+    }
+
+    func testActiveRowPaintsFullStrengthWhetherOrNotMultiSelected() {
+        let active = UUID()
+        for selection in [Set([active]), Set([active, UUID()])] {
+            let style = sidebarWorkspaceRowBackgroundStyle(
+                activeTabIndicatorStyle: .solidFill,
+                isActive: true,
+                isMultiSelected: sidebarWorkspaceRowShowsMultiSelectHighlight(
+                    tabId: active,
+                    selectedTabIds: selection
+                ),
+                customColorHex: nil,
+                colorScheme: .dark,
+                sidebarSelectionColorHex: nil
+            )
+            XCTAssertEqual(
+                style.opacity,
+                1,
+                accuracy: 0.001,
+                "Active row always uses the full-strength selection background"
+            )
+        }
+    }
+}

--- a/cmuxTests/SidebarWidthPolicyTests.swift
+++ b/cmuxTests/SidebarWidthPolicyTests.swift
@@ -1,5 +1,6 @@
 import AppKit
 import SwiftUI
+import Testing
 import XCTest
 
 #if canImport(cmux_DEV)
@@ -335,11 +336,13 @@ final class SidebarWorkspaceSelectionColorTests: XCTestCase {
 // must not paint a second faint row. (The one-frame flash itself is a SwiftUI
 // render-timing artifact and is verified by dogfood, not here; this test pins
 // the rule that makes the stale frame paint identically to the settled one.)
-final class SidebarWorkspaceMultiSelectHighlightTests: XCTestCase {
-    func testLoneSelectedIdNeverPaintsSecondaryHighlight() {
+@Suite("Sidebar workspace multi-select highlight")
+struct SidebarWorkspaceMultiSelectHighlightTests {
+    @Test("A lone selected id never paints the faint secondary highlight")
+    func loneSelectedIdNeverPaintsSecondaryHighlight() {
         let onlySelected = UUID()
-        XCTAssertFalse(
-            sidebarWorkspaceRowShowsMultiSelectHighlight(
+        #expect(
+            !sidebarWorkspaceRowShowsMultiSelectHighlight(
                 tabId: onlySelected,
                 selectedTabIds: [onlySelected]
             ),
@@ -359,16 +362,17 @@ final class SidebarWorkspaceMultiSelectHighlightTests: XCTestCase {
             colorScheme: .dark,
             sidebarSelectionColorHex: nil
         )
-        XCTAssertNil(style.color)
-        XCTAssertEqual(style.opacity, 0, accuracy: 0.001)
+        #expect(style.color == nil)
+        #expect(abs(style.opacity - 0) < 0.001)
     }
 
-    func testGenuineMultiSelectionStillPaintsFaintAccentOnNonActiveMembers() {
+    @Test("A genuine multi-selection still paints the faint accent on non-active members")
+    func genuineMultiSelectionStillPaintsFaintAccentOnNonActiveMembers() {
         let active = UUID()
         let other = UUID()
         let selection: Set<UUID> = [active, other]
 
-        XCTAssertTrue(
+        #expect(
             sidebarWorkspaceRowShowsMultiSelectHighlight(
                 tabId: other,
                 selectedTabIds: selection
@@ -386,30 +390,35 @@ final class SidebarWorkspaceMultiSelectHighlightTests: XCTestCase {
             colorScheme: .dark,
             sidebarSelectionColorHex: nil
         )
-        XCTAssertNotNil(style.color)
-        XCTAssertEqual(style.opacity, 0.25, accuracy: 0.001)
+        #expect(style.color != nil)
+        #expect(abs(style.opacity - 0.25) < 0.001)
     }
 
-    func testActiveRowPaintsFullStrengthWhetherOrNotMultiSelected() {
+    @Test(
+        "The active row always paints full strength, with or without a multi-selection",
+        arguments: [1, 2]
+    )
+    func activeRowPaintsFullStrengthWhetherOrNotMultiSelected(selectionCount: Int) {
         let active = UUID()
-        for selection in [Set([active]), Set([active, UUID()])] {
-            let style = sidebarWorkspaceRowBackgroundStyle(
-                activeTabIndicatorStyle: .solidFill,
-                isActive: true,
-                isMultiSelected: sidebarWorkspaceRowShowsMultiSelectHighlight(
-                    tabId: active,
-                    selectedTabIds: selection
-                ),
-                customColorHex: nil,
-                colorScheme: .dark,
-                sidebarSelectionColorHex: nil
-            )
-            XCTAssertEqual(
-                style.opacity,
-                1,
-                accuracy: 0.001,
-                "Active row always uses the full-strength selection background"
-            )
+        var selection: Set<UUID> = [active]
+        if selectionCount > 1 {
+            selection.insert(UUID())
         }
+
+        let style = sidebarWorkspaceRowBackgroundStyle(
+            activeTabIndicatorStyle: .solidFill,
+            isActive: true,
+            isMultiSelected: sidebarWorkspaceRowShowsMultiSelectHighlight(
+                tabId: active,
+                selectedTabIds: selection
+            ),
+            customColorHex: nil,
+            colorScheme: .dark,
+            sidebarSelectionColorHex: nil
+        )
+        #expect(
+            abs(style.opacity - 1) < 0.001,
+            "Active row always uses the full-strength selection background"
+        )
     }
 }


### PR DESCRIPTION
## Problem

Pressing Cmd+N briefly shows two workspaces highlighted in the sidebar: the new one full blue, the previously active one faint ("half blue"). It also affects Cmd+number, next/prev, and CLI workspace select, anything that moves the active workspace from the model.

## Root cause

The sidebar has two selection sources:
- `tabManager.selectedTabId`: the active workspace, painted full-strength.
- `selectedTabIds: Set<UUID>`: the sidebar multi-select set, where non-active members paint a faint 0.25-opacity "also-selected" background.

On a model-driven selection change the active id updates immediately, but `selectedTabIds` only re-syncs to it one render later, inside `onChange(of: tabManager.selectedTabId)` (ContentView). For that one committed frame the old workspace is still in the lagging set, so it paints faint while the new workspace paints full. `TabItemView`'s `==` excludes the `selectedTabIds` binding, so the row only re-runs `body` when its `isActive` flips, which is exactly the frame that paints the stale faint highlight.

## Fix

The faint "also-selected" treatment is only meaningful for a genuine multi-selection (2+ rows). A lone selected id is always either the active row (already shown via the full highlight, which wins in the style function) or a stale lagging value, so it must never paint faint. Gate the faint highlight on `selectedTabIds.count > 1` via a small pure helper (`sidebarWorkspaceRowShowsMultiSelectHighlight`).

This is robust to SwiftUI frame timing: it makes the stale `selectedTabIds = {old}` frame paint identically to the settled `{new}` frame (neither paints faint on a count-1 set), so the flash cannot appear however many intermediate frames `onChange` produces. It is a no-op in steady state (active row uses the full highlight) and leaves genuine multi-selection (cmd/shift-click) unchanged. The set itself is untouched, so multi-row context-menu operations still work.

## Test

`SidebarWorkspaceMultiSelectHighlightTests` in `cmuxTests/SidebarWidthPolicyTests.swift` (colocated with the existing `sidebarWorkspaceRowBackgroundStyle` tests, already wired into the target). It asserts the user-visible outcome: a lone selected id produces a `.clear` background on a non-active row, a 2+ selection still produces the faint accent, and the active row is always full-strength. The one-frame flash itself is a render-timing artifact that a unit test can't catch, so it pins the predicate; symptom verification is dogfood.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5046"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782805990&installation_id=133855650&pr_number=5046&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5046&signature=35639498be0d303bcb8c2de5249a3c34c3cce8423b05fc068da770bc286cb57b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only selection highlight predicate with unit tests; genuine cmd/shift multi-select behavior is unchanged.
> 
> **Overview**
> Fixes a brief **two-row selected** look in the sidebar when switching the active workspace (Cmd+N, shortcuts, CLI, etc.), caused by `selectedTabIds` lagging one frame behind `selectedTabId`.
> 
> **`sidebarWorkspaceRowShowsMultiSelectHighlight`** now drives row multi-select styling: the faint secondary highlight applies only when **`selectedTabIds` has more than one** id and the row is in that set. **`TabItemView`** uses this helper instead of treating any membership in the set as multi-selected.
> 
> **`SidebarWorkspaceMultiSelectHighlightTests`** (Swift Testing) locks in lone-id → no faint background, real multi-select → faint on non-active rows, and active row stays full-strength.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2bc31b7ae3676ac2979cdac7f77ca48f1a4307f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a transient double-selection flash in the sidebar when switching workspaces (Cmd+N, Cmd+number, next/prev, CLI). Only the active workspace highlights; the faint background now appears only for real multi-selections.

- **Bug Fixes**
  - Gate faint background on selections with more than one item via `sidebarWorkspaceRowShowsMultiSelectHighlight`.
  - Use the helper in `TabItemView.isMultiSelected` to avoid stale single-element highlights during model-driven updates.
  - Tests: port `SidebarWorkspaceMultiSelectHighlightTests` to Swift Testing (`@Suite`, `@Test`, `#expect`) and assert lone vs multi-selection and active-row full highlight; clarify the helper’s doc to describe the count-based rule.

<sup>Written for commit e2bc31b7ae3676ac2979cdac7f77ca48f1a4307f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5046?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined sidebar multi-selection highlighting so the faint highlight appears only when multiple items are selected, removing spurious highlight on single selections and preventing transient visual flashes during rapid selection changes.

* **Tests**
  * Added unit tests covering single vs. multi-selection highlighting and active-row rendering to ensure consistent sidebar visuals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->