### PR TITLE
Respect Ghostty transparency in browser blank chrome

### DIFF
--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -44,6 +44,15 @@ enum GhosttyBackgroundTheme {
         WindowAppearanceSnapshot.clampedOpacity(opacity)
     }
 
+    static func translucentColor(backgroundColor: NSColor, opacity: Double) -> NSColor {
+        backgroundColor.withAlphaComponent(clampedOpacity(opacity))
+    }
+
+    static func surfaceFillColor(backgroundColor: NSColor, opacity: Double) -> NSColor {
+        let color = translucentColor(backgroundColor: backgroundColor, opacity: opacity)
+        return color.alphaComponent < 0.999 ? .clear : color
+    }
+
     static func color(backgroundColor: NSColor, opacity: Double) -> NSColor {
         WindowAppearanceSnapshot.compositedTerminalColor(
             backgroundColor: backgroundColor,
@@ -51,11 +60,11 @@ enum GhosttyBackgroundTheme {
         )
     }
 
-    static func color(
+    private static func backgroundComponents(
         from notification: Notification?,
         fallbackColor: NSColor,
         fallbackOpacity: Double
-    ) -> NSColor {
+    ) -> (color: NSColor, opacity: Double) {
         let userInfo = notification?.userInfo
         let backgroundColor =
             (userInfo?[GhosttyNotificationKey.backgroundColor] as? NSColor)
@@ -70,7 +79,62 @@ enum GhosttyBackgroundTheme {
             opacity = fallbackOpacity
         }
 
-        return color(backgroundColor: backgroundColor, opacity: opacity)
+        return (backgroundColor, opacity)
+    }
+
+    static func color(
+        from notification: Notification?,
+        fallbackColor: NSColor,
+        fallbackOpacity: Double
+    ) -> NSColor {
+        let components = backgroundComponents(
+            from: notification,
+            fallbackColor: fallbackColor,
+            fallbackOpacity: fallbackOpacity
+        )
+        return color(backgroundColor: components.color, opacity: components.opacity)
+    }
+
+    static func translucentColor(
+        from notification: Notification?,
+        fallbackColor: NSColor,
+        fallbackOpacity: Double
+    ) -> NSColor {
+        let components = backgroundComponents(
+            from: notification,
+            fallbackColor: fallbackColor,
+            fallbackOpacity: fallbackOpacity
+        )
+        return translucentColor(backgroundColor: components.color, opacity: components.opacity)
+    }
+
+    static func surfaceFillColor(
+        from notification: Notification?,
+        fallbackColor: NSColor,
+        fallbackOpacity: Double
+    ) -> NSColor {
+        let components = backgroundComponents(
+            from: notification,
+            fallbackColor: fallbackColor,
+            fallbackOpacity: fallbackOpacity
+        )
+        return surfaceFillColor(backgroundColor: components.color, opacity: components.opacity)
+    }
+
+    static func translucentColor(from notification: Notification?) -> NSColor {
+        translucentColor(
+            from: notification,
+            fallbackColor: GhosttyApp.shared.defaultBackgroundColor,
+            fallbackOpacity: GhosttyApp.shared.defaultBackgroundOpacity
+        )
+    }
+
+    static func surfaceFillColor(from notification: Notification?) -> NSColor {
+        surfaceFillColor(
+            from: notification,
+            fallbackColor: GhosttyApp.shared.defaultBackgroundColor,
+            fallbackOpacity: GhosttyApp.shared.defaultBackgroundOpacity
+        )
     }
 
     static func color(from notification: Notification?) -> NSColor {
@@ -83,6 +147,20 @@ enum GhosttyBackgroundTheme {
 
     static func currentColor() -> NSColor {
         color(
+            backgroundColor: GhosttyApp.shared.defaultBackgroundColor,
+            opacity: GhosttyApp.shared.defaultBackgroundOpacity
+        )
+    }
+
+    static func currentTranslucentColor() -> NSColor {
+        translucentColor(
+            backgroundColor: GhosttyApp.shared.defaultBackgroundColor,
+            opacity: GhosttyApp.shared.defaultBackgroundOpacity
+        )
+    }
+
+    static func currentSurfaceFillColor() -> NSColor {
+        surfaceFillColor(
             backgroundColor: GhosttyApp.shared.defaultBackgroundColor,
             opacity: GhosttyApp.shared.defaultBackgroundOpacity
         )
@@ -3919,7 +3997,7 @@ final class BrowserPanel: Panel, ObservableObject {
         // Match only the unpainted/loading background so newly-created browsers don't flash
         // white before content loads. Do not force page appearance or inject color-scheme CSS;
         // websites must keep control of their own theme.
-        webView.underPageBackgroundColor = GhosttyBackgroundTheme.currentColor()
+        webView.underPageBackgroundColor = GhosttyBackgroundTheme.currentSurfaceFillColor()
         // Always present as Safari.
         webView.customUserAgent = BrowserUserAgentSettings.safariUserAgent
         return webView
@@ -4905,7 +4983,7 @@ final class BrowserPanel: Panel, ObservableObject {
         NotificationCenter.default.publisher(for: .ghosttyDefaultBackgroundDidChange)
             .sink { [weak self] notification in
                 guard let self else { return }
-                self.webView.underPageBackgroundColor = GhosttyBackgroundTheme.color(from: notification)
+                self.webView.underPageBackgroundColor = GhosttyBackgroundTheme.surfaceFillColor(from: notification)
             }
             .store(in: &webViewCancellables)
     }
@@ -6985,7 +7063,7 @@ extension BrowserPanel {
     }
 
     func refreshAppearanceDrivenColors() {
-        webView.underPageBackgroundColor = GhosttyBackgroundTheme.currentColor()
+        webView.underPageBackgroundColor = GhosttyBackgroundTheme.currentSurfaceFillColor()
     }
 
     func suppressOmnibarAutofocus(for seconds: TimeInterval) {

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -353,7 +353,10 @@ func resolvedBrowserChromeColorScheme(
         for: colorScheme,
         themeBackgroundColor: themeBackgroundColor
     )
-    return backgroundColor.isLightColor ? .light : .dark
+    let readableBackgroundColor = backgroundColor.alphaComponent < 0.999
+        ? cmuxCompositedNSColor(backgroundColor, over: .windowBackgroundColor)
+        : backgroundColor
+    return readableBackgroundColor.isLightColor ? .light : .dark
 }
 
 func resolvedBrowserOmnibarPillBackgroundColor(
@@ -370,7 +373,11 @@ func resolvedBrowserOmnibarPillBackgroundColor(
         darkenMix = 0.04
     }
 
-    return themeBackgroundColor.blended(withFraction: darkenMix, of: .black) ?? themeBackgroundColor
+    let alpha = themeBackgroundColor.alphaComponent
+    let opaqueBackgroundColor = themeBackgroundColor.withAlphaComponent(1)
+    let blendedColor = opaqueBackgroundColor.blended(withFraction: darkenMix, of: .black)
+        ?? opaqueBackgroundColor
+    return blendedColor.withAlphaComponent(alpha)
 }
 
 private struct BrowserChromeStyle {
@@ -382,17 +389,18 @@ private struct BrowserChromeStyle {
         for colorScheme: ColorScheme,
         themeBackgroundColor: NSColor
     ) -> BrowserChromeStyle {
-        let backgroundColor = resolvedBrowserChromeBackgroundColor(
+        let themeFillColor = resolvedBrowserChromeBackgroundColor(
             for: colorScheme,
             themeBackgroundColor: themeBackgroundColor
         )
+        let backgroundColor = themeFillColor.alphaComponent < 0.999 ? .clear : themeFillColor
         let chromeColorScheme = resolvedBrowserChromeColorScheme(
             for: colorScheme,
-            themeBackgroundColor: backgroundColor
+            themeBackgroundColor: themeFillColor
         )
         let omnibarPillBackgroundColor = resolvedBrowserOmnibarPillBackgroundColor(
             for: chromeColorScheme,
-            themeBackgroundColor: backgroundColor
+            themeBackgroundColor: themeFillColor
         )
         return BrowserChromeStyle(
             backgroundColor: backgroundColor,
@@ -460,7 +468,7 @@ struct BrowserPanelView: View {
     @State private var isBrowserThemeMenuPresented = false
     @State private var browserChromeStyle = BrowserChromeStyle.resolve(
         for: .light,
-        themeBackgroundColor: GhosttyBackgroundTheme.currentColor()
+        themeBackgroundColor: GhosttyBackgroundTheme.currentTranslucentColor()
     )
     // Keep this below half of the compact omnibar height so it reads as a squircle,
     // not a capsule.
@@ -1683,7 +1691,7 @@ struct BrowserPanelView: View {
     private func refreshBrowserChromeStyle() {
         browserChromeStyle = BrowserChromeStyle.resolve(
             for: colorScheme,
-            themeBackgroundColor: GhosttyBackgroundTheme.currentColor()
+            themeBackgroundColor: GhosttyBackgroundTheme.currentTranslucentColor()
         )
     }
 

--- a/Sources/Panels/BrowserPopupWindowController.swift
+++ b/Sources/Panels/BrowserPopupWindowController.swift
@@ -117,7 +117,7 @@ final class BrowserPopupWindowController: NSObject, NSWindowDelegate {
         if #available(macOS 13.3, *) {
             webView.isInspectable = true
         }
-        webView.underPageBackgroundColor = GhosttyBackgroundTheme.currentColor()
+        webView.underPageBackgroundColor = GhosttyBackgroundTheme.currentSurfaceFillColor()
         webView.customUserAgent = BrowserUserAgentSettings.safariUserAgent
         BrowserThemeSettings.apply(openerPanel?.currentBrowserThemeMode ?? BrowserThemeSettings.mode(), to: webView)
         self.webView = webView

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -177,6 +177,27 @@ final class BrowserPanelChromeBackgroundColorTests: XCTestCase {
         XCTAssertEqual(actual.alphaComponent, 0.42, accuracy: 0.001)
     }
 
+    func testTransparentGhosttyBackgroundUsesClearBrowserSurfaceFill() {
+        let actual = GhosttyBackgroundTheme.surfaceFillColor(
+            backgroundColor: NSColor.black,
+            opacity: 0.42
+        )
+
+        XCTAssertEqual(actual.alphaComponent, 0, accuracy: 0.001)
+    }
+
+    func testOpaqueGhosttyBackgroundUsesThemeBrowserSurfaceFill() {
+        let actual = GhosttyBackgroundTheme.surfaceFillColor(
+            backgroundColor: NSColor(srgbRed: 0.13, green: 0.29, blue: 0.47, alpha: 1),
+            opacity: 1
+        )
+
+        XCTAssertEqual(actual.alphaComponent, 1, accuracy: 0.001)
+        XCTAssertEqual(actual.redComponent, 0.13, accuracy: 0.001)
+        XCTAssertEqual(actual.greenComponent, 0.29, accuracy: 0.001)
+        XCTAssertEqual(actual.blueComponent, 0.47, accuracy: 0.001)
+    }
+
     private func assertResolvedColorMatchesTheme(
         for colorScheme: ColorScheme,
         file: StaticString = #filePath,

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -158,6 +158,25 @@ final class BrowserPanelChromeBackgroundColorTests: XCTestCase {
         assertResolvedColorMatchesTheme(for: .dark)
     }
 
+    func testColorSchemeCompositesTransparentThemeBackground() {
+        let themeBackground = NSColor.black.withAlphaComponent(0.05)
+
+        XCTAssertEqual(
+            resolvedBrowserChromeColorScheme(for: .dark, themeBackgroundColor: themeBackground),
+            .light
+        )
+    }
+
+    func testOmnibarPillBackgroundPreservesThemeAlpha() {
+        let themeBackground = NSColor(srgbRed: 0.13, green: 0.29, blue: 0.47, alpha: 0.42)
+        let actual = resolvedBrowserOmnibarPillBackgroundColor(
+            for: .dark,
+            themeBackgroundColor: themeBackground
+        )
+
+        XCTAssertEqual(actual.alphaComponent, 0.42, accuracy: 0.001)
+    }
+
     private func assertResolvedColorMatchesTheme(
         for colorScheme: ColorScheme,
         file: StaticString = #filePath,


### PR DESCRIPTION
## Summary
- Keep blank browser WebKit surfaces clear when Ghostty background opacity is translucent so the window-level Ghostty backdrop shows through.
- Preserve alpha for browser chrome and the omnibar pill while compositing only for readable light/dark contrast decisions.
- Add browser chrome regression coverage for transparent backgrounds and omnibar alpha.

## Testing
- `./scripts/reload.sh --tag btrans` passed.
- `ssh cmux-aws-m4pro ... -only-testing:cmuxTests/BrowserPanelChromeBackgroundColorTests test` was attempted twice, but SSH exited with `255` during package checkout before xcodebuild reported a test result.

## Issues
- Task: browser blank page and omnibar area should respect Ghostty transparent background config.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5183"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782979765&installation_id=133855650&pr_number=5183&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5183&signature=ccfd87993a348adaee6bc2894e47abcd4c8d10718f6692f2ca89256dde6f0490"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only appearance and color resolution in browser panels; no auth, data, or navigation behavior changes.
> 
> **Overview**
> Makes **Ghostty terminal transparency** visible in browser panels: blank **WebKit** loading areas and popups now use a **clear** `underPageBackgroundColor` when background opacity is translucent, instead of an opaque composited fill.
> 
> **`GhosttyBackgroundTheme`** gains separate **translucent** vs **surface fill** (clear vs opaque) helpers shared by panel creation, theme notifications, and appearance refresh. **Browser chrome** is driven by the translucent theme color while the visible chrome background becomes **clear** when alpha is low; **light/dark** chrome contrast composites over the window only for that decision. The **omnibar pill** keeps the theme’s alpha when darkening the fill.
> 
> Adds **`BrowserPanelChromeBackgroundColorTests`** for transparent surface fill, omnibar alpha, and color-scheme compositing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a43bda95b209b9b962ca66f222a725041dd6a391. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the browser’s blank surfaces and chrome respect Ghostty’s background opacity so translucent windows show the backdrop. Preserves omnibar pill alpha and computes light/dark chrome by compositing translucent themes over the window background; addresses the task to have the blank page and omnibar respect Ghostty transparency.

- **New Features**
  - Use a clear surface fill for WebKit’s under-page background when Ghostty opacity is < 1; keep theme color when opaque.
  - Preserve omnibar pill alpha while darkening the opaque component for readability.
  - Determine chrome light/dark by compositing translucent background over the window color.
  - Add regression tests for transparent backgrounds and omnibar alpha.

<sup>Written for commit a43bda95b209b9b962ca66f222a725041dd6a391. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced background color computation to properly handle translucent and transparent colors, improving visual appearance of browser interface elements.
  * Refined color resolution for accurate light/dark mode detection when using transparent backgrounds.

* **Tests**
  * Added comprehensive test coverage for transparent and opaque background color resolution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->