### PR TITLE
Fix update pill badge icon

### DIFF
--- a/Sources/CMUXInstalledExtensionSidebarHostView.swift
+++ b/Sources/CMUXInstalledExtensionSidebarHostView.swift
@@ -217,7 +217,7 @@ struct CMUXInstalledExtensionSidebarHostView: View {
                 .accessibilityIdentifier("CMUXExtensionSidebarEmptyState")
             } else {
                 VStack(spacing: 16) {
-                    Image(systemName: "puzzlepiece.extension")
+                    Image(systemName: RenderableSystemSymbol.sidebarExtensionIcon)
                         .font(.system(size: 26, weight: .regular))
                         .foregroundStyle(.secondary)
                         .frame(width: 60, height: 60)
@@ -344,13 +344,13 @@ struct CMUXInstalledExtensionSidebarHostView: View {
                     Button {
                         selectExtension(enabledIdentity)
                     } label: {
-                        Label(enabledIdentity.localizedName, systemImage: "puzzlepiece.extension")
+                        Label(enabledIdentity.localizedName, systemImage: RenderableSystemSymbol.sidebarExtensionIcon)
                     }
                 }
             } label: {
                 Label(
                     String(localized: "sidebar.extensions.choose.action", defaultValue: "Choose Extension"),
-                    systemImage: "puzzlepiece.extension"
+                    systemImage: RenderableSystemSymbol.sidebarExtensionIcon
                 )
             }
             .menuStyle(.button)
@@ -362,7 +362,7 @@ struct CMUXInstalledExtensionSidebarHostView: View {
         } label: {
             Label(
                 String(localized: "sidebar.extensions.manage.short", defaultValue: "Manage"),
-                systemImage: "puzzlepiece.extension"
+                systemImage: RenderableSystemSymbol.sidebarExtensionIcon
             )
         }
         .controlSize(.small)
@@ -418,7 +418,7 @@ struct CMUXInstalledExtensionSidebarHostView: View {
     private func extensionDetailsPopover(activeIdentity: AppExtensionIdentity?) -> some View {
         VStack(alignment: .leading, spacing: 12) {
             HStack(spacing: 8) {
-                Image(systemName: "puzzlepiece.extension")
+                Image(systemName: RenderableSystemSymbol.sidebarExtensionIcon)
                     .font(.system(size: 18, weight: .medium))
                 VStack(alignment: .leading, spacing: 2) {
                     Text(activeIdentity?.localizedName ?? String(localized: "sidebar.provider.extensions.title", defaultValue: "Extension Sidebar"))
@@ -556,7 +556,7 @@ struct CMUXInstalledExtensionSidebarHostView: View {
         } label: {
             Label(
                 String(localized: "sidebar.extensions.manage.short", defaultValue: "Manage"),
-                systemImage: "puzzlepiece.extension")
+                systemImage: RenderableSystemSymbol.sidebarExtensionIcon)
         }
         .controlSize(.small)
     }
@@ -659,14 +659,14 @@ struct CMUXInstalledExtensionSidebarHostView: View {
                     } label: {
                         Label(
                             enabledIdentity.localizedName,
-                            systemImage: enabledIdentity.bundleIdentifier == activeIdentity?.bundleIdentifier ? "checkmark" : "puzzlepiece.extension"
+                            systemImage: enabledIdentity.bundleIdentifier == activeIdentity?.bundleIdentifier ? "checkmark" : RenderableSystemSymbol.sidebarExtensionIcon
                         )
                     }
                 }
             } label: {
                 Label(
                     activeIdentity?.localizedName ?? String(localized: "sidebar.provider.extensions.title", defaultValue: "Extension Sidebar"),
-                    systemImage: "puzzlepiece.extension"
+                    systemImage: RenderableSystemSymbol.sidebarExtensionIcon
                 )
                 .lineLimit(1)
             }
@@ -675,7 +675,7 @@ struct CMUXInstalledExtensionSidebarHostView: View {
         } else {
             Label(
                 activeIdentity?.localizedName ?? String(localized: "sidebar.provider.extensions.title", defaultValue: "Extension Sidebar"),
-                systemImage: "puzzlepiece.extension"
+                systemImage: RenderableSystemSymbol.sidebarExtensionIcon
             )
             .font(.system(size: 12, weight: .semibold))
             .foregroundStyle(.secondary)
@@ -760,7 +760,7 @@ struct CMUXInstalledExtensionSidebarHostView: View {
     ) -> some View {
         VStack(alignment: .leading, spacing: 14) {
             HStack(spacing: 10) {
-                Image(systemName: "puzzlepiece.extension")
+                Image(systemName: RenderableSystemSymbol.sidebarExtensionIcon)
                     .font(.system(size: 22, weight: .medium))
                 VStack(alignment: .leading, spacing: 2) {
                     Text(String.localizedStringWithFormat(

--- a/Sources/CMUXSidebarExtensionBrowserPanel.swift
+++ b/Sources/CMUXSidebarExtensionBrowserPanel.swift
@@ -11,7 +11,7 @@ final class CMUXSidebarExtensionBrowserPanel: NSObject, Panel, ObservableObject 
     private let title: String
 
     var displayTitle: String { title }
-    var displayIcon: String? { "puzzlepiece.extension" }
+    var displayIcon: String? { RenderableSystemSymbol.sidebarExtensionIcon }
 
     init(title: String) {
         self.title = title

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -9958,7 +9958,7 @@ enum CmuxExtensionSidebarSelection {
                     ? String(localized: "sidebar.provider.extensions.subtitle", defaultValue: "Custom sidebar")
                     : String(localized: "sidebar.provider.extensions.selectedSubtitle", defaultValue: "Sidebar extension")
             ),
-            systemImageName: "puzzlepiece.extension",
+            systemImageName: RenderableSystemSymbol.sidebarExtensionIcon,
             isHostProvided: true
         )
     }
@@ -13029,7 +13029,7 @@ private struct SidebarFooterButtons: View {
                     title: String(localized: "sidebar.extensions.browser.title", defaultValue: "Sidebar Extensions")
                 )
             } label: {
-                Image(systemName: "puzzlepiece.extension")
+                Image(systemName: RenderableSystemSymbol.sidebarExtensionIcon)
                     .symbolRenderingMode(.monochrome)
                     .font(.system(size: 12, weight: .medium))
                     .foregroundStyle(Color(nsColor: .secondaryLabelColor))

--- a/Sources/Panels/ProjectTargetsTabView.swift
+++ b/Sources/Panels/ProjectTargetsTabView.swift
@@ -123,7 +123,7 @@ struct ProjectTargetsTabView: View {
             }
         } else {
             ProjectEmptyDetailView(
-                systemImage: "shippingbox",
+                systemImage: RenderableSystemSymbol.packageIcon,
                 title: "Select a target",
                 hint: "Pick a target on the left to see its product type, dependencies, and configurations."
             )
@@ -226,11 +226,11 @@ struct ProjectTargetsTabView: View {
     private func glyph(for productType: TargetProductType) -> String {
         switch productType {
         case .application: return "app.fill"
-        case .framework, .dynamicLibrary, .staticLibrary, .xcFramework: return "shippingbox"
-        case .bundle: return "shippingbox.fill"
+        case .framework, .dynamicLibrary, .staticLibrary, .xcFramework: return RenderableSystemSymbol.packageIcon
+        case .bundle: return RenderableSystemSymbol.packageFillIcon
         case .unitTest, .uiTest: return "testtube.2"
         case .commandLineTool: return "terminal"
-        case .appExtension: return "puzzlepiece.extension"
+        case .appExtension: return RenderableSystemSymbol.sidebarExtensionIcon
         case .watchApp, .watchExtension: return "applewatch"
         case .other: return "questionmark.square"
         }

--- a/Sources/RenderableSystemSymbol.swift
+++ b/Sources/RenderableSystemSymbol.swift
@@ -1,6 +1,10 @@
 import AppKit
 
 enum RenderableSystemSymbol {
+    static let sidebarExtensionIcon = "puzzlepiece"
+    static let packageIcon = "archivebox"
+    static let packageFillIcon = "archivebox.fill"
+    static let unknownDocumentIcon = "doc.questionmark"
     static let defaultWorkspaceGroupIcon = "folder.fill"
     static let defaultSurfaceTabIcon = "doc.text"
     @MainActor

--- a/Sources/SessionIndexView.swift
+++ b/Sources/SessionIndexView.swift
@@ -799,7 +799,7 @@ private struct SessionTranscriptPreviewView: View {
             loadingStatusRow
         case .missingFile:
             statusRow(
-                systemImage: "doc.badge.questionmark",
+                systemImage: RenderableSystemSymbol.unknownDocumentIcon,
                 text: String(localized: "sessionIndex.preview.noFile", defaultValue: "No transcript file")
             )
         case .failed:

--- a/Sources/Update/UpdateBadge.swift
+++ b/Sources/Update/UpdateBadge.swift
@@ -13,7 +13,7 @@ struct UpdateBadge: View {
     private var badgeContent: some View {
         if model.showsDetectedBackgroundUpdate {
             if let iconName = model.iconName {
-                Image(systemName: iconName)
+                badgeImage(iconName)
             }
         } else {
             switch model.effectiveState {
@@ -22,7 +22,7 @@ struct UpdateBadge: View {
                     let progress = min(1, max(0, Double(download.progress) / Double(expectedLength)))
                     ProgressRingView(progress: progress)
                 } else {
-                    Image(systemName: "arrow.down.circle")
+                    badgeImage("arrow.down.circle")
                 }
 
             case .extracting(let extracting):
@@ -33,10 +33,18 @@ struct UpdateBadge: View {
 
             default:
                 if let iconName = model.iconName {
-                    Image(systemName: iconName)
+                    badgeImage(iconName)
                 }
             }
         }
+    }
+
+    private func badgeImage(_ systemName: String) -> some View {
+        Image(systemName: systemName)
+            .font(.system(size: 13, weight: .semibold))
+            .symbolRenderingMode(.monochrome)
+            .foregroundStyle(model.foregroundColor)
+            .frame(width: 14, height: 14)
     }
 }
 

--- a/Sources/Update/UpdateViewModel.swift
+++ b/Sources/Update/UpdateViewModel.swift
@@ -139,7 +139,7 @@ class UpdateViewModel: ObservableObject {
         case .downloading:
             return "arrow.down.circle"
         case .extracting:
-            return "shippingbox"
+            return RenderableSystemSymbol.packageIcon
         case .installing:
             return "power.circle"
         case .notFound:

--- a/Sources/Update/UpdateViewModel.swift
+++ b/Sources/Update/UpdateViewModel.swift
@@ -125,7 +125,7 @@ class UpdateViewModel: ObservableObject {
 
     var iconName: String? {
         if showsDetectedBackgroundUpdate {
-            return "shippingbox.fill"
+            return "arrow.down.circle.fill"
         }
         switch effectiveState {
         case .idle:
@@ -135,7 +135,7 @@ class UpdateViewModel: ObservableObject {
         case .checking:
             return "arrow.triangle.2.circlepath"
         case .updateAvailable:
-            return "shippingbox.fill"
+            return "arrow.down.circle.fill"
         case .downloading:
             return "arrow.down.circle"
         case .extracting:

--- a/cmuxTests/ShortcutAndCommandPaletteTests.swift
+++ b/cmuxTests/ShortcutAndCommandPaletteTests.swift
@@ -1928,7 +1928,21 @@ final class UpdateViewModelPresentationTests: XCTestCase {
         XCTAssertTrue(viewModel.showsPill)
         XCTAssertTrue(viewModel.showsDetectedBackgroundUpdate)
         XCTAssertEqual(viewModel.text, "Update Available: 9.9.9")
-        XCTAssertEqual(viewModel.iconName, "shippingbox.fill")
+        XCTAssertEqual(viewModel.iconName, "arrow.down.circle.fill")
+        XCTAssertNotNil(NSImage(systemSymbolName: viewModel.iconName ?? "", accessibilityDescription: nil))
+    }
+
+    func testAvailableUpdateUsesResolvableDownloadIcon() throws {
+        let viewModel = UpdateViewModel()
+        let item = try XCTUnwrap(makeAppcastItem(displayVersion: "9.9.9"))
+
+        viewModel.state = .updateAvailable(.init(
+            appcastItem: item,
+            reply: { _ in }
+        ))
+
+        XCTAssertEqual(viewModel.iconName, "arrow.down.circle.fill")
+        XCTAssertNotNil(NSImage(systemSymbolName: viewModel.iconName ?? "", accessibilityDescription: nil))
     }
 
     func testActiveUpdateStateTakesPrecedenceOverDetectedBackgroundVersion() {

--- a/cmuxTests/ShortcutAndCommandPaletteTests.swift
+++ b/cmuxTests/ShortcutAndCommandPaletteTests.swift
@@ -1945,6 +1945,15 @@ final class UpdateViewModelPresentationTests: XCTestCase {
         XCTAssertNotNil(NSImage(systemSymbolName: viewModel.iconName ?? "", accessibilityDescription: nil))
     }
 
+    func testExtractingUpdateUsesResolvablePackageIcon() {
+        let viewModel = UpdateViewModel()
+
+        viewModel.state = .extracting(.init(progress: 0.4))
+
+        XCTAssertEqual(viewModel.iconName, RenderableSystemSymbol.packageIcon)
+        XCTAssertNotNil(NSImage(systemSymbolName: viewModel.iconName ?? "", accessibilityDescription: nil))
+    }
+
     func testActiveUpdateStateTakesPrecedenceOverDetectedBackgroundVersion() {
         let viewModel = UpdateViewModel()
 

--- a/cmuxTests/WorkspaceGroupTests.swift
+++ b/cmuxTests/WorkspaceGroupTests.swift
@@ -708,4 +708,17 @@ struct WorkspaceGroupTests {
         #expect(RenderableSystemSymbol.resolvedSurfaceTabIcon("not.an.sf.symbol") == "doc.text")
         #expect(RenderableSystemSymbol.resolvedSurfaceTabIcon("   ") == "doc.text")
     }
+
+    @Test func appOwnedFallbackSymbolsAreRenderable() {
+        for symbol in [
+            RenderableSystemSymbol.sidebarExtensionIcon,
+            RenderableSystemSymbol.packageIcon,
+            RenderableSystemSymbol.packageFillIcon,
+            RenderableSystemSymbol.unknownDocumentIcon,
+            RenderableSystemSymbol.defaultWorkspaceGroupIcon,
+            RenderableSystemSymbol.defaultSurfaceTabIcon
+        ] {
+            #expect(RenderableSystemSymbol.isRenderable(symbol), "Expected \(symbol) to resolve as an SF Symbol")
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- switch the update-available pill badge to a download-circle SF Symbol
- render update badge symbols with explicit monochrome size and foreground color
- cover detected and active update icon names with resolvable-symbol assertions

## Verification
- `./scripts/reload.sh --tag updico --swift-frontend-workaround`

Local Xcode test actions were not run because this repo forbids local `xcodebuild ... test` runs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5086"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782879280&installation_id=133855650&pr_number=5086&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5086&signature=00975d74e9aa68ca1331b56450c21e2533d1c067569f2ca982f06ef47151f5c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual and symbol-name changes only; no security, data, or core behavior paths beyond icon resolution and update UI presentation.
> 
> **Overview**
> Centralizes **app-owned SF Symbol fallbacks** in `RenderableSystemSymbol` and routes sidebar extension, package/target, and missing-transcript UI through those constants instead of literals like `puzzlepiece.extension` and `shippingbox`, so icons stay **SF Symbol–renderable** on older macOS.
> 
> The **update pill** switches available/background-detected states to **`arrow.down.circle.fill`**, uses **`archivebox`** while extracting, and draws badge icons through a shared **`badgeImage`** helper (fixed 13pt semibold monochrome, 14×14 frame). Tests now assert icon names resolve via `NSImage` and that all centralized fallback symbols pass `isRenderable`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e459ea09811e0f0091adbd1a691d851e238deb87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched the update pill to a download-circle icon and unified its styling. Also standardized SF Symbol usage with safe app-owned fallbacks to prevent unresolved icons.

- **Bug Fixes**
  - Use `arrow.down.circle` / `arrow.down.circle.fill` for detected/available updates; extracting uses `RenderableSystemSymbol.packageIcon`.
  - Centralized badge styling via `badgeImage(...)` (13pt semibold, monochrome, 14×14), with tests ensuring symbol names resolve at runtime.

- **Refactors**
  - Introduced `RenderableSystemSymbol` and replaced raw SF Symbol names across the UI (sidebar extension, project targets, panels, content view).
  - Standardized fallbacks: `puzzlepiece` for extensions, `archivebox`/`archivebox.fill` for packages, `doc.questionmark` for unknown docs; added tests to assert these are renderable.

<sup>Written for commit e459ea09811e0f0091adbd1a691d851e238deb87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5086?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Standardized and updated many app icons for clarity: download-circle for updates, package icons for package-related states, a unified sidebar extension icon, and an improved unknown-document icon.
* **Bug Fixes**
  * Fixed inconsistent or missing symbol rendering across sidebars and status views for more reliable visuals.
* **Tests**
  * Added checks to ensure fallback symbols are renderable at runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->