### PR TITLE
Fix Claude fork cwd drift

### DIFF
--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -420,7 +420,7 @@ enum AgentResumeCommandBuilder {
             }
         }
 
-        return decodeClaudeProjectDir(projectDirName) ?? fallback
+        return fallback
     }
 
     private static func claudeTranscriptProjectDirName(
@@ -446,18 +446,6 @@ enum AgentResumeCommandBuilder {
 
     private static func encodeClaudeProjectDir(_ path: String) -> String {
         path.replacingOccurrences(of: "/", with: "-")
-    }
-
-    private static func decodeClaudeProjectDir(_ raw: String) -> String? {
-        guard !raw.isEmpty else { return nil }
-        let stripped = raw.hasPrefix("-") ? String(raw.dropFirst()) : raw
-        let candidate = "/" + stripped.replacingOccurrences(of: "-", with: "/")
-        var isDirectory: ObjCBool = false
-        guard FileManager.default.fileExists(atPath: candidate, isDirectory: &isDirectory),
-              isDirectory.boolValue else {
-            return nil
-        }
-        return candidate
     }
 
     static func openCodeVersionProbe(

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -289,6 +289,7 @@ enum AgentResumeCommandBuilder {
         sessionId: String,
         launchCommand: AgentLaunchCommandSnapshot?,
         workingDirectory: String?,
+        transcriptPath: String? = nil,
         registrationOverride: CmuxVaultAgentRegistration? = nil,
         includeWorkingDirectoryPrefix: Bool = true
     ) -> String? {
@@ -308,8 +309,10 @@ enum AgentResumeCommandBuilder {
         return shellCommand(
             argv: argv,
             kind: kind,
+            sessionId: sessionId,
             launchCommand: launchCommand,
             workingDirectory: workingDirectory,
+            transcriptPath: transcriptPath,
             customRegistration: customRegistration,
             includeWorkingDirectoryPrefix: includeWorkingDirectoryPrefix
         )
@@ -320,6 +323,7 @@ enum AgentResumeCommandBuilder {
         sessionId: String,
         launchCommand: AgentLaunchCommandSnapshot?,
         workingDirectory: String?,
+        transcriptPath: String? = nil,
         registrationOverride: CmuxVaultAgentRegistration? = nil,
         includeWorkingDirectoryPrefix: Bool = true
     ) -> String? {
@@ -337,8 +341,10 @@ enum AgentResumeCommandBuilder {
         return shellCommand(
             argv: argv,
             kind: kind,
+            sessionId: sessionId,
             launchCommand: launchCommand,
             workingDirectory: workingDirectory,
+            transcriptPath: transcriptPath,
             customRegistration: customRegistration,
             includeWorkingDirectoryPrefix: includeWorkingDirectoryPrefix
         )
@@ -347,8 +353,10 @@ enum AgentResumeCommandBuilder {
     private static func shellCommand(
         argv: [String],
         kind: RestorableAgentKind,
+        sessionId: String,
         launchCommand: AgentLaunchCommandSnapshot?,
         workingDirectory: String?,
+        transcriptPath: String?,
         customRegistration: CmuxVaultAgentRegistration?,
         includeWorkingDirectoryPrefix: Bool
     ) -> String {
@@ -360,9 +368,15 @@ enum AgentResumeCommandBuilder {
         }
         commandParts.append(contentsOf: argv)
 
-        let cwd = !includeWorkingDirectoryPrefix || customRegistration?.cwd == .ignore
-            ? nil
-            : normalized(workingDirectory ?? launchCommand?.workingDirectory)
+        let cwd = shellWorkingDirectory(
+            kind: kind,
+            sessionId: sessionId,
+            launchCommand: launchCommand,
+            workingDirectory: workingDirectory,
+            transcriptPath: transcriptPath,
+            customRegistration: customRegistration,
+            includeWorkingDirectoryPrefix: includeWorkingDirectoryPrefix
+        )
         let sanitizedCommandParts = customRegistration == nil
             ? AgentLaunchSanitizer.removingSavedWorkingDirectoryOptions(
                 from: commandParts,
@@ -371,6 +385,79 @@ enum AgentResumeCommandBuilder {
             : commandParts
         let shellCommand = sanitizedCommandParts.map(shellSingleQuoted).joined(separator: " ")
         return TerminalStartupWorkingDirectoryPrefix.prefix(shellCommand, workingDirectory: cwd)
+    }
+
+    private static func shellWorkingDirectory(
+        kind: RestorableAgentKind,
+        sessionId: String,
+        launchCommand: AgentLaunchCommandSnapshot?,
+        workingDirectory: String?,
+        transcriptPath: String?,
+        customRegistration: CmuxVaultAgentRegistration?,
+        includeWorkingDirectoryPrefix: Bool
+    ) -> String? {
+        guard includeWorkingDirectoryPrefix, customRegistration?.cwd != .ignore else {
+            return nil
+        }
+        let fallback = normalized(workingDirectory ?? launchCommand?.workingDirectory)
+        guard kind == .claude,
+              let projectDirName = claudeTranscriptProjectDirName(
+                  transcriptPath: transcriptPath,
+                  sessionId: sessionId
+              ) else {
+            return fallback
+        }
+
+        let candidates = [workingDirectory, launchCommand?.workingDirectory]
+        for candidate in candidates {
+            guard let cwd = normalized(candidate) else { continue }
+            if encodeClaudeProjectDir(cwd) == projectDirName {
+                return cwd
+            }
+            let expanded = (cwd as NSString).expandingTildeInPath
+            if expanded != cwd, encodeClaudeProjectDir(expanded) == projectDirName {
+                return expanded
+            }
+        }
+
+        return decodeClaudeProjectDir(projectDirName) ?? fallback
+    }
+
+    private static func claudeTranscriptProjectDirName(
+        transcriptPath: String?,
+        sessionId: String
+    ) -> String? {
+        guard let transcriptPath = normalized(transcriptPath),
+              !sessionId.isEmpty else {
+            return nil
+        }
+        let expanded = (transcriptPath as NSString).expandingTildeInPath
+        let url = URL(fileURLWithPath: expanded, isDirectory: false)
+        guard url.lastPathComponent == "\(sessionId).jsonl" else {
+            return nil
+        }
+        let projectDirectory = url.deletingLastPathComponent()
+        guard projectDirectory.deletingLastPathComponent().lastPathComponent == "projects" else {
+            return nil
+        }
+        let name = projectDirectory.lastPathComponent
+        return name.isEmpty ? nil : name
+    }
+
+    private static func encodeClaudeProjectDir(_ path: String) -> String {
+        path.replacingOccurrences(of: "/", with: "-")
+    }
+
+    private static func decodeClaudeProjectDir(_ raw: String) -> String? {
+        guard !raw.isEmpty else { return nil }
+        let stripped = raw.hasPrefix("-") ? String(raw.dropFirst()) : raw
+        let candidate = "/" + stripped.replacingOccurrences(of: "-", with: "/")
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: candidate, isDirectory: &isDirectory),
+              isDirectory.boolValue else {
+            return nil
+        }
+        return candidate
     }
 
     static func openCodeVersionProbe(
@@ -803,6 +890,7 @@ struct SessionRestorableAgentSnapshot: Codable, Sendable {
     var sessionId: String
     var workingDirectory: String?
     var launchCommand: AgentLaunchCommandSnapshot?
+    var transcriptPath: String? = nil
     var registration: CmuxVaultAgentRegistration? = nil
 
     var resumeCommand: String? {
@@ -811,6 +899,7 @@ struct SessionRestorableAgentSnapshot: Codable, Sendable {
             sessionId: sessionId,
             launchCommand: launchCommand,
             workingDirectory: workingDirectory,
+            transcriptPath: transcriptPath,
             registrationOverride: registration
         )
     }
@@ -821,6 +910,7 @@ struct SessionRestorableAgentSnapshot: Codable, Sendable {
             sessionId: sessionId,
             launchCommand: launchCommand,
             workingDirectory: workingDirectory,
+            transcriptPath: transcriptPath,
             registrationOverride: registration
         )
     }
@@ -1136,6 +1226,7 @@ struct RestorableAgentSessionIndex: Sendable {
                     sessionId: normalizedSessionId,
                     workingDirectory: normalizedWorkingDirectory(record.cwd),
                     launchCommand: record.launchCommand,
+                    transcriptPath: normalizedNonEmptyValue(record.transcriptPath),
                     registration: registration
                 )
                 let key = PanelKey(workspaceId: workspaceId, panelId: panelId)

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -411,11 +411,11 @@ enum AgentResumeCommandBuilder {
         let candidates = [workingDirectory, launchCommand?.workingDirectory]
         for candidate in candidates {
             guard let cwd = normalized(candidate) else { continue }
-            if encodeClaudeProjectDir(cwd) == projectDirName {
+            if RestorableAgentSessionIndex.encodeClaudeProjectDir(cwd) == projectDirName {
                 return cwd
             }
             let expanded = (cwd as NSString).expandingTildeInPath
-            if expanded != cwd, encodeClaudeProjectDir(expanded) == projectDirName {
+            if expanded != cwd, RestorableAgentSessionIndex.encodeClaudeProjectDir(expanded) == projectDirName {
                 return expanded
             }
         }
@@ -442,10 +442,6 @@ enum AgentResumeCommandBuilder {
         }
         let name = projectDirectory.lastPathComponent
         return name.isEmpty ? nil : name
-    }
-
-    private static func encodeClaudeProjectDir(_ path: String) -> String {
-        path.replacingOccurrences(of: "/", with: "-")
     }
 
     static func openCodeVersionProbe(

--- a/Sources/SessionIndexStore.swift
+++ b/Sources/SessionIndexStore.swift
@@ -872,13 +872,6 @@ final class SessionIndexStore: ObservableObject {
             ?? url.deletingLastPathComponent().lastPathComponent
     }
 
-    /// Inverse of `decodeClaudeProjectDir`. Used as a fast path: when filtering
-    /// by cwd we can skip enumerating other project dirs entirely.
-    nonisolated private static func encodeClaudeProjectDir(_ path: String) -> String {
-        // "/Users/x/y" -> "-Users-x-y"
-        return path.replacingOccurrences(of: "/", with: "-")
-    }
-
     nonisolated private static func enumerateClaudeJSONLCandidates(
         root: ClaudeSessionRoot,
         cwdFilter: String?,
@@ -907,7 +900,7 @@ final class SessionIndexStore: ObservableObject {
         }
 
         if let cwdFilter {
-            let dirName = encodeClaudeProjectDir(cwdFilter)
+            let dirName = RestorableAgentSessionIndex.encodeClaudeProjectDir(cwdFilter)
             let dirPath = (root.projectsRoot as NSString).appendingPathComponent(dirName)
             var isDir: ObjCBool = false
             if fm.fileExists(atPath: dirPath, isDirectory: &isDir), isDir.boolValue {

--- a/cmuxTests/RestorableAgentSessionIndexTests.swift
+++ b/cmuxTests/RestorableAgentSessionIndexTests.swift
@@ -135,6 +135,61 @@ final class RestorableAgentSessionIndexTests: XCTestCase {
         )
     }
 
+    func testClaudeForkCommandUsesTranscriptProjectWorkingDirectoryWhenHookCwdDrifts() throws {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory
+            .appendingPathComponent("cmux-claude-fork-cwd-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fm.removeItem(at: root) }
+
+        let configDir = root.appendingPathComponent("claude-config", isDirectory: true)
+        let projectsDir = configDir.appendingPathComponent("projects", isDirectory: true)
+        let projectCwd = root.appendingPathComponent("cmuxterm-hq", isDirectory: true)
+        let hookCwd = projectCwd
+            .appendingPathComponent("worktrees", isDirectory: true)
+            .appendingPathComponent("feat-ios-swift-mobile-core", isDirectory: true)
+        try fm.createDirectory(at: hookCwd, withIntermediateDirectories: true)
+
+        let sessionId = "11111111-2222-3333-4444-555555555555"
+        let transcriptURL = projectsDir
+            .appendingPathComponent(RestorableAgentSessionIndex.encodeClaudeProjectDir(projectCwd.path), isDirectory: true)
+            .appendingPathComponent("\(sessionId).jsonl", isDirectory: false)
+        try writeClaudeTranscript(sessionId: sessionId, transcriptURL: transcriptURL, cwd: projectCwd)
+
+        let workspaceId = UUID()
+        let panelId = UUID()
+        try writeClaudeHookStore(
+            root: root,
+            sessions: [
+                sessionId: hookRecord(
+                    sessionId: sessionId,
+                    workspaceId: workspaceId,
+                    panelId: panelId,
+                    cwd: hookCwd.path,
+                    configDir: configDir.path,
+                    transcriptPath: transcriptURL.path,
+                    isRestorable: nil,
+                    updatedAt: 20,
+                    launchWorkingDirectory: projectCwd.path
+                ),
+            ]
+        )
+
+        let snapshot = try XCTUnwrap(
+            RestorableAgentSessionIndex.load(homeDirectory: root.path, fileManager: fm)
+                .snapshot(workspaceId: workspaceId, panelId: panelId)
+        )
+
+        XCTAssertEqual(snapshot.workingDirectory, hookCwd.path)
+        XCTAssertEqual(
+            snapshot.forkCommand,
+            "{ cd -- '\(projectCwd.path)' 2>/dev/null || [ ! -d '\(projectCwd.path)' ]; } && 'env' 'CLAUDE_CONFIG_DIR=\(configDir.path)' 'CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV=1' 'CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV_KEYS=CLAUDE_CONFIG_DIR' '/usr/local/bin/claude' '--resume' '\(sessionId)' '--fork-session' '--dangerously-skip-permissions'"
+        )
+        XCTAssertFalse(
+            snapshot.forkCommand?.contains("{ cd -- '\(hookCwd.path)'") ?? false,
+            "Claude must fork from the transcript project directory, not the later hook cwd, or Claude cannot find the conversation."
+        )
+    }
+
     func testPanelFallbackUsesLatestHookRecord() throws {
         let fm = FileManager.default
         let root = fm.temporaryDirectory
@@ -247,7 +302,8 @@ final class RestorableAgentSessionIndexTests: XCTestCase {
         configDir: String,
         transcriptPath: String?,
         isRestorable: Bool?,
-        updatedAt: TimeInterval
+        updatedAt: TimeInterval,
+        launchWorkingDirectory: String? = nil
     ) -> [String: Any] {
         var record: [String: Any] = [
             "sessionId": sessionId,
@@ -260,7 +316,7 @@ final class RestorableAgentSessionIndexTests: XCTestCase {
                 "launcher": "claude",
                 "executablePath": "/usr/local/bin/claude",
                 "arguments": ["/usr/local/bin/claude", "--dangerously-skip-permissions"],
-                "workingDirectory": cwd,
+                "workingDirectory": launchWorkingDirectory ?? cwd,
                 "environment": ["CLAUDE_CONFIG_DIR": configDir],
                 "capturedAt": updatedAt,
                 "source": "test",

--- a/cmuxTests/RestorableAgentSessionIndexTests.swift
+++ b/cmuxTests/RestorableAgentSessionIndexTests.swift
@@ -190,6 +190,53 @@ final class RestorableAgentSessionIndexTests: XCTestCase {
         )
     }
 
+    func testClaudeForkCommandDoesNotLossilyDecodeHyphenatedTranscriptProjectDirectory() throws {
+        let fm = FileManager.default
+        let root = URL(fileURLWithPath: "/tmp", isDirectory: true)
+            .appendingPathComponent(
+                "cmuxclaudehyphen\(UUID().uuidString.replacingOccurrences(of: "-", with: ""))",
+                isDirectory: true
+            )
+        defer { try? fm.removeItem(at: root) }
+
+        let projectCwd = root.appendingPathComponent("my-project", isDirectory: true)
+        let hookCwd = root.appendingPathComponent("drifted-cwd", isDirectory: true)
+        try fm.createDirectory(at: projectCwd, withIntermediateDirectories: true)
+        try fm.createDirectory(at: hookCwd, withIntermediateDirectories: true)
+
+        let sessionId = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        let encodedProjectDir = RestorableAgentSessionIndex.encodeClaudeProjectDir(projectCwd.path)
+        let transcriptURL = root
+            .appendingPathComponent("claude-config", isDirectory: true)
+            .appendingPathComponent("projects", isDirectory: true)
+            .appendingPathComponent(encodedProjectDir, isDirectory: true)
+            .appendingPathComponent("\(sessionId).jsonl", isDirectory: false)
+
+        let lossyDecodedPath = "/" + String(encodedProjectDir.dropFirst())
+            .replacingOccurrences(of: "-", with: "/")
+        try fm.createDirectory(
+            at: URL(fileURLWithPath: lossyDecodedPath, isDirectory: true),
+            withIntermediateDirectories: true
+        )
+
+        let command = AgentResumeCommandBuilder.forkShellCommand(
+            kind: .claude,
+            sessionId: sessionId,
+            launchCommand: nil,
+            workingDirectory: hookCwd.path,
+            transcriptPath: transcriptURL.path
+        )
+
+        XCTAssertEqual(
+            command,
+            "{ cd -- '\(hookCwd.path)' 2>/dev/null || [ ! -d '\(hookCwd.path)' ]; } && 'claude' '--resume' '\(sessionId)' '--fork-session'"
+        )
+        XCTAssertFalse(
+            command?.contains("{ cd -- '\(lossyDecodedPath)'") ?? false,
+            "Claude transcript project directory names cannot be decoded by replacing every hyphen with a slash."
+        )
+    }
+
     func testPanelFallbackUsesLatestHookRecord() throws {
         let fm = FileManager.default
         let root = fm.temporaryDirectory
@@ -339,6 +386,10 @@ final class RestorableAgentSessionIndexTests: XCTestCase {
     }
 
     private func writeClaudeTranscript(sessionId: String, transcriptURL: URL, cwd: URL) throws {
+        try FileManager.default.createDirectory(
+            at: transcriptURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
         try """
         {"type":"last-prompt","sessionId":"\(sessionId)"}
         {"type":"user","sessionId":"\(sessionId)","cwd":"\(cwd.path)","message":{"role":"user","content":"hello"}}


### PR DESCRIPTION
## Summary
- Preserve Claude hook `transcriptPath` on restorable snapshots.
- Use the transcript project directory for Claude resume/fork cd prefixes when hook cwd has drifted.

## Testing
- `./scripts/reload.sh --tag cldfork` passed.
- AWS targeted xcodebuild test was attempted, but the runner's xcodebuild crashed during Swift package resolution before compiling.

## Issues
- Related: Claude Code fork command failed with `No conversation found with session ID` when the transcript lived under the original project cwd but the hook cwd had moved to a worktree.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782950002&installation_id=133855650&pr_number=5149&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5149&signature=909e78b322ba01a5a90c1a411f5efa77423e0daeb1f1f1aca9c71de84a3ed5dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Claude resume/fork shell commands choose the working directory; incorrect matching could still run Claude from the wrong folder, though scope is limited to restorable Claude sessions and regression tests were added.
> 
> **Overview**
> Fixes Claude **resume/fork** when the hook **cwd** has moved (e.g. into a worktree) but the conversation transcript still lives under the original project folder.
> 
> **Restorable snapshots** now carry Claude **`transcriptPath`** from hook records into **`SessionRestorableAgentSnapshot`**, and **`AgentResumeCommandBuilder`** uses it when building the shell **`cd`** prefix for Claude resume/fork commands.
> 
> For Claude only, the builder reads the encoded project directory name from the transcript path (`…/projects/<encoded>/session.jsonl`) and picks a working directory by matching that name against **`encodeClaudeProjectDir`** on hook/launch cwd candidates (with tilde expansion)—**not** by reversing hyphens to slashes. If nothing matches, behavior falls back to the previous cwd logic.
> 
> **`SessionIndexStore`** drops its local **`encodeClaudeProjectDir`** duplicate in favor of **`RestorableAgentSessionIndex.encodeClaudeProjectDir`**. New tests cover cwd drift and avoiding lossy decode on hyphenated project dir names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 170a021311a1e676a422a22c465b2c411b749516. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Claude resume/fork when the hook cwd drifts by deriving the cd prefix from the transcript’s project directory using a shared encoder for consistent matching. Also avoids lossy decoding of encoded transcript project folders, preventing bad cd paths and the “No conversation found with session ID” error.

- **Bug Fixes**
  - Preserve Claude `transcriptPath` on restorable snapshots so resume/fork can locate the original project.
  - Compute the cd prefix by matching the transcript’s encoded project folder to candidate cwds with a shared encoder; if no match, fall back to the previous cwd (no hyphen→slash decoding).
  - Add regression tests for transcript project cwd selection and for avoiding lossy decoding.

<sup>Written for commit 170a021311a1e676a422a22c465b2c411b749516. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Resume and fork now carry optional transcript information so sessions can better restore context; snapshots persist transcript info.

* **Bug Fixes**
  * Improved working-directory resolution to prefer transcript-derived project directories where applicable and avoid embedding drifted hook paths.

* **Tests**
  * Added coverage for transcript-based working-directory behavior and hardened transcript writing in tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->