### PR TITLE
Nightly: build app with Xcode 26 SDK so Tahoe gets Liquid Glass

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -145,27 +145,38 @@ jobs:
           # on Tahoe (the team is pinned to Xcode 26 via .xcode-version). The zig
           # Ghostty CLI helper must link against a pre-26 SDK because zig 0.15.2
           # cannot cross-link x86_64 against the macOS 26 SDK. Both Xcodes ship on
-          # the macOS 15 runner image, so pick one of each by SDK major.
-          APP_DEVELOPER_DIR=""
-          APP_SDK_MAJOR=""
-          HELPER_DEVELOPER_DIR=""
-          HELPER_SDK_MAJOR=""
+          # the macOS 15 runner image, so pick the newest of each by SDK version.
+          # Compare SDK versions numerically (not lexicographically) so e.g.
+          # 26.10 sorts above 26.3.
+          sdk_rank() {
+            # "26.2" -> 26002 ; "26" -> 26000
+            local v="$1" maj min
+            maj="${v%%.*}"
+            min="${v#*.}"
+            [ "$min" = "$v" ] && min=0
+            min="${min%%.*}"
+            printf '%d' "$(( maj * 1000 + min ))"
+          }
+          APP_DEVELOPER_DIR=""; APP_SDK_VER=""; APP_RANK=-1
+          HELPER_DEVELOPER_DIR=""; HELPER_SDK_VER=""; HELPER_RANK=-1
           while IFS= read -r app; do
             [ -n "$app" ] || continue
             dev="$app/Contents/Developer"
             [ -d "$dev" ] || continue
             sdk_ver="$(DEVELOPER_DIR="$dev" xcrun --sdk macosx --show-sdk-version 2>/dev/null || true)"
             [ -n "$sdk_ver" ] || continue
-            major="${sdk_ver%%.*}"
-            echo "Found $app -> macOS SDK $sdk_ver"
-            if [ "$major" -ge 26 ]; then
-              APP_DEVELOPER_DIR="$dev"
-              APP_SDK_MAJOR="$major"
+            rank="$(sdk_rank "$sdk_ver")"
+            echo "Found $app -> macOS SDK $sdk_ver (rank $rank)"
+            if [ "${sdk_ver%%.*}" -ge 26 ]; then
+              if [ "$rank" -gt "$APP_RANK" ]; then
+                APP_DEVELOPER_DIR="$dev"; APP_SDK_VER="$sdk_ver"; APP_RANK="$rank"
+              fi
             else
-              HELPER_DEVELOPER_DIR="$dev"
-              HELPER_SDK_MAJOR="$major"
+              if [ "$rank" -gt "$HELPER_RANK" ]; then
+                HELPER_DEVELOPER_DIR="$dev"; HELPER_SDK_VER="$sdk_ver"; HELPER_RANK="$rank"
+              fi
             fi
-          done < <(find /Applications -maxdepth 1 -name 'Xcode*.app' -print 2>/dev/null | sort)
+          done < <(find /Applications -maxdepth 1 -name 'Xcode*.app' -print 2>/dev/null)
 
           if [ -z "$APP_DEVELOPER_DIR" ]; then
             echo "No Xcode with the macOS 26+ SDK found; the app would ship without Liquid Glass on Tahoe." >&2
@@ -176,8 +187,8 @@ jobs:
             exit 1
           fi
 
-          echo "App build Xcode (DEVELOPER_DIR): $APP_DEVELOPER_DIR (macOS SDK $APP_SDK_MAJOR)"
-          echo "Helper build Xcode (HELPER_DEVELOPER_DIR): $HELPER_DEVELOPER_DIR (macOS SDK $HELPER_SDK_MAJOR)"
+          echo "App build Xcode (DEVELOPER_DIR): $APP_DEVELOPER_DIR (macOS SDK $APP_SDK_VER)"
+          echo "Helper build Xcode (HELPER_DEVELOPER_DIR): $HELPER_DEVELOPER_DIR (macOS SDK $HELPER_SDK_VER)"
           DEVELOPER_DIR="$APP_DEVELOPER_DIR" xcodebuild -version
           echo "DEVELOPER_DIR=$APP_DEVELOPER_DIR" >> "$GITHUB_ENV"
           echo "HELPER_DEVELOPER_DIR=$HELPER_DEVELOPER_DIR" >> "$GITHUB_ENV"
