### PR TITLE
Fix main window not refitting after a display reconfiguration (Screen Sharing / resolution change)

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1255,6 +1255,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             name: .feedRequestSendText,
             object: nil
         )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleScreenParametersDidChange(_:)),
+            name: NSApplication.didChangeScreenParametersNotification,
+            object: nil
+        )
 
 #if DEBUG
         // UI tests run on a shared VM user profile, so persisted shortcuts can drift and make
@@ -3240,6 +3246,105 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             )
 #endif
         }
+    }
+
+    /// Coalescing token so the burst of `didChangeScreenParameters` notifications a
+    /// single display reconfiguration emits only triggers one reconcile pass.
+    private var screenParametersReconcileToken = 0
+
+    /// cmux main windows set `isMovable = false` (for the custom titlebar drag
+    /// handling in `WindowDragHandleView` / `configureCmuxMainWindowDragBehavior`),
+    /// which opts them out of AppKit's automatic on-screen constraining when the
+    /// display configuration changes. The system therefore leaves them where they
+    /// were after a resolution change, a display connect/disconnect, or a Screen
+    /// Sharing virtual display being resized, so a window sized for the previous
+    /// geometry overflows the new screen instead of re-fitting like ordinary
+    /// (movable) windows do. Reconcile the geometry ourselves.
+    @objc private func handleScreenParametersDidChange(_ notification: Notification) {
+        screenParametersReconcileToken &+= 1
+        let token = screenParametersReconcileToken
+        // Let AppKit settle the new `NSScreen` geometry before we read it back.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+            guard let self, self.screenParametersReconcileToken == token else { return }
+            self.reconcileMainWindowFramesAfterScreenChange()
+        }
+    }
+
+    private func reconcileMainWindowFramesAfterScreenChange() {
+        let displays = currentDisplayGeometries()
+        guard !displays.available.isEmpty else { return }
+
+        let minWidth = CGFloat(SessionPersistencePolicy.minimumWindowWidth)
+        let minHeight = CGFloat(SessionPersistencePolicy.minimumWindowHeight)
+
+        for context in mainWindowContexts.values {
+            guard let window = resolvedWindow(for: context) else { continue }
+            let currentFrame = window.frame
+
+            // Fit the window inside the (possibly smaller) visible frame of the
+            // display it now belongs to. The decision is a no-op when the window
+            // already fits, so windows on displays the reconfiguration did not affect
+            // are left untouched.
+            guard let reconciledFrame = Self.reconciledFrameAfterScreenChange(
+                currentFrame: currentFrame,
+                windowDisplayID: window.screen?.cmuxDisplayID,
+                availableDisplays: displays.available,
+                fallbackDisplay: displays.fallback,
+                minWidth: minWidth,
+                minHeight: minHeight
+            ), !Self.framesAreApproximatelyEqual(reconciledFrame, currentFrame) else { continue }
+
+            window.setFrame(reconciledFrame, display: true)
+#if DEBUG
+            cmuxDebugLog(
+                "window.reconcileForScreenChange window=\(context.windowId.uuidString.prefix(8)) " +
+                    "from={\(debugNSRectDescription(currentFrame))} " +
+                    "to={\(debugNSRectDescription(reconciledFrame))}"
+            )
+#endif
+        }
+    }
+
+    /// Pure geometry decision used by `reconcileMainWindowFramesAfterScreenChange`:
+    /// fit `currentFrame` inside the visible frame of the display the window belongs
+    /// to after a reconfiguration, picking that display by ID (then by overlap /
+    /// proximity, then the fallback). Returns `nil` when there are no displays to
+    /// reconcile against. Left non-private and factored out so it can be unit tested
+    /// without a live window or screen.
+    nonisolated static func reconciledFrameAfterScreenChange(
+        currentFrame: CGRect,
+        windowDisplayID: UInt32?,
+        availableDisplays: [SessionDisplayGeometry],
+        fallbackDisplay: SessionDisplayGeometry?,
+        minWidth: CGFloat,
+        minHeight: CGFloat
+    ) -> CGRect? {
+        guard !availableDisplays.isEmpty else { return nil }
+        let reference = SessionDisplaySnapshot(
+            displayID: windowDisplayID,
+            frame: SessionRectSnapshot(currentFrame),
+            visibleFrame: nil
+        )
+        guard let target = display(for: reference, in: availableDisplays) ?? fallbackDisplay else {
+            return nil
+        }
+        return clampFrame(
+            currentFrame,
+            within: target.visibleFrame,
+            minWidth: minWidth,
+            minHeight: minHeight
+        )
+    }
+
+    private nonisolated static func framesAreApproximatelyEqual(
+        _ lhs: CGRect,
+        _ rhs: CGRect,
+        tolerance: CGFloat = 0.5
+    ) -> Bool {
+        abs(lhs.origin.x - rhs.origin.x) <= tolerance
+            && abs(lhs.origin.y - rhs.origin.y) <= tolerance
+            && abs(lhs.size.width - rhs.size.width) <= tolerance
+            && abs(lhs.size.height - rhs.size.height) <= tolerance
     }
 
     private func resolvedWindowFrame(from snapshot: SessionWindowSnapshot?) -> NSRect? {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -3263,13 +3263,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     @objc private func handleScreenParametersDidChange(_ notification: Notification) {
         screenParametersReconcileToken &+= 1
         let token = screenParametersReconcileToken
-        // Let AppKit settle the new `NSScreen` geometry before we read it back.
+        // Coalesce the burst of notifications a single reconfiguration emits: only the
+        // latest token survives, so we reconcile once. The short delay is a debounce,
+        // not a correctness dependency. The notification is posted after `NSScreen` is
+        // updated, the reconcile re-runs on every notification, and it is idempotent,
+        // so windows end up correct regardless of the exact delay or burst size.
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
             guard let self, self.screenParametersReconcileToken == token else { return }
             self.reconcileMainWindowFramesAfterScreenChange()
         }
     }
 
