### PR TITLE
Add React Doctor web CI

### DIFF
--- a/.github/workflows/react-doctor-web.yml
+++ b/.github/workflows/react-doctor-web.yml
@@ -1,0 +1,122 @@
+name: React Doctor Web
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "web/**"
+      - ".github/workflows/react-doctor-web.yml"
+  pull_request:
+    paths:
+      - "web/**"
+      - ".github/workflows/react-doctor-web.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  react-doctor-web:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: 22.22.2
+          package-manager-cache: false
+
+      - name: Run React Doctor full web scan
+        id: react-doctor
+        shell: bash
+        run: |
+          set -euo pipefail
+          report_file="$RUNNER_TEMP/react-doctor-web-report.json"
+          echo "report-file=$report_file" >> "$GITHUB_OUTPUT"
+          npm exec --yes --package react-doctor@latest -- \
+            react-doctor web \
+            --full \
+            --json \
+            --json-compact \
+            --no-score \
+            --fail-on none \
+            > "$report_file"
+
+      - name: Summarize React Doctor report
+        if: always()
+        shell: bash
+        env:
+          REPORT_FILE: ${{ steps.react-doctor.outputs.report-file }}
+        run: |
+          set -euo pipefail
+          if [ -z "${REPORT_FILE:-}" ] || [ ! -f "$REPORT_FILE" ]; then
+            echo "React Doctor report was not generated." >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+          node <<'NODE'
+          const fs = require("fs");
+          const reportPath = process.env.REPORT_FILE;
+          const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+          const diagnostics = report.diagnostics ?? report.projects?.flatMap((project) => project.diagnostics ?? []) ?? [];
+          const countBy = (key) => {
+            const counts = new Map();
+            for (const diagnostic of diagnostics) {
+              const value = diagnostic[key] ?? "(none)";
+              counts.set(value, (counts.get(value) ?? 0) + 1);
+            }
+            return [...counts.entries()].sort((a, b) => b[1] - a[1]);
+          };
+          const projectRows = (report.projects ?? [])
+            .map((entry) => {
+              const project = entry.project ?? {};
+              return `| ${project.projectName ?? "(unknown)"} | ${project.framework ?? "(unknown)"} | ${project.reactVersion ?? "(unknown)"} | ${project.sourceFileCount ?? 0} |`;
+            })
+            .join("\n");
+          const topRules = countBy("rule").slice(0, 10).map(([rule, count]) => `| ${rule} | ${count} |`).join("\n");
+          const topFiles = countBy("filePath").slice(0, 10).map(([filePath, count]) => `| ${filePath} | ${count} |`).join("\n");
+          const summary = [
+            "# React Doctor Web",
+            "",
+            `- Version: ${report.version ?? "(unknown)"}`,
+            `- Mode: ${report.mode ?? "(unknown)"}`,
+            `- Errors: ${report.summary?.errorCount ?? 0}`,
+            `- Warnings: ${report.summary?.warningCount ?? 0}`,
+            `- Affected files: ${report.summary?.affectedFileCount ?? 0}`,
+            `- Total diagnostics: ${report.summary?.totalDiagnosticCount ?? 0}`,
+            "",
+            "## Projects",
+            "",
+            "| Name | Framework | React | Source files |",
+            "| --- | --- | --- | --- |",
+            projectRows || "| (none) | (none) | (none) | 0 |",
+            "",
+            "## Top Rules",
+            "",
+            "| Rule | Count |",
+            "| --- | ---: |",
+            topRules || "| (none) | 0 |",
+            "",
+            "## Top Files",
+            "",
+            "| File | Count |",
+            "| --- | ---: |",
+            topFiles || "| (none) | 0 |",
+            "",
+          ].join("\n");
+          fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, summary);
+          NODE
+
+      - name: Upload React Doctor report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: react-doctor-web-report
+          path: ${{ steps.react-doctor.outputs.report-file }}
+          if-no-files-found: error


### PR DESCRIPTION
## Summary
- Adds a dedicated React Doctor workflow for the `web/` app.
- Runs `react-doctor web --full` so CI scans the entire React app, not the Swift/app side.
- Keeps the current backlog advisory with `--fail-on none`, writes a job summary, and uploads the JSON report.

## Testing
- `ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0)); puts "yaml ok"' .github/workflows/react-doctor-web.yml`
- `actionlint .github/workflows/react-doctor-web.yml`
- `npx react-doctor@latest web --full --json --json-compact --no-score --fail-on none`

## Issues
- Related: https://github.com/manaflow-ai/cmux/issues/5064
- Related: https://github.com/manaflow-ai/cmux/issues/5065
- Related: https://github.com/manaflow-ai/cmux/issues/5066
- Related: https://github.com/manaflow-ai/cmux/issues/5067
- Related: https://github.com/manaflow-ai/cmux/issues/5068
- Related: https://github.com/manaflow-ai/cmux/issues/5069

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5070"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782867613&installation_id=133855650&pr_number=5070&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5070&signature=584811ca390ac258e3aaf910fd6aed011f0a7d2f5292ca0ef6d20abd5a1fbd98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change with read permissions; scan does not fail the build and does not modify application runtime code.
> 
> **Overview**
> Adds a new GitHub Actions workflow **React Doctor Web** that runs on `web/**` changes (plus manual dispatch on `main`).
> 
> CI checks out the repo, uses Node **22.22.2**, and runs `react-doctor web --full` via `npm exec` with JSON output. **`--fail-on none`** keeps the job advisory while still recording the backlog. A follow-up step builds a **job summary** (counts, projects, top rules/files) from the report, and the JSON artifact **`react-doctor-web-report`** is always uploaded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85f51c697eb2e89b422abe9b5ce7da43cd98cd30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GitHub Actions workflow that runs a full `react-doctor` scan for the `web/` app on pushes and PRs, then posts a job summary and uploads a JSON report without failing CI. This ensures continuous React health checks for the web codebase.

- **New Features**
  - Adds `.github/workflows/react-doctor-web.yml` to scan `web/` with `react-doctor`.
  - Triggers on `web/**` changes for push/PR and `workflow_dispatch`; PR runs cancel previous.
  - Runs `npm exec react-doctor web --full --json --json-compact --no-score --fail-on none`.
  - Writes a report summary (version, counts, top rules/files, per-project stats) to the job summary.
  - Uploads the JSON report artifact; uses Node `22.22.2` with `actions/checkout`, `actions/setup-node`, and `actions/upload-artifact`.

<sup>Written for commit 85f51c697eb2e89b422abe9b5ce7da43cd98cd30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5070?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated continuous integration workflow that runs on web directory changes and pull requests. The workflow executes diagnostic checks, generates comprehensive JSON-formatted reports, uploads artifacts for retention, and automatically provides detailed diagnostic summaries and metrics in pull request reviews and GitHub workflow step summaries for team review and visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->