### PR TITLE
Restore right-click sidebar-button view switcher and built-in views (#5173)

### DIFF
--- a/Examples/CmuxExtensionSidebarExamples/Tests/CmuxExtensionSidebarExamplesTests/SidebarProviderExistentialDispatchTests.swift
+++ b/Examples/CmuxExtensionSidebarExamples/Tests/CmuxExtensionSidebarExamplesTests/SidebarProviderExistentialDispatchTests.swift
@@ -1,0 +1,80 @@
+import CmuxExtensionKit
+@testable import CmuxExtensionSidebarExamples
+import XCTest
+
+/// Regression coverage for https://github.com/manaflow-ai/cmux/issues/5173.
+///
+/// The host renders sidebar views through an `any CmuxExtensionSidebarProvider`
+/// existential (`CmuxExtensionSidebarSelection.provider(for:)?.render(snapshot:)`).
+/// `render(snapshot:)` must therefore be a protocol *requirement* so the call
+/// dynamic-dispatches to the concrete view. When #4994 demoted it to a
+/// protocol-extension default (returning no sections), every built-in view
+/// rendered an empty sidebar even though the provider and snapshot were correct.
+final class SidebarProviderExistentialDispatchTests: XCTestCase {
+    /// Super Compact lists every workspace in a single section, so calling it
+    /// through the existential must yield exactly the same rows as the concrete
+    /// call — not the empty protocol-extension default.
+    func testSuperCompactRendersIdenticallyThroughExistential() {
+        let snapshot = Self.snapshot(workspaceCount: 3)
+        let concrete = SuperCompactSidebar()
+        let existential: any CmuxExtensionSidebarProvider = concrete
+
+        let concreteModel = concrete.render(snapshot: snapshot)
+        let existentialModel = existential.render(snapshot: snapshot)
+
+        XCTAssertFalse(concreteModel.sections.isEmpty, "concrete render should produce a section")
+        XCTAssertEqual(concreteModel.sections.flatMap(\.rows).count, 3)
+        XCTAssertEqual(
+            existentialModel.sections,
+            concreteModel.sections,
+            "render(snapshot:) must dynamic-dispatch through the existential, not the empty default"
+        )
+    }
+
+    /// Every built-in view that distributes all workspaces across sections must
+    /// produce rows when invoked through the existential. (Browser Stack is
+    /// excluded: it renders only browser-tagged workspaces.)
+    func testWorkspaceListingProvidersRenderRowsThroughExistential() {
+        let snapshot = Self.snapshot(workspaceCount: 4)
+        let listingProviderIDs: Set<String> = [
+            "com.example.cmux.sidebar.project-worktrees",
+            "com.example.cmux.sidebar.attention-queue",
+            "com.example.cmux.sidebar.dev-servers",
+            "com.example.cmux.sidebar.last-prompt",
+            "com.example.cmux.sidebar.super-compact",
+        ]
+        for provider in SidebarExamples.providers where listingProviderIDs.contains(provider.descriptor.id) {
+            let model = provider.render(snapshot: snapshot)
+            XCTAssertFalse(
+                model.sections.flatMap(\.rows).isEmpty,
+                "Provider \(provider.descriptor.id) rendered no rows through the existential"
+            )
+        }
+    }
+
+    private static func snapshot(workspaceCount: Int) -> CmuxExtensionSidebarSnapshot {
+        let workspaces = (0..<workspaceCount).map { index in
+            CmuxExtensionWorkspaceSnapshot(
+                id: UUID(),
+                title: "Workspace \(index)",
+                customDescription: nil,
+                isPinned: false,
+                rootPath: "/tmp/ws\(index)",
+                projectRootPath: "/tmp/ws\(index)",
+                branchSummary: "main",
+                remoteDisplayTarget: nil,
+                remoteConnectionState: "disconnected",
+                unreadCount: 0,
+                latestNotificationText: nil,
+                latestSubmittedMessage: "hello",
+                latestSubmittedAt: Date(timeIntervalSince1970: 1_000_000),
+                listeningPorts: []
+            )
+        }
+        return CmuxExtensionSidebarSnapshot(
+            sequence: 1,
+            selectedWorkspaceId: nil,
+            workspaces: workspaces
+        )
+    }
+}

--- a/Packages/CmuxExtensionKit/Sources/CmuxExtensionKit/HostCompatibility/CmuxExtensionSidebarProvider.swift
+++ b/Packages/CmuxExtensionKit/Sources/CmuxExtensionKit/HostCompatibility/CmuxExtensionSidebarProvider.swift
@@ -1,5 +1,29 @@
 import Foundation
 
+/// A host-side sidebar view that renders cmux workspaces into sidebar sections.
+///
+/// Conformers describe themselves with a ``CmuxExtensionSidebarProviderDescriptor``
+/// and turn a ``CmuxExtensionSidebarSnapshot`` into a
+/// ``CmuxExtensionSidebarRenderModel``. The built-in views (Project Worktrees,
+/// Attention Queue, Dev Servers, Last Prompt, Super Compact, Browser Stack) all
+/// conform to this protocol or one of its refinements.
 public protocol CmuxExtensionSidebarProvider: Sendable {
+    /// Menu/registry metadata (title, icon, id) for this sidebar view.
     var descriptor: CmuxExtensionSidebarProviderDescriptor { get }
+
+    /// Produces the sidebar contents for the given workspace snapshot.
+    ///
+    /// This is a protocol *requirement* (not only a protocol-extension default)
+    /// on purpose: the host renders providers through an
+    /// `any CmuxExtensionSidebarProvider` existential, and a method that lives
+    /// solely in a protocol extension would static-dispatch to the extension's
+    /// default instead of the conforming type's implementation — silently
+    /// yielding an empty sidebar. Declaring it here gives every conformer a
+    /// witness-table entry so the call dynamic-dispatches correctly.
+    ///
+    /// ``CmuxExtensionKit`` still supplies a default that returns no sections, so
+    /// providers that render exclusively through
+    /// ``CmuxExtensionSidebarContextualProvider/render(snapshot:context:)`` are
+    /// not forced to implement this directly.
+    func render(snapshot: CmuxExtensionSidebarSnapshot) -> CmuxExtensionSidebarRenderModel
 }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -4,6 +4,7 @@ import Bonsplit
 import Combine
 import CMUXExtensionClient
 import CmuxExtensionKit
+import CmuxExtensionSidebarExamples
 import CmuxSettings
 import CmuxSettingsUI
 import ImageIO
@@ -6795,22 +6796,20 @@ struct ContentView: View {
                 keywords: ["toggle", "sidebar", "left", "layout"]
             )
         )
