### PR TITLE
Add a configurable keyboard shortcut to open the diff viewer

### DIFF
--- a/Packages/CmuxSettings/Sources/CmuxSettings/Values/ShortcutAction+Defaults.swift
+++ b/Packages/CmuxSettings/Sources/CmuxSettings/Values/ShortcutAction+Defaults.swift
@@ -69,6 +69,7 @@ extension ShortcutAction {
         case .focusTextBoxInput: return ShortcutStroke(key: "a", command: true, shift: true)
         case .attachTextBoxFile: return ShortcutStroke(key: "a", command: true, shift: true, option: true)
         case .toggleRightSidebar: return ShortcutStroke(key: "b", command: true, option: true)
+        case .openDiffViewer: return ShortcutStroke(key: "d", command: true, shift: true, control: true)
         case .saveFilePreview: return ShortcutStroke(key: "s", command: true)
         case .openBrowser: return ShortcutStroke(key: "l", command: true, shift: true)
         case .focusBrowserAddressBar: return ShortcutStroke(key: "l", command: true)

--- a/Packages/CmuxSettings/Sources/CmuxSettings/Values/ShortcutAction.swift
+++ b/Packages/CmuxSettings/Sources/CmuxSettings/Values/ShortcutAction.swift
@@ -78,6 +78,7 @@ public enum ShortcutAction: String, CaseIterable, Sendable, Hashable, SettingCod
     case toggleRightSidebar = "toggleFileExplorer"
 
     // MARK: Browser & Find
+    case openDiffViewer
     case saveFilePreview
     case openBrowser
     case focusBrowserAddressBar
@@ -145,7 +146,7 @@ extension ShortcutAction {
              .toggleSplitZoom, .equalizeSplits, .splitBrowserRight, .splitBrowserDown,
              .toggleRightSidebar:
             return .panes
-        case .saveFilePreview, .openBrowser, .focusBrowserAddressBar, .browserBack,
+        case .openDiffViewer, .saveFilePreview, .openBrowser, .focusBrowserAddressBar, .browserBack,
              .browserForward, .browserReload, .browserZoomIn, .browserZoomOut,
              .browserZoomReset, .markdownZoomIn, .markdownZoomOut, .markdownZoomReset,
              .find, .findInDirectory, .findNext, .findPrevious,
@@ -216,6 +217,7 @@ extension ShortcutAction {
         case .splitBrowserRight: return "Split Browser Right"
         case .splitBrowserDown: return "Split Browser Down"
         case .toggleRightSidebar: return "Toggle Right Sidebar"
+        case .openDiffViewer: return "Open Diff Viewer"
         case .saveFilePreview: return "Save File Preview"
         case .openBrowser: return "Open Browser"
         case .focusBrowserAddressBar: return "Focus Address Bar"

--- a/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/CuratedSettingEntry+Default.swift
+++ b/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/CuratedSettingEntry+Default.swift
@@ -127,7 +127,7 @@ extension Array where Element == CuratedSettingEntry {
             .init(section: .globalHotkey, id: "shortcut", title: "Show/Hide All Windows", synonyms: "global hotkey shortcut recorder key command option control"),
 
             // Keyboard shortcuts
-            .init(section: .keyboardShortcuts, id: "shortcuts", title: "Keyboard Shortcuts", synonyms: "shortcuts.bindings hotkeys keybindings key bindings commands keyboard accelerators chords cmux json"),
+            .init(section: .keyboardShortcuts, id: "shortcuts", title: "Keyboard Shortcuts", synonyms: "shortcuts.bindings hotkeys keybindings key bindings commands keyboard accelerators chords cmux json open diff viewer changes review git unstaged"),
             .init(section: .keyboardShortcuts, id: "shortcut-chords", title: "Shortcut Chords", synonyms: "tmux prefix ctrl-b control-b multi key sequence chord cmux json"),
             .init(section: .keyboardShortcuts, id: "reset-defaults", title: "Reset Default Shortcuts", synonyms: "reset restore default defaults built in builtin shortcuts hotkeys keybindings commands"),
 

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -972,6 +972,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let isFirstResponder: Bool
     }
     var debugCloseMainWindowConfirmationHandler: ((NSWindow) -> Bool)?
+    /// Test seam: when set, ``openDiffViewerForFocusedWorkspace(for:)`` invokes this
+    /// instead of spawning the bundled `cmux diff` CLI, so shortcut-dispatch tests can
+    /// assert routing without launching a subprocess.
+    var debugOpenDiffViewerHandler: (() -> Void)?
+    /// Live `cmux diff` viewer subprocesses, keyed by pid, retained until they exit.
+    private var diffViewerProcesses: [Int32: Process] = [:]
     var debugCreateMainWindowSourceIsNativeFullScreenOverride: Bool?
     // Keep debug-only windows alive when tests intentionally inject key mismatches.
     private var debugDetachedContextWindows: [NSWindow] = []
@@ -5863,6 +5869,114 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return mainWindowContexts.values.first { context in
             resolvedWindow(for: context) != nil
         }?.tabManager
+    }
+
+    /// Opens the diff viewer for the focused workspace of `tabManager` by spawning the
+    /// bundled `cmux diff` CLI. This is the single shared diff-open path: both the
+    /// command-palette entry and the Open Diff Viewer keyboard shortcut funnel through
+    /// here so neither duplicates diff-open logic. Returns `false` (caller beeps) when
+    /// there is no focused workspace or the bundled CLI is missing.
+    @discardableResult
+    func openDiffViewerForFocusedWorkspace(for tabManager: TabManager?) -> Bool {
+        if let debugOpenDiffViewerHandler {
+            debugOpenDiffViewerHandler()
+            return true
+        }
+        guard let workspace = tabManager?.selectedWorkspace,
+              let cliURL = Bundle.main.resourceURL?.appendingPathComponent("bin/cmux"),
+              FileManager.default.isExecutableFile(atPath: cliURL.path) else {
+            return false
+        }
+        let socketPath = TerminalController.shared.activeSocketPath(
+            preferredPath: SocketControlSettings.socketPath()
+        )
+        let cwd = workspace.resolvedWorkingDirectory()
+            ?? FileManager.default.homeDirectoryForCurrentUser.path
+        return launchDiffViewerProcess(
+            cliURL: cliURL,
+            socketPath: socketPath,
+            cwd: cwd,
+            workspaceId: workspace.id,
+            surfaceId: workspace.focusedPanelId
+        )
+    }
+
+    @discardableResult
+    private func launchDiffViewerProcess(
+        cliURL: URL,
+        socketPath: String,
+        cwd: String,
+        workspaceId: UUID,
+        surfaceId: UUID?
+    ) -> Bool {
+        let process = Process()
+        process.executableURL = cliURL
+        var arguments = [
+            "--socket", socketPath,
+            "diff",
+            "--unstaged",
+            "--cwd", cwd,
+            "--workspace", workspaceId.uuidString,
+            "--focus", "true",
+        ]
+        if let surfaceId {
+            arguments.append(contentsOf: ["--surface", surfaceId.uuidString])
+        }
+        process.arguments = arguments
+        process.currentDirectoryURL = URL(fileURLWithPath: cwd, isDirectory: true)
+        var environment = ProcessInfo.processInfo.environment
+        environment["CMUX_SOCKET_PATH"] = socketPath
+        environment["CMUX_BUNDLED_CLI_PATH"] = cliURL.path
+        environment["CMUX_WORKSPACE_ID"] = workspaceId.uuidString
+        if let surfaceId {
+            environment["CMUX_SURFACE_ID"] = surfaceId.uuidString
+        }
+        environment.removeValue(forKey: "CMUX_SOCKET")
+        process.environment = environment
+        process.standardInput = FileHandle.nullDevice
+
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+        let outputCollector = ProcessOutputCollector(stdout: stdoutPipe, stderr: stderrPipe)
+        outputCollector.start()
+        process.terminationHandler = { terminatedProcess in
+            let output = outputCollector.finish()
+            let processIdentifier = terminatedProcess.processIdentifier
+            let terminationStatus = terminatedProcess.terminationStatus
+            Task { @MainActor in
+                AppDelegate.shared?.diffViewerProcesses.removeValue(forKey: processIdentifier)
+                guard terminationStatus != 0 else { return }
+                let detail = output.trimmingCharacters(in: .whitespacesAndNewlines)
+                let limitedDetail = detail.isEmpty
+                    ? "status=\(terminationStatus)"
+                    : String(detail.prefix(240))
+#if DEBUG
+                cmuxDebugLog("openDiffViewer exited status=\(terminationStatus) detail=\(limitedDetail)")
+#endif
+                NSSound.beep()
+            }
+        }
+
+        do {
+            try process.run()
+            let processIdentifier = process.processIdentifier
+            diffViewerProcesses[processIdentifier] = process
+            if !process.isRunning {
+                diffViewerProcesses.removeValue(forKey: processIdentifier)
+            }
+#if DEBUG
+            cmuxDebugLog("openDiffViewer pid=\(process.processIdentifier) cwd=\(cwd)")
+#endif
+            return true
+        } catch {
+            outputCollector.cancel()
+#if DEBUG
+            cmuxDebugLog("openDiffViewer failed cwd=\(cwd) error=\(error.localizedDescription)")
+#endif
+            return false
+        }
     }
 
     func allMainWindowTabManagersForDebug() -> [TabManager] {
@@ -12717,6 +12831,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // Check Show Notifications shortcut
         if matchConfiguredShortcut(event: event, action: .showNotifications) {
             toggleNotificationsPopover(animated: false, anchorView: fullscreenControlsViewModel?.notificationsAnchorView)
+            return true
+        }
+
+        if matchConfiguredShortcut(event: event, action: .openDiffViewer) {
+            // Shares the command palette's diff-open path; targets the event window's
+            // focused workspace and beeps if it can't be opened (matching the palette).
+            let manager = activeTabManagerForCommands(preferredWindow: mainWindowForShortcutEvent(event))
+            if !openDiffViewerForFocusedWorkspace(for: manager) {
+                NSSound.beep()
+            }
             return true
         }
 

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -942,6 +942,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         method_exchangeImplementations(originalMethod, swizzledMethod)
     }()
 
+    /// Live `cmux diff` viewer subprocesses, keyed by pid, retained until they exit.
+    /// Declared outside `#if DEBUG` because process retention is production behavior.
+    private var diffViewerProcesses: [Int32: Process] = [:]
+
 #if DEBUG
     private var didSetupJumpUnreadUITest = false
     private var jumpUnreadFocusExpectation: (tabId: UUID, surfaceId: UUID)?
@@ -976,8 +980,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     /// instead of spawning the bundled `cmux diff` CLI, so shortcut-dispatch tests can
     /// assert routing without launching a subprocess.
     var debugOpenDiffViewerHandler: (() -> Void)?
-    /// Live `cmux diff` viewer subprocesses, keyed by pid, retained until they exit.
-    private var diffViewerProcesses: [Int32: Process] = [:]
     var debugCreateMainWindowSourceIsNativeFullScreenOverride: Bool?
     // Keep debug-only windows alive when tests intentionally inject key mismatches.
     private var debugDetachedContextWindows: [NSWindow] = []
@@ -5931,10 +5933,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     /// there is no focused workspace or the bundled CLI is missing.
     @discardableResult
     func openDiffViewerForFocusedWorkspace(for tabManager: TabManager?) -> Bool {
+#if DEBUG
         if let debugOpenDiffViewerHandler {
             debugOpenDiffViewerHandler()
             return true
         }
+#endif
         guard let workspace = tabManager?.selectedWorkspace,
               let cliURL = Bundle.main.resourceURL?.appendingPathComponent("bin/cmux"),
               FileManager.default.isExecutableFile(atPath: cliURL.path) else {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -6001,12 +6001,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             Task { @MainActor in
                 AppDelegate.shared?.diffViewerProcesses.removeValue(forKey: processIdentifier)
                 guard terminationStatus != 0 else { return }
-                let detail = output.trimmingCharacters(in: .whitespacesAndNewlines)
-                let limitedDetail = detail.isEmpty
-                    ? "status=\(terminationStatus)"
-                    : String(detail.prefix(240))
 #if DEBUG
-                cmuxDebugLog("openDiffViewer exited status=\(terminationStatus) detail=\(limitedDetail)")
+                // Log only non-sensitive metadata: the child's stdout/stderr can echo
+                // repo paths and file contents, so report a byte count, not the text.
+                cmuxDebugLog("openDiffViewer exited status=\(terminationStatus) outputBytes=\(output.utf8.count)")
 #endif
                 NSSound.beep()
             }
@@ -6020,13 +6018,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 diffViewerProcesses.removeValue(forKey: processIdentifier)
             }
 #if DEBUG
-            cmuxDebugLog("openDiffViewer pid=\(process.processIdentifier) cwd=\(cwd)")
+            cmuxDebugLog("openDiffViewer pid=\(process.processIdentifier)")
 #endif
             return true
         } catch {
             outputCollector.cancel()
 #if DEBUG
-            cmuxDebugLog("openDiffViewer failed cwd=\(cwd) error=\(error.localizedDescription)")
+            cmuxDebugLog("openDiffViewer failed error=\(error.localizedDescription)")
 #endif
             return false
         }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -6028,7 +6028,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         } catch {
             outputCollector.cancel()
 #if DEBUG
-            cmuxDebugLog("openDiffViewer failed error=\(error.localizedDescription)")
+            cmuxDebugLog("openDiffViewer failed errorType=\(type(of: error))")
 #endif
             return false
         }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -8166,7 +8166,7 @@ struct ContentView: View {
             }
         }
         registry.register(commandId: "palette.openDiffViewer") {
-            if !openDiffViewerFromCommandPalette() {
+            if AppDelegate.shared?.openDiffViewerForFocusedWorkspace(for: tabManager) != true {
                 NSSound.beep()
             }
         }
@@ -8400,129 +8400,9 @@ struct ContentView: View {
         )
     }
 
