### PR TITLE
Revert "Read the Extensions flag via @Setting in the main window"

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1,6 +1,5 @@
 import AppKit
 import CmuxSettings
-import CmuxSettingsUI
 import CmuxSocketControl
 import SwiftUI
 import Bonsplit
@@ -822,14 +821,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     weak var tabManager: TabManager?
     weak var notificationStore: TerminalNotificationStore?
     weak var sidebarState: SidebarState?
-    /// The app's settings dependency container, handed over by `cmuxApp` via
-    /// ``configure(tabManager:notificationStore:sidebarState:settingsRuntime:)``
-    /// before any main window is created. AppKit builds the main window's
-    /// `NSHostingView` itself, so it must inject this into the `ContentView`
-    /// environment (`.environment(\.settingsRuntime, …)`) for `@Setting` to
-    /// resolve inside the sidebar; it is also the source of truth for the
-    /// synchronous reads on `CmuxExtensionSidebarSelection`.
-    var settingsRuntime: SettingsRuntime?
     weak var fileExplorerState: FileExplorerState?
     weak var fullscreenControlsViewModel: TitlebarControlsViewModel?
     weak var sidebarSelectionState: SidebarSelectionState?
@@ -1857,11 +1848,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         ClosedItemHistoryStore.shared.flushPendingSaves()
     }
 
