### PR TITLE
headless: place instance socket under per-user runtime dir, 0600

### DIFF
--- a/daemon/remote/cmd/cmuxd-remote/headless.go
+++ b/daemon/remote/cmd/cmuxd-remote/headless.go
@@ -74,6 +74,15 @@ func runUnixHeadlessServer(ctx context.Context, cfg unixHeadlessServerConfig, st
 	if err != nil {
 		return err
 	}
+	// userRuntimeDir keeps the socket in a private 0700 directory, so tightening
+	// it to 0600 here closes the remaining exposure with no meaningful TOCTOU
+	// window (a process-wide umask would not be goroutine-safe). Remove the socket
+	// on failure so a partially-initialized path is not left behind.
+	if err := os.Chmod(absSocketPath, 0o600); err != nil {
+		listener.Close()
+		_ = os.Remove(absSocketPath)
+		return fmt.Errorf("chmod headless socket %s: %w", absSocketPath, err)
+	}
 	defer listener.Close()
 	defer os.Remove(absSocketPath)
 
@@ -418,7 +427,38 @@ func defaultHeadlessRegistryDir() string {
 }
 
 func defaultHeadlessSocketPath(instanceID string) string {
-	return filepath.Join("/tmp", fmt.Sprintf("cmux-headless-%d-%s.sock", os.Getuid(), instanceID))
+	socketName := fmt.Sprintf("cmux-headless-%d-%s.sock", os.Getuid(), instanceID)
+	if dir := userRuntimeDir(); dir != "" {
+		return filepath.Join(dir, socketName)
+	}
+	return filepath.Join("/tmp", socketName)
+}
+
+// userRuntimeDir returns a private per-user runtime directory for the headless
+// instance socket, preferring $XDG_RUNTIME_DIR and falling back to /run/user/<uid>
+// when it exists. It only accepts a directory that is owned by the current user
+// and not accessible by group/other, so an attacker-controlled $XDG_RUNTIME_DIR
+// cannot redirect the socket into a shared location; otherwise it returns "" and
+// the caller falls back to the world-traversable temp dir.
+func userRuntimeDir() string {
+	if dir := strings.TrimSpace(os.Getenv("XDG_RUNTIME_DIR")); dir != "" && isPrivateDir(dir) {
+		return dir
+	}
+	if runUser := fmt.Sprintf("/run/user/%d", os.Getuid()); isPrivateDir(runUser) {
+		return runUser
+	}
+	return ""
+}
+
+// isPrivateDir reports whether path is a directory owned by the current user with
+// no group/other access (mode 0700), so a socket placed there stays private.
+func isPrivateDir(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil || !info.IsDir() || info.Mode().Perm()&0o077 != 0 {
+		return false
+	}
+	st, ok := info.Sys().(*syscall.Stat_t)
+	return ok && int(st.Uid) == os.Getuid()
 }
 
 func processExists(pid int) bool {

--- a/daemon/remote/cmd/cmuxd-remote/headless_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/headless_test.go
@@ -114,3 +114,25 @@ func TestHeadlessConnectBridgesRPCFrames(t *testing.T) {
 		t.Fatalf("stdout = %q", got)
 	}
 }
+
+func TestUserRuntimeDirPrefersPrivateXDGRuntimeDir(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("XDG_RUNTIME_DIR", dir)
+	if got := userRuntimeDir(); got != dir {
+		t.Fatalf("userRuntimeDir() = %q, want %q", got, dir)
+	}
+}
+
+func TestUserRuntimeDirRejectsWorldAccessibleXDGRuntimeDir(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("XDG_RUNTIME_DIR", dir)
+	if got := userRuntimeDir(); got == dir {
+		t.Fatalf("userRuntimeDir() = %q, want it to reject the group/other-accessible dir", got)
+	}
+}


### PR DESCRIPTION
Follow-up to the Linux dogfooding on #4786 — turning the socket-path note into a fix.

`runUnixHeadlessServer` placed the instance socket at `/tmp/cmux-headless-<uid>-<id>.sock` unconditionally, with whatever the process umask gave it (I saw `0755`). On a shared host that's a world-traversable directory.

This change:
- prefers a private per-user runtime dir for the socket — `$XDG_RUNTIME_DIR`, falling back to `/run/user/<uid>` when it exists (the systemd-managed `0700` dir) — and keeps `/tmp` as the last resort, so macOS behavior is unchanged.
- `chmod`s the listener to `0600` so the socket is owner-only regardless of umask.

Verified on Ubuntu 24.04 / Go 1.26:
- `go test ./...` green (incl. the existing headless/PTY tests); added a unit test for the `$XDG_RUNTIME_DIR` precedence.
- `serve --unix --id rtcheck` now creates `/run/user/1000/cmux-headless-1000-rtcheck.sock` at `srw-------` (0600), and no longer drops anything in `/tmp`.

Attach still works since the attaching process connects as the same user.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5162"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782961784&installation_id=133855650&pr_number=5162&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5162&signature=55c6891ad53b88e5ca7ebc6c56629ec74964efb24d9c775df1f1806debf657bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Secure the headless Unix socket by placing it in a per-user runtime directory and locking it to `0600`. Falls back to `/tmp` if no private dir is available; macOS behavior is unchanged.

- **Bug Fixes**
  - Prefer `$XDG_RUNTIME_DIR`, then `/run/user/<uid>`, only if the dir is owned by the current user and `0700`; otherwise ignore to avoid attacker-controlled paths.
  - `chmod` the socket to `0600` immediately after bind and remove it on failure; the `0700` dir prevents a meaningful TOCTOU window.
  - Added tests to prefer a private `$XDG_RUNTIME_DIR` and reject group/other-accessible dirs.

- **Migration**
  - On Linux, the default socket path moved from `/tmp/cmux-headless-<uid>-<id>.sock` to `$XDG_RUNTIME_DIR/cmux-headless-<uid>-<id>.sock` (or `/run/user/<uid>/...`). Update any hardcoded paths.

<sup>Written for commit a79a3eb48e812ac9a93497c618e35b142495c92b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

