### PR TITLE
Fix #5100: bound focus-surface broadcast re-entrancy (426s hang)

### DIFF
--- a/Sources/FocusSurfaceBroadcaster.swift
+++ b/Sources/FocusSurfaceBroadcaster.swift
@@ -24,8 +24,11 @@ import Foundation
 /// - Multiple emits before a flush coalesce to the most recent payload.
 /// - If an observer synchronously emits again during delivery, that emit updates the
 ///   pending payload instead of recursing; the active flush drains it in a bounded
-///   loop (at most ``maxCoalescedDeliveries`` deliveries) and then stops. A
-///   notification-driven focus cycle can therefore no longer hang the app.
+///   loop (at most ``maxCoalescedDeliveries`` deliveries per turn). If the cycle has
+///   not settled within that bound, the still-pending payload is carried to a fresh
+///   scheduled flush rather than delivered synchronously or dropped — so work stays
+///   bounded per runloop turn (the app keeps responding) while the final selection is
+///   never lost. A notification-driven focus cycle can therefore no longer hang.
 ///
 /// The type is fully testable without AppKit: inject ``deliver`` to capture
 /// broadcasts, and inject ``schedule`` to drive flushes deterministically.
@@ -140,18 +143,35 @@ final class FocusSurfaceBroadcaster {
         // while one is already draining.
         guard !isDelivering else { return }
         isDelivering = true
-        defer { isDelivering = false }
 
         var iterations = 0
         while let next = pending {
             pending = nil
             iterations += 1
             if iterations > maxCoalescedDeliveries {
-                // Re-entrancy did not converge: stop rather than hang, and surface it.
+                // Re-entrancy did not converge within this turn. Don't hang
+                // (delivering synchronously forever) and don't drop the focus
+                // update: keep the latest payload and let the post-loop reschedule
+                // continue it on a fresh runloop turn. Work stays bounded *per turn*
+                // (so the app keeps responding) while still settling on the final
+                // selection.
+                pending = next
                 onDrainBoundExceeded(next)
                 break
             }
             deliver(next)
+        }
+
+        isDelivering = false
+        // A delivery (or `onDrainBoundExceeded`) may have left a payload pending —
+        // either because the per-turn bound tripped, or because a re-entrant emit
+        // raced the `isDelivering` window and returned without scheduling. Schedule
+        // one more flush so the final focus selection is never stranded.
+        if pending != nil, !flushScheduled {
+            flushScheduled = true
+            schedule { @Sendable [weak self] in
+                self?.flush()
+            }
         }
     }
 }

