### PR TITLE
Fix phantom pane ring on back/forward navigation after pane/workspace creation (#5095)

### DIFF
--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -783,6 +783,13 @@ final class TerminalNotificationStore: ObservableObject {
     @Published private(set) var restoredUnreadWorkspaceIds: Set<UUID> = [] {
         didSet { refreshUnreadPresentation() }
     }
+    // INVARIANT (issues #4370, #4589, #5095): the focused-read indicator — and therefore the blue
+    // unreadPaneRing — is changed ONLY by a notification-arrival event (recordNotification, gated on
+    // the focus captured when the notification was generated) or by an explicit "user viewed/marked"
+    // event (markRead / dismissNotification / clearFocusedReadIndicator). Selection, history
+    // navigation, pane/workspace creation, and session-restore observers may only READ this map;
+    // they must never set it. Lighting it from live selection state is what produced the phantom
+    // ring on back/forward navigation. See `shouldMarkArrivalAsFocusedRead`.
     @Published private(set) var focusedReadIndicatorByTabId: [UUID: UUID] = [:]
     @Published private(set) var authorizationState: NotificationAuthorizationState = .unknown
     private var suppressNotificationDiffPublishing = false
@@ -1394,6 +1401,7 @@ final class TerminalNotificationStore: ObservableObject {
             recordNotification(
                 notification,
                 shouldSuppressExternalDelivery: shouldSuppressExternalDelivery,
+                wasFocusedAtGeneration: request.isAppFocused && request.isFocusedPanel,
                 effects: effects,
                 now: now,
                 cooldownReservation: cooldownReservation
@@ -1425,6 +1433,7 @@ final class TerminalNotificationStore: ObservableObject {
     private func recordNotification(
         _ notification: TerminalNotification,
         shouldSuppressExternalDelivery: Bool,
+        wasFocusedAtGeneration: Bool,
         effects: TerminalNotificationPolicyEffects,
         now: Date,
         cooldownReservation: NotificationCooldownReservation?
@@ -1442,7 +1451,10 @@ final class TerminalNotificationStore: ObservableObject {
             focusedReadIndicatorByTabId.removeValue(forKey: notification.tabId)
         }
 
-        if shouldSuppressExternalDelivery, effects.markUnread {
+        if Self.shouldMarkArrivalAsFocusedRead(
+            wasFocusedAtGeneration: wasFocusedAtGeneration,
+            marksUnread: effects.markUnread
+        ) {
             setFocusedReadIndicator(forTabId: notification.tabId, surfaceId: notification.surfaceId)
         }
 
@@ -1660,6 +1672,27 @@ final class TerminalNotificationStore: ObservableObject {
             return workspaceIndex
         }
         return notifications.firstIndex(where: { $0.tabId == tabId })
+    }
+
+    /// Decides whether an arriving notification should leave a focused-read indicator (the subtle
+    /// "you were looking at this surface when it fired" ring).
+    ///
+    /// This is a pure function of facts captured when the notification was *generated*. It must not
+    /// consult live selection, focus, or navigation state: doing so let plain back/forward history
+    /// navigation (after creating a pane or workspace) stamp a phantom ring on a surface the user
+    /// only passed through (#5095, same class as #4370 / #4589).
+    ///
+    /// - Parameters:
+    ///   - wasFocusedAtGeneration: Whether the target surface was the user's focused panel at the
+    ///     moment the notification was generated (`TerminalNotificationPolicyRequest.isFocusedPanel`),
+    ///     not whatever surface happens to be selected when the (possibly async) policy result is applied.
+    ///   - marksUnread: Whether the resolved policy marks this notification unread.
+    /// - Returns: `true` only when the user genuinely had eyes on the surface as it fired.
+    static func shouldMarkArrivalAsFocusedRead(
+        wasFocusedAtGeneration: Bool,
+        marksUnread: Bool
+    ) -> Bool {
+        wasFocusedAtGeneration && marksUnread
     }
 
     func setFocusedReadIndicator(forTabId tabId: UUID, surfaceId: UUID?) {

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -2280,6 +2280,22 @@ final class TerminalNotificationStore: ObservableObject {
         clearWorkspaceRestoredUnread()
         focusedReadIndicatorByTabId.removeAll()
     }
+
+    /// Runs the notification-apply path with an explicit, caller-supplied request so a test can
+    /// drive the generation-time focus (`request.isFocusedPanel`) independently of live selection
+    /// state. Used to prove that history navigation / live focus cannot light the ring.
+    func applyNotificationForTesting(
+        request: TerminalNotificationPolicyRequest,
+        effects: TerminalNotificationPolicyEffects = TerminalNotificationPolicyEffects()
+    ) {
+        applyNotification(
+            request: request,
+            effects: effects,
+            now: Date(),
+            cooldownReservation: nil,
+            clickAction: nil
+        )
+    }
 #endif
 
     private func refreshDockBadge() {

--- a/cmuxTests/WorkspaceManualUnreadTests.swift
+++ b/cmuxTests/WorkspaceManualUnreadTests.swift
@@ -800,6 +800,39 @@ final class WorkspaceManualUnreadTests: XCTestCase {
         XCTAssertNil(store.focusedReadIndicatorSurfaceId(forTabId: workspace.id))
     }
 
+    /// The focused-read decision is a pure function of generation-time facts only. No combination of
+    /// selection/navigation inputs feeds it, so a notification generated while the surface was not
+    /// focused can never light the ring regardless of where focus later lands.
+    func testShouldMarkArrivalAsFocusedReadIsPureFunctionOfGenerationFocus() {
+        XCTAssertTrue(
+            TerminalNotificationStore.shouldMarkArrivalAsFocusedRead(
+                wasFocusedAtGeneration: true,
+                marksUnread: true
+            )
+        )
+        // Generated while unfocused → never a focused-read ring, even though navigation may later
+        // select/focus the surface.
+        XCTAssertFalse(
+            TerminalNotificationStore.shouldMarkArrivalAsFocusedRead(
+                wasFocusedAtGeneration: false,
+                marksUnread: true
+            )
+        )
+        // A notification the policy does not mark unread is not a ring source either.
+        XCTAssertFalse(
+            TerminalNotificationStore.shouldMarkArrivalAsFocusedRead(
+                wasFocusedAtGeneration: true,
+                marksUnread: false
+            )
+        )
+        XCTAssertFalse(
+            TerminalNotificationStore.shouldMarkArrivalAsFocusedRead(
+                wasFocusedAtGeneration: false,
+                marksUnread: false
+            )
+        )
+    }
+
     func testToggleFocusedNotificationUnreadClearsRestoredWorkspaceUnreadWhenPanelIsFocused() throws {
         let appDelegate = AppDelegate.shared ?? AppDelegate()
         let store = TerminalNotificationStore.shared

--- a/cmuxTests/WorkspaceManualUnreadTests.swift
+++ b/cmuxTests/WorkspaceManualUnreadTests.swift
@@ -745,6 +745,61 @@ final class WorkspaceManualUnreadTests: XCTestCase {
         XCTAssertTrue(workspace.manualUnreadPanelIds.contains(panelId))
     }
 
+    /// Regression for #5095 (and the same class as #4370 / #4589): a notification generated while
+    /// the surface was NOT focused must not acquire a focused-read indicator just because live
+    /// selection/navigation later lands focus on that surface (e.g. pressing back then forward
+    /// after creating a pane/workspace). The focused-read indicator — and therefore the blue pane
+    /// ring — is a strict function of the focus captured when the notification was generated, never
+    /// of live selection state observed at apply time.
+    func testHistoryNavigationFocusDoesNotSetFocusedReadIndicatorForUnfocusedArrival() throws {
+        let appDelegate = AppDelegate.shared ?? AppDelegate()
+        let store = TerminalNotificationStore.shared
+
+        let originalNotificationStore = appDelegate.notificationStore
+        let originalFocusOverride = AppFocusState.overrideIsFocused
+
+        store.replaceNotificationsForTesting([])
+        appDelegate.notificationStore = store
+        AppFocusState.overrideIsFocused = true
+        let windowId = appDelegate.createMainWindow(shouldActivate: false)
+
+        defer {
+            appDelegate.windowForMainWindowId(windowId)?.performClose(nil)
+            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+            store.replaceNotificationsForTesting([])
+            appDelegate.notificationStore = originalNotificationStore
+            AppFocusState.overrideIsFocused = originalFocusOverride
+        }
+
+        let manager = try XCTUnwrap(appDelegate.tabManagerFor(windowId: windowId))
+        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let panelId = try XCTUnwrap(workspace.focusedPanelId)
+        let surfaceId = try XCTUnwrap(manager.focusedSurfaceId(for: workspace.id))
+
+        // Live state: the workspace is selected and this surface is focused, exactly as it would be
+        // right after back/forward navigation lands on it. But the notification was generated while
+        // the panel was not focused, so its policy request carries isFocusedPanel = false.
+        let request = TerminalNotificationPolicyRequest(
+            tabId: workspace.id,
+            surfaceId: surfaceId,
+            panelId: panelId,
+            title: "Agent",
+            subtitle: "",
+            body: "",
+            cwd: nil,
+            isAppFocused: false,
+            isFocusedPanel: false
+        )
+
+        store.applyNotificationForTesting(request: request)
+
+        // The arrival is a real notification, so it is recorded as unread...
+        XCTAssertTrue(store.hasUnreadNotification(forTabId: workspace.id, surfaceId: surfaceId))
+        // ...but live focus from navigation must NOT have stamped a focused-read indicator, which is
+        // the phantom blue ring that survives once the unread notification is later cleared.
+        XCTAssertNil(store.focusedReadIndicatorSurfaceId(forTabId: workspace.id))
+    }
+
     func testToggleFocusedNotificationUnreadClearsRestoredWorkspaceUnreadWhenPanelIsFocused() throws {
         let appDelegate = AppDelegate.shared ?? AppDelegate()
         let store = TerminalNotificationStore.shared


### PR DESCRIPTION
Fixes #5095.

## Symptom

The blue `unreadPaneRing` (notification / unread indicator) sometimes lights up on a workspace/pane that has **no actual unread notification**, triggered by pressing **back then forward** in history navigation — most reliably right after creating a new pane or a new workspace. Plain history navigation is not a notification action and should never produce a ring.

## Root cause (architectural, not another point patch)

The ring is rendered from `Workspace.shouldShowUnreadIndicator` fed by `TerminalNotificationStore.hasVisibleNotificationIndicator`, which is an **OR over two sources of truth**:

```
hasUnreadNotification(...)  ||  focusedReadIndicatorByTabId[tab] == surface
```

`focusedReadIndicatorByTabId` was set in `recordNotification` whenever the **live** `shouldSuppressExternalDelivery` predicate — `AppFocusState.isAppFocused() && active-tab && focused-surface`, all read from the *current* `TabManager` — was true **at apply time**.

Notification policy hooks (which Claude Code sessions inject) make `addNotification` **asynchronous**: the focus captured in the policy request when the notification is *generated* can differ from the live focus when the async result is *applied*. Back→forward navigation (which bumps selection twice, and is most likely right after a pane/workspace creation churns focus) transiently selects/focuses a surface inside that window. So a notification generated while the surface was **not** focused got stamped with a focused-read indicator against a surface the user only *navigated through*. That indicator outlives the unread notification, leaving a phantom ring with no real unread.

This is the same **class of bug** as the prior closed issues, which each patched an individual trigger rather than the source-of-truth coupling:

- **#4370** — session resume incorrectly lit / failed to clear the ring (patched the `.terminalInteraction` vs `.activeFocus` dismissal gate).
- **#4589** — the sidebar state indicator persisted/missing after #4370's fix (same subsystem, still fragile).

**How this fix differs:** instead of adding another "don't fire on back/forward" special case, it removes the coupling. The focused-read decision is now a **pure function of the focus captured when the notification was generated** (`request.isAppFocused && request.isFocusedPanel`), extracted as `TerminalNotificationStore.shouldMarkArrivalAsFocusedRead(wasFocusedAtGeneration:marksUnread:)`. Live selection/navigation state is never consulted. After this change, selection, history navigation, pane/workspace creation, and session-restore observers can only **read** the indicator — the only way to light it is a genuine notification-arrival event. The invariant is documented on `focusedReadIndicatorByTabId`.

In the synchronous (no-hook) path the captured and live predicates are identical, so real notification behavior (genuine arrivals still light the ring; viewing still clears it) is unchanged — only the navigation race is removed.

## Tests (two-commit red/green)

1. **Commit 1** adds the failing regression test + a DEBUG-only `applyNotificationForTesting` seam that drives the apply path with an explicit policy request, so generation-time focus is controlled independently of live selection. With the old code the test fails (the indicator is stamped from live focus).
2. **Commit 2** is the fix; the test passes.

- `testHistoryNavigationFocusDoesNotSetFocusedReadIndicatorForUnfocusedArrival` — a notification generated while unfocused, applied while the surface is the live-focused/selected one (as after back/forward), records the real unread notification but does **not** stamp a focused-read indicator.
- `testShouldMarkArrivalAsFocusedReadIsPureFunctionOfGenerationFocus` — pure unit assertion that selection/navigation inputs cannot transition the ring state; only generation-time focus + markUnread can.

## Cross-checks

- No rendering-path changes, so light/dark mode and multi-workspace/multi-pane ring rendering for **genuine** notifications are unaffected; #2887 (active terminal goes black when ring fires) is not touched.
- Existing focused-read / manual-unread / session-restore tests are unchanged in the synchronous path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5097"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782891047&installation_id=133855650&pr_number=5097&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5097&signature=24fb58d6473a1ff316533825172849913d96a77d8739056a977a6c8a9f436e41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when the focused-read indicator is set for all notification arrivals (including async policy hooks); behavior for genuine focused arrivals should match sync paths, but unread UI semantics are user-visible and regression-tested.
> 
> **Overview**
> Fixes a **phantom blue pane ring** (#5095) that could appear after back/forward history navigation when a notification was applied while live focus had moved onto a surface the user had only navigated through.
> 
> **`TerminalNotificationStore`** no longer ties the **focused-read indicator** (`focusedReadIndicatorByTabId`, which drives `hasVisibleNotificationIndicator` / the unread pane ring) to **live** `shouldSuppressExternalDelivery` at apply time. On record, it passes **`wasFocusedAtGeneration`** from the policy request (`request.isAppFocused && request.isFocusedPanel` when the notification was generated) and gates the ring with new **`shouldMarkArrivalAsFocusedRead(wasFocusedAtGeneration:marksUnread:)`** — only generation-time focus plus `markUnread` can set the indicator. An **invariant** comment documents that selection/history must only read this map, not write it from current focus.
> 
> **Tests:** regression that applies a notification with `isFocusedPanel: false` while the surface is live-focused (no focused-read stamp), unit tests for the pure helper, and DEBUG **`applyNotificationForTesting`** to drive apply with a fixed request.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f69592a5a6ad6d132b36ef641147985d171131a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the blue unread pane ring from flashing after back/forward navigation, especially right after creating a pane or workspace. The indicator now depends only on focus captured when the notification was generated. Fixes #5095.

- **Bug Fixes**
  - Gate the focused-read indicator on generation-time focus via a pure helper (`shouldMarkArrivalAsFocusedRead`); selection/history/pane/workspace changes can only read the map, never set it.
  - Added a DEBUG-only apply seam and regression tests to ensure navigation cannot light the ring; genuine notification and read/clear behavior remain the same.

<sup>Written for commit 7f69592a5a6ad6d132b36ef641147985d171131a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5097?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced notification read/unread indicator logic to correctly track whether notifications should be marked as read based on terminal focus state when they were generated.

* **Tests**
  * Added test coverage for notification state management across various scenarios involving terminal focus and read/unread behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->