-        // "Sidebar: <provider>" switch commands only make sense when there
-        // is more than one provider, which is the experimental Extensions
-        // feature. Omit them entirely while it is disabled.
-        if CmuxExtensionSidebarSelection.isEnabled {
-            for descriptor in CmuxExtensionSidebarSelection.descriptors {
-                let title = CmuxExtensionSidebarSelection.localizedTitle(for: descriptor)
-                let titleFormat = String(localized: "command.switchExtensionSidebar.title", defaultValue: "Sidebar: %@")
-                contributions.append(
-                    CommandPaletteCommandContribution(
-                        commandId: commandPaletteExtensionSidebarCommandID(descriptor.id),
-                        title: constant(String.localizedStringWithFormat(titleFormat, title)),
-                        subtitle: constant(String(localized: "command.switchExtensionSidebar.subtitle", defaultValue: "Choose Sidebar")),
-                        keywords: ["sidebar", "switch", "extension", title.lowercased()]
-                    )
+        // "Sidebar: <provider>" switch commands for each available view. The
+        // built-in views are always offered; `descriptors` adds the hosted
+        // extension sidebar only while the experimental Extensions beta is on.
+        for descriptor in CmuxExtensionSidebarSelection.descriptors {
+            let title = CmuxExtensionSidebarSelection.localizedTitle(for: descriptor)
+            let titleFormat = String(localized: "command.switchExtensionSidebar.title", defaultValue: "Sidebar: %@")
+            contributions.append(
+                CommandPaletteCommandContribution(
+                    commandId: commandPaletteExtensionSidebarCommandID(descriptor.id),
+                    title: constant(String.localizedStringWithFormat(titleFormat, title)),
+                    subtitle: constant(String(localized: "command.switchExtensionSidebar.subtitle", defaultValue: "Choose Sidebar")),
+                    keywords: ["sidebar", "switch", "extension", title.lowercased()]
                 )
-            }
+            )
         }
         contributions.append(contentsOf: Self.commandPaletteRightSidebarModeCommandContributions())
         contributions.append(contentsOf: Self.commandPaletteRightSidebarToolPaneCommandContributions())
@@ -7934,7 +7933,11 @@ struct ContentView: View {
         registry.register(commandId: "palette.toggleSidebar") {
             sidebarState.toggle()
         }
-        for descriptor in CmuxExtensionSidebarSelection.descriptors {
+        // Register a handler for every possible view (including the hosted
+        // extension sidebar) regardless of the beta flag, so a contribution that
+        // was visible when the flag was on still resolves after a runtime flip.
+        // Visibility is gated by `descriptors`; the handler set is the superset.
+        for descriptor in CmuxExtensionSidebarSelection.allDescriptors {
             registry.register(commandId: commandPaletteExtensionSidebarCommandID(descriptor.id)) {
                 CmuxExtensionSidebarSelection.setProviderId(descriptor.id)
             }
@@ -10079,11 +10082,31 @@ enum CmuxExtensionSidebarSelection {
     }
 
     static var providers: [any CmuxExtensionSidebarProvider] {
-        []
+        SidebarExamples.providers
     }
 
+    /// The always-available built-in views: the default workspaces sidebar plus
+    /// the bundled preset providers (Project Worktrees, Attention Queue, Dev
+    /// Servers, Last Prompt, Super Compact, Browser Stack). These ship
+    /// independently of the experimental Extensions feature, so they stay in
+    /// the switcher menu regardless of the beta flag.
+    static var builtInDescriptors: [CmuxExtensionSidebarProviderDescriptor] {
+        [.defaultWorkspaces] + providers.map { $0.descriptor }
+    }
+
+    /// Descriptors offered in the switcher menu and command palette. The hosted
+    /// extension entry belongs to the experimental Extensions feature, so it is
+    /// only offered while that beta is enabled; the built-in views are always
+    /// offered.
     static var descriptors: [CmuxExtensionSidebarProviderDescriptor] {
-        [.defaultWorkspaces, hostedExtensionsDescriptor] + providers.map { $0.descriptor }
+        isEnabled ? builtInDescriptors + [hostedExtensionsDescriptor] : builtInDescriptors
+    }
+
+    /// Every descriptor that can ever be selected, ignoring feature gates. Used
+    /// to register command-palette handlers so a runtime flag flip always has a
+    /// handler to invoke; what is *shown* uses ``descriptors``.
+    static var allDescriptors: [CmuxExtensionSidebarProviderDescriptor] {
+        builtInDescriptors + [hostedExtensionsDescriptor]
     }
 
     static var hostedExtensionsDescriptor: CmuxExtensionSidebarProviderDescriptor {
@@ -10113,6 +10136,21 @@ enum CmuxExtensionSidebarSelection {
         providers.first { $0.descriptor.id == providerId }
     }
 
+    /// Resolves the persisted provider selection to the provider that is
+    /// actually rendered. The hosted-extensions provider is part of the
+    /// experimental Extensions feature, so a persisted hosted selection falls
+    /// back to the default workspaces sidebar while the beta is disabled —
+    /// otherwise turning the feature off would strand the user on an empty
+    /// sidebar with no switcher entry to escape it. Built-in views are always
+    /// honored, so the switcher and its active-view checkmark keep working
+    /// regardless of the beta flag.
+    static func effectiveProviderId(_ persistedProviderId: String, extensionsEnabled: Bool) -> String {
+        if persistedProviderId == hostedExtensionsProviderId, !extensionsEnabled {
+            return defaultProviderId
+        }
+        return persistedProviderId
+    }
+
     static func localizedTitle(for descriptor: CmuxExtensionSidebarProviderDescriptor) -> String {
         localizedText(descriptor.title)
     }
@@ -10133,14 +10171,13 @@ enum CmuxExtensionSidebarSelection {
 
     @MainActor
     static func showMenu(anchorView: NSView, event: NSEvent?) {
-        // The sidebar-toggle right-click menu only switches between sidebar
-        // providers, which exists solely for the experimental Extensions
-        // feature. While it is disabled there is nothing to choose, so the
-        // menu does not appear.
-        guard isEnabled else { return }
+        // The right-click menu switches between the always-available built-in
+        // views (and the hosted extension sidebar when the experimental
+        // Extensions beta is enabled), so it is shown regardless of the flag.
         let menu = NSMenu()
+        let persistedProviderId = UserDefaults.standard.string(forKey: defaultsKey) ?? defaultProviderId
         let selectedProviderId = descriptor(
-            for: UserDefaults.standard.string(forKey: defaultsKey) ?? defaultProviderId
+            for: effectiveProviderId(persistedProviderId, extensionsEnabled: isEnabled)
         ).id
         for descriptor in descriptors {
             let item = NSMenuItem(
@@ -10443,17 +10480,20 @@ struct VerticalTabsSidebar: View {
     private var selectedExtensionSidebarProviderId = CmuxExtensionSidebarSelection.defaultProviderId
     @LiveSetting(\.betaFeatures.extensions) private var extensionsExperimentalEnabled
 
-    // The provider to actually render. When the experimental Extensions feature
-    // is disabled, fall back to the default workspaces sidebar regardless of the
-    // persisted selection: turning extensions off hides the provider switcher,
-    // so a hosted-extension selection would otherwise strand the user with no
-    // way back. Deriving the effective provider (rather than mutating the
-    // persisted selection via an observer) routes correctly on the first render
-    // pass and restores the user's choice if extensions are re-enabled.
+    // The provider to actually render. Built-in views are always honored; only
+    // the hosted-extension selection falls back to the default workspaces
+    // sidebar while the experimental Extensions feature is disabled, since
+    // turning extensions off hides that entry and would otherwise strand the
+    // user with no way back. Deriving the effective provider (rather than
+    // mutating the persisted selection via an observer) routes correctly on the
+    // first render pass and restores the user's choice if extensions are
+    // re-enabled. Reading `extensionsExperimentalEnabled` here keeps the view
+    // reactive to the flag toggling.
     private var effectiveExtensionSidebarProviderId: String {
-        extensionsExperimentalEnabled
-            ? selectedExtensionSidebarProviderId
-            : CmuxExtensionSidebarSelection.defaultProviderId
+        CmuxExtensionSidebarSelection.effectiveProviderId(
+            selectedExtensionSidebarProviderId,
+            extensionsEnabled: extensionsExperimentalEnabled
+        )
     }
     @AppStorage("sidebarMatchTerminalBackground")
     private var sidebarMatchTerminalBackground = false
@@ -11099,6 +11139,12 @@ struct VerticalTabsSidebar: View {
                         .receive(on: RunLoop.main)
                         .debounce(for: Self.extensionSidebarObservationCoalesceInterval, scheduler: RunLoop.main)
                 ) { _ in
+                refreshExtensionSidebarSnapshot()
+            }
+            .onReceive(
+                NotificationCenter.default.publisher(for: BrowserStackSidebar.stateDidLoadNotification)
+                    .receive(on: RunLoop.main)
+            ) { _ in
                 refreshExtensionSidebarSnapshot()
             }
         }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -139,6 +139,7 @@
 		E7E000000000000000000001 /* CmuxEventStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7E000000000000000000002 /* CmuxEventStream.swift */; };
 		C0DE46000000000000000001 /* CMUXExtensionClient in Frameworks */ = {isa = PBXBuildFile; productRef = C0DE46000000000000000002 /* CMUXExtensionClient */; };
 		C0DE45000000000000000001 /* CmuxExtensionKit in Frameworks */ = {isa = PBXBuildFile; productRef = C0DE45000000000000000002 /* CmuxExtensionKit */; };
+		C0DE49000000000000000001 /* CmuxExtensionSidebarExamples in Frameworks */ = {isa = PBXBuildFile; productRef = C0DE49000000000000000002 /* CmuxExtensionSidebarExamples */; };
 		CF00F00000000000000000A3 /* CmuxFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = CF00F00000000000000000A2 /* CmuxFoundation */; };
 		C0DE34020000000000000001 /* CmuxHelpCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE34020000000000000003 /* CmuxHelpCommands.swift */; };
 		C0DE34020000000000000002 /* CmuxHelpResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE34020000000000000004 /* CmuxHelpResource.swift */; };
@@ -1207,6 +1208,7 @@
 				5EDB6027B346C46521A93C74 /* CMUXAuthCore in Frameworks */,
 				C0DE46000000000000000001 /* CMUXExtensionClient in Frameworks */,
 				C0DE45000000000000000001 /* CmuxExtensionKit in Frameworks */,
+				C0DE49000000000000000001 /* CmuxExtensionSidebarExamples in Frameworks */,
 				CF00F00000000000000000A3 /* CmuxFoundation in Frameworks */,
 				3069F1D10000000000000005 /* CMUXPasteboardFidelity in Frameworks */,
 				C8000303C8000303C8000303 /* CmuxProcess in Frameworks */,
@@ -1921,6 +1923,7 @@
 				AA11BB22CC33DD44EE550002 /* CMUXWorkstream */,
 				C0DE46000000000000000002 /* CMUXExtensionClient */,
 				C0DE45000000000000000002 /* CmuxExtensionKit */,
+				C0DE49000000000000000002 /* CmuxExtensionSidebarExamples */,
 				3069F1D10000000000000006 /* CMUXPasteboardFidelity */,
 				A5C0DE0000000000000000A2 /* CMUXProjectModel */,
 				F53000A2A1B2C3D4E5F60718 /* CMUXAgentVault */,
@@ -2061,6 +2064,7 @@
 				AA11BB22CC33DD44EE550003 /* XCLocalSwiftPackageReference "CMUXWorkstream" */,
 				C0DE46000000000000000003 /* XCLocalSwiftPackageReference "CMUXExtensionClient" */,
 				C0DE45000000000000000003 /* XCLocalSwiftPackageReference "CmuxExtensionKit" */,
+				C0DE49000000000000000003 /* XCLocalSwiftPackageReference "CmuxExtensionSidebarExamples" */,
 				3069F1D10000000000000007 /* XCLocalSwiftPackageReference "CMUXPasteboardFidelity" */,
 				A5C0DE0000000000000000A1 /* XCLocalSwiftPackageReference "CMUXProjectModel" */,
 				F53000A1A1B2C3D4E5F60718 /* XCLocalSwiftPackageReference "CMUXAgentVault" */,
@@ -3183,6 +3187,10 @@
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/CmuxExtensionKit;
 		};
+		C0DE49000000000000000003 /* XCLocalSwiftPackageReference "CmuxExtensionSidebarExamples" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Examples/CmuxExtensionSidebarExamples;
+		};
 		C0DE46000000000000000003 /* XCLocalSwiftPackageReference "CMUXExtensionClient" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/CMUXExtensionClient;
@@ -3283,6 +3291,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = C0DE45000000000000000003 /* XCLocalSwiftPackageReference "CmuxExtensionKit" */;
 			productName = CmuxExtensionKit;
+		};
+		C0DE49000000000000000002 /* CmuxExtensionSidebarExamples */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C0DE49000000000000000003 /* XCLocalSwiftPackageReference "CmuxExtensionSidebarExamples" */;
+			productName = CmuxExtensionSidebarExamples;
 		};
 		C0DE46000000000000000002 /* CMUXExtensionClient */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -432,6 +432,7 @@
 		CB23911D7E131E8FBC9B82B6 /* SidebarOrderingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC39DE4B96D1931C52AF7D68 /* SidebarOrderingTests.swift */; };
 		EA1F00000000000000000001 /* SidebarPathFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA1F00000000000000000002 /* SidebarPathFormatter.swift */; };
 		C0DEF0A30000000000000001 /* SidebarPortDisplayText.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEF0A30000000000000002 /* SidebarPortDisplayText.swift */; };
