### PR TITLE
Respect Ghostty transparency in browser chrome

### DIFF
--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -45,10 +45,7 @@ enum GhosttyBackgroundTheme {
     }
 
     static func color(backgroundColor: NSColor, opacity: Double) -> NSColor {
-        WindowAppearanceSnapshot.compositedTerminalColor(
-            backgroundColor: backgroundColor,
-            opacity: opacity
-        )
+        backgroundColor.withAlphaComponent(clampedOpacity(opacity))
     }
 
     static func color(

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -353,7 +353,10 @@ func resolvedBrowserChromeColorScheme(
         for: colorScheme,
         themeBackgroundColor: themeBackgroundColor
     )
-    return backgroundColor.isLightColor ? .light : .dark
+    let readableBackgroundColor = backgroundColor.alphaComponent < 0.999
+        ? cmuxCompositedNSColor(backgroundColor, over: .windowBackgroundColor)
+        : backgroundColor
+    return readableBackgroundColor.isLightColor ? .light : .dark
 }
 
 func resolvedBrowserOmnibarPillBackgroundColor(
@@ -370,7 +373,10 @@ func resolvedBrowserOmnibarPillBackgroundColor(
         darkenMix = 0.04
     }
 
-    return themeBackgroundColor.blended(withFraction: darkenMix, of: .black) ?? themeBackgroundColor
+    let opacity = themeBackgroundColor.alphaComponent
+    let opaqueBackgroundColor = themeBackgroundColor.withAlphaComponent(1)
+    return (opaqueBackgroundColor.blended(withFraction: darkenMix, of: .black) ?? opaqueBackgroundColor)
+        .withAlphaComponent(opacity)
 }
 
 private struct BrowserChromeStyle {

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -158,6 +158,46 @@ final class BrowserPanelChromeBackgroundColorTests: XCTestCase {
         assertResolvedColorMatchesTheme(for: .dark)
     }
 
+    func testChromeBackgroundPreservesGhosttyOpacity() {
+        let themeBackground = NSColor(srgbRed: 0.13, green: 0.29, blue: 0.47, alpha: 0.42)
+
+        guard
+            let actual = resolvedBrowserChromeBackgroundColor(
+                for: .dark,
+                themeBackgroundColor: themeBackground
+            ).usingColorSpace(.sRGB),
+            let expected = themeBackground.usingColorSpace(.sRGB)
+        else {
+            XCTFail("Expected sRGB-convertible colors")
+            return
+        }
+
+        XCTAssertEqual(actual.redComponent, expected.redComponent, accuracy: 0.001)
+        XCTAssertEqual(actual.greenComponent, expected.greenComponent, accuracy: 0.001)
+        XCTAssertEqual(actual.blueComponent, expected.blueComponent, accuracy: 0.001)
+        XCTAssertEqual(actual.alphaComponent, expected.alphaComponent, accuracy: 0.001)
+    }
+
+    func testChromeColorSchemeUsesCompositedTransparentBackground() {
+        let transparentBlack = NSColor(srgbRed: 0.0, green: 0.0, blue: 0.0, alpha: 0.05)
+
+        XCTAssertEqual(
+            resolvedBrowserChromeColorScheme(for: .dark, themeBackgroundColor: transparentBlack),
+            .light
+        )
+    }
+
+    func testOmnibarPillBackgroundPreservesGhosttyOpacity() {
+        let themeBackground = NSColor(srgbRed: 0.13, green: 0.29, blue: 0.47, alpha: 0.42)
+
+        let actual = resolvedBrowserOmnibarPillBackgroundColor(
+            for: .dark,
+            themeBackgroundColor: themeBackground
+        )
+
+        XCTAssertEqual(actual.alphaComponent, 0.42, accuracy: 0.001)
+    }
+
     private func assertResolvedColorMatchesTheme(
         for colorScheme: ColorScheme,
         file: StaticString = #filePath,


### PR DESCRIPTION
## Summary
- Preserve Ghostty `background-opacity` when setting browser under-page and blank-tab backgrounds.
- Keep browser omnibar chrome transparent while computing icon/text color from the composited background.
- Add regression coverage for transparent browser chrome and omnibar pill colors.

## Testing
- `./scripts/reload.sh --tag browser-bg` passed.

## Issues
- Task: browser blank page and omnibar should respect transparent Ghostty background config.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5192"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782989517&installation_id=133855650&pr_number=5192&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5192&signature=1b8466c33edcab442cdf521e1bb5643d442f7f8bb31795490277f1f004c15b38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only color/opacity handling for browser chrome and Ghostty backgrounds; no auth, data, or API changes.
> 
> **Overview**
> Browser and Ghostty-themed surfaces now keep **Ghostty `background-opacity`** on the actual draw colors instead of baking transparency into a pre-composited terminal color.
> 
> `GhosttyBackgroundTheme.color` applies opacity via `withAlphaComponent` only, dropping `WindowAppearanceSnapshot.compositedTerminalColor`. Chrome still uses the semi-transparent theme for backgrounds; **light/dark chrome** is chosen from the color composited over the window when alpha is low, and the **omnibar pill** darkens an opaque copy of the theme then restores the original alpha so the bar stays see-through.
> 
> Regression tests cover preserved alpha on chrome background and omnibar pill, and composited color-scheme behavior for nearly transparent backgrounds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b630967f5d1d09f1a7ff2d40a22888127e58f68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Respect Ghostty background opacity in browser chrome, blank pages, and the omnibar while keeping icons/text readable. Addresses the task to have the browser blank page and omnibar respect transparent Ghostty background config.

- **Bug Fixes**
  - Preserve theme alpha for under-page, blank-tab, and omnibar pill backgrounds.
  - Compute chrome color scheme by compositing transparent backgrounds over `.windowBackgroundColor` to maintain contrast with transparent chrome.
  - Add regression tests for chrome/omnibar transparency and color scheme.

<sup>Written for commit 4b630967f5d1d09f1a7ff2d40a22888127e58f68. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved browser panel background color rendering with enhanced opacity and transparency handling.
  * Enhanced color scheme detection for browser UI elements to properly handle semi-transparent backgrounds.

* **Tests**
  * Added test cases validating background color computations and opacity preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->