@@ -253,11 +264,13 @@ jobs:
         if: needs.decide.outputs.should_publish != 'true' || steps.current_head_prebuild.outputs.still_current == 'true'
         run: |
           set -euo pipefail
-          DEST="build-universal/Build/Products/Release/cmux.app/Contents/Resources/bin/ghostty"
-          if [ ! -e "$DEST" ]; then
-            echo "Expected Ghostty helper slot missing at $DEST" >&2
+          APP_DIR="build-universal/Build/Products/Release/cmux.app"
+          if [ ! -d "$APP_DIR" ]; then
+            echo "Built app not found at $APP_DIR" >&2
             exit 1
           fi
+          DEST="$APP_DIR/Contents/Resources/bin/ghostty"
+          mkdir -p "$(dirname "$DEST")"
           install -m 755 /tmp/cmux-ghostty-helper-universal "$DEST"
           echo "Injected Ghostty CLI helper architectures: $(lipo -archs "$DEST")"
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -100,11 +100,15 @@ jobs:
   build-sign-notarize-nightly:
     needs: decide
     if: needs.decide.outputs.should_build == 'true'
-    # Keep publishing builds on macOS 15 until Zig can link the real universal
-    # Ghostty CLI helper on macOS 26. ci-macos-compat.yml covers macOS 26 with
-    # CMUX_SKIP_ZIG_BUILD=1, but nightly needs the real universal helper.
+    # Run on the macOS 15 host because zig 0.15.2 can cross-link the universal
+    # (arm64 + x86_64) Ghostty CLI helper only against a pre-26 SDK. The Swift
+    # app is built with the macOS 26 Xcode on this same runner so it adopts
+    # Liquid Glass on Tahoe; the helper is built separately with the older Xcode
+    # and injected before signing (see Select Xcode + the helper build/inject
+    # steps). Building the whole app with Xcode 16 (#5022) shipped a macOS 15 SDK
+    # binary that Tahoe forced into the legacy non-Liquid-Glass appearance.
     runs-on: ${{ vars.MACOS_RUNNER_15 || 'warp-macos-15-arm64-6x' }}
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - name: Checkout build ref
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -137,26 +141,46 @@ jobs:
         if: needs.decide.outputs.should_publish != 'true' || steps.current_head_prebuild.outputs.still_current == 'true'
         run: |
           set -euo pipefail
-          if [ -d "/Applications/Xcode.app/Contents/Developer" ]; then
-            XCODE_DIR="/Applications/Xcode.app/Contents/Developer"
-          else
-            XCODE_APP="$(
-              find /Applications -maxdepth 1 -name 'Xcode*.app' -print 2>/dev/null \
-                | sort \
-                | tail -n 1 \
-                || true
-            )"
-            if [ -n "$XCODE_APP" ]; then
-              XCODE_DIR="$XCODE_APP/Contents/Developer"
+          # The app must link against the macOS 26 SDK so it adopts Liquid Glass
+          # on Tahoe (the team is pinned to Xcode 26 via .xcode-version). The zig
+          # Ghostty CLI helper must link against a pre-26 SDK because zig 0.15.2
+          # cannot cross-link x86_64 against the macOS 26 SDK. Both Xcodes ship on
+          # the macOS 15 runner image, so pick one of each by SDK major.
+          APP_DEVELOPER_DIR=""
+          APP_SDK_MAJOR=""
+          HELPER_DEVELOPER_DIR=""
+          HELPER_SDK_MAJOR=""
+          while IFS= read -r app; do
+            [ -n "$app" ] || continue
+            dev="$app/Contents/Developer"
+            [ -d "$dev" ] || continue
+            sdk_ver="$(DEVELOPER_DIR="$dev" xcrun --sdk macosx --show-sdk-version 2>/dev/null || true)"
+            [ -n "$sdk_ver" ] || continue
+            major="${sdk_ver%%.*}"
+            echo "Found $app -> macOS SDK $sdk_ver"
+            if [ "$major" -ge 26 ]; then
+              APP_DEVELOPER_DIR="$dev"
+              APP_SDK_MAJOR="$major"
             else
-              echo "No Xcode.app found under /Applications" >&2
-              exit 1
+              HELPER_DEVELOPER_DIR="$dev"
+              HELPER_SDK_MAJOR="$major"
             fi