+		C0DE48000000000000000001 /* SidebarProviderMenuRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE48000000000000000002 /* SidebarProviderMenuRegressionTests.swift */; };
 		B9000130A1B2C3D4E5F60719 /* SidebarPullRequestInteractivityUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000131A1B2C3D4E5F60719 /* SidebarPullRequestInteractivityUITests.swift */; };
 		B8F266236A1A3D9A45BD840F /* SidebarResizeUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 818DBCD4AB69EB72573E8138 /* SidebarResizeUITests.swift */; };
 		C0DE35010000000000000001 /* SidebarScrim.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE35010000000000000002 /* SidebarScrim.swift */; };
@@ -1051,6 +1052,7 @@
 		BC39DE4B96D1931C52AF7D68 /* SidebarOrderingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarOrderingTests.swift; sourceTree = "<group>"; };
 		EA1F00000000000000000002 /* SidebarPathFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarPathFormatter.swift; sourceTree = "<group>"; };
 		C0DEF0A30000000000000002 /* SidebarPortDisplayText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarPortDisplayText.swift; sourceTree = "<group>"; };
+		C0DE48000000000000000002 /* SidebarProviderMenuRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarProviderMenuRegressionTests.swift; sourceTree = "<group>"; };
 		B9000131A1B2C3D4E5F60719 /* SidebarPullRequestInteractivityUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarPullRequestInteractivityUITests.swift; sourceTree = "<group>"; };
 		818DBCD4AB69EB72573E8138 /* SidebarResizeUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarResizeUITests.swift; sourceTree = "<group>"; };
 		C0DE35010000000000000002 /* SidebarScrim.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarScrim.swift; sourceTree = "<group>"; };
@@ -1833,6 +1835,7 @@
 				A11EAA000000000000000001 /* AppearanceSettingsTests.swift */,
 				6083A7DAD962E287FC2FFE94 /* ShortcutAndCommandPaletteTests.swift */,
 				C3408A000000000000000004 /* RightSidebarCommandPaletteTests.swift */,
