### PR TITLE
Align Hermes hook dispatch with Grok

### DIFF
--- a/CLI/CMUXCLI+AgentHookDefinitions.swift
+++ b/CLI/CMUXCLI+AgentHookDefinitions.swift
@@ -64,6 +64,12 @@ extension CMUXCLI {
             let cmuxSubcommand: String
         }
 
+        struct HookInstallSpec {
+            let agentEvent: String
+            let command: String
+            let timeoutMs: Int
+        }
+
         enum PostInstallAction {
             case codexConfigToml // write codex_hooks = true to config.toml on install, remove on uninstall
         }
@@ -284,7 +290,7 @@ extension CMUXCLI {
             events: [
                 .init(agentEvent: "on_session_start", cmuxSubcommand: "session-start"),
                 .init(agentEvent: "pre_llm_call", cmuxSubcommand: "prompt-submit"),
-                .init(agentEvent: "post_llm_call", cmuxSubcommand: "agent-response"),
+                .init(agentEvent: "post_llm_call", cmuxSubcommand: "stop"),
                 .init(agentEvent: "pre_approval_request", cmuxSubcommand: "notification"),
                 .init(agentEvent: "post_approval_response", cmuxSubcommand: "approval-response"),
                 .init(agentEvent: "on_session_end", cmuxSubcommand: "session-end"),
@@ -366,6 +372,43 @@ extension CMUXCLI {
         default:
             return agentHookShellCommand("cmux hooks feed --source \(def.name) --event \(agentEvent)", for: def)
         }
+    }
+
+    static func hookInstallSpecs(for def: AgentHookDef) -> [AgentHookDef.HookInstallSpec] {
+        let lifecycleTimeoutMs = lifecycleHookTimeoutMs(for: def)
+        let lifecycleSpecs = def.events.map { event in
+            AgentHookDef.HookInstallSpec(
+                agentEvent: event.agentEvent,
+                command: hookCommandString(for: def, event: event),
+                timeoutMs: lifecycleTimeoutMs
+            )
+        }
+        let feedSpecs = def.feedHookEvents.map { agentEvent in
+            AgentHookDef.HookInstallSpec(
+                agentEvent: agentEvent,
+                command: feedHookCommandString(for: def, agentEvent: agentEvent),
+                timeoutMs: 120_000
+            )
+        }
+        return lifecycleSpecs + feedSpecs
+    }
+
+    private static func lifecycleHookTimeoutMs(for def: AgentHookDef) -> Int {
+        switch def.format {
+        case .flat, .rovoDevYAML:
+            return 5_000
+        case .nested(let timeoutMs), .kiroAgentJSON(let timeoutMs):
+            return max(timeoutMs, 1)
+        case .antigravityJSON(let timeoutSeconds):
+            return max(timeoutSeconds, 1) * 1_000
+        case .hermesAgentYAML:
+            return 5_000
+        }
+    }
+
+    static func hookTimeoutSeconds(fromMilliseconds timeoutMs: Int) -> Int {
+        let positiveTimeoutMs = max(timeoutMs, 1)
+        return ((positiveTimeoutMs - 1) / 1000) + 1
     }
 
     private static let pinnedHookMarkers: [String: String] = [

--- a/CLI/CMUXCLI+AgentHookDefinitions.swift
+++ b/CLI/CMUXCLI+AgentHookDefinitions.swift
@@ -368,8 +368,11 @@ extension CMUXCLI {
         }
     }
 
-    private static let grokPinnedHookMarker = "cmux-grok-hook-v2"
-    private static let antigravityPinnedHookMarker = "cmux-antigravity-hook-v2"
+    private static let pinnedHookMarkers: [String: String] = [
+        "grok": "cmux-grok-hook-v2",
+        "antigravity": "cmux-antigravity-hook-v2",
+        "hermes-agent": "cmux-hermes-agent-hook-v2",
+    ]
 
     private static func agentHookShellCommand(_ command: String, for def: AgentHookDef) -> String {
         if usesPinnedHookDispatch(def) {
@@ -385,11 +388,11 @@ extension CMUXCLI {
     }
 
     private static func usesPinnedHookDispatch(_ def: AgentHookDef) -> Bool {
-        def.name == "grok" || def.name == "antigravity"
+        pinnedHookMarker(for: def) != nil
     }
 
-    private static func pinnedHookMarker(for def: AgentHookDef) -> String {
-        def.name == "antigravity" ? antigravityPinnedHookMarker : grokPinnedHookMarker
+    private static func pinnedHookMarker(for def: AgentHookDef) -> String? {
+        pinnedHookMarkers[def.name]
     }
 
     private static func pinnedAgentHookShellCommand(_ command: String, for def: AgentHookDef) -> String {
@@ -431,7 +434,8 @@ extension CMUXCLI {
         } else {
             dispatch = "command -v cmux >/dev/null 2>&1 && \(fallbackInvocation) || echo '{}'"
         }
-        return ": \(pinnedHookMarker(for: def)); \(shellTraceStart); printenv \(def.disableEnvVar) | grep -qx 1 && { \(shellTraceDisabled); echo '{}'; } || { \(dispatch); cmux_hook_status=$?; \(shellTraceExit); exit $cmux_hook_status; }"
+        let marker = pinnedHookMarker(for: def) ?? def.hookMarker
+        return ": \(marker); \(shellTraceStart); printenv \(def.disableEnvVar) | grep -qx 1 && { \(shellTraceDisabled); echo '{}'; } || { \(dispatch); cmux_hook_status=$?; \(shellTraceExit); exit $cmux_hook_status; }"
     }
 
     private static func pinnedHookInvocation(
@@ -541,7 +545,7 @@ extension CMUXCLI {
     }
 
     static func isCmuxOwnedHookCommand(_ command: String, for def: AgentHookDef, includeLegacy: Bool = true) -> Bool {
-        if usesPinnedHookDispatch(def), command.contains(pinnedHookMarker(for: def)) {
+        if let marker = pinnedHookMarker(for: def), command.contains(marker) {
             return true
         }
         if def.events.contains(where: { hookCommandString(for: def, event: $0) == command })

--- a/CLI/CMUXCLI+HermesAgentHooks.swift
+++ b/CLI/CMUXCLI+HermesAgentHooks.swift
@@ -7,21 +7,13 @@ extension CMUXCLI {
     }
 
     func hermesAgentEvents(def: AgentHookDef) -> [HermesAgentHookConfig.Event] {
-        var events = def.events.map { event in
+        Self.hookInstallSpecs(for: def).map { spec in
             HermesAgentHookConfig.Event(
-                name: event.agentEvent,
-                command: hermesAgentShellCommand(hookCommand(for: def, event: event)),
-                timeout: 5
+                name: spec.agentEvent,
+                command: hermesAgentShellCommand(spec.command),
+                timeout: Self.hookTimeoutSeconds(fromMilliseconds: spec.timeoutMs)
             )
         }
-        events.append(contentsOf: def.feedHookEvents.map { agentEvent in
-            HermesAgentHookConfig.Event(
-                name: agentEvent,
-                command: hermesAgentShellCommand(feedHookCommand(for: def, agentEvent: agentEvent)),
-                timeout: 120
-            )
-        })
-        return events
     }
 
     func installHermesAgentHooks(_ def: AgentHookDef) throws {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -24735,73 +24735,34 @@ struct CMUXCLI {
 
     private func buildHooksDict(for def: AgentHookDef) -> [String: Any] {
         var result: [String: Any] = [:]
-        for event in def.events {
-            let cmd = hookCommand(for: def, event: event)
+        for spec in Self.hookInstallSpecs(for: def) {
             switch def.format {
             case .flat:
-                var entries = result[event.agentEvent] as? [[String: Any]] ?? []
-                entries.append(["command": cmd])
-                result[event.agentEvent] = entries
-            case .kiroAgentJSON(let timeoutMs):
-                var entries = result[event.agentEvent] as? [[String: Any]] ?? []
-                entries.append([
-                    "command": cmd,
-                    "timeout_ms": max(timeoutMs, 1),
-                ] as [String: Any])
-                result[event.agentEvent] = entries
-            case .nested(let timeoutMs):
-                var groups = result[event.agentEvent] as? [[String: Any]] ?? []
-                let timeout = nestedHookTimeout(timeoutMs, for: def)
-                groups.append([
-                    "hooks": [["type": "command", "command": cmd, "timeout": timeout] as [String: Any]]
-                ] as [String: Any])
-                result[event.agentEvent] = groups
-            case .antigravityJSON(let timeoutSeconds):
-                var entries = result[event.agentEvent] as? [[String: Any]] ?? []
-                entries.append(Self.antigravityHookEntry(
-                    command: cmd,
-                    timeoutSeconds: timeoutSeconds,
-                    eventName: event.agentEvent
-                ))
-                result[event.agentEvent] = entries
-            case .rovoDevYAML, .hermesAgentYAML:
-                break
-            }
-        }
-        // Layer in Feed bridge entries with a long timeout so blocking
-        // user decisions don't trip the agent's default per-event timeout.
-        // Most nested agents use milliseconds; Grok's and Antigravity's
-        // current hook schemas use seconds, so normalize before writing.
-        let feedTimeoutMs = 120_000
-        for agentEvent in def.feedHookEvents {
-            let feedCmd = feedHookCommand(for: def, agentEvent: agentEvent)
-            switch def.format {
-            case .flat:
-                var entries = result[agentEvent] as? [[String: Any]] ?? []
-                entries.append(["command": feedCmd])
-                result[agentEvent] = entries
+                var entries = result[spec.agentEvent] as? [[String: Any]] ?? []
+                entries.append(["command": spec.command])
+                result[spec.agentEvent] = entries
             case .kiroAgentJSON:
-                var entries = result[agentEvent] as? [[String: Any]] ?? []
+                var entries = result[spec.agentEvent] as? [[String: Any]] ?? []
                 entries.append([
-                    "command": feedCmd,
-                    "timeout_ms": feedTimeoutMs,
+                    "command": spec.command,
+                    "timeout_ms": spec.timeoutMs,
                 ] as [String: Any])
-                result[agentEvent] = entries
+                result[spec.agentEvent] = entries
             case .nested:
-                var groups = result[agentEvent] as? [[String: Any]] ?? []
-                let timeout = nestedHookTimeout(feedTimeoutMs, for: def)
+                var groups = result[spec.agentEvent] as? [[String: Any]] ?? []
+                let timeout = nestedHookTimeout(spec.timeoutMs, for: def)
                 groups.append([
-                    "hooks": [["type": "command", "command": feedCmd, "timeout": timeout] as [String: Any]]
+                    "hooks": [["type": "command", "command": spec.command, "timeout": timeout] as [String: Any]]
                 ] as [String: Any])
-                result[agentEvent] = groups
+                result[spec.agentEvent] = groups
             case .antigravityJSON:
-                var entries = result[agentEvent] as? [[String: Any]] ?? []
+                var entries = result[spec.agentEvent] as? [[String: Any]] ?? []
                 entries.append(Self.antigravityHookEntry(
-                    command: feedCmd,
-                    timeoutSeconds: Self.timeoutSecondsFromMilliseconds(feedTimeoutMs),
-                    eventName: agentEvent
+                    command: spec.command,
+                    timeoutSeconds: Self.hookTimeoutSeconds(fromMilliseconds: spec.timeoutMs),
+                    eventName: spec.agentEvent
                 ))
-                result[agentEvent] = entries
+                result[spec.agentEvent] = entries
             case .rovoDevYAML, .hermesAgentYAML:
                 break
             }
@@ -24811,12 +24772,7 @@ struct CMUXCLI {
 
     private func nestedHookTimeout(_ timeoutMs: Int, for def: AgentHookDef) -> Int {
         guard def.name == "grok" else { return timeoutMs }
-        return Self.timeoutSecondsFromMilliseconds(timeoutMs)
-    }
-
-    private static func timeoutSecondsFromMilliseconds(_ timeoutMs: Int) -> Int {
-        let positiveTimeoutMs = max(timeoutMs, 1)
-        return ((positiveTimeoutMs - 1) / 1000) + 1
+        return Self.hookTimeoutSeconds(fromMilliseconds: timeoutMs)
     }
 
     private static func antigravityHookEntry(

--- a/cmuxTests/CLIGenericHookPersistenceTests.swift
+++ b/cmuxTests/CLIGenericHookPersistenceTests.swift
@@ -2874,6 +2874,8 @@ extension CLINotifyProcessIntegrationRegressionTests {
 
         let config = try String(contentsOf: configURL, encoding: .utf8)
         XCTAssertTrue(config.contains("cmux-hermes-agent-hook-v2"), config)
+        XCTAssertTrue(config.contains("hooks hermes-agent stop"), config)
+        XCTAssertFalse(config.contains("hooks hermes-agent agent-response"), config)
 
         let allowlistURL = hermesHome.appendingPathComponent("shell-hooks-allowlist.json", isDirectory: false)
         let allowlist = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(contentsOf: allowlistURL)) as? [String: Any])

--- a/cmuxTests/CLIGenericHookPersistenceTests.swift
+++ b/cmuxTests/CLIGenericHookPersistenceTests.swift
@@ -2839,6 +2839,70 @@ extension CLINotifyProcessIntegrationRegressionTests {
         )
     }
 
+    func testHermesAgentHookInstallPinsInstallingCLIAndSocketLikeGrok() throws {
+        let cliPath = try bundledCLIPath()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-hermes-hook-pin-\(UUID().uuidString)", isDirectory: true)
+        let hermesHome = root.appendingPathComponent(".hermes", isDirectory: true)
+        try FileManager.default.createDirectory(at: hermesHome, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let configURL = hermesHome.appendingPathComponent("config.yaml", isDirectory: false)
+        try "model: anthropic/claude-sonnet-4.6\n".write(to: configURL, atomically: true, encoding: .utf8)
+
+        let pinnedCLI = root.appendingPathComponent("cmux pinned dev cli", isDirectory: false)
+        try "#!/bin/sh\nexit 0\n".write(to: pinnedCLI, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: pinnedCLI.path)
+
+        let socketPath = "/tmp/cmux-debug-hermes-pin.sock"
+        let result = runProcess(
+            executablePath: cliPath,
+            arguments: ["hooks", "hermes-agent", "install", "--yes"],
+            environment: [
+                "HOME": root.path,
+                "HERMES_HOME": hermesHome.path,
+                "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+                "CMUX_BUNDLED_CLI_PATH": pinnedCLI.path,
+                "CMUX_SOCKET_PATH": socketPath,
+                "CMUX_CLI_SENTRY_DISABLED": "1",
+            ],
+            timeout: 5
+        )
+
+        XCTAssertFalse(result.timedOut, result.stderr)
+        XCTAssertEqual(result.status, 0, result.stderr)
+
+        let config = try String(contentsOf: configURL, encoding: .utf8)
+        XCTAssertTrue(config.contains("cmux-hermes-agent-hook-v2"), config)
+
+        let allowlistURL = hermesHome.appendingPathComponent("shell-hooks-allowlist.json", isDirectory: false)
+        let allowlist = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(contentsOf: allowlistURL)) as? [String: Any])
+        let approvals = try XCTUnwrap(allowlist["approvals"] as? [[String: Any]])
+        let commands = approvals.compactMap { $0["command"] as? String }
+
+        XCTAssertFalse(commands.isEmpty)
+        XCTAssertTrue(
+            commands.allSatisfy { $0.contains("cmux-hermes-agent-hook-v2") },
+            "Expected installed Hermes hooks to carry the owned-hook marker, saw \(commands)"
+        )
+        XCTAssertTrue(
+            commands.allSatisfy { $0.contains(pinnedCLI.path) },
+            "Expected installed Hermes hooks to pin the installing CLI path, saw \(commands)"
+        )
+        XCTAssertTrue(
+            commands.allSatisfy { $0.contains("--socket") && $0.contains(socketPath) },
+            "Expected installed Hermes hooks to pin the installing socket path, saw \(commands)"
+        )
+        XCTAssertFalse(
+            commands.contains { $0.contains("CMUX_SURFACE_ID") },
+            "Hermes hook commands should match Grok's dispatch and avoid CMUX_SURFACE_ID gating, saw \(commands)"
+        )
+        XCTAssertFalse(
+            commands.contains { $0.contains("$CMUX_") },
+            "Hermes hook commands should not depend on CMUX environment interpolation, saw \(commands)"
+        )
+    }
+
     func testGrokHookInstallPreservesUserWrappedLegacyCommands() throws {
         let cliPath = try bundledCLIPath()
         let root = FileManager.default.temporaryDirectory


### PR DESCRIPTION
Summary:
- Add Hermes Agent to the pinned hook dispatch path used by Grok and Antigravity.
- Share installed hook spec generation across JSON/YAML hook writers so lifecycle/feed commands and timeouts are assembled once.
- Normalize Hermes post_llm_call to the primary stop hook command instead of the agent-response alias.

Verification:
- ./scripts/reload.sh --tag hooksim
- Built CLI smoke install against temporary HERMES_HOME and HOME for Grok; verified Hermes writes hooks hermes-agent stop, omits hooks hermes-agent agent-response, and both Hermes/Grok configs contain pinned markers.
- swift test --package-path Packages/CMUXAgentLaunch

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782943073&installation_id=133855650&pr_number=5134&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5134&signature=f3d9f373dd6c13b93639d2a330c235c5127b93528a4bfd101f00d142174182d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hermes agent hooks updated: post-LLM calls now trigger the agent "stop" action, pinned-hook markers are generalized with a lookup-and-fallback mechanism, and hook commands derive markers robustly (falling back to agent config). Hook timeouts and event construction were standardized.

* **Tests**
  * Added end-to-end test validating Hermes hook installation, pinned CLI/socket entries, expected stop command in config, and absence of surface-gating or environment interpolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->