### PR TITLE
Report remote PTY allocation failures loudly (#5185)

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -10203,6 +10203,16 @@ struct CMUXCLI {
         if lowered.contains("timed out") || lowered.contains("timeout") {
             return "remote daemon did not respond in time"
         }
+        // Surface the daemon's PTY-allocation diagnostic verbatim (it names the
+        // failing device and the devpts/ptmxmode cause) instead of collapsing it
+        // into a generic message. See issue #5185.
+        if lowered.contains("could not allocate a remote pty") ||
+            lowered.contains("ptmxmode") ||
+            lowered.contains("/dev/ptmx") ||
+            lowered.contains("devpts") ||
+            lowered.contains("pseudo-terminal") {
+            return trimmed
+        }
         return "remote PTY operation failed"
     }
 

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -10205,12 +10205,11 @@ struct CMUXCLI {
         }
         // Surface the daemon's PTY-allocation diagnostic verbatim (it names the
         // failing device and the devpts/ptmxmode cause) instead of collapsing it
-        // into a generic message. See issue #5185.
-        if lowered.contains("could not allocate a remote pty") ||
-            lowered.contains("ptmxmode") ||
-            lowered.contains("/dev/ptmx") ||
-            lowered.contains("devpts") ||
-            lowered.contains("pseudo-terminal") {
+        // into a generic message. Key off the daemon's stable marker only, so an
+        // unrelated error that merely mentions a device path is not leaked. The
+        // peer branches in this CLI helper return plain English, so this branch
+        // does too. See issue #5185.
+        if lowered.contains("could not allocate a remote pty") {
             return trimmed
         }
         return "remote PTY operation failed"

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -5990,15 +5990,17 @@ final class WorkspaceRemotePTYBridgeServer {
                     defaultValue: "remote daemon did not respond in time"
                 )
             }
-            // Surface the daemon's PTY-allocation diagnostic verbatim (it names
-            // the failing device and the devpts/ptmxmode cause) instead of
-            // collapsing it into a generic message. See issue #5185.
-            if lowered.contains("could not allocate a remote pty") ||
-                lowered.contains("ptmxmode") ||
-                lowered.contains("/dev/ptmx") ||
-                lowered.contains("devpts") ||
-                lowered.contains("pseudo-terminal") {
-                return message
+            // Surface the daemon's PTY-allocation diagnostic (it names the failing
+            // device and the devpts/ptmxmode cause) instead of collapsing it into a
+            // generic message. Key off the daemon's stable marker only, so an
+            // unrelated error that merely mentions a device path is not leaked, and
+            // route the dynamic detail through the localization API to match the
+            // surrounding branches. See issue #5185.
+            if lowered.contains("could not allocate a remote pty") {
+                return String(
+                    localized: "remotePTYAttach.error.allocationDiagnostic",
+                    defaultValue: "\(message)"
+                )
             }
             return String(
                 localized: "remotePTYAttach.error.attachFailed",

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -5990,6 +5990,16 @@ final class WorkspaceRemotePTYBridgeServer {
                     defaultValue: "remote daemon did not respond in time"
                 )
             }
+            // Surface the daemon's PTY-allocation diagnostic verbatim (it names
+            // the failing device and the devpts/ptmxmode cause) instead of
+            // collapsing it into a generic message. See issue #5185.
+            if lowered.contains("could not allocate a remote pty") ||
+                lowered.contains("ptmxmode") ||
+                lowered.contains("/dev/ptmx") ||
+                lowered.contains("devpts") ||
+                lowered.contains("pseudo-terminal") {
+                return message
+            }
             return String(
                 localized: "remotePTYAttach.error.attachFailed",
                 defaultValue: "remote PTY attach failed"

--- a/daemon/remote/cmd/cmuxd-remote/ws_pty.go
+++ b/daemon/remote/cmd/cmuxd-remote/ws_pty.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 	"syscall"
 	"time"
+	"unicode/utf8"
 
 	"github.com/creack/pty"
 	"nhooyr.io/websocket"
@@ -316,7 +317,7 @@ func handleWebSocketPTY(w http.ResponseWriter, r *http.Request, cfg wsPTYServerC
 	attachment, err := cfg.PTYHub.attach(r.Context(), conn, auth)
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "ws pty attach failed: %v\n", err)
-		_ = conn.Close(websocket.StatusInternalError, "pty start failed")
+		_ = conn.Close(websocket.StatusInternalError, truncateWebSocketCloseReason(err.Error()))
 		return
 	}
 	defer func() {
@@ -749,6 +750,9 @@ func (h *wsPTYHub) startSessionLocked(sessionKey wsPTYSessionKey, sessionID stri
 		if tmpScript != "" {
 			_ = os.Remove(tmpScript)
 		}
+		if h.stderr != nil {
+			_, _ = fmt.Fprintf(h.stderr, "pty session start failed session=%s: %v\n", sessionID, err)
+		}
 		return nil, err
 	}
 	session := &wsPTYSession{
@@ -779,7 +783,7 @@ func (h *wsPTYHub) startPTYCommand(cmd *exec.Cmd, cols int, rows int) (*os.File,
 	}
 	ptyFile, ttyFile, err := open()
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, newPTYAllocationError(err)
 	}
 	closeFiles := true
 	defer func() {
@@ -816,6 +820,96 @@ func (h *wsPTYHub) startPTYCommand(cmd *exec.Cmd, cols int, rows int) (*os.File,
 	closeFiles = false
 	_ = ttyFile.Close()
 	return ptyFile, nil, nil
+}
+
+// newPTYAllocationError wraps a raw PTY-allocation failure with actionable
+// diagnostics about the remote devpts. Without this, a hardened mount
+// (ptmxmode=000) or a non-writable /dev/ptmx surfaced only a generic
+// "remote PTY attach failed" with a 0-byte daemon log, leaving the operator no
+// way to tell why the terminal would not open. See issue #5185.
+func newPTYAllocationError(err error) error {
+	suffix := ""
+	if detail := describeDevPTS(); detail != "" {
+		suffix = "; " + detail
+	}
+	hint := ""
+	if isPermissionDeniedErr(err) {
+		hint = "; the remote devpts denies /dev/ptmx (e.g. mounted ptmxmode=000): remount it writable with `sudo mount -o remount,ptmxmode=0666 /dev/pts` or expose a writable /dev/ptmx so the cmux daemon can open a terminal"
+	}
+	return fmt.Errorf("could not allocate a remote PTY: %w%s%s", err, suffix, hint)
+}
+
+// describeDevPTS reports the current /dev/ptmx mode and the /dev/pts devpts
+// mount options (which carry ptmxmode) on a best-effort basis. It never errors;
+// missing data is simply omitted from the returned summary.
+func describeDevPTS() string {
+	var parts []string
+	if info, statErr := os.Stat("/dev/ptmx"); statErr == nil {
+		parts = append(parts, fmt.Sprintf("/dev/ptmx mode=%04o", info.Mode().Perm()))
+	} else {
+		parts = append(parts, fmt.Sprintf("/dev/ptmx stat error: %v", statErr))
+	}
+	if opts := devptsMountOptions(); opts != "" {
+		parts = append(parts, "devpts ("+opts+")")
+	}
+	return strings.Join(parts, "; ")
+}
+
+// devptsMountOptions returns the super-block options of the devpts filesystem
+// mounted at /dev/pts (e.g. "rw,gid=5,mode=620,ptmxmode=000"), or "" if it
+// cannot be determined. It parses /proc/self/mountinfo, whose per-line layout
+// places the optional fields and the " - <fstype> <source> <superopts>" tail
+// after a literal " - " separator.
+func devptsMountOptions() string {
+	data, err := os.ReadFile("/proc/self/mountinfo")
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.Fields(line)
+		// mount point is field index 4 (0-based) in the pre-separator section.
+		if len(fields) < 5 || fields[4] != "/dev/pts" {
+			continue
+		}
+		sep := -1
+		for i, f := range fields {
+			if f == "-" {
+				sep = i
+				break
+			}
+		}
+		if sep < 0 || sep+3 >= len(fields) {
+			continue
+		}
+		if fields[sep+1] != "devpts" {
+			continue
+		}
+		return fields[sep+3]
+	}
+	return ""
+}
+
+// truncateWebSocketCloseReason clamps a close reason to the 123-byte limit a
+// WebSocket control frame allows for its UTF-8 reason payload, trimming on a
+// rune boundary so the frame stays valid.
+func truncateWebSocketCloseReason(reason string) string {
+	const maxReasonBytes = 123
+	if len(reason) <= maxReasonBytes {
+		return reason
+	}
+	truncated := reason[:maxReasonBytes]
+	for len(truncated) > 0 && !utf8.ValidString(truncated) {
+		truncated = truncated[:len(truncated)-1]
+	}
+	return truncated
+}
+
+// isPermissionDeniedErr reports whether err is an EACCES/EPERM-class failure,
+// the signature of a devpts that refuses /dev/ptmx.
+func isPermissionDeniedErr(err error) bool {
+	return errors.Is(err, os.ErrPermission) ||
+		errors.Is(err, syscall.EACCES) ||
+		errors.Is(err, syscall.EPERM)
 }
 
 func (h *wsPTYHub) detach(attachment *wsPTYAttachment) bool {

--- a/daemon/remote/cmd/cmuxd-remote/ws_pty.go
+++ b/daemon/remote/cmd/cmuxd-remote/ws_pty.go
@@ -175,7 +175,15 @@ type wsPTYHub struct {
 	stderr           io.Writer
 	scrollbackLimit  int
 	sessionIdleTTL   time.Duration
+	// openPTY allocates a PTY master/slave pair. It defaults to creack/pty.Open
+	// (which opens /dev/ptmx) and exists as a field so tests can simulate a
+	// hardened devpts where allocation is denied.
+	openPTY ptyOpener
 }
+
+// ptyOpener allocates a PTY master/slave pair, returning the master (ptmx) and
+// slave (tty) ends. The production implementation is creack/pty.Open.
+type ptyOpener func() (ptmx *os.File, tty *os.File, err error)
 
 func newWebSocketPTYHub(cfg wsPTYServerConfig, stderr io.Writer) *wsPTYHub {
 	limit := cfg.ScrollbackLimit
@@ -192,6 +200,7 @@ func newWebSocketPTYHub(cfg wsPTYServerConfig, stderr io.Writer) *wsPTYHub {
 		stderr:          stderr,
 		scrollbackLimit: limit,
 		sessionIdleTTL:  idleTTL,
+		openPTY:         pty.Open,
 	}
 }
 
@@ -735,7 +744,7 @@ func (h *wsPTYHub) startSessionLocked(sessionKey wsPTYSessionKey, sessionID stri
 		cmd = exec.Command("/bin/sh", "-c", trimmedCommand)
 	}
 	cmd.Env = defaultWebSocketPTYEnv(shellPath)
-	ptyFile, ttyFile, err := startPTYCommand(cmd, cols, rows)
+	ptyFile, ttyFile, err := h.startPTYCommand(cmd, cols, rows)
 	if err != nil {
 		if tmpScript != "" {
 			_ = os.Remove(tmpScript)
@@ -763,8 +772,12 @@ func (h *wsPTYHub) startSessionLocked(sessionKey wsPTYSessionKey, sessionID stri
 	return session, nil
 }
 
-func startPTYCommand(cmd *exec.Cmd, cols int, rows int) (*os.File, *os.File, error) {
-	ptyFile, ttyFile, err := pty.Open()
+func (h *wsPTYHub) startPTYCommand(cmd *exec.Cmd, cols int, rows int) (*os.File, *os.File, error) {
+	open := h.openPTY
+	if open == nil {
+		open = pty.Open
+	}
+	ptyFile, ttyFile, err := open()
 	if err != nil {
 		return nil, nil, err
 	}

--- a/daemon/remote/cmd/cmuxd-remote/ws_pty_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/ws_pty_test.go
@@ -68,10 +68,12 @@ func TestAttachRPCSurfacesPTYAllocationFailure(t *testing.T) {
 	}
 
 	msg := err.Error()
+	lowered := strings.ToLower(msg)
 	// Pin the stable marker the Swift clients key their passthrough off of: a
 	// daemon wording change that dropped it would silently break client-side
-	// preservation of this diagnostic without failing any other assertion.
-	if !strings.Contains(msg, "could not allocate a remote PTY") {
+	// preservation of this diagnostic without failing any other assertion. Match
+	// case-insensitively, exactly as Sources/Workspace.swift does.
+	if !strings.Contains(lowered, "could not allocate a remote pty") {
 		t.Fatalf("error must preserve the stable PTY-allocation marker the clients key off: %q", msg)
 	}
 	if !strings.Contains(msg, "/dev/ptmx") {
@@ -81,7 +83,6 @@ func TestAttachRPCSurfacesPTYAllocationFailure(t *testing.T) {
 	// independent of /proc/self/mountinfo, so these assertions hold even in a
 	// container/sandbox without a real devpts mount (describeDevPTS may add
 	// nothing there). Key off the hint, not the optional mount summary.
-	lowered := strings.ToLower(msg)
 	if !strings.Contains(lowered, "ptmxmode") || !strings.Contains(lowered, "remount") {
 		t.Fatalf("error should explain the hardened devpts cause and remediation: %q", msg)
 	}

--- a/daemon/remote/cmd/cmuxd-remote/ws_pty_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/ws_pty_test.go
@@ -14,6 +14,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -42,6 +43,45 @@ func newTestWebSocketPTYServer(t *testing.T, leasePath string) (*httptest.Server
 		}
 	})
 	return server, hub
+}
+
+// TestAttachRPCSurfacesPTYAllocationFailure pins the contract that a remote PTY
+// allocation failure (e.g. a hardened devpts mounted ptmxmode=000 where
+// /dev/ptmx cannot be opened) is reported loudly: the error returned to the
+// client names the failing device and explains the devpts cause, and the daemon
+// records the failure instead of leaving a 0-byte log. This is the regression
+// for https://github.com/manaflow-ai/cmux/issues/5185, where the failure
+// collapsed into a generic "remote PTY attach failed" with an empty daemon log.
+func TestAttachRPCSurfacesPTYAllocationFailure(t *testing.T) {
+	stderr := &bytes.Buffer{}
+	hub := newWebSocketPTYHub(wsPTYServerConfig{Shell: "/bin/sh"}, stderr)
+	t.Cleanup(hub.closeAll)
+
+	denied := &os.PathError{Op: "open", Path: "/dev/ptmx", Err: syscall.EACCES}
+	hub.openPTY = func() (*os.File, *os.File, error) {
+		return nil, nil, denied
+	}
+
+	_, _, _, err := hub.attachRPC(context.Background(), "sess-1", "att-1", 80, 24, "", "", false)
+	if err == nil {
+		t.Fatalf("expected attachRPC to fail when PTY allocation is denied")
+	}
+
+	msg := err.Error()
+	if !strings.Contains(msg, "/dev/ptmx") {
+		t.Fatalf("error should name the device that could not be opened: %q", msg)
+	}
+	lowered := strings.ToLower(msg)
+	if !strings.Contains(lowered, "ptmxmode") && !strings.Contains(lowered, "devpts") {
+		t.Fatalf("error should explain the hardened devpts cause: %q", msg)
+	}
+
+	if stderr.Len() == 0 {
+		t.Fatalf("PTY allocation failure must be logged to the daemon log, not swallowed")
+	}
+	if !strings.Contains(stderr.String(), "/dev/ptmx") {
+		t.Fatalf("daemon log should include the allocation failure detail: %q", stderr.String())
+	}
 }
 
 func TestServeWSRequiresExplicitLeaseFile(t *testing.T) {

--- a/daemon/remote/cmd/cmuxd-remote/ws_pty_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/ws_pty_test.go
@@ -71,9 +71,13 @@ func TestAttachRPCSurfacesPTYAllocationFailure(t *testing.T) {
 	if !strings.Contains(msg, "/dev/ptmx") {
 		t.Fatalf("error should name the device that could not be opened: %q", msg)
 	}
+	// The EACCES remediation hint is appended for any permission-denied failure
+	// independent of /proc/self/mountinfo, so these assertions hold even in a
+	// container/sandbox without a real devpts mount (describeDevPTS may add
+	// nothing there). Key off the hint, not the optional mount summary.
 	lowered := strings.ToLower(msg)
-	if !strings.Contains(lowered, "ptmxmode") && !strings.Contains(lowered, "devpts") {
-		t.Fatalf("error should explain the hardened devpts cause: %q", msg)
+	if !strings.Contains(lowered, "ptmxmode") || !strings.Contains(lowered, "remount") {
+		t.Fatalf("error should explain the hardened devpts cause and remediation: %q", msg)
 	}
 
 	if stderr.Len() == 0 {

--- a/daemon/remote/cmd/cmuxd-remote/ws_pty_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/ws_pty_test.go
@@ -68,6 +68,12 @@ func TestAttachRPCSurfacesPTYAllocationFailure(t *testing.T) {
 	}
 
 	msg := err.Error()
+	// Pin the stable marker the Swift clients key their passthrough off of: a
+	// daemon wording change that dropped it would silently break client-side
+	// preservation of this diagnostic without failing any other assertion.
+	if !strings.Contains(msg, "could not allocate a remote PTY") {
+		t.Fatalf("error must preserve the stable PTY-allocation marker the clients key off: %q", msg)
+	}
 	if !strings.Contains(msg, "/dev/ptmx") {
 		t.Fatalf("error should name the device that could not be opened: %q", msg)
 	}


### PR DESCRIPTION
## Problem

`cmux ssh <alias>` fails right after creating a workspace with:

```
Error: ssh-pty-attach: remote PTY attach failed
[cmux] ssh exited with status 1.
```

even though plain OpenSSH works and `workspace.remote.status` reports the remote daemon `ready` with `pty.session.persistent_daemon`. The remote `pty_sessions` list is empty and the remote `daemon.log` is **0 bytes** during the failure. Reporter's host has `/dev/pts` mounted `ptmxmode=000`.

Root cause is structural, not one host: remote PTY allocation has **no observable failure contract**. The persistent-daemon RPC attach path (`startSessionLocked` → `startPTYCommand` → `creack/pty.Open()`) returns the raw allocation error *without logging it*, and three layers (remote start, remote RPC return, client `userFacingBridgeErrorMessage`) discard the real cause and collapse it into a generic "remote PTY attach failed". Any allocation failure — hardened devpts, locked `/dev/ptmx`, fd exhaustion — is undiagnosable.

## What this does

Establishes the invariant: **a remote PTY allocation failure always carries a specific, structured cause to both the daemon log and the user-visible error.**

**Remote daemon** (`ws_pty.go`):
- `newPTYAllocationError` wraps the raw error with the current `/dev/ptmx` mode + the `/dev/pts` devpts mount options (parsed from `/proc/self/mountinfo`, so `ptmxmode` is visible) + an actionable remediation hint for EACCES/EPERM.
- Logs the failure on the persistent-daemon RPC path (no more 0-byte log).
- Carries the cause in the WebSocket close reason (truncated to the 123-byte control-frame limit on a rune boundary).
- Adds an injectable `wsPTYHub.openPTY` seam (default `creack/pty.Open`) for testing.

**Client** (`CLI/cmux.swift`, `Sources/Workspace.swift`): surface the daemon's diagnostic verbatim instead of the generic message.

## Reproduction / verification

Two-commit red/green: commit 1 adds a failing regression test (`TestAttachRPCSurfacesPTYAllocationFailure`) asserting the error names the device + explains the devpts cause + the daemon logs it; commit 2 makes it pass.

Verified **end-to-end on a real Linux host** (`/dev/pts` remounted `ptmxmode=000`, `/dev/ptmx` chmod 000): the real `creack` allocator fails with EACCES and the daemon now emits, to both the client error and the daemon log:

```
could not allocate a remote PTY: open /dev/ptmx: permission denied;
/dev/ptmx mode=0000; devpts (rw,gid=5,mode=620,ptmxmode=000,max=1024);
the remote devpts denies /dev/ptmx (e.g. mounted ptmxmode=000): remount
it writable with `sudo mount -o remount,ptmxmode=0666 /dev/pts` ...
```

### Honest caveat on the reporter's exact host

`ptmxmode=000` **alone does not break allocation when `/dev/ptmx` is itself writable** — confirmed empirically: with a writable standalone `/dev/ptmx` + `/dev/pts` `ptmxmode=000`, `creack/pty.Open()`, Python `openpty`, and `script` all succeed. The reporter confirmed their `/dev/ptmx` *is* writable and `openpty` works, so their true root cause may not be PTY allocation at all. `creack` only fails when `/dev/ptmx` itself resolves to a locked devpts ptmx node (mode 000) — and in that case no userspace allocator (script/tmux/python) can succeed either. This PR does not guess at the reporter's unproven mechanism; it makes **whatever** the true cause is diagnosable next time (the actual bug the reporter hit was an undiagnosable silent failure), and hardens + names the one allocation failure that is genuinely reproducible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5186"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782985745&installation_id=133855650&pr_number=5186&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5186&signature=1ab3abe74d44c54fd6ccb978fdf4919d19131b4c91ad2e022ab1cdea72b8560e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted error-path and messaging changes with a regression test; no changes to auth, RPC protocol shape, or normal PTY attach success paths.
> 
> **Overview**
> Remote PTY allocation failures are no longer swallowed as a generic **remote PTY attach failed** with an empty daemon log.
> 
> The **remote daemon** wraps `pty.Open` failures in a structured error (`could not allocate a remote PTY`) with `/dev/ptmx` mode, **devpts** mount options from `/proc/self/mountinfo`, and an EACCES/EPERM remediation hint; it **logs** RPC session start failures and puts the message in the WebSocket close reason (UTF-8 safe, 123-byte cap). An injectable `openPTY` hook supports tests.
> 
> **CLI** (`cmux.swift`) and **Workspace** pass through that diagnostic when the stable marker is present (Workspace via `remotePTYAttach.error.allocationDiagnostic`). A regression test pins the marker, device path, hint, and logging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40933735d168497e237334c34efdd16dda036168. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make remote PTY allocation failures loud and actionable. Users now see the exact cause (e.g., /dev/ptmx permissions and devpts ptmxmode), the daemon logs it, and clients preserve the diagnostic.

- **Bug Fixes**
  - Wrap PTY allocation errors with the failing device and devpts mount options (parsed from `/proc/self/mountinfo`), plus a hint for EACCES/EPERM.
  - Log allocation failures on the daemon RPC path; no more empty daemon logs.
  - Include the detailed cause in the WebSocket close reason (UTF‑8 safe, truncated to the 123‑byte limit).
  - CLI and Workspace pass through the daemon diagnostic verbatim when the stable marker "could not allocate a remote PTY" is present; Workspace routes it via `remotePTYAttach.error.allocationDiagnostic`.
  - Add an injectable `openPTY` seam (defaults to `creack/pty.Open`) and a regression test that pins the marker (case‑insensitive), the device, the remediation hint, and logging.

<sup>Written for commit 40933735d168497e237334c34efdd16dda036168. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Remote PTY attach failures now preserve and surface the daemon’s specific allocation diagnostic (instead of a generic message), improving guidance for PTY/device configuration and remediation. Close-reason text is also kept within protocol limits to avoid truncated control frames.
* **Localization**
  * Added a localized message key to present the forwarded PTY allocation diagnostic to users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->