+				C0DE48000000000000000002 /* SidebarProviderMenuRegressionTests.swift */,
 				C0DEF4120000000000000002 /* CommandPaletteSettingsToggleTests.swift */,
 				B37A0000000000000000000C /* FileExplorerStateModePersistenceTests.swift */,
 				BC39DE4B96D1931C52AF7D68 /* SidebarOrderingTests.swift */,
@@ -2733,6 +2736,7 @@
 				51D800000000000000000001 /* SidebarIdentifierFormattingTests.swift in Sources */,
 				385C6BA7E78DB87460E5D930 /* SidebarMarkdownRendererTests.swift in Sources */,
 				CB23911D7E131E8FBC9B82B6 /* SidebarOrderingTests.swift in Sources */,
+				C0DE48000000000000000001 /* SidebarProviderMenuRegressionTests.swift in Sources */,
 				D7AB34300000000000000105 /* SidebarTabDropIndicatorPredicateTests.swift in Sources */,
 				CA39C0304FE351A21C372429 /* SidebarWidthPolicyTests.swift in Sources */,
 				D7AB34300000000000000005 /* SidebarWorkspaceDropPlannerTests.swift in Sources */,

--- a/cmuxTests/SidebarProviderMenuRegressionTests.swift
+++ b/cmuxTests/SidebarProviderMenuRegressionTests.swift
@@ -1,0 +1,97 @@
+import Foundation
+import Testing
+import CmuxExtensionKit
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Regression coverage for the right-click sidebar-button view switcher.
+///
+/// v0.64.10 shipped seven built-in sidebar views — Default Workspaces plus the
+/// Project Worktrees, Attention Queue, Dev Servers, Last Prompt, Super Compact,
+/// and Browser Stack presets — that the sidebar-button context menu let users
+/// switch between. #4994 ("Replace sidebar extension kit contract") swept that
+/// menu behind the experimental Extensions beta flag and stubbed the built-in
+/// providers out, so on a default install (beta off) the menu and every one of
+/// its views disappeared (https://github.com/manaflow-ai/cmux/issues/5173).
+///
+/// These tests pin the two guarantees the regression broke: the built-in views
+/// are available regardless of the experimental flag, and a selected view
+/// resolves to itself (which is what drives the menu's active-view checkmark).
+@MainActor
+@Suite(.serialized)
+struct SidebarProviderMenuRegressionTests {
+    /// Stable ids of the seven built-in sidebar views, in menu order.
+    private static let builtInViewIDs: [String] = [
+        "cmux.sidebar.default",
+        "com.example.cmux.sidebar.project-worktrees",
+        "com.example.cmux.sidebar.attention-queue",
+        "com.example.cmux.sidebar.dev-servers",
+        "com.example.cmux.sidebar.last-prompt",
+        "com.example.cmux.sidebar.super-compact",
+        "com.example.cmux.sidebar.browser-stack",
+    ]
+
+    private static let extensionsBetaKey = "extensions.beta.enabled"
+
+    private func withExtensionsBeta(_ enabled: Bool, _ body: () -> Void) {
+        let defaults = UserDefaults.standard
+        let previous = defaults.object(forKey: Self.extensionsBetaKey)
+        defaults.set(enabled, forKey: Self.extensionsBetaKey)
+        defer { restore(previous, forKey: Self.extensionsBetaKey) }
+        body()
+    }
+
+    private func withSelectedProvider(_ providerId: String, _ body: () -> Void) {
+        let defaults = UserDefaults.standard
+        let key = CmuxExtensionSidebarSelection.defaultsKey
+        let previous = defaults.object(forKey: key)
+        defaults.set(providerId, forKey: key)
+        defer { restore(previous, forKey: key) }
+        body()
+    }
+
+    private func restore(_ value: Any?, forKey key: String) {
+        let defaults = UserDefaults.standard
+        if let value {
+            defaults.set(value, forKey: key)
+        } else {
+            defaults.removeObject(forKey: key)
+        }
+    }
+
+    /// The built-in views must remain selectable even when the experimental
+    /// Extensions beta is disabled — the regression hid every one of them.
+    @Test
+    func builtInViewsAvailableWhenExtensionsBetaDisabled() {
+        withExtensionsBeta(false) {
+            let availableIDs = Set(CmuxExtensionSidebarSelection.descriptors.map(\.id))
+            for builtInID in Self.builtInViewIDs {
+                #expect(
+                    availableIDs.contains(builtInID),
+                    "Built-in sidebar view \(builtInID) is missing from the switcher menu"
+                )
+            }
+        }
+    }
+
+    /// Selecting a built-in view resolves that view as the active descriptor,
+    /// which is exactly what the context menu uses to place its checkmark.
+    @Test
+    func selectedBuiltInViewResolvesToItselfForCheckmark() {
+        withExtensionsBeta(false) {
+            for builtInID in Self.builtInViewIDs {
+                withSelectedProvider(builtInID) {
+                    let active = CmuxExtensionSidebarSelection.descriptor(for: builtInID)
+                    #expect(
+                        active.id == builtInID,
+                        "Selecting \(builtInID) did not resolve to itself (menu checkmark would be wrong)"
+                    )
+                }
+            }
+        }
+    }
+}

