### PR TITLE
Hold folder icon/title position at minimum sidebar width

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2364,7 +2364,13 @@ struct ContentView: View {
             }
             .frame(height: titlebarContentHeight)
             .padding(.top, 2)
-            .padding(.leading, (isFullScreen && !sidebarState.isVisible) ? 8 : (sidebarState.isVisible ? sidebarWidth + 12 : titlebarLeadingInset))
+            .padding(.leading, TitlebarFolderTitleLayout.leadingInset(
+                isFullScreen: isFullScreen,
+                sidebarVisible: sidebarState.isVisible,
+                sidebarWidth: sidebarWidth,
+                minimumSidebarWidth: minimumSidebarWidth,
+                collapsedInset: titlebarLeadingInset
+            ))
             .padding(.trailing, 8)
         }
         .frame(height: WindowChromeMetrics.appTitlebarHeight)

--- a/Sources/WindowChromeMetrics.swift
+++ b/Sources/WindowChromeMetrics.swift
@@ -56,8 +56,15 @@ enum TitlebarFolderTitleLayout {
         if isFullScreen && !sidebarVisible {
             return fullscreenCollapsedInset
         }
+        let openInset = sidebarWidth + openSidebarGap
         if sidebarVisible {
-            return sidebarWidth + openSidebarGap
+            return openInset
+        }
+        // Collapsed. At the minimum width, keep the folder icon/title where it sits
+        // when the sidebar is open so toggling the sidebar does not move it. Above the
+        // minimum, slide back to the traffic-light inset.
+        if sidebarWidth <= minimumSidebarWidth + minimumWidthTolerance {
+            return openInset
         }
         return collapsedInset
     }

--- a/Sources/WindowChromeMetrics.swift
+++ b/Sources/WindowChromeMetrics.swift
@@ -18,6 +18,51 @@ enum MinimalModeChromeMetrics {
     static let titlebarHeight: CGFloat = WindowChromeMetrics.appTitlebarHeight
 }
 
+enum TitlebarFolderTitleLayout {
+    /// Horizontal gap between the sidebar's trailing edge and the folder icon/title
+    /// when the sidebar is open.
+    static let openSidebarGap: CGFloat = 12
+    /// Leading inset for the folder icon/title in non-native fullscreen when the
+    /// sidebar is collapsed (the inline fullscreen controls precede it).
+    static let fullscreenCollapsedInset: CGFloat = 8
+    /// Width slop used to treat a sidebar width as "at minimum" (the live width can
+    /// settle a hair above the clamp after a resize).
+    static let minimumWidthTolerance: CGFloat = 0.5
+
+    /// Leading inset for the custom titlebar's folder icon + workspace title.
+    ///
+    /// When the sidebar sits at its minimum width, the folder icon/title keeps the
+    /// same x-position whether the sidebar is open or collapsed, so toggling the
+    /// sidebar does not shift it. Above the minimum width, collapsing the sidebar
+    /// slides the title back to `collapsedInset` (the traffic-light + sidebar-control
+    /// inset); that movement is intentional so a wide sidebar does not leave a large
+    /// gap on the left.
+    ///
+    /// - Parameters:
+    ///   - isFullScreen: Whether the window is in non-native fullscreen.
+    ///   - sidebarVisible: Whether the left sidebar is currently shown.
+    ///   - sidebarWidth: The current (or last persisted) sidebar width.
+    ///   - minimumSidebarWidth: The configured minimum sidebar width.
+    ///   - collapsedInset: The leading inset used when the sidebar is collapsed and
+    ///     wider than the minimum (just past the traffic lights and sidebar controls).
+    /// - Returns: The leading padding for the folder icon/title HStack.
+    static func leadingInset(
+        isFullScreen: Bool,
+        sidebarVisible: Bool,
+        sidebarWidth: CGFloat,
+        minimumSidebarWidth: CGFloat,
+        collapsedInset: CGFloat
+    ) -> CGFloat {
+        if isFullScreen && !sidebarVisible {
+            return fullscreenCollapsedInset
+        }
+        if sidebarVisible {
+            return sidebarWidth + openSidebarGap
+        }
+        return collapsedInset
+    }
+}
+
 enum HeaderChromeControlMetrics {
     static let buttonSize: CGFloat = 20
     static let iconSize: CGFloat = 12

--- a/cmuxTests/TitlebarInteractiveControlTests.swift
+++ b/cmuxTests/TitlebarInteractiveControlTests.swift
@@ -101,3 +101,123 @@ struct TitlebarInteractiveControlTests {
         )
     }
 }
