### PR TITLE
Show browser focus flash above WebKit

### DIFF
--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -1284,6 +1284,11 @@ struct BrowserPortalOmnibarSuggestionsConfiguration {
     let onHighlight: (Int) -> Void
 }
 
+struct BrowserPortalFocusFlashConfiguration {
+    let panelId: UUID
+    let opacity: Double
+}
+
 private struct BrowserPortalOmnibarSuggestionsOverlay: View {
     let configuration: BrowserPortalOmnibarSuggestionsConfiguration
 
@@ -1304,6 +1309,31 @@ private struct BrowserPortalOmnibarSuggestionsOverlay: View {
                 .environment(\.colorScheme, configuration.colorScheme)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+}
+
+private struct BrowserPortalFocusFlashOverlay: View {
+    let configuration: BrowserPortalFocusFlashConfiguration
+
+    var body: some View {
+        Color.clear
+            .overlay {
+                RoundedRectangle(cornerRadius: CGFloat(FocusFlashPattern.ringCornerRadius))
+                    .stroke(cmuxAccentColor().opacity(configuration.opacity), lineWidth: 3)
+                    .shadow(
+                        color: cmuxAccentColor().opacity(configuration.opacity * 0.35),
+                        radius: 10
+                    )
+                    .padding(CGFloat(FocusFlashPattern.ringInset))
+                    .allowsHitTesting(false)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+private final class BrowserPortalFocusFlashHostingView: NSHostingView<BrowserPortalFocusFlashOverlay> {
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        nil
     }
 }
 
@@ -1470,6 +1500,7 @@ final class WindowBrowserSlotView: NSView {
     private let dropZoneOverlayView = BrowserDropZoneOverlayView(frame: .zero)
     private var searchOverlayHostingView: NSHostingView<BrowserSearchOverlay>?
     private var omnibarSuggestionsHostingView: BrowserPortalOmnibarSuggestionsHostingView?
+    private var focusFlashHostingView: BrowserPortalFocusFlashHostingView?
     private weak var hostedWebView: WKWebView?
     private var hostedWebViewConstraints: [NSLayoutConstraint] = []
     private var forwardedDropZone: DropZone?
@@ -1740,6 +1771,43 @@ final class WindowBrowserSlotView: NSView {
         bringInteractionLayersToFrontIfNeeded()
     }
 
+    func setFocusFlash(_ configuration: BrowserPortalFocusFlashConfiguration?) {
+        guard let configuration, configuration.opacity > 0 else {
+            focusFlashHostingView?.removeFromSuperview()
+            focusFlashHostingView = nil
+            return
+        }
+
+        let rootView = BrowserPortalFocusFlashOverlay(configuration: configuration)
+        if let overlay = focusFlashHostingView {
+            overlay.rootView = rootView
+            if overlay.superview !== self {
+                overlay.removeFromSuperview()
+                addSubview(overlay)
+                NSLayoutConstraint.activate([
+                    overlay.topAnchor.constraint(equalTo: topAnchor),
+                    overlay.bottomAnchor.constraint(equalTo: bottomAnchor),
+                    overlay.leadingAnchor.constraint(equalTo: leadingAnchor),
+                    overlay.trailingAnchor.constraint(equalTo: trailingAnchor),
+                ])
+            }
+            bringInteractionLayersToFrontIfNeeded()
+            return
+        }
+
+        let overlay = BrowserPortalFocusFlashHostingView(rootView: rootView)
+        overlay.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(overlay)
+        NSLayoutConstraint.activate([
+            overlay.topAnchor.constraint(equalTo: topAnchor),
+            overlay.bottomAnchor.constraint(equalTo: bottomAnchor),
+            overlay.leadingAnchor.constraint(equalTo: leadingAnchor),
+            overlay.trailingAnchor.constraint(equalTo: trailingAnchor),
+        ])
+        focusFlashHostingView = overlay
+        bringInteractionLayersToFrontIfNeeded()
+    }
+
     private func searchOverlayOwnsFieldEditor(_ fieldEditor: NSTextView, in root: NSView) -> Bool {
         guard fieldEditor.isFieldEditor else { return false }
 
@@ -1964,9 +2032,10 @@ final class WindowBrowserSlotView: NSView {
     }
 
     private func interactionLayerPriority(of view: NSView) -> Int {
-        if view === paneDropTargetView { return 3 }
-        if view === omnibarSuggestionsHostingView { return 2 }
-        if view === searchOverlayHostingView { return 1 }
+        if view === paneDropTargetView { return 4 }
+        if view === omnibarSuggestionsHostingView { return 3 }
+        if view === searchOverlayHostingView { return 2 }
+        if view === focusFlashHostingView { return 1 }
         return 0
     }
 
@@ -2054,6 +2123,7 @@ final class WindowBrowserPortal: NSObject {
         var paneDropContext: BrowserPaneDropContext?
         var searchOverlay: BrowserPortalSearchOverlayConfiguration?
         var omnibarSuggestions: BrowserPortalOmnibarSuggestionsConfiguration?
+        var focusFlash: BrowserPortalFocusFlashConfiguration?
         var paneTopChromeHeight: CGFloat
         var transientRecoveryReason: String?
         var transientRecoveryRetriesRemaining: Int
@@ -2397,6 +2467,21 @@ final class WindowBrowserPortal: NSObject {
         }
     }
 
+    private static func focusFlashConfigurationsEquivalent(
+        _ lhs: BrowserPortalFocusFlashConfiguration?,
+        _ rhs: BrowserPortalFocusFlashConfiguration?
+    ) -> Bool {
+        switch (lhs, rhs) {
+        case (nil, nil):
+            return true
+        case let (lhs?, rhs?):
+            return lhs.panelId == rhs.panelId &&
+                abs(lhs.opacity - rhs.opacity) <= 0.001
+        default:
+            return false
+        }
+    }
+
     /// Convert an anchor view's bounds to window coordinates while honoring ancestor clipping.
     /// SwiftUI/AppKit hosting layers can briefly report an anchor bounds rect larger than the
     /// visible split pane during rearrangement; intersecting through ancestor bounds keeps the
@@ -2644,6 +2729,7 @@ final class WindowBrowserPortal: NSObject {
             existing.setPaneDropContext(entry.paneDropContext)
             existing.setSearchOverlay(entry.searchOverlay)
             existing.setOmnibarSuggestions(entry.omnibarSuggestions)
+            existing.setFocusFlash(entry.focusFlash)
             existing.setPaneTopChromeHeight(entry.paneTopChromeHeight)
             return existing
         }
@@ -2651,6 +2737,7 @@ final class WindowBrowserPortal: NSObject {
         created.setPaneDropContext(entry.paneDropContext)
         created.setSearchOverlay(entry.searchOverlay)
         created.setOmnibarSuggestions(entry.omnibarSuggestions)
+        created.setFocusFlash(entry.focusFlash)
         created.setPaneTopChromeHeight(entry.paneTopChromeHeight)
 #if DEBUG
         cmuxDebugLog(
@@ -3028,6 +3115,17 @@ final class WindowBrowserPortal: NSObject {
         entry.containerView?.setOmnibarSuggestions(configuration)
     }
 
+    func updateFocusFlash(
+        forWebViewId webViewId: ObjectIdentifier,
+        configuration: BrowserPortalFocusFlashConfiguration?
+    ) {
+        guard var entry = entriesByWebViewId[webViewId] else { return }
+        guard !Self.focusFlashConfigurationsEquivalent(entry.focusFlash, configuration) else { return }
+        entry.focusFlash = configuration
+        entriesByWebViewId[webViewId] = entry
+        entry.containerView?.setFocusFlash(configuration)
+    }
+
     func searchOverlayPanelId(for responder: NSResponder) -> UUID? {
         for entry in entriesByWebViewId.values {
             if let panelId = entry.containerView?.searchOverlayPanelId(for: responder) {
@@ -3099,6 +3197,7 @@ final class WindowBrowserPortal: NSObject {
                 paneDropContext: nil,
                 searchOverlay: nil,
                 omnibarSuggestions: nil,
+                focusFlash: nil,
                 paneTopChromeHeight: 0,
                 transientRecoveryReason: nil,
                 transientRecoveryRetriesRemaining: 0
@@ -3136,6 +3235,7 @@ final class WindowBrowserPortal: NSObject {
             paneDropContext: previousEntry?.paneDropContext,
             searchOverlay: previousEntry?.searchOverlay,
             omnibarSuggestions: previousEntry?.omnibarSuggestions,
+            focusFlash: previousEntry?.focusFlash,
             paneTopChromeHeight: previousEntry?.paneTopChromeHeight ?? 0,
             transientRecoveryReason: previousEntry?.transientRecoveryReason,
             transientRecoveryRetriesRemaining: previousEntry?.transientRecoveryRetriesRemaining ?? 0
@@ -3332,6 +3432,7 @@ final class WindowBrowserPortal: NSObject {
             containerView.setPaneTopChromeHeight(0)
             containerView.setSearchOverlay(nil)
             containerView.setOmnibarSuggestions(nil)
+            containerView.setFocusFlash(nil)
             containerView.setPaneDropContext(nil)
             containerView.setPortalDragDropZone(nil)
             containerView.setDropZoneOverlay(zone: nil)
@@ -3751,6 +3852,7 @@ final class WindowBrowserPortal: NSObject {
         containerView.setPaneTopChromeHeight(shouldHide ? 0 : entry.paneTopChromeHeight)
         containerView.setSearchOverlay(shouldHide ? nil : entry.searchOverlay)
         containerView.setOmnibarSuggestions(shouldHide ? nil : entry.omnibarSuggestions)
+        containerView.setFocusFlash(shouldHide ? nil : entry.focusFlash)
         containerView.setPaneDropContext(containerView.isHidden ? nil : entry.paneDropContext)
         containerView.setDropZoneOverlay(zone: containerView.isHidden ? nil : entry.dropZone)
         if revealedForDisplay {
@@ -4129,6 +4231,16 @@ enum BrowserWindowPortalRegistry {
         guard let windowId = webViewToWindowId[webViewId],
               let portal = portalsByWindowId[windowId] else { return }
         portal.updateOmnibarSuggestions(forWebViewId: webViewId, configuration: configuration)
+    }
+
+    static func updateFocusFlash(
+        for webView: WKWebView,
+        configuration: BrowserPortalFocusFlashConfiguration?
+    ) {
+        let webViewId = ObjectIdentifier(webView)
+        guard let windowId = webViewToWindowId[webViewId],
+              let portal = portalsByWindowId[windowId] else { return }
+        portal.updateFocusFlash(forWebViewId: webViewId, configuration: configuration)
     }
 
     static func searchOverlayPanelId(for responder: NSResponder, in window: NSWindow) -> UUID? {

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -606,6 +606,19 @@ struct BrowserPanelView: View {
         )
     }
 
+    private var webViewHostedFocusFlash: BrowserPortalFocusFlashConfiguration? {
+        guard panel.shouldRenderWebView,
+              isVisibleInUI,
+              isCurrentPaneOwner,
+              focusFlashOpacity > 0 else {
+            return nil
+        }
+        return BrowserPortalFocusFlashConfiguration(
+            panelId: panel.id,
+            opacity: focusFlashOpacity
+        )
+    }
+
     private var developerToolsButtonHelp: String {
         let base = String(localized: "browser.toggleDevTools", defaultValue: "Toggle Developer Tools")
         let _ = keyboardShortcutSettingsObserver.revision
@@ -1001,12 +1014,15 @@ struct BrowserPanelView: View {
         }
     }
 
+    @ViewBuilder
     private var focusFlashOverlayView: some View {
-        RoundedRectangle(cornerRadius: FocusFlashPattern.ringCornerRadius)
-            .stroke(cmuxAccentColor().opacity(focusFlashOpacity), lineWidth: 3)
-            .shadow(color: cmuxAccentColor().opacity(focusFlashOpacity * 0.35), radius: 10)
-            .padding(FocusFlashPattern.ringInset)
-            .allowsHitTesting(false)
+        if !panel.shouldRenderWebView {
+            RoundedRectangle(cornerRadius: FocusFlashPattern.ringCornerRadius)
+                .stroke(cmuxAccentColor().opacity(focusFlashOpacity), lineWidth: 3)
+                .shadow(color: cmuxAccentColor().opacity(focusFlashOpacity * 0.35), radius: 10)
+                .padding(FocusFlashPattern.ringInset)
+                .allowsHitTesting(false)
+        }
     }
 
     @ViewBuilder
@@ -1608,6 +1624,7 @@ struct BrowserPanelView: View {
                         )
                     },
                     omnibarSuggestions: portalOmnibarSuggestions,
+                    focusFlash: webViewHostedFocusFlash,
                     paneTopChromeHeight: panel.isOmnibarVisible ? addressBarHeight : 0
                 )
                 .accessibilityIdentifier("BrowserWebViewSurface")
@@ -5011,6 +5028,7 @@ struct WebViewRepresentable: NSViewRepresentable {
     let paneDropZone: DropZone?
     let searchOverlay: BrowserPortalSearchOverlayConfiguration?
     let omnibarSuggestions: BrowserPortalOmnibarSuggestionsConfiguration?
+    let focusFlash: BrowserPortalFocusFlashConfiguration?
     let paneTopChromeHeight: CGFloat
 
     final class Coordinator {
@@ -6880,6 +6898,7 @@ struct WebViewRepresentable: NSViewRepresentable {
             // Split zoom can instantiate a replacement local host before it joins a window.
             // Never let that off-window host steal the live page + inspector hierarchy away
             // from the currently visible local host.
+            slotView.setFocusFlash(nil)
             host.setLocalInlineSlotHidden(true)
             coordinator.lastPortalHostId = nil
             coordinator.lastSynchronizedHostGeometryRevision = 0
@@ -6909,6 +6928,8 @@ struct WebViewRepresentable: NSViewRepresentable {
             )
         }
 #endif
+
+        slotView.setFocusFlash(shouldPreserveExternalFullscreenHost ? nil : focusFlash)
 
         let preferredAttachedWidthState = panel.preferredAttachedDeveloperToolsWidthState()
         host.setPreferredHostedInspectorWidth(
@@ -7074,6 +7095,7 @@ struct WebViewRepresentable: NSViewRepresentable {
         let generation = coordinator.attachGeneration
         let activePaneDropContext = coordinator.desiredPortalVisibleInUI ? paneDropContext : nil
         let activeSearchOverlay = coordinator.desiredPortalVisibleInUI ? searchOverlay : nil
+        let activeFocusFlash = coordinator.desiredPortalVisibleInUI ? focusFlash : nil
         let portalAnchorView = panel.portalAnchorView
         let portalHideReason = !isCurrentPaneOwner ? "lostPaneOwnership" : "hidden"
         let didReleasePortalHost: Bool
@@ -7160,6 +7182,7 @@ struct WebViewRepresentable: NSViewRepresentable {
             BrowserWindowPortalRegistry.updatePaneDropContext(for: webView, context: activePaneDropContext)
             BrowserWindowPortalRegistry.updateSearchOverlay(for: webView, configuration: activeSearchOverlay)
             BrowserWindowPortalRegistry.updateOmnibarSuggestions(for: webView, configuration: activeOmnibarSuggestions)
+            BrowserWindowPortalRegistry.updateFocusFlash(for: webView, configuration: activeFocusFlash)
             coordinator.lastPortalHostId = ObjectIdentifier(host)
             coordinator.lastSynchronizedHostGeometryRevision = host.geometryRevision
         }
@@ -7196,6 +7219,7 @@ struct WebViewRepresentable: NSViewRepresentable {
                 BrowserWindowPortalRegistry.updatePaneDropContext(for: webView, context: activePaneDropContext)
                 BrowserWindowPortalRegistry.updateSearchOverlay(for: webView, configuration: activeSearchOverlay)
                 BrowserWindowPortalRegistry.updateOmnibarSuggestions(for: webView, configuration: activeOmnibarSuggestions)
+                BrowserWindowPortalRegistry.updateFocusFlash(for: webView, configuration: activeFocusFlash)
                 coordinator.lastPortalHostId = hostId
             }
             BrowserWindowPortalRegistry.synchronizeForAnchor(portalAnchorView)
@@ -7244,6 +7268,7 @@ struct WebViewRepresentable: NSViewRepresentable {
             )
             BrowserWindowPortalRegistry.updateSearchOverlay(for: webView, configuration: activeSearchOverlay)
             BrowserWindowPortalRegistry.updateOmnibarSuggestions(for: webView, configuration: activeOmnibarSuggestions)
+            BrowserWindowPortalRegistry.updateFocusFlash(for: webView, configuration: activeFocusFlash)
             if !shouldBindNow,
                coordinator.lastSynchronizedHostGeometryRevision != geometryRevision {
                 BrowserWindowPortalRegistry.synchronizeForAnchor(portalAnchorView)
@@ -7275,6 +7300,7 @@ struct WebViewRepresentable: NSViewRepresentable {
             )
             BrowserWindowPortalRegistry.updateSearchOverlay(for: webView, configuration: activeSearchOverlay)
             BrowserWindowPortalRegistry.updateOmnibarSuggestions(for: webView, configuration: activeOmnibarSuggestions)
+            BrowserWindowPortalRegistry.updateFocusFlash(for: webView, configuration: activeFocusFlash)
         }
 
         panel.restoreDeveloperToolsAfterAttachIfNeeded()


### PR DESCRIPTION
## Summary
- Move the browser focus flash ring into the WebKit host overlay layer when a WKWebView is rendered.
- Keep the existing SwiftUI flash as the empty-tab fallback and cover local-inline DevTools hosting.

## Testing
- `git diff --check`
- `./scripts/reload.sh --tag bflash`

## Issues
- Task: the blue thing flashing over browser does not show above the webview

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5152"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782951290&installation_id=133855650&pr_number=5152&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5152&signature=1f19348f4cc24afc6667aa19a475626f03e81ef5b09cda9450e75821c917ab9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual overlay and portal plumbing only; hit testing is disabled and behavior mirrors existing omnibar/search portal overlays.
> 
> **Overview**
> Moves the browser **focus flash** accent ring into the **window browser portal** so it renders **above** the hosted `WKWebView`, fixing the case where the blue pulse was hidden behind page content.
> 
> Adds `BrowserPortalFocusFlashConfiguration` and a pass-through `NSHostingView` overlay on `WindowBrowserSlotView`, wired through portal entries and `BrowserWindowPortalRegistry.updateFocusFlash` (including hide/sync paths). **`BrowserPanelView`** drives opacity via `webViewHostedFocusFlash` when the panel owns a live web surface; the existing SwiftUI `focusFlashOverlayView` is kept only when **`!panel.shouldRenderWebView`** (empty tab / non-portal content).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77ba8db62cdf386d879384405782c58ee7148812. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the browser focus flash ring into the WebKit host overlay so it appears above `WKWebView` content. Keeps the SwiftUI ring as a fallback for empty tabs and inline DevTools, addressing the task where the blue focus flash didn’t show above the webview.

- **Bug Fixes**
  - Added a hosted focus flash overlay in the portal layer (`BrowserPortalFocusFlashOverlay`) with hit-testing disabled so it sits above web content.
  - Wired portal updates end-to-end: `BrowserPortalFocusFlashConfiguration`, `WindowBrowserSlotView.setFocusFlash`, `WindowBrowserPortal.updateFocusFlash`, and `BrowserWindowPortalRegistry.updateFocusFlash`.
  - Kept the SwiftUI ring only when no webview is rendered, covering empty tabs and local-inline DevTools hosting.
  - Adjusted overlay stacking so the flash is above WebKit but remains below higher-priority UI (drop targets, omnibar suggestions, search overlay), with an equivalence check to avoid redundant updates.

<sup>Written for commit 77ba8db62cdf386d879384405782c58ee7148812. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added focus flash overlay effect to visually highlight when a browser window becomes active.
* Improved visual consistency by eliminating duplicate focus indicators across different display modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->