--- a/cmuxTests/SidebarProviderMenuRegressionTests.swift
+++ b/cmuxTests/SidebarProviderMenuRegressionTests.swift
@@ -94,4 +94,28 @@ struct SidebarProviderMenuRegressionTests {
             }
         }
     }
+
+    /// The hosted-extensions provider belongs to the experimental Extensions
+    /// feature, so the effective selection (which the menu checkmark tracks)
+    /// downgrades it to the default sidebar while the beta is off and honors it
+    /// while the beta is on. Built-in views resolve to themselves either way —
+    /// they are never gated by the flag.
+    @Test
+    func effectiveSelectionGatesHostedExtensionButNotBuiltInViews() {
+        let projectWorktrees = "com.example.cmux.sidebar.project-worktrees"
+        #expect(
+            CmuxExtensionSidebarSelection.effectiveProviderId(projectWorktrees, extensionsEnabled: false) == projectWorktrees
+        )
+        #expect(
+            CmuxExtensionSidebarSelection.effectiveProviderId(projectWorktrees, extensionsEnabled: true) == projectWorktrees
+        )
+
+        let hosted = CmuxExtensionSidebarSelection.hostedExtensionsProviderId
+        #expect(
+            CmuxExtensionSidebarSelection.effectiveProviderId(hosted, extensionsEnabled: true) == hosted
+        )
+        #expect(
+            CmuxExtensionSidebarSelection.effectiveProviderId(hosted, extensionsEnabled: false) == CmuxExtensionSidebarSelection.defaultProviderId
+        )
+    }
 }

