### PR TITLE
Polish sidebar workspace drag reordering

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -10247,6 +10247,12 @@ private final class SidebarTabItemSettingsStore: ObservableObject {
     }
 }
 
+struct SidebarDragFollowerSnapshot: Equatable {
+    let workspaceId: UUID
+    let frame: CGRect
+    let capturedEffectiveGroupId: UUID?
+}
+
 /// Transient sidebar drag/drop state, owned by `VerticalTabsSidebar` and passed
 /// by reference into rows and drop delegates. `@Observable` gives per-property
 /// tracking: writing `draggedTabId` or `dropIndicator` during drag invalidates
@@ -10260,6 +10266,9 @@ final class SidebarDragState {
     var draggedTabId: UUID?
     var dropIndicator: SidebarDropIndicator?
     var dropIndicatorUsesTopLevelRows = false
+    var groupDropPreview: SidebarWorkspaceGroupDropPreview?
+    var dragLocationInDocument: CGPoint?
+    var dragFollowerSnapshot: SidebarDragFollowerSnapshot?
     /// True while the `debug.sidebar.simulate_drag` debug-only V2 method is
     /// driving the drag state. The lifecycle observers honor this by not
     /// starting `SidebarDragFailsafeMonitor` (which would otherwise post a
@@ -10272,12 +10281,45 @@ final class SidebarDragState {
 
     func beginDragging(tabId: UUID) {
         draggedTabId = tabId
+        dragFollowerSnapshot = nil
+        dragLocationInDocument = nil
         clearDropIndicator()
+    }
+
+    func setDragLocationInDocument(_ location: CGPoint?) {
+        guard dragLocationInDocument != location else { return }
+        dragLocationInDocument = location
+    }
+
+    func captureDragFollowerSnapshot(workspaceId: UUID, frame: CGRect?, effectiveGroupId: UUID?) {
+        guard dragFollowerSnapshot?.workspaceId != workspaceId,
+              let frame,
+              frame.width.isFinite,
+              frame.height.isFinite,
+              frame.width > 0,
+              frame.height > 0 else {
+            return
+        }
+        dragFollowerSnapshot = SidebarDragFollowerSnapshot(
+            workspaceId: workspaceId,
+            frame: frame,
+            capturedEffectiveGroupId: effectiveGroupId
+        )
     }
 
     func setDropIndicator(_ indicator: SidebarDropIndicator?, usesTopLevelRows: Bool = false) {
         dropIndicator = indicator
         dropIndicatorUsesTopLevelRows = indicator != nil && usesTopLevelRows
+        groupDropPreview = nil
+    }
+
+    func setGroupDropPreview(_ preview: SidebarWorkspaceGroupDropPreview) {
+        guard groupDropPreview != preview || dropIndicator != nil || dropIndicatorUsesTopLevelRows else {
+            return
+        }
+        groupDropPreview = preview
+        dropIndicator = nil
+        dropIndicatorUsesTopLevelRows = false
     }
 
     func clearDropIndicator() {
@@ -10286,6 +10328,8 @@ final class SidebarDragState {
 
     func clearDrag() {
         draggedTabId = nil
+        dragLocationInDocument = nil
+        dragFollowerSnapshot = nil
         clearDropIndicator()
     }
 }
@@ -10378,6 +10422,11 @@ struct SidebarWorkspaceTopDropIndicator: View {
     }
 }
 
+enum SidebarWorkspaceRowRenderRole {
+    case list
+    case dragFollower
+}
+
 /// Freezes `showsModifierShortcutHints` for the row whose context menu is open,
 /// so pressing/releasing the modifier key while the menu is up does not flip
 /// the underlying row's shortcut badges (which would be visible around the
@@ -10465,6 +10514,7 @@ struct VerticalTabsSidebar: View {
     let tabRowSpacing: CGFloat = 2
     private static let extensionSidebarObservationCoalesceInterval: RunLoop.SchedulerTimeType.Stride = .milliseconds(40)
     private static let extensionSidebarDisclosureAnimation = Animation.easeInOut(duration: 0.18)
+    private static let workspaceReorderAnimation = Animation.snappy(duration: 0.22, extraBounce: 0.02)
     private var sidebarTitlebarInteractionHeight: CGFloat {
         MinimalModeChromeMetrics.titlebarHeight
     }
@@ -10721,6 +10771,7 @@ struct VerticalTabsSidebar: View {
         }
         .onDisappear {
             modifierKeyMonitor.stop()
+            dragAutoScrollController.endCursorTracking()
             dragAutoScrollController.stop()
             dragFailsafeMonitor.stop()
             dragState.clearDrag()
@@ -10744,6 +10795,7 @@ struct VerticalTabsSidebar: View {
             cmuxDebugLog("sidebar.dragState.sidebar tab=\(debugShortSidebarTabId(newDraggedTabId))")
 #endif
             if newDraggedTabId != nil {
+                dragAutoScrollController.startCursorTracking()
                 // The failsafe monitor probes the real mouse-button state and
                 // posts `mouse_up_failsafe` if no mouse is held down. That's
                 // correct for HID-driven drags, but `debug.sidebar.simulate_drag`
@@ -10756,6 +10808,7 @@ struct VerticalTabsSidebar: View {
                 }
                 return
             }
+            dragAutoScrollController.endCursorTracking()
             dragFailsafeMonitor.stop()
             dragAutoScrollController.stop()
             dragState.clearDropIndicator()
@@ -10792,6 +10845,7 @@ struct VerticalTabsSidebar: View {
                 .background(
                     SidebarScrollViewResolver { scrollView in
                         dragAutoScrollController.attach(scrollView: scrollView)
+                        dragAutoScrollController.attach(dragState: dragState)
                     }
                     .frame(width: 0, height: 0)
                 )
@@ -11031,6 +11085,7 @@ struct VerticalTabsSidebar: View {
             .background(
                 SidebarScrollViewResolver { scrollView in
                     dragAutoScrollController.attach(scrollView: scrollView)
+                    dragAutoScrollController.attach(dragState: dragState)
                 }
                 .frame(width: 0, height: 0)
             )
@@ -12016,9 +12071,16 @@ struct VerticalTabsSidebar: View {
     }
 
     private func workspaceRows(renderContext: WorkspaceListRenderContext) -> some View {
-        let renderItems = SidebarWorkspaceRenderItem.renderItems(
+        let baseRenderItems = SidebarWorkspaceRenderItem.renderItems(
             tabs: renderContext.tabs,
             groupsById: renderContext.workspaceGroupById
+        )
+        let renderItems = SidebarWorkspaceRenderItem.dragPreviewItems(
+            baseRenderItems,
+            draggedWorkspaceId: dragState.draggedTabId,
+            dropIndicator: dragState.dropIndicator,
+            reorderWorkspaceIds: renderContext.sidebarReorderIds,
+            groupDropPreview: dragState.groupDropPreview
         )
         // LazyVStack is safe here because `dragState` is @Observable:
         // drag mutations at 60fps invalidate only the rows/overlays that
@@ -12033,72 +12095,108 @@ struct VerticalTabsSidebar: View {
                         memberWorkspaceIds: memberWorkspaceIds,
                         renderContext: renderContext
                     )
-                case .workspace(let tab):
-                    workspaceRow(tab, renderContext: renderContext)
+                case .workspace(let tab, let effectiveGroupId):
+                    workspaceRow(tab, renderContext: renderContext, effectiveGroupId: effectiveGroupId)
                 }
             }
         }
+        .animation(Self.workspaceReorderAnimation, value: renderItems.map(\.id))
         .padding(.vertical, SidebarWorkspaceListMetrics.rowVerticalPadding)
         .frame(maxWidth: .infinity, alignment: .leading)
         .overlayPreferenceValue(SidebarWorkspaceRowFramePreferenceKey.self) { anchors in
             GeometryReader { proxy in
-                SidebarBonsplitTabWorkspaceDropOverlay(
-                    currentSelectedTabId: {
-                        tabManager.selectedTabId
-                    },
-                    sidebarIndexForTabId: { workspaceId in
-                        tabManager.tabs.firstIndex { $0.id == workspaceId }
-                    },
-                    moveToExistingWorkspace: { workspaceId, transfer in
-                        guard let app = AppDelegate.shared else {
-                            return false
-                        }
-                        if let source = app.locateBonsplitSurface(tabId: transfer.tab.id),
-                           source.workspaceId == workspaceId {
-                            return true
-                        }
-                        return app.moveBonsplitTab(
-                            tabId: transfer.tab.id,
-                            toWorkspace: workspaceId,
-                            focus: true,
-                            focusWindow: true
-                        )
-                    },
-                    moveToNewWorkspace: { insertionIndex, transfer in
-                        guard let app = AppDelegate.shared,
-                              let result = app.moveBonsplitTabToNewWorkspace(
+                ZStack(alignment: .topLeading) {
+                    SidebarBonsplitTabWorkspaceDropOverlay(
+                        currentSelectedTabId: {
+                            tabManager.selectedTabId
+                        },
+                        sidebarIndexForTabId: { workspaceId in
+                            tabManager.tabs.firstIndex { $0.id == workspaceId }
+                        },
+                        moveToExistingWorkspace: { workspaceId, transfer in
+                            guard let app = AppDelegate.shared else {
+                                return false
+                            }
+                            if let source = app.locateBonsplitSurface(tabId: transfer.tab.id),
+                               source.workspaceId == workspaceId {
+                                return true
+                            }
+                            return app.moveBonsplitTab(
                                 tabId: transfer.tab.id,
-                                destinationManager: tabManager,
+                                toWorkspace: workspaceId,
                                 focus: true,
-                                focusWindow: true,
-                                insertionIndexOverride: insertionIndex
-                              ) else {
-                            return nil
+                                focusWindow: true
+                            )
+                        },
+                        moveToNewWorkspace: { insertionIndex, transfer in
+                            guard let app = AppDelegate.shared,
+                                  let result = app.moveBonsplitTabToNewWorkspace(
+                                    tabId: transfer.tab.id,
+                                    destinationManager: tabManager,
+                                    focus: true,
+                                    focusWindow: true,
+                                    insertionIndexOverride: insertionIndex
+                                  ) else {
+                                return nil
+                            }
+                            return result.destinationWorkspaceId
+                        },
+                        selectedTabIds: $selectedTabIds,
+                        lastSidebarSelectionIndex: $lastSidebarSelectionIndex,
+                        dropIndicator: dropIndicatorBinding,
+                        updateAutoscroll: {
+                            dragAutoScrollController.updateFromDragLocation()
+                        },
+                        targets: renderContext.tabs.compactMap { tab in
+                            guard let anchor = anchors[tab.id] else { return nil }
+                            return SidebarDropPlanner.WorkspaceDropTarget(
+                                workspaceId: tab.id,
+                                isPinned: tab.isPinned,
+                                frame: proxy[anchor]
+                            )
                         }
-                        return result.destinationWorkspaceId
-                    },
-                    selectedTabIds: $selectedTabIds,
-                    lastSidebarSelectionIndex: $lastSidebarSelectionIndex,
-                    dropIndicator: dropIndicatorBinding,
-                    updateAutoscroll: {
-                        dragAutoScrollController.updateFromDragLocation()
-                    },
-                    targets: renderContext.tabs.compactMap { tab in
-                        guard let anchor = anchors[tab.id] else { return nil }
-                        return SidebarDropPlanner.WorkspaceDropTarget(
-                            workspaceId: tab.id,
-                            isPinned: tab.isPinned,
-                            frame: proxy[anchor]
-                        )
-                    }
-                )
+                    )
+                    SidebarWorkspaceDragCursorTrackingView(
+                        dragAutoScrollController: dragAutoScrollController
+                    )
+                    .frame(width: proxy.size.width, height: proxy.size.height)
+                    .allowsHitTesting(false)
+                    SidebarWorkspaceDragFollowerOverlay(
+                        dragState: dragState,
+                        sourceItems: baseRenderItems,
+                        renderItems: renderItems,
+                        anchors: anchors,
+                        proxy: proxy,
+                        rowContent: { item in
+                            switch item {
+                            case .groupHeader(let group, let memberWorkspaceIds):
+                                AnyView(sidebarWorkspaceGroupHeader(
+                                    group: group,
+                                    memberWorkspaceIds: memberWorkspaceIds,
+                                    renderContext: renderContext,
+                                    role: .dragFollower
+                                ))
+                            case .workspace(let tab, let effectiveGroupId):
+                                AnyView(workspaceRow(
+                                    tab,
+                                    renderContext: renderContext,
+                                    effectiveGroupId: effectiveGroupId,
+                                    role: .dragFollower
+                                ))
+                            }
+                        }
+                    )
+                }
             }
         }
     }
 
+    @ViewBuilder
     private func workspaceRow(
         _ tab: Workspace,
-        renderContext: WorkspaceListRenderContext
+        renderContext: WorkspaceListRenderContext,
+        effectiveGroupId: UUID?,
+        role: SidebarWorkspaceRowRenderRole = .list
     ) -> some View {
         let index = renderContext.tabIndexById[tab.id] ?? 0
         let usesSelectedContextMenuTargets = selectedTabIds.contains(tab.id)
@@ -12157,7 +12255,7 @@ struct VerticalTabsSidebar: View {
         // value snapshots are what get passed to the row. The row's
         // Equatable conformance ignores closures, so rows whose snapshot is
         // unchanged skip re-render when drag state moves.
-        let isBeingDragged = dragState.draggedTabId == tab.id
+        let isBeingDragged = role == .list && dragState.draggedTabId == tab.id
         let sidebarReorderIds = renderContext.sidebarReorderIds
         let topDropIndicatorVisible = SidebarTabDropIndicatorPredicate.topVisible(
             forTabId: tab.id,
@@ -12170,6 +12268,7 @@ struct VerticalTabsSidebar: View {
             cmuxDebugLog("sidebar.onDrag tab=\(tabId.uuidString.prefix(5))")
             #endif
             dragState.beginDragging(tabId: tabId)
+            dragAutoScrollController.recordDragLocation()
             return SidebarTabDragPayload.provider(for: tabId)
         }
         let tabDropDelegateFactory: (CGFloat) -> SidebarTabDropDelegate = { [
@@ -12188,7 +12287,7 @@ struct VerticalTabsSidebar: View {
             )
         }
 
-        return TabItemView(
+        let row = TabItemView(
             tabManager: tabManager,
             notificationStore: notificationStore,
             tab: tab,
@@ -12210,6 +12309,7 @@ struct VerticalTabsSidebar: View {
             showsModifierShortcutHints: resolvedShowsModifierShortcutHints,
             dragAutoScrollController: dragAutoScrollController,
             isBeingDragged: isBeingDragged,
+            isDragFollowerPresentation: role == .dragFollower,
             topDropIndicatorVisible: topDropIndicatorVisible,
             onDragStart: onDragStart,
             tabDropDelegateFactory: tabDropDelegateFactory,
@@ -12224,13 +12324,22 @@ struct VerticalTabsSidebar: View {
             onContextMenuDisappear: onContextMenuDisappear
         )
         .equatable()
-        .id(tab.id)
-        .accessibilityIdentifier("sidebarWorkspace.\(tab.id.uuidString)")
-        .preference(key: SidebarWorkspaceRowIdsPreferenceKey.self, value: Set([tab.id]))
-        .anchorPreference(key: SidebarWorkspaceRowFramePreferenceKey.self, value: .bounds) { anchor in
-            [tab.id: anchor]
+
+        if role == .dragFollower {
+            row
+                .allowsHitTesting(false)
+                .accessibilityHidden(true)
+        } else {
+            row
+                .id(tab.id)
+                .accessibilityIdentifier("sidebarWorkspace.\(tab.id.uuidString)")
+                .preference(key: SidebarWorkspaceRowIdsPreferenceKey.self, value: Set([tab.id]))
+                .anchorPreference(key: SidebarWorkspaceRowFramePreferenceKey.self, value: .bounds) { anchor in
+                    [tab.id: anchor]
+                }
+                .padding(.leading, effectiveGroupId != nil ? SidebarWorkspaceGroupingMetrics.memberIndent : 0)
+                .animation(Self.workspaceReorderAnimation, value: effectiveGroupId)
         }
-        .padding(.leading, tab.groupId != nil ? SidebarWorkspaceGroupingMetrics.memberIndent : 0)
     }
 
     private func debugShortSidebarTabId(_ id: UUID?) -> String {
@@ -12252,6 +12361,108 @@ struct SidebarWorkspaceRowFramePreferenceKey: PreferenceKey {
 
     static func reduce(value: inout [UUID: Anchor<CGRect>], nextValue: () -> [UUID: Anchor<CGRect>]) {
         value.merge(nextValue()) { _, next in next }
+    }
+}
+
+@MainActor
+private struct SidebarWorkspaceDragFollowerOverlay: View {
+    let dragState: SidebarDragState
+    let sourceItems: [SidebarWorkspaceRenderItem]
+    let renderItems: [SidebarWorkspaceRenderItem]
+    let anchors: [UUID: Anchor<CGRect>]
+    let proxy: GeometryProxy
+    let rowContent: (SidebarWorkspaceRenderItem) -> AnyView
+
+    var body: some View {
+        if let draggedWorkspaceId = dragState.draggedTabId,
+           let item = sourceItems.first(where: { $0.representedWorkspaceId == draggedWorkspaceId })
+                ?? renderItems.first(where: { $0.representedWorkspaceId == draggedWorkspaceId }) {
+            let currentFrame = anchors[draggedWorkspaceId].map { proxy[$0] }
+            let snapshot = dragState.dragFollowerSnapshot?.workspaceId == draggedWorkspaceId
+                ? dragState.dragFollowerSnapshot
+                : nil
+            if let frame = snapshot?.frame ?? currentFrame {
+                let y = dragState.dragLocationInDocument?.y ?? frame.midY
+                let capturedIndent: CGFloat = (snapshot?.capturedEffectiveGroupId ?? item.effectiveGroupId) != nil
+                    ? SidebarWorkspaceGroupingMetrics.memberIndent
+                    : 0
+                let previewMembership = renderItems
+                    .first(where: { $0.representedWorkspaceId == draggedWorkspaceId })?
+                    .effectiveGroupId
+                let currentIndent: CGFloat = previewMembership != nil
+                    ? SidebarWorkspaceGroupingMetrics.memberIndent
+                    : 0
+
+                rowContent(item)
+                    .frame(width: max(frame.width, 1), alignment: .topLeading)
+                    .position(x: frame.midX, y: y)
+                    .offset(x: currentIndent - capturedIndent)
+                    .shadow(color: Color.black.opacity(0.14), radius: 10, x: 0, y: 4)
+                    .allowsHitTesting(false)
+                    .accessibilityHidden(true)
+                    .zIndex(1000)
+                    .id(draggedWorkspaceId)
+                    .animation(nil, value: y)
+                    .onAppear {
+                        dragState.captureDragFollowerSnapshot(
+                            workspaceId: draggedWorkspaceId,
+                            frame: currentFrame,
+                            effectiveGroupId: item.effectiveGroupId
+                        )
+                    }
+                    .onChange(of: currentFrame) { _, nextFrame in
+                        dragState.captureDragFollowerSnapshot(
+                            workspaceId: draggedWorkspaceId,
+                            frame: nextFrame,
+                            effectiveGroupId: item.effectiveGroupId
+                        )
+                    }
+                    .transaction { transaction in
+                        transaction.disablesAnimations = true
+                        transaction.animation = nil
+                    }
+            }
+        }
+    }
+}
+
+private struct SidebarWorkspaceDragCursorTrackingView: NSViewRepresentable {
+    let dragAutoScrollController: SidebarDragAutoScrollController
+
+    func makeNSView(context: Context) -> SidebarWorkspaceDragCursorTrackingNSView {
+        let view = SidebarWorkspaceDragCursorTrackingNSView()
+        view.onAttach = { [weak dragAutoScrollController] view in
+            dragAutoScrollController?.attach(cursorTrackingView: view)
+        }
+        return view
+    }
+
+    func updateNSView(_ nsView: SidebarWorkspaceDragCursorTrackingNSView, context: Context) {
+        nsView.onAttach = { [weak dragAutoScrollController] view in
+            dragAutoScrollController?.attach(cursorTrackingView: view)
+        }
+        dragAutoScrollController.attach(cursorTrackingView: nsView)
+    }
+
+    static func dismantleNSView(_ nsView: SidebarWorkspaceDragCursorTrackingNSView, coordinator: ()) {
+        nsView.onAttach = nil
+    }
+}
+
+private final class SidebarWorkspaceDragCursorTrackingNSView: NSView {
+    var onAttach: ((NSView) -> Void)?
+
+    override var isFlipped: Bool { true }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        nil
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        if window != nil {
+            onAttach?(self)
+        }
     }
 }
 
@@ -14664,6 +14875,28 @@ private final class SidebarTabItemContextMenuState: ObservableObject {
     var pendingWorkspaceSnapshot: SidebarWorkspaceSnapshotBuilder.Snapshot?
 }
 
+private struct SidebarRowDragDropModifier: ViewModifier {
+    let enabled: Bool
+    let onDragStart: () -> NSItemProvider
+    let tabDropDelegate: SidebarTabDropDelegate
+    let bonsplitDropDelegate: SidebarBonsplitTabDropDelegate
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if enabled {
+            content
+                .onDrag(onDragStart, preview: {
+                    SidebarWorkspaceInvisibleDragPreview()
+                })
+                .internalOnlyTabDrag()
+                .onDrop(of: SidebarTabDragPayload.dropContentTypes, delegate: tabDropDelegate)
+                .onDrop(of: BonsplitTabDragPayload.dropContentTypes, delegate: bonsplitDropDelegate)
+        } else {
+            content
+        }
+    }
+}
+
 struct TabItemView: View, Equatable {
     private static let workspaceObservationCoalesceInterval: RunLoop.SchedulerTimeType.Stride = .milliseconds(40)
     private static let legacyVMWebSocketDescription = "VM WebSocket PTY"
@@ -14689,6 +14922,7 @@ struct TabItemView: View, Equatable {
         lhs.contextMenuPinState == rhs.contextMenuPinState &&
         lhs.workspaceGroupMenuSnapshot == rhs.workspaceGroupMenuSnapshot &&
         lhs.isBeingDragged == rhs.isBeingDragged &&
+        lhs.isDragFollowerPresentation == rhs.isDragFollowerPresentation &&
         lhs.topDropIndicatorVisible == rhs.topDropIndicatorVisible &&
         lhs.settings == rhs.settings
     }
@@ -14721,6 +14955,7 @@ struct TabItemView: View, Equatable {
     // per-row snapshots and `==` skips re-render for rows whose snapshot is
     // unchanged.
     let isBeingDragged: Bool
+    var isDragFollowerPresentation: Bool = false
     let topDropIndicatorVisible: Bool
     let onDragStart: () -> NSItemProvider
     /// Factory invoked from `body` with the row's measured `rowHeight`. Closure
@@ -15452,14 +15687,16 @@ struct TabItemView: View, Equatable {
         .onChange(of: settings) { _ in
             refreshWorkspaceSnapshot(force: true)
         }
-        .onDrag(onDragStart)
-        .internalOnlyTabDrag()
-        .onDrop(of: SidebarTabDragPayload.dropContentTypes, delegate: tabDropDelegateFactory(rowHeight))
-        .onDrop(of: BonsplitTabDragPayload.dropContentTypes, delegate: SidebarBonsplitTabDropDelegate(
-            targetWorkspaceId: tab.id,
-            tabManager: tabManager,
-            selectedTabIds: $selectedTabIds,
-            lastSidebarSelectionIndex: $lastSidebarSelectionIndex
+        .modifier(SidebarRowDragDropModifier(
+            enabled: !isDragFollowerPresentation,
+            onDragStart: onDragStart,
+            tabDropDelegate: tabDropDelegateFactory(rowHeight),
+            bonsplitDropDelegate: SidebarBonsplitTabDropDelegate(
+                targetWorkspaceId: tab.id,
+                tabManager: tabManager,
+                selectedTabIds: $selectedTabIds,
+                lastSidebarSelectionIndex: $lastSidebarSelectionIndex
+            )
         ))
         .onTapGesture {
             updateSelection()
@@ -16900,6 +17137,9 @@ enum SidebarDragAutoScrollPlanner {
 @MainActor
 final class SidebarDragAutoScrollController: ObservableObject {
     private weak var scrollView: NSScrollView?
+    private weak var dragState: SidebarDragState?
+    private weak var cursorTrackingView: NSView?
+    private var localDragMonitor: Any?
     private var timer: Timer?
     private var activePlan: SidebarAutoScrollPlan?
 
@@ -16907,17 +17147,62 @@ final class SidebarDragAutoScrollController: ObservableObject {
         self.scrollView = scrollView
     }
 
-    func updateFromDragLocation() {
-        guard let scrollView else {
-            stop()
-            return
-        }
-        guard let plan = plan(for: scrollView) else {
-            stop()
-            return
-        }
-        activePlan = plan
+    func attach(dragState: SidebarDragState?) {
+        self.dragState = dragState
+    }
+
+    func attach(cursorTrackingView: NSView?) {
+        self.cursorTrackingView = cursorTrackingView
+    }
+
+    func startCursorTracking() {
+        recordDragLocation()
         startTimerIfNeeded()
+        guard localDragMonitor == nil else { return }
+        localDragMonitor = NSEvent.addLocalMonitorForEvents(matching: [.leftMouseDragged, .leftMouseUp]) { [weak self] event in
+            Task { @MainActor [weak self] in
+                switch event.type {
+                case .leftMouseDragged:
+                    self?.recordDragLocation()
+                case .leftMouseUp:
+                    self?.endCursorTracking()
+                default:
+                    break
+                }
+            }
+            return event
+        }
+    }
+
+    func endCursorTracking() {
+        if let localDragMonitor {
+            NSEvent.removeMonitor(localDragMonitor)
+            self.localDragMonitor = nil
+        }
+        dragState?.setDragLocationInDocument(nil)
+    }
+
+    @discardableResult
+    func recordDragLocation() -> CGPoint? {
+        recordCursorLocation()
+    }
+
+    func updateFromDragLocation() {
+        recordCursorLocation()
+        if let scrollView {
+            activePlan = plan(for: scrollView)
+        }
+        startTimerIfNeeded()
+    }
+
+    @discardableResult
+    private func recordCursorLocation() -> CGPoint? {
+        guard let location = dragLocationInCursorTrackingView()
+            ?? scrollView.flatMap({ dragLocationInScrollDocument(for: $0) }) else {
+            return nil
+        }
+        dragState?.setDragLocationInDocument(location)
+        return location
     }
 
     func stop() {
@@ -16938,30 +17223,25 @@ final class SidebarDragAutoScrollController: ObservableObject {
     }
 
     private func tick() {
-        guard NSEvent.pressedMouseButtons != 0 else {
+        guard dragState?.draggedTabId != nil else {
             stop()
             return
         }
+        recordCursorLocation()
         guard let scrollView else {
-            stop()
             return
         }
 
         // AppKit drag/drop autoscroll guidance recommends autoscroll(with:)
         // when periodic drag updates are available; use it first.
         if applyNativeAutoscroll(to: scrollView) {
+            recordCursorLocation()
             activePlan = plan(for: scrollView)
-            if activePlan == nil {
-                stop()
-            }
             return
         }
 
         activePlan = self.plan(for: scrollView)
-        guard let plan = activePlan else {
-            stop()
-            return
-        }
+        guard let plan = activePlan else { return }
         _ = apply(plan: plan, to: scrollView)
     }
 
@@ -17027,7 +17307,43 @@ final class SidebarDragAutoScrollController: ObservableObject {
 
         clipView.scroll(to: CGPoint(x: clipView.bounds.origin.x, y: targetY))
         scrollView.reflectScrolledClipView(clipView)
+        recordCursorLocation()
         return true
+    }
+
+    private func dragLocationInScrollDocument(for scrollView: NSScrollView) -> CGPoint? {
+        guard let documentView = scrollView.documentView,
+              let window = scrollView.window else {
+            return nil
+        }
+        let mouseInWindow = window.convertPoint(fromScreen: NSEvent.mouseLocation)
+        let point = documentView.convert(mouseInWindow, from: nil)
+        guard documentView.bounds.width.isFinite,
+              documentView.bounds.height.isFinite,
+              point.x.isFinite,
+              point.y.isFinite else {
+            return nil
+        }
+        if documentView.isFlipped {
+            return point
+        }
+        return CGPoint(x: point.x, y: documentView.bounds.height - point.y)
+    }
+
+    private func dragLocationInCursorTrackingView() -> CGPoint? {
+        guard let view = cursorTrackingView,
+              let window = view.window,
+              view.bounds.width > 0,
+              view.bounds.height > 0 else {
+            return nil
+        }
+        let mouseInWindow = window.convertPoint(fromScreen: NSEvent.mouseLocation)
+        let point = view.convert(mouseInWindow, from: nil)
+        guard point.x.isFinite, point.y.isFinite else { return nil }
+        if view.isFlipped {
+            return point
+        }
+        return CGPoint(x: point.x, y: view.bounds.height - point.y)
     }
 }
 

--- a/Sources/SidebarWorkspaceGroupHeaderView.swift
+++ b/Sources/SidebarWorkspaceGroupHeaderView.swift
@@ -1,6 +1,32 @@
 import AppKit
 import SwiftUI
 
+struct SidebarWorkspaceInvisibleDragPreview: View {
+    var body: some View {
+        Color.clear.frame(width: 1, height: 1)
+    }
+}
+
+private struct SidebarGroupHeaderDragDropModifier: ViewModifier {
+    let enabled: Bool
+    let onDragStart: () -> NSItemProvider
+    let dropDelegate: SidebarWorkspaceGroupHeaderDropDelegate
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if enabled {
+            content
+                .onDrag(onDragStart, preview: {
+                    SidebarWorkspaceInvisibleDragPreview()
+                })
+                .internalOnlyTabDrag()
+                .onDrop(of: SidebarTabDragPayload.dropContentTypes, delegate: dropDelegate)
+        } else {
+            content
+        }
+    }
+}
+
 /// Collapsible group header that doubles as the anchor workspace row.
 struct SidebarWorkspaceGroupHeaderView: View, Equatable {
     // Closures and delegate factories are excluded because they are recreated
@@ -27,6 +53,7 @@ struct SidebarWorkspaceGroupHeaderView: View, Equatable {
             lhs.rowSpacing == rhs.rowSpacing &&
             lhs.isFirstRow == rhs.isFirstRow &&
             lhs.isBeingDragged == rhs.isBeingDragged &&
+            lhs.isDragFollowerPresentation == rhs.isDragFollowerPresentation &&
             lhs.topDropIndicatorVisible == rhs.topDropIndicatorVisible
     }
 
@@ -50,6 +77,7 @@ struct SidebarWorkspaceGroupHeaderView: View, Equatable {
     let rowSpacing: CGFloat
     let isFirstRow: Bool
     let isBeingDragged: Bool
+    var isDragFollowerPresentation: Bool = false
     let topDropIndicatorVisible: Bool
     let onDragStart: () -> NSItemProvider
     let tabDropDelegateFactory: (CGFloat) -> SidebarWorkspaceGroupHeaderDropDelegate
@@ -228,9 +256,11 @@ struct SidebarWorkspaceGroupHeaderView: View, Equatable {
                 rowSpacing: rowSpacing
             )
         }
-        .onDrag(onDragStart)
-        .internalOnlyTabDrag()
-        .onDrop(of: SidebarTabDragPayload.dropContentTypes, delegate: tabDropDelegateFactory(rowHeight))
+        .modifier(SidebarGroupHeaderDragDropModifier(
+            enabled: !isDragFollowerPresentation,
+            onDragStart: onDragStart,
+            dropDelegate: tabDropDelegateFactory(rowHeight)
+        ))
         .onHover { hovering in
             isHovered = hovering
         }
@@ -394,6 +424,9 @@ struct SidebarWorkspaceGroupHeaderDropDelegate: DropDelegate {
     }
 
     func dropExited(info: DropInfo) {
+        if dragState.groupDropPreview?.targetGroupId == targetGroupId {
+            dragState.clearDropIndicator()
+        }
         reorderDelegate.dropExited(info: info)
     }
 
@@ -415,7 +448,11 @@ struct SidebarWorkspaceGroupHeaderDropDelegate: DropDelegate {
         defer { clearDropState() }
         switch action {
         case .addWorkspaceToGroup(let draggedTabId):
-            tabManager.addWorkspaceToGroup(workspaceId: draggedTabId, groupId: targetGroupId)
+            tabManager.addWorkspaceToGroup(
+                workspaceId: draggedTabId,
+                groupId: targetGroupId,
+                placement: .end
+            )
         case .noOp:
             break
         }
@@ -423,9 +460,19 @@ struct SidebarWorkspaceGroupHeaderDropDelegate: DropDelegate {
     }
 
     private func updateGroupHeaderCenterDrop(_ info: DropInfo) -> Bool {
-        guard groupHeaderCenterDropAction(info) != nil else { return false }
+        guard let action = groupHeaderCenterDropAction(info) else { return false }
         dragAutoScrollController.updateFromDragLocation()
-        dragState.clearDropIndicator()
+        switch action {
+        case .addWorkspaceToGroup(let draggedTabId):
+            dragState.setGroupDropPreview(
+                SidebarWorkspaceGroupDropPreview(
+                    draggedWorkspaceId: draggedTabId,
+                    targetGroupId: targetGroupId
+                )
+            )
+        case .noOp:
+            dragState.clearDropIndicator()
+        }
         return true
     }
 

--- a/Sources/SidebarWorkspaceRenderItem.swift
+++ b/Sources/SidebarWorkspaceRenderItem.swift
@@ -1,19 +1,52 @@
 import Foundation
 
+struct SidebarWorkspaceGroupDropPreview: Equatable {
+    let draggedWorkspaceId: UUID
+    let targetGroupId: UUID
+}
+
 /// One drawable item in the workspace sidebar.
 @MainActor
 enum SidebarWorkspaceRenderItem {
     case groupHeader(WorkspaceGroup, memberWorkspaceIds: [UUID])
-    case workspace(Workspace)
+    case workspace(Workspace, effectiveGroupId: UUID?)
+
+    var representedWorkspaceId: UUID {
+        switch self {
+        case .groupHeader(let group, _):
+            return group.anchorWorkspaceId
+        case .workspace(let workspace, _):
+            return workspace.id
+        }
+    }
+
+    var effectiveGroupId: UUID? {
+        switch self {
+        case .groupHeader:
+            return nil
+        case .workspace(_, let groupId):
+            return groupId
+        }
+    }
 
     var id: String {
         switch self {
         case .groupHeader(let group, _):
             return "group.\(group.id.uuidString)"
-        case .workspace(let workspace):
+        case .workspace(let workspace, _):
             return "workspace.\(workspace.id.uuidString)"
         }
     }
+
+    func withEffectiveGroupId(_ groupId: UUID?) -> SidebarWorkspaceRenderItem {
+        switch self {
+        case .groupHeader:
+            return self
+        case .workspace(let workspace, _):
+            return .workspace(workspace, effectiveGroupId: groupId)
+        }
+    }
+
     static func renderItems(
         tabs: [Workspace],
         groupsById: [UUID: WorkspaceGroup]
@@ -53,9 +86,171 @@ enum SidebarWorkspaceRenderItem {
                 continue
             }
             if groupId == nil || !skipChildrenUntilNextGroup {
-                items.append(.workspace(tab))
+                items.append(.workspace(tab, effectiveGroupId: groupId))
             }
         }
         return items
+    }
+
+    static func dragPreviewItems(
+        _ items: [SidebarWorkspaceRenderItem],
+        draggedWorkspaceId: UUID?,
+        dropIndicator: SidebarDropIndicator?,
+        reorderWorkspaceIds: [UUID],
+        groupDropPreview: SidebarWorkspaceGroupDropPreview?
+    ) -> [SidebarWorkspaceRenderItem] {
+        if let previewItems = groupDropPreviewItems(items, preview: groupDropPreview) {
+            return previewItems
+        }
+        guard let draggedWorkspaceId,
+              let dropIndicator,
+              reorderWorkspaceIds.contains(draggedWorkspaceId),
+              reorderWorkspaceIds.count > 1 else {
+            return items
+        }
+
+        let topLevelMode = Set(reorderWorkspaceIds) != Set(items.map(\.representedWorkspaceId))
+        let blocks = dragPreviewBlocks(
+            items,
+            reorderWorkspaceIds: reorderWorkspaceIds,
+            draggedWorkspaceId: draggedWorkspaceId,
+            topLevelMode: topLevelMode
+        )
+        let blockIds = blocks.map(\.workspaceId)
+        let reorderIds = reorderWorkspaceIds.filter { blockIds.contains($0) }
+        guard reorderIds.count == blocks.count,
+              Set(reorderIds) == Set(blockIds),
+              reorderIds.contains(draggedWorkspaceId),
+              let nextReorderIds = dragPreviewWorkspaceIds(
+                reorderIds,
+                draggedWorkspaceId: draggedWorkspaceId,
+                dropIndicator: dropIndicator
+              ),
+              nextReorderIds != reorderIds else {
+            return items
+        }
+
+        var blocksById: [UUID: [SidebarWorkspaceRenderItem]] = [:]
+        for block in blocks {
+            guard blocksById[block.workspaceId] == nil else { return items }
+            blocksById[block.workspaceId] = block.items
+        }
+        return nextReorderIds.flatMap { blocksById[$0] ?? [] }
+    }
+
+    private static func groupDropPreviewItems(
+        _ items: [SidebarWorkspaceRenderItem],
+        preview: SidebarWorkspaceGroupDropPreview?
+    ) -> [SidebarWorkspaceRenderItem]? {
+        guard let preview else { return nil }
+        var draggedItem: SidebarWorkspaceRenderItem?
+        var targetHeaderIndex: Int?
+        var result: [SidebarWorkspaceRenderItem] = []
+        result.reserveCapacity(items.count)
+
+        for item in items {
+            switch item {
+            case .groupHeader(let group, let memberWorkspaceIds)
+                where group.id == preview.targetGroupId:
+                let nextMemberWorkspaceIds = memberWorkspaceIds.contains(preview.draggedWorkspaceId)
+                    ? memberWorkspaceIds
+                    : memberWorkspaceIds + [preview.draggedWorkspaceId]
+                targetHeaderIndex = result.count
+                result.append(.groupHeader(group, memberWorkspaceIds: nextMemberWorkspaceIds))
+
+            case .workspace(let workspace, _)
+                where workspace.id == preview.draggedWorkspaceId:
+                draggedItem = item.withEffectiveGroupId(preview.targetGroupId)
+
+            case .groupHeader(let group, _)
+                where group.anchorWorkspaceId == preview.draggedWorkspaceId:
+                return nil
+
+            default:
+                result.append(item)
+            }
+        }
+
+        guard let draggedItem, let targetHeaderIndex else { return nil }
+        var insertionIndex = targetHeaderIndex + 1
+        while insertionIndex < result.endIndex {
+            guard result[insertionIndex].effectiveGroupId == preview.targetGroupId else {
+                break
+            }
+            insertionIndex += 1
+        }
+        result.insert(draggedItem, at: insertionIndex)
+        return result
+    }
+
+    private static func dragPreviewWorkspaceIds(
+        _ ids: [UUID],
+        draggedWorkspaceId: UUID,
+        dropIndicator: SidebarDropIndicator
+    ) -> [UUID]? {
+        guard ids.contains(draggedWorkspaceId) else { return nil }
+        if dropIndicator.tabId == draggedWorkspaceId {
+            return ids
+        }
+
+        var result = ids.filter { $0 != draggedWorkspaceId }
+        let insertionIndex: Int
+        if let targetWorkspaceId = dropIndicator.tabId {
+            guard let targetIndex = result.firstIndex(of: targetWorkspaceId) else {
+                return ids
+            }
+            insertionIndex = dropIndicator.edge == .top ? targetIndex : targetIndex + 1
+        } else {
+            insertionIndex = result.count
+        }
+
+        result.insert(draggedWorkspaceId, at: min(max(insertionIndex, 0), result.count))
+        return result
+    }
+
+    private static func dragPreviewBlocks(
+        _ items: [SidebarWorkspaceRenderItem],
+        reorderWorkspaceIds: [UUID],
+        draggedWorkspaceId: UUID,
+        topLevelMode: Bool
+    ) -> [(workspaceId: UUID, items: [SidebarWorkspaceRenderItem])] {
+        guard topLevelMode else {
+            return items.map { item in
+                (workspaceId: item.representedWorkspaceId, items: [item])
+            }
+        }
+
+        let reorderIdSet = Set(reorderWorkspaceIds)
+        var blocks: [(workspaceId: UUID, items: [SidebarWorkspaceRenderItem])] = []
+        var index = items.startIndex
+        while index < items.endIndex {
+            switch items[index] {
+            case .groupHeader(let group, _):
+                var groupItems = [items[index]]
+                var promotedMemberItems: [SidebarWorkspaceRenderItem] = []
+                index = items.index(after: index)
+                while index < items.endIndex {
+                    guard case .workspace(let workspace, _) = items[index],
+                          workspace.groupId == group.id else {
+                        break
+                    }
+                    if workspace.id == draggedWorkspaceId, reorderIdSet.contains(workspace.id) {
+                        promotedMemberItems.append(items[index].withEffectiveGroupId(nil))
+                    } else {
+                        groupItems.append(items[index])
+                    }
+                    index = items.index(after: index)
+                }
+                blocks.append((workspaceId: group.anchorWorkspaceId, items: groupItems))
+                for item in promotedMemberItems {
+                    blocks.append((workspaceId: item.representedWorkspaceId, items: [item]))
+                }
+
+            case .workspace(let workspace, _):
+                blocks.append((workspaceId: workspace.id, items: [items[index]]))
+                index = items.index(after: index)
+            }
+        }
+        return blocks
     }
 }

--- a/Sources/VerticalTabsSidebar+WorkspaceGroups.swift
+++ b/Sources/VerticalTabsSidebar+WorkspaceGroups.swift
@@ -6,7 +6,8 @@ extension VerticalTabsSidebar {
     func sidebarWorkspaceGroupHeader(
         group: WorkspaceGroup,
         memberWorkspaceIds: [UUID],
-        renderContext: WorkspaceListRenderContext
+        renderContext: WorkspaceListRenderContext,
+        role: SidebarWorkspaceRowRenderRole = .list
     ) -> some View {
         let settings = renderContext.tabItemSettings
         let isAnchorActive = tabManager.selectedTabId == group.anchorWorkspaceId
@@ -45,6 +46,7 @@ extension VerticalTabsSidebar {
             cmuxDebugLog("sidebar.onDrag groupAnchor=\(anchorId.uuidString.prefix(5))")
             #endif
             dragState.beginDragging(tabId: anchorId)
+            dragAutoScrollController.recordDragLocation()
             return SidebarTabDragPayload.provider(for: anchorId)
         }
         let tabDropDelegateFactory: (CGFloat) -> SidebarWorkspaceGroupHeaderDropDelegate = { [
@@ -73,7 +75,7 @@ extension VerticalTabsSidebar {
             )
         }
 
-        SidebarWorkspaceGroupHeaderView(
+        let header = SidebarWorkspaceGroupHeaderView(
             groupId: group.id,
             anchorWorkspaceId: group.anchorWorkspaceId,
             name: group.name,
@@ -93,7 +95,8 @@ extension VerticalTabsSidebar {
             newWorkspacePlacement: newWorkspacePlacement,
             rowSpacing: tabRowSpacing,
             isFirstRow: renderContext.sidebarReorderIds.first == group.anchorWorkspaceId,
-            isBeingDragged: dragState.draggedTabId == group.anchorWorkspaceId,
+            isBeingDragged: role == .list && dragState.draggedTabId == group.anchorWorkspaceId,
+            isDragFollowerPresentation: role == .dragFollower,
             topDropIndicatorVisible: topDropIndicatorVisible,
             onDragStart: onDragStart,
             tabDropDelegateFactory: tabDropDelegateFactory,
@@ -152,11 +155,19 @@ extension VerticalTabsSidebar {
             }
         )
         .equatable()
-        .id(group.anchorWorkspaceId)
-        .accessibilityIdentifier("sidebarWorkspaceGroup.\(group.id.uuidString)")
-        .preference(key: SidebarWorkspaceRowIdsPreferenceKey.self, value: Set([group.anchorWorkspaceId]))
-        .anchorPreference(key: SidebarWorkspaceRowFramePreferenceKey.self, value: .bounds) { [anchorId = group.anchorWorkspaceId] anchor in
-            [anchorId: anchor]
+
+        if role == .dragFollower {
+            header
+                .allowsHitTesting(false)
+                .accessibilityHidden(true)
+        } else {
+            header
+                .id(group.anchorWorkspaceId)
+                .accessibilityIdentifier("sidebarWorkspaceGroup.\(group.id.uuidString)")
+                .preference(key: SidebarWorkspaceRowIdsPreferenceKey.self, value: Set([group.anchorWorkspaceId]))
+                .anchorPreference(key: SidebarWorkspaceRowFramePreferenceKey.self, value: .bounds) { [anchorId = group.anchorWorkspaceId] anchor in
+                    [anchorId: anchor]
+                }
         }
     }
 }

--- a/cmuxTests/WorkspaceGroupTests.swift
+++ b/cmuxTests/WorkspaceGroupTests.swift
@@ -183,7 +183,7 @@ struct WorkspaceGroupTests {
                 groupMemberIds = memberWorkspaceIds
             case .groupHeader:
                 break
-            case .workspace(let workspace):
+            case .workspace(let workspace, _):
                 visibleWorkspaceIds.append(workspace.id)
             }
         }
@@ -195,6 +195,91 @@ struct WorkspaceGroupTests {
         ])
         #expect(!visibleWorkspaceIds.contains(originalIds[1]))
         #expect(!visibleWorkspaceIds.contains(originalIds[2]))
+    }
+
+    @Test func dragPreviewItemsMoveDraggedWorkspaceBeforeCommit() throws {
+        let manager = makeTabManager()
+        let ids = manager.tabs.map(\.id)
+        let baseItems = SidebarWorkspaceRenderItem.renderItems(
+            tabs: manager.tabs,
+            groupsById: [:]
+        )
+
+        let previewItems = SidebarWorkspaceRenderItem.dragPreviewItems(
+            baseItems,
+            draggedWorkspaceId: ids[1],
+            dropIndicator: SidebarDropIndicator(tabId: ids[0], edge: .top),
+            reorderWorkspaceIds: ids,
+            groupDropPreview: nil
+        )
+
+        #expect(previewItems.map(\.representedWorkspaceId) == [ids[1], ids[0]])
+        #expect(manager.tabs.map(\.id) == ids)
+    }
+
+    @Test func dragPreviewItemsMoveWholeGroupAsTopLevelBlock() throws {
+        let manager = makeTabManager()
+        manager.addWorkspace(autoWelcomeIfNeeded: false)
+        let originalIds = manager.tabs.map(\.id)
+        let groupId = try #require(manager.createWorkspaceGroup(name: "Group", childWorkspaceIds: [originalIds[1]]))
+        let group = try #require(manager.workspaceGroups.first { $0.id == groupId })
+        let baseItems = SidebarWorkspaceRenderItem.renderItems(
+            tabs: manager.tabs,
+            groupsById: Dictionary(uniqueKeysWithValues: manager.workspaceGroups.map { ($0.id, $0) })
+        )
+        let reorderIds = manager.sidebarReorderWorkspaceIds(forDraggedWorkspaceId: group.anchorWorkspaceId)
+
+        let previewItems = SidebarWorkspaceRenderItem.dragPreviewItems(
+            baseItems,
+            draggedWorkspaceId: group.anchorWorkspaceId,
+            dropIndicator: SidebarDropIndicator(tabId: nil, edge: .bottom),
+            reorderWorkspaceIds: reorderIds,
+            groupDropPreview: nil
+        )
+
+        #expect(previewItems.map(\.representedWorkspaceId) == [
+            originalIds[0],
+            originalIds[2],
+            group.anchorWorkspaceId,
+            originalIds[1],
+        ])
+        #expect(manager.tabs.map(\.id).contains(group.anchorWorkspaceId))
+    }
+
+    @Test func groupDropPreviewShowsDraggedWorkspaceJoiningGroupAtEnd() throws {
+        let manager = makeTabManager()
+        manager.addWorkspace(autoWelcomeIfNeeded: false)
+        let originalIds = manager.tabs.map(\.id)
+        let groupId = try #require(manager.createWorkspaceGroup(name: "Group", childWorkspaceIds: [originalIds[0]]))
+        let baseItems = SidebarWorkspaceRenderItem.renderItems(
+            tabs: manager.tabs,
+            groupsById: Dictionary(uniqueKeysWithValues: manager.workspaceGroups.map { ($0.id, $0) })
+        )
+
+        let previewItems = SidebarWorkspaceRenderItem.dragPreviewItems(
+            baseItems,
+            draggedWorkspaceId: originalIds[2],
+            dropIndicator: nil,
+            reorderWorkspaceIds: [],
+            groupDropPreview: SidebarWorkspaceGroupDropPreview(
+                draggedWorkspaceId: originalIds[2],
+                targetGroupId: groupId
+            )
+        )
+
+        let groupHeader = try #require(previewItems.first)
+        guard case .groupHeader(_, let memberWorkspaceIds) = groupHeader else {
+            Issue.record("Expected first preview item to be the group header")
+            return
+        }
+        #expect(memberWorkspaceIds.contains(originalIds[2]))
+        guard case .workspace(let previewWorkspace, let effectiveGroupId) = previewItems[2] else {
+            Issue.record("Expected dragged workspace to preview as a group member")
+            return
+        }
+        #expect(previewWorkspace.id == originalIds[2])
+        #expect(effectiveGroupId == groupId)
+        #expect(manager.tabs.first { $0.id == originalIds[2] }?.groupId == nil)
     }
 
     @Test func groupHeaderEdgeDropUsesTopLevelIndicatorScope() throws {


### PR DESCRIPTION
## Summary
- Adds a live row-shift preview for sidebar workspace drag reordering.
- Adds a non-interactive floating row follower so the held workspace stays visible without stealing drop hit-testing.
- Previews center drops into workspace groups before commit while keeping the insertion indicator for edge drops.

## Testing
- ./scripts/setup.sh
- ./scripts/reload.sh --tag dragpol
- Added WorkspaceGroupTests coverage for drag preview ordering and group-drop preview behavior. Not run locally because cmux Xcode tests are not run on the user Mac.

## Issues
- Related: plain-text task, restart sidebar reordering animations from scratch and improve drag feel.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5179"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782973767&installation_id=133855650&pr_number=5179&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5179&signature=6c6fbcceb87220ec375f6672e7e3f56ea52eb45d469f7e1a6c8621aa18b6d0ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches intricate drag state, LazyVStack invalidation, and group reorder edge cases; behavior is covered by new preview tests but regressions in feel or drop targeting are possible.
> 
> **Overview**
> Improves **sidebar workspace drag-and-drop** with live feedback before drop commits.
> 
> While dragging, the list can show a **preview order** (including moving a whole group as one top-level block) driven by `SidebarWorkspaceRenderItem.dragPreviewItems`, with a snappy reorder animation. A **floating follower** mirrors the dragged row at the cursor (system drag preview is hidden) without taking hits, and rows use an **effective group id** so indent updates during group-join previews.
> 
> **Dropping on a group header’s center** now previews membership at the end of the group (`groupDropPreview`) and commits with `placement: .end`; edge drops still use the insertion indicator. Autoscroll tracks document-space cursor position during drag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0251f9ca6aee6a985f4a3eab6d085fc9ff6542a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polishes sidebar workspace drag reordering with a live row-shift preview, a floating non-interactive drag follower, and group center-drop previews for clearer feedback and smoother feel.

- **New Features**
  - Live reorder preview: `SidebarWorkspaceRenderItem.dragPreviewItems` reorders rows in-place during drag; rows animate with a snappy timing.
  - Drag follower: `SidebarWorkspaceDragFollowerOverlay` renders a non-interactive copy of the dragged row that tracks the cursor; default drag preview suppressed via `SidebarWorkspaceInvisibleDragPreview`.
  - Group drop preview: `SidebarWorkspaceGroupDropPreview` shows the dragged workspace joining a group on center drop (edge drops still show the insertion indicator).
  - Autoscroll polish: `SidebarDragAutoScrollController` now tracks cursor/document position, starts/stops with drag, and refreshes during native autoscroll.
  - Safer hit-testing: rows rendered in drag-follower role disable drag/drop handlers and accessibility to avoid stealing events.
  - Tests: added `WorkspaceGroupTests` for drag preview ordering and group-drop preview behavior.

<sup>Written for commit b0251f9ca6aee6a985f4a3eab6d085fc9ff6542a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced drag-and-drop experience for workspaces with improved visual feedback during drag operations, including a visual follower that tracks cursor movement.
  * Improved workspace grouping with better preview rendering when moving workspaces between groups.

* **Tests**
  * Added comprehensive test coverage for drag-preview functionality and workspace group operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->