-    @discardableResult
-    private func openDiffViewerFromCommandPalette() -> Bool {
-        guard let workspace = tabManager.selectedWorkspace,
-              let cliURL = Bundle.main.resourceURL?.appendingPathComponent("bin/cmux"),
-              FileManager.default.isExecutableFile(atPath: cliURL.path) else {
-            return false
-        }
-
-        let preferredSocketPath = SocketControlSettings.socketPath()
-        let activeSocketPath = TerminalController.shared.activeSocketPath(preferredPath: preferredSocketPath)
-        return CommandPaletteDiffViewerLauncher.shared.start(
-            cliURL: cliURL,
-            socketPath: activeSocketPath,
-            cwd: configuredActionBaseCwd(),
-            workspaceId: workspace.id,
-            surfaceId: workspace.focusedPanelId
-        )
-    }
-
-    @MainActor
-    private final class CommandPaletteDiffViewerLauncher {
-        static let shared = CommandPaletteDiffViewerLauncher()
-
-        private var processes: [Int32: Process] = [:]
-
-        private init() {}
-
-        @discardableResult
-        func start(
-            cliURL: URL,
-            socketPath: String,
-            cwd: String,
-            workspaceId: UUID,
-            surfaceId: UUID?
-        ) -> Bool {
-            let process = Process()
-            process.executableURL = cliURL
-            var arguments = [
-                "--socket", socketPath,
-                "diff",
-                "--unstaged",
-                "--cwd", cwd,
-                "--workspace", workspaceId.uuidString,
-                "--focus", "true",
-            ]
-            if let surfaceId {
-                arguments.append(contentsOf: ["--surface", surfaceId.uuidString])
-            }
-            process.arguments = arguments
-            process.currentDirectoryURL = URL(fileURLWithPath: cwd, isDirectory: true)
-            var environment = ProcessInfo.processInfo.environment
-            environment["CMUX_SOCKET_PATH"] = socketPath
-            environment["CMUX_BUNDLED_CLI_PATH"] = cliURL.path
-            environment["CMUX_WORKSPACE_ID"] = workspaceId.uuidString
-            if let surfaceId {
-                environment["CMUX_SURFACE_ID"] = surfaceId.uuidString
-            }
-            environment.removeValue(forKey: "CMUX_SOCKET")
-            process.environment = environment
-            process.standardInput = FileHandle.nullDevice
-
-            let stdoutPipe = Pipe()
-            let stderrPipe = Pipe()
-            process.standardOutput = stdoutPipe
-            process.standardError = stderrPipe
-            let outputCollector = ProcessOutputCollector(stdout: stdoutPipe, stderr: stderrPipe)
-            outputCollector.start()
-            process.terminationHandler = { terminatedProcess in
-                let output = outputCollector.finish()
-                let processIdentifier = terminatedProcess.processIdentifier
-                let terminationStatus = terminatedProcess.terminationStatus
-                Task { @MainActor in
-                    Self.shared.processes.removeValue(forKey: processIdentifier)
-                    guard terminationStatus != 0 else { return }
-                    let detail = output.trimmingCharacters(in: .whitespacesAndNewlines)
-                    let limitedDetail = detail.isEmpty
-                        ? "status=\(terminationStatus)"
-                        : String(detail.prefix(240))
-#if DEBUG
-                    cmuxDebugLog("commandPalette.openDiffViewer exited status=\(terminationStatus) detail=\(limitedDetail)")
-#endif
-                    NSSound.beep()
-                }
-            }
-
-            do {
-                try process.run()
-                let processIdentifier = process.processIdentifier
-                processes[processIdentifier] = process
-                if !process.isRunning {
-                    processes.removeValue(forKey: processIdentifier)
-                }
-#if DEBUG
-                cmuxDebugLog("commandPalette.openDiffViewer pid=\(process.processIdentifier) cwd=\(cwd)")
-#endif
-                return true
-            } catch {
-                outputCollector.cancel()
-#if DEBUG
-                cmuxDebugLog("commandPalette.openDiffViewer failed cwd=\(cwd) error=\(error.localizedDescription)")
-#endif
-                return false
-            }
-        }
-    }
-
     private func configuredActionBaseCwd() -> String {
-        guard let workspace = tabManager.selectedWorkspace else {
-            return FileManager.default.homeDirectoryForCurrentUser.path
-        }
-        let focusedPanelId = workspace.focusedPanelId
-        let candidates = [
-            focusedPanelId.flatMap { workspace.panelDirectories[$0] },
-            focusedPanelId.flatMap { workspace.terminalPanel(for: $0)?.requestedWorkingDirectory },
-            workspace.currentDirectory
-        ]
-        for candidate in candidates {
-            let trimmed = candidate?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-            if !trimmed.isEmpty {
-                return trimmed
-            }
-        }
-        return FileManager.default.homeDirectoryForCurrentUser.path
+        tabManager.selectedWorkspace?.resolvedWorkingDirectory()
+            ?? FileManager.default.homeDirectoryForCurrentUser.path
     }
 
     var focusedPanelContext: (workspace: Workspace, panelId: UUID, panel: any Panel)? {

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -150,6 +150,7 @@ enum KeyboardShortcutSettings {
         case toggleBrowserDeveloperTools
         case showBrowserJavaScriptConsole
         case toggleReactGrab
+        case openDiffViewer
         case diffViewerScrollDown
         case diffViewerScrollUp
         case diffViewerScrollToBottom
@@ -243,6 +244,7 @@ enum KeyboardShortcutSettings {
             case .toggleBrowserDeveloperTools: return String(localized: "shortcut.toggleBrowserDevTools.label", defaultValue: "Toggle Browser Developer Tools")
             case .showBrowserJavaScriptConsole: return String(localized: "shortcut.showBrowserJSConsole.label", defaultValue: "Show Browser JavaScript Console")
             case .toggleReactGrab: return String(localized: "shortcut.toggleReactGrab.label", defaultValue: "Toggle React Grab")
+            case .openDiffViewer: return String(localized: "shortcut.openDiffViewer.label", defaultValue: "Open Diff Viewer")
             case .diffViewerScrollDown: return String(localized: "shortcut.diffViewerScrollDown.label", defaultValue: "Diff Viewer: Scroll Down")
             case .diffViewerScrollUp: return String(localized: "shortcut.diffViewerScrollUp.label", defaultValue: "Diff Viewer: Scroll Up")
             case .diffViewerScrollToBottom: return String(localized: "shortcut.diffViewerScrollToBottom.label", defaultValue: "Diff Viewer: Scroll to Bottom")
@@ -452,6 +454,14 @@ enum KeyboardShortcutSettings {
                 return StoredShortcut(key: "c", command: true, shift: false, option: true, control: false)
             case .toggleReactGrab:
                 return StoredShortcut(key: "g", command: true, shift: true, option: false, control: false)
+            case .openDiffViewer:
+                // Cmd+Ctrl+D. The natural "D for Diff" chord (Cmd+Shift+D) collides
+                // with Split Down, and the entire Cmd-based "D" family is already
+                // taken by split actions (Cmd+D, Cmd+Shift+D, Cmd+Opt+D,
+                // Cmd+Shift+Opt+D). Cmd+Ctrl+D is free and matches cmux's
+                // Cmd+Ctrl+<letter> app-shortcut family (Close Window = Cmd+Ctrl+W,
+                // Toggle Full Screen = Cmd+Ctrl+F).
+                return StoredShortcut(key: "d", command: true, shift: false, option: false, control: true)
             case .diffViewerScrollDown:
                 return StoredShortcut(key: "j", command: false, shift: false, option: false, control: false)
             case .diffViewerScrollUp:

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -455,13 +455,13 @@ enum KeyboardShortcutSettings {
             case .toggleReactGrab:
                 return StoredShortcut(key: "g", command: true, shift: true, option: false, control: false)
             case .openDiffViewer:
-                // Cmd+Ctrl+D. The natural "D for Diff" chord (Cmd+Shift+D) collides
-                // with Split Down, and the entire Cmd-based "D" family is already
-                // taken by split actions (Cmd+D, Cmd+Shift+D, Cmd+Opt+D,
-                // Cmd+Shift+Opt+D). Cmd+Ctrl+D is free and matches cmux's
-                // Cmd+Ctrl+<letter> app-shortcut family (Close Window = Cmd+Ctrl+W,
-                // Toggle Full Screen = Cmd+Ctrl+F).
-                return StoredShortcut(key: "d", command: true, shift: false, option: false, control: true)
+                // Cmd+Ctrl+Shift+D. The plain Cmd+Ctrl+D chord is reserved by macOS for
+                // "Look Up & data detectors" — the OS swallows it before it reaches the
+                // app's key monitor — and the rest of the Cmd-based "D" family is taken
+                // by split actions (Cmd+D, Cmd+Shift+D, Cmd+Opt+D, Cmd+Shift+Opt+D).
+                // Adding Shift yields a chord that reaches cmux while keeping the "D for
+                // Diff" mnemonic. Rebindable in Settings → Keyboard Shortcuts.
+                return StoredShortcut(key: "d", command: true, shift: true, option: false, control: true)
             case .diffViewerScrollDown:
                 return StoredShortcut(key: "j", command: false, shift: false, option: false, control: false)
             case .diffViewerScrollUp:

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -11593,18 +11593,7 @@ final class Workspace: Identifiable, ObservableObject {
     /// its terminal's requested directory, then the workspace's current directory.
     /// Returns `nil` when none is known so callers can apply their own fallback.
     func resolvedWorkingDirectory() -> String? {
-        let candidates = [
-            focusedPanelId.flatMap { panelDirectories[$0] },
-            focusedPanelId.flatMap { terminalPanel(for: $0)?.requestedWorkingDirectory },
-            currentDirectory,
-        ]
-        for candidate in candidates {
-            let trimmed = candidate?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-            if !trimmed.isEmpty {
-                return trimmed
-            }
-        }
-        return nil
+        configTrackingDirectory(for: focusedPanelId)
     }
 
     private func surfaceKind(for panel: any Panel) -> String {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -11588,6 +11588,25 @@ final class Workspace: Identifiable, ObservableObject {
         panels[panelId] as? FilePreviewPanel
     }
 
+    /// The working directory app-level actions (diff viewer, configured commands)
+    /// should target for this workspace: the focused panel's tracked directory, then
+    /// its terminal's requested directory, then the workspace's current directory.
+    /// Returns `nil` when none is known so callers can apply their own fallback.
+    func resolvedWorkingDirectory() -> String? {
+        let candidates = [
+            focusedPanelId.flatMap { panelDirectories[$0] },
+            focusedPanelId.flatMap { terminalPanel(for: $0)?.requestedWorkingDirectory },
+            currentDirectory,
+        ]
+        for candidate in candidates {
+            let trimmed = candidate?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            if !trimmed.isEmpty {
+                return trimmed
+            }
+        }
+        return nil
+    }
+
     private func surfaceKind(for panel: any Panel) -> String {
         switch panel.panelType {
         case .terminal:

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -11592,8 +11592,23 @@ final class Workspace: Identifiable, ObservableObject {
     /// should target for this workspace: the focused panel's tracked directory, then
     /// its terminal's requested directory, then the workspace's current directory.
     /// Returns `nil` when none is known so callers can apply their own fallback.
+    ///
+    /// This is the focused-panel case of ``configTrackingDirectory(for:)`` (the same
+    /// three-tier order); the tiers are spelled out here so the public entry point is
+    /// self-contained.
     func resolvedWorkingDirectory() -> String? {
-        configTrackingDirectory(for: focusedPanelId)
+        let candidates = [
+            focusedPanelId.flatMap { panelDirectories[$0] },
+            focusedPanelId.flatMap { terminalPanel(for: $0)?.requestedWorkingDirectory },
+            currentDirectory,
+        ]
+        for candidate in candidates {
+            let trimmed = candidate?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            if !trimmed.isEmpty {
+                return trimmed
+            }
+        }
+        return nil
     }
 
     private func surfaceKind(for panel: any Panel) -> String {

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -1977,13 +1977,14 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
             return
         }
 
-        // Default is Cmd+Ctrl+D (the natural Cmd+Shift+D collides with Split Down), and
-        // it must be conflict-free so the recorder accepts it as-is.
-        let cmdCtrlD = StoredShortcut(key: "d", command: true, shift: false, option: false, control: true)
-        XCTAssertEqual(KeyboardShortcutSettings.shortcut(for: .openDiffViewer), cmdCtrlD)
+        // Default is Cmd+Ctrl+Shift+D. Plain Cmd+Ctrl+D is reserved by macOS ("Look Up")
+        // and never reaches the app, and the rest of the Cmd+D family is taken by split
+        // actions; the default must be conflict-free so the recorder accepts it as-is.
+        let cmdCtrlShiftD = StoredShortcut(key: "d", command: true, shift: true, option: false, control: true)
+        XCTAssertEqual(KeyboardShortcutSettings.shortcut(for: .openDiffViewer), cmdCtrlShiftD)
         XCTAssertEqual(
-            KeyboardShortcutSettings.Action.openDiffViewer.normalizedRecordedShortcutResult(cmdCtrlD),
-            .accepted(cmdCtrlD),
+            KeyboardShortcutSettings.Action.openDiffViewer.normalizedRecordedShortcutResult(cmdCtrlShiftD),
+            .accepted(cmdCtrlShiftD),
             "Default Open Diff Viewer shortcut must not conflict with any other action"
         )
         XCTAssertTrue(
@@ -2006,18 +2007,18 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
 
         guard let event = makeKeyDownEvent(
             key: "d",
-            modifiers: [.command, .control],
+            modifiers: [.command, .control, .shift],
             keyCode: 2, // kVK_ANSI_D
             windowNumber: targetWindow.windowNumber
         ) else {
-            XCTFail("Failed to construct Cmd+Ctrl+D event")
+            XCTFail("Failed to construct Cmd+Ctrl+Shift+D event")
             return
         }
 
 #if DEBUG
         XCTAssertTrue(
             appDelegate.debugHandleCustomShortcut(event: event),
-            "Cmd+Ctrl+D should be consumed by the Open Diff Viewer shortcut"
+            "Cmd+Ctrl+Shift+D should be consumed by the Open Diff Viewer shortcut"
         )
 #else
         XCTFail("debugHandleCustomShortcut is only available in DEBUG")
@@ -2025,7 +2026,7 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         XCTAssertEqual(
             openDiffViewerCount,
             1,
-            "Cmd+Ctrl+D must route to the shared diff-open path (same path as the command palette)"
+            "Cmd+Ctrl+Shift+D must route to the shared diff-open path (same path as the command palette)"
         )
     }
 

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -1971,6 +1971,64 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         )
     }
 
+    func testOpenDiffViewerShortcutDefaultsToCmdCtrlDAndRoutesToSharedDiffPath() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        // Default is Cmd+Ctrl+D (the natural Cmd+Shift+D collides with Split Down), and
+        // it must be conflict-free so the recorder accepts it as-is.
+        let cmdCtrlD = StoredShortcut(key: "d", command: true, shift: false, option: false, control: true)
+        XCTAssertEqual(KeyboardShortcutSettings.shortcut(for: .openDiffViewer), cmdCtrlD)
+        XCTAssertEqual(
+            KeyboardShortcutSettings.Action.openDiffViewer.normalizedRecordedShortcutResult(cmdCtrlD),
+            .accepted(cmdCtrlD),
+            "Default Open Diff Viewer shortcut must not conflict with any other action"
+        )
+        XCTAssertTrue(
+            KeyboardShortcutSettings.settingsVisibleActions.contains(.openDiffViewer),
+            "Open Diff Viewer must be visible/editable in Settings → Keyboard Shortcuts"
+        )
+
+        let windowId = appDelegate.createMainWindow()
+        defer { closeWindow(withId: windowId) }
+        guard let targetWindow = window(withId: windowId) else {
+            XCTFail("Expected test window")
+            return
+        }
+
+        // Intercept the shared diff-open path so the dispatch test never spawns a
+        // subprocess; we only assert the shortcut routes here.
+        var openDiffViewerCount = 0
+        appDelegate.debugOpenDiffViewerHandler = { openDiffViewerCount += 1 }
+        defer { appDelegate.debugOpenDiffViewerHandler = nil }
+
+        guard let event = makeKeyDownEvent(
+            key: "d",
+            modifiers: [.command, .control],
+            keyCode: 2, // kVK_ANSI_D
+            windowNumber: targetWindow.windowNumber
+        ) else {
+            XCTFail("Failed to construct Cmd+Ctrl+D event")
+            return
+        }
+
+#if DEBUG
+        XCTAssertTrue(
+            appDelegate.debugHandleCustomShortcut(event: event),
+            "Cmd+Ctrl+D should be consumed by the Open Diff Viewer shortcut"
+        )
+#else
+        XCTFail("debugHandleCustomShortcut is only available in DEBUG")
+#endif
+        XCTAssertEqual(
+            openDiffViewerCount,
+            1,
+            "Cmd+Ctrl+D must route to the shared diff-open path (same path as the command palette)"
+        )
+    }
+
     func testCmdCtrlWPromptsBeforeClosingWindow() {
         guard let appDelegate = AppDelegate.shared else {
             XCTFail("Expected AppDelegate.shared")

--- a/web/data/cmux-shortcuts.ts
+++ b/web/data/cmux-shortcuts.ts
@@ -221,6 +221,11 @@ export const shortcutCategories: ShortcutCategory[] = [
     titleKey: "diffViewer",
     shortcuts: [
       {
+        id: "openDiffViewer",
+        combos: [["⌃", "⌘", "D"]],
+        description: { en: "Open diff viewer", ja: "差分ビューアを開く" },
+      },
+      {
         id: "diffViewerScrollDown",
         combos: [["J"]],
         description: { en: "Scroll diff down", ja: "差分を下にスクロール" },

--- a/web/data/cmux-shortcuts.ts
+++ b/web/data/cmux-shortcuts.ts
@@ -222,7 +222,7 @@ export const shortcutCategories: ShortcutCategory[] = [
     shortcuts: [
       {
         id: "openDiffViewer",
-        combos: [["⌃", "⌘", "D"]],
+        combos: [["⌃", "⌘", "⇧", "D"]],
         description: { en: "Open diff viewer", ja: "差分ビューアを開く" },
       },
       {


### PR DESCRIPTION
## Summary

Adds a configurable keyboard shortcut to open the diff viewer for the focused workspace, rebindable in Settings like every other cmux shortcut.

cmux already opens the diff viewer via the `cmux diff` CLI and the **Open Diff Viewer** command-palette entry (which spawns that CLI). This wires up a first-class keyboard shortcut that goes through the **same shared diff-open path** — no duplicated diff-open logic.

## What changed

- **New `openDiffViewer` action** in `KeyboardShortcutSettings.Action` (label "Open Diff Viewer"). It's automatically visible/editable in **Settings → Keyboard Shortcuts** (`settingsVisibleActions` + `ShortcutSettingRow`) and configurable via `~/.config/cmux/cmux.json` (`shortcuts.openDiffViewer`) through `KeyboardShortcutSettingsFileStore`.
- **Shared action path:** extracted the command palette's diff launcher into `AppDelegate.openDiffViewerForFocusedWorkspace(for:)`. Both the command palette **and** the new shortcut now funnel through it (it spawns `cmux diff --unstaged --workspace … --focus true` for the focused workspace). The per-workspace working-directory resolution was lifted to `Workspace.resolvedWorkingDirectory()` and reused by the existing configured-action path too.
- **Dispatch:** `AppDelegate.handleCustomShortcut` gets a `matchConfiguredShortcut(event:action:.openDiffViewer)` branch that opens the diff viewer for the event window's focused workspace (beeps on failure, matching the palette).

## Default shortcut: `Cmd+Ctrl+D`

The issue proposed `Cmd+Shift+D` ("D" for Diff), but that **collides with Split Down**. The entire Cmd-based "D" family is already taken by split actions:

| Chord | Action |
| --- | --- |
| `Cmd+D` | Split Right |
| `Cmd+Shift+D` | Split Down |
| `Cmd+Opt+D` | Split Browser Right |
| `Cmd+Shift+Opt+D` | Split Browser Down |

`Cmd+Ctrl+D` is free, keeps the "D for Diff" mnemonic, and matches cmux's existing `Cmd+Ctrl+<letter>` app-shortcut family (`Cmd+Ctrl+W` Close Window, `Cmd+Ctrl+F` Toggle Full Screen). The added dispatch test asserts the default is conflict-free.

## Docs & localization

- `web/data/cmux-shortcuts.ts` gains an `openDiffViewer` entry (renders into both the keyboard-shortcuts docs page and the `shortcuts.bindings` configuration docs table automatically).
- Added `shortcut.openDiffViewer.label` (en + ja) to `Resources/Localizable.xcstrings`.

## Tests

Added `testOpenDiffViewerShortcutDefaultsToCmdCtrlDAndRoutesToSharedDiffPath` to `cmuxTests/AppDelegateShortcutRoutingTests.swift`: dispatches a `Cmd+Ctrl+D` key event through `handleCustomShortcut` and asserts it routes to the shared diff-open path (via a `debugOpenDiffViewerHandler` test seam, so no subprocess is spawned), the default resolves to `Cmd+Ctrl+D`, it's conflict-free, and it's in `settingsVisibleActions`.

Closes #5169

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5178"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782973030&installation_id=133855650&pr_number=5178&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5178&signature=37e29a1884e33e6890321f35aab5083dc00546c0797386d88629e784415483ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and shortcut wiring around an existing CLI spawn path; no auth or data-model changes, with minor subprocess-launch surface consolidated from the palette.
> 
> **Overview**
> Adds a first-class **Open Diff Viewer** keyboard shortcut (default **⌃⌘⇧D**) that opens unstaged diffs for the focused workspace via the bundled `cmux diff` CLI, rebindable in Settings and `cmux.json` like other shortcuts.
> 
> **⌃⌘⇧D** avoids macOS swallowing plain **⌃⌘D** (“Look Up”) and conflicts with existing **⌘D** split chords. Settings, `ShortcutAction`, docs (`cmux-shortcuts.ts`), search synonyms, and broad `shortcut.openDiffViewer.label` localizations are wired through.
> 
> Diff launching is **centralized** in `AppDelegate.openDiffViewerForFocusedWorkspace(for:)` with subprocess retention and safer DEBUG logging; the command palette and the new shortcut both call it. `ContentView` drops its duplicate launcher. **`Workspace.resolvedWorkingDirectory()`** picks the cwd for diff/commands (focused panel → terminal request → workspace directory).
> 
> Failures **beep**, matching the palette. A routing test uses `debugOpenDiffViewerHandler` so no real subprocess runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5c3051b83267902acd835372a6ad7f66fa106c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a configurable keyboard shortcut to open the diff viewer for the focused workspace through the same shared path as the command palette. Default is Cmd+Ctrl+Shift+D to avoid macOS “Look Up” and split-view conflicts (addresses #5169).

- **New Features**
  - Added `openDiffViewer` action, visible in Settings → Keyboard Shortcuts and configurable via `~/.config/cmux/cmux.json` (`shortcuts.openDiffViewer`); default Cmd+Ctrl+Shift+D with palette-style beep on failure.
  - Updated docs (`web/data/cmux-shortcuts.ts`) and added label localization across all catalog locales.

- **Refactors**
  - Centralized diff launching in `AppDelegate.openDiffViewerForFocusedWorkspace(...)` (spawns `cmux diff --unstaged ...`), with subprocess retention in production and sanitized DEBUG logs (pid/status/output-bytes); palette now calls this shared path. Fixed Release build by hoisting `diffViewerProcesses` out of `#if DEBUG` and gating `debugOpenDiffViewerHandler` behind DEBUG.
  - Added `Workspace.resolvedWorkingDirectory()` with an explicit fallback order (focused panel’s tracked directory → its terminal’s requested directory → workspace’s current directory). Updated dispatch test to assert the Cmd+Ctrl+Shift+D default, no conflicts, and shared-path routing.

<sup>Written for commit f5c3051b83267902acd835372a6ad7f66fa106c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a keyboard shortcut (Cmd+Ctrl+Shift+D) and command-palette action to open the Diff Viewer for the focused workspace; launching uses a single shared path and selects an appropriate working directory (workspace or home). Failures produce an audible alert.

* **Localization**
  * Added localized labels for the Diff Viewer shortcut (including English and Japanese).

* **Tests**
  * Added a test ensuring the default shortcut routes to the shared Diff Viewer path and is configurable in Settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->