### PR TITLE
fix(release): set GH_TOKEN on appcast R2 upload step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -428,6 +428,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.CF_R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.CF_R2_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: auto
+          GH_TOKEN: ${{ github.token }}
           R2_ENDPOINT: "https://${{ secrets.CF_R2_ACCOUNT_ID }}.r2.cloudflarestorage.com"
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary

**What changed?** Add `GH_TOKEN: ${{ github.token }}` to the existing `env:` block of the "Upload release appcast to R2" step in `.github/workflows/release.yml`.

**Why?** CI failure on the v0.64.11 release run ([run 26754933970, job 78852221332](https://github.com/manaflow-ai/cmux/actions/runs/26754933970/job/78852221332)):

```
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable.
Error: Process completed with exit code 4.
```

The "Upload release appcast to R2" step in `build-sign-notarize` runs `gh release list` to decide whether the current tag is the latest semver (so a backport tag can't overwrite the stable appcast). The step's `env:` block only set the R2/AWS credentials — no `GH_TOKEN` in scope at any level (workflow / job / step), so the `gh` CLI bailed before the upload ran. The job's `contents: write` permission isn't enough; `gh` needs the token via env.

`github.token` is the auto-injected GitHub Actions token (same as `secrets.GITHUB_TOKEN`) — no new secret to register. Step-level scope chosen as the smallest blast radius: this is the only `gh` call in the job and the only offender across all workflow files (audited).

**Effect:** Re-running `build-sign-notarize` on a release tag lets `gh release list` succeed, the latest-tag guard executes correctly, and the appcast upload to R2 (`s3://cmux-binaries/stable/appcast.xml`) completes — restoring Sparkle auto-update delivery for the stable channel on tag pushes.

## Testing

Workflow-only change (one env var on one CI step); there is no app/runtime code to build or dogfood. Verification is via CI:

- `workflow-guard-tests` and the rest of the CI matrix pass on this PR.
- The actual fix is exercised by the next release tag push, where `gh release list` now authenticates instead of exiting with code 4.

## Demo Video

N/A — CI/workflow YAML change, no UI or runtime behavior to demo.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally (workflow-only; verified via CI — no app build applicable)
- [x] I added or updated tests for behavior changes (N/A — CI workflow YAML, no behavioral test seam)
- [x] I updated docs/changelog if needed (N/A — internal release tooling fix)
- [x] I requested bot reviews after my latest commit
- [x] All code review bot comments are resolved
- [x] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782944493&installation_id=133855650&pr_number=5139&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5139&signature=0f8989761d2fa1898bcbbb63c8694b04ad67240de358985abf1127b5301f0243"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single env var on one workflow step; no app runtime, auth, or data-path changes.
> 
> **Overview**
> Fixes release CI for the **Upload release appcast to R2** step by setting **`GH_TOKEN`** from **`github.token`** in that step’s `env` block.
> 
> The step already runs **`gh release list`** to skip R2 stable appcast uploads when the pushed tag isn’t the highest semver (backport guard). Without **`GH_TOKEN`**, the GitHub CLI exits in Actions and the job fails before the R2 upload, which blocked stable Sparkle appcast updates on tag pushes (e.g. v0.64.11).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02cc3e0106d9df865e7abc0f968beb3c0cc0b4b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `GH_TOKEN: ${{ github.token }}` on the "Upload release appcast to R2" step so `gh release list` can run in CI. This fixes the release workflow and restores the stable appcast upload (Sparkle auto-updates) on tag pushes.

<sup>Written for commit 02cc3e0106d9df865e7abc0f968beb3c0cc0b4b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow authentication for improved deployment reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
