### PR TITLE
Fix close confirmation button localization

### DIFF
--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -7584,8 +7584,8 @@ class TabManager: ObservableObject {
         alert.messageText = title
         alert.informativeText = message
         alert.alertStyle = .warning
-        alert.addButton(withTitle: String(localized: "dialog.closeTab.close", defaultValue: "Close"))
-        alert.addButton(withTitle: String(localized: "dialog.closeTab.cancel", defaultValue: "Cancel"))
+        alert.addButton(withTitle: String(localized: "common.close", defaultValue: "Close"))
+        alert.addButton(withTitle: String(localized: "common.cancel", defaultValue: "Cancel"))
 
         if let closeButton = alert.buttons.first {
             closeButton.keyEquivalent = "\r"
@@ -7870,8 +7870,8 @@ class TabManager: ObservableObject {
         alert.messageText = title
         alert.informativeText = message
         alert.alertStyle = .warning
-        alert.addButton(withTitle: String(localized: "dialog.closeTab.close", defaultValue: "Close"))
-        alert.addButton(withTitle: String(localized: "dialog.closeTab.cancel", defaultValue: "Cancel"))
+        alert.addButton(withTitle: String(localized: "common.close", defaultValue: "Close"))
+        alert.addButton(withTitle: String(localized: "common.cancel", defaultValue: "Cancel"))
         let suppressionButton = NSButton(
             checkboxWithTitle: String(
                 localized: "dialog.dontAskAgain",

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -17854,8 +17854,8 @@ extension Workspace: BonsplitDelegate {
         alert.messageText = title
         alert.informativeText = message
         alert.alertStyle = .warning
-        alert.addButton(withTitle: String(localized: "dialog.closeTab.close", defaultValue: "Close"))
-        alert.addButton(withTitle: String(localized: "dialog.closeTab.cancel", defaultValue: "Cancel"))
+        alert.addButton(withTitle: String(localized: "common.close", defaultValue: "Close"))
+        alert.addButton(withTitle: String(localized: "common.cancel", defaultValue: "Cancel"))
 
         if let closeButton = alert.buttons.first {
             closeButton.keyEquivalent = "\r"


### PR DESCRIPTION
## Summary

- Use shared `common.close` and `common.cancel` strings for close confirmation alert buttons.
- This avoids reusing tab-specific button keys for workspace, group-anchor, and tab close prompts.
- Fixes #5060.

## Testing

- `git diff --check`
- Verified `common.close` and `common.cancel` have `zh-Hans` values (`关闭` / `取消`) in `Resources/Localizable.xcstrings`.
- `CMUX_SKIP_ZIG_BUILD=1 ./scripts/reload.sh --tag fix-close-dialog-l10n --swift-frontend-workaround`

Full `reload.sh` without `CMUX_SKIP_ZIG_BUILD=1` is blocked on my machine because the build script requires Zig 0.15.2 and the installed Zig is 0.16.0.

## Demo Video

Not attached; this is a string-key fix for native confirmation alert button labels.

## Checklist

- [x] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5061"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782863770&installation_id=133855650&pr_number=5061&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5061&signature=1fae2052dcd15404b89e3edc5c4ba01606640593cf1ad1a7fee51c9da096888e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch close confirmation alerts to the shared `common.close` and `common.cancel` strings across the app and add Khmer translations for these keys. Fixes #5060.

- **Bug Fixes**
  - Replaced `dialog.closeTab.close`/`dialog.closeTab.cancel` with `common.close`/`common.cancel` in `TabManager` and `Workspace`.
  - Added Khmer (`km`) translations in `Resources/Localizable.xcstrings` for Close/Cancel.

<sup>Written for commit 2ef14ac4128dedfac064c43a93bd0ac652256840. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5061?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized confirmation dialog button labels to use shared common localization keys across multiple dialogs for consistent wording.

* **Chores**
  * Added/updated Khmer translations for the affected dialog labels to ensure translated UI strings are present and marked as translated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->