### PR TITLE
Improve update pill tooltip

### DIFF
--- a/Sources/Update/UpdatePill.swift
+++ b/Sources/Update/UpdatePill.swift
@@ -45,7 +45,7 @@ struct UpdatePill: View {
             .contentShape(Capsule())
         }
         .buttonStyle(.plain)
-        .safeHelp(model.text)
+        .safeHelp(model.pillHelpText)
         .accessibilityLabel(model.text)
         .accessibilityIdentifier("UpdatePill")
     }

--- a/Sources/Update/UpdateViewModel.swift
+++ b/Sources/Update/UpdateViewModel.swift
@@ -109,6 +109,10 @@ class UpdateViewModel: ObservableObject {
         }
     }
 
+    var pillHelpText: String {
+        String(localized: "update.pill.help", defaultValue: "Open update details and actions")
+    }
+
     var maxWidthText: String {
         if let detectedText = detectedUpdateText {
             return detectedText


### PR DESCRIPTION
## Summary
- Add a dedicated localized tooltip for the update pill.
- Keep the visible pill text state-specific while hover help explains the click action.

## Testing
- `jq empty Resources/Localizable.xcstrings`
- `./scripts/setup.sh`
- `./scripts/reload.sh --tag task-update-pill-tooltip`

## Issues
- Plain-text task: improve the cmux macOS update pill tooltip and provide a tagged dogfood build.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782992943&installation_id=133855650&pr_number=5205&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5205&signature=a14894c9e8588e6281d413c2c71299d688fa6fe73af83a4a6d1eb0a13e404855"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit ced03d7b21cec73ed0949b33d85ce1ce8c502702. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dedicated, localized tooltip to the update pill that explains the click action (“Open update details and actions”) while keeping the pill text state-specific. Localized for English and Japanese.

<sup>Written for commit ced03d7b21cec73ed0949b33d85ce1ce8c502702. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

