### PR TITLE
Read the Extensions flag via @Setting in the main window

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1,5 +1,6 @@
 import AppKit
 import CmuxSettings
+import CmuxSettingsUI
 import CmuxSocketControl
 import SwiftUI
 import Bonsplit
@@ -821,6 +822,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     weak var tabManager: TabManager?
     weak var notificationStore: TerminalNotificationStore?
     weak var sidebarState: SidebarState?
+    /// The app's settings dependency container, handed over by `cmuxApp` via
+    /// ``configure(tabManager:notificationStore:sidebarState:settingsRuntime:)``
+    /// before any main window is created. AppKit builds the main window's
+    /// `NSHostingView` itself, so it must inject this into the `ContentView`
+    /// environment (`.environment(\.settingsRuntime, …)`) for `@Setting` to
+    /// resolve inside the sidebar; it is also the source of truth for the
+    /// synchronous reads on `CmuxExtensionSidebarSelection`.
+    var settingsRuntime: SettingsRuntime?
     weak var fileExplorerState: FileExplorerState?
     weak var fullscreenControlsViewModel: TitlebarControlsViewModel?
     weak var sidebarSelectionState: SidebarSelectionState?
@@ -1848,10 +1857,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         ClosedItemHistoryStore.shared.flushPendingSaves()
     }
 
