### PR TITLE
Show fork commands when context menu can fork

### DIFF
--- a/Sources/ContentView+ForkAgentConversation.swift
+++ b/Sources/ContentView+ForkAgentConversation.swift
@@ -209,17 +209,16 @@ extension ContentView {
                 isRemoteTerminal: isRemoteTerminal
             ) {
             case .supportedWithoutProbe:
-                guard commandPaletteForkableAgentProbeResultMatches(
+                let probeResultMatches = commandPaletteForkableAgentProbeResultMatches(
                     panelKey: panelKey,
                     supportedPanelKeys: supportedPanelKeys,
                     supportedRemoteContextsByPanelKey: supportedRemoteContextsByPanelKey,
                     snapshotFingerprintsByPanelKey: snapshotFingerprintsByPanelKey,
                     expectedSnapshotFingerprint: fallbackFingerprint,
                     isRemoteTerminal: isRemoteTerminal
-                ) else {
-                    return nil
-                }
-                if let cachedSnapshot = verifiedCachedSnapshot(expectedFingerprint: fallbackFingerprint) {
+                )
+                if probeResultMatches,
+                   let cachedSnapshot = verifiedCachedSnapshot(expectedFingerprint: fallbackFingerprint) {
                     return CommandPaletteForkSnapshotSelection(
                         snapshot: cachedSnapshot,
                         usedFallbackSnapshot: false

--- a/Sources/ContentView+ForkAgentConversation.swift
+++ b/Sources/ContentView+ForkAgentConversation.swift
@@ -41,7 +41,7 @@ extension ContentView {
             panelId: panelId
         )
 
-        let fallbackSnapshot = currentContext.workspace.restoredAgentSnapshotsByPanelId[panelId]
+        let fallbackSnapshot = currentContext.workspace.forkableAgentSnapshot(forPanelId: panelId)
         let isRemoteContext = currentContext.workspace.isRemoteTerminalSurface(panelId)
         let selection = Self.commandPaletteImmediateForkExecutionSnapshotSelection(
             workspaceId: workspaceId,
@@ -118,6 +118,12 @@ extension ContentView {
                    launch.terminalWorkingDirectory == nil,
                    let forkPanelId = forkWorkspace.focusedPanelId {
                     forkWorkspace.updatePanelDirectory(panelId: forkPanelId, directory: workingDirectory)
+                }
+                if let forkPanelId = forkWorkspace.focusedPanelId {
+                    forkWorkspace.recordForkedAgentFallbackSnapshot(
+                        launch.forkedAgentSnapshot,
+                        panelId: forkPanelId
+                    )
                 }
                 didFork = true
             case .right, .left, .top, .bottom:

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -6080,6 +6080,12 @@ struct ContentView: View {
             }
             return true
         }
+        if let fallbackSnapshot {
+            return commandPaletteSnapshotForkAvailability(
+                fallbackSnapshot,
+                isRemoteTerminal: isRemoteTerminal
+            ) == .supportedWithoutProbe
+        }
         return false
     }
 
@@ -6098,7 +6104,7 @@ struct ContentView: View {
         let panelKey = Self.commandPaletteForkableAgentPanelKey(workspaceId: workspaceId, panelId: panelId)
         let panelChanged = commandPaletteForkableAgentActivePanelKey != panelKey
         commandPaletteForkableAgentActivePanelKey = panelKey
-        let fallbackSnapshot = panelContext.workspace.restoredAgentSnapshotsByPanelId[panelId]
+        let fallbackSnapshot = panelContext.workspace.forkableAgentSnapshot(forPanelId: panelId)
 
         if let fallbackSnapshot {
             let fallbackFingerprint = Self.commandPaletteForkSnapshotFingerprint(fallbackSnapshot)
@@ -6124,20 +6130,17 @@ struct ContentView: View {
                     expectedSnapshotFingerprint: fallbackFingerprint,
                     isRemoteTerminal: isRemoteTerminal
                 )
-                if probeResultMatches {
-                    commandPaletteForkableAgentSupportedPanelKeys.insert(panelKey)
-                    commandPaletteForkableAgentRemoteContextsByPanelKey[panelKey] = isRemoteTerminal
-                    commandPaletteForkableAgentResultHadFallbackByPanelKey[panelKey] =
-                        Self.commandPaletteForkMatchedFallbackProbeResultHadFallback(
-                            cachedResultHadFallback: commandPaletteForkableAgentResultHadFallbackByPanelKey[panelKey]
-                        )
-                } else {
-                    commandPaletteForkableAgentSupportedPanelKeys.remove(panelKey)
-                    commandPaletteForkableAgentSnapshotsByPanelKey.removeValue(forKey: panelKey)
-                    commandPaletteForkableAgentSnapshotFingerprintsByPanelKey.removeValue(forKey: panelKey)
-                    commandPaletteForkableAgentRemoteContextsByPanelKey.removeValue(forKey: panelKey)
-                    commandPaletteForkableAgentResultHadFallbackByPanelKey.removeValue(forKey: panelKey)
+                commandPaletteForkableAgentSupportedPanelKeys.insert(panelKey)
+                if !probeResultMatches || commandPaletteForkableAgentSnapshotsByPanelKey[panelKey] == nil {
+                    commandPaletteForkableAgentSnapshotsByPanelKey[panelKey] = fallbackSnapshot
+                    commandPaletteForkableAgentSnapshotFingerprintsByPanelKey[panelKey] = fallbackFingerprint
                 }
+                commandPaletteForkableAgentRemoteContextsByPanelKey[panelKey] = isRemoteTerminal
+                commandPaletteForkableAgentResultHadFallbackByPanelKey[panelKey] = probeResultMatches
+                    ? Self.commandPaletteForkMatchedFallbackProbeResultHadFallback(
+                        cachedResultHadFallback: commandPaletteForkableAgentResultHadFallbackByPanelKey[panelKey]
+                    )
+                    : true
                 if panelChanged || !probeResultMatches {
                     startCommandPaletteForkableAgentAvailabilityProbe(
                         panelKey: panelKey,
@@ -6560,7 +6563,7 @@ struct ContentView: View {
             )
             snapshot.setBool(CommandPaletteContextKeys.panelIsTerminal, panelIsTerminal)
             snapshot.setBool(CommandPaletteContextKeys.panelHasPane, workspace.paneId(forPanelId: panelId) != nil)
-            let fallbackForkableSnapshot = workspace.restoredAgentSnapshotsByPanelId[panelId]
+            let fallbackForkableSnapshot = workspace.forkableAgentSnapshot(forPanelId: panelId)
             snapshot.setBool(
                 CommandPaletteContextKeys.panelHasForkableAgent,
                 Self.commandPalettePanelHasForkableAgent(

--- a/Sources/Workspace+PanelLifecycle.swift
+++ b/Sources/Workspace+PanelLifecycle.swift
@@ -341,6 +341,7 @@ extension Workspace {
 #endif
         discardAgentRuntimeState(closedAgentRuntimeState)
         restoredAgentSnapshotsByPanelId.removeValue(forKey: panelId)
+        forkedAgentFallbackSnapshotsByPanelId.removeValue(forKey: panelId)
         restoredAgentResumeStatesByPanelId.removeValue(forKey: panelId)
         invalidatedRestoredAgentFingerprintsByPanelId.removeValue(forKey: panelId)
         PortScanner.shared.unregisterPanel(workspaceId: id, panelId: panelId)

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -17724,6 +17724,22 @@ final class Workspace: Identifiable, ObservableObject {
     func recordForkedAgentFallbackSnapshot(_ snapshot: SessionRestorableAgentSnapshot, panelId: UUID) {
         guard panels[panelId] is TerminalPanel else { return }
         forkedAgentFallbackSnapshotsByPanelId[panelId] = snapshot
+        if let binding = forkedAgentStartupBinding(snapshot) {
+            surfaceResumeBindingsByPanelId[panelId] = binding
+        }
+    }
+
+    private func forkedAgentStartupBinding(_ snapshot: SessionRestorableAgentSnapshot) -> SurfaceResumeBindingSnapshot? {
+        guard let command = snapshot.forkCommand else { return nil }
+        return SurfaceResumeBindingSnapshot(
+            name: snapshot.agentDisplayName,
+            kind: snapshot.kind.rawValue,
+            command: command,
+            cwd: snapshot.workingDirectory,
+            checkpointId: snapshot.sessionId,
+            source: "agent-hook",
+            autoResume: true
+        )
     }
 
     /// Fork the panel's agent conversation into a brand-new sibling tab placed immediately

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -17678,7 +17678,7 @@ final class Workspace: Identifiable, ObservableObject {
     /// whether to surface the Fork Conversation item for a given anchor tab. Restricted to
     /// `.supportedWithoutProbe` so we never offer an item that may quietly fail; agents
     /// requiring a probe (e.g. shell-launched OpenCode) stay reachable from the command
-    /// palette path that performs that probe first.
+    /// palette after that probe succeeds.
     func canForkAgentConversationFromPanel(_ panelId: UUID) -> Bool {
         guard panels[panelId] is TerminalPanel else { return false }
         guard let snapshot = forkableAgentSnapshot(forPanelId: panelId) else {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -268,6 +268,7 @@ extension Workspace {
         debugSessionSnapshotSyntheticScrollbackByPanelId.removeAll(keepingCapacity: false)
 #endif
         restoredAgentSnapshotsByPanelId.removeAll(keepingCapacity: false)
+        forkedAgentFallbackSnapshotsByPanelId.removeAll(keepingCapacity: false)
         restoredAgentResumeStatesByPanelId.removeAll(keepingCapacity: false)
         invalidatedRestoredAgentFingerprintsByPanelId.removeAll(keepingCapacity: false)
         surfaceResumeBindingsByPanelId.removeAll(keepingCapacity: false)
@@ -10514,6 +10515,7 @@ final class Workspace: Identifiable, ObservableObject {
     var debugSessionSnapshotSyntheticScrollbackByPanelId: [UUID: String] = [:]
 #endif
     var restoredAgentSnapshotsByPanelId: [UUID: SessionRestorableAgentSnapshot] = [:]
+    var forkedAgentFallbackSnapshotsByPanelId: [UUID: SessionRestorableAgentSnapshot] = [:]
     var surfaceResumeBindingsByPanelId: [UUID: SurfaceResumeBindingSnapshot] = [:]
     enum RestoredAgentResumeState: Equatable {
         case manualResumeAvailable
@@ -12662,6 +12664,9 @@ final class Workspace: Identifiable, ObservableObject {
             refreshTrackedAgentPorts()
         }
         restoredAgentSnapshotsByPanelId = restoredAgentSnapshotsByPanelId.filter {
+            validSurfaceIds.contains($0.key)
+        }
+        forkedAgentFallbackSnapshotsByPanelId = forkedAgentFallbackSnapshotsByPanelId.filter {
             validSurfaceIds.contains($0.key)
         }
         surfaceResumeBindingsByPanelId = surfaceResumeBindingsByPanelId.filter {
@@ -17577,11 +17582,12 @@ final class Workspace: Identifiable, ObservableObject {
         return newPanel
     }
 
-    struct AgentConversationForkWorkspaceLaunch: Equatable {
+    struct AgentConversationForkWorkspaceLaunch {
         var workingDirectory: String?
         var terminalWorkingDirectory: String?
         var initialTerminalCommand: String?
         var initialTerminalInput: String
+        var forkedAgentSnapshot: SessionRestorableAgentSnapshot
         var remoteConfiguration: WorkspaceRemoteConfiguration?
         var autoConnectRemoteConfiguration: Bool
     }
@@ -17612,6 +17618,7 @@ final class Workspace: Identifiable, ObservableObject {
             terminalWorkingDirectory: isRemoteFork ? nil : workingDirectory,
             initialTerminalCommand: remoteConfiguration?.terminalStartupCommand ?? remoteStartupCommand,
             initialTerminalInput: startupInput,
+            forkedAgentSnapshot: launchSnapshot,
             remoteConfiguration: remoteConfiguration,
             autoConnectRemoteConfiguration: remoteConfiguration != nil
         )
@@ -17655,6 +17662,9 @@ final class Workspace: Identifiable, ObservableObject {
            remoteStartupCommand != nil,
            let workingDirectory {
             updatePanelDirectory(panelId: forkedPanel.id, directory: workingDirectory)
+        }
+        if let forkedPanel {
+            recordForkedAgentFallbackSnapshot(launchSnapshot, panelId: forkedPanel.id)
         }
         if forkedPanel == nil, let zoomedPaneId {
             _ = bonsplitController.togglePaneZoom(inPane: zoomedPaneId)
@@ -17705,7 +17715,15 @@ final class Workspace: Identifiable, ObservableObject {
         if let snapshot = restoredAgentSnapshotsByPanelId[panelId] {
             return snapshot
         }
-        return SharedLiveAgentIndex.shared.snapshot(workspaceId: id, panelId: panelId)
+        if let snapshot = SharedLiveAgentIndex.shared.snapshot(workspaceId: id, panelId: panelId) {
+            return snapshot
+        }
+        return forkedAgentFallbackSnapshotsByPanelId[panelId]
+    }
+
+    func recordForkedAgentFallbackSnapshot(_ snapshot: SessionRestorableAgentSnapshot, panelId: UUID) {
+        guard panels[panelId] is TerminalPanel else { return }
+        forkedAgentFallbackSnapshotsByPanelId[panelId] = snapshot
     }
 
     /// Fork the panel's agent conversation into a brand-new sibling tab placed immediately
@@ -17751,6 +17769,7 @@ final class Workspace: Identifiable, ObservableObject {
             if remoteStartupCommand != nil, let workingDirectory {
                 updatePanelDirectory(panelId: forkedPanel.id, directory: workingDirectory)
             }
+            recordForkedAgentFallbackSnapshot(launchSnapshot, panelId: forkedPanel.id)
         } else if let zoomedPaneId {
             _ = bonsplitController.togglePaneZoom(inPane: zoomedPaneId)
         }
@@ -19243,6 +19262,12 @@ extension Workspace: BonsplitDelegate {
            launch.terminalWorkingDirectory == nil,
            let forkPanelId = forkWorkspace.focusedPanelId {
             forkWorkspace.updatePanelDirectory(panelId: forkPanelId, directory: workingDirectory)
+        }
+        if let forkPanelId = forkWorkspace.focusedPanelId {
+            forkWorkspace.recordForkedAgentFallbackSnapshot(
+                launch.forkedAgentSnapshot,
+                panelId: forkPanelId
+            )
         }
         return true
     }

--- a/cmuxTests/CommandPaletteSearchEngineTests.swift
+++ b/cmuxTests/CommandPaletteSearchEngineTests.swift
@@ -602,7 +602,7 @@ final class CommandPaletteSearchEngineTests: XCTestCase {
         )
     }
 
-    func testForkableAgentFallbackSnapshotRequiresVerifiedProbeForVisibility() {
+    func testForkableAgentProbeFreeFallbackSnapshotIsVisibleBeforePaletteProbe() {
         let workspaceId = UUID()
         let panelId = UUID()
         let supportedKey = ContentView.commandPaletteForkableAgentPanelKey(
@@ -644,7 +644,7 @@ final class CommandPaletteSearchEngineTests: XCTestCase {
             )
         )
 
-        XCTAssertFalse(
+        XCTAssertTrue(
             ContentView.commandPalettePanelHasForkableAgent(
                 workspaceId: workspaceId,
                 panelId: panelId,
@@ -669,7 +669,7 @@ final class CommandPaletteSearchEngineTests: XCTestCase {
                 fallbackSnapshot: directOpenCode
             )
         )
-        XCTAssertFalse(
+        XCTAssertTrue(
             ContentView.commandPalettePanelHasForkableAgent(
                 workspaceId: workspaceId,
                 panelId: panelId,
@@ -688,7 +688,7 @@ final class CommandPaletteSearchEngineTests: XCTestCase {
                 isRemoteTerminal: true
             )
         )
-        XCTAssertFalse(
+        XCTAssertTrue(
             ContentView.commandPalettePanelHasForkableAgent(
                 workspaceId: workspaceId,
                 panelId: panelId,
@@ -738,7 +738,7 @@ final class CommandPaletteSearchEngineTests: XCTestCase {
 
         XCTAssertNotNil(snapshot.forkStartupInput(allowLauncherScript: true))
         XCTAssertNil(snapshot.forkStartupInput(allowLauncherScript: false))
-        XCTAssertFalse(
+        XCTAssertTrue(
             ContentView.commandPalettePanelHasForkableAgent(
                 workspaceId: workspaceId,
                 panelId: panelId,
@@ -799,7 +799,7 @@ final class CommandPaletteSearchEngineTests: XCTestCase {
         )
     }
 
-    func testImmediateForkExecutionRejectsFallbackSnapshotBeforeProbeVerification() {
+    func testImmediateForkExecutionUsesProbeFreeFallbackSnapshotBeforeProbeVerification() {
         let workspaceId = UUID()
         let panelId = UUID()
         let fallback = SessionRestorableAgentSnapshot(
@@ -807,6 +807,38 @@ final class CommandPaletteSearchEngineTests: XCTestCase {
             sessionId: "fallback-codex-session",
             workingDirectory: "/tmp/fallback repo",
             launchCommand: nil
+        )
+
+        let snapshot = ContentView.commandPaletteImmediateForkExecutionSnapshot(
+            workspaceId: workspaceId,
+            panelId: panelId,
+            isRemoteTerminal: false,
+            supportedPanelKeys: [],
+            supportedRemoteContextsByPanelKey: [:],
+            snapshotFingerprintsByPanelKey: [:],
+            fallbackSnapshot: fallback,
+            cachedSnapshot: nil
+        )
+
+        XCTAssertEqual(snapshot?.sessionId, fallback.sessionId)
+    }
+
+    func testImmediateForkExecutionRejectsProbeRequiredFallbackSnapshotBeforeProbeVerification() {
+        let workspaceId = UUID()
+        let panelId = UUID()
+        let fallback = SessionRestorableAgentSnapshot(
+            kind: .opencode,
+            sessionId: "fallback-opencode-session",
+            workingDirectory: "/tmp/opencode repo",
+            launchCommand: AgentLaunchCommandSnapshot(
+                launcher: "opencode",
+                executablePath: "/opt/homebrew/bin/opencode",
+                arguments: ["/opt/homebrew/bin/opencode"],
+                workingDirectory: "/tmp/opencode repo",
+                environment: nil,
+                capturedAt: 123,
+                source: "environment"
+            )
         )
 
         let snapshot = ContentView.commandPaletteImmediateForkExecutionSnapshot(

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -5739,6 +5739,65 @@ final class WorkspacePanelGitBranchTests: XCTestCase {
         )
     }
 
+    func testForkedSplitPersistsForkStartupBindingBeforeLiveScan() throws {
+        try withAgentSessionAutoResumeSetting(true) {
+            let workspace = Workspace()
+            let sourcePanelId = try XCTUnwrap(workspace.focusedPanelId)
+            let snapshot = SessionRestorableAgentSnapshot(
+                kind: .codex,
+                sessionId: "019dad34-d218-7943-b81a-eddac5c87951",
+                workingDirectory: "/tmp/fork repo",
+                launchCommand: AgentLaunchCommandSnapshot(
+                    launcher: "codex",
+                    executablePath: "/Users/example/.bun/bin/codex",
+                    arguments: ["/Users/example/.bun/bin/codex", "--search"],
+                    workingDirectory: "/tmp/fork repo",
+                    environment: nil,
+                    capturedAt: 123,
+                    source: "process"
+                )
+            )
+
+            let forkPanel = try XCTUnwrap(
+                workspace.forkAgentConversation(
+                    fromPanelId: sourcePanelId,
+                    snapshot: snapshot,
+                    direction: .right
+                )
+            )
+            let savedSnapshot = workspace.sessionSnapshot(
+                includeScrollback: false,
+                restorableAgentIndex: .empty,
+                surfaceResumeBindingIndex: .empty
+            )
+            let forkPanelSnapshot = try XCTUnwrap(
+                savedSnapshot.panels.first { $0.id == forkPanel.id }
+            )
+            let binding = try XCTUnwrap(forkPanelSnapshot.terminal?.resumeBinding)
+
+            XCTAssertNil(forkPanelSnapshot.terminal?.agent)
+            XCTAssertEqual(binding.source, "agent-hook")
+            XCTAssertEqual(binding.kind, "codex")
+            XCTAssertEqual(binding.checkpointId, snapshot.sessionId)
+            XCTAssertEqual(binding.autoResume, true)
+            XCTAssertEqual(binding.command, snapshot.forkCommand)
+
+            let restored = Workspace()
+            restored.restoreSessionSnapshot(savedSnapshot)
+            let restoredPanelId = try XCTUnwrap(restored.focusedPanelId)
+            let restoredPanel = try XCTUnwrap(restored.terminalPanel(for: restoredPanelId))
+            let initialCommand = try XCTUnwrap(restoredPanel.surface.debugInitialCommand())
+            XCTAssertTrue(initialCommand.hasPrefix("/bin/zsh '"), initialCommand)
+
+            let scriptPath = String(initialCommand.dropFirst("/bin/zsh '".count).dropLast())
+            defer { try? FileManager.default.removeItem(atPath: scriptPath) }
+            let scriptContents = try String(contentsOfFile: scriptPath, encoding: .utf8)
+            XCTAssertTrue(scriptContents.contains("codex"), scriptContents)
+            XCTAssertTrue(scriptContents.contains("fork"), scriptContents)
+            XCTAssertTrue(scriptContents.contains(snapshot.sessionId), scriptContents)
+        }
+    }
+
     func testForkAgentConversationUsesWorkspaceDirectoryFallback() throws {
         let workspace = Workspace()
         workspace.currentDirectory = "/tmp/workspace fork repo"
@@ -6994,6 +7053,25 @@ final class WorkspacePanelGitBranchTests: XCTestCase {
             1,
             "Configured New Tab default should keep the fork in the source pane"
         )
+    }
+
+    private func withAgentSessionAutoResumeSetting<T>(
+        _ value: Bool,
+        _ body: () throws -> T
+    ) rethrows -> T {
+        let defaults = UserDefaults.standard
+        let key = AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey
+        let previousValue = defaults.object(forKey: key)
+        defer {
+            if let previousValue {
+                defaults.set(previousValue, forKey: key)
+            } else {
+                defaults.removeObject(forKey: key)
+            }
+        }
+
+        defaults.set(value, forKey: key)
+        return try body()
     }
 }
 

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -5692,6 +5692,53 @@ final class WorkspacePanelGitBranchTests: XCTestCase {
         }
     }
 
+    func testForkedSplitCanBeForkedAgainImmediately() throws {
+        let workspace = Workspace()
+        let sourcePanelId = try XCTUnwrap(workspace.focusedPanelId)
+        let snapshot = SessionRestorableAgentSnapshot(
+            kind: .codex,
+            sessionId: "019dad34-d218-7943-b81a-eddac5c87951",
+            workingDirectory: "/tmp/fork repo",
+            launchCommand: AgentLaunchCommandSnapshot(
+                launcher: "codex",
+                executablePath: "/Users/example/.bun/bin/codex",
+                arguments: ["/Users/example/.bun/bin/codex", "--search"],
+                workingDirectory: "/tmp/fork repo",
+                environment: nil,
+                capturedAt: 123,
+                source: "process"
+            )
+        )
+
+        let rightForkPanel = try XCTUnwrap(
+            workspace.forkAgentConversation(
+                fromPanelId: sourcePanelId,
+                snapshot: snapshot,
+                direction: .right
+            )
+        )
+        let immediateForkSnapshot = try XCTUnwrap(
+            workspace.forkableAgentSnapshot(forPanelId: rightForkPanel.id)
+        )
+
+        let bottomForkPanel = try XCTUnwrap(
+            workspace.forkAgentConversation(
+                fromPanelId: rightForkPanel.id,
+                snapshot: immediateForkSnapshot,
+                direction: .down
+            )
+        )
+
+        XCTAssertNotEqual(bottomForkPanel.id, rightForkPanel.id)
+        XCTAssertEqual(workspace.focusedPanelId, bottomForkPanel.id)
+        XCTAssertEqual(workspace.bonsplitController.allPaneIds.count, 3)
+        XCTAssertEqual(bottomForkPanel.requestedWorkingDirectory, "/tmp/fork repo")
+        XCTAssertEqual(
+            bottomForkPanel.surface.initialInput,
+            snapshot.forkCommand.map { $0 + "\n" }
+        )
+    }
+
     func testForkAgentConversationUsesWorkspaceDirectoryFallback() throws {
         let workspace = Workspace()
         workspace.currentDirectory = "/tmp/workspace fork repo"


### PR DESCRIPTION
## Summary
- Use the same forkable-agent snapshot source for command palette visibility as the right-click tab menu.
- Allow probe-free fork snapshots to show and execute immediately while preserving the probe gate for local direct OpenCode.

## Testing
- ./scripts/reload.sh --tag forkpal, passed
- Not run: Xcode unit tests locally, local test actions are prohibited on this Mac.

## Issues
- Related: plain-text task, cmd-shift-p sometimes hides fork options while right-click shows them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches fork availability, immediate execution, and session resume bindings across palette and workspace lifecycle; probe gating for local OpenCode is preserved but behavior changes for other agent types.
> 
> **Overview**
> Fixes **Cmd+Shift+P** sometimes hiding fork commands while the tab context menu still offered them by routing palette visibility and execution through **`workspace.forkableAgentSnapshot(forPanelId:)`** (restored → live index → per-panel **fork fallback** cache) instead of only restored snapshots.
> 
> **Probe-free** agents (e.g. Codex, remote OpenCode, `omo`) now show in the palette and can fork immediately; the palette seeds its cache from the fallback while a background probe still runs. **Probe-required** local direct OpenCode stays gated until verification succeeds.
> 
> After any fork (split, new tab, or new workspace), the app **records the fork snapshot** on the new panel and writes an **auto-resume surface binding** from the fork command so chained forks and session restore work before a live agent scan lands. Fallback entries are cleared on panel close and session reset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87933a1b64d0bf74f4b99ff2b0d6587fb1eac035. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782990929&installation_id=133855650&pr_number=5200&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5200&signature=e58a30309b10924f5eb3df28930421968cc1d90cfe02d64e7546448d931a6c1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the command palette with the tab context menu so fork commands appear and run when a probe‑free forkable snapshot exists. Also persists fork startup bindings so restored sessions auto‑resume and can be forked again immediately.

- **Bug Fixes**
  - Use `workspace.forkableAgentSnapshot(forPanelId:)` to decide palette visibility and selection, and persist the fork snapshot and startup binding in new panels so they can fork again right away and auto‑resume on restore.
  - Show and execute fork commands immediately for probe‑free snapshots; seed the palette with the fallback snapshot while a probe runs, and clean up stored snapshots on panel close.
  - Keep probe gating for probe‑required snapshots (e.g., local `OpenCode`), with new regression tests covering visibility, immediate execution paths, chained forks, and restore auto‑resume.

<sup>Written for commit 87933a1b64d0bf74f4b99ff2b0d6587fb1eac035. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Command palette now shows forked-agent entries using a fallback snapshot before probe verification, enabling faster immediate forks (including immediate re-forks).

* **Bug Fixes**
  * More consistent detection and caching of fork availability to avoid stale or missing entries.
  * Fallback snapshot handling prefers verified matches but reliably falls back when verification isn’t yet available.

* **Tests**
  * Updated and added tests to validate probe-free fallback visibility and immediate-fork behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->