--- a/Sources/FocusSurfaceBroadcaster.swift
+++ b/Sources/FocusSurfaceBroadcaster.swift
@@ -1,0 +1,138 @@
+import Foundation
+
+/// Coalesces and defers `.ghosttyDidFocusSurface` focus broadcasts so that emitting
+/// one mid-mutation can never synchronously re-enter the focus/selection path.
+///
+/// ## Why this exists
+///
+/// `Workspace.applyTabSelectionNow` mutates a large amount of `@Published` selection
+/// state and, historically, finished by posting `.ghosttyDidFocusSurface`
+/// *synchronously*. The Combine `.onReceive` subscriber in `ContentView` delivers
+/// that notification synchronously on the posting thread and reacts by calling back
+/// into `TabManager.focusTab` → `Workspace.focusPanel` → `applyTabSelectionNow`,
+/// which posts the notification again. Because the only re-entrancy guard
+/// (`Workspace.isApplyingTabSelection`) is *per-instance*, a cycle that bounces
+/// through SwiftUI body re-evaluation and across different `Workspace` instances
+/// (command-palette focus restore + cross-workspace handoff) was unbounded. That is
+/// the 426s main-thread hang in https://github.com/manaflow-ai/cmux/issues/5100.
+///
+/// ## Contract
+///
+/// - ``emit(_:)`` never delivers synchronously. It records the latest payload and
+///   schedules a single flush on the main queue, so all `@Published` mutations made
+///   by the caller settle before any observer runs.
+/// - Multiple emits before a flush coalesce to the most recent payload.
+/// - If an observer synchronously emits again during delivery, that emit updates the
+///   pending payload instead of recursing; the active flush drains it in a bounded
+///   loop (at most ``maxCoalescedDeliveries`` deliveries) and then stops. A
+///   notification-driven focus cycle can therefore no longer hang the app.
+///
+/// The type is fully testable without AppKit: inject ``deliver`` to capture
+/// broadcasts, and inject ``schedule`` to drive flushes deterministically.
+@MainActor
+final class FocusSurfaceBroadcaster {
+    /// The focused-surface identity carried by a `.ghosttyDidFocusSurface` broadcast.
+    struct FocusSurfacePayload: Equatable, Sendable {
+        /// The workspace (tab) whose surface gained focus.
+        let workspaceId: UUID
+        /// The focused panel/surface within ``workspaceId``.
+        let panelId: UUID
+        /// Whether the focus change reflects explicit user intent.
+        let explicitFocusIntent: Bool
+
+        /// Creates a payload describing a focused surface.
+        init(workspaceId: UUID, panelId: UUID, explicitFocusIntent: Bool) {
+            self.workspaceId = workspaceId
+            self.panelId = panelId
+            self.explicitFocusIntent = explicitFocusIntent
+        }
+    }
+
+    /// The app-wide broadcaster used by ``Workspace`` to emit focus broadcasts.
+    ///
+    /// Posts the real `.ghosttyDidFocusSurface` notification and logs (DEBUG builds)
+    /// whenever the bounded drain trips, so a future re-entrancy regression is
+    /// observable instead of a silent hang.
+    static let shared = FocusSurfaceBroadcaster(
+        onDrainBoundExceeded: { payload in
+#if DEBUG
+            cmuxDebugLog(
+                "focus.broadcast.drain.exceeded workspace=\(payload.workspaceId.uuidString.prefix(5)) " +
+                "panel=\(payload.panelId.uuidString.prefix(5)) explicit=\(payload.explicitFocusIntent ? 1 : 0)"
+            )
+#endif
+        }
+    )
+
+    private let deliver: @MainActor (FocusSurfacePayload) -> Void
+    private let schedule: @MainActor (@escaping @MainActor @Sendable () -> Void) -> Void
+    private let maxCoalescedDeliveries: Int
+    private let onDrainBoundExceeded: @MainActor (FocusSurfacePayload) -> Void
+
+    private var pending: FocusSurfacePayload?
+    private var flushScheduled = false
+    private var isDelivering = false
+
+    /// Creates a broadcaster.
+    ///
+    /// - Parameters:
+    ///   - maxCoalescedDeliveries: Upper bound on deliveries performed by a single
+    ///     flush. Caps a re-entrant focus cycle so it can never hang. Defaults to 8,
+    ///     matching `Workspace.applyTabSelection`'s existing per-instance drain bound.
+    ///   - schedule: Schedules deferred flush work on the main queue. Defaults to
+    ///     `DispatchQueue.main.async`. Injected by tests to flush deterministically.
+    ///   - onDrainBoundExceeded: Invoked with the still-pending payload when a flush
+    ///     hits ``maxCoalescedDeliveries`` and stops. Used for structured logging.
+    ///   - deliver: Performs the actual broadcast. Defaults to posting
+    ///     `.ghosttyDidFocusSurface`. Injected by tests to capture deliveries.
+    init(
+        maxCoalescedDeliveries: Int = 8,
+        schedule: @escaping @MainActor (@escaping @MainActor @Sendable () -> Void) -> Void = { work in
+            DispatchQueue.main.async {
+                MainActor.assumeIsolated { work() }
+            }
+        },
+        onDrainBoundExceeded: @escaping @MainActor (FocusSurfacePayload) -> Void = { _ in },
+        deliver: @escaping @MainActor (FocusSurfacePayload) -> Void = { payload in
+            NotificationCenter.default.post(
+                name: .ghosttyDidFocusSurface,
+                object: nil,
+                userInfo: [
+                    GhosttyNotificationKey.tabId: payload.workspaceId,
+                    GhosttyNotificationKey.surfaceId: payload.panelId,
+                    GhosttyNotificationKey.explicitFocusIntent: payload.explicitFocusIntent,
+                ]
+            )
+        }
+    ) {
+        self.maxCoalescedDeliveries = max(1, maxCoalescedDeliveries)
+        self.schedule = schedule
+        self.onDrainBoundExceeded = onDrainBoundExceeded
+        self.deliver = deliver
+    }
+
+    /// Records a focus broadcast for asynchronous, coalesced delivery.
+    ///
+    /// Never delivers synchronously: this is what makes emitting safe while
+    /// `@Published` selection state is mid-mutation. If a delivery is already in
+    /// progress (an observer re-entered during a flush), the payload is recorded for
+    /// the active drain loop instead of scheduling another flush.
+    func emit(_ payload: FocusSurfacePayload) {
+        // Issue #5100 reproduction: deliver synchronously, mirroring the old
+        // `NotificationCenter.post(.ghosttyDidFocusSurface)` call site — no deferral,
+        // no coalescing, no re-entrancy bound. An observer that re-emits during
+        // delivery recurses without limit. The fix replaces this body.
+        pending = payload
+        deliver(payload)
+    }
+
+    /// Delivers the pending broadcast(s) on the main queue.
+    ///
+    /// Drains coalesced payloads in a bounded loop so a re-entrant observer cannot
+    /// spin forever. Exposed (non-private) so tests can run the scheduled flush
+    /// deterministically.
+    func flush() {
+        // Issue #5100 reproduction: nothing is deferred, so there is no scheduled
+        // work to run. The fix replaces this body.
+    }
+}

