### PR TITLE
Clarify new tab button tooltip

### DIFF
--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -996,7 +996,7 @@ struct TitlebarControlsView: View {
                 }) {
                 iconLabel(systemName: "plus", config: config, iconGeometryKeyPrefix: "titlebarControl_newTabIcon")
             }
-            .safeHelp(KeyboardShortcutSettings.Action.newTab.tooltip(String(localized: "titlebar.newWorkspace.tooltip", defaultValue: "New workspace")))
+            .safeHelp(KeyboardShortcutSettings.Action.newTab.tooltip(String(localized: "titlebar.newTab.tooltip", defaultValue: "Create a new workspace tab")))
 
             TitlebarControlButton(
                 config: config,


### PR DESCRIPTION
## Summary
- Add a dedicated localized tooltip for the tab-bar new-tab (+) button.
- Update the titlebar new-tab hover text to say it creates a workspace tab.

## Testing
- `jq -e ... Resources/Localizable.xcstrings` => true
- `git diff --check` => pass
- `./scripts/reload.sh --tag ntabtip` => succeeded in 187s

## Issues
- Plain-text task: improve the cmux macOS tab-bar new-tab (+) hover tooltip.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5206"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782993185&installation_id=133855650&pr_number=5206&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5206&signature=75e64293ad295023fabdf537c8b966c0ea580e80515c89d40107a5dabfd9e09a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and localization only; no logic, shortcuts, or accessibility label changes beyond the help string key.
> 
> **Overview**
> The titlebar **+** control’s hover help no longer uses the generic **New workspace** string (`titlebar.newWorkspace.tooltip`). It now pulls a dedicated key **`titlebar.newTab.tooltip`** whose copy says **Create a new workspace tab** (English and Japanese added in `Localizable.xcstrings`).
> 
> Behavior of the button is unchanged; only the tooltip text users see on hover (plus any keyboard-shortcut suffix from `.safeHelp`) is clearer that the action opens a **workspace tab**, not a vague “new workspace.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7b63857f8aaee8d45399d153548991c5f9c2541. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Added multi-language support for the New Workspace tab button tooltip, enabling users to see localized text in their preferred language.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->