### PR TITLE
Fix #5075: clear split zoom when closing maximized tab

### DIFF
--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -18401,6 +18401,9 @@ extension Workspace: BonsplitDelegate {
         let shouldClearSplitZoom = postCloseClearSplitZoomTabIds.remove(tabId) != nil
         let closedBrowserRestoreSnapshot = pendingClosedBrowserRestoreSnapshots.removeValue(forKey: tabId)
         let isDetaching = detachingTabIds.remove(tabId) != nil || isDetachingCloseTransaction
+        if shouldClearSplitZoom {
+            clearSplitZoom()
+        }
 
         // Clean up our panel
         guard let panelId = panelIdFromSurfaceId(tabId) else {
@@ -18487,9 +18490,6 @@ extension Workspace: BonsplitDelegate {
         clearRemoteConfigurationIfWorkspaceBecameLocal()
         if !isDetaching, let cleanupConfiguration = closedRemoteCleanupConfiguration {
             Self.requestSSHControlMasterCleanupIfNeeded(configuration: cleanupConfiguration)
-        }
-        if shouldClearSplitZoom {
-            clearSplitZoom()
         }
 
         // Keep the workspace invariant for normal close paths.

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -11251,6 +11251,7 @@ final class Workspace: Identifiable, ObservableObject {
     /// Deterministic tab selection to apply after a tab closes.
     /// Keyed by the closing tab ID, value is the tab ID we want to select next.
     private var postCloseSelectTabId: [TabID: TabID] = [:]
+    private var postCloseClearSplitZoomTabIds: Set<TabID> = []
     /// Panel IDs that were in a pane when a pane-close operation was approved.
     /// Bonsplit pane-close does not emit per-tab didClose callbacks.
     private var pendingPaneClosePanelIds: [UUID: [UUID]] = [:]
@@ -18258,7 +18259,14 @@ extension Workspace: BonsplitDelegate {
     }
 
     func splitTabBar(_ controller: BonsplitController, shouldCloseTab tab: Bonsplit.Tab, inPane pane: PaneID) -> Bool {
-        func recordPostCloseSelection() {
+        func recordPostCloseState() {
+            if controller.zoomedPaneId == pane,
+               controller.selectedTab(inPane: pane)?.id == tab.id {
+                postCloseClearSplitZoomTabIds.insert(tab.id)
+            } else {
+                postCloseClearSplitZoomTabIds.remove(tab.id)
+            }
+
             let tabs = controller.tabs(inPane: pane)
             guard let idx = tabs.firstIndex(where: { $0.id == tab.id }) else {
                 postCloseSelectTabId.removeValue(forKey: tab.id)
@@ -18287,7 +18295,7 @@ extension Workspace: BonsplitDelegate {
             } else {
                 clearStagedClosedBrowserRestoreSnapshot(for: tab.id)
             }
-            recordPostCloseSelection()
+            recordPostCloseState()
             return true
         }
 
@@ -18325,7 +18333,7 @@ extension Workspace: BonsplitDelegate {
         // Check if the panel needs close confirmation
         guard let panelId = panelIdFromSurfaceId(tab.id) else {
             stageClosedBrowserRestoreSnapshotIfNeeded(for: tab, inPane: pane)
-            recordPostCloseSelection()
+            recordPostCloseState()
             return true
         }
 
@@ -18382,7 +18390,7 @@ extension Workspace: BonsplitDelegate {
         } else {
             clearStagedClosedBrowserRestoreSnapshot(for: tab.id)
         }
-        recordPostCloseSelection()
+        recordPostCloseState()
         return true
     }
 
@@ -18390,6 +18398,7 @@ extension Workspace: BonsplitDelegate {
         forceCloseTabIds.remove(tabId)
         tabCloseButtonCloseTabIds.remove(tabId)
         let selectTabId = postCloseSelectTabId.removeValue(forKey: tabId)
+        let shouldClearSplitZoom = postCloseClearSplitZoomTabIds.remove(tabId) != nil
         let closedBrowserRestoreSnapshot = pendingClosedBrowserRestoreSnapshots.removeValue(forKey: tabId)
         let isDetaching = detachingTabIds.remove(tabId) != nil || isDetachingCloseTransaction
 
@@ -18478,6 +18487,9 @@ extension Workspace: BonsplitDelegate {
         clearRemoteConfigurationIfWorkspaceBecameLocal()
         if !isDetaching, let cleanupConfiguration = closedRemoteCleanupConfiguration {
             Self.requestSSHControlMasterCleanupIfNeeded(configuration: cleanupConfiguration)
+        }
+        if shouldClearSplitZoom {
+            clearSplitZoom()
         }
 
         // Keep the workspace invariant for normal close paths.

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -2262,6 +2262,8 @@ final class TabManagerNotificationFocusTests: XCTestCase {
         XCTAssertTrue(workspace.bonsplitController.isSplitZoomed, "Expected workspace to start zoomed")
 
         XCTAssertTrue(workspace.closePanel(secondTabPanel.id, force: true), "Expected selected tab close to succeed")
+        drainMainQueue()
+        drainMainQueue()
 
         XCTAssertEqual(workspace.focusedPanelId, firstPanelId, "Expected the surviving tab in the pane to become focused")
         XCTAssertFalse(

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -2246,6 +2246,35 @@ final class TabManagerNotificationFocusTests: XCTestCase {
         XCTAssertFalse(manager.focusTabFromNotification(workspace.id, surfaceId: UUID()))
     }
 
+    func testClosingSelectedTabInZoomedPaneClearsSplitZoomBeforeSelectingNextTab() {
+        let manager = TabManager()
+        guard let workspace = manager.selectedWorkspace,
+              let firstPanelId = workspace.focusedPanelId,
+              let firstPaneId = workspace.bonsplitController.focusedPaneId,
+              workspace.newTerminalSplit(from: firstPanelId, orientation: .horizontal) != nil,
+              let secondTabPanel = workspace.newTerminalSurface(inPane: firstPaneId, focus: true) else {
+            XCTFail("Expected split workspace with two tabs in the first pane")
+            return
+        }
+
+        XCTAssertEqual(workspace.focusedPanelId, secondTabPanel.id)
+        XCTAssertTrue(workspace.toggleSplitZoom(panelId: secondTabPanel.id), "Expected split zoom to enable")
+        XCTAssertTrue(workspace.bonsplitController.isSplitZoomed, "Expected workspace to start zoomed")
+
+        XCTAssertTrue(workspace.closePanel(secondTabPanel.id, force: true), "Expected selected tab close to succeed")
+
+        XCTAssertEqual(workspace.focusedPanelId, firstPanelId, "Expected the surviving tab in the pane to become focused")
+        XCTAssertFalse(
+            workspace.bonsplitController.isSplitZoomed,
+            "Closing the selected tab that owns zoom must not transfer the maximized layout to the next tab"
+        )
+        XCTAssertTrue(
+            workspace.toggleSplitZoom(panelId: firstPanelId),
+            "The surviving tab should still be zoomable on demand"
+        )
+        XCTAssertTrue(workspace.bonsplitController.isSplitZoomed)
+    }
+
     func testFocusTabFromNotificationDismissesUnreadWithDismissFlash() {
         let appDelegate = AppDelegate.shared ?? AppDelegate()
         let manager = TabManager()


### PR DESCRIPTION
## Summary
- record whether the closing tab owns the active split-zoom state before Bonsplit mutates selection
- clear split zoom during the shared close lifecycle before handing focus to the next selected tab
- add a regression test for closing a selected tab in a zoomed pane and re-zooming the survivor

Fixes #5075.

## Verification
- ./scripts/lint-pbxproj-test-wiring.sh
- ./scripts/check-pbxproj.sh
- git diff --check
- Attempted targeted xcodebuild test with isolated derivedDataPath; local build is blocked because GhosttyKit.xcframework is missing in this worktree before tests run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5076"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782870098&installation_id=133855650&pr_number=5076&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5076&signature=b01e6731c37c167faf3d09d2f686618b28168bfb5df890fdee427968776237aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted tab-close lifecycle change with a regression test; no auth, data, or broad architectural impact.
> 
> **Overview**
> Fixes **split zoom sticking** when you close the **selected tab in a maximized (zoomed) pane**: the workspace now records whether that closing tab owned the active zoom **before** Bonsplit changes selection, then calls **`clearSplitZoom()`** in the shared tab-close path so the next tab is not left in a transferred maximized layout.
> 
> Adds a unit test that closes the zoomed tab, asserts zoom is off and focus moves to the surviving tab, and that the survivor can still be zoomed again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03ab55e7401fcc93488e39d92a2986e24a2b3613. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clear split zoom when closing the selected tab that owns a maximized pane so the next tab doesn’t inherit zoom. Fixes #5075.

- **Bug Fixes**
  - Record if the closing tab owns split-zoom before Bonsplit changes selection and clear it in the shared close handler to cover all close paths (force, confirm, detach).
  - Add a regression test to verify zoom clears on close, focus moves to the surviving tab, and the survivor can re-zoom.

<sup>Written for commit 4c766757572285786ad516f74bbaa439234b7397. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5076?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Split-zoom now reliably clears when closing the selected tab in a zoomed pane; focus moves to the remaining panel and split-zoom can be re-enabled afterward.

* **Tests**
  * Added unit test verifying split-zoom is cleared during tab closure and focus correctly shifts to the surviving panel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->