### PR TITLE
Start terminals for configured workspace commands

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -949,9 +949,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private var didSetupTerminalCmdClickUITest = false
     private var didSetupGotoSplitUITest = false
     private var didSetupBonsplitTabDragUITest = false
+    private var didSetupWorkspaceCommandStartupUITest = false
     private var terminalCmdClickUITestPoller: DispatchSourceTimer?
     private var bonsplitTabDragUITestRecorder: DispatchSourceTimer?
     private var gotoSplitUITestRecorder: DispatchSourceTimer?
+    private var workspaceCommandStartupUITestRecorder: DispatchSourceTimer?
     private var gotoSplitUITestObservers: [NSObjectProtocol] = []
     private var didSetupMultiWindowNotificationsUITest = false
     private var didSetupDisplayResolutionUITestDiagnostics = false
@@ -1870,6 +1872,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         setupTerminalCmdClickUITestIfNeeded()
         setupGotoSplitUITestIfNeeded()
         setupBonsplitTabDragUITestIfNeeded()
+        setupWorkspaceCommandStartupUITestIfNeeded()
         setupMultiWindowNotificationsUITestIfNeeded()
         setupDisplayResolutionUITestDiagnosticsIfNeeded()
         setupPortalStatsUITestDiagnosticsIfNeeded()
@@ -9812,6 +9815,60 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             guard self != nil else { return }
             runSetupWhenWindowReady()
         }
+    }
+
+    private func setupWorkspaceCommandStartupUITestIfNeeded() {
+        guard !didSetupWorkspaceCommandStartupUITest else { return }
+        didSetupWorkspaceCommandStartupUITest = true
+        let env = ProcessInfo.processInfo.environment
+        guard env["CMUX_UI_TEST_WORKSPACE_COMMAND_STARTUP_SETUP"] == "1",
+              let path = env["CMUX_UI_TEST_WORKSPACE_COMMAND_STARTUP_PATH"],
+              !path.isEmpty else {
+            return
+        }
+
+        workspaceCommandStartupUITestRecorder?.cancel()
+        workspaceCommandStartupUITestRecorder = nil
+
+        let timer = DispatchSource.makeTimerSource(queue: .main)
+        timer.schedule(deadline: .now(), repeating: .milliseconds(100))
+        timer.setEventHandler { [weak self] in
+            self?.recordWorkspaceCommandStartupUITestState(path: path)
+        }
+        workspaceCommandStartupUITestRecorder = timer
+        timer.resume()
+    }
+
+    private func recordWorkspaceCommandStartupUITestState(path: String) {
+        guard let tabManager else { return }
+
+        let workspace = tabManager.selectedWorkspace
+        let terminalPanel = workspace?.focusedTerminalPanel
+        let updates: [String: String] = [
+            "workspaceCount": String(tabManager.tabs.count),
+            "selectedWorkspaceId": workspace?.id.uuidString ?? "",
+            "selectedWorkspaceTitle": workspace?.title ?? "",
+            "focusedPanelId": workspace?.focusedPanelId?.uuidString ?? "",
+            "focusedPanelKind": terminalPanel == nil ? "nonTerminal" : "terminal",
+            "selectedTerminalPanelId": terminalPanel?.id.uuidString ?? "",
+            "selectedTerminalSurfaceCreateAttempts": String(terminalPanel?.surface.debugRuntimeSurfaceCreateAttemptCountForTesting() ?? 0),
+            "selectedTerminalHasHeadlessStartupWindow": (terminalPanel?.surface.debugHasHeadlessStartupWindowForTesting() == true) ? "true" : "false"
+        ]
+
+        var payload = loadWorkspaceCommandStartupUITestData(at: path)
+        for (key, value) in updates {
+            payload[key] = value
+        }
+        guard let data = try? JSONSerialization.data(withJSONObject: payload) else { return }
+        try? data.write(to: URL(fileURLWithPath: path), options: .atomic)
+    }
+
+    private func loadWorkspaceCommandStartupUITestData(at path: String) -> [String: String] {
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: String] else {
+            return [:]
+        }
+        return object
     }
 
     private func bonsplitTabDragUITestDataPath() -> String? {

--- a/Sources/CmuxConfigExecutor.swift
+++ b/Sources/CmuxConfigExecutor.swift
@@ -498,7 +498,7 @@ struct CmuxConfigExecutor {
         }
 
         let resolvedCwd = CmuxConfigStore.resolveCwd(wsDef.cwd, relativeTo: baseCwd)
-        let newWorkspace = tabManager.addWorkspace(workingDirectory: resolvedCwd)
+        let newWorkspace = tabManager.addWorkspace(workingDirectory: resolvedCwd, eagerLoadTerminal: true)
         newWorkspace.setCustomTitle(workspaceName)
         if let color = wsDef.color {
             newWorkspace.setCustomColor(color)

--- a/Sources/Feed/FeedCoordinator.swift
+++ b/Sources/Feed/FeedCoordinator.swift
@@ -591,6 +591,18 @@ private extension FeedCoordinator {
                         effects: effects
                     )
                 case .notDetermined:
+#if DEBUG
+                    if ProcessInfo.processInfo.environment["CMUX_UI_TEST_DISABLE_NOTIFICATION_AUTHORIZATION_PROMPT"] == "1" {
+                        self.runFallbackEffectsIfStillAwaiting(
+                            requestId: requestId,
+                            title: title,
+                            subtitle: subtitle,
+                            body: body,
+                            effects: effects
+                        )
+                        return
+                    }
+#endif
                     let granted = (
                         try? await center.requestAuthorization(options: [.alert, .sound])
                     ) ?? false

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -2074,6 +2074,14 @@ final class TerminalNotificationStore: ObservableObject {
             completion(false)
             return
         }
+#if DEBUG
+        if isAutomaticRequest,
+           ProcessInfo.processInfo.environment["CMUX_UI_TEST_DISABLE_NOTIFICATION_AUTHORIZATION_PROMPT"] == "1" {
+            logAuthorization("request suppressed for ui test origin=\(origin.rawValue)")
+            completion(false)
+            return
+        }
+#endif
         if isAutomaticRequest {
             hasRequestedAutomaticAuthorization = true
         }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -142,6 +142,7 @@
 		CF00F00000000000000000A3 /* CmuxFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = CF00F00000000000000000A2 /* CmuxFoundation */; };
 		C0DE34020000000000000001 /* CmuxHelpCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE34020000000000000003 /* CmuxHelpCommands.swift */; };
 		C0DE34020000000000000002 /* CmuxHelpResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE34020000000000000004 /* CmuxHelpResource.swift */; };
