### PR TITLE
Improve terminal text context menu

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2423,6 +2423,59 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                     payload["lastCommandError"] = "Selection or hover suppression failed"
                 }
 
+            case "context_menu_token":
+                guard let hitPoint = commandPoint(
+                    from: command,
+                    defaultPayloadKey: "tokenHitPointInTerminal",
+                    in: terminalPanel
+                ) else {
+                    payload["lastCommandError"] = "Missing command point"
+                    break
+                }
+
+                let result = terminalPanel.hostedView.debugContextMenuDetails(at: hitPoint)
+                payload["lastCommandResult"] = result
+                payload["lastCommandMenuTitles"] = result["menuTitles"]
+                if result["hasLookUp"] as? String == "1",
+                   result["hasPaste"] as? String == "1",
+                   result["hasSplitHorizontally"] as? String == "1",
+                   result["hasResetTerminal"] as? String == "1",
+                   result["hasCopy"] as? String != "1" {
+                    payload["lastCommandSucceeded"] = "1"
+                } else if let error = result["error"] as? String {
+                    payload["lastCommandError"] = error
+                } else {
+                    payload["lastCommandError"] = "Unselected token context menu did not include expected text and pane actions"
+                }
+
+            case "context_menu_selected_token":
+                guard let selectionStart = pointFromPayload("tokenSelectionStartInTerminal", in: terminalPanel),
+                      let selectionEnd = pointFromPayload("tokenSelectionEndInTerminal", in: terminalPanel) else {
+                    payload["lastCommandError"] = "Missing token selection points"
+                    break
+                }
+
+                let selectionActive = terminalPanel.hostedView.debugSimulateSelection(
+                    from: selectionStart,
+                    to: selectionEnd
+                )
+                let result = terminalPanel.hostedView.debugContextMenuDetails(at: selectionEnd)
+                payload["lastCommandSelectionActive"] = selectionActive ? "1" : "0"
+                payload["lastCommandResult"] = result
+                payload["lastCommandMenuTitles"] = result["menuTitles"]
+                if selectionActive,
+                   result["hasCopy"] as? String == "1",
+                   result["hasLookUp"] as? String == "1",
+                   result["hasPaste"] as? String == "1",
+                   result["hasSplitHorizontally"] as? String == "1",
+                   result["hasResetTerminal"] as? String == "1" {
+                    payload["lastCommandSucceeded"] = "1"
+                } else if let error = result["error"] as? String {
+                    payload["lastCommandError"] = error
+                } else {
+                    payload["lastCommandError"] = "Selected token context menu did not include expected text and pane actions"
+                }
+
             case "capture_window":
                 let label = (command["label"] as? String)?
                     .trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -8585,7 +8585,8 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         return self
     }
 
