### PR TITLE
Fix Claude fork cwd selection

### DIFF
--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -17623,6 +17623,7 @@ final class Workspace: Identifiable, ObservableObject {
     ) -> String? {
         Self.firstNonEmptyPath([
             snapshot.workingDirectory,
+            snapshot.launchCommand?.workingDirectory,
             panelDirectories[panelId],
             terminalPanel(for: panelId)?.requestedWorkingDirectory,
             currentDirectory

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -5726,6 +5726,49 @@ final class WorkspacePanelGitBranchTests: XCTestCase {
         )
     }
 
+    func testForkAgentConversationUsesLaunchDirectoryBeforeLivePanelDirectory() throws {
+        let workspace = Workspace()
+        workspace.currentDirectory = "/Users/lawrence/fun/cmuxterm-hq/worktrees/feat-ios-swift-mobile-core"
+        let sourcePanelId = try XCTUnwrap(workspace.focusedPanelId)
+        workspace.updatePanelDirectory(
+            panelId: sourcePanelId,
+            directory: "/Users/lawrence/fun/cmuxterm-hq/worktrees/feat-ios-swift-mobile-core"
+        )
+        let snapshot = SessionRestorableAgentSnapshot(
+            kind: .claude,
+            sessionId: "a1fcdb44-3fe9-4045-98bf-256e21051de3",
+            workingDirectory: nil,
+            launchCommand: AgentLaunchCommandSnapshot(
+                launcher: "claude",
+                executablePath: "/Users/lawrence/.local/bin/claude",
+                arguments: [
+                    "/Users/lawrence/.local/bin/claude",
+                    "--dangerously-skip-permissions"
+                ],
+                workingDirectory: "/Users/lawrence/fun/cmuxterm-hq",
+                environment: [
+                    "CLAUDE_CONFIG_DIR": "/Users/lawrence/.codex-accounts/claude/_p1775010019397"
+                ],
+                capturedAt: 123,
+                source: "environment"
+            )
+        )
+
+        let forkPanel = try XCTUnwrap(
+            workspace.forkAgentConversation(
+                fromPanelId: sourcePanelId,
+                snapshot: snapshot,
+                direction: .right
+            )
+        )
+
+        XCTAssertEqual(forkPanel.requestedWorkingDirectory, "/Users/lawrence/fun/cmuxterm-hq")
+        XCTAssertEqual(
+            forkPanel.surface.initialInput,
+            "{ cd -- '/Users/lawrence/fun/cmuxterm-hq' 2>/dev/null || [ ! -d '/Users/lawrence/fun/cmuxterm-hq' ]; } && 'env' 'CLAUDE_CONFIG_DIR=/Users/lawrence/.codex-accounts/claude/_p1775010019397' 'CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV=1' 'CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV_KEYS=CLAUDE_CONFIG_DIR' '/Users/lawrence/.local/bin/claude' '--resume' 'a1fcdb44-3fe9-4045-98bf-256e21051de3' '--fork-session' '--dangerously-skip-permissions'\n"
+        )
+    }
+
     func testForkAgentConversationInRemoteWorkspaceUsesRemoteStartupCommand() throws {
         let workspace = Workspace()
         workspace.configureRemoteConnection(


### PR DESCRIPTION
## Summary
- Keep Claude fork resume IDs paired with the captured launch working directory before falling back to the live panel directory.
- Add a regression test for a Claude session launched from the HQ root after the terminal moves into a worktree.

## Testing
- Passed on cmux-aws-m4pro: `xcodebuild -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -derivedDataPath /tmp/cmux-claudefork-1780366773 -destination "platform=macOS,arch=arm64" -only-testing:cmuxTests/WorkspacePanelGitBranchTests/testForkAgentConversationUsesLaunchDirectoryBeforeLivePanelDirectory test`
- Passed: `./scripts/reload.sh --tag clfork`

## Issues
- Related: user-reported Claude Code fork command resumed session `a1fcdb44-3fe9-4045-98bf-256e21051de3` from the wrong cwd.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782959163&installation_id=133855650&pr_number=5159&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5159&signature=45ff806df2b3bf08702e13ecf625f1b7f406c709e628fc070e2d6c761262013a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to cwd precedence for fork flows plus a regression test; no auth or broad behavioral refactors.
> 
> **Overview**
> Agent conversation forks now pick the fork terminal’s working directory from the **captured launch cwd** (`launchCommand.workingDirectory`) when the snapshot’s top-level `workingDirectory` is missing, **before** using the live panel or workspace directory.
> 
> That keeps fork/resume commands (e.g. Claude `--resume` / `--fork-session`) aligned with where the session actually started when the tab has since `cd`’d elsewhere—such as into a git worktree while the agent was launched from the repo root.
> 
> A unit test asserts the forked panel’s `requestedWorkingDirectory` and `initialInput` `cd` use the launch directory, not the updated panel path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd0533cc653c13341e099d4ed16c8ec30d23b3c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cwd selection when forking Claude sessions by preferring the captured launch working directory, ensuring resume runs in the right place. Adds a regression test for launching from HQ root then moving into a worktree.

- **Bug Fixes**
  - Update cwd resolution to check `snapshot.workingDirectory`, then `snapshot.launchCommand?.workingDirectory`, then panel/terminal dirs, then current dir.
  - Add test `testForkAgentConversationUsesLaunchDirectoryBeforeLivePanelDirectory` to prevent regressions in the HQ-root → worktree scenario.

<sup>Written for commit cd0533cc653c13341e099d4ed16c8ec30d23b3c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved working directory selection precedence when forking agent conversations.

* **Tests**
  * Added test coverage for working directory handling in fork operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->