+		C0DE51510000000000000001 /* CmuxHomeWorkspaceCommandStartupUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE51510000000000000002 /* CmuxHomeWorkspaceCommandStartupUITests.swift */; };
 		C0DE46010000000000000001 /* CMUXInstalledExtensionSidebarHostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE46010000000000000002 /* CMUXInstalledExtensionSidebarHostView.swift */; };
 		E7E00000000000000000000B /* CmuxLifecycleEventPublishing.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7E00000000000000000000C /* CmuxLifecycleEventPublishing.swift */; };
 		2F0C07000000000000000002 /* CmuxMainWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0C07000000000000000001 /* CmuxMainWindow.swift */; };
@@ -773,6 +774,7 @@
 		E7E000000000000000000002 /* CmuxEventStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxEventStream.swift; sourceTree = "<group>"; };
 		C0DE34020000000000000003 /* CmuxHelpCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/CmuxHelpCommands.swift; sourceTree = "<group>"; };
 		C0DE34020000000000000004 /* CmuxHelpResource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/CmuxHelpResource.swift; sourceTree = "<group>"; };
+		C0DE51510000000000000002 /* CmuxHomeWorkspaceCommandStartupUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxHomeWorkspaceCommandStartupUITests.swift; sourceTree = "<group>"; };
 		C0DE46010000000000000002 /* CMUXInstalledExtensionSidebarHostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMUXInstalledExtensionSidebarHostView.swift; sourceTree = "<group>"; };
 		E7E00000000000000000000C /* CmuxLifecycleEventPublishing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxLifecycleEventPublishing.swift; sourceTree = "<group>"; };
 		2F0C07000000000000000001 /* CmuxMainWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/CmuxMainWindow.swift; sourceTree = "<group>"; };
@@ -1315,6 +1317,7 @@
 					C0DE34020000000000000006 /* HelpMenuUITests.swift */,
 					B8F266256A1A3D9A45BD840F /* SidebarHelpMenuUITests.swift */,
 					C0DE32470000000000000006 /* CommandPaletteIdentifierClipboardUITests.swift */,