-    @objc func writeSelection(to pasteboard: NSPasteboard, types: [NSPasteboard.PasteboardType]) -> Bool {
+    @objc(writeSelectionToPasteboard:types:)
+    func writeSelection(to pasteboard: NSPasteboard, types: [NSPasteboard.PasteboardType]) -> Bool {
         guard !Self.textServicePasteboardTypes.isDisjoint(with: Set(types)),
               let snapshot = readSelectionSnapshot(),
               !snapshot.string.isEmpty else {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -10784,7 +10784,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         var payload: [String: Any] = [
             "menuTitles": titles,
             "hasCopy": titles.contains(String(localized: "terminalContextMenu.copy", defaultValue: "Copy")) ? "1" : "0",
-            "hasLookUp": titles.contains { $0.hasPrefix("Look Up ") } ? "1" : "0",
+            "hasLookUp": menu.items.contains { $0.action == #selector(lookUpContextMenuText(_:)) } ? "1" : "0",
             "hasPaste": titles.contains(String(localized: "terminalContextMenu.paste", defaultValue: "Paste")) ? "1" : "0",
             "hasSplitHorizontally": titles.contains(String(localized: "terminalContextMenu.splitHorizontally", defaultValue: "Split Horizontally")) ? "1" : "0",
             "hasResetTerminal": titles.contains(String(localized: "terminalContextMenu.resetTerminal", defaultValue: "Reset Terminal")) ? "1" : "0"

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -8536,7 +8536,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     ) -> Bool {
         guard returnType == nil else { return false }
         guard sendType.map({ textServicePasteboardTypes.contains($0) }) ?? true else { return false }
-        guard let sendType else { return true }
+        guard let sendType else { return hasSelection }
         return textServicePasteboardTypes.contains(sendType) && hasSelection
     }
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -8558,19 +8558,27 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         forSendType sendType: NSPasteboard.PasteboardType?,
         returnType: NSPasteboard.PasteboardType?
     ) -> Any? {
-        guard returnType == nil,
-              let snapshot = readSelectionSnapshot(),
-              !snapshot.string.isEmpty else {
+        let textTypes: Set<NSPasteboard.PasteboardType> = [
+            .string,
+            NSPasteboard.PasteboardType("public.utf8-plain-text")
+        ]
+        let supportsReturnType = returnType.map { textTypes.contains($0) } ?? true
+        let supportsSendType = sendType.map { textTypes.contains($0) } ?? true
+        guard supportsReturnType, supportsSendType else {
             return super.validRequestor(forSendType: sendType, returnType: returnType)
         }
-        if sendType == nil || sendType == .string {
-            return self
+
+        if let sendType, textTypes.contains(sendType) {
+            guard let surface, ghostty_surface_has_selection(surface) else {
+                return super.validRequestor(forSendType: sendType, returnType: returnType)
+            }
         }
-        return super.validRequestor(forSendType: sendType, returnType: returnType)
+
+        return self
     }
 
     @objc func writeSelection(to pasteboard: NSPasteboard, types: [NSPasteboard.PasteboardType]) -> Bool {
-        guard types.contains(.string),
+        guard (types.contains(.string) || types.contains(NSPasteboard.PasteboardType("public.utf8-plain-text"))),
               let snapshot = readSelectionSnapshot(),
               !snapshot.string.isEmpty else {
             return false

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1218,6 +1218,73 @@ private func cmuxShellEscapedTokenContainingColumn(
     return nil
 }
 
+private func cmuxWhitespaceDelimitedTokenContainingColumn(
+    in line: String,
+    column: Int
+) -> String? {
+    let characters = Array(line)
+    guard !characters.isEmpty, column >= 0, column < characters.count else { return nil }
+    guard !characters[column].isWhitespace else { return nil }
+
+    var start = column
+    while start > 0, !characters[start - 1].isWhitespace {
+        start -= 1
+    }
+
+    var end = column
+    while (end + 1) < characters.count, !characters[end + 1].isWhitespace {
+        end += 1
+    }
+
+    let candidate = String(characters[start...end]).trimmingCharacters(in: .whitespacesAndNewlines)
+    return candidate.isEmpty ? nil : candidate
+}
+
+private func cmuxVisibleBackslashJoinedTokenContainingColumn(
+    in line: String,
+    column: Int
+) -> String? {
+    let characters = Array(line)
+    guard !characters.isEmpty, column >= 0, column < characters.count else { return nil }
+
+    var index = 0
+    while index < characters.count {
+        while index < characters.count, characters[index].isWhitespace {
+            index += 1
+        }
+        let start = index
+
+        while index < characters.count {
+            guard characters[index].isWhitespace else {
+                index += 1
+                continue
+            }
+
+            if index > start, characters[index - 1] == "\\" {
+                index += 1
+                continue
+            }
+
+            break
+        }
+
+        if start < index, column >= start, column < index {
+            return String(characters[start..<index])
+        }
+    }
+
+    return nil
+}
+
+private func cmuxVisibleTextTokenContainingColumn(
+    in line: String,
+    column: Int
+) -> String? {
+    cmuxVisibleBackslashJoinedTokenContainingColumn(in: line, column: column)
+        ?? cmuxShellEscapedTokenContainingColumn(in: line, column: column)
+        ?? cmuxWhitespaceDelimitedTokenContainingColumn(in: line, column: column)
+}
+
 private func cmuxIsHardPathDelimiter(
     in characters: [Character],
     at index: Int
@@ -8715,8 +8782,77 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         )
     }
 
-    private func readContextMenuTextSnapshot() -> TextMenuSnapshot? {
-        readSelectionTextMenuSnapshot() ?? readQuickLookWordTextMenuSnapshot()
+    private func readVisibleTextMenuSnapshot(at point: NSPoint) -> TextMenuSnapshot? {
+        guard let terminalSurface,
+              let workspace = terminalSurface.owningWorkspace(),
+              let panel = workspace.terminalPanel(for: terminalSurface.id),
+              let surface else {
+            return nil
+        }
+
+        let size = ghostty_surface_size(surface)
+        let rows = max(Int(size.rows), 1)
+        let cols = max(Int(size.columns), 1)
+        let resolvedCellWidth = cellSize.width > 0 ? cellSize.width : CGFloat(size.cell_width_px)
+        let resolvedCellHeight = cellSize.height > 0 ? cellSize.height : CGFloat(size.cell_height_px)
+        guard resolvedCellWidth > 0, resolvedCellHeight > 0 else { return nil }
+
+        let visibleText = TerminalController.shared.readTerminalTextForSnapshot(
+            terminalPanel: panel,
+            lineLimit: max(200, rows * 4)
+        ) ?? ""
+        let visibleLines = cmuxVisibleTerminalLines(from: visibleText, rows: rows)
+        let rowOffset = max(0, rows - visibleLines.count)
+        let xInset = max(0, (bounds.width - (CGFloat(cols) * resolvedCellWidth)) / 2)
+        let yInset = max(0, (bounds.height - (CGFloat(rows) * resolvedCellHeight)) / 2)
+
+        let yFromTop = bounds.height - point.y
+        let xInGrid = point.x - xInset
+        let yInGrid = yFromTop - yInset
+        guard xInGrid >= 0,
+              xInGrid < CGFloat(cols) * resolvedCellWidth,
+              yInGrid >= 0,
+              yInGrid < CGFloat(rows) * resolvedCellHeight else {
+            return nil
+        }
+
+        let rowFromTop = Int(yInGrid / resolvedCellHeight)
+        let visibleRow = rowFromTop - rowOffset
+        guard visibleRow >= 0, visibleRow < visibleLines.count else { return nil }
+
+        let column = Int(xInGrid / resolvedCellWidth)
+        guard let token = cmuxVisibleTextTokenContainingColumn(
+            in: visibleLines[visibleRow],
+            column: column
+        ) else {
+            return nil
+        }
+
+        return TextMenuSnapshot(
+            string: token,
+            topLeft: CGPoint(
+                x: xInset + (CGFloat(column) * resolvedCellWidth),
+                y: yInset + (CGFloat(rowFromTop) * resolvedCellHeight)
+            ),
+            isSelection: false
+        )
+    }
+
+    private func readContextMenuTextSnapshot(at point: NSPoint) -> TextMenuSnapshot? {
+        if let selectionSnapshot = readSelectionTextMenuSnapshot() {
+            return selectionSnapshot
+        }
+
+        let quickLookSnapshot = readQuickLookWordTextMenuSnapshot()
+        let visibleSnapshot = readVisibleTextMenuSnapshot(at: point)
+        if let quickLookSnapshot,
+           quickLookSnapshot.string.hasSuffix("\\"),
+           let visibleSnapshot,
+           visibleSnapshot.string.count > quickLookSnapshot.string.count {
+            return visibleSnapshot
+        }
+
+        return quickLookSnapshot ?? visibleSnapshot
     }
 
     private func visibleDocumentRectInScreenCoordinates() -> NSRect {
@@ -10580,7 +10716,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         window?.makeFirstResponder(self)
         let point = convert(event.locationInWindow, from: nil)
         ghostty_surface_mouse_pos(surface, point.x, bounds.height - point.y, modsFromEvent(event))
-        contextMenuTextSnapshot = readContextMenuTextSnapshot()
+        contextMenuTextSnapshot = readContextMenuTextSnapshot(at: point)
 
         let menu = NSMenu()
         if let contextMenuTextSnapshot {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7612,6 +7612,8 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     private var deferredSurfaceSizeRetryQueued = false
     private var lastDrawableSize: CGSize = .zero
     private var isFindEscapeSuppressionArmed = false
+    private var selectionSharingServicePicker: NSSharingServicePicker?
+    private var contextMenuTextSnapshot: TextMenuSnapshot?
 #if DEBUG
     private var lastSizeSkipSignature: String?
 #endif
@@ -8438,6 +8440,41 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         _ = performBindingAction("copy_to_clipboard")
     }
 
+    @objc private func lookUpContextMenuText(_ sender: Any?) {
+        guard let snapshot = contextMenuTextSnapshot ?? readSelectionTextMenuSnapshot(),
+              !snapshot.string.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            NSSound.beep()
+            return
+        }
+        let attributed = NSAttributedString(string: snapshot.string)
+        showDefinition(for: attributed, at: selectionDefinitionOrigin(for: snapshot))
+    }
+
+    private func selectionDefinitionOrigin(for snapshot: TextMenuSnapshot) -> NSPoint {
+        NSPoint(
+            x: max(0, snapshot.topLeft.x),
+            y: max(0, bounds.height - snapshot.topLeft.y)
+        )
+    }
+
+    private func lookUpMenuTitle(for text: String) -> String {
+        let previewLimit = 40
+        let normalized = text
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "\t", with: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let preview: String
+        if normalized.count > previewLimit {
+            preview = String(normalized.prefix(previewLimit)).trimmingCharacters(in: .whitespaces) + "\u{2026}"
+        } else {
+            preview = normalized
+        }
+        return String.localizedStringWithFormat(
+            String(localized: "terminalContextMenu.lookUpFormat", defaultValue: "Look Up \"%@\""),
+            preview
+        )
+    }
+
     @IBAction func copyWorkspaceAndSurfaceIdentifiers(_ sender: Any?) {
         guard let terminalSurface else { return }
         let paneId = terminalSurface.owningWorkspace()?.paneId(forPanelId: terminalSurface.id)?.id
@@ -8501,6 +8538,9 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         case #selector(copy(_:)):
             guard let surface = surface else { return false }
             return ghostty_surface_has_selection(surface)
+        case #selector(lookUpContextMenuText(_:)):
+            let snapshot = contextMenuTextSnapshot ?? readSelectionTextMenuSnapshot()
+            return snapshot?.string.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
         case #selector(paste(_:)):
             return GhosttyPasteboardHelper.hasString(for: GHOSTTY_CLIPBOARD_STANDARD)
         case #selector(pasteAsPlainText(_:)):
@@ -8512,6 +8552,31 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         default:
             return true
         }
+    }
+
+    override func validRequestor(
+        forSendType sendType: NSPasteboard.PasteboardType?,
+        returnType: NSPasteboard.PasteboardType?
+    ) -> Any? {
+        guard returnType == nil,
+              let snapshot = readSelectionSnapshot(),
+              !snapshot.string.isEmpty else {
+            return super.validRequestor(forSendType: sendType, returnType: returnType)
+        }
+        if sendType == nil || sendType == .string {
+            return self
+        }
+        return super.validRequestor(forSendType: sendType, returnType: returnType)
+    }
+
+    @objc func writeSelection(to pasteboard: NSPasteboard, types: [NSPasteboard.PasteboardType]) -> Bool {
+        guard types.contains(.string),
+              let snapshot = readSelectionSnapshot(),
+              !snapshot.string.isEmpty else {
+            return false
+        }
+        pasteboard.clearContents()
+        return pasteboard.setString(snapshot.string, forType: .string)
     }
 
     // MARK: - Accessibility
@@ -8601,6 +8666,40 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             string: selected,
             topLeft: CGPoint(x: text.tl_px_x, y: text.tl_px_y)
         )
+    }
+
+    private func readSelectionTextMenuSnapshot() -> TextMenuSnapshot? {
+        guard let snapshot = readSelectionSnapshot(),
+              !snapshot.string.isEmpty else {
+            return nil
+        }
+        return TextMenuSnapshot(
+            string: snapshot.string,
+            topLeft: snapshot.topLeft,
+            isSelection: true
+        )
+    }
+
+    private func readQuickLookWordTextMenuSnapshot() -> TextMenuSnapshot? {
+        guard let surface else { return nil }
+
+        var text = ghostty_text_s()
+        guard ghostty_surface_quicklook_word(surface, &text) else { return nil }
+        defer { ghostty_surface_free_text(surface, &text) }
+        guard let ptr = text.text, text.text_len > 0 else { return nil }
+
+        let wordData = Data(bytes: ptr, count: Int(text.text_len))
+        let word = String(decoding: wordData, as: UTF8.self)
+        guard !word.isEmpty else { return nil }
+        return TextMenuSnapshot(
+            string: word,
+            topLeft: CGPoint(x: text.tl_px_x, y: text.tl_px_y),
+            isSelection: false
+        )
+    }
+
+    private func readContextMenuTextSnapshot() -> TextMenuSnapshot? {
+        readSelectionTextMenuSnapshot() ?? readQuickLookWordTextMenuSnapshot()
     }
 
     private func visibleDocumentRectInScreenCoordinates() -> NSRect {
@@ -8744,6 +8843,12 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         let range: NSRange
         let string: String
         let topLeft: CGPoint
+    }
+
+    private struct TextMenuSnapshot {
+        let string: String
+        let topLeft: CGPoint
+        let isSelection: Bool
     }
 
 #if DEBUG
@@ -10461,6 +10566,11 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         _ = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_RIGHT, modsFromEvent(event))
 
         let menu = NSMenu()
+        contextMenuTextSnapshot = readContextMenuTextSnapshot()
+        if let contextMenuTextSnapshot {
+            appendTerminalTextContextMenuItems(to: menu, snapshot: contextMenuTextSnapshot)
+            menu.addItem(.separator())
+        }
         if onTriggerFlash != nil {
             let flashItem = menu.addItem(
                 withTitle: String(localized: "terminalContextMenu.triggerFlash", defaultValue: "Trigger Flash"),
@@ -10470,14 +10580,34 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             flashItem.target = self
             menu.addItem(.separator())
         }
-        if ghostty_surface_has_selection(surface) {
-            let item = menu.addItem(
+        appendTerminalPaneContextMenuItems(to: menu)
+        return menu
+    }
+
+    private func appendTerminalTextContextMenuItems(to menu: NSMenu, snapshot: TextMenuSnapshot) {
+        if snapshot.isSelection {
+            let copyItem = menu.addItem(
                 withTitle: String(localized: "terminalContextMenu.copy", defaultValue: "Copy"),
                 action: #selector(copy(_:)),
                 keyEquivalent: ""
             )
-            item.target = self
+            copyItem.target = self
         }
+
+        let lookUpItem = menu.addItem(
+            withTitle: lookUpMenuTitle(for: snapshot.string),
+            action: #selector(lookUpContextMenuText(_:)),
+            keyEquivalent: ""
+        )
+        lookUpItem.target = self
+
+        selectionSharingServicePicker = NSSharingServicePicker(items: [snapshot.string])
+        if let shareItem = selectionSharingServicePicker?.standardShareMenuItem {
+            menu.addItem(shareItem)
+        }
+    }
+
+    private func appendTerminalPaneContextMenuItems(to menu: NSMenu) {
         let pasteItem = menu.addItem(
             withTitle: String(localized: "terminalContextMenu.paste", defaultValue: "Paste"),
             action: #selector(paste(_:)),
@@ -10534,7 +10664,6 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             )
             linkItem.target = self
         }
-        return menu
     }
 
     private func canSplitCurrentSurface() -> Bool {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -8457,8 +8457,23 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         )
     }
 
-    private func lookUpMenuTitle(for text: String) -> String {
-        let previewLimit = 40
+    static let textServicePasteboardTypes: Set<NSPasteboard.PasteboardType> = [
+        .string,
+        NSPasteboard.PasteboardType("public.utf8-plain-text")
+    ]
+
+    static func supportsTextServiceRequest(
+        sendType: NSPasteboard.PasteboardType?,
+        returnType: NSPasteboard.PasteboardType?,
+        hasSelection: Bool
+    ) -> Bool {
+        guard returnType == nil else { return false }
+        guard sendType.map({ textServicePasteboardTypes.contains($0) }) ?? true else { return false }
+        guard let sendType else { return true }
+        return textServicePasteboardTypes.contains(sendType) && hasSelection
+    }
+
+    static func lookUpMenuTitle(for text: String, previewLimit: Int = 40) -> String {
         let normalized = text
             .replacingOccurrences(of: "\n", with: " ")
             .replacingOccurrences(of: "\t", with: " ")
@@ -8558,27 +8573,20 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         forSendType sendType: NSPasteboard.PasteboardType?,
         returnType: NSPasteboard.PasteboardType?
     ) -> Any? {
-        let textTypes: Set<NSPasteboard.PasteboardType> = [
-            .string,
-            NSPasteboard.PasteboardType("public.utf8-plain-text")
-        ]
-        let supportsReturnType = returnType.map { textTypes.contains($0) } ?? true
-        let supportsSendType = sendType.map { textTypes.contains($0) } ?? true
-        guard supportsReturnType, supportsSendType else {
+        let hasSelection = surface.map { ghostty_surface_has_selection($0) } ?? false
+        guard Self.supportsTextServiceRequest(
+            sendType: sendType,
+            returnType: returnType,
+            hasSelection: hasSelection
+        ) else {
             return super.validRequestor(forSendType: sendType, returnType: returnType)
-        }
-
-        if let sendType, textTypes.contains(sendType) {
-            guard let surface, ghostty_surface_has_selection(surface) else {
-                return super.validRequestor(forSendType: sendType, returnType: returnType)
-            }
         }
 
         return self
     }
 
     @objc func writeSelection(to pasteboard: NSPasteboard, types: [NSPasteboard.PasteboardType]) -> Bool {
-        guard (types.contains(.string) || types.contains(NSPasteboard.PasteboardType("public.utf8-plain-text"))),
+        guard !Self.textServicePasteboardTypes.isDisjoint(with: Set(types)),
               let snapshot = readSelectionSnapshot(),
               !snapshot.string.isEmpty else {
             return false
@@ -10603,7 +10611,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         }
 
         let lookUpItem = menu.addItem(
-            withTitle: lookUpMenuTitle(for: snapshot.string),
+            withTitle: Self.lookUpMenuTitle(for: snapshot.string),
             action: #selector(lookUpContextMenuText(_:)),
             keyEquivalent: ""
         )
@@ -10614,6 +10622,38 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             menu.addItem(shareItem)
         }
     }
+
+#if DEBUG
+    func debugContextMenuDetails(at point: NSPoint) -> [String: Any] {
+        guard let window else { return ["error": "Missing window"] }
+        let locationInWindow = convert(point, to: nil)
+        guard let event = NSEvent.mouseEvent(
+            with: .rightMouseDown,
+            location: locationInWindow,
+            modifierFlags: [],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 1
+        ) else {
+            return ["error": "Failed to create right-click event"]
+        }
+        guard let menu = menu(for: event) else { return ["error": "No context menu"] }
+        let titles = menu.items
+            .filter { !$0.isSeparatorItem }
+            .map(\.title)
+        return [
+            "menuTitles": titles,
+            "hasCopy": titles.contains(String(localized: "terminalContextMenu.copy", defaultValue: "Copy")) ? "1" : "0",
+            "hasLookUp": titles.contains { $0.hasPrefix("Look Up ") } ? "1" : "0",
+            "hasPaste": titles.contains(String(localized: "terminalContextMenu.paste", defaultValue: "Paste")) ? "1" : "0",
+            "hasSplitHorizontally": titles.contains(String(localized: "terminalContextMenu.splitHorizontally", defaultValue: "Split Horizontally")) ? "1" : "0",
+            "hasResetTerminal": titles.contains(String(localized: "terminalContextMenu.resetTerminal", defaultValue: "Reset Terminal")) ? "1" : "0"
+        ]
+    }
+#endif
 
     private func appendTerminalPaneContextMenuItems(to menu: NSMenu) {
         let pasteItem = menu.addItem(
@@ -11513,6 +11553,10 @@ final class GhosttySurfaceScrollView: NSView {
 
     func debugSimulateCommandClick(at point: NSPoint) -> [String: Any] {
         surfaceView.debugSimulateCommandClick(at: debugPointInSurface(point))
+    }
+
+    func debugContextMenuDetails(at point: NSPoint) -> [String: Any] {
+        surfaceView.debugContextMenuDetails(at: debugPointInSurface(point))
     }
 #endif
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -10580,14 +10580,14 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         window?.makeFirstResponder(self)
         let point = convert(event.locationInWindow, from: nil)
         ghostty_surface_mouse_pos(surface, point.x, bounds.height - point.y, modsFromEvent(event))
-        _ = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_RIGHT, modsFromEvent(event))
+        contextMenuTextSnapshot = readContextMenuTextSnapshot()
 
         let menu = NSMenu()
-        contextMenuTextSnapshot = readContextMenuTextSnapshot()
         if let contextMenuTextSnapshot {
             appendTerminalTextContextMenuItems(to: menu, snapshot: contextMenuTextSnapshot)
             menu.addItem(.separator())
         }
+        _ = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_RIGHT, modsFromEvent(event))
         if onTriggerFlash != nil {
             let flashItem = menu.addItem(
                 withTitle: String(localized: "terminalContextMenu.triggerFlash", defaultValue: "Trigger Flash"),
@@ -10645,7 +10645,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         let titles = menu.items
             .filter { !$0.isSeparatorItem }
             .map(\.title)
-        return [
+        var payload: [String: Any] = [
             "menuTitles": titles,
             "hasCopy": titles.contains(String(localized: "terminalContextMenu.copy", defaultValue: "Copy")) ? "1" : "0",
             "hasLookUp": titles.contains { $0.hasPrefix("Look Up ") } ? "1" : "0",
@@ -10653,6 +10653,11 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             "hasSplitHorizontally": titles.contains(String(localized: "terminalContextMenu.splitHorizontally", defaultValue: "Split Horizontally")) ? "1" : "0",
             "hasResetTerminal": titles.contains(String(localized: "terminalContextMenu.resetTerminal", defaultValue: "Reset Terminal")) ? "1" : "0"
         ]
+        if let contextMenuTextSnapshot {
+            payload["textSnapshotString"] = contextMenuTextSnapshot.string
+            payload["textSnapshotIsSelection"] = contextMenuTextSnapshot.isSelection ? "1" : "0"
+        }
+        return payload
     }
 #endif
 

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -939,6 +939,62 @@ final class GhosttyPasteboardHelperTests: XCTestCase {
     }
 }
 
+final class GhosttyTerminalContextMenuTests: XCTestCase {
+    func testLookUpTitleIncludesQuotedSelectionPreview() {
+        XCTAssertEqual(
+            GhosttyNSView.lookUpMenuTitle(for: "hello"),
+            "Look Up “hello”"
+        )
+    }
+
+    func testLookUpTitleNormalizesWhitespaceAndTruncatesLongText() {
+        let title = GhosttyNSView.lookUpMenuTitle(
+            for: "  abc\tdef\n" + String(repeating: "x", count: 80),
+            previewLimit: 10
+        )
+
+        XCTAssertEqual(title, "Look Up “abc def xx…”")
+    }
+
+    func testTextServicesRequireSendOnlyTextAndSelection() {
+        XCTAssertTrue(
+            GhosttyNSView.supportsTextServiceRequest(
+                sendType: .string,
+                returnType: nil,
+                hasSelection: true
+            )
+        )
+        XCTAssertTrue(
+            GhosttyNSView.supportsTextServiceRequest(
+                sendType: NSPasteboard.PasteboardType("public.utf8-plain-text"),
+                returnType: nil,
+                hasSelection: true
+            )
+        )
+        XCTAssertFalse(
+            GhosttyNSView.supportsTextServiceRequest(
+                sendType: .string,
+                returnType: nil,
+                hasSelection: false
+            )
+        )
+        XCTAssertFalse(
+            GhosttyNSView.supportsTextServiceRequest(
+                sendType: .string,
+                returnType: .string,
+                hasSelection: true
+            )
+        )
+        XCTAssertFalse(
+            GhosttyNSView.supportsTextServiceRequest(
+                sendType: .png,
+                returnType: nil,
+                hasSelection: true
+            )
+        )
+    }
+}
+
 @MainActor
 final class TerminalOffscreenStartupTests: XCTestCase {
     func testPlainSurfaceDoesNotStartRuntimeBeforeWindowAttachmentOrInput() {

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -1,7 +1,6 @@
 import XCTest
 import CmuxSocketControl
 import AppKit
-import Testing
 import SwiftUI
 import UniformTypeIdentifiers
 import WebKit
@@ -940,80 +939,95 @@ final class GhosttyPasteboardHelperTests: XCTestCase {
     }
 }
 
-@MainActor
-@Suite("Ghostty terminal context menu")
-struct GhosttyTerminalContextMenuTests {
-    @Test
-    func lookUpTitleIncludesQuotedSelectionPreview() {
+final class GhosttyTerminalContextMenuTests: XCTestCase {
+    func testLookUpTitleIncludesQuotedSelectionPreview() {
         let title = GhosttyNSView.lookUpMenuTitle(for: "hello")
 
-        #expect(title == Self.localizedLookUpTitle(preview: "hello"))
+        XCTAssertEqual(title, Self.localizedLookUpTitle(preview: "hello"))
     }
 
-    @Test
-    func lookUpTitleNormalizesWhitespaceAndTruncatesLongText() {
+    func testLookUpTitleNormalizesWhitespaceAndTruncatesLongText() {
         let title = GhosttyNSView.lookUpMenuTitle(
             for: "  abc\tdef\n" + String(repeating: "x", count: 80),
             previewLimit: 10
         )
 
-        #expect(title == Self.localizedLookUpTitle(preview: "abc def xx…"))
+        XCTAssertEqual(title, Self.localizedLookUpTitle(preview: "abc def xx…"))
     }
 
-    @Test
-    func textServicesRequireSendOnlyTextAndSelection() {
-        #expect(
+    func testTextServicesRequireSendOnlyTextAndSelection() {
+        XCTAssertTrue(
+            GhosttyNSView.supportsTextServiceRequest(
+                sendType: nil,
+                returnType: nil,
+                hasSelection: true
+            )
+        )
+        XCTAssertTrue(
             GhosttyNSView.supportsTextServiceRequest(
                 sendType: .string,
                 returnType: nil,
                 hasSelection: true
             )
         )
-        #expect(
+        XCTAssertTrue(
             GhosttyNSView.supportsTextServiceRequest(
                 sendType: NSPasteboard.PasteboardType("public.utf8-plain-text"),
                 returnType: nil,
                 hasSelection: true
             )
         )
-        #expect(
+        XCTAssertFalse(
+            GhosttyNSView.supportsTextServiceRequest(
+                sendType: nil,
+                returnType: nil,
+                hasSelection: false
+            )
+        )
+        XCTAssertFalse(
+            GhosttyNSView.supportsTextServiceRequest(
+                sendType: nil,
+                returnType: .string,
+                hasSelection: true
+            )
+        )
+        XCTAssertFalse(
             GhosttyNSView.supportsTextServiceRequest(
                 sendType: .string,
                 returnType: nil,
                 hasSelection: false
-            ) == false
+            )
         )
-        #expect(
+        XCTAssertFalse(
             GhosttyNSView.supportsTextServiceRequest(
                 sendType: .string,
                 returnType: .string,
                 hasSelection: true
-            ) == false
+            )
         )
-        #expect(
+        XCTAssertFalse(
             GhosttyNSView.supportsTextServiceRequest(
                 sendType: .png,
                 returnType: nil,
                 hasSelection: true
-            ) == false
+            )
         )
     }
 
-    @Test
-    func textServicesExposeAppKitPasteboardWriterSelector() {
+    func testTextServicesExposeAppKitPasteboardWriterSelector() {
         let view = GhosttyNSView(frame: .zero)
 
-        #expect(
+        XCTAssertTrue(
             view.responds(to: NSSelectorFromString("writeSelectionToPasteboard:types:"))
         )
-        #expect(
-            view.responds(to: NSSelectorFromString("writeSelectionTo:types:")) == false
+        XCTAssertFalse(
+            view.responds(to: NSSelectorFromString("writeSelectionTo:types:"))
         )
     }
 
     private static func localizedLookUpTitle(preview: String) -> String {
         String.localizedStringWithFormat(
-            String(localized: "terminalContextMenu.lookUpFormat", defaultValue: "Look Up “%@”"),
+            String(localized: "terminalContextMenu.lookUpFormat", defaultValue: "Look Up \"%@\""),
             preview
         )
     }

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -947,7 +947,7 @@ struct GhosttyTerminalContextMenuTests {
     func lookUpTitleIncludesQuotedSelectionPreview() {
         let title = GhosttyNSView.lookUpMenuTitle(for: "hello")
 
-        #expect(title.contains("hello"))
+        #expect(title == Self.localizedLookUpTitle(preview: "hello"))
     }
 
     @Test
@@ -957,7 +957,7 @@ struct GhosttyTerminalContextMenuTests {
             previewLimit: 10
         )
 
-        #expect(title.contains("abc def xx…"))
+        #expect(title == Self.localizedLookUpTitle(preview: "abc def xx…"))
     }
 
     @Test
@@ -1008,6 +1008,13 @@ struct GhosttyTerminalContextMenuTests {
         )
         #expect(
             view.responds(to: NSSelectorFromString("writeSelectionTo:types:")) == false
+        )
+    }
+
+    private static func localizedLookUpTitle(preview: String) -> String {
+        String.localizedStringWithFormat(
+            String(localized: "terminalContextMenu.lookUpFormat", defaultValue: "Look Up “%@”"),
+            preview
         )
     }
 }

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -993,6 +993,17 @@ final class GhosttyTerminalContextMenuTests: XCTestCase {
             )
         )
     }
+
+    func testTextServicesExposeAppKitPasteboardWriterSelector() {
+        let view = GhosttyNSView(frame: .zero)
+
+        XCTAssertTrue(
+            view.responds(to: NSSelectorFromString("writeSelectionToPasteboard:types:"))
+        )
+        XCTAssertFalse(
+            view.responds(to: NSSelectorFromString("writeSelectionTo:types:"))
+        )
+    }
 }
 
 @MainActor

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 import CmuxSocketControl
 import AppKit
+import Testing
 import SwiftUI
 import UniformTypeIdentifiers
 import WebKit
@@ -939,69 +940,74 @@ final class GhosttyPasteboardHelperTests: XCTestCase {
     }
 }
 
-final class GhosttyTerminalContextMenuTests: XCTestCase {
-    func testLookUpTitleIncludesQuotedSelectionPreview() {
-        XCTAssertEqual(
-            GhosttyNSView.lookUpMenuTitle(for: "hello"),
-            "Look Up “hello”"
-        )
+@MainActor
+@Suite("Ghostty terminal context menu")
+struct GhosttyTerminalContextMenuTests {
+    @Test
+    func lookUpTitleIncludesQuotedSelectionPreview() {
+        let title = GhosttyNSView.lookUpMenuTitle(for: "hello")
+
+        #expect(title.contains("hello"))
     }
 
-    func testLookUpTitleNormalizesWhitespaceAndTruncatesLongText() {
+    @Test
+    func lookUpTitleNormalizesWhitespaceAndTruncatesLongText() {
         let title = GhosttyNSView.lookUpMenuTitle(
             for: "  abc\tdef\n" + String(repeating: "x", count: 80),
             previewLimit: 10
         )
 
-        XCTAssertEqual(title, "Look Up “abc def xx…”")
+        #expect(title.contains("abc def xx…"))
     }
 
-    func testTextServicesRequireSendOnlyTextAndSelection() {
-        XCTAssertTrue(
+    @Test
+    func textServicesRequireSendOnlyTextAndSelection() {
+        #expect(
             GhosttyNSView.supportsTextServiceRequest(
                 sendType: .string,
                 returnType: nil,
                 hasSelection: true
             )
         )
-        XCTAssertTrue(
+        #expect(
             GhosttyNSView.supportsTextServiceRequest(
                 sendType: NSPasteboard.PasteboardType("public.utf8-plain-text"),
                 returnType: nil,
                 hasSelection: true
             )
         )
-        XCTAssertFalse(
+        #expect(
             GhosttyNSView.supportsTextServiceRequest(
                 sendType: .string,
                 returnType: nil,
                 hasSelection: false
-            )
+            ) == false
         )
-        XCTAssertFalse(
+        #expect(
             GhosttyNSView.supportsTextServiceRequest(
                 sendType: .string,
                 returnType: .string,
                 hasSelection: true
-            )
+            ) == false
         )
-        XCTAssertFalse(
+        #expect(
             GhosttyNSView.supportsTextServiceRequest(
                 sendType: .png,
                 returnType: nil,
                 hasSelection: true
-            )
+            ) == false
         )
     }
 
-    func testTextServicesExposeAppKitPasteboardWriterSelector() {
+    @Test
+    func textServicesExposeAppKitPasteboardWriterSelector() {
         let view = GhosttyNSView(frame: .zero)
 
-        XCTAssertTrue(
+        #expect(
             view.responds(to: NSSelectorFromString("writeSelectionToPasteboard:types:"))
         )
-        XCTAssertFalse(
-            view.responds(to: NSSelectorFromString("writeSelectionTo:types:"))
+        #expect(
+            view.responds(to: NSSelectorFromString("writeSelectionTo:types:")) == false
         )
     }
 }

--- a/cmuxUITests/TerminalCmdClickUITests.swift
+++ b/cmuxUITests/TerminalCmdClickUITests.swift
@@ -100,6 +100,57 @@ final class TerminalCmdClickUITests: XCTestCase {
         )
     }
 
+    func testContextMenuOnUnselectedTerminalWordIncludesLookupAndPaneActions() throws {
+        let app = launchApp(captureOpenPaths: false, captureHoverDiagnostics: false)
+        defer { app.terminate() }
+
+        _ = try waitForReadySetup()
+        let result = try runCommand(action: "context_menu_token")
+        XCTAssertEqual(
+            result["lastCommandSucceeded"] as? String,
+            "1",
+            "Expected unselected token context menu to include Look Up plus pane actions without Copy. result=\(result)"
+        )
+
+        let titles = try XCTUnwrap(result["lastCommandMenuTitles"] as? [String])
+        XCTAssertTrue(
+            titles.contains { $0.hasPrefix("Look Up “Cmd\\ Click\\ Fixture.txt") || $0.hasPrefix("Look Up “Cmd Click Fixture.txt") },
+            "Expected Look Up title to include the right-clicked terminal word. titles=\(titles)"
+        )
+        XCTAssertFalse(titles.contains("Copy"), "Unselected word menu should not expose selection Copy. titles=\(titles)")
+        XCTAssertTrue(titles.contains("Paste"), "Expected pane Paste action to remain available. titles=\(titles)")
+        XCTAssertTrue(titles.contains("Split Horizontally"), "Expected pane split action to remain available. titles=\(titles)")
+        XCTAssertTrue(titles.contains("Reset Terminal"), "Expected pane reset action to remain available. titles=\(titles)")
+    }
+
+    func testContextMenuOnSelectedTerminalTextIncludesCopyLookupAndPaneActions() throws {
+        let app = launchApp(captureOpenPaths: false, captureHoverDiagnostics: false)
+        defer { app.terminate() }
+
+        _ = try waitForReadySetup()
+        let result = try runCommand(action: "context_menu_selected_token")
+        XCTAssertEqual(
+            result["lastCommandSucceeded"] as? String,
+            "1",
+            "Expected selected token context menu to include Copy, Look Up, and pane actions. result=\(result)"
+        )
+        XCTAssertEqual(
+            result["lastCommandSelectionActive"] as? String,
+            "1",
+            "Expected UI harness to create a real Ghostty selection before inspecting the menu. result=\(result)"
+        )
+
+        let titles = try XCTUnwrap(result["lastCommandMenuTitles"] as? [String])
+        XCTAssertTrue(titles.contains("Copy"), "Expected selected text menu to expose Copy. titles=\(titles)")
+        XCTAssertTrue(
+            titles.contains { $0.hasPrefix("Look Up “") },
+            "Expected selected text menu to expose quoted Look Up title. titles=\(titles)"
+        )
+        XCTAssertTrue(titles.contains("Paste"), "Expected pane Paste action to remain available. titles=\(titles)")
+        XCTAssertTrue(titles.contains("Split Horizontally"), "Expected pane split action to remain available. titles=\(titles)")
+        XCTAssertTrue(titles.contains("Reset Terminal"), "Expected pane reset action to remain available. titles=\(titles)")
+    }
+
     func testCmdClickEscapedPathWithSpacesOpensResolvedFile() throws {
         let app = launchApp(
             displayMode: .escaped,

--- a/cmuxUITests/TerminalCmdClickUITests.swift
+++ b/cmuxUITests/TerminalCmdClickUITests.swift
@@ -811,6 +811,7 @@ final class TerminalCmdClickUITests: XCTestCase {
         viewportOffsetDelta: Int? = nil
     ) -> XCUIApplication {
         let app = XCUIApplication()
+        app.launchArguments += ["-AppleLanguages", "(en)", "-AppleLocale", "en_US"]
         app.launchEnvironment["CMUX_TAG"] = "ui-test-terminal-cmd-click"
         app.launchEnvironment["CMUX_UI_TEST_MODE"] = "1"
         app.launchEnvironment["CMUX_UI_TEST_TERMINAL_CMD_CLICK_SETUP"] = "1"


### PR DESCRIPTION
## Summary

- Preserve terminal pane context actions while adding text-specific actions for selections and the right-clicked word.
- Add native AppKit Look Up, Share, and Services support for terminal selected text.
- Format Look Up menu titles with a quoted, truncated preview.

## Validation

- `jq empty Resources/Localizable.xcstrings`
- `git diff --check`
- `./scripts/reload.sh --tag termctx`
- `./scripts/reload.sh --tag feat-terminal-context-selection`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5135"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782941610&installation_id=133855650&pr_number=5135&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5135&signature=21ba691d047365ee1ce48f3827f1843c4f6c127c90c1dd2766df3153620b6b53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the terminal context menu with text-aware actions for selections and right-clicked words while keeping pane actions. Adds localized Look Up with previews, Share, and tighter macOS Services rules that require a real selection.

- New Features
  - Show text actions when available: Copy (selection), Look Up (selection or word) with a quoted, localized preview, and Share; placed above pane actions.
  - Capture context text before right‑click; when no selection, prefer the Ghostty quick‑look word, or if missing/incomplete (e.g., trailing backslash), resolve the visible token.
  - Localized Look Up title (en/ja/ko) with whitespace normalization and smart truncation.

- Bug Fixes
  - macOS Services: require a selection, accept only text send types, disallow return types; don’t read selection contents during validation; use the correct AppKit selector writeSelectionToPasteboard:types:.
  - Stabilize context menu tests by pinning locale to en_US and asserting localized Look Up titles for selected and unselected cases.

<sup>Written for commit fee0dc1b8b967f9a329876c3860289ae7d576aeb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Look Up" option to the terminal context menu for selected and unselected text; includes quoting, whitespace normalization, truncation, and correct pane-action visibility; supports sharing via pasteboard/text services.

* **Tests**
  * Added unit and UI tests verifying context-menu entries, preview formatting, text-service eligibility, pasteboard behavior, and pane-action visibility.

* **Localization**
  * Added localized "Look Up" menu strings (English, Japanese, Korean).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->