--- a/Sources/FocusSurfaceBroadcaster.swift
+++ b/Sources/FocusSurfaceBroadcaster.swift
@@ -118,12 +118,15 @@ final class FocusSurfaceBroadcaster {
     /// progress (an observer re-entered during a flush), the payload is recorded for
     /// the active drain loop instead of scheduling another flush.
     func emit(_ payload: FocusSurfacePayload) {
-        // Issue #5100 reproduction: deliver synchronously, mirroring the old
-        // `NotificationCenter.post(.ghosttyDidFocusSurface)` call site — no deferral,
-        // no coalescing, no re-entrancy bound. An observer that re-emits during
-        // delivery recurses without limit. The fix replaces this body.
         pending = payload
-        deliver(payload)
+        // A re-entrant emit during delivery hands the payload to the running drain
+        // loop; scheduling another flush here would re-introduce the storm.
+        if isDelivering { return }
+        if flushScheduled { return }
+        flushScheduled = true
+        schedule { @Sendable [weak self] in
+            self?.flush()
+        }
     }
 
     /// Delivers the pending broadcast(s) on the main queue.
@@ -132,7 +135,23 @@ final class FocusSurfaceBroadcaster {
     /// spin forever. Exposed (non-private) so tests can run the scheduled flush
     /// deterministically.
     func flush() {
-        // Issue #5100 reproduction: nothing is deferred, so there is no scheduled
-        // work to run. The fix replaces this body.
+        flushScheduled = false
+        // Defensive: never run nested deliveries even if a flush is somehow scheduled
+        // while one is already draining.
+        guard !isDelivering else { return }
+        isDelivering = true
+        defer { isDelivering = false }
+
+        var iterations = 0
+        while let next = pending {
+            pending = nil
+            iterations += 1
+            if iterations > maxCoalescedDeliveries {
+                // Re-entrancy did not converge: stop rather than hang, and surface it.
+                onDrainBoundExceeded(next)
+                break
+            }
+            deliver(next)
+        }
     }
 }

--- a/Sources/FocusSurfaceBroadcaster.swift
+++ b/Sources/FocusSurfaceBroadcaster.swift
@@ -85,7 +85,8 @@ final class FocusSurfaceBroadcaster {
     ///   - schedule: Schedules deferred flush work on the main queue. Defaults to
     ///     `DispatchQueue.main.async`. Injected by tests to flush deterministically.
     ///   - onDrainBoundExceeded: Invoked with the still-pending payload when a flush
-    ///     hits ``maxCoalescedDeliveries`` and stops. Used for structured logging.
+    ///     hits ``maxCoalescedDeliveries`` and defers the remainder to a follow-up
+    ///     flush. Used for structured logging of a non-converging focus cycle.
     ///   - deliver: Performs the actual broadcast. Defaults to posting
     ///     `.ghosttyDidFocusSurface`. Injected by tests to capture deliveries.
     init(

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -18095,11 +18095,17 @@ extension Workspace: BonsplitDelegate {
         gitBranch = panelGitBranches[panelId]
         pullRequest = panelPullRequests[panelId]
 
-        // Post notification
-        NotificationCenter.default.post(
-            name: .ghosttyDidFocusSurface,
-            object: nil,
-            userInfo: [GhosttyNotificationKey.tabId: self.id, GhosttyNotificationKey.surfaceId: panelId, GhosttyNotificationKey.explicitFocusIntent: explicitFocusIntent]
+        // Broadcast the focus change. This is deferred + coalesced (not posted
+        // synchronously) so the `@Published` mutations above settle before any
+        // observer runs, and so a notification-driven focus cycle (command-palette
+        // restore + cross-workspace handoff) cannot synchronously re-enter
+        // applyTabSelectionNow and hang the main thread. See issue #5100.
+        FocusSurfaceBroadcaster.shared.emit(
+            FocusSurfaceBroadcaster.FocusSurfacePayload(
+                workspaceId: self.id,
+                panelId: panelId,
+                explicitFocusIntent: explicitFocusIntent
+            )
         )
         publishCmuxFocusedSelection(paneId: focusedPane, surfaceId: panelId, origin: "bonsplit_selection")
 #if DEBUG

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -257,6 +257,8 @@
 		F1A0C0DE0000000000000002 /* FindTextFieldSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A0C0DE0000000000000001 /* FindTextFieldSupport.swift */; };
 		F0C05170000000000000002 /* FocusHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0C05170000000000000001 /* FocusHistory.swift */; };
 		C4160A020000000000000001 /* FocusHistoryMenuInvalidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4160A020000000000000002 /* FocusHistoryMenuInvalidator.swift */; };
+		C0DEFB100000000000000001 /* FocusSurfaceBroadcaster.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEFB100000000000000002 /* FocusSurfaceBroadcaster.swift */; };
+		C0DEFB300000000000000001 /* FocusSurfaceBroadcasterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEFB300000000000000002 /* FocusSurfaceBroadcasterTests.swift */; };
 		D0B10012A1B2C3D4E5F60001 /* GhosttyApp+SurfaceConfigurationReload.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B10013A1B2C3D4E5F60001 /* GhosttyApp+SurfaceConfigurationReload.swift */; };
 		1718C0DE1718C0DE17180002 /* GhosttyCommandShiftForwardingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1718C0DE1718C0DE17180001 /* GhosttyCommandShiftForwardingTests.swift */; };
 		A5001004 /* GhosttyConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001014 /* GhosttyConfig.swift */; };
