### PR TITLE
Fix #5099: titlebar band swallows right-sidebar button clicks

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2416,6 +2416,18 @@ struct ContentView: View {
             .frame(maxWidth: .infinity)
             .overlay(alignment: .topLeading) {
                 customTitlebar(appearance: appearance)
+                    // The workspace titlebar band spans the full window width and sits at
+                    // zIndex(100) over the content/sidebar layout. Its drag/double-click
+                    // surface (`WindowDragHandleView` + `.contentShape(Rectangle())`) must
+                    // not cover the right sidebar, whose mode bar (Files/Search/Feed/Vault)
+                    // lives inside the titlebar-height strip — otherwise the band wins the
+                    // hit-test and swallows every click/hover on those buttons (#5099).
+                    // Confine the interactive titlebar surface to the area left of the
+                    // right sidebar, matching the pre-#5017 "only over terminal content,
+                    // not the sidebar" intent. The left sidebar's titlebar controls live in
+                    // the AppKit titlebar accessory (above this band), so only the trailing
+                    // (right-sidebar) edge needs to be ceded here.
+                    .padding(.trailing, rightSidebarVisible ? rightSidebarWidth : 0)
             }
             .overlay(alignment: .topLeading) {
                 if isFullScreen && sidebarState.isVisible {


### PR DESCRIPTION
Fixes #5099.

> Supersedes #5101. That PR (now merged) removed the `titlebarInteractiveControl()` reparenting and added registry-based first-mouse — both fine hardening, but they were the **wrong layer**: the buttons stayed dead. This PR fixes the actual cause.

## Symptom
Right-sidebar top buttons (Files / Search / Feed / Vault, plus close + open-as-pane) render normally but **dead-click** — no hover, no press, no panel switch. The **keyboard toggle still works**, which isolates it to *buttons not receiving mouse events*, not the `RightSidebarMode` action path.

## Root cause (regression from #5017, `ca73d65cf`)
Before #5017 the workspace titlebar was an overlay placed *"only over terminal content, not the sidebar."* #5017 ("Polish sidebar extensions and titlebar chrome") changed it into a **full-width** `workspaceTitlebarBand` layered at `zIndex(100)` over the content/sidebar layout. Its `customTitlebar` is:

```swift
.frame(maxWidth: .infinity)
.contentShape(Rectangle())   // full-width, hit-capturing
```

The right-sidebar mode bar lives **inside the titlebar-height strip** but **below** that band, so the band wins the SwiftUI hit-test across the entire top row and absorbs every click/hover on those buttons.

The left sidebar's titlebar controls live in the AppKit titlebar accessory (*above* the band), so only the right sidebar regressed. The keyboard path never goes through hit-testing, so it kept working — exactly the reported behavior.

## How it was confirmed (empirical, on a tagged dev build)
- An `NSView.hitTest` probe on the content host resolved right-sidebar button clicks (winPt x≈799–993, top strip) to the **hosting view itself** — i.e. no NSView subview (drag handle, portal, etc.) claimed them.
- A probe inside the mode-button action (`rightSidebar.modeButton.tap`) and the button's `onHover` both fired **zero times** on clicks/hover — the full-width SwiftUI band in front was consuming the events before SwiftUI routed them to the buttons.

## Fix
Confine the band's interactive surface to the area left of the right sidebar, restoring the pre-#5017 "not over the sidebar" intent:

```swift
customTitlebar(appearance: appearance)
    .padding(.trailing, rightSidebarVisible ? rightSidebarWidth : 0)
```

The title text is left-aligned, so the trailing inset hides nothing; window-drag/double-click over the terminal-area titlebar is preserved; and the right-sidebar mode bar now receives its own clicks. Only the trailing (right-sidebar) edge needs ceding — the left sidebar's controls are in the titlebar accessory above the band.

## Tests
This is a SwiftUI hit-test / z-order layering bug in the full-size-content titlebar band; it depends on the real `NSWindow` titlebar compositing and is not cleanly reproducible in a headless unit test, so I'm not adding a synthetic one rather than faking a passing test. Verified manually on a tagged dev build (the mode-button action fires on click after the change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5102"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782903676&installation_id=133855650&pr_number=5102&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5102&signature=5e439bc9a7ab23026cb3fa2ed5855085dbe35e208b946fb77e3e542e6c04d8d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where right sidebar controls were not responding to clicks and hover events when the right sidebar was visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->