### PR TITLE
Clarify browser dev tools tooltip

### DIFF
--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -608,7 +608,7 @@ struct BrowserPanelView: View {
     }
 
     private var developerToolsButtonHelp: String {
-        let base = String(localized: "browser.toggleDevTools", defaultValue: "Toggle Developer Tools")
+        let base = String(localized: "browser.toggleDevTools", defaultValue: "Open or close Browser Developer Tools for this page")
         let _ = keyboardShortcutSettingsObserver.revision
         return "\(base) (\(KeyboardShortcutSettings.shortcut(for: .toggleBrowserDeveloperTools).displayString))"
     }


### PR DESCRIPTION
## Summary
- Clarify the browser Developer Tools toolbar tooltip so a gear-style icon is not mistaken for app settings.
- Update the English and Japanese localized tooltip text.

## Testing
- `jq empty Resources/Localizable.xcstrings`
- `git diff --check`
- `./scripts/reload-cloud.sh --tag gear-tip`

## Issues
- Task: user request in cmuxterm-hq chat

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5213"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782994264&installation_id=133855650&pr_number=5213&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5213&signature=ae3870b039d67b119dbb7d9d4f51ba8ee6c00c6a9a9336c10a16b8effd09f9d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit eef4673dcc6e2034a5ee786b0b983b8c7a2fc166. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified the Browser Developer Tools toolbar tooltip so the gear icon isn’t mistaken for app settings. Updated the EN/JA `browser.toggleDevTools` string and the Swift fallback to: “Open or close Browser Developer Tools for this page.”

<sup>Written for commit eef4673dcc6e2034a5ee786b0b983b8c7a2fc166. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

