### PR TITLE
Honor Settings rebinding of Global Search (parse package object-form cmux.json bindings)

### DIFF
--- a/Sources/KeyboardShortcutSettingsFileStore.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore.swift
@@ -1004,6 +1004,17 @@ final class CmuxSettingsFileStore {
                     allowBareFirstStroke: action.allowsBareFirstStroke
                 )
             }
+            // Object form written by the CmuxSettings package recorder (the
+            // in-app Settings UI): { "first": { key, command, ... }, "second": { ... }? }.
+            // The package serializes StoredShortcut as nested stroke objects, so
+            // a rebinding made in Settings only reaches this store in that shape.
+            // Decode it here so every action resolved through this store — most
+            // visibly the system-wide Carbon hotkeys (globalSearch,
+            // showHideAllWindows) — honors the rebinding instead of silently
+            // dropping it and falling back to the built-in default.
+            if let object = rawValue as? [String: Any] {
+                return parseShortcutObjectForm(object)
+            }
             return nil
         }()
 
@@ -1011,6 +1022,39 @@ final class CmuxSettingsFileStore {
         // Settings-file parsing runs while the shared store may still be initializing.
         // Avoid the UI recorder's conflict lookup here because it reads the shared store.
         return action.normalizedSettingsFileShortcut(shortcut)
+    }
+
+    /// Decodes the nested-object binding the CmuxSettings package writes
+    /// (`{ "first": { stroke }, "second": { stroke }? }`) into the app-target
+    /// ``StoredShortcut``. An empty primary key is the package's explicit
+    /// "unbound" marker. Returns `nil` only when `first` is missing or
+    /// malformed, matching the silently-ignored behavior of the string forms.
+    private func parseShortcutObjectForm(_ object: [String: Any]) -> StoredShortcut? {
+        guard let firstValue = object["first"],
+              let first = parseShortcutStrokeObject(firstValue) else {
+            return nil
+        }
+        if first.key.isEmpty {
+            return .unbound
+        }
+        let second = object["second"].flatMap(parseShortcutStrokeObject)
+        return StoredShortcut(first: first, second: second)
+    }
+
+    private func parseShortcutStrokeObject(_ rawValue: Any) -> ShortcutStroke? {
+        if rawValue is NSNull { return nil }
+        guard let dict = rawValue as? [String: Any],
+              let key = jsonString(dict["key"]) else {
+            return nil
+        }
+        return ShortcutStroke(
+            key: key,
+            command: jsonBool(dict["command"]) ?? false,
+            shift: jsonBool(dict["shift"]) ?? false,
+            option: jsonBool(dict["option"]) ?? false,
+            control: jsonBool(dict["control"]) ?? false,
+            keyCode: jsonInt(dict["keyCode"]).map { UInt16(truncatingIfNeeded: $0) }
+        )
     }
 
     private func parseNullableHex(

--- a/Sources/KeyboardShortcutSettingsFileStore.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore.swift
@@ -1013,7 +1013,7 @@ final class CmuxSettingsFileStore {
             // showHideAllWindows) — honors the rebinding instead of silently
             // dropping it and falling back to the built-in default.
             if let object = rawValue as? [String: Any] {
-                return parseShortcutObjectForm(object)
+                return parseShortcutObjectForm(object, action: action)
             }
             return nil
         }()
@@ -1027,9 +1027,15 @@ final class CmuxSettingsFileStore {
     /// Decodes the nested-object binding the CmuxSettings package writes
     /// (`{ "first": { stroke }, "second": { stroke }? }`) into the app-target
     /// ``StoredShortcut``. An empty primary key is the package's explicit
-    /// "unbound" marker. Returns `nil` only when `first` is missing or
-    /// malformed, matching the silently-ignored behavior of the string forms.
-    private func parseShortcutObjectForm(_ object: [String: Any]) -> StoredShortcut? {
+    /// "unbound" marker. Returns `nil` when `first` is missing or malformed —
+    /// and, to stay consistent with the string parser, when a present `second`
+    /// stroke is malformed (a chord must not silently degrade to a single
+    /// stroke) or when a bare first stroke is used by an action that requires a
+    /// modifier.
+    private func parseShortcutObjectForm(
+        _ object: [String: Any],
+        action: KeyboardShortcutSettings.Action
+    ) -> StoredShortcut? {
         guard let firstValue = object["first"],
               let first = parseShortcutStrokeObject(firstValue) else {
             return nil
@@ -1037,7 +1043,23 @@ final class CmuxSettingsFileStore {
         if first.key.isEmpty {
             return .unbound
         }
-        let second = object["second"].flatMap(parseShortcutStrokeObject)
+        // Mirror StoredShortcut.parseConfig(strokes:allowBareFirstStroke:): a
+        // bare first stroke is only valid for actions that opt into it, or for
+        // the space key.
+        guard action.allowsBareFirstStroke || !first.modifierFlags.isEmpty || first.key == "space" else {
+            return nil
+        }
+        let second: ShortcutStroke?
+        if let secondValue = object["second"], !(secondValue is NSNull) {
+            // A present-but-malformed second stroke invalidates the whole
+            // binding rather than silently dropping the chord half.
+            guard let parsedSecond = parseShortcutStrokeObject(secondValue) else {
+                return nil
+            }
+            second = parsedSecond
+        } else {
+            second = nil
+        }
         return StoredShortcut(first: first, second: second)
     }
 
@@ -1047,13 +1069,22 @@ final class CmuxSettingsFileStore {
               let key = jsonString(dict["key"]) else {
             return nil
         }
+        // An out-of-range keyCode is a corrupt binding, not a key to silently
+        // wrap into a valid UInt16 (which would re-target a different key).
+        let keyCode: UInt16?
+        if let rawKeyCode = jsonInt(dict["keyCode"]) {
+            guard let value = UInt16(exactly: rawKeyCode) else { return nil }
+            keyCode = value
+        } else {
+            keyCode = nil
+        }
         return ShortcutStroke(
             key: key,
             command: jsonBool(dict["command"]) ?? false,
             shift: jsonBool(dict["shift"]) ?? false,
             option: jsonBool(dict["option"]) ?? false,
             control: jsonBool(dict["control"]) ?? false,
-            keyCode: jsonInt(dict["keyCode"]).map { UInt16(truncatingIfNeeded: $0) }
+            keyCode: keyCode
         )
     }
 

--- a/cmuxTests/GlobalSearchShortcutSettingsTests.swift
+++ b/cmuxTests/GlobalSearchShortcutSettingsTests.swift
@@ -94,6 +94,121 @@ final class GlobalSearchShortcutSettingsTests: XCTestCase {
         )
     }
 
+    func testSettingsFileStoreParsesPackageObjectFormGlobalSearchShortcut() throws {
+        // Regression for https://github.com/manaflow-ai/cmux/issues/5137.
+        // The in-app Settings UI (CmuxSettings package) persists every
+        // shortcut rebinding to cmux.json under `shortcuts.bindings.<action>`
+        // as a nested StoredShortcut object ({"first": {key, command, ...}}),
+        // not the legacy human-editable "cmd+opt+f" string. The file store
+        // that feeds KeyboardShortcutSettings — and therefore the system-wide
+        // Carbon hotkeys (globalSearch, showHideAllWindows) — must understand
+        // that object form. Otherwise SystemWideHotkeyController never sees the
+        // rebinding and the default ⌥⌘F keeps opening Global Search.
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-global-search-object-settings-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let settingsFileURL = directoryURL.appendingPathComponent("cmux.json", isDirectory: false)
+        try """
+        {
+          "shortcuts": {
+            "bindings": {
+              "globalSearch": {
+                "first": { "key": "j", "command": true, "shift": false, "option": false, "control": true }
+              }
+            }
+          }
+        }
+        """.write(to: settingsFileURL, atomically: true, encoding: .utf8)
+
+        let store = KeyboardShortcutSettingsFileStore(
+            primaryPath: settingsFileURL.path,
+            fallbackPath: nil,
+            startWatching: false
+        )
+
+        XCTAssertEqual(
+            store.override(for: .globalSearch),
+            StoredShortcut(key: "j", command: true, shift: false, option: false, control: true)
+        )
+    }
+
+    func testSettingsFileStoreParsesPackageObjectFormChordShortcut() throws {
+        // The package object form also encodes two-stroke chords as
+        // {"first": {...}, "second": {...}}. A non-system-wide action exercises
+        // the general path so the fix is not narrowed to global search.
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-chord-object-settings-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let settingsFileURL = directoryURL.appendingPathComponent("cmux.json", isDirectory: false)
+        try """
+        {
+          "shortcuts": {
+            "bindings": {
+              "newTab": {
+                "first": { "key": "b", "command": false, "shift": false, "option": false, "control": true },
+                "second": { "key": "n", "command": false, "shift": false, "option": false, "control": false }
+              }
+            }
+          }
+        }
+        """.write(to: settingsFileURL, atomically: true, encoding: .utf8)
+
+        let store = KeyboardShortcutSettingsFileStore(
+            primaryPath: settingsFileURL.path,
+            fallbackPath: nil,
+            startWatching: false
+        )
+
+        XCTAssertEqual(
+            store.override(for: .newTab),
+            StoredShortcut(
+                key: "b",
+                command: false,
+                shift: false,
+                option: false,
+                control: true,
+                chordKey: "n",
+                chordCommand: false,
+                chordShift: false,
+                chordOption: false,
+                chordControl: false
+            )
+        )
+    }
+
+    func testSettingsFileStoreParsesPackageObjectFormUnboundShortcut() throws {
+        // The package marks an explicit "no shortcut" override with an empty
+        // primary key ({"first": {"key": ""}}). The legacy reader must treat
+        // that as unbound, not as an invalid binding to be dropped.
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-unbound-object-settings-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let settingsFileURL = directoryURL.appendingPathComponent("cmux.json", isDirectory: false)
+        try """
+        {
+          "shortcuts": {
+            "bindings": {
+              "globalSearch": { "first": { "key": "", "command": false, "shift": false, "option": false, "control": false } }
+            }
+          }
+        }
+        """.write(to: settingsFileURL, atomically: true, encoding: .utf8)
+
+        let store = KeyboardShortcutSettingsFileStore(
+            primaryPath: settingsFileURL.path,
+            fallbackPath: nil,
+            startWatching: false
+        )
+
+        XCTAssertEqual(store.override(for: .globalSearch), .unbound)
+    }
+
     func testSettingsFileStoreRejectsGlobalSearchChordBinding() throws {
         let directoryURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-global-search-invalid-settings-\(UUID().uuidString)", isDirectory: true)

--- a/cmuxTests/GlobalSearchShortcutSettingsTests.swift
+++ b/cmuxTests/GlobalSearchShortcutSettingsTests.swift
@@ -209,6 +209,66 @@ final class GlobalSearchShortcutSettingsTests: XCTestCase {
         XCTAssertEqual(store.override(for: .globalSearch), .unbound)
     }
 
+    func testSettingsFileStoreRejectsObjectFormChordWithMalformedSecondStroke() throws {
+        // A present-but-malformed `second` stroke must invalidate the whole
+        // binding rather than silently degrading the chord to a single stroke
+        // (which could create an unintended single-key shortcut).
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-bad-chord-object-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let settingsFileURL = directoryURL.appendingPathComponent("cmux.json", isDirectory: false)
+        try """
+        {
+          "shortcuts": {
+            "bindings": {
+              "newTab": {
+                "first": { "key": "b", "command": false, "shift": false, "option": false, "control": true },
+                "second": { "command": false }
+              }
+            }
+          }
+        }
+        """.write(to: settingsFileURL, atomically: true, encoding: .utf8)
+
+        let store = KeyboardShortcutSettingsFileStore(
+            primaryPath: settingsFileURL.path,
+            fallbackPath: nil,
+            startWatching: false
+        )
+
+        XCTAssertNil(store.override(for: .newTab))
+    }
+
+    func testSettingsFileStoreRejectsObjectFormBareKeyForModifierRequiringAction() throws {
+        // Object-form parsing must apply the same bare-first-stroke rule as the
+        // string parser: an action that requires a modifier rejects a bare key.
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-bare-object-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let settingsFileURL = directoryURL.appendingPathComponent("cmux.json", isDirectory: false)
+        try """
+        {
+          "shortcuts": {
+            "bindings": {
+              "newTab": { "first": { "key": "j", "command": false, "shift": false, "option": false, "control": false } }
+            }
+          }
+        }
+        """.write(to: settingsFileURL, atomically: true, encoding: .utf8)
+
+        let store = KeyboardShortcutSettingsFileStore(
+            primaryPath: settingsFileURL.path,
+            fallbackPath: nil,
+            startWatching: false
+        )
+
+        XCTAssertNil(store.override(for: .newTab))
+    }
+
     func testSettingsFileStoreRejectsGlobalSearchChordBinding() throws {
         let directoryURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-global-search-invalid-settings-\(UUID().uuidString)", isDirectory: true)


### PR DESCRIPTION
## Summary

Fixes #5137 — pressing **⌥⌘F** kept opening Global Search even after rebinding the Global Search shortcut in **Settings → Keyboard Shortcuts**, so the binding was effectively hardcoded.

## Root cause (dual source of truth, divergent on-disk schema)

The keyboard-shortcut system is mid-migration into the `CmuxSettings`/`CmuxSettingsUI` packages, and the in-app Settings UI now lives in the package. When you rebind a shortcut, the package persists it to `~/.config/cmux/cmux.json` under `shortcuts.bindings.<action>` as a **nested `StoredShortcut` object**:

```json
{ "shortcuts": { "bindings": { "globalSearch": { "first": { "key": "j", "command": true, "control": true } } } } }
```

But `SystemWideHotkeyController` (the Carbon `RegisterEventHotKey` owner for the system-wide hotkeys) resolves its shortcut through the **legacy** `KeyboardShortcutSettings` → `KeyboardShortcutSettingsFileStore`, whose `parseShortcutBindingValue` only understood the human-editable **string** form (`"cmd+opt+f"`) and string-array chords. It returned `nil` for the object form and logged *"ignoring invalid shortcut binding"*, so the rebinding never reached the store — the controller kept the built-in ⌥⌘F default registered.

This is a **class** of bug, not a one-off: every action resolved through the legacy file store (the two system-wide Carbon hotkeys `globalSearch` and `showHideAllWindows`) silently ignored any rebinding made in the package Settings UI. `globalSearch` is the visible victim because it is always enabled; `showHideAllWindows` is off by default so the same gap went unnoticed.

## Reproduced + verified locally (running Debug app)

Driving the real Carbon hotkey via synthesized `CGEvent`s and reading the in-app `globalHotkey.*` debug log:

| `shortcuts.bindings.globalSearch` in cmux.json | legacy reader | ⌥⌘F fires? | ⌃⌘J fires? |
|---|---|---|---|
| `{"first":{"key":"j","command":true,"control":true}}` (**what the Settings UI writes**) — before fix | dropped → stays ⌥⌘F | **YES (bug)** | no |
| `"ctrl+cmd+j"` (legacy string form) | parsed → re-registers ⌃⌘J | no | yes |
| object form — **after fix** | parsed → re-registers ⌃⌘J | no | yes |

## Fix

Teach `KeyboardShortcutSettingsFileStore` to decode the package's nested object form (`{ "first": { stroke }, "second": { stroke }? }`), including the empty-first-key "unbound" marker and two-stroke chords. The legacy reader now understands every form that can legitimately appear in cmux.json, converging both cmux.json readers on one on-disk contract instead of patching a single shortcut.

## Tests

Two-commit structure (failing test → fix). Added behavior-level regression coverage to `cmuxTests/GlobalSearchShortcutSettingsTests.swift` that exercises `KeyboardShortcutSettingsFileStore.override(for:)` through cmux.json:
- `testSettingsFileStoreParsesPackageObjectFormGlobalSearchShortcut` — fails before the fix (returns the default instead of the rebinding), passes after.
- `testSettingsFileStoreParsesPackageObjectFormChordShortcut` — a non-system-wide action, proving the fix is general.
- `testSettingsFileStoreParsesPackageObjectFormUnboundShortcut` — the explicit "no shortcut" marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5143"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782946035&installation_id=133855650&pr_number=5143&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5143&signature=8fd75b014a847ae0f9c21130e6186176887fa713a176454209a442ec58dfb443"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized settings-file parsing with strict validation and broad test coverage; no auth or data-path changes.
> 
> **Overview**
> The legacy **`KeyboardShortcutSettingsFileStore`** path only accepted string / string-array shortcut bindings in `cmux.json`, so rebinding in the **CmuxSettings** Settings UI (nested `{"first": {...}, "second": {...}?}` objects under `shortcuts.bindings`) was dropped and **system-wide** shortcuts like **Global Search** kept their built-in defaults.
> 
> This PR **adds object-form decoding** in `parseShortcutBindingValue`, including **unbound** (empty `first.key`), **two-stroke chords**, and the same validation as the string parser (bare keys for modifier-required actions, reject malformed `second` instead of degrading to a single stroke, strict `keyCode` handling). **Regression tests** in `GlobalSearchShortcutSettingsTests` cover global search, chords, unbound, and rejection cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00ca077bb21336cfc5852afdb6c47c8e102afb42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #5137 by making Global Search honor the shortcut set in Settings. The legacy reader now parses the object-form bindings the `CmuxSettings` UI writes to `cmux.json`, so ⌥⌘F no longer triggers after a rebind.

- **Bug Fixes**
  - Parse nested object form {"first": {...}, "second": {...}?} in `KeyboardShortcutSettingsFileStore`, including the empty "unbound" marker, two-stroke chords, and validation (reject malformed `second`, out-of-range `keyCode`, and bare first-stroke when a modifier is required).
  - Ensure system-wide hotkeys (globalSearch, showHideAllWindows) use the updated bindings.
  - Add regression tests for object-form parsing: chords, explicit unbinding, malformed chords, and bare-key rejection.

<sup>Written for commit 00ca077bb21336cfc5852afdb6c47c8e102afb42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced keyboard shortcut parsing to support nested object-style bindings in settings files, enabling two-stroke chords and explicit unbound overrides.

* **Bug Fixes**
  * Stricter validation: malformed or out-of-range stroke data and invalid bare-stroke actions are rejected to prevent incorrect bindings.

* **Tests**
  * Added unit tests covering object-form parsing, chord handling, unbound overrides, and rejection cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->