+    /// Refits every tracked main window onto the display it now belongs to after a
+    /// display reconfiguration, leaving windows that already fit untouched.
     private func reconcileMainWindowFramesAfterScreenChange() {
         let displays = currentDisplayGeometries()
         guard !displays.available.isEmpty else { return }
@@ -3277,7 +3283,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let minWidth = CGFloat(SessionPersistencePolicy.minimumWindowWidth)
         let minHeight = CGFloat(SessionPersistencePolicy.minimumWindowHeight)
 
-        for context in mainWindowContexts.values {
+        // Snapshot the contexts before iterating: `resolvedWindow(for:)` can reindex
+        // `mainWindowContexts`, and mutating the dictionary mid-enumeration crashes.
+        for context in Array(mainWindowContexts.values) {
             guard let window = resolvedWindow(for: context) else { continue }
             let currentFrame = window.frame
 
@@ -3336,6 +3344,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         )
     }
 
+    /// Whether two frames match within `tolerance` points on every component, used to
+    /// skip a redundant `setFrame` when reconciliation produces an unchanged frame.
     private nonisolated static func framesAreApproximatelyEqual(
         _ lhs: CGRect,
         _ rhs: CGRect,

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -1,4 +1,5 @@
 import Darwin
+import Testing
 import XCTest
 
 #if canImport(cmux_DEV)
@@ -5796,5 +5797,97 @@ extension SessionPersistenceTests {
         XCTAssertNil(MarkdownPanelFileLinkResolver.resolve(rawPath: "missing.md", relativeToMarkdownFile: openedFile.path))
         XCTAssertNil(MarkdownPanelFileLinkResolver.resolve(rawPath: "notes.txt", relativeToMarkdownFile: openedFile.path))
         XCTAssertNil(MarkdownPanelFileLinkResolver.resolve(rawPath: "https://example.com/notes.md", relativeToMarkdownFile: openedFile.path))
+    }
+}
+
+@Suite("Window reconciliation on display reconfiguration")
+struct ScreenParameterReconciliationTests {
+    private static let minWidth = CGFloat(SessionPersistencePolicy.minimumWindowWidth)
+    private static let minHeight = CGFloat(SessionPersistencePolicy.minimumWindowHeight)
+
+    // Regression for the screen-sharing / virtual-display resize bug: a main window
+    // sized for the previous (larger) display geometry must be refit inside the new
+    // (smaller) visible frame when the display is reconfigured, the way macOS does
+    // automatically for ordinary movable windows.
+    @Test func fitsOversizedWindowToShrunkDisplay() throws {
+        // The window was valid on a larger display; the display is now 1280x800
+        // (same display ID, e.g. a Screen Sharing window that got smaller).
+        let shrunkDisplay = AppDelegate.SessionDisplayGeometry(
+            displayID: 1,
+            frame: CGRect(x: 0, y: 0, width: 1_280, height: 800),
+            visibleFrame: CGRect(x: 0, y: 0, width: 1_280, height: 800)
+        )
+
+        let reconciled = try #require(AppDelegate.reconciledFrameAfterScreenChange(
+            currentFrame: CGRect(x: 100, y: 100, width: 1_600, height: 900),
+            windowDisplayID: 1,
+            availableDisplays: [shrunkDisplay],
+            fallbackDisplay: shrunkDisplay,
+            minWidth: Self.minWidth,
+            minHeight: Self.minHeight
+        ))
+
+        // Window is capped to the new visible frame and pulled fully on-screen.
+        #expect(reconciled.width == 1_280)
+        #expect(reconciled.height == 800)
+        #expect(reconciled.minX == 0)
+        #expect(reconciled.minY == 0)
+        #expect(shrunkDisplay.visibleFrame.contains(reconciled))
+    }
+
+    @Test func leavesFittingWindowUntouched() {
+        let display = AppDelegate.SessionDisplayGeometry(
+            displayID: 1,
+            frame: CGRect(x: 0, y: 0, width: 1_280, height: 800),
+            visibleFrame: CGRect(x: 0, y: 0, width: 1_280, height: 800)
+        )
+        let currentFrame = CGRect(x: 100, y: 50, width: 800, height: 600)
+
+        let reconciled = AppDelegate.reconciledFrameAfterScreenChange(
+            currentFrame: currentFrame,
+            windowDisplayID: 1,
+            availableDisplays: [display],
+            fallbackDisplay: display,
+            minWidth: Self.minWidth,
+            minHeight: Self.minHeight
+        )
+
+        #expect(reconciled == currentFrame)
+    }
+
+    @Test func pullsOffscreenWindowBackOnDisplay() throws {
+        let display = AppDelegate.SessionDisplayGeometry(
+            displayID: 1,
+            frame: CGRect(x: 0, y: 0, width: 1_280, height: 800),
+            visibleFrame: CGRect(x: 0, y: 0, width: 1_280, height: 800)
+        )
+
+        // Window left entirely off every screen (its display disappeared), so it no
+        // longer reports a screen of its own.
+        let reconciled = try #require(AppDelegate.reconciledFrameAfterScreenChange(
+            currentFrame: CGRect(x: 3_000, y: 3_000, width: 800, height: 600),
+            windowDisplayID: nil,
+            availableDisplays: [display],
+            fallbackDisplay: display,
+            minWidth: Self.minWidth,
+            minHeight: Self.minHeight
+        ))
+
+        #expect(display.visibleFrame.contains(reconciled))
+        #expect(reconciled.width == 800)
+        #expect(reconciled.height == 600)
+    }
+
+    @Test func returnsNilWithoutDisplays() {
+        let reconciled = AppDelegate.reconciledFrameAfterScreenChange(
+            currentFrame: CGRect(x: 0, y: 0, width: 800, height: 600),
+            windowDisplayID: 1,
+            availableDisplays: [],
+            fallbackDisplay: nil,
+            minWidth: Self.minWidth,
+            minHeight: Self.minHeight
+        )
+
+        #expect(reconciled == nil)
     }
 }