-    func configure(tabManager: TabManager, notificationStore: TerminalNotificationStore, sidebarState: SidebarState, settingsRuntime: SettingsRuntime) {
+    func configure(tabManager: TabManager, notificationStore: TerminalNotificationStore, sidebarState: SidebarState) {
         self.tabManager = tabManager
         self.notificationStore = notificationStore
         self.sidebarState = sidebarState
-        self.settingsRuntime = settingsRuntime
         scheduleGhosttyCrashBreadcrumbIfNeeded(notificationStore: notificationStore)
         disableSuddenTerminationIfNeeded()
         installLifecycleSnapshotObserversIfNeeded()
@@ -7838,12 +7828,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             .environmentObject(sidebarSelectionState)
             .environmentObject(fileExplorerState)
             .environmentObject(cmuxConfigStore)
-            // AppKit hosts this ContentView in its own NSHostingView, which does
-            // not inherit the SwiftUI environment from the App scene. Inject the
-            // settings runtime here so `@Setting` resolves throughout the main
-            // window (e.g. the sidebar). The environment key is optional, so a
-            // nil runtime simply falls back to each key's default.
-            .environment(\.settingsRuntime, settingsRuntime)
 
         // Use the current key window's size for new windows so Cmd+Shift+N
         // creates a window matching the previous one's dimensions.

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -5,7 +5,6 @@ import Combine
 import CMUXExtensionClient
 import CmuxExtensionKit
 import CmuxSettings
-import CmuxSettingsUI
 import ImageIO
 import Observation
 import SwiftUI
@@ -9999,17 +9998,18 @@ enum CmuxExtensionSidebarSelection {
     static let defaultProviderId = CmuxExtensionSidebarProviderDescriptor.defaultWorkspacesID
     static let hostedExtensionsProviderId = "cmux.sidebar.extensions"
 
-    /// Synchronous read of the experimental Extensions flag for the on-demand
-    /// AppKit/static paths (the toggle menu, the command-palette builder, the
-    /// extensions-browser opener) that have no `SettingsRuntime` in scope and
-    /// run outside the SwiftUI update cycle.
-    ///
-    /// SwiftUI views bind reactively via `@Setting(\.betaFeatures.extensions)`.
-    /// The settings store is `actor`-isolated and async-only, so these
-    /// synchronous callers resolve the value from the catalog key
-    /// (`BetaFeaturesCatalogSection.extensions`) read against `UserDefaults`,
-    /// which is the same suite and key the store persists to — the catalog
-    /// remains the single definition of the key, decode, and default.
+    /// The UserDefaults key and default for the experimental Extensions flag,
+    /// resolved from the settings catalog (`BetaFeaturesCatalogSection.extensions`)
+    /// so the key and default are never re-declared. The sidebar lives in an
+    /// AppKit-hosted subtree where the `SettingsRuntime` environment does not
+    /// reach, so SwiftUI views observe the flag with `@AppStorage(enabledDefaultsKey)`
+    /// (reactive and environment-independent) rather than `@Setting`.
+    static var enabledDefaultsKey: String { SettingCatalog().betaFeatures.extensions.userDefaultsKey }
+    static var enabledDefault: Bool { SettingCatalog().betaFeatures.extensions.defaultValue }
+
+    /// Synchronous read of the flag for the on-demand AppKit/static paths (the
+    /// toggle menu, the command-palette builder, the extensions-browser opener)
+    /// that have no `SettingsRuntime` in scope and run outside the SwiftUI cycle.
     static var isEnabled: Bool {
         let key = SettingCatalog().betaFeatures.extensions
         return Bool.decodeFromUserDefaults(UserDefaults.standard.object(forKey: key.userDefaultsKey)) ?? key.defaultValue
@@ -10378,7 +10378,8 @@ struct VerticalTabsSidebar: View {
     private var workspacePresentationMode = WorkspacePresentationModeSettings.defaultMode.rawValue
     @AppStorage(CmuxExtensionSidebarSelection.defaultsKey)
     private var selectedExtensionSidebarProviderId = CmuxExtensionSidebarSelection.defaultProviderId
-    @Setting(\.betaFeatures.extensions) private var extensionsExperimentalEnabled
+    @AppStorage(CmuxExtensionSidebarSelection.enabledDefaultsKey)
+    private var extensionsExperimentalEnabled = CmuxExtensionSidebarSelection.enabledDefault
     @AppStorage("sidebarMatchTerminalBackground")
     private var sidebarMatchTerminalBackground = false
     @AppStorage(MinimalModeTitlebarDebugSettings.leftControlsLeadingInsetKey)
@@ -13123,7 +13124,8 @@ private struct SidebarFooterButtons: View {
     @ObservedObject var fileExplorerState: FileExplorerState
     let onSendFeedback: () -> Void
     @State private var extensionBrowserAnchorView: NSView?
-    @Setting(\.betaFeatures.extensions) private var extensionsExperimentalEnabled
+    @AppStorage(CmuxExtensionSidebarSelection.enabledDefaultsKey)
+    private var extensionsExperimentalEnabled = CmuxExtensionSidebarSelection.enabledDefault
 
     var body: some View {
         HStack(spacing: 4) {

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -155,7 +155,7 @@ struct cmuxApp: App {
         // UI tests depend on AppDelegate wiring happening even if SwiftUI view appearance
         // callbacks (e.g. `.onAppear`) are delayed or skipped.
         StartupBreadcrumbLog.append("app.init.delegate.configure.begin")
-        appDelegate.configure(tabManager: tabManager, notificationStore: notificationStore, sidebarState: sidebarState, settingsRuntime: settingsRuntime)
+        appDelegate.configure(tabManager: tabManager, notificationStore: notificationStore, sidebarState: sidebarState)
         StartupBreadcrumbLog.append("app.init.delegate.configured")
     }
 


### PR DESCRIPTION
Reverts manaflow-ai/cmux#5094

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5110"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782908178&installation_id=133855650&pr_number=5110&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5110&signature=91e3cfc8aa6a259237c0017e04206e1368793b554caf8488eca333a7d59a1e72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the change that read the Extensions beta flag via @Setting in the main window. Restores an AppKit-safe approach using UserDefaults and @AppStorage so the flag works in the sidebar and menus.

- **Bug Fixes**
  - Ensures the Extensions flag resolves in AppKit-hosted views (toggle menu, command palette, extensions browser) without a SwiftUI settings environment.

- **Refactors**
  - Remove `settingsRuntime` from AppDelegate and stop injecting `.environment(\.settingsRuntime, ...)`.
  - Switch `@Setting(\.betaFeatures.extensions)` to `@AppStorage` using catalog-derived key/default.
  - Add `enabledDefaultsKey` and `enabledDefault` on `CmuxExtensionSidebarSelection`; keep sync `isEnabled`.
  - Drop `CmuxSettingsUI` imports and update `cmuxApp` to the new `configure` signature.

<sup>Written for commit 47991100353fc9339d3e8ff539a7578fb665dd6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal optimizations to application architecture and settings management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->