--- a/cmuxTests/SidebarProviderMenuRegressionTests.swift
+++ b/cmuxTests/SidebarProviderMenuRegressionTests.swift
@@ -78,17 +78,26 @@ struct SidebarProviderMenuRegressionTests {
         }
     }
 
-    /// Selecting a built-in view resolves that view as the active descriptor,
-    /// which is exactly what the context menu uses to place its checkmark.
+    /// Persisting a built-in view as the selection drives the menu's active-view
+    /// checkmark to that view. This exercises the same path `showMenu` uses to
+    /// decide which item is checked — read the persisted id from `UserDefaults`,
+    /// resolve it through `effectiveProviderId`, then look up the descriptor —
+    /// rather than asserting on the id in isolation.
     @Test
-    func selectedBuiltInViewResolvesToItselfForCheckmark() {
+    func persistedBuiltInSelectionDrivesMenuCheckmark() {
         withExtensionsBeta(false) {
             for builtInID in Self.builtInViewIDs {
                 withSelectedProvider(builtInID) {
-                    let active = CmuxExtensionSidebarSelection.descriptor(for: builtInID)
+                    let persisted = UserDefaults.standard.string(forKey: CmuxExtensionSidebarSelection.defaultsKey)
+                        ?? CmuxExtensionSidebarSelection.defaultProviderId
+                    let effective = CmuxExtensionSidebarSelection.effectiveProviderId(
+                        persisted,
+                        extensionsEnabled: CmuxExtensionSidebarSelection.isEnabled
+                    )
+                    let checkedID = CmuxExtensionSidebarSelection.descriptor(for: effective).id
                     #expect(
-                        active.id == builtInID,
-                        "Selecting \(builtInID) did not resolve to itself (menu checkmark would be wrong)"
+                        checkedID == builtInID,
+                        "Persisted selection \(builtInID) did not drive the menu checkmark (got \(checkedID))"
                     )
                 }
             }

--- a/cmuxTests/SidebarProviderMenuRegressionTests.swift
+++ b/cmuxTests/SidebarProviderMenuRegressionTests.swift
@@ -127,4 +127,48 @@ struct SidebarProviderMenuRegressionTests {
             CmuxExtensionSidebarSelection.effectiveProviderId(hosted, extensionsEnabled: false) == CmuxExtensionSidebarSelection.defaultProviderId
         )
     }
+
+    /// The host renders the selected view through an
+    /// `any CmuxExtensionSidebarProvider` existential
+    /// (`CmuxExtensionSidebarSelection.provider(for:)?.render(snapshot:)`).
+    /// `render(snapshot:)` must dynamic-dispatch to the concrete view; if it
+    /// instead hits the empty protocol-extension default, every built-in view
+    /// renders an empty sidebar even though the provider and workspaces are
+    /// present — the second half of #5173. Super Compact lists every workspace
+    /// in one section, so its rows must equal the workspace count.
+    @Test
+    func builtInProviderRendersRowsThroughHostExistential() {
+        let snapshot = Self.populatedSnapshot(workspaceCount: 3)
+        let provider = CmuxExtensionSidebarSelection.provider(for: "com.example.cmux.sidebar.super-compact")
+        #expect(provider != nil, "Super Compact provider should be registered")
+        let model = provider?.render(snapshot: snapshot)
+        #expect(
+            (model?.sections.flatMap(\.rows).count ?? 0) == 3,
+            "Selected view rendered no rows through the host existential (empty-sidebar regression)"
+        )
+    }
+
+    private static func populatedSnapshot(workspaceCount: Int) -> CmuxExtensionSidebarSnapshot {
+        let workspaces = (0..<workspaceCount).map { index in
+            CmuxExtensionWorkspaceSnapshot(
+                id: UUID(),
+                title: "Workspace \(index)",
+                customDescription: nil,
+                isPinned: false,
+                rootPath: "/tmp/ws\(index)",
+                projectRootPath: "/tmp/ws\(index)",
+                branchSummary: "main",
+                remoteDisplayTarget: nil,
+                remoteConnectionState: "disconnected",
+                unreadCount: 0,
+                latestNotificationText: nil,
+                listeningPorts: []
+            )
+        }
+        return CmuxExtensionSidebarSnapshot(
+            sequence: 1,
+            selectedWorkspaceId: nil,
+            workspaces: workspaces
+        )
+    }
 }


