### PR TITLE
Fix Claude fork/resume failing when session changed directories

### DIFF
--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -1134,7 +1134,12 @@ struct RestorableAgentSessionIndex: Sendable {
                 let snapshot = SessionRestorableAgentSnapshot(
                     kind: kind,
                     sessionId: normalizedSessionId,
-                    workingDirectory: normalizedWorkingDirectory(record.cwd),
+                    workingDirectory: restorableWorkingDirectory(
+                        for: record,
+                        kind: kind,
+                        fileManager: fileManager,
+                        lookup: claudeTranscriptLookup
+                    ),
                     launchCommand: record.launchCommand,
                     registration: registration
                 )
@@ -1271,6 +1276,64 @@ struct RestorableAgentSessionIndex: Sendable {
         return false
     }
 
+    /// The directory cmux must `cd` into to resume or fork this session.
+    ///
+    /// Claude stores a transcript under the project directory derived from the cwd the session
+    /// was *created* in, and `claude --resume` / `--fork-session` only locate it from that same
+    /// directory. The hook-reported `cwd` drifts when the agent `cd`s elsewhere mid-session
+    /// (e.g. starting in a repo root, then moving into a worktree for the rest of the session),
+    /// so trusting it makes fork/resume fail with "No conversation found". For Claude, prefer the
+    /// candidate directory whose project folder actually holds the transcript: the launch cwd or
+    /// the recorded cwd, matched first against the transcript's known storage path, then against
+    /// the config directory on disk. Falls back to the recorded cwd when neither can be verified.
+    private static func restorableWorkingDirectory(
+        for record: RestorableAgentHookSessionRecord,
+        kind: RestorableAgentKind,
+        fileManager: FileManager,
+        lookup: ClaudeTranscriptLookupCache
+    ) -> String? {
+        let recordedCwd = normalizedWorkingDirectory(record.cwd)
+        guard kind == .claude else { return recordedCwd }
+
+        let launchCwd = normalizedWorkingDirectory(record.launchCommand?.workingDirectory)
+        guard let sessionId = normalizedNonEmptyValue(record.sessionId),
+              claudeSessionIdIsSafeFilename(sessionId) else {
+            return recordedCwd ?? launchCwd
+        }
+        let candidates = [launchCwd, recordedCwd].compactMap { $0 }
+
+        // The transcript's own storage path names the project directory Claude will look in,
+        // so the candidate whose encoding matches it is the one Claude can resume from.
+        if let transcriptPath = normalizedNonEmptyValue(record.transcriptPath) {
+            let expandedTranscriptPath = (transcriptPath as NSString).expandingTildeInPath
+            let projectDir = (expandedTranscriptPath as NSString).deletingLastPathComponent
+            let expectedProjectDirName = (projectDir as NSString).lastPathComponent
+            if !expectedProjectDirName.isEmpty,
+               let matched = candidates.first(where: {
+                   encodeClaudeProjectDir($0) == expectedProjectDirName
+               }) {
+                return matched
+            }
+        }
+
+        // No transcript path on record: probe the config directory for the candidate that holds it.
+        let roots = lookup.configRoots(for: record)
+        if !roots.isEmpty {
+            for candidate in candidates {
+                let projectDirName = encodeClaudeProjectDir(candidate)
+                for root in roots where claudeTranscriptFileExists(
+                    configRoot: root,
+                    projectDirName: projectDirName,
+                    sessionId: sessionId,
+                    fileManager: fileManager
+                ) {
+                    return candidate
+                }
+            }
+        }
+        return recordedCwd ?? launchCwd
+    }
+
     private static func claudeSessionIdIsSafeFilename(_ sessionId: String) -> Bool {
         sessionId.range(of: #"[\\/]"#, options: .regularExpression) == nil
             && !sessionId.isEmpty
@@ -1279,7 +1342,11 @@ struct RestorableAgentSessionIndex: Sendable {
     }
 
     static func encodeClaudeProjectDir(_ path: String) -> String {
+        // Claude derives a project directory name by replacing both "/" and "." with "-"
+        // (e.g. "/Users/x/repo/.claude" -> "-Users-x-repo--claude"). Missing the "." case
+        // sent dotted paths to the wrong project directory.
         path.replacingOccurrences(of: "/", with: "-")
+            .replacingOccurrences(of: ".", with: "-")
     }
 
     private static func claudeTranscriptFileExists(

--- a/Sources/SessionIndexStore.swift
+++ b/Sources/SessionIndexStore.swift
@@ -872,13 +872,6 @@ final class SessionIndexStore: ObservableObject {
             ?? url.deletingLastPathComponent().lastPathComponent
     }
 
-    /// Inverse of `decodeClaudeProjectDir`. Used as a fast path: when filtering
-    /// by cwd we can skip enumerating other project dirs entirely.
-    nonisolated private static func encodeClaudeProjectDir(_ path: String) -> String {
-        // "/Users/x/y" -> "-Users-x-y"
-        return path.replacingOccurrences(of: "/", with: "-")
-    }
-
     nonisolated private static func enumerateClaudeJSONLCandidates(
         root: ClaudeSessionRoot,
         cwdFilter: String?,
@@ -907,7 +900,9 @@ final class SessionIndexStore: ObservableObject {
         }
 
         if let cwdFilter {
-            let dirName = encodeClaudeProjectDir(cwdFilter)
+            // Single-sourced with RestorableAgentSessionIndex so this fast-path cwd filter
+            // encodes dotted paths ("." -> "-") identically to the transcript-discovery path.
+            let dirName = RestorableAgentSessionIndex.encodeClaudeProjectDir(cwdFilter)
             let dirPath = (root.projectsRoot as NSString).appendingPathComponent(dirName)
             var isDir: ObjCBool = false
             if fm.fileExists(atPath: dirPath, isDirectory: &isDir), isDir.boolValue {

--- a/cmuxTests/RestorableAgentSessionIndexTests.swift
+++ b/cmuxTests/RestorableAgentSessionIndexTests.swift
@@ -199,6 +199,155 @@ final class RestorableAgentSessionIndexTests: XCTestCase {
         )
     }
 
+    // A Claude session can start in one directory and `cd` into another (e.g. a repo root then a
+    // worktree); the hook-reported `cwd` drifts to the latter, but Claude keeps the transcript in
+    // the start directory's project folder. Fork/resume must cd into the directory that actually
+    // holds the transcript, otherwise `claude --resume` fails with "No conversation found".
+    func testClaudeForkResolvesDriftedCwdViaTranscriptPath() throws {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory
+            .appendingPathComponent("cmux-claude-fork-drift-path-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fm.removeItem(at: root) }
+
+        let configDir = root.appendingPathComponent("claude-config", isDirectory: true)
+        let projectsDir = configDir.appendingPathComponent("projects", isDirectory: true)
+        let launchCwd = root.appendingPathComponent("repo", isDirectory: true)
+        let driftedCwd = root.appendingPathComponent("worktree", isDirectory: true)
+        try fm.createDirectory(at: launchCwd, withIntermediateDirectories: true)
+        try fm.createDirectory(at: driftedCwd, withIntermediateDirectories: true)
+        try fm.createDirectory(
+            at: projectsDir.appendingPathComponent(
+                RestorableAgentSessionIndex.encodeClaudeProjectDir(launchCwd.path),
+                isDirectory: true
+            ),
+            withIntermediateDirectories: true
+        )
+
+        let sessionId = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+        let workspaceId = UUID()
+        let panelId = UUID()
+        try writeClaudeTranscript(sessionId: sessionId, cwd: launchCwd, projectsDir: projectsDir)
+        let transcriptPath = projectsDir
+            .appendingPathComponent(
+                RestorableAgentSessionIndex.encodeClaudeProjectDir(launchCwd.path),
+                isDirectory: true
+            )
+            .appendingPathComponent("\(sessionId).jsonl", isDirectory: false)
+            .path
+
+        try writeClaudeHookStore(
+            root: root,
+            sessions: [
+                sessionId: driftedHookRecord(
+                    sessionId: sessionId,
+                    workspaceId: workspaceId,
+                    panelId: panelId,
+                    recordedCwd: driftedCwd.path,
+                    launchCwd: launchCwd.path,
+                    configDir: configDir.path,
+                    transcriptPath: transcriptPath,
+                    updatedAt: 10
+                ),
+            ]
+        )
+
+        let index = RestorableAgentSessionIndex.load(homeDirectory: root.path, fileManager: fm)
+        let snapshot = try XCTUnwrap(index.snapshot(workspaceId: workspaceId, panelId: panelId))
+
+        XCTAssertEqual(snapshot.workingDirectory, launchCwd.path)
+        let forkCommand = try XCTUnwrap(snapshot.forkCommand)
+        XCTAssertTrue(
+            forkCommand.contains("cd -- '\(launchCwd.path)'"),
+            "fork should cd into the transcript's directory; got: \(forkCommand)"
+        )
+        XCTAssertFalse(
+            forkCommand.contains(driftedCwd.path),
+            "fork must not cd into the drifted cwd; got: \(forkCommand)"
+        )
+    }
+
+    // Same drift, but the record carries no explicit transcriptPath: resolution must still find the
+    // correct directory by probing the Claude config directory on disk.
+    func testClaudeForkResolvesDriftedCwdViaConfigScanWhenTranscriptPathMissing() throws {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory
+            .appendingPathComponent("cmux-claude-fork-drift-scan-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fm.removeItem(at: root) }
+
+        let configDir = root.appendingPathComponent("claude-config", isDirectory: true)
+        let projectsDir = configDir.appendingPathComponent("projects", isDirectory: true)
+        let launchCwd = root.appendingPathComponent("repo", isDirectory: true)
+        let driftedCwd = root.appendingPathComponent("worktree", isDirectory: true)
+        try fm.createDirectory(at: launchCwd, withIntermediateDirectories: true)
+        try fm.createDirectory(at: driftedCwd, withIntermediateDirectories: true)
+        try fm.createDirectory(
+            at: projectsDir.appendingPathComponent(
+                RestorableAgentSessionIndex.encodeClaudeProjectDir(launchCwd.path),
+                isDirectory: true
+            ),
+            withIntermediateDirectories: true
+        )
+
+        let sessionId = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+        let workspaceId = UUID()
+        let panelId = UUID()
+        try writeClaudeTranscript(sessionId: sessionId, cwd: launchCwd, projectsDir: projectsDir)
+
+        try writeClaudeHookStore(
+            root: root,
+            sessions: [
+                sessionId: driftedHookRecord(
+                    sessionId: sessionId,
+                    workspaceId: workspaceId,
+                    panelId: panelId,
+                    recordedCwd: driftedCwd.path,
+                    launchCwd: launchCwd.path,
+                    configDir: configDir.path,
+                    transcriptPath: nil,
+                    updatedAt: 10
+                ),
+            ]
+        )
+
+        let index = RestorableAgentSessionIndex.load(homeDirectory: root.path, fileManager: fm)
+        let snapshot = try XCTUnwrap(index.snapshot(workspaceId: workspaceId, panelId: panelId))
+
+        XCTAssertEqual(snapshot.workingDirectory, launchCwd.path)
+    }
+
+    private func driftedHookRecord(
+        sessionId: String,
+        workspaceId: UUID,
+        panelId: UUID,
+        recordedCwd: String,
+        launchCwd: String,
+        configDir: String,
+        transcriptPath: String?,
+        updatedAt: TimeInterval
+    ) -> [String: Any] {
+        var record: [String: Any] = [
+            "sessionId": sessionId,
+            "workspaceId": workspaceId.uuidString,
+            "surfaceId": panelId.uuidString,
+            "cwd": recordedCwd,
+            "pid": NSNull(),
+            "updatedAt": updatedAt,
+            "launchCommand": [
+                "launcher": "claude",
+                "executablePath": "/usr/local/bin/claude",
+                "arguments": ["/usr/local/bin/claude", "--dangerously-skip-permissions"],
+                "workingDirectory": launchCwd,
+                "environment": ["CLAUDE_CONFIG_DIR": configDir],
+                "capturedAt": updatedAt,
+                "source": "test",
+            ],
+        ]
+        if let transcriptPath {
+            record["transcriptPath"] = transcriptPath
+        }
+        return record
+    }
+
     private func hookRecord(
         sessionId: String,
         workspaceId: UUID,

--- a/cmuxTests/RestorableAgentSessionIndexTests.swift
+++ b/cmuxTests/RestorableAgentSessionIndexTests.swift
@@ -203,6 +203,10 @@ final class RestorableAgentSessionIndexTests: XCTestCase {
     // worktree); the hook-reported `cwd` drifts to the latter, but Claude keeps the transcript in
     // the start directory's project folder. Fork/resume must cd into the directory that actually
     // holds the transcript, otherwise `claude --resume` fails with "No conversation found".
+    //
+    // The launch path contains a "." so this also exercises encodeClaudeProjectDir's "." -> "-"
+    // contract, and the on-disk fixture is placed using a project-dir name computed independently of
+    // the production helper so a regression in that helper fails the test instead of being masked.
     func testClaudeForkResolvesDriftedCwdViaTranscriptPath() throws {
         let fm = FileManager.default
         let root = fm.temporaryDirectory
@@ -211,29 +215,21 @@ final class RestorableAgentSessionIndexTests: XCTestCase {
 
         let configDir = root.appendingPathComponent("claude-config", isDirectory: true)
         let projectsDir = configDir.appendingPathComponent("projects", isDirectory: true)
-        let launchCwd = root.appendingPathComponent("repo", isDirectory: true)
+        let launchCwd = root.appendingPathComponent("repo.main", isDirectory: true)
         let driftedCwd = root.appendingPathComponent("worktree", isDirectory: true)
         try fm.createDirectory(at: launchCwd, withIntermediateDirectories: true)
         try fm.createDirectory(at: driftedCwd, withIntermediateDirectories: true)
-        try fm.createDirectory(
-            at: projectsDir.appendingPathComponent(
-                RestorableAgentSessionIndex.encodeClaudeProjectDir(launchCwd.path),
-                isDirectory: true
-            ),
-            withIntermediateDirectories: true
+        let projectDir = projectsDir.appendingPathComponent(
+            expectedClaudeProjectDirName(launchCwd.path),
+            isDirectory: true
         )
+        try fm.createDirectory(at: projectDir, withIntermediateDirectories: true)
 
         let sessionId = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
         let workspaceId = UUID()
         let panelId = UUID()
-        try writeClaudeTranscript(sessionId: sessionId, cwd: launchCwd, projectsDir: projectsDir)
-        let transcriptPath = projectsDir
-            .appendingPathComponent(
-                RestorableAgentSessionIndex.encodeClaudeProjectDir(launchCwd.path),
-                isDirectory: true
-            )
-            .appendingPathComponent("\(sessionId).jsonl", isDirectory: false)
-            .path
+        let transcriptURL = projectDir.appendingPathComponent("\(sessionId).jsonl", isDirectory: false)
+        try writeClaudeTranscript(sessionId: sessionId, transcriptURL: transcriptURL, cwd: launchCwd)
 
         try writeClaudeHookStore(
             root: root,
@@ -245,7 +241,7 @@ final class RestorableAgentSessionIndexTests: XCTestCase {
                     recordedCwd: driftedCwd.path,
                     launchCwd: launchCwd.path,
                     configDir: configDir.path,
-                    transcriptPath: transcriptPath,
+                    transcriptPath: transcriptURL.path,
                     updatedAt: 10
                 ),
             ]
@@ -276,22 +272,21 @@ final class RestorableAgentSessionIndexTests: XCTestCase {
 
         let configDir = root.appendingPathComponent("claude-config", isDirectory: true)
         let projectsDir = configDir.appendingPathComponent("projects", isDirectory: true)
-        let launchCwd = root.appendingPathComponent("repo", isDirectory: true)
+        let launchCwd = root.appendingPathComponent("repo.main", isDirectory: true)
         let driftedCwd = root.appendingPathComponent("worktree", isDirectory: true)
         try fm.createDirectory(at: launchCwd, withIntermediateDirectories: true)
         try fm.createDirectory(at: driftedCwd, withIntermediateDirectories: true)
-        try fm.createDirectory(
-            at: projectsDir.appendingPathComponent(
-                RestorableAgentSessionIndex.encodeClaudeProjectDir(launchCwd.path),
-                isDirectory: true
-            ),
-            withIntermediateDirectories: true
+        let projectDir = projectsDir.appendingPathComponent(
+            expectedClaudeProjectDirName(launchCwd.path),
+            isDirectory: true
         )
+        try fm.createDirectory(at: projectDir, withIntermediateDirectories: true)
 
         let sessionId = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
         let workspaceId = UUID()
         let panelId = UUID()
-        try writeClaudeTranscript(sessionId: sessionId, cwd: launchCwd, projectsDir: projectsDir)
+        let transcriptURL = projectDir.appendingPathComponent("\(sessionId).jsonl", isDirectory: false)
+        try writeClaudeTranscript(sessionId: sessionId, transcriptURL: transcriptURL, cwd: launchCwd)
 
         try writeClaudeHookStore(
             root: root,
@@ -313,6 +308,14 @@ final class RestorableAgentSessionIndexTests: XCTestCase {
         let snapshot = try XCTUnwrap(index.snapshot(workspaceId: workspaceId, panelId: panelId))
 
         XCTAssertEqual(snapshot.workingDirectory, launchCwd.path)
+    }
+
+    /// Mirrors Claude's external project-directory naming rule ("/" and "." both become "-")
+    /// independently of the production `encodeClaudeProjectDir`, so these regression tests fail if
+    /// that helper regresses instead of masking it by sharing the same code path.
+    private func expectedClaudeProjectDirName(_ path: String) -> String {
+        path.replacingOccurrences(of: "/", with: "-")
+            .replacingOccurrences(of: ".", with: "-")
     }
 
     private func driftedHookRecord(


### PR DESCRIPTION
## Summary
Forking (and restoring) a Claude conversation could fail with `No conversation found with session ID: ...` when the session had moved directories since it started.

Claude stores each transcript under the project directory derived from the cwd the session was *created* in, and `claude --resume` / `--fork-session` only locate it from that same directory. cmux's Claude hook reports the agent's *current* cwd, which drifts when the agent `cd`s elsewhere mid-session (a very common pattern: start in a repo root, then move into a worktree for the rest of the session). The restore snapshot took its working directory from that drifted cwd, so fork/resume `cd` into the wrong directory and Claude can't find the transcript there.

Observed concretely: session `a1fcdb44` started in `/Users/lawrence/fun/cmuxterm-hq`, so its transcript lives at `projects/-Users-lawrence-fun-cmuxterm-hq/a1fcdb44-….jsonl`. 27 seconds in it `cd`'d into `worktrees/feat-ios-swift-mobile-core` and worked there for ~2 days. A fork launched into the worktree failed; a fork launched from the start directory succeeded. Same session, only the directory differed.

Fix: for Claude, resolve the restore snapshot's working directory to the candidate directory whose project folder actually holds the transcript (prefer the launch cwd, matched first against the transcript's known storage path and then against the config directory on disk), before falling back to the recorded cwd. No transcript is copied; cmux just `cd`s into where it already lives. Also fixes `encodeClaudeProjectDir` to replace `.` with `-`, matching Claude's real project-directory naming (e.g. `/x/.claude` -> `-x--claude`), which the match relies on.

This restores consistency: resume already used the launch directory and worked; fork now does the same.

## Testing
- Added `RestorableAgentSessionIndexTests.testClaudeForkResolvesDriftedCwdViaTranscriptPath` and `...ViaConfigScanWhenTranscriptPathMissing`. Two-commit red/green: the first commit adds the tests (red), the second adds the fix (green). They build a hook store whose recorded cwd is a drifted sibling directory while the transcript lives under the launch cwd, then assert the restored snapshot's working directory and `forkCommand` `cd` into the launch cwd, not the drift.
- Unit tests run in CI (`cmux-unit` / `tests` job); local test runs are disabled in this environment.

## Issues
- Reported via internal dogfood (no GitHub issue).

## Scope and known follow-up
This PR fixes the reported symptom: forking a Claude conversation (a snapshot-driven action) that had changed directories. Verified empirically: the same session forks successfully from its start directory but failed from the drifted directory.

The same root-cause drift also reaches the auto-resume **binding** path (`source: agent-hook`, `--resume`), whose cwd originates in the CLI hook (`CLI/cmux.swift`) recording Claude's reported cwd and is re-applied at restore via `replacingRequiredChangeDirectoryPrefix` using the binding's own cwd, bypassing the snapshot fixed here. A persisted drifted `--resume` binding can therefore still fail auto-resume. Fixing that cleanly spans a second target (the CLI hook) with broader blast radius on the shared auto-resume path, so it is intentionally left as a focused follow-up rather than rushed into this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Claude restore snapshots choose working directories and unifies project-dir encoding used for transcript lookup and session-index cwd filters; behavior is well covered by new tests but affects fork/resume shell commands.
> 
> **Overview**
> Fixes **Claude fork and restore** when the agent’s hook-reported `cwd` has drifted after mid-session `cd` (e.g. repo root → worktree). Restore snapshots now set **`workingDirectory`** via **`restorableWorkingDirectory`**: for Claude only, pick launch vs recorded cwd by matching the transcript’s on-disk project folder (from **`transcriptPath`** when present, else scan **`CLAUDE_CONFIG_DIR`**), so generated **`forkCommand`** / resume shells **`cd`** where Claude actually stores the session.
> 
> Also corrects **`encodeClaudeProjectDir`** to map **`.` → `-`** like Claude’s project dirs, and **single-sources** that helper in **`SessionIndexStore`** for cwd-scoped session listing so dotted paths stay consistent with discovery.
> 
> Adds regression tests for drifted-cwd fork resolution (with and without **`transcriptPath`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4c5021b1ca2532f3909b7703231772f7673a618. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session restoration to correctly resolve working directories when they differ from where transcripts are stored. Sessions now reliably resume in the proper project directory, even when paths have changed.

* **Tests**
  * Added test coverage for session restoration scenarios with drifted working directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->