### PR TITLE
Fix feedback email typing lag

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1051,6 +1051,10 @@ func titlebarShortcutHintShouldShow(
 }
 
 struct ContentView: View {
+#if DEBUG
+    private static var didOpenFeedbackComposerForUITest = false
+#endif
+
     @ObservedObject var updateViewModel: UpdateViewModel
     let windowId: UUID
     @EnvironmentObject var tabManager: TabManager
@@ -2753,6 +2757,7 @@ struct ContentView: View {
             }
             syncSidebarSelectedWorkspaceIds()
             applyUITestSidebarSelectionIfNeeded(tabs: tabManager.tabs)
+            openFeedbackComposerForUITestIfNeeded()
             updateTitlebarText()
             syncTrafficLightInset()
 
@@ -8970,6 +8975,21 @@ struct ContentView: View {
         }
     }
 
+    private func openFeedbackComposerForUITestIfNeeded() {
+#if DEBUG
+        guard Thread.isMainThread else {
+            DispatchQueue.main.async {
+                openFeedbackComposerForUITestIfNeeded()
+            }
+            return
+        }
+        guard !Self.didOpenFeedbackComposerForUITest else { return }
+        guard ProcessInfo.processInfo.environment["CMUX_UI_TEST_OPEN_FEEDBACK_COMPOSER"] == "1" else { return }
+        Self.didOpenFeedbackComposerForUITest = true
+        presentFeedbackComposer()
+#endif
+    }
+
     static func shouldHandleCommandPaletteRequest(
         observedWindow: NSWindow?,
         requestedWindow: NSWindow?,
@@ -13421,14 +13441,16 @@ private enum SidebarHelpMenuAction {
 private struct SidebarFeedbackComposerSheet: View {
     private static let formMaxHeight: CGFloat = 560
 
-    @AppStorage(FeedbackComposerSettings.storedEmailKey) private var email = ""
     @Environment(\.dismiss) private var dismiss
 
+    @AppStorage(FeedbackComposerSettings.storedEmailKey) private var email = ""
     @State private var message = ""
     @State private var attachments: [FeedbackComposerAttachment] = []
     @State private var isSubmitting = false
     @State private var submissionErrorMessage: String?
     @State private var didSend = false
+
+    private let defaults = UserDefaults.standard
 
     private var trimmedMessage: String {
         message.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -13461,6 +13483,17 @@ private struct SidebarFeedbackComposerSheet: View {
         .padding(20)
         .frame(width: 520)
         .accessibilityIdentifier("SidebarFeedbackDialog")
+#if DEBUG
+        .onAppear {
+            Task { @MainActor in
+                clearStoredEmailForUITestIfNeeded()
+                captureEmailDefaultsState(reason: "appear")
+            }
+        }
+        .onChange(of: email) { _, _ in
+            captureEmailDefaultsState(reason: "email-change")
+        }
+#endif
     }
 
     private var successView: some View {
@@ -13671,6 +13704,38 @@ private struct SidebarFeedbackComposerSheet: View {
     private func removeAttachment(_ attachment: FeedbackComposerAttachment) {
         attachments.removeAll { $0.id == attachment.id }
         submissionErrorMessage = nil
+    }
+
+    private func clearStoredEmailForUITestIfNeeded() {
+#if DEBUG
+        guard ProcessInfo.processInfo.environment["CMUX_UI_TEST_FEEDBACK_EMAIL_CLEAR_STORED"] == "1" else {
+            return
+        }
+        defaults.removeObject(forKey: FeedbackComposerSettings.storedEmailKey)
+        email = ""
+#endif
+    }
+
+    private func captureEmailDefaultsState(reason: String) {
+#if DEBUG
+        _ = CmuxUITestCapture.mutateJSONObjectIfConfigured(
+            envKey: "CMUX_UI_TEST_FEEDBACK_EMAIL_CAPTURE_PATH"
+        ) { payload in
+            var events = payload["emailEvents"] as? [[String: Any]] ?? []
+            let storedEmail = defaults.string(forKey: FeedbackComposerSettings.storedEmailKey)
+            events.append([
+                "reason": reason,
+                "draftEmailIsPresent": email.isEmpty == false,
+                "draftEmailCharacterCount": email.count,
+                "draftEmailUTF8ByteCount": email.utf8.count,
+                "storedEmailIsPresent": storedEmail != nil,
+                "storedEmailCharacterCount": storedEmail?.count ?? 0,
+                "storedEmailUTF8ByteCount": storedEmail?.utf8.count ?? 0,
+                "storedEmailMatchesDraft": storedEmail == email,
+            ])
+            payload["emailEvents"] = events
+        }
+#endif
     }
 
     private func submitFeedback() async {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -13443,14 +13443,19 @@ private struct SidebarFeedbackComposerSheet: View {
 
     @Environment(\.dismiss) private var dismiss
 
-    @AppStorage(FeedbackComposerSettings.storedEmailKey) private var email = ""
+    @State private var email: String
     @State private var message = ""
     @State private var attachments: [FeedbackComposerAttachment] = []
     @State private var isSubmitting = false
     @State private var submissionErrorMessage: String?
     @State private var didSend = false
 
-    private let defaults = UserDefaults.standard
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        _email = State(initialValue: defaults.string(forKey: FeedbackComposerSettings.storedEmailKey) ?? "")
+    }
 
     private var trimmedMessage: String {
         message.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -13494,6 +13499,9 @@ private struct SidebarFeedbackComposerSheet: View {
             captureEmailDefaultsState(reason: "email-change")
         }
 #endif
+        .onDisappear {
+            persistEmail(email)
+        }
     }
 
     private var successView: some View {
@@ -13706,6 +13714,13 @@ private struct SidebarFeedbackComposerSheet: View {
         submissionErrorMessage = nil
     }
 
+    private func persistEmail(_ rawValue: String) {
+        defaults.set(
+            rawValue.trimmingCharacters(in: .whitespacesAndNewlines),
+            forKey: FeedbackComposerSettings.storedEmailKey
+        )
+    }
+
     private func clearStoredEmailForUITestIfNeeded() {
 #if DEBUG
         guard ProcessInfo.processInfo.environment["CMUX_UI_TEST_FEEDBACK_EMAIL_CLEAR_STORED"] == "1" else {
@@ -13768,6 +13783,7 @@ private struct SidebarFeedbackComposerSheet: View {
 
         await MainActor.run {
             email = trimmedEmail
+            persistEmail(trimmedEmail)
             submissionErrorMessage = nil
             isSubmitting = true
         }

--- a/Sources/Feed/FeedCoordinator.swift
+++ b/Sources/Feed/FeedCoordinator.swift
@@ -591,6 +591,18 @@ private extension FeedCoordinator {
                         effects: effects
                     )
                 case .notDetermined:
+#if DEBUG
+                    if ProcessInfo.processInfo.environment["CMUX_UI_TEST_SUPPRESS_NOTIFICATION_AUTH"] == "1" {
+                        self.runFallbackEffectsIfStillAwaiting(
+                            requestId: requestId,
+                            title: title,
+                            subtitle: subtitle,
+                            body: body,
+                            effects: effects
+                        )
+                        return
+                    }
+#endif
                     let granted = (
                         try? await center.requestAuthorization(options: [.alert, .sound])
                     ) ?? false

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -2081,6 +2081,13 @@ final class TerminalNotificationStore: ObservableObject {
         logAuthorization(
             "request starting origin=\(origin.rawValue) automatic=\(isAutomaticRequest) hasRequestedAutomatic=\(hasRequestedAutomaticAuthorization)"
         )
+#if DEBUG
+        if ProcessInfo.processInfo.environment["CMUX_UI_TEST_SUPPRESS_NOTIFICATION_AUTH"] == "1" {
+            logAuthorization("request suppressed origin=\(origin.rawValue) uiTest=1")
+            completion(false)
+            return
+        }
+#endif
         center.requestAuthorization(options: [.alert, .sound]) { granted, error in
             DispatchQueue.main.async {
                 if granted {

--- a/cmuxUITests/SidebarHelpMenuUITests.swift
+++ b/cmuxUITests/SidebarHelpMenuUITests.swift
@@ -123,6 +123,49 @@ final class SidebarHelpMenuUITests: XCTestCase {
         XCTAssertTrue(app.staticTexts["5/4000"].waitForExistence(timeout: 2.0))
     }
 
+    func testFeedbackEmailDraftDoesNotPersistWhileEditing() throws {
+        let capturePath = NSTemporaryDirectory()
+            + "cmux-feedback-email-\(ProcessInfo.processInfo.globallyUniqueString).json"
+        try? FileManager.default.removeItem(atPath: capturePath)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(atPath: capturePath)
+        }
+        let email = "lag@example.com"
+
+        let app = XCUIApplication()
+        app.launchEnvironment["CMUX_UI_TEST_MODE"] = "1"
+        app.launchEnvironment["CMUX_UI_TEST_AUTO_ALLOW_PERMISSION"] = "1"
+        app.launchEnvironment["CMUX_UI_TEST_SUPPRESS_NOTIFICATION_AUTH"] = "1"
+        app.launchEnvironment["CMUX_UI_TEST_OPEN_FEEDBACK_COMPOSER"] = "1"
+        app.launchEnvironment["CMUX_UI_TEST_FEEDBACK_EMAIL_CLEAR_STORED"] = "1"
+        app.launchEnvironment["CMUX_UI_TEST_FEEDBACK_EMAIL_CAPTURE_PATH"] = capturePath
+        launchAndActivate(app)
+
+        XCTAssertTrue(app.staticTexts["Send Feedback"].waitForExistence(timeout: 5.0))
+        let emailField = requireElement(
+            candidates: [
+                app.textFields["SidebarFeedbackEmailField"],
+                app.textFields["Your Email"],
+            ],
+            timeout: 3.0,
+            description: "feedback email field"
+        )
+        emailField.click()
+        emailField.typeText(email)
+
+        let typedEvent = try waitForFeedbackEmailEvent(
+            at: capturePath,
+            timeout: 4.0
+        ) { event in
+            event["reason"] as? String == "email-change" &&
+                event["draftEmailCharacterCount"] as? Int == email.count &&
+                event["draftEmailUTF8ByteCount"] as? Int == email.utf8.count
+        }
+
+        XCTAssertEqual(typedEvent["storedEmailMatchesDraft"] as? Bool, false)
+        XCTAssertEqual(typedEvent["storedEmailIsPresent"] as? Bool, false)
+    }
+
     private func waitForWindowCount(atLeast count: Int, app: XCUIApplication, timeout: TimeInterval) -> Bool {
         sidebarHelpPollUntil(timeout: timeout) {
             app.windows.count >= count
@@ -175,6 +218,30 @@ final class SidebarHelpMenuUITests: XCTestCase {
             return candidates[0]
         }
         return element
+    }
+
+    private func waitForFeedbackEmailEvent(
+        at path: String,
+        timeout: TimeInterval,
+        matching predicate: ([String: Any]) -> Bool
+    ) throws -> [String: Any] {
+        var matchedEvent: [String: Any]?
+        let found = sidebarHelpPollUntil(timeout: timeout) {
+            guard let events = try? readFeedbackEmailEvents(at: path) else {
+                return false
+            }
+            matchedEvent = events.last(where: predicate)
+            return matchedEvent != nil
+        }
+        XCTAssertTrue(found, "Expected feedback email capture event matching predicate")
+        return try XCTUnwrap(matchedEvent)
+    }
+
+    private func readFeedbackEmailEvents(at path: String) throws -> [[String: Any]] {
+        let data = try Data(contentsOf: URL(fileURLWithPath: path))
+        let object = try JSONSerialization.jsonObject(with: data)
+        let payload = try XCTUnwrap(object as? [String: Any])
+        return payload["emailEvents"] as? [[String: Any]] ?? []
     }
 
     private func launchAndActivate(_ app: XCUIApplication, activateTimeout: TimeInterval = 2.0) {


### PR DESCRIPTION
## Summary
- Stop binding the feedback composer email field directly to UserDefaults via @AppStorage.
- Keep the draft email in local SwiftUI state while editing.
- Persist the trimmed email only when the sheet closes or a valid submit starts.
- Keep UI-test diagnostics DEBUG-only, process-wide where needed, and redacted.

## Verification
- Tagged local build passed: ./scripts/reload.sh --tag fbemail
- Red regression run failed on the test-only commit as expected: https://github.com/manaflow-ai/cmux/actions/runs/26787482714
- Red artifact issue: https://github.com/manaflow-ai/cmux-dev-artifacts/issues/2057
- Green fix run passed: https://github.com/manaflow-ai/cmux/actions/runs/26787483856
- Green artifact issue: https://github.com/manaflow-ai/cmux-dev-artifacts/issues/2058

## Proof Note
- Cloud CUA before/after video proof was not completed. The regression proof for this PR is the hosted XCUITest split above, with workflow video artifacts.

## Dogfood Build
- Tag: fbemail