### PR TITLE
Fix Settings window opener

### DIFF
--- a/Sources/App/SettingsAppKitWindowPresenter.swift
+++ b/Sources/App/SettingsAppKitWindowPresenter.swift
@@ -1,0 +1,58 @@
+import AppKit
+import CmuxSettings
+import CmuxSettingsUI
+import SwiftUI
+
+@MainActor
+final class SettingsAppKitWindowPresenter: NSObject, NSWindowDelegate {
+    static let shared = SettingsAppKitWindowPresenter()
+
+    private var window: NSWindow?
+    private var hostingController: NSHostingController<SettingsAppKitWindowRoot>?
+
+    func show(runtime: SettingsRuntime) {
+        if let window {
+            SettingsWindowPresenter.configure(window: window)
+            SettingsWindowPresenter.refocusIfVisible()
+            return
+        }
+
+        let root = SettingsAppKitWindowRoot(runtime: runtime)
+        let hostingController = NSHostingController(rootView: root)
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 980, height: 680),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = String(localized: "settings.title", defaultValue: "Settings")
+        window.contentViewController = hostingController
+        window.isReleasedWhenClosed = false
+        window.delegate = self
+        window.center()
+
+        self.window = window
+        self.hostingController = hostingController
+        SettingsWindowPresenter.configure(window: window)
+        SettingsWindowPresenter.refocusIfVisible()
+    }
+
+    func windowShouldClose(_ sender: NSWindow) -> Bool {
+        sender.orderOut(nil)
+        return false
+    }
+}
+
+private struct SettingsAppKitWindowRoot: View {
+    let runtime: SettingsRuntime
+    @AppStorage(AppearanceSettings.appearanceModeKey) private var appearanceMode = AppearanceSettings.defaultMode.rawValue
+
+    var body: some View {
+        SettingsWindowRoot(runtime: runtime)
+            .settingsRuntime(runtime)
+            .background(WindowAccessor(dedupeByWindow: false) { window in
+                SettingsWindowPresenter.configure(window: window)
+            })
+            .cmuxAppearanceColorScheme(appearanceMode)
+    }
+}

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -412,7 +412,6 @@ struct BrowserPanelView: View {
     let portalPriority: Int
     let onRequestPanelFocus: () -> Void
     @Environment(\.colorScheme) private var colorScheme
-    @Environment(\.openWindow) private var openWindow
     @Environment(\.paneDropZone) private var paneDropZone
     @State private var omnibarState = OmnibarState()
     @State private var addressBarFocused: Bool = false
@@ -2074,10 +2073,7 @@ struct BrowserPanelView: View {
 
     private func openBrowserImportSettings() {
         isBrowserImportHintPopoverPresented = false
-        SettingsWindowPresenter.show(
-            navigationTarget: .browserImport,
-            openWindowOverride: { openWindow(id: SettingsWindowPresenter.windowID) }
-        )
+        SettingsWindowPresenter.show(navigationTarget: .browserImport)
         NSRunningApplication.current.activate(options: [.activateAllWindows])
     }
 

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -27,7 +27,6 @@ struct cmuxApp: App {
     @AppStorage(BrowserToolbarAccessorySpacingDebugSettings.key) private var browserToolbarAccessorySpacingRaw = BrowserToolbarAccessorySpacingDebugSettings.defaultSpacing
     @StateObject var focusHistoryMenuInvalidator = FocusHistoryMenuInvalidator()
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
-    @Environment(\.openWindow) private var openWindow
 
     private var browserToolbarAccessorySpacing: Int {
         BrowserToolbarAccessorySpacingDebugSettings.resolved(browserToolbarAccessorySpacingRaw)
@@ -276,7 +275,7 @@ struct cmuxApp: App {
                 .onAppear {
                     SettingsWindowPresenter.configure(
                         openWindow: {
-                            openWindow(id: SettingsWindowPresenter.windowID)
+                            SettingsAppKitWindowPresenter.shared.show(runtime: settingsRuntime)
                         },
                         parentWindowProvider: {
                             AppDelegate.shared?.preferredMainWindowForSettingsPresentation()
@@ -1249,7 +1248,6 @@ private struct MainWindowBootstrapView: View {
             })
     }
 }
-
 
 private let cmuxAuxiliaryWindowIdentifiers: Set<String> = [
     "cmux.settings",

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -404,6 +404,7 @@
 		F5320002A1B2C3D4E5F60718 /* SessionTranscriptTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5320003A1B2C3D4E5F60718 /* SessionTranscriptTypes.swift */; };
 		D10000000000000000A00020 /* SettingsAccountJSONResetBehaviorUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000000000000000A00021 /* SettingsAccountJSONResetBehaviorUITests.swift */; };
 		D10000000000000000A00012 /* SettingsAppBehaviorUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000000000000000A00013 /* SettingsAppBehaviorUITests.swift */; };
+		D36090020000000000000001 /* SettingsAppKitWindowPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36090020000000000000002 /* SettingsAppKitWindowPresenter.swift */; };
 		D10000000000000000A00018 /* SettingsAutomationBehaviorUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000000000000000A00019 /* SettingsAutomationBehaviorUITests.swift */; };
 		D10000000000000000A0001A /* SettingsBrowserBehaviorUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000000000000000A0001B /* SettingsBrowserBehaviorUITests.swift */; };
 		B37A00000000000000000007 /* SettingsCardNote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B37A00000000000000000008 /* SettingsCardNote.swift */; };