### PR DESCRIPTION
## Problem

On a Mac accessed via macOS Screen Sharing (for example a headless Mac mini reached from a laptop), connecting or resizing the viewer resizes the host's virtual display. macOS refits ordinary windows to the new geometry, but the cmux window stays where it was and ends up pinned against a screen edge or overflowing the display. The same happens on a plain resolution change or when an external display is connected or disconnected.

## Root cause

cmux main windows set `isMovable = false` for the custom titlebar drag handling (`WindowDragHandleView`, `configureCmuxMainWindowDragBehavior`). A non-movable `NSWindow` is excluded from AppKit's automatic on-screen constraining on display reconfiguration, so nothing repositions or resizes the window when `NSApplication.didChangeScreenParametersNotification` fires. The geometry-resolution helpers already exist (`resolvedWindowFrame`, `clampFrame`, `display(for:in:)`) but only run at launch and session restore, never reactively while the app is open.

## Fix

- Observe `NSApplication.didChangeScreenParametersNotification` in `AppDelegate`.
- For each registered main window, refit it onto the visible frame of the display it now belongs to (matched by display ID, then overlap or proximity, then the fallback display), reusing the existing helpers (`currentDisplayGeometries`, `display(for:in:)`, `clampFrame`).
- The pass is a no-op when a window already fits, so windows on displays the reconfiguration did not affect are left untouched.
- Notifications are coalesced (one reconcile pass per reconfiguration) with a short settle delay so the `NSScreen` geometry is current when read back.

