### PR TITLE
Gate extension UI behind an experimental Beta Features toggle

### DIFF
--- a/Packages/CmuxSettings/Sources/CmuxSettings/Keys/BetaFeaturesCatalogSection.swift
+++ b/Packages/CmuxSettings/Sources/CmuxSettings/Keys/BetaFeaturesCatalogSection.swift
@@ -15,5 +15,16 @@ public struct BetaFeaturesCatalogSection: SettingCatalogSection {
         userDefaultsKey: "rightSidebar.beta.dock.enabled"
     )
 
+    /// Extensions: the experimental ExtensionKit sidebar-extension surface
+    /// (puzzle button, sidebar-toggle provider menu, installed-extension
+    /// host, and the extensions browser). Defaults off; while off, every
+    /// extension-related entry point is hidden so the feature stays opt-in
+    /// while it is in beta.
+    public let extensions = DefaultsKey<Bool>(
+        id: "extensions.beta.enabled",
+        defaultValue: false,
+        userDefaultsKey: "extensions.beta.enabled"
+    )
+
     public init() {}
 }

--- a/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/BetaFeaturesSection.swift
+++ b/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/BetaFeaturesSection.swift
@@ -1,15 +1,17 @@
 import CmuxSettings
 import SwiftUI
 
-/// **Beta Features** section — mirrors the legacy
-/// `BetaFeaturesSettingsView`: warning note followed by a single
-/// `Dock` toggle.
+/// **Beta Features** section — a warning note followed by the
+/// experimental toggles: `Dock` and `Extensions`. Each toggle gates an
+/// unstable feature that is off by default.
 @MainActor
 public struct BetaFeaturesSection: View {
     @State private var dock: DefaultsValueModel<Bool>
+    @State private var extensions: DefaultsValueModel<Bool>
 
     public init(defaultsStore: UserDefaultsSettingsStore, catalog: SettingCatalog) {
         _dock = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.betaFeatures.rightSidebarDock))
+        _extensions = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.betaFeatures.extensions))
     }
 
     public var body: some View {
@@ -17,10 +19,12 @@ public struct BetaFeaturesSection: View {
             SettingsSectionHeader(String(localized: "settings.section.betaFeatures", defaultValue: "Beta Features"), section: .betaFeatures)
             SettingsCard {
                 BetaFeaturesWarningNote(
-                    String(localized: "settings.betaFeatures.warning", defaultValue: "Dock is unstable and may change or break. Enable it only when you are testing it.")
+                    String(localized: "settings.betaFeatures.warning", defaultValue: "These features are experimental and may change or break. Enable them only when you are testing them.")
                 )
                 SettingsCardDivider()
                 dockRow
+                SettingsCardDivider()
+                extensionsRow
             }
         }
     }
