### PR TITLE
Add Jupyter inline web mode

### DIFF
--- a/Sources/App/TerminalDirectoryOpenSupport.swift
+++ b/Sources/App/TerminalDirectoryOpenSupport.swift
@@ -80,12 +80,14 @@ enum TerminalDirectoryOpenTarget: String, CaseIterable {
 
     struct DetectionEnvironment {
         let homeDirectoryPath: String
+        let environmentVariables: [String: String]
         let fileExistsAtPath: (String) -> Bool
         let isExecutableFileAtPath: (String) -> Bool
         let applicationPathForName: (String) -> String?
 
         static let live = DetectionEnvironment(
             homeDirectoryPath: FileManager.default.homeDirectoryForCurrentUser.path,
+            environmentVariables: ProcessInfo.processInfo.environment,
             fileExistsAtPath: { FileManager.default.fileExists(atPath: $0) },
             isExecutableFileAtPath: { FileManager.default.isExecutableFile(atPath: $0) },
             applicationPathForName: { NSWorkspace.shared.fullPath(forApplication: $0) }
@@ -93,7 +95,7 @@ enum TerminalDirectoryOpenTarget: String, CaseIterable {
     }
 
     static var commandPaletteShortcutTargets: [Self] {
-        Array(allCases)
+        allCases.filter { $0 != .vscodeInline }
     }
 
     static func availableTargets(in environment: DetectionEnvironment = .live) -> Set<Self> {
@@ -348,6 +350,100 @@ enum VSCodeCLILaunchConfigurationBuilder {
             executableURL: codeTunnelURL,
             argumentsPrefix: [],
             environment: environment
+        )
+    }
+}
+
+enum InlineWebServerURLBuilder {
+    static func extractLocalHTTPURL(from output: String) -> URL? {
+        let allowedHosts: Set<String> = ["127.0.0.1", "localhost"]
+        for token in output.split(whereSeparator: { $0.isWhitespace || $0 == "[" || $0 == "]" }) {
+            let candidate = token.trimmingCharacters(in: CharacterSet(charactersIn: "\"'(),"))
+            guard candidate.hasPrefix("http://") || candidate.hasPrefix("https://"),
+                  let url = URL(string: candidate),
+                  let host = url.host,
+                  allowedHosts.contains(host) else {
+                continue
+            }
+            return url
+        }
+        return nil
+    }
+}
+
+enum CommandLineExecutableResolver {
+    static func executableURL(
+        named executableName: String,
+        environment: [String: String],
+        homeDirectoryPath: String,
+        isExecutableAtPath: (String) -> Bool
+    ) -> URL? {
+        let pathDirectories = (environment["PATH"] ?? "")
+            .split(separator: ":")
+            .map(String.init)
+        let fallbackDirectories = [
+            "/opt/homebrew/bin",
+            "/usr/local/bin",
+            "/usr/bin",
+            "\(homeDirectoryPath)/.local/bin",
+            "\(homeDirectoryPath)/miniconda3/bin",
+            "\(homeDirectoryPath)/anaconda3/bin",
+        ]
+
+        var seen: Set<String> = []
+        for directory in pathDirectories + fallbackDirectories {
+            let expandedDirectory = directory.replacingOccurrences(of: "~", with: homeDirectoryPath)
+            let candidate = (expandedDirectory as NSString).appendingPathComponent(executableName)
+            guard seen.insert(candidate).inserted, isExecutableAtPath(candidate) else { continue }
+            return URL(fileURLWithPath: candidate, isDirectory: false)
+        }
+        return nil
+    }
+}
+
+struct InlineCommandWebServerLaunchConfiguration {
+    let executableURL: URL
+    let arguments: [String]
+    let environment: [String: String]
+}
+
+enum JupyterInlineLaunchConfigurationBuilder {
+    static func executableURL(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        homeDirectoryPath: String = FileManager.default.homeDirectoryForCurrentUser.path,
+        isExecutableAtPath: (String) -> Bool = { FileManager.default.isExecutableFile(atPath: $0) }
+    ) -> URL? {
+        CommandLineExecutableResolver.executableURL(
+            named: "jupyter",
+            environment: environment,
+            homeDirectoryPath: homeDirectoryPath,
+            isExecutableAtPath: isExecutableAtPath
+        )
+    }
+
+    static func launchConfiguration(
+        directoryURL: URL,
+        baseEnvironment: [String: String] = ProcessInfo.processInfo.environment,
+        homeDirectoryPath: String = FileManager.default.homeDirectoryForCurrentUser.path,
+        isExecutableAtPath: (String) -> Bool = { FileManager.default.isExecutableFile(atPath: $0) }
+    ) -> InlineCommandWebServerLaunchConfiguration? {
+        guard let executableURL = executableURL(
+            environment: baseEnvironment,
+            homeDirectoryPath: homeDirectoryPath,
+            isExecutableAtPath: isExecutableAtPath
+        ) else { return nil }
+
+        return InlineCommandWebServerLaunchConfiguration(
+            executableURL: executableURL,
+            arguments: [
+                "lab",
+                "--no-browser",
+                "--ServerApp.ip=127.0.0.1",
+                "--ServerApp.port=0",
+                "--ServerApp.open_browser=False",
+                "--ServerApp.root_dir=\(directoryURL.standardizedFileURL.path)",
+            ],
+            environment: baseEnvironment
         )
     }
 }
@@ -706,12 +802,494 @@ final class VSCodeServeWebController {
     }
 }
 
+final class InlineCommandWebServerController {
+    private let startupTimeoutSeconds: TimeInterval
+    private let launchConfiguration: (URL) -> InlineCommandWebServerLaunchConfiguration?
+    private let extractServerURL: (String) -> URL?
+    private let queue: DispatchQueue
+    private let launchQueue: DispatchQueue
+    private var serverProcess: Process?
+    private var launchingProcess: Process?
+    private var serverURL: URL?
+    private var serverDirectoryPath: String?
+    private var launchingDirectoryPath: String?
+    private var pendingCompletions: [(generation: UInt64, completion: (URL?) -> Void)] = []
+    private var isLaunching = false
+    private var activeLaunchGeneration: UInt64?
+    private var lifecycleGeneration: UInt64 = 0
+
+    init(
+        id: String,
+        startupTimeoutSeconds: TimeInterval,
+        launchConfiguration: @escaping (URL) -> InlineCommandWebServerLaunchConfiguration?,
+        extractServerURL: @escaping (String) -> URL?
+    ) {
+        self.startupTimeoutSeconds = startupTimeoutSeconds
+        self.launchConfiguration = launchConfiguration
+        self.extractServerURL = extractServerURL
+        self.queue = DispatchQueue(label: "cmux.inlineWeb.\(id)")
+        self.launchQueue = DispatchQueue(label: "cmux.inlineWeb.\(id).launch")
+    }
+
+    func ensureServerURL(directoryURL: URL, completion: @escaping (URL?) -> Void) {
+        let normalizedDirectoryURL = directoryURL.standardizedFileURL
+        let requestedDirectoryPath = normalizedDirectoryURL.path
+        queue.async {
+            if let process = self.serverProcess,
+               process.isRunning,
+               self.serverDirectoryPath == requestedDirectoryPath,
+               let url = self.serverURL {
+                DispatchQueue.main.async {
+                    completion(url)
+                }
+                return
+            }
+
+            if let process = self.serverProcess, process.isRunning {
+                process.terminate()
+            }
+            self.serverProcess = nil
+            self.serverURL = nil
+            self.serverDirectoryPath = nil
+
+            if self.isLaunching {
+                if self.launchingDirectoryPath == requestedDirectoryPath {
+                    let completionGeneration = self.lifecycleGeneration
+                    self.pendingCompletions.append((generation: completionGeneration, completion: completion))
+                    return
+                }
+
+                self.lifecycleGeneration &+= 1
+                self.isLaunching = false
+                self.activeLaunchGeneration = nil
+                self.launchingDirectoryPath = nil
+                if let process = self.launchingProcess, process.isRunning {
+                    process.terminate()
+                }
+                self.launchingProcess = nil
+                let staleCompletions = self.pendingCompletions.map(\.completion)
+                self.pendingCompletions.removeAll()
+                if !staleCompletions.isEmpty {
+                    DispatchQueue.main.async {
+                        staleCompletions.forEach { $0(nil) }
+                    }
+                }
+            }
+
+            let completionGeneration = self.lifecycleGeneration
+            self.pendingCompletions.append((generation: completionGeneration, completion: completion))
+            guard !self.isLaunching else { return }
+
+            self.isLaunching = true
+            let launchGeneration = completionGeneration
+            self.activeLaunchGeneration = launchGeneration
+            self.launchingDirectoryPath = requestedDirectoryPath
+
+            self.launchQueue.async {
+                let shouldLaunch = self.queue.sync {
+                    self.lifecycleGeneration == launchGeneration
+                }
+                guard shouldLaunch else {
+                    self.queue.async {
+                        guard self.activeLaunchGeneration == launchGeneration else { return }
+                        self.isLaunching = false
+                        self.activeLaunchGeneration = nil
+                        self.launchingDirectoryPath = nil
+                    }
+                    return
+                }
+
+                let launchResult = self.launchServerProcess(
+                    directoryURL: normalizedDirectoryURL,
+                    expectedGeneration: launchGeneration
+                )
+                self.queue.async {
+                    guard self.activeLaunchGeneration == launchGeneration else {
+                        if let process = launchResult?.process, process.isRunning {
+                            process.terminate()
+                        }
+                        return
+                    }
+                    self.isLaunching = false
+                    self.activeLaunchGeneration = nil
+                    self.launchingDirectoryPath = nil
+
+                    guard self.lifecycleGeneration == launchGeneration else {
+                        if let launchedProcess = launchResult?.process,
+                           self.launchingProcess === launchedProcess {
+                            self.launchingProcess = nil
+                        }
+                        if let process = launchResult?.process, process.isRunning {
+                            process.terminate()
+                        }
+                        return
+                    }
+
+                    if let launchResult {
+                        self.launchingProcess = nil
+                        self.serverProcess = launchResult.process
+                        self.serverURL = launchResult.url
+                        self.serverDirectoryPath = requestedDirectoryPath
+                    } else {
+                        self.launchingProcess = nil
+                        self.serverProcess = nil
+                        self.serverURL = nil
+                        self.serverDirectoryPath = nil
+                    }
+
+                    var completions: [(URL?) -> Void] = []
+                    var remaining: [(generation: UInt64, completion: (URL?) -> Void)] = []
+                    for pending in self.pendingCompletions {
+                        if pending.generation == launchGeneration {
+                            completions.append(pending.completion)
+                        } else {
+                            remaining.append(pending)
+                        }
+                    }
+                    self.pendingCompletions = remaining
+                    let resolvedURL = self.serverURL
+                    DispatchQueue.main.async {
+                        completions.forEach { $0(resolvedURL) }
+                    }
+                }
+            }
+        }
+    }
+
+    func stop() {
+        let (processes, completions): ([Process], [(URL?) -> Void]) = queue.sync {
+            self.lifecycleGeneration &+= 1
+            self.isLaunching = false
+            self.activeLaunchGeneration = nil
+            self.launchingDirectoryPath = nil
+            var processes: [Process] = []
+            if let process = self.serverProcess {
+                processes.append(process)
+            }
+            if let process = self.launchingProcess,
+               !processes.contains(where: { $0 === process }) {
+                processes.append(process)
+            }
+            self.serverProcess = nil
+            self.launchingProcess = nil
+            self.serverURL = nil
+            self.serverDirectoryPath = nil
+            self.launchingDirectoryPath = nil
+            let completions = self.pendingCompletions.map(\.completion)
+            self.pendingCompletions.removeAll()
+            return (processes, completions)
+        }
+
+        for process in processes where process.isRunning {
+            process.terminate()
+        }
+
+        if !completions.isEmpty {
+            DispatchQueue.main.async {
+                completions.forEach { $0(nil) }
+            }
+        }
+    }
+
+    func restart(directoryURL: URL, completion: @escaping (URL?) -> Void) {
+        stop()
+        ensureServerURL(directoryURL: directoryURL, completion: completion)
+    }
+
+    private func launchServerProcess(
+        directoryURL: URL,
+        expectedGeneration: UInt64
+    ) -> (process: Process, url: URL)? {
+        guard let launchConfiguration = launchConfiguration(directoryURL) else { return nil }
+
+        let process = Process()
+        process.executableURL = launchConfiguration.executableURL
+        process.arguments = launchConfiguration.arguments
+        process.environment = launchConfiguration.environment
+
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        let collector = ServeWebOutputCollector(extractURL: extractServerURL)
+        let outputReader: (FileHandle) -> Void = { fileHandle in
+            switch ProcessPipeReader.readAvailableDataOrEndOfFile(from: fileHandle) {
+            case .data(let data):
+                collector.append(data)
+            case .wouldBlock:
+                return
+            case .endOfFile:
+                fileHandle.readabilityHandler = nil
+            }
+        }
+        stdoutPipe.fileHandleForReading.readabilityHandler = outputReader
+        stderrPipe.fileHandleForReading.readabilityHandler = outputReader
+
+        process.terminationHandler = { [weak self] terminatedProcess in
+            stdoutPipe.fileHandleForReading.readabilityHandler = nil
+            stderrPipe.fileHandleForReading.readabilityHandler = nil
+            Self.drainAvailableOutput(from: stdoutPipe.fileHandleForReading, collector: collector)
+            Self.drainAvailableOutput(from: stderrPipe.fileHandleForReading, collector: collector)
+            collector.markProcessExited()
+            self?.queue.async {
+                guard let self else { return }
+                if self.launchingProcess === terminatedProcess {
+                    self.launchingProcess = nil
+                    self.launchingDirectoryPath = nil
+                }
+                if self.serverProcess === terminatedProcess {
+                    self.serverProcess = nil
+                    self.serverURL = nil
+                    self.serverDirectoryPath = nil
+                }
+            }
+        }
+
+        let didStart: Bool = queue.sync {
+            guard self.lifecycleGeneration == expectedGeneration,
+                  self.activeLaunchGeneration == expectedGeneration else {
+                return false
+            }
+            self.launchingProcess = process
+            do {
+                try process.run()
+                return true
+            } catch {
+                if self.launchingProcess === process {
+                    self.launchingProcess = nil
+                }
+                return false
+            }
+        }
+        guard didStart else {
+            stdoutPipe.fileHandleForReading.readabilityHandler = nil
+            stderrPipe.fileHandleForReading.readabilityHandler = nil
+            return nil
+        }
+
+        guard collector.waitForURL(timeoutSeconds: startupTimeoutSeconds),
+              let serverURL = collector.webUIURL else {
+            stdoutPipe.fileHandleForReading.readabilityHandler = nil
+            stderrPipe.fileHandleForReading.readabilityHandler = nil
+            if process.isRunning {
+                process.terminate()
+            } else {
+                queue.sync {
+                    if self.launchingProcess === process {
+                        self.launchingProcess = nil
+                    }
+                    if self.serverProcess === process {
+                        self.serverProcess = nil
+                        self.serverURL = nil
+                        self.serverDirectoryPath = nil
+                    }
+                }
+            }
+            return nil
+        }
+
+        return (process, serverURL)
+    }
+
+    private static func drainAvailableOutput(from fileHandle: FileHandle, collector: ServeWebOutputCollector) {
+        while true {
+            switch ProcessPipeReader.readAvailableDataOrEndOfFile(from: fileHandle) {
+            case .data(let data):
+                collector.append(data)
+            case .wouldBlock, .endOfFile:
+                return
+            }
+        }
+    }
+}
+
+struct TerminalDirectoryInlineWebMode: Identifiable {
+    let id: String
+    let openFolderCommandId: String
+    let terminalOpenCommandId: String
+    let stopCommandId: String
+    let restartCommandId: String
+    let menuTitle: () -> String
+    let openFolderTitle: () -> String
+    let openFolderSubtitle: () -> String
+    let panelTitle: () -> String
+    let panelPrompt: () -> String
+    let terminalOpenTitle: () -> String
+    let stopTitle: () -> String
+    let restartTitle: () -> String
+    let keywords: [String]
+    let serverKeywords: [String]
+    let isAvailable: (TerminalDirectoryOpenTarget.DetectionEnvironment) -> Bool
+    let ensureServerURL: (URL, @escaping (URL?) -> Void) -> Void
+    let stopServer: () -> Void
+    let restartServer: (URL, @escaping (URL?) -> Void) -> Void
+    let openFolderURL: (URL, URL) -> URL?
+
+    func isAvailable(in environment: TerminalDirectoryOpenTarget.DetectionEnvironment = .live) -> Bool {
+        isAvailable(environment)
+    }
+
+    func openURL(serverURL: URL, directoryURL: URL) -> URL? {
+        openFolderURL(serverURL, directoryURL.standardizedFileURL)
+    }
+}
+
+extension TerminalDirectoryInlineWebMode {
+    private static let jupyterController = InlineCommandWebServerController(
+        id: "jupyter",
+        startupTimeoutSeconds: 90,
+        launchConfiguration: { directoryURL in
+            JupyterInlineLaunchConfigurationBuilder.launchConfiguration(directoryURL: directoryURL)
+        },
+        extractServerURL: InlineWebServerURLBuilder.extractLocalHTTPURL(from:)
+    )
+
+    static let vscode = TerminalDirectoryInlineWebMode(
+        id: "vscode",
+        openFolderCommandId: "palette.openFolderInVSCodeInline",
+        terminalOpenCommandId: "palette.terminalOpenDirectory.vscodeInline",
+        stopCommandId: "palette.vscodeServeWebStop",
+        restartCommandId: "palette.vscodeServeWebRestart",
+        menuTitle: {
+            String(localized: "menu.file.openFolderInVSCodeInline", defaultValue: "Open Folder in VS Code (Inline)…")
+        },
+        openFolderTitle: {
+            String(localized: "command.openFolderInVSCodeInline.title", defaultValue: "Open Folder in VS Code (Inline)…")
+        },
+        openFolderSubtitle: {
+            String(localized: "command.openFolderInVSCodeInline.subtitle", defaultValue: "VS Code Inline")
+        },
+        panelTitle: {
+            String(localized: "menu.file.openFolderInVSCodeInline.panelTitle", defaultValue: "Open Folder in VS Code (Inline)")
+        },
+        panelPrompt: {
+            String(localized: "menu.file.openFolderInVSCodeInline.panelPrompt", defaultValue: "Open in VS Code")
+        },
+        terminalOpenTitle: {
+            String(localized: "menu.openInVSCode", defaultValue: "Open Current Directory in VS Code (Inline)")
+        },
+        stopTitle: {
+            String(localized: "command.vscodeServeWebStop.title", defaultValue: "Stop VS Code Inline Server")
+        },
+        restartTitle: {
+            String(localized: "command.vscodeServeWebRestart.title", defaultValue: "Restart VS Code Inline Server")
+        },
+        keywords: ["open", "folder", "directory", "project", "vs", "code", "inline", "editor", "browser"],
+        serverKeywords: ["vscode", "inline", "serve-web", "server"],
+        isAvailable: { environment in
+            TerminalDirectoryOpenTarget.vscodeInline.isAvailable(in: environment)
+        },
+        ensureServerURL: { _, completion in
+            guard let vscodeApplicationURL = TerminalDirectoryOpenTarget.vscodeInline.applicationURL() else {
+                completion(nil)
+                return
+            }
+            VSCodeServeWebController.shared.ensureServeWebURL(
+                vscodeApplicationURL: vscodeApplicationURL,
+                completion: completion
+            )
+        },
+        stopServer: {
+            VSCodeServeWebController.shared.stop()
+        },
+        restartServer: { _, completion in
+            guard let vscodeApplicationURL = TerminalDirectoryOpenTarget.vscodeInline.applicationURL() else {
+                completion(nil)
+                return
+            }
+            VSCodeServeWebController.shared.restart(
+                vscodeApplicationURL: vscodeApplicationURL,
+                completion: completion
+            )
+        },
+        openFolderURL: { serverURL, directoryURL in
+            VSCodeServeWebURLBuilder.openFolderURL(
+                baseWebUIURL: serverURL,
+                directoryPath: directoryURL.path
+            )
+        }
+    )
+
+    static let jupyter = TerminalDirectoryInlineWebMode(
+        id: "jupyter",
+        openFolderCommandId: "palette.openFolderInJupyterInline",
+        terminalOpenCommandId: "palette.terminalOpenDirectory.jupyterInline",
+        stopCommandId: "palette.jupyterInlineServerStop",
+        restartCommandId: "palette.jupyterInlineServerRestart",
+        menuTitle: {
+            String(localized: "menu.file.openFolderInJupyterInline", defaultValue: "Open Folder in Jupyter (Inline)…")
+        },
+        openFolderTitle: {
+            String(localized: "command.openFolderInJupyterInline.title", defaultValue: "Open Folder in Jupyter (Inline)…")
+        },
+        openFolderSubtitle: {
+            String(localized: "command.openFolderInJupyterInline.subtitle", defaultValue: "Jupyter Inline")
+        },
+        panelTitle: {
+            String(localized: "menu.file.openFolderInJupyterInline.panelTitle", defaultValue: "Open Folder in Jupyter (Inline)")
+        },
+        panelPrompt: {
+            String(localized: "menu.file.openFolderInJupyterInline.panelPrompt", defaultValue: "Open in Jupyter")
+        },
+        terminalOpenTitle: {
+            String(localized: "menu.openInJupyterInline", defaultValue: "Open Current Directory in Jupyter (Inline)")
+        },
+        stopTitle: {
+            String(localized: "command.jupyterInlineServerStop.title", defaultValue: "Stop Jupyter Inline Server")
+        },
+        restartTitle: {
+            String(localized: "command.jupyterInlineServerRestart.title", defaultValue: "Restart Jupyter Inline Server")
+        },
+        keywords: ["open", "folder", "directory", "project", "jupyter", "notebook", "lab", "inline", "browser"],
+        serverKeywords: ["jupyter", "notebook", "lab", "inline", "server"],
+        isAvailable: { environment in
+            JupyterInlineLaunchConfigurationBuilder.executableURL(
+                environment: environment.environmentVariables,
+                homeDirectoryPath: environment.homeDirectoryPath,
+                isExecutableAtPath: environment.isExecutableFileAtPath
+            ) != nil
+        },
+        ensureServerURL: { directoryURL, completion in
+            jupyterController.ensureServerURL(directoryURL: directoryURL, completion: completion)
+        },
+        stopServer: {
+            jupyterController.stop()
+        },
+        restartServer: { directoryURL, completion in
+            jupyterController.restart(directoryURL: directoryURL, completion: completion)
+        },
+        openFolderURL: { serverURL, _ in
+            serverURL
+        }
+    )
+
+    static var defaultModes: [TerminalDirectoryInlineWebMode] {
+        [.vscode, .jupyter]
+    }
+}
+
+enum TerminalDirectoryInlineWebModeRegistry {
+    static var modes: [TerminalDirectoryInlineWebMode] {
+        TerminalDirectoryInlineWebMode.defaultModes
+    }
+
+    static func mode(id: String) -> TerminalDirectoryInlineWebMode? {
+        modes.first { $0.id == id }
+    }
+}
+
 final class ServeWebOutputCollector {
     private let lock = NSLock()
     private let semaphore = DispatchSemaphore(value: 0)
+    private let extractURL: (String) -> URL?
     private var outputBuffer = ""
     private var resolvedURL: URL?
     private var didSignal = false
+
+    init(extractURL: @escaping (String) -> URL? = VSCodeServeWebURLBuilder.extractWebUIURL(from:)) {
+        self.extractURL = extractURL
+    }
 
     var webUIURL: URL? {
         lock.lock()
@@ -728,7 +1306,7 @@ final class ServeWebOutputCollector {
         while let newlineIndex = outputBuffer.firstIndex(where: \.isNewline) {
             let line = String(outputBuffer[..<newlineIndex])
             outputBuffer.removeSubrange(...newlineIndex)
-            guard let parsedURL = VSCodeServeWebURLBuilder.extractWebUIURL(from: line) else {
+            guard let parsedURL = extractURL(line) else {
                 continue
             }
             resolvedURL = parsedURL
@@ -745,7 +1323,7 @@ final class ServeWebOutputCollector {
         lock.lock()
         defer { lock.unlock() }
         if resolvedURL == nil, !outputBuffer.isEmpty,
-           let parsedURL = VSCodeServeWebURLBuilder.extractWebUIURL(from: outputBuffer) {
+           let parsedURL = extractURL(outputBuffer) {
             resolvedURL = parsedURL
             outputBuffer.removeAll(keepingCapacity: false)
         }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -7137,16 +7137,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     @discardableResult
-    func openDirectoryInInlineVSCode(
+    func openDirectoryInInlineWebMode(
         _ directoryURL: URL,
+        mode: TerminalDirectoryInlineWebMode,
         tabManager preferredTabManager: TabManager? = nil
     ) -> Bool {
-        guard let vscodeApplicationURL = TerminalDirectoryOpenTarget.vscodeInline.applicationURL() else {
-            return false
-        }
-
         let targetTabManager = preferredTabManager
-            ?? preferredMainWindowContextForWorkspaceCreation(debugSource: "inlineVSCode.open.target")?.tabManager
+            ?? preferredMainWindowContextForWorkspaceCreation(debugSource: "inlineWeb.\(mode.id).open.target")?.tabManager
         guard let targetTabManager else {
             return false
         }
@@ -7156,11 +7153,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             ?? targetTabManager.addWorkspace(select: true).id
         let normalizedDirectoryURL = directoryURL.standardizedFileURL
 
-        VSCodeServeWebController.shared.ensureServeWebURL(vscodeApplicationURL: vscodeApplicationURL) { serveWebURL in
-            guard let serveWebURL,
-                  let openFolderURL = VSCodeServeWebURLBuilder.openFolderURL(
-                      baseWebUIURL: serveWebURL,
-                      directoryPath: normalizedDirectoryURL.path
+        mode.ensureServerURL(normalizedDirectoryURL) { serverURL in
+            guard let serverURL,
+                  let openFolderURL = mode.openURL(
+                      serverURL: serverURL,
+                      directoryURL: normalizedDirectoryURL
                   ) else {
                 NSSound.beep()
                 return
@@ -7179,14 +7176,29 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return true
     }
 
-    func showOpenFolderInInlineVSCodePanel(tabManager preferredTabManager: TabManager? = nil) {
-        guard TerminalDirectoryOpenTarget.vscodeInline.isAvailable() else {
+    @discardableResult
+    func openDirectoryInInlineVSCode(
+        _ directoryURL: URL,
+        tabManager preferredTabManager: TabManager? = nil
+    ) -> Bool {
+        openDirectoryInInlineWebMode(
+            directoryURL,
+            mode: .vscode,
+            tabManager: preferredTabManager
+        )
+    }
+
+    func showOpenFolderInInlineWebModePanel(
+        mode: TerminalDirectoryInlineWebMode,
+        tabManager preferredTabManager: TabManager? = nil
+    ) {
+        guard mode.isAvailable() else {
             NSSound.beep()
             return
         }
 
         let targetTabManager = preferredTabManager
-            ?? preferredMainWindowContextForWorkspaceCreation(debugSource: "inlineVSCode.panel.target")?.tabManager
+            ?? preferredMainWindowContextForWorkspaceCreation(debugSource: "inlineWeb.\(mode.id).panel.target")?.tabManager
         guard let targetTabManager else {
             NSSound.beep()
             return
@@ -7196,14 +7208,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         panel.canChooseFiles = false
         panel.canChooseDirectories = true
         panel.allowsMultipleSelection = false
-        panel.title = String(
-            localized: "menu.file.openFolderInVSCodeInline.panelTitle",
-            defaultValue: "Open Folder in VS Code (Inline)"
-        )
-        panel.prompt = String(
-            localized: "menu.file.openFolderInVSCodeInline.panelPrompt",
-            defaultValue: "Open in VS Code"
-        )
+        panel.title = mode.panelTitle()
+        panel.prompt = mode.panelPrompt()
         if let cwd = targetTabManager.selectedWorkspace?.currentDirectory,
            !cwd.isEmpty {
             panel.directoryURL = URL(fileURLWithPath: cwd)
@@ -7211,9 +7217,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         if panel.runModal() == .OK,
            let url = panel.url,
-           !openDirectoryInInlineVSCode(url, tabManager: targetTabManager) {
+           !openDirectoryInInlineWebMode(url, mode: mode, tabManager: targetTabManager) {
             NSSound.beep()
         }
+    }
+
+    func showOpenFolderInInlineVSCodePanel(tabManager preferredTabManager: TabManager? = nil) {
+        showOpenFolderInInlineWebModePanel(mode: .vscode, tabManager: preferredTabManager)
     }
 
     @objc func openWindow(

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1492,6 +1492,9 @@ struct ContentView: View {
         static func terminalOpenTargetAvailable(_ target: TerminalDirectoryOpenTarget) -> String {
             "terminal.openTarget.\(target.rawValue).available"
         }
+        static func terminalInlineWebModeAvailable(_ mode: TerminalDirectoryInlineWebMode) -> String {
+            "terminal.inlineWebMode.\(mode.id).available"
+        }
     }
 
     struct CommandPaletteCommandContribution {
@@ -6588,6 +6591,12 @@ struct ContentView: View {
                         availableTargets.contains(target)
                     )
                 }
+                for mode in TerminalDirectoryInlineWebModeRegistry.modes {
+                    snapshot.setBool(
+                        CommandPaletteContextKeys.terminalInlineWebModeAvailable(mode),
+                        mode.isAvailable()
+                    )
+                }
             }
         }
 
@@ -6700,25 +6709,17 @@ struct ContentView: View {
                 keywords: ["open", "folder", "repository", "project", "directory"]
             )
         )
-        contributions.append(
-            CommandPaletteCommandContribution(
-                commandId: "palette.openFolderInVSCodeInline",
-                title: constant(
-                    String(
-                        localized: "command.openFolderInVSCodeInline.title",
-                        defaultValue: "Open Folder in VS Code (Inline)…"
-                    )
-                ),
-                subtitle: constant(
-                    String(
-                        localized: "command.openFolderInVSCodeInline.subtitle",
-                        defaultValue: "VS Code Inline"
-                    )
-                ),
-                keywords: ["open", "folder", "directory", "project", "vs", "code", "inline", "editor", "browser"],
-                when: { _ in TerminalDirectoryOpenTarget.vscodeInline.isAvailable() }
+        for mode in TerminalDirectoryInlineWebModeRegistry.modes {
+            contributions.append(
+                CommandPaletteCommandContribution(
+                    commandId: mode.openFolderCommandId,
+                    title: constant(mode.openFolderTitle()),
+                    subtitle: constant(mode.openFolderSubtitle()),
+                    keywords: mode.keywords,
+                    when: { _ in mode.isAvailable() }
+                )
             )
-        )
+        }
         contributions.append(
             CommandPaletteCommandContribution(
                 commandId: "palette.reopenPreviousSession",
@@ -7460,30 +7461,44 @@ struct ContentView: View {
                 )
             )
         }
-        contributions.append(
-            CommandPaletteCommandContribution(
-                commandId: "palette.vscodeServeWebStop",
-                title: constant(String(localized: "command.vscodeServeWebStop.title", defaultValue: "Stop VS Code Inline Server")),
-                subtitle: terminalPanelSubtitle,
-                keywords: ["vscode", "inline", "serve-web", "stop", "server"],
-                when: { context in
-                    context.bool(CommandPaletteContextKeys.panelIsTerminal)
-                        && context.bool(CommandPaletteContextKeys.terminalOpenTargetAvailable(.vscodeInline))
-                }
+        for mode in TerminalDirectoryInlineWebModeRegistry.modes {
+            contributions.append(
+                CommandPaletteCommandContribution(
+                    commandId: mode.terminalOpenCommandId,
+                    title: constant(mode.terminalOpenTitle()),
+                    subtitle: terminalPanelSubtitle,
+                    keywords: mode.keywords,
+                    when: { context in
+                        context.bool(CommandPaletteContextKeys.panelIsTerminal)
+                            && context.bool(CommandPaletteContextKeys.terminalInlineWebModeAvailable(mode))
+                    }
+                )
             )
-        )
-        contributions.append(
-            CommandPaletteCommandContribution(
-                commandId: "palette.vscodeServeWebRestart",
-                title: constant(String(localized: "command.vscodeServeWebRestart.title", defaultValue: "Restart VS Code Inline Server")),
-                subtitle: terminalPanelSubtitle,
-                keywords: ["vscode", "inline", "serve-web", "restart", "server"],
-                when: { context in
-                    context.bool(CommandPaletteContextKeys.panelIsTerminal)
-                        && context.bool(CommandPaletteContextKeys.terminalOpenTargetAvailable(.vscodeInline))
-                }
+            contributions.append(
+                CommandPaletteCommandContribution(
+                    commandId: mode.stopCommandId,
+                    title: constant(mode.stopTitle()),
+                    subtitle: terminalPanelSubtitle,
+                    keywords: mode.serverKeywords + ["stop"],
+                    when: { context in
+                        context.bool(CommandPaletteContextKeys.panelIsTerminal)
+                            && context.bool(CommandPaletteContextKeys.terminalInlineWebModeAvailable(mode))
+                    }
+                )
             )
-        )
+            contributions.append(
+                CommandPaletteCommandContribution(
+                    commandId: mode.restartCommandId,
+                    title: constant(mode.restartTitle()),
+                    subtitle: terminalPanelSubtitle,
+                    keywords: mode.serverKeywords + ["restart"],
+                    when: { context in
+                        context.bool(CommandPaletteContextKeys.panelIsTerminal)
+                            && context.bool(CommandPaletteContextKeys.terminalInlineWebModeAvailable(mode))
+                    }
+                )
+            )
+        }
         contributions.append(
             CommandPaletteCommandContribution(
                 commandId: "palette.findInDirectory",
@@ -7864,9 +7879,14 @@ struct ContentView: View {
                 }
             }
         }
-        registry.register(commandId: "palette.openFolderInVSCodeInline") {
-            DispatchQueue.main.async {
-                AppDelegate.shared?.showOpenFolderInInlineVSCodePanel(tabManager: tabManager)
+        for mode in TerminalDirectoryInlineWebModeRegistry.modes {
+            registry.register(commandId: mode.openFolderCommandId) {
+                DispatchQueue.main.async {
+                    AppDelegate.shared?.showOpenFolderInInlineWebModePanel(
+                        mode: mode,
+                        tabManager: tabManager
+                    )
+                }
             }
         }
         registry.register(commandId: "palette.reopenPreviousSession") {
@@ -8269,12 +8289,19 @@ struct ContentView: View {
                 }
             }
         }
-        registry.register(commandId: "palette.vscodeServeWebStop") {
-            stopInlineVSCodeServeWeb()
-        }
-        registry.register(commandId: "palette.vscodeServeWebRestart") {
-            if !restartInlineVSCodeServeWeb() {
-                NSSound.beep()
+        for mode in TerminalDirectoryInlineWebModeRegistry.modes {
+            registry.register(commandId: mode.terminalOpenCommandId) {
+                if !openFocusedDirectory(inInlineWebMode: mode) {
+                    NSSound.beep()
+                }
+            }
+            registry.register(commandId: mode.stopCommandId) {
+                mode.stopServer()
+            }
+            registry.register(commandId: mode.restartCommandId) {
+                if !restartInlineWebServer(mode: mode) {
+                    NSSound.beep()
+                }
             }
         }
         registry.register(commandId: "palette.terminalFind") {
@@ -9875,8 +9902,6 @@ struct ContentView: View {
         case .finder:
             NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: directoryURL.path)
             return true
-        case .vscodeInline:
-            return openFocusedDirectoryInInlineVSCode(directoryURL)
         default:
             guard let applicationURL = target.applicationURL() else { return false }
             let configuration = NSWorkspace.OpenConfiguration()
@@ -9885,20 +9910,19 @@ struct ContentView: View {
         }
     }
 
-    private func openFocusedDirectoryInInlineVSCode(_ directoryURL: URL) -> Bool {
-        AppDelegate.shared?.openDirectoryInInlineVSCode(directoryURL, tabManager: tabManager) ?? false
+    private func openFocusedDirectory(inInlineWebMode mode: TerminalDirectoryInlineWebMode) -> Bool {
+        guard let directoryURL = focusedTerminalDirectoryURL() else { return false }
+        return AppDelegate.shared?.openDirectoryInInlineWebMode(
+            directoryURL,
+            mode: mode,
+            tabManager: tabManager
+        ) ?? false
     }
 
-    private func stopInlineVSCodeServeWeb() {
-        VSCodeServeWebController.shared.stop()
-    }
-
-    private func restartInlineVSCodeServeWeb() -> Bool {
-        guard let vscodeApplicationURL = TerminalDirectoryOpenTarget.vscodeInline.applicationURL() else {
-            return false
-        }
-        VSCodeServeWebController.shared.restart(vscodeApplicationURL: vscodeApplicationURL) { serveWebURL in
-            if serveWebURL == nil {
+    private func restartInlineWebServer(mode: TerminalDirectoryInlineWebMode) -> Bool {
+        guard let directoryURL = focusedTerminalDirectoryURL() else { return false }
+        mode.restartServer(directoryURL) { serverURL in
+            if serverURL == nil {
                 NSSound.beep()
             }
         }

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -632,15 +632,12 @@ struct cmuxApp: App {
                     AppDelegate.shared?.showOpenFolderPanel()
                 }
 
-                Button(
-                    String(
-                        localized: "menu.file.openFolderInVSCodeInline",
-                        defaultValue: "Open Folder in VS Code (Inline)…"
-                    )
-                ) {
-                    AppDelegate.shared?.showOpenFolderInInlineVSCodePanel()
+                ForEach(TerminalDirectoryInlineWebModeRegistry.modes) { mode in
+                    Button(mode.menuTitle()) {
+                        AppDelegate.shared?.showOpenFolderInInlineWebModePanel(mode: mode)
+                    }
+                    .disabled(!mode.isAvailable())
                 }
-                .disabled(!TerminalDirectoryOpenTarget.vscodeInline.isAvailable())
             }
 
             // Close tab/workspace

--- a/cmuxTests/CommandPaletteNucleoFixtures.swift
+++ b/cmuxTests/CommandPaletteNucleoFixtures.swift
@@ -66,6 +66,24 @@ func makeOpenFolderEntries() -> [FixtureEntry] {
                 "browser",
             ]
         ),
+        FixtureEntry(
+            id: "palette.openFolderInJupyterInline",
+            rank: 4,
+            title: "Open Folder in Jupyter (Inline)...",
+            searchableTexts: [
+                "Open Folder in Jupyter (Inline)...",
+                "Jupyter Inline",
+                "open",
+                "folder",
+                "directory",
+                "project",
+                "jupyter",
+                "notebook",
+                "lab",
+                "inline",
+                "browser",
+            ]
+        ),
     ]
 }
 

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -2084,6 +2084,7 @@ final class TerminalDirectoryOpenTargetAvailabilityTests: XCTestCase {
     ) -> TerminalDirectoryOpenTarget.DetectionEnvironment {
         TerminalDirectoryOpenTarget.DetectionEnvironment(
             homeDirectoryPath: homeDirectoryPath,
+            environmentVariables: ["PATH": "/opt/homebrew/bin:/usr/local/bin:/usr/bin"],
             fileExistsAtPath: { existingPaths.contains($0) },
             isExecutableFileAtPath: { existingPaths.contains($0) },
             applicationPathForName: { applicationPathsByName[$0] }
@@ -2155,7 +2156,8 @@ final class TerminalDirectoryOpenTargetAvailabilityTests: XCTestCase {
 
         let availableTargets = TerminalDirectoryOpenTarget.availableTargets(in: env)
         XCTAssertTrue(availableTargets.contains(.vscode))
-        XCTAssertTrue(availableTargets.contains(.vscodeInline))
+        XCTAssertFalse(availableTargets.contains(.vscodeInline))
+        XCTAssertTrue(TerminalDirectoryInlineWebMode.vscode.isAvailable(in: env))
     }
 
     func testTowerDetectedViaApplicationLookupOutsideApplications() {
@@ -2174,6 +2176,22 @@ final class TerminalDirectoryOpenTargetAvailabilityTests: XCTestCase {
         let targets = TerminalDirectoryOpenTarget.commandPaletteShortcutTargets
         XCTAssertFalse(targets.contains(where: { $0.commandPaletteTitle == "Open Current Directory in IDE" }))
         XCTAssertFalse(targets.contains(where: { $0.commandPaletteCommandId == "palette.terminalOpenDirectory" }))
+        XCTAssertFalse(targets.contains(.vscodeInline))
+    }
+
+    func testJupyterInlineRequiresJupyterExecutable() {
+        let missing = environment(existingPaths: [])
+        XCTAssertFalse(TerminalDirectoryInlineWebMode.jupyter.isAvailable(in: missing))
+
+        let present = environment(existingPaths: ["/opt/homebrew/bin/jupyter"])
+        XCTAssertTrue(TerminalDirectoryInlineWebMode.jupyter.isAvailable(in: present))
+    }
+
+    func testDefaultInlineWebModesIncludeVSCodeAndJupyter() {
+        XCTAssertEqual(
+            TerminalDirectoryInlineWebModeRegistry.modes.map(\.id),
+            ["vscode", "jupyter"]
+        )
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds a shared inline web directory mode abstraction with VS Code and Jupyter defaults.
- Wires inline modes into File menu, command palette open-folder actions, current-directory actions, and server stop/restart commands.
- Adds Jupyter localization and availability coverage.

## Testing
- ./scripts/setup.sh
- ./scripts/reload.sh --tag jup (passed)
- git diff --check (passed)

## Issues
- Task: make cmux Jupyter mode similar to inline VS Code mode with customizable defaults

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5199"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782990897&installation_id=133855650&pr_number=5199&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5199&signature=c1f7438e5c7bac54a18de9573e029bf00df0e65c78c03cca80d353d90e05e628"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Spawns and manages local subprocess servers (Jupyter/VS Code) and parses URLs from their output; bound to localhost but increases process-lifecycle and directory-handling complexity in core terminal/open flows.
> 
> **Overview**
> Introduces a **pluggable inline web directory mode** (`TerminalDirectoryInlineWebMode` + registry) so VS Code inline and new **Jupyter Lab inline** share the same flows instead of one-off VS Code code.
> 
> **Jupyter inline** resolves a `jupyter` executable (PATH + common fallbacks), starts `jupyter lab` bound to **127.0.0.1** with `--ServerApp.root_dir` set to the chosen folder, parses a local HTTP URL from process output, and opens it in the in-app browser. A generic `InlineCommandWebServerController` handles launch/stop/restart and directory-scoped reuse; VS Code still uses `VSCodeServeWebController` but is wired through the same mode struct.
> 
> **UI wiring** is driven by the registry: File menu open-folder actions, command palette (open folder, open current directory from terminal, stop/restart server), and `AppDelegate`/`ContentView` handlers are generalized from VS Code-only APIs. **`vscodeInline` is removed** from terminal “open in app” shortcut targets; inline VS Code/Jupyter are availability-gated via separate palette context keys. Adds **en/JA strings** for Jupyter commands and updates tests/fixtures for availability and palette ranking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a706a5ab143f00b807b847916a379c0621f48f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add customizable inline web directory modes and introduce a Jupyter inline mode. This fulfills the task to make Jupyter inline match the VS Code inline experience with configurable defaults.

- **New Features**
  - Added a shared inline web mode abstraction with defaults for VS Code and Jupyter.
  - New Jupyter inline mode: launches `jupyter lab` headless on `127.0.0.1` with a dynamic port and root set to the chosen folder.
  - Integrated modes into the File menu and command palette (open current directory, stop server, restart server).
  - Availability checks: Jupyter is shown only when a `jupyter` executable is found (PATH + common fallbacks).
  - Added EN/JA localizations for Jupyter menu and command titles.
  - Updated tests and fixtures for Jupyter availability and default mode registration.

- **Refactors**
  - Introduced a generic inline command web server controller and a simple mode registry.
  - Made URL parsing pluggable in the serve-web output collector.
  - Consolidated menu and command palette wiring to iterate over registered modes.
  - Removed VS Code inline from generic terminal targets; it now participates via the shared modes system.

<sup>Written for commit 1a706a5ab143f00b807b847916a379c0621f48f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced "Open Folder in Jupyter (Inline)" for seamless folder access with integrated inline Jupyter server lifecycle management (start/stop/restart).
  * Extended the File menu and Command Palette with new Jupyter inline mode options and command entries.
  * Added complete Japanese language localization support for Jupyter inline commands and associated menu items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->