### PR TITLE
Open diff viewer pane immediately

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -7,7 +7,7 @@
 19052	Sources/ContentView.swift
 17860	Sources/AppDelegate.swift
 16503	Sources/GhosttyTerminalView.swift
-13589	Sources/Panels/BrowserPanel.swift
+13789	Sources/Panels/BrowserPanel.swift
 11756	cmuxTests/AppDelegateShortcutRoutingTests.swift
 9914	Sources/TabManager.swift
 8494	cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -16,7 +16,7 @@
 6968	cmuxTests/WorkspaceRemoteConnectionTests.swift
 6489	cmuxTests/GhosttyConfigTests.swift
 6299	cmuxTests/TerminalAndGhosttyTests.swift
-6119	CLI/cmux_open.swift
+6389	CLI/cmux_open.swift
 5938	Sources/TextBoxInput.swift
 5770	cmuxTests/SessionPersistenceTests.swift
 5482	cmuxTests/BrowserConfigTests.swift
@@ -33,7 +33,7 @@
 3255	Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
 3202	Sources/Update/UpdateTitlebarAccessory.swift
 2953	Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
-2887	cmuxTests/CMUXOpenCommandTests.swift
+2916	cmuxTests/CMUXOpenCommandTests.swift
 2871	Sources/SessionIndexView.swift
 2654	Sources/Panels/CmuxWebView.swift
 2545	cmuxTests/WorkspaceManualUnreadTests.swift

