### PR TITLE
release: build app against macOS 26 SDK for parity with nightly (port #5077)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,26 +95,57 @@ jobs:
         if: steps.guard_release_assets.outputs.skip_all != 'true'
         run: |
           set -euo pipefail
-          if [ -d "/Applications/Xcode.app/Contents/Developer" ]; then
-            XCODE_DIR="/Applications/Xcode.app/Contents/Developer"
-          else
-            XCODE_APP="$(
-              find /Applications -maxdepth 1 -name 'Xcode*.app' -print 2>/dev/null \
-                | sort \
-                | tail -n 1 \
-                || true
-            )"
-            if [ -n "$XCODE_APP" ]; then
-              XCODE_DIR="$XCODE_APP/Contents/Developer"
+          # The app must link against the macOS 26 SDK so it adopts Liquid Glass
+          # on Tahoe (the team is pinned to Xcode 26 via .xcode-version). The zig
+          # Ghostty CLI helper must link against a pre-26 SDK because zig 0.15.2
+          # cannot cross-link x86_64 against the macOS 26 SDK. Both Xcodes ship on
+          # the macOS 15 runner image, so pick the newest of each by SDK version.
+          # Compare SDK versions numerically (not lexicographically) so e.g.
+          # 26.10 sorts above 26.3.
+          sdk_rank() {
+            # "26.2" -> 26002 ; "26" -> 26000
+            local v="$1" maj min
+            maj="${v%%.*}"
+            min="${v#*.}"
+            [ "$min" = "$v" ] && min=0
+            min="${min%%.*}"
+            printf '%d' "$(( maj * 1000 + min ))"
+          }
+          APP_DEVELOPER_DIR=""; APP_SDK_VER=""; APP_RANK=-1
+          HELPER_DEVELOPER_DIR=""; HELPER_SDK_VER=""; HELPER_RANK=-1
+          while IFS= read -r app; do
+            [ -n "$app" ] || continue
+            dev="$app/Contents/Developer"
+            [ -d "$dev" ] || continue
+            sdk_ver="$(DEVELOPER_DIR="$dev" xcrun --sdk macosx --show-sdk-version 2>/dev/null || true)"
+            [ -n "$sdk_ver" ] || continue
+            rank="$(sdk_rank "$sdk_ver")"
+            echo "Found $app -> macOS SDK $sdk_ver (rank $rank)"
+            if [ "${sdk_ver%%.*}" -ge 26 ]; then
+              if [ "$rank" -gt "$APP_RANK" ]; then
+                APP_DEVELOPER_DIR="$dev"; APP_SDK_VER="$sdk_ver"; APP_RANK="$rank"
+              fi
             else
-              echo "No Xcode.app found under /Applications" >&2
-              exit 1
+              if [ "$rank" -gt "$HELPER_RANK" ]; then
+                HELPER_DEVELOPER_DIR="$dev"; HELPER_SDK_VER="$sdk_ver"; HELPER_RANK="$rank"
+              fi
             fi
+          done < <(find /Applications -maxdepth 1 -name 'Xcode*.app' -print 2>/dev/null)
+
+          if [ -z "$APP_DEVELOPER_DIR" ]; then
+            echo "No Xcode with the macOS 26+ SDK found; the app would ship without Liquid Glass on Tahoe." >&2
+            exit 1
           fi
-          echo "DEVELOPER_DIR=$XCODE_DIR" >> "$GITHUB_ENV"
-          export DEVELOPER_DIR="$XCODE_DIR"
-          xcodebuild -version
-          xcrun --sdk macosx --show-sdk-path
+          if [ -z "$HELPER_DEVELOPER_DIR" ]; then
+            echo "No pre-26 Xcode found to cross-link the universal Ghostty CLI helper (zig 0.15.2 cannot link x86_64 against the macOS 26 SDK)." >&2
+            exit 1
+          fi
+
+          echo "App build Xcode (DEVELOPER_DIR): $APP_DEVELOPER_DIR (macOS SDK $APP_SDK_VER)"
+          echo "Helper build Xcode (HELPER_DEVELOPER_DIR): $HELPER_DEVELOPER_DIR (macOS SDK $HELPER_SDK_VER)"
+          DEVELOPER_DIR="$APP_DEVELOPER_DIR" xcodebuild -version
+          echo "DEVELOPER_DIR=$APP_DEVELOPER_DIR" >> "$GITHUB_ENV"
+          echo "HELPER_DEVELOPER_DIR=$HELPER_DEVELOPER_DIR" >> "$GITHUB_ENV"
 
       - name: Install build deps
         if: steps.guard_release_assets.outputs.skip_all != 'true'