@@ -1039,6 +1040,7 @@
 		F5320003A1B2C3D4E5F60718 /* SessionTranscriptTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionTranscriptTypes.swift; sourceTree = "<group>"; };
 		D10000000000000000A00021 /* SettingsAccountJSONResetBehaviorUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsAccountJSONResetBehaviorUITests.swift; sourceTree = "<group>"; };
 		D10000000000000000A00013 /* SettingsAppBehaviorUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsAppBehaviorUITests.swift; sourceTree = "<group>"; };
+		D36090020000000000000002 /* SettingsAppKitWindowPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/SettingsAppKitWindowPresenter.swift; sourceTree = "<group>"; };
 		D10000000000000000A00019 /* SettingsAutomationBehaviorUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsAutomationBehaviorUITests.swift; sourceTree = "<group>"; };
 		D10000000000000000A0001B /* SettingsBrowserBehaviorUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsBrowserBehaviorUITests.swift; sourceTree = "<group>"; };
 		B37A00000000000000000008 /* SettingsCardNote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsCardNote.swift; sourceTree = "<group>"; };
@@ -1414,6 +1416,7 @@
 				A50019A1 /* SettingsNavigation.swift */,
 				A50019B1 /* SettingsSearchAliases.swift */,
 				D3610C010000000000000002 /* CmuxSettingsJSONPathSupport.swift */,
+				D36090020000000000000002 /* SettingsAppKitWindowPresenter.swift */,
 				D36090010000000000000002 /* SettingsWindowPresenter.swift */,
 				B37A00000000000000000002 /* BetaFeaturesSettingsView.swift */,
 				B37A00000000000000000008 /* SettingsCardNote.swift */,
@@ -2432,6 +2435,7 @@
 				A5001670 /* SessionRestoredTerminalCommandStore.swift in Sources */,
 				A50016B1A1B2C3D4E5F60718 /* SessionSnapshotDebugBenchmark.swift in Sources */,
 				F5320002A1B2C3D4E5F60718 /* SessionTranscriptTypes.swift in Sources */,
+				D36090020000000000000001 /* SettingsAppKitWindowPresenter.swift in Sources */,
 				B37A00000000000000000007 /* SettingsCardNote.swift in Sources */,
 				D9CCF002D9CCF002D9CCF002 /* SettingsLazyLoadHelpers.swift in Sources */,
 				A50019A0 /* SettingsNavigation.swift in Sources */,

