### PR TITLE
Respect Ghostty transparency in browser chrome

### DIFF
--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -44,11 +44,32 @@ enum GhosttyBackgroundTheme {
         WindowAppearanceSnapshot.clampedOpacity(opacity)
     }
 
+    static func usesClearSurfaceBackground(
+        opacity: Double,
+        backgroundBlur: GhosttyBackgroundBlur,
+        usesTransparentWindow: Bool = cmuxShouldUseTransparentBackgroundWindow()
+    ) -> Bool {
+        usesTransparentWindow || backgroundBlur.isMacOSGlassStyle || opacity < 0.999
+    }
+
     static func color(backgroundColor: NSColor, opacity: Double) -> NSColor {
         WindowAppearanceSnapshot.compositedTerminalColor(
             backgroundColor: backgroundColor,
             opacity: opacity
         )
+    }
+
+    static func surfaceColor(
+        backgroundColor: NSColor,
+        opacity: Double,
+        backgroundBlur: GhosttyBackgroundBlur,
+        usesTransparentWindow: Bool = cmuxShouldUseTransparentBackgroundWindow()
+    ) -> NSColor {
+        usesClearSurfaceBackground(
+            opacity: opacity,
+            backgroundBlur: backgroundBlur,
+            usesTransparentWindow: usesTransparentWindow
+        ) ? .clear : color(backgroundColor: backgroundColor, opacity: opacity)
     }
 
     static func color(
@@ -85,6 +106,14 @@ enum GhosttyBackgroundTheme {
         color(
             backgroundColor: GhosttyApp.shared.defaultBackgroundColor,
             opacity: GhosttyApp.shared.defaultBackgroundOpacity
+        )
+    }
+
+    static func currentSurfaceColor() -> NSColor {
+        surfaceColor(
+            backgroundColor: GhosttyApp.shared.defaultBackgroundColor,
+            opacity: GhosttyApp.shared.defaultBackgroundOpacity,
+            backgroundBlur: GhosttyApp.shared.defaultBackgroundBlur
         )
     }
 }