@@ -134,6 +165,19 @@ jobs:
           rustup target add aarch64-apple-darwin x86_64-apple-darwin
           ./scripts/install-zig-ci.sh
           npm install --global "create-dmg@${CREATE_DMG_VERSION}"
+
+      - name: Build universal Ghostty CLI helper
+        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        env:
+          # zig 0.15.2 can cross-link the x86_64 slice only against a pre-26 SDK.
+          DEVELOPER_DIR: ${{ env.HELPER_DEVELOPER_DIR }}
+        run: |
+          set -euo pipefail
+          ./scripts/build-ghostty-cli-helper.sh --universal --output /tmp/cmux-ghostty-helper-universal
+          ARCHS_OUT="$(lipo -archs /tmp/cmux-ghostty-helper-universal)"
+          echo "Universal Ghostty CLI helper architectures: $ARCHS_OUT"
+          case " $ARCHS_OUT " in *" arm64 "*) ;; *) echo "helper missing arm64 slice" >&2; exit 1 ;; esac
+          case " $ARCHS_OUT " in *" x86_64 "*) ;; *) echo "helper missing x86_64 slice" >&2; exit 1 ;; esac
 
       - name: Download pre-built GhosttyKit.xcframework
         if: steps.guard_release_assets.outputs.skip_all != 'true'
@@ -170,6 +214,11 @@ jobs:
 
       - name: Build universal app (Release)
         if: steps.guard_release_assets.outputs.skip_all != 'true'
+        env:
+          # Skip the in-Xcode zig helper build; it would fail to cross-link
+          # x86_64 against the macOS 26 SDK. The real universal helper is built
+          # by the "Build universal Ghostty CLI helper" step and injected below.
+          CMUX_SKIP_ZIG_BUILD: "1"
         run: |
           xcodebuild -scheme cmux -configuration Release -derivedDataPath build-universal \
             -destination 'generic/platform=macOS' \
@@ -177,6 +226,20 @@ jobs:
             ARCHS="arm64 x86_64" \
             ONLY_ACTIVE_ARCH=NO \
             CODE_SIGNING_ALLOWED=NO build
+
+      - name: Inject universal Ghostty CLI helper
+        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        run: |
+          set -euo pipefail
+          APP_DIR="build-universal/Build/Products/Release/cmux.app"
+          if [ ! -d "$APP_DIR" ]; then
+            echo "Built app not found at $APP_DIR" >&2
+            exit 1
+          fi
+          DEST="$APP_DIR/Contents/Resources/bin/ghostty"
+          mkdir -p "$(dirname "$DEST")"
+          install -m 755 /tmp/cmux-ghostty-helper-universal "$DEST"
+          echo "Injected Ghostty CLI helper architectures: $(lipo -archs "$DEST")"
 
       - name: Verify binary architectures
         if: steps.guard_release_assets.outputs.skip_all != 'true'


### PR DESCRIPTION
## What