@@ -884,6 +886,8 @@
 		F1A0C0DE0000000000000001 /* FindTextFieldSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Find/FindTextFieldSupport.swift; sourceTree = "<group>"; };
 		F0C05170000000000000001 /* FocusHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusHistory.swift; sourceTree = "<group>"; };
 		C4160A020000000000000002 /* FocusHistoryMenuInvalidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusHistoryMenuInvalidator.swift; sourceTree = "<group>"; };
+		C0DEFB100000000000000002 /* FocusSurfaceBroadcaster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusSurfaceBroadcaster.swift; sourceTree = "<group>"; };
+		C0DEFB300000000000000002 /* FocusSurfaceBroadcasterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusSurfaceBroadcasterTests.swift; sourceTree = "<group>"; };
 		A5001017 /* ghostty.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ghostty.h; sourceTree = "<group>"; };
 		D0B10013A1B2C3D4E5F60001 /* GhosttyApp+SurfaceConfigurationReload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GhosttyApp+SurfaceConfigurationReload.swift"; sourceTree = "<group>"; };
 		1718C0DE1718C0DE17180001 /* GhosttyCommandShiftForwardingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyCommandShiftForwardingTests.swift; sourceTree = "<group>"; };
@@ -1474,6 +1478,7 @@
 					A50012F4 /* KeyboardLayout.swift */,
 					A5001013 /* TabManager.swift */,
 					F0C05170000000000000001 /* FocusHistory.swift */,
+					C0DEFB100000000000000002 /* FocusSurfaceBroadcaster.swift */,
 					C10D51700000000000000001 /* ClosedItemHistory.swift */,
 					C3677003000000000000002 /* TabManager+CompatibilityTypes.swift */,
 					E3309A04 /* TabManager+EqualizeSplits.swift */,
@@ -1824,6 +1829,7 @@
 				2907A0042907A0042907A004 /* AppDelegateIssue2907RoutingTests.swift */,
 				E50320010000000000000002 /* ExtensionWorktreeSpawnArgsTests.swift */,
 				C0DE49950000000000000002 /* FilePreviewKindResolverTests.swift */,
+				C0DEFB300000000000000002 /* FocusSurfaceBroadcasterTests.swift */,
 				A5001435A5001435A5001435 /* FilePreviewPDFThumbnailSidebarTests.swift */,
 				D3664001D3664001D3664001 /* MarkdownPanelTests.swift */,
 				C0DE31390000000000000104 /* FilePreviewReviewFeedbackTests.swift */,
@@ -2341,6 +2347,7 @@
 					F1A0C0DE0000000000000002 /* FindTextFieldSupport.swift in Sources */,
 					F0C05170000000000000002 /* FocusHistory.swift in Sources */,
 				C4160A020000000000000001 /* FocusHistoryMenuInvalidator.swift in Sources */,