+					C0DE51510000000000000002 /* CmuxHomeWorkspaceCommandStartupUITests.swift */,
 					B8F266276A1A3D9A45BD840F /* DisplayResolutionRegressionUITests.swift */,
 				F0F0A002A1B2C3D4E5F60718 /* WorkspaceSidebarScrollUITests.swift */,
 				C2577001A1B2C3D4E5F60718 /* TerminalCmdClickUITests.swift */,
@@ -2593,6 +2596,7 @@
 				B9000023A1B2C3D4E5F60719 /* CloseWorkspaceCmdDUITests.swift in Sources */,
 				B900001AA1B2C3D4E5F60719 /* CloseWorkspaceConfirmDialogUITests.swift in Sources */,
 				B900001BA1B2C3D4E5F60719 /* CloseWorkspacesConfirmDialogUITests.swift in Sources */,
+					C0DE51510000000000000001 /* CmuxHomeWorkspaceCommandStartupUITests.swift in Sources */,
 					C0DE32470000000000000005 /* CommandPaletteIdentifierClipboardUITests.swift in Sources */,
 					B8F266266A1A3D9A45BD840F /* DisplayResolutionRegressionUITests.swift in Sources */,
 				FEED0000000000000000F009 /* FeedSidebarUITests.swift in Sources */,

