### PR TITLE
Fix release appcast R2 upload: provide GH_TOKEN to gh release list

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -425,6 +425,7 @@ jobs:
       - name: Upload release appcast to R2
         if: steps.guard_release_assets.outputs.skip_upload != 'true' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         env:
+          GH_TOKEN: ${{ github.token }}
           AWS_ACCESS_KEY_ID: ${{ secrets.CF_R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.CF_R2_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: auto


### PR DESCRIPTION
## Problem

The v0.64.11 release run ([26754933970](https://github.com/manaflow-ai/cmux/actions/runs/26754933970)) went red at the final **"Upload release appcast to R2"** step:

```
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable.
##[error]Process completed with exit code 4.
```

That step (added by [#4918](https://github.com/manaflow-ai/cmux/pull/4918)) runs `gh release list` for the highest-semver guard, but its `env:` block only carried the R2 credentials, not `GH_TOKEN`. `gh` exits 4 and `set -euo pipefail` fails the whole step.

## Impact

Limited. The build, sign, notarize, and GitHub Release publish steps all succeeded first, so v0.64.11 is published with `cmux-macos.dmg` and a signed `appcast.xml`. The app's `SUFeedURL` reads the GitHub release appcast asset (`releases/latest/download/appcast.xml`), not R2, so stable auto-update is unaffected. Only the secondary R2 mirror upload failed, and the failure turned every release run red.

## Fix

Add `GH_TOKEN: ${{ github.token }}` to the step's env block so the semver guard's `gh release list` authenticates.

No meaningful automated test is practical for a single workflow env line; the verification is the next release run reaching the R2 step green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5116"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782915488&installation_id=133855650&pr_number=5116&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5116&signature=ea15bf672eff32da5b7b0e7e72105e0cf04ddb69fcac7fb43ea15a9ec9f91c9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single workflow env var; no app, auth, or release artifact logic changes.
> 
> **Overview**
> The **Upload release appcast to R2** job in `release.yml` now sets **`GH_TOKEN`** from `${{ github.token }}` so the step’s **`gh release list`** semver guard can authenticate in Actions.
> 
> Without it, that step failed with exit code 4 while build, sign, and GitHub Release publish still succeeded—only the optional R2 mirror upload was blocked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7f5f7eb4e6485d8b7c930a0a7e44ba9682ad575. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Provide `GH_TOKEN` to the "Upload release appcast to R2" workflow step so `gh release list` can authenticate. This prevents exit code 4 and restores the R2 mirror upload, keeping release runs green.

<sup>Written for commit e7f5f7eb4e6485d8b7c930a0a7e44ba9682ad575. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced macOS release workflow environment configuration to improve reliability and security during the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->