+					C0DEFB100000000000000001 /* FocusSurfaceBroadcaster.swift in Sources */,
 				D0B10012A1B2C3D4E5F60001 /* GhosttyApp+SurfaceConfigurationReload.swift in Sources */,
 				A5001004 /* GhosttyConfig.swift in Sources */,
 				C3873001C3873001C3873001 /* GhosttyCrashBreadcrumb.swift in Sources */,
@@ -2686,6 +2693,7 @@
 				C0DE31390000000000000103 /* FilePreviewReviewFeedbackTests.swift in Sources */,
 				FE002103 /* FileSearchRipgrepParserTests.swift in Sources */,
 				C35610000000000000000001 /* FinderFileDropRegressionTests.swift in Sources */,
+				C0DEFB300000000000000001 /* FocusSurfaceBroadcasterTests.swift in Sources */,
 				1718C0DE1718C0DE17180002 /* GhosttyCommandShiftForwardingTests.swift in Sources */,
 				A11EB0000000000000000000 /* GhosttyConfigPathResolverTests.swift in Sources */,
 				F4000000A1B2C3D4E5F60718 /* GhosttyConfigTests.swift in Sources */,

--- a/cmuxTests/FocusSurfaceBroadcasterTests.swift
+++ b/cmuxTests/FocusSurfaceBroadcasterTests.swift
@@ -102,14 +102,15 @@ struct FocusSurfaceBroadcasterTests {
         #expect(delivered == [third])
     }
 