--- a/cmuxTests/CmuxConfigTests.swift
+++ b/cmuxTests/CmuxConfigTests.swift
@@ -1867,6 +1867,34 @@ final class CmuxCommandIdentityTests: XCTestCase {
 @MainActor
 final class CmuxConfigWorkspaceCommandExecutionTests: XCTestCase {
 
+    func testWorkspaceCommandStartsSelectedTerminalWithoutSidebarClick() throws {
+        let manager = TabManager()
+        let command = CmuxCommandDefinition(
+            name: "cmux-home",
+            workspace: CmuxWorkspaceDefinition(name: "cmux-home")
+        )
+
+        XCTAssertTrue(CmuxConfigExecutor.execute(
+            command: command,
+            tabManager: manager,
+            baseCwd: NSTemporaryDirectory(),
+            configSourcePath: nil,
+            globalConfigPath: "/tmp/cmux-test-global-config.json"
+        ))
+
+        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let terminalPanel = try XCTUnwrap(workspace.focusedTerminalPanel)
+        defer { terminalPanel.surface.teardownSurface() }
+
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+
+        XCTAssertGreaterThan(
+            terminalPanel.surface.debugRuntimeSurfaceCreateAttemptCountForTesting(),
+            0,
+            "Workspace commands launched from cmux home must start the selected terminal immediately instead of waiting for a sidebar click."
+        )
+    }
+
     func testWorkspaceCommandCreatesNewWorkspaceByDefaultWhenNameAlreadyExists() {
         let manager = TabManager()
         let existingWorkspace = manager.tabs[0]

--- a/cmuxUITests/CmuxHomeWorkspaceCommandStartupUITests.swift
+++ b/cmuxUITests/CmuxHomeWorkspaceCommandStartupUITests.swift
@@ -1,0 +1,195 @@
+import XCTest
+
+final class CmuxHomeWorkspaceCommandStartupUITests: XCTestCase {
+    private var dataPath = ""
+    private var originalConfigData: Data?
+    private var configURL: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        continueAfterFailure = false
+        dataPath = "/tmp/cmux-ui-test-workspace-command-startup-\(UUID().uuidString).json"
+        try? FileManager.default.removeItem(atPath: dataPath)
+        configURL = Self.globalConfigURL()
+        originalConfigData = try? Data(contentsOf: configURL)
+        try writeCmuxHomeCommandConfig()
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(atPath: dataPath)
+        if let originalConfigData {
+            try? FileManager.default.createDirectory(
+                at: configURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try? originalConfigData.write(to: configURL, options: .atomic)
+        } else {
+            try? FileManager.default.removeItem(at: configURL)
+        }
+        try super.tearDownWithError()
+    }
+
+    func testCmuxHomeCommandPaletteReturnStartsTerminalImmediately() throws {
+        let app = XCUIApplication()
+        app.launchArguments += ["-AppleLanguages", "(en)", "-AppleLocale", "en_US", "-menuBarOnly", "false"]
+        app.launchEnvironment["CMUX_UI_TEST_MODE"] = "1"
+        app.launchEnvironment["CMUX_UI_TEST_DISABLE_NOTIFICATION_AUTHORIZATION_PROMPT"] = "1"
+        app.launchEnvironment["CMUX_UI_TEST_WORKSPACE_COMMAND_STARTUP_SETUP"] = "1"
+        app.launchEnvironment["CMUX_UI_TEST_WORKSPACE_COMMAND_STARTUP_PATH"] = dataPath
+        launchAndActivate(app)
+        addTeardownBlock { app.terminate() }
+
+        XCTAssertTrue(
+            pollUntil(timeout: 8.0) { app.windows.count >= 1 },
+            "Expected the main window to be visible"
+        )
+        dismissUserNotificationCenterDialogs()
+        app.activate()
+
+        app.typeKey("p", modifierFlags: [.command, .shift])
+        let searchField = app.textFields["CommandPaletteSearchField"]
+        XCTAssertTrue(searchField.waitForExistence(timeout: 5.0), "Expected command palette search field")
+        dismissUserNotificationCenterDialogs()
+        app.activate()
+        searchField.click()
+        dismissUserNotificationCenterDialogs()
+        app.activate()
+        searchField.click()
+        searchField.typeText("cmux-home")
+
+        let firstRow = app.descendants(matching: .any)
+            .matching(NSPredicate(
+                format: "identifier BEGINSWITH %@",
+                "CommandPaletteResultRow."
+            ))
+            .firstMatch
+        XCTAssertTrue(firstRow.waitForExistence(timeout: 5.0), "Expected command palette results for cmux-home")
+
+        searchField.typeKey(XCUIKeyboardKey.return.rawValue, modifierFlags: [])
+        XCTAssertTrue(
+            pollUntil(timeout: 2.0) { !searchField.exists },
+            "Expected command palette to dismiss after pressing Return"
+        )
+
+        var latest: [String: String] = [:]
+        XCTAssertTrue(
+            pollUntil(timeout: 8.0) {
+                latest = self.loadData()
+                guard latest["selectedWorkspaceTitle"] == "cmux-home",
+                      latest["focusedPanelKind"] == "terminal",
+                      let attempts = Int(latest["selectedTerminalSurfaceCreateAttempts"] ?? "") else {
+                    return false
+                }
+                return attempts > 0
+            },
+            "Expected cmux-home Return to start the selected terminal immediately without clicking the workspace. latest=\(latest)"
+        )
+    }
+
+    private func writeCmuxHomeCommandConfig() throws {
+        try FileManager.default.createDirectory(
+            at: configURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let config = """
+        {
+          "commands": [
+            {
+              "name": "cmux-home",
+              "workspace": {
+                "name": "cmux-home"
+              }
+            }
+          ]
+        }
+        """
+        try config.write(to: configURL, atomically: true, encoding: .utf8)
+    }
+
+    private func launchAndActivate(_ app: XCUIApplication) {
+        let launchOptions = XCTExpectedFailure.Options()
+        launchOptions.isStrict = false
+        XCTExpectFailure("App activation may fail on headless CI runners", options: launchOptions) {
+            app.launch()
+        }
+
+        if app.state == .runningForeground { return }
+
+        var reachedForeground = false
+        let activateOptions = XCTExpectedFailure.Options()
+        activateOptions.isStrict = false
+        XCTExpectFailure("App activation may fail on headless CI runners", options: activateOptions) {
+            reachedForeground = pollUntil(timeout: 4.0) {
+                if app.state != .runningForeground {
+                    app.activate()
+                }
+                return app.state == .runningForeground
+            }
+            XCTAssertTrue(reachedForeground, "App did not reach runningForeground before UI interactions")
+        }
+        if reachedForeground || app.state == .runningBackground {
+            return
+        }
+        XCTFail("App failed to start. state=\(app.state.rawValue)")
+    }
+
+    private func loadData() -> [String: String] {
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: dataPath)),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: String] else {
+            return [:]
+        }
+        return object
+    }
+
+    private func dismissUserNotificationCenterDialogs() {
+        let notificationCenter = XCUIApplication(bundleIdentifier: "com.apple.UserNotificationCenter")
+        for _ in 0..<3 {
+            let dialog = notificationCenter.dialogs.firstMatch
+            guard dialog.waitForExistence(timeout: 0.2) else { return }
+
+            if clickFirstExistingButton(
+                in: dialog,
+                identifiers: ["Close", "Dismiss", "action-button-3", "action-button-1"]
+            ) {
+                _ = pollUntil(timeout: 1.0) { !dialog.exists }
+                continue
+            }
+
+            notificationCenter.typeKey(XCUIKeyboardKey.escape.rawValue, modifierFlags: [])
+            _ = pollUntil(timeout: 1.0) { !dialog.exists }
+        }
+    }
+
+    private func clickFirstExistingButton(in element: XCUIElement, identifiers: [String]) -> Bool {
+        for identifier in identifiers {
+            let button = element.buttons[identifier]
+            if button.exists {
+                button.click()
+                return true
+            }
+        }
+        return false
+    }
+
+    private func pollUntil(
+        timeout: TimeInterval,
+        pollInterval: TimeInterval = 0.05,
+        condition: () -> Bool
+    ) -> Bool {
+        let start = ProcessInfo.processInfo.systemUptime
+        while true {
+            if condition() {
+                return true
+            }
+            if (ProcessInfo.processInfo.systemUptime - start) >= timeout {
+                return false
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(pollInterval))
+        }
+    }
+
+    private static func globalConfigURL() -> URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".config/cmux/cmux.json", isDirectory: false)
+    }
+}


