### PR TITLE
Add profile-backed Jupyter inline mode

### DIFF
--- a/Sources/App/TerminalDirectoryOpenSupport.swift
+++ b/Sources/App/TerminalDirectoryOpenSupport.swift
@@ -73,6 +73,7 @@ enum TerminalDirectoryOpenTarget: String, CaseIterable {
     case tower
     case vscode
     case vscodeInline
+    case jupyterInline
     case warp
     case windsurf
     case xcode
@@ -80,12 +81,14 @@ enum TerminalDirectoryOpenTarget: String, CaseIterable {
 
     struct DetectionEnvironment {
         let homeDirectoryPath: String
+        let pathEnvironment: String
         let fileExistsAtPath: (String) -> Bool
         let isExecutableFileAtPath: (String) -> Bool
         let applicationPathForName: (String) -> String?
 
         static let live = DetectionEnvironment(
             homeDirectoryPath: FileManager.default.homeDirectoryForCurrentUser.path,
+            pathEnvironment: ProcessInfo.processInfo.environment["PATH"] ?? "",
             fileExistsAtPath: { FileManager.default.fileExists(atPath: $0) },
             isExecutableFileAtPath: { FileManager.default.isExecutableFile(atPath: $0) },
             applicationPathForName: { NSWorkspace.shared.fullPath(forApplication: $0) }
@@ -94,6 +97,10 @@ enum TerminalDirectoryOpenTarget: String, CaseIterable {
 
     static var commandPaletteShortcutTargets: [Self] {
         Array(allCases)
+    }
+
+    static var inlineOpenFolderTargets: [Self] {
+        InlineWebAppRegistry.default.profiles.map(\.target)
     }
 
     static func availableTargets(in environment: DetectionEnvironment = .live) -> Set<Self> {
@@ -128,6 +135,8 @@ enum TerminalDirectoryOpenTarget: String, CaseIterable {
             return String(localized: "menu.openInVSCodeDesktop", defaultValue: "Open Current Directory in VS Code")
         case .vscodeInline:
             return String(localized: "menu.openInVSCode", defaultValue: "Open Current Directory in VS Code (Inline)")
+        case .jupyterInline:
+            return String(localized: "menu.openInJupyterInline", defaultValue: "Open Current Directory in Jupyter (Inline)")
         case .warp:
             return String(localized: "menu.openInWarp", defaultValue: "Open Current Directory in Warp")
         case .windsurf:
@@ -164,6 +173,8 @@ enum TerminalDirectoryOpenTarget: String, CaseIterable {
             return common + ["vs", "code", "visual", "studio", "desktop", "app"]
         case .vscodeInline:
             return common + ["vs", "code", "visual", "studio", "inline", "browser", "serve-web"]
+        case .jupyterInline:
+            return common + ["jupyter", "notebook", "lab", "inline", "browser", "python"]
         case .warp:
             return common + ["warp", "terminal", "shell"]
         case .windsurf:
@@ -176,12 +187,11 @@ enum TerminalDirectoryOpenTarget: String, CaseIterable {
     }
 
     func isAvailable(in environment: DetectionEnvironment = .live) -> Bool {
+        if let profile = InlineWebAppRegistry.default.profile(for: self) {
+            return profile.isAvailable(in: environment)
+        }
         guard let applicationPath = applicationPath(in: environment) else { return false }
-        guard self == .vscodeInline else { return true }
-        return VSCodeCLILaunchConfigurationBuilder.launchConfiguration(
-            vscodeApplicationURL: URL(fileURLWithPath: applicationPath, isDirectory: true),
-            isExecutableAtPath: environment.isExecutableFileAtPath
-        ) != nil
+        return true
     }
 
     func applicationURL(in environment: DetectionEnvironment = .live) -> URL? {
@@ -268,6 +278,8 @@ enum TerminalDirectoryOpenTarget: String, CaseIterable {
                 "/Applications/Visual Studio Code.app",
                 "/Applications/Code.app",
             ]
+        case .jupyterInline:
+            return []
         case .warp:
             return ["/Applications/Warp.app"]
         case .windsurf:
@@ -293,76 +305,447 @@ enum TerminalDirectoryOpenTarget: String, CaseIterable {
     }
 }
 
-enum VSCodeServeWebURLBuilder {
-    static func extractWebUIURL(from output: String) -> URL? {
-        let prefix = "Web UI available at "
-        for line in output.split(whereSeparator: \.isNewline).reversed() {
-            guard let range = line.range(of: prefix) else { continue }
-            let rawURL = line[range.upperBound...].trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !rawURL.isEmpty, let url = URL(string: rawURL) else { continue }
-            return url
-        }
-        return nil
-    }
-
-    static func openFolderURL(baseWebUIURL: URL, directoryPath: String) -> URL? {
-        var components = URLComponents(url: baseWebUIURL, resolvingAgainstBaseURL: false)
-        var queryItems = components?.queryItems ?? []
-        queryItems.removeAll { $0.name == "folder" }
-        queryItems.append(URLQueryItem(name: "folder", value: directoryPath))
-        components?.queryItems = queryItems
-        return components?.url
-    }
-}
-
-struct VSCodeCLILaunchConfiguration {
+nonisolated struct InlineWebAppLaunchConfiguration {
     let executableURL: URL
-    let argumentsPrefix: [String]
+    let arguments: [String]
     let environment: [String: String]
+    let connectionTokenFileURL: URL?
 }
 
-enum VSCodeCLILaunchConfigurationBuilder {
-    static func launchConfiguration(
-        vscodeApplicationURL: URL,
+enum InlineWebAppExecutable {
+    case applicationBundle(bundlePathCandidates: [String], executableRelativePath: String)
+    case command(names: [String], fallbackPaths: [String])
+
+    func resolve(in environment: TerminalDirectoryOpenTarget.DetectionEnvironment) -> URL? {
+        switch self {
+        case .applicationBundle(let bundlePathCandidates, let executableRelativePath):
+            for bundlePath in expandedBundlePaths(bundlePathCandidates, homeDirectoryPath: environment.homeDirectoryPath)
+                where environment.fileExistsAtPath(bundlePath) {
+                let executablePath = URL(fileURLWithPath: bundlePath, isDirectory: true)
+                    .appendingPathComponent(executableRelativePath, isDirectory: false)
+                    .path
+                if environment.isExecutableFileAtPath(executablePath) {
+                    return URL(fileURLWithPath: executablePath, isDirectory: false)
+                }
+            }
+
+            let applicationNames = inlineWebAppUniquePreservingOrder(
+                bundlePathCandidates.map {
+                    URL(fileURLWithPath: $0).deletingPathExtension().lastPathComponent
+                }
+            )
+            for applicationName in applicationNames {
+                guard let bundlePath = environment.applicationPathForName(applicationName),
+                      environment.fileExistsAtPath(bundlePath) else {
+                    continue
+                }
+                let executablePath = URL(fileURLWithPath: bundlePath, isDirectory: true)
+                    .appendingPathComponent(executableRelativePath, isDirectory: false)
+                    .path
+                if environment.isExecutableFileAtPath(executablePath) {
+                    return URL(fileURLWithPath: executablePath, isDirectory: false)
+                }
+            }
+            return nil
+        case .command(let names, let fallbackPaths):
+            let pathDirectories = environment.pathEnvironment
+                .split(separator: ":", omittingEmptySubsequences: true)
+                .map(String.init)
+            var candidates = fallbackPaths
+            for directory in pathDirectories {
+                for name in names {
+                    candidates.append(
+                        URL(fileURLWithPath: directory, isDirectory: true)
+                            .appendingPathComponent(name, isDirectory: false)
+                            .path
+                    )
+                }
+            }
+            for path in inlineWebAppUniquePreservingOrder(candidates) where environment.isExecutableFileAtPath(path) {
+                return URL(fileURLWithPath: path, isDirectory: false)
+            }
+            return nil
+        }
+    }
+
+    private func expandedBundlePaths(_ paths: [String], homeDirectoryPath: String) -> [String] {
+        let globalPrefix = "/Applications/"
+        let userPrefix = "\(homeDirectoryPath)/Applications/"
+        var expanded: [String] = []
+        for path in paths {
+            expanded.append(path)
+            if path.hasPrefix(globalPrefix) {
+                expanded.append(userPrefix + String(path.dropFirst(globalPrefix.count)))
+            }
+        }
+        return inlineWebAppUniquePreservingOrder(expanded)
+    }
+}
+
+enum InlineWebAppArgument {
+    case literal(String)
+    case directoryPath
+    case connectionTokenFilePath
+
+    func value(directoryURL: URL, connectionTokenFileURL: URL?) -> String? {
+        switch self {
+        case .literal(let value):
+            return value
+        case .directoryPath:
+            return directoryURL.path(percentEncoded: false)
+        case .connectionTokenFilePath:
+            return connectionTokenFileURL?.path
+        }
+    }
+}
+
+enum InlineWebAppServerIdentity {
+    case global
+    case directory
+
+    func value(for directoryURL: URL) -> String {
+        switch self {
+        case .global:
+            return "global"
+        case .directory:
+            return directoryURL.standardizedFileURL.path(percentEncoded: false)
+        }
+    }
+}
+
+enum InlineWebAppOpenURLStrategy {
+    case queryItem(name: String)
+    case direct
+
+    func url(baseURL: URL, directoryURL: URL) -> URL? {
+        switch self {
+        case .queryItem(let name):
+            var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false)
+            var queryItems = components?.queryItems ?? []
+            queryItems.removeAll { $0.name == name }
+            queryItems.append(URLQueryItem(name: name, value: directoryURL.path(percentEncoded: false)))
+            components?.queryItems = queryItems
+            return components?.url
+        case .direct:
+            return baseURL
+        }
+    }
+}
+
+enum InlineWebAppOutputURLExtractor {
+    case linePrefix(String)
+    case firstLoopbackHTTPURL
+
+    func extract(from output: String) -> URL? {
+        switch self {
+        case .linePrefix(let prefix):
+            for line in output.split(whereSeparator: \.isNewline).reversed() {
+                guard let range = line.range(of: prefix) else { continue }
+                let rawURL = line[range.upperBound...].trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !rawURL.isEmpty, let url = URL(string: rawURL) else { continue }
+                return url
+            }
+            return nil
+        case .firstLoopbackHTTPURL:
+            guard let regex = try? NSRegularExpression(pattern: #"https?://[^\s<>"']+"#) else { return nil }
+            let nsRange = NSRange(output.startIndex..<output.endIndex, in: output)
+            for match in regex.matches(in: output, range: nsRange).reversed() {
+                guard let range = Range(match.range, in: output) else { continue }
+                let rawURL = String(output[range])
+                    .trimmingCharacters(in: CharacterSet(charactersIn: ".,);]}\n\r\t "))
+                guard let url = URL(string: rawURL),
+                      let host = url.host?.lowercased(),
+                      ["127.0.0.1", "localhost", "::1"].contains(host) else {
+                    continue
+                }
+                return url
+            }
+            return nil
+        }
+    }
+}
+
+struct InlineWebAppProfile {
+    let target: TerminalDirectoryOpenTarget
+    let displayName: () -> String
+    let openFolderCommandId: String
+    let openFolderTitle: () -> String
+    let openFolderSubtitle: () -> String
+    let openFolderPanelTitle: () -> String
+    let openFolderPanelPrompt: () -> String
+    let stopServerCommandId: String
+    let stopServerTitle: () -> String
+    let restartServerCommandId: String
+    let restartServerTitle: () -> String
+    let keywords: [String]
+    let executable: InlineWebAppExecutable
+    let arguments: [InlineWebAppArgument]
+    let serverIdentity: InlineWebAppServerIdentity
+    let openURLStrategy: InlineWebAppOpenURLStrategy
+    let outputURLExtractor: InlineWebAppOutputURLExtractor
+    let requiresConnectionTokenFile: Bool
+    let environmentTransform: ([String: String]) -> [String: String]
+
+    func isAvailable(in environment: TerminalDirectoryOpenTarget.DetectionEnvironment = .live) -> Bool {
+        executable.resolve(in: environment) != nil
+    }
+
+    func serverIdentityValue(for directoryURL: URL) -> String {
+        serverIdentity.value(for: directoryURL)
+    }
+
+    func openURL(baseURL: URL, directoryURL: URL) -> URL? {
+        openURLStrategy.url(baseURL: baseURL, directoryURL: directoryURL)
+    }
+
+    func launchConfiguration(
+        directoryURL: URL,
         baseEnvironment: [String: String] = ProcessInfo.processInfo.environment,
-        isExecutableAtPath: (String) -> Bool = { FileManager.default.isExecutableFile(atPath: $0) }
-    ) -> VSCodeCLILaunchConfiguration? {
-        let contentsURL = vscodeApplicationURL.appendingPathComponent("Contents", isDirectory: true)
-        let codeTunnelURL = contentsURL.appendingPathComponent("Resources/app/bin/code-tunnel", isDirectory: false)
-        guard isExecutableAtPath(codeTunnelURL.path) else { return nil }
-
-        var environment = baseEnvironment
-        environment["ELECTRON_RUN_AS_NODE"] = "1"
-        environment.removeValue(forKey: "VSCODE_NODE_OPTIONS")
-        environment.removeValue(forKey: "VSCODE_NODE_REPL_EXTERNAL_MODULE")
-        if let nodeOptions = environment["NODE_OPTIONS"] {
-            environment["VSCODE_NODE_OPTIONS"] = nodeOptions
+        environment: TerminalDirectoryOpenTarget.DetectionEnvironment = .live
+    ) -> InlineWebAppLaunchConfiguration? {
+        guard let executableURL = executable.resolve(in: environment) else { return nil }
+        let connectionTokenFileURL: URL?
+        if requiresConnectionTokenFile {
+            guard let tokenFileURL = Self.makeConnectionTokenFile(targetRawValue: target.rawValue) else { return nil }
+            connectionTokenFileURL = tokenFileURL
+        } else {
+            connectionTokenFileURL = nil
         }
-        if let nodeReplExternalModule = environment["NODE_REPL_EXTERNAL_MODULE"] {
-            environment["VSCODE_NODE_REPL_EXTERNAL_MODULE"] = nodeReplExternalModule
-        }
-        environment.removeValue(forKey: "NODE_OPTIONS")
-        environment.removeValue(forKey: "NODE_REPL_EXTERNAL_MODULE")
 
-        return VSCodeCLILaunchConfiguration(
-            executableURL: codeTunnelURL,
-            argumentsPrefix: [],
-            environment: environment
+        var resolvedArguments: [String] = []
+        for argument in arguments {
+            guard let value = argument.value(
+                directoryURL: directoryURL,
+                connectionTokenFileURL: connectionTokenFileURL
+            ) else {
+                if let connectionTokenFileURL {
+                    Self.removeConnectionTokenFile(at: connectionTokenFileURL)
+                }
+                return nil
+            }
+            resolvedArguments.append(value)
+        }
+
+        return InlineWebAppLaunchConfiguration(
+            executableURL: executableURL,
+            arguments: resolvedArguments,
+            environment: environmentTransform(baseEnvironment),
+            connectionTokenFileURL: connectionTokenFileURL
         )
     }
+
+    private static func randomConnectionToken() -> String {
+        UUID().uuidString.replacingOccurrences(of: "-", with: "")
+    }
+
+    private static func makeConnectionTokenFile(targetRawValue: String) -> URL? {
+        let token = randomConnectionToken()
+        let tokenFileName = "cmux-\(targetRawValue)-token-\(UUID().uuidString)"
+        let tokenFileURL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent(tokenFileName, isDirectory: false)
+        guard let tokenData = token.data(using: .utf8) else { return nil }
+
+        let fileDescriptor = open(tokenFileURL.path, O_WRONLY | O_CREAT | O_EXCL, S_IRUSR | S_IWUSR)
+        guard fileDescriptor >= 0 else { return nil }
+        defer { _ = close(fileDescriptor) }
+
+        let wroteAllBytes = tokenData.withUnsafeBytes { rawBuffer in
+            guard let baseAddress = rawBuffer.baseAddress else { return false }
+            return write(fileDescriptor, baseAddress, rawBuffer.count) == rawBuffer.count
+        }
+        guard wroteAllBytes else {
+            removeConnectionTokenFile(at: tokenFileURL)
+            return nil
+        }
+
+        return tokenFileURL
+    }
+
+    static func removeConnectionTokenFile(at url: URL) {
+        try? FileManager.default.removeItem(at: url)
+    }
 }
 
-final class VSCodeServeWebController {
-    static let shared = VSCodeServeWebController()
-    private static let serveWebStartupTimeoutSeconds: TimeInterval = 60
+struct InlineWebAppRegistry {
+    static let `default` = InlineWebAppRegistry(profiles: [
+        InlineWebAppProfile.vscode,
+        InlineWebAppProfile.jupyter,
+    ])
 
-    private let queue = DispatchQueue(label: "cmux.vscode.serveWeb")
-    private let launchQueue = DispatchQueue(label: "cmux.vscode.serveWeb.launch")
+    let profiles: [InlineWebAppProfile]
+
+    func profile(for target: TerminalDirectoryOpenTarget) -> InlineWebAppProfile? {
+        profiles.first { $0.target == target }
+    }
+}
+
+extension InlineWebAppProfile {
+    static let vscode = InlineWebAppProfile(
+        target: .vscodeInline,
+        displayName: {
+            String(localized: "command.openFolderInVSCodeInline.subtitle", defaultValue: "VS Code Inline")
+        },
+        openFolderCommandId: "palette.openFolderInVSCodeInline",
+        openFolderTitle: {
+            String(localized: "command.openFolderInVSCodeInline.title", defaultValue: "Open Folder in VS Code (Inline)...")
+        },
+        openFolderSubtitle: {
+            String(localized: "command.openFolderInVSCodeInline.subtitle", defaultValue: "VS Code Inline")
+        },
+        openFolderPanelTitle: {
+            String(localized: "menu.file.openFolderInVSCodeInline.panelTitle", defaultValue: "Open Folder in VS Code (Inline)")
+        },
+        openFolderPanelPrompt: {
+            String(localized: "menu.file.openFolderInVSCodeInline.panelPrompt", defaultValue: "Open in VS Code")
+        },
+        stopServerCommandId: "palette.vscodeServeWebStop",
+        stopServerTitle: {
+            String(localized: "command.vscodeServeWebStop.title", defaultValue: "Stop VS Code Inline Server")
+        },
+        restartServerCommandId: "palette.vscodeServeWebRestart",
+        restartServerTitle: {
+            String(localized: "command.vscodeServeWebRestart.title", defaultValue: "Restart VS Code Inline Server")
+        },
+        keywords: ["open", "folder", "directory", "project", "vs", "code", "inline", "editor", "browser"],
+        executable: .applicationBundle(
+            bundlePathCandidates: ["/Applications/Visual Studio Code.app", "/Applications/Code.app"],
+            executableRelativePath: "Contents/Resources/app/bin/code-tunnel"
+        ),
+        arguments: [
+            .literal("serve-web"),
+            .literal("--accept-server-license-terms"),
+            .literal("--host"),
+            .literal("127.0.0.1"),
+            .literal("--port"),
+            .literal("0"),
+            .literal("--connection-token-file"),
+            .connectionTokenFilePath,
+        ],
+        serverIdentity: .global,
+        openURLStrategy: .queryItem(name: "folder"),
+        outputURLExtractor: .linePrefix("Web UI available at "),
+        requiresConnectionTokenFile: true,
+        environmentTransform: { baseEnvironment in
+            var environment = baseEnvironment
+            environment["ELECTRON_RUN_AS_NODE"] = "1"
+            environment.removeValue(forKey: "VSCODE_NODE_OPTIONS")
+            environment.removeValue(forKey: "VSCODE_NODE_REPL_EXTERNAL_MODULE")
+            if let nodeOptions = environment["NODE_OPTIONS"] {
+                environment["VSCODE_NODE_OPTIONS"] = nodeOptions
+            }
+            if let nodeReplExternalModule = environment["NODE_REPL_EXTERNAL_MODULE"] {
+                environment["VSCODE_NODE_REPL_EXTERNAL_MODULE"] = nodeReplExternalModule
+            }
+            environment.removeValue(forKey: "NODE_OPTIONS")
+            environment.removeValue(forKey: "NODE_REPL_EXTERNAL_MODULE")
+            return environment
+        }
+    )
+
+    static let jupyter = InlineWebAppProfile(
+        target: .jupyterInline,
+        displayName: {
+            String(localized: "command.openFolderInJupyterInline.subtitle", defaultValue: "Jupyter Inline")
+        },
+        openFolderCommandId: "palette.openFolderInJupyterInline",
+        openFolderTitle: {
+            String(localized: "command.openFolderInJupyterInline.title", defaultValue: "Open Folder in Jupyter (Inline)...")
+        },
+        openFolderSubtitle: {
+            String(localized: "command.openFolderInJupyterInline.subtitle", defaultValue: "Jupyter Inline")
+        },
+        openFolderPanelTitle: {
+            String(localized: "menu.file.openFolderInJupyterInline.panelTitle", defaultValue: "Open Folder in Jupyter (Inline)")
+        },
+        openFolderPanelPrompt: {
+            String(localized: "menu.file.openFolderInJupyterInline.panelPrompt", defaultValue: "Open in Jupyter")
+        },
+        stopServerCommandId: "palette.jupyterServeWebStop",
+        stopServerTitle: {
+            String(localized: "command.jupyterServeWebStop.title", defaultValue: "Stop Jupyter Inline Server")
+        },
+        restartServerCommandId: "palette.jupyterServeWebRestart",
+        restartServerTitle: {
+            String(localized: "command.jupyterServeWebRestart.title", defaultValue: "Restart Jupyter Inline Server")
+        },
+        keywords: ["open", "folder", "directory", "project", "jupyter", "notebook", "lab", "inline", "browser", "python"],
+        executable: .command(
+            names: ["jupyter"],
+            fallbackPaths: ["/opt/homebrew/bin/jupyter", "/usr/local/bin/jupyter", "/opt/local/bin/jupyter"]
+        ),
+        arguments: [
+            .literal("lab"),
+            .literal("--no-browser"),
+            .literal("--ip=127.0.0.1"),
+            .literal("--port=0"),
+            .literal("--ServerApp.open_browser=False"),
+            .literal("--ServerApp.root_dir"),
+            .directoryPath,
+        ],
+        serverIdentity: .directory,
+        openURLStrategy: .direct,
+        outputURLExtractor: .firstLoopbackHTTPURL,
+        requiresConnectionTokenFile: false,
+        environmentTransform: { $0 }
+    )
+}
+
+final class InlineWebAppRuntimeManager {
+    static let shared = InlineWebAppRuntimeManager()
+
+    private let lock = NSLock()
+    private var controllers: [TerminalDirectoryOpenTarget: InlineWebAppController] = [:]
+
+    func ensureOpenURL(
+        for profile: InlineWebAppProfile,
+        directoryURL: URL,
+        completion: @escaping (URL?) -> Void
+    ) {
+        controller(for: profile).ensureServerURL(directoryURL: directoryURL) { serverURL in
+            guard let serverURL else {
+                completion(nil)
+                return
+            }
+            completion(profile.openURL(baseURL: serverURL, directoryURL: directoryURL.standardizedFileURL))
+        }
+    }
+
+    func stop(profile: InlineWebAppProfile) {
+        controller(for: profile).stop()
+    }
+
+    func restart(
+        profile: InlineWebAppProfile,
+        directoryURL: URL,
+        completion: @escaping (URL?) -> Void
+    ) {
+        controller(for: profile).restart(directoryURL: directoryURL, completion: completion)
+    }
+
+    private func controller(for profile: InlineWebAppProfile) -> InlineWebAppController {
+        lock.lock()
+        defer { lock.unlock() }
+        if let controller = controllers[profile.target] {
+            return controller
+        }
+        let controller = InlineWebAppController(profile: profile)
+        controllers[profile.target] = controller
+        return controller
+    }
+}
+
+final class InlineWebAppController {
+    private static let startupTimeoutSeconds: TimeInterval = 60
+
+    private let profile: InlineWebAppProfile
+    private let queue: DispatchQueue
+    private let launchQueue: DispatchQueue
     private let launchProcessOverride: ((URL, UInt64) -> (process: Process, url: URL)?)?
-    private var serveWebProcess: Process?
+    private var serverProcess: Process?
     private var launchingProcess: Process?
     private var connectionTokenFilesByProcessID: [ObjectIdentifier: URL] = [:]
-    private var serveWebURL: URL?
+    private var serverURL: URL?
+    private var serverIdentityValue: String?
     private var pendingCompletions: [(generation: UInt64, completion: (URL?) -> Void)] = []
     private var isLaunching = false
     private var activeLaunchGeneration: UInt64?
@@ -371,15 +754,22 @@ final class VSCodeServeWebController {
     private var testingTrackedProcesses: [Process] = []
 #endif
 
-    private init(launchProcessOverride: ((URL, UInt64) -> (process: Process, url: URL)?)? = nil) {
+    init(
+        profile: InlineWebAppProfile,
+        launchProcessOverride: ((URL, UInt64) -> (process: Process, url: URL)?)? = nil
+    ) {
+        self.profile = profile
+        self.queue = DispatchQueue(label: "cmux.inlineWebApp.\(profile.target.rawValue)")
+        self.launchQueue = DispatchQueue(label: "cmux.inlineWebApp.\(profile.target.rawValue).launch")
         self.launchProcessOverride = launchProcessOverride
     }
 
 #if DEBUG
     static func makeForTesting(
+        profile: InlineWebAppProfile,
         launchProcessOverride: @escaping (URL, UInt64) -> (process: Process, url: URL)?
-    ) -> VSCodeServeWebController {
-        VSCodeServeWebController(launchProcessOverride: launchProcessOverride)
+    ) -> InlineWebAppController {
+        InlineWebAppController(profile: profile, launchProcessOverride: launchProcessOverride)
     }
 
     func trackConnectionTokenFileForTesting(
@@ -393,7 +783,7 @@ final class VSCodeServeWebController {
                 self.launchingProcess = process
             }
             if setAsServeWebProcess {
-                self.serveWebProcess = process
+                self.serverProcess = process
             }
             if !setAsLaunchingProcess && !setAsServeWebProcess {
                 self.testingTrackedProcesses.append(process)
@@ -403,15 +793,21 @@ final class VSCodeServeWebController {
     }
 #endif
 
-    func ensureServeWebURL(vscodeApplicationURL: URL, completion: @escaping (URL?) -> Void) {
+    func ensureServerURL(directoryURL: URL, completion: @escaping (URL?) -> Void) {
+        let normalizedDirectoryURL = directoryURL.standardizedFileURL
+        let requestedIdentity = profile.serverIdentityValue(for: normalizedDirectoryURL)
         queue.async {
-            if let process = self.serveWebProcess,
+            if let process = self.serverProcess,
                process.isRunning,
-               let url = self.serveWebURL {
-                DispatchQueue.main.async {
-                    completion(url)
-                }
+               let url = self.serverURL,
+               self.serverIdentityValue == requestedIdentity {
+                DispatchQueue.main.async { completion(url) }
                 return
+            }
+
+            if self.serverIdentityValue != nil,
+               self.serverIdentityValue != requestedIdentity {
+                Self.finishStop(self.stopLocked(completePendingWithNil: true))
             }
 
             let completionGeneration = self.lifecycleGeneration
@@ -419,13 +815,12 @@ final class VSCodeServeWebController {
             guard !self.isLaunching else { return }
 
             self.isLaunching = true
+            self.serverIdentityValue = requestedIdentity
             let launchGeneration = completionGeneration
             self.activeLaunchGeneration = launchGeneration
 
             self.launchQueue.async {
-                let shouldLaunch = self.queue.sync {
-                    self.lifecycleGeneration == launchGeneration
-                }
+                let shouldLaunch = self.queue.sync { self.lifecycleGeneration == launchGeneration }
                 guard shouldLaunch else {
                     self.queue.async {
                         guard self.activeLaunchGeneration == launchGeneration else { return }
@@ -434,8 +829,9 @@ final class VSCodeServeWebController {
                     }
                     return
                 }
-                let launchResult = self.launchServeWebProcess(
-                    vscodeApplicationURL: vscodeApplicationURL,
+
+                let launchResult = self.launchServerProcess(
+                    directoryURL: normalizedDirectoryURL,
                     expectedGeneration: launchGeneration
                 )
                 self.queue.async {
@@ -449,10 +845,6 @@ final class VSCodeServeWebController {
                     self.activeLaunchGeneration = nil
 
                     guard self.lifecycleGeneration == launchGeneration else {
-                        if let launchedProcess = launchResult?.process,
-                           self.launchingProcess === launchedProcess {
-                            self.launchingProcess = nil
-                        }
                         if let process = launchResult?.process, process.isRunning {
                             process.terminate()
                         }
@@ -461,12 +853,13 @@ final class VSCodeServeWebController {
 
                     if let launchResult {
                         self.launchingProcess = nil
-                        self.serveWebProcess = launchResult.process
-                        self.serveWebURL = launchResult.url
+                        self.serverProcess = launchResult.process
+                        self.serverURL = launchResult.url
                     } else {
                         self.launchingProcess = nil
-                        self.serveWebProcess = nil
-                        self.serveWebURL = nil
+                        self.serverProcess = nil
+                        self.serverURL = nil
+                        self.serverIdentityValue = nil
                     }
 
                     var completions: [(URL?) -> Void] = []
@@ -479,7 +872,7 @@ final class VSCodeServeWebController {
                         }
                     }
                     self.pendingCompletions = remaining
-                    let resolvedURL = self.serveWebURL
+                    let resolvedURL = self.serverURL
                     DispatchQueue.main.async {
                         completions.forEach { $0(resolvedURL) }
                     }
@@ -489,79 +882,71 @@ final class VSCodeServeWebController {
     }
 
     func stop() {
-        let (processes, tokenFileURLs, completions): ([Process], [URL], [(URL?) -> Void]) = queue.sync {
-            self.lifecycleGeneration &+= 1
-            self.isLaunching = false
-            self.activeLaunchGeneration = nil
-            var processes: [Process] = []
-            if let process = self.serveWebProcess {
-                processes.append(process)
-            }
-            if let process = self.launchingProcess,
-               !processes.contains(where: { $0 === process }) {
-                processes.append(process)
-            }
-            self.serveWebProcess = nil
-            self.launchingProcess = nil
+        Self.finishStop(queue.sync { self.stopLocked(completePendingWithNil: true) })
+    }
+
+    func restart(directoryURL: URL, completion: @escaping (URL?) -> Void) {
+        stop()
+        ensureServerURL(directoryURL: directoryURL, completion: completion)
+    }
+
+    private func stopLocked(
+        completePendingWithNil: Bool
+    ) -> (processes: [Process], tokenFileURLs: [URL], completions: [(URL?) -> Void]) {
+        lifecycleGeneration &+= 1
+        isLaunching = false
+        activeLaunchGeneration = nil
+        let processes = [serverProcess, launchingProcess].compactMap { $0 }
+        serverProcess = nil
+        launchingProcess = nil
 #if DEBUG
-            self.testingTrackedProcesses.removeAll()
+        testingTrackedProcesses.removeAll()
 #endif
-            var tokenFileURLs = processes.compactMap {
-                self.connectionTokenFilesByProcessID.removeValue(forKey: ObjectIdentifier($0))
-            }
-            tokenFileURLs.append(contentsOf: self.connectionTokenFilesByProcessID.values)
-            self.connectionTokenFilesByProcessID.removeAll()
-            self.serveWebURL = nil
-            let completions = self.pendingCompletions.map(\.completion)
-            self.pendingCompletions.removeAll()
-            return (processes, tokenFileURLs, completions)
+        var tokenFileURLs = processes.compactMap {
+            connectionTokenFilesByProcessID.removeValue(forKey: ObjectIdentifier($0))
         }
-
-        for tokenFileURL in tokenFileURLs {
-            Self.removeConnectionTokenFile(at: tokenFileURL)
+        tokenFileURLs.append(contentsOf: connectionTokenFilesByProcessID.values)
+        connectionTokenFilesByProcessID.removeAll()
+        serverURL = nil
+        serverIdentityValue = nil
+        let completions = completePendingWithNil ? pendingCompletions.map(\.completion) : []
+        if completePendingWithNil {
+            pendingCompletions.removeAll()
         }
+        return (processes, tokenFileURLs, completions)
+    }
 
-        for process in processes where process.isRunning {
+    private static func finishStop(
+        _ stopped: (processes: [Process], tokenFileURLs: [URL], completions: [(URL?) -> Void])
+    ) {
+        for tokenFileURL in stopped.tokenFileURLs {
+            InlineWebAppProfile.removeConnectionTokenFile(at: tokenFileURL)
+        }
+        for process in stopped.processes where process.isRunning {
             process.terminate()
         }
-
-        if !completions.isEmpty {
+        if !stopped.completions.isEmpty {
             DispatchQueue.main.async {
-                completions.forEach { $0(nil) }
+                stopped.completions.forEach { $0(nil) }
             }
         }
     }
 
-    func restart(vscodeApplicationURL: URL, completion: @escaping (URL?) -> Void) {
-        stop()
-        ensureServeWebURL(vscodeApplicationURL: vscodeApplicationURL, completion: completion)
-    }
-
-    private func launchServeWebProcess(
-        vscodeApplicationURL: URL,
+    private func launchServerProcess(
+        directoryURL: URL,
         expectedGeneration: UInt64
     ) -> (process: Process, url: URL)? {
         if let launchProcessOverride {
-            return launchProcessOverride(vscodeApplicationURL, expectedGeneration)
+            return launchProcessOverride(directoryURL, expectedGeneration)
         }
 
-        guard let launchConfiguration = VSCodeCLILaunchConfigurationBuilder.launchConfiguration(
-            vscodeApplicationURL: vscodeApplicationURL
-        ) else { return nil }
-
-        guard let connectionTokenFileURL = Self.makeConnectionTokenFile() else {
+        guard let launchConfiguration = profile.launchConfiguration(directoryURL: directoryURL) else {
             return nil
         }
 
         let process = Process()
         process.executableURL = launchConfiguration.executableURL
-        process.arguments = launchConfiguration.argumentsPrefix + [
-            "serve-web",
-            "--accept-server-license-terms",
-            "--host", "127.0.0.1",
-            "--port", "0",
-            "--connection-token-file", connectionTokenFileURL.path,
-        ]
+        process.arguments = launchConfiguration.arguments
         process.environment = launchConfiguration.environment
 
         let stdoutPipe = Pipe()
@@ -569,7 +954,7 @@ final class VSCodeServeWebController {
         process.standardOutput = stdoutPipe
         process.standardError = stderrPipe
 
-        let collector = ServeWebOutputCollector()
+        let collector = InlineWebAppOutputCollector(extractor: profile.outputURLExtractor)
         let outputReader: (FileHandle) -> Void = { fileHandle in
             switch ProcessPipeReader.readAvailableDataOrEndOfFile(from: fileHandle) {
             case .data(let data):
@@ -594,36 +979,35 @@ final class VSCodeServeWebController {
                 if self.launchingProcess === terminatedProcess {
                     self.launchingProcess = nil
                 }
-                if self.serveWebProcess === terminatedProcess {
-                    self.serveWebProcess = nil
-                    self.serveWebURL = nil
+                if self.serverProcess === terminatedProcess {
+                    self.serverProcess = nil
+                    self.serverURL = nil
+                    self.serverIdentityValue = nil
                 }
                 if let tokenFileURL = self.connectionTokenFilesByProcessID.removeValue(
                     forKey: ObjectIdentifier(terminatedProcess)
                 ) {
-                    Self.removeConnectionTokenFile(at: tokenFileURL)
+                    InlineWebAppProfile.removeConnectionTokenFile(at: tokenFileURL)
                 }
             }
         }
 
         let didStart: Bool = queue.sync {
-            guard self.lifecycleGeneration == expectedGeneration,
-                  self.activeLaunchGeneration == expectedGeneration else {
+            guard lifecycleGeneration == expectedGeneration,
+                  activeLaunchGeneration == expectedGeneration else {
                 return false
             }
-            self.launchingProcess = process
-            self.connectionTokenFilesByProcessID[ObjectIdentifier(process)] = connectionTokenFileURL
+            launchingProcess = process
+            if let connectionTokenFileURL = launchConfiguration.connectionTokenFileURL {
+                connectionTokenFilesByProcessID[ObjectIdentifier(process)] = connectionTokenFileURL
+            }
             do {
                 try process.run()
                 return true
             } catch {
-                if self.launchingProcess === process {
-                    self.launchingProcess = nil
-                }
-                if let tokenFileURL = self.connectionTokenFilesByProcessID.removeValue(
-                    forKey: ObjectIdentifier(process)
-                ) {
-                    Self.removeConnectionTokenFile(at: tokenFileURL)
+                launchingProcess = nil
+                if let tokenFileURL = connectionTokenFilesByProcessID.removeValue(forKey: ObjectIdentifier(process)) {
+                    InlineWebAppProfile.removeConnectionTokenFile(at: tokenFileURL)
                 }
                 return false
             }
@@ -631,39 +1015,26 @@ final class VSCodeServeWebController {
         guard didStart else {
             stdoutPipe.fileHandleForReading.readabilityHandler = nil
             stderrPipe.fileHandleForReading.readabilityHandler = nil
-            Self.removeConnectionTokenFile(at: connectionTokenFileURL)
-            return nil
-        }
-
-        guard collector.waitForURL(timeoutSeconds: Self.serveWebStartupTimeoutSeconds),
-              let serveWebURL = collector.webUIURL else {
-            stdoutPipe.fileHandleForReading.readabilityHandler = nil
-            stderrPipe.fileHandleForReading.readabilityHandler = nil
-            if process.isRunning {
-                process.terminate()
-            } else {
-                queue.sync {
-                    if self.launchingProcess === process {
-                        self.launchingProcess = nil
-                    }
-                    if self.serveWebProcess === process {
-                        self.serveWebProcess = nil
-                        self.serveWebURL = nil
-                    }
-                    if let tokenFileURL = self.connectionTokenFilesByProcessID.removeValue(
-                        forKey: ObjectIdentifier(process)
-                    ) {
-                        Self.removeConnectionTokenFile(at: tokenFileURL)
-                    }
-                }
+            if let connectionTokenFileURL = launchConfiguration.connectionTokenFileURL {
+                InlineWebAppProfile.removeConnectionTokenFile(at: connectionTokenFileURL)
             }
             return nil
         }
 
-        return (process, serveWebURL)
+        guard collector.waitForURL(timeoutSeconds: Self.startupTimeoutSeconds),
+              let serverURL = collector.webUIURL else {
+            stdoutPipe.fileHandleForReading.readabilityHandler = nil
+            stderrPipe.fileHandleForReading.readabilityHandler = nil
+            if process.isRunning {
+                process.terminate()
+            }
+            return nil
+        }
+
+        return (process, serverURL)
     }
 
-    private static func drainAvailableOutput(from fileHandle: FileHandle, collector: ServeWebOutputCollector) {
+    private static func drainAvailableOutput(from fileHandle: FileHandle, collector: InlineWebAppOutputCollector) {
         while true {
             switch ProcessPipeReader.readAvailableDataOrEndOfFile(from: fileHandle) {
             case .data(let data):
@@ -673,40 +1044,10 @@ final class VSCodeServeWebController {
             }
         }
     }
-
-    private static func randomConnectionToken() -> String {
-        UUID().uuidString.replacingOccurrences(of: "-", with: "")
-    }
-
-    private static func makeConnectionTokenFile() -> URL? {
-        let token = randomConnectionToken()
-        let tokenFileName = "cmux-vscode-token-\(UUID().uuidString)"
-        let tokenFileURL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
-            .appendingPathComponent(tokenFileName, isDirectory: false)
-        guard let tokenData = token.data(using: .utf8) else { return nil }
-
-        let fileDescriptor = open(tokenFileURL.path, O_WRONLY | O_CREAT | O_EXCL, S_IRUSR | S_IWUSR)
-        guard fileDescriptor >= 0 else { return nil }
-        defer { _ = close(fileDescriptor) }
-
-        let wroteAllBytes = tokenData.withUnsafeBytes { rawBuffer in
-            guard let baseAddress = rawBuffer.baseAddress else { return false }
-            return write(fileDescriptor, baseAddress, rawBuffer.count) == rawBuffer.count
-        }
-        guard wroteAllBytes else {
-            removeConnectionTokenFile(at: tokenFileURL)
-            return nil
-        }
-
-        return tokenFileURL
-    }
-
-    private static func removeConnectionTokenFile(at url: URL) {
-        try? FileManager.default.removeItem(at: url)
-    }
 }
 
-final class ServeWebOutputCollector {
+final class InlineWebAppOutputCollector {
+    private let extractor: InlineWebAppOutputURLExtractor
     private let lock = NSLock()
     private let semaphore = DispatchSemaphore(value: 0)
     private var outputBuffer = ""
@@ -719,6 +1060,10 @@ final class ServeWebOutputCollector {
         return resolvedURL
     }
 
+    init(extractor: InlineWebAppOutputURLExtractor) {
+        self.extractor = extractor
+    }
+
     func append(_ data: Data) {
         guard let text = String(data: data, encoding: .utf8), !text.isEmpty else { return }
         lock.lock()
@@ -728,9 +1073,7 @@ final class ServeWebOutputCollector {
         while let newlineIndex = outputBuffer.firstIndex(where: \.isNewline) {
             let line = String(outputBuffer[..<newlineIndex])
             outputBuffer.removeSubrange(...newlineIndex)
-            guard let parsedURL = VSCodeServeWebURLBuilder.extractWebUIURL(from: line) else {
-                continue
-            }
+            guard let parsedURL = extractor.extract(from: line) else { continue }
             resolvedURL = parsedURL
             outputBuffer.removeAll(keepingCapacity: false)
             if !didSignal {
@@ -745,7 +1088,7 @@ final class ServeWebOutputCollector {
         lock.lock()
         defer { lock.unlock() }
         if resolvedURL == nil, !outputBuffer.isEmpty,
-           let parsedURL = VSCodeServeWebURLBuilder.extractWebUIURL(from: outputBuffer) {
+           let parsedURL = extractor.extract(from: outputBuffer) {
             resolvedURL = parsedURL
             outputBuffer.removeAll(keepingCapacity: false)
         }
@@ -759,6 +1102,15 @@ final class ServeWebOutputCollector {
         _ = semaphore.wait(timeout: .now() + timeoutSeconds)
         return webUIURL != nil
     }
+}
+
+private func inlineWebAppUniquePreservingOrder(_ paths: [String]) -> [String] {
+    var seen: Set<String> = []
+    var deduped: [String] = []
+    for path in paths where seen.insert(path).inserted {
+        deduped.append(path)
+    }
+    return deduped
 }
 
 enum WorkspaceShortcutMapper {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1836,7 +1836,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         CmuxSSHURLProcessLauncher.shared.terminateAll()
         TerminalController.shared.stop()
         GhosttyPasteboardHelper.cleanupAllOwnedTemporaryImageFiles()
-        VSCodeServeWebController.shared.stop()
+        for profile in InlineWebAppRegistry.default.profiles {
+            InlineWebAppRuntimeManager.shared.stop(profile: profile)
+        }
         BrowserProfileStore.shared.flushPendingSaves()
         if TelemetrySettings.enabledForCurrentLaunch {
             PostHogAnalytics.shared.flush()
@@ -7257,13 +7259,28 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         _ directoryURL: URL,
         tabManager preferredTabManager: TabManager? = nil
     ) -> Bool {
-        guard let vscodeApplicationURL = TerminalDirectoryOpenTarget.vscodeInline.applicationURL() else {
+        openDirectoryInInlineWebApp(.vscode, directoryURL, tabManager: preferredTabManager)
+    }
+
+    func showOpenFolderInInlineVSCodePanel(tabManager preferredTabManager: TabManager? = nil) {
+        showOpenFolderInInlineWebAppPanel(.vscode, tabManager: preferredTabManager)
+    }
+
+    @discardableResult
+    func openDirectoryInInlineWebApp(
+        _ profile: InlineWebAppProfile,
+        _ directoryURL: URL,
+        tabManager preferredTabManager: TabManager? = nil
+    ) -> Bool {
+        guard profile.isAvailable() else {
+            NSSound.beep()
             return false
         }
 
         let targetTabManager = preferredTabManager
-            ?? preferredMainWindowContextForWorkspaceCreation(debugSource: "inlineVSCode.open.target")?.tabManager
+            ?? preferredMainWindowContextForWorkspaceCreation(debugSource: "inlineWebApp.open.\(profile.target.rawValue)")?.tabManager
         guard let targetTabManager else {
+            NSSound.beep()
             return false
         }
 
@@ -7272,21 +7289,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             ?? targetTabManager.addWorkspace(select: true).id
         let normalizedDirectoryURL = directoryURL.standardizedFileURL
 
-        VSCodeServeWebController.shared.ensureServeWebURL(vscodeApplicationURL: vscodeApplicationURL) { serveWebURL in
-            guard let serveWebURL,
-                  let openFolderURL = VSCodeServeWebURLBuilder.openFolderURL(
-                      baseWebUIURL: serveWebURL,
-                      directoryPath: normalizedDirectoryURL.path
-                  ) else {
-                NSSound.beep()
-                return
-            }
-
-            guard targetTabManager.openBrowser(
-                inWorkspace: targetWorkspaceId,
-                url: openFolderURL,
-                preferSplitRight: true
-            ) != nil else {
+        InlineWebAppRuntimeManager.shared.ensureOpenURL(
+            for: profile,
+            directoryURL: normalizedDirectoryURL
+        ) { openURL in
+            guard let openURL,
+                  targetTabManager.openBrowser(
+                      inWorkspace: targetWorkspaceId,
+                      url: openURL,
+                      preferSplitRight: true
+                  ) != nil else {
                 NSSound.beep()
                 return
             }
@@ -7295,14 +7307,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return true
     }
 
-    func showOpenFolderInInlineVSCodePanel(tabManager preferredTabManager: TabManager? = nil) {
-        guard TerminalDirectoryOpenTarget.vscodeInline.isAvailable() else {
+    func showOpenFolderInInlineWebAppPanel(
+        _ profile: InlineWebAppProfile,
+        tabManager preferredTabManager: TabManager? = nil
+    ) {
+        guard profile.isAvailable() else {
             NSSound.beep()
             return
         }
 
         let targetTabManager = preferredTabManager
-            ?? preferredMainWindowContextForWorkspaceCreation(debugSource: "inlineVSCode.panel.target")?.tabManager
+            ?? preferredMainWindowContextForWorkspaceCreation(debugSource: "inlineWebApp.panel.\(profile.target.rawValue)")?.tabManager
         guard let targetTabManager else {
             NSSound.beep()
             return
@@ -7312,14 +7327,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         panel.canChooseFiles = false
         panel.canChooseDirectories = true
         panel.allowsMultipleSelection = false
-        panel.title = String(
-            localized: "menu.file.openFolderInVSCodeInline.panelTitle",
-            defaultValue: "Open Folder in VS Code (Inline)"
-        )
-        panel.prompt = String(
-            localized: "menu.file.openFolderInVSCodeInline.panelPrompt",
-            defaultValue: "Open in VS Code"
-        )
+        panel.title = profile.openFolderPanelTitle()
+        panel.prompt = profile.openFolderPanelPrompt()
         if let cwd = targetTabManager.selectedWorkspace?.currentDirectory,
            !cwd.isEmpty {
             panel.directoryURL = URL(fileURLWithPath: cwd)
@@ -7327,7 +7336,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         if panel.runModal() == .OK,
            let url = panel.url,
-           !openDirectoryInInlineVSCode(url, tabManager: targetTabManager) {
+           !openDirectoryInInlineWebApp(profile, url, tabManager: targetTabManager) {
             NSSound.beep()
         }
     }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -6700,25 +6700,17 @@ struct ContentView: View {
                 keywords: ["open", "folder", "repository", "project", "directory"]
             )
         )
-        contributions.append(
-            CommandPaletteCommandContribution(
-                commandId: "palette.openFolderInVSCodeInline",
-                title: constant(
-                    String(
-                        localized: "command.openFolderInVSCodeInline.title",
-                        defaultValue: "Open Folder in VS Code (Inline)…"
-                    )
-                ),
-                subtitle: constant(
-                    String(
-                        localized: "command.openFolderInVSCodeInline.subtitle",
-                        defaultValue: "VS Code Inline"
-                    )
-                ),
-                keywords: ["open", "folder", "directory", "project", "vs", "code", "inline", "editor", "browser"],
-                when: { _ in TerminalDirectoryOpenTarget.vscodeInline.isAvailable() }
+        for profile in InlineWebAppRegistry.default.profiles {
+            contributions.append(
+                CommandPaletteCommandContribution(
+                    commandId: profile.openFolderCommandId,
+                    title: { _ in profile.openFolderTitle() },
+                    subtitle: { _ in profile.openFolderSubtitle() },
+                    keywords: profile.keywords,
+                    when: { _ in profile.isAvailable() }
+                )
             )
-        )
+        }
         contributions.append(
             CommandPaletteCommandContribution(
                 commandId: "palette.reopenPreviousSession",
@@ -7460,30 +7452,32 @@ struct ContentView: View {
                 )
             )
         }
-        contributions.append(
-            CommandPaletteCommandContribution(
-                commandId: "palette.vscodeServeWebStop",
-                title: constant(String(localized: "command.vscodeServeWebStop.title", defaultValue: "Stop VS Code Inline Server")),
-                subtitle: terminalPanelSubtitle,
-                keywords: ["vscode", "inline", "serve-web", "stop", "server"],
-                when: { context in
-                    context.bool(CommandPaletteContextKeys.panelIsTerminal)
-                        && context.bool(CommandPaletteContextKeys.terminalOpenTargetAvailable(.vscodeInline))
-                }
+        for profile in InlineWebAppRegistry.default.profiles {
+            contributions.append(
+                CommandPaletteCommandContribution(
+                    commandId: profile.stopServerCommandId,
+                    title: { _ in profile.stopServerTitle() },
+                    subtitle: terminalPanelSubtitle,
+                    keywords: profile.keywords + ["stop", "server"],
+                    when: { context in
+                        context.bool(CommandPaletteContextKeys.panelIsTerminal)
+                            && context.bool(CommandPaletteContextKeys.terminalOpenTargetAvailable(profile.target))
+                    }
+                )
             )
-        )
-        contributions.append(
-            CommandPaletteCommandContribution(
-                commandId: "palette.vscodeServeWebRestart",
-                title: constant(String(localized: "command.vscodeServeWebRestart.title", defaultValue: "Restart VS Code Inline Server")),
-                subtitle: terminalPanelSubtitle,
-                keywords: ["vscode", "inline", "serve-web", "restart", "server"],
-                when: { context in
-                    context.bool(CommandPaletteContextKeys.panelIsTerminal)
-                        && context.bool(CommandPaletteContextKeys.terminalOpenTargetAvailable(.vscodeInline))
-                }
+            contributions.append(
+                CommandPaletteCommandContribution(
+                    commandId: profile.restartServerCommandId,
+                    title: { _ in profile.restartServerTitle() },
+                    subtitle: terminalPanelSubtitle,
+                    keywords: profile.keywords + ["restart", "server"],
+                    when: { context in
+                        context.bool(CommandPaletteContextKeys.panelIsTerminal)
+                            && context.bool(CommandPaletteContextKeys.terminalOpenTargetAvailable(profile.target))
+                    }
+                )
             )
-        )
+        }
         contributions.append(
             CommandPaletteCommandContribution(
                 commandId: "palette.findInDirectory",
@@ -7864,9 +7858,11 @@ struct ContentView: View {
                 }
             }
         }
-        registry.register(commandId: "palette.openFolderInVSCodeInline") {
-            DispatchQueue.main.async {
-                AppDelegate.shared?.showOpenFolderInInlineVSCodePanel(tabManager: tabManager)
+        for profile in InlineWebAppRegistry.default.profiles {
+            registry.register(commandId: profile.openFolderCommandId) {
+                DispatchQueue.main.async {
+                    AppDelegate.shared?.showOpenFolderInInlineWebAppPanel(profile, tabManager: tabManager)
+                }
             }
         }
         registry.register(commandId: "palette.reopenPreviousSession") {
@@ -8269,12 +8265,14 @@ struct ContentView: View {
                 }
             }
         }
-        registry.register(commandId: "palette.vscodeServeWebStop") {
-            stopInlineVSCodeServeWeb()
-        }
-        registry.register(commandId: "palette.vscodeServeWebRestart") {
-            if !restartInlineVSCodeServeWeb() {
-                NSSound.beep()
+        for profile in InlineWebAppRegistry.default.profiles {
+            registry.register(commandId: profile.stopServerCommandId) {
+                stopInlineWebAppServer(profile)
+            }
+            registry.register(commandId: profile.restartServerCommandId) {
+                if !restartInlineWebAppServer(profile) {
+                    NSSound.beep()
+                }
             }
         }
         registry.register(commandId: "palette.terminalFind") {
@@ -9755,8 +9753,9 @@ struct ContentView: View {
         case .finder:
             NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: directoryURL.path)
             return true
-        case .vscodeInline:
-            return openFocusedDirectoryInInlineVSCode(directoryURL)
+        case let target where InlineWebAppRegistry.default.profile(for: target) != nil:
+            guard let profile = InlineWebAppRegistry.default.profile(for: target) else { return false }
+            return openFocusedDirectoryInInlineWebApp(profile, directoryURL)
         default:
             guard let applicationURL = target.applicationURL() else { return false }
             let configuration = NSWorkspace.OpenConfiguration()
@@ -9765,19 +9764,20 @@ struct ContentView: View {
         }
     }
 
-    private func openFocusedDirectoryInInlineVSCode(_ directoryURL: URL) -> Bool {
-        AppDelegate.shared?.openDirectoryInInlineVSCode(directoryURL, tabManager: tabManager) ?? false
+    private func openFocusedDirectoryInInlineWebApp(_ profile: InlineWebAppProfile, _ directoryURL: URL) -> Bool {
+        AppDelegate.shared?.openDirectoryInInlineWebApp(profile, directoryURL, tabManager: tabManager) ?? false
     }
 
-    private func stopInlineVSCodeServeWeb() {
-        VSCodeServeWebController.shared.stop()
+    private func stopInlineWebAppServer(_ profile: InlineWebAppProfile) {
+        InlineWebAppRuntimeManager.shared.stop(profile: profile)
     }
 
-    private func restartInlineVSCodeServeWeb() -> Bool {
-        guard let vscodeApplicationURL = TerminalDirectoryOpenTarget.vscodeInline.applicationURL() else {
+    private func restartInlineWebAppServer(_ profile: InlineWebAppProfile) -> Bool {
+        guard profile.isAvailable(),
+              let directoryURL = focusedTerminalDirectoryURL() else {
             return false
         }
-        VSCodeServeWebController.shared.restart(vscodeApplicationURL: vscodeApplicationURL) { serveWebURL in
+        InlineWebAppRuntimeManager.shared.restart(profile: profile, directoryURL: directoryURL) { serveWebURL in
             if serveWebURL == nil {
                 NSSound.beep()
             }

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -632,15 +632,12 @@ struct cmuxApp: App {
                     AppDelegate.shared?.showOpenFolderPanel()
                 }
 
-                Button(
-                    String(
-                        localized: "menu.file.openFolderInVSCodeInline",
-                        defaultValue: "Open Folder in VS Code (Inline)…"
-                    )
-                ) {
-                    AppDelegate.shared?.showOpenFolderInInlineVSCodePanel()
+                ForEach(InlineWebAppRegistry.default.profiles, id: \.target.rawValue) { profile in
+                    Button(profile.openFolderTitle()) {
+                        AppDelegate.shared?.showOpenFolderInInlineWebAppPanel(profile)
+                    }
+                    .disabled(!profile.isAvailable())
                 }
-                .disabled(!TerminalDirectoryOpenTarget.vscodeInline.isAvailable())
             }
 
             // Close tab/workspace

--- a/cmuxTests/OmnibarAndToolsTests.swift
+++ b/cmuxTests/OmnibarAndToolsTests.swift
@@ -171,7 +171,7 @@ final class FinderServicePathResolverTests: XCTestCase {
 }
 
 
-final class VSCodeServeWebURLBuilderTests: XCTestCase {
+final class InlineWebAppProfileVSCodeTests: XCTestCase {
     func testExtractWebUIURLParsesServeWebOutput() {
         let output = """
         *
@@ -180,16 +180,16 @@ final class VSCodeServeWebURLBuilderTests: XCTestCase {
         Web UI available at http://127.0.0.1:5555?tkn=test-token
         """
 
-        let url = VSCodeServeWebURLBuilder.extractWebUIURL(from: output)
+        let url = InlineWebAppProfile.vscode.outputURLExtractor.extract(from: output)
         XCTAssertEqual(url?.absoluteString, "http://127.0.0.1:5555?tkn=test-token")
     }
 
     func testOpenFolderURLAppendsFolderQueryWhilePreservingToken() {
         let baseURL = URL(string: "http://127.0.0.1:5555?tkn=test-token")!
 
-        let url = VSCodeServeWebURLBuilder.openFolderURL(
-            baseWebUIURL: baseURL,
-            directoryPath: "/Users/tester/Projects/cmux"
+        let url = InlineWebAppProfile.vscode.openURL(
+            baseURL: baseURL,
+            directoryURL: URL(fileURLWithPath: "/Users/tester/Projects/cmux", isDirectory: true)
         )
 
         let components = URLComponents(url: url!, resolvingAgainstBaseURL: false)
@@ -200,9 +200,9 @@ final class VSCodeServeWebURLBuilderTests: XCTestCase {
     func testOpenFolderURLReplacesExistingFolderQuery() {
         let baseURL = URL(string: "http://127.0.0.1:5555?tkn=test-token&folder=/tmp/old")!
 
-        let url = VSCodeServeWebURLBuilder.openFolderURL(
-            baseWebUIURL: baseURL,
-            directoryPath: "/Users/tester/New Folder"
+        let url = InlineWebAppProfile.vscode.openURL(
+            baseURL: baseURL,
+            directoryURL: URL(fileURLWithPath: "/Users/tester/New Folder", isDirectory: true)
         )
 
         let components = URLComponents(url: url!, resolvingAgainstBaseURL: false)
@@ -218,32 +218,64 @@ final class VSCodeServeWebURLBuilderTests: XCTestCase {
 }
 
 
-final class VSCodeCLILaunchConfigurationBuilderTests: XCTestCase {
-    func testLaunchConfigurationUsesCodeTunnelBinary() {
-        let appURL = URL(fileURLWithPath: "/Applications/Visual Studio Code.app", isDirectory: true)
-        let expectedExecutablePath = "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code-tunnel"
-
-        let configuration = VSCodeCLILaunchConfigurationBuilder.launchConfiguration(
-            vscodeApplicationURL: appURL,
-            baseEnvironment: [:],
-            isExecutableAtPath: { $0 == expectedExecutablePath }
+final class InlineWebAppLaunchConfigurationTests: XCTestCase {
+    private func environment(existingPaths: Set<String>) -> TerminalDirectoryOpenTarget.DetectionEnvironment {
+        TerminalDirectoryOpenTarget.DetectionEnvironment(
+            homeDirectoryPath: "/Users/tester",
+            pathEnvironment: "",
+            fileExistsAtPath: { existingPaths.contains($0) },
+            isExecutableFileAtPath: { existingPaths.contains($0) },
+            applicationPathForName: { _ in nil }
         )
+    }
+
+    func testLaunchConfigurationUsesCodeTunnelBinary() {
+        let expectedExecutablePath = "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code-tunnel"
+        let env = environment(existingPaths: [
+            "/Applications/Visual Studio Code.app",
+            expectedExecutablePath,
+        ])
+
+        let configuration = InlineWebAppProfile.vscode.launchConfiguration(
+            directoryURL: URL(fileURLWithPath: "/Users/tester/project", isDirectory: true),
+            baseEnvironment: [:],
+            environment: env
+        )
+        defer {
+            if let connectionTokenFileURL = configuration?.connectionTokenFileURL {
+                InlineWebAppProfile.removeConnectionTokenFile(at: connectionTokenFileURL)
+            }
+        }
 
         XCTAssertEqual(configuration?.executableURL.path, expectedExecutablePath)
-        XCTAssertEqual(configuration?.argumentsPrefix, [])
+        XCTAssertEqual(
+            Array(configuration?.arguments.prefix(2) ?? ArraySlice<String>()),
+            ["serve-web", "--accept-server-license-terms"]
+        )
         XCTAssertEqual(configuration?.environment["ELECTRON_RUN_AS_NODE"], "1")
     }
 
     func testLaunchConfigurationMapsNodeEnvironmentVariables() {
-        let configuration = VSCodeCLILaunchConfigurationBuilder.launchConfiguration(
-            vscodeApplicationURL: URL(fileURLWithPath: "/Applications/Visual Studio Code.app", isDirectory: true),
+        let expectedExecutablePath = "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code-tunnel"
+        let env = environment(existingPaths: [
+            "/Applications/Visual Studio Code.app",
+            expectedExecutablePath,
+        ])
+
+        let configuration = InlineWebAppProfile.vscode.launchConfiguration(
+            directoryURL: URL(fileURLWithPath: "/Users/tester/project", isDirectory: true),
             baseEnvironment: [
                 "PATH": "/usr/bin:/bin",
                 "NODE_OPTIONS": "--max-old-space-size=4096",
                 "NODE_REPL_EXTERNAL_MODULE": "module-name"
             ],
-            isExecutableAtPath: { _ in true }
+            environment: env
         )
+        defer {
+            if let connectionTokenFileURL = configuration?.connectionTokenFileURL {
+                InlineWebAppProfile.removeConnectionTokenFile(at: connectionTokenFileURL)
+            }
+        }
 
         XCTAssertEqual(configuration?.environment["PATH"], "/usr/bin:/bin")
         XCTAssertEqual(configuration?.environment["VSCODE_NODE_OPTIONS"], "--max-old-space-size=4096")
@@ -253,15 +285,26 @@ final class VSCodeCLILaunchConfigurationBuilderTests: XCTestCase {
     }
 
     func testLaunchConfigurationClearsStaleVSCodeNodeVariablesWhenNodeVariablesAreAbsent() {
-        let configuration = VSCodeCLILaunchConfigurationBuilder.launchConfiguration(
-            vscodeApplicationURL: URL(fileURLWithPath: "/Applications/Visual Studio Code.app", isDirectory: true),
+        let expectedExecutablePath = "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code-tunnel"
+        let env = environment(existingPaths: [
+            "/Applications/Visual Studio Code.app",
+            expectedExecutablePath,
+        ])
+
+        let configuration = InlineWebAppProfile.vscode.launchConfiguration(
+            directoryURL: URL(fileURLWithPath: "/Users/tester/project", isDirectory: true),
             baseEnvironment: [
                 "PATH": "/usr/bin:/bin",
                 "VSCODE_NODE_OPTIONS": "--stale",
                 "VSCODE_NODE_REPL_EXTERNAL_MODULE": "stale-module"
             ],
-            isExecutableAtPath: { _ in true }
+            environment: env
         )
+        defer {
+            if let connectionTokenFileURL = configuration?.connectionTokenFileURL {
+                InlineWebAppProfile.removeConnectionTokenFile(at: connectionTokenFileURL)
+            }
+        }
 
         XCTAssertEqual(configuration?.environment["PATH"], "/usr/bin:/bin")
         XCTAssertNil(configuration?.environment["VSCODE_NODE_OPTIONS"])
@@ -270,9 +313,9 @@ final class VSCodeCLILaunchConfigurationBuilderTests: XCTestCase {
 }
 
 
-final class ServeWebOutputCollectorTests: XCTestCase {
+final class InlineWebAppOutputCollectorTests: XCTestCase {
     func testWaitForURLReturnsFalseAfterProcessExitSignal() {
-        let collector = ServeWebOutputCollector()
+        let collector = InlineWebAppOutputCollector(extractor: .linePrefix("Web UI available at "))
 
         DispatchQueue.global().asyncAfter(deadline: .now() + 0.05) {
             collector.markProcessExited()
@@ -287,7 +330,7 @@ final class ServeWebOutputCollectorTests: XCTestCase {
     }
 
     func testWaitForURLReturnsTrueWhenURLIsCollected() {
-        let collector = ServeWebOutputCollector()
+        let collector = InlineWebAppOutputCollector(extractor: .linePrefix("Web UI available at "))
         let urlLine = "Web UI available at http://127.0.0.1:7777?tkn=test-token\n"
 
         DispatchQueue.global().asyncAfter(deadline: .now() + 0.05) {
@@ -299,7 +342,7 @@ final class ServeWebOutputCollectorTests: XCTestCase {
     }
 
     func testMarkProcessExitedParsesFinalURLWithoutTrailingNewline() {
-        let collector = ServeWebOutputCollector()
+        let collector = InlineWebAppOutputCollector(extractor: .linePrefix("Web UI available at "))
         let finalChunk = "Web UI available at http://127.0.0.1:9001?tkn=final-token"
 
         collector.append(Data(finalChunk.utf8))
@@ -311,7 +354,7 @@ final class ServeWebOutputCollectorTests: XCTestCase {
 }
 
 
-final class VSCodeServeWebControllerTests: XCTestCase {
+final class InlineWebAppControllerTests: XCTestCase {
     func testStopDuringInFlightLaunchDoesNotDropNextGenerationCompletion() {
         let firstLaunchStarted = expectation(description: "first launch started")
         let firstCompletionCalled = expectation(description: "first generation completion called")
@@ -321,7 +364,7 @@ final class VSCodeServeWebControllerTests: XCTestCase {
         let launchCallLock = NSLock()
         var launchCallCount = 0
 
-        let controller = VSCodeServeWebController.makeForTesting { _, _ in
+        let controller = InlineWebAppController.makeForTesting(profile: .vscode) { _, _ in
             launchCallLock.lock()
             launchCallCount += 1
             let callNumber = launchCallCount
@@ -337,9 +380,9 @@ final class VSCodeServeWebControllerTests: XCTestCase {
         let callbackLock = NSLock()
         var firstGenerationCallbacks: [URL?] = []
         var secondGenerationCallbacks: [URL?] = []
-        let vscodeAppURL = URL(fileURLWithPath: "/Applications/Visual Studio Code.app", isDirectory: true)
+        let directoryURL = URL(fileURLWithPath: "/Users/tester/project", isDirectory: true)
 
-        controller.ensureServeWebURL(vscodeApplicationURL: vscodeAppURL) { url in
+        controller.ensureServerURL(directoryURL: directoryURL) { url in
             callbackLock.lock()
             firstGenerationCallbacks.append(url)
             callbackLock.unlock()
@@ -349,7 +392,7 @@ final class VSCodeServeWebControllerTests: XCTestCase {
         wait(for: [firstLaunchStarted], timeout: 1)
         controller.stop()
 
-        controller.ensureServeWebURL(vscodeApplicationURL: vscodeAppURL) { url in
+        controller.ensureServerURL(directoryURL: directoryURL) { url in
             callbackLock.lock()
             secondGenerationCallbacks.append(url)
             callbackLock.unlock()
@@ -385,7 +428,7 @@ final class VSCodeServeWebControllerTests: XCTestCase {
         try Data("token".utf8).write(to: tokenFileURL)
         XCTAssertTrue(FileManager.default.fileExists(atPath: tokenFileURL.path))
 
-        let controller = VSCodeServeWebController.makeForTesting { _, _ in
+        let controller = InlineWebAppController.makeForTesting(profile: .vscode) { _, _ in
             XCTFail("Expected no launch")
             return nil
         }

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -2080,10 +2080,12 @@ final class TerminalDirectoryOpenTargetAvailabilityTests: XCTestCase {
     private func environment(
         existingPaths: Set<String>,
         homeDirectoryPath: String = "/Users/tester",
+        pathEnvironment: String = "",
         applicationPathsByName: [String: String] = [:]
     ) -> TerminalDirectoryOpenTarget.DetectionEnvironment {
         TerminalDirectoryOpenTarget.DetectionEnvironment(
             homeDirectoryPath: homeDirectoryPath,
+            pathEnvironment: pathEnvironment,
             fileExistsAtPath: { existingPaths.contains($0) },
             isExecutableFileAtPath: { existingPaths.contains($0) },
             applicationPathForName: { applicationPathsByName[$0] }
@@ -2131,6 +2133,17 @@ final class TerminalDirectoryOpenTargetAvailabilityTests: XCTestCase {
         XCTAssertFalse(TerminalDirectoryOpenTarget.vscodeInline.isAvailable(in: env))
     }
 
+    func testJupyterInlineRequiresExecutable() {
+        let missingEnv = environment(existingPaths: [])
+        XCTAssertFalse(TerminalDirectoryOpenTarget.jupyterInline.isAvailable(in: missingEnv))
+
+        let pathEnv = environment(
+            existingPaths: ["/Users/tester/.local/bin/jupyter"],
+            pathEnvironment: "/Users/tester/.local/bin"
+        )
+        XCTAssertTrue(TerminalDirectoryOpenTarget.jupyterInline.isAvailable(in: pathEnv))
+    }
+
     func testITerm2DetectsLegacyBundleName() {
         let env = environment(existingPaths: ["/Applications/iTerm.app"])
         XCTAssertTrue(TerminalDirectoryOpenTarget.iterm2.isAvailable(in: env))
@@ -2156,6 +2169,98 @@ final class TerminalDirectoryOpenTargetAvailabilityTests: XCTestCase {
         let availableTargets = TerminalDirectoryOpenTarget.availableTargets(in: env)
         XCTAssertTrue(availableTargets.contains(.vscode))
         XCTAssertTrue(availableTargets.contains(.vscodeInline))
+    }
+
+    func testInlineWebAppOpenURLStrategies() throws {
+        let baseURL = try XCTUnwrap(URL(string: "http://127.0.0.1:3000/?tkn=abc"))
+        let directoryURL = URL(fileURLWithPath: "/Users/tester/project", isDirectory: true)
+
+        let vscodeURL = try XCTUnwrap(InlineWebAppProfile.vscode.openURL(
+            baseURL: baseURL,
+            directoryURL: directoryURL
+        ))
+        XCTAssertEqual(vscodeURL.absoluteString, "http://127.0.0.1:3000/?tkn=abc&folder=/Users/tester/project")
+
+        let jupyterURL = try XCTUnwrap(InlineWebAppProfile.jupyter.openURL(
+            baseURL: baseURL,
+            directoryURL: directoryURL
+        ))
+        XCTAssertEqual(jupyterURL, baseURL)
+    }
+
+    func testInlineWebAppProfilesBuildLaunchConfigurations() throws {
+        let vscodePath = "/Applications/Visual Studio Code.app"
+        let vscodeEnv = environment(
+            existingPaths: [
+                vscodePath,
+                "\(vscodePath)/Contents/Resources/app/bin/code-tunnel",
+            ]
+        )
+        let vscodeConfig = try XCTUnwrap(InlineWebAppProfile.vscode.launchConfiguration(
+            directoryURL: URL(fileURLWithPath: "/Users/tester/project", isDirectory: true),
+            baseEnvironment: [
+                "NODE_OPTIONS": "--inspect",
+                "NODE_REPL_EXTERNAL_MODULE": "loader",
+            ],
+            environment: vscodeEnv
+        ))
+        defer {
+            if let connectionTokenFileURL = vscodeConfig.connectionTokenFileURL {
+                InlineWebAppProfile.removeConnectionTokenFile(at: connectionTokenFileURL)
+            }
+        }
+
+        XCTAssertEqual(vscodeConfig.executableURL.path, "\(vscodePath)/Contents/Resources/app/bin/code-tunnel")
+        XCTAssertEqual(
+            Array(vscodeConfig.arguments.prefix(6)),
+            ["serve-web", "--accept-server-license-terms", "--host", "127.0.0.1", "--port", "0"]
+        )
+        XCTAssertTrue(vscodeConfig.arguments.contains("--connection-token-file"))
+        XCTAssertEqual(vscodeConfig.environment["ELECTRON_RUN_AS_NODE"], "1")
+        XCTAssertNil(vscodeConfig.environment["NODE_OPTIONS"])
+        XCTAssertEqual(vscodeConfig.environment["VSCODE_NODE_OPTIONS"], "--inspect")
+        XCTAssertEqual(vscodeConfig.environment["VSCODE_NODE_REPL_EXTERNAL_MODULE"], "loader")
+
+        let jupyterEnv = environment(
+            existingPaths: ["/opt/homebrew/bin/jupyter"],
+            pathEnvironment: "/opt/homebrew/bin"
+        )
+        let jupyterConfig = try XCTUnwrap(InlineWebAppProfile.jupyter.launchConfiguration(
+            directoryURL: URL(fileURLWithPath: "/Users/tester/notebooks", isDirectory: true),
+            baseEnvironment: [:],
+            environment: jupyterEnv
+        ))
+
+        XCTAssertEqual(jupyterConfig.executableURL.path, "/opt/homebrew/bin/jupyter")
+        XCTAssertEqual(
+            jupyterConfig.arguments,
+            [
+                "lab",
+                "--no-browser",
+                "--ip=127.0.0.1",
+                "--port=0",
+                "--ServerApp.open_browser=False",
+                "--ServerApp.root_dir",
+                "/Users/tester/notebooks",
+            ]
+        )
+        XCTAssertNil(jupyterConfig.connectionTokenFileURL)
+    }
+
+    func testInlineWebAppOutputExtractors() throws {
+        let vscodeURL = InlineWebAppOutputURLExtractor.linePrefix("Web UI available at ")
+            .extract(from: "ready\nWeb UI available at http://127.0.0.1:49152/?tkn=abc\n")
+        XCTAssertEqual(vscodeURL?.absoluteString, "http://127.0.0.1:49152/?tkn=abc")
+
+        let jupyterURL = InlineWebAppOutputURLExtractor.firstLoopbackHTTPURL.extract(
+            from: "or copy and paste one of these URLs:\n    http://127.0.0.1:8888/lab?token=abc\n"
+        )
+        XCTAssertEqual(jupyterURL?.absoluteString, "http://127.0.0.1:8888/lab?token=abc")
+
+        let externalURL = InlineWebAppOutputURLExtractor.firstLoopbackHTTPURL.extract(
+            from: "https://example.com/lab?token=abc"
+        )
+        XCTAssertNil(externalURL)
     }
 
     func testTowerDetectedViaApplicationLookupOutsideApplications() {


### PR DESCRIPTION
## Summary
- Add a reusable inline web app profile abstraction for directory-backed browser modes.
- Move VS Code Inline onto the shared profile/controller path and add Jupyter Inline as a default profile.
- Wire File menu, command palette open/stop/restart actions, localization, and unit coverage for profile URL/build behavior.

## Testing
- ./scripts/reload.sh --tag jupmod (pass)
- git diff --check (pass)
- plutil -convert json -o /tmp/cmux-localizable-jupmod.json Resources/Localizable.xcstrings && jq empty /tmp/cmux-localizable-jupmod.json (pass)
- ./scripts/lint-pbxproj-test-wiring.sh (pass)

## Issues
- Related: plain-text task request from chat

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782993214&installation_id=133855650&pr_number=5207&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5207&signature=7930c26c4bc5cb557d14e6c48af39efdcd91d208f9153a7fcd72a774d6799945"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Spawns and manages local child processes and loopback URLs; behavior is user-facing but not security-critical beyond normal local server exposure.
> 
> **Overview**
> Introduces a **profile-driven inline web app** layer and adds **Jupyter (Inline)** alongside the refactored **VS Code (Inline)** path.
> 
> VS Code–specific `serve-web` code is replaced with shared types (`InlineWebAppProfile`, registry, runtime manager, controller) that launch a local server, parse its URL from stdout, and open it in an embedded browser tab. Profiles differ by executable resolution (app bundle vs `PATH`), launch args, whether the server is **global** (VS Code) or **per directory** (Jupyter Lab with `ServerApp.root_dir`), and how the folder is passed (query `folder` vs direct URL).
> 
> **UI and lifecycle** now iterate registered profiles: File menu open-folder actions, command palette open/stop/restart, terminal “open current directory,” and app quit all stop every inline server. New **en/ja** strings cover Jupyter commands and menus. Tests were renamed/extended for profiles, launch config, URL extraction, and availability (including `PATH` for `jupyter`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 919b527aa17fbea0c0090f033bc25db67d403394. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a profile-backed inline web app system and introduces Jupyter Inline alongside VS Code Inline, letting users open folders inline and manage servers with simple commands and menus.

- **New Features**
  - New `InlineWebAppProfile` + `InlineWebAppRegistry` and `InlineWebAppRuntimeManager` to launch and manage inline servers.
  - Added Jupyter Inline profile (runs `jupyter lab`), detected via PATH, with localized File menu and command palette actions (EN/JA).
  - Per-profile open/stop/restart commands; URL handling per app (VS Code adds a folder query, Jupyter uses the base URL).

- **Refactors**
  - VS Code Inline moved onto the shared profile/controller; replaced `VSCodeServeWebController` with `InlineWebAppController`.
  - File menu and command palette now iterate profiles; availability and open flows unified.
  - Tests updated and added for launch configs, URL extraction, PATH-based detection, and Jupyter availability.

<sup>Written for commit 919b527aa17fbea0c0090f033bc25db67d403394. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

