### PR TITLE
Support browser mouse history buttons

### DIFF
--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -3659,9 +3659,7 @@ final class BrowserPanel: Panel, ObservableObject {
         isMainFrameProvisionalNavigationActive = false
         oldWebView.navigationDelegate = nil
         oldWebView.uiDelegate = nil
-        if let oldCmuxWebView = oldWebView as? CmuxWebView {
-            oldCmuxWebView.onContextMenuDownloadStateChanged = nil
-        }
+        unbindWebView(oldWebView)
 
         let replacement = Self.makeWebView(
             profileID: profileID,
@@ -4005,12 +4003,30 @@ final class BrowserPanel: Panel, ObservableObject {
         webView.onContextMenuOpenLinkInNewTab = { [weak self] url in
             self?.openLinkInNewTab(url: url)
         }
+        webView.onMouseBackButton = { [weak self] in
+            self?.goBack()
+        }
+        webView.onMouseForwardButton = { [weak self] in
+            self?.goForward()
+        }
         configureMoveTabToNewWorkspaceContextMenu(for: webView); configureNavigationDelegateCallbacks()
         webView.navigationDelegate = navigationDelegate
         webView.uiDelegate = uiDelegate
         setupObservers(for: webView)
         setupReactGrabMessageHandler(for: webView)
         applyMuteState(to: webView, reason: "bindWebView")
+    }
+
+    private func unbindWebView(_ webView: WKWebView) {
+        guard let cmuxWebView = webView as? CmuxWebView else { return }
+        cmuxWebView.onContextMenuDownloadStateChanged = nil
+        cmuxWebView.onContextMenuOpenLinkInNewTab = nil
+        cmuxWebView.onMouseBackButton = nil
+        cmuxWebView.onMouseForwardButton = nil
+        cmuxWebView.contextMenuLinkURLProvider = nil
+        cmuxWebView.contextMenuDefaultBrowserOpener = nil
+        cmuxWebView.contextMenuCanMoveTabToNewWorkspace = nil
+        cmuxWebView.contextMenuMoveTabToNewWorkspace = nil
     }
 
     private func configureNavigationDelegateCallbacks() {
@@ -4548,9 +4564,7 @@ final class BrowserPanel: Panel, ObservableObject {
         isMainFrameProvisionalNavigationActive = false
         previousWebView.navigationDelegate = nil
         previousWebView.uiDelegate = nil
-        if let previousCmuxWebView = previousWebView as? CmuxWebView {
-            previousCmuxWebView.onContextMenuDownloadStateChanged = nil
-        }
+        unbindWebView(previousWebView)
 
         profileID = resolvedProfileID
         historyStore = BrowserProfileStore.shared.historyStore(for: resolvedProfileID)
@@ -4956,9 +4970,7 @@ final class BrowserPanel: Panel, ObservableObject {
         isMainFrameProvisionalNavigationActive = false
         oldWebView.navigationDelegate = nil
         oldWebView.uiDelegate = nil
-        if let oldCmuxWebView = oldWebView as? CmuxWebView {
-            oldCmuxWebView.onContextMenuDownloadStateChanged = nil
-        }
+        unbindWebView(oldWebView)
 
         let replacement = Self.makeWebView(
             profileID: profileID,
@@ -5911,9 +5923,7 @@ extension BrowserPanel {
         isMainFrameProvisionalNavigationActive = false
         oldWebView.navigationDelegate = nil
         oldWebView.uiDelegate = nil
-        if let oldCmuxWebView = oldWebView as? CmuxWebView {
-            oldCmuxWebView.onContextMenuDownloadStateChanged = nil
-        }
+        unbindWebView(oldWebView)
 
         let replacement = Self.makeWebView(
             profileID: profileID,

--- a/Sources/Panels/CmuxWebView.swift
+++ b/Sources/Panels/CmuxWebView.swift
@@ -4,6 +4,40 @@ import ObjectiveC
 import UniformTypeIdentifiers
 import WebKit
 
+enum BrowserMouseNavigationAction: Equatable {
+    case back
+    case forward
+}
+
+func browserMouseNavigationAction(buttonNumber: Int) -> BrowserMouseNavigationAction? {
+    switch buttonNumber {
+    case 3:
+        return .back
+    case 4:
+        return .forward
+    default:
+        return nil
+    }
+}
+
+@discardableResult
+func browserHandleMouseNavigationButton(
+    buttonNumber: Int,
+    goBack: () -> Void,
+    goForward: () -> Void
+) -> Bool {
+    switch browserMouseNavigationAction(buttonNumber: buttonNumber) {
+    case .back:
+        goBack()
+        return true
+    case .forward:
+        goForward()
+        return true
+    case nil:
+        return false
+    }
+}
+
 extension WKWebView {
     nonisolated private static var cmuxSetPageMutedSelector: Selector {
         NSSelectorFromString("_setPageMuted:")
@@ -375,6 +409,8 @@ final class CmuxWebView: WKWebView {
     /// Called when "Open Link in New Tab" context menu is selected.
     /// Bypasses createWebViewWith so the link opens as a tab, not a popup.
     var onContextMenuOpenLinkInNewTab: ((URL) -> Void)?
+    var onMouseBackButton: (() -> Void)?
+    var onMouseForwardButton: (() -> Void)?
     var contextMenuLinkURLProvider: ((CmuxWebView, NSPoint, @escaping (URL?) -> Void) -> Void)?
     var contextMenuDefaultBrowserOpener: ((URL) -> Bool)?
     var contextMenuCanMoveTabToNewWorkspace: (() -> Bool)?; var contextMenuMoveTabToNewWorkspace: (() -> Bool)?
@@ -777,21 +813,33 @@ final class CmuxWebView: WKWebView {
 #endif
         // Button 3 = back, button 4 = forward (multi-button mice like Logitech).
         // Consume the event so WebKit doesn't handle it.
-        switch event.buttonNumber {
-        case 3:
+        let handledNavigationButton = browserHandleMouseNavigationButton(
+            buttonNumber: event.buttonNumber,
+            goBack: { [weak self] in
+                guard let self else { return }
 #if DEBUG
-            cmuxDebugLog("browser.mouse.otherDown.action web=\(ObjectIdentifier(self)) kind=goBack canGoBack=\(canGoBack ? 1 : 0)")
+                cmuxDebugLog("browser.mouse.otherDown.action web=\(ObjectIdentifier(self)) kind=goBack canGoBack=\(canGoBack ? 1 : 0)")
 #endif
-            goBack()
-            return
-        case 4:
+                if let onMouseBackButton = self.onMouseBackButton {
+                    onMouseBackButton()
+                } else {
+                    _ = self.goBack()
+                }
+            },
+            goForward: { [weak self] in
+                guard let self else { return }
 #if DEBUG
-            cmuxDebugLog("browser.mouse.otherDown.action web=\(ObjectIdentifier(self)) kind=goForward canGoForward=\(canGoForward ? 1 : 0)")
+                cmuxDebugLog("browser.mouse.otherDown.action web=\(ObjectIdentifier(self)) kind=goForward canGoForward=\(canGoForward ? 1 : 0)")
 #endif
-            goForward()
+                if let onMouseForwardButton = self.onMouseForwardButton {
+                    onMouseForwardButton()
+                } else {
+                    _ = self.goForward()
+                }
+            }
+        )
+        if handledNavigationButton {
             return
-        default:
-            break
         }
         super.otherMouseDown(with: event)
     }
@@ -808,6 +856,9 @@ final class CmuxWebView: WKWebView {
             "clicks=\(event.clickCount) mods=\(mods) point=(\(Int(point.x)),\(Int(point.y)))"
         )
 #endif
+        if browserMouseNavigationAction(buttonNumber: event.buttonNumber) != nil {
+            return
+        }
         super.otherMouseUp(with: event)
     }
 

--- a/cmuxTests/BrowserConfigTests.swift
+++ b/cmuxTests/BrowserConfigTests.swift
@@ -2129,6 +2129,66 @@ final class BrowserNavigationNewTabDecisionTests: XCTestCase {
 }
 
 
+final class BrowserMouseNavigationButtonTests: XCTestCase {
+    func testButtonThreeMapsToBackNavigation() {
+        XCTAssertEqual(browserMouseNavigationAction(buttonNumber: 3), .back)
+    }
+
+    func testButtonFourMapsToForwardNavigation() {
+        XCTAssertEqual(browserMouseNavigationAction(buttonNumber: 4), .forward)
+    }
+
+    func testMiddleButtonDoesNotMapToHistoryNavigation() {
+        XCTAssertNil(browserMouseNavigationAction(buttonNumber: 2))
+    }
+
+    func testMouseNavigationDispatchesBackCallback() {
+        var backCallCount = 0
+        var forwardCallCount = 0
+
+        let handled = browserHandleMouseNavigationButton(
+            buttonNumber: 3,
+            goBack: { backCallCount += 1 },
+            goForward: { forwardCallCount += 1 }
+        )
+
+        XCTAssertTrue(handled)
+        XCTAssertEqual(backCallCount, 1)
+        XCTAssertEqual(forwardCallCount, 0)
+    }
+
+    func testMouseNavigationDispatchesForwardCallback() {
+        var backCallCount = 0
+        var forwardCallCount = 0
+
+        let handled = browserHandleMouseNavigationButton(
+            buttonNumber: 4,
+            goBack: { backCallCount += 1 },
+            goForward: { forwardCallCount += 1 }
+        )
+
+        XCTAssertTrue(handled)
+        XCTAssertEqual(backCallCount, 0)
+        XCTAssertEqual(forwardCallCount, 1)
+    }
+
+    func testMouseNavigationIgnoresNonHistoryButton() {
+        var backCallCount = 0
+        var forwardCallCount = 0
+
+        let handled = browserHandleMouseNavigationButton(
+            buttonNumber: 2,
+            goBack: { backCallCount += 1 },
+            goForward: { forwardCallCount += 1 }
+        )
+
+        XCTAssertFalse(handled)
+        XCTAssertEqual(backCallCount, 0)
+        XCTAssertEqual(forwardCallCount, 0)
+    }
+}
+
+
 final class BrowserNilTargetFallbackDecisionTests: XCTestCase {
     func testOtherNavigationDoesNotFallbackToNewTab() {
         XCTAssertFalse(


### PR DESCRIPTION
Summary
- Routes browser mouse back/forward buttons through BrowserPanel history actions.
- Consumes side-button mouse-up events so WebKit does not receive stray history-button events.
- Adds unit coverage for side-button mapping and callback dispatch.

Verification
- ./scripts/reload.sh --tag mousefb passed.
- git diff --check passed.
- Did not run local xcodebuild tests because cmux tests must not run on the user local Mac.

Dogfood
- Open [mousefb](http://127.0.0.1:17320/mousefb).
- In a browser pane, navigate to two or more pages, click the mouse back side button, and confirm it moves to the previous page.
- Then click the mouse forward side button and confirm it returns to the next page.
- Also confirm middle-click still opens links in a new browser tab.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5191"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782989378&installation_id=133855650&pr_number=5191&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5191&signature=5e8725d4fe4c45e7112c1fd804689c423e7c1eb65304dae6f6c181abf5efb2c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized input routing and callback lifecycle cleanup in browser panels; no auth, security, or data-model changes.
> 
> **Overview**
> Adds **mouse side-button history navigation** (buttons 3/4) in browser panes by centralizing button mapping in `CmuxWebView` and routing back/forward through **`BrowserPanel`** `goBack()` / `goForward()` when the web view is bound.
> 
> **`CmuxWebView`** now uses shared helpers for back/forward clicks, prefers optional `onMouseBackButton` / `onMouseForwardButton` callbacks, and **swallows** matching `otherMouseUp` events so WebKit does not handle stray history-button input. **`BrowserPanel`** wires those callbacks on bind and introduces **`unbindWebView`** to clear all `CmuxWebView` hooks (including context-menu handlers) whenever the web view is torn down—replacing ad hoc download-callback cleanup at several reset sites.
> 
> Unit tests cover button mapping and callback dispatch for back, forward, and non-history buttons.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db6c2857345519a2057dabcb12d901dd2d6106d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add support for mouse back/forward side buttons in browser panes by routing them through BrowserPanel history actions. Side-button events are consumed to prevent duplicate WebKit navigation.

- **New Features**
  - Map mouse side buttons: 3 → back, 4 → forward; others (e.g., middle-click) are unchanged.
  - Consume side-button down/up events to avoid duplicate WebKit handling.
  - Added hooks (`onMouseBackButton`, `onMouseForwardButton`) with fallback to `goBack`/`goForward`, plus unit tests for mapping and dispatch.

- **Refactors**
  - Introduced `unbindWebView(_:)` to clear `CmuxWebView` callbacks when swapping `WKWebView` instances.

<sup>Written for commit db6c2857345519a2057dabcb12d901dd2d6106d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented mouse back and forward button navigation support, enabling users to navigate browser history using dedicated mouse buttons

* **Refactor**
  * Centralized WebView callback management for improved code maintainability and consistency

* **Tests**
  * Added test coverage for mouse navigation button handling and event dispatch behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->