### PR TITLE
Route browser side mouse buttons through panel history

### DIFF
--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -3659,9 +3659,7 @@ final class BrowserPanel: Panel, ObservableObject {
         isMainFrameProvisionalNavigationActive = false
         oldWebView.navigationDelegate = nil
         oldWebView.uiDelegate = nil
-        if let oldCmuxWebView = oldWebView as? CmuxWebView {
-            oldCmuxWebView.onContextMenuDownloadStateChanged = nil
-        }
+        clearCmuxWebViewCallbacks(oldWebView)
 
         let replacement = Self.makeWebView(
             profileID: profileID,
@@ -4005,12 +4003,30 @@ final class BrowserPanel: Panel, ObservableObject {
         webView.onContextMenuOpenLinkInNewTab = { [weak self] url in
             self?.openLinkInNewTab(url: url)
         }
+        webView.onMouseBackButton = { [weak self] in
+            guard let self, self.canGoBack else { return false }
+            self.goBack()
+            return true
+        }
+        webView.onMouseForwardButton = { [weak self] in
+            guard let self, self.canGoForward else { return false }
+            self.goForward()
+            return true
+        }
         configureMoveTabToNewWorkspaceContextMenu(for: webView); configureNavigationDelegateCallbacks()
         webView.navigationDelegate = navigationDelegate
         webView.uiDelegate = uiDelegate
         setupObservers(for: webView)
         setupReactGrabMessageHandler(for: webView)
         applyMuteState(to: webView, reason: "bindWebView")
+    }
+
+    private func clearCmuxWebViewCallbacks(_ webView: WKWebView) {
+        guard let cmuxWebView = webView as? CmuxWebView else { return }
+        cmuxWebView.onContextMenuDownloadStateChanged = nil
+        cmuxWebView.onContextMenuOpenLinkInNewTab = nil
+        cmuxWebView.onMouseBackButton = nil
+        cmuxWebView.onMouseForwardButton = nil
     }
 
     private func configureNavigationDelegateCallbacks() {
@@ -4548,9 +4564,7 @@ final class BrowserPanel: Panel, ObservableObject {
         isMainFrameProvisionalNavigationActive = false
         previousWebView.navigationDelegate = nil
         previousWebView.uiDelegate = nil
-        if let previousCmuxWebView = previousWebView as? CmuxWebView {
-            previousCmuxWebView.onContextMenuDownloadStateChanged = nil
-        }
+        clearCmuxWebViewCallbacks(previousWebView)
 
         profileID = resolvedProfileID
         historyStore = BrowserProfileStore.shared.historyStore(for: resolvedProfileID)
@@ -4956,9 +4970,7 @@ final class BrowserPanel: Panel, ObservableObject {
         isMainFrameProvisionalNavigationActive = false
         oldWebView.navigationDelegate = nil
         oldWebView.uiDelegate = nil
-        if let oldCmuxWebView = oldWebView as? CmuxWebView {
-            oldCmuxWebView.onContextMenuDownloadStateChanged = nil
-        }
+        clearCmuxWebViewCallbacks(oldWebView)
 
         let replacement = Self.makeWebView(
             profileID: profileID,
@@ -5768,6 +5780,12 @@ final class BrowserPanel: Panel, ObservableObject {
         webViewCancellables.removeAll()
         let webView = webView
         Task { @MainActor in
+            if let cmuxWebView = webView as? CmuxWebView {
+                cmuxWebView.onContextMenuDownloadStateChanged = nil
+                cmuxWebView.onContextMenuOpenLinkInNewTab = nil
+                cmuxWebView.onMouseBackButton = nil
+                cmuxWebView.onMouseForwardButton = nil
+            }
             BrowserWindowPortalRegistry.detach(webView: webView)
         }
     }
@@ -5911,9 +5929,7 @@ extension BrowserPanel {
         isMainFrameProvisionalNavigationActive = false
         oldWebView.navigationDelegate = nil
         oldWebView.uiDelegate = nil
-        if let oldCmuxWebView = oldWebView as? CmuxWebView {
-            oldCmuxWebView.onContextMenuDownloadStateChanged = nil
-        }
+        clearCmuxWebViewCallbacks(oldWebView)
 
         let replacement = Self.makeWebView(
             profileID: profileID,

--- a/Sources/Panels/CmuxWebView.swift
+++ b/Sources/Panels/CmuxWebView.swift
@@ -375,6 +375,10 @@ final class CmuxWebView: WKWebView {
     /// Called when "Open Link in New Tab" context menu is selected.
     /// Bypasses createWebViewWith so the link opens as a tab, not a popup.
     var onContextMenuOpenLinkInNewTab: ((URL) -> Void)?
+    /// Called for the hardware mouse back button.
+    var onMouseBackButton: (() -> Bool)?
+    /// Called for the hardware mouse forward button.
+    var onMouseForwardButton: (() -> Bool)?
     var contextMenuLinkURLProvider: ((CmuxWebView, NSPoint, @escaping (URL?) -> Void) -> Void)?
     var contextMenuDefaultBrowserOpener: ((URL) -> Bool)?
     var contextMenuCanMoveTabToNewWorkspace: (() -> Bool)?; var contextMenuMoveTabToNewWorkspace: (() -> Bool)?
@@ -780,15 +784,19 @@ final class CmuxWebView: WKWebView {
         switch event.buttonNumber {
         case 3:
 #if DEBUG
-            cmuxDebugLog("browser.mouse.otherDown.action web=\(ObjectIdentifier(self)) kind=goBack canGoBack=\(canGoBack ? 1 : 0)")
+            cmuxDebugLog("browser.mouse.otherDown.action web=\(ObjectIdentifier(self)) kind=goBack canGoBack=\(canGoBack ? 1 : 0) routed=\(onMouseBackButton == nil ? 0 : 1)")
 #endif
-            goBack()
+            if onMouseBackButton?() != true {
+                goBack()
+            }
             return
         case 4:
 #if DEBUG
-            cmuxDebugLog("browser.mouse.otherDown.action web=\(ObjectIdentifier(self)) kind=goForward canGoForward=\(canGoForward ? 1 : 0)")
+            cmuxDebugLog("browser.mouse.otherDown.action web=\(ObjectIdentifier(self)) kind=goForward canGoForward=\(canGoForward ? 1 : 0) routed=\(onMouseForwardButton == nil ? 0 : 1)")
 #endif
-            goForward()
+            if onMouseForwardButton?() != true {
+                goForward()
+            }
             return
         default:
             break

--- a/cmuxTests/CmuxWebViewDragRoutingTests.swift
+++ b/cmuxTests/CmuxWebViewDragRoutingTests.swift
@@ -253,6 +253,62 @@ final class CmuxWebViewDragRoutingTests: XCTestCase {
 
         XCTAssertEqual(cmuxUnitTestWKWebViewDragLifecycleEvents, [])
     }
+
+    func testMouseBackButtonRoutesThroughOwnerCallback() {
+        let webView = CmuxWebView(frame: NSRect(x: 0, y: 0, width: 320, height: 240), configuration: WKWebViewConfiguration())
+        var backCount = 0
+        var forwardCount = 0
+        webView.onMouseBackButton = {
+            backCount += 1
+            return true
+        }
+        webView.onMouseForwardButton = {
+            forwardCount += 1
+            return true
+        }
+
+        webView.otherMouseDown(with: makeOtherMouseEvent(buttonNumber: 3))
+
+        XCTAssertEqual(backCount, 1)
+        XCTAssertEqual(forwardCount, 0)
+    }
+
+    func testMouseForwardButtonRoutesThroughOwnerCallback() {
+        let webView = CmuxWebView(frame: NSRect(x: 0, y: 0, width: 320, height: 240), configuration: WKWebViewConfiguration())
+        var backCount = 0
+        var forwardCount = 0
+        webView.onMouseBackButton = {
+            backCount += 1
+            return true
+        }
+        webView.onMouseForwardButton = {
+            forwardCount += 1
+            return true
+        }
+
+        webView.otherMouseDown(with: makeOtherMouseEvent(buttonNumber: 4))
+
+        XCTAssertEqual(backCount, 0)
+        XCTAssertEqual(forwardCount, 1)
+    }
+
+    private func makeOtherMouseEvent(buttonNumber: Int) -> NSEvent {
+        guard let event = NSEvent.mouseEvent(
+            with: .otherMouseDown,
+            location: NSPoint(x: 12, y: 24),
+            modifierFlags: [],
+            timestamp: 1,
+            windowNumber: 0,
+            context: nil,
+            eventNumber: 1,
+            clickCount: 1,
+            pressure: 1,
+            buttonNumber: buttonNumber
+        ) else {
+            fatalError("Failed to create other mouse event")
+        }
+        return event
+    }
 }
 
 @MainActor


### PR DESCRIPTION
Summary:
- Route browser hardware back/forward mouse buttons through BrowserPanel history actions.
- Keep WebKit history fallback when no panel owner handles the event.
- Add regression tests for button 3 and button 4 owner callback routing.

Verification:
- ./scripts/reload.sh --tag diffmouse passed.
- git diff --check passed.
- Focused AWS unit test could not run because cmux-aws-m4pro is out of disk before package resolution.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5188"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782988666&installation_id=133855650&pr_number=5188&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5188&signature=57a68598b291dc19476a5fcfd87d57e1af509819fa0eb8b0febce05ed6aa2fc1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized input routing and callback lifecycle cleanup; WebKit navigation remains as fallback when the panel does not handle the click.
> 
> **Overview**
> Hardware mouse **back** (button 3) and **forward** (button 4) are now handled through **`BrowserPanel`** history (`goBack` / `goForward` when `canGoBack` / `canGoForward`) instead of only WebKit’s in-view history.
> 
> **`CmuxWebView`** exposes optional `onMouseBackButton` / `onMouseForwardButton` hooks that return whether the event was consumed; if not, it still falls back to WebKit `goBack()` / `goForward()`.
> 
> Teardown paths use a shared **`clearCmuxWebViewCallbacks`** helper so context-menu and mouse-button closures are cleared whenever the web view is replaced or discarded, including on panel shutdown.
> 
> Unit tests assert buttons 3 and 4 invoke the owner callbacks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e81812774a06938dd3c04a2d0dc7e9ebba522606. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route mouse side buttons (back/forward) through panel history so users can navigate with hardware buttons in the browser panel. If no owner handles the event, we fall back to WebKit history.

- **New Features**
  - Added `onMouseBackButton` and `onMouseForwardButton` callbacks on `CmuxWebView`, wired in `BrowserPanel` to `goBack`/`goForward` and falling back to WebKit when unhandled.
  - Added regression tests for button 3 and 4 routing through owner callbacks.

- **Refactors**
  - Centralized clearing of `CmuxWebView` callbacks when swapping/detaching web views to avoid stale handlers.

<sup>Written for commit e81812774a06938dd3c04a2d0dc7e9ebba522606. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for mouse back/forward buttons to navigate web content.

* **Bug Fixes**
  * Fixed stale callback handlers persisting across web view lifecycle transitions, improving stability when switching profiles or contexts.

* **Tests**
  * Added test coverage for mouse button event routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->