### PR TITLE
Fix Claude fork resume cwd

### DIFF
--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -362,7 +362,11 @@ enum AgentResumeCommandBuilder {
 
         let cwd = !includeWorkingDirectoryPrefix || customRegistration?.cwd == .ignore
             ? nil
-            : normalized(workingDirectory ?? launchCommand?.workingDirectory)
+            : commandWorkingDirectory(
+                kind: kind,
+                launchCommand: launchCommand,
+                workingDirectory: workingDirectory
+            )
         let sanitizedCommandParts = customRegistration == nil
             ? AgentLaunchSanitizer.removingSavedWorkingDirectoryOptions(
                 from: commandParts,
@@ -371,6 +375,17 @@ enum AgentResumeCommandBuilder {
             : commandParts
         let shellCommand = sanitizedCommandParts.map(shellSingleQuoted).joined(separator: " ")
         return TerminalStartupWorkingDirectoryPrefix.prefix(shellCommand, workingDirectory: cwd)
+    }
+
+    private static func commandWorkingDirectory(
+        kind: RestorableAgentKind,
+        launchCommand: AgentLaunchCommandSnapshot?,
+        workingDirectory: String?
+    ) -> String? {
+        if kind == .claude {
+            return normalized(launchCommand?.workingDirectory) ?? normalized(workingDirectory)
+        }
+        return normalized(workingDirectory ?? launchCommand?.workingDirectory)
     }
 
     static func openCodeVersionProbe(

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -2424,6 +2424,40 @@ final class SocketListenerAcceptPolicyTests: XCTestCase {
         )
     }
 
+    func testClaudeResumeAndForkCommandsUseLaunchProjectDirectoryWhenSnapshotDirectoryDrifts() {
+        let snapshot = SessionRestorableAgentSnapshot(
+            kind: .claude,
+            sessionId: "a1fcdb44-3fe9-4045-98bf-256e21051de3",
+            workingDirectory: "/Users/lawrence/fun/cmuxterm-hq/worktrees/feat-ios-swift-mobile-core",
+            launchCommand: AgentLaunchCommandSnapshot(
+                launcher: "claude",
+                executablePath: "/Users/lawrence/.local/bin/claude",
+                arguments: [
+                    "/Users/lawrence/.local/bin/claude",
+                    "--dangerously-skip-permissions"
+                ],
+                workingDirectory: "/Users/lawrence/fun/cmuxterm-hq",
+                environment: [
+                    "CLAUDE_CONFIG_DIR": "/Users/lawrence/.codex-accounts/claude/_p1775010019397"
+                ],
+                capturedAt: 123,
+                source: "environment"
+            )
+        )
+
+        XCTAssertEqual(
+            snapshot.resumeCommand,
+            "{ cd -- '/Users/lawrence/fun/cmuxterm-hq' 2>/dev/null || [ ! -d '/Users/lawrence/fun/cmuxterm-hq' ]; } && 'env' 'CLAUDE_CONFIG_DIR=/Users/lawrence/.codex-accounts/claude/_p1775010019397' 'CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV=1' 'CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV_KEYS=CLAUDE_CONFIG_DIR' '/Users/lawrence/.local/bin/claude' '--resume' 'a1fcdb44-3fe9-4045-98bf-256e21051de3' '--dangerously-skip-permissions'"
+        )
+        XCTAssertEqual(
+            snapshot.forkCommand,
+            "{ cd -- '/Users/lawrence/fun/cmuxterm-hq' 2>/dev/null || [ ! -d '/Users/lawrence/fun/cmuxterm-hq' ]; } && 'env' 'CLAUDE_CONFIG_DIR=/Users/lawrence/.codex-accounts/claude/_p1775010019397' 'CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV=1' 'CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV_KEYS=CLAUDE_CONFIG_DIR' '/Users/lawrence/.local/bin/claude' '--resume' 'a1fcdb44-3fe9-4045-98bf-256e21051de3' '--fork-session' '--dangerously-skip-permissions'"
+        )
+        XCTAssertFalse(
+            snapshot.forkCommand?.contains("/Users/lawrence/fun/cmuxterm-hq/worktrees/feat-ios-swift-mobile-core") ?? true
+        )
+    }
+
     func testForkCommandsUseVerifiedAgentForkSyntaxAndPreserveContext() {
         let claude = SessionRestorableAgentSnapshot(
             kind: .claude,

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -5726,6 +5726,53 @@ final class WorkspacePanelGitBranchTests: XCTestCase {
         )
     }
 
+    func testForkAgentConversationForClaudeUsesLaunchProjectDirectoryWhenPanelDirectoryDrifts() throws {
+        let workspace = Workspace()
+        let launchProjectDirectory = "/Users/lawrence/fun/cmuxterm-hq"
+        let driftedPanelDirectory = "/Users/lawrence/fun/cmuxterm-hq/worktrees/feat-ios-swift-mobile-core"
+        workspace.currentDirectory = driftedPanelDirectory
+        let sourcePanelId = try XCTUnwrap(workspace.focusedPanelId)
+        let snapshot = SessionRestorableAgentSnapshot(
+            kind: .claude,
+            sessionId: "a1fcdb44-3fe9-4045-98bf-256e21051de3",
+            workingDirectory: nil,
+            launchCommand: AgentLaunchCommandSnapshot(
+                launcher: "claude",
+                executablePath: "/Users/lawrence/.local/bin/claude",
+                arguments: [
+                    "/Users/lawrence/.local/bin/claude",
+                    "--dangerously-skip-permissions"
+                ],
+                workingDirectory: launchProjectDirectory,
+                environment: [
+                    "CLAUDE_CONFIG_DIR": "/Users/lawrence/.codex-accounts/claude/_p1775010019397"
+                ],
+                capturedAt: 123,
+                source: "environment"
+            )
+        )
+
+        let forkPanel = try XCTUnwrap(
+            workspace.forkAgentConversation(
+                fromPanelId: sourcePanelId,
+                snapshot: snapshot,
+                direction: .right
+            )
+        )
+        let initialInput = try XCTUnwrap(forkPanel.surface.initialInput)
+
+        XCTAssertEqual(forkPanel.requestedWorkingDirectory, driftedPanelDirectory)
+        XCTAssertTrue(
+            initialInput.hasPrefix("{ cd -- '\(launchProjectDirectory)' 2>/dev/null"),
+            initialInput
+        )
+        XCTAssertFalse(initialInput.contains("{ cd -- '\(driftedPanelDirectory)'"), initialInput)
+        XCTAssertTrue(
+            initialInput.contains("'--resume' 'a1fcdb44-3fe9-4045-98bf-256e21051de3' '--fork-session'"),
+            initialInput
+        )
+    }
+
     func testForkAgentConversationInRemoteWorkspaceUsesRemoteStartupCommand() throws {
         let workspace = Workspace()
         workspace.configureRemoteConnection(


### PR DESCRIPTION
## Summary
- Preserve Claude Code's launch project directory when building resume and fork commands.
- Add regression coverage for drifted panel cwd producing the wrong Claude project scope.

## Testing
- git diff --check
- ./scripts/reload.sh --tag cfrcwd

## Issues
- Related: user-reported command failed with `No conversation found with session ID: a1fcdb44-3fe9-4045-98bf-256e21051de3` after cmux launched Claude from `/Users/lawrence/fun/cmuxterm-hq/worktrees/feat-ios-swift-mobile-core` instead of `/Users/lawrence/fun/cmuxterm-hq`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5142"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782945709&installation_id=133855650&pr_number=5142&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5142&signature=ad552eccf184cf96f48a7149b4d7620e7dc2c35455ac06c008b5d32ba83f3bcc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow agent-kind branch in resume command building with targeted tests; no auth or broad behavioral change for non-Claude agents.
> 
> **Overview**
> Claude **resume** and **fork** shell commands now pick the `cd` prefix from the **launch snapshot’s project directory** when it differs from the panel or snapshot working directory (e.g. a git worktree path). Other agents still prefer the current panel/snapshot cwd over the launch snapshot.
> 
> Regression tests cover drifted cwd on persisted resume/fork strings and on workspace fork UI startup input.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6709bf7e0c792efcd9c307f886763957f90c7416. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure Claude resume and fork commands use the original launch project directory. This preserves the correct project scope and fixes session resume failures when the panel cwd drifts.

- **Bug Fixes**
  - For `kind: .claude`, resolve cwd to `launchCommand.workingDirectory` (fallback to provided cwd) when building resume/fork commands.
  - Added regression tests for resume/fork and workspace fork flows when the panel directory differs from the launch directory.
  - Prevents errors like "No conversation found with session ID: a1fcdb44-3fe9-4045-98bf-256e21051de3" caused by launching from a worktree.

<sup>Written for commit 6709bf7e0c792efcd9c307f886763957f90c7416. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed working directory resolution for Claude agent sessions when resuming or forking conversations in workspaces where the current directory differs from the launch configuration directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->