+          done < <(find /Applications -maxdepth 1 -name 'Xcode*.app' -print 2>/dev/null | sort)
+
+          if [ -z "$APP_DEVELOPER_DIR" ]; then
+            echo "No Xcode with the macOS 26+ SDK found; the app would ship without Liquid Glass on Tahoe." >&2
+            exit 1
           fi
-          echo "DEVELOPER_DIR=$XCODE_DIR" >> "$GITHUB_ENV"
-          export DEVELOPER_DIR="$XCODE_DIR"
-          xcodebuild -version
-          xcrun --sdk macosx --show-sdk-path
+          if [ -z "$HELPER_DEVELOPER_DIR" ]; then
+            echo "No pre-26 Xcode found to cross-link the universal Ghostty CLI helper (zig 0.15.2 cannot link x86_64 against the macOS 26 SDK)." >&2
+            exit 1
+          fi
+
+          echo "App build Xcode (DEVELOPER_DIR): $APP_DEVELOPER_DIR (macOS SDK $APP_SDK_MAJOR)"
+          echo "Helper build Xcode (HELPER_DEVELOPER_DIR): $HELPER_DEVELOPER_DIR (macOS SDK $HELPER_SDK_MAJOR)"
+          DEVELOPER_DIR="$APP_DEVELOPER_DIR" xcodebuild -version
+          echo "DEVELOPER_DIR=$APP_DEVELOPER_DIR" >> "$GITHUB_ENV"
+          echo "HELPER_DEVELOPER_DIR=$HELPER_DEVELOPER_DIR" >> "$GITHUB_ENV"
 
       - name: Install build deps
         if: needs.decide.outputs.should_publish != 'true' || steps.current_head_prebuild.outputs.still_current == 'true'
@@ -164,6 +188,19 @@ jobs:
           ./scripts/install-rust-ci.sh
           ./scripts/install-zig-ci.sh
           npm install --global "create-dmg@${CREATE_DMG_VERSION}"
+
+      - name: Build universal Ghostty CLI helper
+        if: needs.decide.outputs.should_publish != 'true' || steps.current_head_prebuild.outputs.still_current == 'true'
+        env:
+          # zig 0.15.2 can cross-link the x86_64 slice only against a pre-26 SDK.
+          DEVELOPER_DIR: ${{ env.HELPER_DEVELOPER_DIR }}
+        run: |
+          set -euo pipefail
+          ./scripts/build-ghostty-cli-helper.sh --universal --output /tmp/cmux-ghostty-helper-universal
+          ARCHS_OUT="$(lipo -archs /tmp/cmux-ghostty-helper-universal)"
+          echo "Universal Ghostty CLI helper architectures: $ARCHS_OUT"
+          case " $ARCHS_OUT " in *" arm64 "*) ;; *) echo "helper missing arm64 slice" >&2; exit 1 ;; esac
+          case " $ARCHS_OUT " in *" x86_64 "*) ;; *) echo "helper missing x86_64 slice" >&2; exit 1 ;; esac
 
       - name: Download pre-built GhosttyKit.xcframework
         if: needs.decide.outputs.should_publish != 'true' || steps.current_head_prebuild.outputs.still_current == 'true'
@@ -199,6 +236,11 @@ jobs:
 
       - name: Build universal nightly app (Release)
         if: needs.decide.outputs.should_publish != 'true' || steps.current_head_prebuild.outputs.still_current == 'true'
+        env:
+          # Skip the in-Xcode zig helper build; it would fail to cross-link
+          # x86_64 against the macOS 26 SDK. The real universal helper is built
+          # by the "Build universal Ghostty CLI helper" step and injected below.
+          CMUX_SKIP_ZIG_BUILD: "1"
         run: |
           xcodebuild -scheme cmux -configuration Release -derivedDataPath build-universal \
             -destination 'generic/platform=macOS' \
@@ -206,6 +248,18 @@ jobs:
             ARCHS="arm64 x86_64" \
             ONLY_ACTIVE_ARCH=NO \
             CODE_SIGNING_ALLOWED=NO ASSETCATALOG_COMPILER_APPICON_NAME=AppIcon-Nightly build
