### PR TITLE
Clear stuck agent "Running" badge when the shell returns to its prompt

### DIFF
--- a/Sources/Workspace+PanelLifecycle.swift
+++ b/Sources/Workspace+PanelLifecycle.swift
@@ -247,6 +247,67 @@ extension Workspace {
         recomputeListeningPorts()
     }
 
+    /// Retire a panel's stale structured-agent "Running" status once the shell
+    /// returns to its prompt.
+    ///
+    /// Structured agents (claude_code, codex, …) run as the shell's foreground
+    /// process, so the integration only reports `promptIdle` after the agent
+    /// process has exited. Hooks normally clear the status/lifecycle on
+    /// Stop/SessionEnd, but abnormal exits (SIGKILL, crash, the 1s SessionEnd
+    /// hook timeout, a SessionEnd with no session_id, nested-subagent
+    /// suppression) can leave the sidebar pill stuck on "Running". This is the
+    /// app-side safety net the hooks lack: when the prompt returns, clear any
+    /// structured runtime for this panel whose tracked process is no longer
+    /// alive (or that never recorded a PID to probe).
+    @discardableResult
+    func reconcileStuckAgentStatusOnPromptIdle(panelId: UUID) -> Bool {
+        let pidKeys = agentPIDKeysByPanelId[panelId] ?? []
+        let structuredPIDStatusKeys = Set(
+            pidKeys
+                .filter { isStructuredAgentHookPIDKey($0) }
+                .map { agentStatusKey(forAgentPIDKey: $0) }
+        )
+
+        var didChange = false
+        for key in pidKeys where isStructuredAgentHookPIDKey(key) {
+            if let pid = agentPIDs[key], Self.isAgentProcessAlive(pid) {
+                continue
+            }
+            if clearAgentPID(key: key, panelId: panelId, clearStatus: true, refreshPorts: false) {
+                didChange = true
+            }
+        }
+
+        // Structured lifecycle/status set without an owning PID key (the
+        // set_agent_pid hook never recorded a PID, so there is nothing to
+        // probe). promptIdle alone is enough to retire it.
+        let orphanLifecycleKeys = (agentLifecycleStatesByPanelId[panelId].map { Array($0.keys) } ?? [])
+            .filter { Self.structuredAgentHookStatusKeys.contains($0) && !structuredPIDStatusKeys.contains($0) }
+        for key in orphanLifecycleKeys {
+            if clearAgentLifecycle(key: key, panelId: panelId) {
+                didChange = true
+            }
+            if !hasAgentRuntime(forStatusKey: key),
+               statusEntries.removeValue(forKey: key) != nil {
+                didChange = true
+            }
+        }
+
+        if didChange {
+            refreshTrackedAgentPorts()
+        }
+        return didChange
+    }
+
+    private static func isAgentProcessAlive(_ pid: pid_t) -> Bool {
+        guard pid > 0 else { return false }
+        if kill(pid, 0) == 0 {
+            return true
+        }
+        // EPERM means the process exists but is owned by another user.
+        return errno == EPERM
+    }
+
     @discardableResult
     private func discardAgentRuntimeState(_ runtimeState: DetachedAgentRuntimeState?) -> Bool {
         guard let runtimeState else { return false }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -10984,6 +10984,9 @@ final class Workspace: Identifiable, ObservableObject {
                 shellState: state
             )
         }
