### PR TITLE
Mark markdown-viewer bundles as vendored/generated for Linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,8 @@
 Resources/markdown-viewer/diff-viewer/**/*.mjs -whitespace
+
+# Resources/markdown-viewer holds vendored third-party runtime bundles (mermaid,
+# vega, highlight.js, the Pierre/Shiki diff renderer + per-language grammars and
+# WASM) plus the generated diff-viewer React app build. They are not authored
+# source, so exclude them from GitHub Linguist's language stats.
+Resources/markdown-viewer/** linguist-vendored
+Resources/markdown-viewer/diff-viewer-app/** linguist-generated


### PR DESCRIPTION
`Resources/markdown-viewer/` carries ~25MB of vendored third-party runtime JS (mermaid, vega, highlight.js, and the Pierre/Shiki diff renderer with per-language grammars + WASM) plus the generated diff-viewer React app build. That now outweighs the Swift source, so GitHub Linguist was reporting the repo as mostly JavaScript.

This marks `Resources/markdown-viewer/**` as `linguist-vendored` and the generated `diff-viewer-app/**` build as `linguist-generated`, so the language stats reflect the actual authored source. Metadata-only: no runtime or build behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5212"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782994143&installation_id=133855650&pr_number=5212&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5212&signature=2896dc4643082a5bd1f611e3c362e5cd2866d75254a7ecf9c57a4439121da521"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only .gitattributes changes with no runtime, security, or build impact.
> 
> **Overview**
> Updates **`.gitattributes`** so GitHub Linguist stops counting large **markdown-viewer** assets as authored JavaScript. **`Resources/markdown-viewer/**`** is marked **`linguist-vendored`** (third-party bundles such as mermaid, vega, highlight.js, Shiki/Pierre diff assets), and **`Resources/markdown-viewer/diff-viewer-app/**`** is **`linguist-generated`** for the built React diff viewer. The existing **`diff-viewer/**/*.mjs -whitespace`** rule is unchanged.
> 
> **No application or build behavior changes**—only repository language statistics and diff metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 245733025a7a31b3a6e86d51c426765e5ad82015. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `.gitattributes` to mark `Resources/markdown-viewer/**` as `linguist-vendored` and `Resources/markdown-viewer/diff-viewer-app/**` as `linguist-generated`, so GitHub Linguist reflects authored source instead of bundled JS. No runtime or build changes.

<sup>Written for commit 245733025a7a31b3a6e86d51c426765e5ad82015. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5212?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration settings for improved code statistics accuracy on GitHub.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->