--- a/CLI/cmux_open.swift
+++ b/CLI/cmux_open.swift
@@ -310,6 +310,12 @@ extension CMUXCLI {
     private struct DiffViewerURLMapper {
         static let scheme = "cmux-diff-viewer"
         static let sessionHistoryMarker = "cmux-diff-viewer"
+
+        enum Transport {
+            case http
+            case appScheme
+        }
+
         private static let requestPathAllowedCharacters: CharacterSet = {
             var characters = CharacterSet.urlPathAllowed
             characters.remove(charactersIn: "/?#%")
@@ -318,19 +324,36 @@ extension CMUXCLI {
 
         var token: String
         var rootDirectory: URL
-        var origin: URL
+        var origin: URL?
+        var transport: Transport = .http
 
         func viewerURL(for fileURL: URL) throws -> URL {
-            guard var components = URLComponents(url: origin, resolvingAgainstBaseURL: false) else {
-                throw CLIError(message: "Failed to build diff viewer URL")
+            let requestPath = try requestPath(for: fileURL)
+            switch transport {
+            case .http:
+                guard let origin,
+                      var components = URLComponents(url: origin, resolvingAgainstBaseURL: false) else {
+                    throw CLIError(message: "Failed to build diff viewer URL")
+                }
+                components.percentEncodedPath = "/\(token)\(requestPath)"
+                components.query = nil
+                components.fragment = Self.sessionHistoryMarker
+                guard let url = components.url else {
+                    throw CLIError(message: "Failed to build diff viewer URL")
+                }
+                return url
+            case .appScheme:
+                var components = URLComponents()
+                components.scheme = Self.scheme
+                components.host = token
+                components.percentEncodedPath = requestPath
+                components.query = nil
+                components.fragment = nil
+                guard let url = components.url else {
+                    throw CLIError(message: "Failed to build diff viewer URL")
+                }
+                return url
             }
-            components.percentEncodedPath = "/\(token)\(try requestPath(for: fileURL))"
-            components.query = nil
-            components.fragment = Self.sessionHistoryMarker
-            guard let url = components.url else {
-                throw CLIError(message: "Failed to build diff viewer URL")
-            }
-            return url
         }
 
         func allowedFile(fileURL: URL, mimeType: String) throws -> DiffViewerAllowedFile {
@@ -832,7 +855,7 @@ extension CMUXCLI {
             branchBaseRef: parsedArgs.branchBase
         )
         if let cwd = parsedArgs.cwd {
-            diffSourceContext.repoRoot = try gitRepoRoot(startingAt: resolvePath(cwd))
+            diffSourceContext.repoRoot = resolvePath(cwd)
         }
         if parsedArgs.source != nil {
             try resolveTargetIfNeeded()
@@ -3118,8 +3141,8 @@ extension CMUXCLI {
         context: DiffSourceContext,
         runtime: URL?
     ) throws -> DiffViewerWriteResult {
-        let target = try makeDiffViewerGitHTMLSetTarget(runtime: runtime)
         if selectedSource != .lastTurn {
+            let target = try makeDiffViewerGitOpeningHTMLSetTarget(runtime: runtime)
             return try writeOpeningGitDiffViewerHTMLSet(
                 selectedSource: selectedSource,
                 titleOverride: titleOverride,
@@ -3130,6 +3153,7 @@ extension CMUXCLI {
                 target: target
             )
         }
+        let target = try makeDiffViewerGitHTMLSetTarget(runtime: runtime)
         return try writeCompleteGitDiffViewerHTMLSet(
             selectedSource: selectedSource,
             titleOverride: titleOverride,
@@ -3138,6 +3162,39 @@ extension CMUXCLI {
             appearance: appearance,
             context: context,
             target: target
+        )
+    }
+
+    private func makeDiffViewerGitOpeningHTMLSetTarget(runtime: URL?) throws -> DiffViewerGitHTMLSetTarget {
+        let directory = try diffViewerDirectory()
+        let mapper = DiffViewerURLMapper(
+            token: UUID().uuidString.lowercased(),
+            rootDirectory: directory,
+            origin: nil,
+            transport: .appScheme
+        )
+        let timestamp = Int(Date().timeIntervalSince1970)
+        let groupID = "\(timestamp)-\(UUID().uuidString.prefix(8))"
+        return DiffViewerGitHTMLSetTarget(directory: directory, mapper: mapper, groupID: groupID, runtime: runtime)
+    }
+
+    private func makeDiffViewerGitCompletionHTMLSetTarget(
+        openingTarget: DiffViewerGitHTMLSetTarget
+    ) throws -> DiffViewerGitHTMLSetTarget {
+        let origin = try diffViewerHTTPServerOrigin(
+            rootDirectory: openingTarget.directory,
+            runtime: openingTarget.runtime
+        )
+        let mapper = DiffViewerURLMapper(
+            token: UUID().uuidString.lowercased(),
+            rootDirectory: openingTarget.directory,
+            origin: origin
+        )
+        return DiffViewerGitHTMLSetTarget(
+            directory: openingTarget.directory,
+            mapper: mapper,
+            groupID: openingTarget.groupID,
+            runtime: openingTarget.runtime
         )
     }
 
@@ -3174,7 +3231,6 @@ extension CMUXCLI {
         let directory = target.directory
         let mapper = target.mapper
         let groupID = target.groupID
-        let repoRoot = try gitRepoRootForDiff(context)
         let openingFileURL = directory.appendingPathComponent(
             "diff-\(groupID)-opening.html",
             isDirectory: false
@@ -3183,33 +3239,25 @@ extension CMUXCLI {
         let sourceLabel = "git \(selectedSource.slug)"
         let title = titleOverride ?? selectedSource.title
         let message = diffViewerLoadingDiffMessage(selectedSource.menuLabel)
-        try writeDiffViewerStatusHTML(
+        try writeDiffViewerOpeningStatusHTML(
             to: openingFileURL,
             title: title,
             sourceLabel: sourceLabel,
             message: message,
-            isError: false,
-            pollForReplacement: true,
             layout: layout,
-            layoutSource: layoutSource,
-            appearance: appearance,
-            sourceOptions: [],
-            repoOptions: [],
-            baseOptions: [],
-            repoRoot: repoRoot,
-            branchBaseRef: selectedSource == .branch ? context.branchBaseRef : nil,
-            runtime: target.runtime
+            appearance: appearance
         )
-        let assets = try ensureDiffViewerAssets(nextTo: openingFileURL, runtime: target.runtime)
         let allowedFiles = try diffViewerAllowedFiles(
             pageURLs: [openingFileURL],
-            assets: assets,
+            assets: DiffViewerAssets(
+                appModuleURL: "",
+                diffsModuleURL: "",
+                treesModuleURL: "",
+                workerPoolModuleURL: "",
+                workerModuleURL: "",
+                files: []
+            ),
             mapper: mapper
-        )
-        try writeDiffViewerHTTPManifest(
-            token: mapper.token,
-            files: allowedFiles,
-            rootDirectory: directory
         )
 
         let responseInput = DiffInput(
@@ -3227,6 +3275,7 @@ extension CMUXCLI {
             allowedFiles: allowedFiles,
             completeDeferred: { [self] in
                 do {
+                    let completionTarget = try makeDiffViewerGitCompletionHTMLSetTarget(openingTarget: target)
                     let completed = try writeCompleteGitDiffViewerHTMLSet(
                         selectedSource: selectedSource,
                         titleOverride: titleOverride,
@@ -3234,40 +3283,49 @@ extension CMUXCLI {
                         layoutSource: layoutSource,
                         appearance: appearance,
                         context: context,
-                        target: target,
-                        extraAllowedPageURL: openingFileURL
+                        target: completionTarget
                     )
                     var finalized = completed
 
                     var completedPageURLs = Set<URL>()
                     do {
-                        if let selectedCompletion = try completeDeferredDiffViewerSelectedSource(
+                        guard let selectedCompletion = try completeDeferredDiffViewerSelectedSource(
                             completed.deferredSourceSet,
                             selectedURL: completed.fileURL
-                        ) {
-                            completedPageURLs.formUnion(selectedCompletion.completedPageURLs)
-                            finalized.fileURL = selectedCompletion.fileURL
-                            finalized.url = selectedCompletion.viewerURL
-                            finalized.input = selectedCompletion.input
-                            finalized.title = titleOverride ?? selectedCompletion.input.defaultTitle
+                        ) else {
+                            throw CLIError(message: "Failed to finish diff viewer")
                         }
+                        completedPageURLs.formUnion(selectedCompletion.completedPageURLs)
+                        try writeDiffViewerEmbeddedHTML(
+                            to: openingFileURL,
+                            title: titleOverride ?? selectedCompletion.input.defaultTitle,
+                            targetURL: selectedCompletion.viewerURL,
+                            appearance: appearance
+                        )
+                        finalized.fileURL = selectedCompletion.fileURL
+                        finalized.url = selectedCompletion.viewerURL
+                        finalized.input = selectedCompletion.input
+                        finalized.title = titleOverride ?? selectedCompletion.input.defaultTitle
                     } catch {
-                        try? writeDiffViewerRedirectHTML(
+                        try? writeDiffViewerStatusHTML(
                             to: openingFileURL,
                             title: title,
-                            targetURL: completed.url,
+                            sourceLabel: sourceLabel,
+                            message: diffViewerErrorMessage(error),
+                            isError: true,
+                            pollForReplacement: false,
+                            layout: layout,
+                            layoutSource: layoutSource,
                             appearance: appearance,
+                            sourceOptions: [],
+                            repoOptions: [],
+                            baseOptions: [],
+                            repoRoot: context.repoRoot,
+                            branchBaseRef: selectedSource == .branch ? context.branchBaseRef : nil,
                             runtime: target.runtime
                         )
                         throw error
                     }
-                    try writeDiffViewerRedirectHTML(
-                        to: openingFileURL,
-                        title: finalized.title,
-                        targetURL: finalized.url,
-                        appearance: appearance,
-                        runtime: target.runtime
-                    )
                     _ = try completeDeferredDiffViewerSources(
                         completed.deferredSourceSet,
                         selectedURL: completed.fileURL,
@@ -3289,7 +3347,7 @@ extension CMUXCLI {
                         sourceOptions: [],
                         repoOptions: [],
                         baseOptions: [],
-                        repoRoot: repoRoot,
+                        repoRoot: context.repoRoot,
                         branchBaseRef: selectedSource == .branch ? context.branchBaseRef : nil,
                         runtime: target.runtime
                     )
@@ -5544,34 +5602,246 @@ extension CMUXCLI {
         )
     }
 
-    private func writeDiffViewerRedirectHTML(
+    private func writeDiffViewerOpeningStatusHTML(
+        to viewerURL: URL,
+        title: String,
+        sourceLabel: String,
+        message: String,
+        layout: String,
+        appearance: DiffViewerAppearance
+    ) throws {
+        try writeDiffViewerPatchSidecar("", for: viewerURL)
+        let labels = DiffViewerLabels.localized()
+        let escapedTitle = htmlEscaped(title)
+        let escapedSourceLabel = htmlEscaped(sourceLabel)
+        let escapedMessage = htmlEscaped(message)
+        let renderFailedLabel = try jsonStringLiteral(labels["renderFailed"])
+        let lightBackground = htmlEscaped(appearance.lightTheme.background)
+        let lightForeground = htmlEscaped(appearance.lightTheme.foreground)
+        let lightBorder = htmlEscaped(appearance.lightTheme.selectionBackground)
+        let darkBackground = htmlEscaped(appearance.darkTheme.background)
+        let darkForeground = htmlEscaped(appearance.darkTheme.foreground)
+        let darkBorder = htmlEscaped(appearance.darkTheme.selectionBackground)
+        let fontFamily = try jsonStringLiteral(appearance.fontFamily)
+        let fontSize = String(format: "%.2f", locale: Locale(identifier: "en_US_POSIX"), appearance.fontSize)
+        let escapedLayout = htmlEscaped(layout)
+        let html = """
+        <!doctype html>
+        <html data-cmux-diff-pending="true">
+        <head>
+          <meta charset="utf-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1">
+          <title>\(escapedTitle)</title>
+          <style>
+            :root { color-scheme: dark light; }
+            * { box-sizing: border-box; }
+            body {
+              margin: 0;
+              min-height: 100vh;
+              background: \(lightBackground);
+              color: \(lightForeground);
+              font: \(fontSize)px \(fontFamily), -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
+            }
+            #toolbar {
+              min-height: 44px;
+              display: flex;
+              align-items: center;
+              gap: 10px;
+              padding: 0 16px;
+              border-bottom: 1px solid \(lightBorder);
+            }
+            #viewer {
+              min-height: calc(100vh - 44px);
+              display: grid;
+              place-items: center;
+              padding: 32px;
+            }
+            body[data-cmux-diff-embedded="true"] {
+              overflow: hidden;
+            }
+            #diff-viewer-frame {
+              display: block;
+              width: 100vw;
+              height: 100vh;
+              border: 0;
+              background: \(lightBackground);
+            }
+            #status {
+              max-width: 680px;
+              display: flex;
+              align-items: center;
+              gap: 14px;
+              color: inherit;
+              opacity: 0.88;
+            }
+            #spinner {
+              width: 22px;
+              height: 22px;
+              border-radius: 50%;
+              border: 2px solid rgba(128, 128, 128, 0.35);
+              border-top-color: currentColor;
+              animation: spin 0.8s linear infinite;
+              flex: 0 0 auto;
+            }
+            #title {
+              font-weight: 600;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+            #source {
+              opacity: 0.62;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+            @keyframes spin { to { transform: rotate(360deg); } }
+            @media (prefers-color-scheme: dark) {
+              body {
+                background: \(darkBackground);
+                color: \(darkForeground);
+              }
+              #toolbar {
+                border-bottom-color: \(darkBorder);
+              }
+            }
+          </style>
+        </head>
+        <body data-status-only="true" data-layout="\(escapedLayout)">
+          <div id="toolbar">
+            <div id="title">\(escapedTitle)</div>
+            <div id="source">\(escapedSourceLabel)</div>
+          </div>
+          <main id="viewer">
+            <div id="status" data-pending="true">
+              <div id="spinner" aria-hidden="true"></div>
+              <div>\(escapedMessage)</div>
+            </div>
+          </main>
+          <script>
+            const renderFailedLabel = \(renderFailedLabel);
+            function trustedEmbeddedURL(rawURL) {
+              if (!rawURL) { return null; }
+              try {
+                const url = new URL(rawURL);
+                if (url.protocol === "http:" && url.hostname === "127.0.0.1") {
+                  return url.href;
+                }
+              } catch {}
+              return null;
+            }
+            function embeddedViewerURLFrom(text) {
+              const parsed = new DOMParser().parseFromString(text, "text/html");
+              const marker = parsed.querySelector("[data-cmux-diff-embed-url]");
+              return trustedEmbeddedURL(marker?.getAttribute("data-cmux-diff-embed-url"));
+            }
+            function restartScripts() {
+              for (const inertScript of Array.from(document.scripts)) {
+                const script = document.createElement("script");
+                for (const attribute of Array.from(inertScript.attributes)) {
+                  script.setAttribute(attribute.name, attribute.value);
+                }
+                script.text = inertScript.text;
+                inertScript.replaceWith(script);
+              }
+            }
+            function replaceDocumentWith(text) {
+              const parsed = new DOMParser().parseFromString(text, "text/html");
+              document.title = parsed.title || document.title;
+              for (const attribute of Array.from(document.documentElement.attributes)) {
+                document.documentElement.removeAttribute(attribute.name);
+              }
+              for (const attribute of Array.from(parsed.documentElement.attributes)) {
+                document.documentElement.setAttribute(attribute.name, attribute.value);
+              }
+              document.head.replaceChildren(...Array.from(parsed.head.childNodes).map((node) => document.importNode(node, true)));
+              document.body.replaceWith(document.importNode(parsed.body, true));
+              restartScripts();
+            }
+            function showEmbeddedViewer(targetURL) {
+              document.documentElement.removeAttribute("data-cmux-diff-pending");
+              document.documentElement.dataset.cmuxDiffReady = "true";
+              document.body.dataset.cmuxDiffEmbedded = "true";
+              document.body.replaceChildren();
+              const frame = document.createElement("iframe");
+              frame.id = "diff-viewer-frame";
+              frame.src = targetURL;
+              frame.title = document.title;
+              frame.referrerPolicy = "no-referrer";
+              document.body.append(frame);
+            }
+            function showFailure() {
+              document.documentElement.dataset.cmuxDiffWait = "failed";
+              const spinner = document.getElementById("spinner");
+              spinner?.remove();
+              const status = document.getElementById("status");
+              if (status) {
+                status.dataset.error = "true";
+                status.textContent = renderFailedLabel;
+              }
+            }
+            async function waitForReplacement() {
+              try {
+                const response = await fetch("/__cmux_diff_viewer_wait" + location.pathname, { cache: "no-store" });
+                const text = await response.text();
+                if (!response.ok || text.includes("data-cmux-diff-pending=\\"true\\"")) {
+                  showFailure();
+                  return;
+                }
+                const embeddedURL = embeddedViewerURLFrom(text);
+                if (embeddedURL) {
+                  showEmbeddedViewer(embeddedURL);
+                } else {
+                  replaceDocumentWith(text);
+                }
+              } catch {
+                showFailure();
+              }
+            }
+            waitForReplacement();
+          </script>
+        </body>
+        </html>
+        """
+        try html.write(to: viewerURL, atomically: true, encoding: .utf8)
+    }
+
+    private func writeDiffViewerEmbeddedHTML(
         to viewerURL: URL,
         title: String,
         targetURL: URL,
-        appearance: DiffViewerAppearance,
-        runtime: URL? = nil
+        appearance: DiffViewerAppearance
     ) throws {
         try writeDiffViewerPatchSidecar("", for: viewerURL)
-        _ = try ensureDiffViewerAssets(nextTo: viewerURL, runtime: runtime)
         let target = targetURL.absoluteString
-        let targetLiteral = try jsonStringLiteral(target)
         let escapedTitle = htmlEscaped(title)
         let escapedTarget = htmlEscaped(target)
         let prepaintStyle = diffViewerPrepaintStyle(appearance: appearance)
         let html = """
         <!doctype html>
-        <html>
+        <html data-cmux-diff-embedded="true">
         <head>
           <meta charset="utf-8">
           <meta name="viewport" content="width=device-width, initial-scale=1">
-          <meta http-equiv="refresh" content="0;url=\(escapedTarget)">
           <title>\(escapedTitle)</title>
           \(prepaintStyle)
+          <style>
+            html, body {
+              width: 100%;
+              height: 100%;
+              overflow: hidden;
+            }
+            #diff-viewer-frame {
+              display: block;
+              width: 100vw;
+              height: 100vh;
+              border: 0;
+              background: transparent;
+            }
+          </style>
         </head>
-        <body data-cmux-diff-redirect="\(escapedTarget)">
-          <script>
-            window.location.replace(\(targetLiteral));
-          </script>
+        <body data-cmux-diff-embedded="true" data-cmux-diff-embed-url="\(escapedTarget)">
+          <iframe id="diff-viewer-frame" src="\(escapedTarget)" title="\(escapedTitle)" referrerpolicy="no-referrer"></iframe>
         </body>
         </html>
         """

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -2559,6 +2559,9 @@ final class CmuxDiffViewerURLSchemeHandler: NSObject, WKURLSchemeHandler {
     static let scheme = "cmux-diff-viewer"
     static let shared = CmuxDiffViewerURLSchemeHandler()
     static let maxRegisteredFiles = 1024
+    private static let replacementWaitPrefix = "/__cmux_diff_viewer_wait/"
+    private static let pendingReplacementMarker = Data("data-cmux-diff-pending=\"true\"".utf8)
+    private static let replacementWaitTimeout: TimeInterval = 120
 
     struct RegisteredFile {
         let requestPath: String
@@ -2576,6 +2579,9 @@ final class CmuxDiffViewerURLSchemeHandler: NSObject, WKURLSchemeHandler {
         let condition = NSCondition()
         var isStopped = false
         var callbacksInFlight = 0
+        var replacementWaitFinished = false
+        var replacementWatcher: DispatchSourceFileSystemObject?
+        var replacementTimeout: DispatchSourceTimer?
     }
 
     private let lock = NSLock()
@@ -2659,8 +2665,17 @@ final class CmuxDiffViewerURLSchemeHandler: NSObject, WKURLSchemeHandler {
     }
 
     func webView(_ webView: WKWebView, start urlSchemeTask: WKURLSchemeTask) {
-        guard let requestURL = urlSchemeTask.request.url,
-              let file = registeredFile(for: requestURL) else {
+        guard let requestURL = urlSchemeTask.request.url else {
+            urlSchemeTask.didFailWithError(NSError(domain: NSURLErrorDomain, code: NSURLErrorFileDoesNotExist))
+            return
+        }
+
+        if let file = registeredReplacementWaitFile(for: requestURL) {
+            startStreamingFile(file, requestURL: requestURL, urlSchemeTask: urlSchemeTask, waitForReplacement: true)
+            return
+        }
+
+        guard let file = registeredFile(for: requestURL) else {
             urlSchemeTask.didFailWithError(NSError(domain: NSURLErrorDomain, code: NSURLErrorFileDoesNotExist))
             return
         }
@@ -2808,6 +2823,33 @@ final class CmuxDiffViewerURLSchemeHandler: NSObject, WKURLSchemeHandler {
         return requestPath
     }
 
+    private func registeredReplacementWaitFile(for url: URL, now: Date = Date()) -> RegisteredFile? {
+        guard url.scheme == Self.scheme,
+              let token = url.host,
+              url.query == nil,
+              url.fragment == nil,
+              Self.isValidToken(token) else {
+            return nil
+        }
+        let rawPath = URLComponents(url: url, resolvingAgainstBaseURL: false)?.percentEncodedPath ?? url.path
+        guard rawPath.hasPrefix(Self.replacementWaitPrefix) else {
+            return nil
+        }
+        let targetPath = "/" + String(rawPath.dropFirst(Self.replacementWaitPrefix.count))
+        guard Self.isValidRequestPath(targetPath) else {
+            return nil
+        }
+
+        lock.lock()
+        pruneExpiredSessionsLocked(now: now)
+        let file = sessions[token]?.filesByPath[targetPath]
+        lock.unlock()
+        guard file?.mimeType == "text/html" else {
+            return nil
+        }
+        return file
+    }
+
     private static func isAllowedMimeType(_ mimeType: String) -> Bool {
         mimeType == "text/html" || mimeType == "text/javascript" || mimeType == "text/x-diff"
     }
@@ -2828,7 +2870,8 @@ final class CmuxDiffViewerURLSchemeHandler: NSObject, WKURLSchemeHandler {
     private func startStreamingFile(
         _ file: RegisteredFile,
         requestURL: URL,
-        urlSchemeTask: WKURLSchemeTask
+        urlSchemeTask: WKURLSchemeTask,
+        waitForReplacement: Bool = false
     ) {
         let taskID = ObjectIdentifier(urlSchemeTask as AnyObject)
         let state = SchemeTaskState()
@@ -2836,6 +2879,24 @@ final class CmuxDiffViewerURLSchemeHandler: NSObject, WKURLSchemeHandler {
         activeSchemeTasks[taskID] = state
         lock.unlock()
 
+        if waitForReplacement {
+            startWaitingForReplacement(
+                file,
+                requestURL: requestURL,
+                urlSchemeTask: urlSchemeTask,
+                taskID: taskID
+            )
+        } else {
+            enqueueStreamingFile(file, requestURL: requestURL, urlSchemeTask: urlSchemeTask, taskID: taskID)
+        }
+    }
+
+    private func enqueueStreamingFile(
+        _ file: RegisteredFile,
+        requestURL: URL,
+        urlSchemeTask: WKURLSchemeTask,
+        taskID: ObjectIdentifier
+    ) {
         streamQueue.async { [weak self] in
             guard let self else { return }
             do {
@@ -2880,6 +2941,134 @@ final class CmuxDiffViewerURLSchemeHandler: NSObject, WKURLSchemeHandler {
                 }) else { return }
                 self.finishSchemeTask(taskID)
             }
+        }
+    }
+
+    private func startWaitingForReplacement(
+        _ file: RegisteredFile,
+        requestURL: URL,
+        urlSchemeTask: WKURLSchemeTask,
+        taskID: ObjectIdentifier
+    ) {
+        guard isSchemeTaskActive(taskID) else { return }
+        guard diffViewerReplacementIsPending(file.fileURL) else {
+            enqueueStreamingFile(file, requestURL: requestURL, urlSchemeTask: urlSchemeTask, taskID: taskID)
+            return
+        }
+
+        let fd = open(file.fileURL.path, O_EVTONLY)
+        guard fd >= 0 else {
+            failSchemeTask(taskID, urlSchemeTask: urlSchemeTask, errorCode: NSURLErrorFileDoesNotExist)
+            return
+        }
+
+        let watcher = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: fd,
+            eventMask: [.write, .extend, .attrib, .delete, .rename],
+            queue: streamQueue
+        )
+        let timeout = DispatchSource.makeTimerSource(queue: streamQueue)
+
+        watcher.setEventHandler { [weak self, weak watcher, weak timeout] in
+            guard let self else { return }
+            guard !self.diffViewerReplacementIsPending(file.fileURL) else { return }
+            guard self.finishReplacementWait(taskID, watcher: watcher, timeout: timeout) else { return }
+            self.enqueueStreamingFile(file, requestURL: requestURL, urlSchemeTask: urlSchemeTask, taskID: taskID)
+        }
+        watcher.setCancelHandler {
+            close(fd)
+        }
+        timeout.setEventHandler { [weak self, weak watcher, weak timeout] in
+            guard let self else { return }
+            guard self.finishReplacementWait(taskID, watcher: watcher, timeout: timeout) else { return }
+            self.failSchemeTask(taskID, urlSchemeTask: urlSchemeTask, errorCode: NSURLErrorTimedOut)
+        }
+        timeout.schedule(deadline: .now() + Self.replacementWaitTimeout)
+
+        guard storeReplacementWaitSources(taskID, watcher: watcher, timeout: timeout) else {
+            watcher.cancel()
+            watcher.resume()
+            timeout.cancel()
+            timeout.resume()
+            return
+        }
+        watcher.resume()
+        timeout.resume()
+
+        guard !diffViewerReplacementIsPending(file.fileURL) else { return }
+        guard finishReplacementWait(taskID, watcher: watcher, timeout: timeout) else { return }
+        enqueueStreamingFile(file, requestURL: requestURL, urlSchemeTask: urlSchemeTask, taskID: taskID)
+    }
+
+    private func diffViewerReplacementIsPending(_ fileURL: URL) -> Bool {
+        guard let data = try? Data(contentsOf: fileURL) else {
+            return true
+        }
+        return data.range(of: Self.pendingReplacementMarker) != nil
+    }
+
+    private func storeReplacementWaitSources(
+        _ taskID: ObjectIdentifier,
+        watcher: DispatchSourceFileSystemObject,
+        timeout: DispatchSourceTimer
+    ) -> Bool {
+        lock.lock()
+        let state = activeSchemeTasks[taskID]
+        lock.unlock()
+        guard let state else { return false }
+
+        state.condition.lock()
+        guard !state.isStopped else {
+            state.condition.unlock()
+            return false
+        }
+        state.replacementWatcher = watcher
+        state.replacementTimeout = timeout
+        state.condition.unlock()
+        return true
+    }
+
+    private func finishReplacementWait(
+        _ taskID: ObjectIdentifier,
+        watcher suppliedWatcher: DispatchSourceFileSystemObject?,
+        timeout suppliedTimeout: DispatchSourceTimer?
+    ) -> Bool {
+        lock.lock()
+        let state = activeSchemeTasks[taskID]
+        lock.unlock()
+        guard let state else { return false }
+
+        let watcher: DispatchSourceFileSystemObject?
+        let timeout: DispatchSourceTimer?
+        state.condition.lock()
+        guard !state.isStopped,
+              !state.replacementWaitFinished else {
+            state.condition.unlock()
+            return false
+        }
+        state.replacementWaitFinished = true
+        watcher = state.replacementWatcher ?? suppliedWatcher
+        timeout = state.replacementTimeout ?? suppliedTimeout
+        state.replacementWatcher = nil
+        state.replacementTimeout = nil
+        state.condition.unlock()
+
+        watcher?.cancel()
+        timeout?.cancel()
+        return true
+    }
+
+    private func failSchemeTask(
+        _ taskID: ObjectIdentifier,
+        urlSchemeTask: WKURLSchemeTask,
+        errorCode: Int
+    ) {
+        streamQueue.async { [weak self] in
+            guard let self else { return }
+            guard self.performSchemeTaskCallback(taskID, {
+                urlSchemeTask.didFailWithError(NSError(domain: NSURLErrorDomain, code: errorCode))
+            }) else { return }
+            self.finishSchemeTask(taskID)
         }
     }
 
@@ -2931,12 +3120,21 @@ final class CmuxDiffViewerURLSchemeHandler: NSObject, WKURLSchemeHandler {
         lock.unlock()
         guard let state else { return }
 
+        let watcher: DispatchSourceFileSystemObject?
+        let timeout: DispatchSourceTimer?
         state.condition.lock()
         state.isStopped = true
+        watcher = state.replacementWatcher
+        timeout = state.replacementTimeout
+        state.replacementWatcher = nil
+        state.replacementTimeout = nil
         while state.callbacksInFlight > 0 {
             state.condition.wait()
         }
         state.condition.unlock()
+
+        watcher?.cancel()
+        timeout?.cancel()
     }
 
     private static func fileSize(for url: URL) -> Int {
@@ -2972,6 +3170,8 @@ final class CmuxDiffViewerURLSchemeHandler: NSObject, WKURLSchemeHandler {
                 "style-src 'unsafe-inline'",
                 "img-src 'self' data:",
                 "connect-src 'self'",
+                "frame-src http://127.0.0.1:*",
+                "child-src http://127.0.0.1:*",
                 "font-src 'none'",
                 "object-src 'none'",
                 "base-uri 'none'",

--- a/cmuxTests/CMUXOpenCommandTests.swift
+++ b/cmuxTests/CMUXOpenCommandTests.swift
@@ -1648,6 +1648,7 @@ final class CMUXOpenCommandTests: XCTestCase {
         let repoURL = rootURL.appendingPathComponent("repo", isDirectory: true)
         let fakeBinURL = rootURL.appendingPathComponent("bin", isDirectory: true)
         let fakeGitURL = fakeBinURL.appendingPathComponent("git", isDirectory: false)
+        let gitInvokedURL = rootURL.appendingPathComponent("git-invoked", isDirectory: false)
         let diffStartedURL = rootURL.appendingPathComponent("diff-started", isDirectory: false)
         let releaseDiffURL = rootURL.appendingPathComponent("release-diff", isDirectory: false)
         let alternateStartedURL = rootURL.appendingPathComponent("alternate-started", isDirectory: false)
@@ -1661,6 +1662,7 @@ final class CMUXOpenCommandTests: XCTestCase {
         if [ "${1:-}" = "-C" ]; then
           shift 2
         fi
+        : > "$CMUX_FAKE_GIT_INVOKED"
         if [ "${1:-}" = "rev-parse" ] && [ "${2:-}" = "--show-toplevel" ]; then
           printf '%s\\n' "$CMUX_FAKE_GIT_REPO_ROOT"
           exit 0
@@ -1708,6 +1710,9 @@ final class CMUXOpenCommandTests: XCTestCase {
         let openedURLBox = AsyncValueBox<String?>(nil)
         let openedHTMLURLBox = AsyncValueBox<URL?>(nil)
         let pendingHTMLBox = AsyncValueBox<String?>(nil)
+        let openedSchemeBox = AsyncValueBox<String?>(nil)
+        let registeredFileCountBox = AsyncValueBox<Int?>(nil)
+        let gitHadStartedWhenOpenedBox = AsyncValueBox<Bool?>(nil)
         let diffHadStartedWhenOpenedBox = AsyncValueBox<Bool?>(nil)
         let openHandled = expectation(description: "browser opened before fake git diff completed")
         defer {
@@ -1725,8 +1730,11 @@ final class CMUXOpenCommandTests: XCTestCase {
                 return Self.v2Response(id: "unknown", ok: false, error: ["code": "unexpected"])
             }
             openedURLBox.set(rawURL)
+            openedSchemeBox.set(URL(string: rawURL)?.scheme)
+            registeredFileCountBox.set((params["diff_viewer_files"] as? [[String: Any]])?.count)
+            gitHadStartedWhenOpenedBox.set(FileManager.default.fileExists(atPath: gitInvokedURL.path))
             diffHadStartedWhenOpenedBox.set(FileManager.default.fileExists(atPath: diffStartedURL.path))
-            if let htmlURL = Self.diffViewerHTMLFileURLFromHTTPManifest(for: rawURL) {
+            if let htmlURL = Self.diffViewerHTMLFileURLFromOpenParams(for: rawURL, params: params) {
                 openedHTMLURLBox.set(htmlURL)
                 pendingHTMLBox.set(try? String(contentsOf: htmlURL, encoding: .utf8))
             }
@@ -1746,6 +1754,7 @@ final class CMUXOpenCommandTests: XCTestCase {
         environment["CMUX_SOCKET_PATH"] = socketPath
         environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
         environment["CMUX_CLAUDE_HOOK_SENTRY_DISABLED"] = "1"
+        environment["CMUX_FAKE_GIT_INVOKED"] = gitInvokedURL.path
         environment["CMUX_FAKE_GIT_REPO_ROOT"] = repoURL.path
         environment["CMUX_FAKE_GIT_STARTED"] = diffStartedURL.path
         environment["CMUX_FAKE_GIT_RELEASE"] = releaseDiffURL.path
@@ -1763,21 +1772,24 @@ final class CMUXOpenCommandTests: XCTestCase {
 
         wait(for: [openHandled], timeout: 5)
         XCTAssertNotNil(openedURLBox.get())
+        XCTAssertEqual(openedSchemeBox.get(), "cmux-diff-viewer")
+        XCTAssertEqual(registeredFileCountBox.get(), 2)
+        XCTAssertEqual(gitHadStartedWhenOpenedBox.get() ?? true, false)
         XCTAssertEqual(diffHadStartedWhenOpenedBox.get() ?? true, false)
         let pendingHTML = try XCTUnwrap(pendingHTMLBox.get())
-        let pendingPayload = try diffViewerPayload(from: pendingHTML)
         XCTAssertTrue(pendingHTML.contains("data-cmux-diff-pending=\"true\""), pendingHTML)
-        XCTAssertFalse(pendingHTML.contains("data-status-only=\"true\""), pendingHTML)
-        XCTAssertTrue(pendingHTML.contains("<div id=\"root\"></div>"), pendingHTML)
-        XCTAssertEqual(pendingPayload["pendingReplacement"] as? Bool, true)
-        XCTAssertEqual(pendingPayload["title"] as? String, "Slow diff")
-        XCTAssertEqual(pendingPayload["statusIsError"] as? Bool, false)
+        XCTAssertTrue(pendingHTML.contains("data-status-only=\"true\""), pendingHTML)
+        XCTAssertTrue(pendingHTML.contains("id=\"toolbar\""), pendingHTML)
+        XCTAssertTrue(pendingHTML.contains("id=\"viewer\""), pendingHTML)
+        XCTAssertTrue(pendingHTML.contains("Slow diff"), pendingHTML)
         XCTAssertFalse(FileManager.default.fileExists(atPath: releaseDiffURL.path))
         FileManager.default.createFile(atPath: releaseDiffURL.path, contents: Data())
         let openingHTMLURL = try XCTUnwrap(openedHTMLURLBox.get())
         XCTAssertTrue(waitUntil(timeout: 5) {
             let html = (try? String(contentsOf: openingHTMLURL, encoding: .utf8)) ?? ""
-            return html.contains("data-cmux-diff-redirect=")
+            return html.contains("data-cmux-diff-embedded=\"true\"")
+                && html.contains("data-cmux-diff-embed-url=")
+                && !html.contains("data-cmux-diff-redirect=")
                 && FileManager.default.fileExists(atPath: alternateStartedURL.path)
         })
         XCTAssertFalse(FileManager.default.fileExists(atPath: releaseAlternateURL.path))
@@ -2249,11 +2261,17 @@ final class CMUXOpenCommandTests: XCTestCase {
         let rawURL = try XCTUnwrap(params["url"] as? String)
         XCTAssertEqual(params["bypass_remote_proxy"] as? Bool, true)
         let viewerURL = try XCTUnwrap(URL(string: rawURL))
-        XCTAssertEqual(viewerURL.scheme, "http")
-        XCTAssertEqual(viewerURL.host, "127.0.0.1")
-        XCTAssertEqual(viewerURL.fragment, "cmux-diff-viewer")
-        XCTAssertNil(params["diff_viewer_token"])
-        XCTAssertNil(params["diff_viewer_files"])
+        if viewerURL.scheme == "http" {
+            XCTAssertEqual(viewerURL.host, "127.0.0.1")
+            XCTAssertEqual(viewerURL.fragment, "cmux-diff-viewer")
+            XCTAssertNil(params["diff_viewer_token"])
+            XCTAssertNil(params["diff_viewer_files"])
+        } else {
+            XCTAssertEqual(viewerURL.scheme, "cmux-diff-viewer")
+            XCTAssertEqual(viewerURL.fragment, nil)
+            XCTAssertEqual(params["diff_viewer_token"] as? String, viewerURL.host)
+            XCTAssertNotNil(params["diff_viewer_files"])
+        }
         let openedFileURL = try diffViewerHTMLFileURL(for: rawURL, from: params)
         let viewerFileURL = try resolvedDiffViewerHTMLFileURL(openedFileURL, from: params)
         if openedFileURL != viewerFileURL {
@@ -2276,16 +2294,17 @@ final class CMUXOpenCommandTests: XCTestCase {
         var current = fileURL
         for _ in 0..<4 {
             let html = try String(contentsOf: current, encoding: .utf8)
-            guard let redirectURL = Self.diffViewerRedirectURL(from: html) else {
-                return current
+            if let embeddedURL = Self.diffViewerEmbeddedURL(from: html) {
+                current = try diffViewerHTMLFileURL(for: embeddedURL, from: params)
+                continue
             }
-            current = try diffViewerHTMLFileURL(for: redirectURL, from: params)
+            return current
         }
         return current
     }
 
-    private static func diffViewerRedirectURL(from html: String) -> String? {
-        let marker = "data-cmux-diff-redirect=\""
+    private static func diffViewerEmbeddedURL(from html: String) -> String? {
+        let marker = "data-cmux-diff-embed-url=\""
         guard let start = html.range(of: marker)?.upperBound else { return nil }
         let tail = html[start...]
         guard let end = tail.firstIndex(of: "\"") else { return nil }
@@ -2322,6 +2341,32 @@ final class CMUXOpenCommandTests: XCTestCase {
                   file["request_path"] as? String == manifestRequestPath &&
                       file["mime_type"] as? String == "text/html"
               }),
+              let filePath = entry["file_path"] as? String else {
+            return nil
+        }
+        return URL(fileURLWithPath: filePath, isDirectory: false)
+    }
+
+    private static func diffViewerHTMLFileURLFromOpenParams(
+        for rawURL: String,
+        params: [String: Any]
+    ) -> URL? {
+        guard let viewerURL = URL(string: rawURL) else {
+            return nil
+        }
+        if viewerURL.scheme == "http" {
+            return diffViewerHTMLFileURLFromHTTPManifest(for: rawURL)
+        }
+        guard viewerURL.scheme == "cmux-diff-viewer",
+              let files = params["diff_viewer_files"] as? [[String: Any]] else {
+            return nil
+        }
+        let rawRequestPath = URLComponents(url: viewerURL, resolvingAgainstBaseURL: false)?.percentEncodedPath ?? viewerURL.path
+        let requestPath = rawRequestPath.isEmpty ? "/" : rawRequestPath
+        guard let entry = files.first(where: { file in
+            file["request_path"] as? String == requestPath &&
+                file["mime_type"] as? String == "text/html"
+        }),
               let filePath = entry["file_path"] as? String else {
             return nil
         }


### PR DESCRIPTION
Summary
- Open git diff viewer panes with a tiny cmux-diff-viewer:// pending page before starting git or the HTTP asset server.
- Defer git/source/asset work until after browser.open_split returns, then replace the pending page with the completed HTTP viewer.
- Add an event-driven app-scheme wait endpoint so replacement waits do not block the shared stream operation, and cover the no-git-before-open path.

Testing
- swiftc -parse CLI/cmux_open.swift
- swiftc -parse Sources/Panels/BrowserPanel.swift
- swiftc -parse cmuxTests/CMUXOpenCommandTests.swift
- git diff --check
- /Users/lawrence/fun/cmuxterm-hq/skills/codex-review/scripts/codex-review --parallel-tests "swiftc -parse CLI/cmux_open.swift && swiftc -parse Sources/Panels/BrowserPanel.swift && swiftc -parse cmuxTests/CMUXOpenCommandTests.swift && git diff --check"
- ./scripts/reload.sh --tag task-diff-viewer-404-instant-pane --swift-frontend-workaround
- Tagged CLI slow-git socket repro: browser.open_split in 35 ms, cmux-diff-viewer scheme, 2 initial files, no git before open, process exited 0.

Notes
- Codex review found no correctness issues after the event-driven wait fix. cmux-policy still notes the existing XCTest-based non-UI test file preference for Swift Testing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5047"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782806081&installation_id=133855650&pr_number=5047&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5047&signature=756a1dd1ba62eaf989061030be376ae1add82943b00530f4a3f964358200f80e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches diff viewer URL transport, WKWebView custom scheme streaming, and CSP framing of localhost; behavior change for all non-lastTurn git diff opens but covered by integration tests.
> 
> **Overview**
> Git diff panes now open **immediately** on a lightweight `cmux-diff-viewer://` pending page instead of waiting for git, asset bundling, and the local HTTP server.
> 
> **CLI (`cmux_open`)** splits opening vs completion: non–`lastTurn` sources use **app-scheme** URLs and a minimal status HTML (toolbar + spinner); heavy work runs in `completeDeferred` after `browser.open_split`. `DiffViewerURLMapper` gains **http** vs **appScheme** transports; `--cwd` sets repo root without an upfront `git rev-parse`. Redirect HTML is replaced by **opening status** (client fetch to `/__cmux_diff_viewer_wait…`) and **embedded** pages that iframe the finished `http://127.0.0.1` viewer.
> 
> **Browser (`CmuxDiffViewerURLSchemeHandler`)** handles the wait path with **file-system watching** and a **120s** timeout so replacement does not block the shared stream queue; HTML CSP allows **frame-src** to localhost.
> 
> **Tests** assert app-scheme open, two registered files, no git before open, and embedded-URL resolution instead of redirects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2c155860b884e0a77e11e6e7f440e5f17cccb35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Open the diff viewer pane instantly with a lightweight `cmux-diff-viewer://` pending page, then embed the full HTTP viewer once git and assets are ready. This removes the initial blank delay and keeps the UI responsive even when git is slow.

- **New Features**
  - Open via `cmux-diff-viewer://` with minimal status-only HTML (toolbar + spinner); no git, asset bundling, or HTTP server work before the pane appears.
  - Add an event-driven wait path `/__cmux_diff_viewer_wait/...` that blocks on file changes and streams the final HTML after the pending marker clears; 120s timeout and non-blocking.
  - Swap to the completed viewer by embedding an iframe (trusted `http://127.0.0.1` only) or replacing the document; restart scripts on replace; CSP allows `frame-src` and `child-src` for `http://127.0.0.1:*`.
  - Extend URL mapping with `http` and app-scheme transports; opening uses app-scheme and completion switches to HTTP. Use `--cwd` for repo root to avoid upfront `git`. Tests cover app-scheme open, two registered files, “no git before open,” and embedded-URL completion instead of redirect.

<sup>Written for commit e2c155860b884e0a77e11e6e7f440e5f17cccb35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5047?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Diff viewer opens a lightweight "pending" page immediately and client-side polling swaps in the fully rendered viewer when ready.
  * Viewer URLs support both HTTP and app-scheme modes for improved loading and embedding.
  * In-browser replacement now updates attributes/head/body and restarts inert scripts for a seamless swap.

* **Bug Fixes / Reliability**
  * Added a replacement-wait streaming flow with timeout to avoid hangs and surface timed-out errors.
  * Content-Security-Policy relaxed to allow local frame sources.

* **Tests**
  * Updated tests to validate pending-open ordering, scheme-based viewer URLs, and embedded-URL resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->