+
+@Suite("Titlebar folder title layout")
+struct TitlebarFolderTitleLayoutTests {
+    // Representative traffic-light + sidebar-control inset: where the folder
+    // icon/title lands when the sidebar is collapsed and wider than the minimum.
+    private let collapsedInset: CGFloat = 96
+    private let defaultMinimum: CGFloat = 216
+
+    @Test("At minimum sidebar width the folder title does not move when toggling the sidebar")
+    func stableAtMinimumWidth() {
+        let open = TitlebarFolderTitleLayout.leadingInset(
+            isFullScreen: false,
+            sidebarVisible: true,
+            sidebarWidth: defaultMinimum,
+            minimumSidebarWidth: defaultMinimum,
+            collapsedInset: collapsedInset
+        )
+        let collapsed = TitlebarFolderTitleLayout.leadingInset(
+            isFullScreen: false,
+            sidebarVisible: false,
+            sidebarWidth: defaultMinimum,
+            minimumSidebarWidth: defaultMinimum,
+            collapsedInset: collapsedInset
+        )
+        #expect(
+            open == collapsed,
+            "At minimum sidebar width, the folder icon/title must hold its x-position when the sidebar is toggled."
+        )
+    }
+
+    @Test("Collapsing at minimum width keeps the folder title at the open (content) position")
+    func collapsedAtMinimumUsesOpenAnchor() {
+        let collapsed = TitlebarFolderTitleLayout.leadingInset(
+            isFullScreen: false,
+            sidebarVisible: false,
+            sidebarWidth: defaultMinimum,
+            minimumSidebarWidth: defaultMinimum,
+            collapsedInset: collapsedInset
+        )
+        #expect(collapsed == defaultMinimum + TitlebarFolderTitleLayout.openSidebarGap)
+    }
+
+    @Test("Above minimum width collapsing the sidebar still moves the folder title")
+    func movesAboveMinimumWidth() {
+        let width = defaultMinimum + 140
+        let open = TitlebarFolderTitleLayout.leadingInset(
+            isFullScreen: false,
+            sidebarVisible: true,
+            sidebarWidth: width,
+            minimumSidebarWidth: defaultMinimum,
+            collapsedInset: collapsedInset
+        )
+        let collapsed = TitlebarFolderTitleLayout.leadingInset(
+            isFullScreen: false,
+            sidebarVisible: false,
+            sidebarWidth: width,
+            minimumSidebarWidth: defaultMinimum,
+            collapsedInset: collapsedInset
+        )
+        #expect(open != collapsed)
+        #expect(
+            collapsed == collapsedInset,
+            "Above minimum width, a collapsed sidebar returns the title to the traffic-light inset."
+        )
+    }
+
+    @Test(
+        "Configured minimum widths still pin the collapsed title",
+        arguments: [120.0, 180.0, 216.0, 260.0] as [CGFloat]
+    )
+    func stableAtConfiguredMinimum(_ minimum: CGFloat) {
+        let open = TitlebarFolderTitleLayout.leadingInset(
+            isFullScreen: false,
+            sidebarVisible: true,
+            sidebarWidth: minimum,
+            minimumSidebarWidth: minimum,
+            collapsedInset: collapsedInset
+        )
+        let collapsed = TitlebarFolderTitleLayout.leadingInset(
+            isFullScreen: false,
+            sidebarVisible: false,
+            sidebarWidth: minimum,
+            minimumSidebarWidth: minimum,
+            collapsedInset: collapsedInset
+        )
+        #expect(open == collapsed)
+    }
+
+    @Test("A width within tolerance of the minimum is treated as minimum")
+    func toleranceTreatedAsMinimum() {
+        let width = defaultMinimum + TitlebarFolderTitleLayout.minimumWidthTolerance / 2
+        let open = TitlebarFolderTitleLayout.leadingInset(
+            isFullScreen: false,
+            sidebarVisible: true,
+            sidebarWidth: width,
+            minimumSidebarWidth: defaultMinimum,
+            collapsedInset: collapsedInset
+        )
+        let collapsed = TitlebarFolderTitleLayout.leadingInset(
+            isFullScreen: false,
+            sidebarVisible: false,
+            sidebarWidth: width,
+            minimumSidebarWidth: defaultMinimum,
+            collapsedInset: collapsedInset
+        )
+        #expect(open == collapsed)
+    }
+
+    @Test("Fullscreen with the sidebar collapsed uses the inline fullscreen inset")
+    func fullscreenCollapsedUsesInlineInset() {
+        let inset = TitlebarFolderTitleLayout.leadingInset(
+            isFullScreen: true,
+            sidebarVisible: false,
+            sidebarWidth: defaultMinimum,
+            minimumSidebarWidth: defaultMinimum,
+            collapsedInset: collapsedInset
+        )
+        #expect(inset == TitlebarFolderTitleLayout.fullscreenCollapsedInset)
+    }
+}