Ports the macOS‑26‑SDK Xcode selection from `nightly.yml` (PR #5077) into `release.yml`, so the official release builds the app against the **macOS 26 SDK** (adopting Liquid Glass on Tahoe) instead of whatever Xcode happens to be the runner's default. This gives the official release **parity with nightly** on the runner/SDK used.

## Why

Both workflows run on the macOS **15** runner (`MACOS_RUNNER_15`) because zig 0.15.2 cannot cross‑link the universal Ghostty CLI helper's x86_64 slice against the macOS 26 SDK.

- #5022 (`c4911439e`) moved **both** nightly and release off the macOS 26 runner onto the macOS 15 runner — so both started building against a macOS 15 SDK.
- #5077 (`4fdaa0a2a`) added SDK‑aware Xcode selection to **`nightly.yml` only**. `release.yml` was left on the pre‑#5077 lexicographic `find | sort | tail -n 1` picker with no macOS‑26 guarantee.

Net effect today: a release links against whatever Xcode is `/Applications/Xcode.app` on the runner, with no explicit macOS‑26 selection or hard‑fail guard — so it can ship without Liquid Glass on Tahoe. This PR closes that gap.

## Changes to `release.yml`

1. **Select Xcode** — rank every `/Applications/Xcode*.app` by numeric macOS SDK version; pick the newest ≥26‑SDK Xcode for the app (`APP_DEVELOPER_DIR`) and the newest pre‑26 Xcode for the helper (`HELPER_DEVELOPER_DIR`); hard‑fail if either is missing.
2. **Build universal Ghostty CLI helper** — new step, built under the pre‑26 Xcode (`DEVELOPER_DIR=HELPER_DEVELOPER_DIR`), with a lipo arch assertion.
3. **Build app** — add `CMUX_SKIP_ZIG_BUILD=1` so the in‑Xcode zig helper is skipped and the app inherits the macOS‑26 `DEVELOPER_DIR`.
4. **Inject universal Ghostty CLI helper** — new step, injects the real universal helper over the skip‑build stub, before the existing "Verify binary architectures" step.

Mirrors `nightly.yml` exactly except: release keeps its own `steps.guard_release_assets.outputs.skip_all` guards and its release app icon (no `AppIcon-Nightly`).

## Notes

- Stays on the macOS 15 runner — the two‑Xcode split works because that image ships both an Xcode 26 and a pre‑26 Xcode.
- The helper is injected before signing/notarization, so the bundle signature stays valid; the existing arch‑verify step now validates the real injected helper.
- `release.yml` uses no composite action or reusable workflow, so these four in‑file edits are the complete port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5167"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782969666&installation_id=133855650&pr_number=5167&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5167&signature=c9a844a6f189d05da63015ffe576858228a68904e1cf3b9c65201e8331ac06c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only CI packaging for official releases; wrong Xcode selection or a failed helper inject could ship a broken or non-universal `ghostty` binary before notarization.
> 
> **Overview**
> Ports the **nightly** dual-Xcode macOS release pipeline into **`release.yml`** so tagged releases build the app against the **macOS 26+ SDK** (Liquid Glass on Tahoe) instead of whichever Xcode the runner picks by default.
> 
> **Select Xcode** now scans all `Xcode*.app` installs, ranks SDK versions numerically, sets `DEVELOPER_DIR` to the newest **26+** Xcode for the app and `HELPER_DEVELOPER_DIR` to the newest **pre-26** Xcode for Zig, and **fails the job** if either bucket is missing.
> 
> New steps build the **universal Ghostty CLI helper** under the pre-26 toolchain (with `lipo` arch checks), set **`CMUX_SKIP_ZIG_BUILD=1`** on the Release `xcodebuild` so in-Xcode Zig does not cross-link x86_64 against SDK 26, then **inject** that helper into `cmux.app` before the existing architecture verification and signing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac9284f286fff28a42683292eb8df0fa39687c59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Build the release app with the macOS 26 SDK to match nightly, ensuring Liquid Glass on Tahoe and removing reliance on the runner’s default Xcode. Adds dual-Xcode selection so the app links against 26+ while the Ghostty CLI helper links against a pre-26 SDK.

- **Bug Fixes**
  - Select Xcode by SDK version: newest 26+ for the app (`DEVELOPER_DIR`), newest pre-26 for the helper (`HELPER_DEVELOPER_DIR`); hard-fail if missing.
  - Build the universal Ghostty CLI helper under the pre-26 Xcode, assert arm64/x86_64 slices, and inject it into the app before arch verification.
  - Set `CMUX_SKIP_ZIG_BUILD=1` so the app build inherits the macOS 26 SDK and skips the in-Xcode zig helper.
  - Stays on the macOS 15 runner and mirrors `nightly.yml` behavior while keeping existing release guards and icon.

<sup>Written for commit ac9284f286fff28a42683292eb8df0fa39687c59. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined macOS release build workflow to use separate Xcode toolchains for app and CLI helper compilation.
  * Added automated universal binary construction for the Ghostty CLI helper with architecture validation.
  * Improved app bundle assembly with injection of prebuilt universal CLI helper binary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->