### PR TITLE
Add daily Codex docs audit workflow

### DIFF
--- a/.github/prompts/daily-docs-codex.md
+++ b/.github/prompts/daily-docs-codex.md
@@ -1,0 +1,34 @@
+You are running in GitHub Actions on the `manaflow-ai/cmux` repository.
+
+Goal: audit the recent and historical commit stream for product, CLI, app, cloud, automation, and docs changes that should be reflected in cmux documentation. Update docs when the repository now exposes behavior that the docs do not explain, or when existing docs are stale.
+
+Use the filesystem and git history. Start from `git log --stat --decorate --date=iso --all`, then inspect the relevant source files, existing docs, and web docs implementation before editing. The checkout has full history. Prefer precise, user-facing docs updates over broad generated prose.
+
+Docs surfaces:
+- End-user docs site: `web/app/[locale]/docs/**`, `web/app/[locale]/components/docs-nav-items.ts`, and `web/messages/*.json`
+- Source docs and operational runbooks: `docs/**`
+- Changelog source: `CHANGELOG.md`
+
+When adding or changing web docs:
+- Keep docs concise.
+- Update `web/app/[locale]/components/docs-nav-items.ts` for new pages.
+- Update every `web/messages/*.json` locale file for any new or changed message keys. If exact translation is uncertain, use clear English fallback rather than leaving a missing key.
+- Keep all user-facing web strings routed through the message files.
+- Avoid raw `useEffect` in React code.
+
+When changing source docs:
+- Keep commands root-relative.
+- Use full GitHub URLs instead of bare issue or PR references.
+
+Do not:
+- Push, create branches, create PRs, or call GitHub write APIs. The workflow handles that.
+- Run macOS app builds, reload scripts, local Xcode tests, or anything that can launch cmux.
+- Add low-value tests that only assert source file shape.
+- Invent docs for behavior you cannot verify in code or commit history.
+
+Verification:
+- If you touch `web/**`, run the narrowest practical web check from `web/`, normally `bun tsc --noEmit` and `bun test` if dependencies are already available or cheap to install.
+- If you touch only Markdown docs, inspect the edited files and skip heavyweight checks.
+- Leave a final summary explaining what changed and what you verified.
+
+If no docs update is justified after the audit, make no file changes and say that clearly in the final summary.