### PR DESCRIPTION
## Summary
- At the minimum sidebar width, the custom titlebar folder icon/title now holds its x-position when the sidebar is toggled, instead of jumping horizontally.
- It anchors to the open (content-side) position: when you hide the sidebar at minimum width, the icon/title stays put while the sidebar control buttons remain where they are.
- Above the minimum width, behavior is unchanged: collapsing the sidebar still slides the title back to the traffic-light inset, so a wide sidebar does not leave a large gap.
- Extracted the inline padding math into a pure `TitlebarFolderTitleLayout.leadingInset(...)` helper in `WindowChromeMetrics.swift` so the layout is unit-testable.

## Testing
- Added `TitlebarFolderTitleLayoutTests` (Swift Testing) covering: no movement at minimum width (open vs collapsed), collapsed-at-minimum anchors to the open position, movement still allowed above minimum, configured minimum widths (120/180/216/260), within-tolerance widths treated as minimum, and the fullscreen-collapsed inset. Runs in CI via the `cmux-unit` scheme.
- Two-commit red/green: commit 1 adds the failing test against the old behavior; commit 2 adds the minimum-width branch that turns it green.
- Local tagged Debug build for dogfood: `./scripts/reload.sh --tag sidebar-min-title`.

## Task
- Task: at minimum sidebar width, the folder icon/title must not move when the sidebar is opened or closed; above minimum width, movement is fine.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5048"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782806096&installation_id=133855650&pr_number=5048&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5048&signature=50a84bcd718b6f703d28afdca66bd13f24f440cdedc3e8b5e17f5563c79d92f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized titlebar padding logic with pure functions and tests; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes a **horizontal jump** of the custom titlebar **folder icon and workspace title** when the left sidebar is toggled while the sidebar is at (or within tolerance of) its **minimum width**.
> 
> The titlebar’s leading padding no longer uses a simple open-vs-collapsed branch. It now goes through **`TitlebarFolderTitleLayout.leadingInset(...)`** in `WindowChromeMetrics.swift`, which keeps the title at the **open (sidebar + gap) anchor** when collapsed at minimum width, still uses the **traffic-light / control inset** when collapsed above minimum width, and preserves the **fullscreen collapsed** inset. **`ContentView`** calls that helper with **`minimumSidebarWidth`** and the existing collapsed inset.
> 
> **`TitlebarFolderTitleLayoutTests`** (Swift Testing) lock in minimum-width stability, above-minimum movement, configured minimums, width tolerance, and fullscreen behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0147385a29b694d44606e1eea28cb374818618f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the custom titlebar folder icon/title from shifting when toggling the sidebar at its minimum width. Above the minimum, collapsing still returns it to the traffic-light inset. Satisfies the task requirement.

- **Bug Fixes**
  - Hold the folder icon/title x-position at minimum sidebar width (with small tolerance).
  - Fullscreen + collapsed uses the inline inset; control buttons remain unchanged.
  - Above minimum width, collapsing still returns the title to the traffic-light inset.

- **Refactors**
  - Extracted layout math to `TitlebarFolderTitleLayout.leadingInset(...)` in `WindowChromeMetrics.swift`; `ContentView` now calls it.
  - Added Swift Testing in `TitlebarFolderTitleLayoutTests` for minimum-width, tolerance, configured minimums, and fullscreen cases.

<sup>Written for commit e0147385a29b694d44606e1eea28cb374818618f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5048?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stabilized titlebar folder title positioning so its leading inset updates correctly with sidebar visibility, width and collapse thresholds—reducing jarring horizontal shifts when toggling or resizing the sidebar and ensuring consistent fullscreen behavior.

* **Tests**
  * Added tests covering titlebar inset calculations across sidebar visible/collapsed states, minimum-width tolerance edge cases, and fullscreen scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->