### PR TITLE
Follow-up to #5102: simplify titlebar inset + fix sidebar-toggle animation desync

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2427,7 +2427,14 @@ struct ContentView: View {
                     // not the sidebar" intent. The left sidebar's titlebar controls live in
                     // the AppKit titlebar accessory (above this band), so only the trailing
                     // (right-sidebar) edge needs to be ceded here.
-                    .padding(.trailing, rightSidebarVisible ? rightSidebarWidth : 0)
+                    //
+                    // `rightSidebarWidth` is already `rightSidebarVisible ? fileExplorerWidth : 0`,
+                    // so it collapses to 0 when the sidebar is hidden. The sidebar panel itself
+                    // snaps without animation (`.transaction { $0.animation = nil }`), so we match
+                    // that here — otherwise this inset could animate out of step with the panel on
+                    // toggle and momentarily expose (or re-cover) the mode bar mid-transition.
+                    .padding(.trailing, rightSidebarWidth)
+                    .animation(nil, value: rightSidebarWidth)
             }
             .overlay(alignment: .topLeading) {
                 if isFullScreen && sidebarState.isVisible {


### PR DESCRIPTION
Follow-up to #5102 (the #5099 titlebar-band hit-region fix). #5102 merged at its first commit, so these two review-feedback improvements from Greptile didn't make it into main:

1. **Redundant ternary** — `rightSidebarVisible ? rightSidebarWidth : 0` is redundant because `rightSidebarWidth` already evaluates to `0` when the sidebar is hidden. Simplified to `.padding(.trailing, rightSidebarWidth)`.

2. **Animation desync (P2)** — the right sidebar panel snaps without animation (`.transaction { $0.animation = nil }`), but the titlebar band's trailing inset could animate out of step during toggle, momentarily re-covering the right-sidebar mode bar (a brief dead-click window right after the sidebar appears). Added `.animation(nil, value: rightSidebarWidth)` so the band's hit-region edge snaps in lockstep with the panel.

No functional change to the merged fix; this only tightens the inset and removes the transient desync. Addresses the two open Greptile threads on #5102.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5104"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782905549&installation_id=133855650&pr_number=5104&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5104&signature=249f95f6e3c3aec5ff43d35ac88e583b5356bf06b1f04bca6d0cf7ed47c20778"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small SwiftUI layout/hit-testing tweak in the titlebar overlay with no auth, data, or API impact.
> 
> **Overview**
> Tightens the **fullscreen titlebar drag band** trailing inset in `ContentView`: it now uses `rightSidebarWidth` directly (no redundant `rightSidebarVisible` check) and disables animation on that inset so it **snaps in sync** with the right sidebar panel.
> 
> That removes a brief window where the band could animate out of step with the sidebar and **re-cover the right-sidebar mode bar** after toggle—dead clicks on Files/Search/Feed/Vault controls—without changing the underlying #5099/#5102 hit-region fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3a34114b2bc283ee2d357b20d5c6cbf0df3f6eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified the titlebar band's trailing inset and synced it with the right sidebar snap to eliminate a brief dead-click window during sidebar toggle.

- **Bug Fixes**
  - Snap the band's trailing hit-region by disabling animation tied to `rightSidebarWidth`, matching the sidebar panel’s non-animated toggle.

- **Refactors**
  - Use `rightSidebarWidth` directly for trailing padding; remove redundant ternary.

<sup>Written for commit e3a34114b2bc283ee2d357b20d5c6cbf0df3f6eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved alignment of the interactive titlebar area when toggling the right sidebar visibility to prevent misalignment during transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->