### PR TITLE
Add daily Codex docs maintenance workflow

### DIFF
--- a/.github/workflows/daily-docs-codex.yml
+++ b/.github/workflows/daily-docs-codex.yml
@@ -1,0 +1,109 @@
+name: Daily docs Codex
+
+on:
+  schedule:
+    - cron: "37 11 * * *"
+  workflow_dispatch:
+    inputs:
+      prompt_suffix:
+        description: Extra instructions to append to the docs maintenance prompt
+        required: false
+        default: ""
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: daily-docs-codex
+  cancel-in-progress: false
+
+jobs:
+  docs-maintenance:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    env:
+      BRANCH_NAME: automation/daily-docs-codex
+      CODEX_DOCS_PROMPT_SUFFIX: ${{ inputs.prompt_suffix || '' }}
+      CODEX_MODEL: ${{ vars.DAILY_DOCS_CODEX_MODEL || 'gpt-5.5' }}
+      CODEX_REASONING_EFFORT: ${{ vars.DAILY_DOCS_CODEX_REASONING_EFFORT || 'high' }}
+      CODEX_SUBROUTER_API_KEY: ${{ secrets.SUBROUTER_CODEX_API_KEY }}
+      CODEX_SUBROUTER_BASE_URL: ${{ vars.SUBROUTER_CODEX_BASE_URL || secrets.SUBROUTER_CODEX_BASE_URL }}
+      SUBROUTER_CODEX_ACCOUNT_ID: ${{ vars.SUBROUTER_CODEX_ACCOUNT_ID || secrets.SUBROUTER_CODEX_ACCOUNT_ID }}
+      SUBROUTER_CODEX_USER_EMAIL: ${{ vars.SUBROUTER_CODEX_USER_EMAIL || secrets.SUBROUTER_CODEX_USER_EMAIL }}
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Install Codex CLI
+        run: npm install -g @openai/codex@0.136.0
+
+      - name: Run Codex docs maintenance through Subrouter
+        id: codex
+        run: |
+          set -euo pipefail
+          scripts/run-daily-docs-codex.sh
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create or update pull request
+        if: steps.codex.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git config user.name "cmux docs bot"
+          git config user.email "cmux-docs-bot@users.noreply.github.com"
+          git switch -c "$BRANCH_NAME"
+          git add -A
+          git commit -m "Update docs from daily Codex audit"
+          git fetch origin "$BRANCH_NAME:refs/remotes/origin/$BRANCH_NAME" || true
+          git push --force-with-lease origin "HEAD:$BRANCH_NAME"
+
+          pr_body="$RUNNER_TEMP/daily-docs-codex-pr-body.md"
+          {
+            echo "## Summary"
+            echo "- Runs the daily Codex documentation audit against recent and historical commits."
+            echo "- Updates this PR branch with any docs changes Codex produced through Subrouter."
+            echo
+            echo "## Codex report"
+            codex_report="${CODEX_DOCS_OUTPUT_FILE:-$RUNNER_TEMP/codex-docs-maintenance.txt}"
+            if [ -s "$codex_report" ]; then
+              sed -n '1,160p' "$codex_report"
+            else
+              echo "- Codex did not write a final report file."
+            fi
+            echo
+            echo "## Testing"
+            echo "- scripts/run-daily-docs-codex.sh completed through Subrouter."
+          } > "$pr_body"
+
+          existing_number="$(
+            gh pr list \
+              --repo "$GITHUB_REPOSITORY" \
+              --head "$BRANCH_NAME" \
+              --state open \
+              --json number \
+              --jq '.[0].number // ""'
+          )"
+
+          if [ -n "$existing_number" ]; then
+            gh pr edit "$existing_number" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "Update docs from daily Codex audit" \
+              --body-file "$pr_body"
+            gh pr view "$existing_number" --repo "$GITHUB_REPOSITORY" --json url --jq '.url'
+          else
+            gh pr create \
+              --repo "$GITHUB_REPOSITORY" \
+              --base main \
+              --head "$BRANCH_NAME" \
+              --title "Update docs from daily Codex audit" \
+              --body-file "$pr_body"
+          fi

