### PR TITLE
Restore sidebar minimum width

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1581,21 +1581,8 @@ struct ContentView: View {
     private static let maximumRightSidebarWidth: CGFloat = 1200
     private static let minimumTerminalWidthWithRightSidebar: CGFloat = 360
 
-    /// Gap kept between the rightmost titlebar shortcut-hint tooltip and the sidebar's
-    /// trailing edge, so the last tooltip never sits flush against (or spills over) the
-    /// sidebar divider.
-    private static let sidebarTooltipClearance: CGFloat = 8
-
     private var minimumSidebarWidth: CGFloat {
-        let userFloor = CGFloat(SessionPersistencePolicy.sanitizedMinimumSidebarWidth(sidebarMinimumWidthSetting))
-        // The sidebar must be at least as wide as everything in the leading titlebar
-        // accessory area (traffic lights + controls + the shortcut-hint tooltips) plus a
-        // small gap, so the rightmost tooltip stays within the sidebar column instead of
-        // spilling past the divider. `titlebarLeadingInset` is measured at runtime as the
-        // traffic-light inset plus every leading accessory's width, and the accessory's
-        // width now reserves the tooltip extent (see TitlebarControlsLayoutMetrics.contentSize).
-        let tooltipFloor = titlebarLeadingInset + Self.sidebarTooltipClearance
-        return max(userFloor, tooltipFloor)
+        CGFloat(SessionPersistencePolicy.sanitizedMinimumSidebarWidth(sidebarMinimumWidthSetting))
     }
 
     private enum SidebarResizerHandle: Hashable {

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -863,8 +863,6 @@ struct TitlebarControlsView: View {
         )
         let foregroundColor = Color(nsColor: titlebarControlForegroundNSColor(opacity: 1.0))
         controlsGroup(config: config, foregroundColor: foregroundColor)
-            .padding(.top, -1)
-            .padding(.bottom, 1)
             .padding(.leading, TitlebarControlsLayoutMetrics.hintLeadingPadding)
             .padding(.trailing, titlebarHintTrailingInset)
             .frame(width: contentSize.width, height: contentSize.height, alignment: .leading)

--- a/Sources/WindowDragHandleView.swift
+++ b/Sources/WindowDragHandleView.swift
@@ -675,9 +675,8 @@ enum MinimalModeSidebarTitlebarControlsMetrics {
     static let hostHeight: CGFloat = 28
     static let singleButtonHostWidth: CGFloat = hostHeight
 
-    static func titlebarControlsOpticalYOffset(backingScaleFactor: CGFloat?) -> CGFloat {
-        let scale = max(1.0, backingScaleFactor ?? 1.0)
-        return 1.0 / scale
+    static func titlebarControlsOpticalYOffset(backingScaleFactor _: CGFloat?) -> CGFloat {
+        0
     }
 
     @MainActor

--- a/cmuxTests/WindowAndDragTests.swift
+++ b/cmuxTests/WindowAndDragTests.swift
@@ -1035,15 +1035,11 @@ final class WindowDragHandleHitTests: XCTestCase {
         }
 
         let trafficLightFrame = closeButtonSuperview.convert(closeButton.frame, to: contentView)
-        let opticalYOffset = MinimalModeSidebarTitlebarControlsMetrics.titlebarControlsOpticalYOffset(in: window)
-        let expectedHostCenterY = contentView.isFlipped
-            ? trafficLightFrame.midY + opticalYOffset
-            : trafficLightFrame.midY - opticalYOffset
         XCTAssertEqual(
             target.frame.midY,
-            expectedHostCenterY,
+            trafficLightFrame.midY,
             accuracy: 0.25,
-            "Minimal-mode sidebar controls should compensate for the titlebar icon padding by one backing pixel"
+            "Minimal-mode sidebar controls should share the traffic-light center Y"
         )
     }
 


### PR DESCRIPTION
## Summary
- remove the tooltip-derived floor from the sidebar minimum width
- remove titlebar control vertical offsets so icons align with traffic-light centers
- update the minimal-mode titlebar alignment expectation

## Verification
- Built tagged app: `./scripts/reload.sh --tag minsb3 --swift-frontend-workaround`
- Launched `cmux DEV minsb3` and verified debug CLI connection
- Captured running app screenshot and measured traffic-light/icon center alignment from pixels

Requested by user to merge quickly without waiting for CI/tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5062"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782865693&installation_id=133855650&pr_number=5062&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5062&signature=059a3790c83b41148a3afa28c86e8f13c96d7b031fe9d15a3b75d6ca0f175dfb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores sidebar minimum width to honor the saved preference and fixes titlebar control alignment. Removes the tooltip-based width floor and centers minimal-mode controls with the traffic lights.

- **Bug Fixes**
  - Sidebar minimum width now uses the sanitized user setting; removed the tooltip clearance constraint.
  - Removed vertical offsets in titlebar controls so icons align with traffic-light centers; minimal mode optical Y offset is 0.
  - Updated tests to assert shared center Y with the traffic lights.

<sup>Written for commit 00e2efaf4ce73cd29a053ec7bc053c723bd20130. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5062?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined sidebar width calculations by removing redundant constraint logic
  * Improved titlebar accessory vertical spacing computation
  * Adjusted minimal mode controls positioning calculations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->