--- a/cmuxUITests/BrowserImportProfilesUITests.swift
+++ b/cmuxUITests/BrowserImportProfilesUITests.swift
@@ -127,7 +127,8 @@ final class BrowserImportProfilesUITests: XCTestCase {
         let capture = try XCTUnwrap(waitForSettingsOpenCapture(timeout: 5.0))
         XCTAssertEqual(capture["opened"] as? Bool, true)
         XCTAssertEqual(capture["target"] as? String, "browserImport")
-        XCTAssertEqual(capture["used_open_window_override"] as? Bool, true)
+        XCTAssertEqual(capture["used_open_window_override"] as? Bool, false)
+        XCTAssertTrue(app.windows["Settings"].waitForExistence(timeout: 5.0))
     }
 
     func testBlankBrowserImportHintCanBeDismissed() {


### PR DESCRIPTION
## Summary
- replace the SwiftUI scene opener captured by the hidden bootstrap window with a retained AppKit Settings window presenter
- route the browser import Settings hint through the shared presenter path
- update the browser import UI test to assert the Settings window appears

## Test plan
- CMUX_SKIP_ZIG_BUILD=1 ./scripts/reload.sh --tag setfix --swift-frontend-workaround
- launched http://127.0.0.1:17320/setfix
- CMUX_TAG=setfix scripts/cmux-debug-cli.sh settings open
- verified CoreGraphics sees one on-screen Settings window for cmux DEV setfix
- closed Settings via Accessibility, reopened with CMUX_TAG=setfix scripts/cmux-debug-cli.sh settings open, verified count returned to one

## Notes
- Recent Liquid Glass search found settings UI changes in https://github.com/manaflow-ai/cmux/pull/4975 and https://github.com/manaflow-ai/cmux/pull/5012, but no recent runtime flag or environment override that disables Settings Liquid Glass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5078"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782870843&installation_id=133855650&pr_number=5078&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5078&signature=74a7f885339881e13c4bc59f22e5a24af88e9d3b9a5aea47854c72a1a6da6f6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches global window presentation and focus/parent-window behavior for a core surface; scope is limited but regressions could affect menu shortcuts, deep links, and multi-window focus.
> 
> **Overview**
> Settings now opens through a **retained AppKit `NSWindow`** (`SettingsAppKitWindowPresenter`) that hosts the existing `SettingsWindowRoot` SwiftUI tree, instead of relying on SwiftUI’s `openWindow` from the main scene (which could be tied to the wrong/hidden bootstrap window).
> 
> App startup wires `SettingsWindowPresenter`’s open hook to `SettingsAppKitWindowPresenter.shared.show(runtime:)`. Closing the window **hides** it (`orderOut`) rather than releasing it, so repeat opens refocus the same instance. The blank-tab browser import hint calls `SettingsWindowPresenter.show(navigationTarget: .browserImport)` without a per-view `openWindow` override.
> 
> UI tests now expect the shared presenter path (`used_open_window_override` false) and that an accessibility **Settings** window appears.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfe18679ac92d96d61ec89b58eee3429ee51477f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Settings window not opening or refocusing by replacing the SwiftUI scene opener with a retained AppKit presenter. Routes the Browser Import hint through the shared presenter and adds a UI test to confirm the window appears.

- **Bug Fixes**
  - Added an AppKit-based Settings window presenter that creates, retains, and refocuses the window.
  - Switched app wiring to use the presenter via `SettingsWindowPresenter` and stop using SwiftUI `openWindow`.
  - Routed the Browser Import hint to the shared presenter.
  - Updated the UI test to verify the Settings window exists and no override was used.

<sup>Written for commit bfe18679ac92d96d61ec89b58eee3429ee51477f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5078?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced Settings window behavior on macOS with improved window lifecycle management
  * Settings window now properly reuses and maintains state when reopened

<!-- end of auto-generated comment: release notes by coderabbit.ai -->