This is intentionally scoped to the missing reactive refit: it clamps the window to fit, it does not restore previously saved per-display geometry (that broader behavior is what #2667 is working toward).

## Tests

Adds a Swift Testing suite for the pure decision (`AppDelegate.reconciledFrameAfterScreenChange`): an oversized window on a shrunk display is refit, an already-fitting window is untouched, an off-screen window is pulled back on-screen, and an empty display list returns nil.

## Verification

- New unit tests pass; the existing window-geometry tests still pass.
- Verified end to end on a Mac mini reached from a MacBook via macOS Screen Sharing: as the viewer (virtual display) resized between 3440x1440, 1920x1080 and 1512x883, the window refit to stay fully on-screen each time instead of staying pinned to an edge.

Related: #2666, #2824, #2667 (same area: window geometry on display configuration change).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5193"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782989728&installation_id=133855650&pr_number=5193&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5193&signature=3663ee7f7286c539160eb0349dbb8a4cf88ffb40bae0e34eb845aaa6f0cd0a39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes main window not refitting after display changes (Screen Sharing, resolution changes, display connect/disconnect). Windows now clamp to the visible screen so they stay fully on-screen.

- **Bug Fixes**
  - Observe `NSApplication.didChangeScreenParametersNotification` and run one coalesced reconcile pass after changes.
  - Refit each main window to its display’s visible frame using `currentDisplayGeometries`, `display(for:in:)`, and `clampFrame` (no-op if it already fits).
  - Handle off-screen and disappeared-display cases; enforce minimum window size. Added `AppDelegate.reconciledFrameAfterScreenChange` with unit tests for oversized, already-fitting, off-screen, and no-display scenarios.
  - Snapshot `mainWindowContexts` before iterating to avoid mutate-during-enumeration crashes, and skip redundant `setFrame` calls when the frame is unchanged.

<sup>Written for commit e7a8920e709a1a74d257eadb3dc43d3a7025c3df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved window handling when display geometry changes: windows are automatically repositioned and resized into visible areas after monitor connects, disconnects, or resolution changes.

* **Tests**
  * Added tests covering window frame reconciliation across display changes to ensure stable, idempotent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->