### PR TITLE
Back off PR refresh cadence for branches with no PR (#3136)

### DIFF
--- a/Packages/CmuxSidebarGit/Sources/CmuxSidebarGit/Hosting/SidebarGitHosting.swift
+++ b/Packages/CmuxSidebarGit/Sources/CmuxSidebarGit/Hosting/SidebarGitHosting.swift
@@ -55,6 +55,9 @@ public protocol SidebarGitHosting: AnyObject {
     /// Whether the panel is the focused panel of the selected workspace
     /// (drives the faster selected-panel PR poll cadence).
     func isSelectedFocusedPanel(workspaceId: UUID, panelId: UUID) -> Bool
+    /// The (workspace id, panel id) of the currently selected workspace's focused panel, if any. Used by the PR poll
+    /// service to recompute the focused-cadence deadline when the host's selection changes.
+    func selectedFocusedPanel() -> (workspaceId: UUID, panelId: UUID)?
 
     // MARK: Projection writes
 

--- a/Packages/CmuxSidebarGit/Sources/CmuxSidebarGit/Service/PullRequestPollService+Apply.swift
+++ b/Packages/CmuxSidebarGit/Sources/CmuxSidebarGit/Service/PullRequestPollService+Apply.swift
@@ -187,31 +187,101 @@ extension PullRequestPollService {
             workspacePullRequestLastTerminalStateRefreshAtByKey[key] = now
         }
 
-        if case .resolved(let resolvedPullRequest) = resolution,
-           let status = PullRequestStatus(rawValue: resolvedPullRequest.statusRawValue),
-           status != .open {
+        let outcome = classifyWorkspacePullRequestPollOutcome(key: key, resolution: resolution)
+        switch outcome {
+        case .terminalPullRequest:
             workspacePullRequestLastTerminalStateRefreshAtByKey[key] = now
-            workspacePullRequestNextPollAtByKey[key] = now.addingTimeInterval(PullRequestProbeService.terminalStateSweepInterval)
-            return
-        }
-
-        if case .transientFailure = resolution,
-           workspacePullRequestLastTerminalStateRefreshAtByKey[key] != nil {
-            workspacePullRequestNextPollAtByKey[key] = now.addingTimeInterval(PullRequestProbeService.terminalStateSweepInterval)
-            return
-        }
-
-        if case .unsupportedRepository = resolution {
+        case .openPullRequest, .noPullRequest, .unsupportedRepository:
             workspacePullRequestLastTerminalStateRefreshAtByKey.removeValue(forKey: key)
-            workspacePullRequestNextPollAtByKey[key] = now.addingTimeInterval(Self.jitteredPollInterval(base: Self.backgroundPollInterval))
+        case .transientFailure:
+            break
+        }
+        workspacePullRequestLastOutcomeByKey[key] = outcome
+
+        let isFocused = host?.isSelectedFocusedPanel(workspaceId: workspaceId, panelId: panelId) ?? false
+        workspacePullRequestNextPollAtByKey[key] = Self.nextWorkspacePullRequestPollAt(
+            from: now,
+            outcome: outcome,
+            isFocused: isFocused
+        )
+    }
+
+    func classifyWorkspacePullRequestPollOutcome(
+        key: WorkspaceGitProbeKey,
+        resolution: WorkspacePullRequestRefreshResult.Resolution
+    ) -> WorkspacePullRequestPollOutcome {
+        switch resolution {
+        case .resolved(let resolvedPullRequest):
+            if let status = PullRequestStatus(rawValue: resolvedPullRequest.statusRawValue),
+               status != .open {
+                return .terminalPullRequest
+            }
+            return .openPullRequest
+        case .notFound:
+            return .noPullRequest
+        case .unsupportedRepository:
+            return .unsupportedRepository
+        case .transientFailure:
+            return .transientFailure(hadTerminalState: workspacePullRequestLastTerminalStateRefreshAtByKey[key] != nil)
+        }
+    }
+
+    /// Brings the newly-focused panel's next-poll deadline forward when the focused cadence would fire sooner than
+    /// the previously scheduled (unfocused) deadline. Called by the host when its selection changes so the focused
+    /// cadence asymmetry takes effect immediately. The previously-focused key keeps its existing deadline — it fires
+    /// on the already-shorter focused schedule and is rescheduled to the unfocused cadence afterwards.
+    public func rescheduleWorkspacePullRequestPollsForFocusChange() {
+        guard let host, let (workspaceId, panelId) = host.selectedFocusedPanel() else { return }
+        let key = WorkspaceGitProbeKey(workspaceId: workspaceId, panelId: panelId)
+        guard let outcome = workspacePullRequestLastOutcomeByKey[key],
+              Self.workspacePullRequestPollOutcomeIsFocusSensitive(outcome) else { return }
+        let now = Date()
+        // The newly-selected workspace's focused panel is by definition focused — host.selectedFocusedPanel resolved it.
+        let target = Self.nextWorkspacePullRequestPollAt(from: now, outcome: outcome, isFocused: true)
+        if let current = workspacePullRequestNextPollAtByKey[key], current <= target {
             return
         }
+        workspacePullRequestNextPollAtByKey[key] = target
+        updateWorkspacePullRequestPollTimer()
+    }
 
-        workspacePullRequestLastTerminalStateRefreshAtByKey.removeValue(forKey: key)
-        let baseInterval = (host?.isSelectedFocusedPanel(workspaceId: workspaceId, panelId: panelId) ?? false)
-            ? Self.selectedPollInterval
-            : Self.backgroundPollInterval
-        workspacePullRequestNextPollAtByKey[key] = now.addingTimeInterval(Self.jitteredPollInterval(base: baseInterval))
+    nonisolated static func workspacePullRequestPollOutcomeIsFocusSensitive(
+        _ outcome: WorkspacePullRequestPollOutcome
+    ) -> Bool {
+        switch outcome {
+        case .openPullRequest, .transientFailure(hadTerminalState: false):
+            return true
+        case .terminalPullRequest, .noPullRequest, .unsupportedRepository, .transientFailure(hadTerminalState: true):
+            return false
+        }
+    }
+
+    /// Returns the next-poll Date for a key given its last classified outcome and current focus state. Jitter is
+    /// applied uniformly so simultaneous transitions (e.g. ten PRs merging in one sweep) don't converge on a single
+    /// wake-up.
+    nonisolated static func nextWorkspacePullRequestPollAt(
+        from now: Date,
+        outcome: WorkspacePullRequestPollOutcome,
+        isFocused: Bool
+    ) -> Date {
+        let base: TimeInterval
+        switch outcome {
+        case .terminalPullRequest:
+            base = PullRequestProbeService.terminalStateSweepInterval
+        case .transientFailure(let hadTerminalState):
+            if hadTerminalState {
+                base = PullRequestProbeService.terminalStateSweepInterval
+            } else {
+                base = isFocused ? workspacePullRequestTransientFailurePollInterval : backgroundPollInterval
+            }
+        case .noPullRequest:
+            base = workspacePullRequestNoPullRequestPollInterval
+        case .unsupportedRepository:
+            base = workspacePullRequestUnsupportedRepositoryPollInterval
+        case .openPullRequest:
+            base = isFocused ? selectedPollInterval : backgroundPollInterval
+        }
+        return now.addingTimeInterval(jitteredPollInterval(base: base))
     }
 
     // MARK: Tracking bookkeeping
@@ -221,6 +291,7 @@ extension PullRequestPollService {
         workspacePullRequestProbeStateByKey = workspacePullRequestProbeStateByKey.filter { validKeys.contains($0.key) }
         workspacePullRequestLastTerminalStateRefreshAtByKey = workspacePullRequestLastTerminalStateRefreshAtByKey.filter { validKeys.contains($0.key) }
         workspacePullRequestTransientFailureCountByKey = workspacePullRequestTransientFailureCountByKey.filter { validKeys.contains($0.key) }
+        workspacePullRequestLastOutcomeByKey = workspacePullRequestLastOutcomeByKey.filter { validKeys.contains($0.key) }
         let repoCacheCutoff = Date().addingTimeInterval(-Self.workspacePullRequestRepoCachePruneLifetime)
         workspacePullRequestRepoCacheBySlug = workspacePullRequestRepoCacheBySlug.filter {
             $0.value.fetchedAt >= repoCacheCutoff
@@ -233,6 +304,7 @@ extension PullRequestPollService {
         workspacePullRequestProbeStateByKey.removeValue(forKey: key)
         workspacePullRequestLastTerminalStateRefreshAtByKey.removeValue(forKey: key)
         workspacePullRequestTransientFailureCountByKey.removeValue(forKey: key)
+        workspacePullRequestLastOutcomeByKey.removeValue(forKey: key)
         updateWorkspacePullRequestPollTimer()
     }
 
@@ -247,6 +319,7 @@ extension PullRequestPollService {
         workspacePullRequestProbeStateByKey = workspacePullRequestProbeStateByKey.filter { $0.key.workspaceId != workspaceId }
         workspacePullRequestLastTerminalStateRefreshAtByKey = workspacePullRequestLastTerminalStateRefreshAtByKey.filter { $0.key.workspaceId != workspaceId }
         workspacePullRequestTransientFailureCountByKey = workspacePullRequestTransientFailureCountByKey.filter { $0.key.workspaceId != workspaceId }
+        workspacePullRequestLastOutcomeByKey = workspacePullRequestLastOutcomeByKey.filter { $0.key.workspaceId != workspaceId }
         updateWorkspacePullRequestPollTimer()
     }
 
@@ -271,6 +344,7 @@ extension PullRequestPollService {
         workspacePullRequestNextPollAtByKey.removeAll()
         workspacePullRequestLastTerminalStateRefreshAtByKey.removeAll()
         workspacePullRequestTransientFailureCountByKey.removeAll()
+        workspacePullRequestLastOutcomeByKey.removeAll()
         workspacePullRequestRepoCacheBySlug.removeAll()
         workspacePullRequestFollowUpShouldBypassRepoCache = false
         updateWorkspacePullRequestPollTimer()

--- a/Packages/CmuxSidebarGit/Sources/CmuxSidebarGit/Service/PullRequestPollService.swift
+++ b/Packages/CmuxSidebarGit/Sources/CmuxSidebarGit/Service/PullRequestPollService.swift
@@ -25,7 +25,14 @@ public final class PullRequestPollService: PullRequestProbing {
     // MARK: Tuning constants (legacy TabManager values, preserved exactly)
 
     nonisolated static let backgroundPollInterval: TimeInterval = 60
-    nonisolated static let selectedPollInterval: TimeInterval = 10
+    nonisolated static let selectedPollInterval: TimeInterval = 15
+    // No-PR branches gain a PR via local action that fires its own event-driven refresh, so poll rarely here (issue #3136).
+    // Coincides with backgroundPollInterval today but is intentionally its own constant: the no-PR rationale is
+    // event-driven coverage, not the unfocused-watch cadence, so the two are free to diverge.
+    nonisolated static let workspacePullRequestNoPullRequestPollInterval: TimeInterval = 60
+    nonisolated static let workspacePullRequestUnsupportedRepositoryPollInterval: TimeInterval = 5 * 60
+    // Transient failures keep their own short retry so they don't ride the open-PR cadence (which is intentionally relaxed to 15s).
+    nonisolated static let workspacePullRequestTransientFailurePollInterval: TimeInterval = 10
     nonisolated static let workspacePullRequestRepoCachePruneLifetime: TimeInterval = 60
     nonisolated static let workspacePullRequestPollJitterFraction = 0.10
     nonisolated static let workspacePullRequestRefreshBatchLimit = 3
@@ -52,6 +59,7 @@ public final class PullRequestPollService: PullRequestProbing {
     var workspacePullRequestNextPollAtByKey: [WorkspaceGitProbeKey: Date] = [:]
     var workspacePullRequestLastTerminalStateRefreshAtByKey: [WorkspaceGitProbeKey: Date] = [:]
     var workspacePullRequestTransientFailureCountByKey: [WorkspaceGitProbeKey: Int] = [:]
+    var workspacePullRequestLastOutcomeByKey: [WorkspaceGitProbeKey: WorkspacePullRequestPollOutcome] = [:]
     var workspacePullRequestRepoCacheBySlug: [String: WorkspacePullRequestRepoCacheEntry] = [:]
     var workspacePullRequestPollTask: Task<Void, Never>?
     var workspacePullRequestRefreshTask: Task<Void, Never>?

--- a/Packages/CmuxSidebarGit/Sources/CmuxSidebarGit/Service/PullRequestProbing.swift
+++ b/Packages/CmuxSidebarGit/Sources/CmuxSidebarGit/Service/PullRequestProbing.swift
@@ -36,6 +36,10 @@ public protocol PullRequestProbing: AnyObject {
     func clearWorkspacePullRequestTracking(workspaceId: UUID)
     /// Cancels any in-flight refresh and drops all tracking and caches.
     func resetWorkspacePullRequestRefreshState()
+    /// Brings the newly-focused panel's next-poll deadline forward when the focused cadence would fire sooner than
+    /// the previously scheduled (unfocused) deadline. Hosts call this when their selection changes so the
+    /// focused/unfocused asymmetry takes effect immediately instead of waiting out the prior poll.
+    func rescheduleWorkspacePullRequestPollsForFocusChange()
     /// Panel ids with any PR poll tracking state (test seam).
     func workspacePullRequestTrackedPanelIds(workspaceId: UUID) -> Set<UUID>
 }

--- a/Packages/CmuxSidebarGit/Sources/CmuxSidebarGit/Service/WorkspacePullRequestPollOutcome.swift
+++ b/Packages/CmuxSidebarGit/Sources/CmuxSidebarGit/Service/WorkspacePullRequestPollOutcome.swift
@@ -1,0 +1,11 @@
+public import Foundation
+
+/// The cadence-relevant classification of a PR refresh result. Persisted per probe key so the focus-change reschedule
+/// hook can recompute deadlines without rerunning the full classifier.
+public enum WorkspacePullRequestPollOutcome: Sendable, Equatable {
+    case openPullRequest
+    case terminalPullRequest
+    case noPullRequest
+    case unsupportedRepository
+    case transientFailure(hadTerminalState: Bool)
+}

--- a/Packages/CmuxSidebarGit/Tests/CmuxSidebarGitTests/PullRequestPollServiceTests.swift
+++ b/Packages/CmuxSidebarGit/Tests/CmuxSidebarGitTests/PullRequestPollServiceTests.swift
@@ -33,7 +33,7 @@ import CmuxGit
 
     /// A refresh against a panel whose directory resolves to no GitHub repo
     /// applies `unsupportedRepository` (badge cleared) and re-arms the poll
-    /// timer with the jittered background interval, floored at 0.25 seconds.
+    /// timer with the jittered 5-minute non-GitHub-repo interval, floored at 0.25 seconds.
     @Test func unsupportedRepositoryClearsBadgeAndArmsJitteredPollDeadline() async throws {
         let host = RecordingSidebarGitHost()
         host.pollingEnabled = true
@@ -60,11 +60,11 @@ import CmuxGit
         #expect(cleared)
         #expect(host.workspaces[0].state.panels[panelId]?.badge == nil)
 
-        // The next poll deadline: max(0.25, jittered 60s background interval).
+        // The next poll deadline: max(0.25, jittered 5-min non-GitHub-repo interval).
         await clock.waitForSleeper()
         let armed = try #require(await clock.lastRecordedDuration)
         #expect(armed >= 0.25)
-        #expect(armed <= 66.1)
+        #expect(armed <= 330.1)
         // The panel stays tracked for the next sweep.
         #expect(service.workspacePullRequestTrackedPanelIds(workspaceId: workspaceId) == [panelId])
     }

--- a/Packages/CmuxSidebarGit/Tests/CmuxSidebarGitTests/Support/Fakes.swift
+++ b/Packages/CmuxSidebarGit/Tests/CmuxSidebarGitTests/Support/Fakes.swift
@@ -65,6 +65,7 @@ final class RecordingPullRequestProbing: PullRequestProbing {
     func resetWorkspacePullRequestRefreshState() {
         resetCount += 1
     }
+    func rescheduleWorkspacePullRequestPollsForFocusChange() {}
     func workspacePullRequestTrackedPanelIds(workspaceId: UUID) -> Set<UUID> { [] }
 }
 

--- a/Packages/CmuxSidebarGit/Tests/CmuxSidebarGitTests/Support/RecordingSidebarGitHost.swift
+++ b/Packages/CmuxSidebarGit/Tests/CmuxSidebarGitTests/Support/RecordingSidebarGitHost.swift
@@ -112,6 +112,10 @@ final class RecordingSidebarGitHost: SidebarGitHosting {
     func isSelectedFocusedPanel(workspaceId: UUID, panelId: UUID) -> Bool {
         selectedWorkspaceId == workspaceId && state(workspaceId)?.focusedPanelId == panelId
     }
+    func selectedFocusedPanel() -> (workspaceId: UUID, panelId: UUID)? {
+        guard let selectedWorkspaceId, let panelId = state(selectedWorkspaceId)?.focusedPanelId else { return nil }
+        return (selectedWorkspaceId, panelId)
+    }
 
     // MARK: Writes
 

--- a/Sources/TabManager+SidebarGitHosting.swift
+++ b/Sources/TabManager+SidebarGitHosting.swift
@@ -79,7 +79,13 @@ extension TabManager: SidebarGitHosting {
     }
 
     func isSelectedFocusedPanel(workspaceId: UUID, panelId: UUID) -> Bool {
-        selectedWorkspace?.id == workspaceId && selectedWorkspace?.focusedPanelId == panelId
+        guard let selected = selectedWorkspace else { return false }
+        return selected.id == workspaceId && selected.focusedPanelId == panelId
+    }
+
+    func selectedFocusedPanel() -> (workspaceId: UUID, panelId: UUID)? {
+        guard let workspace = selectedWorkspace, let panelId = workspace.focusedPanelId else { return nil }
+        return (workspace.id, panelId)
     }
 
     // MARK: Projection writes

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -362,6 +362,7 @@ class TabManager: ObservableObject {
                 }
             }
             publishCmuxWorkspaceSelectedChange(from: previousTabId)
+            pullRequestProbing.rescheduleWorkspacePullRequestPollsForFocusChange()
             let notificationDismissalContext = notificationDismissal.takePendingSelectionContext() ?? .activeFocus
 #if DEBUG
             let switchId = debugWorkspaceSwitchId


### PR DESCRIPTION
## Summary

- Branches without a PR were re-polled at the same fast cadence as branches with an open PR (every 10s when focused), hammering the GitHub API. They rarely gain a PR without a local action (push, `gh pr create`), and those fire event-driven refreshes that bypass the periodic cadence — so back off to **60s for no-PR branches** and **5min for non-GitHub repos**. Focused open-PR cadence relaxes from **10s to 15s**.
- Classify refresh outcomes in one place (`classifyWorkspacePullRequestPollOutcome`) rather than splitting the mapping across two early-return guards plus a tail switch. Adding a new `Resolution` case now touches one site.
- Reschedule pending polls on `selectedTabId` change. The focused/unfocused cadence asymmetry took effect only on the *next* refresh; now focus changes recompute target `nextPollAt` immediately, so Cmd-Tab into an open-PR workspace honors the 15s focused cadence without waiting out the prior 60s. (Within-tab panel focus changes are still not hooked; noted in the doc comment.)
- Centralize jitter inside `nextWorkspacePullRequestPollAt` so all cadence paths spread load, including terminal-sweep transitions (previously un-jittered, prone to thundering-herd on bulk merges).
- Keep transient-failure retries on a dedicated 10s constant so they don't ride the (now slower) open-PR cadence change.
- `isSelectedFocusedPanel` reads `selectedWorkspace` once instead of twice.

Fixes #3136.

## Test plan

- [ ] `./scripts/reload.sh --tag fix-pr-poll-3136` builds cleanly
- [ ] Open workspace with an open PR: badge refreshes ~every 15s when focused, ~60s when unfocused
- [ ] Open workspace with no PR: badge refresh quiets to ~60s regardless of focus
- [ ] Open non-GitHub workspace: PR probe quiets to ~5min
- [ ] Cmd-Tab from an unfocused-scheduled workspace into it: next refresh fires within 15s (focused cadence), not 60s
- [ ] Run `gh pr create` in the integrated terminal of a no-PR workspace: PR badge appears via the event-driven refresh path (not the 60s periodic)
- [ ] Bulk-merge multiple PRs: re-poll wake-ups are spread across the jitter window rather than firing simultaneously

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782928929&installation_id=133855650&pr_number=5125&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5125&signature=c3f69fab19719fabbe385f7eb63ab5e24d9ef525341b695628759f8297ca4a71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backed off PR refresh polling to reduce GitHub API load and make focus changes apply immediately. No-PR branches poll every 60s, non-GitHub repos every 5m, and open PRs every 15s when focused (60s unfocused). Fixes #3136.

- **Bug Fixes**
  - Outcome-based intervals: no PR 60s, unsupported repo 5m, open PR 15s focused / 60s unfocused.
  - Recompute next poll on selection change; newly focused panel’s deadline is pulled forward.
  - Add jitter to all paths, including terminal-state sweeps; transient failures retry at 10s (or sweep interval if previously terminal).

- **Refactors**
  - Centralize classification and scheduling in `classifyWorkspacePullRequestPollOutcome` and `nextWorkspacePullRequestPollAt`; add `WorkspacePullRequestPollOutcome`.
  - Track last outcome per key for rescheduling and pruning; add `selectedFocusedPanel()` and invoke reschedule on workspace selection.

<sup>Written for commit ce6437390df51e92ce87ae24b6a0672a1b64bdcf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Polling for GitHub PRs is now focus-aware: active/focused PR tabs refresh more responsively while background or unsupported views poll less frequently to save resources.
  * Switching tabs triggers an immediate reschedule so the newly viewed PRs refresh promptly.

* **Bug Fixes**
  * Improved cleanup of polling state to avoid stale or duplicate refreshes after panel/workspace changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->