### PR TITLE
Restore modern macOS Settings chrome (regression from #4975)

### DIFF
--- a/Sources/App/SettingsWindowPresenter.swift
+++ b/Sources/App/SettingsWindowPresenter.swift
@@ -262,6 +262,11 @@ enum SettingsWindowPresenter {
             window.toolbar = toolbar
         }
         window.toolbarStyle = .unifiedCompact
+        // `titlebarSeparatorStyle` is the authoritative, non-deprecated control
+        // for the window-level line under the titlebar/toolbar (NSToolbar's
+        // `showsBaselineSeparator` was deprecated in macOS 15). `.none` matches
+        // the seamless titlebar the `Settings { }` scene produced before #4975.
+        window.titlebarSeparatorStyle = .none
     }
 
     private static func clampToVisibleAreaIfNeeded(_ window: NSWindow) {

--- a/Sources/App/SettingsWindowPresenter.swift
+++ b/Sources/App/SettingsWindowPresenter.swift
@@ -42,6 +42,7 @@ enum SettingsWindowPresenter {
         window.isRestorable = false
         window.minSize = minimumSize
         window.contentMinSize = minimumSize
+        applyModernSettingsChrome(window)
         clampToVisibleAreaIfNeeded(window)
         attachToPreferredParent(window)
         if shouldFocusAfterConfiguration {
@@ -241,6 +242,26 @@ enum SettingsWindowPresenter {
             window.deminiaturize(nil)
         }
         window.orderFront(nil)
+    }
+
+    private static let toolbarIdentifier = NSToolbar.Identifier("cmux.settings.toolbar")
+
+    // Restore the modern macOS Settings chrome (unified compact toolbar,
+    // transparent titlebar integrated with the content, full-size content
+    // view) that the SwiftUI `Settings { }` scene provided for free before
+    // #4975 switched Settings to a generic `Window(...)` scene. `Window`
+    // defaults to the legacy titled-window chrome, so it must be applied to
+    // the AppKit window explicitly.
+    private static func applyModernSettingsChrome(_ window: NSWindow) {
+        window.styleMask.insert(.fullSizeContentView)
+        window.titlebarAppearsTransparent = true
+        window.titleVisibility = .hidden
+        if window.toolbar == nil {
+            let toolbar = NSToolbar(identifier: toolbarIdentifier)
+            toolbar.allowsUserCustomization = false
+            window.toolbar = toolbar
+        }
+        window.toolbarStyle = .unifiedCompact
     }
 
     private static func clampToVisibleAreaIfNeeded(_ window: NSWindow) {

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -683,6 +683,7 @@ struct cmuxApp: App {
         }
         .defaultSize(width: 980, height: 680)
         .windowResizability(.contentMinSize)
+        .windowToolbarStyle(.unifiedCompact)
         .commands {
             SidebarCommands()
         }

--- a/cmuxTests/SettingsWindowPresenterTests.swift
+++ b/cmuxTests/SettingsWindowPresenterTests.swift
@@ -1,5 +1,5 @@
 import AppKit
-import XCTest
+import Testing
 
 #if canImport(cmux_DEV)
 @testable import cmux_DEV
@@ -8,14 +8,14 @@ import XCTest
 #endif
 
 #if DEBUG
+// `.serialized`: every test mutates `SettingsWindowPresenter`'s shared static
+// state and resets it on exit, so they must not run concurrently with each
+// other (Swift Testing parallelizes by default).
 @MainActor
-final class SettingsWindowPresenterTests: XCTestCase {
-    override func tearDown() {
-        SettingsWindowPresenter.resetForTests()
-        super.tearDown()
-    }
-
-    func testConfigureWindowAppliesModernSettingsChrome() {
+@Suite(.serialized)
+struct SettingsWindowPresenterTests {
+    @Test func configureWindowAppliesModernSettingsChrome() {
+        defer { SettingsWindowPresenter.resetForTests() }
         let settingsWindow = makeWindow(identifier: SettingsWindowPresenter.windowIdentifier)
         defer {
             settingsWindow.orderOut(nil)
@@ -23,15 +23,16 @@ final class SettingsWindowPresenterTests: XCTestCase {
 
         SettingsWindowPresenter.configure(window: settingsWindow)
 
-        XCTAssertEqual(settingsWindow.toolbarStyle, .unifiedCompact)
-        XCTAssertTrue(settingsWindow.styleMask.contains(.fullSizeContentView))
-        XCTAssertTrue(settingsWindow.titlebarAppearsTransparent)
-        XCTAssertEqual(settingsWindow.titleVisibility, .hidden)
-        XCTAssertEqual(settingsWindow.titlebarSeparatorStyle, .none)
-        XCTAssertNotNil(settingsWindow.toolbar)
+        #expect(settingsWindow.toolbarStyle == .unifiedCompact)
+        #expect(settingsWindow.styleMask.contains(.fullSizeContentView))
+        #expect(settingsWindow.titlebarAppearsTransparent)
+        #expect(settingsWindow.titleVisibility == .hidden)
+        #expect(settingsWindow.titlebarSeparatorStyle == .none)
+        #expect(settingsWindow.toolbar != nil)
     }
 
-    func testConfigureWindowLeavesPendingNavigationForSettingsViews() {
+    @Test func configureWindowLeavesPendingNavigationForSettingsViews() {
+        defer { SettingsWindowPresenter.resetForTests() }
         let settingsWindow = makeWindow(identifier: SettingsWindowPresenter.windowIdentifier)
         var didOpen = false
         defer {
@@ -44,14 +45,15 @@ final class SettingsWindowPresenterTests: XCTestCase {
         )
         SettingsWindowPresenter.configure(window: settingsWindow)
 
-        XCTAssertTrue(didOpen)
-        XCTAssertEqual(SettingsWindowPresenter.consumePendingNavigationTarget(), .browserImport)
-        XCTAssertEqual(SettingsWindowPresenter.consumePendingContentNavigationTarget(), .browserImport)
-        XCTAssertNil(SettingsWindowPresenter.consumePendingNavigationTarget())
-        XCTAssertNil(SettingsWindowPresenter.consumePendingContentNavigationTarget())
+        #expect(didOpen)
+        #expect(SettingsWindowPresenter.consumePendingNavigationTarget() == .browserImport)
+        #expect(SettingsWindowPresenter.consumePendingContentNavigationTarget() == .browserImport)
+        #expect(SettingsWindowPresenter.consumePendingNavigationTarget() == nil)
+        #expect(SettingsWindowPresenter.consumePendingContentNavigationTarget() == nil)
     }
 
-    func testRepeatedConfigureForSameSettingsWindowDoesNotRefocus() async {
+    @Test func repeatedConfigureForSameSettingsWindowDoesNotRefocus() async {
+        defer { SettingsWindowPresenter.resetForTests() }
         let settingsWindow = makeWindow(identifier: SettingsWindowPresenter.windowIdentifier)
         var focusedWindows: [NSWindow] = []
         defer {
@@ -67,11 +69,12 @@ final class SettingsWindowPresenterTests: XCTestCase {
         SettingsWindowPresenter.configure(window: settingsWindow)
         await Task.yield()
 
-        XCTAssertEqual(focusedWindows.count, 1)
-        XCTAssertTrue(focusedWindows.first === settingsWindow)
+        #expect(focusedWindows.count == 1)
+        #expect(focusedWindows.first === settingsWindow)
     }
 
-    func testShowPreservesPendingNavigationWhenExistingSettingsWindowIsMiniaturized() async {
+    @Test func showPreservesPendingNavigationWhenExistingSettingsWindowIsMiniaturized() async {
+        defer { SettingsWindowPresenter.resetForTests() }
         let settingsWindow = makeWindow(
             identifier: SettingsWindowPresenter.windowIdentifier,
             isMiniaturizedForTests: true
@@ -90,12 +93,13 @@ final class SettingsWindowPresenterTests: XCTestCase {
             openWindowOverride: { didOpen = true }
         )
 
-        XCTAssertFalse(didOpen)
-        XCTAssertEqual(SettingsWindowPresenter.consumePendingNavigationTarget(), .browserImport)
-        XCTAssertEqual(SettingsWindowPresenter.consumePendingContentNavigationTarget(), .browserImport)
+        #expect(!didOpen)
+        #expect(SettingsWindowPresenter.consumePendingNavigationTarget() == .browserImport)
+        #expect(SettingsWindowPresenter.consumePendingContentNavigationTarget() == .browserImport)
     }
 
-    func testParentsSettingsAbovePreferredMainWindow() {
+    @Test func parentsSettingsAbovePreferredMainWindow() {
+        defer { SettingsWindowPresenter.resetForTests() }
         let parentWindow = makeWindow(identifier: "cmux.main.\(UUID().uuidString)")
         let settingsWindow = makeWindow(identifier: SettingsWindowPresenter.windowIdentifier)
         defer {
@@ -109,11 +113,12 @@ final class SettingsWindowPresenterTests: XCTestCase {
         )
         SettingsWindowPresenter.configure(window: settingsWindow)
 
-        XCTAssertTrue(settingsWindow.parent === parentWindow)
-        XCTAssertTrue(parentWindow.childWindows?.contains(where: { $0 === settingsWindow }) == true)
+        #expect(settingsWindow.parent === parentWindow)
+        #expect(parentWindow.childWindows?.contains(where: { $0 === settingsWindow }) == true)
     }
 
-    func testReparentsSettingsWhenPreferredMainWindowChanges() {
+    @Test func reparentsSettingsWhenPreferredMainWindowChanges() {
+        defer { SettingsWindowPresenter.resetForTests() }
         let firstParent = makeWindow(identifier: "cmux.main.\(UUID().uuidString)")
         let secondParent = makeWindow(identifier: "cmux.main.\(UUID().uuidString)")
         let settingsWindow = makeWindow(identifier: SettingsWindowPresenter.windowIdentifier)
@@ -129,21 +134,22 @@ final class SettingsWindowPresenterTests: XCTestCase {
             parentWindowProvider: { preferredParent }
         )
         SettingsWindowPresenter.configure(window: settingsWindow)
-        XCTAssertTrue(settingsWindow.parent === firstParent)
+        #expect(settingsWindow.parent === firstParent)
 
         preferredParent = secondParent
         SettingsWindowPresenter.refocusIfVisible()
-        XCTAssertTrue(settingsWindow.parent === firstParent)
+        #expect(settingsWindow.parent === firstParent)
 
         settingsWindow.orderFront(nil)
         SettingsWindowPresenter.refocusIfVisible()
 
-        XCTAssertTrue(settingsWindow.parent === secondParent)
-        XCTAssertFalse(firstParent.childWindows?.contains(where: { $0 === settingsWindow }) == true)
-        XCTAssertTrue(secondParent.childWindows?.contains(where: { $0 === settingsWindow }) == true)
+        #expect(settingsWindow.parent === secondParent)
+        #expect(firstParent.childWindows?.contains(where: { $0 === settingsWindow }) != true)
+        #expect(secondParent.childWindows?.contains(where: { $0 === settingsWindow }) == true)
     }
 
-    func testDetachesSettingsBeforePreferredMainWindowCloses() {
+    @Test func detachesSettingsBeforePreferredMainWindowCloses() {
+        defer { SettingsWindowPresenter.resetForTests() }
         let parentWindow = makeWindow(identifier: "cmux.main.\(UUID().uuidString)")
         let settingsWindow = makeWindow(identifier: SettingsWindowPresenter.windowIdentifier)
         defer {
@@ -157,19 +163,20 @@ final class SettingsWindowPresenterTests: XCTestCase {
         )
         SettingsWindowPresenter.configure(window: settingsWindow)
         settingsWindow.orderFront(nil)
-        XCTAssertTrue(settingsWindow.parent === parentWindow)
+        #expect(settingsWindow.parent === parentWindow)
 
         NotificationCenter.default.post(name: NSWindow.willCloseNotification, object: parentWindow)
 
-        XCTAssertNil(settingsWindow.parent)
-        XCTAssertFalse(parentWindow.childWindows?.contains(where: { $0 === settingsWindow }) == true)
-        XCTAssertTrue(settingsWindow.isVisible)
+        #expect(settingsWindow.parent == nil)
+        #expect(parentWindow.childWindows?.contains(where: { $0 === settingsWindow }) != true)
+        #expect(settingsWindow.isVisible)
     }
 
-    func testConfigureClampsOversizedSettingsFrameToVisibleArea() throws {
-        guard let screen = NSScreen.main else {
-            throw XCTSkip("No screen available for Settings frame clamping")
-        }
+    @Test func configureClampsOversizedSettingsFrameToVisibleArea() {
+        defer { SettingsWindowPresenter.resetForTests() }
+        // Skip when no screen is available (headless runner): there is no
+        // visible area to clamp against. Mirrors the previous `XCTSkip`.
+        guard let screen = NSScreen.main else { return }
         let settingsWindow = makeWindow(identifier: SettingsWindowPresenter.windowIdentifier)
         let visibleFrame = screen.visibleFrame
         settingsWindow.setFrame(
@@ -197,15 +204,15 @@ final class SettingsWindowPresenterTests: XCTestCase {
             visibleFrame.height - 2 * inset
         )
         let frame = settingsWindow.frame
-        XCTAssertLessThanOrEqual(frame.width, availableWidth)
-        XCTAssertLessThanOrEqual(frame.height, availableHeight)
-        XCTAssertGreaterThanOrEqual(frame.minX, visibleFrame.minX + inset)
-        XCTAssertGreaterThanOrEqual(frame.minY, visibleFrame.minY + inset)
+        #expect(frame.width <= availableWidth)
+        #expect(frame.height <= availableHeight)
+        #expect(frame.minX >= visibleFrame.minX + inset)
+        #expect(frame.minY >= visibleFrame.minY + inset)
         if frame.width <= visibleFrame.width - 2 * inset {
-            XCTAssertLessThanOrEqual(frame.maxX, visibleFrame.maxX - inset)
+            #expect(frame.maxX <= visibleFrame.maxX - inset)
         }
         if frame.height <= visibleFrame.height - 2 * inset {
-            XCTAssertLessThanOrEqual(frame.maxY, visibleFrame.maxY - inset)
+            #expect(frame.maxY <= visibleFrame.maxY - inset)
         }
     }
 

--- a/cmuxTests/SettingsWindowPresenterTests.swift
+++ b/cmuxTests/SettingsWindowPresenterTests.swift
@@ -26,6 +26,8 @@ final class SettingsWindowPresenterTests: XCTestCase {
         XCTAssertEqual(settingsWindow.toolbarStyle, .unifiedCompact)
         XCTAssertTrue(settingsWindow.styleMask.contains(.fullSizeContentView))
         XCTAssertTrue(settingsWindow.titlebarAppearsTransparent)
+        XCTAssertEqual(settingsWindow.titleVisibility, .hidden)
+        XCTAssertEqual(settingsWindow.titlebarSeparatorStyle, .none)
         XCTAssertNotNil(settingsWindow.toolbar)
     }
 

--- a/cmuxTests/SettingsWindowPresenterTests.swift
+++ b/cmuxTests/SettingsWindowPresenterTests.swift
@@ -15,6 +15,20 @@ final class SettingsWindowPresenterTests: XCTestCase {
         super.tearDown()
     }
 
+    func testConfigureWindowAppliesModernSettingsChrome() {
+        let settingsWindow = makeWindow(identifier: SettingsWindowPresenter.windowIdentifier)
+        defer {
+            settingsWindow.orderOut(nil)
+        }
+
+        SettingsWindowPresenter.configure(window: settingsWindow)
+
+        XCTAssertEqual(settingsWindow.toolbarStyle, .unifiedCompact)
+        XCTAssertTrue(settingsWindow.styleMask.contains(.fullSizeContentView))
+        XCTAssertTrue(settingsWindow.titlebarAppearsTransparent)
+        XCTAssertNotNil(settingsWindow.toolbar)
+    }
+
     func testConfigureWindowLeavesPendingNavigationForSettingsViews() {
         let settingsWindow = makeWindow(identifier: SettingsWindowPresenter.windowIdentifier)
         var didOpen = false


### PR DESCRIPTION
## Summary

After the Settings rewrite in #4975, the Settings window rendered with the legacy macOS titled-window chrome instead of the modern macOS Settings chrome on macOS 14+/Tahoe. The rewrite switched the Settings scene from SwiftUI's `Settings { }` (which gets the modern unified-compact Settings chrome for free) to a generic `Window(...)` scene, which defaults to the legacy titled-window look. Neither the SwiftUI scene nor `SettingsWindowPresenter.configure(window:)` applied the chrome explicitly.

## Fix — Path A (chosen over Path B)

Path A preserves the `Window(...)` scene and applies the chrome explicitly. I chose it over Path B (reverting to `Settings { }`) because the `Window(...)` form backs the existing multi-instance / window-ID deep-link hooks — `openWindow(id: SettingsWindowPresenter.windowID)` (`Sources/cmuxApp.swift:251`) and the `windowIdentifier`-based focus/reuse logic in `SettingsWindowPresenter`. The dedicated `Settings { }` scene lacks those `openWindow(id:)` hooks, so switching scenes would be a larger, riskier change. Path A is the smaller, safer fix.

Changes:
- `Sources/cmuxApp.swift` — add `.windowToolbarStyle(.unifiedCompact)` to the Settings `Window(...)` scene.
- `Sources/App/SettingsWindowPresenter.swift` — `configure(window:)` now applies `.fullSizeContentView`, `titlebarAppearsTransparent = true`, `titleVisibility = .hidden`, attaches a non-customizable `NSToolbar` with no baseline separator, and sets `toolbarStyle = .unifiedCompact` on the AppKit window.

## Regression test

Two-commit structure so CI proves the test catches the bug:
1. Failing test only (red): `testConfigureWindowAppliesModernSettingsChrome` in `cmuxTests/SettingsWindowPresenterTests.swift` drives `configure(window:)` and asserts `toolbarStyle == .unifiedCompact`, `styleMask.contains(.fullSizeContentView)`, `titlebarAppearsTransparent == true`, and `toolbar != nil`.
2. The fix (green).

Fixes #5071.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only window chrome and test harness changes; existing Settings window ID, focus, and parenting behavior are unchanged.
> 
> **Overview**
> Restores **modern macOS Settings window chrome** after the Settings scene moved from SwiftUI `Settings { }` to a generic `Window(...)`, which regressed to legacy titled-window styling.
> 
> `SettingsWindowPresenter.configure(window:)` now calls **`applyModernSettingsChrome`**, setting full-size content view, transparent/hidden titlebar, a fixed non-customizable `NSToolbar`, **unified compact** toolbar style, and **no titlebar separator**. The Settings `Window` scene in **`cmuxApp`** also applies **`.windowToolbarStyle(.unifiedCompact)`** so SwiftUI and AppKit stay aligned.
> 
> Tests in **`SettingsWindowPresenterTests`** migrate from **XCTest** to **Swift Testing** (serialized suite for shared static state) and add coverage that configuration applies the modern chrome flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 152c881a503441419b582674c3b48de36fe1f504. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5073"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782868736&installation_id=133855650&pr_number=5073&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5073&signature=76725983f021b4693808ed06f588150a27c4c6556c30447dfe1eae8e918dca1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Settings window now uses a modern macOS appearance: transparent titlebar, hidden title, full‑size content view, no titlebar separator, and unified compact toolbar styling for a more native, streamlined experience.

* **Tests**
  * Test suite migrated to the new testing framework, serialized to avoid concurrent state issues, and updated/expanded to cover window styling, focus/parenting behavior, and size/clamping scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->