### PR DESCRIPTION
## Summary

Fixes the v0.64.11 regression where right-clicking the sidebar button (top-left, by the traffic lights) no longer opened the context menu for switching between built-in sidebar views — and the views themselves (Default Workspaces, Project Worktrees, Attention Queue, Dev Servers, Last Prompt, Super Compact, Browser Stack) were gone.

Closes #5173

## What #4994 changed

`a086dd1fd` ("Replace sidebar extension kit contract") swapped the old in-process sidebar-provider contract for an XPC-based ExtensionKit host. It **kept** the in-process compatibility render layer (`CmuxExtensionCompatibility.swift`) and `ContentView`'s render pipeline, but it:

- stubbed `CmuxExtensionSidebarSelection.providers` to `[]` (was `SidebarExamples.providers`, the six built-in preset views) and **unlinked** the `CmuxExtensionSidebarExamples` package from the app target;
- gated the sidebar-button right-click menu behind the experimental **Extensions** beta flag (`guard isEnabled` in `showMenu`, and `effectiveExtensionSidebarProviderId` forcing Default Workspaces whenever the flag was off — see `BetaFeaturesCatalogSection.extensions`, which is **off by default**);
- dropped the `BrowserStackSidebar.stateDidLoadNotification` live-refresh.

Net effect on a default install (beta off): the menu and **all** of its built-in views disappeared.

## How this restores them (on top of the new contract, not a revert)

The new XPC contract is intentional, so this re-implements the built-in views on top of it and lets both coexist. The experimental flag now gates **only** the new XPC surface (the hosted "Extension Sidebar" entry, the puzzle button, the extensions browser); the built-in views are always available again, exactly as in v0.64.10.

