### PR TITLE
Fix Web Inspector reopening after manual close + navigation (#5172)

### DIFF
--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -6618,10 +6618,30 @@ extension BrowserPanel {
 
     func noteDeveloperToolsHostAttached() {
         cancelPendingDeveloperToolsVisibilityLossCheck()
-        developerToolsLastAttachedHostAt = Date()
+        // `developerToolsLastAttachedHostAt` anchors the manual-close detection
+        // grace (see `consumeAttachedDeveloperToolsManualCloseIfNeeded`). Refresh it
+        // only when this attach reflects genuine inspector churn: the inspector is
+        // currently visible, a forced refresh is pending, or a restore retry is in
+        // flight. While DevTools intent is set the browser stays in local-inline
+        // hosting, so `BrowserPanelView` re-runs this on every `updateNSView`. A
+        // plain re-render (e.g. navigating to another page) is not a reattach;
+        // resetting the grace there would defer a user's manual inspector close
+        // indefinitely and let `restoreDeveloperToolsAfterAttachIfNeeded` reopen it.
+        if developerToolsLastAttachedHostAt == nil || hasActiveDeveloperToolsReattachReason {
+            developerToolsLastAttachedHostAt = Date()
+        }
         if isDeveloperToolsVisible() {
             developerToolsLastKnownVisibleAt = Date()
         }
+    }
+
+    /// Whether a host attach should count as genuine inspector churn that resets
+    /// the manual-close grace window, rather than a steady-state re-render while
+    /// the inspector is already closed.
+    private var hasActiveDeveloperToolsReattachReason: Bool {
+        isDeveloperToolsVisible()
+            || forceDeveloperToolsRefreshOnNextAttach
+            || developerToolsRestoreRetryWorkItem != nil
     }
 
     func scheduleDeveloperToolsVisibilityLossCheck() {

--- a/cmuxTests/BrowserConfigTests.swift
+++ b/cmuxTests/BrowserConfigTests.swift
@@ -3574,6 +3574,101 @@ final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
         XCTAssertEqual(inspector.showCount, 2)
     }
 
+    private func attachPanelWebViewToWindow(_ panel: BrowserPanel) -> NSWindow {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 360, height: 240),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        let host = NSView(frame: window.contentView?.bounds ?? .zero)
+        window.contentView?.addSubview(host)
+        panel.webView.frame = NSRect(x: 0, y: 0, width: 180, height: host.bounds.height)
+        host.addSubview(panel.webView)
+        // Intentionally not made key / ordered front: consume's attach gate only
+        // needs webView.window != nil, and a key window + live WKWebView + runloop
+        // spin can recurse SwiftUI<->AppKit layout in the unit-test host.
+        return window
+    }
+
+    private func teardownWindowedPanel(_ panel: BrowserPanel, window: NSWindow) {
+        // Detach the live WKWebView from the window before any teardown so the
+        // window-close cascade never walks the web view's responder/layout tree
+        // (that path can recurse SwiftUI<->AppKit and overflow the stack here).
+        panel.webView.removeFromSuperview()
+        BrowserWindowPortalRegistry.detach(webView: panel.webView)
+        panel.webView.cmuxSetUnitTestInspector(nil)
+        window.contentView = nil
+        window.orderOut(nil)
+        panel.close()
+    }
+
+    func testManuallyClosedInspectorStaysClosedAfterNavigationReattach() {
+        let (panel, inspector) = makePanelWithInspector()
+        let window = attachPanelWebViewToWindow(panel)
+        defer { teardownWindowedPanel(panel, window: window) }
+
+        // User opens the Web Inspector; it attaches alongside the page.
+        XCTAssertTrue(panel.showDeveloperTools())
+        XCTAssertTrue(panel.isDeveloperToolsVisible())
+        panel.noteDeveloperToolsHostAttached()
+
+        // Let the inspector sit open past the manual-close detection grace so a
+        // later invisibility is unambiguously a deliberate close, and let the
+        // open transition settle.
+        RunLoop.current.run(until: Date().addingTimeInterval(0.4))
+
+        // User closes the inspector via its own UI. cmux did not initiate this,
+        // so the persisted intent is still "visible" until the close is detected.
+        inspector.close()
+        XCTAssertFalse(panel.isDeveloperToolsVisible())
+        XCTAssertTrue(panel.preferredDeveloperToolsVisible)
+        let showCountAfterClose = inspector.showCount
+
+        // User navigates to another page. While the DevTools intent is set the
+        // browser stays in local-inline hosting, so SwiftUI re-runs the same
+        // host-attach + after-attach restore that BrowserPanelView performs on
+        // every updateNSView.
+        panel.noteDeveloperToolsHostAttached()
+        panel.restoreDeveloperToolsAfterAttachIfNeeded()
+
+        XCTAssertFalse(
+            panel.isDeveloperToolsVisible(),
+            "A manually-closed Web Inspector must stay closed after navigating to another page"
+        )
+        XCTAssertFalse(
+            panel.preferredDeveloperToolsVisible,
+            "The persisted DevTools intent must follow the user's manual close instead of desyncing"
+        )
+        XCTAssertEqual(
+            inspector.showCount,
+            showCountAfterClose,
+            "Navigation after a manual inspector close must not re-show the inspector"
+        )
+    }
+
+    func testInspectorLeftOpenStaysOpenAcrossNavigationReattach() {
+        let (panel, inspector) = makePanelWithInspector()
+        let window = attachPanelWebViewToWindow(panel)
+        defer { teardownWindowedPanel(panel, window: window) }
+
+        XCTAssertTrue(panel.showDeveloperTools())
+        XCTAssertTrue(panel.isDeveloperToolsVisible())
+        panel.noteDeveloperToolsHostAttached()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.4))
+
+        // Navigate while the inspector is still open: it must persist, not close.
+        panel.noteDeveloperToolsHostAttached()
+        panel.restoreDeveloperToolsAfterAttachIfNeeded()
+
+        XCTAssertTrue(
+            panel.isDeveloperToolsVisible(),
+            "An inspector the user left open must persist across navigation"
+        )
+        XCTAssertTrue(panel.preferredDeveloperToolsVisible)
+        XCTAssertEqual(inspector.closeCount, 0)
+    }
+
     func testAttachedInspectorRevealReattachesFrontendAfterLayoutReentry() {
         let (panel, inspector) = makePanelWithInspector(requiresAttachmentToShow: true)
         defer { closeBrowserPanel(panel) }


### PR DESCRIPTION
## Bug

Browser **Web Inspector reopens itself** after closing it and navigating to another page (#5172). After that, the inspector's open/closed state desyncs from the user's intent.

## Root cause — confirmed by repro, *not* the issue's timing hypothesis

When the Web Inspector is open, the browser uses **local-inline DevTools hosting**, so *every* SwiftUI `updateNSView` — including the re-render triggered by navigating to a new URL — calls `noteDeveloperToolsHostAttached()` immediately followed by `restoreDeveloperToolsAfterAttachIfNeeded()` (`Sources/Panels/BrowserPanelView.swift`).

`noteDeveloperToolsHostAttached()` **unconditionally reset** `developerToolsLastAttachedHostAt = Date()`. That timestamp anchors the 0.35 s manual-close grace in `consumeAttachedDeveloperToolsManualCloseIfNeeded()`. After a user closes the inspector via its own UI (which leaves `preferredDeveloperToolsVisible == true` until detected), the navigation re-render **re-notes the attach** → the grace always looks "too fresh" → the manual close is never consumed → `restoreDeveloperToolsAfterAttachIfNeeded()` falls through to `revealDeveloperTools()` and **re-opens** the inspector, leaving `preferredDeveloperToolsVisible` desynced.

This is **deterministic**, not the sub-350 ms race the issue hypothesized: the grace is measured from the navigation re-attach, not from the user's close, so *any* navigation after a manual close reopens it.

## Fix

`noteDeveloperToolsHostAttached()` now refreshes the grace anchor **only on genuine inspector churn** — the inspector is currently visible, a forced refresh is pending, or a restore retry is in flight — not on steady-state re-renders while the inspector is already closed. A navigation re-render therefore preserves the original attach time, so the manual close is consumed and the inspector stays closed.

Intent is respected **both ways**: an inspector the user left *open* still persists across navigation (it is visible, so `restoreDeveloperToolsAfterAttachIfNeeded()` early-returns); genuine churn paths (webview replacement / forced refresh / retry) still re-reveal it.

The change is one method plus a small computed helper; no call sites change.

## Tests (model-level, in `BrowserDeveloperToolsVisibilityPersistenceTests`)

- **`testManuallyClosedInspectorStaysClosedAfterNavigationReattach`** — open → manual close → navigate (note + restore, exactly what `BrowserPanelView` does); asserts the inspector stays closed **and** `preferredDeveloperToolsVisible` stays in sync.
- **`testInspectorLeftOpenStaysOpenAcrossNavigationReattach`** — open → navigate (no close); asserts it persists, guarding against overcorrecting into "always close".

Two-commit red/green:
- **Commit 1 (test only):** `testManuallyClosed…` **fails** — inspector reopens (`vis 0→1`), intent desyncs, inspector re-shown.
- **Commit 2 (fix):** `testManuallyClosed…` **passes**; `testInspectorLeftOpen…` passes.

Verified locally against `cmux-unit`: a controlled baseline-vs-fixed run of the whole `BrowserDeveloperToolsVisibilityPersistenceTests` class shows the **only** test whose result changes is `testManuallyClosed…` (fail → pass); every other test's result is identical with and without the fix, so the change regresses nothing.

Closes #5172

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5180"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782975008&installation_id=133855650&pr_number=5180&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5180&signature=1b8db25fd65aca30e0e25831ac7e9d1bc0a1d1e4f2865b53ea52a9226db72ac5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to DevTools attach timestamp logic plus regression tests; low risk to auth or data paths.
> 
> **Overview**
> Fixes **Web Inspector reopening after the user closes it and navigates** while DevTools intent is still set.
> 
> `noteDeveloperToolsHostAttached()` no longer always resets `developerToolsLastAttachedHostAt`. It only refreshes that grace anchor when attach reflects **real inspector churn** (inspector visible, forced refresh pending, or restore retry in flight)—not on every SwiftUI `updateNSView` during local-inline hosting. Navigation re-renders used to reset the manual-close grace so `restoreDeveloperToolsAfterAttachIfNeeded()` could re-show the inspector and leave `preferredDeveloperToolsVisible` out of sync.
> 
> Adds **`hasActiveDeveloperToolsReattachReason`** and unit tests: manual close then simulated navigation attach/restore stays closed with intent synced; inspector left open still persists across navigation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 912324a6d392ab8427860d1322e8cee2d8e1f8b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a deterministic bug where the Web Inspector reopens after a manual close followed by navigation. The inspector now respects user intent and stays in sync with the persisted visibility state.

- **Bug Fixes**
  - Refresh the attach timestamp only on genuine inspector churn (inspector visible, forced refresh pending, or restore retry), not on steady-state re-renders.
  - Preserve the original attach time on navigation so a manual close is consumed and the inspector stays closed; inspectors left open persist across navigation.

<sup>Written for commit 912324a6d392ab8427860d1322e8cee2d8e1f8b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Developer Tools state handling during navigation to maintain stability and prevent unexpected visibility changes.

* **Tests**
  * Added comprehensive test coverage for Developer Tools visibility behavior across navigation and inspector reattachment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->