@@ -3919,7 +3948,7 @@ final class BrowserPanel: Panel, ObservableObject {
         // Match only the unpainted/loading background so newly-created browsers don't flash
         // white before content loads. Do not force page appearance or inject color-scheme CSS;
         // websites must keep control of their own theme.
-        webView.underPageBackgroundColor = GhosttyBackgroundTheme.currentColor()
+        webView.underPageBackgroundColor = GhosttyBackgroundTheme.currentSurfaceColor()
         // Always present as Safari.
         webView.customUserAgent = BrowserUserAgentSettings.safariUserAgent
         return webView
@@ -4905,7 +4934,14 @@ final class BrowserPanel: Panel, ObservableObject {
         NotificationCenter.default.publisher(for: .ghosttyDefaultBackgroundDidChange)
             .sink { [weak self] notification in
                 guard let self else { return }
-                self.webView.underPageBackgroundColor = GhosttyBackgroundTheme.color(from: notification)
+                self.webView.underPageBackgroundColor = GhosttyBackgroundTheme.surfaceColor(
+                    backgroundColor: (notification.userInfo?[GhosttyNotificationKey.backgroundColor] as? NSColor)
+                        ?? GhosttyApp.shared.defaultBackgroundColor,
+                    opacity: (notification.userInfo?[GhosttyNotificationKey.backgroundOpacity] as? NSNumber)?.doubleValue
+                        ?? (notification.userInfo?[GhosttyNotificationKey.backgroundOpacity] as? Double)
+                        ?? GhosttyApp.shared.defaultBackgroundOpacity,
+                    backgroundBlur: GhosttyApp.shared.defaultBackgroundBlur
+                )
             }
             .store(in: &webViewCancellables)
     }
@@ -6985,7 +7021,7 @@ extension BrowserPanel {
     }
 
     func refreshAppearanceDrivenColors() {
-        webView.underPageBackgroundColor = GhosttyBackgroundTheme.currentColor()
+        webView.underPageBackgroundColor = GhosttyBackgroundTheme.currentSurfaceColor()
     }
 
     func suppressOmnibarAutofocus(for seconds: TimeInterval) {

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -373,31 +373,46 @@ func resolvedBrowserOmnibarPillBackgroundColor(
     return themeBackgroundColor.blended(withFraction: darkenMix, of: .black) ?? themeBackgroundColor
 }
 
-private struct BrowserChromeStyle {
+struct BrowserChromeStyle {
     let backgroundColor: NSColor
     let colorScheme: ColorScheme
     let omnibarPillBackgroundColor: NSColor
 
     static func resolve(
         for colorScheme: ColorScheme,
-        themeBackgroundColor: NSColor
+        themeBackgroundColor: NSColor,
+        drawsSurfaceBackground: Bool = true
     ) -> BrowserChromeStyle {
-        let backgroundColor = resolvedBrowserChromeBackgroundColor(
+        let semanticBackgroundColor = resolvedBrowserChromeBackgroundColor(
             for: colorScheme,
             themeBackgroundColor: themeBackgroundColor
         )
         let chromeColorScheme = resolvedBrowserChromeColorScheme(
             for: colorScheme,
-            themeBackgroundColor: backgroundColor
+            themeBackgroundColor: semanticBackgroundColor
         )
-        let omnibarPillBackgroundColor = resolvedBrowserOmnibarPillBackgroundColor(
+        let resolvedOmnibarPillBackgroundColor = resolvedBrowserOmnibarPillBackgroundColor(
             for: chromeColorScheme,
-            themeBackgroundColor: backgroundColor
+            themeBackgroundColor: semanticBackgroundColor
         )
+        let omnibarPillBackgroundColor = drawsSurfaceBackground
+            ? resolvedOmnibarPillBackgroundColor
+            : resolvedOmnibarPillBackgroundColor.withAlphaComponent(0.74)
         return BrowserChromeStyle(
-            backgroundColor: backgroundColor,
+            backgroundColor: drawsSurfaceBackground ? semanticBackgroundColor : .clear,
             colorScheme: chromeColorScheme,
             omnibarPillBackgroundColor: omnibarPillBackgroundColor
+        )
+    }
+
+    static func current(for colorScheme: ColorScheme) -> BrowserChromeStyle {
+        resolve(
+            for: colorScheme,
+            themeBackgroundColor: GhosttyBackgroundTheme.currentColor(),
+            drawsSurfaceBackground: !GhosttyBackgroundTheme.usesClearSurfaceBackground(
+                opacity: GhosttyApp.shared.defaultBackgroundOpacity,
+                backgroundBlur: GhosttyApp.shared.defaultBackgroundBlur
+            )
         )
     }
 }
@@ -458,10 +473,7 @@ struct BrowserPanelView: View {
     @State private var suppressNextFocusGainedSelectAll: Bool = false
     @State private var isBrowserProfileMenuPresented = false
     @State private var isBrowserThemeMenuPresented = false
-    @State private var browserChromeStyle = BrowserChromeStyle.resolve(
-        for: .light,
-        themeBackgroundColor: GhosttyBackgroundTheme.currentColor()
-    )
+    @State private var browserChromeStyle = BrowserChromeStyle.current(for: .light)
     // Keep this below half of the compact omnibar height so it reads as a squircle,
     // not a capsule.
     private let omnibarPillCornerRadius: CGFloat = 10
@@ -1681,10 +1693,7 @@ struct BrowserPanelView: View {
     }
 
     private func refreshBrowserChromeStyle() {
-        browserChromeStyle = BrowserChromeStyle.resolve(
-            for: colorScheme,
-            themeBackgroundColor: GhosttyBackgroundTheme.currentColor()
-        )
+        browserChromeStyle = BrowserChromeStyle.current(for: colorScheme)
     }
 
     private func syncWebViewResponderPolicyWithViewState(

--- a/Sources/Panels/BrowserPopupWindowController.swift
+++ b/Sources/Panels/BrowserPopupWindowController.swift
@@ -117,7 +117,7 @@ final class BrowserPopupWindowController: NSObject, NSWindowDelegate {
         if #available(macOS 13.3, *) {
             webView.isInspectable = true
         }
-        webView.underPageBackgroundColor = GhosttyBackgroundTheme.currentColor()
+        webView.underPageBackgroundColor = GhosttyBackgroundTheme.currentSurfaceColor()
         webView.customUserAgent = BrowserUserAgentSettings.safariUserAgent
         BrowserThemeSettings.apply(openerPanel?.currentBrowserThemeMode ?? BrowserThemeSettings.mode(), to: webView)
         self.webView = webView

--- a/cmuxTests/WindowAppearanceSnapshotTests.swift
+++ b/cmuxTests/WindowAppearanceSnapshotTests.swift
@@ -21,6 +21,56 @@ final class WindowAppearanceSnapshotTests: XCTestCase {
         assertClearBackdrop(snapshot.policy(for: .rightSidebar))
     }
 
+    func testBrowserSurfaceColorClearsForTransparentGhosttyBackground() {
+        guard let backgroundColor = NSColor(hex: "#101820") else {
+            XCTFail("Expected valid test color")
+            return
+        }
+
+        let color = GhosttyBackgroundTheme.surfaceColor(
+            backgroundColor: backgroundColor,
+            opacity: 0.5,
+            backgroundBlur: .disabled,
+            usesTransparentWindow: false
+        )
+
+        XCTAssertEqual(color.alphaComponent, 0, accuracy: 0.0001)
+    }
+
+    func testBrowserChromeStyleKeepsReadableSchemeWhenDrawingClearSurface() {
+        guard let backgroundColor = NSColor(hex: "#101820") else {
+            XCTFail("Expected valid test color")
+            return
+        }
+
+        let style = BrowserChromeStyle.resolve(
+            for: .dark,
+            themeBackgroundColor: backgroundColor,
+            drawsSurfaceBackground: false
+        )
+
+        XCTAssertEqual(style.backgroundColor.alphaComponent, 0, accuracy: 0.0001)
+        XCTAssertEqual(style.colorScheme, .dark)
+        XCTAssertEqual(style.omnibarPillBackgroundColor.alphaComponent, 0.74, accuracy: 0.0001)
+    }
+
+    func testBrowserSurfaceColorDrawsOpaqueForOpaqueGhosttyBackground() {
+        guard let backgroundColor = NSColor(hex: "#101820") else {
+            XCTFail("Expected valid test color")
+            return
+        }
+
+        let color = GhosttyBackgroundTheme.surfaceColor(
+            backgroundColor: backgroundColor,
+            opacity: 1,
+            backgroundBlur: .disabled,
+            usesTransparentWindow: false
+        )
+
+        XCTAssertEqual(color.alphaComponent, 1, accuracy: 0.0001)
+        XCTAssertEqual(color.hexString(), "#101820")
+    }
+
     func testSeparateSurfaceBackdropsKeepRootBackdropAndSidebarMaterialsSeparate() {
         let snapshot = makeSnapshot(unifySurfaceBackdrops: false)
 


### PR DESCRIPTION
## Summary
- Clear browser blank-tab and toolbar backgrounds when Ghostty background opacity or glass requires a transparent host backdrop.
- Use the same clear surface color for WebKit under-page backgrounds so empty/loading browser pages do not flash opaque.
- Add resolver coverage for transparent and opaque browser surface behavior.

## Testing
- `./scripts/reload.sh --tag btrans` passed.
- `git diff --check` passed.
- Local `xcodebuild test` was not run because cmux forbids local test actions against the app test host.

## Issues
- Related task: browser blank page and omnibar should respect transparent Ghostty background config.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782978766&installation_id=133855650&pr_number=5181&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5181&signature=8b459e6cf7be91218eaae91eda5ff8c206731d623b42f959d36474b5786ed186"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Appearance-only changes to browser chrome and WebKit background colors; no auth, data, or networking logic.
> 
> **Overview**
> Browser panels now follow Ghostty’s transparent or glass window settings instead of painting opaque chrome and WebKit backgrounds on top of the host backdrop.
> 
> **`GhosttyBackgroundTheme`** gains shared rules (`usesClearSurfaceBackground` / `surfaceColor`) that return **clear** when the app uses a transparent window, macOS glass blur, or background opacity below ~1. **`WKWebView.underPageBackgroundColor`** (main panel, popups, and live theme updates) uses that surface color so loading/blank pages don’t flash an opaque fill.
> 
> **`BrowserChromeStyle`** can draw a **clear** toolbar background while keeping light/dark scheme and a slightly translucent omnibar pill (0.74 alpha) for readability. **`BrowserChromeStyle.current`** ties that to the same transparency rules as the web surface.
> 
> Unit tests cover clear vs opaque surface colors and chrome styling when the surface background is not drawn.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd0644b3757947104df28952f0f67e5e8617d6cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the browser blank page and toolbar respect Ghostty transparency and glass settings to avoid opaque flashes while loading. Addresses the task for the blank page and omnibar to follow transparent Ghostty background config.

- **Bug Fixes**
  - WebKit under-page background now clears when the window is transparent or uses glass; otherwise it composites with the theme color.
  - Browser chrome draws a clear background when needed and keeps the omnibar pill readable with slight translucency.
  - Added tests covering transparent vs. opaque surfaces and chrome readability.

<sup>Written for commit bd0644b3757947104df28952f0f67e5e8617d6cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced browser background rendering with improved transparency and blur handling to better match the window's transparency settings.
  * Refined visual appearance of the browser chrome when transparency and blur effects are applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->