### PR TITLE
Fix titlebar shortcut-hint pills clipped at bottom on macOS 26.5

### DIFF
--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -1930,13 +1930,21 @@ final class TitlebarControlsAccessoryViewController: NSTitlebarAccessoryViewCont
 
         view = containerView
         containerView.translatesAutoresizingMaskIntoConstraints = true
-        // Prevent the titlebar accessory from clipping button backgrounds
-        // at the bottom edge (the system constrains accessory height to the
-        // titlebar, which can be slightly shorter than the button frames).
+        // The shortcut-hint pills (and button backgrounds) sit below the button
+        // row and overflow the accessory's titlebar-height content frame on
+        // purpose. macOS 26.5 began re-deriving `layer.masksToBounds` from the
+        // AppKit `clipsToBounds` property on every layout pass, which clobbered
+        // a bare `layer?.masksToBounds = false` write and re-clipped that
+        // overflow (the hint captions got cut off at the bottom). Set
+        // `clipsToBounds = false` on both the container and the hosting view so
+        // the non-clipping intent persists across layout on every macOS version.
         containerView.wantsLayer = true
+        containerView.clipsToBounds = false
         containerView.layer?.masksToBounds = false
         hostingView.translatesAutoresizingMaskIntoConstraints = true
         hostingView.autoresizingMask = []
+        hostingView.clipsToBounds = false
+        hostingView.layer?.masksToBounds = false
         containerView.addSubview(hostingView)
 
         userDefaultsObserver = NotificationCenter.default.addObserver(


### PR DESCRIPTION
## Summary
- Titlebar shortcut-hint pills (⌘B, ⌘N, etc.) sit below the button row and overflow the accessory's titlebar-height content frame on purpose.
- macOS 26.5 began re-deriving `layer.masksToBounds` from the AppKit `clipsToBounds` property on every layout pass. That clobbered the bare `containerView.layer?.masksToBounds = false` the accessory relied on, and the `NSHostingView` that actually draws the pills was never set non-clipping at all, so the hint captions got cut off at the bottom on 26.5 (26.3 / 26.4.1 rendered them fine).
- Set `clipsToBounds = false` (the AppKit property, which persists across layout) on both the accessory container and the hosting view.

## Testing
- Built a tagged debug app on macOS 26.5 (the reported-broken OS) and captured the real on-screen rendering with hints forced visible (`CMUX_UI_TEST_SHORTCUT_HINTS_ALWAYS_SHOW=1`).
  - Before (unfixed `main`): pill bottoms sliced off flat at the titlebar boundary.
  - After (this change): full rounded pills with breathing room below.
- The clip reproduced in a plain debug build, confirming it is an OS clipping-behavior change, not a nightly-vs-release build-config difference.
- No automated regression test added: the defect is a macOS-26.5-specific compositing clip with no reliable CI surface (screenshot baselines flake and it only manifests on this point release), and a `clipsToBounds` property assertion would require constructing the side-effect-heavy accessory controller against a singleton store. Verification is the empirical before/after on the 26.5 repro machine above.

## Issues
- Reported via internal dogfood thread (titlebar shortcut-hint clipping on macOS Tahoe 26.5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5145"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782948068&installation_id=133855650&pr_number=5145&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5145&signature=4db9cb39fc10d057bf16ae67e121a11f023c7cc9049d41b73c91f905b0f555c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized AppKit clipping flags in titlebar accessory setup; no auth, data, or business-logic changes.
> 
> **Overview**
> Fixes **titlebar shortcut-hint pills** (⌘B, ⌘N, etc.) being **cut off at the bottom on macOS 26.5**. The hints intentionally draw below the button row inside `TitlebarControlsAccessoryViewController`, but the system titlebar frame is shorter than that content.
> 
> On **26.5**, AppKit started syncing **`layer.masksToBounds` from `clipsToBounds` on every layout**, which undid the previous **`masksToBounds = false`** on the accessory **container** only. The **`NSHostingView`** was never configured to allow overflow.
> 
> The change sets **`clipsToBounds = false`** (and keeps **`layer?.masksToBounds = false`**) on **both** the container and the **hosting** view so overflow survives layout across OS versions. Comments in `UpdateTitlebarAccessory.swift` document the 26.5 behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f16dfabe02a8ee201b1bff719ff60b81bdb57df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix clipped titlebar shortcut-hint pills (⌘B, ⌘N, etc.) on macOS 26.5 by setting `clipsToBounds = false` on the accessory container and the `NSHostingView`, and keeping `masksToBounds = false` on both so pills can overflow the titlebar frame as intended. macOS 26.5 started re-deriving `layer.masksToBounds` from AppKit `clipsToBounds` during layout; these settings make the non-clipping behavior persist.

<sup>Written for commit 8f16dfabe02a8ee201b1bff719ff60b81bdb57df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed visual clipping issues in the titlebar accessory display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->