### PR TITLE
Rank visible title matches above hidden metadata in workspace switcher

### DIFF
--- a/Native/CommandPaletteNucleoFFI/src/lib.rs
+++ b/Native/CommandPaletteNucleoFFI/src/lib.rs
@@ -4,7 +4,7 @@ use std::collections::BinaryHeap;
 use std::slice;
 use std::str;
 
-use nucleo::pattern::{AtomKind, CaseMatching, Normalization, Pattern};
+use nucleo::pattern::{Atom, AtomKind, CaseMatching, Normalization, Pattern};
 use nucleo::{Config, Matcher, Utf32Str};
 
 #[repr(C)]
@@ -52,6 +52,37 @@ struct SearchToken {
     initialism_query: Option<InitialismQuery>,
 }
 
+/// Whole-query literal-title matchers, built once per search. `exact`/`prefix` use the matcher's
+/// own normalization (case + Smart diacritic folding) so a localized title like "Éclair" is still
+/// recognized as a prefix of "e", matching the fuzzy matcher's notion of equality.
+struct TitleLiteralQuery {
+    exact: Atom,
+    prefix: Atom,
+    token_count: usize,
+}
+
+impl TitleLiteralQuery {
+    fn new(query: &str) -> TitleLiteralQuery {
+        TitleLiteralQuery {
+            exact: Atom::new(
+                query,
+                CaseMatching::Ignore,
+                Normalization::Smart,
+                AtomKind::Exact,
+                true,
+            ),
+            prefix: Atom::new(
+                query,
+                CaseMatching::Ignore,
+                Normalization::Smart,
+                AtomKind::Prefix,
+                true,
+            ),
+            token_count: query.split_whitespace().count().max(1),
+        }
+    }
+}
+
 struct WorstFirstScoredCandidate(ScoredCandidate);
 
 impl PartialEq for WorstFirstScoredCandidate {
@@ -83,6 +114,11 @@ impl SearchState {
     fn score_text(&mut self, pattern: &Pattern, text: &str) -> Option<u32> {
         self.utf32_buf.clear();
         pattern.score(Utf32Str::new(text, &mut self.utf32_buf), &mut self.matcher)
+    }
+
+    fn atom_score(&mut self, atom: &Atom, text: &str) -> Option<u16> {
+        self.utf32_buf.clear();
+        atom.score(Utf32Str::new(text, &mut self.utf32_buf), &mut self.matcher)
     }
 }
 
@@ -262,6 +298,7 @@ unsafe fn cmux_nucleo_index_search_impl(
     } else {
         let query_mask = ascii_mask_query(&normalized_query);
         let search_tokens = search_tokens(&normalized_query);
+        let title_literal = TitleLiteralQuery::new(&normalized_query);
         let mut best_matches = BinaryHeap::with_capacity(output_limit);
 
         SEARCH_STATE.with(|state| {
@@ -277,9 +314,13 @@ unsafe fn cmux_nucleo_index_search_impl(
                     }
                 }
 
-                let Some(score) =
-                    weighted_query_score(&mut state, &normalized_query, &search_tokens, candidate)
-                else {
+                let Some(score) = weighted_query_score(
+                    &mut state,
+                    &normalized_query,
+                    &search_tokens,
+                    &title_literal,
+                    candidate,
+                ) else {
                     continue;
                 };
                 append_scored_candidate(
@@ -374,6 +415,7 @@ fn weighted_query_score(
     state: &mut SearchState,
     query: &str,
     tokens: &[SearchToken],
+    title_literal: &TitleLiteralQuery,
     candidate: &Candidate,
 ) -> Option<f64> {
     let token_score = token_sum_score(state, query, tokens, candidate);
@@ -385,7 +427,7 @@ fn weighted_query_score(
     // jackpot in `exact_search_text_line_score`. `title_literal_score` sits above every keyword
     // tier so the visible title wins. This mirrors the Swift `CommandPaletteSearchEngine`
     // reference ordering (title prefix > exact keyword).
-    match (token_score, title_literal_score(candidate, query)) {
+    match (token_score, title_literal_score(state, title_literal, candidate)) {
         (Some(token), Some(literal)) => Some(token.max(literal)),
         (Some(token), None) => Some(token),
         (None, Some(literal)) => Some(literal),
@@ -524,37 +566,25 @@ const TITLE_EXACT_TOKEN_SCORE: f64 = KEYWORD_EXACT_CEILING + 4_000.0;
 /// "app" near 60_060). A flat title constant would lose to that sum; scaling per token keeps a
 /// visible title match dominant for any query length, not just single-token queries.
 ///
-/// Prefix matches of the same length share one score on purpose: a per-character-length penalty
-/// would invent a "shortest title wins" rule that mis-ranks when one title is a character-prefix
-/// of another (e.g. query "workspace 1901" preferring "Workspace 19010" over "Workspace 1901
-/// ..."). Equal scores defer to `scored_candidate_order`'s `(rank, index)` tiebreak, which keeps
-/// the switcher's natural order. Diacritic-only differences fall through to `None` and are handled
-/// by the fuzzy matcher (`Normalization::Smart`).
-fn title_literal_score(candidate: &Candidate, query: &str) -> Option<f64> {
-    let query = query.trim();
-    if query.is_empty() {
-        return None;
+/// Prefix matches share one score on purpose: a per-character-length penalty would invent a
+/// "shortest title wins" rule that mis-ranks when one title is a character-prefix of another
+/// (e.g. query "workspace 1901" preferring "Workspace 19010" over "Workspace 1901 ..."). Equal
+/// scores defer to `scored_candidate_order`'s `(rank, index)` tiebreak, which keeps the switcher's
+/// natural order. The match itself uses `TitleLiteralQuery`'s `Atom`s, so case and Smart diacritic
+/// normalization are consistent with the fuzzy matcher (e.g. "e" prefix-matches "Éclair").
+fn title_literal_score(
+    state: &mut SearchState,
+    query: &TitleLiteralQuery,
+    candidate: &Candidate,
+) -> Option<f64> {
+    let token_count = query.token_count as f64;
+    if state.atom_score(&query.exact, &candidate.title).is_some() {
+        return Some(TITLE_EXACT_TOKEN_SCORE * token_count);
     }
-    let title = candidate.title.trim();
-
-    let mut title_chars = title.chars();
-    for query_char in query.chars() {
-        match title_chars.next() {
-            Some(title_char) if chars_equal_ignoring_case(title_char, query_char) => {}
-            _ => return None,
-        }
+    if state.atom_score(&query.prefix, &candidate.title).is_some() {
+        return Some(TITLE_PREFIX_TOKEN_SCORE * token_count);
     }
-
-    let token_count = query.split_whitespace().count().max(1) as f64;
-    if title_chars.next().is_none() {
-        Some(TITLE_EXACT_TOKEN_SCORE * token_count)
-    } else {
-        Some(TITLE_PREFIX_TOKEN_SCORE * token_count)
-    }
-}
-
-fn chars_equal_ignoring_case(lhs: char, rhs: char) -> bool {
-    lhs == rhs || lhs.to_ascii_lowercase() == rhs.to_ascii_lowercase()
+    None
 }
 
 fn initialism_query(query: &str) -> Option<InitialismQuery> {

--- a/Native/CommandPaletteNucleoFFI/src/lib.rs
+++ b/Native/CommandPaletteNucleoFFI/src/lib.rs
@@ -505,23 +505,31 @@ fn keyword_exact_line_score(query_char_count: usize) -> f64 {
     1_800.0 + f64::from(query_char_count as u32) * 10.0
 }
 
-/// Tier scores for a literal title match. Keyword-exact tops out at `30_030`
-/// (`keyword_exact_line_score`), so both literal-title tiers stay strictly above it: a workspace
-/// whose visible title matches the query always outranks one that only matched a hidden field.
-/// Exact beats prefix; ties within a tier fall back to the existing `(rank, index)` order.
-const TITLE_EXACT_SCORE: f64 = 34_000.0;
-const TITLE_PREFIX_SCORE: f64 = 32_000.0;
+/// Upper bound of `keyword_exact_line_score` for one short (<= 3 char) query token (`30_000 + 3 *
+/// 10`). A hidden exact-keyword line can contribute at most this much per token.
+const KEYWORD_EXACT_CEILING: f64 = 30_030.0;
+/// Per-query-token tier scores for a literal title match, derived from `KEYWORD_EXACT_CEILING` plus
+/// a margin so each stays strictly above the per-token keyword path. Exact beats prefix; ties
+/// within a tier fall back to the existing `(rank, index)` order.
+const TITLE_PREFIX_TOKEN_SCORE: f64 = KEYWORD_EXACT_CEILING + 2_000.0;
+const TITLE_EXACT_TOKEN_SCORE: f64 = KEYWORD_EXACT_CEILING + 4_000.0;
 
 /// Scores a whole-query literal match against the candidate title: the full query equal to the
-/// title (`TITLE_EXACT_SCORE`) or a leading prefix of it (`TITLE_PREFIX_SCORE`). Returns `None`
-/// when the query is not a title prefix; the fuzzy/keyword tiers still apply in that case.
+/// title (exact tier) or a leading prefix of it (prefix tier). Returns `None` when the query is
+/// not a title prefix; the fuzzy/keyword tiers still apply in that case.
 ///
-/// All prefix matches share one flat score on purpose: a per-length penalty would invent a
-/// "shortest title wins" rule that mis-ranks when one title is a character-prefix of another
-/// (e.g. query "workspace 1901" preferring "Workspace 19010" over "Workspace 1901 ..."). Equal
-/// scores instead defer to `scored_candidate_order`'s `(rank, index)` tiebreak, which keeps the
-/// switcher's natural order. Diacritic-only differences fall through to `None` and are handled by
-/// the fuzzy matcher (`Normalization::Smart`).
+/// The tier scores are multiplied by the query's token count. `weighted_query_score` *sums* the
+/// per-token keyword path, so a hidden row with an exact metadata line for every query token can
+/// reach `token_count * KEYWORD_EXACT_CEILING` (e.g. query "ios app" scoring a hidden "ios" +
+/// "app" near 60_060). A flat title constant would lose to that sum; scaling per token keeps a
+/// visible title match dominant for any query length, not just single-token queries.
+///
+/// Prefix matches of the same length share one score on purpose: a per-character-length penalty
+/// would invent a "shortest title wins" rule that mis-ranks when one title is a character-prefix
+/// of another (e.g. query "workspace 1901" preferring "Workspace 19010" over "Workspace 1901
+/// ..."). Equal scores defer to `scored_candidate_order`'s `(rank, index)` tiebreak, which keeps
+/// the switcher's natural order. Diacritic-only differences fall through to `None` and are handled
+/// by the fuzzy matcher (`Normalization::Smart`).
 fn title_literal_score(candidate: &Candidate, query: &str) -> Option<f64> {
     let query = query.trim();
     if query.is_empty() {
@@ -537,10 +545,11 @@ fn title_literal_score(candidate: &Candidate, query: &str) -> Option<f64> {
         }
     }
 
+    let token_count = query.split_whitespace().count().max(1) as f64;
     if title_chars.next().is_none() {
-        Some(TITLE_EXACT_SCORE)
+        Some(TITLE_EXACT_TOKEN_SCORE * token_count)
     } else {
-        Some(TITLE_PREFIX_SCORE)
+        Some(TITLE_PREFIX_TOKEN_SCORE * token_count)
     }
 }
 

--- a/Native/CommandPaletteNucleoFFI/src/lib.rs
+++ b/Native/CommandPaletteNucleoFFI/src/lib.rs
@@ -508,16 +508,20 @@ fn keyword_exact_line_score(query_char_count: usize) -> f64 {
 /// Tier scores for a literal title match. Keyword-exact tops out at `30_030`
 /// (`keyword_exact_line_score`), so both literal-title tiers stay strictly above it: a workspace
 /// whose visible title matches the query always outranks one that only matched a hidden field.
+/// Exact beats prefix; ties within a tier fall back to the existing `(rank, index)` order.
 const TITLE_EXACT_SCORE: f64 = 34_000.0;
 const TITLE_PREFIX_SCORE: f64 = 32_000.0;
-const TITLE_PREFIX_MIN_SCORE: f64 = 31_000.0;
 
 /// Scores a whole-query literal match against the candidate title: the full query equal to the
-/// title (`TITLE_EXACT_SCORE`), or a leading prefix of it (`TITLE_PREFIX_SCORE` minus a
-/// per-extra-character penalty so shorter, closer titles win, floored at `TITLE_PREFIX_MIN_SCORE`
-/// so even a long title prefix beats keyword-exact). Returns `None` when the query is not a title
-/// prefix; the fuzzy/keyword tiers still apply in that case. Diacritic-only differences fall
-/// through to `None` and are handled by the fuzzy matcher (`Normalization::Smart`).
+/// title (`TITLE_EXACT_SCORE`) or a leading prefix of it (`TITLE_PREFIX_SCORE`). Returns `None`
+/// when the query is not a title prefix; the fuzzy/keyword tiers still apply in that case.
+///
+/// All prefix matches share one flat score on purpose: a per-length penalty would invent a
+/// "shortest title wins" rule that mis-ranks when one title is a character-prefix of another
+/// (e.g. query "workspace 1901" preferring "Workspace 19010" over "Workspace 1901 ..."). Equal
+/// scores instead defer to `scored_candidate_order`'s `(rank, index)` tiebreak, which keeps the
+/// switcher's natural order. Diacritic-only differences fall through to `None` and are handled by
+/// the fuzzy matcher (`Normalization::Smart`).
 fn title_literal_score(candidate: &Candidate, query: &str) -> Option<f64> {
     let query = query.trim();
     if query.is_empty() {
@@ -526,21 +530,18 @@ fn title_literal_score(candidate: &Candidate, query: &str) -> Option<f64> {
     let title = candidate.title.trim();
 
     let mut title_chars = title.chars();
-    let mut matched = 0usize;
     for query_char in query.chars() {
         match title_chars.next() {
-            Some(title_char) if chars_equal_ignoring_case(title_char, query_char) => {
-                matched += 1;
-            }
+            Some(title_char) if chars_equal_ignoring_case(title_char, query_char) => {}
             _ => return None,
         }
     }
 
     if title_chars.next().is_none() {
-        return Some(TITLE_EXACT_SCORE);
+        Some(TITLE_EXACT_SCORE)
+    } else {
+        Some(TITLE_PREFIX_SCORE)
     }
-    let extra = title.chars().count().saturating_sub(matched) as f64;
-    Some((TITLE_PREFIX_SCORE - extra).max(TITLE_PREFIX_MIN_SCORE))
 }
 
 fn chars_equal_ignoring_case(lhs: char, rhs: char) -> bool {

--- a/Native/CommandPaletteNucleoFFI/src/lib.rs
+++ b/Native/CommandPaletteNucleoFFI/src/lib.rs
@@ -376,6 +376,29 @@ fn weighted_query_score(
     tokens: &[SearchToken],
     candidate: &Candidate,
 ) -> Option<f64> {
+    let token_score = token_sum_score(state, query, tokens, candidate);
+
+    // A literal title match (the whole query equals, or is a leading prefix of, the candidate
+    // title) is the strongest, most user-legible signal: the row the user sees in the switcher
+    // starts with exactly what they typed. It must outrank an exact match on a hidden search
+    // field (branch, directory, description), which otherwise wins via the 30_030 short-query
+    // jackpot in `exact_search_text_line_score`. `title_literal_score` sits above every keyword
+    // tier so the visible title wins. This mirrors the Swift `CommandPaletteSearchEngine`
+    // reference ordering (title prefix > exact keyword).
+    match (token_score, title_literal_score(candidate, query)) {
+        (Some(token), Some(literal)) => Some(token.max(literal)),
+        (Some(token), None) => Some(token),
+        (None, Some(literal)) => Some(literal),
+        (None, None) => None,
+    }
+}
+
+fn token_sum_score(
+    state: &mut SearchState,
+    query: &str,
+    tokens: &[SearchToken],
+    candidate: &Candidate,
+) -> Option<f64> {
     if tokens.len() == 1 {
         return weighted_token_score(state, &tokens[0], candidate);
     }
@@ -480,6 +503,48 @@ fn keyword_exact_line_score(query_char_count: usize) -> f64 {
         return 30_000.0 + f64::from(query_char_count as u32) * 10.0;
     }
     1_800.0 + f64::from(query_char_count as u32) * 10.0
+}
+
+/// Tier scores for a literal title match. Keyword-exact tops out at `30_030`
+/// (`keyword_exact_line_score`), so both literal-title tiers stay strictly above it: a workspace
+/// whose visible title matches the query always outranks one that only matched a hidden field.
+const TITLE_EXACT_SCORE: f64 = 34_000.0;
+const TITLE_PREFIX_SCORE: f64 = 32_000.0;
+const TITLE_PREFIX_MIN_SCORE: f64 = 31_000.0;
+
+/// Scores a whole-query literal match against the candidate title: the full query equal to the
+/// title (`TITLE_EXACT_SCORE`), or a leading prefix of it (`TITLE_PREFIX_SCORE` minus a
+/// per-extra-character penalty so shorter, closer titles win, floored at `TITLE_PREFIX_MIN_SCORE`
+/// so even a long title prefix beats keyword-exact). Returns `None` when the query is not a title
+/// prefix; the fuzzy/keyword tiers still apply in that case. Diacritic-only differences fall
+/// through to `None` and are handled by the fuzzy matcher (`Normalization::Smart`).
+fn title_literal_score(candidate: &Candidate, query: &str) -> Option<f64> {
+    let query = query.trim();
+    if query.is_empty() {
+        return None;
+    }
+    let title = candidate.title.trim();
+
+    let mut title_chars = title.chars();
+    let mut matched = 0usize;
+    for query_char in query.chars() {
+        match title_chars.next() {
+            Some(title_char) if chars_equal_ignoring_case(title_char, query_char) => {
+                matched += 1;
+            }
+            _ => return None,
+        }
+    }
+
+    if title_chars.next().is_none() {
+        return Some(TITLE_EXACT_SCORE);
+    }
+    let extra = title.chars().count().saturating_sub(matched) as f64;
+    Some((TITLE_PREFIX_SCORE - extra).max(TITLE_PREFIX_MIN_SCORE))
+}
+
+fn chars_equal_ignoring_case(lhs: char, rhs: char) -> bool {
+    lhs == rhs || lhs.to_ascii_lowercase() == rhs.to_ascii_lowercase()
 }
 
 fn initialism_query(query: &str) -> Option<InitialismQuery> {

--- a/cmuxTests/CommandPaletteNucleoFFITests.swift
+++ b/cmuxTests/CommandPaletteNucleoFFITests.swift
@@ -108,7 +108,7 @@ final class CommandPaletteNucleoFFITests: XCTestCase {
         // description word produced by commandPaletteWorkspaceSearchMetadata). For short queries
         // an exact match on such a hidden line scored 30_030 and beat the visible title prefix,
         // which only reached nucleo(~88) + 2_000. The "ios" row shown to the user therefore had
-        // no highlighted title yet sat at the top. https://github.com/manaflow-ai/cmux/pull/0000
+        // no highlighted title yet sat at the top. https://github.com/manaflow-ai/cmux/pull/5148
         let library = try NucleoLibrary()
         let entries = [
             FixtureEntry(

--- a/cmuxTests/CommandPaletteNucleoFFITests.swift
+++ b/cmuxTests/CommandPaletteNucleoFFITests.swift
@@ -169,6 +169,35 @@ final class CommandPaletteNucleoFFITests: XCTestCase {
         XCTAssertEqual(resultIDs.first, "workspace.iosApp")
     }
 
+    func testNucleoFFIPrefersDiacriticTitlePrefixOverHiddenKeyword() throws {
+        // Regression: the literal-title check must use the matcher's case + Smart diacritic
+        // normalization, so a localized title like "Éclair" is recognized as a prefix of "e" and
+        // still beats a row that only has a hidden exact "e" metadata token.
+        // https://github.com/manaflow-ai/cmux/pull/5148
+        let library = try NucleoLibrary()
+        let entries = [
+            FixtureEntry(
+                id: "workspace.eclair",
+                rank: 0,
+                title: "Éclair Notes",
+                searchableTexts: ["Éclair Notes", "Workspace", "workspace", "switch", "go"]
+            ),
+            FixtureEntry(
+                id: "workspace.hiddenEKeyword",
+                rank: 1,
+                title: "Some Other Workspace",
+                searchableTexts: [
+                    "Some Other Workspace", "Workspace", "workspace", "switch", "go", "branch", "e",
+                ]
+            ),
+        ]
+        let index = try NucleoIndex(library: library, entries: entries)
+
+        let resultIDs = try index.search(query: "e", limit: 5).map(\.id)
+
+        XCTAssertEqual(resultIDs.first, "workspace.eclair")
+    }
+
     func testNucleoFFIDoesNotMatchSingleTokenAcrossSearchFields() throws {
         let library = try NucleoLibrary()
         let entries = [

--- a/cmuxTests/CommandPaletteNucleoFFITests.swift
+++ b/cmuxTests/CommandPaletteNucleoFFITests.swift
@@ -102,6 +102,41 @@ final class CommandPaletteNucleoFFITests: XCTestCase {
         XCTAssertEqual(resultIDs.first, "palette.checkForUpdates")
     }
 
+    func testNucleoFFIPrefersVisibleTitlePrefixOverHiddenMetadataKeyword() throws {
+        // Regression: in the workspace switcher, a workspace whose visible title starts with the
+        // query must rank above one that only matched a hidden metadata token (a branch or
+        // description word produced by commandPaletteWorkspaceSearchMetadata). For short queries
+        // an exact match on such a hidden line scored 30_030 and beat the visible title prefix,
+        // which only reached nucleo(~88) + 2_000. The "ios" row shown to the user therefore had
+        // no highlighted title yet sat at the top. https://github.com/manaflow-ai/cmux/pull/0000
+        let library = try NucleoLibrary()
+        let entries = [
+            FixtureEntry(
+                id: "workspace.iosMobileTerminal",
+                rank: 0,
+                title: "iOS Mobile Terminal",
+                searchableTexts: ["iOS Mobile Terminal", "Workspace", "workspace", "switch", "go"]
+            ),
+            FixtureEntry(
+                id: "workspace.forkSessionNotFound",
+                rank: 1,
+                title: "Fork Session Not Found",
+                // "ios" here stands in for a hidden branch/description token, the field that the
+                // switcher indexes but never highlights in the row.
+                searchableTexts: [
+                    "Fork Session Not Found", "Workspace", "workspace", "switch", "go",
+                    "branch", "ios",
+                ]
+            ),
+        ]
+        let index = try NucleoIndex(library: library, entries: entries)
+
+        let resultIDs = try index.search(query: "ios", limit: 5).map(\.id)
+
+        XCTAssertEqual(resultIDs.first, "workspace.iosMobileTerminal")
+        XCTAssertTrue(resultIDs.contains("workspace.forkSessionNotFound"))
+    }
+
     func testNucleoFFIDoesNotMatchSingleTokenAcrossSearchFields() throws {
         let library = try NucleoLibrary()
         let entries = [

--- a/cmuxTests/CommandPaletteNucleoFFITests.swift
+++ b/cmuxTests/CommandPaletteNucleoFFITests.swift
@@ -137,6 +137,38 @@ final class CommandPaletteNucleoFFITests: XCTestCase {
         XCTAssertTrue(resultIDs.contains("workspace.forkSessionNotFound"))
     }
 
+    func testNucleoFFIPrefersTitleOverSummedHiddenKeywordsForMultiTokenQuery() throws {
+        // Regression: the per-token keyword path is summed, so a multi-token query like "ios app"
+        // can give a hidden row an exact line per token (~30_030 each, ~60_060 summed) that beats a
+        // flat title-literal score. The title tier is scaled by query token count so a visible
+        // title match still wins for multi-token queries.
+        // https://github.com/manaflow-ai/cmux/pull/5148
+        let library = try NucleoLibrary()
+        let entries = [
+            FixtureEntry(
+                id: "workspace.iosApp",
+                rank: 0,
+                title: "iOS App",
+                searchableTexts: ["iOS App", "Workspace", "workspace", "switch", "go"]
+            ),
+            FixtureEntry(
+                id: "workspace.hiddenMetadataRow",
+                rank: 1,
+                title: "Some Unrelated Workspace",
+                // Both query tokens present only as hidden metadata tokens (branch/description).
+                searchableTexts: [
+                    "Some Unrelated Workspace", "Workspace", "workspace", "switch", "go",
+                    "branch", "ios", "app",
+                ]
+            ),
+        ]
+        let index = try NucleoIndex(library: library, entries: entries)
+
+        let resultIDs = try index.search(query: "ios app", limit: 5).map(\.id)
+
+        XCTAssertEqual(resultIDs.first, "workspace.iosApp")
+    }
+
     func testNucleoFFIDoesNotMatchSingleTokenAcrossSearchFields() throws {
         let library = try NucleoLibrary()
         let entries = [


### PR DESCRIPTION
## Summary
- The workspace switcher ranked a row whose visible title did not match the query above a clean title prefix. Typing "ios" put "fork session not found" (matched only on a hidden branch/description token "ios", no highlighted title) above "iOS Mobile Terminal".
- Root cause is the Rust nucleo scorer (`Native/CommandPaletteNucleoFFI/src/lib.rs`). For a short query, an exact match on any hidden search-field line scored 30,030, while a visible title prefix only reached nucleo(~88) + 2,000, so the hidden match always won.
- Added a whole-query title-literal tier layered into `weighted_query_score`: a title equal to the query scores 34,000 and a title prefix scores a flat 32,000, both above keyword-exact's 30,030. A workspace whose visible title starts with the query now wins. Per-token and multi-token sums are untouched; this only adds a `max()` term when the whole query is a title prefix. This matches the Swift `CommandPaletteSearchEngine` reference ordering (title prefix > exact keyword), so the two engines now agree.
- Prefix matches share one flat score on purpose. A per-length penalty would invent a "shortest title wins" rule that mis-ranks when one title is a character-prefix of another (e.g. "workspace 1901" preferring "Workspace 19010 ..." over "Workspace 1901 ..."). Ties defer to the existing `(rank, index)` order, preserving the switcher's natural order.

## Testing
- `cargo build --release` (offline) clean, no warnings.
- New regression test `testNucleoFFIPrefersVisibleTitlePrefixOverHiddenMetadataKeyword` in `cmuxTests/CommandPaletteNucleoFFITests.swift`, run by the CI tests job (which builds the dylib). Two-commit red/green: the test lands first, the scoring fix second.
- Replayed the exact existing `CommandPaletteNucleoFFITests` fixtures (open-folder top-2, initialism, café accent, deep-workspace numeric prefix) through the real scorer to confirm no ordering regressions; the deep-workspace replay is what caught and killed the length-penalty mis-ranking.

## Notes
- "fork session not found" still appears at #2: its hidden exact-keyword match outranks scattered title-fuzzy rows, matching the Swift reference. If you want every visible-title match to rank above every hidden-metadata match, that is a larger change to both engines; say the word.

## Issues
- Reported via screenshot (no GitHub issue).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search ranking now favors visible titles that exactly match or start with your trimmed, case-insensitive query (including diacritic-normalized matches), allowing whole-title exact/prefix matches to outrank token-only or metadata matches.

* **Tests**
  * Added regression tests ensuring single- and multi-token queries prefer visible title matches over hidden-metadata-only matches while still including metadata-only results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes command-palette/workspace switcher result ordering in production scoring; well-tested but affects core UX for all palette searches.
> 
> **Overview**
> Fixes workspace/command-palette ranking where **hidden metadata** (branch/description tokens) could beat a **visible title** that actually matches what the user typed—e.g. query `ios` putting a row with only a hidden `ios` keyword above **iOS Mobile Terminal**.
> 
> The Rust **nucleo FFI** scorer adds a **whole-query title literal** tier: case-insensitive **exact** or **prefix** match on the candidate title (via `Atom` + Smart diacritic folding), combined with existing token scores as **`max(token, literal)`**. Literal tiers sit above the short-query **keyword-exact** jackpot (~30_030) and **scale by query token count** so multi-token queries like `ios app` still lose to summed hidden keyword lines.
> 
> Prefix matches use a **flat** score (no length penalty) so numeric/workspace titles don’t mis-order; ties still use existing rank/index ordering. **Swift FFI tests** cover single-token, multi-token, and diacritic regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4718dc9acd4058c3e7db1478679249ca4a82339. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->