-    func configure(tabManager: TabManager, notificationStore: TerminalNotificationStore, sidebarState: SidebarState) {
+    func configure(tabManager: TabManager, notificationStore: TerminalNotificationStore, sidebarState: SidebarState, settingsRuntime: SettingsRuntime) {
         self.tabManager = tabManager
         self.notificationStore = notificationStore
         self.sidebarState = sidebarState
+        self.settingsRuntime = settingsRuntime
         scheduleGhosttyCrashBreadcrumbIfNeeded(notificationStore: notificationStore)
         disableSuddenTerminationIfNeeded()
         installLifecycleSnapshotObserversIfNeeded()
@@ -7828,6 +7838,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             .environmentObject(sidebarSelectionState)
             .environmentObject(fileExplorerState)
             .environmentObject(cmuxConfigStore)
+            // AppKit hosts this ContentView in its own NSHostingView, which does
+            // not inherit the SwiftUI environment from the App scene. Inject the
+            // settings runtime here so `@Setting` resolves throughout the main
+            // window (e.g. the sidebar). The environment key is optional, so a
+            // nil runtime simply falls back to each key's default.
+            .environment(\.settingsRuntime, settingsRuntime)
 
         // Use the current key window's size for new windows so Cmd+Shift+N
         // creates a window matching the previous one's dimensions.

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -5,6 +5,7 @@ import Combine
 import CMUXExtensionClient
 import CmuxExtensionKit
 import CmuxSettings
+import CmuxSettingsUI
 import ImageIO
 import Observation
 import SwiftUI
@@ -9974,18 +9975,17 @@ enum CmuxExtensionSidebarSelection {
     static let defaultProviderId = CmuxExtensionSidebarProviderDescriptor.defaultWorkspacesID
     static let hostedExtensionsProviderId = "cmux.sidebar.extensions"
 
-    /// The UserDefaults key and default for the experimental Extensions flag,
-    /// resolved from the settings catalog (`BetaFeaturesCatalogSection.extensions`)
-    /// so the key and default are never re-declared. The sidebar lives in an
-    /// AppKit-hosted subtree where the `SettingsRuntime` environment does not
-    /// reach, so SwiftUI views observe the flag with `@AppStorage(enabledDefaultsKey)`
-    /// (reactive and environment-independent) rather than `@Setting`.
-    static var enabledDefaultsKey: String { SettingCatalog().betaFeatures.extensions.userDefaultsKey }
-    static var enabledDefault: Bool { SettingCatalog().betaFeatures.extensions.defaultValue }
-
-    /// Synchronous read of the flag for the on-demand AppKit/static paths (the
-    /// toggle menu, the command-palette builder, the extensions-browser opener)
-    /// that have no `SettingsRuntime` in scope and run outside the SwiftUI cycle.
+    /// Synchronous read of the experimental Extensions flag for the on-demand
+    /// AppKit/static paths (the toggle menu, the command-palette builder, the
+    /// extensions-browser opener) that have no `SettingsRuntime` in scope and
+    /// run outside the SwiftUI update cycle.
+    ///
+    /// SwiftUI views bind reactively via `@Setting(\.betaFeatures.extensions)`.
+    /// The settings store is `actor`-isolated and async-only, so these
+    /// synchronous callers resolve the value from the catalog key
+    /// (`BetaFeaturesCatalogSection.extensions`) read against `UserDefaults`,
+    /// which is the same suite and key the store persists to — the catalog
+    /// remains the single definition of the key, decode, and default.
     static var isEnabled: Bool {
         let key = SettingCatalog().betaFeatures.extensions
         return Bool.decodeFromUserDefaults(UserDefaults.standard.object(forKey: key.userDefaultsKey)) ?? key.defaultValue
@@ -10311,8 +10311,7 @@ struct VerticalTabsSidebar: View {
     private var workspacePresentationMode = WorkspacePresentationModeSettings.defaultMode.rawValue
     @AppStorage(CmuxExtensionSidebarSelection.defaultsKey)
     private var selectedExtensionSidebarProviderId = CmuxExtensionSidebarSelection.defaultProviderId
-    @AppStorage(CmuxExtensionSidebarSelection.enabledDefaultsKey)
-    private var extensionsExperimentalEnabled = CmuxExtensionSidebarSelection.enabledDefault
+    @Setting(\.betaFeatures.extensions) private var extensionsExperimentalEnabled
     @AppStorage("sidebarMatchTerminalBackground")
     private var sidebarMatchTerminalBackground = false
     @AppStorage(MinimalModeTitlebarDebugSettings.leftControlsLeadingInsetKey)
@@ -13057,8 +13056,7 @@ private struct SidebarFooterButtons: View {
     @ObservedObject var fileExplorerState: FileExplorerState
     let onSendFeedback: () -> Void
     @State private var extensionBrowserAnchorView: NSView?
-    @AppStorage(CmuxExtensionSidebarSelection.enabledDefaultsKey)
-    private var extensionsExperimentalEnabled = CmuxExtensionSidebarSelection.enabledDefault
+    @Setting(\.betaFeatures.extensions) private var extensionsExperimentalEnabled
 
     var body: some View {
         HStack(spacing: 4) {

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -155,7 +155,7 @@ struct cmuxApp: App {
         // UI tests depend on AppDelegate wiring happening even if SwiftUI view appearance
         // callbacks (e.g. `.onAppear`) are delayed or skipped.
         StartupBreadcrumbLog.append("app.init.delegate.configure.begin")
-        appDelegate.configure(tabManager: tabManager, notificationStore: notificationStore, sidebarState: sidebarState)
+        appDelegate.configure(tabManager: tabManager, notificationStore: notificationStore, sidebarState: sidebarState, settingsRuntime: settingsRuntime)
         StartupBreadcrumbLog.append("app.init.delegate.configured")
     }
 


### PR DESCRIPTION
Follow-up to #5092 (per request: use the settings-package building blocks throughout instead of `@AppStorage`/`UserDefaults` as a parallel source of truth).

#5092 had to read the experimental Extensions flag with `@AppStorage` in the sidebar because `@Setting` silently returned the key's default there. Root cause: the main window's `ContentView` is hosted by an AppKit `NSHostingView` (`MainWindowHostingView`) that doesn't inherit the SwiftUI environment from the `App` scene, so the `SettingsRuntime` that `@Setting` resolves against was absent.

**Fix:** inject the runtime at the same point the window's other shared dependencies are injected. `AppDelegate` builds the `ContentView` root with an `.environmentObject(...)` chain (the same path that delivers `TabManager` to the sidebar), so this adds `.environment(\.settingsRuntime, settingsRuntime)` right there. `cmuxApp` hands the runtime to `AppDelegate` through the existing `configure(...)` DI seam (called in `App.init`, before any window is created). The environment key is optional, so a nil runtime degrades to each key's default exactly as before.

With the runtime in scope throughout the main window, the two sidebar reads (the puzzle button and the extension-host render gate) go back to `@Setting(\.betaFeatures.extensions)` instead of `@AppStorage`. The settings catalog + `@Setting` is now the single source of truth for the flag.

The synchronous AppKit/static paths (toggle menu, command-palette builder, browser opener) still resolve the catalog key directly, because the settings store is `actor`-isolated and async-only — there is no synchronous building-block read for non-SwiftUI callers. That reads the same suite and key the store persists to, so it is not a separate source of truth.

Verification: build with the Swift frontend workaround succeeds; the tagged dogfood app is launched with the flag enabled so the puzzle button + extension sidebar appear via `@Setting`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5094"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782887069&installation_id=133855650&pr_number=5094&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5094&signature=4ff0a6cbf1e85774bc1a7c8c82032a9da1b63c53b8b72d3aaff551eec0b47f7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Injects `SettingsRuntime` into the AppKit-hosted main window so `@Setting(\.betaFeatures.extensions)` resolves correctly, and switches the sidebar back from `@AppStorage` to `@Setting` for the Extensions flag to keep a single source of truth.

- **Bug Fixes**
  - Injected `settingsRuntime` into `ContentView` via `.environment(\.settingsRuntime, ...)` in `AppDelegate`.
  - `cmuxApp` now passes `settingsRuntime` into `AppDelegate.configure(...)`.
  - Replaced `@AppStorage` reads in `VerticalTabsSidebar` and `SidebarFooterButtons` with `@Setting(\.betaFeatures.extensions)`.
  - Kept sync reads for menu/command palette/browser via the catalog key to support non-SwiftUI call sites.

<sup>Written for commit 78de495d32efb7ea8e74ae7bed052af5b5a448d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5094?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized application settings management through a unified runtime system.
  * Migrated extensions feature flag to the new settings system for consistent state synchronization across the app.
  * Updated configuration flow to properly inject settings into the application environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->