### PR TITLE
Fix Starship prompt going static in bash sessions (#5164)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,9 @@ jobs:
       - name: Validate bash shell integration job control
         run: python3 tests/test_bash_integration_no_done_notifications.py
 
+      - name: Validate bash prompt bootstrap composes with user PROMPT_COMMAND (starship)
+        run: python3 tests/test_issue_5164_starship_prompt_composition.py
+
       # Paused: stale-base merge races (two PRs each fitting the budget can
       # overshoot when merged back-to-back without rebasing). CodeRabbit and
       # Greptile already flag large-file growth on PRs. Re-enable by uncommenting

--- a/Resources/shell-integration/cmux-bash-bootstrap.bash
+++ b/Resources/shell-integration/cmux-bash-bootstrap.bash
@@ -2,14 +2,27 @@
 #
 # macOS ships /bin/bash 3.2, where Ghostty's automatic bash integration is
 # unsupported and HOME-based wrapper startup is not reliable. cmux instead
-# exports the contents of this file as PROMPT_COMMAND so it runs once on the
-# first interactive prompt: it sources cmux's bash integration and then hands
-# control to _cmux_prompt_command.
+# exports this script as PROMPT_COMMAND so it runs once on the first interactive
+# prompt: it sources cmux's bash integration and then hands control to
+# _cmux_prompt_command.
+#
+# COMPOSE, don't clobber. A user's startup files may have appended their own
+# command to PROMPT_COMMAND *after* this bootstrap before the first prompt --
+# most notably `eval "$(starship init bash)"`, which appends starship_precmd.
+# We must remove only this bootstrap and keep whatever the user appended, so
+# hooks like starship_precmd keep running on every prompt instead of being wiped
+# after the first one (https://github.com/manaflow-ai/cmux/issues/5164).
+#
+# How: strip everything up to and including the marker at the end of this script
+# (the marker is the last occurrence, so the greedy ## match lands on it), which
+# leaves exactly the user's appended tail. Then trim the leading separator and
+# let cmux-bash-integration.bash's PROMPT_COMMAND merge prepend _cmux_prompt_command.
 #
 # This file is the single source of truth. Sources/GhosttyTerminalView.swift
-# reads it and exports it verbatim as PROMPT_COMMAND, and
+# reads it (stripping these comments) and exports it as PROMPT_COMMAND, and
 # tests/test_issue_5164_starship_prompt_composition.py exercises it.
-unset PROMPT_COMMAND
+PROMPT_COMMAND="${PROMPT_COMMAND##*__cmux_bash_bootstrap_marker__}"
+while [[ "$PROMPT_COMMAND" == [[:space:]\;]* ]]; do PROMPT_COMMAND="${PROMPT_COMMAND#?}"; done
 if [[ "${CMUX_LOAD_GHOSTTY_BASH_INTEGRATION:-0}" == "1" && -n "${GHOSTTY_RESOURCES_DIR:-}" ]]; then
     _cmux_ghostty_bash="$GHOSTTY_RESOURCES_DIR/shell-integration/bash/ghostty.bash"
     [[ -r "$_cmux_ghostty_bash" ]] && source "$_cmux_ghostty_bash"
@@ -20,3 +33,4 @@ if [[ "${CMUX_SHELL_INTEGRATION:-1}" != "0" && -n "${CMUX_SHELL_INTEGRATION_DIR:
 fi
 unset _cmux_ghostty_bash _cmux_bash_integration
 if declare -F _cmux_prompt_command >/dev/null 2>&1; then _cmux_prompt_command; fi
+: __cmux_bash_bootstrap_marker__

--- a/Resources/shell-integration/cmux-bash-bootstrap.bash
+++ b/Resources/shell-integration/cmux-bash-bootstrap.bash
@@ -1,0 +1,22 @@
+# cmux bash prompt bootstrap.
+#
+# macOS ships /bin/bash 3.2, where Ghostty's automatic bash integration is
+# unsupported and HOME-based wrapper startup is not reliable. cmux instead
+# exports the contents of this file as PROMPT_COMMAND so it runs once on the
+# first interactive prompt: it sources cmux's bash integration and then hands
+# control to _cmux_prompt_command.
+#
+# This file is the single source of truth. Sources/GhosttyTerminalView.swift
+# reads it and exports it verbatim as PROMPT_COMMAND, and
+# tests/test_issue_5164_starship_prompt_composition.py exercises it.
+unset PROMPT_COMMAND
+if [[ "${CMUX_LOAD_GHOSTTY_BASH_INTEGRATION:-0}" == "1" && -n "${GHOSTTY_RESOURCES_DIR:-}" ]]; then
+    _cmux_ghostty_bash="$GHOSTTY_RESOURCES_DIR/shell-integration/bash/ghostty.bash"
+    [[ -r "$_cmux_ghostty_bash" ]] && source "$_cmux_ghostty_bash"
+fi
+if [[ "${CMUX_SHELL_INTEGRATION:-1}" != "0" && -n "${CMUX_SHELL_INTEGRATION_DIR:-}" ]]; then
+    _cmux_bash_integration="$CMUX_SHELL_INTEGRATION_DIR/cmux-bash-integration.bash"
+    [[ -r "$_cmux_bash_integration" ]] && source "$_cmux_bash_integration"
+fi
+unset _cmux_ghostty_bash _cmux_bash_integration
+if declare -F _cmux_prompt_command >/dev/null 2>&1; then _cmux_prompt_command; fi

--- a/Resources/shell-integration/cmux-bash-bootstrap.bash
+++ b/Resources/shell-integration/cmux-bash-bootstrap.bash
@@ -21,6 +21,12 @@
 # This file is the single source of truth. Sources/GhosttyTerminalView.swift
 # reads it (stripping these comments) and exports it as PROMPT_COMMAND, and
 # tests/test_issue_5164_starship_prompt_composition.py exercises it.
+#
+# INJECTION CONSTRAINT: the app and the test both drop full-line `#` comments and
+# blank lines before exporting this as PROMPT_COMMAND (so users never see a wall
+# of comments in $PROMPT_COMMAND). Such lines are bash comments anyway, so this is
+# behavior-preserving -- but every executable line below must stand on its own and
+# must not begin with `#` (no full-line comments interleaved in the body).
 PROMPT_COMMAND="${PROMPT_COMMAND##*__cmux_bash_bootstrap_marker__}"
 while [[ "$PROMPT_COMMAND" == [[:space:]\;]* ]]; do PROMPT_COMMAND="${PROMPT_COMMAND#?}"; done
 if [[ "${CMUX_LOAD_GHOSTTY_BASH_INTEGRATION:-0}" == "1" && -n "${GHOSTTY_RESOURCES_DIR:-}" ]]; then

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -6436,7 +6436,8 @@ final class TerminalSurface: Identifiable, ObservableObject {
                 // users never see them in $PROMPT_COMMAND; the test mirrors this.
                 let bashBootstrapPath = (integrationDir as NSString)
                     .appendingPathComponent("cmux-bash-bootstrap.bash")
-                if let rawBootstrap = try? String(contentsOfFile: bashBootstrapPath, encoding: .utf8) {
+                do {
+                    let rawBootstrap = try String(contentsOfFile: bashBootstrapPath, encoding: .utf8)
                     let bootstrap = rawBootstrap
                         .components(separatedBy: "\n")
                         .filter { line in
@@ -6447,13 +6448,15 @@ final class TerminalSurface: Identifiable, ObservableObject {
                     if !bootstrap.isEmpty {
                         setManagedEnvironmentValue("PROMPT_COMMAND", bootstrap)
                     }
-                } else {
+                } catch {
                     // The bootstrap ships in the app bundle alongside
                     // cmux-bash-integration.bash, so a read failure means a
-                    // corrupt/partial bundle. Surface it in unified logging
-                    // rather than silently leaving bash without cmux integration.
+                    // corrupt/partial bundle. Surface it (with the underlying
+                    // error) in unified logging rather than silently leaving bash
+                    // without cmux integration. The path is logged privately so
+                    // user-specific install paths are not exposed in the log.
                     Logger(subsystem: "com.cmuxterm.app", category: "ghostty.initialization")
-                        .error("cmux bash bootstrap missing or unreadable at \(bashBootstrapPath, privacy: .public); bash shell integration will not load")
+                        .error("cmux bash bootstrap unreadable at \(bashBootstrapPath, privacy: .private): \(error.localizedDescription, privacy: .public); bash shell integration will not load")
                 }
             }
         }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -6429,20 +6429,25 @@ final class TerminalSurface: Identifiable, ObservableObject {
                 // macOS ships /bin/bash 3.2, where Ghostty's automatic bash
                 // integration is unsupported and HOME-based wrapper startup is
                 // not reliable. Bootstrap cmux bash integration on the first
-                // interactive prompt instead.
-                setManagedEnvironmentValue("PROMPT_COMMAND", """
-                unset PROMPT_COMMAND; \
-                if [[ "${CMUX_LOAD_GHOSTTY_BASH_INTEGRATION:-0}" == "1" && -n "${GHOSTTY_RESOURCES_DIR:-}" ]]; then \
-                _cmux_ghostty_bash="$GHOSTTY_RESOURCES_DIR/shell-integration/bash/ghostty.bash"; \
-                [[ -r "$_cmux_ghostty_bash" ]] && source "$_cmux_ghostty_bash"; \
-                fi; \
-                if [[ "${CMUX_SHELL_INTEGRATION:-1}" != "0" && -n "${CMUX_SHELL_INTEGRATION_DIR:-}" ]]; then \
-                _cmux_bash_integration="$CMUX_SHELL_INTEGRATION_DIR/cmux-bash-integration.bash"; \
-                [[ -r "$_cmux_bash_integration" ]] && source "$_cmux_bash_integration"; \
-                fi; \
-                unset _cmux_ghostty_bash _cmux_bash_integration; \
-                if declare -F _cmux_prompt_command >/dev/null 2>&1; then _cmux_prompt_command; fi
-                """)
+                // interactive prompt by exporting the shared bootstrap script as
+                // PROMPT_COMMAND. The script lives in Resources/shell-integration
+                // so the app and the regression test share one source of truth
+                // (see issue #5164). Doc comments and blank lines are stripped so
+                // users never see them in $PROMPT_COMMAND; the test mirrors this.
+                let bashBootstrapPath = (integrationDir as NSString)
+                    .appendingPathComponent("cmux-bash-bootstrap.bash")
+                if let rawBootstrap = try? String(contentsOfFile: bashBootstrapPath, encoding: .utf8) {
+                    let bootstrap = rawBootstrap
+                        .components(separatedBy: "\n")
+                        .filter { line in
+                            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                            return !trimmed.isEmpty && !trimmed.hasPrefix("#")
+                        }
+                        .joined(separator: "\n")
+                    if !bootstrap.isEmpty {
+                        setManagedEnvironmentValue("PROMPT_COMMAND", bootstrap)
+                    }
+                }
             }
         }
         env = Self.mergedStartupEnvironment(

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -6447,6 +6447,13 @@ final class TerminalSurface: Identifiable, ObservableObject {
                     if !bootstrap.isEmpty {
                         setManagedEnvironmentValue("PROMPT_COMMAND", bootstrap)
                     }
+                } else {
+                    // The bootstrap ships in the app bundle alongside
+                    // cmux-bash-integration.bash, so a read failure means a
+                    // corrupt/partial bundle. Surface it in unified logging
+                    // rather than silently leaving bash without cmux integration.
+                    Logger(subsystem: "com.cmuxterm.app", category: "ghostty.initialization")
+                        .error("cmux bash bootstrap missing or unreadable at \(bashBootstrapPath, privacy: .public); bash shell integration will not load")
                 }
             }
         }

--- a/tests/test_issue_5164_starship_prompt_composition.py
+++ b/tests/test_issue_5164_starship_prompt_composition.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""
+Regression coverage for https://github.com/manaflow-ai/cmux/issues/5164.
+
+Using Starship as the bash prompt inside a cmux session breaks: Starship's
+status line stops updating after the first command. The root cause is the local
+macOS bash bootstrap that cmux injects as ``PROMPT_COMMAND`` (see
+``Resources/shell-integration/cmux-bash-bootstrap.bash``). The user's startup
+files run ``eval "$(starship init bash)"`` *before* the first prompt, which
+appends ``starship_precmd`` to ``PROMPT_COMMAND``. If the bootstrap then takes
+exclusive ownership of ``PROMPT_COMMAND`` (the old code began with
+``unset PROMPT_COMMAND``), ``starship_precmd`` is discarded after running once,
+so the prompt freezes.
+
+This test drives the *actual* bootstrap file through real bash with a faithful
+Starship stub and asserts that a user-registered ``PROMPT_COMMAND`` hook
+survives and keeps running on every prompt. It is deterministic (it models
+bash's "evaluate PROMPT_COMMAND before each prompt" loop directly) rather than
+relying on a PTY.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BOOTSTRAP = REPO_ROOT / "Resources/shell-integration/cmux-bash-bootstrap.bash"
+INTEGRATION_DIR = REPO_ROOT / "Resources/shell-integration"
+
+
+def _lean_bootstrap(text: str) -> str:
+    """Drop full-line ``#`` comments and blank lines from the bootstrap.
+
+    This mirrors how ``Sources/GhosttyTerminalView.swift`` turns the documented
+    bootstrap file into the lean string it exports as ``PROMPT_COMMAND`` (so the
+    user never sees a wall of comments in ``$PROMPT_COMMAND``). The two
+    implementations must stay in sync.
+    """
+    kept = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        kept.append(line)
+    return "\n".join(kept)
+
+# A faithful-enough stand-in for `starship init bash`: it defines
+# starship_precmd (which renders PS1 from `starship prompt`) and appends it to
+# PROMPT_COMMAND exactly the way the real starship does for non-bash-preexec
+# shells. `starship prompt` emits the cwd plus a monotonic counter so a *stale*
+# (no longer re-rendered) prompt is detectable.
+STARSHIP_STUB = """#!/bin/bash
+case "$1" in
+  init)
+    cat <<'INIT'
+STARSHIP_PREEXEC_READY="true"
+starship_precmd() {
+    local STARSHIP_CMD_STATUS=$?
+    PS1="$(starship prompt --status=$STARSHIP_CMD_STATUS)"
+    STARSHIP_PREEXEC_READY="true"
+}
+starship_preexec() { :; }
+if [[ "${PROMPT_COMMAND:-}" != *"starship_precmd"* ]]; then
+    if [[ "$(declare -p PROMPT_COMMAND 2>/dev/null)" == "declare -a"* ]]; then
+        PROMPT_COMMAND+=(starship_precmd)
+    else
+        PROMPT_COMMAND=${PROMPT_COMMAND:+$PROMPT_COMMAND$'\\n'}"starship_precmd"
+    fi
+fi
+trap 'starship_preexec "$_"' DEBUG
+INIT
+    ;;
+  prompt)
+    ctr="$STARSHIP_COUNTER_FILE"
+    n=0; [[ -r "$ctr" ]] && n="$(cat "$ctr")"
+    n=$((n + 1)); printf '%s' "$n" > "$ctr"
+    printf 'SS[cwd=%s n=%s]$ ' "${PWD##*/}" "$n"
+    ;;
+  time)
+    printf '0'
+    ;;
+esac
+"""
+
+# Driver: model bash's prompt loop. Inherit the bootstrap as PROMPT_COMMAND (as
+# cmux does via the environment), let the user's rc append starship_precmd, then
+# render three prompts (with a cd in between) by evaluating PROMPT_COMMAND the
+# way bash itself does.
+DRIVER = r"""
+set +e
+
+# bash inherits the cmux bootstrap as PROMPT_COMMAND from the environment. The
+# file already has its doc comments stripped (matching the app's injection).
+PROMPT_COMMAND="$(cat "$CMUX_BOOTSTRAP_FILE")"
+
+# The user's startup files run starship init before the first prompt.
+eval "$(starship init bash)"
+
+# Squash newlines so each marker is one line for the test parser.
+_emit() { printf '%s<%s>\n' "$1" "${2//$'\n'/<NL>}"; }
+_emit PC_AFTER_RC "$PROMPT_COMMAND"
+
+_render() {
+    # bash reads PROMPT_COMMAND fresh and executes it before drawing each prompt.
+    if [[ "$(declare -p PROMPT_COMMAND 2>/dev/null)" == "declare -a"* ]]; then
+        local pc; for pc in "${PROMPT_COMMAND[@]}"; do eval "$pc"; done
+    else
+        eval "$PROMPT_COMMAND"
+    fi
+}
+
+i=0
+while (( i < 3 )); do
+    i=$(( i + 1 ))
+    (( i == 3 )) && cd "$CMUX_CD_TARGET"
+    _render
+    _emit "PS1_$i" "$PS1"
+    _emit "PC_$i" "$PROMPT_COMMAND"
+done
+"""
+
+
+def _run_driver() -> dict[str, str]:
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        starship = bin_dir / "starship"
+        starship.write_text(STARSHIP_STUB, encoding="utf-8")
+        starship.chmod(0o755)
+
+        cd_target = tmp_path / "cd-target"
+        cd_target.mkdir()
+
+        # Inject exactly what the app injects: the bootstrap with doc comments
+        # stripped (see _lean_bootstrap / GhosttyTerminalView.swift).
+        lean_bootstrap = tmp_path / "bootstrap.bash"
+        lean_bootstrap.write_text(
+            _lean_bootstrap(BOOTSTRAP.read_text(encoding="utf-8")), encoding="utf-8"
+        )
+
+        env = {
+            key: value
+            for key, value in os.environ.items()
+            if not key.startswith("CMUX")
+        }
+        env.update(
+            {
+                "LC_ALL": "C",
+                "LANG": "C",
+                "PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}",
+                "CMUX_BOOTSTRAP_FILE": str(lean_bootstrap),
+                "CMUX_SHELL_INTEGRATION": "1",
+                "CMUX_SHELL_INTEGRATION_DIR": str(INTEGRATION_DIR),
+                "CMUX_LOAD_GHOSTTY_BASH_INTEGRATION": "0",
+                "GHOSTTY_RESOURCES_DIR": "",
+                "CMUX_TAB_ID": "tab-test",
+                "CMUX_PANEL_ID": "panel-test",
+                # No unix socket: _cmux_prompt_command's body early-returns, which
+                # keeps this test focused on PROMPT_COMMAND/PS1 composition.
+                "CMUX_SOCKET_PATH": "",
+                "STARSHIP_COUNTER_FILE": str(tmp_path / "counter"),
+                "CMUX_CD_TARGET": str(cd_target),
+            }
+        )
+
+        proc = subprocess.run(
+            ["/bin/bash", "--noprofile", "--norc", "-c", DRIVER],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if proc.returncode != 0:
+            raise AssertionError(
+                f"driver bash exited {proc.returncode}\n"
+                f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+            )
+
+        fields: dict[str, str] = {}
+        # Parse line-oriented KEY<...> markers (values are single-line here).
+        for line in proc.stdout.splitlines():
+            m = re.match(r"^([A-Z0-9_]+)<(.*)>$", line)
+            if m:
+                fields[m.group(1)] = m.group(2)
+        fields["__stdout__"] = proc.stdout
+        fields["__stderr__"] = proc.stderr
+        return fields
+
+
+def test_starship_precmd_survives_under_cmux_bash_bootstrap() -> None:
+    assert BOOTSTRAP.exists(), f"missing bootstrap file: {BOOTSTRAP}"
+    fields = _run_driver()
+    debug = (
+        f"\n\n--- driver stdout ---\n{fields.get('__stdout__', '')}"
+        f"\n--- driver stderr ---\n{fields.get('__stderr__', '')}"
+    )
+
+    # Sanity: starship init appended its hook before the first prompt.
+    assert "starship_precmd" in fields.get("PC_AFTER_RC", ""), (
+        "starship init did not append starship_precmd to PROMPT_COMMAND" + debug
+    )
+
+    # cmux must compose, not clobber: after the one-shot bootstrap runs, the
+    # user's starship hook must still be present in PROMPT_COMMAND...
+    for i in (1, 2, 3):
+        pc = fields.get(f"PC_{i}", "")
+        assert "starship_precmd" in pc, (
+            f"starship_precmd was dropped from PROMPT_COMMAND at prompt {i}; "
+            f"cmux took exclusive ownership instead of composing. PROMPT_COMMAND=<{pc}>"
+            + debug
+        )
+        assert "_cmux_prompt_command" in pc, (
+            f"cmux's own prompt hook missing from PROMPT_COMMAND at prompt {i}: <{pc}>"
+            + debug
+        )
+
+    # ...and the rendered prompt must keep updating (starship_precmd actually
+    # runs every prompt). A static prompt is the reported symptom: the counter
+    # stays at 1 and the cwd never reflects the `cd`.
+    ps1_values = [fields.get(f"PS1_{i}", "") for i in (1, 2, 3)]
+    assert ps1_values[0] != ps1_values[1] != ps1_values[2], (
+        "starship prompt went static across prompts (it stopped re-rendering): "
+        f"{ps1_values}" + debug
+    )
+    assert "n=3" in ps1_values[2], (
+        f"starship_precmd did not run on every prompt; final PS1=<{ps1_values[2]}>" + debug
+    )
+    assert "cwd=cd-target" in ps1_values[2], (
+        f"prompt did not pick up the new cwd after cd; final PS1=<{ps1_values[2]}>" + debug
+    )
+
+
+if __name__ == "__main__":
+    test_starship_precmd_survives_under_cmux_bash_bootstrap()
+    print("PASS: starship_precmd survives under the cmux bash bootstrap")

--- a/tests/test_issue_5164_starship_prompt_composition.py
+++ b/tests/test_issue_5164_starship_prompt_composition.py
@@ -99,7 +99,9 @@ set +e
 PROMPT_COMMAND="$(cat "$CMUX_BOOTSTRAP_FILE")"
 
 # The user's startup files run starship init before the first prompt.
-eval "$(starship init bash)"
+if [[ "${CMUX_WITH_STARSHIP:-1}" == "1" ]]; then
+    eval "$(starship init bash)"
+fi
 
 # Squash newlines so each marker is one line for the test parser.
 _emit() { printf '%s<%s>\n' "$1" "${2//$'\n'/<NL>}"; }
@@ -125,7 +127,7 @@ done
 """
 
 
-def _run_driver() -> dict[str, str]:
+def _run_driver(*, with_starship: bool = True) -> dict[str, str]:
     with tempfile.TemporaryDirectory() as tmp:
         tmp_path = Path(tmp)
         bin_dir = tmp_path / "bin"
@@ -166,6 +168,7 @@ def _run_driver() -> dict[str, str]:
                 "CMUX_SOCKET_PATH": "",
                 "STARSHIP_COUNTER_FILE": str(tmp_path / "counter"),
                 "CMUX_CD_TARGET": str(cd_target),
+                "CMUX_WITH_STARSHIP": "1" if with_starship else "0",
             }
         )
 
@@ -236,6 +239,27 @@ def test_starship_precmd_survives_under_cmux_bash_bootstrap() -> None:
     )
 
 
+def test_plain_bash_bootstrap_installs_cmux_prompt_command() -> None:
+    """No-regression guard: with no user PROMPT_COMMAND hook, the bootstrap must
+    still install _cmux_prompt_command (and remove its own marker)."""
+    assert BOOTSTRAP.exists(), f"missing bootstrap file: {BOOTSTRAP}"
+    fields = _run_driver(with_starship=False)
+    debug = (
+        f"\n\n--- driver stdout ---\n{fields.get('__stdout__', '')}"
+        f"\n--- driver stderr ---\n{fields.get('__stderr__', '')}"
+    )
+    for i in (1, 2, 3):
+        pc = fields.get(f"PC_{i}", "")
+        assert pc == "_cmux_prompt_command", (
+            f"plain-bash PROMPT_COMMAND at prompt {i} should be exactly "
+            f"_cmux_prompt_command, got <{pc}>" + debug
+        )
+        assert "__cmux_bash_bootstrap_marker__" not in pc, (
+            f"bootstrap marker leaked into PROMPT_COMMAND at prompt {i}: <{pc}>" + debug
+        )
+
+
 if __name__ == "__main__":
     test_starship_precmd_survives_under_cmux_bash_bootstrap()
-    print("PASS: starship_precmd survives under the cmux bash bootstrap")
+    test_plain_bash_bootstrap_installs_cmux_prompt_command()
+    print("PASS: cmux bash bootstrap composes with (and without) user prompt hooks")

--- a/tests/test_issue_5164_starship_prompt_composition.py
+++ b/tests/test_issue_5164_starship_prompt_composition.py
@@ -250,12 +250,19 @@ def test_plain_bash_bootstrap_installs_cmux_prompt_command() -> None:
     )
     for i in (1, 2, 3):
         pc = fields.get(f"PC_{i}", "")
-        assert pc == "_cmux_prompt_command", (
-            f"plain-bash PROMPT_COMMAND at prompt {i} should be exactly "
-            f"_cmux_prompt_command, got <{pc}>" + debug
+        # Assert the observable contract (hook installed, bootstrap removed, no
+        # phantom hook) rather than the exact integration-internal string, so this
+        # stays green if cmux-bash-integration.bash ever tweaks PROMPT_COMMAND.
+        assert "_cmux_prompt_command" in pc, (
+            f"plain-bash bootstrap did not install _cmux_prompt_command at prompt {i}: <{pc}>"
+            + debug
         )
         assert "__cmux_bash_bootstrap_marker__" not in pc, (
             f"bootstrap marker leaked into PROMPT_COMMAND at prompt {i}: <{pc}>" + debug
+        )
+        assert "starship_precmd" not in pc, (
+            f"unexpected starship hook in plain-bash PROMPT_COMMAND at prompt {i}: <{pc}>"
+            + debug
         )
 
 


### PR DESCRIPTION
## Summary

Using Starship as the bash prompt inside a cmux session (`eval "$(starship init bash)"`) breaks: Starship's status line (cwd, git branch, command duration) stops updating — it goes **static after the first command**. Plain bash sessions are unaffected.

Fixes #5164.

## Verified root cause (not the reporter's hypothesis)

The reporter suspected cmux *resets `PS1`*. I reproduced the bug and confirmed that is **not** what happens — cmux never touches `PS1`. The real mechanism:

1. On macOS, cmux bootstraps bash integration by exporting a script as `PROMPT_COMMAND` (the local path in `GhosttyTerminalView.swift`; `/bin/bash` 3.2 has no reliable HOME-based startup hook).
2. The user's startup files run `eval "$(starship init bash)"` **before** the first prompt. Starship *appends* `starship_precmd` to the existing `PROMPT_COMMAND`, so it becomes `<cmux-bootstrap>\nstarship_precmd`.
3. The bootstrap's first action was **`unset PROMPT_COMMAND`** — which discards everything, including `starship_precmd`. It then sourced the integration, which set `PROMPT_COMMAND="_cmux_prompt_command"`. `starship_precmd` ran once (prompt 1 looked correct), but on every prompt after that `PROMPT_COMMAND` was only `_cmux_prompt_command`, so `starship_precmd` never ran again → frozen prompt.

Empirically (faithful starship stub, real bash, modelling bash's "evaluate `PROMPT_COMMAND` before each prompt" loop):

```
# before the fix
Prompt 1 -> PS1=<SS[cwd=cmux161 n=1]$ >   PROMPT_COMMAND=<_cmux_prompt_command>
Prompt 2 -> PS1=<SS[cwd=cmux161 n=1]$ >   PROMPT_COMMAND=<_cmux_prompt_command>   # static
Prompt 3 -> PS1=<SS[cwd=cmux161 n=1]$ >   PROMPT_COMMAND=<_cmux_prompt_command>   # static (cd ignored)
```

The remote path (`RemoteInteractiveShellBootstrapBuilder`) was already fine because it sources the integration *after* the user's rc with no `unset`, so the integration's existing merge composed correctly (`_cmux_prompt_command;starship_precmd`). The bug was isolated to the local bootstrap's `unset`.

## Fix

cmux's prompt integration must **compose** with the user's `PROMPT_COMMAND`, not take exclusive ownership. The bootstrap now removes **only its own text** (keyed on a trailing marker) and preserves whatever the user appended:

```
PROMPT_COMMAND="${PROMPT_COMMAND##*__cmux_bash_bootstrap_marker__}"   # strip just this bootstrap
# trim the leading separator the strip leaves, then source the integration,
# whose existing merge prepends _cmux_prompt_command -> _cmux_prompt_command;starship_precmd
```

After the fix the prompt stays live (`n` increments, cwd tracks `cd`):

```
Prompt 1 -> PS1=<SS[cwd=cmux161 n=1]$ >    PROMPT_COMMAND=<_cmux_prompt_command;starship_precmd>
Prompt 2 -> PS1=<SS[cwd=cmux161 n=2]$ >    PROMPT_COMMAND=<_cmux_prompt_command;starship_precmd>
Prompt 3 -> PS1=<SS[cwd=cd-target n=3]$ >  PROMPT_COMMAND=<_cmux_prompt_command;starship_precmd>
```

The bootstrap was also extracted from a hardcoded Swift string into `Resources/shell-integration/cmux-bash-bootstrap.bash` so the app and the regression test share one source of truth. `GhosttyTerminalView.swift` reads it (stripping doc comments so `$PROMPT_COMMAND` stays lean).

This is a general fix (any user-appended `PROMPT_COMMAND` hook survives), not the brittle "re-`eval` starship every prompt" workaround.

## zsh is unaffected

cmux's zsh integration registers hooks via `add-zsh-hook precmd/preexec` (which *append* to `precmd_functions`/`preexec_functions`) and never reassigns those arrays or `PS1`. Starship's zsh init uses the same mechanism, so they compose. Scoped the fix to bash, the reported shell.

## Test (red → green)

`tests/test_issue_5164_starship_prompt_composition.py` drives the **actual** bootstrap file + a faithful starship stub through real bash and asserts `starship_precmd` survives and keeps re-rendering on every prompt; plus a plain-bash no-regression case. Wired into the `workflow-guard-tests` CI job.

Two-commit structure per the repo policy:
- **Commit 1** keeps the buggy `unset` → test is **red**.
- **Commit 2** applies the compose fix → test is **green**.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5187"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782986811&installation_id=133855650&pr_number=5187&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5187&signature=185bb98feb48b5370d20fc2315f63c2ed2bdcd78a460ab8d472c82106942b7fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to local bash shell-integration startup and environment injection; no auth, network, or data-path changes.
> 
> **Overview**
> Addresses **#5164** (Starship/bash prompts freezing after the first command) by moving the macOS bash **`PROMPT_COMMAND`** bootstrap out of **`GhosttyTerminalView.swift`** into **`Resources/shell-integration/cmux-bash-bootstrap.bash`**, so the app and tests use the same script.
> 
> **`GhosttyTerminalView`** now reads that file, strips comment/blank lines, and exports the lean body as **`PROMPT_COMMAND`** instead of embedding a long inline string. A new **`tests/test_issue_5164_starship_prompt_composition.py`** drives real bash with a Starship stub and checks that **`starship_precmd`** stays on **`PROMPT_COMMAND`** and keeps updating **`PS1`** across prompts; CI **`workflow-guard-tests`** runs it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76f2c2ec1aa51f690507ad80e23c79b6d0a71361. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Starship prompts freezing in bash sessions by composing with the user’s `PROMPT_COMMAND` instead of resetting it, so `starship_precmd` runs on every prompt and the prompt stays live. Also moves the bash bootstrap to a shared script and adds regression coverage. Fixes #5164.

- **Bug Fixes**
  - Compose with existing `PROMPT_COMMAND`: remove only this bootstrap via a trailing marker, trim the leading separator, and preserve user hooks like `starship_precmd`.
  - Move bootstrap to `Resources/shell-integration/cmux-bash-bootstrap.bash`; `GhosttyTerminalView.swift` reads it, strips comments/blank lines, exports a lean body as `PROMPT_COMMAND`, and logs unreadable files via `os.Logger` with the path redacted and the underlying error included.
  - Add `tests/test_issue_5164_starship_prompt_composition.py` with starship composition and a plain-bash case; asserts the observable contract and runs in CI.

<sup>Written for commit 56f9150bf9cefacabc76d48ce217a9c9b9b1aa97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated bash bootstrap for interactive shell integration.

* **Bug Fixes**
  * Preserve and compose user prompt hooks (e.g., Starship) with the app’s prompt handling so both run across prompts.

* **Tests**
  * Added deterministic regression tests that validate prompt composition and prompt-command behavior across multiple prompts.

* **Chores**
  * CI now runs the new regression test as part of validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->