### PR TITLE
Add a Lisp for customizing the sidebar

### DIFF
--- a/Packages/CmuxSidebarScript/Package.swift
+++ b/Packages/CmuxSidebarScript/Package.swift
@@ -1,0 +1,37 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "CmuxSidebarScript",
+    platforms: [
+        .macOS(.v14),
+    ],
+    products: [
+        .library(
+            name: "CmuxSidebarScript",
+            targets: ["CmuxSidebarScript"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "CmuxSidebarScript",
+            resources: [
+                .process("Resources"),
+            ],
+            swiftSettings: [
+                // The engine runs synchronously on the main thread behind a single
+                // entry point; language mode 5 keeps the small interpreter free of
+                // Sendable ceremony that buys nothing here.
+                .swiftLanguageMode(.v5),
+            ]
+        ),
+        .testTarget(
+            name: "CmuxSidebarScriptTests",
+            dependencies: ["CmuxSidebarScript"],
+            swiftSettings: [
+                .swiftLanguageMode(.v5),
+            ]
+        ),
+    ]
+)

--- a/Packages/CmuxSidebarScript/README.md
+++ b/Packages/CmuxSidebarScript/README.md
@@ -1,0 +1,83 @@
+# CmuxSidebarScript
+
+A small Lisp for customizing the cmux sidebar. A script's `render-row` function
+receives one workspace's data and returns a view tree, which the host renders as
+SwiftUI. Anything the bridge exposes (stacks, text, images, shapes, colors,
+fonts, and the usual view modifiers) is available; adding a new view or modifier
+is one registry entry plus one render case.
+
+## Pipeline
+
+```
+source ──Reader──▶ [LispValue] ──Evaluator + Bridge──▶ RenderNode ──RenderNodeView──▶ SwiftUI
+```
+
+`RenderNode` is a pure, `Equatable` value tree with no SwiftUI in it. That split
+is the performance contract: a sidebar row recomputes its node only when its
+input data changes, and the row stays `.equatable()` over the node so SwiftUI
+skips untouched rows at 1000-workspace scale. Evaluation is therefore fully unit
+testable without booting SwiftUI.
+
+## Language
+
+Scheme-ish core with one ergonomic twist: view options are `:keyword` arguments,
+so a form reads like SwiftUI.
+
+```lisp
+(vstack :spacing 4 :max-width infinity :frame-align leading
+  (text (get ws :title)
+    :font (font :size 13 :weight semibold)
+    :foreground (color :primary)
+    :line-limit 1
+    :truncation tail)
+  (when (get ws :branch)
+    (hstack :spacing 4
+      (image :system "arrow.triangle.branch" :font (font :size 10))
+      (text (get ws :branch) :font (font :size 10 :design monospaced)))))
+```
+
+- Special forms: `if`, `when`, `unless`, `cond`, `and`, `or`, `let`, `def`,
+  `fn`/`lambda`, `set!`, `do`, `quote`.
+- Data: ints, doubles, strings, `true`/`false`/`nil`, `:keywords`, lists, and
+  records (maps) read with `(get record :key default)`.
+- Library: arithmetic, comparisons, `map`/`filter`/`reduce`, list and string
+  ops, `str`/`join`, `record`/`assoc`/`get`/`keys`.
+- Views: `vstack` `hstack` `zstack` `group` `text` `image` `label` `spacer`
+  `divider` `rectangle` `capsule` `circle` `rounded-rectangle` `progress-view`
+  `button`.
+- Options (modifiers): `:font :foreground :background :tint :padding :frame`
+  (`:width :height :max-width :frame-align ...`) `:corner-radius :opacity
+  :line-limit :truncation :text-align :shadow :overlay :offset :bold :italic
+  :underline :strikethrough :border :help :on-tap` and more.
+- Style constructors: `(color :name)` `(hex "#rrggbb")` `(rgb r g b)`
+  `(font :size :weight :design)` `(gradient c1 c2 :direction)` `(edges ...)`
+  `(shadow ...)`.
+- Actions: `(open-url url)`, `(copy-text text)`.
+
+A malformed script raises a localized `LispError` at compile time; a render
+fault raises one per row. The host treats both as "fall back to the native row".
+
+## Usage
+
+```swift
+let script = try SidebarScript(source: lispSource)   // parse + bind once
+let node = try script.render(context)                // per row, returns RenderNode
+RenderNodeView(node: node, onAction: handleAction)    // render as SwiftUI
+```
+
+`SidebarScript.makeDefault()` compiles the bundled `DefaultSidebar.lisp`.
+
+## Testing
+
+Everything but `RenderNodeView` is pure and host-free. Evaluate a string and
+inspect the resulting node tree:
+
+```swift
+let node = try SidebarScript(source: """
+    (def (render-row ws) (text (upper (get ws :title))))
+    """).render(SidebarScriptContext(title: "hello"))
+#expect(node.containsText("HELLO"))
+```
+
+No global state: `SidebarScript` takes its source via `init`, and tests build
+`SidebarScriptContext` values directly. Run with `swift test`.

--- a/Packages/CmuxSidebarScript/README.md
+++ b/Packages/CmuxSidebarScript/README.md
@@ -42,13 +42,14 @@ so a form reads like SwiftUI.
   records (maps) read with `(get record :key default)`.
 - Library: arithmetic, comparisons, `map`/`filter`/`reduce`, list and string
   ops, `str`/`join`, `record`/`assoc`/`get`/`keys`.
-- Views: `vstack` `hstack` `zstack` `group` `text` `image` `label` `spacer`
-  `divider` `rectangle` `capsule` `circle` `rounded-rectangle` `progress-view`
-  `button`.
+- Views: `vstack` `hstack` `zstack` `grid` `group` `text` `image` `label`
+  `spacer` `divider` `rectangle` `capsule` `circle` `rounded-rectangle`
+  `progress-view` `button`.
 - Options (modifiers): `:font :foreground :background :tint :padding :frame`
   (`:width :height :max-width :frame-align ...`) `:corner-radius :opacity
-  :line-limit :truncation :text-align :shadow :overlay :offset :bold :italic
-  :underline :strikethrough :border :help :on-tap` and more.
+  :line-limit :minimum-scale-factor :truncation :text-align :shadow :overlay
+  :offset :scale :mask :bold :italic :underline :strikethrough :border :help
+  :on-tap` and more.
 - Style constructors: `(color :name)` `(hex "#rrggbb")` `(rgb r g b)`
   `(font :size :weight :design)` `(gradient c1 c2 :direction)` `(edges ...)`
   `(shadow ...)`.

--- a/Packages/CmuxSidebarScript/README.md
+++ b/Packages/CmuxSidebarScript/README.md
@@ -55,7 +55,9 @@ so a form reads like SwiftUI.
   `(font :size :weight :design)` `(gradient c1 c2 :direction)` `(edges ...)`
   `(shadow ...)`.
 - Actions: `(open-url url)`, `(copy-text text)`, `(select-workspace ws-or-id)`,
-  `(close-workspace ws-or-id)`, `(new-workspace :title "Scratch" :directory "/path")`.
+  `(close-workspace ws-or-id)`, `(new-workspace :title "Scratch" :directory "/path")`,
+  `(open-workspace file-or-directory)`, `(set-sidebar-state key value)`,
+  `(toggle-sidebar-state key)`.
 
 A malformed script raises a localized `LispError` at compile time. A whole
 sidebar render fault falls back to the native sidebar; a row render fault falls
@@ -75,7 +77,12 @@ Whole-sidebar scripts receive a record with `:workspaces`, `:workspace-count`,
 `:selected-workspace-id`, `:window-id`, and `:dark-mode`. Each workspace record
 also has `:id`, `:index`, `:title`, `:detail`, `:branch`, `:directory`,
 `:directories`, `:pull-requests`, `:ports`, `:unread`, `:pinned`, `:active`,
-`:selected`, `:color`, `:message`, `:progress`, `:remote`, and `:status`.
+`:selected`, `:color`, `:message`, `:progress`, `:remote`, `:status`, and
+`:files`. File records expose `:name`, `:path`, `:directory`,
+`:workspace-title`, and `:workspace-directory`, so a Finder-like sidebar can
+turn each file or folder into a workspace launch target. Whole-sidebar scripts
+also receive `:state`, a persisted string map stored at
+`~/.config/cmux/sidebar-state.json`.
 
 `SidebarScript.makeDefault()` compiles the bundled `DefaultSidebar.lisp`.
 

--- a/Packages/CmuxSidebarScript/README.md
+++ b/Packages/CmuxSidebarScript/README.md
@@ -1,10 +1,11 @@
 # CmuxSidebarScript
 
-A small Lisp for customizing the cmux sidebar. A script's `render-row` function
-receives one workspace's data and returns a view tree, which the host renders as
-SwiftUI. Anything the bridge exposes (stacks, text, images, shapes, colors,
-fonts, and the usual view modifiers) is available; adding a new view or modifier
-is one registry entry plus one render case.
+A small Lisp for customizing the cmux sidebar. A script can define
+`render-sidebar` to own the entire sidebar surface. Legacy scripts can still
+define `render-row` to customize one workspace row inside the native list.
+Anything the bridge exposes (stacks, text, images, shapes, colors, fonts, and
+the usual view modifiers) is available; adding a new view or modifier is one
+registry entry plus one render case.
 
 ## Pipeline
 
@@ -13,10 +14,10 @@ source ──Reader──▶ [LispValue] ──Evaluator + Bridge──▶ Rende
 ```
 
 `RenderNode` is a pure, `Equatable` value tree with no SwiftUI in it. That split
-is the performance contract: a sidebar row recomputes its node only when its
-input data changes, and the row stays `.equatable()` over the node so SwiftUI
-skips untouched rows at 1000-workspace scale. Evaluation is therefore fully unit
-testable without booting SwiftUI.
+is the performance contract: scripts render deterministic node trees from data,
+and evaluation is fully unit testable without booting SwiftUI. Row scripts keep
+the old per-row `.equatable()` behavior; whole-sidebar scripts trade native row
+chrome for complete layout control.
 
 ## Language
 
@@ -53,21 +54,28 @@ so a form reads like SwiftUI.
 - Style constructors: `(color :name)` `(hex "#rrggbb")` `(rgb r g b)`
   `(font :size :weight :design)` `(gradient c1 c2 :direction)` `(edges ...)`
   `(shadow ...)`.
-- Actions: `(open-url url)`, `(copy-text text)`.
+- Actions: `(open-url url)`, `(copy-text text)`, `(select-workspace ws-or-id)`,
+  `(close-workspace ws-or-id)`, `(new-workspace :title "Scratch" :directory "/path")`.
 
-A malformed script raises a localized `LispError` at compile time; a render
-fault raises one per row. The host treats both as "fall back to the native row".
-Top-level bindings are frozen after compile, so `render-row` stays deterministic
-for a given workspace. `set!` is still available for local `let` bindings inside
-one render pass.
+A malformed script raises a localized `LispError` at compile time. A whole
+sidebar render fault falls back to the native sidebar; a row render fault falls
+back to the native row. Top-level bindings are frozen after compile, so renders
+stay deterministic for a given input. `set!` is still available for local `let`
+bindings inside one render pass.
 
 ## Usage
 
 ```swift
 let script = try SidebarScript(source: lispSource)   // parse + bind once
-let node = try script.render(context)                // per row, returns RenderNode
+let node = try script.renderSidebar(sidebarContext)   // whole sidebar RenderNode
 RenderNodeView(node: node, onAction: handleAction)    // render as SwiftUI
 ```
+
+Whole-sidebar scripts receive a record with `:workspaces`, `:workspace-count`,
+`:selected-workspace-id`, `:window-id`, and `:dark-mode`. Each workspace record
+also has `:id`, `:index`, `:title`, `:detail`, `:branch`, `:directory`,
+`:directories`, `:pull-requests`, `:ports`, `:unread`, `:pinned`, `:active`,
+`:selected`, `:color`, `:message`, `:progress`, `:remote`, and `:status`.
 
 `SidebarScript.makeDefault()` compiles the bundled `DefaultSidebar.lisp`.
 
@@ -75,13 +83,12 @@ Bundled demos live in `Sources/CmuxSidebarScript/Resources/` and are exposed by
 `SidebarScriptDemo.all`:
 
 - `DefaultSidebar.lisp`: the normal rich workspace row.
-- `LiquidGlassSidebar.lisp`: translucent rounded badges and layered symbols.
-- `HighDensityIDESidebar.lisp`: compact IDE rows with dense metadata.
-- `TerminalStealthSidebar.lisp`: monospaced terminal-oriented rows.
-- `ProStudioSidebar.lisp`: chunkier pro-app cards and pill metadata.
-- `FinderSidebar.lisp`: filled icons and Finder-like hierarchy.
-- `AgentOpsSidebar.lisp`: a compact ops dashboard with PR, port, status, and
-  progress widgets.
+- `LiquidGlassSidebar.lisp`: a full-sidebar layered poster layout.
+- `HighDensityIDESidebar.lisp`: a full-sidebar dense IDE matrix.
+- `TerminalStealthSidebar.lisp`: a full-sidebar terminal transcript.
+- `ProStudioSidebar.lisp`: a full-sidebar production timeline.
+- `FinderSidebar.lisp`: a full-sidebar Finder-like hierarchy.
+- `AgentOpsSidebar.lisp`: a full-sidebar ops dashboard.
 
 The bridge intentionally does not execute arbitrary Swift. To support more of
 SwiftUI, add view constructors or modifiers to `Bridge` and `RenderNodeView`.

--- a/Packages/CmuxSidebarScript/README.md
+++ b/Packages/CmuxSidebarScript/README.md
@@ -56,6 +56,9 @@ so a form reads like SwiftUI.
 
 A malformed script raises a localized `LispError` at compile time; a render
 fault raises one per row. The host treats both as "fall back to the native row".
+Top-level bindings are frozen after compile, so `render-row` stays deterministic
+for a given workspace. `set!` is still available for local `let` bindings inside
+one render pass.
 
 ## Usage
 

--- a/Packages/CmuxSidebarScript/README.md
+++ b/Packages/CmuxSidebarScript/README.md
@@ -70,6 +70,23 @@ RenderNodeView(node: node, onAction: handleAction)    // render as SwiftUI
 
 `SidebarScript.makeDefault()` compiles the bundled `DefaultSidebar.lisp`.
 
+Bundled demos live in `Sources/CmuxSidebarScript/Resources/` and are exposed by
+`SidebarScriptDemo.all`:
+
+- `DefaultSidebar.lisp`: the normal rich workspace row.
+- `LiquidGlassSidebar.lisp`: translucent rounded badges and layered symbols.
+- `HighDensityIDESidebar.lisp`: compact IDE rows with dense metadata.
+- `TerminalStealthSidebar.lisp`: monospaced terminal-oriented rows.
+- `ProStudioSidebar.lisp`: chunkier pro-app cards and pill metadata.
+- `FinderSidebar.lisp`: filled icons and Finder-like hierarchy.
+- `AgentOpsSidebar.lisp`: a compact ops dashboard with PR, port, status, and
+  progress widgets.
+
+The bridge intentionally does not execute arbitrary Swift. To support more of
+SwiftUI, add view constructors or modifiers to `Bridge` and `RenderNodeView`.
+That preserves deterministic rendering, row equatability, and native fallback
+when a user script fails.
+
 ## Testing
 
 Everything but `RenderNodeView` is pure and host-free. Evaluate a string and

--- a/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Bridge.swift
+++ b/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Bridge.swift
@@ -1,0 +1,423 @@
+import Foundation
+
+/// Installs the SwiftUI bridge: style constructors, view constructors, the
+/// modifier vocabulary, and a few bare-symbol constants. This is where "support
+/// everything in SwiftUI" lives: adding a view or modifier is a single entry
+/// here plus a case in `RenderNodeView`.
+enum Bridge {
+    static func install(into env: LispEnvironment) {
+        installConstants(env)
+        installStyleConstructors(env)
+        installActionConstructors(env)
+        installViewConstructors(env)
+    }
+
+    private static func builtin(_ name: String, _ env: LispEnvironment,
+                                _ body: @escaping ([LispValue], Evaluator) throws -> LispValue) {
+        env.define(name, .function(LispFunction(name: name, kind: .builtin(body))))
+    }
+
+    // MARK: - Constants
+
+    private static func installConstants(_ env: LispEnvironment) {
+        // Bare-symbol shorthands. Everything here is also expressible as a
+        // :keyword literal, but these read nicely in font/stack options.
+        for w in ["thin", "ultralight", "light", "regular", "medium", "semibold", "bold", "heavy", "black"] {
+            env.define(w, .keyword(w))
+        }
+        for a in ["leading", "center", "trailing", "top", "bottom"] {
+            env.define(a, .keyword(a))
+        }
+        for d in ["monospaced", "rounded", "serif"] {
+            env.define(d, .keyword(d))
+        }
+        env.define("infinity", .double(.infinity))
+    }
+
+    // MARK: - Style constructors
+
+    private static func installStyleConstructors(_ env: LispEnvironment) {
+        builtin("hex", env) { args, _ in
+            guard case .string(let s)? = args.first else {
+                throw LispError.type("hex", expected: "a \"#rrggbb\" string", got: args.first ?? .null)
+            }
+            return .style(.color(.hex(s)))
+        }
+        builtin("rgb", env) { args, _ in
+            guard args.count >= 3 else { throw LispError.arity("rgb", expected: "3 numbers", got: args.count) }
+            return .style(.color(.rgba(try Coercion.number(args[0], "rgb"),
+                                       try Coercion.number(args[1], "rgb"),
+                                       try Coercion.number(args[2], "rgb"), 1)))
+        }
+        builtin("rgba", env) { args, _ in
+            guard args.count >= 4 else { throw LispError.arity("rgba", expected: "4 numbers", got: args.count) }
+            return .style(.color(.rgba(try Coercion.number(args[0], "rgba"),
+                                       try Coercion.number(args[1], "rgba"),
+                                       try Coercion.number(args[2], "rgba"),
+                                       try Coercion.number(args[3], "rgba"))))
+        }
+        builtin("color", env) { args, _ in
+            guard let v = args.first else { throw LispError.arity("color", expected: "a name", got: 0) }
+            return .style(.color(try Coercion.color(v, "color")))
+        }
+        builtin("font", env) { args, _ in try .style(.font(fontValue(args))) }
+        builtin("gradient", env) { args, _ in try .style(.gradient(gradientValue(args))) }
+        builtin("edges", env) { args, _ in try .style(.edges(edgesValue(args))) }
+        builtin("shadow", env) { args, _ in try .style(.shadow(shadowValue(args))) }
+    }
+
+    private static func installActionConstructors(_ env: LispEnvironment) {
+        builtin("open-url", env) { args, _ in
+            .style(.action(RNAction(kind: "open-url", payload: ["url": Builtins.display(args.first ?? .null)])))
+        }
+        builtin("copy-text", env) { args, _ in
+            .style(.action(RNAction(kind: "copy", payload: ["text": Builtins.display(args.first ?? .null)])))
+        }
+    }
+
+    // MARK: - View constructors
+
+    private static func installViewConstructors(_ env: LispEnvironment) {
+        builtin("vstack", env) { args, ev in try stack("vstack", args, ev) }
+        builtin("hstack", env) { args, ev in try stack("hstack", args, ev) }
+        builtin("zstack", env) { args, ev in try stack("zstack", args, ev) }
+        builtin("text", env) { args, _ in try text(args) }
+        builtin("image", env) { args, _ in try image(args) }
+        builtin("label", env) { args, _ in try label(args) }
+        builtin("spacer", env) { args, _ in try spacer(args) }
+        builtin("divider", env) { args, _ in
+            try .node(finish(RenderNode(kind: "divider"), "divider",
+                             Coercion.split(args, formName: "divider").options))
+        }
+        builtin("rectangle", env) { args, _ in try shape("rectangle", args) }
+        builtin("capsule", env) { args, _ in try shape("capsule", args) }
+        builtin("circle", env) { args, _ in try shape("circle", args) }
+        builtin("rounded-rectangle", env) { args, _ in try roundedRectangle(args) }
+        builtin("progress-view", env) { args, _ in try progressView(args) }
+        builtin("button", env) { args, _ in try button(args) }
+        builtin("group", env) { args, _ in
+            let split = try Coercion.split(args, formName: "group")
+            let node = RenderNode(kind: "group", children: try Coercion.childNodes(split.positional, formName: "group"))
+            return .node(try finish(node, "group", split.options))
+        }
+    }
+
+    // MARK: - View builders
+
+    private static func stack(_ kind: String, _ args: [LispValue], _ ev: Evaluator) throws -> LispValue {
+        let split = try Coercion.split(args, formName: kind)
+        var node = RenderNode(kind: kind, children: try Coercion.childNodes(split.positional, formName: kind))
+        var leftover: [(String, LispValue)] = []
+        for (k, v) in split.options {
+            switch k {
+            case "spacing": node.content["spacing"] = .number(try Coercion.number(v, kind))
+            case "alignment": node.content["alignment"] = .alignment(try Coercion.alignment(v, kind))
+            default: leftover.append((k, v))
+            }
+        }
+        return .node(try finish(node, kind, leftover))
+    }
+
+    private static func text(_ args: [LispValue]) throws -> LispValue {
+        let split = try Coercion.split(args, formName: "text")
+        let s = split.positional.map { Builtins.display($0) }.joined()
+        let node = RenderNode(kind: "text", content: ["text": .string(s)])
+        return .node(try finish(node, "text", split.options))
+    }
+
+    private static func image(_ args: [LispValue]) throws -> LispValue {
+        let split = try Coercion.split(args, formName: "image")
+        var node = RenderNode(kind: "image")
+        if let sys = split.option("system") {
+            node.content["system"] = .string(Builtins.display(sys))
+        } else if let name = split.option("name") {
+            node.content["name"] = .string(Builtins.display(name))
+        } else if let first = split.positional.first {
+            node.content["system"] = .string(Builtins.display(first))
+        } else {
+            throw LispError.arity("image", expected: "a :system or :name", got: 0)
+        }
+        let leftover = split.options.filter { $0.0 != "system" && $0.0 != "name" }
+        return .node(try finish(node, "image", leftover))
+    }
+
+    private static func label(_ args: [LispValue]) throws -> LispValue {
+        let split = try Coercion.split(args, formName: "label")
+        var node = RenderNode(kind: "label")
+        let title = split.option("text") ?? split.positional.first ?? .string("")
+        node.content["text"] = .string(Builtins.display(title))
+        if let sys = split.option("system") { node.content["system"] = .string(Builtins.display(sys)) }
+        let leftover = split.options.filter { $0.0 != "text" && $0.0 != "system" }
+        return .node(try finish(node, "label", leftover))
+    }
+
+    private static func spacer(_ args: [LispValue]) throws -> LispValue {
+        let split = try Coercion.split(args, formName: "spacer")
+        var node = RenderNode(kind: "spacer")
+        if let m = split.option("min") { node.content["min"] = .number(try Coercion.number(m, "spacer")) }
+        let leftover = split.options.filter { $0.0 != "min" }
+        return .node(try finish(node, "spacer", leftover))
+    }
+
+    private static func shape(_ kind: String, _ args: [LispValue]) throws -> LispValue {
+        let split = try Coercion.split(args, formName: kind)
+        var node = RenderNode(kind: kind)
+        try applyShapePaint(&node, split, kind)
+        let leftover = split.options.filter { !shapePaintKeys.contains($0.0) }
+        return .node(try finish(node, kind, leftover))
+    }
+
+    private static func roundedRectangle(_ args: [LispValue]) throws -> LispValue {
+        let split = try Coercion.split(args, formName: "rounded-rectangle")
+        var node = RenderNode(kind: "rounded-rectangle")
+        if let r = split.option("radius") { node.content["radius"] = .number(try Coercion.number(r, "rounded-rectangle")) }
+        try applyShapePaint(&node, split, "rounded-rectangle")
+        let leftover = split.options.filter { $0.0 != "radius" && !shapePaintKeys.contains($0.0) }
+        return .node(try finish(node, "rounded-rectangle", leftover))
+    }
+
+    private static let shapePaintKeys: Set<String> = ["fill", "stroke", "stroke-width"]
+
+    private static func applyShapePaint(_ node: inout RenderNode, _ split: SplitArgs, _ form: String) throws {
+        if let fill = split.option("fill") { node.content["fill"] = try paint(fill, form) }
+        if let stroke = split.option("stroke") { node.content["stroke"] = .color(try Coercion.color(stroke, form)) }
+        if let w = split.option("stroke-width") { node.content["stroke-width"] = .number(try Coercion.number(w, form)) }
+    }
+
+    private static func progressView(_ args: [LispValue]) throws -> LispValue {
+        let split = try Coercion.split(args, formName: "progress-view")
+        var node = RenderNode(kind: "progress-view")
+        let value = split.option("value") ?? split.positional.first
+        if let value { node.content["value"] = .number(try Coercion.number(value, "progress-view")) }
+        if let total = split.option("total") { node.content["total"] = .number(try Coercion.number(total, "progress-view")) }
+        let leftover = split.options.filter { $0.0 != "value" && $0.0 != "total" }
+        return .node(try finish(node, "progress-view", leftover))
+    }
+
+    private static func button(_ args: [LispValue]) throws -> LispValue {
+        let split = try Coercion.split(args, formName: "button")
+        var node = RenderNode(kind: "button", children: try Coercion.childNodes(split.positional, formName: "button"))
+        if let action = split.option("action") {
+            node.content["action"] = .action(try actionValue(action, "button"))
+        }
+        let leftover = split.options.filter { $0.0 != "action" }
+        return .node(try finish(node, "button", leftover))
+    }
+
+    // MARK: - Modifier application
+
+    private static let frameKeys: Set<String> =
+        ["width", "height", "min-width", "max-width", "min-height", "max-height", "frame-align"]
+    private static let borderKeys: Set<String> = ["border", "border-width"]
+
+    /// Applies leftover `:keyword` options as ordered modifiers. `frame` and
+    /// `border` options are coalesced into one modifier each (preserving the
+    /// position of their first appearance) so multi-field SwiftUI modifiers stay
+    /// correct.
+    static func finish(_ base: RenderNode, _ viewName: String, _ options: [(String, LispValue)]) throws -> RenderNode {
+        var node = base
+        var frameDone = false
+        var borderDone = false
+        for (key, _) in options {
+            if frameKeys.contains(key) {
+                if !frameDone {
+                    frameDone = true
+                    var named: [String: RNValue] = [:]
+                    for (k, v) in options where frameKeys.contains(k) { named[k] = try frameField(k, v, viewName) }
+                    node = node.adding(RenderModifier("frame", named: named))
+                }
+                continue
+            }
+            if borderKeys.contains(key) {
+                if !borderDone {
+                    borderDone = true
+                    var named: [String: RNValue] = [:]
+                    for (k, v) in options where borderKeys.contains(k) {
+                        named[k] = k == "border" ? .color(try Coercion.color(v, viewName))
+                                                  : .number(try Coercion.number(v, viewName))
+                    }
+                    node = node.adding(RenderModifier("border", named: named))
+                }
+                continue
+            }
+            // Re-find the value for this key (last value wins for repeats).
+            let value = options.last(where: { $0.0 == key })!.1
+            node = try applyModifier(node, key, value, viewName)
+        }
+        return node
+    }
+
+    private static func frameField(_ key: String, _ v: LispValue, _ form: String) throws -> RNValue {
+        if key == "frame-align" { return .alignment(try Coercion.alignment(v, form)) }
+        return .number(try Coercion.number(v, form))
+    }
+
+    private static func applyModifier(_ node: RenderNode, _ key: String, _ v: LispValue, _ viewName: String) throws -> RenderNode {
+        switch key {
+        case "padding":
+            return node.adding(RenderModifier("padding", values: [.edges(try Coercion.edges(v, "padding"))]))
+        case "background":
+            return node.adding(RenderModifier("background", values: [try paint(v, "background")]))
+        case "foreground", "color", "foreground-color":
+            return node.adding(RenderModifier("foreground", values: [try paint(v, "foreground")]))
+        case "tint":
+            return node.adding(RenderModifier("tint", values: [.color(try Coercion.color(v, "tint"))]))
+        case "font":
+            return node.adding(RenderModifier("font", values: [.font(try fontFromValue(v))]))
+        case "corner-radius":
+            return node.adding(RenderModifier("corner-radius", values: [.number(try Coercion.number(v, "corner-radius"))]))
+        case "opacity":
+            return node.adding(RenderModifier("opacity", values: [.number(try Coercion.number(v, "opacity"))]))
+        case "blur":
+            return node.adding(RenderModifier("blur", values: [.number(try Coercion.number(v, "blur"))]))
+        case "rotation":
+            return node.adding(RenderModifier("rotation", values: [.number(try Coercion.number(v, "rotation"))]))
+        case "line-limit":
+            return node.adding(RenderModifier("line-limit", values: [.number(try Coercion.number(v, "line-limit"))]))
+        case "kerning", "tracking":
+            return node.adding(RenderModifier("kerning", values: [.number(try Coercion.number(v, "kerning"))]))
+        case "layout-priority":
+            return node.adding(RenderModifier("layout-priority", values: [.number(try Coercion.number(v, "layout-priority"))]))
+        case "z-index":
+            return node.adding(RenderModifier("z-index", values: [.number(try Coercion.number(v, "z-index"))]))
+        case "truncation":
+            return node.adding(RenderModifier("truncation", values: [.string(tokenName(v))]))
+        case "text-align", "multiline-align":
+            return node.adding(RenderModifier("text-align", values: [.alignment(try Coercion.alignment(v, "text-align"))]))
+        case "shadow":
+            return node.adding(RenderModifier("shadow", values: [.shadow(try shadowFromValue(v))]))
+        case "overlay":
+            return node.adding(RenderModifier("overlay", values: [.node(try nodeValue(v, "overlay"))]))
+        case "offset":
+            return node.adding(RenderModifier("offset", values: [try offsetValue(v)]))
+        case "bold":
+            return node.adding(RenderModifier("bold", values: [.bool(v.isTruthy)]))
+        case "italic":
+            return node.adding(RenderModifier("italic", values: [.bool(v.isTruthy)]))
+        case "underline":
+            return node.adding(RenderModifier("underline", values: [.bool(v.isTruthy)]))
+        case "strikethrough":
+            return node.adding(RenderModifier("strikethrough", values: [.bool(v.isTruthy)]))
+        case "monospaced-digit":
+            return node.adding(RenderModifier("monospaced-digit", values: [.bool(v.isTruthy)]))
+        case "fixed-size":
+            return node.adding(RenderModifier("fixed-size", values: [.bool(v.isTruthy)]))
+        case "clip":
+            return node.adding(RenderModifier("clip", values: [.bool(v.isTruthy)]))
+        case "disabled":
+            return node.adding(RenderModifier("disabled", values: [.bool(v.isTruthy)]))
+        case "help":
+            return node.adding(RenderModifier("help", values: [.string(Builtins.display(v))]))
+        case "on-tap", "tap":
+            return node.adding(RenderModifier("on-tap", values: [.action(try actionValue(v, "on-tap"))]))
+        default:
+            throw LispError.unknownModifier(key, on: viewName)
+        }
+    }
+
+    // MARK: - Value coercion for the bridge
+
+    /// A fill/foreground "paint": a color or a gradient, or a view (for
+    /// background/overlay layering).
+    private static func paint(_ v: LispValue, _ form: String) throws -> RNValue {
+        switch v {
+        case .style(.gradient(let g)): return .gradient(g)
+        case .style(.color(let c)): return .color(c)
+        case .node(let n): return .node(n)
+        case .string(let s): return .color(Coercion.parseColorString(s))
+        case .keyword(let k), .symbol(let k): return .color(Coercion.colorFromName(k))
+        default: throw LispError.type(form, expected: "a color, gradient, or view", got: v)
+        }
+    }
+
+    private static func nodeValue(_ v: LispValue, _ form: String) throws -> RenderNode {
+        if case .node(let n) = v { return n }
+        throw LispError.type(form, expected: "a view", got: v)
+    }
+
+    private static func actionValue(_ v: LispValue, _ form: String) throws -> RNAction {
+        if case .style(.action(let a)) = v { return a }
+        throw LispError.type(form, expected: "an action", got: v)
+    }
+
+    private static func offsetValue(_ v: LispValue) throws -> RNValue {
+        guard case .list(let items) = v, items.count == 2 else {
+            throw LispError.type("offset", expected: "a (list x y)", got: v)
+        }
+        return .list([.number(try Coercion.number(items[0], "offset")),
+                      .number(try Coercion.number(items[1], "offset"))])
+    }
+
+    private static func tokenName(_ v: LispValue) -> String {
+        switch v {
+        case .keyword(let k), .symbol(let k), .string(let k): return k
+        default: return Builtins.display(v)
+        }
+    }
+
+    private static func fontFromValue(_ v: LispValue) throws -> RNFont {
+        switch v {
+        case .style(.font(let f)): return f
+        case .int(let i): return RNFont(size: Double(i))
+        case .double(let d): return RNFont(size: d)
+        case .keyword(let k), .symbol(let k), .string(let k): return RNFont(textStyle: k)
+        default: throw LispError.type("font", expected: "a font, size, or text style", got: v)
+        }
+    }
+
+    private static func shadowFromValue(_ v: LispValue) throws -> RNShadow {
+        if case .style(.shadow(let s)) = v { return s }
+        if let r = v.asDouble { return RNShadow(color: .rgba(0, 0, 0, 0.33), radius: r) }
+        throw LispError.type("shadow", expected: "a shadow or radius", got: v)
+    }
+
+    // MARK: - Style constructor bodies
+
+    private static func fontValue(_ args: [LispValue]) throws -> RNFont {
+        let split = try Coercion.split(args, formName: "font")
+        var font = RNFont()
+        if let first = split.positional.first, let size = first.asDouble { font.size = size }
+        if let s = split.option("size") { font.size = try Coercion.number(s, "font") }
+        if let w = split.option("weight") { font.weight = tokenName(w) }
+        if let d = split.option("design") { font.design = tokenName(d) }
+        if let st = split.option("style") { font.textStyle = tokenName(st) }
+        if let it = split.option("italic") { font.italic = it.isTruthy }
+        if let md = split.option("monospaced-digit") { font.monospacedDigit = md.isTruthy }
+        return font
+    }
+
+    private static func gradientValue(_ args: [LispValue]) throws -> RNGradient {
+        let split = try Coercion.split(args, formName: "gradient")
+        let colors = try split.positional.map { try Coercion.color($0, "gradient") }
+        let dir = split.option("direction").map { tokenName($0) } ?? "vertical"
+        return RNGradient(colors: colors, direction: RNGradient.Direction(rawValue: dir) ?? .vertical)
+    }
+
+    private static func edgesValue(_ args: [LispValue]) throws -> RNEdges {
+        let split = try Coercion.split(args, formName: "edges")
+        if let first = split.positional.first, let u = first.asDouble, split.options.isEmpty {
+            return .uniform(u)
+        }
+        var e = RNEdges()
+        func read(_ key: String) throws -> Double? {
+            guard let v = split.option(key) else { return nil }
+            return try Coercion.number(v, "edges")
+        }
+        if let h = try read("horizontal") { e.leading = h; e.trailing = h }
+        if let v = try read("vertical") { e.top = v; e.bottom = v }
+        if let t = try read("top") { e.top = t }
+        if let l = try read("leading") { e.leading = l }
+        if let b = try read("bottom") { e.bottom = b }
+        if let r = try read("trailing") { e.trailing = r }
+        return e
+    }
+
+    private static func shadowValue(_ args: [LispValue]) throws -> RNShadow {
+        let split = try Coercion.split(args, formName: "shadow")
+        let color = try split.option("color").map { try Coercion.color($0, "shadow") } ?? .rgba(0, 0, 0, 0.33)
+        let radius = try split.option("radius").map { try Coercion.number($0, "shadow") } ?? 4
+        let x = try split.option("x").map { try Coercion.number($0, "shadow") } ?? 0
+        let y = try split.option("y").map { try Coercion.number($0, "shadow") } ?? 0
+        return RNShadow(color: color, radius: radius, x: x, y: y)
+    }
+}

--- a/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Bridge.swift
+++ b/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Bridge.swift
@@ -31,6 +31,17 @@ enum Bridge {
         for d in ["monospaced", "rounded", "serif"] {
             env.define(d, .keyword(d))
         }
+        // Truncation modes for :truncation, and extra 2D alignments.
+        for t in ["head", "middle", "tail"] {
+            env.define(t, .keyword(t))
+        }
+        for a in ["top-leading", "top-trailing", "bottom-leading", "bottom-trailing"] {
+            env.define(a, .keyword(a))
+        }
+        // Gradient directions.
+        for g in ["vertical", "horizontal", "diagonal"] {
+            env.define(g, .keyword(g))
+        }
         env.define("infinity", .double(.infinity))
     }
 

--- a/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Bridge.swift
+++ b/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Bridge.swift
@@ -84,6 +84,30 @@ enum Bridge {
         builtin("copy-text", env) { args, _ in
             .style(.action(RNAction(kind: "copy", payload: ["text": Builtins.display(args.first ?? .null)])))
         }
+        builtin("select-workspace", env) { args, _ in
+            .style(.action(RNAction(kind: "select-workspace", payload: ["id": actionTargetId(args.first ?? .null)])))
+        }
+        builtin("close-workspace", env) { args, _ in
+            .style(.action(RNAction(kind: "close-workspace", payload: ["id": actionTargetId(args.first ?? .null)])))
+        }
+        builtin("new-workspace", env) { args, _ in
+            let split = try Coercion.split(args, formName: "new-workspace")
+            var payload: [String: String] = [:]
+            if let title = split.option("title") ?? split.positional.first {
+                payload["title"] = Builtins.display(title)
+            }
+            if let directory = split.option("directory") ?? split.option("cwd") {
+                payload["directory"] = Builtins.display(directory)
+            }
+            return .style(.action(RNAction(kind: "new-workspace", payload: payload)))
+        }
+    }
+
+    private static func actionTargetId(_ value: LispValue) -> String {
+        if case .map(let map) = value, let id = map["id"] {
+            return Builtins.display(id)
+        }
+        return Builtins.display(value)
     }
 
     // MARK: - View constructors

--- a/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Bridge.swift
+++ b/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Bridge.swift
@@ -101,6 +101,33 @@ enum Bridge {
             }
             return .style(.action(RNAction(kind: "new-workspace", payload: payload)))
         }
+        builtin("open-workspace", env) { args, _ in
+            let split = try Coercion.split(args, formName: "open-workspace")
+            var payload: [String: String] = [:]
+            if let workspace = split.positional.first, case .map(let map) = workspace {
+                if let id = map["id"] { payload["id"] = Builtins.display(id) }
+                if let title = map["workspace-title"] ?? map["title"] { payload["title"] = Builtins.display(title) }
+                if let directory = map["workspace-directory"] ?? map["directory"] { payload["directory"] = Builtins.display(directory) }
+            } else if let directory = split.positional.first {
+                payload["directory"] = Builtins.display(directory)
+            }
+            if let id = split.option("id") { payload["id"] = Builtins.display(id) }
+            if let title = split.option("title") { payload["title"] = Builtins.display(title) }
+            if let directory = split.option("directory") ?? split.option("cwd") {
+                payload["directory"] = Builtins.display(directory)
+            }
+            return .style(.action(RNAction(kind: "open-workspace", payload: payload)))
+        }
+        builtin("set-sidebar-state", env) { args, _ in
+            guard args.count >= 2 else { throw LispError.arity("set-sidebar-state", expected: "2 arguments", got: args.count) }
+            return .style(.action(RNAction(kind: "set-sidebar-state", payload: [
+                "key": Builtins.display(args[0]),
+                "value": Builtins.display(args[1]),
+            ])))
+        }
+        builtin("toggle-sidebar-state", env) { args, _ in
+            .style(.action(RNAction(kind: "toggle-sidebar-state", payload: ["key": Builtins.display(args.first ?? .null)])))
+        }
     }
 
     private static func actionTargetId(_ value: LispValue) -> String {

--- a/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Bridge.swift
+++ b/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Bridge.swift
@@ -92,6 +92,7 @@ enum Bridge {
         builtin("vstack", env) { args, ev in try stack("vstack", args, ev) }
         builtin("hstack", env) { args, ev in try stack("hstack", args, ev) }
         builtin("zstack", env) { args, ev in try stack("zstack", args, ev) }
+        builtin("grid", env) { args, _ in try grid(args) }
         builtin("text", env) { args, _ in try text(args) }
         builtin("image", env) { args, _ in try image(args) }
         builtin("label", env) { args, _ in try label(args) }
@@ -134,6 +135,20 @@ enum Bridge {
         let s = split.positional.map { Builtins.display($0) }.joined()
         let node = RenderNode(kind: "text", content: ["text": .string(s)])
         return .node(try finish(node, "text", split.options))
+    }
+
+    private static func grid(_ args: [LispValue]) throws -> LispValue {
+        let split = try Coercion.split(args, formName: "grid")
+        var node = RenderNode(kind: "grid", children: try Coercion.childNodes(split.positional, formName: "grid"))
+        var leftover: [(String, LispValue)] = []
+        for (k, v) in split.options {
+            switch k {
+            case "columns": node.content["columns"] = .number(try Coercion.number(v, "grid"))
+            case "spacing": node.content["spacing"] = .number(try Coercion.number(v, "grid"))
+            default: leftover.append((k, v))
+            }
+        }
+        return .node(try finish(node, "grid", leftover))
     }
 
     private static func image(_ args: [LispValue]) throws -> LispValue {
@@ -285,6 +300,8 @@ enum Bridge {
             return node.adding(RenderModifier("rotation", values: [.number(try Coercion.number(v, "rotation"))]))
         case "line-limit":
             return node.adding(RenderModifier("line-limit", values: [.number(try Coercion.number(v, "line-limit"))]))
+        case "minimum-scale-factor", "min-scale":
+            return node.adding(RenderModifier("minimum-scale-factor", values: [.number(try Coercion.number(v, "minimum-scale-factor"))]))
         case "kerning", "tracking":
             return node.adding(RenderModifier("kerning", values: [.number(try Coercion.number(v, "kerning"))]))
         case "layout-priority":
@@ -301,6 +318,10 @@ enum Bridge {
             return node.adding(RenderModifier("overlay", values: [.node(try nodeValue(v, "overlay"))]))
         case "offset":
             return node.adding(RenderModifier("offset", values: [try offsetValue(v)]))
+        case "scale":
+            return node.adding(RenderModifier("scale", values: [.number(try Coercion.number(v, "scale"))]))
+        case "mask":
+            return node.adding(RenderModifier("mask", values: [.node(try nodeValue(v, "mask"))]))
         case "bold":
             return node.adding(RenderModifier("bold", values: [.bool(v.isTruthy)]))
         case "italic":

--- a/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Builtins.swift
+++ b/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Builtins.swift
@@ -1,0 +1,312 @@
+import Foundation
+
+/// Installs the core, SwiftUI-agnostic standard library into an environment.
+enum Builtins {
+    static func install(into env: LispEnvironment) {
+        func def(_ name: String, _ body: @escaping (_ args: [LispValue], _ ev: Evaluator) throws -> LispValue) {
+            env.define(name, .function(LispFunction(name: name, kind: .builtin(body))))
+        }
+
+        // MARK: Arithmetic
+        def("+") { args, _ in try .number(args.reduce(0) { $0 + (try num($1, "+")) }) }
+        def("*") { args, _ in try .number(args.reduce(1) { $0 * (try num($1, "*")) }) }
+        def("-") { args, _ in
+            guard let head = args.first else { return .int(0) }
+            if args.count == 1 { return .number(-(try num(head, "-"))) }
+            return try .number(args.dropFirst().reduce(num(head, "-")) { $0 - (try num($1, "-")) })
+        }
+        def("/") { args, _ in
+            guard let head = args.first else { throw LispError.arity("/", expected: "≥1 argument", got: 0) }
+            if args.count == 1 { return try .number(1 / num(head, "/")) }
+            return try .number(args.dropFirst().reduce(num(head, "/")) { $0 / (try num($1, "/")) })
+        }
+        def("mod") { args, _ in
+            try pair("mod", args); let a = try num(args[0], "mod"), b = try num(args[1], "mod")
+            return .number(a.truncatingRemainder(dividingBy: b))
+        }
+        def("abs") { args, _ in try .number(abs(num(one(args, "abs"), "abs"))) }
+        def("floor") { args, _ in try .number(num(one(args, "floor"), "floor").rounded(.down)) }
+        def("ceil") { args, _ in try .number(num(one(args, "ceil"), "ceil").rounded(.up)) }
+        def("round") { args, _ in try .number(num(one(args, "round"), "round").rounded()) }
+        def("min") { args, _ in try .number(args.map { try num($0, "min") }.min() ?? 0) }
+        def("max") { args, _ in try .number(args.map { try num($0, "max") }.max() ?? 0) }
+
+        // MARK: Comparison & logic
+        def("=") { args, _ in .bool(allAdjacent(args) { $0 == $1 }) }
+        def("not=") { args, _ in .bool(!allAdjacent(args) { $0 == $1 }) }
+        def("<") { args, _ in try .bool(numCompare(args, "<") { $0 < $1 }) }
+        def(">") { args, _ in try .bool(numCompare(args, ">") { $0 > $1 }) }
+        def("<=") { args, _ in try .bool(numCompare(args, "<=") { $0 <= $1 }) }
+        def(">=") { args, _ in try .bool(numCompare(args, ">=") { $0 >= $1 }) }
+        def("not") { args, _ in .bool(!one(args, "not").isTruthy) }
+
+        // MARK: Type predicates
+        def("nil?") { args, _ in .bool({ if case .null = one(args, "nil?") { return true }; return false }()) }
+        def("number?") { args, _ in .bool(one(args, "number?").asDouble != nil) }
+        def("string?") { args, _ in .bool({ if case .string = one(args, "string?") { return true }; return false }()) }
+        def("list?") { args, _ in .bool({ if case .list = one(args, "list?") { return true }; return false }()) }
+        def("bool?") { args, _ in .bool({ if case .bool = one(args, "bool?") { return true }; return false }()) }
+        def("node?") { args, _ in .bool({ if case .node = one(args, "node?") { return true }; return false }()) }
+        def("empty?") { args, _ in
+            switch one(args, "empty?") {
+            case .null: return .bool(true)
+            case .list(let l): return .bool(l.isEmpty)
+            case .string(let s): return .bool(s.isEmpty)
+            default: return .bool(false)
+            }
+        }
+
+        // MARK: Lists
+        def("list") { args, _ in .list(args) }
+        def("cons") { args, _ in
+            try pair("cons", args)
+            if case .list(let rest) = args[1] { return .list([args[0]] + rest) }
+            return .list([args[0], args[1]])
+        }
+        def("first") { args, _ in (try listArg(one(args, "first"), "first")).first ?? .null }
+        def("last") { args, _ in (try listArg(one(args, "last"), "last")).last ?? .null }
+        def("rest") { args, _ in .list(Array((try listArg(one(args, "rest"), "rest")).dropFirst())) }
+        def("count") { args, _ in
+            switch one(args, "count") {
+            case .list(let l): return .int(l.count)
+            case .string(let s): return .int(s.count)
+            case .null: return .int(0)
+            case .map(let m): return .int(m.keys.count)
+            default: return .int(0)
+            }
+        }
+        def("nth") { args, _ in
+            try pair("nth", args)
+            let list = try listArg(args[0], "nth")
+            let i = Int(try num(args[1], "nth"))
+            return (i >= 0 && i < list.count) ? list[i] : (args.count > 2 ? args[2] : .null)
+        }
+        def("reverse") { args, _ in .list((try listArg(one(args, "reverse"), "reverse")).reversed()) }
+        def("append") { args, _ in
+            var out: [LispValue] = []
+            for a in args { out.append(contentsOf: try listArg(a, "append")) }
+            return .list(out)
+        }
+        def("contains?") { args, _ in
+            try pair("contains?", args)
+            return .bool((try listArg(args[0], "contains?")).contains(args[1]))
+        }
+        def("range") { args, _ in try rangeBuiltin(args) }
+
+        // MARK: Higher-order
+        def("map") { args, ev in
+            try pair("map", args)
+            let fn = args[0]
+            return .list(try listArg(args[1], "map").map { try ev.apply(fn, [$0]) })
+        }
+        def("map-indexed") { args, ev in
+            try pair("map-indexed", args)
+            let fn = args[0]
+            return .list(try listArg(args[1], "map-indexed").enumerated().map {
+                try ev.apply(fn, [.int($0.offset), $0.element])
+            })
+        }
+        def("filter") { args, ev in
+            try pair("filter", args)
+            let fn = args[0]
+            return .list(try listArg(args[1], "filter").filter { try ev.apply(fn, [$0]).isTruthy })
+        }
+        def("reduce") { args, ev in
+            guard args.count == 3 else { throw LispError.arity("reduce", expected: "3 arguments", got: args.count) }
+            let fn = args[0]
+            var acc = args[1]
+            for item in try listArg(args[2], "reduce") { acc = try ev.apply(fn, [acc, item]) }
+            return acc
+        }
+        def("for-each") { args, ev in
+            try pair("for-each", args)
+            let fn = args[0]
+            for item in try listArg(args[1], "for-each") { _ = try ev.apply(fn, [item]) }
+            return .null
+        }
+
+        // MARK: Strings
+        def("str") { args, _ in .string(args.map { display($0) }.joined()) }
+        def("join") { args, _ in
+            try pair("join", args)
+            let sep = try str(args[0], "join")
+            return .string((try listArg(args[1], "join")).map { display($0) }.joined(separator: sep))
+        }
+        def("split") { args, _ in
+            try pair("split", args)
+            let s = try str(args[0], "split"), sep = try str(args[1], "split")
+            let parts = sep.isEmpty ? s.map { String($0) } : s.components(separatedBy: sep)
+            return .list(parts.map { .string($0) })
+        }
+        def("upper") { args, _ in .string((try str(one(args, "upper"), "upper")).uppercased()) }
+        def("lower") { args, _ in .string((try str(one(args, "lower"), "lower")).lowercased()) }
+        def("trim") { args, _ in .string((try str(one(args, "trim"), "trim")).trimmingCharacters(in: .whitespacesAndNewlines)) }
+        def("string-length") { args, _ in .int((try str(one(args, "string-length"), "string-length")).count) }
+        def("starts-with?") { args, _ in
+            try pair("starts-with?", args)
+            return .bool((try str(args[0], "starts-with?")).hasPrefix(try str(args[1], "starts-with?")))
+        }
+        def("ends-with?") { args, _ in
+            try pair("ends-with?", args)
+            return .bool((try str(args[0], "ends-with?")).hasSuffix(try str(args[1], "ends-with?")))
+        }
+        def("includes?") { args, _ in
+            try pair("includes?", args)
+            return .bool((try str(args[0], "includes?")).contains(try str(args[1], "includes?")))
+        }
+        def("substring") { args, _ in try substringBuiltin(args) }
+        def("replace") { args, _ in
+            guard args.count == 3 else { throw LispError.arity("replace", expected: "3 arguments", got: args.count) }
+            let s = try str(args[0], "replace")
+            return .string(s.replacingOccurrences(of: try str(args[1], "replace"), with: try str(args[2], "replace")))
+        }
+        def("pad-left") { args, _ in try pad(args, left: true) }
+        def("pad-right") { args, _ in try pad(args, left: false) }
+
+        // MARK: Records (maps)
+        def("record") { args, _ in
+            var m = LispMap()
+            var i = 0
+            while i + 1 < args.count {
+                guard case .keyword(let k) = args[i] else {
+                    throw LispError.eval(String(localized: "sidebarScript.error.recordKey",
+                        defaultValue: "'record' keys must be :keywords.", bundle: .module))
+                }
+                m[k] = args[i + 1]
+                i += 2
+            }
+            return .map(m)
+        }
+        def("get") { args, _ in try getBuiltin(args) }
+        def("has?") { args, _ in
+            try pair("has?", args)
+            if case .map(let m) = args[0] { return .bool(m[keyName(args[1])] != nil) }
+            return .bool(false)
+        }
+        def("keys") { args, _ in
+            if case .map(let m) = one(args, "keys") { return .list(m.keys.map { .keyword($0) }) }
+            return .list([])
+        }
+        def("assoc") { args, _ in
+            guard args.count >= 3, case .map(var m) = args[0] else {
+                throw LispError.type("assoc", expected: "a record", got: args.first ?? .null)
+            }
+            var i = 1
+            while i + 1 < args.count {
+                m[keyName(args[i])] = args[i + 1]
+                i += 2
+            }
+            return .map(m)
+        }
+
+        def("identity") { args, _ in one(args, "identity") }
+    }
+
+    // MARK: - Helpers
+
+    private static func num(_ v: LispValue, _ form: String) throws -> Double {
+        guard let d = v.asDouble else { throw LispError.type(form, expected: "a number", got: v) }
+        return d
+    }
+    private static func str(_ v: LispValue, _ form: String) throws -> String {
+        if case .string(let s) = v { return s }
+        throw LispError.type(form, expected: "a string", got: v)
+    }
+    private static func one(_ args: [LispValue], _ form: String) -> LispValue { args.first ?? .null }
+    private static func pair(_ form: String, _ args: [LispValue]) throws {
+        guard args.count >= 2 else { throw LispError.arity(form, expected: "2 arguments", got: args.count) }
+    }
+    private static func listArg(_ v: LispValue, _ form: String) throws -> [LispValue] {
+        switch v {
+        case .list(let l): return l
+        case .null: return []
+        default: throw LispError.type(form, expected: "a list", got: v)
+        }
+    }
+    private static func keyName(_ v: LispValue) -> String {
+        switch v {
+        case .keyword(let k), .string(let k), .symbol(let k): return k
+        default: return display(v)
+        }
+    }
+
+    private static func allAdjacent(_ args: [LispValue], _ ok: (LispValue, LispValue) -> Bool) -> Bool {
+        guard args.count >= 2 else { return true }
+        for i in 1..<args.count where !ok(args[i - 1], args[i]) { return false }
+        return true
+    }
+    private static func numCompare(_ args: [LispValue], _ form: String, _ ok: (Double, Double) -> Bool) throws -> Bool {
+        guard args.count >= 2 else { return true }
+        for i in 1..<args.count where !(ok(try num(args[i - 1], form), try num(args[i], form))) { return false }
+        return true
+    }
+
+    private static func rangeBuiltin(_ args: [LispValue]) throws -> LispValue {
+        let nums = try args.map { try num($0, "range") }
+        let start: Double, end: Double, step: Double
+        switch nums.count {
+        case 1: start = 0; end = nums[0]; step = 1
+        case 2: start = nums[0]; end = nums[1]; step = 1
+        case 3: start = nums[0]; end = nums[1]; step = nums[2]
+        default: throw LispError.arity("range", expected: "1 to 3 arguments", got: args.count)
+        }
+        guard step != 0 else { return .list([]) }
+        var out: [LispValue] = []
+        var x = start
+        if step > 0 { while x < end { out.append(.int(Int(x))); x += step } }
+        else { while x > end { out.append(.int(Int(x))); x += step } }
+        return .list(out)
+    }
+
+    private static func substringBuiltin(_ args: [LispValue]) throws -> LispValue {
+        guard args.count >= 2 else { throw LispError.arity("substring", expected: "2 or 3 arguments", got: args.count) }
+        let s = Array(try str(args[0], "substring"))
+        let from = max(0, min(s.count, Int(try num(args[1], "substring"))))
+        let to = args.count > 2 ? max(from, min(s.count, Int(try num(args[2], "substring")))) : s.count
+        return .string(String(s[from..<to]))
+    }
+
+    private static func getBuiltin(_ args: [LispValue]) throws -> LispValue {
+        guard args.count >= 2 else { throw LispError.arity("get", expected: "2 or 3 arguments", got: args.count) }
+        let fallback: LispValue = args.count > 2 ? args[2] : .null
+        switch args[0] {
+        case .map(let m): return m[keyName(args[1])] ?? fallback
+        case .list(let l):
+            let i = Int((try? num(args[1], "get")) ?? -1)
+            return (i >= 0 && i < l.count) ? l[i] : fallback
+        case .null: return fallback
+        default: return fallback
+        }
+    }
+
+    private static func pad(_ args: [LispValue], left: Bool) throws -> LispValue {
+        guard args.count >= 2 else { throw LispError.arity("pad", expected: "2 or 3 arguments", got: args.count) }
+        let s = display(args[0])
+        let width = Int(try num(args[1], "pad"))
+        let padChar = args.count > 2 ? display(args[2]).first ?? " " : " "
+        if s.count >= width { return .string(s) }
+        let padding = String(repeating: padChar, count: width - s.count)
+        return .string(left ? padding + s : s + padding)
+    }
+
+    /// Human-readable rendering for `str`/`join`. Integers print without a
+    /// trailing `.0`; nil prints empty.
+    static func display(_ v: LispValue) -> String {
+        switch v {
+        case .null: return ""
+        case .bool(let b): return b ? "true" : "false"
+        case .int(let i): return String(i)
+        case .double(let d):
+            if d == d.rounded() && abs(d) < 1e15 { return String(Int(d)) }
+            return String(d)
+        case .string(let s): return s
+        case .symbol(let s): return s
+        case .keyword(let k): return ":" + k
+        case .list(let l): return "(" + l.map { display($0) }.joined(separator: " ") + ")"
+        case .map(let m): return "{" + m.pairs.map { ":\($0.0) \(display($0.1))" }.joined(separator: " ") + "}"
+        case .function(let f): return "#<fn \(f.name)>"
+        case .style: return "#<style>"
+        case .node(let n): return "#<view \(n.kind)>"
+        }
+    }
+}

--- a/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Builtins.swift
+++ b/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Builtins.swift
@@ -78,7 +78,7 @@ enum Builtins {
         def("nth") { args, _ in
             try pair("nth", args)
             let list = try listArg(args[0], "nth")
-            let i = Int(try num(args[1], "nth"))
+            let i = try intValue(args[1], "nth")
             return (i >= 0 && i < list.count) ? list[i] : (args.count > 2 ? args[2] : .null)
         }
         def("reverse") { args, _ in .list((try listArg(one(args, "reverse"), "reverse")).reversed()) }
@@ -91,37 +91,47 @@ enum Builtins {
             try pair("contains?", args)
             return .bool((try listArg(args[0], "contains?")).contains(args[1]))
         }
-        def("range") { args, _ in try rangeBuiltin(args) }
+        def("range") { args, ev in try rangeBuiltin(args, ev) }
 
         // MARK: Higher-order
         def("map") { args, ev in
             try pair("map", args)
             let fn = args[0]
-            return .list(try listArg(args[1], "map").map { try ev.apply(fn, [$0]) })
+            let list = try listArg(args[1], "map")
+            try ev.consumeStep(list.count)
+            return .list(try list.map { try ev.apply(fn, [$0]) })
         }
         def("map-indexed") { args, ev in
             try pair("map-indexed", args)
             let fn = args[0]
-            return .list(try listArg(args[1], "map-indexed").enumerated().map {
+            let list = try listArg(args[1], "map-indexed")
+            try ev.consumeStep(list.count)
+            return .list(try list.enumerated().map {
                 try ev.apply(fn, [.int($0.offset), $0.element])
             })
         }
         def("filter") { args, ev in
             try pair("filter", args)
             let fn = args[0]
-            return .list(try listArg(args[1], "filter").filter { try ev.apply(fn, [$0]).isTruthy })
+            let list = try listArg(args[1], "filter")
+            try ev.consumeStep(list.count)
+            return .list(try list.filter { try ev.apply(fn, [$0]).isTruthy })
         }
         def("reduce") { args, ev in
             guard args.count == 3 else { throw LispError.arity("reduce", expected: "3 arguments", got: args.count) }
             let fn = args[0]
             var acc = args[1]
-            for item in try listArg(args[2], "reduce") { acc = try ev.apply(fn, [acc, item]) }
+            let list = try listArg(args[2], "reduce")
+            try ev.consumeStep(list.count)
+            for item in list { acc = try ev.apply(fn, [acc, item]) }
             return acc
         }
         def("for-each") { args, ev in
             try pair("for-each", args)
             let fn = args[0]
-            for item in try listArg(args[1], "for-each") { _ = try ev.apply(fn, [item]) }
+            let list = try listArg(args[1], "for-each")
+            try ev.consumeStep(list.count)
+            for item in list { _ = try ev.apply(fn, [item]) }
             return .null
         }
 
@@ -136,6 +146,7 @@ enum Builtins {
             try pair("split", args)
             let s = try str(args[0], "split"), sep = try str(args[1], "split")
             let parts = sep.isEmpty ? s.map { String($0) } : s.components(separatedBy: sep)
+            guard parts.count <= Evaluator.generatedCollectionLimit else { throw LispError.collectionLimit }
             return .list(parts.map { .string($0) })
         }
         def("upper") { args, _ in .string((try str(one(args, "upper"), "upper")).uppercased()) }
@@ -160,8 +171,8 @@ enum Builtins {
             let s = try str(args[0], "replace")
             return .string(s.replacingOccurrences(of: try str(args[1], "replace"), with: try str(args[2], "replace")))
         }
-        def("pad-left") { args, _ in try pad(args, left: true) }
-        def("pad-right") { args, _ in try pad(args, left: false) }
+        def("pad-left") { args, ev in try pad(args, left: true, ev) }
+        def("pad-right") { args, ev in try pad(args, left: false, ev) }
 
         // MARK: Records (maps)
         def("record") { args, _ in
@@ -241,7 +252,7 @@ enum Builtins {
         return true
     }
 
-    private static func rangeBuiltin(_ args: [LispValue]) throws -> LispValue {
+    private static func rangeBuiltin(_ args: [LispValue], _ ev: Evaluator) throws -> LispValue {
         let nums = try args.map { try num($0, "range") }
         let start: Double, end: Double, step: Double
         switch nums.count {
@@ -250,7 +261,16 @@ enum Builtins {
         case 3: start = nums[0]; end = nums[1]; step = nums[2]
         default: throw LispError.arity("range", expected: "1 to 3 arguments", got: args.count)
         }
+        guard start.isFinite, end.isFinite, step.isFinite else {
+            throw LispError.type("range", expected: "finite numbers", got: args.first ?? .null)
+        }
         guard step != 0 else { return .list([]) }
+        let rawCount = (end - start) / step
+        guard rawCount.isFinite else { throw LispError.collectionLimit }
+        guard rawCount <= Double(Evaluator.generatedCollectionLimit) else { throw LispError.collectionLimit }
+        let count = rawCount > 0 ? Int(ceil(rawCount)) : 0
+        guard count <= Evaluator.generatedCollectionLimit else { throw LispError.collectionLimit }
+        try ev.consumeStep(count)
         var out: [LispValue] = []
         var x = start
         if step > 0 { while x < end { out.append(.int(Int(x))); x += step } }
@@ -261,8 +281,8 @@ enum Builtins {
     private static func substringBuiltin(_ args: [LispValue]) throws -> LispValue {
         guard args.count >= 2 else { throw LispError.arity("substring", expected: "2 or 3 arguments", got: args.count) }
         let s = Array(try str(args[0], "substring"))
-        let from = max(0, min(s.count, Int(try num(args[1], "substring"))))
-        let to = args.count > 2 ? max(from, min(s.count, Int(try num(args[2], "substring")))) : s.count
+        let from = max(0, min(s.count, try intValue(args[1], "substring")))
+        let to = args.count > 2 ? max(from, min(s.count, try intValue(args[2], "substring"))) : s.count
         return .string(String(s[from..<to]))
     }
 
@@ -279,14 +299,25 @@ enum Builtins {
         }
     }
 
-    private static func pad(_ args: [LispValue], left: Bool) throws -> LispValue {
+    private static func pad(_ args: [LispValue], left: Bool, _ ev: Evaluator) throws -> LispValue {
         guard args.count >= 2 else { throw LispError.arity("pad", expected: "2 or 3 arguments", got: args.count) }
         let s = display(args[0])
-        let width = Int(try num(args[1], "pad"))
+        let width = try intValue(args[1], "pad")
         let padChar = args.count > 2 ? display(args[2]).first ?? " " : " "
         if s.count >= width { return .string(s) }
-        let padding = String(repeating: padChar, count: width - s.count)
+        let paddingCount = width - s.count
+        guard paddingCount <= Evaluator.generatedCollectionLimit else { throw LispError.collectionLimit }
+        try ev.consumeStep(paddingCount)
+        let padding = String(repeating: padChar, count: paddingCount)
         return .string(left ? padding + s : s + padding)
+    }
+
+    private static func intValue(_ v: LispValue, _ form: String) throws -> Int {
+        let n = try num(v, form)
+        guard n.isFinite, n >= Double(Int.min), n <= Double(Int.max) else {
+            throw LispError.type(form, expected: "a finite integer", got: v)
+        }
+        return Int(n)
     }
 
     /// Human-readable rendering for `str`/`join`. Integers print without a

--- a/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Coercion.swift
+++ b/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Coercion.swift
@@ -1,0 +1,144 @@
+import Foundation
+
+/// Splits a flat evaluated argument list into positional args and `:keyword`
+/// options. A keyword consumes exactly the next value, so positionals and
+/// options can interleave freely: `(vstack :spacing 4 child1 child2)` and
+/// `(vstack child1 child2 :spacing 4)` mean the same thing.
+struct SplitArgs {
+    var positional: [LispValue]
+    /// Keyword options in source order (a keyword may repeat, last wins on read).
+    var options: [(String, LispValue)]
+
+    func option(_ key: String) -> LispValue? {
+        options.last(where: { $0.0 == key })?.1
+    }
+}
+
+enum Coercion {
+    static func split(_ args: [LispValue], formName: String) throws -> SplitArgs {
+        var positional: [LispValue] = []
+        var options: [(String, LispValue)] = []
+        var i = 0
+        while i < args.count {
+            if case .keyword(let key) = args[i] {
+                guard i + 1 < args.count else {
+                    throw LispError.eval(String(
+                        localized: "sidebarScript.error.danglingKeyword",
+                        defaultValue: "':\(key)' in '\(formName)' is missing a value.",
+                        bundle: .module))
+                }
+                options.append((key, args[i + 1]))
+                i += 2
+            } else {
+                positional.append(args[i])
+                i += 1
+            }
+        }
+        return SplitArgs(positional: positional, options: options)
+    }
+
+    /// Flattens children: a positional arg that is a list (or nil) is spliced in,
+    /// so `(map ...)` returning a list of nodes works as container content. Only
+    /// node-producing values become children; nil is dropped.
+    static func childNodes(_ values: [LispValue], formName: String) throws -> [RenderNode] {
+        var nodes: [RenderNode] = []
+        for v in values {
+            try collectNodes(v, into: &nodes, formName: formName)
+        }
+        return nodes
+    }
+
+    private static func collectNodes(_ v: LispValue, into nodes: inout [RenderNode], formName: String) throws {
+        switch v {
+        case .node(let n):
+            nodes.append(n)
+        case .null:
+            break // skip; lets scripts use nil for "render nothing"
+        case .list(let items):
+            for item in items { try collectNodes(item, into: &nodes, formName: formName) }
+        case .string(let s):
+            // Convenience: a bare string in container content is plain text.
+            nodes.append(RenderNode(kind: "text", content: ["text": .string(s)]))
+        default:
+            throw LispError.eval(String(
+                localized: "sidebarScript.error.childType",
+                defaultValue: "'\(formName)' can only contain views, but got a \(v.typeName).",
+                bundle: .module))
+        }
+    }
+
+    static func number(_ v: LispValue, _ form: String) throws -> Double {
+        guard let d = v.asDouble else { throw LispError.type(form, expected: "a number", got: v) }
+        return d
+    }
+
+    static func string(_ v: LispValue, _ form: String) throws -> String {
+        if case .string(let s) = v { return s }
+        throw LispError.type(form, expected: "a string", got: v)
+    }
+
+    /// Coerces a Lisp value into an `RNValue` for use in a modifier/content slot.
+    /// Strings that look like hex colors are NOT auto-converted here; callers
+    /// that want color coercion use `color(_:)`.
+    static func rnValue(_ v: LispValue) throws -> RNValue {
+        switch v {
+        case .null: return .null
+        case .bool(let b): return .bool(b)
+        case .int(let i): return .number(Double(i))
+        case .double(let d): return .number(d)
+        case .string(let s): return .string(s)
+        case .keyword(let k): return .string(k)
+        case .symbol(let s): return .string(s)
+        case .node(let n): return .node(n)
+        case .list(let items): return .list(try items.map { try rnValue($0) })
+        case .style(let style): return style.rnValue
+        case .map, .function:
+            throw LispError.eval(String(
+                localized: "sidebarScript.error.notRenderable",
+                defaultValue: "A \(v.typeName) cannot be used here.", bundle: .module))
+        }
+    }
+
+    /// Coerces a value into a color: accepts a style color, a `#hex` string, or a
+    /// color-name keyword/symbol like `red` / `:accent`.
+    static func color(_ v: LispValue, _ form: String) throws -> RNColor {
+        switch v {
+        case .style(.color(let c)): return c
+        case .string(let s): return parseColorString(s)
+        case .keyword(let k), .symbol(let k): return colorFromName(k)
+        default:
+            throw LispError.type(form, expected: "a color", got: v)
+        }
+    }
+
+    static func parseColorString(_ s: String) -> RNColor {
+        if s.hasPrefix("#") { return .hex(s) }
+        return colorFromName(s)
+    }
+
+    static func colorFromName(_ name: String) -> RNColor {
+        switch name {
+        case "primary", "secondary", "accent", "clear", "label", "tint":
+            return .semantic(name)
+        default:
+            return .named(name)
+        }
+    }
+
+    /// Coerces a value into an alignment token.
+    static func alignment(_ v: LispValue, _ form: String) throws -> RNAlignment {
+        switch v {
+        case .style(.alignment(let a)): return a
+        case .keyword(let k), .symbol(let k), .string(let k): return RNAlignment(k)
+        default:
+            throw LispError.type(form, expected: "an alignment", got: v)
+        }
+    }
+
+    /// Coerces a value into edge insets: a number (uniform) or an edges style.
+    static func edges(_ v: LispValue, _ form: String) throws -> RNEdges {
+        if let d = v.asDouble { return .uniform(d) }
+        if case .style(.edges(let e)) = v { return e }
+        throw LispError.type(form, expected: "a number or edges", got: v)
+    }
+}

--- a/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Errors.swift
+++ b/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Errors.swift
@@ -1,0 +1,109 @@
+import Foundation
+
+/// An error raised while reading or evaluating a sidebar script.
+///
+/// `message` is a localized, user-facing sentence: these errors are surfaced in
+/// the UI when a user's `sidebar.lisp` is malformed, so they must read well.
+public struct LispError: Error, CustomStringConvertible {
+    public enum Stage: String {
+        case read
+        case eval
+    }
+
+    public let stage: Stage
+    public let message: String
+    /// 1-based source line, when known.
+    public let line: Int?
+
+    public init(stage: Stage, message: String, line: Int? = nil) {
+        self.stage = stage
+        self.message = message
+        self.line = line
+    }
+
+    public var description: String {
+        if let line {
+            let prefix = String(
+                localized: "sidebarScript.error.linePrefix",
+                defaultValue: "Line \(line): ",
+                bundle: .module
+            )
+            return prefix + message
+        }
+        return message
+    }
+
+    // MARK: Factories
+
+    static func read(_ message: String, line: Int? = nil) -> LispError {
+        LispError(stage: .read, message: message, line: line)
+    }
+
+    static func eval(_ message: String) -> LispError {
+        LispError(stage: .eval, message: message)
+    }
+
+    static func unbound(_ name: String) -> LispError {
+        .eval(String(
+            localized: "sidebarScript.error.unbound",
+            defaultValue: "Unknown name '\(name)'.",
+            bundle: .module
+        ))
+    }
+
+    static func notCallable(_ value: LispValue) -> LispError {
+        .eval(String(
+            localized: "sidebarScript.error.notCallable",
+            defaultValue: "Tried to call a \(value.typeName), which is not a function.",
+            bundle: .module
+        ))
+    }
+
+    static func arity(_ fn: String, expected: String, got: Int) -> LispError {
+        .eval(String(
+            localized: "sidebarScript.error.arity",
+            defaultValue: "'\(fn)' expects \(expected) but got \(got).",
+            bundle: .module
+        ))
+    }
+
+    static func type(_ fn: String, expected: String, got: LispValue) -> LispError {
+        .eval(String(
+            localized: "sidebarScript.error.type",
+            defaultValue: "'\(fn)' expects \(expected) but got a \(got.typeName).",
+            bundle: .module
+        ))
+    }
+
+    static func unknownModifier(_ name: String, on view: String) -> LispError {
+        .eval(String(
+            localized: "sidebarScript.error.unknownModifier",
+            defaultValue: "'\(view)' has no ':\(name)' option.",
+            bundle: .module
+        ))
+    }
+
+    static func unknownView(_ name: String) -> LispError {
+        .eval(String(
+            localized: "sidebarScript.error.unknownView",
+            defaultValue: "Unknown view '\(name)'.",
+            bundle: .module
+        ))
+    }
+
+    static var stepLimit: LispError {
+        .eval(String(
+            localized: "sidebarScript.error.stepLimit",
+            defaultValue: "Script did too much work (possible infinite loop).",
+            bundle: .module
+        ))
+    }
+
+    static var depthLimit: LispError {
+        .eval(String(
+            localized: "sidebarScript.error.depthLimit",
+            defaultValue: "Script recursed too deeply.",
+            bundle: .module
+        ))
+    }
+}

--- a/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Errors.swift
+++ b/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Errors.swift
@@ -91,10 +91,26 @@ public struct LispError: Error, CustomStringConvertible {
         ))
     }
 
+    static func immutableBinding(_ name: String) -> LispError {
+        .eval(String(
+            localized: "sidebarScript.error.immutableBinding",
+            defaultValue: "Cannot change top-level binding '\(name)' while rendering.",
+            bundle: .module
+        ))
+    }
+
     static var stepLimit: LispError {
         .eval(String(
             localized: "sidebarScript.error.stepLimit",
             defaultValue: "Script did too much work (possible infinite loop).",
+            bundle: .module
+        ))
+    }
+
+    static var collectionLimit: LispError {
+        .eval(String(
+            localized: "sidebarScript.error.collectionLimit",
+            defaultValue: "Script tried to create too many values at once.",
             bundle: .module
         ))
     }

--- a/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Evaluator.swift
+++ b/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Evaluator.swift
@@ -12,17 +12,26 @@ public final class Evaluator {
     public let stepLimit: Int
     public let depthLimit: Int
 
+    /// Maximum number of values one builtin may generate at once. This prevents
+    /// scripts from allocating giant arrays before the step budget can trip.
+    public static let generatedCollectionLimit = 4_096
+
     // A sidebar row never legitimately recurses deep; this bound trips a runaway
     // script well before its Swift call stack (which uses several frames per Lisp
     // level) can overflow a small worker-thread stack.
-    public init(stepLimit: Int = 2_000_000, depthLimit: Int = 64) {
+    public init(stepLimit: Int = 100_000, depthLimit: Int = 64) {
         self.stepLimit = stepLimit
         self.depthLimit = depthLimit
     }
 
-    public func eval(_ form: LispValue, in env: LispEnvironment) throws -> LispValue {
-        steps += 1
+    public func consumeStep(_ count: Int = 1) throws {
+        guard count > 0 else { return }
+        steps += count
         if steps > stepLimit { throw LispError.stepLimit }
+    }
+
+    public func eval(_ form: LispValue, in env: LispEnvironment) throws -> LispValue {
+        try consumeStep()
 
         switch form {
         case .int, .double, .string, .bool, .null, .keyword, .function, .style, .node, .map:
@@ -125,7 +134,14 @@ public final class Evaluator {
                     defaultValue: "'set!' needs a name and a value.", bundle: .module))
             }
             let value = try eval(args[1], in: env)
-            if !env.set(target, value) { throw LispError.unbound(target) }
+            switch env.set(target, value) {
+            case .assigned:
+                break
+            case .missing:
+                throw LispError.unbound(target)
+            case .immutable:
+                throw LispError.immutableBinding(target)
+            }
             return value
 
         case "fn", "lambda":

--- a/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Evaluator.swift
+++ b/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Evaluator.swift
@@ -12,7 +12,10 @@ public final class Evaluator {
     public let stepLimit: Int
     public let depthLimit: Int
 
-    public init(stepLimit: Int = 2_000_000, depthLimit: Int = 512) {
+    // A sidebar row never legitimately recurses deep; this bound trips a runaway
+    // script well before its Swift call stack (which uses several frames per Lisp
+    // level) can overflow a small worker-thread stack.
+    public init(stepLimit: Int = 2_000_000, depthLimit: Int = 64) {
         self.stepLimit = stepLimit
         self.depthLimit = depthLimit
     }

--- a/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Evaluator.swift
+++ b/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Evaluator.swift
@@ -1,0 +1,274 @@
+import Foundation
+
+/// Evaluates `LispValue` forms against an `LispEnvironment`.
+///
+/// One evaluator instance is used per render pass and is not shared across
+/// threads. A step budget and recursion-depth guard bound the work a script can
+/// do so a malformed `sidebar.lisp` can never wedge the main thread.
+public final class Evaluator {
+    public private(set) var steps = 0
+    private var depth = 0
+
+    public let stepLimit: Int
+    public let depthLimit: Int
+
+    public init(stepLimit: Int = 2_000_000, depthLimit: Int = 512) {
+        self.stepLimit = stepLimit
+        self.depthLimit = depthLimit
+    }
+
+    public func eval(_ form: LispValue, in env: LispEnvironment) throws -> LispValue {
+        steps += 1
+        if steps > stepLimit { throw LispError.stepLimit }
+
+        switch form {
+        case .int, .double, .string, .bool, .null, .keyword, .function, .style, .node, .map:
+            return form
+        case .symbol(let name):
+            guard let value = env.lookup(name) else { throw LispError.unbound(name) }
+            return value
+        case .list(let items):
+            return try evalList(items, in: env)
+        }
+    }
+
+    private func evalList(_ items: [LispValue], in env: LispEnvironment) throws -> LispValue {
+        guard let head = items.first else { return .null } // () evaluates to nil
+
+        // Special forms dispatch on a bare leading symbol.
+        if case .symbol(let name) = head {
+            if let result = try evalSpecialForm(name, Array(items.dropFirst()), in: env) {
+                return result
+            }
+        }
+
+        let fn = try eval(head, in: env)
+        let args = try items.dropFirst().map { try eval($0, in: env) }
+        return try apply(fn, Array(args))
+    }
+
+    /// Returns nil when `name` is not a special form (so it falls through to a
+    /// normal function call).
+    private func evalSpecialForm(_ name: String, _ args: [LispValue], in env: LispEnvironment) throws -> LispValue? {
+        switch name {
+        case "quote":
+            return args.first ?? .null
+
+        case "if":
+            guard args.count == 2 || args.count == 3 else {
+                throw LispError.arity("if", expected: "2 or 3 arguments", got: args.count)
+            }
+            if try eval(args[0], in: env).isTruthy {
+                return try eval(args[1], in: env)
+            } else if args.count == 3 {
+                return try eval(args[2], in: env)
+            }
+            return .null
+
+        case "when":
+            guard let test = args.first else { return .null }
+            if try eval(test, in: env).isTruthy {
+                return try evalBody(Array(args.dropFirst()), in: env)
+            }
+            return .null
+
+        case "unless":
+            guard let test = args.first else { return .null }
+            if try !eval(test, in: env).isTruthy {
+                return try evalBody(Array(args.dropFirst()), in: env)
+            }
+            return .null
+
+        case "cond":
+            for clause in args {
+                guard case .list(let parts) = clause, let test = parts.first else {
+                    throw LispError.eval(String(localized: "sidebarScript.error.condClause",
+                        defaultValue: "Each 'cond' clause must be a list.", bundle: .module))
+                }
+                let isElse = (test == .symbol("else")) || (test == .keyword("else"))
+                if isElse {
+                    return try evalBody(Array(parts.dropFirst()), in: env)
+                }
+                if try eval(test, in: env).isTruthy {
+                    return try evalBody(Array(parts.dropFirst()), in: env)
+                }
+            }
+            return .null
+
+        case "and":
+            var last: LispValue = .bool(true)
+            for a in args {
+                last = try eval(a, in: env)
+                if !last.isTruthy { return last }
+            }
+            return last
+
+        case "or":
+            for a in args {
+                let v = try eval(a, in: env)
+                if v.isTruthy { return v }
+            }
+            return .null
+
+        case "let", "let*":
+            return try evalLet(args, in: env)
+
+        case "def", "define":
+            return try evalDef(args, in: env)
+
+        case "set!":
+            guard args.count == 2, case .symbol(let target) = args[0] else {
+                throw LispError.eval(String(localized: "sidebarScript.error.setForm",
+                    defaultValue: "'set!' needs a name and a value.", bundle: .module))
+            }
+            let value = try eval(args[1], in: env)
+            if !env.set(target, value) { throw LispError.unbound(target) }
+            return value
+
+        case "fn", "lambda":
+            return try makeClosure(args, in: env)
+
+        case "do", "begin":
+            return try evalBody(args, in: env)
+
+        case "quasiquote", "unquote":
+            // Not supported; keep the core small.
+            return nil
+
+        default:
+            return nil
+        }
+    }
+
+    private func evalBody(_ forms: [LispValue], in env: LispEnvironment) throws -> LispValue {
+        var result: LispValue = .null
+        for f in forms { result = try eval(f, in: env) }
+        return result
+    }
+
+    private func evalLet(_ args: [LispValue], in env: LispEnvironment) throws -> LispValue {
+        guard let bindingsForm = args.first, case .list(let bindings) = bindingsForm else {
+            throw LispError.eval(String(localized: "sidebarScript.error.letBindings",
+                defaultValue: "'let' needs a list of bindings.", bundle: .module))
+        }
+        let scope = env.child()
+        for binding in bindings {
+            guard case .list(let pair) = binding, pair.count == 2,
+                  case .symbol(let name) = pair[0] else {
+                throw LispError.eval(String(localized: "sidebarScript.error.letBindingShape",
+                    defaultValue: "Each 'let' binding must be (name value).", bundle: .module))
+            }
+            // Sequential binding (let*): later bindings see earlier ones.
+            scope.define(name, try eval(pair[1], in: scope))
+        }
+        return try evalBody(Array(args.dropFirst()), in: scope)
+    }
+
+    private func evalDef(_ args: [LispValue], in env: LispEnvironment) throws -> LispValue {
+        guard let target = args.first else {
+            throw LispError.arity("def", expected: "a name", got: 0)
+        }
+        switch target {
+        case .symbol(let name):
+            let value = args.count > 1 ? try eval(args[1], in: env) : .null
+            env.define(name, value)
+            return value
+        case .list(let sig):
+            // (def (name params...) body...) function sugar.
+            guard case .symbol(let name)? = sig.first else {
+                throw LispError.eval(String(localized: "sidebarScript.error.defShape",
+                    defaultValue: "Function definition needs a name.", bundle: .module))
+            }
+            let (params, rest) = try parseParams(Array(sig.dropFirst()))
+            let closure = LispValue.function(LispFunction(
+                name: name,
+                kind: .closure(params: params, rest: rest, body: Array(args.dropFirst()), env: env)
+            ))
+            env.define(name, closure)
+            return closure
+        default:
+            throw LispError.eval(String(localized: "sidebarScript.error.defShape",
+                defaultValue: "Function definition needs a name.", bundle: .module))
+        }
+    }
+
+    private func makeClosure(_ args: [LispValue], in env: LispEnvironment) throws -> LispValue {
+        guard let paramsForm = args.first, case .list(let rawParams) = paramsForm else {
+            throw LispError.eval(String(localized: "sidebarScript.error.fnParams",
+                defaultValue: "'fn' needs a parameter list.", bundle: .module))
+        }
+        let (params, rest) = try parseParams(rawParams)
+        return .function(LispFunction(
+            name: "lambda",
+            kind: .closure(params: params, rest: rest, body: Array(args.dropFirst()), env: env)
+        ))
+    }
+
+    private func parseParams(_ forms: [LispValue]) throws -> (params: [String], rest: String?) {
+        var params: [String] = []
+        var rest: String?
+        var i = 0
+        while i < forms.count {
+            guard case .symbol(let s) = forms[i] else {
+                throw LispError.eval(String(localized: "sidebarScript.error.paramName",
+                    defaultValue: "Parameter names must be symbols.", bundle: .module))
+            }
+            if s == "&" {
+                guard i + 1 < forms.count, case .symbol(let r) = forms[i + 1] else {
+                    throw LispError.eval(String(localized: "sidebarScript.error.restParam",
+                        defaultValue: "'&' must be followed by one rest parameter.", bundle: .module))
+                }
+                rest = r
+                break
+            }
+            params.append(s)
+            i += 1
+        }
+        return (params, rest)
+    }
+
+    // MARK: - Application
+
+    public func apply(_ fn: LispValue, _ args: [LispValue]) throws -> LispValue {
+        guard case .function(let function) = fn else {
+            throw LispError.notCallable(fn)
+        }
+        switch function.kind {
+        case .builtin(let body):
+            return try body(args, self)
+        case .special:
+            throw LispError.eval(String(localized: "sidebarScript.error.specialApplied",
+                defaultValue: "'\(function.name)' cannot be used as a value.", bundle: .module))
+        case let .closure(params, rest, body, closureEnv):
+            return try applyClosure(function.name, params, rest, body, closureEnv, args)
+        }
+    }
+
+    private func applyClosure(
+        _ name: String,
+        _ params: [String],
+        _ rest: String?,
+        _ body: [LispValue],
+        _ closureEnv: LispEnvironment,
+        _ args: [LispValue]
+    ) throws -> LispValue {
+        depth += 1
+        defer { depth -= 1 }
+        if depth > depthLimit { throw LispError.depthLimit }
+
+        if rest == nil && args.count != params.count {
+            throw LispError.arity(name, expected: "\(params.count) arguments", got: args.count)
+        }
+        if rest != nil && args.count < params.count {
+            throw LispError.arity(name, expected: "at least \(params.count) arguments", got: args.count)
+        }
+        let scope = closureEnv.child()
+        for (i, p) in params.enumerated() {
+            scope.define(p, args[i])
+        }
+        if let rest {
+            scope.define(rest, .list(Array(args.dropFirst(params.count))))
+        }
+        return try evalBody(body, in: scope)
+    }
+}

--- a/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/LispEnvironment.swift
+++ b/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/LispEnvironment.swift
@@ -3,11 +3,19 @@ import Foundation
 /// A lexical scope. `define` writes into the current scope; lookup and `set!`
 /// walk up the parent chain.
 public final class LispEnvironment {
+    public enum SetResult {
+        case assigned
+        case missing
+        case immutable
+    }
+
     private var vars: [String: LispValue]
+    private var isMutable: Bool
     public let parent: LispEnvironment?
 
-    public init(parent: LispEnvironment? = nil) {
+    public init(parent: LispEnvironment? = nil, isMutable: Bool = true) {
         self.vars = [:]
+        self.isMutable = isMutable
         self.parent = parent
     }
 
@@ -24,17 +32,22 @@ public final class LispEnvironment {
         return nil
     }
 
+    public func freeze() {
+        isMutable = false
+    }
+
     @discardableResult
-    public func set(_ name: String, _ value: LispValue) -> Bool {
+    public func set(_ name: String, _ value: LispValue) -> SetResult {
         var scope: LispEnvironment? = self
         while let s = scope {
             if s.vars[name] != nil {
+                guard s.isMutable else { return .immutable }
                 s.vars[name] = value
-                return true
+                return .assigned
             }
             scope = s.parent
         }
-        return false
+        return .missing
     }
 
     /// A child scope. Used for function calls and `let`.

--- a/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/LispEnvironment.swift
+++ b/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/LispEnvironment.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// A lexical scope. `define` writes into the current scope; lookup and `set!`
+/// walk up the parent chain.
+public final class LispEnvironment {
+    private var vars: [String: LispValue]
+    public let parent: LispEnvironment?
+
+    public init(parent: LispEnvironment? = nil) {
+        self.vars = [:]
+        self.parent = parent
+    }
+
+    public func define(_ name: String, _ value: LispValue) {
+        vars[name] = value
+    }
+
+    public func lookup(_ name: String) -> LispValue? {
+        var scope: LispEnvironment? = self
+        while let s = scope {
+            if let v = s.vars[name] { return v }
+            scope = s.parent
+        }
+        return nil
+    }
+
+    @discardableResult
+    public func set(_ name: String, _ value: LispValue) -> Bool {
+        var scope: LispEnvironment? = self
+        while let s = scope {
+            if s.vars[name] != nil {
+                s.vars[name] = value
+                return true
+            }
+            scope = s.parent
+        }
+        return false
+    }
+
+    /// A child scope. Used for function calls and `let`.
+    public func child() -> LispEnvironment {
+        LispEnvironment(parent: self)
+    }
+}

--- a/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/LispFunction.swift
+++ b/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/LispFunction.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// A callable value.
+///
+/// Three kinds, distinguished by how arguments reach them:
+/// - ``Kind/special``: receives **unevaluated** argument forms plus the call
+///   environment, for control flow that can't eagerly evaluate its arguments.
+/// - ``Kind/builtin``: receives already-evaluated arguments; the standard
+///   library and SwiftUI bridge are builtins.
+/// - ``Kind/closure``: a script-defined `fn`/`def` lambda, capturing its
+///   defining environment.
+public struct LispFunction {
+    /// How a function is invoked.
+    public enum Kind {
+        /// A special form: arguments arrive unevaluated with the call environment.
+        case special((_ args: [LispValue], _ env: LispEnvironment, _ ev: Evaluator) throws -> LispValue)
+        /// A native builtin: arguments arrive evaluated.
+        case builtin((_ args: [LispValue], _ ev: Evaluator) throws -> LispValue)
+        /// A user closure with bound parameters, optional rest parameter, body
+        /// forms, and the environment it captured at definition.
+        case closure(params: [String], rest: String?, body: [LispValue], env: LispEnvironment)
+    }
+
+    /// The function's name, used in error messages and `display`.
+    public let name: String
+    /// How the function is invoked.
+    public let kind: Kind
+
+    public init(name: String, kind: Kind) {
+        self.name = name
+        self.kind = kind
+    }
+}

--- a/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/LispMap.swift
+++ b/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/LispMap.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// An insertion-ordered, string-keyed record.
+///
+/// Used for the workspace passed to `render-row` and for any script-built record
+/// (`(record :a 1 :b 2)`). Keys preserve insertion order so display and
+/// iteration are stable; a `:title` key is stored under the bare string
+/// `"title"`.
+public struct LispMap {
+    /// Keys in insertion order.
+    public private(set) var keys: [String]
+    private var storage: [String: LispValue]
+
+    /// An empty record.
+    public init() {
+        keys = []
+        storage = [:]
+    }
+
+    /// A record built from ordered key/value pairs. Later pairs with a repeated
+    /// key overwrite earlier values while keeping the first key position.
+    public init(_ pairs: [(String, LispValue)]) {
+        keys = []
+        storage = [:]
+        for (k, v) in pairs { self[k] = v }
+    }
+
+    /// Reads or writes a value by key. Setting nil removes the key.
+    public subscript(_ key: String) -> LispValue? {
+        get { storage[key] }
+        set {
+            if let newValue {
+                if storage[key] == nil { keys.append(key) }
+                storage[key] = newValue
+            } else {
+                if storage[key] != nil { keys.removeAll { $0 == key } }
+                storage[key] = nil
+            }
+        }
+    }
+
+    /// The key/value pairs in insertion order.
+    public var pairs: [(String, LispValue)] { keys.map { ($0, storage[$0]!) } }
+}
+
+extension LispMap: Equatable {
+    public static func == (lhs: LispMap, rhs: LispMap) -> Bool {
+        guard lhs.keys == rhs.keys else { return false }
+        for k in lhs.keys where lhs[k] != rhs[k] { return false }
+        return true
+    }
+}

--- a/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Reader.swift
+++ b/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Reader.swift
@@ -1,0 +1,209 @@
+import Foundation
+
+/// Turns source text into a list of top-level `LispValue` forms.
+///
+/// Syntax (Scheme-ish):
+///   - lists `(...)`, scalars, `:keywords`, `'quote` sugar
+///   - `;` line comments
+///   - strings with `\n \t \" \\` escapes
+///   - `true`, `false`, `nil` literals
+///   - integers and doubles, including negatives
+public struct Reader {
+    public init() {}
+
+    public func read(_ source: String) throws -> [LispValue] {
+        var tokenizer = Tokenizer(source)
+        let tokens = try tokenizer.tokenize()
+        var parser = Parser(tokens)
+        return try parser.parseAll()
+    }
+}
+
+// MARK: - Tokens
+
+private enum Token: Equatable {
+    case lparen(line: Int)
+    case rparen(line: Int)
+    case quote(line: Int)
+    case atom(String, line: Int)
+    case string(String, line: Int)
+
+    var line: Int {
+        switch self {
+        case let .lparen(l), let .rparen(l), let .quote(l): return l
+        case let .atom(_, l), let .string(_, l): return l
+        }
+    }
+}
+
+private struct Tokenizer {
+    private let chars: [Character]
+    private var index = 0
+    private var line = 1
+
+    init(_ source: String) { chars = Array(source) }
+
+    private var current: Character? { index < chars.count ? chars[index] : nil }
+
+    private mutating func advance() -> Character {
+        let c = chars[index]
+        index += 1
+        if c == "\n" { line += 1 }
+        return c
+    }
+
+    mutating func tokenize() throws -> [Token] {
+        var tokens: [Token] = []
+        while let c = current {
+            if c == "\n" || c == " " || c == "\t" || c == "\r" || c == "," {
+                _ = advance()
+            } else if c == ";" {
+                while let n = current, n != "\n" { _ = advance() }
+            } else if c == "(" || c == "[" {
+                let l = line; _ = advance(); tokens.append(.lparen(line: l))
+            } else if c == ")" || c == "]" {
+                let l = line; _ = advance(); tokens.append(.rparen(line: l))
+            } else if c == "'" {
+                let l = line; _ = advance(); tokens.append(.quote(line: l))
+            } else if c == "\"" {
+                tokens.append(try readString())
+            } else {
+                tokens.append(readAtom())
+            }
+        }
+        return tokens
+    }
+
+    private mutating func readString() throws -> Token {
+        let startLine = line
+        _ = advance() // opening quote
+        var out = ""
+        while let c = current {
+            if c == "\"" {
+                _ = advance()
+                return .string(out, line: startLine)
+            } else if c == "\\" {
+                _ = advance()
+                guard let esc = current else { break }
+                _ = advance()
+                switch esc {
+                case "n": out.append("\n")
+                case "t": out.append("\t")
+                case "r": out.append("\r")
+                case "\"": out.append("\"")
+                case "\\": out.append("\\")
+                default: out.append(esc)
+                }
+            } else {
+                out.append(advance())
+            }
+        }
+        throw LispError.read(
+            String(localized: "sidebarScript.error.unterminatedString",
+                   defaultValue: "Unterminated string.", bundle: .module),
+            line: startLine
+        )
+    }
+
+    private mutating func readAtom() -> Token {
+        let startLine = line
+        var out = ""
+        while let c = current {
+            if c == " " || c == "\t" || c == "\n" || c == "\r" || c == ","
+                || c == "(" || c == ")" || c == "[" || c == "]"
+                || c == "'" || c == "\"" || c == ";" {
+                break
+            }
+            out.append(advance())
+        }
+        return .atom(out, line: startLine)
+    }
+}
+
+// MARK: - Parser
+
+private struct Parser {
+    private let tokens: [Token]
+    private var index = 0
+
+    init(_ tokens: [Token]) { self.tokens = tokens }
+
+    private var current: Token? { index < tokens.count ? tokens[index] : nil }
+
+    mutating func parseAll() throws -> [LispValue] {
+        var forms: [LispValue] = []
+        while current != nil {
+            forms.append(try parseForm())
+        }
+        return forms
+    }
+
+    private mutating func parseForm() throws -> LispValue {
+        guard let token = current else {
+            throw LispError.read(String(
+                localized: "sidebarScript.error.unexpectedEnd",
+                defaultValue: "Unexpected end of input.", bundle: .module))
+        }
+        switch token {
+        case .lparen:
+            index += 1
+            var items: [LispValue] = []
+            while let t = current, !isRParen(t) {
+                items.append(try parseForm())
+            }
+            guard let close = current, isRParen(close) else {
+                throw LispError.read(String(
+                    localized: "sidebarScript.error.unclosedList",
+                    defaultValue: "Missing ')'.", bundle: .module), line: token.line)
+            }
+            index += 1
+            return .list(items)
+        case .rparen(let l):
+            throw LispError.read(String(
+                localized: "sidebarScript.error.unexpectedParen",
+                defaultValue: "Unexpected ')'.", bundle: .module), line: l)
+        case .quote:
+            index += 1
+            let quoted = try parseForm()
+            return .list([.symbol("quote"), quoted])
+        case let .string(s, _):
+            index += 1
+            return .string(s)
+        case let .atom(a, line):
+            index += 1
+            return atomValue(a, line: line)
+        }
+    }
+
+    private func isRParen(_ t: Token) -> Bool {
+        if case .rparen = t { return true }
+        return false
+    }
+
+    private func atomValue(_ atom: String, line: Int) -> LispValue {
+        if atom == "true" { return .bool(true) }
+        if atom == "false" { return .bool(false) }
+        if atom == "nil" { return .null }
+        if atom.hasPrefix(":"), atom.count > 1 {
+            return .keyword(String(atom.dropFirst()))
+        }
+        if let i = parseInt(atom) { return .int(i) }
+        if let d = parseDouble(atom) { return .double(d) }
+        return .symbol(atom)
+    }
+
+    private func parseInt(_ s: String) -> Int? {
+        guard !s.isEmpty else { return nil }
+        // Reject things like "1.0" or "1e3" here; those are doubles.
+        guard s.allSatisfy({ $0.isNumber || $0 == "-" || $0 == "+" }) else { return nil }
+        return Int(s)
+    }
+
+    private func parseDouble(_ s: String) -> Double? {
+        // Require at least one digit so bare symbols like "+" don't parse as 0.
+        guard s.contains(where: { $0.isNumber }) else { return nil }
+        let allowed = Set("0123456789.eE+-")
+        guard s.allSatisfy({ allowed.contains($0) }) else { return nil }
+        return Double(s)
+    }
+}

--- a/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/RenderNode.swift
+++ b/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/RenderNode.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// A pure, `Equatable` description of a SwiftUI view tree.
+///
+/// Scripts evaluate to `RenderNode`s; `RenderNodeView` turns them into actual
+/// SwiftUI. Keeping this layer free of SwiftUI and `Equatable` is the
+/// performance contract: a row recomputes its node only when its input data
+/// changes, and the row view stays `.equatable()` over the node so SwiftUI
+/// skips untouched rows in a 1000-workspace sidebar.
+public struct RenderNode: Equatable {
+    /// The view constructor name: "vstack", "text", "image", ...
+    public var kind: String
+    /// Inline content (text string, image name, shape) keyed by role.
+    public var content: [String: RNValue]
+    /// Child nodes (for containers).
+    public var children: [RenderNode]
+    /// Ordered, applied modifiers. Order matters: SwiftUI applies them in turn.
+    public var modifiers: [RenderModifier]
+
+    public init(
+        kind: String,
+        content: [String: RNValue] = [:],
+        children: [RenderNode] = [],
+        modifiers: [RenderModifier] = []
+    ) {
+        self.kind = kind
+        self.content = content
+        self.children = children
+        self.modifiers = modifiers
+    }
+
+    /// Returns a copy with a modifier appended.
+    public func adding(_ modifier: RenderModifier) -> RenderNode {
+        var copy = self
+        copy.modifiers.append(modifier)
+        return copy
+    }
+
+    public static let empty = RenderNode(kind: "empty")
+}
+
+/// One applied modifier, e.g. `.padding(8)` or `.frame(width: 100)`.
+public struct RenderModifier: Equatable {
+    public var name: String
+    /// Positional values (most modifiers carry exactly one).
+    public var values: [RNValue]
+    /// Named values (e.g. frame's width/height/alignment).
+    public var named: [String: RNValue]
+
+    public init(_ name: String, values: [RNValue] = [], named: [String: RNValue] = [:]) {
+        self.name = name
+        self.values = values
+        self.named = named
+    }
+
+    public var first: RNValue? { values.first }
+}

--- a/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/RenderNodeView.swift
+++ b/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/RenderNodeView.swift
@@ -1,0 +1,483 @@
+import SwiftUI
+
+/// Renders a `RenderNode` tree as SwiftUI. This is the only SwiftUI-aware part
+/// of the engine; everything upstream is pure, `Equatable` data.
+public struct RenderNodeView: View {
+    public let node: RenderNode
+    /// Host handler for tap targets (`open-url`, `copy-text`, ...). Optional so
+    /// the engine and previews work without a host.
+    public var onAction: ((RNAction) -> Void)?
+
+    public init(node: RenderNode, onAction: ((RNAction) -> Void)? = nil) {
+        self.node = node
+        self.onAction = onAction
+    }
+
+    public var body: some View {
+        RenderNodeRenderer(onAction: onAction).view(for: node)
+    }
+}
+
+/// Stateless converter from `RenderNode` to `AnyView`. `AnyView` is used because
+/// the node tree is dynamic; the `.equatable()` guard on the row (over the node)
+/// keeps SwiftUI from rebuilding untouched rows, so the type erasure here costs
+/// only the rows that actually change.
+struct RenderNodeRenderer {
+    let onAction: ((RNAction) -> Void)?
+
+    func view(for node: RenderNode) -> AnyView {
+        let base = baseView(for: node)
+        return applyModifiers(base, node.modifiers)
+    }
+
+    @ViewBuilder
+    private func children(_ nodes: [RenderNode]) -> some View {
+        ForEach(Array(nodes.enumerated()), id: \.offset) { _, child in
+            view(for: child)
+        }
+    }
+
+    // MARK: - Base views
+
+    private func baseView(for node: RenderNode) -> AnyView {
+        switch node.kind {
+        case "vstack":
+            return AnyView(VStack(
+                alignment: horizontal(node.content["alignment"]) ?? .leading,
+                spacing: node.content["spacing"]?.number.map { CGFloat($0) }
+            ) { children(node.children) })
+        case "hstack":
+            return AnyView(HStack(
+                alignment: vertical(node.content["alignment"]) ?? .center,
+                spacing: node.content["spacing"]?.number.map { CGFloat($0) }
+            ) { children(node.children) })
+        case "zstack":
+            return AnyView(ZStack(
+                alignment: alignment2D(node.content["alignment"]) ?? .center
+            ) { children(node.children) })
+        case "group":
+            return AnyView(Group { children(node.children) })
+        case "text":
+            return AnyView(Text(node.content["text"]?.string ?? ""))
+        case "image":
+            if let sys = node.content["system"]?.string {
+                return AnyView(Image(systemName: sys))
+            } else if let name = node.content["name"]?.string {
+                return AnyView(Image(name))
+            }
+            return AnyView(EmptyView())
+        case "label":
+            let title = node.content["text"]?.string ?? ""
+            if let sys = node.content["system"]?.string {
+                return AnyView(Label(title, systemImage: sys))
+            }
+            return AnyView(Text(title))
+        case "spacer":
+            return AnyView(Spacer(minLength: node.content["min"]?.number.map { CGFloat($0) }))
+        case "divider":
+            return AnyView(Divider())
+        case "rectangle":
+            return shapeView(Rectangle(), node)
+        case "capsule":
+            return shapeView(Capsule(), node)
+        case "circle":
+            return shapeView(Circle(), node)
+        case "rounded-rectangle":
+            let r = node.content["radius"]?.number ?? 6
+            return shapeView(RoundedRectangle(cornerRadius: CGFloat(r), style: .continuous), node)
+        case "progress-view":
+            if let value = node.content["value"]?.number {
+                let total = node.content["total"]?.number ?? 1
+                return AnyView(ProgressView(value: value, total: total).progressViewStyle(.linear))
+            }
+            return AnyView(ProgressView())
+        case "button":
+            let action = node.content["action"]?.actionValue
+            return AnyView(Button {
+                if let action { onAction?(action) }
+            } label: {
+                VStack(alignment: .leading, spacing: 0) { children(node.children) }
+            }.buttonStyle(.plain))
+        case "empty":
+            return AnyView(EmptyView())
+        default:
+            return AnyView(EmptyView())
+        }
+    }
+
+    private func shapeView<S: Shape>(_ shape: S, _ node: RenderNode) -> AnyView {
+        let filled: AnyView
+        if let fill = node.content["fill"] {
+            filled = AnyView(shape.fill(shapeStyle(fill)))
+        } else if node.content["stroke"] != nil {
+            filled = AnyView(shape.fill(Color.clear))
+        } else {
+            filled = AnyView(shape.fill(Color.primary))
+        }
+        guard case .color(let strokeColor)? = node.content["stroke"] else { return filled }
+        let width = node.content["stroke-width"]?.number ?? 1
+        return AnyView(filled.overlay(shape.stroke(color(strokeColor), lineWidth: CGFloat(width))))
+    }
+
+    // MARK: - Modifiers
+
+    private func applyModifiers(_ view: AnyView, _ mods: [RenderModifier]) -> AnyView {
+        var v = view
+        for m in mods { v = apply(m, to: v) }
+        return v
+    }
+
+    private func apply(_ m: RenderModifier, to view: AnyView) -> AnyView {
+        switch m.name {
+        case "padding":
+            if case .edges(let e)? = m.first { return AnyView(view.padding(insets(e))) }
+            return view
+        case "frame":
+            return frame(view, m.named)
+        case "border":
+            return border(view, m.named)
+        case "foreground":
+            return foreground(view, m.first)
+        case "background":
+            return background(view, m.first)
+        case "tint":
+            if case .color(let c)? = m.first { return AnyView(view.tint(color(c))) }
+            return view
+        case "font":
+            if case .font(let f)? = m.first { return AnyView(view.font(font(f))) }
+            return view
+        case "corner-radius":
+            let r = m.first?.number ?? 0
+            return AnyView(view.clipShape(RoundedRectangle(cornerRadius: CGFloat(r), style: .continuous)))
+        case "opacity":
+            return AnyView(view.opacity(m.first?.number ?? 1))
+        case "blur":
+            return AnyView(view.blur(radius: CGFloat(m.first?.number ?? 0)))
+        case "rotation":
+            return AnyView(view.rotationEffect(.degrees(m.first?.number ?? 0)))
+        case "line-limit":
+            return AnyView(view.lineLimit(Int(m.first?.number ?? 1)))
+        case "kerning":
+            return AnyView(view.kerning(CGFloat(m.first?.number ?? 0)))
+        case "layout-priority":
+            return AnyView(view.layoutPriority(m.first?.number ?? 0))
+        case "z-index":
+            return AnyView(view.zIndex(m.first?.number ?? 0))
+        case "truncation":
+            return AnyView(view.truncationMode(truncationMode(m.first?.string)))
+        case "text-align":
+            if case .alignment(let a)? = m.first { return AnyView(view.multilineTextAlignment(textAlignment(a))) }
+            return view
+        case "shadow":
+            if case .shadow(let s)? = m.first {
+                return AnyView(view.shadow(color: color(s.color), radius: CGFloat(s.radius),
+                                           x: CGFloat(s.x), y: CGFloat(s.y)))
+            }
+            return view
+        case "overlay":
+            if case .node(let n)? = m.first { return AnyView(view.overlay { self.view(for: n) }) }
+            return view
+        case "offset":
+            if case .list(let xy)? = m.first, xy.count == 2 {
+                return AnyView(view.offset(x: CGFloat(xy[0].number ?? 0), y: CGFloat(xy[1].number ?? 0)))
+            }
+            return view
+        case "bold":
+            return boolOn(m) ? AnyView(view.bold()) : view
+        case "italic":
+            return boolOn(m) ? AnyView(view.italic()) : view
+        case "underline":
+            return AnyView(view.underline(boolOn(m)))
+        case "strikethrough":
+            return AnyView(view.strikethrough(boolOn(m)))
+        case "monospaced-digit":
+            return boolOn(m) ? AnyView(view.monospacedDigit()) : view
+        case "fixed-size":
+            return boolOn(m) ? AnyView(view.fixedSize()) : view
+        case "clip":
+            return boolOn(m) ? AnyView(view.clipped()) : view
+        case "disabled":
+            return AnyView(view.disabled(boolOn(m)))
+        case "help":
+            return AnyView(view.help(m.first?.string ?? ""))
+        case "on-tap":
+            if case .action(let a)? = m.first {
+                return AnyView(view.contentShape(Rectangle()).onTapGesture { onAction?(a) })
+            }
+            return view
+        default:
+            return view
+        }
+    }
+
+    private func boolOn(_ m: RenderModifier) -> Bool {
+        if case .bool(let b)? = m.first { return b }
+        return true
+    }
+
+    private func frame(_ view: AnyView, _ named: [String: RNValue]) -> AnyView {
+        let align = (named["frame-align"].flatMap { v -> RNAlignment? in
+            if case .alignment(let a) = v { return a }; return nil
+        }).map(alignment) ?? .center
+        let w = named["width"]?.number
+        let h = named["height"]?.number
+        if w != nil || h != nil {
+            return AnyView(view.frame(
+                width: w.map { CGFloat($0) },
+                height: h.map { CGFloat($0) },
+                alignment: align))
+        }
+        return AnyView(view.frame(
+            minWidth: named["min-width"]?.number.map { CGFloat($0) },
+            maxWidth: named["max-width"]?.number.map { CGFloat($0) },
+            minHeight: named["min-height"]?.number.map { CGFloat($0) },
+            maxHeight: named["max-height"]?.number.map { CGFloat($0) },
+            alignment: align))
+    }
+
+    private func border(_ view: AnyView, _ named: [String: RNValue]) -> AnyView {
+        guard case .color(let c)? = named["border"] else { return view }
+        let width = named["border-width"]?.number ?? 1
+        return AnyView(view.border(color(c), width: CGFloat(width)))
+    }
+
+    private func foreground(_ view: AnyView, _ value: RNValue?) -> AnyView {
+        switch value {
+        case .color(let c)?: return AnyView(view.foregroundStyle(color(c)))
+        case .gradient(let g)?: return AnyView(view.foregroundStyle(gradient(g)))
+        default: return view
+        }
+    }
+
+    private func background(_ view: AnyView, _ value: RNValue?) -> AnyView {
+        switch value {
+        case .color(let c)?: return AnyView(view.background(color(c)))
+        case .gradient(let g)?: return AnyView(view.background(gradient(g)))
+        case .node(let n)?: return AnyView(view.background { self.view(for: n) })
+        default: return view
+        }
+    }
+
+    private func shapeStyle(_ value: RNValue) -> AnyShapeStyle {
+        switch value {
+        case .color(let c): return AnyShapeStyle(color(c))
+        case .gradient(let g): return AnyShapeStyle(gradient(g))
+        default: return AnyShapeStyle(Color.primary)
+        }
+    }
+
+    // MARK: - Conversions
+
+    private func color(_ c: RNColor) -> Color {
+        switch c {
+        case .hex(let s): return Color(hex: s) ?? .clear
+        case .rgba(let r, let g, let b, let a):
+            let (rr, gg, bb) = normalizeRGB(r, g, b)
+            return Color(.sRGB, red: rr, green: gg, blue: bb, opacity: a)
+        case .semantic(let name): return semanticColor(name)
+        case .named(let name): return namedColor(name)
+        }
+    }
+
+    private func normalizeRGB(_ r: Double, _ g: Double, _ b: Double) -> (Double, Double, Double) {
+        if r > 1 || g > 1 || b > 1 { return (r / 255, g / 255, b / 255) }
+        return (r, g, b)
+    }
+
+    private func semanticColor(_ name: String) -> Color {
+        switch name {
+        case "primary", "label": return .primary
+        case "secondary": return .secondary
+        case "accent", "tint": return .accentColor
+        case "clear": return .clear
+        default: return .primary
+        }
+    }
+
+    private func namedColor(_ name: String) -> Color {
+        switch name {
+        case "red": return .red
+        case "orange": return .orange
+        case "yellow": return .yellow
+        case "green": return .green
+        case "mint": return .mint
+        case "teal": return .teal
+        case "cyan": return .cyan
+        case "blue": return .blue
+        case "indigo": return .indigo
+        case "purple": return .purple
+        case "pink": return .pink
+        case "brown": return .brown
+        case "gray", "grey": return .gray
+        case "black": return .black
+        case "white": return .white
+        default: return Color(name) // asset catalog fallback
+        }
+    }
+
+    private func gradient(_ g: RNGradient) -> LinearGradient {
+        let colors = g.colors.map(color)
+        let (start, end): (UnitPoint, UnitPoint)
+        switch g.direction {
+        case .vertical: (start, end) = (.top, .bottom)
+        case .horizontal: (start, end) = (.leading, .trailing)
+        case .diagonal: (start, end) = (.topLeading, .bottomTrailing)
+        }
+        return LinearGradient(colors: colors, startPoint: start, endPoint: end)
+    }
+
+    private func font(_ f: RNFont) -> Font {
+        var base: Font
+        if let size = f.size {
+            base = .system(size: CGFloat(size), weight: weight(f.weight), design: design(f.design))
+        } else if let style = f.textStyle {
+            base = textStyleFont(style)
+            if let w = f.weight { base = base.weight(weight(w)) }
+        } else {
+            base = .body
+            if let w = f.weight { base = base.weight(weight(w)) }
+        }
+        if f.italic { base = base.italic() }
+        if f.monospacedDigit { base = base.monospacedDigit() }
+        return base
+    }
+
+    private func weight(_ name: String?) -> Font.Weight {
+        switch name {
+        case "thin": return .thin
+        case "ultralight": return .ultraLight
+        case "light": return .light
+        case "regular": return .regular
+        case "medium": return .medium
+        case "semibold": return .semibold
+        case "bold": return .bold
+        case "heavy": return .heavy
+        case "black": return .black
+        default: return .regular
+        }
+    }
+
+    private func design(_ name: String?) -> Font.Design {
+        switch name {
+        case "serif": return .serif
+        case "rounded": return .rounded
+        case "monospaced": return .monospaced
+        default: return .default
+        }
+    }
+
+    private func textStyleFont(_ name: String) -> Font {
+        switch name {
+        case "large-title": return .largeTitle
+        case "title": return .title
+        case "title2": return .title2
+        case "title3": return .title3
+        case "headline": return .headline
+        case "subheadline": return .subheadline
+        case "body": return .body
+        case "callout": return .callout
+        case "footnote": return .footnote
+        case "caption": return .caption
+        case "caption2": return .caption2
+        default: return .body
+        }
+    }
+
+    private func insets(_ e: RNEdges) -> EdgeInsets {
+        EdgeInsets(top: CGFloat(e.top), leading: CGFloat(e.leading),
+                   bottom: CGFloat(e.bottom), trailing: CGFloat(e.trailing))
+    }
+
+    private func horizontal(_ v: RNValue?) -> HorizontalAlignment? {
+        guard case .alignment(let a)? = v else { return nil }
+        switch a.raw {
+        case "leading", "top-leading", "bottom-leading": return .leading
+        case "trailing", "top-trailing", "bottom-trailing": return .trailing
+        default: return .center
+        }
+    }
+
+    private func vertical(_ v: RNValue?) -> VerticalAlignment? {
+        guard case .alignment(let a)? = v else { return nil }
+        switch a.raw {
+        case "top", "top-leading", "top-trailing": return .top
+        case "bottom", "bottom-leading", "bottom-trailing": return .bottom
+        case "firstTextBaseline", "first-text-baseline": return .firstTextBaseline
+        case "lastTextBaseline", "last-text-baseline": return .lastTextBaseline
+        default: return .center
+        }
+    }
+
+    private func alignment2D(_ v: RNValue?) -> Alignment? {
+        guard case .alignment(let a)? = v else { return nil }
+        return alignment(a)
+    }
+
+    private func alignment(_ a: RNAlignment) -> Alignment {
+        switch a.raw {
+        case "leading": return .leading
+        case "trailing": return .trailing
+        case "top": return .top
+        case "bottom": return .bottom
+        case "top-leading": return .topLeading
+        case "top-trailing": return .topTrailing
+        case "bottom-leading": return .bottomLeading
+        case "bottom-trailing": return .bottomTrailing
+        case "center": return .center
+        default: return .center
+        }
+    }
+
+    private func textAlignment(_ a: RNAlignment) -> TextAlignment {
+        switch a.raw {
+        case "leading": return .leading
+        case "trailing": return .trailing
+        default: return .center
+        }
+    }
+
+    private func truncationMode(_ name: String?) -> Text.TruncationMode {
+        switch name {
+        case "head": return .head
+        case "middle": return .middle
+        default: return .tail
+        }
+    }
+}
+
+private extension RNValue {
+    var actionValue: RNAction? {
+        if case .action(let a) = self { return a }
+        return nil
+    }
+}
+
+extension Color {
+    /// Parses `#rgb`, `#rrggbb`, or `#rrggbbaa`. Returns nil on malformed input.
+    init?(hex: String) {
+        var s = hex
+        if s.hasPrefix("#") { s.removeFirst() }
+        guard let value = UInt64(s, radix: 16) else { return nil }
+        let r, g, b, a: Double
+        switch s.count {
+        case 3:
+            r = Double((value >> 8) & 0xF) / 15
+            g = Double((value >> 4) & 0xF) / 15
+            b = Double(value & 0xF) / 15
+            a = 1
+        case 6:
+            r = Double((value >> 16) & 0xFF) / 255
+            g = Double((value >> 8) & 0xFF) / 255
+            b = Double(value & 0xFF) / 255
+            a = 1
+        case 8:
+            r = Double((value >> 24) & 0xFF) / 255
+            g = Double((value >> 16) & 0xFF) / 255
+            b = Double((value >> 8) & 0xFF) / 255
+            a = Double(value & 0xFF) / 255
+        default:
+            return nil
+        }
+        self = Color(.sRGB, red: r, green: g, blue: b, opacity: a)
+    }
+}

--- a/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/RenderNodeView.swift
+++ b/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/RenderNodeView.swift
@@ -55,6 +55,13 @@ struct RenderNodeRenderer {
             return AnyView(ZStack(
                 alignment: alignment2D(node.content["alignment"]) ?? .center
             ) { children(node.children) })
+        case "grid":
+            let columnCount = max(1, Int(node.content["columns"]?.number ?? 2))
+            let spacing = CGFloat(node.content["spacing"]?.number ?? 4)
+            let columns = Array(repeating: GridItem(.flexible(), spacing: spacing), count: columnCount)
+            return AnyView(LazyVGrid(columns: columns, alignment: .leading, spacing: spacing) {
+                children(node.children)
+            })
         case "group":
             return AnyView(Group { children(node.children) })
         case "text":
@@ -157,6 +164,8 @@ struct RenderNodeRenderer {
             return AnyView(view.rotationEffect(.degrees(m.first?.number ?? 0)))
         case "line-limit":
             return AnyView(view.lineLimit(Int(m.first?.number ?? 1)))
+        case "minimum-scale-factor":
+            return AnyView(view.minimumScaleFactor(CGFloat(m.first?.number ?? 1)))
         case "kerning":
             return AnyView(view.kerning(CGFloat(m.first?.number ?? 0)))
         case "layout-priority":
@@ -181,6 +190,11 @@ struct RenderNodeRenderer {
             if case .list(let xy)? = m.first, xy.count == 2 {
                 return AnyView(view.offset(x: CGFloat(xy[0].number ?? 0), y: CGFloat(xy[1].number ?? 0)))
             }
+            return view
+        case "scale":
+            return AnyView(view.scaleEffect(CGFloat(m.first?.number ?? 1)))
+        case "mask":
+            if case .node(let n)? = m.first { return AnyView(view.mask { self.view(for: n) }) }
             return view
         case "bold":
             return boolOn(m) ? AnyView(view.bold()) : view

--- a/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/RenderValues.swift
+++ b/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/RenderValues.swift
@@ -1,0 +1,125 @@
+import Foundation
+
+/// A resolved value carried by render nodes and modifiers. Distinct from
+/// `LispValue`: this layer has no functions, symbols, or environments, so it can
+/// be compared cheaply and is safe to retain across render passes.
+public indirect enum RNValue: Equatable {
+    case number(Double)
+    case string(String)
+    case bool(Bool)
+    case color(RNColor)
+    case font(RNFont)
+    case gradient(RNGradient)
+    case alignment(RNAlignment)
+    case edges(RNEdges)
+    case shadow(RNShadow)
+    case action(RNAction)
+    case node(RenderNode)
+    case list([RNValue])
+    case null
+
+    public var number: Double? {
+        if case .number(let n) = self { return n }
+        return nil
+    }
+    public var string: String? {
+        if case .string(let s) = self { return s }
+        return nil
+    }
+}
+
+public enum RNColor: Equatable {
+    case hex(String)
+    case rgba(Double, Double, Double, Double)
+    /// A named SwiftUI Color asset or CSS-ish color name.
+    case named(String)
+    /// A semantic color: "primary", "secondary", "accent", "clear".
+    case semantic(String)
+}
+
+public struct RNFont: Equatable {
+    public var size: Double?
+    /// "thin", "light", "regular", "medium", "semibold", "bold", "heavy", "black".
+    public var weight: String?
+    /// "default", "serif", "rounded", "monospaced".
+    public var design: String?
+    /// A system text style, e.g. "body", "headline", "caption".
+    public var textStyle: String?
+    public var italic: Bool
+    public var monospacedDigit: Bool
+
+    public init(
+        size: Double? = nil,
+        weight: String? = nil,
+        design: String? = nil,
+        textStyle: String? = nil,
+        italic: Bool = false,
+        monospacedDigit: Bool = false
+    ) {
+        self.size = size
+        self.weight = weight
+        self.design = design
+        self.textStyle = textStyle
+        self.italic = italic
+        self.monospacedDigit = monospacedDigit
+    }
+}
+
+public struct RNGradient: Equatable {
+    public enum Direction: String { case vertical, horizontal, diagonal }
+    public var colors: [RNColor]
+    public var direction: Direction
+    public init(colors: [RNColor], direction: Direction) {
+        self.colors = colors
+        self.direction = direction
+    }
+}
+
+/// A 2D alignment token: "leading", "center", "trailing", "top", "bottom",
+/// "top-leading", "bottom-trailing", etc.
+public struct RNAlignment: Equatable {
+    public var raw: String
+    public init(_ raw: String) { self.raw = raw }
+}
+
+/// Edge inset spec (a uniform amount or per-edge).
+public struct RNEdges: Equatable {
+    public var top: Double
+    public var leading: Double
+    public var bottom: Double
+    public var trailing: Double
+    public init(top: Double = 0, leading: Double = 0, bottom: Double = 0, trailing: Double = 0) {
+        self.top = top
+        self.leading = leading
+        self.bottom = bottom
+        self.trailing = trailing
+    }
+    public static func uniform(_ v: Double) -> RNEdges {
+        RNEdges(top: v, leading: v, bottom: v, trailing: v)
+    }
+}
+
+public struct RNShadow: Equatable {
+    public var color: RNColor
+    public var radius: Double
+    public var x: Double
+    public var y: Double
+    public init(color: RNColor, radius: Double, x: Double = 0, y: Double = 0) {
+        self.color = color
+        self.radius = radius
+        self.x = x
+        self.y = y
+    }
+}
+
+/// A side-effect a node can request (a tap target). The host resolves these to
+/// real behavior (open a URL, copy text, ...). Equatable so nodes stay
+/// comparable; the payload is plain data.
+public struct RNAction: Equatable {
+    public var kind: String
+    public var payload: [String: String]
+    public init(kind: String, payload: [String: String] = [:]) {
+        self.kind = kind
+        self.payload = payload
+    }
+}

--- a/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Resources/AgentOpsSidebar.lisp
+++ b/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Resources/AgentOpsSidebar.lisp
@@ -54,3 +54,26 @@
       (map port-button (get ws :ports)))
     (when (get ws :progress)
       (progress-view :value (get ws :progress) :total 1 :tint (accent ws)))))
+
+(def (ops-card ws)
+  (button
+    (render-row ws)
+    :action (select-workspace ws)
+    :padding (edges :horizontal 6 :vertical 6)
+    :background (if (get ws :active) (rgba 52 199 89 0.12) (rgba 127 127 127 0.08))
+    :overlay (rounded-rectangle :radius 10 :stroke (if (get ws :active) (color :green) (rgba 127 127 127 0.18)) :stroke-width 1)
+    :corner-radius 10
+    :max-width infinity
+    :frame-align leading))
+
+(def (render-sidebar sidebar)
+  (vstack :spacing 8 :max-width infinity :frame-align leading
+    (grid :columns 3 :spacing 4
+      (tile "TOTAL" (str (get sidebar :workspace-count)) "rectangle.stack.fill" (color :blue))
+      (tile "MODE" "LISP" "curlybraces" (color :purple))
+      (tile "SCOPE" "FULL" "sidebar.left" (color :green)))
+    (map ops-card (get sidebar :workspaces))
+    (button
+      (tile "SPAWN" "NEW" "plus.circle.fill" (color :green))
+      :action (new-workspace :title "Agent Ops"))
+    :padding (edges :horizontal 8 :vertical 10)))

--- a/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Resources/AgentOpsSidebar.lisp
+++ b/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Resources/AgentOpsSidebar.lisp
@@ -1,108 +1,56 @@
-;; A user-provided-style ops dashboard: row content becomes a compact status
-;; console for ports, PRs, remote targets, messages, and progress.
-
-(def (muted ws)
-  (if (get ws :dark-mode) (rgba 235 235 245 0.55) (rgba 60 60 67 0.58)))
+;; Ops dashboard. A tile board with alerts, service links, PR state, and status.
 
 (def (accent ws)
   (if (get ws :active) (color :green) (if (get ws :color) (hex (get ws :color)) (color :accent))))
 
-(def (metric title value color)
-  (vstack :spacing 1 :frame-align leading
-    (text title
-      :font (font :size 8 :weight bold :design monospaced)
-      :foreground (rgba 180 180 190 0.75)
-      :line-limit 1)
+(def (tile label value system tint)
+  (vstack :spacing 3 :frame-align leading
+    (hstack :spacing 4
+      (image :system system :font (font :size 9 :weight black) :foreground tint)
+      (text label
+        :font (font :size 8 :weight black :design monospaced)
+        :foreground (color :secondary)))
     (text value
-      :font (font :size 12 :weight black :design monospaced)
-      :foreground color
+      :font (font :size 13 :weight black :design monospaced)
+      :foreground tint
       :line-limit 1)
-    :padding (edges :horizontal 7 :vertical 5)
-    :background (rounded-rectangle :radius 8 :fill (rgba 127 127 127 0.14))
-    :overlay (rounded-rectangle :radius 8 :stroke (rgba 255 255 255 0.10) :stroke-width 1)))
+    :padding (edges :horizontal 7 :vertical 6)
+    :background (rounded-rectangle :radius 9 :fill (rgba 127 127 127 0.13))
+    :overlay (rounded-rectangle :radius 9 :stroke (rgba 255 255 255 0.10) :stroke-width 1)))
 
-(def (pr-state-count state prs)
-  (count (filter (fn (pr) (= (get pr :state) state)) prs)))
+(def (status-tile item)
+  (tile (upper (get item :label)) (get item :value) "circle.fill"
+    (if (get item :color) (hex (get item :color)) (color :green))))
 
-(def (status-dot item)
-  (hstack :spacing 5
-    (circle :fill (if (get item :color) (hex (get item :color)) (color :green)) :width 7 :height 7)
-    (text (str (upper (get item :label)) " " (get item :value))
-      :font (font :size 9 :weight semibold :design monospaced)
-      :line-limit 1
-      :truncation tail)))
+(def (open-prs prs)
+  (count (filter (fn (pr) (= (get pr :state) "open")) prs)))
 
-(def (port-link port)
+(def (port-button port)
   (button
-    (hstack :spacing 4
-      (image :system "link" :font (font :size 8 :weight bold))
-      (text (str port) :font (font :size 10 :weight bold :design monospaced)))
-    :action (open-url (str "http://localhost:" port))
-    :foreground (color :white)
-    :padding (edges :horizontal 6 :vertical 3)
-    :background (rgba 10 132 255 0.82)
-    :corner-radius 7))
-
-(def (pr-link pr)
-  (button
-    (hstack :spacing 4
-      (image :system (if (get pr :stale) "clock.badge.exclamationmark" "arrow.triangle.pull")
-        :font (font :size 9 :weight bold))
-      (text (str "#" (get pr :number))
-        :font (font :size 10 :weight bold :design monospaced)))
-    :action (open-url (get pr :url))
-    :foreground (cond
-      ((= (get pr :state) "merged") (color :purple))
-      ((= (get pr :state) "closed") (color :red))
-      ((get pr :draft) (color :gray))
-      (else (color :green)))
-    :padding (edges :horizontal 5 :vertical 3)
-    :background (rgba 127 127 127 0.12)
-    :corner-radius 7))
+    (tile "HTTP" (str port) "link" (color :blue))
+    :action (open-url (str "http://localhost:" port))))
 
 (def (render-row ws)
-  (vstack :spacing 7 :max-width infinity :frame-align leading
+  (vstack :spacing 6 :max-width infinity :frame-align leading
     (hstack :spacing 6
-      (zstack
-        (circle :fill (accent ws) :width 18 :height 18 :opacity 0.24)
-        (circle :stroke (accent ws) :stroke-width 1 :width 18 :height 18)
-        (circle :fill (accent ws) :width 6 :height 6))
-      (vstack :spacing 1 :frame-align leading :max-width infinity
-        (text (upper (get ws :title))
-          :font (font :size 11 :weight black :design monospaced)
-          :line-limit 1
-          :truncation tail)
-        (when (get ws :message)
-          (text (get ws :message)
-            :font (font :size 10)
-            :foreground (muted ws)
-            :line-limit 1
-            :truncation tail)))
+      (circle :fill (accent ws) :width 9 :height 9)
+      (text (upper (get ws :title))
+        :font (font :size 11 :weight black :design monospaced)
+        :line-limit 1
+        :truncation tail)
+      (spacer)
       (when (> (get ws :unread) 0)
-        (metric "ALERT" (str (get ws :unread)) (color :red))))
-    (hstack :spacing 5
-      (metric "PRS" (str (count (get ws :pull-requests))) (color :purple))
-      (metric "OPEN" (str (pr-state-count "open" (get ws :pull-requests))) (color :green))
-      (metric "PORTS" (str (count (get ws :ports))) (color :blue)))
-    (when (or (get ws :branch) (get ws :remote))
-      (hstack :spacing 6
-        (when (get ws :branch)
-          (label :system "arrow.triangle.branch" :text (get ws :branch)
-            :font (font :size 10 :weight semibold :design monospaced)
-            :foreground (muted ws)
-            :line-limit 1
-            :truncation middle))
-        (when (get ws :remote)
-          (label :system "antenna.radiowaves.left.and.right" :text (get ws :remote)
-            :font (font :size 10 :weight semibold :design monospaced)
-            :foreground (color :green)
-            :line-limit 1))))
-    (when (not (empty? (get ws :status)))
-      (vstack :spacing 2 :max-width infinity :frame-align leading
-        (map status-dot (get ws :status))))
-    (when (not (empty? (get ws :ports)))
-      (hstack :spacing 4 (map port-link (get ws :ports))))
-    (when (not (empty? (get ws :pull-requests)))
-      (hstack :spacing 4 (map pr-link (get ws :pull-requests))))
+        (text "ALERT"
+          :font (font :size 8 :weight black :design monospaced)
+          :foreground (color :white)
+          :padding (edges :horizontal 6 :vertical 2)
+          :background (color :red)
+          :corner-radius 6)))
+    (grid :columns 3 :spacing 4
+      (tile "PRS" (str (open-prs (get ws :pull-requests))) "arrow.triangle.pull" (color :purple))
+      (tile "PORTS" (str (count (get ws :ports))) "network" (color :blue))
+      (tile "MSG" (str (get ws :unread)) "bell.fill" (color :red))
+      (map status-tile (get ws :status))
+      (map port-button (get ws :ports)))
     (when (get ws :progress)
       (progress-view :value (get ws :progress) :total 1 :tint (accent ws)))))

--- a/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Resources/AgentOpsSidebar.lisp
+++ b/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Resources/AgentOpsSidebar.lisp
@@ -1,0 +1,108 @@
+;; A user-provided-style ops dashboard: row content becomes a compact status
+;; console for ports, PRs, remote targets, messages, and progress.
+
+(def (muted ws)
+  (if (get ws :dark-mode) (rgba 235 235 245 0.55) (rgba 60 60 67 0.58)))
+
+(def (accent ws)
+  (if (get ws :active) (color :green) (if (get ws :color) (hex (get ws :color)) (color :accent))))
+
+(def (metric title value color)
+  (vstack :spacing 1 :frame-align leading
+    (text title
+      :font (font :size 8 :weight bold :design monospaced)
+      :foreground (rgba 180 180 190 0.75)
+      :line-limit 1)
+    (text value
+      :font (font :size 12 :weight black :design monospaced)
+      :foreground color
+      :line-limit 1)
+    :padding (edges :horizontal 7 :vertical 5)
+    :background (rounded-rectangle :radius 8 :fill (rgba 127 127 127 0.14))
+    :overlay (rounded-rectangle :radius 8 :stroke (rgba 255 255 255 0.10) :stroke-width 1)))
+
+(def (pr-state-count state prs)
+  (count (filter (fn (pr) (= (get pr :state) state)) prs)))
+
+(def (status-dot item)
+  (hstack :spacing 5
+    (circle :fill (if (get item :color) (hex (get item :color)) (color :green)) :width 7 :height 7)
+    (text (str (upper (get item :label)) " " (get item :value))
+      :font (font :size 9 :weight semibold :design monospaced)
+      :line-limit 1
+      :truncation tail)))
+
+(def (port-link port)
+  (button
+    (hstack :spacing 4
+      (image :system "link" :font (font :size 8 :weight bold))
+      (text (str port) :font (font :size 10 :weight bold :design monospaced)))
+    :action (open-url (str "http://localhost:" port))
+    :foreground (color :white)
+    :padding (edges :horizontal 6 :vertical 3)
+    :background (rgba 10 132 255 0.82)
+    :corner-radius 7))
+
+(def (pr-link pr)
+  (button
+    (hstack :spacing 4
+      (image :system (if (get pr :stale) "clock.badge.exclamationmark" "arrow.triangle.pull")
+        :font (font :size 9 :weight bold))
+      (text (str "#" (get pr :number))
+        :font (font :size 10 :weight bold :design monospaced)))
+    :action (open-url (get pr :url))
+    :foreground (cond
+      ((= (get pr :state) "merged") (color :purple))
+      ((= (get pr :state) "closed") (color :red))
+      ((get pr :draft) (color :gray))
+      (else (color :green)))
+    :padding (edges :horizontal 5 :vertical 3)
+    :background (rgba 127 127 127 0.12)
+    :corner-radius 7))
+
+(def (render-row ws)
+  (vstack :spacing 7 :max-width infinity :frame-align leading
+    (hstack :spacing 6
+      (zstack
+        (circle :fill (accent ws) :width 18 :height 18 :opacity 0.24)
+        (circle :stroke (accent ws) :stroke-width 1 :width 18 :height 18)
+        (circle :fill (accent ws) :width 6 :height 6))
+      (vstack :spacing 1 :frame-align leading :max-width infinity
+        (text (upper (get ws :title))
+          :font (font :size 11 :weight black :design monospaced)
+          :line-limit 1
+          :truncation tail)
+        (when (get ws :message)
+          (text (get ws :message)
+            :font (font :size 10)
+            :foreground (muted ws)
+            :line-limit 1
+            :truncation tail)))
+      (when (> (get ws :unread) 0)
+        (metric "ALERT" (str (get ws :unread)) (color :red))))
+    (hstack :spacing 5
+      (metric "PRS" (str (count (get ws :pull-requests))) (color :purple))
+      (metric "OPEN" (str (pr-state-count "open" (get ws :pull-requests))) (color :green))
+      (metric "PORTS" (str (count (get ws :ports))) (color :blue)))
+    (when (or (get ws :branch) (get ws :remote))
+      (hstack :spacing 6
+        (when (get ws :branch)
+          (label :system "arrow.triangle.branch" :text (get ws :branch)
+            :font (font :size 10 :weight semibold :design monospaced)
+            :foreground (muted ws)
+            :line-limit 1
+            :truncation middle))
+        (when (get ws :remote)
+          (label :system "antenna.radiowaves.left.and.right" :text (get ws :remote)
+            :font (font :size 10 :weight semibold :design monospaced)
+            :foreground (color :green)
+            :line-limit 1))))
+    (when (not (empty? (get ws :status)))
+      (vstack :spacing 2 :max-width infinity :frame-align leading
+        (map status-dot (get ws :status))))
+    (when (not (empty? (get ws :ports)))
+      (hstack :spacing 4 (map port-link (get ws :ports))))
+    (when (not (empty? (get ws :pull-requests)))
+      (hstack :spacing 4 (map pr-link (get ws :pull-requests))))
+    (when (get ws :progress)
+      (progress-view :value (get ws :progress) :total 1 :tint (accent ws)))))

--- a/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Resources/DefaultSidebar.lisp
+++ b/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Resources/DefaultSidebar.lisp
@@ -1,0 +1,121 @@
+;; cmux default sidebar row.
+;;
+;; `render-row` receives one workspace record and returns a view. Copy this file
+;; to ~/.config/cmux/sidebar.lisp and edit it to customize the sidebar. Anything
+;; you can express in SwiftUI you can build here: stacks, text, images, shapes,
+;; colors, fonts, and the usual view modifiers as :keyword options.
+;;
+;; The workspace record fields: :title :detail :branch :directory :directories
+;; :pull-requests (list of {:number :state :url :title :draft :stale})
+;; :ports (list) :unread :pinned :active :selected :color :dark-mode :message
+;; :progress :remote :status (list of {:label :value :color}).
+
+(def (secondary ws)
+  (if (get ws :dark-mode)
+      (rgba 235 235 245 0.6)
+      (rgba 60 60 67 0.6)))
+
+(def (title-color ws)
+  (cond
+    ((get ws :active) (if (get ws :dark-mode) (color :white) (color :black)))
+    (else (color :primary))))
+
+(def (pr-color pr)
+  (cond
+    ((= (get pr :state) "merged") (color :purple))
+    ((= (get pr :state) "closed") (color :red))
+    ((get pr :draft) (color :gray))
+    (else (color :green))))
+
+(def (unread-badge ws)
+  (when (> (get ws :unread) 0)
+    (text (str (get ws :unread))
+      :font (font :size 10 :weight bold :monospaced-digit true)
+      :foreground (color :white)
+      :padding (edges :horizontal 5 :vertical 1)
+      :background (color :red)
+      :corner-radius 8)))
+
+(def (header ws)
+  (hstack :spacing 5
+    (when (get ws :pinned)
+      (image :system "pin.fill"
+        :font (font :size 9)
+        :foreground (secondary ws)))
+    (text (get ws :title)
+      :font (font :size 13 :weight semibold)
+      :foreground (title-color ws)
+      :line-limit 1
+      :truncation tail)
+    (spacer)
+    (unread-badge ws)))
+
+(def (branch-line ws)
+  (when (get ws :branch)
+    (hstack :spacing 4
+      (image :system "arrow.triangle.branch"
+        :font (font :size 10)
+        :foreground (secondary ws))
+      (text (get ws :branch)
+        :font (font :size 10 :design monospaced)
+        :foreground (secondary ws)
+        :line-limit 1
+        :truncation middle))))
+
+(def (directory-line ws)
+  (when (get ws :directory)
+    (text (get ws :directory)
+      :font (font :size 10)
+      :foreground (secondary ws)
+      :line-limit 1
+      :truncation head)))
+
+(def (pr-row pr)
+  (hstack :spacing 4
+    (image :system "circle.fill"
+      :font (font :size 7)
+      :foreground (pr-color pr))
+    (text (str "#" (get pr :number))
+      :font (font :size 10 :weight medium :design monospaced)
+      :foreground (pr-color pr)
+      :line-limit 1)
+    (when (get pr :stale)
+      (image :system "clock.badge.exclamationmark"
+        :font (font :size 9)
+        :foreground (color :orange)))
+    :on-tap (open-url (get pr :url))))
+
+(def (port-chip port)
+  (text (str port)
+    :font (font :size 9 :design monospaced)
+    :foreground (color :white)
+    :padding (edges :horizontal 4 :vertical 1)
+    :background (rgba 10 132 255 0.85)
+    :corner-radius 4
+    :on-tap (open-url (str "http://localhost:" port))))
+
+(def (ports-line ws)
+  (when (not (empty? (get ws :ports)))
+    (hstack :spacing 4
+      (map port-chip (get ws :ports)))))
+
+(def (progress-bar ws)
+  (when (get ws :progress)
+    (progress-view :value (get ws :progress) :total 1
+      :tint (color :accent))))
+
+;; cmux draws the row's selection background, padding, and chrome. The script
+;; owns the row's content: layout, typography, badges, and colors.
+(def (render-row ws)
+  (vstack :spacing 4 :max-width infinity :frame-align leading
+    (header ws)
+    (when (get ws :detail)
+      (text (get ws :detail)
+        :font (font :size 11)
+        :foreground (secondary ws)
+        :line-limit 2))
+    (branch-line ws)
+    (directory-line ws)
+    (map pr-row (get ws :pull-requests))
+    (ports-line ws)
+    (progress-bar ws)))

--- a/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Resources/FinderSidebar.lisp
+++ b/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Resources/FinderSidebar.lisp
@@ -53,6 +53,45 @@
     (tree-line 2 (str "localhost:" port) "network" (color :blue) false)
     :action (open-url (str "http://localhost:" port))))
 
+(def (workspace-expanded-key ws)
+  (str "finder.workspace." (get ws :id)))
+
+(def (expanded? state key)
+  (= (get state key "false") "true"))
+
+(def (disclosure ws state)
+  (button
+    (image :system (if (expanded? state (workspace-expanded-key ws)) "chevron.down" "chevron.right")
+      :font (font :size 9 :weight bold)
+      :foreground (muted ws)
+      :width 13
+      :frame-align center)
+    :action (toggle-sidebar-state (workspace-expanded-key ws))))
+
+(def (file-row file ws)
+  (button
+    (hstack :spacing 5
+      (image :system (if (get file :directory) "folder.fill" "doc")
+        :font (font :size 11 :weight medium)
+        :foreground (if (get file :directory) (color :blue) (muted ws))
+        :width 16
+        :frame-align center)
+      (text (get file :name)
+        :font (font :size 11)
+        :line-limit 1
+        :truncation tail)
+      (spacer)
+      :padding (edges :leading 34 :trailing 4 :vertical 2)
+      :corner-radius 5)
+    :action (open-workspace file)
+    :max-width infinity
+    :frame-align leading))
+
+(def (workspace-files ws state)
+  (when (expanded? state (workspace-expanded-key ws))
+    (vstack :spacing 1 :max-width infinity :frame-align leading
+      (map (fn (file) (file-row file ws)) (get ws :files)))))
+
 (def (render-row ws)
   (vstack :spacing 2 :max-width infinity :frame-align leading
     (hstack :spacing 6
@@ -72,12 +111,16 @@
     (map pr-leaf (get ws :pull-requests))
     (map port-leaf (get ws :ports))))
 
-(def (workspace-node ws)
-  (button
-    (render-row ws)
-    :action (select-workspace ws)
-    :max-width infinity
-    :frame-align leading))
+(def (workspace-node ws state)
+  (vstack :spacing 1 :max-width infinity :frame-align leading
+    (hstack :spacing 0
+      (disclosure ws state)
+      (button
+        (render-row ws)
+        :action (select-workspace ws)
+        :max-width infinity
+        :frame-align leading))
+    (workspace-files ws state)))
 
 (def (render-sidebar sidebar)
   (vstack :spacing 5 :max-width infinity :frame-align leading
@@ -89,7 +132,7 @@
       (text (str (get sidebar :workspace-count))
         :font (font :size 10 :weight bold :monospaced-digit true)
         :foreground (color :secondary)))
-    (map workspace-node (get sidebar :workspaces))
+    (map (fn (ws) (workspace-node ws (get sidebar :state))) (get sidebar :workspaces))
     (button
       (tree-line 0 "New Workspace" "plus" (color :blue) false)
       :action (new-workspace :title "Scratch"))

--- a/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Resources/FinderSidebar.lisp
+++ b/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Resources/FinderSidebar.lisp
@@ -1,0 +1,77 @@
+;; Finder-like rows with filled icons, rounded selections inside the content, and
+;; hover-friendly spacing.
+
+(def (muted ws)
+  (if (get ws :dark-mode) (rgba 235 235 245 0.56) (rgba 60 60 67 0.56)))
+
+(def (folder-symbol ws)
+  (cond
+    ((get ws :pinned) "pin.fill")
+    ((get ws :remote) "externaldrive.connected.to.line.below.fill")
+    ((not (empty? (get ws :ports))) "network")
+    (else "folder.fill")))
+
+(def (branch ws)
+  (when (get ws :branch)
+    (hstack :spacing 4
+      (image :system "arrow.triangle.branch" :font (font :size 10 :weight medium))
+      (text (get ws :branch)
+        :font (font :size 11)
+        :line-limit 1
+        :truncation middle)
+      :foreground (muted ws))))
+
+(def (pr-count ws)
+  (let ((open (count (filter (fn (pr) (= (get pr :state) "open")) (get ws :pull-requests)))))
+    (when (> open 0)
+      (text (str open)
+        :font (font :size 11 :weight semibold :monospaced-digit true)
+        :foreground (color :white)
+        :padding (edges :horizontal 6 :vertical 1)
+        :background (color :blue)
+        :corner-radius 8))))
+
+(def (status-row item ws)
+  (hstack :spacing 5
+    (circle :fill (if (get item :color) (hex (get item :color)) (color :green)) :width 6 :height 6)
+    (text (get item :label)
+      :font (font :size 10)
+      :foreground (muted ws)
+      :line-limit 1)
+    (spacer)
+    (text (get item :value)
+      :font (font :size 10 :weight medium)
+      :foreground (color :primary)
+      :line-limit 1)))
+
+(def (render-row ws)
+  (vstack :spacing 5 :max-width infinity :frame-align leading
+    (hstack :spacing 7
+      (image :system (folder-symbol ws)
+        :font (font :size 16 :weight medium)
+        :foreground (if (get ws :active) (color :accent) (color :blue))
+        :frame-align center
+        :width 19)
+      (text (get ws :title)
+        :font (font :size 13 :weight medium)
+        :line-limit 1
+        :truncation tail)
+      (spacer)
+      (pr-count ws)
+      (when (> (get ws :unread) 0)
+        (text (str (get ws :unread))
+          :font (font :size 11 :weight semibold :monospaced-digit true)
+          :foreground (color :red))))
+    (hstack :spacing 8
+      (branch ws)
+      (when (get ws :directory)
+        (text (get ws :directory)
+          :font (font :size 11)
+          :foreground (muted ws)
+          :line-limit 1
+          :truncation head)))
+    (when (not (empty? (get ws :status)))
+      (vstack :spacing 2 :max-width infinity :frame-align leading
+        (map (fn (entry) (status-row entry ws)) (get ws :status))))
+    (when (get ws :progress)
+      (progress-view :value (get ws :progress) :total 1 :tint (color :blue)))))

--- a/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Resources/FinderSidebar.lisp
+++ b/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Resources/FinderSidebar.lisp
@@ -71,3 +71,26 @@
       (tree-line 1 (get ws :branch) "arrow.triangle.branch" (color :green) false))
     (map pr-leaf (get ws :pull-requests))
     (map port-leaf (get ws :ports))))
+
+(def (workspace-node ws)
+  (button
+    (render-row ws)
+    :action (select-workspace ws)
+    :max-width infinity
+    :frame-align leading))
+
+(def (render-sidebar sidebar)
+  (vstack :spacing 5 :max-width infinity :frame-align leading
+    (hstack :spacing 6
+      (image :system "folder.fill" :font (font :size 13 :weight semibold) :foreground (color :blue))
+      (text "Workspaces"
+        :font (font :size 13 :weight bold))
+      (spacer)
+      (text (str (get sidebar :workspace-count))
+        :font (font :size 10 :weight bold :monospaced-digit true)
+        :foreground (color :secondary)))
+    (map workspace-node (get sidebar :workspaces))
+    (button
+      (tree-line 0 "New Workspace" "plus" (color :blue) false)
+      :action (new-workspace :title "Scratch"))
+    :padding (edges :horizontal 8 :vertical 10)))

--- a/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Resources/FinderSidebar.lisp
+++ b/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Resources/FinderSidebar.lisp
@@ -1,77 +1,73 @@
-;; Finder-like rows with filled icons, rounded selections inside the content, and
-;; hover-friendly spacing.
+;; Nested Finder tree. Uses the row as a miniature filesystem navigator instead
+;; of a flat workspace card.
 
 (def (muted ws)
-  (if (get ws :dark-mode) (rgba 235 235 245 0.56) (rgba 60 60 67 0.56)))
+  (if (get ws :dark-mode) (rgba 235 235 245 0.55) (rgba 60 60 67 0.55)))
 
-(def (folder-symbol ws)
-  (cond
-    ((get ws :pinned) "pin.fill")
-    ((get ws :remote) "externaldrive.connected.to.line.below.fill")
-    ((not (empty? (get ws :ports))) "network")
-    (else "folder.fill")))
+(def (path-parts ws)
+  (if (get ws :directory)
+      (split (replace (replace (get ws :directory) "~/" "home/") " " "-") "/")
+      (list "workspace" (get ws :title))))
 
-(def (branch ws)
-  (when (get ws :branch)
-    (hstack :spacing 4
-      (image :system "arrow.triangle.branch" :font (font :size 10 :weight medium))
-      (text (get ws :branch)
-        :font (font :size 11)
-        :line-limit 1
-        :truncation middle)
-      :foreground (muted ws))))
-
-(def (pr-count ws)
-  (let ((open (count (filter (fn (pr) (= (get pr :state) "open")) (get ws :pull-requests)))))
-    (when (> open 0)
-      (text (str open)
-        :font (font :size 11 :weight semibold :monospaced-digit true)
-        :foreground (color :white)
-        :padding (edges :horizontal 6 :vertical 1)
-        :background (color :blue)
-        :corner-radius 8))))
-
-(def (status-row item ws)
+(def (tree-line depth label system tint selected)
   (hstack :spacing 5
-    (circle :fill (if (get item :color) (hex (get item :color)) (color :green)) :width 6 :height 6)
-    (text (get item :label)
-      :font (font :size 10)
-      :foreground (muted ws)
-      :line-limit 1)
+    (when (> depth 0)
+      (rectangle :fill (rgba 127 127 127 0.25) :width 1 :height 18
+        :padding (edges :leading (+ 6 (* (- depth 1) 12)))))
+    (image :system system
+      :font (font :size 12 :weight medium)
+      :foreground tint
+      :frame-align center
+      :width 16)
+    (text label
+      :font (font :size 12 :weight (if selected semibold regular))
+      :line-limit 1
+      :truncation tail)
     (spacer)
-    (text (get item :value)
-      :font (font :size 10 :weight medium)
-      :foreground (color :primary)
-      :line-limit 1)))
+    :padding (edges :leading (* depth 12) :trailing 4 :vertical 2)
+    :background (if selected (rgba 10 132 255 0.18) (color :clear))
+    :corner-radius 5))
+
+(def (path-line index part ws)
+  (let ((last (= index (- (count (path-parts ws)) 1))))
+    (tree-line index part
+      (cond
+        ((= index 0) "house.fill")
+        (last "folder.fill")
+        (else "folder"))
+      (if last (color :blue) (muted ws))
+      last)))
+
+(def (pr-leaf pr)
+  (tree-line 2
+    (str "#" (get pr :number) " " (get pr :state))
+    (if (get pr :stale) "clock.badge.exclamationmark" "arrow.triangle.pull")
+    (cond
+      ((= (get pr :state) "merged") (color :purple))
+      ((= (get pr :state) "closed") (color :red))
+      (else (color :green)))
+    false))
+
+(def (port-leaf port)
+  (button
+    (tree-line 2 (str "localhost:" port) "network" (color :blue) false)
+    :action (open-url (str "http://localhost:" port))))
 
 (def (render-row ws)
-  (vstack :spacing 5 :max-width infinity :frame-align leading
-    (hstack :spacing 7
-      (image :system (folder-symbol ws)
-        :font (font :size 16 :weight medium)
-        :foreground (if (get ws :active) (color :accent) (color :blue))
-        :frame-align center
-        :width 19)
+  (vstack :spacing 2 :max-width infinity :frame-align leading
+    (hstack :spacing 6
+      (image :system "sidebar.left" :font (font :size 12 :weight semibold) :foreground (color :blue))
       (text (get ws :title)
-        :font (font :size 13 :weight medium)
+        :font (font :size 12 :weight semibold)
         :line-limit 1
         :truncation tail)
       (spacer)
-      (pr-count ws)
       (when (> (get ws :unread) 0)
         (text (str (get ws :unread))
-          :font (font :size 11 :weight semibold :monospaced-digit true)
+          :font (font :size 10 :weight bold :monospaced-digit true)
           :foreground (color :red))))
-    (hstack :spacing 8
-      (branch ws)
-      (when (get ws :directory)
-        (text (get ws :directory)
-          :font (font :size 11)
-          :foreground (muted ws)
-          :line-limit 1
-          :truncation head)))
-    (when (not (empty? (get ws :status)))
-      (vstack :spacing 2 :max-width infinity :frame-align leading
-        (map (fn (entry) (status-row entry ws)) (get ws :status))))
-    (when (get ws :progress)
-      (progress-view :value (get ws :progress) :total 1 :tint (color :blue)))))
+    (map-indexed (fn (index part) (path-line index part ws)) (path-parts ws))
+    (when (get ws :branch)
+      (tree-line 1 (get ws :branch) "arrow.triangle.branch" (color :green) false))
+    (map pr-leaf (get ws :pull-requests))
+    (map port-leaf (get ws :ports))))

--- a/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Resources/HighDensityIDESidebar.lisp
+++ b/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Resources/HighDensityIDESidebar.lisp
@@ -1,72 +1,51 @@
-;; Compact IDE-style rows: small type, edge-to-edge structure, dense metadata.
+;; Dense IDE matrix. The row becomes a compact telemetry table instead of a
+;; title/detail stack.
 
 (def (muted ws)
   (if (get ws :dark-mode) (rgba 235 235 245 0.48) (rgba 60 60 67 0.55)))
 
-(def (state-color pr)
-  (cond
-    ((= (get pr :state) "merged") (color :purple))
-    ((= (get pr :state) "closed") (color :red))
-    ((get pr :draft) (color :gray))
-    (else (color :green))))
+(def (metric label value tint)
+  (vstack :spacing 1 :frame-align leading
+    (text label
+      :font (font :size 8 :weight bold :design monospaced)
+      :foreground (color :secondary)
+      :line-limit 1)
+    (text value
+      :font (font :size 12 :weight black :design monospaced)
+      :foreground tint
+      :line-limit 1
+      :minimum-scale-factor 0.7)
+    :padding (edges :horizontal 5 :vertical 4)
+    :background (rgba 127 127 127 0.11)
+    :overlay (rectangle :stroke (rgba 127 127 127 0.22) :stroke-width 1)))
 
-(def (short-path path)
-  (if (> (string-length path) 28)
-      (str "..." (substring path (- (string-length path) 25)))
-      path))
-
-(def (pr-token pr)
-  (button
-    (hstack :spacing 3
-      (circle :fill (state-color pr) :width 5 :height 5)
-      (text (str (get pr :number))
-        :font (font :size 10 :weight medium :design monospaced)
-        :foreground (state-color pr)))
-    :action (open-url (get pr :url))
-    :help (get pr :title)))
-
-(def (status-token item)
-  (text (str (get item :label) ":" (get item :value))
-    :font (font :size 9 :design monospaced)
-    :foreground (if (get item :color) (hex (get item :color)) (color :secondary))
-    :line-limit 1))
+(def (open-prs prs)
+  (count (filter (fn (pr) (= (get pr :state) "open")) prs)))
 
 (def (render-row ws)
-  (vstack :spacing 2 :max-width infinity :frame-align leading
+  (vstack :spacing 4 :max-width infinity :frame-align leading
     (hstack :spacing 4
-      (image :system (if (get ws :pinned) "pin.fill" "terminal")
-        :font (font :size 10)
-        :foreground (muted ws))
-      (text (get ws :title)
-        :font (font :size 11 :weight medium)
-        :line-limit 1
-        :truncation tail)
+      (text (substring (upper (get ws :title)) 0 24)
+        :font (font :size 10 :weight black :design monospaced)
+        :line-limit 1)
       (spacer)
-      (when (> (get ws :unread) 0)
-        (text (str (get ws :unread))
-          :font (font :size 9 :weight bold :monospaced-digit true)
-          :foreground (color :red))))
-    (hstack :spacing 6
+      (text (if (get ws :active) "ACTIVE" "IDLE")
+        :font (font :size 8 :weight black :design monospaced)
+        :foreground (if (get ws :active) (color :green) (muted ws))))
+    (grid :columns 4 :spacing 3
+      (metric "PR" (str (open-prs (get ws :pull-requests))) (color :purple))
+      (metric "PORT" (str (count (get ws :ports))) (color :blue))
+      (metric "MSG" (str (get ws :unread)) (color :red))
+      (metric "RUN" (if (get ws :progress) (str (round (* 100 (get ws :progress))) "%") "--") (color :green)))
+    (hstack :spacing 4
       (when (get ws :branch)
-        (label :system "arrow.triangle.branch" :text (get ws :branch)
-          :font (font :size 10 :design monospaced)
+        (text (get ws :branch)
+          :font (font :size 9 :design monospaced)
           :foreground (muted ws)
           :line-limit 1
           :truncation middle))
-      (when (get ws :directory)
-        (text (short-path (get ws :directory))
-          :font (font :size 10 :design monospaced)
-          :foreground (muted ws)
-          :line-limit 1
-          :truncation head)))
-    (when (or (not (empty? (get ws :pull-requests))) (not (empty? (get ws :status))))
-      (hstack :spacing 7
-        (map pr-token (get ws :pull-requests))
-        (map status-token (get ws :status))))
-    (when (not (empty? (get ws :ports)))
-      (text (str "ports " (join " " (get ws :ports)))
-        :font (font :size 9 :design monospaced)
-        :foreground (color :blue)
-        :line-limit 1))
-    (when (get ws :progress)
-      (progress-view :value (get ws :progress) :total 1 :tint (color :blue)))))
+      (spacer)
+      (when (not (empty? (get ws :ports)))
+        (text (join "," (get ws :ports))
+          :font (font :size 9 :weight medium :design monospaced)
+          :foreground (color :blue))))))

--- a/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Resources/HighDensityIDESidebar.lisp
+++ b/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Resources/HighDensityIDESidebar.lisp
@@ -49,3 +49,36 @@
         (text (join "," (get ws :ports))
           :font (font :size 9 :weight medium :design monospaced)
           :foreground (color :blue))))))
+
+(def (workspace-cell ws)
+  (button
+    (render-row ws)
+    :action (select-workspace ws)
+    :padding (edges :horizontal 6 :vertical 5)
+    :background (rgba 127 127 127 0.08)
+    :overlay (rectangle :stroke (if (get ws :active) (color :blue) (rgba 127 127 127 0.20)) :stroke-width 1)
+    :max-width infinity
+    :frame-align leading))
+
+(def (render-sidebar sidebar)
+  (vstack :spacing 6 :max-width infinity :frame-align leading
+    (hstack :spacing 6
+      (text "CMUX::SIDEBAR"
+        :font (font :size 11 :weight black :design monospaced))
+      (spacer)
+      (text (str (get sidebar :workspace-count) " WS")
+        :font (font :size 9 :weight black :design monospaced)
+        :foreground (color :secondary)))
+    (grid :columns 1 :spacing 5
+      (map workspace-cell (get sidebar :workspaces)))
+    (button
+      (text "+ NEW"
+        :font (font :size 10 :weight black :design monospaced)
+        :foreground (color :blue)
+        :max-width infinity
+        :frame-align center
+        :padding (edges :vertical 6)
+        :border (rgba 127 127 127 0.3)
+        :border-width 1)
+      :action (new-workspace :title "Scratch"))
+    :padding (edges :horizontal 8 :vertical 10)))

--- a/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Resources/HighDensityIDESidebar.lisp
+++ b/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Resources/HighDensityIDESidebar.lisp
@@ -1,0 +1,72 @@
+;; Compact IDE-style rows: small type, edge-to-edge structure, dense metadata.
+
+(def (muted ws)
+  (if (get ws :dark-mode) (rgba 235 235 245 0.48) (rgba 60 60 67 0.55)))
+
+(def (state-color pr)
+  (cond
+    ((= (get pr :state) "merged") (color :purple))
+    ((= (get pr :state) "closed") (color :red))
+    ((get pr :draft) (color :gray))
+    (else (color :green))))
+
+(def (short-path path)
+  (if (> (string-length path) 28)
+      (str "..." (substring path (- (string-length path) 25)))
+      path))
+
+(def (pr-token pr)
+  (button
+    (hstack :spacing 3
+      (circle :fill (state-color pr) :width 5 :height 5)
+      (text (str (get pr :number))
+        :font (font :size 10 :weight medium :design monospaced)
+        :foreground (state-color pr)))
+    :action (open-url (get pr :url))
+    :help (get pr :title)))
+
+(def (status-token item)
+  (text (str (get item :label) ":" (get item :value))
+    :font (font :size 9 :design monospaced)
+    :foreground (if (get item :color) (hex (get item :color)) (color :secondary))
+    :line-limit 1))
+
+(def (render-row ws)
+  (vstack :spacing 2 :max-width infinity :frame-align leading
+    (hstack :spacing 4
+      (image :system (if (get ws :pinned) "pin.fill" "terminal")
+        :font (font :size 10)
+        :foreground (muted ws))
+      (text (get ws :title)
+        :font (font :size 11 :weight medium)
+        :line-limit 1
+        :truncation tail)
+      (spacer)
+      (when (> (get ws :unread) 0)
+        (text (str (get ws :unread))
+          :font (font :size 9 :weight bold :monospaced-digit true)
+          :foreground (color :red))))
+    (hstack :spacing 6
+      (when (get ws :branch)
+        (label :system "arrow.triangle.branch" :text (get ws :branch)
+          :font (font :size 10 :design monospaced)
+          :foreground (muted ws)
+          :line-limit 1
+          :truncation middle))
+      (when (get ws :directory)
+        (text (short-path (get ws :directory))
+          :font (font :size 10 :design monospaced)
+          :foreground (muted ws)
+          :line-limit 1
+          :truncation head)))
+    (when (or (not (empty? (get ws :pull-requests))) (not (empty? (get ws :status))))
+      (hstack :spacing 7
+        (map pr-token (get ws :pull-requests))
+        (map status-token (get ws :status))))
+    (when (not (empty? (get ws :ports)))
+      (text (str "ports " (join " " (get ws :ports)))
+        :font (font :size 9 :design monospaced)
+        :foreground (color :blue)
+        :line-limit 1))
+    (when (get ws :progress)
+      (progress-view :value (get ws :progress) :total 1 :tint (color :blue)))))

--- a/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Resources/LiquidGlassSidebar.lisp
+++ b/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Resources/LiquidGlassSidebar.lisp
@@ -1,97 +1,49 @@
-;; Rounded, translucent row content inspired by the existing Liquid Glass file
-;; explorer style. cmux still owns the outer selection chrome.
-
-(def (secondary ws)
-  (if (get ws :dark-mode) (rgba 235 235 245 0.62) (rgba 60 60 67 0.62)))
+;; Layered glass poster. Uses z-stacks, masks, scale, and translucent geometry
+;; so it does not share the standard sidebar-row skeleton.
 
 (def (accent ws)
-  (if (get ws :color) (hex (get ws :color)) (color :accent)))
-
-(def (badge label fill)
-  (text label
-    :font (font :size 9 :weight semibold :monospaced-digit true)
-    :foreground (color :white)
-    :padding (edges :horizontal 5 :vertical 2)
-    :background fill
-    :corner-radius 8))
-
-(def (count-pill system value fill)
-  (when (> value 0)
-    (hstack :spacing 3
-      (image :system system :font (font :size 8 :weight semibold))
-      (text (str value) :font (font :size 9 :weight semibold :monospaced-digit true))
-      :foreground (color :white)
-      :padding (edges :horizontal 6 :vertical 2)
-      :background fill
-      :corner-radius 9)))
-
-(def (branch-pill ws)
-  (when (get ws :branch)
-    (hstack :spacing 4
-      (image :system "arrow.triangle.branch" :font (font :size 9 :weight medium))
-      (text (get ws :branch)
-        :font (font :size 10 :weight medium :design monospaced)
-        :line-limit 1
-        :truncation middle)
-      :foreground (secondary ws)
-      :padding (edges :horizontal 6 :vertical 3)
-      :background (rounded-rectangle :radius 8 :fill (rgba 127 127 127 0.13))
-      :overlay (rounded-rectangle :radius 8 :stroke (rgba 255 255 255 0.12) :stroke-width 1))))
-
-(def (pr-dot pr)
-  (circle
-    :fill (cond
-      ((= (get pr :state) "merged") (color :purple))
-      ((= (get pr :state) "closed") (color :red))
-      ((get pr :draft) (color :gray))
-      (else (color :green)))
-    :width 6
-    :height 6))
-
-(def (pr-chip pr)
-  (button
-    (hstack :spacing 4
-      (pr-dot pr)
-      (text (str "#" (get pr :number))
-        :font (font :size 10 :weight medium :design monospaced)
-        :line-limit 1))
-    :action (open-url (get pr :url))
-    :padding (edges :horizontal 6 :vertical 2)
-    :background (rgba 127 127 127 0.12)
-    :corner-radius 7))
-
-(def (ports ws)
-  (when (not (empty? (get ws :ports)))
-    (hstack :spacing 4
-      (map (fn (port)
-        (badge (str port) (rgba 10 132 255 0.85)))
-        (get ws :ports)))))
+  (if (get ws :color) (hex (get ws :color)) (rgba 10 132 255 1)))
 
 (def (render-row ws)
-  (vstack :spacing 6 :max-width infinity :frame-align leading
-    (hstack :spacing 6
-      (zstack
-        (circle :fill (accent ws) :width 18 :height 18 :opacity 0.28)
-        (image :system (if (get ws :active) "sparkle" "macwindow")
-          :font (font :size 10 :weight semibold)
-          :foreground (accent ws)))
-      (text (get ws :title)
-        :font (font :size 13 :weight semibold)
-        :line-limit 1
-        :truncation tail)
-      (spacer)
-      (count-pill "bell.fill" (get ws :unread) (color :red)))
-    (when (get ws :detail)
-      (text (get ws :detail)
-        :font (font :size 11)
-        :foreground (secondary ws)
-        :line-limit 2))
-    (hstack :spacing 5
-      (branch-pill ws)
-      (when (get ws :remote)
-        (badge (get ws :remote) (rgba 52 199 89 0.78))))
-    (when (not (empty? (get ws :pull-requests)))
-      (hstack :spacing 4 (map pr-chip (get ws :pull-requests))))
-    (ports ws)
-    (when (get ws :progress)
-      (progress-view :value (get ws :progress) :total 1 :tint (accent ws)))))
+  (zstack :alignment bottom-leading :max-width infinity :height 88
+    (rounded-rectangle :radius 14
+      :fill (gradient (rgba 10 132 255 0.30) (rgba 175 82 222 0.18) :direction diagonal)
+      :height 84
+      :max-width infinity)
+    (circle :fill (accent ws) :width 74 :height 74 :opacity 0.18
+      :offset (list 82 -16)
+      :blur 1.5)
+    (circle :fill (color :white) :width 36 :height 36 :opacity 0.12
+      :offset (list -74 24)
+      :scale 1.35)
+    (vstack :spacing 5 :max-width infinity :frame-align leading
+      (hstack :spacing 6
+        (zstack
+          (circle :fill (rgba 255 255 255 0.20) :width 28 :height 28)
+          (image :system (if (get ws :active) "sparkles" "rectangle.3.group")
+            :font (font :size 13 :weight black)
+            :foreground (color :white)))
+        (text (get ws :title)
+          :font (font :size 14 :weight black)
+          :foreground (color :white)
+          :line-limit 2)
+        (spacer))
+      (hstack :spacing 5
+        (when (get ws :branch)
+          (text (get ws :branch)
+            :font (font :size 10 :weight semibold :design monospaced)
+            :foreground (color :white)
+            :padding (edges :horizontal 7 :vertical 3)
+            :background (rgba 0 0 0 0.22)
+            :corner-radius 9))
+        (when (> (get ws :unread) 0)
+          (text (str (get ws :unread) " alerts")
+            :font (font :size 10 :weight semibold)
+            :foreground (color :white)
+            :padding (edges :horizontal 7 :vertical 3)
+            :background (rgba 255 59 48 0.82)
+            :corner-radius 9)))
+      (when (get ws :progress)
+        (progress-view :value (get ws :progress) :total 1 :tint (color :white))))
+    :padding (edges :horizontal 8 :vertical 8)
+    :mask (rounded-rectangle :radius 14 :fill (color :white) :height 84 :max-width infinity)))

--- a/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Resources/LiquidGlassSidebar.lisp
+++ b/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Resources/LiquidGlassSidebar.lisp
@@ -1,0 +1,97 @@
+;; Rounded, translucent row content inspired by the existing Liquid Glass file
+;; explorer style. cmux still owns the outer selection chrome.
+
+(def (secondary ws)
+  (if (get ws :dark-mode) (rgba 235 235 245 0.62) (rgba 60 60 67 0.62)))
+
+(def (accent ws)
+  (if (get ws :color) (hex (get ws :color)) (color :accent)))
+
+(def (badge label fill)
+  (text label
+    :font (font :size 9 :weight semibold :monospaced-digit true)
+    :foreground (color :white)
+    :padding (edges :horizontal 5 :vertical 2)
+    :background fill
+    :corner-radius 8))
+
+(def (count-pill system value fill)
+  (when (> value 0)
+    (hstack :spacing 3
+      (image :system system :font (font :size 8 :weight semibold))
+      (text (str value) :font (font :size 9 :weight semibold :monospaced-digit true))
+      :foreground (color :white)
+      :padding (edges :horizontal 6 :vertical 2)
+      :background fill
+      :corner-radius 9)))
+
+(def (branch-pill ws)
+  (when (get ws :branch)
+    (hstack :spacing 4
+      (image :system "arrow.triangle.branch" :font (font :size 9 :weight medium))
+      (text (get ws :branch)
+        :font (font :size 10 :weight medium :design monospaced)
+        :line-limit 1
+        :truncation middle)
+      :foreground (secondary ws)
+      :padding (edges :horizontal 6 :vertical 3)
+      :background (rounded-rectangle :radius 8 :fill (rgba 127 127 127 0.13))
+      :overlay (rounded-rectangle :radius 8 :stroke (rgba 255 255 255 0.12) :stroke-width 1))))
+
+(def (pr-dot pr)
+  (circle
+    :fill (cond
+      ((= (get pr :state) "merged") (color :purple))
+      ((= (get pr :state) "closed") (color :red))
+      ((get pr :draft) (color :gray))
+      (else (color :green)))
+    :width 6
+    :height 6))
+
+(def (pr-chip pr)
+  (button
+    (hstack :spacing 4
+      (pr-dot pr)
+      (text (str "#" (get pr :number))
+        :font (font :size 10 :weight medium :design monospaced)
+        :line-limit 1))
+    :action (open-url (get pr :url))
+    :padding (edges :horizontal 6 :vertical 2)
+    :background (rgba 127 127 127 0.12)
+    :corner-radius 7))
+
+(def (ports ws)
+  (when (not (empty? (get ws :ports)))
+    (hstack :spacing 4
+      (map (fn (port)
+        (badge (str port) (rgba 10 132 255 0.85)))
+        (get ws :ports)))))
+
+(def (render-row ws)
+  (vstack :spacing 6 :max-width infinity :frame-align leading
+    (hstack :spacing 6
+      (zstack
+        (circle :fill (accent ws) :width 18 :height 18 :opacity 0.28)
+        (image :system (if (get ws :active) "sparkle" "macwindow")
+          :font (font :size 10 :weight semibold)
+          :foreground (accent ws)))
+      (text (get ws :title)
+        :font (font :size 13 :weight semibold)
+        :line-limit 1
+        :truncation tail)
+      (spacer)
+      (count-pill "bell.fill" (get ws :unread) (color :red)))
+    (when (get ws :detail)
+      (text (get ws :detail)
+        :font (font :size 11)
+        :foreground (secondary ws)
+        :line-limit 2))
+    (hstack :spacing 5
+      (branch-pill ws)
+      (when (get ws :remote)
+        (badge (get ws :remote) (rgba 52 199 89 0.78))))
+    (when (not (empty? (get ws :pull-requests)))
+      (hstack :spacing 4 (map pr-chip (get ws :pull-requests))))
+    (ports ws)
+    (when (get ws :progress)
+      (progress-view :value (get ws :progress) :total 1 :tint (accent ws)))))

--- a/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Resources/LiquidGlassSidebar.lisp
+++ b/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Resources/LiquidGlassSidebar.lisp
@@ -47,3 +47,29 @@
         (progress-view :value (get ws :progress) :total 1 :tint (color :white))))
     :padding (edges :horizontal 8 :vertical 8)
     :mask (rounded-rectangle :radius 14 :fill (color :white) :height 84 :max-width infinity)))
+
+(def (poster ws)
+  (button
+    (render-row ws)
+    :action (select-workspace ws)
+    :max-width infinity
+    :frame-align leading))
+
+(def (render-sidebar sidebar)
+  (zstack :alignment top-leading :max-width infinity
+    (circle :fill (rgba 10 132 255 0.14) :width 180 :height 180 :offset (list 70 -60) :blur 8)
+    (circle :fill (rgba 175 82 222 0.12) :width 150 :height 150 :offset (list -60 160) :blur 8)
+    (vstack :spacing 10 :max-width infinity :frame-align leading
+      (text "Liquid Spaces"
+        :font (font :size 18 :weight black)
+        :foreground (color :primary))
+      (map poster (get sidebar :workspaces))
+      (button
+        (text "Create a new glass workspace"
+          :font (font :size 12 :weight semibold)
+          :foreground (color :white)
+          :padding (edges :horizontal 10 :vertical 8)
+          :background (gradient (rgba 10 132 255 0.8) (rgba 175 82 222 0.72) :direction horizontal)
+          :corner-radius 12)
+        :action (new-workspace :title "Glass Workspace"))
+      :padding (edges :horizontal 9 :vertical 11))))

--- a/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Resources/ProStudioSidebar.lisp
+++ b/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Resources/ProStudioSidebar.lisp
@@ -1,81 +1,39 @@
-;; Chunkier "pro app" row with large title, pill metadata, and layered badges.
-
-(def (accent ws)
-  (if (get ws :color) (hex (get ws :color)) (rgba 255 159 10 1)))
+;; Timeline rail. A production-console row with vertical stages and status chips.
 
 (def (muted ws)
-  (if (get ws :dark-mode) (rgba 235 235 245 0.58) (rgba 60 60 67 0.58)))
+  (if (get ws :dark-mode) (rgba 235 235 245 0.52) (rgba 60 60 67 0.55)))
 
-(def (pill label system fill)
-  (hstack :spacing 4
-    (image :system system :font (font :size 9 :weight semibold))
-    (text label :font (font :size 10 :weight semibold))
-    :foreground (color :white)
-    :padding (edges :horizontal 7 :vertical 3)
-    :background fill
-    :corner-radius 10))
-
-(def (pr-card pr)
-  (button
-    (hstack :spacing 5
-      (image :system (if (get pr :draft) "doc.badge.clock" "arrow.triangle.pull")
-        :font (font :size 10 :weight semibold))
-      (text (str "#" (get pr :number))
-        :font (font :size 11 :weight bold :design monospaced)))
-    :action (open-url (get pr :url))
-    :foreground (color :white)
-    :padding (edges :horizontal 7 :vertical 4)
-    :background (cond
-      ((= (get pr :state) "merged") (color :purple))
-      ((= (get pr :state) "closed") (color :red))
-      ((get pr :draft) (color :gray))
-      (else (color :green)))
-    :corner-radius 8))
-
-(def (port-card port)
-  (button
-    (label :system "network" :text (str port)
-      :font (font :size 10 :weight bold :design monospaced))
-    :action (open-url (str "http://localhost:" port))
-    :foreground (color :white)
-    :padding (edges :horizontal 7 :vertical 4)
-    :background (rgba 10 132 255 0.88)
-    :corner-radius 8))
+(def (stage label value system tint last)
+  (hstack :spacing 7
+    (vstack :spacing 0
+      (zstack
+        (circle :fill tint :width 16 :height 16 :opacity 0.22)
+        (image :system system :font (font :size 8 :weight black) :foreground tint))
+      (unless last
+        (rectangle :fill (rgba 127 127 127 0.22) :width 1 :height 13)))
+    (vstack :spacing 1 :frame-align leading :max-width infinity
+      (text label
+        :font (font :size 9 :weight black :design monospaced)
+        :foreground tint
+        :line-limit 1)
+      (text value
+        :font (font :size 11 :weight medium)
+        :line-limit 1
+        :truncation tail))))
 
 (def (render-row ws)
-  (vstack :spacing 7 :max-width infinity :frame-align leading
-    (hstack :spacing 7
-      (zstack
-        (rounded-rectangle :radius 8 :fill (accent ws) :width 30 :height 30 :opacity 0.22)
-        (rounded-rectangle :radius 8 :stroke (accent ws) :stroke-width 1 :width 30 :height 30)
-        (image :system (if (get ws :active) "play.fill" "square.stack.3d.up")
-          :font (font :size 13 :weight black)
-          :foreground (accent ws)))
-      (vstack :spacing 1 :max-width infinity :frame-align leading
-        (text (get ws :title)
-          :font (font :size 14 :weight bold)
-          :line-limit 1
-          :truncation tail)
-        (when (get ws :detail)
-          (text (get ws :detail)
-            :font (font :size 11 :weight medium)
-            :foreground (muted ws)
-            :line-limit 1
-            :truncation tail)))
-      (when (> (get ws :unread) 0)
-        (pill (str (get ws :unread)) "bell.fill" (color :red))))
-    (hstack :spacing 5
-      (when (get ws :branch) (pill (get ws :branch) "arrow.triangle.branch" (rgba 255 159 10 0.85)))
-      (when (get ws :remote) (pill (get ws :remote) "antenna.radiowaves.left.and.right" (rgba 52 199 89 0.78))))
-    (when (get ws :directory)
-      (label :system "folder.fill" :text (get ws :directory)
-        :font (font :size 11 :weight medium)
-        :foreground (muted ws)
+  (vstack :spacing 5 :max-width infinity :frame-align leading
+    (hstack :spacing 6
+      (text (get ws :title)
+        :font (font :size 13 :weight bold)
         :line-limit 1
-        :truncation head))
-    (when (or (not (empty? (get ws :pull-requests))) (not (empty? (get ws :ports))))
-      (hstack :spacing 5
-        (map pr-card (get ws :pull-requests))
-        (map port-card (get ws :ports))))
-    (when (get ws :progress)
-      (progress-view :value (get ws :progress) :total 1 :tint (accent ws)))))
+        :truncation tail)
+      (spacer)
+      (when (get ws :progress)
+        (text (str (round (* 100 (get ws :progress))) "%")
+          :font (font :size 10 :weight black :design monospaced)
+          :foreground (color :orange))))
+    (stage "WORKTREE" (if (get ws :directory) (get ws :directory) "not opened") "folder.fill" (color :blue) false)
+    (stage "BRANCH" (if (get ws :branch) (get ws :branch) "detached") "arrow.triangle.branch" (color :green) false)
+    (stage "REVIEW" (str (count (get ws :pull-requests)) " pull requests") "arrow.triangle.pull" (color :purple) false)
+    (stage "RUNTIME" (if (empty? (get ws :ports)) "no ports" (str "ports " (join "," (get ws :ports)))) "play.circle.fill" (color :orange) true)))

--- a/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Resources/ProStudioSidebar.lisp
+++ b/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Resources/ProStudioSidebar.lisp
@@ -37,3 +37,25 @@
     (stage "BRANCH" (if (get ws :branch) (get ws :branch) "detached") "arrow.triangle.branch" (color :green) false)
     (stage "REVIEW" (str (count (get ws :pull-requests)) " pull requests") "arrow.triangle.pull" (color :purple) false)
     (stage "RUNTIME" (if (empty? (get ws :ports)) "no ports" (str "ports " (join "," (get ws :ports)))) "play.circle.fill" (color :orange) true)))
+
+(def (timeline-card ws)
+  (button
+    (render-row ws)
+    :action (select-workspace ws)
+    :padding (edges :horizontal 8 :vertical 7)
+    :background (rounded-rectangle :radius 8 :fill (rgba 127 127 127 0.10))
+    :overlay (rounded-rectangle :radius 8 :stroke (if (get ws :active) (color :orange) (rgba 127 127 127 0.18)) :stroke-width 1)
+    :max-width infinity
+    :frame-align leading))
+
+(def (render-sidebar sidebar)
+  (vstack :spacing 7 :max-width infinity :frame-align leading
+    (hstack :spacing 6
+      (image :system "slider.horizontal.3" :font (font :size 14 :weight bold) :foreground (color :orange))
+      (text "Production Queue" :font (font :size 14 :weight bold))
+      (spacer))
+    (map timeline-card (get sidebar :workspaces))
+    (button
+      (stage "CREATE" "new blank workspace" "plus" (color :orange) true)
+      :action (new-workspace :title "Production Scratch"))
+    :padding (edges :horizontal 8 :vertical 10)))

--- a/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Resources/ProStudioSidebar.lisp
+++ b/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Resources/ProStudioSidebar.lisp
@@ -1,0 +1,81 @@
+;; Chunkier "pro app" row with large title, pill metadata, and layered badges.
+
+(def (accent ws)
+  (if (get ws :color) (hex (get ws :color)) (rgba 255 159 10 1)))
+
+(def (muted ws)
+  (if (get ws :dark-mode) (rgba 235 235 245 0.58) (rgba 60 60 67 0.58)))
+
+(def (pill label system fill)
+  (hstack :spacing 4
+    (image :system system :font (font :size 9 :weight semibold))
+    (text label :font (font :size 10 :weight semibold))
+    :foreground (color :white)
+    :padding (edges :horizontal 7 :vertical 3)
+    :background fill
+    :corner-radius 10))
+
+(def (pr-card pr)
+  (button
+    (hstack :spacing 5
+      (image :system (if (get pr :draft) "doc.badge.clock" "arrow.triangle.pull")
+        :font (font :size 10 :weight semibold))
+      (text (str "#" (get pr :number))
+        :font (font :size 11 :weight bold :design monospaced)))
+    :action (open-url (get pr :url))
+    :foreground (color :white)
+    :padding (edges :horizontal 7 :vertical 4)
+    :background (cond
+      ((= (get pr :state) "merged") (color :purple))
+      ((= (get pr :state) "closed") (color :red))
+      ((get pr :draft) (color :gray))
+      (else (color :green)))
+    :corner-radius 8))
+
+(def (port-card port)
+  (button
+    (label :system "network" :text (str port)
+      :font (font :size 10 :weight bold :design monospaced))
+    :action (open-url (str "http://localhost:" port))
+    :foreground (color :white)
+    :padding (edges :horizontal 7 :vertical 4)
+    :background (rgba 10 132 255 0.88)
+    :corner-radius 8))
+
+(def (render-row ws)
+  (vstack :spacing 7 :max-width infinity :frame-align leading
+    (hstack :spacing 7
+      (zstack
+        (rounded-rectangle :radius 8 :fill (accent ws) :width 30 :height 30 :opacity 0.22)
+        (rounded-rectangle :radius 8 :stroke (accent ws) :stroke-width 1 :width 30 :height 30)
+        (image :system (if (get ws :active) "play.fill" "square.stack.3d.up")
+          :font (font :size 13 :weight black)
+          :foreground (accent ws)))
+      (vstack :spacing 1 :max-width infinity :frame-align leading
+        (text (get ws :title)
+          :font (font :size 14 :weight bold)
+          :line-limit 1
+          :truncation tail)
+        (when (get ws :detail)
+          (text (get ws :detail)
+            :font (font :size 11 :weight medium)
+            :foreground (muted ws)
+            :line-limit 1
+            :truncation tail)))
+      (when (> (get ws :unread) 0)
+        (pill (str (get ws :unread)) "bell.fill" (color :red))))
+    (hstack :spacing 5
+      (when (get ws :branch) (pill (get ws :branch) "arrow.triangle.branch" (rgba 255 159 10 0.85)))
+      (when (get ws :remote) (pill (get ws :remote) "antenna.radiowaves.left.and.right" (rgba 52 199 89 0.78))))
+    (when (get ws :directory)
+      (label :system "folder.fill" :text (get ws :directory)
+        :font (font :size 11 :weight medium)
+        :foreground (muted ws)
+        :line-limit 1
+        :truncation head))
+    (when (or (not (empty? (get ws :pull-requests))) (not (empty? (get ws :ports))))
+      (hstack :spacing 5
+        (map pr-card (get ws :pull-requests))
+        (map port-card (get ws :ports))))
+    (when (get ws :progress)
+      (progress-view :value (get ws :progress) :total 1 :tint (accent ws)))))

--- a/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Resources/TerminalStealthSidebar.lisp
+++ b/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Resources/TerminalStealthSidebar.lisp
@@ -1,0 +1,72 @@
+;; Desaturated, monospaced rows for terminal-heavy workspaces.
+
+(def (ink ws)
+  (if (get ws :active) (color :primary) (if (get ws :dark-mode) (rgba 235 235 245 0.7) (rgba 60 60 67 0.7))))
+
+(def (dim ws)
+  (if (get ws :dark-mode) (rgba 235 235 245 0.42) (rgba 60 60 67 0.45)))
+
+(def (prompt ws)
+  (if (get ws :active) ">" "$"))
+
+(def (line label value ws)
+  (when value
+    (hstack :spacing 6
+      (text label
+        :font (font :size 10 :weight medium :design monospaced)
+        :foreground (dim ws)
+        :frame-align trailing
+        :width 28)
+      (text value
+        :font (font :size 10 :design monospaced)
+        :foreground (ink ws)
+        :line-limit 1
+        :truncation middle))))
+
+(def (pr-line pr)
+  (button
+    (hstack :spacing 6
+      (text "pr"
+        :font (font :size 10 :weight medium :design monospaced)
+        :foreground (color :secondary)
+        :frame-align trailing
+        :width 28)
+      (text (str "#" (get pr :number) " " (get pr :state))
+        :font (font :size 10 :design monospaced)
+        :foreground (cond
+          ((= (get pr :state) "merged") (color :purple))
+          ((= (get pr :state) "closed") (color :red))
+          (else (color :green)))
+        :line-limit 1))
+    :action (open-url (get pr :url))))
+
+(def (render-row ws)
+  (vstack :spacing 3 :max-width infinity :frame-align leading
+    (hstack :spacing 6
+      (text (prompt ws)
+        :font (font :size 12 :weight bold :design monospaced)
+        :foreground (if (get ws :active) (color :green) (dim ws)))
+      (text (lower (replace (get ws :title) " " "-"))
+        :font (font :size 12 :weight medium :design monospaced)
+        :foreground (ink ws)
+        :line-limit 1
+        :truncation tail)
+      (spacer)
+      (when (> (get ws :unread) 0)
+        (text (pad-left (get ws :unread) 2 "0")
+          :font (font :size 10 :weight bold :design monospaced)
+          :foreground (color :orange))))
+    (line "git" (get ws :branch) ws)
+    (line "cwd" (get ws :directory) ws)
+    (when (get ws :remote) (line "ssh" (get ws :remote) ws))
+    (map pr-line (get ws :pull-requests))
+    (when (not (empty? (get ws :ports)))
+      (line "http" (join "," (get ws :ports)) ws))
+    (when (get ws :message)
+      (text (get ws :message)
+        :font (font :size 10 :design monospaced)
+        :foreground (dim ws)
+        :line-limit 1
+        :truncation tail))
+    (when (get ws :progress)
+      (progress-view :value (get ws :progress) :total 1 :tint (color :green)))))

--- a/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Resources/TerminalStealthSidebar.lisp
+++ b/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Resources/TerminalStealthSidebar.lisp
@@ -37,3 +37,23 @@
       (line "log" (get ws :message) (dim ws)))
     (when (> (get ws :unread) 0)
       (line "!" (str (get ws :unread) " unread notifications") (color :red)))))
+
+(def (workspace-block ws)
+  (button
+    (render-row ws)
+    :action (select-workspace ws)
+    :padding (edges :vertical 4)
+    :max-width infinity
+    :frame-align leading))
+
+(def (render-sidebar sidebar)
+  (vstack :spacing 4 :max-width infinity :frame-align leading
+    (line "$" "cmux sidebar --mode lisp" (color :green))
+    (line ">" (str "workspaces=" (get sidebar :workspace-count)) (color :blue))
+    (divider :opacity 0.4)
+    (map workspace-block (get sidebar :workspaces))
+    (button
+      (line "$" "cmux new-workspace Scratch" (color :green))
+      :action (new-workspace :title "Scratch"))
+    :padding (edges :horizontal 9 :vertical 10)
+    :background (rgba 0 0 0 0.82)))

--- a/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Resources/TerminalStealthSidebar.lisp
+++ b/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Resources/TerminalStealthSidebar.lisp
@@ -1,72 +1,39 @@
-;; Desaturated, monospaced rows for terminal-heavy workspaces.
-
-(def (ink ws)
-  (if (get ws :active) (color :primary) (if (get ws :dark-mode) (rgba 235 235 245 0.7) (rgba 60 60 67 0.7))))
+;; Terminal transcript. The row looks like a tiny command session.
 
 (def (dim ws)
   (if (get ws :dark-mode) (rgba 235 235 245 0.42) (rgba 60 60 67 0.45)))
 
-(def (prompt ws)
-  (if (get ws :active) ">" "$"))
-
-(def (line label value ws)
-  (when value
-    (hstack :spacing 6
-      (text label
-        :font (font :size 10 :weight medium :design monospaced)
-        :foreground (dim ws)
-        :frame-align trailing
-        :width 28)
-      (text value
-        :font (font :size 10 :design monospaced)
-        :foreground (ink ws)
-        :line-limit 1
-        :truncation middle))))
+(def (line prompt body tint)
+  (hstack :spacing 6
+    (text prompt
+      :font (font :size 10 :weight bold :design monospaced)
+      :foreground tint
+      :width 16
+      :frame-align trailing)
+    (text body
+      :font (font :size 10 :design monospaced)
+      :line-limit 1
+      :truncation middle)))
 
 (def (pr-line pr)
   (button
-    (hstack :spacing 6
-      (text "pr"
-        :font (font :size 10 :weight medium :design monospaced)
-        :foreground (color :secondary)
-        :frame-align trailing
-        :width 28)
-      (text (str "#" (get pr :number) " " (get pr :state))
-        :font (font :size 10 :design monospaced)
-        :foreground (cond
-          ((= (get pr :state) "merged") (color :purple))
-          ((= (get pr :state) "closed") (color :red))
-          (else (color :green)))
-        :line-limit 1))
+    (line "gh" (str "pr view " (get pr :number) " --state " (get pr :state))
+      (cond
+        ((= (get pr :state) "merged") (color :purple))
+        ((= (get pr :state) "closed") (color :red))
+        (else (color :green))))
     :action (open-url (get pr :url))))
 
 (def (render-row ws)
   (vstack :spacing 3 :max-width infinity :frame-align leading
-    (hstack :spacing 6
-      (text (prompt ws)
-        :font (font :size 12 :weight bold :design monospaced)
-        :foreground (if (get ws :active) (color :green) (dim ws)))
-      (text (lower (replace (get ws :title) " " "-"))
-        :font (font :size 12 :weight medium :design monospaced)
-        :foreground (ink ws)
-        :line-limit 1
-        :truncation tail)
-      (spacer)
-      (when (> (get ws :unread) 0)
-        (text (pad-left (get ws :unread) 2 "0")
-          :font (font :size 10 :weight bold :design monospaced)
-          :foreground (color :orange))))
-    (line "git" (get ws :branch) ws)
-    (line "cwd" (get ws :directory) ws)
-    (when (get ws :remote) (line "ssh" (get ws :remote) ws))
+    (line "$" (str "cd " (if (get ws :directory) (get ws :directory) (get ws :title))) (color :green))
+    (line ">" (str "cmux workspace " (lower (replace (get ws :title) " " "-"))) (color :blue))
+    (when (get ws :branch)
+      (line "git" (str "branch --show-current  # " (get ws :branch)) (color :orange)))
     (map pr-line (get ws :pull-requests))
     (when (not (empty? (get ws :ports)))
-      (line "http" (join "," (get ws :ports)) ws))
+      (line "http" (str "open " (join " " (get ws :ports))) (color :cyan)))
     (when (get ws :message)
-      (text (get ws :message)
-        :font (font :size 10 :design monospaced)
-        :foreground (dim ws)
-        :line-limit 1
-        :truncation tail))
-    (when (get ws :progress)
-      (progress-view :value (get ws :progress) :total 1 :tint (color :green)))))
+      (line "log" (get ws :message) (dim ws)))
+    (when (> (get ws :unread) 0)
+      (line "!" (str (get ws :unread) " unread notifications") (color :red)))))

--- a/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/SidebarScript.swift
+++ b/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/SidebarScript.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+/// A compiled sidebar script.
+///
+/// `init` parses the source and evaluates its top-level forms once (which should
+/// `def` a `render-row` function and any helpers). `render(_:)` then calls
+/// `render-row` with one row's data and returns a pure `RenderNode`.
+///
+/// The expensive parse + top-level evaluation happens once at load. Per-row
+/// rendering is a single function application against a fresh evaluator, cheap
+/// enough to run for visible rows and memoizable by the host on context
+/// equality.
+public final class SidebarScript {
+    private let baseEnv: LispEnvironment
+
+    /// The entry-point function name a script must define.
+    public static let entryPoint = "render-row"
+
+    public init(source: String) throws {
+        let forms = try Reader().read(source)
+        baseEnv = LispEnvironment()
+        Builtins.install(into: baseEnv)
+        Bridge.install(into: baseEnv)
+        let evaluator = Evaluator()
+        for form in forms {
+            _ = try evaluator.eval(form, in: baseEnv)
+        }
+        guard baseEnv.lookup(Self.entryPoint) != nil else {
+            throw LispError.eval(String(
+                localized: "sidebarScript.error.missingEntry",
+                defaultValue: "The script must define a 'render-row' function.",
+                bundle: .module))
+        }
+    }
+
+    /// Renders one row to a pure node tree. Throws a localized `LispError` if the
+    /// script faults; the caller falls back to native rendering.
+    public func render(_ context: SidebarScriptContext) throws -> RenderNode {
+        guard let fn = baseEnv.lookup(Self.entryPoint) else {
+            throw LispError.eval(String(
+                localized: "sidebarScript.error.missingEntry",
+                defaultValue: "The script must define a 'render-row' function.",
+                bundle: .module))
+        }
+        let evaluator = Evaluator()
+        let result = try evaluator.apply(fn, [context.lispValue])
+        guard case .node(let node) = result else {
+            throw LispError.eval(String(
+                localized: "sidebarScript.error.entryReturn",
+                defaultValue: "'render-row' must return a view, but returned a \(result.typeName).",
+                bundle: .module))
+        }
+        return node
+    }
+
+    /// The bundled default script, used when the user has no `sidebar.lisp`.
+    public static func defaultSource() -> String {
+        guard let url = Bundle.module.url(forResource: "DefaultSidebar", withExtension: "lisp"),
+              let text = try? String(contentsOf: url, encoding: .utf8) else {
+            return ""
+        }
+        return text
+    }
+
+    /// Convenience: compile the bundled default script.
+    public static func makeDefault() throws -> SidebarScript {
+        try SidebarScript(source: defaultSource())
+    }
+}

--- a/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/SidebarScript.swift
+++ b/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/SidebarScript.swift
@@ -3,8 +3,9 @@ import Foundation
 /// A compiled sidebar script.
 ///
 /// `init` parses the source and evaluates its top-level forms once (which should
-/// `def` a `render-row` function and any helpers). `render(_:)` then calls
-/// `render-row` with one row's data and returns a pure `RenderNode`.
+/// `def` a `render-sidebar` or `render-row` function and any helpers).
+/// `renderSidebar(_:)` lets a script own the whole sidebar; `render(_:)` keeps
+/// legacy row scripts working by calling `render-row`.
 ///
 /// The expensive parse + top-level evaluation happens once at load. Per-row
 /// rendering is a single function application against a fresh evaluator, cheap
@@ -13,8 +14,10 @@ import Foundation
 public final class SidebarScript {
     private let baseEnv: LispEnvironment
 
-    /// The entry-point function name a script must define.
+    /// The legacy per-row entry-point function name.
     public static let entryPoint = "render-row"
+    /// The whole-sidebar entry-point function name.
+    public static let sidebarEntryPoint = "render-sidebar"
 
     public init(source: String) throws {
         let forms = try Reader().read(source)
@@ -25,13 +28,17 @@ public final class SidebarScript {
         for form in forms {
             _ = try evaluator.eval(form, in: baseEnv)
         }
-        guard baseEnv.lookup(Self.entryPoint) != nil else {
+        guard baseEnv.lookup(Self.sidebarEntryPoint) != nil || baseEnv.lookup(Self.entryPoint) != nil else {
             throw LispError.eval(String(
                 localized: "sidebarScript.error.missingEntry",
-                defaultValue: "The script must define a 'render-row' function.",
+                defaultValue: "The script must define a 'render-sidebar' or 'render-row' function.",
                 bundle: .module))
         }
         baseEnv.freeze()
+    }
+
+    public var supportsSidebarRendering: Bool {
+        baseEnv.lookup(Self.sidebarEntryPoint) != nil
     }
 
     /// Renders one row to a pure node tree. Throws a localized `LispError` if the
@@ -49,6 +56,27 @@ public final class SidebarScript {
             throw LispError.eval(String(
                 localized: "sidebarScript.error.entryReturn",
                 defaultValue: "'render-row' must return a view, but returned a \(result.typeName).",
+                bundle: .module))
+        }
+        return node
+    }
+
+    /// Renders the entire sidebar to a pure node tree. Throws a localized
+    /// `LispError` if the script lacks `render-sidebar` or faults; the caller
+    /// falls back to the native sidebar.
+    public func renderSidebar(_ context: SidebarScriptSidebarContext) throws -> RenderNode {
+        guard let fn = baseEnv.lookup(Self.sidebarEntryPoint) else {
+            throw LispError.eval(String(
+                localized: "sidebarScript.error.missingSidebarEntry",
+                defaultValue: "The script must define a 'render-sidebar' function.",
+                bundle: .module))
+        }
+        let evaluator = Evaluator()
+        let result = try evaluator.apply(fn, [context.lispValue])
+        guard case .node(let node) = result else {
+            throw LispError.eval(String(
+                localized: "sidebarScript.error.sidebarEntryReturn",
+                defaultValue: "'render-sidebar' must return a view, but returned a \(result.typeName).",
                 bundle: .module))
         }
         return node

--- a/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/SidebarScript.swift
+++ b/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/SidebarScript.swift
@@ -31,6 +31,7 @@ public final class SidebarScript {
                 defaultValue: "The script must define a 'render-row' function.",
                 bundle: .module))
         }
+        baseEnv.freeze()
     }
 
     /// Renders one row to a pure node tree. Throws a localized `LispError` if the

--- a/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/SidebarScriptContext.swift
+++ b/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/SidebarScriptContext.swift
@@ -36,6 +36,8 @@ public struct SidebarScriptContext: Equatable {
         }
     }
 
+    public var id: String?
+    public var index: Int?
     public var title: String
     public var detail: String?
     public var branch: String?
@@ -55,6 +57,8 @@ public struct SidebarScriptContext: Equatable {
     public var statusEntries: [StatusEntry]
 
     public init(
+        id: String? = nil,
+        index: Int? = nil,
         title: String,
         detail: String? = nil,
         branch: String? = nil,
@@ -73,6 +77,8 @@ public struct SidebarScriptContext: Equatable {
         remoteTarget: String? = nil,
         statusEntries: [StatusEntry] = []
     ) {
+        self.id = id
+        self.index = index
         self.title = title
         self.detail = detail
         self.branch = branch
@@ -95,6 +101,8 @@ public struct SidebarScriptContext: Equatable {
     /// Projects into the record passed to `render-row` as its single argument.
     public var lispValue: LispValue {
         var m = LispMap()
+        m["id"] = id.map(LispValue.string) ?? .null
+        m["index"] = index.map(LispValue.int) ?? .null
         m["title"] = .string(title)
         m["detail"] = detail.map(LispValue.string) ?? .null
         m["branch"] = branch.map(LispValue.string) ?? .null
@@ -127,6 +135,43 @@ public struct SidebarScriptContext: Equatable {
             s["color"] = entry.colorHex.map(LispValue.string) ?? .null
             return .map(s)
         })
+        return .map(m)
+    }
+}
+
+/// Whole-sidebar data for scripts that define `render-sidebar`.
+///
+/// This is deliberately just data, not live app objects. The host turns it into
+/// the same deterministic record format the row renderer uses, so a user script
+/// can own the entire sidebar without gaining arbitrary app execution.
+public struct SidebarScriptSidebarContext: Equatable {
+    public var windowId: String?
+    public var selectedWorkspaceId: String?
+    public var workspaceCount: Int
+    public var isDarkMode: Bool
+    public var workspaces: [SidebarScriptContext]
+
+    public init(
+        windowId: String? = nil,
+        selectedWorkspaceId: String? = nil,
+        workspaceCount: Int? = nil,
+        isDarkMode: Bool = true,
+        workspaces: [SidebarScriptContext]
+    ) {
+        self.windowId = windowId
+        self.selectedWorkspaceId = selectedWorkspaceId
+        self.workspaceCount = workspaceCount ?? workspaces.count
+        self.isDarkMode = isDarkMode
+        self.workspaces = workspaces
+    }
+
+    public var lispValue: LispValue {
+        var m = LispMap()
+        m["window-id"] = windowId.map(LispValue.string) ?? .null
+        m["selected-workspace-id"] = selectedWorkspaceId.map(LispValue.string) ?? .null
+        m["workspace-count"] = .int(workspaceCount)
+        m["dark-mode"] = .bool(isDarkMode)
+        m["workspaces"] = .list(workspaces.map(\.lispValue))
         return .map(m)
     }
 }

--- a/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/SidebarScriptContext.swift
+++ b/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/SidebarScriptContext.swift
@@ -1,0 +1,132 @@
+import Foundation
+
+/// The per-row data a script's `render-row` receives, as a host-friendly Swift
+/// struct. The integration layer fills this from the existing sidebar snapshot;
+/// `lispValue` projects it into the record the script sees.
+///
+/// Equatable so the integration can memoize: a row re-runs the script only when
+/// its context changes.
+public struct SidebarScriptContext: Equatable {
+    public struct PullRequest: Equatable {
+        public var number: Int
+        public var state: String      // "open", "merged", "closed", "draft"
+        public var url: String
+        public var title: String?
+        public var isDraft: Bool
+        public var isStale: Bool
+        public init(number: Int, state: String, url: String, title: String? = nil,
+                    isDraft: Bool = false, isStale: Bool = false) {
+            self.number = number
+            self.state = state
+            self.url = url
+            self.title = title
+            self.isDraft = isDraft
+            self.isStale = isStale
+        }
+    }
+
+    public struct StatusEntry: Equatable {
+        public var label: String
+        public var value: String
+        public var colorHex: String?
+        public init(label: String, value: String, colorHex: String? = nil) {
+            self.label = label
+            self.value = value
+            self.colorHex = colorHex
+        }
+    }
+
+    public var title: String
+    public var detail: String?
+    public var branch: String?
+    public var directory: String?
+    public var directories: [String]
+    public var pullRequests: [PullRequest]
+    public var ports: [Int]
+    public var unreadCount: Int
+    public var isPinned: Bool
+    public var isActive: Bool
+    public var isSelected: Bool
+    public var colorHex: String?
+    public var isDarkMode: Bool
+    public var latestMessage: String?
+    public var progress: Double?
+    public var remoteTarget: String?
+    public var statusEntries: [StatusEntry]
+
+    public init(
+        title: String,
+        detail: String? = nil,
+        branch: String? = nil,
+        directory: String? = nil,
+        directories: [String] = [],
+        pullRequests: [PullRequest] = [],
+        ports: [Int] = [],
+        unreadCount: Int = 0,
+        isPinned: Bool = false,
+        isActive: Bool = false,
+        isSelected: Bool = false,
+        colorHex: String? = nil,
+        isDarkMode: Bool = true,
+        latestMessage: String? = nil,
+        progress: Double? = nil,
+        remoteTarget: String? = nil,
+        statusEntries: [StatusEntry] = []
+    ) {
+        self.title = title
+        self.detail = detail
+        self.branch = branch
+        self.directory = directory
+        self.directories = directories
+        self.pullRequests = pullRequests
+        self.ports = ports
+        self.unreadCount = unreadCount
+        self.isPinned = isPinned
+        self.isActive = isActive
+        self.isSelected = isSelected
+        self.colorHex = colorHex
+        self.isDarkMode = isDarkMode
+        self.latestMessage = latestMessage
+        self.progress = progress
+        self.remoteTarget = remoteTarget
+        self.statusEntries = statusEntries
+    }
+
+    /// Projects into the record passed to `render-row` as its single argument.
+    public var lispValue: LispValue {
+        var m = LispMap()
+        m["title"] = .string(title)
+        m["detail"] = detail.map(LispValue.string) ?? .null
+        m["branch"] = branch.map(LispValue.string) ?? .null
+        m["directory"] = directory.map(LispValue.string) ?? .null
+        m["directories"] = .list(directories.map(LispValue.string))
+        m["pull-requests"] = .list(pullRequests.map { pr in
+            var p = LispMap()
+            p["number"] = .int(pr.number)
+            p["state"] = .string(pr.state)
+            p["url"] = .string(pr.url)
+            p["title"] = pr.title.map(LispValue.string) ?? .null
+            p["draft"] = .bool(pr.isDraft)
+            p["stale"] = .bool(pr.isStale)
+            return .map(p)
+        })
+        m["ports"] = .list(ports.map(LispValue.int))
+        m["unread"] = .int(unreadCount)
+        m["pinned"] = .bool(isPinned)
+        m["active"] = .bool(isActive)
+        m["selected"] = .bool(isSelected)
+        m["color"] = colorHex.map(LispValue.string) ?? .null
+        m["dark-mode"] = .bool(isDarkMode)
+        m["message"] = latestMessage.map(LispValue.string) ?? .null
+        m["progress"] = progress.map(LispValue.double) ?? .null
+        m["remote"] = remoteTarget.map(LispValue.string) ?? .null
+        m["status"] = .list(statusEntries.map { entry in
+            var s = LispMap()
+            s["label"] = .string(entry.label)
+            s["value"] = .string(entry.value)
+            s["color"] = entry.colorHex.map(LispValue.string) ?? .null
+            return .map(s)
+        })
+        return .map(m)
+    }
+}

--- a/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/SidebarScriptContext.swift
+++ b/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/SidebarScriptContext.swift
@@ -36,6 +36,34 @@ public struct SidebarScriptContext: Equatable {
         }
     }
 
+    public struct FileEntry: Equatable {
+        public var name: String
+        public var path: String
+        public var isDirectory: Bool
+        public var workspaceTitle: String
+        public var workspaceDirectory: String
+
+        public init(
+            name: String,
+            path: String,
+            isDirectory: Bool,
+            workspaceTitle: String? = nil,
+            workspaceDirectory: String? = nil
+        ) {
+            self.name = name
+            self.path = path
+            self.isDirectory = isDirectory
+            self.workspaceTitle = workspaceTitle ?? name
+            if let workspaceDirectory {
+                self.workspaceDirectory = workspaceDirectory
+            } else if isDirectory {
+                self.workspaceDirectory = path
+            } else {
+                self.workspaceDirectory = (path as NSString).deletingLastPathComponent
+            }
+        }
+    }
+
     public var id: String?
     public var index: Int?
     public var title: String
@@ -55,6 +83,7 @@ public struct SidebarScriptContext: Equatable {
     public var progress: Double?
     public var remoteTarget: String?
     public var statusEntries: [StatusEntry]
+    public var fileEntries: [FileEntry]
 
     public init(
         id: String? = nil,
@@ -75,7 +104,8 @@ public struct SidebarScriptContext: Equatable {
         latestMessage: String? = nil,
         progress: Double? = nil,
         remoteTarget: String? = nil,
-        statusEntries: [StatusEntry] = []
+        statusEntries: [StatusEntry] = [],
+        fileEntries: [FileEntry] = []
     ) {
         self.id = id
         self.index = index
@@ -96,6 +126,7 @@ public struct SidebarScriptContext: Equatable {
         self.progress = progress
         self.remoteTarget = remoteTarget
         self.statusEntries = statusEntries
+        self.fileEntries = fileEntries
     }
 
     /// Projects into the record passed to `render-row` as its single argument.
@@ -135,6 +166,15 @@ public struct SidebarScriptContext: Equatable {
             s["color"] = entry.colorHex.map(LispValue.string) ?? .null
             return .map(s)
         })
+        m["files"] = .list(fileEntries.map { entry in
+            var f = LispMap()
+            f["name"] = .string(entry.name)
+            f["path"] = .string(entry.path)
+            f["directory"] = .bool(entry.isDirectory)
+            f["workspace-title"] = .string(entry.workspaceTitle)
+            f["workspace-directory"] = .string(entry.workspaceDirectory)
+            return .map(f)
+        })
         return .map(m)
     }
 }
@@ -150,19 +190,22 @@ public struct SidebarScriptSidebarContext: Equatable {
     public var workspaceCount: Int
     public var isDarkMode: Bool
     public var workspaces: [SidebarScriptContext]
+    public var state: [String: String]
 
     public init(
         windowId: String? = nil,
         selectedWorkspaceId: String? = nil,
         workspaceCount: Int? = nil,
         isDarkMode: Bool = true,
-        workspaces: [SidebarScriptContext]
+        workspaces: [SidebarScriptContext],
+        state: [String: String] = [:]
     ) {
         self.windowId = windowId
         self.selectedWorkspaceId = selectedWorkspaceId
         self.workspaceCount = workspaceCount ?? workspaces.count
         self.isDarkMode = isDarkMode
         self.workspaces = workspaces
+        self.state = state
     }
 
     public var lispValue: LispValue {
@@ -172,6 +215,11 @@ public struct SidebarScriptSidebarContext: Equatable {
         m["workspace-count"] = .int(workspaceCount)
         m["dark-mode"] = .bool(isDarkMode)
         m["workspaces"] = .list(workspaces.map(\.lispValue))
+        var stateMap = LispMap()
+        for key in state.keys.sorted() {
+            stateMap[key] = state[key].map(LispValue.string) ?? .null
+        }
+        m["state"] = .map(stateMap)
         return .map(m)
     }
 }

--- a/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/SidebarScriptDemo.swift
+++ b/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/SidebarScriptDemo.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Bundled sidebar scripts users can install into `~/.config/cmux/sidebar.lisp`.
+public struct SidebarScriptDemo: Identifiable, Equatable {
+    public let id: String
+    public let resourceName: String
+    public let source: String
+
+    public init(id: String, resourceName: String, source: String) {
+        self.id = id
+        self.resourceName = resourceName
+        self.source = source
+    }
+
+    public static let all: [SidebarScriptDemo] = [
+        SidebarScriptDemo(id: "default", resourceName: "DefaultSidebar", source: SidebarScript.defaultSource()),
+        demo(id: "liquid-glass", resourceName: "LiquidGlassSidebar"),
+        demo(id: "high-density-ide", resourceName: "HighDensityIDESidebar"),
+        demo(id: "terminal-stealth", resourceName: "TerminalStealthSidebar"),
+        demo(id: "pro-studio", resourceName: "ProStudioSidebar"),
+        demo(id: "finder", resourceName: "FinderSidebar"),
+        demo(id: "agent-ops", resourceName: "AgentOpsSidebar"),
+    ]
+
+    public static func matchingDemoId(for source: String) -> String? {
+        let normalized = normalize(source)
+        return all.first { normalize($0.source) == normalized }?.id
+    }
+
+    private static func demo(id: String, resourceName: String) -> SidebarScriptDemo {
+        SidebarScriptDemo(id: id, resourceName: resourceName, source: source(resourceName: resourceName))
+    }
+
+    private static func source(resourceName: String) -> String {
+        guard let url = Bundle.module.url(forResource: resourceName, withExtension: "lisp"),
+              let text = try? String(contentsOf: url, encoding: .utf8) else {
+            return ""
+        }
+        return text
+    }
+
+    private static func normalize(_ source: String) -> String {
+        source.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/StyleValue.swift
+++ b/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/StyleValue.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// A first-class style value in the Lisp, produced by constructors like
+/// `(color ...)`, `(font ...)`, `(gradient ...)`. These are passed to view
+/// options (`:color`, `:font`, ...) and never rendered on their own.
+public enum StyleValue: Equatable {
+    case color(RNColor)
+    case font(RNFont)
+    case gradient(RNGradient)
+    case alignment(RNAlignment)
+    case edges(RNEdges)
+    case shadow(RNShadow)
+    case action(RNAction)
+
+    /// Projection into the render layer.
+    var rnValue: RNValue {
+        switch self {
+        case .color(let c): return .color(c)
+        case .font(let f): return .font(f)
+        case .gradient(let g): return .gradient(g)
+        case .alignment(let a): return .alignment(a)
+        case .edges(let e): return .edges(e)
+        case .shadow(let s): return .shadow(s)
+        case .action(let a): return .action(a)
+        }
+    }
+}

--- a/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Value.swift
+++ b/Packages/CmuxSidebarScript/Sources/CmuxSidebarScript/Value.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+/// A value in the sidebar Lisp.
+///
+/// The language is deliberately small: scalars, symbols, keywords, lists, and
+/// functions, plus two host-bridge values (`style` and `node`) that let scripts
+/// build SwiftUI render trees. Records (maps) carry structured host data such as
+/// the workspace passed to `render-row`.
+public indirect enum LispValue {
+    case null
+    case bool(Bool)
+    case int(Int)
+    case double(Double)
+    case string(String)
+    case symbol(String)
+    /// A `:keyword`. Used for map keys and as lightweight enum tokens
+    /// (alignments, weights, etc.).
+    case keyword(String)
+    case list([LispValue])
+    /// An ordered record. Keys are bare strings (a `:title` key is stored as
+    /// `"title"`). Used for the workspace passed to scripts and for any
+    /// script-built record.
+    case map(LispMap)
+    case function(LispFunction)
+    /// A resolved style value (color, font, gradient, ...). Consumed by view
+    /// modifiers; never rendered on its own.
+    case style(StyleValue)
+    /// A built render node. The result of a view form.
+    case node(RenderNode)
+}
+
+extension LispValue {
+    /// Scheme-ish truthiness: only `false`, `nil`, and the empty list are falsy.
+    /// Numbers (including 0) and strings (including "") are truthy so scripts can
+    /// branch on the presence of optional data without surprises.
+    public var isTruthy: Bool {
+        switch self {
+        case .bool(let b): return b
+        case .null: return false
+        case .list(let items): return !items.isEmpty
+        default: return true
+        }
+    }
+
+    public var typeName: String {
+        switch self {
+        case .null: return "nil"
+        case .bool: return "bool"
+        case .int: return "int"
+        case .double: return "double"
+        case .string: return "string"
+        case .symbol: return "symbol"
+        case .keyword: return "keyword"
+        case .list: return "list"
+        case .map: return "map"
+        case .function: return "function"
+        case .style: return "style"
+        case .node: return "node"
+        }
+    }
+
+    /// Numeric coercion for arithmetic and style params.
+    public var asDouble: Double? {
+        switch self {
+        case .int(let i): return Double(i)
+        case .double(let d): return d
+        default: return nil
+        }
+    }
+
+    /// Builds a numeric value from a `Double`. Integral, finite magnitudes
+    /// collapse to `.int` for clean display; everything else stays `.double`.
+    public static func number(_ d: Double) -> LispValue {
+        if d.isFinite, d == d.rounded(), abs(d) < 9e15 { return .int(Int(d)) }
+        return .double(d)
+    }
+}
+
+// MARK: - Equality (functions compare unequal; everything else is structural)
+
+extension LispValue: Equatable {
+    public static func == (lhs: LispValue, rhs: LispValue) -> Bool {
+        switch (lhs, rhs) {
+        case (.null, .null): return true
+        case let (.bool(a), .bool(b)): return a == b
+        case let (.int(a), .int(b)): return a == b
+        case let (.double(a), .double(b)): return a == b
+        case let (.int(a), .double(b)), let (.double(b), .int(a)): return Double(a) == b
+        case let (.string(a), .string(b)): return a == b
+        case let (.symbol(a), .symbol(b)): return a == b
+        case let (.keyword(a), .keyword(b)): return a == b
+        case let (.list(a), .list(b)): return a == b
+        case let (.map(a), .map(b)): return a == b
+        case let (.style(a), .style(b)): return a == b
+        case let (.node(a), .node(b)): return a == b
+        case (.function, .function): return false
+        default: return false
+        }
+    }
+}

--- a/Packages/CmuxSidebarScript/Tests/CmuxSidebarScriptTests/BridgeTests.swift
+++ b/Packages/CmuxSidebarScript/Tests/CmuxSidebarScriptTests/BridgeTests.swift
@@ -83,6 +83,27 @@ import Testing
         #expect(tap.first == .action(RNAction(kind: "open-url", payload: ["url": "https://example.com"])))
     }
 
+    @Test func workspaceActionsCarryIds() throws {
+        let node = try #require(try run("""
+        (button
+          (text "workspace")
+          :action (select-workspace (record :id "abc")))
+        """).asNode)
+        #expect(node.content["action"] == .action(RNAction(kind: "select-workspace", payload: ["id": "abc"])))
+    }
+
+    @Test func newWorkspaceActionCarriesOptions() throws {
+        let node = try #require(try run("""
+        (button
+          (text "new")
+          :action (new-workspace :title "Scratch" :directory "/tmp"))
+        """).asNode)
+        #expect(node.content["action"] == .action(RNAction(
+            kind: "new-workspace",
+            payload: ["title": "Scratch", "directory": "/tmp"]
+        )))
+    }
+
     @Test func gradientBackground() throws {
         let node = try #require(try run("""
         (rectangle :fill (gradient (color :red) (color :blue) :direction horizontal))

--- a/Packages/CmuxSidebarScript/Tests/CmuxSidebarScriptTests/BridgeTests.swift
+++ b/Packages/CmuxSidebarScript/Tests/CmuxSidebarScriptTests/BridgeTests.swift
@@ -89,4 +89,29 @@ import Testing
         """).asNode)
         #expect(node.content["fill"] == .gradient(RNGradient(colors: [.named("red"), .named("blue")], direction: .horizontal)))
     }
+
+    @Test func gridCarriesColumnsAndChildren() throws {
+        let node = try #require(try run("""
+        (grid :columns 3 :spacing 2
+          (text "a")
+          (text "b")
+          (text "c"))
+        """).asNode)
+        #expect(node.kind == "grid")
+        #expect(node.content["columns"] == .number(3))
+        #expect(node.content["spacing"] == .number(2))
+        #expect(node.children.count == 3)
+    }
+
+    @Test func maskAndScaleModifiersCarryNodesAndNumbers() throws {
+        let node = try #require(try run("""
+        (text "x" :scale 1.2 :minimum-scale-factor 0.7 :mask (circle :fill (color :white)))
+        """).asNode)
+        #expect(node.modifier("scale")?.first == .number(1.2))
+        #expect(node.modifier("minimum-scale-factor")?.first == .number(0.7))
+        #expect(node.modifier("mask")?.first == .node(RenderNode(
+            kind: "circle",
+            content: ["fill": .color(.named("white"))]
+        )))
+    }
 }

--- a/Packages/CmuxSidebarScript/Tests/CmuxSidebarScriptTests/BridgeTests.swift
+++ b/Packages/CmuxSidebarScript/Tests/CmuxSidebarScriptTests/BridgeTests.swift
@@ -1,0 +1,92 @@
+import Testing
+@testable import CmuxSidebarScript
+
+@Suite struct BridgeTests {
+    @Test func textNodeCarriesContentAndFontModifier() throws {
+        let node = try #require(try run("""
+        (text "hello"
+          :font (font :size 13 :weight semibold)
+          :foreground (color :red))
+        """).asNode)
+        #expect(node.kind == "text")
+        #expect(node.content["text"]?.string == "hello")
+        let font = try #require(node.modifier("font"))
+        #expect(font.first == .font(RNFont(size: 13, weight: "semibold")))
+        let fg = try #require(node.modifier("foreground"))
+        #expect(fg.first == .color(.named("red")))
+    }
+
+    @Test func stackParamsAndChildren() throws {
+        let node = try #require(try run("""
+        (vstack :spacing 4 :alignment leading
+          (text "a")
+          (text "b"))
+        """).asNode)
+        #expect(node.kind == "vstack")
+        #expect(node.content["spacing"] == .number(4))
+        #expect(node.content["alignment"] == .alignment(RNAlignment("leading")))
+        #expect(node.children.count == 2)
+        #expect(node.containsText("a"))
+        #expect(node.containsText("b"))
+    }
+
+    @Test func mapResultSplicesAsChildren() throws {
+        let node = try #require(try run("""
+        (hstack (map (fn (n) (text (str n))) (list 1 2 3)))
+        """).asNode)
+        #expect(node.children.count == 3)
+        #expect(node.containsText("1"))
+        #expect(node.containsText("3"))
+    }
+
+    @Test func nilChildIsDropped() throws {
+        let node = try #require(try run("""
+        (vstack (text "a") (when false (text "b")) (text "c"))
+        """).asNode)
+        #expect(node.children.count == 2)
+    }
+
+    @Test func hexColorAndPadding() throws {
+        let node = try #require(try run("""
+        (text "x" :background (hex "#ff8800") :padding (edges :horizontal 6 :vertical 2))
+        """).asNode)
+        #expect(node.modifier("background")?.first == .color(.hex("#ff8800")))
+        let padding = try #require(node.modifier("padding"))
+        #expect(padding.first == .edges(RNEdges(top: 2, leading: 6, bottom: 2, trailing: 6)))
+    }
+
+    @Test func frameOptionsCoalesce() throws {
+        let node = try #require(try run("""
+        (text "x" :max-width infinity :frame-align leading)
+        """).asNode)
+        let frame = try #require(node.modifier("frame"))
+        #expect(frame.named["max-width"] == .number(.infinity))
+        #expect(frame.named["frame-align"] == .alignment(RNAlignment("leading")))
+    }
+
+    @Test func modifierOrderIsPreserved() throws {
+        let node = try #require(try run("""
+        (text "x" :padding 4 :background (color :red) :corner-radius 6)
+        """).asNode)
+        #expect(node.modifiers.map(\.name) == ["padding", "background", "corner-radius"])
+    }
+
+    @Test func unknownModifierThrows() {
+        #expect(throws: LispError.self) { try run("(text \"x\" :bogus 1)") }
+    }
+
+    @Test func onTapCarriesAction() throws {
+        let node = try #require(try run("""
+        (text "open" :on-tap (open-url "https://example.com"))
+        """).asNode)
+        let tap = try #require(node.modifier("on-tap"))
+        #expect(tap.first == .action(RNAction(kind: "open-url", payload: ["url": "https://example.com"])))
+    }
+
+    @Test func gradientBackground() throws {
+        let node = try #require(try run("""
+        (rectangle :fill (gradient (color :red) (color :blue) :direction horizontal))
+        """).asNode)
+        #expect(node.content["fill"] == .gradient(RNGradient(colors: [.named("red"), .named("blue")], direction: .horizontal)))
+    }
+}

--- a/Packages/CmuxSidebarScript/Tests/CmuxSidebarScriptTests/BridgeTests.swift
+++ b/Packages/CmuxSidebarScript/Tests/CmuxSidebarScriptTests/BridgeTests.swift
@@ -104,6 +104,34 @@ import Testing
         )))
     }
 
+    @Test func openWorkspaceAndStateActionsCarryPayloads() throws {
+        let openNode = try #require(try run("""
+        (button
+          (text "open")
+          :action (open-workspace (record :workspace-title "Package" :workspace-directory "/repo/Package.swift")))
+        """).asNode)
+        #expect(openNode.content["action"] == .action(RNAction(
+            kind: "open-workspace",
+            payload: ["title": "Package", "directory": "/repo/Package.swift"]
+        )))
+
+        let toggleNode = try #require(try run("""
+        (button (text "toggle") :action (toggle-sidebar-state "finder.workspace.1"))
+        """).asNode)
+        #expect(toggleNode.content["action"] == .action(RNAction(
+            kind: "toggle-sidebar-state",
+            payload: ["key": "finder.workspace.1"]
+        )))
+
+        let setNode = try #require(try run("""
+        (button (text "set") :action (set-sidebar-state "layout" "finder"))
+        """).asNode)
+        #expect(setNode.content["action"] == .action(RNAction(
+            kind: "set-sidebar-state",
+            payload: ["key": "layout", "value": "finder"]
+        )))
+    }
+
     @Test func gradientBackground() throws {
         let node = try #require(try run("""
         (rectangle :fill (gradient (color :red) (color :blue) :direction horizontal))

--- a/Packages/CmuxSidebarScript/Tests/CmuxSidebarScriptTests/BuiltinTests.swift
+++ b/Packages/CmuxSidebarScript/Tests/CmuxSidebarScriptTests/BuiltinTests.swift
@@ -1,0 +1,37 @@
+import Testing
+@testable import CmuxSidebarScript
+
+@Suite struct BuiltinTests {
+    @Test func stringBuilding() throws {
+        #expect(try run("(str \"#\" 42)") == .string("#42"))
+        #expect(try run("(join \", \" (list 1 2 3))") == .string("1, 2, 3"))
+        #expect(try run("(upper \"abc\")") == .string("ABC"))
+        #expect(try run("(substring \"hello\" 1 3)") == .string("el"))
+    }
+
+    @Test func stringPredicates() throws {
+        #expect(try run("(starts-with? \"feature/x\" \"feature/\")") == .bool(true))
+        #expect(try run("(includes? \"abc\" \"b\")") == .bool(true))
+    }
+
+    @Test func listOps() throws {
+        #expect(try run("(count (list 1 2 3))") == .int(3))
+        #expect(try run("(first (list 7 8))") == .int(7))
+        #expect(try run("(rest (list 7 8 9))") == .list([.int(8), .int(9)]))
+        #expect(try run("(append (list 1) (list 2 3))") == .list([.int(1), .int(2), .int(3)]))
+        #expect(try run("(empty? (list))") == .bool(true))
+        #expect(try run("(range 3)") == .list([.int(0), .int(1), .int(2)]))
+    }
+
+    @Test func records() throws {
+        #expect(try run("(get (record :a 1 :b 2) :b)") == .int(2))
+        #expect(try run("(get (record :a 1) :missing 9)") == .int(9))
+        #expect(try run("(has? (record :a 1) :a)") == .bool(true))
+        #expect(try run("(get (assoc (record :a 1) :a 5) :a)") == .int(5))
+    }
+
+    @Test func getOnNilIsSafe() throws {
+        #expect(try run("(get nil :anything)") == .null)
+        #expect(try run("(get nil :anything 3)") == .int(3))
+    }
+}

--- a/Packages/CmuxSidebarScript/Tests/CmuxSidebarScriptTests/EvaluatorTests.swift
+++ b/Packages/CmuxSidebarScript/Tests/CmuxSidebarScriptTests/EvaluatorTests.swift
@@ -89,4 +89,26 @@ import Testing
             for f in forms { _ = try ev.eval(f, in: env) }
         }
     }
+
+    @Test func generatedCollectionsAreCapped() {
+        #expect(throws: LispError.self) {
+            try run("(count (range 100000))")
+        }
+        #expect(throws: LispError.self) {
+            try run("(pad-left \"x\" 100000)")
+        }
+        let longString = String(repeating: "a", count: Evaluator.generatedCollectionLimit + 1)
+        #expect(throws: LispError.self) {
+            try run("(count (split \"\(longString)\" \"\"))")
+        }
+    }
+
+    @Test func nonFiniteIntegerInputsThrow() {
+        #expect(throws: LispError.self) {
+            try run("(nth (list 1 2 3) (/ 0 0))")
+        }
+        #expect(throws: LispError.self) {
+            try run("(substring \"abc\" (/ 1 0))")
+        }
+    }
 }

--- a/Packages/CmuxSidebarScript/Tests/CmuxSidebarScriptTests/EvaluatorTests.swift
+++ b/Packages/CmuxSidebarScript/Tests/CmuxSidebarScriptTests/EvaluatorTests.swift
@@ -1,0 +1,92 @@
+import Testing
+@testable import CmuxSidebarScript
+
+@Suite struct EvaluatorTests {
+    @Test func arithmetic() throws {
+        #expect(try run("(+ 1 2 3)") == .number(6))
+        #expect(try run("(- 10 3 2)") == .number(5))
+        #expect(try run("(* 2 3 4)") == .number(24))
+        #expect(try run("(/ 12 3 2)") == .number(2))
+        #expect(try run("(- 5)") == .number(-5))
+        #expect(try run("(mod 7 3)") == .number(1))
+    }
+
+    @Test func comparisonAndLogic() throws {
+        #expect(try run("(< 1 2 3)") == .bool(true))
+        #expect(try run("(< 1 3 2)") == .bool(false))
+        #expect(try run("(= 2 2 2)") == .bool(true))
+        #expect(try run("(and true 1 2)") == .int(2))
+        #expect(try run("(or false nil 7)") == .int(7))
+        #expect(try run("(not nil)") == .bool(true))
+    }
+
+    @Test func ifAndCond() throws {
+        #expect(try run("(if true 1 2)") == .int(1))
+        #expect(try run("(if nil 1 2)") == .int(2))
+        #expect(try run("(if (> 1 2) 1)") == .null)
+        #expect(try run("(cond (false 1) (true 2) (else 3))") == .int(2))
+        #expect(try run("(cond (false 1) (else 3))") == .int(3))
+    }
+
+    @Test func whenUnless() throws {
+        #expect(try run("(when true 1 2)") == .int(2))
+        #expect(try run("(when false 1)") == .null)
+        #expect(try run("(unless false 9)") == .int(9))
+    }
+
+    @Test func letBindsSequentially() throws {
+        #expect(try run("(let ((a 2) (b (* a 3))) (+ a b))") == .number(8))
+    }
+
+    @Test func defineAndClosures() throws {
+        #expect(try run("(def x 5) (* x x)") == .number(25))
+        #expect(try run("(def (sq n) (* n n)) (sq 6)") == .number(36))
+        #expect(try run("((fn (a b) (+ a b)) 3 4)") == .number(7))
+    }
+
+    @Test func restParameters() throws {
+        #expect(try run("(def (f a & more) (count more)) (f 1 2 3 4)") == .int(3))
+    }
+
+    @Test func recursion() throws {
+        let src = """
+        (def (fact n) (if (<= n 1) 1 (* n (fact (- n 1)))))
+        (fact 5)
+        """
+        #expect(try run(src) == .number(120))
+    }
+
+    @Test func higherOrder() throws {
+        #expect(try run("(map (fn (x) (* x 2)) (list 1 2 3))")
+            == .list([.number(2), .number(4), .number(6)]))
+        #expect(try run("(filter (fn (x) (> x 1)) (list 0 1 2 3))")
+            == .list([.int(2), .int(3)]))
+        #expect(try run("(reduce + 0 (list 1 2 3 4))") == .number(10))
+    }
+
+    @Test func unboundSymbolThrows() {
+        #expect(throws: LispError.self) { try run("nope") }
+    }
+
+    @Test func arityErrorThrows() {
+        #expect(throws: LispError.self) { try run("(def (f a) a) (f 1 2)") }
+    }
+
+    @Test func infiniteRecursionIsBounded() {
+        #expect(throws: LispError.self) {
+            try run("(def (loop n) (loop (+ n 1))) (loop 0)")
+        }
+    }
+
+    @Test func stepLimitStopsRunawayLoops() {
+        // A tight non-recursive expansion that blows the step budget.
+        let forms = try! Reader().read("(reduce + 0 (range 100))")
+        let env = LispEnvironment()
+        Builtins.install(into: env)
+        Bridge.install(into: env)
+        let ev = Evaluator(stepLimit: 5, depthLimit: 512)
+        #expect(throws: LispError.self) {
+            for f in forms { _ = try ev.eval(f, in: env) }
+        }
+    }
+}

--- a/Packages/CmuxSidebarScript/Tests/CmuxSidebarScriptTests/ReaderTests.swift
+++ b/Packages/CmuxSidebarScript/Tests/CmuxSidebarScriptTests/ReaderTests.swift
@@ -1,0 +1,47 @@
+import Testing
+@testable import CmuxSidebarScript
+
+@Suite struct ReaderTests {
+    @Test func readsScalars() throws {
+        #expect(try Reader().read("42") == [.int(42)])
+        #expect(try Reader().read("-7") == [.int(-7)])
+        #expect(try Reader().read("3.5") == [.double(3.5)])
+        #expect(try Reader().read("\"hi\"") == [.string("hi")])
+        #expect(try Reader().read("true false nil") == [.bool(true), .bool(false), .null])
+        #expect(try Reader().read(":title") == [.keyword("title")])
+        #expect(try Reader().read("foo") == [.symbol("foo")])
+    }
+
+    @Test func readsNestedLists() throws {
+        let forms = try Reader().read("(a (b c) 1)")
+        #expect(forms == [.list([.symbol("a"), .list([.symbol("b"), .symbol("c")]), .int(1)])])
+    }
+
+    @Test func bracketsAreLists() throws {
+        #expect(try Reader().read("[1 2]") == [.list([.int(1), .int(2)])])
+    }
+
+    @Test func quoteSugarExpands() throws {
+        #expect(try Reader().read("'x") == [.list([.symbol("quote"), .symbol("x")])])
+    }
+
+    @Test func stringEscapes() throws {
+        #expect(try Reader().read("\"a\\nb\\t\\\"c\\\"\"") == [.string("a\nb\t\"c\"")])
+    }
+
+    @Test func lineCommentsAndCommasIgnored() throws {
+        let forms = try Reader().read("""
+        ; leading comment
+        (a, b) ; trailing
+        """)
+        #expect(forms == [.list([.symbol("a"), .symbol("b")])])
+    }
+
+    @Test func unterminatedStringThrows() {
+        #expect(throws: LispError.self) { try Reader().read("\"oops") }
+    }
+
+    @Test func unclosedListThrows() {
+        #expect(throws: LispError.self) { try Reader().read("(a b") }
+    }
+}

--- a/Packages/CmuxSidebarScript/Tests/CmuxSidebarScriptTests/SidebarScriptTests.swift
+++ b/Packages/CmuxSidebarScript/Tests/CmuxSidebarScriptTests/SidebarScriptTests.swift
@@ -78,6 +78,41 @@ import Testing
         #expect(node.containsText("HELLO"))
     }
 
+    @Test func customScriptCanRenderWholeSidebar() throws {
+        let script = try SidebarScript(source: """
+        (def (workspace-button ws)
+          (button
+            (text (get ws :title))
+            :action (select-workspace ws)))
+        (def (render-sidebar sidebar)
+          (vstack :spacing 2
+            (text (str "count=" (get sidebar :workspace-count)))
+            (map workspace-button (get sidebar :workspaces))))
+        """)
+        #expect(script.supportsSidebarRendering)
+        let node = try script.renderSidebar(SidebarScriptSidebarContext(
+            selectedWorkspaceId: "workspace-2",
+            workspaces: [
+                SidebarScriptContext(id: "workspace-1", index: 0, title: "alpha"),
+                SidebarScriptContext(id: "workspace-2", index: 1, title: "beta", isActive: true),
+            ]
+        ))
+        #expect(node.containsText("count=2"))
+        #expect(node.containsText("alpha"))
+        #expect(node.containsText("beta"))
+        #expect(node.nodes(kind: "button").count == 2)
+    }
+
+    @Test func renderRowRemainsOptionalForWholeSidebarScripts() throws {
+        let script = try SidebarScript(source: """
+        (def (render-sidebar sidebar)
+          (text (get sidebar :workspace-count)))
+        """)
+        #expect(throws: LispError.self) {
+            _ = try script.render(SidebarScriptContext(title: "x"))
+        }
+    }
+
     @Test func contextProjectsPullRequestFields() throws {
         let script = try SidebarScript(source: """
         (def (render-row ws)

--- a/Packages/CmuxSidebarScript/Tests/CmuxSidebarScriptTests/SidebarScriptTests.swift
+++ b/Packages/CmuxSidebarScript/Tests/CmuxSidebarScriptTests/SidebarScriptTests.swift
@@ -91,4 +91,28 @@ import Testing
         let b = try script.render(sampleContext())
         #expect(a == b)
     }
+
+    @Test func renderCannotMutateTopLevelBindings() throws {
+        let script = try SidebarScript(source: """
+        (def counter 0)
+        (def (render-row ws)
+          (do
+            (set! counter (+ counter 1))
+            (text (str counter))))
+        """)
+        #expect(throws: LispError.self) {
+            _ = try script.render(SidebarScriptContext(title: "x"))
+        }
+    }
+
+    @Test func renderCanMutateLocalBindings() throws {
+        let script = try SidebarScript(source: """
+        (def (render-row ws)
+          (let ((value 1))
+            (set! value 2)
+            (text (str value))))
+        """)
+        let node = try script.render(SidebarScriptContext(title: "x"))
+        #expect(node.containsText("2"))
+    }
 }

--- a/Packages/CmuxSidebarScript/Tests/CmuxSidebarScriptTests/SidebarScriptTests.swift
+++ b/Packages/CmuxSidebarScript/Tests/CmuxSidebarScriptTests/SidebarScriptTests.swift
@@ -103,6 +103,30 @@ import Testing
         #expect(node.nodes(kind: "button").count == 2)
     }
 
+    @Test func sidebarContextProjectsPersistentStateAndFiles() throws {
+        let script = try SidebarScript(source: """
+        (def (render-sidebar sidebar)
+          (let ((ws (first (get sidebar :workspaces))))
+            (vstack
+              (text (get (get sidebar :state) "finder.workspace.1"))
+              (text (get (first (get ws :files)) :name)))))
+        """)
+        let node = try script.renderSidebar(SidebarScriptSidebarContext(
+            workspaces: [
+                SidebarScriptContext(
+                    id: "workspace-1",
+                    title: "repo",
+                    fileEntries: [
+                        .init(name: "Package.swift", path: "/repo/Package.swift", isDirectory: false),
+                    ]
+                ),
+            ],
+            state: ["finder.workspace.1": "true"]
+        ))
+        #expect(node.containsText("true"))
+        #expect(node.containsText("Package.swift"))
+    }
+
     @Test func renderRowRemainsOptionalForWholeSidebarScripts() throws {
         let script = try SidebarScript(source: """
         (def (render-sidebar sidebar)

--- a/Packages/CmuxSidebarScript/Tests/CmuxSidebarScriptTests/SidebarScriptTests.swift
+++ b/Packages/CmuxSidebarScript/Tests/CmuxSidebarScriptTests/SidebarScriptTests.swift
@@ -33,7 +33,7 @@ import Testing
                 let script = try SidebarScript(source: demo.source)
                 let node = try script.render(sampleContext())
                 #expect(node != .empty)
-                #expect(node.containsText("issue-118-korean-ime") || node.containsText("ISSUE-118-KOREAN-IME"))
+                #expect(node.containsTextContaining("issue-118") || node.containsTextContaining("ISSUE-118"))
             } catch {
                 Issue.record("Demo '\(demo.id)' failed: \(error)")
             }

--- a/Packages/CmuxSidebarScript/Tests/CmuxSidebarScriptTests/SidebarScriptTests.swift
+++ b/Packages/CmuxSidebarScript/Tests/CmuxSidebarScriptTests/SidebarScriptTests.swift
@@ -1,0 +1,94 @@
+import Testing
+@testable import CmuxSidebarScript
+
+@Suite struct SidebarScriptTests {
+    private func sampleContext() -> SidebarScriptContext {
+        SidebarScriptContext(
+            title: "issue-118-korean-ime",
+            detail: "Fix Korean IME composition",
+            branch: "issue-118-korean-ime",
+            directory: "~/cmux/worktrees/issue-118",
+            pullRequests: [
+                .init(number: 5108, state: "open", url: "https://github.com/manaflow-ai/cmux/pull/5108"),
+                .init(number: 5099, state: "merged", url: "https://github.com/x/y/pull/5099", isStale: true),
+            ],
+            ports: [3000, 5173],
+            unreadCount: 3,
+            isPinned: true,
+            isActive: true,
+            progress: 0.4
+        )
+    }
+
+    @Test func defaultScriptCompiles() throws {
+        _ = try SidebarScript.makeDefault()
+    }
+
+    @Test func defaultScriptRendersRichRow() throws {
+        let script = try SidebarScript.makeDefault()
+        let node = try script.render(sampleContext())
+
+        // Title is present.
+        #expect(node.containsText("issue-118-korean-ime"))
+        // Unread badge.
+        #expect(node.containsText("3"))
+        // Branch line exists.
+        #expect(node.firstNode(kind: "image") != nil)
+        // Both PR numbers rendered.
+        #expect(node.containsText("#5108"))
+        #expect(node.containsText("#5099"))
+        // Ports rendered.
+        #expect(node.containsText("3000"))
+        #expect(node.containsText("5173"))
+        // Progress bar present.
+        #expect(node.firstNode(kind: "progress-view") != nil)
+    }
+
+    @Test func minimalContextHidesOptionalRows() throws {
+        let script = try SidebarScript.makeDefault()
+        let node = try script.render(SidebarScriptContext(title: "scratch"))
+        #expect(node.containsText("scratch"))
+        // No PRs, ports, or progress.
+        #expect(node.nodes(kind: "progress-view").isEmpty)
+        #expect(!node.containsText("#"))
+    }
+
+    @Test func customScriptOverridesRendering() throws {
+        let script = try SidebarScript(source: """
+        (def (render-row ws)
+          (text (upper (get ws :title)) :font (font :size 20)))
+        """)
+        let node = try script.render(SidebarScriptContext(title: "hello"))
+        #expect(node.containsText("HELLO"))
+    }
+
+    @Test func contextProjectsPullRequestFields() throws {
+        let script = try SidebarScript(source: """
+        (def (render-row ws)
+          (text (get (first (get ws :pull-requests)) :state)))
+        """)
+        let node = try script.render(sampleContext())
+        #expect(node.containsText("open"))
+    }
+
+    @Test func missingEntryPointThrows() {
+        #expect(throws: LispError.self) {
+            _ = try SidebarScript(source: "(def x 1)")
+        }
+    }
+
+    @Test func entryReturningNonViewThrows() throws {
+        let script = try SidebarScript(source: "(def (render-row ws) 42)")
+        #expect(throws: LispError.self) {
+            _ = try script.render(SidebarScriptContext(title: "x"))
+        }
+    }
+
+    @Test func equalContextsProduceEqualNodes() throws {
+        // Underpins per-row memoization: same input → identical (Equatable) node.
+        let script = try SidebarScript.makeDefault()
+        let a = try script.render(sampleContext())
+        let b = try script.render(sampleContext())
+        #expect(a == b)
+    }
+}

--- a/Packages/CmuxSidebarScript/Tests/CmuxSidebarScriptTests/SidebarScriptTests.swift
+++ b/Packages/CmuxSidebarScript/Tests/CmuxSidebarScriptTests/SidebarScriptTests.swift
@@ -24,6 +24,22 @@ import Testing
         _ = try SidebarScript.makeDefault()
     }
 
+    @Test func bundledDemoScriptsCompileAndRender() throws {
+        let demos = SidebarScriptDemo.all
+        #expect(demos.count >= 6)
+
+        for demo in demos {
+            do {
+                let script = try SidebarScript(source: demo.source)
+                let node = try script.render(sampleContext())
+                #expect(node != .empty)
+                #expect(node.containsText("issue-118-korean-ime") || node.containsText("ISSUE-118-KOREAN-IME"))
+            } catch {
+                Issue.record("Demo '\(demo.id)' failed: \(error)")
+            }
+        }
+    }
+
     @Test func defaultScriptRendersRichRow() throws {
         let script = try SidebarScript.makeDefault()
         let node = try script.render(sampleContext())

--- a/Packages/CmuxSidebarScript/Tests/CmuxSidebarScriptTests/TestSupport.swift
+++ b/Packages/CmuxSidebarScript/Tests/CmuxSidebarScriptTests/TestSupport.swift
@@ -40,6 +40,10 @@ extension RenderNode {
     func containsText(_ value: String) -> Bool {
         nodes(kind: "text").contains { $0.content["text"]?.string == value }
     }
+
+    func containsTextContaining(_ value: String) -> Bool {
+        nodes(kind: "text").contains { ($0.content["text"]?.string ?? "").contains(value) }
+    }
 }
 
 extension LispValue {

--- a/Packages/CmuxSidebarScript/Tests/CmuxSidebarScriptTests/TestSupport.swift
+++ b/Packages/CmuxSidebarScript/Tests/CmuxSidebarScriptTests/TestSupport.swift
@@ -1,0 +1,50 @@
+import Testing
+@testable import CmuxSidebarScript
+
+/// Evaluates a source string against a fresh environment with the full standard
+/// library + SwiftUI bridge installed, returning the value of the last form.
+func run(_ source: String) throws -> LispValue {
+    let forms = try Reader().read(source)
+    let env = LispEnvironment()
+    Builtins.install(into: env)
+    Bridge.install(into: env)
+    let ev = Evaluator()
+    var result: LispValue = .null
+    for form in forms { result = try ev.eval(form, in: env) }
+    return result
+}
+
+extension RenderNode {
+    /// Depth-first search for the first descendant (or self) with `kind`.
+    func firstNode(kind: String) -> RenderNode? {
+        if self.kind == kind { return self }
+        for child in children {
+            if let found = child.firstNode(kind: kind) { return found }
+        }
+        return nil
+    }
+
+    /// All descendant nodes (including self) with `kind`.
+    func nodes(kind: String) -> [RenderNode] {
+        var out: [RenderNode] = []
+        if self.kind == kind { out.append(self) }
+        for child in children { out.append(contentsOf: child.nodes(kind: kind)) }
+        return out
+    }
+
+    func modifier(_ name: String) -> RenderModifier? {
+        modifiers.first { $0.name == name }
+    }
+
+    /// Whether any descendant text node renders exactly `value`.
+    func containsText(_ value: String) -> Bool {
+        nodes(kind: "text").contains { $0.content["text"]?.string == value }
+    }
+}
+
+extension LispValue {
+    var asNode: RenderNode? {
+        if case .node(let n) = self { return n }
+        return nil
+    }
+}

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -15046,6 +15046,41 @@ struct TabItemView: View, Equatable {
         }
     }
 
+    private func nativeSidebarHeader(
+        workspaceSnapshot: SidebarWorkspaceSnapshotBuilder.Snapshot,
+        scaledUnreadBadgeSize: CGFloat,
+        protectedWorkspaceTooltip: String
+    ) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            if unreadCount > 0 {
+                ZStack {
+                    Circle()
+                        .fill(activeUnreadBadgeFillColor)
+                    Text("\(unreadCount)")
+                        .font(.system(size: scaledFontSize(9), weight: .semibold))
+                        .foregroundColor(activeUnreadBadgeTextColor)
+                }
+                .frame(width: scaledUnreadBadgeSize, height: scaledUnreadBadgeSize)
+            }
+
+            if workspaceSnapshot.isPinned {
+                Image(systemName: "pin.fill")
+                    .font(.system(size: scaledFontSize(9), weight: .semibold))
+                    .foregroundColor(activeSecondaryColor(0.8))
+                    .safeHelp(protectedWorkspaceTooltip)
+            }
+
+            Text(workspaceSnapshot.title)
+                .font(.system(size: scaledFontSize(12.5), weight: titleFontWeight))
+                .foregroundColor(activePrimaryTextColor)
+                .lineLimit(settings.wrapsWorkspaceTitles ? nil : 1)
+                .truncationMode(.tail)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .layoutPriority(1)
+        }
+    }
+
     var body: some View {
         let workspaceSnapshot = self.workspaceSnapshot
         let closeWorkspaceTooltip = String(localized: "sidebar.closeWorkspace.tooltip", defaultValue: "Close Workspace")
@@ -15082,34 +15117,11 @@ struct TabItemView: View, Equatable {
                 .frame(maxWidth: .infinity, alignment: .leading)
         } else {
         VStack(alignment: .leading, spacing: 4) {
-            HStack(alignment: .top, spacing: 8) {
-                if unreadCount > 0 {
-                    ZStack {
-                        Circle()
-                            .fill(activeUnreadBadgeFillColor)
-                        Text("\(unreadCount)")
-                            .font(.system(size: scaledFontSize(9), weight: .semibold))
-                            .foregroundColor(activeUnreadBadgeTextColor)
-                    }
-                    .frame(width: scaledUnreadBadgeSize, height: scaledUnreadBadgeSize)
-                }
-
-                if workspaceSnapshot.isPinned {
-                    Image(systemName: "pin.fill")
-                        .font(.system(size: scaledFontSize(9), weight: .semibold))
-                        .foregroundColor(activeSecondaryColor(0.8))
-                        .safeHelp(protectedWorkspaceTooltip)
-                }
-
-                Text(workspaceSnapshot.title)
-                    .font(.system(size: scaledFontSize(12.5), weight: titleFontWeight))
-                    .foregroundColor(activePrimaryTextColor)
-                    .lineLimit(settings.wrapsWorkspaceTitles ? nil : 1)
-                    .truncationMode(.tail)
-                    .fixedSize(horizontal: false, vertical: true)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .layoutPriority(1)
-            }
+            nativeSidebarHeader(
+                workspaceSnapshot: workspaceSnapshot,
+                scaledUnreadBadgeSize: scaledUnreadBadgeSize,
+                protectedWorkspaceTooltip: protectedWorkspaceTooltip
+            )
 
             if let description = workspaceSnapshot.customDescription {
                 SidebarWorkspaceDescriptionText(

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -10355,9 +10355,9 @@ struct VerticalTabsSidebar: View {
     )
     @ObservedObject private var keyboardShortcutSettingsObserver = KeyboardShortcutSettingsObserver.shared
     @State var dragState = SidebarDragState()
-    /// Compiled once at sidebar construction; nil unless the user has a valid
-    /// ~/.config/cmux/sidebar.lisp. Passed by value into each row.
-    @State private var sidebarScriptStore = SidebarScriptStore()
+    /// Current ~/.config/cmux/sidebar.lisp compiler state. Passed by value into
+    /// each row so menu changes force a row re-render through `version`.
+    @StateObject private var sidebarScriptStore = SidebarScriptStore()
     // Freezes `showsModifierShortcutHints` for the workspace whose context menu
     // is open. Set on the row's contextMenu.onAppear and cleared on
     // .onDisappear so modifier-key transitions don't flip the badges on the
@@ -10629,7 +10629,12 @@ struct VerticalTabsSidebar: View {
             } else {
                 extensionSidebarScrollArea(renderContext: renderContext)
             }
-            SidebarFooter(updateViewModel: updateViewModel, fileExplorerState: fileExplorerState, onSendFeedback: onSendFeedback)
+            SidebarFooter(
+                updateViewModel: updateViewModel,
+                fileExplorerState: fileExplorerState,
+                sidebarScriptStore: sidebarScriptStore,
+                onSendFeedback: onSendFeedback
+            )
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
         .accessibilityIdentifier("Sidebar")
@@ -13121,13 +13126,24 @@ final class WindowScopedShortcutHintModifierMonitor {
 private struct SidebarFooter: View {
     @ObservedObject var updateViewModel: UpdateViewModel
     @ObservedObject var fileExplorerState: FileExplorerState
+    @ObservedObject var sidebarScriptStore: SidebarScriptStore
     let onSendFeedback: () -> Void
 
     var body: some View {
 #if DEBUG
-        SidebarDevFooter(updateViewModel: updateViewModel, fileExplorerState: fileExplorerState, onSendFeedback: onSendFeedback)
+        SidebarDevFooter(
+            updateViewModel: updateViewModel,
+            fileExplorerState: fileExplorerState,
+            sidebarScriptStore: sidebarScriptStore,
+            onSendFeedback: onSendFeedback
+        )
 #else
-        SidebarFooterButtons(updateViewModel: updateViewModel, fileExplorerState: fileExplorerState, onSendFeedback: onSendFeedback)
+        SidebarFooterButtons(
+            updateViewModel: updateViewModel,
+            fileExplorerState: fileExplorerState,
+            sidebarScriptStore: sidebarScriptStore,
+            onSendFeedback: onSendFeedback
+        )
             .padding(.leading, 6)
             .padding(.trailing, 10)
             .padding(.bottom, 6)
@@ -13138,6 +13154,7 @@ private struct SidebarFooter: View {
 private struct SidebarFooterButtons: View {
     @ObservedObject var updateViewModel: UpdateViewModel
     @ObservedObject var fileExplorerState: FileExplorerState
+    @ObservedObject var sidebarScriptStore: SidebarScriptStore
     let onSendFeedback: () -> Void
     @State private var extensionBrowserAnchorView: NSView?
     @LiveSetting(\.betaFeatures.extensions) private var extensionsExperimentalEnabled
@@ -13145,6 +13162,7 @@ private struct SidebarFooterButtons: View {
     var body: some View {
         HStack(spacing: 4) {
             SidebarHelpMenuButton(onSendFeedback: onSendFeedback)
+            SidebarScriptLayoutMenuButton(scriptStore: sidebarScriptStore)
             // The puzzle button opens the extensions browser; it only shows
             // while the experimental Extensions feature is enabled.
             if extensionsExperimentalEnabled {
@@ -13170,6 +13188,89 @@ private struct SidebarFooterButtons: View {
             UpdatePill(model: updateViewModel)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+private struct SidebarScriptLayoutMenuButton: View {
+    @ObservedObject var scriptStore: SidebarScriptStore
+
+    private let buttonTitle = String(localized: "sidebar.script.menu.title", defaultValue: "Sidebar Layouts")
+    private let nativeTitle = String(localized: "sidebar.script.menu.native", defaultValue: "Native Sidebar")
+    private let buttonSize: CGFloat = 22
+    private let iconSize: CGFloat = 12
+
+    var body: some View {
+        Menu {
+            menuContent
+        } label: {
+            Image(systemName: "sidebar.left")
+                .symbolRenderingMode(.monochrome)
+                .font(.system(size: iconSize, weight: .medium))
+                .foregroundStyle(Color(nsColor: .secondaryLabelColor))
+                .frame(width: buttonSize, height: buttonSize, alignment: .center)
+        }
+        .menuStyle(.borderlessButton)
+        .frame(width: buttonSize, height: buttonSize, alignment: .center)
+        .contextMenu {
+            menuContent
+        }
+        .safeHelp(buttonTitle)
+        .accessibilityLabel(buttonTitle)
+        .accessibilityIdentifier("SidebarScriptLayoutMenuButton")
+    }
+
+    @ViewBuilder
+    private var menuContent: some View {
+        Button {
+            scriptStore.useNativeSidebar()
+        } label: {
+            Label(nativeTitle, systemImage: scriptStore.isNativeActive ? "checkmark.circle.fill" : "sidebar.left")
+        }
+
+        Divider()
+
+        ForEach(SidebarScriptDemo.all) { demo in
+            Button {
+                scriptStore.applyDemo(demo)
+            } label: {
+                Label(demoTitle(demo), systemImage: iconName(for: demo))
+            }
+        }
+    }
+
+    private func iconName(for demo: SidebarScriptDemo) -> String {
+        guard scriptStore.activeDemoId != demo.id else { return "checkmark.circle.fill" }
+        switch demo.id {
+        case "default": return "text.alignleft"
+        case "liquid-glass": return "sparkles"
+        case "high-density-ide": return "rectangle.grid.1x2"
+        case "terminal-stealth": return "terminal"
+        case "pro-studio": return "slider.horizontal.3"
+        case "finder": return "folder.fill"
+        case "agent-ops": return "chart.bar.xaxis"
+        default: return "sidebar.left"
+        }
+    }
+
+    private func demoTitle(_ demo: SidebarScriptDemo) -> String {
+        switch demo.id {
+        case "default":
+            return String(localized: "sidebar.script.demo.default", defaultValue: "Default Lisp")
+        case "liquid-glass":
+            return String(localized: "sidebar.script.demo.liquidGlass", defaultValue: "Liquid Glass")
+        case "high-density-ide":
+            return String(localized: "sidebar.script.demo.highDensityIDE", defaultValue: "High-Density IDE")
+        case "terminal-stealth":
+            return String(localized: "sidebar.script.demo.terminalStealth", defaultValue: "Terminal Stealth")
+        case "pro-studio":
+            return String(localized: "sidebar.script.demo.proStudio", defaultValue: "Pro Studio")
+        case "finder":
+            return String(localized: "sidebar.script.demo.finder", defaultValue: "Finder")
+        case "agent-ops":
+            return String(localized: "sidebar.script.demo.agentOps", defaultValue: "Agent Ops")
+        default:
+            return demo.id
+        }
     }
 }
 
@@ -14336,13 +14437,19 @@ private struct SidebarFooterIconButtonStyleBody: View {
 private struct SidebarDevFooter: View {
     @ObservedObject var updateViewModel: UpdateViewModel
     @ObservedObject var fileExplorerState: FileExplorerState
+    @ObservedObject var sidebarScriptStore: SidebarScriptStore
     let onSendFeedback: () -> Void
     @AppStorage(DevBuildBannerDebugSettings.sidebarBannerVisibleKey)
     private var showSidebarDevBuildBanner = DevBuildBannerDebugSettings.defaultShowSidebarBanner
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
-            SidebarFooterButtons(updateViewModel: updateViewModel, fileExplorerState: fileExplorerState, onSendFeedback: onSendFeedback)
+            SidebarFooterButtons(
+                updateViewModel: updateViewModel,
+                fileExplorerState: fileExplorerState,
+                sidebarScriptStore: sidebarScriptStore,
+                onSendFeedback: onSendFeedback
+            )
             if showSidebarDevBuildBanner {
                 Text(String(localized: "debug.devBuildBanner.title", defaultValue: "THIS IS A DEV BUILD"))
                     .font(.system(size: 11, weight: .semibold))

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -5,6 +5,7 @@ import Combine
 import CMUXExtensionClient
 import CmuxExtensionKit
 import CmuxSettings
+import CmuxSidebarScript
 import CmuxSettingsUI
 import ImageIO
 import Observation
@@ -10354,6 +10355,9 @@ struct VerticalTabsSidebar: View {
     )
     @ObservedObject private var keyboardShortcutSettingsObserver = KeyboardShortcutSettingsObserver.shared
     @State var dragState = SidebarDragState()
+    /// Compiled once at sidebar construction; nil unless the user has a valid
+    /// ~/.config/cmux/sidebar.lisp. Passed by value into each row.
+    @State private var sidebarScriptStore = SidebarScriptStore()
     // Freezes `showsModifierShortcutHints` for the workspace whose context menu
     // is open. Set on the row's contextMenu.onAppear and cleared on
     // .onDisappear so modifier-key transitions don't flip the badges on the
@@ -12156,6 +12160,8 @@ struct VerticalTabsSidebar: View {
             contextMenuPinState: contextMenuPinState,
             workspaceGroupMenuSnapshot: renderContext.workspaceGroupMenuSnapshot,
             settings: renderContext.tabItemSettings,
+            sidebarScript: sidebarScriptStore.script,
+            sidebarScriptVersion: sidebarScriptStore.version,
             onContextMenuAppear: onContextMenuAppear,
             onContextMenuDisappear: onContextMenuDisappear
         )
@@ -14626,6 +14632,7 @@ struct TabItemView: View, Equatable {
         lhs.workspaceGroupMenuSnapshot == rhs.workspaceGroupMenuSnapshot &&
         lhs.isBeingDragged == rhs.isBeingDragged &&
         lhs.topDropIndicatorVisible == rhs.topDropIndicatorVisible &&
+        lhs.sidebarScriptVersion == rhs.sidebarScriptVersion &&
         lhs.settings == rhs.settings
     }
 
@@ -14670,6 +14677,11 @@ struct TabItemView: View, Equatable {
     let contextMenuPinState: WorkspaceActionDispatcher.PinState?
     let workspaceGroupMenuSnapshot: WorkspaceGroupMenuSnapshot
     let settings: SidebarTabItemSettingsSnapshot
+    /// Optional user sidebar script. A plain immutable reference (like
+    /// `tabManager`), excluded from `==`; row re-render on script change is gated
+    /// by `sidebarScriptVersion`. Nil means render the native row.
+    let sidebarScript: SidebarScript?
+    let sidebarScriptVersion: Int
     /// Called from this row's contextMenu.onAppear so the parent can freeze
     /// `showsModifierShortcutHints` to the value it last passed in. Prevents
     /// modifier-key transitions from flipping the badges on the row sitting
@@ -14965,6 +14977,75 @@ struct TabItemView: View, Equatable {
         )
     }
 
+    // MARK: - Sidebar script rendering
+
+    /// Renders this row through the user's sidebar script, or returns nil to use
+    /// the native row. Any render fault logs and falls back to native, so a bad
+    /// script never breaks the sidebar. Called from `body`; performs no state
+    /// mutation.
+    private func renderedSidebarScriptNode(
+        workspaceSnapshot: SidebarWorkspaceSnapshotBuilder.Snapshot
+    ) -> RenderNode? {
+        guard let sidebarScript else { return nil }
+        do {
+            return try sidebarScript.render(makeSidebarScriptContext(workspaceSnapshot))
+        } catch {
+            SidebarScriptStore.logRenderFailure(error)
+            return nil
+        }
+    }
+
+    private func makeSidebarScriptContext(
+        _ snapshot: SidebarWorkspaceSnapshotBuilder.Snapshot
+    ) -> SidebarScriptContext {
+        SidebarScriptContext(
+            title: snapshot.title,
+            detail: snapshot.customDescription,
+            branch: snapshot.compactGitBranchSummaryText,
+            directory: snapshot.compactDirectoryCandidates.first,
+            directories: snapshot.compactDirectoryCandidates,
+            pullRequests: snapshot.pullRequestRows.map {
+                SidebarScriptContext.PullRequest(
+                    number: $0.number,
+                    state: $0.status.rawValue,
+                    url: $0.url.absoluteString,
+                    title: $0.label,
+                    isDraft: false,
+                    isStale: $0.isStale
+                )
+            },
+            ports: snapshot.listeningPorts,
+            unreadCount: unreadCount,
+            isPinned: snapshot.isPinned,
+            isActive: isActive,
+            isSelected: isMultiSelected,
+            colorHex: snapshot.customColorHex,
+            isDarkMode: colorScheme == .dark,
+            latestMessage: latestNotificationText ?? snapshot.latestConversationMessage,
+            progress: snapshot.progress?.value,
+            remoteTarget: snapshot.remoteWorkspaceSidebarText,
+            statusEntries: snapshot.metadataEntries.map {
+                SidebarScriptContext.StatusEntry(label: $0.key, value: $0.value, colorHex: $0.color)
+            }
+        )
+    }
+
+    private func handleSidebarScriptAction(_ action: RNAction) {
+        switch action.kind {
+        case "open-url":
+            guard let raw = action.payload["url"], let url = URL(string: raw) else { return }
+            if tabManager.openBrowser(inWorkspace: tab.id, url: url, insertAtEnd: true) == nil {
+                NSWorkspace.shared.open(url)
+            }
+        case "copy":
+            guard let text = action.payload["text"] else { return }
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(text, forType: .string)
+        default:
+            break
+        }
+    }
+
     var body: some View {
         let workspaceSnapshot = self.workspaceSnapshot
         let closeWorkspaceTooltip = String(localized: "sidebar.closeWorkspace.tooltip", defaultValue: "Close Workspace")
@@ -14995,6 +15076,11 @@ struct TabItemView: View, Equatable {
             scaledCloseButtonHitSize
         )
 
+        Group {
+        if let scriptNode = renderedSidebarScriptNode(workspaceSnapshot: workspaceSnapshot) {
+            RenderNodeView(node: scriptNode, onAction: { handleSidebarScriptAction($0) })
+                .frame(maxWidth: .infinity, alignment: .leading)
+        } else {
         VStack(alignment: .leading, spacing: 4) {
             HStack(alignment: .top, spacing: 8) {
                 if unreadCount > 0 {
@@ -15260,6 +15346,8 @@ struct TabItemView: View, Equatable {
                 .foregroundColor(activeSecondaryColor(0.75))
                 .lineLimit(1)
             }
+        }
+        }
         }
         .animation(.easeInOut(duration: 0.2), value: workspaceSnapshot.latestLog)
         .animation(.easeInOut(duration: 0.2), value: workspaceSnapshot.progress != nil)

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -14606,6 +14606,82 @@ private final class SidebarTabItemContextMenuState: ObservableObject {
     var pendingWorkspaceSnapshot: SidebarWorkspaceSnapshotBuilder.Snapshot?
 }
 
+private struct SidebarWorkspaceRowChrome<Content: View>: View {
+    let content: Content
+    let latestLog: SidebarLogEntry?
+    let progress: SidebarProgressState?
+    let metadataBlockCount: Int
+    let backgroundColor: Color
+    let activeBorderColor: Color
+    let activeBorderLineWidth: CGFloat
+    let showsLeadingRail: Bool
+    let railColor: Color
+    let showsWorkspaceShortcutHint: Bool
+    let workspaceShortcutLabel: String?
+    let shortcutHintEmphasis: Double
+    let sidebarShortcutHintXOffset: Double
+    let sidebarShortcutHintYOffset: Double
+    let shortcutHintFontSize: CGFloat
+    let showCloseButton: Bool
+    let closeButtonTooltip: String
+    let closeButtonFontSize: CGFloat
+    let closeButtonForegroundColor: Color
+    let closeButtonWidth: CGFloat
+    let closeButtonHitSize: CGFloat
+    let closeWorkspace: () -> Void
+
+    var body: some View {
+        content
+            .animation(.easeInOut(duration: 0.2), value: latestLog)
+            .animation(.easeInOut(duration: 0.2), value: progress != nil)
+            .animation(.easeInOut(duration: 0.2), value: metadataBlockCount)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
+            .background(
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(backgroundColor)
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 6)
+                            .strokeBorder(activeBorderColor, lineWidth: activeBorderLineWidth)
+                    }
+                    .overlay(alignment: .leading) {
+                        if showsLeadingRail {
+                            Capsule(style: .continuous)
+                                .fill(railColor)
+                                .frame(width: 3)
+                                .padding(.leading, 4)
+                                .padding(.vertical, 5)
+                                .offset(x: -1)
+                        }
+                    }
+            )
+            .sidebarShortcutHintOverlay(
+                text: showsWorkspaceShortcutHint ? workspaceShortcutLabel : nil,
+                emphasis: shortcutHintEmphasis,
+                offsetX: sidebarShortcutHintXOffset,
+                offsetY: sidebarShortcutHintYOffset,
+                fontSize: shortcutHintFontSize
+            )
+            .overlay(alignment: .topTrailing) {
+                if showsWorkspaceShortcutHint {
+                    EmptyView()
+                } else if showCloseButton {
+                    Button(action: closeWorkspace) {
+                        Image(systemName: "xmark")
+                            .font(.system(size: closeButtonFontSize, weight: .medium))
+                            .foregroundColor(closeButtonForegroundColor)
+                    }
+                    .buttonStyle(.plain)
+                    .safeHelp(closeButtonTooltip)
+                    .frame(width: closeButtonWidth, height: closeButtonHitSize, alignment: .center)
+                    .padding(.top, 8)
+                    .padding(.trailing, 10)
+                }
+            }
+            .shortcutHintVisibilityAnimation(value: showsWorkspaceShortcutHint)
+    }
+}
+
 struct TabItemView: View, Equatable {
     private static let workspaceObservationCoalesceInterval: RunLoop.SchedulerTimeType.Stride = .milliseconds(40)
     private static let legacyVMWebSocketDescription = "VM WebSocket PTY"
@@ -15380,59 +15456,35 @@ struct TabItemView: View, Equatable {
             scaledUnreadBadgeSize: scaledUnreadBadgeSize,
             protectedWorkspaceTooltip: protectedWorkspaceTooltip
         ))
-        (scriptedSidebarRow ?? nativeSidebarRow)
-        .animation(.easeInOut(duration: 0.2), value: workspaceSnapshot.latestLog)
-        .animation(.easeInOut(duration: 0.2), value: workspaceSnapshot.progress != nil)
-        .animation(.easeInOut(duration: 0.2), value: workspaceSnapshot.metadataBlocks.count)
-        .padding(.horizontal, 10)
-        .padding(.vertical, 8)
-        .background(
-            RoundedRectangle(cornerRadius: 6)
-                .fill(backgroundColor)
-                .overlay {
-                    RoundedRectangle(cornerRadius: 6)
-                        .strokeBorder(activeBorderColor, lineWidth: activeBorderLineWidth)
-                }
-                .overlay(alignment: .leading) {
-                    if showsLeadingRail {
-                        Capsule(style: .continuous)
-                            .fill(railColor)
-                            .frame(width: 3)
-                            .padding(.leading, 4)
-                            .padding(.vertical, 5)
-                            .offset(x: -1)
-                    }
-                }
-        )
-        .sidebarShortcutHintOverlay(
-            text: showsWorkspaceShortcutHint ? workspaceShortcutLabel : nil,
-            emphasis: shortcutHintEmphasis,
-            offsetX: sidebarShortcutHintXOffset,
-            offsetY: sidebarShortcutHintYOffset,
-            fontSize: scaledFontSize(10)
-        )
-        .overlay(alignment: .topTrailing) {
-            if showsWorkspaceShortcutHint {
-                EmptyView()
-            } else if showCloseButton {
-                Button(action: {
-                    #if DEBUG
-                    cmuxDebugLog("sidebar.close workspace=\(tab.id.uuidString.prefix(5)) method=button")
-                    #endif
-                    tabManager.closeWorkspaceWithConfirmation(tab)
-                }) {
-                    Image(systemName: "xmark")
-                        .font(.system(size: scaledFontSize(9), weight: .medium))
-                        .foregroundColor(activeSecondaryColor(0.7))
-                }
-                .buttonStyle(.plain)
-                .safeHelp(closeButtonTooltip)
-                .frame(width: scaledCloseButtonWidth, height: scaledCloseButtonHitSize, alignment: .center)
-                .padding(.top, 8)
-                .padding(.trailing, 10)
+        SidebarWorkspaceRowChrome(
+            content: scriptedSidebarRow ?? nativeSidebarRow,
+            latestLog: workspaceSnapshot.latestLog,
+            progress: workspaceSnapshot.progress,
+            metadataBlockCount: workspaceSnapshot.metadataBlocks.count,
+            backgroundColor: backgroundColor,
+            activeBorderColor: activeBorderColor,
+            activeBorderLineWidth: activeBorderLineWidth,
+            showsLeadingRail: showsLeadingRail,
+            railColor: railColor,
+            showsWorkspaceShortcutHint: showsWorkspaceShortcutHint,
+            workspaceShortcutLabel: workspaceShortcutLabel,
+            shortcutHintEmphasis: shortcutHintEmphasis,
+            sidebarShortcutHintXOffset: sidebarShortcutHintXOffset,
+            sidebarShortcutHintYOffset: sidebarShortcutHintYOffset,
+            shortcutHintFontSize: scaledFontSize(10),
+            showCloseButton: showCloseButton,
+            closeButtonTooltip: closeButtonTooltip,
+            closeButtonFontSize: scaledFontSize(9),
+            closeButtonForegroundColor: activeSecondaryColor(0.7),
+            closeButtonWidth: scaledCloseButtonWidth,
+            closeButtonHitSize: scaledCloseButtonHitSize,
+            closeWorkspace: {
+                #if DEBUG
+                cmuxDebugLog("sidebar.close workspace=\(tab.id.uuidString.prefix(5)) method=button")
+                #endif
+                tabManager.closeWorkspaceWithConfirmation(tab)
             }
-        }
-        .shortcutHintVisibilityAnimation(value: showsWorkspaceShortcutHint)
+        )
         .padding(.horizontal, 6)
         .background { rowHeightProbe }
         .contentShape(Rectangle())

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -10357,7 +10357,7 @@ struct VerticalTabsSidebar: View {
     @State var dragState = SidebarDragState()
     /// Current ~/.config/cmux/sidebar.lisp compiler state. Passed by value into
     /// each row so menu changes force a row re-render through `version`.
-    @StateObject private var sidebarScriptStore = SidebarScriptStore()
+    @ObservedObject private var sidebarScriptStore = SidebarScriptStore.shared
     // Freezes `showsModifierShortcutHints` for the workspace whose context menu
     // is open. Set on the row's contextMenu.onAppear and cleared on
     // .onDisappear so modifier-key transitions don't flip the badges on the
@@ -10632,7 +10632,6 @@ struct VerticalTabsSidebar: View {
             SidebarFooter(
                 updateViewModel: updateViewModel,
                 fileExplorerState: fileExplorerState,
-                sidebarScriptStore: sidebarScriptStore,
                 onSendFeedback: onSendFeedback
             )
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -13126,7 +13125,6 @@ final class WindowScopedShortcutHintModifierMonitor {
 private struct SidebarFooter: View {
     @ObservedObject var updateViewModel: UpdateViewModel
     @ObservedObject var fileExplorerState: FileExplorerState
-    @ObservedObject var sidebarScriptStore: SidebarScriptStore
     let onSendFeedback: () -> Void
 
     var body: some View {
@@ -13134,14 +13132,12 @@ private struct SidebarFooter: View {
         SidebarDevFooter(
             updateViewModel: updateViewModel,
             fileExplorerState: fileExplorerState,
-            sidebarScriptStore: sidebarScriptStore,
             onSendFeedback: onSendFeedback
         )
 #else
         SidebarFooterButtons(
             updateViewModel: updateViewModel,
             fileExplorerState: fileExplorerState,
-            sidebarScriptStore: sidebarScriptStore,
             onSendFeedback: onSendFeedback
         )
             .padding(.leading, 6)
@@ -13154,7 +13150,6 @@ private struct SidebarFooter: View {
 private struct SidebarFooterButtons: View {
     @ObservedObject var updateViewModel: UpdateViewModel
     @ObservedObject var fileExplorerState: FileExplorerState
-    @ObservedObject var sidebarScriptStore: SidebarScriptStore
     let onSendFeedback: () -> Void
     @State private var extensionBrowserAnchorView: NSView?
     @LiveSetting(\.betaFeatures.extensions) private var extensionsExperimentalEnabled
@@ -13162,7 +13157,6 @@ private struct SidebarFooterButtons: View {
     var body: some View {
         HStack(spacing: 4) {
             SidebarHelpMenuButton(onSendFeedback: onSendFeedback)
-            SidebarScriptLayoutMenuButton(scriptStore: sidebarScriptStore)
             // The puzzle button opens the extensions browser; it only shows
             // while the experimental Extensions feature is enabled.
             if extensionsExperimentalEnabled {
@@ -13188,89 +13182,6 @@ private struct SidebarFooterButtons: View {
             UpdatePill(model: updateViewModel)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-    }
-}
-
-private struct SidebarScriptLayoutMenuButton: View {
-    @ObservedObject var scriptStore: SidebarScriptStore
-
-    private let buttonTitle = String(localized: "sidebar.script.menu.title", defaultValue: "Sidebar Layouts")
-    private let nativeTitle = String(localized: "sidebar.script.menu.native", defaultValue: "Native Sidebar")
-    private let buttonSize: CGFloat = 22
-    private let iconSize: CGFloat = 12
-
-    var body: some View {
-        Menu {
-            menuContent
-        } label: {
-            Image(systemName: "sidebar.left")
-                .symbolRenderingMode(.monochrome)
-                .font(.system(size: iconSize, weight: .medium))
-                .foregroundStyle(Color(nsColor: .secondaryLabelColor))
-                .frame(width: buttonSize, height: buttonSize, alignment: .center)
-        }
-        .menuStyle(.borderlessButton)
-        .frame(width: buttonSize, height: buttonSize, alignment: .center)
-        .contextMenu {
-            menuContent
-        }
-        .safeHelp(buttonTitle)
-        .accessibilityLabel(buttonTitle)
-        .accessibilityIdentifier("SidebarScriptLayoutMenuButton")
-    }
-
-    @ViewBuilder
-    private var menuContent: some View {
-        Button {
-            scriptStore.useNativeSidebar()
-        } label: {
-            Label(nativeTitle, systemImage: scriptStore.isNativeActive ? "checkmark.circle.fill" : "sidebar.left")
-        }
-
-        Divider()
-
-        ForEach(SidebarScriptDemo.all) { demo in
-            Button {
-                scriptStore.applyDemo(demo)
-            } label: {
-                Label(demoTitle(demo), systemImage: iconName(for: demo))
-            }
-        }
-    }
-
-    private func iconName(for demo: SidebarScriptDemo) -> String {
-        guard scriptStore.activeDemoId != demo.id else { return "checkmark.circle.fill" }
-        switch demo.id {
-        case "default": return "text.alignleft"
-        case "liquid-glass": return "sparkles"
-        case "high-density-ide": return "rectangle.grid.1x2"
-        case "terminal-stealth": return "terminal"
-        case "pro-studio": return "slider.horizontal.3"
-        case "finder": return "folder.fill"
-        case "agent-ops": return "chart.bar.xaxis"
-        default: return "sidebar.left"
-        }
-    }
-
-    private func demoTitle(_ demo: SidebarScriptDemo) -> String {
-        switch demo.id {
-        case "default":
-            return String(localized: "sidebar.script.demo.default", defaultValue: "Default Lisp")
-        case "liquid-glass":
-            return String(localized: "sidebar.script.demo.liquidGlass", defaultValue: "Liquid Glass")
-        case "high-density-ide":
-            return String(localized: "sidebar.script.demo.highDensityIDE", defaultValue: "High-Density IDE")
-        case "terminal-stealth":
-            return String(localized: "sidebar.script.demo.terminalStealth", defaultValue: "Terminal Stealth")
-        case "pro-studio":
-            return String(localized: "sidebar.script.demo.proStudio", defaultValue: "Pro Studio")
-        case "finder":
-            return String(localized: "sidebar.script.demo.finder", defaultValue: "Finder")
-        case "agent-ops":
-            return String(localized: "sidebar.script.demo.agentOps", defaultValue: "Agent Ops")
-        default:
-            return demo.id
-        }
     }
 }
 
@@ -14437,7 +14348,6 @@ private struct SidebarFooterIconButtonStyleBody: View {
 private struct SidebarDevFooter: View {
     @ObservedObject var updateViewModel: UpdateViewModel
     @ObservedObject var fileExplorerState: FileExplorerState
-    @ObservedObject var sidebarScriptStore: SidebarScriptStore
     let onSendFeedback: () -> Void
     @AppStorage(DevBuildBannerDebugSettings.sidebarBannerVisibleKey)
     private var showSidebarDevBuildBanner = DevBuildBannerDebugSettings.defaultShowSidebarBanner
@@ -14447,7 +14357,6 @@ private struct SidebarDevFooter: View {
             SidebarFooterButtons(
                 updateViewModel: updateViewModel,
                 fileExplorerState: fileExplorerState,
-                sidebarScriptStore: sidebarScriptStore,
                 onSendFeedback: onSendFeedback
             )
             if showSidebarDevBuildBanner {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -15111,43 +15111,14 @@ struct TabItemView: View, Equatable {
         }
     }
 
-    var body: some View {
-        let workspaceSnapshot = self.workspaceSnapshot
-        let closeWorkspaceTooltip = String(localized: "sidebar.closeWorkspace.tooltip", defaultValue: "Close Workspace")
-        let protectedWorkspaceTooltip = String(
-            localized: "sidebar.pinnedWorkspaceProtected.tooltip",
-            defaultValue: "Pinned workspace. Closing requires confirmation."
-        )
-        let closeButtonTooltip = workspaceSnapshot.isPinned
-            ? protectedWorkspaceTooltip
-            : KeyboardShortcutSettings.Action.closeWorkspace.tooltip(closeWorkspaceTooltip)
-        let accessibilityHintText = String(localized: "sidebar.workspace.accessibilityHint", defaultValue: "Activate to focus this workspace. Drag to reorder, or use Move Up and Move Down actions.")
-        let moveUpActionText = String(localized: "sidebar.workspace.moveUpAction", defaultValue: "Move Up")
-        let moveDownActionText = String(localized: "sidebar.workspace.moveDownAction", defaultValue: "Move Down")
-        let finderDirectoryPath = WorkspaceFinderDirectoryResolver.path(for: tab)
-        let finderDirectoryCacheKey = WorkspaceFinderDirectoryCacheKey(path: finderDirectoryPath)
-        let latestNotificationSubtitle = latestNotificationText
-        let conversationMessageSubtitle = !settings.hidesAllDetails && settings.iMessageModeEnabled
-            ? workspaceSnapshot.latestConversationMessage?
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-                .nilIfEmpty
-            : nil
-        let effectiveSubtitle = latestNotificationSubtitle ?? conversationMessageSubtitle
-        let detailVisibility = visibleAuxiliaryDetails
-        let scaledUnreadBadgeSize = 16 * fontScale
-        let scaledCloseButtonHitSize = max(16, 16 * fontScale)
-        let scaledCloseButtonWidth = max(
-            SidebarTrailingAccessoryWidthPolicy.closeButtonWidth,
-            scaledCloseButtonHitSize
-        )
-        let scriptedSidebarRow = renderedSidebarScriptNode(workspaceSnapshot: workspaceSnapshot).map { scriptNode in
-            AnyView(
-                RenderNodeView(node: scriptNode, onAction: { handleSidebarScriptAction($0) })
-                    .frame(maxWidth: .infinity, alignment: .leading)
-            )
-        }
-
-        let nativeSidebarRow = AnyView(VStack(alignment: .leading, spacing: 4) {
+    private func nativeSidebarRowContent(
+        workspaceSnapshot: SidebarWorkspaceSnapshotBuilder.Snapshot,
+        effectiveSubtitle: String?,
+        detailVisibility: SidebarWorkspaceAuxiliaryDetailVisibility,
+        scaledUnreadBadgeSize: CGFloat,
+        protectedWorkspaceTooltip: String
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
             nativeSidebarHeader(
                 workspaceSnapshot: workspaceSnapshot,
                 scaledUnreadBadgeSize: scaledUnreadBadgeSize,
@@ -15216,7 +15187,6 @@ struct TabItemView: View, Equatable {
                 .transition(.opacity.combined(with: .move(edge: .top)))
             }
 
-            // Branch + directory row
             if detailVisibility.showsBranchDirectory {
                 if sidebarBranchVerticalLayout {
                     if !workspaceSnapshot.branchDirectoryLines.isEmpty {
@@ -15313,7 +15283,6 @@ struct TabItemView: View, Equatable {
                 }
             }
 
-            // Pull request rows
             if detailVisibility.showsPullRequests, !workspaceSnapshot.pullRequestRows.isEmpty {
                 VStack(alignment: .leading, spacing: 1) {
                     ForEach(workspaceSnapshot.pullRequestRows) { pullRequest in
@@ -15345,7 +15314,6 @@ struct TabItemView: View, Equatable {
                 }
             }
 
-            // Ports row
             if detailVisibility.showsPorts, !workspaceSnapshot.listeningPorts.isEmpty {
                 HStack(spacing: 4) {
                     ForEach(workspaceSnapshot.listeningPorts, id: \.self) { port in
@@ -15366,7 +15334,52 @@ struct TabItemView: View, Equatable {
                 .foregroundColor(activeSecondaryColor(0.75))
                 .lineLimit(1)
             }
-        })
+        }
+    }
+
+    var body: some View {
+        let workspaceSnapshot = self.workspaceSnapshot
+        let closeWorkspaceTooltip = String(localized: "sidebar.closeWorkspace.tooltip", defaultValue: "Close Workspace")
+        let protectedWorkspaceTooltip = String(
+            localized: "sidebar.pinnedWorkspaceProtected.tooltip",
+            defaultValue: "Pinned workspace. Closing requires confirmation."
+        )
+        let closeButtonTooltip = workspaceSnapshot.isPinned
+            ? protectedWorkspaceTooltip
+            : KeyboardShortcutSettings.Action.closeWorkspace.tooltip(closeWorkspaceTooltip)
+        let accessibilityHintText = String(localized: "sidebar.workspace.accessibilityHint", defaultValue: "Activate to focus this workspace. Drag to reorder, or use Move Up and Move Down actions.")
+        let moveUpActionText = String(localized: "sidebar.workspace.moveUpAction", defaultValue: "Move Up")
+        let moveDownActionText = String(localized: "sidebar.workspace.moveDownAction", defaultValue: "Move Down")
+        let finderDirectoryPath = WorkspaceFinderDirectoryResolver.path(for: tab)
+        let finderDirectoryCacheKey = WorkspaceFinderDirectoryCacheKey(path: finderDirectoryPath)
+        let latestNotificationSubtitle = latestNotificationText
+        let conversationMessageSubtitle = !settings.hidesAllDetails && settings.iMessageModeEnabled
+            ? workspaceSnapshot.latestConversationMessage?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .nilIfEmpty
+            : nil
+        let effectiveSubtitle = latestNotificationSubtitle ?? conversationMessageSubtitle
+        let detailVisibility = visibleAuxiliaryDetails
+        let scaledUnreadBadgeSize = 16 * fontScale
+        let scaledCloseButtonHitSize = max(16, 16 * fontScale)
+        let scaledCloseButtonWidth = max(
+            SidebarTrailingAccessoryWidthPolicy.closeButtonWidth,
+            scaledCloseButtonHitSize
+        )
+        let scriptedSidebarRow = renderedSidebarScriptNode(workspaceSnapshot: workspaceSnapshot).map { scriptNode in
+            AnyView(
+                RenderNodeView(node: scriptNode, onAction: { handleSidebarScriptAction($0) })
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            )
+        }
+
+        let nativeSidebarRow = AnyView(nativeSidebarRowContent(
+            workspaceSnapshot: workspaceSnapshot,
+            effectiveSubtitle: effectiveSubtitle,
+            detailVisibility: detailVisibility,
+            scaledUnreadBadgeSize: scaledUnreadBadgeSize,
+            protectedWorkspaceTooltip: protectedWorkspaceTooltip
+        ))
         (scriptedSidebarRow ?? nativeSidebarRow)
         .animation(.easeInOut(duration: 0.2), value: workspaceSnapshot.latestLog)
         .animation(.easeInOut(duration: 0.2), value: workspaceSnapshot.progress != nil)

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -15081,6 +15081,36 @@ struct TabItemView: View, Equatable {
         }
     }
 
+    @ViewBuilder
+    private func nativeSidebarMetadata(
+        workspaceSnapshot: SidebarWorkspaceSnapshotBuilder.Snapshot
+    ) -> some View {
+        let metadataEntries = workspaceSnapshot.metadataEntries
+        let metadataBlocks = workspaceSnapshot.metadataBlocks
+        if !metadataEntries.isEmpty {
+            SidebarMetadataRows(
+                entries: metadataEntries,
+                isActive: usesInvertedActiveForeground,
+                activeForegroundColor: activeSecondaryColor(0.95),
+                activeSecondaryForegroundColor: activeSecondaryColor(0.65),
+                fontScale: fontScale,
+                onFocus: { updateSelection() }
+            )
+            .transition(.opacity.combined(with: .move(edge: .top)))
+        }
+        if !metadataBlocks.isEmpty {
+            SidebarMetadataMarkdownBlocks(
+                blocks: metadataBlocks,
+                isActive: usesInvertedActiveForeground,
+                activeForegroundColor: activeSecondaryColor(0.8),
+                activeSecondaryForegroundColor: activeSecondaryColor(0.65),
+                fontScale: fontScale,
+                onFocus: { updateSelection() }
+            )
+            .transition(.opacity.combined(with: .move(edge: .top)))
+        }
+    }
+
     var body: some View {
         let workspaceSnapshot = self.workspaceSnapshot
         let closeWorkspaceTooltip = String(localized: "sidebar.closeWorkspace.tooltip", defaultValue: "Close Workspace")
@@ -15146,30 +15176,7 @@ struct TabItemView: View, Equatable {
             remoteWorkspaceSection
 
             if detailVisibility.showsMetadata {
-                let metadataEntries = workspaceSnapshot.metadataEntries
-                let metadataBlocks = workspaceSnapshot.metadataBlocks
-                if !metadataEntries.isEmpty {
-                    SidebarMetadataRows(
-                        entries: metadataEntries,
-                        isActive: usesInvertedActiveForeground,
-                        activeForegroundColor: activeSecondaryColor(0.95),
-                        activeSecondaryForegroundColor: activeSecondaryColor(0.65),
-                        fontScale: fontScale,
-                        onFocus: { updateSelection() }
-                    )
-                    .transition(.opacity.combined(with: .move(edge: .top)))
-                }
-                if !metadataBlocks.isEmpty {
-                    SidebarMetadataMarkdownBlocks(
-                        blocks: metadataBlocks,
-                        isActive: usesInvertedActiveForeground,
-                        activeForegroundColor: activeSecondaryColor(0.8),
-                        activeSecondaryForegroundColor: activeSecondaryColor(0.65),
-                        fontScale: fontScale,
-                        onFocus: { updateSelection() }
-                    )
-                    .transition(.opacity.combined(with: .move(edge: .top)))
-                }
+                nativeSidebarMetadata(workspaceSnapshot: workspaceSnapshot)
             }
 
             if detailVisibility.showsLog, let latestLog = workspaceSnapshot.latestLog {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -15110,13 +15110,14 @@ struct TabItemView: View, Equatable {
             SidebarTrailingAccessoryWidthPolicy.closeButtonWidth,
             scaledCloseButtonHitSize
         )
+        let scriptedSidebarRow = renderedSidebarScriptNode(workspaceSnapshot: workspaceSnapshot).map { scriptNode in
+            AnyView(
+                RenderNodeView(node: scriptNode, onAction: { handleSidebarScriptAction($0) })
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            )
+        }
 
-        Group {
-        if let scriptNode = renderedSidebarScriptNode(workspaceSnapshot: workspaceSnapshot) {
-            RenderNodeView(node: scriptNode, onAction: { handleSidebarScriptAction($0) })
-                .frame(maxWidth: .infinity, alignment: .leading)
-        } else {
-        VStack(alignment: .leading, spacing: 4) {
+        let nativeSidebarRow = AnyView(VStack(alignment: .leading, spacing: 4) {
             nativeSidebarHeader(
                 workspaceSnapshot: workspaceSnapshot,
                 scaledUnreadBadgeSize: scaledUnreadBadgeSize,
@@ -15358,9 +15359,8 @@ struct TabItemView: View, Equatable {
                 .foregroundColor(activeSecondaryColor(0.75))
                 .lineLimit(1)
             }
-        }
-        }
-        }
+        })
+        (scriptedSidebarRow ?? nativeSidebarRow)
         .animation(.easeInOut(duration: 0.2), value: workspaceSnapshot.latestLog)
         .animation(.easeInOut(duration: 0.2), value: workspaceSnapshot.progress != nil)
         .animation(.easeInOut(duration: 0.2), value: workspaceSnapshot.metadataBlocks.count)

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -10344,6 +10344,7 @@ struct VerticalTabsSidebar: View {
     @EnvironmentObject var tabManager: TabManager
     @EnvironmentObject var notificationStore: TerminalNotificationStore
     @EnvironmentObject var cmuxConfigStore: CmuxConfigStore
+    @Environment(\.colorScheme) private var colorScheme
     @Binding var selection: SidebarSelection
     @Binding var selectedTabIds: Set<UUID>
     @Binding var lastSidebarSelectionIndex: Int?
@@ -10629,12 +10630,14 @@ struct VerticalTabsSidebar: View {
             } else {
                 extensionSidebarScrollArea(renderContext: renderContext)
             }
-            SidebarFooter(
-                updateViewModel: updateViewModel,
-                fileExplorerState: fileExplorerState,
-                onSendFeedback: onSendFeedback
-            )
-                .frame(maxWidth: .infinity, alignment: .leading)
+            if !usesWholeSidebarScript {
+                SidebarFooter(
+                    updateViewModel: updateViewModel,
+                    fileExplorerState: fileExplorerState,
+                    onSendFeedback: onSendFeedback
+                )
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
         }
         .accessibilityIdentifier("Sidebar")
         .ignoresSafeArea()
@@ -10718,6 +10721,10 @@ struct VerticalTabsSidebar: View {
             frozenShortcutHintsTabId = nil
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    private var usesWholeSidebarScript: Bool {
+        sidebarScriptStore.script?.supportsSidebarRendering == true
     }
 
     private func workspaceScrollArea(renderContext: WorkspaceListRenderContext) -> some View {
@@ -10838,6 +10845,21 @@ struct VerticalTabsSidebar: View {
                     // and `+` placement reflect the previous cwd until some
                     // unrelated sidebar event fires.
                     anchorCwdRevision &+= 1
+                }
+                .onReceive(
+                    extensionSidebarImmediateObservationPublisher(renderContext: renderContext)
+                        .receive(on: RunLoop.main)
+                ) { _ in
+                    guard usesWholeSidebarScript else { return }
+                    refreshExtensionSidebarSnapshot()
+                }
+                .onReceive(
+                    extensionSidebarDebouncedObservationPublisher(renderContext: renderContext)
+                        .receive(on: RunLoop.main)
+                        .debounce(for: Self.extensionSidebarObservationCoalesceInterval, scheduler: RunLoop.main)
+                ) { _ in
+                    guard usesWholeSidebarScript else { return }
+                    refreshExtensionSidebarSnapshot()
                 }
                 .onReceive(NotificationCenter.default.publisher(for: .sidebarMultiSelectionDidHide)) { notification in
                     // Group collapse hides some workspaces without changing
@@ -11941,22 +11963,138 @@ struct VerticalTabsSidebar: View {
         renderContext: WorkspaceListRenderContext,
         minHeight: CGFloat
     ) -> some View {
-        VStack(spacing: 0) {
-            workspaceRows(renderContext: renderContext)
+        Group {
+            if usesWholeSidebarScript,
+               let scriptNode = renderedSidebarScriptNode(renderContext: renderContext) {
+                RenderNodeView(node: scriptNode, onAction: { handleSidebarScriptAction($0) })
+                    .frame(maxWidth: .infinity, minHeight: minHeight, alignment: .topLeading)
+            } else {
+                VStack(spacing: 0) {
+                    workspaceRows(renderContext: renderContext)
 
-            SidebarEmptyArea(
-                rowSpacing: tabRowSpacing,
-                selection: $selection,
-                selectedTabIds: $selectedTabIds,
-                lastSidebarSelectionIndex: $lastSidebarSelectionIndex,
-                dragAutoScrollController: dragAutoScrollController,
-                topDropIndicatorVisible: emptyAreaTopDropIndicatorVisible(),
-                tabDropDelegate: emptyAreaTabDropDelegate(),
-                bonsplitDropIndicator: dropIndicatorBinding
-            )
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    SidebarEmptyArea(
+                        rowSpacing: tabRowSpacing,
+                        selection: $selection,
+                        selectedTabIds: $selectedTabIds,
+                        lastSidebarSelectionIndex: $lastSidebarSelectionIndex,
+                        dragAutoScrollController: dragAutoScrollController,
+                        topDropIndicatorVisible: emptyAreaTopDropIndicatorVisible(),
+                        tabDropDelegate: emptyAreaTabDropDelegate(),
+                        bonsplitDropIndicator: dropIndicatorBinding
+                    )
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                }
+                .frame(minHeight: minHeight, alignment: .top)
+            }
         }
-        .frame(minHeight: minHeight, alignment: .top)
+    }
+
+    private func renderedSidebarScriptNode(renderContext: WorkspaceListRenderContext) -> RenderNode? {
+        guard let script = sidebarScriptStore.script, script.supportsSidebarRendering else { return nil }
+        let _ = extensionSidebarUpdateToken
+        do {
+            return try script.renderSidebar(makeSidebarScriptSidebarContext(renderContext: renderContext))
+        } catch {
+            SidebarScriptStore.logRenderFailure(error)
+            return nil
+        }
+    }
+
+    private func makeSidebarScriptSidebarContext(
+        renderContext: WorkspaceListRenderContext
+    ) -> SidebarScriptSidebarContext {
+        SidebarScriptSidebarContext(
+            windowId: windowId.uuidString,
+            selectedWorkspaceId: tabManager.selectedTabId?.uuidString,
+            workspaceCount: renderContext.workspaceCount,
+            isDarkMode: colorScheme == .dark,
+            workspaces: renderContext.tabs.enumerated().map { index, workspace in
+                makeSidebarScriptContext(workspace: workspace, index: index)
+            }
+        )
+    }
+
+    private func makeSidebarScriptContext(workspace: Workspace, index: Int) -> SidebarScriptContext {
+        let latestNotificationText: String? = {
+            guard let notification = notificationStore.latestNotification(forTabId: workspace.id) else {
+                return nil
+            }
+            let text = notification.body.isEmpty ? notification.title : notification.body
+            return text.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+        }()
+        let directory = workspace.currentDirectory.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+        return SidebarScriptContext(
+            id: workspace.id.uuidString,
+            index: index,
+            title: workspace.title,
+            detail: workspace.customDescription,
+            branch: workspace.gitBranch?.branch,
+            directory: directory,
+            directories: workspace.sidebarDirectoriesInDisplayOrder(),
+            pullRequests: workspace.sidebarPullRequestsInDisplayOrder().map {
+                SidebarScriptContext.PullRequest(
+                    number: $0.number,
+                    state: $0.status.rawValue,
+                    url: $0.url.absoluteString,
+                    title: $0.label,
+                    isDraft: false,
+                    isStale: $0.isStale
+                )
+            },
+            ports: workspace.listeningPorts,
+            unreadCount: notificationStore.unreadCount(forTabId: workspace.id),
+            isPinned: workspace.isPinned,
+            isActive: tabManager.selectedTabId == workspace.id,
+            isSelected: selectedTabIds.contains(workspace.id),
+            colorHex: workspace.customColor,
+            isDarkMode: colorScheme == .dark,
+            latestMessage: latestNotificationText ?? workspace.latestSubmittedMessage,
+            progress: workspace.progress?.value,
+            remoteTarget: workspace.remoteDisplayTarget,
+            statusEntries: workspace.sidebarStatusEntriesInDisplayOrder().map {
+                SidebarScriptContext.StatusEntry(label: $0.key, value: $0.value, colorHex: $0.color)
+            }
+        )
+    }
+
+    private func handleSidebarScriptAction(_ action: RNAction) {
+        switch action.kind {
+        case "open-url":
+            guard let raw = action.payload["url"], let url = URL(string: raw) else { return }
+            if let workspaceId = tabManager.selectedTabId,
+               tabManager.openBrowser(inWorkspace: workspaceId, url: url, insertAtEnd: true) != nil {
+                return
+            }
+            NSWorkspace.shared.open(url)
+        case "copy":
+            guard let text = action.payload["text"] else { return }
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(text, forType: .string)
+        case "select-workspace":
+            guard let id = action.payload["id"].flatMap(UUID.init(uuidString:)),
+                  let workspace = tabManager.tabs.first(where: { $0.id == id }) else { return }
+            tabManager.selectWorkspace(workspace)
+            selection = .tabs
+            selectedTabIds = [workspace.id]
+            if let index = tabManager.tabs.firstIndex(where: { $0.id == workspace.id }) {
+                lastSidebarSelectionIndex = index
+            }
+        case "close-workspace":
+            guard let id = action.payload["id"].flatMap(UUID.init(uuidString:)) else { return }
+            tabManager.closeWorkspaceWithConfirmation(tabId: id)
+        case "new-workspace":
+            let directory = action.payload["directory"]?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+            let title = action.payload["title"]?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+            tabManager.addWorkspace(
+                title: title,
+                workingDirectory: directory,
+                inheritWorkingDirectory: directory == nil,
+                select: true,
+                eagerLoadTerminal: false
+            )
+        default:
+            break
+        }
     }
 
     private func workspaceRows(renderContext: WorkspaceListRenderContext) -> some View {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -10406,6 +10406,7 @@ struct VerticalTabsSidebar: View {
     let tabRowSpacing: CGFloat = 2
     private static let extensionSidebarObservationCoalesceInterval: RunLoop.SchedulerTimeType.Stride = .milliseconds(40)
     private static let extensionSidebarDisclosureAnimation = Animation.easeInOut(duration: 0.18)
+    private static let sidebarScriptFileEntryLimit = 40
     private var sidebarTitlebarInteractionHeight: CGFloat {
         MinimalModeChromeMetrics.titlebarHeight
     }
@@ -12010,7 +12011,8 @@ struct VerticalTabsSidebar: View {
             isDarkMode: colorScheme == .dark,
             workspaces: renderContext.tabs.enumerated().map { index, workspace in
                 makeSidebarScriptContext(workspace: workspace, index: index)
-            }
+            },
+            state: sidebarScriptStore.state
         )
     }
 
@@ -12053,8 +12055,50 @@ struct VerticalTabsSidebar: View {
             remoteTarget: workspace.remoteDisplayTarget,
             statusEntries: workspace.sidebarStatusEntriesInDisplayOrder().map {
                 SidebarScriptContext.StatusEntry(label: $0.key, value: $0.value, colorHex: $0.color)
-            }
+            },
+            fileEntries: sidebarScriptFileEntries(for: directory)
         )
+    }
+
+    private func sidebarScriptFileEntries(for directory: String?) -> [SidebarScriptContext.FileEntry] {
+        guard let directory else { return [] }
+        let url = URL(fileURLWithPath: directory, isDirectory: true)
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory),
+              isDirectory.boolValue else {
+            return []
+        }
+        guard let entries = try? FileManager.default.contentsOfDirectory(
+            at: url,
+            includingPropertiesForKeys: [.isDirectoryKey, .isRegularFileKey, .isHiddenKey],
+            options: [.skipsPackageDescendants]
+        ) else {
+            return []
+        }
+        return entries.compactMap { entry -> (SidebarScriptContext.FileEntry, Bool)? in
+            guard let values = try? entry.resourceValues(forKeys: [.isDirectoryKey, .isRegularFileKey, .isHiddenKey]),
+                  values.isHidden != true,
+                  values.isDirectory == true || values.isRegularFile == true else {
+                return nil
+            }
+            let isDir = values.isDirectory == true
+            return (
+                SidebarScriptContext.FileEntry(
+                    name: entry.lastPathComponent,
+                    path: entry.path,
+                    isDirectory: isDir,
+                    workspaceTitle: entry.lastPathComponent,
+                    workspaceDirectory: isDir ? entry.path : url.path
+                ),
+                isDir
+            )
+        }
+        .sorted {
+            if $0.1 != $1.1 { return $0.1 && !$1.1 }
+            return $0.0.name.localizedStandardCompare($1.0.name) == .orderedAscending
+        }
+        .prefix(Self.sidebarScriptFileEntryLimit)
+        .map(\.0)
     }
 
     private func handleSidebarScriptAction(_ action: RNAction) {
@@ -12092,9 +12136,41 @@ struct VerticalTabsSidebar: View {
                 select: true,
                 eagerLoadTerminal: false
             )
+        case "open-workspace":
+            openSidebarScriptWorkspace(action.payload)
+        case "set-sidebar-state":
+            guard let key = action.payload["key"], let value = action.payload["value"] else { return }
+            sidebarScriptStore.setState(key: key, value: value)
+        case "toggle-sidebar-state":
+            guard let key = action.payload["key"] else { return }
+            sidebarScriptStore.toggleState(key: key)
         default:
             break
         }
+    }
+
+    private func openSidebarScriptWorkspace(_ payload: [String: String]) {
+        if let id = payload["id"].flatMap(UUID.init(uuidString:)),
+           let workspace = tabManager.tabs.first(where: { $0.id == id }) {
+            tabManager.selectWorkspace(workspace)
+            return
+        }
+        let directory = payload["directory"]?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+        if let directory,
+           let workspace = tabManager.tabs.first(where: { workspace in
+               workspace.currentDirectory == directory || workspace.sidebarDirectoriesInDisplayOrder().contains(directory)
+           }) {
+            tabManager.selectWorkspace(workspace)
+            return
+        }
+        let title = payload["title"]?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+        tabManager.addWorkspace(
+            title: title,
+            workingDirectory: directory,
+            inheritWorkingDirectory: directory == nil,
+            select: true,
+            eagerLoadTerminal: false
+        )
     }
 
     private func workspaceRows(renderContext: WorkspaceListRenderContext) -> some View {

--- a/Sources/SidebarScriptStore.swift
+++ b/Sources/SidebarScriptStore.swift
@@ -1,28 +1,30 @@
+import Combine
 import Foundation
 import OSLog
 import CmuxSidebarScript
 
-/// Loads and compiles the user's optional sidebar customization script.
+/// Loads, compiles, and updates the user's optional sidebar customization script.
 ///
 /// The sidebar renders rows natively unless `~/.config/cmux/sidebar.lisp` exists
 /// and compiles. When it does, `script` is non-nil and each row renders through
 /// it; any compile or render fault falls back to the native row, so a broken
 /// script can never break the sidebar.
-///
-/// The script is compiled once when the store is created (i.e. at sidebar
-/// construction). Editing the file takes effect on the next app launch. Live
-/// reload is a deliberate follow-up.
 @MainActor
-final class SidebarScriptStore {
+final class SidebarScriptStore: ObservableObject {
     /// The compiled script, or nil when the user has no `sidebar.lisp` (or it
     /// failed to compile).
-    let script: SidebarScript?
+    @Published private(set) var script: SidebarScript?
+
+    /// The active source text. Non-nil even for a script that failed to compile
+    /// so the menu can still report whether it matches a bundled demo.
+    @Published private(set) var source: String?
 
     /// Bumps whenever the active script identity changes. Folded into the row's
     /// equatability so a new script re-renders every row.
-    let version: Int
+    @Published private(set) var version: Int = 0
 
     private static let logger = Logger(subsystem: "com.manaflow.cmux", category: "SidebarScript")
+    private let url: URL
 
     /// Logs a per-row render failure. Called from the sidebar row when a script
     /// faults so the row can fall back to native rendering.
@@ -37,21 +39,72 @@ final class SidebarScriptStore {
     }
 
     init(url: URL = SidebarScriptStore.scriptURL) {
+        self.url = url
+        reload()
+    }
+
+    var activeDemoId: String? {
+        source.flatMap(SidebarScriptDemo.matchingDemoId(for:))
+    }
+
+    var isNativeActive: Bool {
+        source == nil
+    }
+
+    func reload() {
         guard let source = try? String(contentsOf: url, encoding: .utf8) else {
-            script = nil
-            version = 0
+            setSource(nil, compiledScript: nil)
             return
         }
+
+        load(source: source)
+    }
+
+    func useNativeSidebar() {
         do {
-            script = try SidebarScript(source: source)
-            // A within-run identity for the compiled script. `hashValue` is only
-            // compared within this process, where it is stable.
-            version = source.hashValue
+            if FileManager.default.fileExists(atPath: url.path) {
+                try FileManager.default.removeItem(at: url)
+            }
+            setSource(nil, compiledScript: nil)
+            Self.logger.info("Disabled custom sidebar.lisp.")
+        } catch {
+            Self.logger.error("Failed to remove sidebar.lisp: \(String(describing: error), privacy: .public)")
+        }
+    }
+
+    func applyDemo(_ demo: SidebarScriptDemo) {
+        applySource(demo.source, logName: demo.id)
+    }
+
+    private func applySource(_ source: String, logName: String) {
+        do {
+            let compiledScript = try SidebarScript(source: source)
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try source.write(to: url, atomically: true, encoding: .utf8)
+            setSource(source, compiledScript: compiledScript)
+            Self.logger.info("Applied sidebar Lisp demo '\(logName, privacy: .public)' (\(source.count) chars).")
+        } catch {
+            Self.logger.error("Failed to apply sidebar Lisp demo '\(logName, privacy: .public)': \(String(describing: error), privacy: .public)")
+        }
+    }
+
+    private func load(source: String) {
+        do {
+            let compiledScript = try SidebarScript(source: source)
+            setSource(source, compiledScript: compiledScript)
             Self.logger.info("Loaded custom sidebar.lisp (\(source.count) chars).")
         } catch {
-            script = nil
-            version = 0
+            setSource(source, compiledScript: nil)
             Self.logger.error("sidebar.lisp failed to compile: \(String(describing: error), privacy: .public)")
         }
+    }
+
+    private func setSource(_ source: String?, compiledScript: SidebarScript?) {
+        self.source = source
+        script = compiledScript
+        version = source?.hashValue ?? 0
     }
 }

--- a/Sources/SidebarScriptStore.swift
+++ b/Sources/SidebarScriptStore.swift
@@ -1,0 +1,57 @@
+import Foundation
+import OSLog
+import CmuxSidebarScript
+
+/// Loads and compiles the user's optional sidebar customization script.
+///
+/// The sidebar renders rows natively unless `~/.config/cmux/sidebar.lisp` exists
+/// and compiles. When it does, `script` is non-nil and each row renders through
+/// it; any compile or render fault falls back to the native row, so a broken
+/// script can never break the sidebar.
+///
+/// The script is compiled once when the store is created (i.e. at sidebar
+/// construction). Editing the file takes effect on the next app launch. Live
+/// reload is a deliberate follow-up.
+@MainActor
+final class SidebarScriptStore {
+    /// The compiled script, or nil when the user has no `sidebar.lisp` (or it
+    /// failed to compile).
+    let script: SidebarScript?
+
+    /// Bumps whenever the active script identity changes. Folded into the row's
+    /// equatability so a new script re-renders every row.
+    let version: Int
+
+    private static let logger = Logger(subsystem: "com.manaflow.cmux", category: "SidebarScript")
+
+    /// Logs a per-row render failure. Called from the sidebar row when a script
+    /// faults so the row can fall back to native rendering.
+    static func logRenderFailure(_ error: Error) {
+        logger.error("sidebar.lisp render failed: \(String(describing: error), privacy: .public)")
+    }
+
+    /// The default path users edit to customize the sidebar.
+    nonisolated static var scriptURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".config/cmux/sidebar.lisp")
+    }
+
+    init(url: URL = SidebarScriptStore.scriptURL) {
+        guard let source = try? String(contentsOf: url, encoding: .utf8) else {
+            script = nil
+            version = 0
+            return
+        }
+        do {
+            script = try SidebarScript(source: source)
+            // A within-run identity for the compiled script. `hashValue` is only
+            // compared within this process, where it is stable.
+            version = source.hashValue
+            Self.logger.info("Loaded custom sidebar.lisp (\(source.count) chars).")
+        } catch {
+            script = nil
+            version = 0
+            Self.logger.error("sidebar.lisp failed to compile: \(String(describing: error), privacy: .public)")
+        }
+    }
+}

--- a/Sources/SidebarScriptStore.swift
+++ b/Sources/SidebarScriptStore.swift
@@ -1,5 +1,7 @@
+import AppKit
 import Combine
 import Foundation
+import ObjectiveC
 import OSLog
 import CmuxSidebarScript
 
@@ -11,6 +13,8 @@ import CmuxSidebarScript
 /// script can never break the sidebar.
 @MainActor
 final class SidebarScriptStore: ObservableObject {
+    static let shared = SidebarScriptStore()
+
     /// The compiled script, or nil when the user has no `sidebar.lisp` (or it
     /// failed to compile).
     @Published private(set) var script: SidebarScript?
@@ -106,5 +110,108 @@ final class SidebarScriptStore: ObservableObject {
         self.source = source
         script = compiledScript
         version = source?.hashValue ?? 0
+    }
+}
+
+private var sidebarScriptLayoutMenuTargetKey: UInt8 = 0
+
+@MainActor
+enum SidebarScriptLayoutMenuController {
+    static func showMenu(scriptStore: SidebarScriptStore, anchorView: NSView, event: NSEvent?) {
+        let menu = NSMenu(title: String(localized: "sidebar.script.menu.title", defaultValue: "Sidebar Layouts"))
+        let target = SidebarScriptLayoutMenuTarget(scriptStore: scriptStore)
+        objc_setAssociatedObject(menu, &sidebarScriptLayoutMenuTargetKey, target, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+
+        let nativeItem = NSMenuItem(
+            title: String(localized: "sidebar.script.menu.native", defaultValue: "Native Sidebar"),
+            action: #selector(SidebarScriptLayoutMenuTarget.useNativeSidebar(_:)),
+            keyEquivalent: ""
+        )
+        nativeItem.target = target
+        nativeItem.state = scriptStore.isNativeActive ? .on : .off
+        nativeItem.image = NSImage(systemSymbolName: "sidebar.left", accessibilityDescription: nil)
+        menu.addItem(nativeItem)
+        menu.addItem(.separator())
+
+        for demo in SidebarScriptDemo.all {
+            let item = NSMenuItem(
+                title: demoTitle(demo),
+                action: #selector(SidebarScriptLayoutMenuTarget.applyDemo(_:)),
+                keyEquivalent: ""
+            )
+            item.target = target
+            item.representedObject = demo.id
+            item.state = scriptStore.activeDemoId == demo.id ? .on : .off
+            item.image = NSImage(systemSymbolName: iconName(for: demo), accessibilityDescription: nil)
+            menu.addItem(item)
+        }
+
+        menu.popUp(
+            positioning: nil,
+            at: menuPoint(anchorView: anchorView, event: event),
+            in: anchorView
+        )
+    }
+
+    private static func menuPoint(anchorView: NSView, event: NSEvent?) -> NSPoint {
+        guard let event else {
+            return NSPoint(x: 0, y: anchorView.bounds.maxY + 2)
+        }
+        return anchorView.convert(event.locationInWindow, from: nil)
+    }
+
+    private static func iconName(for demo: SidebarScriptDemo) -> String {
+        switch demo.id {
+        case "default": return "text.alignleft"
+        case "liquid-glass": return "sparkles"
+        case "high-density-ide": return "rectangle.grid.1x2"
+        case "terminal-stealth": return "terminal"
+        case "pro-studio": return "slider.horizontal.3"
+        case "finder": return "folder.fill"
+        case "agent-ops": return "chart.bar.xaxis"
+        default: return "sidebar.left"
+        }
+    }
+
+    private static func demoTitle(_ demo: SidebarScriptDemo) -> String {
+        switch demo.id {
+        case "default":
+            return String(localized: "sidebar.script.demo.default", defaultValue: "Default Lisp")
+        case "liquid-glass":
+            return String(localized: "sidebar.script.demo.liquidGlass", defaultValue: "Liquid Glass")
+        case "high-density-ide":
+            return String(localized: "sidebar.script.demo.highDensityIDE", defaultValue: "High-Density IDE")
+        case "terminal-stealth":
+            return String(localized: "sidebar.script.demo.terminalStealth", defaultValue: "Terminal Stealth")
+        case "pro-studio":
+            return String(localized: "sidebar.script.demo.proStudio", defaultValue: "Pro Studio")
+        case "finder":
+            return String(localized: "sidebar.script.demo.finder", defaultValue: "Finder")
+        case "agent-ops":
+            return String(localized: "sidebar.script.demo.agentOps", defaultValue: "Agent Ops")
+        default:
+            return demo.id
+        }
+    }
+}
+
+@MainActor
+private final class SidebarScriptLayoutMenuTarget: NSObject {
+    private let scriptStore: SidebarScriptStore
+
+    init(scriptStore: SidebarScriptStore) {
+        self.scriptStore = scriptStore
+    }
+
+    @objc func useNativeSidebar(_ sender: NSMenuItem) {
+        scriptStore.useNativeSidebar()
+    }
+
+    @objc func applyDemo(_ sender: NSMenuItem) {
+        guard let demoId = sender.representedObject as? String,
+              let demo = SidebarScriptDemo.all.first(where: { $0.id == demoId }) else {
+            return
+        }
+        scriptStore.applyDemo(demo)
     }
 }

--- a/Sources/SidebarScriptStore.swift
+++ b/Sources/SidebarScriptStore.swift
@@ -27,8 +27,13 @@ final class SidebarScriptStore: ObservableObject {
     /// equatability so a new script re-renders every row.
     @Published private(set) var version: Int = 0
 
+    /// Persistent user state for whole-sidebar scripts, stored as string values
+    /// so scripts can keep layout state without executing arbitrary Swift.
+    @Published private(set) var state: [String: String] = [:]
+
     private static let logger = Logger(subsystem: "com.manaflow.cmux", category: "SidebarScript")
     private let url: URL
+    private let stateURL: URL
 
     /// Logs a per-row render failure. Called from the sidebar row when a script
     /// faults so the row can fall back to native rendering.
@@ -42,8 +47,15 @@ final class SidebarScriptStore: ObservableObject {
             .appendingPathComponent(".config/cmux/sidebar.lisp")
     }
 
-    init(url: URL = SidebarScriptStore.scriptURL) {
+    nonisolated static var stateURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".config/cmux/sidebar-state.json")
+    }
+
+    init(url: URL = SidebarScriptStore.scriptURL, stateURL: URL = SidebarScriptStore.stateURL) {
         self.url = url
+        self.stateURL = stateURL
+        state = Self.loadState(from: stateURL)
         reload()
     }
 
@@ -80,6 +92,19 @@ final class SidebarScriptStore: ObservableObject {
         applySource(demo.source, logName: demo.id)
     }
 
+    func setState(key: String, value: String) {
+        guard !key.isEmpty else { return }
+        var next = state
+        next[key] = value
+        setState(next)
+    }
+
+    func toggleState(key: String) {
+        guard !key.isEmpty else { return }
+        let current = state[key]
+        setState(key: key, value: current == "true" ? "false" : "true")
+    }
+
     private func applySource(_ source: String, logName: String) {
         do {
             let compiledScript = try SidebarScript(source: source)
@@ -110,6 +135,31 @@ final class SidebarScriptStore: ObservableObject {
         self.source = source
         script = compiledScript
         version = source?.hashValue ?? 0
+    }
+
+    private func setState(_ next: [String: String]) {
+        state = next
+        version &+= 1
+        do {
+            try FileManager.default.createDirectory(
+                at: stateURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            let data = try JSONEncoder().encode(next)
+            try data.write(to: stateURL, options: .atomic)
+        } catch {
+            Self.logger.error("Failed to persist sidebar Lisp state: \(String(describing: error), privacy: .public)")
+        }
+    }
+
+    private static func loadState(from url: URL) -> [String: String] {
+        guard let data = try? Data(contentsOf: url) else { return [:] }
+        do {
+            return try JSONDecoder().decode([String: String].self, from: data)
+        } catch {
+            logger.error("Failed to load sidebar Lisp state: \(String(describing: error), privacy: .public)")
+            return [:]
+        }
     }
 }
 

--- a/Sources/Update/MinimalModeSidebarControls.swift
+++ b/Sources/Update/MinimalModeSidebarControls.swift
@@ -195,7 +195,7 @@ final class MinimalModeSidebarControlActionView: NSView {
         }
         switch slot {
         case .toggleSidebar:
-            CmuxExtensionSidebarSelection.showMenu(anchorView: self, event: event)
+            SidebarScriptLayoutMenuController.showMenu(scriptStore: .shared, anchorView: self, event: event)
         case .newTab:
             _ = AppDelegate.shared?.showNewWorkspaceContextMenu(anchorView: self, event: event)
         case .focusHistoryBack:

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -940,7 +940,11 @@ struct TitlebarControlsView: View {
                 onToggleSidebar()
             },
                 rightClickAction: { anchorView, event in
-                    CmuxExtensionSidebarSelection.showMenu(anchorView: anchorView, event: event)
+                    SidebarScriptLayoutMenuController.showMenu(
+                        scriptStore: .shared,
+                        anchorView: anchorView,
+                        event: event
+                    )
                 }) {
                 sidebarIconLabel(config: config, iconGeometryKeyPrefix: "titlebarControl_toggleSidebarIcon")
             }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -154,6 +154,8 @@
 		D3610C010000000000000001 /* CmuxSettingsJSONPathSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3610C010000000000000002 /* CmuxSettingsJSONPathSupport.swift */; };
 		CD0CFE5600000000CD0CFE56 /* CmuxSettingsUI in Frameworks */ = {isa = PBXBuildFile; productRef = CD0CFE5500000000CD0CFE55 /* CmuxSettingsUI */; };
 		C0DE46030000000000000001 /* CMUXSidebarExtensionBrowserPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE46030000000000000002 /* CMUXSidebarExtensionBrowserPanel.swift */; };
+		C0DE5512C0DE5512C0DE5512 /* CmuxSidebarScript in Frameworks */ = {isa = PBXBuildFile; productRef = C0DE5511C0DE5511C0DE5511 /* CmuxSidebarScript */; };
+		C0DE5513C0DE5513C0DE5513 /* CmuxSidebarScript in Frameworks */ = {isa = PBXBuildFile; productRef = C0DE5511C0DE5511C0DE5511 /* CmuxSidebarScript */; };
 		A5354303A5354303A5354303 /* CmuxSocketControl in Frameworks */ = {isa = PBXBuildFile; productRef = A5354305A5354305A5354305 /* CmuxSocketControl */; };
 		B900004CA1B2C3D4E5F60719 /* CmuxSocketControl in Frameworks */ = {isa = PBXBuildFile; productRef = A5354305A5354305A5354305 /* CmuxSocketControl */; };
 		E7E000000000000000000009 /* CmuxSocketEventMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7E00000000000000000000A /* CmuxSocketEventMapper.swift */; };
@@ -435,6 +437,7 @@
 		B9000130A1B2C3D4E5F60719 /* SidebarPullRequestInteractivityUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000131A1B2C3D4E5F60719 /* SidebarPullRequestInteractivityUITests.swift */; };
 		B8F266236A1A3D9A45BD840F /* SidebarResizeUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 818DBCD4AB69EB72573E8138 /* SidebarResizeUITests.swift */; };
 		C0DE35010000000000000001 /* SidebarScrim.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE35010000000000000002 /* SidebarScrim.swift */; };
+		C0DE5521C0DE5521C0DE5521 /* SidebarScriptStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE5520C0DE5520C0DE5520 /* SidebarScriptStore.swift */; };
 		E62155868BB29FEB5DAAAF25 /* SidebarSelectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AD52285508B1D6A9875E7B3 /* SidebarSelectionState.swift */; };
 		F57072635F25EBCA741E125D /* SidebarState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1614EAD3CCF70A177A51BD1 /* SidebarState.swift */; };
 		D7AB34300000000000000105 /* SidebarTabDropIndicatorPredicateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB34300000000000000106 /* SidebarTabDropIndicatorPredicateTests.swift */; };
@@ -1054,6 +1057,7 @@
 		B9000131A1B2C3D4E5F60719 /* SidebarPullRequestInteractivityUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarPullRequestInteractivityUITests.swift; sourceTree = "<group>"; };
 		818DBCD4AB69EB72573E8138 /* SidebarResizeUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarResizeUITests.swift; sourceTree = "<group>"; };
 		C0DE35010000000000000002 /* SidebarScrim.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarScrim.swift; sourceTree = "<group>"; };
+		C0DE5520C0DE5520C0DE5520 /* SidebarScriptStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarScriptStore.swift; sourceTree = "<group>"; };
 		9AD52285508B1D6A9875E7B3 /* SidebarSelectionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarSelectionState.swift; sourceTree = "<group>"; };
 		D1614EAD3CCF70A177A51BD1 /* SidebarState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarState.swift; sourceTree = "<group>"; };
 		D7AB34300000000000000106 /* SidebarTabDropIndicatorPredicateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarTabDropIndicatorPredicateTests.swift; sourceTree = "<group>"; };
@@ -1211,6 +1215,7 @@
 				A5C0DE0000000000000000A3 /* CMUXProjectModel in Frameworks */,
 				CD0CFE5300000000CD0CFE53 /* CmuxSettings in Frameworks */,
 				CD0CFE5600000000CD0CFE56 /* CmuxSettingsUI in Frameworks */,
+				C0DE5512C0DE5512C0DE5512 /* CmuxSidebarScript in Frameworks */,
 				A5354303A5354303A5354303 /* CmuxSocketControl in Frameworks */,
 				AA11BB22CC33DD44EE550001 /* CMUXWorkstream in Frameworks */,
 				A5001006 /* GhosttyKit.xcframework in Frameworks */,
@@ -1235,6 +1240,7 @@
 			files = (
 				A5B00004A1B2C3D4E5F60718 /* CMUXAgentLaunch in Frameworks */,
 				C8000304C8000304C8000304 /* CmuxProcess in Frameworks */,
+				C0DE5513C0DE5513C0DE5513 /* CmuxSidebarScript in Frameworks */,
 				B900004CA1B2C3D4E5F60719 /* CmuxSocketControl in Frameworks */,
 				B9000024A1B2C3D4E5F60719 /* Sentry in Frameworks */,
 			);
@@ -1476,6 +1482,7 @@
 					A5001013 /* TabManager.swift */,
 					F0C05170000000000000001 /* FocusHistory.swift */,
 					C0DEFB100000000000000002 /* FocusSurfaceBroadcaster.swift */,
+					C0DE5520C0DE5520C0DE5520 /* SidebarScriptStore.swift */,
 					C10D51700000000000000001 /* ClosedItemHistory.swift */,
 					C3677003000000000000002 /* TabManager+CompatibilityTypes.swift */,
 					E3309A04 /* TabManager+EqualizeSplits.swift */,
@@ -1923,6 +1930,7 @@
 				F53000A2A1B2C3D4E5F60718 /* CMUXAgentVault */,
 				A5B00002A1B2C3D4E5F60718 /* CMUXAgentLaunch */,
 				A5354305A5354305A5354305 /* CmuxSocketControl */,
+				C0DE5511C0DE5511C0DE5511 /* CmuxSidebarScript */,
 				C8000302C8000302C8000302 /* CmuxProcess */,
 				A500D013A1B2C3D4E5F60718 /* CMUXDebugLog */,
 				CD0CFE5200000000CD0CFE52 /* CmuxSettings */,
@@ -1950,6 +1958,7 @@
 				A5001251 /* Sentry */,
 				A5B00002A1B2C3D4E5F60718 /* CMUXAgentLaunch */,
 				A5354305A5354305A5354305 /* CmuxSocketControl */,
+				C0DE5511C0DE5511C0DE5511 /* CmuxSidebarScript */,
 				C8000302C8000302C8000302 /* CmuxProcess */,
 			);
 			productName = cmux;
@@ -2064,6 +2073,7 @@
 				A5B00001A1B2C3D4E5F60718 /* XCLocalSwiftPackageReference "CMUXAgentLaunch" */,
 				A500D012A1B2C3D4E5F60718 /* XCLocalSwiftPackageReference "CMUXDebugLog" */,
 				A5354304A5354304A5354304 /* XCLocalSwiftPackageReference "CmuxSocketControl" */,
+				C0DE5510C0DE5510C0DE5510 /* XCLocalSwiftPackageReference "CmuxSidebarScript" */,
 				C8000301C8000301C8000301 /* XCLocalSwiftPackageReference "CmuxProcess" */,
 				CD0CFE5100000000CD0CFE51 /* XCLocalSwiftPackageReference "CmuxSettings" */,
 				CD0CFE5400000000CD0CFE54 /* XCLocalSwiftPackageReference "CmuxSettingsUI" */,
@@ -2446,6 +2456,7 @@
 				EA1F00000000000000000001 /* SidebarPathFormatter.swift in Sources */,
 				C0DEF0A30000000000000001 /* SidebarPortDisplayText.swift in Sources */,
 				C0DE35010000000000000001 /* SidebarScrim.swift in Sources */,
+					C0DE5521C0DE5521C0DE5521 /* SidebarScriptStore.swift in Sources */,
 				E62155868BB29FEB5DAAAF25 /* SidebarSelectionState.swift in Sources */,
 				F57072635F25EBCA741E125D /* SidebarState.swift in Sources */,
 				C9A57103C9A57103C9A57103 /* SidebarWorkspaceGroupConfigOpener.swift in Sources */,
@@ -3207,6 +3218,10 @@
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/CmuxSocketControl;
 		};
+		C0DE5510C0DE5510C0DE5510 /* XCLocalSwiftPackageReference "CmuxSidebarScript" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Packages/CmuxSidebarScript;
+		};
 		C8000301C8000301C8000301 /* XCLocalSwiftPackageReference "CmuxProcess" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/CmuxProcess;
@@ -3314,6 +3329,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = A5354304A5354304A5354304 /* XCLocalSwiftPackageReference "CmuxSocketControl" */;
 			productName = CmuxSocketControl;
+		};
+		C0DE5511C0DE5511C0DE5511 /* CmuxSidebarScript */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C0DE5510C0DE5510C0DE5510 /* XCLocalSwiftPackageReference "CmuxSidebarScript" */;
+			productName = CmuxSidebarScript;
 		};
 		C8000302C8000302C8000302 /* CmuxProcess */ = {
 			isa = XCSwiftPackageProductDependency;


### PR DESCRIPTION
## Summary

Adds a small Lisp for customizing the sidebar. A user drops a `render-row`
function in `~/.config/cmux/sidebar.lisp`; it receives one workspace's data and
returns a view tree that cmux renders as SwiftUI. With no script file present the
sidebar renders exactly as before, so this is fully opt-in and the default path
is unchanged.

New package `Packages/CmuxSidebarScript` (standalone, `swift test`-able, no app
dependency):

- **Reader** — s-expression parser. Scheme-ish core (`if`/`when`/`cond`/`let`/`def`/`fn`/`map`/...) with `:keyword` view options so a form reads like SwiftUI.
- **Evaluator** — lexical scopes, closures, a step + recursion-depth budget so a malformed script can never wedge the main thread.
- **Bridge** — the SwiftUI vocabulary: views (`vstack`/`hstack`/`zstack`/`text`/`image`/`label`/shapes/`progress-view`/`button`/...) and ~30 modifiers (`:font :foreground :background :padding :frame :corner-radius :line-limit :truncation :shadow :overlay :on-tap ...`). Adding a view or modifier is one registry entry plus one render case.
- **RenderNode** — a pure, `Equatable` view tree. `RenderNodeView` turns it into SwiftUI. This split is the perf contract: a row recomputes its node only when its data changes and stays `.equatable()`, so untouched rows are skipped at 1000-workspace scale. It also makes evaluation fully unit-testable without booting SwiftUI.
- **DefaultSidebar.lisp** — a real row (title, pin, unread badge, branch, directory, PRs, ports, progress) proving the DSL is expressive. Ships as the documented starting point users copy.

Integration in `TabItemView`: when a script is active, the row's content renders
through `RenderNodeView`; cmux keeps the selection background, close button,
drag/drop, tap, and context menu. The script is passed in as an immutable value
(a plain `let`, like `tabManager`) plus a version folded into `==`, so the
snapshot-boundary and typing-latency contracts hold. Compile/render faults log
and fall back to the native row.

## Example

```lisp
(def (render-row ws)
  (vstack :spacing 4 :max-width infinity :frame-align leading
    (text (get ws :title)
      :font (font :size 13 :weight semibold)
      :foreground (if (get ws :active) (color :white) (color :primary))
      :line-limit 1 :truncation tail)
    (when (get ws :branch)
      (hstack :spacing 4
        (image :system "arrow.triangle.branch" :font (font :size 10))
        (text (get ws :branch) :font (font :size 10 :design monospaced))))))
```

## Testing

- `swift test --package-path Packages/CmuxSidebarScript` — reader, evaluator, builtins, bridge, and end-to-end default-script rendering. All green.
- Tagged macOS build (`./scripts/reload.sh --tag sidebar-lisp`) builds and links into `cmux` and `cmux-unit`.
- Dogfood: with no `~/.config/cmux/sidebar.lisp`, sidebar is unchanged; with the default script copied in, rows render through the engine.

## Notes / follow-ups

- Live reload of the script (currently picked up on next launch) and a Settings/Debug "Reload sidebar script" action.
- Per-row node memoization in the parent scope (the `Equatable` RenderNode already supports it) if profiling shows need at extreme scale.
- Broader modifier/view coverage as needs arise (the registry is the seam).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5177"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782972643&installation_id=133855650&pr_number=5177&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5177&signature=badeeede857cd17d0c62068e120ce18961c92adb20e025cf57e6098815e39bbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new interpreter runs on the main thread during renders (bounded but still a perf/fault surface); user scripts drive UI actions and persisted sidebar state, though the host must wire handlers and the design avoids arbitrary code execution.
> 
> **Overview**
> Introduces the **`CmuxSidebarScript`** Swift package: a Scheme-style Lisp that compiles user scripts into pure **`RenderNode`** trees, then **`RenderNodeView`** maps them to SwiftUI—without executing arbitrary Swift.
> 
> Scripts can define **`render-row`** (per-workspace row inside native chrome) or **`render-sidebar`** (full sidebar). The evaluator enforces step/recursion/collection limits; top-level bindings freeze after compile. The bridge exposes stacks, shapes, ~30 `:keyword` modifiers, and actions (`select-workspace`, `new-workspace`, `open-url`, persisted **`set-sidebar-state`** / **`toggle-sidebar-state`**). **`SidebarScriptContext`** / **`SidebarScriptSidebarContext`** supply workspace, file, and state records.
> 
> Ships **`DefaultSidebar.lisp`** plus six full-sidebar demo presets and **`SidebarScriptDemo`** for discovery. Adds localized strings for **Sidebar Layouts** menu labels (native vs demo names).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd0a438c0479a373f522c98741995a4250392dba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a small Lisp engine to customize the sidebar, now supporting per-row `render-row` and full `render-sidebar` control with safe fallback to the native UI. Includes layout presets and a titlebar Sidebar Layouts menu; the Finder preset now persists its tree state.

- **New Features**
  - New package `CmuxSidebarScript`: Reader, Evaluator (step budget, depth 64, generated-collection cap), user-facing errors (line numbers), and a SwiftUI bridge (views, actions like `open-url`/`copy-text`, ~30 `:keyword` modifiers).
  - Two entry points: `render-row` keeps native row chrome; `render-sidebar` can own the entire sidebar. Pure `RenderNode` + `RenderNodeView` keep rows `.equatable()`; comprehensive tests.
  - App integration: `SidebarScriptStore` compiles once at sidebar construction; native fallback on compile/render errors. Binds truncation (tail/head/middle) and gradient direction (vertical/horizontal/diagonal) tokens. Titlebar/minimal-mode Sidebar Layouts menu to preview/install presets and manage the user script. Ships `DefaultSidebar.lisp` and distinct presets; the Finder preset persists expansion/selection state.

- **Migration**
  - Optional: create `~/.config/cmux/sidebar.lisp` with `render-sidebar` or `render-row`.
  - No action needed to keep the current sidebar; changes apply on next launch.

<sup>Written for commit dd0a438c0479a373f522c98741995a4250392dba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-user sidebar scripting to fully customize workspace row layout, styling, badges, buttons, progress, PRs and ports; scripts can emit deterministic view trees and trigger open/copy actions. Runtime compilation, automatic fallback to native UI on error, and row re-rendering when scripts change.

* **Documentation**
  * Added comprehensive usage docs and examples for the sidebar scripting language, host integration, and testing approach.

* **Tests**
  * Extensive unit and integration tests for parsing, evaluation, builtins, bridge-to-UI mapping, and end-to-end rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->