@@ -39,6 +43,23 @@ public struct BetaFeaturesSection: View {
                 .labelsHidden()
                 .controlSize(.small)
                 .accessibilityIdentifier("SettingsBetaDockToggle")
+        }
+    }
+
+    @ViewBuilder
+    private var extensionsRow: some View {
+        SettingsCardRow(
+            configurationReview: .settingsOnly,
+            searchAnchorID: "setting:betaFeatures:extensions",
+            String(localized: "settings.betaFeatures.extensions", defaultValue: "Extensions"),
+            subtitle: extensions.current
+                ? String(localized: "settings.betaFeatures.extensions.subtitleOn", defaultValue: "Shows the puzzle button, the sidebar-toggle extension menu, and lets you install and host sidebar extensions.")
+                : String(localized: "settings.betaFeatures.extensions.subtitleOff", defaultValue: "Hides all extension UI until you enable it here.")
+        ) {
+            Toggle("", isOn: Binding(get: { extensions.current }, set: { extensions.set($0) }))
+                .labelsHidden()
+                .controlSize(.small)
+                .accessibilityIdentifier("SettingsBetaExtensionsToggle")
         }
     }
 }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -13457,6 +13457,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     @discardableResult
     func openSidebarExtensionBrowser(from anchorView: NSView?, title: String) -> UUID? {
+        // Defensive gate: the extensions browser is part of the experimental
+        // Extensions feature. Its entry points are hidden while disabled, but
+        // guard here too so no other path can open it.
+        guard CmuxExtensionSidebarSelection.isEnabled else { return nil }
         let preferredWindow = anchorView?.window ?? NSApp.keyWindow ?? NSApp.mainWindow
         let targetTabManager = synchronizeActiveMainWindowContext(preferredWindow: preferredWindow)
         guard let workspace = targetTabManager?.selectedWorkspace,

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -5,7 +5,6 @@ import Combine
 import CMUXExtensionClient
 import CmuxExtensionKit
 import CmuxSettings
-import CmuxSettingsUI
 import ImageIO
 import Observation
 import SwiftUI
@@ -9944,13 +9943,18 @@ enum CmuxExtensionSidebarSelection {
     static let defaultProviderId = CmuxExtensionSidebarProviderDescriptor.defaultWorkspacesID
     static let hostedExtensionsProviderId = "cmux.sidebar.extensions"
 
-    /// Whether the experimental Extensions feature is enabled, read from the
-    /// settings catalog (`BetaFeaturesCatalogSection.extensions`) so the key
-    /// and default are not duplicated. SwiftUI views observe the same flag
-    /// reactively via `@Setting(\.betaFeatures.extensions)`; this synchronous
-    /// read is for the on-demand AppKit/static paths (the toggle menu, the
-    /// command-palette builder, the extensions-browser opener) that have no
-    /// `SettingsRuntime` in scope.
+    /// The UserDefaults key and default for the experimental Extensions flag,
+    /// resolved from the settings catalog (`BetaFeaturesCatalogSection.extensions`)
+    /// so the key and default are never re-declared. The sidebar lives in an
+    /// AppKit-hosted subtree where the `SettingsRuntime` environment does not
+    /// reach, so SwiftUI views observe the flag with `@AppStorage(enabledDefaultsKey)`
+    /// (reactive and environment-independent) rather than `@Setting`.
+    static var enabledDefaultsKey: String { SettingCatalog().betaFeatures.extensions.userDefaultsKey }
+    static var enabledDefault: Bool { SettingCatalog().betaFeatures.extensions.defaultValue }
+
+    /// Synchronous read of the flag for the on-demand AppKit/static paths (the
+    /// toggle menu, the command-palette builder, the extensions-browser opener)
+    /// that have no `SettingsRuntime` in scope and run outside the SwiftUI cycle.
     static var isEnabled: Bool {
         let key = SettingCatalog().betaFeatures.extensions
         return Bool.decodeFromUserDefaults(UserDefaults.standard.object(forKey: key.userDefaultsKey)) ?? key.defaultValue
@@ -10276,7 +10280,8 @@ struct VerticalTabsSidebar: View {
     private var workspacePresentationMode = WorkspacePresentationModeSettings.defaultMode.rawValue
     @AppStorage(CmuxExtensionSidebarSelection.defaultsKey)
     private var selectedExtensionSidebarProviderId = CmuxExtensionSidebarSelection.defaultProviderId
-    @Setting(\.betaFeatures.extensions) private var extensionsExperimentalEnabled
+    @AppStorage(CmuxExtensionSidebarSelection.enabledDefaultsKey)
+    private var extensionsExperimentalEnabled = CmuxExtensionSidebarSelection.enabledDefault
     @AppStorage("sidebarMatchTerminalBackground")
     private var sidebarMatchTerminalBackground = false
     @AppStorage(MinimalModeTitlebarDebugSettings.leftControlsLeadingInsetKey)
@@ -13021,7 +13026,8 @@ private struct SidebarFooterButtons: View {
     @ObservedObject var fileExplorerState: FileExplorerState
     let onSendFeedback: () -> Void
     @State private var extensionBrowserAnchorView: NSView?
-    @Setting(\.betaFeatures.extensions) private var extensionsExperimentalEnabled
+    @AppStorage(CmuxExtensionSidebarSelection.enabledDefaultsKey)
+    private var extensionsExperimentalEnabled = CmuxExtensionSidebarSelection.enabledDefault
 
     var body: some View {
         HStack(spacing: 4) {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -4,6 +4,8 @@ import Bonsplit
 import Combine
 import CMUXExtensionClient
 import CmuxExtensionKit
+import CmuxSettings
+import CmuxSettingsUI
 import ImageIO
 import Observation
 import SwiftUI
@@ -6721,17 +6723,22 @@ struct ContentView: View {
                 keywords: ["toggle", "sidebar", "left", "layout"]
             )
         )
-        for descriptor in CmuxExtensionSidebarSelection.descriptors {
-            let title = CmuxExtensionSidebarSelection.localizedTitle(for: descriptor)
-            let titleFormat = String(localized: "command.switchExtensionSidebar.title", defaultValue: "Sidebar: %@")
-            contributions.append(
-                CommandPaletteCommandContribution(
-                    commandId: commandPaletteExtensionSidebarCommandID(descriptor.id),
-                    title: constant(String.localizedStringWithFormat(titleFormat, title)),
-                    subtitle: constant(String(localized: "command.switchExtensionSidebar.subtitle", defaultValue: "Choose Sidebar")),
-                    keywords: ["sidebar", "switch", "extension", title.lowercased()]
+        // "Sidebar: <provider>" switch commands only make sense when there
+        // is more than one provider, which is the experimental Extensions
+        // feature. Omit them entirely while it is disabled.
+        if CmuxExtensionSidebarSelection.isEnabled {
+            for descriptor in CmuxExtensionSidebarSelection.descriptors {
+                let title = CmuxExtensionSidebarSelection.localizedTitle(for: descriptor)
+                let titleFormat = String(localized: "command.switchExtensionSidebar.title", defaultValue: "Sidebar: %@")
+                contributions.append(
+                    CommandPaletteCommandContribution(
+                        commandId: commandPaletteExtensionSidebarCommandID(descriptor.id),
+                        title: constant(String.localizedStringWithFormat(titleFormat, title)),
+                        subtitle: constant(String(localized: "command.switchExtensionSidebar.subtitle", defaultValue: "Choose Sidebar")),
+                        keywords: ["sidebar", "switch", "extension", title.lowercased()]
+                    )
                 )
-            )
+            }
         }
         contributions.append(contentsOf: Self.commandPaletteRightSidebarModeCommandContributions())
         contributions.append(contentsOf: Self.commandPaletteRightSidebarToolPaneCommandContributions())
@@ -9937,6 +9944,18 @@ enum CmuxExtensionSidebarSelection {
     static let defaultProviderId = CmuxExtensionSidebarProviderDescriptor.defaultWorkspacesID
     static let hostedExtensionsProviderId = "cmux.sidebar.extensions"
 
+    /// Whether the experimental Extensions feature is enabled, read from the
+    /// settings catalog (`BetaFeaturesCatalogSection.extensions`) so the key
+    /// and default are not duplicated. SwiftUI views observe the same flag
+    /// reactively via `@Setting(\.betaFeatures.extensions)`; this synchronous
+    /// read is for the on-demand AppKit/static paths (the toggle menu, the
+    /// command-palette builder, the extensions-browser opener) that have no
+    /// `SettingsRuntime` in scope.
+    static var isEnabled: Bool {
+        let key = SettingCatalog().betaFeatures.extensions
+        return Bool.decodeFromUserDefaults(UserDefaults.standard.object(forKey: key.userDefaultsKey)) ?? key.defaultValue
+    }
+
     static var providers: [any CmuxExtensionSidebarProvider] {
         []
     }
@@ -9992,6 +10011,11 @@ enum CmuxExtensionSidebarSelection {
 
     @MainActor
     static func showMenu(anchorView: NSView, event: NSEvent?) {
+        // The sidebar-toggle right-click menu only switches between sidebar
+        // providers, which exists solely for the experimental Extensions
+        // feature. While it is disabled there is nothing to choose, so the
+        // menu does not appear.
+        guard isEnabled else { return }
         let menu = NSMenu()
         let selectedProviderId = descriptor(
             for: UserDefaults.standard.string(forKey: defaultsKey) ?? defaultProviderId
@@ -10252,6 +10276,7 @@ struct VerticalTabsSidebar: View {
     private var workspacePresentationMode = WorkspacePresentationModeSettings.defaultMode.rawValue
     @AppStorage(CmuxExtensionSidebarSelection.defaultsKey)
     private var selectedExtensionSidebarProviderId = CmuxExtensionSidebarSelection.defaultProviderId
+    @Setting(\.betaFeatures.extensions) private var extensionsExperimentalEnabled
     @AppStorage("sidebarMatchTerminalBackground")
     private var sidebarMatchTerminalBackground = false
     @AppStorage(MinimalModeTitlebarDebugSettings.leftControlsLeadingInsetKey)
@@ -10738,7 +10763,8 @@ struct VerticalTabsSidebar: View {
 
     @ViewBuilder
     private func extensionSidebarScrollArea(renderContext: WorkspaceListRenderContext) -> some View {
-        if selectedExtensionSidebarProviderId == CmuxExtensionSidebarSelection.hostedExtensionsProviderId {
+        if extensionsExperimentalEnabled,
+           selectedExtensionSidebarProviderId == CmuxExtensionSidebarSelection.hostedExtensionsProviderId {
             CMUXInstalledExtensionSidebarHostView(
                 snapshotProvider: { cmuxSidebarSnapshotForCurrentTabs() },
                 snapshotUpdateToken: extensionSidebarUpdateToken,
@@ -12995,28 +13021,33 @@ private struct SidebarFooterButtons: View {
     @ObservedObject var fileExplorerState: FileExplorerState
     let onSendFeedback: () -> Void
     @State private var extensionBrowserAnchorView: NSView?
+    @Setting(\.betaFeatures.extensions) private var extensionsExperimentalEnabled
 
     var body: some View {
         HStack(spacing: 4) {
             SidebarHelpMenuButton(onSendFeedback: onSendFeedback)
-            Button {
-                _ = AppDelegate.shared?.openSidebarExtensionBrowser(
-                    from: extensionBrowserAnchorView,
-                    title: String(localized: "sidebar.extensions.browser.title", defaultValue: "Sidebar Extensions")
-                )
-            } label: {
-                Image(systemName: "puzzlepiece.extension")
-                    .symbolRenderingMode(.monochrome)
-                    .font(.system(size: 12, weight: .medium))
-                    .foregroundStyle(Color(nsColor: .secondaryLabelColor))
-                    .frame(width: 22, height: 22, alignment: .center)
+            // The puzzle button opens the extensions browser; it only shows
+            // while the experimental Extensions feature is enabled.
+            if extensionsExperimentalEnabled {
+                Button {
+                    _ = AppDelegate.shared?.openSidebarExtensionBrowser(
+                        from: extensionBrowserAnchorView,
+                        title: String(localized: "sidebar.extensions.browser.title", defaultValue: "Sidebar Extensions")
+                    )
+                } label: {
+                    Image(systemName: "puzzlepiece.extension")
+                        .symbolRenderingMode(.monochrome)
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(Color(nsColor: .secondaryLabelColor))
+                        .frame(width: 22, height: 22, alignment: .center)
+                }
+                .buttonStyle(SidebarFooterIconButtonStyle())
+                .frame(width: 22, height: 22, alignment: .center)
+                .safeHelp(String(localized: "sidebar.extensions.browser.title", defaultValue: "Sidebar Extensions"))
+                .accessibilityLabel(String(localized: "sidebar.extensions.browser.title", defaultValue: "Sidebar Extensions"))
+                .accessibilityIdentifier("SidebarExtensionMenuButton")
+                .background(TitlebarControlAnchorView { extensionBrowserAnchorView = $0 })
             }
-            .buttonStyle(SidebarFooterIconButtonStyle())
-            .frame(width: 22, height: 22, alignment: .center)
-            .safeHelp(String(localized: "sidebar.extensions.browser.title", defaultValue: "Sidebar Extensions"))
-            .accessibilityLabel(String(localized: "sidebar.extensions.browser.title", defaultValue: "Sidebar Extensions"))
-            .accessibilityIdentifier("SidebarExtensionMenuButton")
-            .background(TitlebarControlAnchorView { extensionBrowserAnchorView = $0 })
             UpdatePill(model: updateViewModel)
         }
         .frame(maxWidth: .infinity, alignment: .leading)


### PR DESCRIPTION
Extensions are still in beta, so this hides all extension-related UX behind an opt-in toggle.

Adds an **Extensions** switch to Settings > Beta Features (off by default, under the existing experimental warning). While off, every extension entry point is hidden:

- the puzzle button in the sidebar footer
- the sidebar-toggle right-click provider menu (titlebar and minimal mode)
- the command-palette "Sidebar:" switch commands
- the extensions browser
- the installed-extension sidebar host (and its manage/identity/access UI and workspace rows)

The flag lives once in the settings catalog (`betaFeatures.extensions`). SwiftUI views read and observe it via `@Setting(\.betaFeatures.extensions)`; the AppKit/static paths that have no `SettingsRuntime` in scope read it synchronously through `CmuxExtensionSidebarSelection.isEnabled`, which resolves the same catalog key, so there is no duplicated key or default.

Default off. Toggling at runtime updates the SwiftUI surfaces reactively; the menu/palette/browser read the current value on demand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5092"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782884902&installation_id=133855650&pr_number=5092&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5092&signature=42f9271f5f4018023d1d9d6d3aa5731404931373a40b785cfa0d042aa728ae57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate all extension UI behind a new “Extensions” toggle in Settings > Beta Features. Default is off, which hides the puzzle button, provider menu, “Sidebar:” commands, extensions browser, and hosted sidebar until enabled.

- **New Features**
  - Adds an “Extensions” switch under Settings > Beta Features (default off; warning copy updated).
  - Introduces `betaFeatures.extensions` in the settings catalog; sidebar views read it with `@AppStorage` (catalog key) to stay reactive outside `SettingsRuntime`, and on-demand AppKit/static paths use `CmuxExtensionSidebarSelection.isEnabled`.
  - Gates all extension entry points when off, including the puzzle button, titlebar/minimal right‑click provider menu, “Sidebar:” command‑palette items, a defensive guard on the browser opener, and the installed‑extension sidebar host; adds localized strings.

<sup>Written for commit 5478c78393f0ad00ec180a32719a2f36112377a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5092?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an experimental "Extensions" toggle in Beta Features to control the ExtensionKit sidebar and related UI.

* **UI**
  * Beta Features card now shows separate rows for Dock and Extensions with updated warning copy and dividers; extension-related sidebar controls and footer button are hidden when off.

* **Localization**
  * Added localized strings for the new Extensions toggle and updated the experimental warning text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->