### PR TITLE
fix(cmuxd-remote): avoid E2BIG when startup script exceeds MAX_ARG_STRLEN

### DIFF
--- a/daemon/remote/cmd/cmuxd-remote/ws_pty.go
+++ b/daemon/remote/cmd/cmuxd-remote/ws_pty.go
@@ -146,6 +146,7 @@ type wsPTYSession struct {
 	id             string
 	key            wsPTYSessionKey
 	cmd            *exec.Cmd
+	tmpScript      string // temp file path for large startup scripts; cleaned up on exit
 	ptyFile        *os.File
 	ttyFile        *os.File
 	attachments    map[string]*wsPTYAttachment
@@ -711,8 +712,25 @@ func (h *wsPTYHub) startSessionLocked(sessionKey wsPTYSessionKey, sessionID stri
 	shellPath := resolvePTYShell(h.shell)
 	trimmedCommand := strings.TrimSpace(command)
 	var cmd *exec.Cmd
+	var tmpScript string
 	if trimmedCommand == "" {
 		cmd = exec.Command(shellPath)
+	} else if len(trimmedCommand) > 120*1024 {
+		// Startup script exceeds Linux's MAX_ARG_STRLEN (~128KB). Write to a
+		// temp file and exec /bin/sh <file> to avoid E2BIG from execve.
+		f, err := os.CreateTemp("", "cmuxd-startup-*.sh")
+		if err != nil {
+			return nil, fmt.Errorf("could not create startup script temp file: %w", err)
+		}
+		tmpScript = f.Name()
+		if _, err := f.WriteString(trimmedCommand); err != nil {
+			_ = f.Close()
+			_ = os.Remove(tmpScript)
+			return nil, fmt.Errorf("could not write startup script: %w", err)
+		}
+		_ = f.Chmod(0o700)
+		_ = f.Close()
+		cmd = exec.Command("/bin/sh", tmpScript)
 	} else {
 		cmd = exec.Command("/bin/sh", "-c", trimmedCommand)
 	}
@@ -725,6 +743,7 @@ func (h *wsPTYHub) startSessionLocked(sessionKey wsPTYSessionKey, sessionID stri
 		id:            sessionID,
 		key:           sessionKey,
 		cmd:           cmd,
+		tmpScript:     tmpScript,
 		ptyFile:       ptyFile,
 		ttyFile:       ttyFile,
 		attachments:   map[string]*wsPTYAttachment{},
@@ -989,6 +1008,9 @@ func (h *wsPTYHub) sessionSnapshotLocked(session *wsPTYSession) map[string]any {
 func (h *wsPTYHub) waitSessionProcess(session *wsPTYSession) {
 	if session.cmd != nil {
 		_ = session.cmd.Wait()
+	}
+	if session.tmpScript != "" {
+		_ = os.Remove(session.tmpScript)
 	}
 	session.closeTTYFile()
 }

--- a/daemon/remote/cmd/cmuxd-remote/ws_pty.go
+++ b/daemon/remote/cmd/cmuxd-remote/ws_pty.go
@@ -728,7 +728,7 @@ func (h *wsPTYHub) startSessionLocked(sessionKey wsPTYSessionKey, sessionID stri
 			_ = os.Remove(tmpScript)
 			return nil, fmt.Errorf("could not write startup script: %w", err)
 		}
-		_ = f.Chmod(0o700)
+		_ = f.Chmod(0o400)
 		_ = f.Close()
 		cmd = exec.Command("/bin/sh", tmpScript)
 	} else {

--- a/daemon/remote/cmd/cmuxd-remote/ws_pty.go
+++ b/daemon/remote/cmd/cmuxd-remote/ws_pty.go
@@ -737,6 +737,9 @@ func (h *wsPTYHub) startSessionLocked(sessionKey wsPTYSessionKey, sessionID stri
 	cmd.Env = defaultWebSocketPTYEnv(shellPath)
 	ptyFile, ttyFile, err := startPTYCommand(cmd, cols, rows)
 	if err != nil {
+		if tmpScript != "" {
+			_ = os.Remove(tmpScript)
+		}
 		return nil, err
 	}
 	session := &wsPTYSession{


### PR DESCRIPTION
## Problem

Linux's `execve(2)` rejects any single argument longer than `MAX_ARG_STRLEN` (~128KB per argument). cmux embeds shell integration inline as a startup command passed to `/bin/sh -c <command>`. This script is ~135KB, which exceeds the limit and causes PTY sessions to fail with:

```
fork/exec /bin/sh: argument list too long
```

This affects `cmux ssh` sessions into Linux containers and VMs.

## Fix

When the trimmed startup command exceeds 120KB, write it to a temp file and exec `/bin/sh <file>` instead of passing it as a `-c` argument. The temp file is removed when the session process exits.

The 120KB threshold gives an 8KB buffer below the kernel limit while still handling all normal (short) commands through the existing path.

## Testing

Reproduced against a Debian bookworm container over `cmux ssh`. Session previously failed immediately; with this patch PTY sessions establish successfully.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5133"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782939302&installation_id=133855650&pr_number=5133&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5133&signature=8ecfe40d10ce2a0e776f4f99e212e64ff467a8c366731c3fb713c5c43243c58f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix PTY startup failures on Linux by avoiding E2BIG when the inline startup script exceeds `MAX_ARG_STRLEN`. Large scripts are written to a temp file and run via `/bin/sh <file>`, so `cmux ssh` sessions work again.

- **Bug Fixes**
  - Detect commands >120KB and write to a temp file (chmod 0400).
  - Run `/bin/sh <file>` instead of `/bin/sh -c <command>`.
  - Remove the temp file on `startPTYCommand` errors and after the session process exits.

<sup>Written for commit 9d440d3ebf5584aebe26714d0312017cada56eb6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed failures when starting terminal sessions with very large startup commands (≈120KB+); such commands are now executed reliably using an alternate handling method.
  * Ensured temporary artifacts created for large commands are cleaned up after the session ends to avoid leftover files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->