+        if state == .promptIdle {
+            reconcileStuckAgentStatusOnPromptIdle(panelId: panelId)
+        }
 #if DEBUG
         cmuxDebugLog(
             "surface.shellState workspace=\(id.uuidString.prefix(5)) " +

--- a/cmuxTests/AgentHibernationTests.swift
+++ b/cmuxTests/AgentHibernationTests.swift
@@ -282,6 +282,82 @@ final class AgentHibernationTests: XCTestCase {
         XCTAssertEqual(workspace.agentHibernationLifecycleState(panelId: secondPanelId, fallback: nil), .running)
     }
 
+    /// Launch and reap a throwaway process so we get a PID that is guaranteed
+    /// dead by the time the test probes it.
+    private func deadProcessPID() throws -> pid_t {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/true")
+        try process.run()
+        process.waitUntilExit()
+        return process.processIdentifier
+    }
+
+    @MainActor
+    func testPromptIdleClearsStuckRunningStatusWhenAgentProcessDead() throws {
+        let workspace = Workspace()
+        let panelId = try XCTUnwrap(workspace.focusedPanelId)
+        let deadPID = try deadProcessPID()
+
+        workspace.statusEntries["claude_code"] = SidebarStatusEntry(
+            key: "claude_code",
+            value: "Running",
+            icon: "bolt.fill",
+            color: "#4C8DFF"
+        )
+        workspace.recordAgentPID(key: "claude_code.session", pid: deadPID, panelId: panelId, refreshPorts: false)
+        workspace.setAgentLifecycle(key: "claude_code", panelId: panelId, lifecycle: .running)
+
+        workspace.updatePanelShellActivityState(panelId: panelId, state: .promptIdle)
+
+        XCTAssertNil(workspace.statusEntries["claude_code"], "stale Running pill should be cleared")
+        XCTAssertEqual(workspace.agentHibernationLifecycleState(panelId: panelId, fallback: nil), .unknown)
+        XCTAssertNil(workspace.agentPIDs["claude_code.session"])
+    }
+
+    @MainActor
+    func testPromptIdleClearsOrphanedRunningStatusWithoutTrackedPID() throws {
+        let workspace = Workspace()
+        let panelId = try XCTUnwrap(workspace.focusedPanelId)
+
+        // Status + lifecycle were reported but the set_agent_pid hook never
+        // recorded a PID, so there is no process to probe.
+        workspace.statusEntries["claude_code"] = SidebarStatusEntry(
+            key: "claude_code",
+            value: "Running",
+            icon: "bolt.fill",
+            color: "#4C8DFF"
+        )
+        workspace.setAgentLifecycle(key: "claude_code", panelId: panelId, lifecycle: .running)
+
+        workspace.updatePanelShellActivityState(panelId: panelId, state: .promptIdle)
+
+        XCTAssertNil(workspace.statusEntries["claude_code"])
+        XCTAssertEqual(workspace.agentHibernationLifecycleState(panelId: panelId, fallback: nil), .unknown)
+    }
+
+    @MainActor
+    func testPromptIdleKeepsRunningStatusWhileAgentProcessAlive() throws {
+        let workspace = Workspace()
+        let panelId = try XCTUnwrap(workspace.focusedPanelId)
+
+        // The test runner process is unambiguously alive.
+        let livePID = ProcessInfo.processInfo.processIdentifier
+        workspace.statusEntries["claude_code"] = SidebarStatusEntry(
+            key: "claude_code",
+            value: "Running",
+            icon: "bolt.fill",
+            color: "#4C8DFF"
+        )
+        workspace.recordAgentPID(key: "claude_code.session", pid: livePID, panelId: panelId, refreshPorts: false)
+        workspace.setAgentLifecycle(key: "claude_code", panelId: panelId, lifecycle: .running)
+
+        workspace.updatePanelShellActivityState(panelId: panelId, state: .promptIdle)
+
+        XCTAssertNotNil(workspace.statusEntries["claude_code"], "a live agent's status must not be cleared")
+        XCTAssertEqual(workspace.agentHibernationLifecycleState(panelId: panelId, fallback: nil), .running)
+        XCTAssertEqual(workspace.agentPIDs["claude_code.session"], livePID)
+    }
+
     func testSessionIndexLoadsAgentLifecycleFromHookStore() throws {
         let home = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-agent-hibernation-index-\(UUID().uuidString)", isDirectory: true)


### PR DESCRIPTION
## Problem

The sidebar shows a stuck **⚡ Running** badge on a workspace whose agent is no longer running — the terminal sits idle at the shell prompt, but the pill never clears.

![stale Running badge: workspace shows ⚡ Running while the terminal is idle at the shell prompt]

### Root cause

The structured-agent status pill (`claude_code` "Running", and the matching hibernation lifecycle) is **entirely hook-driven**. The bundled agent wrapper installs hooks that send the app:

```
set_status claude_code Running --icon=bolt.fill --color=#4C8DFF …
set_agent_lifecycle claude_code running …
set_agent_pid claude_code.<sessionId> <pid> …
```

It is only ever cleared by:
1. a hook event — `Stop` (→ idle) or `SessionEnd` (→ `clear_agent_pid … --clear-status`), or
2. the tab/panel closing.

There is **no app-side liveness check**. So any abnormal agent exit that skips a clean `SessionEnd` leaves the badge stuck on "Running" until the tab is closed or the app restarts:

- `kill -9` / crash (no hook fires at all)
- the `SessionEnd` hook's **1-second** timeout elapses
- a `SessionEnd` with no `session_id` (the CLI can't resolve the record to clear)
- nested-subagent visible-mutation suppression

`AgentHibernationController` polls every 30s but only *hibernates idle agents* — it never retires a stale status.

## Fix

Add the app-side safety net the hooks lack. Structured agents run as the shell's **foreground** process, so cmux's shell integration only reports `promptIdle` *after* the agent process exits (zsh `precmd`, `cmux-zsh-integration.zsh`). That is a reliable "the foreground agent is gone" signal — it cannot fire mid-session.

On a `promptIdle` transition, `Workspace.reconcileStuckAgentStatusOnPromptIdle(panelId:)` reconciles the panel's structured-agent status. It is **PID-liveness gated**:

- clear the status / lifecycle / tracked PID only when the tracked agent PID is **dead** (`kill(pid, 0)`);
- fall back to clearing entries that never recorded a PID to probe;
- **leave untouched** a genuinely live agent, and a status key shared with a still-running agent on another panel (`hasAgentRuntime` guard).

This only runs on command-boundary transitions (not the typing hot path), and `kill(pid, 0)` is cheap.

## Tests

Behavior-level tests in `cmuxTests/AgentHibernationTests.swift` (drive a real `Workspace` through `updatePanelShellActivityState(.promptIdle)`):

- `testPromptIdleClearsStuckRunningStatusWhenAgentProcessDead` — the core repro (reaps `/usr/bin/true` for a guaranteed-dead PID).
- `testPromptIdleClearsOrphanedRunningStatusWithoutTrackedPID` — the no-PID fallback.
- `testPromptIdleKeepsRunningStatusWhileAgentProcessAlive` — guards against over-clearing a live agent.

Per the repo's two-commit regression policy, the tests land first (red) and the fix second (green):
1. `Add failing tests for stuck agent "Running" badge on shell prompt return`
2. `Clear stuck agent "Running" badge when the shell returns to its prompt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5129"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782931402&installation_id=133855650&pr_number=5129&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5129&signature=481246c9b562c96c17697e068fa885197a9e8e8843a0b256a35cb86e786a064c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the stuck "⚡ Running" badge by clearing it when the terminal returns to the shell prompt. Uses a PID liveness check to only clear crashed or terminated agents, not live ones.

- **Bug Fixes**
  - On `promptIdle`, call `Workspace.reconcileStuckAgentStatusOnPromptIdle(panelId:)` to reconcile structured-agent state.
  - Clear status/lifecycle and tracked PID only if the recorded PID is dead (`kill(pid, 0)`), or if no PID was recorded.
  - Leave live agents and statuses shared with another panel intact; refresh tracked ports after changes.
  - Added behavior tests for dead PID, missing PID, and live PID cases.

<sup>Written for commit 4b984255a3c30d8a47985dbd1851a30dae2e0a0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed issue where agent status could remain stuck on "Running" after abnormal termination. The sidebar now properly clears stale status entries and refreshes agent information when the shell prompt returns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->