+
+      - name: Inject universal Ghostty CLI helper
+        if: needs.decide.outputs.should_publish != 'true' || steps.current_head_prebuild.outputs.still_current == 'true'
+        run: |
+          set -euo pipefail
+          DEST="build-universal/Build/Products/Release/cmux.app/Contents/Resources/bin/ghostty"
+          if [ ! -e "$DEST" ]; then
+            echo "Expected Ghostty helper slot missing at $DEST" >&2
+            exit 1
+          fi
+          install -m 755 /tmp/cmux-ghostty-helper-universal "$DEST"
+          echo "Injected Ghostty CLI helper architectures: $(lipo -archs "$DEST")"
 
       - name: Run bundled Ghostty theme picker helper regression
         if: needs.decide.outputs.should_publish != 'true' || steps.current_head_prebuild.outputs.still_current == 'true'


### PR DESCRIPTION
## Problem

Nightly settings (and the whole app) render with the legacy, non-Liquid-Glass appearance on macOS 26 Tahoe. This regressed in https://github.com/manaflow-ai/cmux/pull/5022 (2026-05-30), which moved the nightly build off the macOS 26 runner onto macOS 15 to fix the universal Ghostty CLI helper link.

Root cause is the linked SDK, not any opt-out key. The macOS 15 runner's default Xcode is 16.4 (MacOSX15.5 SDK), confirmed from the latest nightly run log. A binary linked against a pre-26 SDK is automatically placed in the legacy compatibility appearance on Tahoe, the same effect as `UIDesignRequiresCompatibility=YES`. Before #5022 nightly built on the Tahoe runner (#2231, 2026-03-26) and got Liquid Glass.

## Fix

Keep the macOS 15 host, because zig 0.15.2 can cross-link the x86_64 helper slice only against a pre-26 SDK, but build the Swift app with the macOS 26 Xcode that already ships on the runner image (matching the `.xcode-version` 26 pin). The universal Ghostty helper is built in a separate step with the older Xcode and injected into the bundle before signing.

- `Select Xcode` now picks the newest macOS 26+ Xcode for the app build (`DEVELOPER_DIR`) and the newest pre-26 Xcode for the helper (`HELPER_DEVELOPER_DIR`), failing loudly if either is missing so a legacy-SDK build can't silently ship again.
- New `Build universal Ghostty CLI helper` step builds the arm64+x86_64 helper with the older SDK and verifies both slices.
- The app build runs with `CMUX_SKIP_ZIG_BUILD=1` (the in-Xcode helper build would fail to cross-link x86_64 against the 26 SDK), then the real helper is injected at `Contents/Resources/bin/ghostty` before the theme-picker regression, arch verification, and signing.

The existing `Verify nightly binary architectures` step still gates universality of the app, CLI, and helper.

## Validation

Triggering a branch run of `nightly.yml` (`should_publish=false`, so it builds + signs + notarizes a branch DMG without moving the `nightly` tag or publishing) to confirm the universal arch checks pass and the produced app adopts Liquid Glass on Tahoe.

## Note

`release.yml` has the identical `Select Xcode` (Xcode 16.4) pattern, so stable releases also ship the legacy appearance on Tahoe. The same fix should be applied there; not included here to keep this change focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5077"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782870476&installation_id=133855650&pr_number=5077&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5077&signature=94af5f4ea1a691ccec462c596983a2f1d36c90e39919a8030f75a37ef526db88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Build the nightly app with the macOS 26 SDK so Tahoe renders with Liquid Glass. The universal Ghostty CLI helper is built against a pre-26 SDK and injected to keep a universal binary.

- **Bug Fixes**
  - Select Xcode 26+ for the app (`DEVELOPER_DIR`) and pre-26 for the helper (`HELPER_DEVELOPER_DIR`) using numeric SDK ranking; fail if either is missing.
  - Add a step to build the universal Ghostty CLI helper with `zig 0.15.2` and verify `arm64`/`x86_64`.
  - Build the app with `CMUX_SKIP_ZIG_BUILD=1` and inject the verified helper before signing; use mkdir/install to make the inject step robust.
  - Keep the macOS 15 runner and raise the timeout to 30 minutes; existing arch verification remains.

<sup>Written for commit 6ed048f0d522a0f56d499f83ffde765372ed14c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5077?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved nightly macOS workflow with better Xcode/SDK discovery and increased timeout.
  * Builds a universal helper binary (arm64 + x86_64) and injects it into the app bundle during the nightly build.
  * Prevents a failing in-project helper build by skipping it when incompatible SDK cross-linking is detected, improving build reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->