### PR TITLE
[codex] fix spinner terminal title flooding

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -4602,17 +4602,23 @@ class GhosttyApp {
             let title = action.action.set_title.title
                 .flatMap { String(cString: $0) } ?? ""
             if let tabId = surfaceView.tabId,
-               let surfaceId = surfaceView.terminalSurface?.id {
+               let terminalSurface = surfaceView.terminalSurface {
+                let surfaceId = terminalSurface.id
                 DispatchQueue.main.async {
-                    NotificationCenter.default.post(
-                        name: .ghosttyDidSetTitle,
-                        object: surfaceView,
-                        userInfo: [
-                            GhosttyNotificationKey.tabId: tabId,
-                            GhosttyNotificationKey.surfaceId: surfaceId,
-                            GhosttyNotificationKey.title: title,
-                        ]
-                    )
+                    MainActor.assumeIsolated {
+                        guard let publishedTitle = terminalSurface.publishableTerminalTitle(title) else {
+                            return
+                        }
+                        NotificationCenter.default.post(
+                            name: .ghosttyDidSetTitle,
+                            object: surfaceView,
+                            userInfo: [
+                                GhosttyNotificationKey.tabId: tabId,
+                                GhosttyNotificationKey.surfaceId: surfaceId,
+                                GhosttyNotificationKey.title: publishedTitle,
+                            ]
+                        )
+                    }
                 }
             }
             return true
@@ -5269,6 +5275,7 @@ final class TerminalSurface: Identifiable, ObservableObject {
 
     private(set) var surface: ghostty_surface_t?
     private weak var attachedView: GhosttyNSView?
+    private var lastPublishedTerminalTitle: String?
 
     /// Whether the runtime Ghostty surface exists and has not begun teardown.
     ///
@@ -5518,7 +5525,41 @@ final class TerminalSurface: Identifiable, ObservableObject {
         tabId = newTabId
         attachedView?.tabId = newTabId
         surfaceView.tabId = newTabId
+        lastPublishedTerminalTitle = nil
     }
+
+    @MainActor
+    func publishableTerminalTitle(_ title: String) -> String? {
+        let stableTitle = Self.stableTerminalNotificationTitle(title)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !stableTitle.isEmpty else { return nil }
+        guard lastPublishedTerminalTitle != stableTitle else { return nil }
+        lastPublishedTerminalTitle = stableTitle
+        return stableTitle
+    }
+
+    private static func stableTerminalNotificationTitle(_ title: String) -> String {
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let first = trimmed.first,
+              terminalTitleSpinnerCharacters.contains(first) else {
+            return title
+        }
+
+        let afterSpinner = trimmed.index(after: trimmed.startIndex)
+        guard afterSpinner < trimmed.endIndex,
+              trimmed[afterSpinner].isWhitespace else {
+            return title
+        }
+
+        guard let remainderStart = trimmed[afterSpinner...].firstIndex(where: { !$0.isWhitespace }) else {
+            return title
+        }
+        return String(trimmed[remainderStart...])
+    }
+
+    private static let terminalTitleSpinnerCharacters = Set<Character>(
+        "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+    )
 
     @MainActor
     private func scheduleHeadlessRuntimeStartIfNeeded(reason: String) {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -4604,21 +4604,21 @@ class GhosttyApp {
             if let tabId = surfaceView.tabId,
                let terminalSurface = surfaceView.terminalSurface {
                 let surfaceId = terminalSurface.id
-                DispatchQueue.main.async {
-                    MainActor.assumeIsolated {
-                        guard let publishedTitle = terminalSurface.publishableTerminalTitle(title) else {
-                            return
-                        }
-                        NotificationCenter.default.post(
-                            name: .ghosttyDidSetTitle,
-                            object: surfaceView,
-                            userInfo: [
-                                GhosttyNotificationKey.tabId: tabId,
-                                GhosttyNotificationKey.surfaceId: surfaceId,
-                                GhosttyNotificationKey.title: publishedTitle,
-                            ]
-                        )
+                Task { @MainActor [weak surfaceView, weak terminalSurface] in
+                    guard let surfaceView,
+                          let terminalSurface,
+                          let publishedTitle = terminalSurface.publishableTerminalTitle(title) else {
+                        return
                     }
+                    NotificationCenter.default.post(
+                        name: .ghosttyDidSetTitle,
+                        object: surfaceView,
+                        userInfo: [
+                            GhosttyNotificationKey.tabId: tabId,
+                            GhosttyNotificationKey.surfaceId: surfaceId,
+                            GhosttyNotificationKey.title: publishedTitle,
+                        ]
+                    )
                 }
             }
             return true
@@ -5521,6 +5521,7 @@ final class TerminalSurface: Identifiable, ObservableObject {
         }
     }
 
+    @MainActor
     func updateWorkspaceId(_ newTabId: UUID) {
         tabId = newTabId
         attachedView?.tabId = newTabId

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -1501,7 +1501,11 @@ class TabManager: ObservableObject {
                 guard let tabId = notification.userInfo?[GhosttyNotificationKey.tabId] as? UUID else { return }
                 guard let surfaceId = notification.userInfo?[GhosttyNotificationKey.surfaceId] as? UUID else { return }
                 guard let title = notification.userInfo?[GhosttyNotificationKey.title] as? String else { return }
-                enqueuePanelTitleUpdate(tabId: tabId, panelId: surfaceId, title: title)
+                enqueuePanelTitleUpdate(
+                    tabId: tabId,
+                    panelId: surfaceId,
+                    title: Self.stableTerminalPanelTitle(title)
+                )
             }
         })
         observers.append(NotificationCenter.default.addObserver(
@@ -8578,13 +8582,21 @@ class TabManager: ObservableObject {
     private func enqueuePanelTitleUpdate(tabId: UUID, panelId: UUID, title: String) {
         let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
+        let key = PanelTitleUpdateKey(tabId: tabId, panelId: panelId)
+        if pendingPanelTitleUpdates[key] == trimmed {
+            return
+        }
+        if let tab = tabs.first(where: { $0.id == tabId }),
+           tab.alreadyReflectsPanelTitleUpdate(panelId: panelId, title: trimmed),
+           selectedTabId != tabId || window?.title == windowTitle(for: tab) {
+            return
+        }
 #if DEBUG
         cmuxDebugLog(
             "workspace.title.enqueue workspace=\(Self.debugShortWorkspaceId(tabId)) " +
             "panel=\(panelId.uuidString.prefix(5)) title=\"\(Self.debugTitlePreview(trimmed))\""
         )
 #endif
-        let key = PanelTitleUpdateKey(tabId: tabId, panelId: panelId)
         pendingPanelTitleUpdates[key] = trimmed
         panelTitleUpdateCoalescer.signal { [weak self] in
             self?.flushPendingPanelTitleUpdates()
@@ -8611,6 +8623,28 @@ class TabManager: ObservableObject {
             }
         }
     }
+
+    private static func stableTerminalPanelTitle(_ title: String) -> String {
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let first = trimmed.first,
+              terminalTitleSpinnerCharacters.contains(first) else {
+            return title
+        }
+
+        let afterSpinner = trimmed.index(after: trimmed.startIndex)
+        guard afterSpinner < trimmed.endIndex,
+              trimmed[afterSpinner].isWhitespace else {
+            return title
+        }
+
+        let remainderStart = trimmed[afterSpinner...].firstIndex { !$0.isWhitespace }
+        guard let remainderStart else { return title }
+        return String(trimmed[remainderStart...])
+    }
+
+    private static let terminalTitleSpinnerCharacters = Set<Character>(
+        "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+    )
 
     func focusedSurfaceTitleDidChange(tabId: UUID) {
         guard let tab = tabs.first(where: { $0.id == tabId }),

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -1267,7 +1267,12 @@ class TabManager: ObservableObject {
     /// Used to apply title updates to the correct window instead of NSApp.keyWindow.
     weak var window: NSWindow?
 
-    @Published var tabs: [Workspace] = []
+    @Published var tabs: [Workspace] = [] {
+        didSet {
+            rebuildTabLookup()
+        }
+    }
+    private var tabById: [UUID: Workspace] = [:]
     /// Named groupings of workspaces shown as collapsible sections in the sidebar.
     /// Group order in this array defines section order in the sidebar.
     /// Each member workspace stores its `groupId` on the `Workspace` model.
@@ -1501,11 +1506,7 @@ class TabManager: ObservableObject {
                 guard let tabId = notification.userInfo?[GhosttyNotificationKey.tabId] as? UUID else { return }
                 guard let surfaceId = notification.userInfo?[GhosttyNotificationKey.surfaceId] as? UUID else { return }
                 guard let title = notification.userInfo?[GhosttyNotificationKey.title] as? String else { return }
-                enqueuePanelTitleUpdate(
-                    tabId: tabId,
-                    panelId: surfaceId,
-                    title: Self.stableTerminalPanelTitle(title)
-                )
+                enqueuePanelTitleUpdate(tabId: tabId, panelId: surfaceId, title: title)
             }
         })
         observers.append(NotificationCenter.default.addObserver(
@@ -2545,7 +2546,7 @@ class TabManager: ObservableObject {
 
     var selectedWorkspace: Workspace? {
         guard let selectedTabId else { return nil }
-        return tabs.first(where: { $0.id == selectedTabId })
+        return tabById[selectedTabId]
     }
 
     // Keep selectedTab as convenience alias
@@ -8586,7 +8587,7 @@ class TabManager: ObservableObject {
         if pendingPanelTitleUpdates[key] == trimmed {
             return
         }
-        if let tab = tabs.first(where: { $0.id == tabId }),
+        if let tab = tabById[tabId],
            tab.alreadyReflectsPanelTitleUpdate(panelId: panelId, title: trimmed),
            selectedTabId != tabId || window?.title == windowTitle(for: tab) {
             return
@@ -8612,8 +8613,17 @@ class TabManager: ObservableObject {
         }
     }
 
+    private func rebuildTabLookup() {
+        var lookup: [UUID: Workspace] = [:]
+        lookup.reserveCapacity(tabs.count)
+        for tab in tabs {
+            lookup[tab.id] = tab
+        }
+        tabById = lookup
+    }
+
     private func updatePanelTitle(tabId: UUID, panelId: UUID, title: String) {
-        guard let tab = tabs.first(where: { $0.id == tabId }) else { return }
+        guard let tab = tabById[tabId] else { return }
         _ = tab.updatePanelTitle(panelId: panelId, title: title)
 
         if tab.focusedPanelId == panelId {
@@ -8624,30 +8634,8 @@ class TabManager: ObservableObject {
         }
     }
 
-    private static func stableTerminalPanelTitle(_ title: String) -> String {
-        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let first = trimmed.first,
-              terminalTitleSpinnerCharacters.contains(first) else {
-            return title
-        }
-
-        let afterSpinner = trimmed.index(after: trimmed.startIndex)
-        guard afterSpinner < trimmed.endIndex,
-              trimmed[afterSpinner].isWhitespace else {
-            return title
-        }
-
-        let remainderStart = trimmed[afterSpinner...].firstIndex { !$0.isWhitespace }
-        guard let remainderStart else { return title }
-        return String(trimmed[remainderStart...])
-    }
-
-    private static let terminalTitleSpinnerCharacters = Set<Character>(
-        "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
-    )
-
     func focusedSurfaceTitleDidChange(tabId: UUID) {
-        guard let tab = tabs.first(where: { $0.id == tabId }),
+        guard let tab = tabById[tabId],
               let focusedPanelId = tab.focusedPanelId,
               let title = tab.panelTitles[focusedPanelId] else { return }
         tab.applyProcessTitle(title)

--- a/Sources/WindowToolbarController.swift
+++ b/Sources/WindowToolbarController.swift
@@ -36,9 +36,14 @@ final class WindowToolbarController: NSObject, NSToolbarDelegate {
             forName: .ghosttyDidSetTitle,
             object: nil,
             queue: .main
-        ) { [weak self] _ in
+        ) { [weak self] notification in
             Task { @MainActor [weak self] in
-                self?.scheduleFocusedCommandTextUpdate()
+                guard let self,
+                      let tabId = notification.userInfo?[GhosttyNotificationKey.tabId] as? UUID,
+                      tabId == self.tabManager?.selectedTabId else {
+                    return
+                }
+                self.scheduleFocusedCommandTextUpdate()
             }
         })
 

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -12007,6 +12007,15 @@ final class Workspace: Identifiable, ObservableObject {
         self.title = title
     }
 
+    func alreadyReflectsPanelTitleUpdate(panelId: UUID, title: String) -> Bool {
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return true }
+        guard panelTitles[panelId] == trimmed else { return false }
+        guard focusedPanelId == panelId else { return true }
+        guard processTitle == trimmed else { return false }
+        return customTitle != nil || self.title == trimmed
+    }
+
     func setCustomColor(_ hex: String?) {
         if let hex {
             customColor = WorkspaceTabColorSettings.normalizedHex(hex)

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -610,7 +610,24 @@ final class TabManagerWorkspaceOwnershipTests: XCTestCase {
         XCTAssertNotEqual(workspace.panelTitles[splitPanel.id], Optional(workspace.title))
     }
 
-    func testCodexSpinnerTerminalTitlesCollapseToStablePanelTitle() throws {
+    @MainActor
+    func testTerminalSurfacePublishesOnlyStableSpinnerTitles() {
+        let surface = TerminalSurface(
+            tabId: UUID(),
+            context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
+            configTemplate: nil,
+            workingDirectory: nil
+        )
+
+        XCTAssertEqual(surface.publishableTerminalTitle("⠋ cmux-ctrixin"), "cmux-ctrixin")
+        XCTAssertNil(surface.publishableTerminalTitle("⠹ cmux-ctrixin"))
+        XCTAssertEqual(surface.publishableTerminalTitle("⠼ cmux-ctrixin build"), "cmux-ctrixin build")
+
+        surface.updateWorkspaceId(UUID())
+        XCTAssertEqual(surface.publishableTerminalTitle("⠙ cmux-ctrixin build"), "cmux-ctrixin build")
+    }
+
+    func testStableTerminalTitleNotificationsUpdatePanelTitle() throws {
         let manager = TabManager()
         let workspace = try XCTUnwrap(manager.selectedWorkspace)
         let focusedPanelId = try XCTUnwrap(workspace.focusedPanelId)
@@ -621,7 +638,7 @@ final class TabManagerWorkspaceOwnershipTests: XCTestCase {
             userInfo: [
                 GhosttyNotificationKey.tabId: workspace.id,
                 GhosttyNotificationKey.surfaceId: focusedPanelId,
-                GhosttyNotificationKey.title: "⠋ cmux-ctrixin"
+                GhosttyNotificationKey.title: "cmux-ctrixin"
             ]
         )
 
@@ -638,7 +655,7 @@ final class TabManagerWorkspaceOwnershipTests: XCTestCase {
             userInfo: [
                 GhosttyNotificationKey.tabId: workspace.id,
                 GhosttyNotificationKey.surfaceId: focusedPanelId,
-                GhosttyNotificationKey.title: "⠹ cmux-ctrixin"
+                GhosttyNotificationKey.title: "cmux-ctrixin"
             ]
         )
 
@@ -657,7 +674,7 @@ final class TabManagerWorkspaceOwnershipTests: XCTestCase {
             userInfo: [
                 GhosttyNotificationKey.tabId: workspace.id,
                 GhosttyNotificationKey.surfaceId: focusedPanelId,
-                GhosttyNotificationKey.title: "⠼ cmux-ctrixin"
+                GhosttyNotificationKey.title: "cmux-ctrixin"
             ]
         )
 

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -609,6 +609,65 @@ final class TabManagerWorkspaceOwnershipTests: XCTestCase {
         XCTAssertNil(workspace.customTitle)
         XCTAssertNotEqual(workspace.panelTitles[splitPanel.id], Optional(workspace.title))
     }
+
+    func testCodexSpinnerTerminalTitlesCollapseToStablePanelTitle() throws {
+        let manager = TabManager()
+        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let focusedPanelId = try XCTUnwrap(workspace.focusedPanelId)
+
+        NotificationCenter.default.post(
+            name: .ghosttyDidSetTitle,
+            object: nil,
+            userInfo: [
+                GhosttyNotificationKey.tabId: workspace.id,
+                GhosttyNotificationKey.surfaceId: focusedPanelId,
+                GhosttyNotificationKey.title: "⠋ cmux-ctrixin"
+            ]
+        )
+
+        XCTAssertTrue(
+            waitForCondition(timeout: 1.0) {
+                workspace.panelTitles[focusedPanelId] == "cmux-ctrixin" &&
+                    workspace.title == "cmux-ctrixin"
+            }
+        )
+
+        NotificationCenter.default.post(
+            name: .ghosttyDidSetTitle,
+            object: nil,
+            userInfo: [
+                GhosttyNotificationKey.tabId: workspace.id,
+                GhosttyNotificationKey.surfaceId: focusedPanelId,
+                GhosttyNotificationKey.title: "⠹ cmux-ctrixin"
+            ]
+        )
+
+        drainMainQueue()
+        XCTAssertTrue(
+            waitForCondition(timeout: 1.0) {
+                workspace.panelTitles[focusedPanelId] == "cmux-ctrixin" &&
+                    workspace.title == "cmux-ctrixin"
+            }
+        )
+
+        workspace.title = "stale title"
+        NotificationCenter.default.post(
+            name: .ghosttyDidSetTitle,
+            object: nil,
+            userInfo: [
+                GhosttyNotificationKey.tabId: workspace.id,
+                GhosttyNotificationKey.surfaceId: focusedPanelId,
+                GhosttyNotificationKey.title: "⠼ cmux-ctrixin"
+            ]
+        )
+
+        XCTAssertTrue(
+            waitForCondition(timeout: 1.0) {
+                workspace.panelTitles[focusedPanelId] == "cmux-ctrixin" &&
+                    workspace.title == "cmux-ctrixin"
+            }
+        )
+    }
 }
 
 @MainActor


### PR DESCRIPTION
## Summary

This is the focused hotfix split out of #4808 for the terminal-title spinner hang.

CLI tools such as Codex/QDex loading states and package managers can emit rapidly changing Braille spinner prefixes in the terminal title, for example `⠋ project`, `⠙ project`, `⠹ project`. Each frame currently fans out through `ghosttyDidSetTitle`, panel title updates, workspace/window title refreshes, and toolbar command text refreshes. Under sustained output this can saturate the main actor and swallow sidebar clicks.

## Changes

- Strip known spinner prefixes from terminal titles before publishing Ghostty title notifications.
- Deduplicate repeated publishable terminal titles at the `TerminalSurface` notification source.
- Deduplicate pending panel title updates when the workspace already reflects the stable title.
- Ignore title notifications for non-selected tabs in `WindowToolbarController`.
- Add a regression test that posts Codex-style spinner titles and verifies the workspace title collapses to the stable title.

## Validation

- `git diff --check`
- `./scripts/check-pbxproj.sh`
- `CMUX_SKIP_ZIG_BUILD=1 ./scripts/reload.sh --tag spinner-title-hotfix`

Note: local macOS 26.5 + Zig 0.15.2 cannot link the real Ghostty CLI helper, matching the existing upstream CI workaround, so the tagged build used `CMUX_SKIP_ZIG_BUILD=1` to validate the Swift/Xcode side.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5118"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782917209&installation_id=133855650&pr_number=5118&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5118&signature=774aa804bb10cdd2abedc15cc115faa65dab7617f0cf792f8262016d083381ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes UI stalls caused by spinner frames flooding terminal title updates. Spinner prefixes are stripped and titles are deduped at the source so noisy CLI loads no longer block the main thread.

- **Bug Fixes**
  - Normalize and dedupe spinner titles in `TerminalSurface`; strip Braille prefixes and publish only stable titles to `.`ghosttyDidSetTitle``.
  - Cache workspace lookup in `TabManager` and coalesce panel title updates; skip when the window/workspace already reflects the stable title.
  - Reset the title dedupe cache when a surface moves to a new workspace; keep updates actor-isolated on the main thread.
  - Update `WindowToolbarController` to only refresh toolbar command text for the selected tab; expand tests to cover spinner normalization and stable panel/window titles.

<sup>Written for commit fbb28e98ea89734e0dc522a5d711e5c2df959106. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More stable terminal titles: spinner/animated prefixes are normalized and empty/unchanged titles are suppressed.
  * Reduced duplicate title notifications and ensured title updates are applied only to the currently active tab.

* **Tests**
  * Added unit tests covering terminal title normalization and stable updates during animated spinner changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->