--- a/scripts/run-daily-docs-codex.sh
+++ b/scripts/run-daily-docs-codex.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+codex_bin="${CODEX_BIN:-codex}"
+codex_home="${CODEX_HOME:-${RUNNER_TEMP:-/tmp}/codex-docs-home}"
+subrouter_base_url="${CODEX_SUBROUTER_BASE_URL:-}"
+subrouter_api_key="${CODEX_SUBROUTER_API_KEY:-}"
+subrouter_account_id="${SUBROUTER_CODEX_ACCOUNT_ID:-}"
+subrouter_user_email="${SUBROUTER_CODEX_USER_EMAIL:-}"
+model="${CODEX_MODEL:-gpt-5.5}"
+reasoning_effort="${CODEX_REASONING_EFFORT:-high}"
+output_file="${CODEX_DOCS_OUTPUT_FILE:-${RUNNER_TEMP:-/tmp}/codex-docs-maintenance.txt}"
+
+if [ -z "$subrouter_base_url" ]; then
+  echo "::error::Set CODEX_SUBROUTER_BASE_URL to the Subrouter OpenAI-compatible /v1 endpoint."
+  exit 1
+fi
+
+if [ -z "$subrouter_api_key" ]; then
+  echo "::error::Set CODEX_SUBROUTER_API_KEY so Codex can authenticate through Subrouter."
+  exit 1
+fi
+
+toml_string() {
+  node -e 'process.stdout.write(JSON.stringify(process.argv[1]))' "$1"
+}
+
+mkdir -p "$codex_home"
+chmod 700 "$codex_home"
+
+{
+  echo "# Written by scripts/run-daily-docs-codex.sh for scheduled docs maintenance."
+  echo "model_provider = \"subrouter\""
+  echo "model = $(toml_string "$model")"
+  echo "model_reasoning_effort = $(toml_string "$reasoning_effort")"
+  echo
+  echo "[model_providers.subrouter]"
+  echo "name = \"Subrouter\""
+  echo "base_url = $(toml_string "$subrouter_base_url")"
+  echo "wire_api = \"responses\""
+  if [ -n "$subrouter_account_id" ] || [ -n "$subrouter_user_email" ]; then
+    echo
+    echo "[model_providers.subrouter.http_headers]"
+    if [ -n "$subrouter_account_id" ]; then
+      echo "X-Subrouter-Account-ID = $(toml_string "$subrouter_account_id")"
+    fi
+    if [ -n "$subrouter_user_email" ]; then
+      echo "X-Subrouter-User-Email = $(toml_string "$subrouter_user_email")"
+    fi
+  fi
+  echo
+  echo "[projects.$(toml_string "$repo_root")]"
+  echo "trust_level = \"trusted\""
+} > "$codex_home/config.toml"
+chmod 600 "$codex_home/config.toml"
+
+export CODEX_HOME="$codex_home"
+export OPENAI_API_KEY="$subrouter_api_key"
+export CODEX_API_KEY="$subrouter_api_key"
+
+prompt_file="${RUNNER_TEMP:-/tmp}/codex-docs-maintenance-prompt.md"
+cat > "$prompt_file" <<'PROMPT'
+You are running the scheduled cmux documentation maintenance pass.
+
+Goal:
+Review the repository's commit history and current product surface, then update docs where shipped behavior is missing, stale, misleading, or deserves a new docs page. If the docs are already good, leave the working tree unchanged.
+
+Required scope:
+- Inspect commit history with git. Prioritize recent main commits, but look further back when a feature appears underdocumented.
+- Compare code, CLI help, changelog entries, existing docs, and web docs before editing.
+- Make focused documentation changes only. Good targets include docs/*.md, README*.md, CHANGELOG.md, web docs pages, docs navigation, docs search fixtures, and localized docs message files.
+- If you change web docs content, preserve the existing localization architecture. Add or update all required locale keys. Do not leave English-only user-facing strings in TSX.
+- Do not edit Swift, app runtime, backend runtime, packaging, release automation, or non-doc product code.
+- Do not run xcodebuild test, xcodebuild test-without-building, test-unit.sh, or local XCUITest.
+- Prefer a small useful PR over broad churn. Avoid formatting-only changes.
+- If you add a new docs page, wire it into docs navigation and any docs index/search expectations that need it.
+
+At the end, summarize what you changed and why. If no docs update is warranted, say so and make no file changes.
+PROMPT
+
+if [ -n "${CODEX_DOCS_PROMPT_SUFFIX:-}" ]; then
+  {
+    echo
+    echo "Additional operator instructions:"
+    echo "$CODEX_DOCS_PROMPT_SUFFIX"
+  } >> "$prompt_file"
+fi
+
+"$codex_bin" exec \
+  --dangerously-bypass-approvals-and-sandbox \
+  --ask-for-approval never \
+  --sandbox danger-full-access \
+  --cd "$repo_root" \
+  --output-last-message "$output_file" \
+  "$(cat "$prompt_file")"
+
+if [ -z "$(git status --porcelain)" ]; then
+  echo "Codex found no docs changes to propose."
+  exit 0
+fi
+
+disallowed_paths="$(
+  git status --porcelain=v1 | sed -E 's/^.. //' | sed -E 's/^.* -> //' | while IFS= read -r path; do
+    case "$path" in
+      CHANGELOG.md|README.md|README.*.md|docs/*|web/app/\[locale\]/docs/*|web/app/\[locale\]/components/docs-*|web/messages/*|web/tests/*docs*|web/tests/agent-page-variants.test.ts|web/tools/build-docs-search.mjs)
+        ;;
+      *)
+        printf '%s\n' "$path"
+        ;;
+    esac
+  done
+)"
+
+if [ -n "$disallowed_paths" ]; then
+  echo "::error::Codex changed non-doc paths. Refusing to create a PR."
+  printf '%s\n' "$disallowed_paths"
+  git status --short
+  exit 1
+fi
+
+echo "Codex produced docs changes:"
+git status --short


### PR DESCRIPTION
## Summary
- Add a daily scheduled GitHub Actions workflow that runs Codex against commit history and docs coverage.
- Route Codex through Subrouter with a temporary `CODEX_HOME` provider config, including optional Subrouter account and user headers.
- Refuse PR creation if Codex changes non-doc paths.

## Testing
- `bash -n scripts/run-daily-docs-codex.sh`
- `shellcheck scripts/run-daily-docs-codex.sh`
- `actionlint .github/workflows/daily-docs-codex.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/daily-docs-codex.yml"); puts "workflow yaml ok"'`
- Fake-Codex dry run verified Subrouter config generation and allowed new docs files.
- Fake-Codex negative dry run verified non-doc changes are rejected.

## Issues
- Task: set up a once-daily GitHub Actions Codex docs maintenance PR job that talks to Subrouter.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Grants write/PR permissions and runs Codex with full sandbox bypass and trusted project settings, though output is restricted to doc paths and requires Subrouter secrets.
> 
> **Overview**
> Adds **daily automated documentation maintenance** via a new GitHub Actions workflow and `scripts/run-daily-docs-codex.sh`.
> 
> The workflow runs on a cron schedule (and `workflow_dispatch` with an optional prompt suffix), checks out `main` with full history, installs Codex CLI, and invokes the script. The script builds a temporary `CODEX_HOME` config to route Codex through **Subrouter** (model, reasoning effort, API key, optional account/user headers), runs `codex exec` with a docs-only maintenance prompt, and **fails the job** if any changed paths fall outside an allowlist of doc-related files.
> 
> When Codex leaves doc edits, the workflow commits to `automation/daily-docs-codex`, force-pushes with lease, and **creates or updates** an open PR whose body includes a truncated Codex report.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60b8de13e1cf63d845a615c16ba316021695636e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a once-daily GitHub Actions job that runs Codex via Subrouter to audit and update docs, then opens/updates a PR with any changes. Fulfills the task to run daily and route through Subrouter while blocking non-doc edits.

- **New Features**
  - Adds `.github/workflows/daily-docs-codex.yml` scheduled at 11:37 UTC, plus manual run with an optional prompt suffix.
  - Runs `@openai/codex` through Subrouter using a temporary `CODEX_HOME`, with optional `X-Subrouter-Account-ID` and `X-Subrouter-User-Email` headers.
  - Commits to `automation/daily-docs-codex` and creates or updates a PR including the Codex report.
  - Rejects the run if any non-doc paths are changed; allows only docs-related files.
  - Configurable model and reasoning via vars, defaulting to `gpt-5.5` and `high`.
  - Uses concurrency to avoid overlapping runs.

- **Migration**
  - Set repo secret `SUBROUTER_CODEX_API_KEY` and var or secret `SUBROUTER_CODEX_BASE_URL` (OpenAI-compatible `/v1` endpoint).
  - Optional: set vars/secrets `SUBROUTER_CODEX_ACCOUNT_ID`, `SUBROUTER_CODEX_USER_EMAIL`.
  - Optional: override `DAILY_DOCS_CODEX_MODEL` and `DAILY_DOCS_CODEX_REASONING_EFFORT`.

<sup>Written for commit 60b8de13e1cf63d845a615c16ba316021695636e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced automated daily documentation maintenance with automatic pull request creation for doc updates, including validation to ensure only documentation files are modified.

* **Chores**
  * Added scheduled automation workflow and supporting script infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->