### PR TITLE
Fix restored scrollback keeping original theme's colors (white-on-white after theme change)

### DIFF
--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -1964,7 +1964,14 @@ enum SessionScrollbackReplayStore {
     private static func normalizedScrollback(_ scrollback: String?) -> String? {
         guard let scrollback else { return nil }
         guard scrollback.contains(where: { !$0.isWhitespace }) else { return nil }
-        guard let truncated = SessionPersistencePolicy.truncatedScrollback(scrollback) else { return nil }
+        // Restored history must not reconfigure the live terminal's colors: the
+        // active theme owns the default foreground/background (and palette), so
+        // default-colored cells track it. The captured scrollback bakes the
+        // capture-time theme via terminal-color OSC sequences (e.g. OSC 10/11),
+        // which would otherwise survive a theme change as white-on-white output
+        // (issue #5165). Strip them before replay.
+        let themePortable = strippingTerminalColorOSCSequences(scrollback)
+        guard let truncated = SessionPersistencePolicy.truncatedScrollback(themePortable) else { return nil }
         return ansiSafeReplayText(truncated)
     }
 
@@ -1979,6 +1986,97 @@ enum SessionScrollbackReplayStore {
             output += ansiReset
         }
         return output
+    }
+
+    /// Removes terminal-color OSC sequences (palette entries and the dynamic
+    /// foreground/background/cursor/highlight colors plus their resets) from
+    /// captured scrollback so the restored history does not reconfigure the live
+    /// terminal's colors.
+    ///
+    /// Ghostty's `write_screen_file:copy,vt` export bakes the capture-time theme
+    /// by prepending `OSC 10` / `OSC 11` (and resolving palette entries). Replaying
+    /// those into a freshly launched terminal would override the active theme's
+    /// default colors, so restored default-colored cells would keep the old theme
+    /// (white-on-white after a theme change — issue #5165). Explicit per-cell SGR
+    /// colors and every non-color escape sequence (titles, hyperlinks, prompt
+    /// marks, …) are preserved verbatim.
+    private static func strippingTerminalColorOSCSequences(_ text: String) -> String {
+        let escByte: UInt8 = 0x1B
+        let oscIntroducer: UInt8 = 0x5D // ]
+        let bel: UInt8 = 0x07
+        let backslash: UInt8 = 0x5C
+        let zero: UInt8 = 0x30
+        let nine: UInt8 = 0x39
+
+        let bytes = Array(text.utf8)
+        guard bytes.contains(escByte) else { return text }
+
+        var output = [UInt8]()
+        output.reserveCapacity(bytes.count)
+        let count = bytes.count
+        var index = 0
+        while index < count {
+            let byte = bytes[index]
+            guard byte == escByte,
+                  index + 1 < count,
+                  bytes[index + 1] == oscIntroducer else {
+                output.append(byte)
+                index += 1
+                continue
+            }
+
+            // Parse the OSC numeric command (Ps) following `ESC ]`.
+            var cursor = index + 2
+            var code = 0
+            var sawDigit = false
+            while cursor < count, bytes[cursor] >= zero, bytes[cursor] <= nine {
+                code = (code * 10) + Int(bytes[cursor] - zero)
+                sawDigit = true
+                cursor += 1
+                if code > 100_000 { break } // overflow guard for malformed input
+            }
+
+            guard sawDigit, isTerminalColorOSCCode(code) else {
+                // Not a terminal-color OSC; emit `ESC` and resume scanning so the
+                // rest of the preserved sequence is copied verbatim.
+                output.append(byte)
+                index += 1
+                continue
+            }
+
+            // Consume through the OSC terminator (BEL or `ESC \` / ST). A truncated
+            // (unterminated) color OSC at the end of the buffer is dropped as well.
+            var end = cursor
+            var terminated = false
+            while end < count {
+                if bytes[end] == bel {
+                    end += 1
+                    terminated = true
+                    break
+                }
+                if bytes[end] == escByte, end + 1 < count, bytes[end + 1] == backslash {
+                    end += 2
+                    terminated = true
+                    break
+                }
+                end += 1
+            }
+            index = terminated ? end : count
+        }
+
+        return String(decoding: output, as: UTF8.self)
+    }
+
+    /// Returns `true` for OSC command numbers that configure terminal colors
+    /// (palette entries and the dynamic foreground/background/cursor/highlight
+    /// colors plus their resets), which restored scrollback must not carry.
+    private static func isTerminalColorOSCCode(_ code: Int) -> Bool {
+        switch code {
+        case 4, 5, 104, 105: return true // palette / special color set + reset
+        case 10...19: return true        // dynamic colors (fg, bg, cursor, …)
+        case 110...119: return true      // dynamic color resets
+        default: return false
+        }
     }
 
     private static func writeReplayFile(contents: String, tempDirectory: URL) -> URL? {

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -486,6 +486,62 @@ final class SessionPersistenceTests: XCTestCase {
         XCTAssertTrue(contents.hasSuffix(reset))
     }
 
+    // Regression for https://github.com/manaflow-ai/cmux/issues/5165.
+    //
+    // Ghostty's `write_screen_file:copy,vt` export (used to capture session
+    // scrollback) prepends OSC 10 / OSC 11 sequences that bake the capture-time
+    // theme's default foreground/background. Replaying those into a freshly
+    // launched terminal reconfigures the live terminal's dynamic colors, so
+    // restored default-colored cells keep the OLD theme instead of tracking the
+    // active one — producing white-on-white scrollback after a theme change.
+    // The active theme owns default fg/bg, so the restored history must not carry
+    // these terminal-color OSC sequences.
+    func testScrollbackReplayStripsThemeBakedDefaultColorOSCSequences() {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-scrollback-replay-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let esc = "\u{001B}"
+        // Captured under a dark theme: default fg baked white, default bg baked dark.
+        let setForeground = "\(esc)]10;rgb:ff/ff/ff\(esc)\\"
+        let setBackground = "\(esc)]11;rgb:28/2c/34\(esc)\\"
+        // A BEL-terminated cursor-color OSC, the other dynamic-color terminator form.
+        let setCursor = "\(esc)]12;rgb:c0/c1/b5\u{0007}"
+        let red = "\(esc)[31m"
+        let reset = "\(esc)[0m"
+        // OSC 8 hyperlinks are scrollback content, not terminal color config; keep them.
+        let hyperlink = "\(esc)]8;;https://example.com\(esc)\\link\(esc)]8;;\(esc)\\"
+        let source = "\(setForeground)\(setBackground)\(setCursor)plain default text\n"
+            + "\(red)RED\(reset) \(hyperlink)\n"
+
+        let environment = SessionScrollbackReplayStore.replayEnvironment(
+            for: source,
+            tempDirectory: tempDir
+        )
+
+        guard let path = environment[SessionScrollbackReplayStore.environmentKey] else {
+            XCTFail("Expected replay file path")
+            return
+        }
+        guard let contents = try? String(contentsOfFile: path, encoding: .utf8) else {
+            XCTFail("Expected replay file contents")
+            return
+        }
+
+        // Terminal-color OSC sequences must be stripped so the active theme owns
+        // default fg/bg/cursor and restored default cells track it.
+        XCTAssertFalse(contents.contains("\(esc)]10;"), "OSC 10 (set foreground) must be stripped")
+        XCTAssertFalse(contents.contains("\(esc)]11;"), "OSC 11 (set background) must be stripped")
+        XCTAssertFalse(contents.contains("\(esc)]12;"), "OSC 12 (set cursor color) must be stripped")
+        XCTAssertFalse(contents.contains("rgb:ff/ff/ff"), "baked default-color payload must be gone")
+
+        // Explicit SGR colors, plain text, and hyperlinks are preserved verbatim.
+        XCTAssertTrue(contents.contains("plain default text"))
+        XCTAssertTrue(contents.contains("\(red)RED\(reset)"))
+        XCTAssertTrue(contents.contains(hyperlink), "non-color OSC sequences must be preserved")
+    }
+
     func testSessionScrollbackPersistenceHonorsReportedShellState() {
         XCTAssertTrue(
             Workspace.shouldPersistSessionScrollback(

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -508,11 +508,17 @@ final class SessionPersistenceTests: XCTestCase {
         let setBackground = "\(esc)]11;rgb:28/2c/34\(esc)\\"
         // A BEL-terminated cursor-color OSC, the other dynamic-color terminator form.
         let setCursor = "\(esc)]12;rgb:c0/c1/b5\u{0007}"
+        // Palette set/reset and a dynamic-color reset are equally theme state that
+        // restored history must not re-impose, so they are stripped too.
+        let setPalette = "\(esc)]4;1;rgb:aa/00/00\(esc)\\"
+        let resetPalette = "\(esc)]104;1\(esc)\\"
+        let resetForeground = "\(esc)]110;\(esc)\\"
         let red = "\(esc)[31m"
         let reset = "\(esc)[0m"
         // OSC 8 hyperlinks are scrollback content, not terminal color config; keep them.
         let hyperlink = "\(esc)]8;;https://example.com\(esc)\\link\(esc)]8;;\(esc)\\"
-        let source = "\(setForeground)\(setBackground)\(setCursor)plain default text\n"
+        let source = "\(setForeground)\(setBackground)\(setCursor)"
+            + "\(setPalette)\(resetPalette)\(resetForeground)plain default text\n"
             + "\(red)RED\(reset) \(hyperlink)\n"
 
         let environment = SessionScrollbackReplayStore.replayEnvironment(
@@ -534,7 +540,11 @@ final class SessionPersistenceTests: XCTestCase {
         XCTAssertFalse(contents.contains("\(esc)]10;"), "OSC 10 (set foreground) must be stripped")
         XCTAssertFalse(contents.contains("\(esc)]11;"), "OSC 11 (set background) must be stripped")
         XCTAssertFalse(contents.contains("\(esc)]12;"), "OSC 12 (set cursor color) must be stripped")
+        XCTAssertFalse(contents.contains("\(esc)]4;"), "OSC 4 (set palette entry) must be stripped")
+        XCTAssertFalse(contents.contains("\(esc)]104;"), "OSC 104 (reset palette entry) must be stripped")
+        XCTAssertFalse(contents.contains("\(esc)]110;"), "OSC 110 (reset foreground) must be stripped")
         XCTAssertFalse(contents.contains("rgb:ff/ff/ff"), "baked default-color payload must be gone")
+        XCTAssertFalse(contents.contains("rgb:aa/00/00"), "baked palette payload must be gone")
 
         // Explicit SGR colors, plain text, and hyperlinks are preserved verbatim.
         XCTAssertTrue(contents.contains("plain default text"))


### PR DESCRIPTION
## Summary

Fixes #5165. When cmux restores the previous session's scrollback on launch, restored history kept the **default foreground/background baked from the theme it was created under** instead of tracking the currently active theme. After a theme change this rendered restored default-colored cells as unreadable **white-on-white**.

## Root cause

Session scrollback is captured via Ghostty's `write_screen_file:copy,vt` export (`TerminalController.readTerminalTextFromVTExportForSnapshot`). That export is told to bake the live theme — `Surface.writeScreenFile` passes `.foreground`, `.background`, and `.palette` to the VT formatter, which **prepends `OSC 10` / `OSC 11` dynamic-color sequences** carrying the capture-time default fg/bg (and resolves palette entries to literal RGB).

On restore, cmux replays the captured scrollback by `cat`-ing it into the freshly launched shell (`SessionScrollbackReplayStore` → `CMUX_RESTORE_SCROLLBACK_FILE` → shell integration). Replaying `OSC 10`/`OSC 11` **reconfigures the live terminal's dynamic colors**, overriding the active theme — so default-colored cells in restored history render with the *old* theme's default fg/bg (white-on-white when the new theme has a contrasting background).

Empirically confirmed (captured under dark Dracula, restored under a light theme); the snapshot scrollback begins with:

```
ESC]10;rgb:ff/ff/ff ST   # set foreground = Dracula white
ESC]11;rgb:28/2c/34 ST   # set background = Dracula dark
```

…and the default-colored restored lines (shell prompt, command output) render invisible (white-on-white) under the light theme.

## Fix

Strip terminal-color OSC sequences from the captured scrollback before replay (`SessionScrollbackReplayStore`). The active theme owns the terminal's default foreground/background/cursor/palette, so restored history must not carry sequences that reconfigure them. Stripped: OSC `4`/`5`/`104`/`105` (palette/special set+reset), `10`–`19` (dynamic fg/bg/cursor/highlight/…), `110`–`119` (their resets). Explicit per-cell SGR colors and every non-color escape (titles, OSC 8 hyperlinks, OSC 133 prompt marks, …) are preserved verbatim.

This is done at replay time, so it also repairs scrollback captured by older builds already on disk.

After the fix, restored default-colored cells track the active theme (dark-on-white under a light theme); the white-on-white is gone.

## Reproduction / verification

- Captured a real session snapshot under a dark theme and restored it under a light theme: default-colored lines were invisible (white-on-white). Confirmed the snapshot bakes `OSC 10`/`OSC 11`.
- After the fix, the same restored snapshot renders readable dark-on-white. (Before/after screenshots in the handoff.)

## Tests

Two-commit structure per `CLAUDE.md`:
1. **Failing test** — `SessionPersistenceTests.testScrollbackReplayStripsThemeBakedDefaultColorOSCSequences` asserts the replay path strips terminal-color OSC sequences while preserving SGR colors and non-color escapes. Fails without the fix.
2. **The fix** — test passes.

Added to the already-wired `cmuxTests/SessionPersistenceTests.swift` (XCTest, matching its sibling replay tests). Verified locally with `xcodebuild -scheme cmux-unit -only-testing:cmuxTests/SessionPersistenceTests/testScrollbackReplayStripsThemeBakedDefaultColorOSCSequences` → `** TEST SUCCEEDED **`. E2E/UI left to CI per repo policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5175"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782972054&installation_id=133855650&pr_number=5175&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5175&signature=659f2df05227c33e5a5b07afb132cc4c24884a2c1110f3d7fdfea6f84efa4c09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized replay-path text sanitization with a focused regression test; no auth, persistence schema, or network changes.
> 
> **Overview**
> Fixes **#5165** by sanitizing captured session scrollback **before replay** so restored default-colored text follows the **active theme** instead of the theme baked in at capture time.
> 
> **`SessionScrollbackReplayStore`** now runs scrollback through **`strippingTerminalColorOSCSequences`** ahead of truncation and ANSI-safe wrapping. That removes OSC sequences that set or reset terminal colors (palette `4`/`5`/`104`/`105`, dynamic fg/bg/cursor `10`–`19`, resets `110`–`119`), including BEL- and ST-terminated forms, while leaving SGR colors and other escapes (e.g. OSC 8 hyperlinks) intact. Because this runs at replay time, **existing on-disk snapshots** are corrected without re-capture.
> 
> Adds regression test **`testScrollbackReplayStripsThemeBakedDefaultColorOSCSequences`** in `SessionPersistenceTests`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00a0390b5ec03a2d46c17c290b25d9abfead91ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #5165 by stripping terminal-color OSC sequences during restored scrollback replay so default-colored text uses the active theme, avoiding white-on-white after theme changes. Done in the replay path so existing snapshots on disk are fixed too.

- **Bug Fixes**
  - Strip terminal-color OSC in replay: 4/5/104/105, 10–19, 110–119. Preserve SGR colors and non‑color OSC (e.g., OSC 8 links, titles). Handle BEL and ST (`ESC \`) terminators; drop truncated sequences.
  - Broadened regression test `testScrollbackReplayStripsThemeBakedDefaultColorOSCSequences` to cover palette set/reset and dynamic‑color resets, ensuring only theme-reconfiguring OSC are removed while text, SGR, and hyperlinks remain.

<sup>Written for commit 00a0390b5ec03a2d46c17c290b25d9abfead91ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Scrollback replay now strips embedded terminal color/theme OSC control sequences so replayed output preserves plain text, explicit SGR colors, and hyperlinks without altering the live terminal theme.

* **Tests**
  * Added a regression test verifying color/theme OSC sequences are removed while preserving SGR color output, hyperlinks, and plain text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->