### PR TITLE
feat(cmuxd-remote): expand relay CLI with missing v2 commands

### DIFF
--- a/daemon/remote/cmd/cmuxd-remote/cli.go
+++ b/daemon/remote/cmd/cmuxd-remote/cli.go
@@ -71,23 +71,48 @@ var commands = []commandSpec{
 
 	// V2 JSON-RPC commands
 	{name: "capabilities", proto: protoV2, v2Method: "system.capabilities", noParams: true},
+
+	// Workspace management
 	{name: "list-workspaces", proto: protoV2, v2Method: "workspace.list", noParams: true},
 	{name: "new-workspace", proto: protoV2, v2Method: "workspace.create", flagKeys: []string{"command", "working-directory", "name"}},
+	{name: "rename-workspace", proto: protoV2, v2Method: "workspace.rename", flagKeys: []string{"workspace", "title"}},
 	{name: "close-workspace", proto: protoV2, v2Method: "workspace.close", flagKeys: []string{"workspace"}},
 	{name: "select-workspace", proto: protoV2, v2Method: "workspace.select", flagKeys: []string{"workspace"}},
 	{name: "current-workspace", proto: protoV2, v2Method: "workspace.current", noParams: true},
-	{name: "list-panels", proto: protoV2, v2Method: "surface.list", flagKeys: []string{"workspace"}},
-	{name: "focus-panel", proto: protoV2, v2Method: "surface.focus", flagKeys: []string{"panel", "workspace"}, paramKeyOverrides: map[string]string{"panel": "surface_id"}},
+	{name: "next-workspace", proto: protoV2, v2Method: "workspace.next", noParams: true},
+	{name: "previous-workspace", proto: protoV2, v2Method: "workspace.previous", noParams: true},
+	{name: "last-workspace", proto: protoV2, v2Method: "workspace.last", noParams: true},
+	{name: "move-workspace-to-window", proto: protoV2, v2Method: "workspace.move_to_window", flagKeys: []string{"workspace", "window"}},
+	{name: "equalize-splits", proto: protoV2, v2Method: "workspace.equalize_splits", flagKeys: []string{"workspace"}},
+
+	// Pane management
 	{name: "list-panes", proto: protoV2, v2Method: "pane.list", flagKeys: []string{"workspace"}},
 	{name: "list-pane-surfaces", proto: protoV2, v2Method: "pane.surfaces", flagKeys: []string{"pane"}},
 	{name: "new-pane", proto: protoV2, v2Method: "pane.create", flagKeys: []string{"workspace", "direction", "type", "url"}, defaultParams: map[string]any{"direction": "right"}},
+	{name: "last-pane", proto: protoV2, v2Method: "pane.last", flagKeys: []string{"workspace"}},
+	{name: "resize-pane", proto: protoV2, v2Method: "pane.resize", flagKeys: []string{"pane"}},
+	{name: "swap-pane", proto: protoV2, v2Method: "pane.swap", flagKeys: []string{"pane"}},
+	{name: "break-pane", proto: protoV2, v2Method: "pane.break", flagKeys: []string{"pane"}},
+	{name: "join-pane", proto: protoV2, v2Method: "pane.join", flagKeys: []string{"pane"}},
+
+	// Surface (panel) management
+	{name: "list-panels", proto: protoV2, v2Method: "surface.list", flagKeys: []string{"workspace"}},
+	{name: "focus-panel", proto: protoV2, v2Method: "surface.focus", flagKeys: []string{"panel", "workspace"}, paramKeyOverrides: map[string]string{"panel": "surface_id"}},
 	{name: "new-surface", proto: protoV2, v2Method: "surface.create", flagKeys: []string{"workspace", "pane", "type", "url"}},
 	{name: "new-split", proto: protoV2, v2Method: "surface.split", flagKeys: []string{"surface", "direction"}},
 	{name: "close-surface", proto: protoV2, v2Method: "surface.close", flagKeys: []string{"surface"}},
 	{name: "send", proto: protoV2, v2Method: "surface.send_text", flagKeys: []string{"surface", "text"}},
 	{name: "send-key", proto: protoV2, v2Method: "surface.send_key", flagKeys: []string{"surface", "key"}},
-	{name: "notify", proto: protoV2, v2Method: "notification.create", flagKeys: []string{"title", "body", "workspace"}},
+	{name: "read-screen", proto: protoV2, v2Method: "surface.read_text", flagKeys: []string{"surface"}},
+	{name: "clear-history", proto: protoV2, v2Method: "surface.clear_history", flagKeys: []string{"surface"}},
 	{name: "refresh-surfaces", proto: protoV2, v2Method: "surface.refresh", noParams: true},
+
+	// Notifications
+	{name: "notify", proto: protoV2, v2Method: "notification.create", flagKeys: []string{"title", "body", "workspace"}},
+	{name: "dismiss-notification", proto: protoV2, v2Method: "notification.dismiss", flagKeys: []string{"id"}},
+	{name: "mark-notification-read", proto: protoV2, v2Method: "notification.mark_read", flagKeys: []string{"id"}},
+	{name: "open-notification", proto: protoV2, v2Method: "notification.open", flagKeys: []string{"id"}},
+	{name: "jump-to-unread", proto: protoV2, v2Method: "notification.jump_to_unread", noParams: true},
 }
 
 var browserCommands = map[string]browserCommandSpec{


### PR DESCRIPTION
## Summary

The remote relay CLI (`cmuxd-remote` in CLI mode) only exposed a subset of the v2 JSON-RPC methods the Mac app supports. This meant commands like `rename-workspace`, `read-screen`, and pane navigation weren't callable from inside SSH sessions.

This PR adds 17 missing commands — all thin mappings to existing v2 methods already implemented in the Mac app, following the same pattern as the existing relay commands.

**Workspace:** `rename-workspace`, `next-workspace`, `previous-workspace`, `last-workspace`, `move-workspace-to-window`, `equalize-splits`

**Pane:** `last-pane`, `resize-pane`, `swap-pane`, `break-pane`, `join-pane`

**Surface:** `read-screen` (`surface.read_text`), `clear-history` (`surface.clear_history`)

**Notifications:** `dismiss-notification`, `mark-notification-read`, `open-notification`, `jump-to-unread`

Also reorganised the commands list into labelled sections.

## Not included

- `set-status`, `clear-status`, `set-progress`, `clear-progress` — these use the V1 text protocol with a complex positional+flag format that the relay's V1 handler doesn't currently support. Left for a follow-up that could either port them to V2 or extend the V1 handler.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5157"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782955492&installation_id=133855650&pr_number=5157&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5157&signature=966f02a43524b2c80ff22b24d82077c8b3a8b6f503a990c8020beb029bd8cdbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add 17 missing v2 JSON-RPC commands to `cmuxd-remote`, enabling full workspace, pane, surface, and notification control over SSH. Also reorganizes the CLI command list into labeled sections.

- **New Features**
  - Workspace: rename-workspace, next-workspace, previous-workspace, last-workspace, move-workspace-to-window, equalize-splits
  - Pane: last-pane, resize-pane, swap-pane, break-pane, join-pane
  - Surface: read-screen (surface.read_text), clear-history (surface.clear_history)
  - Notifications: dismiss-notification, mark-notification-read, open-notification, jump-to-unread

<sup>Written for commit 19f474f5f23adab8f826334fb8a802ecb4123650. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended CLI command support with new workspace management operations (rename, select, move, equalize).
  * Added pane management commands (last, resize, swap, break, join).
  * Enhanced surface operations with screen and history management capabilities.
  * Expanded notification handling with dismissal, read/unread marking, and navigation options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->