### PR TITLE
Center empty sidebar-extension state and fade the host's bottom edge

### DIFF
--- a/Sources/CMUXInstalledExtensionSidebarHostView.swift
+++ b/Sources/CMUXInstalledExtensionSidebarHostView.swift
@@ -204,35 +204,51 @@ struct CMUXInstalledExtensionSidebarHostView: View {
                         blockedExtensionView(reason: blockedManifestReason)
                     }
                 }
+            } else if isLoading {
+                VStack(spacing: 10) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text(String(localized: "sidebar.extensions.loading", defaultValue: "Loading sidebar extensions"))
+                        .font(.system(size: 12))
+                        .foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+                .padding(24)
+                .accessibilityIdentifier("CMUXExtensionSidebarEmptyState")
             } else {
-                VStack(alignment: .leading, spacing: 10) {
-                    if isLoading {
-                        ProgressView()
-                            .controlSize(.small)
-                        Text(String(localized: "sidebar.extensions.loading", defaultValue: "Loading sidebar extensions"))
-                            .font(.system(size: 12))
-                            .foregroundStyle(.secondary)
-                    } else {
-                        Image(systemName: "puzzlepiece.extension")
-                            .font(.system(size: 22, weight: .regular))
-                            .foregroundStyle(.secondary)
+                VStack(spacing: 16) {
+                    Image(systemName: "puzzlepiece.extension")
+                        .font(.system(size: 26, weight: .regular))
+                        .foregroundStyle(.secondary)
+                        .frame(width: 60, height: 60)
+                        .background(
+                            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                                .fill(Color(nsColor: .controlBackgroundColor).opacity(0.7))
+                        )
+                    VStack(spacing: 6) {
                         Text(emptyStateTitle)
-                            .font(.system(size: 13, weight: .medium))
+                            .font(.system(size: 14, weight: .semibold))
                             .foregroundStyle(.primary)
+                            .multilineTextAlignment(.center)
                         Text(errorText ?? emptyStateDetail)
                             .font(.system(size: 12))
                             .foregroundStyle(.secondary)
+                            .multilineTextAlignment(.center)
                             .fixedSize(horizontal: false, vertical: true)
                         if disabledExtensionCount > 0 || unapprovedExtensionCount > 0 {
                             Text(extensionAvailabilityDetail)
                                 .font(.system(size: 12))
                                 .foregroundStyle(.secondary)
+                                .multilineTextAlignment(.center)
                                 .fixedSize(horizontal: false, vertical: true)
                         }
-                        extensionEmptyActions()
                     }
+                    extensionEmptyActions()
+                        .padding(.top, 2)
                 }
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                .frame(maxWidth: 320)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+                .padding(24)
                 .accessibilityIdentifier("CMUXExtensionSidebarEmptyState")
             }
         }
@@ -315,7 +331,7 @@ struct CMUXInstalledExtensionSidebarHostView: View {
             HStack(spacing: 8) {
                 extensionEmptyActionButtons()
             }
-            VStack(alignment: .leading, spacing: 8) {
+            VStack(spacing: 8) {
                 extensionEmptyActionButtons()
             }
         }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -10775,6 +10775,16 @@ struct VerticalTabsSidebar: View {
             ) { _ in
                 refreshExtensionSidebarSnapshot()
             }
+            // Fade the extension's content out at the bottom so it dissolves behind the
+            // sidebar footer instead of overlapping it sharply, matching the default
+            // workspace sidebar's bottom scrim. Top stays sharp so the control strip
+            // remains crisp.
+            .mask(
+                SidebarWorkspaceScrollEdgeFadeMask(
+                    topHeight: 0,
+                    bottomHeight: sidebarBottomScrimHeight
+                )
+            )
         } else {
             TimelineView(.periodic(from: .now, by: 30)) { timeline in
                 let model = extensionSidebarRenderModel(renderContext: renderContext, now: timeline.date)


### PR DESCRIPTION
Two sidebar-extension polish fixes.

## 1. Centered empty/placeholder state
The "No sidebar extension enabled" placeholder was pinned top-leading with no padding, so it looked like a broken layout. It's now centered vertically and horizontally: icon in a rounded tile, semibold title, centered wrapped copy, centered action buttons. The loading state is centered too.

## 2. Bottom edge-fade on the hosted extension
The hosted-extension area fills the whole sidebar height (`ZStack(.bottomLeading)` with `SidebarFooter` overlaid on top), so the extension's content rendered under the footer (help/puzzle buttons + dev banner) and collided with it. It now uses the same `SidebarWorkspaceScrollEdgeFadeMask` the default workspace sidebar uses, bottom only (top stays sharp so the control strip is crisp), so the content dissolves into the footer instead of overlapping.

Verified on a tagged build (`ext-fix`): centered placeholder + clean bottom fade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5057"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782849425&installation_id=133855650&pr_number=5057&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5057&signature=e78b2546d016c97fbbcd8db3a0ca1cb9d5f2c9a9bdff9f1688b3e1b2663ccacd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centers the empty and loading states in the extension sidebar and adds a bottom edge fade to prevent content from colliding with the footer. This cleans up the layout and matches the default workspace sidebar behavior.

- **Bug Fixes**
  - Centered placeholder/loading content with an icon tile, semibold title, centered text, and actions; added padding and a max-width.
  - Applied a bottom-only edge fade in the extension host so content dissolves behind the footer; top edge stays sharp for the control strip.

<sup>Written for commit b0331f525a4b782397fa58094c9b7f6fd9732890. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5057?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar loading and empty state displays with better visual organization and layout separation.
  * Added fade-out effect to extension content to seamlessly blend with the sidebar footer area instead of sharp overlapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->