- **Re-link `CmuxExtensionSidebarExamples`** into the `cmux` target and restore `providers` + the import. The example providers compile **unchanged** against the kept compatibility layer (verified with a standalone `swift build`).
- **Split the descriptor lists:** `builtInDescriptors` (always: Default + 6 presets, in v0.64.10 menu order) vs `descriptors` (adds the hosted entry only when the beta is on) vs `allDescriptors` (handler superset for command registration).
- **Add the pure `effectiveProviderId(_:extensionsEnabled:)`** so the menu checkmark and the rendered provider track the persisted selection, downgrading only a *hosted* selection to Default while the beta is off (so the experimental feature can't strand the user). The view's `effectiveExtensionSidebarProviderId` now delegates to it.
- **Un-gate the menu:** drop `guard isEnabled` in `showMenu`; the checkmark reflects the effective selection. Also un-gate the command-palette "Sidebar: <view>" contributions.
- **Restore** the `BrowserStackSidebar` live-refresh subscription.

## Tests

Two-commit red/green structure:

- **Commit 1** adds a failing Swift Testing regression suite (`cmuxTests/SidebarProviderMenuRegressionTests.swift`, wired into the project) that asserts all seven built-in views are present in `CmuxExtensionSidebarSelection.descriptors` with the Extensions beta **off**, and that a selected built-in view resolves to itself (drives the checkmark). CI should be **red** on this commit.
- **Commit 2** applies the fix (CI green) and adds a check that `effectiveProviderId` gates the hosted entry but never the built-in views.

`xcodebuild -scheme cmux-unit` could not be run locally (submodules/GhosttyKit not provisioned in this worktree and disk is constrained); relying on the `tests` CI job to gate the build per the repo's testing policy. The Examples↔compatibility-layer contract was verified locally with `swift build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches primary sidebar selection/rendering paths and Swift protocol dispatch; risk is mitigated by focused regression tests but behavior spans AppKit menus, command palette, and SwiftUI effective provider routing.
> 
> **Overview**
> Fixes the v0.64.11 regression where built-in sidebar views and the sidebar-button view switcher disappeared when the Extensions beta was off (#5173).
> 
> **`CmuxExtensionKit`:** `render(snapshot:)` is declared as a protocol **requirement** on `CmuxExtensionSidebarProvider` so calls through `any CmuxExtensionSidebarProvider` dynamic-dispatch to concrete implementations instead of the empty extension default.
> 
> **App wiring:** Re-links **`CmuxExtensionSidebarExamples`**, restores `providers` from `SidebarExamples.providers`, and splits descriptor lists (`builtInDescriptors`, `descriptors` with hosted entry only when beta is on, `allDescriptors` for palette handler registration). Adds **`effectiveProviderId`** so built-in selections always render; only a persisted **hosted** extension selection falls back to Default Workspaces when the beta is off. The right-click switcher and command-palette “Sidebar: …” entries are no longer gated entirely on the beta; menu checkmarks use the effective id. **`BrowserStackSidebar.stateDidLoadNotification`** again triggers sidebar snapshot refresh.
> 
> **Tests:** Regression suites assert built-in menu availability, checkmark resolution, existential rendering, and host-path rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d27b449a1159ab066e1126ec3b26bc55dc4522db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5182"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782979742&installation_id=133855650&pr_number=5182&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5182&signature=27722ceb481e53cff2be4dbff5ce70b57aaa3a0d47fd023758a1822c50e4557d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the right-click sidebar-button view switcher and the seven built-in views lost in v0.64.11, and fixes an empty-render regression by restoring dynamic dispatch for `render(snapshot:)` (fixes #5173). Keeps the new XPC sidebar host; the Extensions beta now gates only the hosted “Extension Sidebar” entry.

- **Bug Fixes**
  - Built-in views (Default + six presets) always appear in the menu and command palette; the hosted entry shows only when the Extensions beta is on.
  - Re-linked `CmuxExtensionSidebarExamples` and restored its `providers`.
  - Added `effectiveProviderId(...)` to honor built-ins; a hosted selection downgrades to Default when the beta is off.
  - Ungated the right-click menu and “Sidebar: <view>” commands; registered palette handlers for all descriptors via `allDescriptors`.
  - Restored BrowserStack sidebar live refresh.
  - Fixed empty sidebar renders by making `CmuxExtensionSidebarProvider.render(snapshot:)` a protocol requirement in `CmuxExtensionKit`; added existential-dispatch tests in app tests and `CmuxExtensionSidebarExamples` to lock this in.

<sup>Written for commit d27b449a1159ab066e1126ec3b26bc55dc4522db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sidebar provider switching now handles runtime toggling of the experimental extensions feature and correctly falls back to the default provider when disabled.
  * Command palette and context-menu sidebar selections continue to resolve correctly if the extensions flag changes.
  * Sidebar browser view refreshes snapshots when sidebar state loads.

* **Tests**
  * Added regression tests covering sidebar provider menu behavior and rendering through the provider existential.

* **Documentation**
  * Clarified documentation for extension sidebar provider rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->