### PR TITLE
Simplify Hermes hook dispatch

### DIFF
--- a/CLI/CMUXCLI+AgentHookDefinitions.swift
+++ b/CLI/CMUXCLI+AgentHookDefinitions.swift
@@ -370,6 +370,7 @@ extension CMUXCLI {
 
     private static let grokPinnedHookMarker = "cmux-grok-hook-v2"
     private static let antigravityPinnedHookMarker = "cmux-antigravity-hook-v2"
+    private static let hermesAgentPinnedHookMarker = "cmux-hermes-agent-hook-v2"
 
     private static func agentHookShellCommand(_ command: String, for def: AgentHookDef) -> String {
         if usesPinnedHookDispatch(def) {
@@ -385,35 +386,23 @@ extension CMUXCLI {
     }
 
     private static func usesPinnedHookDispatch(_ def: AgentHookDef) -> Bool {
-        def.name == "grok" || def.name == "antigravity"
+        def.name == "grok" || def.name == "antigravity" || def.name == "hermes-agent"
     }
 
     private static func pinnedHookMarker(for def: AgentHookDef) -> String {
-        def.name == "antigravity" ? antigravityPinnedHookMarker : grokPinnedHookMarker
+        switch def.name {
+        case "antigravity":
+            return antigravityPinnedHookMarker
+        case "hermes-agent":
+            return hermesAgentPinnedHookMarker
+        default:
+            return grokPinnedHookMarker
+        }
     }
 
     private static func pinnedAgentHookShellCommand(_ command: String, for def: AgentHookDef) -> String {
         let routedArguments = command.hasPrefix("cmux ") ? String(command.dropFirst("cmux ".count)) : command
         let socketPath = pinnedAgentHookSocketPath()
-        let shellTraceStart = pinnedHookShellTraceCommand(
-            agentName: def.name,
-            phase: "start",
-            routedArguments: routedArguments,
-            socketPath: socketPath
-        )
-        let shellTraceDisabled = pinnedHookShellTraceCommand(
-            agentName: def.name,
-            phase: "disabled",
-            routedArguments: routedArguments,
-            socketPath: socketPath
-        )
-        let shellTraceExit = pinnedHookShellTraceCommand(
-            agentName: def.name,
-            phase: "exit",
-            routedArguments: routedArguments,
-            socketPath: socketPath,
-            statusExpression: "$cmux_hook_status"
-        )
         let fallbackInvocation = pinnedHookInvocation(
             executable: "cmux",
             routedArguments: routedArguments,
@@ -431,7 +420,7 @@ extension CMUXCLI {
         } else {
             dispatch = "command -v cmux >/dev/null 2>&1 && \(fallbackInvocation) || echo '{}'"
         }
-        return ": \(pinnedHookMarker(for: def)); \(shellTraceStart); printenv \(def.disableEnvVar) | grep -qx 1 && { \(shellTraceDisabled); echo '{}'; } || { \(dispatch); cmux_hook_status=$?; \(shellTraceExit); exit $cmux_hook_status; }"
+        return ": \(pinnedHookMarker(for: def)); printenv \(def.disableEnvVar) | grep -qx 1 && echo '{}' || { \(dispatch); cmux_hook_status=$?; exit $cmux_hook_status; }"
     }
 
     private static func pinnedHookInvocation(
@@ -494,38 +483,6 @@ extension CMUXCLI {
             .trimmingCharacters(in: CharacterSet(charactersIn: "-"))
         guard !slug.isEmpty else { return nil }
         return "/tmp/cmux-debug-\(slug).sock"
-    }
-
-    private static func pinnedHookShellTraceCommand(
-        agentName: String,
-        phase: String,
-        routedArguments: String,
-        socketPath: String?,
-        statusExpression: String? = nil
-    ) -> String {
-#if DEBUG
-        let logPath = shellSingleQuote(pinnedHookShellTraceLogPath(socketPath: socketPath))
-        let event = shellSingleQuote(routedArguments)
-        let socket = shellSingleQuote(socketPath.map { URL(fileURLWithPath: $0).lastPathComponent } ?? "nil")
-        let statusField = statusExpression == nil ? "" : " status=%s"
-        let statusArgument = statusExpression.map { " \($0)" } ?? ""
-        return "printf '%s \(agentName)Hook.shell phase=%s event=%s pid=%s ppid=%s socket=%s\(statusField)\\n' \"$(date +%s)\" \(shellSingleQuote(phase)) \(event) \"$$\" \"${PPID:-}\" \(socket)\(statusArgument) >> \(logPath) 2>/dev/null || true"
-#else
-        return ":"
-#endif
-    }
-
-    private static func pinnedHookShellTraceLogPath(socketPath: String?) -> String {
-        guard let socketPath else {
-            return "/tmp/cmux-debug.log"
-        }
-        let socketName = URL(fileURLWithPath: socketPath).lastPathComponent
-        if socketName.hasPrefix("cmux-debug-"), socketName.hasSuffix(".sock") {
-            return URL(fileURLWithPath: "/tmp", isDirectory: true)
-                .appendingPathComponent(String(socketName.dropLast(".sock".count)) + ".log")
-                .path
-        }
-        return "/tmp/cmux-debug.log"
     }
 
     private static func normalizedHookInstallValue(_ value: String?) -> String? {

--- a/cmuxTests/CLIGenericHookPersistenceTests.swift
+++ b/cmuxTests/CLIGenericHookPersistenceTests.swift
@@ -948,6 +948,70 @@ extension CLINotifyProcessIntegrationRegressionTests {
         XCTAssertNotNil(cmuxGroup["PostToolUse"])
     }
 
+    func testHermesAgentHookInstallUsesPinnedDispatcherAndAllowlist() throws {
+        let cliPath = try bundledCLIPath()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-hermes-hook-install-\(UUID().uuidString)", isDirectory: true)
+        let hermesHome = root.appendingPathComponent(".hermes", isDirectory: true)
+        try FileManager.default.createDirectory(at: hermesHome, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let pinnedCLI = root.appendingPathComponent("cmux pinned dev cli", isDirectory: false)
+        try "#!/bin/sh\nexit 0\n".write(to: pinnedCLI, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: pinnedCLI.path)
+
+        let socketPath = "/tmp/cmux-debug-hermes-pin.sock"
+        let result = runProcess(
+            executablePath: cliPath,
+            arguments: ["hooks", "hermes-agent", "install", "--yes"],
+            environment: [
+                "HOME": root.path,
+                "HERMES_HOME": hermesHome.path,
+                "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+                "CMUX_BUNDLED_CLI_PATH": pinnedCLI.path,
+                "CMUX_SOCKET_PATH": socketPath,
+                "CMUX_CLI_SENTRY_DISABLED": "1",
+            ],
+            timeout: 5
+        )
+
+        XCTAssertFalse(result.timedOut, result.stderr)
+        XCTAssertEqual(result.status, 0, result.stderr)
+
+        let configURL = hermesHome.appendingPathComponent("config.yaml", isDirectory: false)
+        let config = try String(contentsOf: configURL, encoding: .utf8)
+        XCTAssertTrue(config.contains("cmux-hermes-agent-hook-v2"), config)
+        XCTAssertTrue(config.contains("sh -c"), config)
+        XCTAssertFalse(config.contains("printf"), config)
+        XCTAssertFalse(config.contains("Hook.shell"), config)
+        XCTAssertTrue(config.contains("hooks hermes-agent session-start"), config)
+        XCTAssertTrue(config.contains("hooks feed --source hermes-agent --event pre_tool_call"), config)
+        XCTAssertTrue(config.contains(pinnedCLI.path), config)
+        XCTAssertTrue(config.contains(socketPath), config)
+        XCTAssertFalse(
+            config.contains(#"[ -n "$CMUX_SURFACE_ID" ]"#),
+            "Hermes hooks should use the same pinned dispatch path as Grok and Antigravity, saw \(config)"
+        )
+        XCTAssertFalse(
+            config.contains("$CMUX_"),
+            "Hermes hook config should avoid live CMUX_* shell interpolation, saw \(config)"
+        )
+
+        let allowlistURL = hermesHome.appendingPathComponent("shell-hooks-allowlist.json", isDirectory: false)
+        let allowlist = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(contentsOf: allowlistURL)) as? [String: Any])
+        let approvals = try XCTUnwrap(allowlist["approvals"] as? [[String: Any]])
+        let approvedCommands = approvals.compactMap { $0["command"] as? String }
+        XCTAssertFalse(approvedCommands.isEmpty)
+        XCTAssertTrue(
+            approvedCommands.allSatisfy { $0.contains("cmux-hermes-agent-hook-v2") },
+            "Expected Hermes allowlist entries to match pinned cmux hook commands, saw \(approvedCommands)"
+        )
+        XCTAssertTrue(
+            approvedCommands.contains { $0.contains("hooks feed --source hermes-agent --event pre_tool_call") },
+            "Expected Hermes Feed bridge to be allowlisted, saw \(approvedCommands)"
+        )
+    }
+
     func testKiroHookInstallUsesAgentConfigShapeAndPreservesDenyExit() throws {
         let cliPath = try bundledCLIPath()
         let root = FileManager.default.temporaryDirectory
@@ -2824,6 +2888,10 @@ extension CLINotifyProcessIntegrationRegressionTests {
         XCTAssertTrue(
             allCommands.allSatisfy { $0.contains("cmux-grok-hook-v2") },
             "Expected installed Grok hooks to carry the owned-hook marker, saw \(allCommands)"
+        )
+        XCTAssertFalse(
+            allCommands.contains { $0.contains("printf") || $0.contains("Hook.shell") },
+            "Installed Grok hooks should stay compact and avoid debug shell tracing, saw \(allCommands)"
         )
         XCTAssertTrue(
             allCommands.allSatisfy { $0.contains("'\(pinnedCLI.path)'") },

--- a/docs/agent-hooks.md
+++ b/docs/agent-hooks.md
@@ -11,7 +11,7 @@ cmux hooks setup --agent <agent>
 cmux hooks uninstall <agent>
 ```
 
-Supported agent names are `codex`, `grok`, `opencode`, `pi`, `amp`, `cursor`, `gemini`, `kiro`, `rovodev` (or `rovo`), `copilot`, `codebuddy`, `factory`, and `qoder`. `cmux hooks setup` skips agents whose binary is not on `PATH` and prints a summary.
+Supported agent names are `codex`, `grok`, `opencode`, `pi`, `amp`, `cursor`, `gemini`, `kiro`, `antigravity` (or `agy`), `rovodev` (or `rovo`), `hermes-agent`, `copilot`, `codebuddy`, `factory`, and `qoder`. `cmux hooks setup` skips agents whose binary is not on `PATH` and prints a summary.
 
 ## Integrations
 
@@ -26,7 +26,9 @@ Supported agent names are `codex`, `grok`, `opencode`, `pi`, `amp`, `cursor`, `g
 | Cursor CLI | `cursor-agent` | `~/.cursor/hooks.json` | `cursor-agent --resume <id>` | beforeShellExecution |
 | Gemini | `gemini` | `~/.gemini/settings.json` | `gemini --resume <id>` | PreToolUse |
 | Kiro CLI | `kiro-cli` | `~/.kiro/agents/cmux.json` or `$KIRO_HOME/agents/cmux.json` | `kiro-cli chat --resume-id <id>` | preToolUse, postToolUse |
+| Antigravity | `agy` | `~/.gemini/config/hooks.json` | `agy --conversation <id>` | PreToolUse, PostToolUse |
 | Rovo Dev | `acli` | `~/.rovodev/config.yml` | `acli rovodev run --restore <id>` | none |
+| Hermes Agent | `hermes` | `~/.hermes/config.yaml`, `~/.hermes/shell-hooks-allowlist.json` | `hermes --resume <id>` | pre_tool_call, post_tool_call, pre_approval_request, post_approval_response |
 | Copilot | `copilot` | `~/.copilot/config.json` | `copilot --resume <id>` | PreToolUse |
 | CodeBuddy | `codebuddy` | `~/.codebuddy/settings.json` | `codebuddy --resume <id>` | PreToolUse |
 | Factory | `droid` | `~/.factory/settings.json` | `droid --resume <id>` | PreToolUse |
@@ -118,7 +120,9 @@ and browser state. Restored agent terminals stay idle until you resume them manu
 | Cursor CLI | none | `CMUX_CURSOR_HOOKS_DISABLED=1` |
 | Gemini | none | `CMUX_GEMINI_HOOKS_DISABLED=1` |
 | Kiro CLI | `KIRO_HOME` | `CMUX_KIRO_HOOKS_DISABLED=1` |
+| Antigravity | none | `CMUX_ANTIGRAVITY_HOOKS_DISABLED=1` |
 | Rovo Dev | none | `CMUX_ROVODEV_HOOKS_DISABLED=1` |
+| Hermes Agent | `HERMES_HOME` | `CMUX_HERMES_AGENT_HOOKS_DISABLED=1` |
 | Copilot | `COPILOT_HOME` | `CMUX_COPILOT_HOOKS_DISABLED=1` |
 | CodeBuddy | `CODEBUDDY_CONFIG_DIR` | `CMUX_CODEBUDDY_HOOKS_DISABLED=1` |
 | Factory | none | `CMUX_FACTORY_HOOKS_DISABLED=1` |


### PR DESCRIPTION
## Summary
- route Hermes Agent hooks through the same pinned cmux CLI/socket dispatcher used by Grok and Antigravity
- keep Hermes-specific YAML and shell-hook allowlist handling isolated to the Hermes installer
- document Hermes Agent and Antigravity in agent hook docs

## Verification
- ./scripts/reload.sh --tag hghooks
- built CLI smoke test for `cmux hooks hermes-agent install --yes`, verified pinned marker, socket pin, Feed bridge, and allowlist entries
- AWS xcodebuild runner could not run `xcodebuild -list` for the clean checkout, exited 133 before compile with no stderr

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5140"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782945337&installation_id=133855650&pr_number=5140&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5140&signature=e57298e59dd07d914110334fa995451cfd11d2c48e9543b150072615e914fcf0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes installed hook command shape and how agents invoke cmux at runtime; follows an existing pinned pattern but affects session/Feed bridging for Hermes and Grok/Antigravity installs.
> 
> **Overview**
> **Hermes Agent** hook install now uses the same **pinned** `cmux` CLI and socket dispatcher as **Grok** and **Antigravity**, with owned marker `cmux-hermes-agent-hook-v2`, instead of runtime `CMUX_SURFACE_ID` / `$CMUX_*` shell gating.
> 
> Pinned hook shell snippets are **simplified** by dropping DEBUG-only `printf` / `Hook.shell` trace logging (applies to all pinned agents, not only Hermes).
> 
> Adds an install regression test for Hermes (pinned paths, Feed bridge, shell-hook allowlist) and tightens the Grok pin test to forbid debug tracing. **Docs** list `hermes-agent` and `antigravity` in supported agents, integration table, and disable env vars.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d3a58b54931ef465f2e8ff0e67f085ef3b5d019. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies `hermes-agent` hook dispatch by using the same pinned `cmux` CLI/socket path as `grok` and `antigravity`, and removes debug shell tracing for a smaller, safer shell. Adds tests and docs to cover the new flow.

- **Refactors**
  - Route `hermes-agent` through the pinned dispatcher (`cmux-hermes-agent-hook-v2`) used by `grok`/`antigravity`.
  - Remove debug shell tracing from pinned hook commands; keep disable-env check and exit status.
  - Keep Hermes YAML + allowlist in the installer, including the Feed bridge; avoid `$CMUX_*` interpolation.
  - Add a Hermes install regression test and tighten Grok tests to assert no shell tracing; update docs with `hermes-agent`/`antigravity` in integrations and env overrides.

<sup>Written for commit 7d3a58b54931ef465f2e8ff0e67f085ef3b5d019. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for hermes-agent and antigravity in the pinned hook dispatch, enabling proper detection and pinned dispatch for those agents.

* **Documentation**
  * Expanded agent-hooks docs with Antigravity and Hermes Agent details: binaries, session restore, env overrides, and feed/approval bridging.

* **Bug Fixes**
  * Simplified generated hook shell commands by removing embedded debug-tracing instrumentation.

* **Tests**
  * Added tests validating pinned dispatch, allowlist entries, and absence of debug-tracing in installed hook commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->