--- a/.github/workflows/daily-docs-codex.yml
+++ b/.github/workflows/daily-docs-codex.yml
@@ -1,0 +1,165 @@
+name: Daily Codex Docs Audit
+
+on:
+  schedule:
+    - cron: "17 11 * * *"
+  workflow_dispatch:
+    inputs:
+      model:
+        description: Codex model to use through subrouter
+        required: false
+        default: gpt-5.5
+
+concurrency:
+  group: daily-codex-docs-audit
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  audit:
+    name: Audit docs with Codex
+    runs-on: ${{ vars.CODEX_DOCS_RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 90
+    env:
+      CODEX_MODEL: ${{ inputs.model || vars.CODEX_DOCS_MODEL || 'gpt-5.5' }}
+      DOCS_AUDIT_BRANCH: automation/daily-codex-docs-audit
+      SUBROUTER_OPENAI_BASE_URL: ${{ secrets.SUBROUTER_OPENAI_BASE_URL }}
+      SUBROUTER_CHATGPT_BASE_URL: ${{ secrets.SUBROUTER_CHATGPT_BASE_URL }}
+      SUBROUTER_API_KEY: ${{ secrets.SUBROUTER_API_KEY }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Checkout full history
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+
+      - name: Verify subrouter configuration
+        run: |
+          set -euo pipefail
+          if [ -z "${SUBROUTER_OPENAI_BASE_URL}" ]; then
+            echo "::error::SUBROUTER_OPENAI_BASE_URL secret is required so Codex talks to subrouter."
+            exit 1
+          fi
+          if [ -z "${SUBROUTER_API_KEY}" ]; then
+            echo "::error::SUBROUTER_API_KEY secret is required so Codex can authenticate to subrouter."
+            exit 1
+          fi
+
+      - name: Install Codex CLI
+        run: npm install --global @openai/codex@0.136.0
+
+      - name: Configure Codex for subrouter
+        run: |
+          set -euo pipefail
+          CODEX_HOME="${RUNNER_TEMP}/codex-home"
+          mkdir -p "${CODEX_HOME}"
+          echo "CODEX_HOME=${CODEX_HOME}" >> "${GITHUB_ENV}"
+
+          chatgpt_base_url="${SUBROUTER_CHATGPT_BASE_URL}"
+          if [ -z "${chatgpt_base_url}" ]; then
+            chatgpt_base_url="${SUBROUTER_OPENAI_BASE_URL%/v1}/backend-api"
+          fi
+
+          cat > "${CODEX_HOME}/config.toml" <<EOF
+          model = "${CODEX_MODEL}"
+          model_reasoning_effort = "high"
+          openai_base_url = "${SUBROUTER_OPENAI_BASE_URL}"
+          chatgpt_base_url = "${chatgpt_base_url}"
+          experimental_realtime_ws_base_url = "${SUBROUTER_OPENAI_BASE_URL}"
+
+          [projects."${GITHUB_WORKSPACE}"]
+          trust_level = "trusted"
+
+          [notice]
+          hide_full_access_warning = true
+          EOF
+
+      - name: Run Codex docs audit
+        env:
+          OPENAI_API_KEY: ${{ secrets.SUBROUTER_API_KEY }}
+        run: |
+          set -euo pipefail
+          codex --version
+          codex exec \
+            --cd "${GITHUB_WORKSPACE}" \
+            --sandbox workspace-write \
+            --ask-for-approval never \
+            --model "${CODEX_MODEL}" \
+            --output-last-message "${RUNNER_TEMP}/codex-docs-summary.md" \
+            - < .github/prompts/daily-docs-codex.md
+
+      - name: Detect docs changes
+        id: changes
+        run: |
+          set -euo pipefail
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "changed=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "changed=false" >> "${GITHUB_OUTPUT}"
+            {
+              echo "### Codex docs audit"
+              echo
+              cat "${RUNNER_TEMP}/codex-docs-summary.md"
+            } >> "${GITHUB_STEP_SUMMARY}"
+          fi
+
+      - name: Commit and push docs changes
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
+          git config user.name "cmux-docs-bot"
+          git config user.email "cmux-docs-bot@users.noreply.github.com"
+          git switch -c "${DOCS_AUDIT_BRANCH}"
+          git add -A
+          git commit -m "Update docs from daily Codex audit"
+          git push --force-with-lease origin "HEAD:${DOCS_AUDIT_BRANCH}"
+
+      - name: Create or update pull request
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
+          body_file="${RUNNER_TEMP}/docs-audit-pr-body.md"
+          {
+            echo "## Summary"
+            echo "- Daily Codex docs audit found documentation updates based on repository history."
+            echo "- Codex was configured to use subrouter via SUBROUTER_OPENAI_BASE_URL."
+            echo
+            echo "## Codex Notes"
+            cat "${RUNNER_TEMP}/codex-docs-summary.md"
+            echo
+            echo "## Testing"
+            echo "- Performed by Codex during the audit when applicable; see notes above."
+          } > "${body_file}"
+
+          existing_pr="$(
+            gh pr list \
+              --repo "${GITHUB_REPOSITORY}" \
+              --head "${DOCS_AUDIT_BRANCH}" \
+              --state open \
+              --json number \
+              --jq '.[0].number // empty'
+          )"
+
+          if [ -n "${existing_pr}" ]; then
+            gh pr edit "${existing_pr}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --title "Update docs from daily Codex audit" \
+              --body-file "${body_file}"
+            echo "Updated PR: https://github.com/${GITHUB_REPOSITORY}/pull/${existing_pr}" >> "${GITHUB_STEP_SUMMARY}"
+          else
+            pr_url="$(
+              gh pr create \
+                --repo "${GITHUB_REPOSITORY}" \
+                --base main \
+                --head "${DOCS_AUDIT_BRANCH}" \
+                --title "Update docs from daily Codex audit" \
+                --body-file "${body_file}"
+            )"
+            echo "Created PR: ${pr_url}" >> "${GITHUB_STEP_SUMMARY}"
+          fi


### PR DESCRIPTION
## Summary
- Add a daily scheduled GitHub Actions workflow that runs Codex over full git history to audit docs coverage and create or update a docs PR only when files change.
- Configure Codex through subrouter-only secrets and a temporary `CODEX_HOME` config.
- Add a reusable prompt that tells Codex how to update web docs, source docs, localized messages, nav, and verification notes.

## Testing
- `actionlint .github/workflows/daily-docs-codex.yml`
- `ruby -e 'require "yaml"; YAML.load_file(ARGV[0]); puts "yaml ok"' .github/workflows/daily-docs-codex.yml`
- `bash -n` against every workflow `run:` block

## Issues
- Task: set up a once-a-day Codex docs audit GitHub Action that talks to subrouter and opens a PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782993792&installation_id=133855650&pr_number=5210&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5210&signature=c554c89dfaa6bbede21a568729b583d60e41b0885c78cf1253d0116f3647bd79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit f77607956a5a558cfeb3bd7715925827684afb33. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a daily GitHub Actions workflow that audits docs with Codex via subrouter and opens/updates a docs PR only when needed. Includes a focused prompt to update web docs, nav, messages, source docs, and changelog.

- **New Features**
  - Runs daily at 11:17 UTC and supports manual dispatch with a `model` input.
  - Uses `@openai/codex` with a temporary `CODEX_HOME` and subrouter endpoints; checks out full git history.
  - Only commits when changes exist, pushes to `automation/daily-codex-docs-audit`, and creates/updates a PR to `main`.
  - Adds `.github/prompts/daily-docs-codex.md` with rules for docs surfaces and lightweight verification.

- **Migration**
  - Required secrets: `SUBROUTER_OPENAI_BASE_URL`, `SUBROUTER_API_KEY`; optional: `SUBROUTER_CHATGPT_BASE_URL`.
  - Optional repo vars: `CODEX_DOCS_MODEL`, `CODEX_DOCS_RUNNER`.
  - No manual steps beyond secrets; the workflow manages PRs automatically.

<sup>Written for commit f77607956a5a558cfeb3bd7715925827684afb33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