-    @Test("a re-entrant emit during delivery is bounded and cannot recurse unbounded")
-    func reentrantEmitDuringDeliveryIsBounded() {
+    @Test("a re-entrant emit is bounded per turn, never recurses, and never hangs")
+    func reentrantEmitIsBoundedPerTurn() {
         let scheduler = ManualScheduler()
         var delivered: [FocusSurfaceBroadcaster.FocusSurfacePayload] = []
         var boundExceeded: [FocusSurfaceBroadcaster.FocusSurfacePayload] = []
         var broadcaster: FocusSurfaceBroadcaster!
+        let reentryTarget = Self.payload(99)
         // Simulates the .onReceive → focusTab → applyTabSelectionNow → emit cycle:
-        // every delivery re-focuses, far more often than the drain bound allows.
+        // every delivery re-focuses, far more often than the per-turn bound allows.
         var reentryBudget = 100
 
         broadcaster = FocusSurfaceBroadcaster(
@@ -120,23 +121,37 @@ struct FocusSurfaceBroadcasterTests {
                 delivered.append(payload)
                 if reentryBudget > 0 {
                     reentryBudget -= 1
-                    broadcaster.emit(Self.payload(99))
+                    broadcaster.emit(reentryTarget)
                 }
             }
         )
 
         broadcaster.emit(Self.payload(0))
-        scheduler.runAll()
 
-        // Without the fix the deliver closure recurses `reentryBudget` deep
-        // (delivered.count == 101). The bounded drain caps it instead.
+        // The first flush delivers at most the bound, then defers the rest instead
+        // of recursing `reentryBudget` deep (the un-fixed behavior delivers 101 in a
+        // single synchronous call).
+        scheduler.runAll()
         #expect(delivered.count == 8)
         #expect(boundExceeded.count == 1)
-        // Re-entrant emits updated `pending` in place; no extra flush was scheduled,
-        // so the storm is fully contained within the one flush.
-        #expect(scheduler.count == 0)
-        // The observer kept asking to re-focus, but the bound stopped the cycle.
-        #expect(reentryBudget < 100)
+        #expect(scheduler.count == 1)   // a continuation was scheduled, not dropped
+
+        // Each subsequent turn also stays bounded; the cycle eventually drains.
+        var turns = 1
+        while scheduler.count > 0 {
+            turns += 1
+            #expect(turns < 1000)       // converges — not an infinite cross-turn loop
+            if turns >= 1000 { break }
+            let before = delivered.count
+            scheduler.runAll()
+            #expect(delivered.count - before <= 8)   // never more than the bound per turn
+        }
+
+        // Nothing was dropped: the initial focus plus all re-emits were delivered,
+        // and the system settled on the final selection.
+        #expect(delivered.count == 101)
+        #expect(delivered.last == reentryTarget)
+        #expect(reentryBudget == 0)
     }
 
     @Test("a converging re-entrant cycle settles on the final selection")

--- a/cmuxTests/FocusSurfaceBroadcasterTests.swift
+++ b/cmuxTests/FocusSurfaceBroadcasterTests.swift
@@ -1,0 +1,172 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Regression coverage for the focus-broadcast re-entrancy hang (issue #5100).
+///
+/// Production symptom: `Workspace.applyTabSelectionNow` posted
+/// `.ghosttyDidFocusSurface` *synchronously* while `@Published` selection state was
+/// mid-mutation. The Combine `.onReceive` subscriber in `ContentView` received it on
+/// the posting thread and synchronously re-entered the focus path
+/// (`attemptCommandPaletteFocusRestoreIfNeeded` → `TabManager.focusTab` →
+/// `Workspace.focusPanel` → `applyTabSelectionNow` → post again). The only guard
+/// (`Workspace.isApplyingTabSelection`) is per-instance, so a cycle that bounced
+/// through SwiftUI body re-evaluation and across workspace instances was unbounded —
+/// a 426s main-thread hang.
+///
+/// ``FocusSurfaceBroadcaster`` is the fix seam: emitting a focus broadcast is now
+/// deferred + coalesced and a re-entrant emit during delivery is drained in a bounded
+/// loop instead of recursing. These tests exercise that contract directly, without
+/// AppKit, by injecting a manual scheduler and capturing deliveries.
+@MainActor
+@Suite("Focus surface broadcaster re-entrancy")
+struct FocusSurfaceBroadcasterTests {
+
+    /// Distinct payloads; the `explicitFocusIntent` flag just varies for identity.
+    private static func payload(_ seed: Int) -> FocusSurfaceBroadcaster.FocusSurfacePayload {
+        FocusSurfaceBroadcaster.FocusSurfacePayload(
+            workspaceId: UUID(),
+            panelId: UUID(),
+            explicitFocusIntent: seed.isMultiple(of: 2)
+        )
+    }
+
+    /// Deterministic stand-in for `DispatchQueue.main.async`: captured flush closures
+    /// are stored and run on demand so the test controls runloop turns.
+    @MainActor
+    private final class ManualScheduler {
+        private(set) var pending: [@MainActor @Sendable () -> Void] = []
+
+        func append(_ work: @escaping @MainActor @Sendable () -> Void) {
+            pending.append(work)
+        }
+
+        var count: Int { pending.count }
+
+        /// Runs every currently-queued flush. Clears the queue first so re-entrant
+        /// scheduling during a run is observable via ``count``.
+        func runAll() {
+            let work = pending
+            pending.removeAll()
+            for unit in work { unit() }
+        }
+    }
+
+    @Test("emit() defers delivery to a scheduled flush instead of firing synchronously")
+    func emitDefersDeliveryUntilFlush() {
+        let scheduler = ManualScheduler()
+        var delivered: [FocusSurfaceBroadcaster.FocusSurfacePayload] = []
+        let broadcaster = FocusSurfaceBroadcaster(
+            schedule: { scheduler.append($0) },
+            deliver: { delivered.append($0) }
+        )
+
+        let only = Self.payload(1)
+        broadcaster.emit(only)
+
+        // The whole point: nothing is delivered on the emit() call itself, so a
+        // caller mutating @Published state is fully settled before observers run.
+        #expect(delivered.isEmpty)
+        #expect(scheduler.count == 1)
+
+        scheduler.runAll()
+        #expect(delivered == [only])
+    }
+
+    @Test("multiple emits before a flush coalesce to the latest payload")
+    func coalescesEmitsBeforeFlush() {
+        let scheduler = ManualScheduler()
+        var delivered: [FocusSurfaceBroadcaster.FocusSurfacePayload] = []
+        let broadcaster = FocusSurfaceBroadcaster(
+            schedule: { scheduler.append($0) },
+            deliver: { delivered.append($0) }
+        )
+
+        let first = Self.payload(1)
+        let second = Self.payload(2)
+        let third = Self.payload(3)
+        broadcaster.emit(first)
+        broadcaster.emit(second)
+        broadcaster.emit(third)
+
+        #expect(delivered.isEmpty)
+        // Only one flush is scheduled no matter how many emits land in the same turn.
+        #expect(scheduler.count == 1)
+
+        scheduler.runAll()
+        #expect(delivered == [third])
+    }
+
+    @Test("a re-entrant emit during delivery is bounded and cannot recurse unbounded")
+    func reentrantEmitDuringDeliveryIsBounded() {
+        let scheduler = ManualScheduler()
+        var delivered: [FocusSurfaceBroadcaster.FocusSurfacePayload] = []
+        var boundExceeded: [FocusSurfaceBroadcaster.FocusSurfacePayload] = []
+        var broadcaster: FocusSurfaceBroadcaster!
+        // Simulates the .onReceive → focusTab → applyTabSelectionNow → emit cycle:
+        // every delivery re-focuses, far more often than the drain bound allows.
+        var reentryBudget = 100
+
+        broadcaster = FocusSurfaceBroadcaster(
+            maxCoalescedDeliveries: 8,
+            schedule: { scheduler.append($0) },
+            onDrainBoundExceeded: { boundExceeded.append($0) },
+            deliver: { payload in
+                delivered.append(payload)
+                if reentryBudget > 0 {
+                    reentryBudget -= 1
+                    broadcaster.emit(Self.payload(99))
+                }
+            }
+        )
+
+        broadcaster.emit(Self.payload(0))
+        scheduler.runAll()
+
+        // Without the fix the deliver closure recurses `reentryBudget` deep
+        // (delivered.count == 101). The bounded drain caps it instead.
+        #expect(delivered.count == 8)
+        #expect(boundExceeded.count == 1)
+        // Re-entrant emits updated `pending` in place; no extra flush was scheduled,
+        // so the storm is fully contained within the one flush.
+        #expect(scheduler.count == 0)
+        // The observer kept asking to re-focus, but the bound stopped the cycle.
+        #expect(reentryBudget < 100)
+    }
+
+    @Test("a converging re-entrant cycle settles on the final selection")
+    func reentrantEmitConvergesToFinalSelection() {
+        let scheduler = ManualScheduler()
+        var delivered: [FocusSurfaceBroadcaster.FocusSurfacePayload] = []
+        var broadcaster: FocusSurfaceBroadcaster!
+        let finalTarget = Self.payload(7)
+        // The observer re-focuses the same target a couple of times, then stops —
+        // the realistic case where focus restore eventually converges.
+        var reEmitsRemaining = 2
+
+        broadcaster = FocusSurfaceBroadcaster(
+            maxCoalescedDeliveries: 8,
+            schedule: { scheduler.append($0) },
+            deliver: { payload in
+                delivered.append(payload)
+                if reEmitsRemaining > 0 {
+                    reEmitsRemaining -= 1
+                    broadcaster.emit(finalTarget)
+                }
+            }
+        )
+
+        broadcaster.emit(Self.payload(0))
+        scheduler.runAll()
+
+        // Initial delivery + two convergent re-emits, then quiescent.
+        #expect(delivered.count == 3)
+        #expect(delivered.last == finalTarget)
+        #expect(scheduler.count == 0)
+    }
+}


### PR DESCRIPTION
## Issue

[#5100](https://github.com/manaflow-ai/cmux/issues/5100) — 426s main-thread hang (not a crash): `handleCustomShortcut -> focusTab -> applyTabSelection -> applyTabSelectionNow` posts `.ghosttyDidFocusSurface` synchronously, which re-enters the focus path and spins. Sentry app-hang `E828D561-CCD2-40C0-84FD-35B0A80000B1` (0.64.10, macOS 26.4.1, arm64).

## Root cause (confirmed against current `main`)

`Workspace.applyTabSelectionNow` finished by posting `.ghosttyDidFocusSurface` **synchronously** while a large amount of `@Published` selection state was mid-mutation. The Combine `.onReceive(publisher(for: .ghosttyDidFocusSurface))` subscriber in `ContentView` (line ~2893) delivers that notification **synchronously on the posting thread** and reacts via `attemptCommandPaletteFocusRestoreIfNeeded() -> TabManager.focusTab -> Workspace.focusPanel -> applyTabSelection -> applyTabSelectionNow -> post(.ghosttyDidFocusSurface)` — a synchronous cycle.

The only existing guard, `Workspace.isApplyingTabSelection`, is **per-instance**. The cycle bounces through SwiftUI body re-evaluation and across **different** `Workspace` instances (command-palette focus restore + cross-workspace handoff), so a single per-instance bool never bounds it → unbounded re-entrancy → 426s hang.

Notably, **all 9 `NotificationCenter` observers** of `.ghosttyDidFocusSurface` already register with `queue: .main` (async). The lone synchronous consumer is the `ContentView` Combine `.onReceive` — i.e. the sole synchronous re-entry vector.

## Fix — make focus broadcasts safe to emit mid-mutation, by construction

New `FocusSurfaceBroadcaster` (`Sources/FocusSurfaceBroadcaster.swift`) replaces the direct synchronous post in `applyTabSelectionNow`. It:

1. **Defers** delivery to a scheduled main-queue flush — so `@Published` mutations settle before any observer runs, and the synchronous `.onReceive` re-entry path is broken.
2. **Coalesces** multiple emits in the same runloop turn to the latest payload (normal single-selection turns post exactly once, so behavior is unchanged there; only a re-entrancy storm collapses).
3. **Bounds** re-entrant emits during delivery via a drain loop (`maxCoalescedDeliveries`, default 8) and emits structured DEBUG logging when the bound trips — so a future re-entrancy is observable instead of a silent hang.

This targets the **class** of bug (a synchronous focus broadcast fired during `@Published` mutation driving SwiftUI body + observers back into the focus path), across workspace instances — not just one call site. The broadcaster is a single shared boundary that covers the notification-driven and cross-workspace cycle the per-`Workspace` guard misses.

## Tests (`cmuxTests/FocusSurfaceBroadcasterTests.swift`, Swift Testing)

Two-commit red/green per repo policy:
- **Commit 1 (red):** introduces the broadcaster + Workspace wiring + test, but with `emit` delivering synchronously (faithful repro of the old behavior) so the contract tests fail.
- **Commit 2 (green):** the defer/coalesce/bound fix; all tests pass.

Coverage of the re-entrancy contract (no AppKit needed; injected scheduler + deliver):
- `emit()` defers delivery (nothing delivered synchronously — mutation settles first).
- multiple emits coalesce to a single scheduled flush + latest payload.
- a re-entrant emit during delivery is **bounded** (drains ≤ `maxCoalescedDeliveries` instead of recursing) — this is the one that turns a 426s hang into a bounded operation.
- a converging re-entrant cycle settles on the **final** selection.

## Notes / risk

- No behavior change for the 9 already-async observers; the previously-synchronous `ContentView` `.onReceive` now runs one runloop turn later (state settled), which is strictly more correct.
- `TabManagerSessionSnapshotTests` post `.ghosttyDidFocusSurface` directly (bypassing the broadcaster) + `drainMainQueue()`; unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5108"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782907879&installation_id=133855650&pr_number=5108&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5108&signature=e6d2b271518a639bd3458a40df153a85cbcd1123815136212c28efd07dbf8b32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes timing of focus notifications (one runloop turn later for the synchronous ContentView path) and touches core tab/panel selection; bounded delivery should prevent hangs but focus ordering in edge cases deserves manual QA.
> 
> **Overview**
> Fixes the **426s main-thread hang** ([#5100](https://github.com/manaflow-ai/cmux/issues/5100)) by routing `.ghosttyDidFocusSurface` through a new **`FocusSurfaceBroadcaster`** instead of posting from `Workspace.applyTabSelectionNow` while `@Published` selection state is still mutating.
> 
> **`FocusSurfaceBroadcaster`** defers delivery to the main queue, coalesces rapid emits to the latest payload, and caps re-entrant delivery per runloop turn (default **8**), rescheduling any remainder so the final focus is not dropped. DEBUG logging fires when the per-turn bound trips.
> 
> **`Workspace`** now calls `FocusSurfaceBroadcaster.shared.emit(...)` in place of `NotificationCenter.default.post` for focus surface changes. Xcode project wiring and **`FocusSurfaceBroadcasterTests`** cover deferral, coalescing, bounded re-entrancy, and convergence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51470e57a25550a7df128cc7dc87ed2d05ccb01f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #5100 by deferring and bounding focus-surface broadcasts to stop re-entrant focus loops and the 426s hang. Ensures the final focus update is never dropped by rescheduling when the per-turn bound trips.

- **Bug Fixes**
  - Added `FocusSurfaceBroadcaster` that delivers on the main queue, coalesces to the latest payload, and drains re-entrant emits with `maxCoalescedDeliveries` (default 8); when the cap is hit, it preserves the pending payload and schedules a follow-up flush (with DEBUG logs; docs clarified to reflect deferral).
  - Replaced the synchronous `.ghosttyDidFocusSurface` post in `Workspace.applyTabSelectionNow` with the broadcaster to avoid synchronous re-entry via `ContentView.onReceive`.

- **Tests**
  - Added `FocusSurfaceBroadcasterTests` covering deferral, coalescing, per-turn bounding with reschedule, and convergence to the final selection without dropping payloads.

<sup>Written for commit 51470e57a25550a7df128cc7dc87ed2d05ccb01f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Focus notifications now batch and defer delivery to avoid synchronous re-entrant broadcasts, improving UI responsiveness and stability during rapid or nested focus changes.

* **Tests**
  * Added tests validating batching, deferred delivery, bounded re-entrancy handling, and eventual convergence of focus notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->