### PR TITLE
Fix #3799: paint OSC 11 overrides on the surface host layer

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7697,9 +7697,13 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         // The window root backdrop is the single surface fill for solid-color
         // terminal backgrounds. Painting the terminal host layer too would
         // double-composite it against the surrounding chrome.
+        //
+        // An explicit OSC 11 override is pane-local, so it owns the host layer
+        // directly. The shared backdrop only paints the active surface, so routing
+        // overrides through it drops the tint on every other pane (#3799). Panes
+        // without an override stay on the shared backdrop, preserving #3179.
         let usesHostLayerFill = renderingMode.usesWindowHostBackdrop &&
-            !sharesWindowBackdrop &&
-            !usesBonsplitPaneBackdrop
+            (backgroundColor != nil || (!sharesWindowBackdrop && !usesBonsplitPaneBackdrop))
         let color = usesHostLayerFill
             ? effectiveBackgroundColor()
             : .clear

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7702,8 +7702,14 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         // directly. The shared backdrop only paints the active surface, so routing
         // overrides through it drops the tint on every other pane (#3799). Panes
         // without an override stay on the shared backdrop, preserving #3179.
+        //
+        // Only opaque overrides take ownership: a translucent fill would composite
+        // over the shared backdrop on the active pane and read too dark, so those
+        // keep using the shared backdrop.
+        let opaqueOverride = backgroundColor != nil &&
+            GhosttyApp.shared.defaultBackgroundOpacity >= 1
         let usesHostLayerFill = renderingMode.usesWindowHostBackdrop &&
-            (backgroundColor != nil || (!sharesWindowBackdrop && !usesBonsplitPaneBackdrop))
+            (opaqueOverride || (!sharesWindowBackdrop && !usesBonsplitPaneBackdrop))
         let color = usesHostLayerFill
             ? effectiveBackgroundColor()
             : .clear


### PR DESCRIPTION
#3886 fixed this but got reverted in #5106 about an hour after it landed, so #3799 is back on main. Still repros on v0.64.11 and nightly 264455e with an opaque config: a single full-window pane and split panes both ignore `\e]11;...\a`.

This drops the Core Image cutout that #3886 used and takes the gate from the original report instead. When a surface has an explicit OSC 11 override (`backgroundColor != nil`), it paints the surface host layer itself instead of going through the shared window-root backdrop. That backdrop only paints the active surface, which is why the tint disappeared on every other pane.

Surfaces with no override are untouched (still owned by the shared backdrop), so the titlebar matching from #3179 stays as-is.

Only opaque overrides take ownership: a translucent override would composite over the shared backdrop on the active pane and read too dark, so those keep using the shared backdrop and behave exactly as before. The gate is the one @ct-mahendra verified locally in the report.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Opaque per-pane custom background colors are now correctly rendered and preserved, ensuring panes with explicit opaque background overrides display as expected and no longer blend unexpectedly with the shared backdrop.
  * Panes without opaque overrides retain the previous backdrop behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->