### PR DESCRIPTION
## Summary
- Start the focused terminal immediately when a configured workspace command creates/selects a workspace.
- Add a regression test for the cmux-home style workspace command path.

## Testing
- ./scripts/lint-pbxproj-test-wiring.sh
- ./scripts/reload.sh --tag cmhome
- Depot unit-only run: https://github.com/manaflow-ai/cmux/actions/runs/26789666059

## Issues
- Plain-text task: cmux-home Enter creates a workspace but the terminal stays unloaded until the workspace is clicked.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5151"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782951168&installation_id=133855650&pr_number=5151&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5151&signature=da689bee840442f6ae19e3561dce24a82475e7a61bc9811a39100869afbe94fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is scoped to workspace-command creation and DEBUG-only UI-test hooks; no production auth or data-path changes beyond eager terminal init.
> 
> **Overview**
> Configured **workspace commands** (e.g. **cmux-home** from the command palette) now create workspaces with **`eagerLoadTerminal: true`**, so the focused terminal starts loading immediately instead of staying idle until the workspace is clicked in the sidebar.
> 
> **Tests and UI-test support** were added: a unit test on `CmuxConfigExecutor`, a new UI test that runs the palette flow and asserts terminal surface creation via a DEBUG JSON recorder in `AppDelegate`, and **`CMUX_UI_TEST_DISABLE_NOTIFICATION_AUTHORIZATION_PROMPT`** so feed/terminal notification paths skip authorization prompts during UI tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d77d7ad6e45711516c35295ea10b7936ad34751. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Workspaces now eagerly initialize terminals on creation so selected terminals start immediately.
  * Notification authorization prompts can be suppressed during UI-test runs to avoid blocking flows.

* **Tests**
  * Added unit and UI tests validating workspace-command startup and immediate terminal creation.
  * Added a UI-test recorder that captures workspace/terminal startup metrics for verification.

* **Chores**
  * Test harness and project test registration updated to support the new UI tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->