### PR TITLE
Web: APNs push notification backend hardening

### DIFF
--- a/web/app/api/device-tokens/route.ts
+++ b/web/app/api/device-tokens/route.ts
@@ -2,16 +2,17 @@
 // Auth: Stack Bearer (native client) or cookie. A row only exists after the
 // user explicitly opts in on their device, so presence == "wants phone pushes".
 
-import { and, eq } from "drizzle-orm";
+import { and, count, eq, ne } from "drizzle-orm";
 import { cloudDb } from "../../../db/client";
 import { deviceTokens } from "../../../db/schema";
 import { jsonResponse } from "../../../services/vms/routeHelpers";
 import { unauthorized, verifyRequest } from "../../../services/vms/auth";
+import { MAX_DEVICE_TOKENS_PER_USER, normalizeApnsBundle } from "../../../services/apns/routePolicy";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-const HEX_TOKEN = /^[0-9a-fA-F]{8,200}$/;
+const HEX_TOKEN = /^[0-9a-fA-F]{64,200}$/;
 
 async function readJson(request: Request): Promise<Record<string, unknown> | null> {
   try {
@@ -34,23 +35,54 @@ export async function POST(request: Request): Promise<Response> {
 
   const deviceToken = typeof body.deviceToken === "string" ? body.deviceToken.trim() : "";
   const bundleId = typeof body.bundleId === "string" ? body.bundleId.trim() : "";
-  const environment = body.environment === "sandbox" ? "sandbox" : "production";
   const platform = typeof body.platform === "string" ? body.platform.trim() || "ios" : "ios";
+  const bundle = normalizeApnsBundle(bundleId);
 
   if (!HEX_TOKEN.test(deviceToken)) {
     return jsonResponse({ error: "invalid_device_token" }, 400);
   }
-  if (!bundleId) {
-    return jsonResponse({ error: "missing_bundle_id" }, 400);
+  if (!bundle) {
+    return jsonResponse({ error: "invalid_bundle_id" }, 400);
+  }
+  if (platform !== "ios") {
+    return jsonResponse({ error: "invalid_platform" }, 400);
   }
 
   const db = cloudDb();
+  const [existingToken] = await db
+    .select({ userId: deviceTokens.userId })
+    .from(deviceTokens)
+    .where(eq(deviceTokens.deviceToken, deviceToken))
+    .limit(1);
+
+  if (existingToken?.userId !== user.id) {
+    const [registered] = await db
+      .select({ total: count() })
+      .from(deviceTokens)
+      .where(and(eq(deviceTokens.userId, user.id), ne(deviceTokens.deviceToken, deviceToken)));
+    if (Number(registered?.total ?? 0) >= MAX_DEVICE_TOKENS_PER_USER) {
+      return jsonResponse({ error: "too_many_devices" }, 429);
+    }
+  }
+
   await db
     .insert(deviceTokens)
-    .values({ userId: user.id, deviceToken, bundleId, environment, platform })
+    .values({
+      userId: user.id,
+      deviceToken,
+      bundleId: bundle.bundleId,
+      environment: bundle.environment,
+      platform,
+    })
     .onConflictDoUpdate({
       target: deviceTokens.deviceToken,
-      set: { userId: user.id, bundleId, environment, platform, updatedAt: new Date() },
+      set: {
+        userId: user.id,
+        bundleId: bundle.bundleId,
+        environment: bundle.environment,
+        platform,
+        updatedAt: new Date(),
+      },
     });
 
   return jsonResponse({ ok: true });
@@ -64,6 +96,7 @@ export async function DELETE(request: Request): Promise<Response> {
   if (!body) return jsonResponse({ error: "invalid_json" }, 400);
   const deviceToken = typeof body.deviceToken === "string" ? body.deviceToken.trim() : "";
   if (!deviceToken) return jsonResponse({ error: "missing_device_token" }, 400);
+  if (!HEX_TOKEN.test(deviceToken)) return jsonResponse({ error: "invalid_device_token" }, 400);
 
   const db = cloudDb();
   await db

--- a/web/app/api/device-tokens/route.ts
+++ b/web/app/api/device-tokens/route.ts
@@ -1,0 +1,74 @@
+// Register / unregister an iOS APNs device token for push notifications.
+// Auth: Stack Bearer (native client) or cookie. A row only exists after the
+// user explicitly opts in on their device, so presence == "wants phone pushes".
+
+import { and, eq } from "drizzle-orm";
+import { cloudDb } from "../../../db/client";
+import { deviceTokens } from "../../../db/schema";
+import { jsonResponse } from "../../../services/vms/routeHelpers";
+import { unauthorized, verifyRequest } from "../../../services/vms/auth";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const HEX_TOKEN = /^[0-9a-fA-F]{8,200}$/;
+
+async function readJson(request: Request): Promise<Record<string, unknown> | null> {
+  try {
+    const text = await request.text();
+    if (!text) return {};
+    const raw = JSON.parse(text) as unknown;
+    if (raw === null || typeof raw !== "object" || Array.isArray(raw)) return null;
+    return raw as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+export async function POST(request: Request): Promise<Response> {
+  const user = await verifyRequest(request);
+  if (!user) return unauthorized();
+
+  const body = await readJson(request);
+  if (!body) return jsonResponse({ error: "invalid_json" }, 400);
+
+  const deviceToken = typeof body.deviceToken === "string" ? body.deviceToken.trim() : "";
+  const bundleId = typeof body.bundleId === "string" ? body.bundleId.trim() : "";
+  const environment = body.environment === "sandbox" ? "sandbox" : "production";
+  const platform = typeof body.platform === "string" ? body.platform.trim() || "ios" : "ios";
+
+  if (!HEX_TOKEN.test(deviceToken)) {
+    return jsonResponse({ error: "invalid_device_token" }, 400);
+  }
+  if (!bundleId) {
+    return jsonResponse({ error: "missing_bundle_id" }, 400);
+  }
+
+  const db = cloudDb();
+  await db
+    .insert(deviceTokens)
+    .values({ userId: user.id, deviceToken, bundleId, environment, platform })
+    .onConflictDoUpdate({
+      target: deviceTokens.deviceToken,
+      set: { userId: user.id, bundleId, environment, platform, updatedAt: new Date() },
+    });
+
+  return jsonResponse({ ok: true });
+}
+
+export async function DELETE(request: Request): Promise<Response> {
+  const user = await verifyRequest(request);
+  if (!user) return unauthorized();
+
+  const body = await readJson(request);
+  if (!body) return jsonResponse({ error: "invalid_json" }, 400);
+  const deviceToken = typeof body.deviceToken === "string" ? body.deviceToken.trim() : "";
+  if (!deviceToken) return jsonResponse({ error: "missing_device_token" }, 400);
+
+  const db = cloudDb();
+  await db
+    .delete(deviceTokens)
+    .where(and(eq(deviceTokens.deviceToken, deviceToken), eq(deviceTokens.userId, user.id)));
+
+  return jsonResponse({ ok: true });
+}

--- a/web/app/api/device-tokens/route.ts
+++ b/web/app/api/device-tokens/route.ts
@@ -1,5 +1,5 @@
 // Register / unregister an iOS APNs device token for push notifications.
-// Auth: Stack Bearer (native client) or cookie. A row only exists after the
+// Auth: Stack Bearer from the native client. A row only exists after the
 // user explicitly opts in on their device, so presence == "wants phone pushes".
 
 import { and, count, eq, ne } from "drizzle-orm";
@@ -7,35 +7,28 @@ import { cloudDb } from "../../../db/client";
 import { deviceTokens } from "../../../db/schema";
 import { jsonResponse } from "../../../services/vms/routeHelpers";
 import { unauthorized, verifyRequest } from "../../../services/vms/auth";
-import { MAX_DEVICE_TOKENS_PER_USER, normalizeApnsBundle } from "../../../services/apns/routePolicy";
+import {
+  MAX_DEVICE_TOKENS_PER_USER,
+  MAX_PUSH_REQUEST_BYTES,
+  normalizeApnsBundle,
+  readBoundedJsonObject,
+} from "../../../services/apns/routePolicy";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 const HEX_TOKEN = /^[0-9a-fA-F]{64,200}$/;
 
-async function readJson(request: Request): Promise<Record<string, unknown> | null> {
-  try {
-    const text = await request.text();
-    if (!text) return {};
-    const raw = JSON.parse(text) as unknown;
-    if (raw === null || typeof raw !== "object" || Array.isArray(raw)) return null;
-    return raw as Record<string, unknown>;
-  } catch {
-    return null;
-  }
-}
-
 export async function POST(request: Request): Promise<Response> {
-  const user = await verifyRequest(request);
+  const user = await verifyRequest(request, { allowCookie: false });
   if (!user) return unauthorized();
 
-  const body = await readJson(request);
-  if (!body) return jsonResponse({ error: "invalid_json" }, 400);
+  const body = await readBoundedJsonObject(request, MAX_PUSH_REQUEST_BYTES);
+  if (!body.ok) return jsonResponse({ error: body.error }, body.error === "request_too_large" ? 413 : 400);
 
-  const deviceToken = typeof body.deviceToken === "string" ? body.deviceToken.trim() : "";
-  const bundleId = typeof body.bundleId === "string" ? body.bundleId.trim() : "";
-  const platform = typeof body.platform === "string" ? body.platform.trim() || "ios" : "ios";
+  const deviceToken = typeof body.value.deviceToken === "string" ? body.value.deviceToken.trim() : "";
+  const bundleId = typeof body.value.bundleId === "string" ? body.value.bundleId.trim() : "";
+  const platform = typeof body.value.platform === "string" ? body.value.platform.trim() || "ios" : "ios";
   const bundle = normalizeApnsBundle(bundleId);
 
   if (!HEX_TOKEN.test(deviceToken)) {
@@ -89,12 +82,12 @@ export async function POST(request: Request): Promise<Response> {
 }
 
 export async function DELETE(request: Request): Promise<Response> {
-  const user = await verifyRequest(request);
+  const user = await verifyRequest(request, { allowCookie: false });
   if (!user) return unauthorized();
 
-  const body = await readJson(request);
-  if (!body) return jsonResponse({ error: "invalid_json" }, 400);
-  const deviceToken = typeof body.deviceToken === "string" ? body.deviceToken.trim() : "";
+  const body = await readBoundedJsonObject(request, MAX_PUSH_REQUEST_BYTES);
+  if (!body.ok) return jsonResponse({ error: body.error }, body.error === "request_too_large" ? 413 : 400);
+  const deviceToken = typeof body.value.deviceToken === "string" ? body.value.deviceToken.trim() : "";
   if (!deviceToken) return jsonResponse({ error: "missing_device_token" }, 400);
   if (!HEX_TOKEN.test(deviceToken)) return jsonResponse({ error: "invalid_device_token" }, 400);
 

--- a/web/app/api/device-tokens/route.ts
+++ b/web/app/api/device-tokens/route.ts
@@ -49,7 +49,7 @@ async function registerDeviceToken(request: Request): Promise<Response> {
   const db = cloudDb();
 
   const registered = await db.transaction(async (tx) => {
-    await tx.execute(sql`select pg_advisory_xact_lock(hashtextextended(${user.id}, 0))`);
+    await tx.execute(sql`select pg_advisory_xact_lock(hashtextextended(${user.id}, 2))`);
 
     const [existingToken] = await tx
       .select({ userId: deviceTokens.userId })

--- a/web/app/api/device-tokens/route.ts
+++ b/web/app/api/device-tokens/route.ts
@@ -2,7 +2,7 @@
 // Auth: Stack Bearer from the native client. A row only exists after the
 // user explicitly opts in on their device, so presence == "wants phone pushes".
 
-import { and, count, eq, ne } from "drizzle-orm";
+import { and, count, eq, ne, sql } from "drizzle-orm";
 import { cloudDb } from "../../../db/client";
 import { deviceTokens } from "../../../db/schema";
 import { jsonResponse } from "../../../services/vms/routeHelpers";
@@ -42,41 +42,52 @@ export async function POST(request: Request): Promise<Response> {
   }
 
   const db = cloudDb();
-  const [existingToken] = await db
-    .select({ userId: deviceTokens.userId })
-    .from(deviceTokens)
-    .where(eq(deviceTokens.deviceToken, deviceToken))
-    .limit(1);
 
-  if (existingToken?.userId !== user.id) {
-    const [registered] = await db
-      .select({ total: count() })
+  const registered = await db.transaction(async (tx) => {
+    await tx.execute(sql`select pg_advisory_xact_lock(hashtextextended(${user.id}, 0))`);
+
+    const [existingToken] = await tx
+      .select({ userId: deviceTokens.userId })
       .from(deviceTokens)
-      .where(and(eq(deviceTokens.userId, user.id), ne(deviceTokens.deviceToken, deviceToken)));
-    if (Number(registered?.total ?? 0) >= MAX_DEVICE_TOKENS_PER_USER) {
-      return jsonResponse({ error: "too_many_devices" }, 429);
-    }
-  }
+      .where(eq(deviceTokens.deviceToken, deviceToken))
+      .limit(1);
 
-  await db
-    .insert(deviceTokens)
-    .values({
-      userId: user.id,
-      deviceToken,
-      bundleId: bundle.bundleId,
-      environment: bundle.environment,
-      platform,
-    })
-    .onConflictDoUpdate({
-      target: deviceTokens.deviceToken,
-      set: {
+    if (existingToken?.userId !== user.id) {
+      const [registrationCount] = await tx
+        .select({ total: count() })
+        .from(deviceTokens)
+        .where(and(eq(deviceTokens.userId, user.id), ne(deviceTokens.deviceToken, deviceToken)));
+      if (Number(registrationCount?.total ?? 0) >= MAX_DEVICE_TOKENS_PER_USER) {
+        return false;
+      }
+    }
+
+    await tx
+      .insert(deviceTokens)
+      .values({
         userId: user.id,
+        deviceToken,
         bundleId: bundle.bundleId,
         environment: bundle.environment,
         platform,
-        updatedAt: new Date(),
-      },
-    });
+      })
+      .onConflictDoUpdate({
+        target: deviceTokens.deviceToken,
+        set: {
+          userId: user.id,
+          bundleId: bundle.bundleId,
+          environment: bundle.environment,
+          platform,
+          updatedAt: new Date(),
+        },
+      });
+
+    return true;
+  });
+
+  if (!registered) {
+    return jsonResponse({ error: "too_many_devices" }, 429);
+  }
 
   return jsonResponse({ ok: true });
 }

--- a/web/app/api/device-tokens/route.ts
+++ b/web/app/api/device-tokens/route.ts
@@ -7,6 +7,7 @@ import { cloudDb } from "../../../db/client";
 import { deviceTokens } from "../../../db/schema";
 import { jsonResponse } from "../../../services/vms/routeHelpers";
 import { unauthorized, verifyRequest } from "../../../services/vms/auth";
+import { withApnsApiRoute } from "../../../services/apns/routeHandler";
 import {
   MAX_DEVICE_TOKENS_PER_USER,
   MAX_PUSH_REQUEST_BYTES,
@@ -20,13 +21,17 @@ export const dynamic = "force-dynamic";
 const HEX_TOKEN = /^[0-9a-fA-F]{64,200}$/;
 
 export async function POST(request: Request): Promise<Response> {
+  return withApnsApiRoute(request, "/api/device-tokens", "register", async () => registerDeviceToken(request));
+}
+
+async function registerDeviceToken(request: Request): Promise<Response> {
   const user = await verifyRequest(request, { allowCookie: false });
   if (!user) return unauthorized();
 
   const body = await readBoundedJsonObject(request, MAX_PUSH_REQUEST_BYTES);
   if (!body.ok) return jsonResponse({ error: body.error }, body.error === "request_too_large" ? 413 : 400);
 
-  const deviceToken = typeof body.value.deviceToken === "string" ? body.value.deviceToken.trim() : "";
+  const deviceToken = typeof body.value.deviceToken === "string" ? body.value.deviceToken.trim().toLowerCase() : "";
   const bundleId = typeof body.value.bundleId === "string" ? body.value.bundleId.trim() : "";
   const platform = typeof body.value.platform === "string" ? body.value.platform.trim() || "ios" : "ios";
   const bundle = normalizeApnsBundle(bundleId);
@@ -93,12 +98,16 @@ export async function POST(request: Request): Promise<Response> {
 }
 
 export async function DELETE(request: Request): Promise<Response> {
+  return withApnsApiRoute(request, "/api/device-tokens", "delete", async () => deleteDeviceToken(request));
+}
+
+async function deleteDeviceToken(request: Request): Promise<Response> {
   const user = await verifyRequest(request, { allowCookie: false });
   if (!user) return unauthorized();
 
   const body = await readBoundedJsonObject(request, MAX_PUSH_REQUEST_BYTES);
   if (!body.ok) return jsonResponse({ error: body.error }, body.error === "request_too_large" ? 413 : 400);
-  const deviceToken = typeof body.value.deviceToken === "string" ? body.value.deviceToken.trim() : "";
+  const deviceToken = typeof body.value.deviceToken === "string" ? body.value.deviceToken.trim().toLowerCase() : "";
   if (!deviceToken) return jsonResponse({ error: "missing_device_token" }, 400);
   if (!HEX_TOKEN.test(deviceToken)) return jsonResponse({ error: "invalid_device_token" }, 400);
 

--- a/web/app/api/notifications/push/route.ts
+++ b/web/app/api/notifications/push/route.ts
@@ -1,0 +1,91 @@
+// Send a push to the authenticated user's registered iOS devices. Called by the
+// macOS app when it shows a terminal notification AND the user enabled phone
+// forwarding. No-ops (no APNs traffic) when the user has no registered devices.
+// Auth: Stack Bearer (the Mac's signed-in user); routing is by that user id.
+
+import { and, eq, inArray } from "drizzle-orm";
+import { env } from "../../../env";
+import { cloudDb } from "../../../../db/client";
+import { deviceTokens } from "../../../../db/schema";
+import { jsonResponse } from "../../../../services/vms/routeHelpers";
+import { unauthorized, verifyRequest } from "../../../../services/vms/auth";
+import { sendApnsNotification, type ApnsConfig } from "../../../../services/apns/sender";
+
+export const runtime = "nodejs"; // http2 + node:crypto, not edge
+export const dynamic = "force-dynamic";
+
+function apnsConfig(): ApnsConfig | null {
+  const keyP8 = env.CMUX_APNS_KEY_P8;
+  const keyId = env.CMUX_APNS_KEY_ID;
+  const teamId = env.CMUX_APNS_TEAM_ID;
+  if (!keyP8 || !keyId || !teamId) return null;
+  return { keyP8, keyId, teamId };
+}
+
+export async function POST(request: Request): Promise<Response> {
+  const user = await verifyRequest(request);
+  if (!user) return unauthorized();
+
+  let body: Record<string, unknown>;
+  try {
+    const text = await request.text();
+    const raw = text ? (JSON.parse(text) as unknown) : {};
+    if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+      return jsonResponse({ error: "invalid_json" }, 400);
+    }
+    body = raw as Record<string, unknown>;
+  } catch {
+    return jsonResponse({ error: "invalid_json" }, 400);
+  }
+
+  const title = typeof body.title === "string" ? body.title : "";
+  const subtitle = typeof body.subtitle === "string" ? body.subtitle : null;
+  const text = typeof body.body === "string" ? body.body : "";
+  const workspaceId = typeof body.workspaceId === "string" ? body.workspaceId : null;
+  const surfaceId = typeof body.surfaceId === "string" ? body.surfaceId : null;
+  const hideContent = body.hideContent === true;
+  if (!title && !text) return jsonResponse({ error: "empty_notification" }, 400);
+
+  const db = cloudDb();
+  const tokens = await db
+    .select({
+      deviceToken: deviceTokens.deviceToken,
+      bundleId: deviceTokens.bundleId,
+      environment: deviceTokens.environment,
+    })
+    .from(deviceTokens)
+    .where(eq(deviceTokens.userId, user.id));
+
+  if (tokens.length === 0) {
+    return jsonResponse({ sent: 0, devices: 0 });
+  }
+
+  const config = apnsConfig();
+  if (!config) {
+    return jsonResponse({ error: "apns_not_configured" }, 503);
+  }
+
+  const results = await sendApnsNotification(config, tokens, {
+    title,
+    subtitle,
+    body: text,
+    workspaceId,
+    surfaceId,
+    hideContent,
+  });
+
+  const dead = results.filter((r) => r.prune).map((r) => r.deviceToken);
+  if (dead.length > 0) {
+    await db
+      .delete(deviceTokens)
+      .where(and(eq(deviceTokens.userId, user.id), inArray(deviceTokens.deviceToken, dead)));
+  }
+
+  const sent = results.filter((r) => r.status >= 200 && r.status < 300).length;
+  return jsonResponse({
+    sent,
+    devices: tokens.length,
+    pruned: dead.length,
+    results: results.map((r) => ({ status: r.status, reason: r.reason })),
+  });
+}

--- a/web/app/api/notifications/push/route.ts
+++ b/web/app/api/notifications/push/route.ts
@@ -3,12 +3,19 @@
 // forwarding. No-ops (no APNs traffic) when the user has no registered devices.
 // Auth: Stack Bearer (the Mac's signed-in user); routing is by that user id.
 
+import { checkRateLimit } from "@vercel/firewall";
 import { and, eq, inArray } from "drizzle-orm";
 import { env } from "../../../env";
 import { cloudDb } from "../../../../db/client";
 import { deviceTokens } from "../../../../db/schema";
 import { jsonResponse } from "../../../../services/vms/routeHelpers";
 import { unauthorized, verifyRequest } from "../../../../services/vms/auth";
+import { recordPushSendOrThrow, PushRateLimitExceededError } from "../../../../services/apns/rateLimit";
+import {
+  MAX_DEVICE_TOKENS_PER_USER,
+  MAX_PUSH_REQUEST_BYTES,
+  parsePushPayload,
+} from "../../../../services/apns/routePolicy";
 import { sendApnsNotification, type ApnsConfig } from "../../../../services/apns/sender";
 
 export const runtime = "nodejs"; // http2 + node:crypto, not edge
@@ -22,29 +29,43 @@ function apnsConfig(): ApnsConfig | null {
   return { keyP8, keyId, teamId };
 }
 
+async function readJson(request: Request): Promise<Record<string, unknown> | null> {
+  const text = await request.text();
+  if (text.length > MAX_PUSH_REQUEST_BYTES) return null;
+  if (!text) return {};
+  try {
+    const raw = JSON.parse(text) as unknown;
+    if (raw === null || typeof raw !== "object" || Array.isArray(raw)) return null;
+    return raw as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function rateLimitResponse(error: PushRateLimitExceededError): Response {
+  return new Response(
+    JSON.stringify({ error: "rate_limited", retryAfterSeconds: error.retryAfterSeconds }),
+    {
+      status: 429,
+      headers: {
+        "content-type": "application/json",
+        "retry-after": String(error.retryAfterSeconds),
+      },
+    },
+  );
+}
+
 export async function POST(request: Request): Promise<Response> {
   const user = await verifyRequest(request);
   if (!user) return unauthorized();
 
-  let body: Record<string, unknown>;
-  try {
-    const text = await request.text();
-    const raw = text ? (JSON.parse(text) as unknown) : {};
-    if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
-      return jsonResponse({ error: "invalid_json" }, 400);
-    }
-    body = raw as Record<string, unknown>;
-  } catch {
+  const body = await readJson(request);
+  if (!body) {
     return jsonResponse({ error: "invalid_json" }, 400);
   }
 
-  const title = typeof body.title === "string" ? body.title : "";
-  const subtitle = typeof body.subtitle === "string" ? body.subtitle : null;
-  const text = typeof body.body === "string" ? body.body : "";
-  const workspaceId = typeof body.workspaceId === "string" ? body.workspaceId : null;
-  const surfaceId = typeof body.surfaceId === "string" ? body.surfaceId : null;
-  const hideContent = body.hideContent === true;
-  if (!title && !text) return jsonResponse({ error: "empty_notification" }, 400);
+  const payload = parsePushPayload(body);
+  if (!payload.ok) return jsonResponse({ error: payload.error }, 400);
 
   const db = cloudDb();
   const tokens = await db
@@ -54,7 +75,8 @@ export async function POST(request: Request): Promise<Response> {
       environment: deviceTokens.environment,
     })
     .from(deviceTokens)
-    .where(eq(deviceTokens.userId, user.id));
+    .where(eq(deviceTokens.userId, user.id))
+    .limit(MAX_DEVICE_TOKENS_PER_USER);
 
   if (tokens.length === 0) {
     return jsonResponse({ sent: 0, devices: 0 });
@@ -65,14 +87,32 @@ export async function POST(request: Request): Promise<Response> {
     return jsonResponse({ error: "apns_not_configured" }, 503);
   }
 
-  const results = await sendApnsNotification(config, tokens, {
-    title,
-    subtitle,
-    body: text,
-    workspaceId,
-    surfaceId,
-    hideContent,
-  });
+  if (process.env.VERCEL === "1" && env.CMUX_PUSH_RATE_LIMIT_ID) {
+    const { error, rateLimited } = await checkRateLimit(env.CMUX_PUSH_RATE_LIMIT_ID, {
+      request,
+      rateLimitKey: user.id,
+    });
+    if (rateLimited || error === "blocked") {
+      return new Response(JSON.stringify({ error: "rate_limited" }), {
+        status: 429,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (error === "not-found") {
+      console.error("notifications.push.rate_limit_not_found", env.CMUX_PUSH_RATE_LIMIT_ID);
+    }
+  }
+
+  try {
+    await recordPushSendOrThrow(db, user.id, tokens.length);
+  } catch (error) {
+    if (error instanceof PushRateLimitExceededError) {
+      return rateLimitResponse(error);
+    }
+    throw error;
+  }
+
+  const results = await sendApnsNotification(config, tokens, payload.value);
 
   const dead = results.filter((r) => r.prune).map((r) => r.deviceToken);
   if (dead.length > 0) {

--- a/web/app/api/notifications/push/route.ts
+++ b/web/app/api/notifications/push/route.ts
@@ -11,6 +11,7 @@ import { deviceTokens } from "../../../../db/schema";
 import { jsonResponse } from "../../../../services/vms/routeHelpers";
 import { unauthorized, verifyRequest } from "../../../../services/vms/auth";
 import { recordPushSendOrThrow, PushRateLimitExceededError } from "../../../../services/apns/rateLimit";
+import { withApnsApiRoute } from "../../../../services/apns/routeHandler";
 import {
   MAX_DEVICE_TOKENS_PER_USER,
   MAX_PUSH_REQUEST_BYTES,
@@ -44,6 +45,10 @@ function rateLimitResponse(error: PushRateLimitExceededError): Response {
 }
 
 export async function POST(request: Request): Promise<Response> {
+  return withApnsApiRoute(request, "/api/notifications/push", "send", async () => sendPush(request));
+}
+
+async function sendPush(request: Request): Promise<Response> {
   const user = await verifyRequest(request, { allowCookie: false });
   if (!user) return unauthorized();
 

--- a/web/app/api/notifications/push/route.ts
+++ b/web/app/api/notifications/push/route.ts
@@ -19,6 +19,7 @@ import {
   readBoundedJsonObject,
 } from "../../../../services/apns/routePolicy";
 import { sendApnsNotification, type ApnsConfig } from "../../../../services/apns/sender";
+import { summarizeApnsSendResults } from "../../../../services/apns/response";
 
 export const runtime = "nodejs"; // http2 + node:crypto, not edge
 export const dynamic = "force-dynamic";
@@ -77,7 +78,7 @@ async function sendPush(request: Request): Promise<Response> {
 
   const config = apnsConfig();
   if (!config) {
-    return jsonResponse({ error: "apns_not_configured" }, 503);
+    return jsonResponse({ error: "push_service_not_configured" }, 503);
   }
 
   if (process.env.VERCEL === "1" && env.CMUX_PUSH_RATE_LIMIT_ID) {
@@ -114,11 +115,5 @@ async function sendPush(request: Request): Promise<Response> {
       .where(and(eq(deviceTokens.userId, user.id), inArray(deviceTokens.deviceToken, dead)));
   }
 
-  const sent = results.filter((r) => r.status >= 200 && r.status < 300).length;
-  return jsonResponse({
-    sent,
-    devices: tokens.length,
-    pruned: dead.length,
-    results: results.map((r) => ({ status: r.status, reason: r.reason })),
-  });
+  return jsonResponse(summarizeApnsSendResults(results));
 }

--- a/web/app/api/notifications/push/route.ts
+++ b/web/app/api/notifications/push/route.ts
@@ -1,7 +1,7 @@
 // Send a push to the authenticated user's registered iOS devices. Called by the
 // macOS app when it shows a terminal notification AND the user enabled phone
 // forwarding. No-ops (no APNs traffic) when the user has no registered devices.
-// Auth: Stack Bearer (the Mac's signed-in user); routing is by that user id.
+// Auth: Stack Bearer from the Mac's signed-in user; routing is by that user id.
 
 import { checkRateLimit } from "@vercel/firewall";
 import { and, eq, inArray } from "drizzle-orm";
@@ -15,6 +15,7 @@ import {
   MAX_DEVICE_TOKENS_PER_USER,
   MAX_PUSH_REQUEST_BYTES,
   parsePushPayload,
+  readBoundedJsonObject,
 } from "../../../../services/apns/routePolicy";
 import { sendApnsNotification, type ApnsConfig } from "../../../../services/apns/sender";
 
@@ -27,19 +28,6 @@ function apnsConfig(): ApnsConfig | null {
   const teamId = env.CMUX_APNS_TEAM_ID;
   if (!keyP8 || !keyId || !teamId) return null;
   return { keyP8, keyId, teamId };
-}
-
-async function readJson(request: Request): Promise<Record<string, unknown> | null> {
-  const text = await request.text();
-  if (text.length > MAX_PUSH_REQUEST_BYTES) return null;
-  if (!text) return {};
-  try {
-    const raw = JSON.parse(text) as unknown;
-    if (raw === null || typeof raw !== "object" || Array.isArray(raw)) return null;
-    return raw as Record<string, unknown>;
-  } catch {
-    return null;
-  }
 }
 
 function rateLimitResponse(error: PushRateLimitExceededError): Response {
@@ -56,15 +44,15 @@ function rateLimitResponse(error: PushRateLimitExceededError): Response {
 }
 
 export async function POST(request: Request): Promise<Response> {
-  const user = await verifyRequest(request);
+  const user = await verifyRequest(request, { allowCookie: false });
   if (!user) return unauthorized();
 
-  const body = await readJson(request);
-  if (!body) {
-    return jsonResponse({ error: "invalid_json" }, 400);
+  const body = await readBoundedJsonObject(request, MAX_PUSH_REQUEST_BYTES);
+  if (!body.ok) {
+    return jsonResponse({ error: body.error }, body.error === "request_too_large" ? 413 : 400);
   }
 
-  const payload = parsePushPayload(body);
+  const payload = parsePushPayload(body.value);
   if (!payload.ok) return jsonResponse({ error: payload.error }, 400);
 
   const db = cloudDb();

--- a/web/app/api/notifications/push/route.ts
+++ b/web/app/api/notifications/push/route.ts
@@ -69,11 +69,11 @@ async function sendPush(request: Request): Promise<Response> {
       environment: deviceTokens.environment,
     })
     .from(deviceTokens)
-    .where(eq(deviceTokens.userId, user.id))
+    .where(and(eq(deviceTokens.userId, user.id), eq(deviceTokens.platform, "ios")))
     .limit(MAX_DEVICE_TOKENS_PER_USER);
 
   if (tokens.length === 0) {
-    return jsonResponse({ sent: 0, devices: 0 });
+    return jsonResponse({ sent: 0, devices: 0, pruned: 0 });
   }
 
   const config = apnsConfig();
@@ -112,7 +112,7 @@ async function sendPush(request: Request): Promise<Response> {
   if (dead.length > 0) {
     await db
       .delete(deviceTokens)
-      .where(and(eq(deviceTokens.userId, user.id), inArray(deviceTokens.deviceToken, dead)));
+      .where(and(eq(deviceTokens.userId, user.id), eq(deviceTokens.platform, "ios"), inArray(deviceTokens.deviceToken, dead)));
   }
 
   return jsonResponse(summarizeApnsSendResults(results));

--- a/web/app/api/notifications/push/route.ts
+++ b/web/app/api/notifications/push/route.ts
@@ -73,7 +73,7 @@ async function sendPush(request: Request): Promise<Response> {
     .limit(MAX_DEVICE_TOKENS_PER_USER);
 
   if (tokens.length === 0) {
-    return jsonResponse({ sent: 0, devices: 0, pruned: 0 });
+    return jsonResponse(summarizeApnsSendResults([]));
   }
 
   const config = apnsConfig();

--- a/web/app/env.ts
+++ b/web/app/env.ts
@@ -35,6 +35,7 @@ export const env = createEnv({
     CMUX_APNS_KEY_P8: z.string().min(1).optional(),
     CMUX_APNS_KEY_ID: z.string().min(1).optional(),
     CMUX_APNS_TEAM_ID: z.string().min(1).optional(),
+    CMUX_PUSH_RATE_LIMIT_ID: z.string().min(1).optional(),
   },
   client: {
     NEXT_PUBLIC_STACK_PROJECT_ID: z.string().min(1),
@@ -47,6 +48,7 @@ export const env = createEnv({
     CMUX_APNS_KEY_P8: trimEnv(process.env.CMUX_APNS_KEY_P8),
     CMUX_APNS_KEY_ID: trimEnv(process.env.CMUX_APNS_KEY_ID),
     CMUX_APNS_TEAM_ID: trimEnv(process.env.CMUX_APNS_TEAM_ID),
+    CMUX_PUSH_RATE_LIMIT_ID: trimEnv(process.env.CMUX_PUSH_RATE_LIMIT_ID),
     NEXT_PUBLIC_STACK_PROJECT_ID: stackEnv(
       process.env.NEXT_PUBLIC_STACK_PROJECT_ID,
       "00000000-0000-4000-8000-000000000000"

--- a/web/app/env.ts
+++ b/web/app/env.ts
@@ -28,6 +28,13 @@ export const env = createEnv({
     CMUX_FEEDBACK_FROM_EMAIL: z.string().email(),
     CMUX_FEEDBACK_RATE_LIMIT_ID: z.string().min(1),
     STACK_SECRET_SERVER_KEY: z.string().min(1),
+    // APNs push (iOS notifications). Optional: the app boots without them; the
+    // push route returns a clear "not configured" error until they are set.
+    // CMUX_APNS_KEY_P8 holds the .p8 PEM (literal "\n" escapes are normalized
+    // by the sender).
+    CMUX_APNS_KEY_P8: z.string().min(1).optional(),
+    CMUX_APNS_KEY_ID: z.string().min(1).optional(),
+    CMUX_APNS_TEAM_ID: z.string().min(1).optional(),
   },
   client: {
     NEXT_PUBLIC_STACK_PROJECT_ID: z.string().min(1),
@@ -37,6 +44,9 @@ export const env = createEnv({
     RESEND_API_KEY: trimEnv(process.env.RESEND_API_KEY),
     CMUX_FEEDBACK_FROM_EMAIL: trimEnv(process.env.CMUX_FEEDBACK_FROM_EMAIL),
     CMUX_FEEDBACK_RATE_LIMIT_ID: trimEnv(process.env.CMUX_FEEDBACK_RATE_LIMIT_ID),
+    CMUX_APNS_KEY_P8: trimEnv(process.env.CMUX_APNS_KEY_P8),
+    CMUX_APNS_KEY_ID: trimEnv(process.env.CMUX_APNS_KEY_ID),
+    CMUX_APNS_TEAM_ID: trimEnv(process.env.CMUX_APNS_TEAM_ID),
     NEXT_PUBLIC_STACK_PROJECT_ID: stackEnv(
       process.env.NEXT_PUBLIC_STACK_PROJECT_ID,
       "00000000-0000-4000-8000-000000000000"

--- a/web/db/migrations/20260601230221_brief_skreet/migration.sql
+++ b/web/db/migrations/20260601230221_brief_skreet/migration.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "device_tokens" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+	"user_id" text NOT NULL,
+	"device_token" text NOT NULL,
+	"platform" text DEFAULT 'ios' NOT NULL,
+	"bundle_id" text NOT NULL,
+	"environment" text DEFAULT 'production' NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX "device_tokens_user_idx" ON "device_tokens" ("user_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "device_tokens_device_token_unique" ON "device_tokens" ("device_token");

--- a/web/db/migrations/20260601230221_brief_skreet/snapshot.json
+++ b/web/db/migrations/20260601230221_brief_skreet/snapshot.json
@@ -1,0 +1,1325 @@
+{
+  "version": "8",
+  "dialect": "postgres",
+  "id": "719ada3b-0fc5-446c-b367-177d73cc49e1",
+  "prevIds": [
+    "399a2558-b881-4169-98e1-5906059fc3fd"
+  ],
+  "ddl": [
+    {
+      "values": [
+        "pty",
+        "rpc",
+        "ssh"
+      ],
+      "name": "vm_lease_kind",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "e2b",
+        "freestyle"
+      ],
+      "name": "vm_provider",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "provisioning",
+        "running",
+        "failed",
+        "paused",
+        "destroyed"
+      ],
+      "name": "vm_status",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "cloud_vm_billing_grants",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "cloud_vm_leases",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "cloud_vm_usage_events",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "cloud_vms",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "device_tokens",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_billing_grants"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "billing_customer_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_billing_grants"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "billing_customer_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_billing_grants"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "billing_plan_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_billing_grants"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "item_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_billing_grants"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "amount",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_billing_grants"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "reason",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_billing_grants"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "applied_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_billing_grants"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_billing_grants"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_billing_grants"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "vm_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "type": "vm_lease_kind",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "kind",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "token_hash",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "provider_identity_handle",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "transport",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{}'",
+      "generated": null,
+      "identity": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "consumed_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "revoked_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "billing_team_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "billing_plan_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "vm_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "event_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "type": "vm_provider",
+      "typeSchema": "public",
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "provider",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{}'",
+      "generated": null,
+      "identity": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "billing_team_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "billing_plan_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "vm_provider",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "provider",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "provider_vm_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image_version",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "vm_status",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'provisioning'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "idempotency_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "destroyed_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "failure_code",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "failure_message",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_tokens"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_tokens"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "device_token",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_tokens"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'ios'",
+      "generated": null,
+      "identity": null,
+      "name": "platform",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_tokens"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "bundle_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_tokens"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'production'",
+      "generated": null,
+      "identity": null,
+      "name": "environment",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_tokens"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_tokens"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_tokens"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "billing_customer_type",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "billing_customer_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vm_billing_grants_customer_created_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vm_billing_grants"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "billing_customer_type",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "billing_customer_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "item_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "reason",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vm_billing_grants_customer_item_reason_unique",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vm_billing_grants"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "vm_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "kind",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vm_leases_vm_kind_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "provider_identity_handle",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vm_leases_identity_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "expires_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vm_leases_user_expires_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "token_hash",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vm_leases_token_hash_unique",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vm_usage_events_user_created_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "billing_team_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vm_usage_events_billing_team_created_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "vm_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vm_usage_events_vm_created_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "event_type",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vm_usage_events_type_created_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "status",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vms_user_status_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "billing_team_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "status",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vms_billing_team_status_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "idempotency_key",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "\"idempotency_key\" is not null",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vms_user_idempotency_key_unique",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "provider",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "provider_vm_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "\"provider_vm_id\" is not null",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vms_provider_vm_id_unique",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "device_tokens_user_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "device_tokens"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "device_token",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "device_tokens_device_token_unique",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "device_tokens"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "vm_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "cloud_vms",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "cloud_vm_leases_vm_id_cloud_vms_id_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "vm_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "cloud_vms",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "name": "cloud_vm_usage_events_vm_id_cloud_vms_id_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "cloud_vm_billing_grants_pkey",
+      "schema": "public",
+      "table": "cloud_vm_billing_grants",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "cloud_vm_leases_pkey",
+      "schema": "public",
+      "table": "cloud_vm_leases",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "cloud_vm_usage_events_pkey",
+      "schema": "public",
+      "table": "cloud_vm_usage_events",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "cloud_vms_pkey",
+      "schema": "public",
+      "table": "cloud_vms",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "device_tokens_pkey",
+      "schema": "public",
+      "table": "device_tokens",
+      "entityType": "pks"
+    }
+  ],
+  "renames": []
+}

--- a/web/db/migrations/20260602093000_notification_send_events/migration.sql
+++ b/web/db/migrations/20260602093000_notification_send_events/migration.sql
@@ -1,0 +1,8 @@
+CREATE TABLE "notification_send_events" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+	"user_id" text NOT NULL,
+	"device_count" integer NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX "notification_send_events_user_created_idx" ON "notification_send_events" ("user_id","created_at");

--- a/web/db/migrations/20260602093000_notification_send_events/snapshot.json
+++ b/web/db/migrations/20260602093000_notification_send_events/snapshot.json
@@ -1,0 +1,1421 @@
+{
+  "version": "8",
+  "dialect": "postgres",
+  "id": "82769d22-cd97-490a-af75-97c410198ccc",
+  "prevIds": [
+    "719ada3b-0fc5-446c-b367-177d73cc49e1"
+  ],
+  "ddl": [
+    {
+      "values": [
+        "pty",
+        "rpc",
+        "ssh"
+      ],
+      "name": "vm_lease_kind",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "e2b",
+        "freestyle"
+      ],
+      "name": "vm_provider",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "provisioning",
+        "running",
+        "failed",
+        "paused",
+        "destroyed"
+      ],
+      "name": "vm_status",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "cloud_vm_billing_grants",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "cloud_vm_leases",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "cloud_vm_usage_events",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "cloud_vms",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "device_tokens",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "notification_send_events",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_billing_grants"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "billing_customer_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_billing_grants"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "billing_customer_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_billing_grants"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "billing_plan_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_billing_grants"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "item_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_billing_grants"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "amount",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_billing_grants"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "reason",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_billing_grants"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "applied_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_billing_grants"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_billing_grants"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_billing_grants"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "vm_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "type": "vm_lease_kind",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "kind",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "token_hash",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "provider_identity_handle",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "transport",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{}'",
+      "generated": null,
+      "identity": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "consumed_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "revoked_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "billing_team_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "billing_plan_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "vm_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "event_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "type": "vm_provider",
+      "typeSchema": "public",
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "provider",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{}'",
+      "generated": null,
+      "identity": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "billing_team_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "billing_plan_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "vm_provider",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "provider",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "provider_vm_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image_version",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "vm_status",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'provisioning'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "idempotency_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "destroyed_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "failure_code",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "failure_message",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_tokens"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_tokens"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "device_token",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_tokens"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'ios'",
+      "generated": null,
+      "identity": null,
+      "name": "platform",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_tokens"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "bundle_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_tokens"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'production'",
+      "generated": null,
+      "identity": null,
+      "name": "environment",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_tokens"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_tokens"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_tokens"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "notification_send_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "notification_send_events"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "device_count",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "notification_send_events"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "notification_send_events"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "billing_customer_type",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "billing_customer_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vm_billing_grants_customer_created_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vm_billing_grants"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "billing_customer_type",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "billing_customer_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "item_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "reason",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vm_billing_grants_customer_item_reason_unique",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vm_billing_grants"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "vm_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "kind",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vm_leases_vm_kind_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "provider_identity_handle",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vm_leases_identity_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "expires_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vm_leases_user_expires_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "token_hash",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vm_leases_token_hash_unique",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vm_usage_events_user_created_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "billing_team_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vm_usage_events_billing_team_created_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "vm_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vm_usage_events_vm_created_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "event_type",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vm_usage_events_type_created_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "status",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vms_user_status_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "billing_team_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "status",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vms_billing_team_status_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "idempotency_key",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "\"idempotency_key\" is not null",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vms_user_idempotency_key_unique",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "provider",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "provider_vm_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "\"provider_vm_id\" is not null",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vms_provider_vm_id_unique",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "device_tokens_user_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "device_tokens"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "device_token",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "device_tokens_device_token_unique",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "device_tokens"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "notification_send_events_user_created_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "notification_send_events"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "vm_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "cloud_vms",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "cloud_vm_leases_vm_id_cloud_vms_id_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "vm_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "cloud_vms",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "name": "cloud_vm_usage_events_vm_id_cloud_vms_id_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "cloud_vm_billing_grants_pkey",
+      "schema": "public",
+      "table": "cloud_vm_billing_grants",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "cloud_vm_leases_pkey",
+      "schema": "public",
+      "table": "cloud_vm_leases",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "cloud_vm_usage_events_pkey",
+      "schema": "public",
+      "table": "cloud_vm_usage_events",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "cloud_vms_pkey",
+      "schema": "public",
+      "table": "cloud_vms",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "device_tokens_pkey",
+      "schema": "public",
+      "table": "device_tokens",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "notification_send_events_pkey",
+      "schema": "public",
+      "table": "notification_send_events",
+      "entityType": "pks"
+    }
+  ],
+  "renames": []
+}

--- a/web/db/schema.ts
+++ b/web/db/schema.ts
@@ -132,6 +132,19 @@ export const deviceTokens = pgTable(
   ],
 );
 
+export const notificationSendEvents = pgTable(
+  "notification_send_events",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    userId: text("user_id").notNull(),
+    deviceCount: integer("device_count").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("notification_send_events_user_created_idx").on(table.userId, table.createdAt),
+  ],
+);
+
 export const cloudVmBillingGrants = pgTable(
   "cloud_vm_billing_grants",
   {

--- a/web/db/schema.ts
+++ b/web/db/schema.ts
@@ -103,6 +103,35 @@ export const cloudVmUsageEvents = pgTable(
   ],
 );
 
+/**
+ * APNs device tokens for iOS push notifications. A row exists only after the
+ * user explicitly opts in on their device (the feature is off by default), so
+ * the mere presence of a row for a user means "this user wants phone pushes".
+ * Keyed unique by `deviceToken` so a device re-registering (e.g. after an
+ * account switch) updates its `userId` instead of duplicating.
+ */
+export const deviceTokens = pgTable(
+  "device_tokens",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    userId: text("user_id").notNull(),
+    deviceToken: text("device_token").notNull(),
+    platform: text("platform").notNull().default("ios"),
+    // The APNs topic the token belongs to (the iOS bundle id, which varies by
+    // build: dev.cmux.ios.<tag>, dev.cmux.app.beta, com.cmuxterm.app).
+    bundleId: text("bundle_id").notNull(),
+    // "sandbox" for development builds, "production" for TestFlight/App Store —
+    // selects which APNs host the sender uses.
+    environment: text("environment").notNull().default("production"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("device_tokens_user_idx").on(table.userId),
+    uniqueIndex("device_tokens_device_token_unique").on(table.deviceToken),
+  ],
+);
+
 export const cloudVmBillingGrants = pgTable(
   "cloud_vm_billing_grants",
   {

--- a/web/scripts/load-dev-env.sh
+++ b/web/scripts/load-dev-env.sh
@@ -103,6 +103,7 @@ fi
 export RESEND_API_KEY="${RESEND_API_KEY:-cmux-local-dev}"
 export CMUX_FEEDBACK_FROM_EMAIL="${CMUX_FEEDBACK_FROM_EMAIL:-dev@example.invalid}"
 export CMUX_FEEDBACK_RATE_LIMIT_ID="${CMUX_FEEDBACK_RATE_LIMIT_ID:-cmux-feedback-local}"
+export CMUX_PUSH_RATE_LIMIT_ID="${CMUX_PUSH_RATE_LIMIT_ID:-cmux-push-local}"
 
 export CMUX_WEB_SECRET_ENV_FILE="$cmux_secret_file"
 export CMUX_WEB_EXTRA_SECRET_ENV_FILE="$cmux_extra_secret_file"

--- a/web/services/apns/payload.ts
+++ b/web/services/apns/payload.ts
@@ -1,0 +1,68 @@
+// Pure, dependency-free helpers for building APNs requests. Kept separate from
+// the http2/crypto sender so they can be unit-tested in isolation.
+
+export type ApnsEnvironment = "sandbox" | "production";
+
+export const APNS_HOSTS: Record<ApnsEnvironment, string> = {
+  sandbox: "api.sandbox.push.apple.com",
+  production: "api.push.apple.com",
+};
+
+/** APNs host for a stored token's environment (defaults to production). */
+export function apnsHostForEnvironment(environment: string): string {
+  return environment === "sandbox" ? APNS_HOSTS.sandbox : APNS_HOSTS.production;
+}
+
+export interface ApnsNotificationInput {
+  readonly title: string;
+  readonly subtitle?: string | null;
+  readonly body: string;
+  readonly workspaceId?: string | null;
+  readonly surfaceId?: string | null;
+  /** When true, replace the real title/body with a generic message so terminal
+   * content never leaves the Mac even after the user opted into forwarding. */
+  readonly hideContent?: boolean;
+}
+
+/**
+ * Build the APNs JSON payload. Adds `cmux.workspaceId`/`cmux.surfaceId` custom
+ * keys so a tapped notification can deep-link to the right terminal, and marks
+ * the alert time-sensitive (the app holds that entitlement).
+ */
+export function buildApnsPayload(input: ApnsNotificationInput): Record<string, unknown> {
+  const hidden = input.hideContent === true;
+  const title = hidden ? "cmux" : input.title.trim() || "cmux";
+  const body = hidden ? "An agent needs your attention" : input.body;
+  const subtitle = hidden ? undefined : input.subtitle?.trim() || undefined;
+
+  const alert: Record<string, string> = { title };
+  if (subtitle) alert.subtitle = subtitle;
+  if (body) alert.body = body;
+
+  const aps: Record<string, unknown> = {
+    alert,
+    sound: "default",
+    "interruption-level": "time-sensitive",
+  };
+
+  const cmux: Record<string, string> = {};
+  if (input.workspaceId) cmux.workspaceId = input.workspaceId;
+  if (input.surfaceId) cmux.surfaceId = input.surfaceId;
+
+  return Object.keys(cmux).length > 0 ? { aps, cmux } : { aps };
+}
+
+/**
+ * Whether an APNs response means the token is permanently invalid and should be
+ * deleted. 410 (Unregistered, with a timestamp) and the `BadDeviceToken` /
+ * `DeviceTokenNotForTopic` / `Unregistered` reasons are terminal; transient
+ * failures (timeouts, 5xx, connection errors with status 0) are not pruned.
+ */
+export function shouldPruneToken(status: number, reason: string | undefined): boolean {
+  if (status === 410) return true;
+  if (reason === "Unregistered") return true;
+  if (status === 400 && (reason === "BadDeviceToken" || reason === "DeviceTokenNotForTopic")) {
+    return true;
+  }
+  return false;
+}

--- a/web/services/apns/rateLimit.ts
+++ b/web/services/apns/rateLimit.ts
@@ -27,7 +27,7 @@ export async function recordPushSendOrThrow(
   const windowStart = new Date(now.getTime() - PUSH_RATE_LIMIT_WINDOW_MS);
 
   await db.transaction(async (tx) => {
-    await tx.execute(sql`select pg_advisory_xact_lock(hashtextextended(${userId}, 0))`);
+    await tx.execute(sql`select pg_advisory_xact_lock(hashtextextended(${userId}, 1))`);
     await tx
       .delete(notificationSendEvents)
       .where(and(eq(notificationSendEvents.userId, userId), lt(notificationSendEvents.createdAt, windowStart)));

--- a/web/services/apns/rateLimit.ts
+++ b/web/services/apns/rateLimit.ts
@@ -1,0 +1,47 @@
+import { and, count, eq, gte, lt, sql } from "drizzle-orm";
+
+import type { cloudDb } from "../../db/client";
+import { notificationSendEvents } from "../../db/schema";
+
+type NotificationDb = ReturnType<typeof cloudDb>;
+
+const PUSH_RATE_LIMIT_WINDOW_MS = 10 * 60 * 1000;
+const PUSH_RATE_LIMIT_MAX_EVENTS = 60;
+
+export class PushRateLimitExceededError extends Error {
+  readonly retryAfterSeconds: number;
+
+  constructor(retryAfterSeconds: number) {
+    super("push rate limit exceeded");
+    this.name = "PushRateLimitExceededError";
+    this.retryAfterSeconds = retryAfterSeconds;
+  }
+}
+
+export async function recordPushSendOrThrow(
+  db: NotificationDb,
+  userId: string,
+  deviceCount: number,
+  now = new Date(),
+): Promise<void> {
+  const windowStart = new Date(now.getTime() - PUSH_RATE_LIMIT_WINDOW_MS);
+
+  await db.transaction(async (tx) => {
+    await tx.execute(sql`select pg_advisory_xact_lock(hashtextextended(${userId}, 0))`);
+    await tx
+      .delete(notificationSendEvents)
+      .where(and(eq(notificationSendEvents.userId, userId), lt(notificationSendEvents.createdAt, windowStart)));
+
+    const [recent] = await tx
+      .select({ total: count() })
+      .from(notificationSendEvents)
+      .where(and(eq(notificationSendEvents.userId, userId), gte(notificationSendEvents.createdAt, windowStart)));
+
+    const recentCount = Number(recent?.total ?? 0);
+    if (recentCount >= PUSH_RATE_LIMIT_MAX_EVENTS) {
+      throw new PushRateLimitExceededError(Math.ceil(PUSH_RATE_LIMIT_WINDOW_MS / 1000));
+    }
+
+    await tx.insert(notificationSendEvents).values({ userId, deviceCount, createdAt: now });
+  });
+}

--- a/web/services/apns/response.ts
+++ b/web/services/apns/response.ts
@@ -1,0 +1,13 @@
+import type { ApnsSendResult } from "./sender";
+
+export interface PushSendSummary {
+  readonly sent: number;
+  readonly devices: number;
+  readonly pruned: number;
+}
+
+export function summarizeApnsSendResults(results: readonly ApnsSendResult[]): PushSendSummary {
+  const sent = results.filter((r) => r.status >= 200 && r.status < 300).length;
+  const pruned = results.filter((r) => r.prune).length;
+  return { sent, devices: results.length, pruned };
+}

--- a/web/services/apns/routeHandler.ts
+++ b/web/services/apns/routeHandler.ts
@@ -1,0 +1,29 @@
+import { recordSpanError, withApiRouteSpan, type MaybeAttributes } from "../telemetry";
+
+export async function withApnsApiRoute(
+  request: Request,
+  route: string,
+  operation: string,
+  handler: () => Promise<Response>,
+): Promise<Response> {
+  return withApiRouteSpan(
+    request,
+    route,
+    {
+      "cmux.subsystem": "apns",
+      "cmux.apns.operation": operation,
+    } satisfies MaybeAttributes,
+    async (span) => {
+      try {
+        return await handler();
+      } catch (error) {
+        recordSpanError(span, error);
+        console.error(`${route} ${operation} failed`, error);
+        return new Response(JSON.stringify({ error: "push_internal_error" }), {
+          status: 500,
+          headers: { "content-type": "application/json" },
+        });
+      }
+    },
+  );
+}

--- a/web/services/apns/routePolicy.ts
+++ b/web/services/apns/routePolicy.ts
@@ -24,6 +24,10 @@ export type PushPayloadResult =
   | { readonly ok: true; readonly value: PushPayload }
   | { readonly ok: false; readonly error: string };
 
+export type JsonObjectResult =
+  | { readonly ok: true; readonly value: Record<string, unknown> }
+  | { readonly ok: false; readonly error: "invalid_json" | "request_too_large" };
+
 const DEV_TAGGED_BUNDLE_ID = /^dev\.cmux\.ios\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
 const PROD_BUNDLE_IDS = new Set(["com.cmuxterm.app", "dev.cmux.app.beta"]);
 
@@ -73,4 +77,64 @@ export function parsePushPayload(body: Record<string, unknown>): PushPayloadResu
       hideContent: body.hideContent === true,
     },
   };
+}
+
+export async function readBoundedJsonObject(
+  request: Request,
+  maxBytes: number,
+): Promise<JsonObjectResult> {
+  const contentLength = request.headers.get("content-length");
+  if (contentLength) {
+    const parsedLength = Number(contentLength);
+    if (Number.isFinite(parsedLength) && parsedLength > maxBytes) {
+      return { ok: false, error: "request_too_large" };
+    }
+  }
+
+  const textResult = await readBoundedText(request, maxBytes);
+  if (!textResult.ok) return textResult;
+  const text = textResult.value;
+  if (!text) return { ok: true, value: {} };
+
+  try {
+    const raw = JSON.parse(text) as unknown;
+    if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+      return { ok: false, error: "invalid_json" };
+    }
+    return { ok: true, value: raw as Record<string, unknown> };
+  } catch {
+    return { ok: false, error: "invalid_json" };
+  }
+}
+
+async function readBoundedText(
+  request: Request,
+  maxBytes: number,
+): Promise<{ readonly ok: true; readonly value: string } | { readonly ok: false; readonly error: "request_too_large" }> {
+  if (!request.body) {
+    return { ok: true, value: "" };
+  }
+
+  const reader = request.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    totalBytes += value.byteLength;
+    if (totalBytes > maxBytes) {
+      await reader.cancel();
+      return { ok: false, error: "request_too_large" };
+    }
+    chunks.push(value);
+  }
+
+  const body = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return { ok: true, value: new TextDecoder().decode(body) };
 }

--- a/web/services/apns/routePolicy.ts
+++ b/web/services/apns/routePolicy.ts
@@ -1,0 +1,76 @@
+export const MAX_DEVICE_TOKENS_PER_USER = 10;
+
+export const MAX_PUSH_TITLE_CHARS = 120;
+export const MAX_PUSH_SUBTITLE_CHARS = 120;
+export const MAX_PUSH_BODY_CHARS = 500;
+export const MAX_PUSH_ID_CHARS = 200;
+export const MAX_PUSH_REQUEST_BYTES = 8 * 1024;
+
+export type ApnsBundlePolicy = {
+  readonly bundleId: string;
+  readonly environment: "sandbox" | "production";
+};
+
+export type PushPayload = {
+  readonly title: string;
+  readonly subtitle: string | null;
+  readonly body: string;
+  readonly workspaceId: string | null;
+  readonly surfaceId: string | null;
+  readonly hideContent: boolean;
+};
+
+export type PushPayloadResult =
+  | { readonly ok: true; readonly value: PushPayload }
+  | { readonly ok: false; readonly error: string };
+
+const DEV_TAGGED_BUNDLE_ID = /^dev\.cmux\.ios\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
+const PROD_BUNDLE_IDS = new Set(["com.cmuxterm.app", "dev.cmux.app.beta"]);
+
+function stringValue(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function boundedString(value: unknown, maxChars: number): string | null {
+  const text = stringValue(value);
+  if (text.length > maxChars) return null;
+  return text;
+}
+
+export function normalizeApnsBundle(bundleId: string): ApnsBundlePolicy | null {
+  const normalized = bundleId.trim();
+  if (PROD_BUNDLE_IDS.has(normalized)) {
+    return { bundleId: normalized, environment: "production" };
+  }
+  if (DEV_TAGGED_BUNDLE_ID.test(normalized)) {
+    return { bundleId: normalized, environment: "sandbox" };
+  }
+  return null;
+}
+
+export function parsePushPayload(body: Record<string, unknown>): PushPayloadResult {
+  const title = boundedString(body.title, MAX_PUSH_TITLE_CHARS);
+  const subtitle = body.subtitle == null ? "" : boundedString(body.subtitle, MAX_PUSH_SUBTITLE_CHARS);
+  const text = boundedString(body.body, MAX_PUSH_BODY_CHARS);
+  const workspaceId = body.workspaceId == null ? "" : boundedString(body.workspaceId, MAX_PUSH_ID_CHARS);
+  const surfaceId = body.surfaceId == null ? "" : boundedString(body.surfaceId, MAX_PUSH_ID_CHARS);
+
+  if (title == null) return { ok: false, error: "title_too_long" };
+  if (subtitle == null) return { ok: false, error: "subtitle_too_long" };
+  if (text == null) return { ok: false, error: "body_too_long" };
+  if (workspaceId == null) return { ok: false, error: "workspace_id_too_long" };
+  if (surfaceId == null) return { ok: false, error: "surface_id_too_long" };
+  if (!title && !text) return { ok: false, error: "empty_notification" };
+
+  return {
+    ok: true,
+    value: {
+      title,
+      subtitle: subtitle || null,
+      body: text,
+      workspaceId: workspaceId || null,
+      surfaceId: surfaceId || null,
+      hideContent: body.hideContent === true,
+    },
+  };
+}

--- a/web/services/apns/sender.ts
+++ b/web/services/apns/sender.ts
@@ -1,0 +1,171 @@
+// APNs token-based (JWT) sender over HTTP/2. No external deps: ES256 signing
+// via node:crypto, transport via node:http2. Must run on the Node runtime
+// (not edge). Pure helpers live in ./payload; this module owns crypto + I/O.
+
+import crypto from "node:crypto";
+import http2 from "node:http2";
+import {
+  apnsHostForEnvironment,
+  buildApnsPayload,
+  shouldPruneToken,
+  type ApnsNotificationInput,
+} from "./payload";
+
+export interface ApnsConfig {
+  /** Contents of the APNs Auth Key .p8 (PEM). Literal "\n" escapes allowed. */
+  readonly keyP8: string;
+  readonly keyId: string;
+  readonly teamId: string;
+}
+
+export interface ApnsTarget {
+  readonly deviceToken: string;
+  readonly bundleId: string;
+  readonly environment: string; // "sandbox" | "production"
+}
+
+export interface ApnsSendResult {
+  readonly deviceToken: string;
+  readonly status: number; // 0 = transport error / timeout
+  readonly reason?: string;
+  readonly prune: boolean;
+}
+
+/** Normalize a .p8 that was stored with literal `\n` (common in env vars). */
+export function normalizeP8(keyP8: string): string {
+  return keyP8.includes("\\n") ? keyP8.replace(/\\n/g, "\n") : keyP8;
+}
+
+function base64url(input: Buffer | string): string {
+  return Buffer.from(input)
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+/**
+ * Sign an APNs provider-authentication JWT (ES256). `nowSeconds` is injected so
+ * the signer is deterministic and unit-testable.
+ */
+export function signApnsJwt(config: ApnsConfig, nowSeconds: number): string {
+  const header = base64url(JSON.stringify({ alg: "ES256", kid: config.keyId }));
+  const claims = base64url(JSON.stringify({ iss: config.teamId, iat: nowSeconds }));
+  const signingInput = `${header}.${claims}`;
+  const key = crypto.createPrivateKey(normalizeP8(config.keyP8));
+  // APNs (JOSE) requires the raw r||s signature, not DER.
+  const signature = crypto.sign("sha256", Buffer.from(signingInput), {
+    key,
+    dsaEncoding: "ieee-p1363",
+  });
+  return `${signingInput}.${base64url(signature)}`;
+}
+
+// APNs allows reusing a provider token for up to 1h; refresh well before that.
+const JWT_TTL_SECONDS = 50 * 60;
+let cachedJwt: { token: string; issuedAt: number; keyId: string } | null = null;
+
+function providerToken(config: ApnsConfig): string {
+  const now = Math.floor(Date.now() / 1000);
+  if (cachedJwt && cachedJwt.keyId === config.keyId && now - cachedJwt.issuedAt < JWT_TTL_SECONDS) {
+    return cachedJwt.token;
+  }
+  const token = signApnsJwt(config, now);
+  cachedJwt = { token, issuedAt: now, keyId: config.keyId };
+  return token;
+}
+
+/**
+ * Send one payload to every target (grouped by APNs host so each host reuses a
+ * single HTTP/2 connection). Returns a per-token result; callers prune tokens
+ * whose `prune` is true.
+ */
+export async function sendApnsNotification(
+  config: ApnsConfig,
+  targets: readonly ApnsTarget[],
+  input: ApnsNotificationInput,
+  timeoutMs = 8000,
+): Promise<ApnsSendResult[]> {
+  if (targets.length === 0) return [];
+  const jwt = providerToken(config);
+  const body = Buffer.from(JSON.stringify(buildApnsPayload(input)));
+
+  const byHost = new Map<string, ApnsTarget[]>();
+  for (const t of targets) {
+    const host = apnsHostForEnvironment(t.environment);
+    (byHost.get(host) ?? byHost.set(host, []).get(host)!).push(t);
+  }
+
+  const results: ApnsSendResult[] = [];
+  for (const [host, hostTargets] of byHost) {
+    const client = http2.connect(`https://${host}`);
+    // A connection-level error fails every in-flight request for this host.
+    const connError: Promise<null> = new Promise((resolve) => {
+      client.once("error", () => resolve(null));
+    });
+    try {
+      const hostResults = await Promise.all(
+        hostTargets.map((t) => sendOne(client, jwt, t, body, timeoutMs, connError)),
+      );
+      results.push(...hostResults);
+    } finally {
+      client.close();
+    }
+  }
+  return results;
+}
+
+function sendOne(
+  client: http2.ClientHttp2Session,
+  jwt: string,
+  target: ApnsTarget,
+  body: Buffer,
+  timeoutMs: number,
+  connError: Promise<null>,
+): Promise<ApnsSendResult> {
+  return new Promise<ApnsSendResult>((resolve) => {
+    let settled = false;
+    const finish = (status: number, reason?: string) => {
+      if (settled) return;
+      settled = true;
+      resolve({ deviceToken: target.deviceToken, status, reason, prune: shouldPruneToken(status, reason) });
+    };
+    void connError.then(() => finish(0, "connection_error"));
+
+    const req = client.request({
+      ":method": "POST",
+      ":path": `/3/device/${target.deviceToken}`,
+      "apns-topic": target.bundleId,
+      "apns-push-type": "alert",
+      authorization: `bearer ${jwt}`,
+      "content-type": "application/json",
+      "content-length": String(body.length),
+    });
+    req.setTimeout(timeoutMs, () => {
+      req.close();
+      finish(0, "timeout");
+    });
+
+    let status = 0;
+    let data = "";
+    req.on("response", (headers) => {
+      status = Number(headers[":status"]) || 0;
+    });
+    req.on("data", (chunk) => {
+      data += chunk;
+    });
+    req.on("end", () => {
+      let reason: string | undefined;
+      if (data) {
+        try {
+          reason = (JSON.parse(data) as { reason?: string }).reason;
+        } catch {
+          // non-JSON body (success has empty body); leave reason undefined
+        }
+      }
+      finish(status, reason);
+    });
+    req.on("error", (err) => finish(0, err instanceof Error ? err.message : "request_error"));
+    req.end(body);
+  });
+}

--- a/web/services/vms/auth.ts
+++ b/web/services/vms/auth.ts
@@ -27,7 +27,7 @@ export type AuthedTeam = {
  */
 export async function verifyRequest(
   request: Request,
-  options: { readonly requestedTeamId?: string | null } = {},
+  options: { readonly requestedTeamId?: string | null; readonly allowCookie?: boolean } = {},
 ): Promise<AuthedUser | null> {
   if (!isStackConfigured()) {
     return null;
@@ -48,6 +48,10 @@ export async function verifyRequest(
         return await authedUserFromStackUser(user, options);
       }
     }
+  }
+
+  if (options.allowCookie === false) {
+    return null;
   }
 
   // Fall back to the Next.js cookie flow (when browser hits the route).

--- a/web/tests/apns-route-handler.test.ts
+++ b/web/tests/apns-route-handler.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import { withApnsApiRoute } from "../services/apns/routeHandler";
+
+describe("APNs route handler", () => {
+  test("records unexpected failures as generic API errors", async () => {
+    const originalError = console.error;
+    console.error = mock(() => {}) as unknown as typeof console.error;
+    try {
+      const response = await withApnsApiRoute(
+        new Request("https://cmux.test/api/notifications/push", { method: "POST" }),
+        "/api/notifications/push",
+        "send",
+        async () => {
+          throw new Error("database connection failed");
+        },
+      );
+
+      expect(response.status).toBe(500);
+      expect(await response.json()).toEqual({ error: "push_internal_error" });
+      const calls = (console.error as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+      expect(calls[0]?.[0]).toBe("/api/notifications/push send failed");
+      expect(calls[0]?.[1]).toBeInstanceOf(Error);
+    } finally {
+      console.error = originalError;
+    }
+  });
+});

--- a/web/tests/apns.test.ts
+++ b/web/tests/apns.test.ts
@@ -1,0 +1,98 @@
+import crypto from "node:crypto";
+import { describe, expect, test } from "bun:test";
+import {
+  apnsHostForEnvironment,
+  buildApnsPayload,
+  shouldPruneToken,
+} from "../services/apns/payload";
+import { signApnsJwt, normalizeP8 } from "../services/apns/sender";
+
+describe("apns payload", () => {
+  test("builds a time-sensitive alert with deep-link keys", () => {
+    const payload = buildApnsPayload({
+      title: "claude",
+      subtitle: "issue-118",
+      body: "Agent finished",
+      workspaceId: "ws-1",
+      surfaceId: "sf-2",
+    }) as { aps: Record<string, unknown>; cmux: Record<string, string> };
+
+    expect(payload.aps.alert).toEqual({ title: "claude", subtitle: "issue-118", body: "Agent finished" });
+    expect(payload.aps["interruption-level"]).toBe("time-sensitive");
+    expect(payload.aps.sound).toBe("default");
+    expect(payload.cmux).toEqual({ workspaceId: "ws-1", surfaceId: "sf-2" });
+  });
+
+  test("omits cmux block when no ids", () => {
+    const payload = buildApnsPayload({ title: "t", body: "b" }) as Record<string, unknown>;
+    expect("cmux" in payload).toBe(false);
+  });
+
+  test("hideContent redacts title/subtitle/body but keeps deep-link", () => {
+    const payload = buildApnsPayload({
+      title: "secret-host",
+      subtitle: "secret",
+      body: "rm -rf secret output",
+      workspaceId: "ws-9",
+      hideContent: true,
+    }) as { aps: { alert: Record<string, string> }; cmux: Record<string, string> };
+
+    expect(payload.aps.alert.title).toBe("cmux");
+    expect(payload.aps.alert.body).toBe("An agent needs your attention");
+    expect(payload.aps.alert.subtitle).toBeUndefined();
+    expect(payload.cmux).toEqual({ workspaceId: "ws-9" });
+  });
+
+  test("empty title falls back to cmux", () => {
+    const payload = buildApnsPayload({ title: "   ", body: "b" }) as { aps: { alert: { title: string } } };
+    expect(payload.aps.alert.title).toBe("cmux");
+  });
+});
+
+describe("apns host + pruning", () => {
+  test("host selection", () => {
+    expect(apnsHostForEnvironment("sandbox")).toBe("api.sandbox.push.apple.com");
+    expect(apnsHostForEnvironment("production")).toBe("api.push.apple.com");
+    expect(apnsHostForEnvironment("unknown")).toBe("api.push.apple.com");
+  });
+
+  test("prunes only terminal failures", () => {
+    expect(shouldPruneToken(410, undefined)).toBe(true);
+    expect(shouldPruneToken(400, "BadDeviceToken")).toBe(true);
+    expect(shouldPruneToken(400, "DeviceTokenNotForTopic")).toBe(true);
+    expect(shouldPruneToken(200, undefined)).toBe(false);
+    expect(shouldPruneToken(0, "timeout")).toBe(false); // transient
+    expect(shouldPruneToken(503, "ServiceUnavailable")).toBe(false); // transient
+    expect(shouldPruneToken(429, "TooManyRequests")).toBe(false);
+  });
+});
+
+describe("apns jwt", () => {
+  test("normalizeP8 expands literal newlines", () => {
+    expect(normalizeP8("a\\nb\\nc")).toBe("a\nb\nc");
+    expect(normalizeP8("a\nb")).toBe("a\nb");
+  });
+
+  test("signs a verifiable ES256 JWT with kid/iss/iat", () => {
+    const { privateKey, publicKey } = crypto.generateKeyPairSync("ec", { namedCurve: "P-256" });
+    const p8 = privateKey.export({ type: "pkcs8", format: "pem" }) as string;
+
+    const now = 1_700_000_000;
+    const jwt = signApnsJwt({ keyP8: p8, keyId: "KID123", teamId: "TEAM456" }, now);
+
+    const [headerB64, claimsB64, sigB64] = jwt.split(".");
+    const decode = (s: string) =>
+      JSON.parse(Buffer.from(s.replace(/-/g, "+").replace(/_/g, "/"), "base64").toString("utf8"));
+    expect(decode(headerB64)).toEqual({ alg: "ES256", kid: "KID123" });
+    expect(decode(claimsB64)).toEqual({ iss: "TEAM456", iat: now });
+
+    const signature = Buffer.from(sigB64.replace(/-/g, "+").replace(/_/g, "/"), "base64");
+    const valid = crypto.verify(
+      "sha256",
+      Buffer.from(`${headerB64}.${claimsB64}`),
+      { key: publicKey, dsaEncoding: "ieee-p1363" },
+      signature,
+    );
+    expect(valid).toBe(true);
+  });
+});

--- a/web/tests/apns.test.ts
+++ b/web/tests/apns.test.ts
@@ -6,6 +6,11 @@ import {
   shouldPruneToken,
 } from "../services/apns/payload";
 import { signApnsJwt, normalizeP8 } from "../services/apns/sender";
+import {
+  MAX_PUSH_BODY_CHARS,
+  normalizeApnsBundle,
+  parsePushPayload,
+} from "../services/apns/routePolicy";
 
 describe("apns payload", () => {
   test("builds a time-sensitive alert with deep-link keys", () => {
@@ -64,6 +69,59 @@ describe("apns host + pruning", () => {
     expect(shouldPruneToken(0, "timeout")).toBe(false); // transient
     expect(shouldPruneToken(503, "ServiceUnavailable")).toBe(false); // transient
     expect(shouldPruneToken(429, "TooManyRequests")).toBe(false);
+  });
+});
+
+describe("apns route policy", () => {
+  test("allows only cmux iOS bundle IDs and derives the APNs environment", () => {
+    expect(normalizeApnsBundle("com.cmuxterm.app")).toEqual({
+      bundleId: "com.cmuxterm.app",
+      environment: "production",
+    });
+    expect(normalizeApnsBundle("dev.cmux.app.beta")).toEqual({
+      bundleId: "dev.cmux.app.beta",
+      environment: "production",
+    });
+    expect(normalizeApnsBundle("dev.cmux.ios.push1")).toEqual({
+      bundleId: "dev.cmux.ios.push1",
+      environment: "sandbox",
+    });
+
+    expect(normalizeApnsBundle("com.example.app")).toBeNull();
+    expect(normalizeApnsBundle("dev.cmux.ios.bad_topic")).toBeNull();
+    expect(normalizeApnsBundle("dev.cmux.ios.-bad")).toBeNull();
+  });
+
+  test("bounds and trims push payloads before sending to APNs", () => {
+    const parsed = parsePushPayload({
+      title: " agent ",
+      subtitle: " workspace ",
+      body: " done ",
+      workspaceId: " ws-1 ",
+      surfaceId: " sf-1 ",
+      hideContent: true,
+    });
+
+    expect(parsed).toEqual({
+      ok: true,
+      value: {
+        title: "agent",
+        subtitle: "workspace",
+        body: "done",
+        workspaceId: "ws-1",
+        surfaceId: "sf-1",
+        hideContent: true,
+      },
+    });
+
+    expect(parsePushPayload({ title: "", body: "" })).toEqual({
+      ok: false,
+      error: "empty_notification",
+    });
+    expect(parsePushPayload({ title: "agent", body: "x".repeat(MAX_PUSH_BODY_CHARS + 1) })).toEqual({
+      ok: false,
+      error: "body_too_long",
+    });
   });
 });
 

--- a/web/tests/apns.test.ts
+++ b/web/tests/apns.test.ts
@@ -5,6 +5,7 @@ import {
   buildApnsPayload,
   shouldPruneToken,
 } from "../services/apns/payload";
+import { summarizeApnsSendResults } from "../services/apns/response";
 import { signApnsJwt, normalizeP8 } from "../services/apns/sender";
 import {
   MAX_PUSH_BODY_CHARS,
@@ -70,6 +71,19 @@ describe("apns host + pruning", () => {
     expect(shouldPruneToken(0, "timeout")).toBe(false); // transient
     expect(shouldPruneToken(503, "ServiceUnavailable")).toBe(false); // transient
     expect(shouldPruneToken(429, "TooManyRequests")).toBe(false);
+  });
+});
+
+describe("apns response", () => {
+  test("summarizes sends without exposing provider reasons", () => {
+    const summary = summarizeApnsSendResults([
+      { deviceToken: "a".repeat(64), status: 200, prune: false },
+      { deviceToken: "b".repeat(64), status: 400, reason: "BadDeviceToken", prune: true },
+    ]);
+
+    expect(summary).toEqual({ sent: 1, devices: 2, pruned: 1 });
+    expect(JSON.stringify(summary)).not.toContain("BadDeviceToken");
+    expect(JSON.stringify(summary)).not.toContain("apns");
   });
 });
 

--- a/web/tests/apns.test.ts
+++ b/web/tests/apns.test.ts
@@ -75,6 +75,10 @@ describe("apns host + pruning", () => {
 });
 
 describe("apns response", () => {
+  test("uses a stable summary shape when there are no devices", () => {
+    expect(summarizeApnsSendResults([])).toEqual({ sent: 0, devices: 0, pruned: 0 });
+  });
+
   test("summarizes sends without exposing provider reasons", () => {
     const summary = summarizeApnsSendResults([
       { deviceToken: "a".repeat(64), status: 200, prune: false },

--- a/web/tests/apns.test.ts
+++ b/web/tests/apns.test.ts
@@ -10,6 +10,7 @@ import {
   MAX_PUSH_BODY_CHARS,
   normalizeApnsBundle,
   parsePushPayload,
+  readBoundedJsonObject,
 } from "../services/apns/routePolicy";
 
 describe("apns payload", () => {
@@ -122,6 +123,49 @@ describe("apns route policy", () => {
       ok: false,
       error: "body_too_long",
     });
+  });
+
+  test("reads only bounded JSON objects from requests", async () => {
+    await expect(
+      readBoundedJsonObject(
+        new Request("https://example.test", {
+          method: "POST",
+          headers: { "content-length": "9000" },
+          body: "{}",
+        }),
+        8,
+      ),
+    ).resolves.toEqual({ ok: false, error: "request_too_large" });
+
+    await expect(
+      readBoundedJsonObject(
+        new Request("https://example.test", {
+          method: "POST",
+          body: JSON.stringify({ body: "123456789" }),
+        }),
+        8,
+      ),
+    ).resolves.toEqual({ ok: false, error: "request_too_large" });
+
+    await expect(
+      readBoundedJsonObject(
+        new Request("https://example.test", {
+          method: "POST",
+          body: JSON.stringify(["not", "object"]),
+        }),
+        64,
+      ),
+    ).resolves.toEqual({ ok: false, error: "invalid_json" });
+
+    await expect(
+      readBoundedJsonObject(
+        new Request("https://example.test", {
+          method: "POST",
+          body: JSON.stringify({ title: "agent" }),
+        }),
+        64,
+      ),
+    ).resolves.toEqual({ ok: true, value: { title: "agent" } });
   });
 });
 

--- a/web/tests/device-tokens-route.test.ts
+++ b/web/tests/device-tokens-route.test.ts
@@ -19,7 +19,7 @@ mock.module("../app/lib/stack", () => ({
   isStackConfigured: () => true,
 }));
 
-const { POST } = await import("../app/api/device-tokens/route");
+const { DELETE, POST } = await import("../app/api/device-tokens/route");
 
 let sql: Sql | null = null;
 
@@ -69,5 +69,50 @@ describe("device token route", () => {
       select count(*)::int as total from device_tokens where user_id = 'push-user-1'
     `;
     expect(stored.total).toBe(10);
+  });
+
+  dbTest("canonicalizes token casing for register and delete", async () => {
+    if (!sql) throw new Error("test database not initialized");
+    await sql`truncate device_tokens restart identity cascade`;
+
+    const token = "a".repeat(64);
+    const headers = {
+      authorization: "Bearer access-token",
+      "x-stack-refresh-token": "refresh-token",
+    };
+    const register = (deviceToken: string) =>
+      POST(
+        new Request("https://cmux.test/api/device-tokens", {
+          method: "POST",
+          headers,
+          body: JSON.stringify({
+            deviceToken,
+            bundleId: "dev.cmux.ios.push1",
+            platform: "ios",
+          }),
+        }),
+      );
+
+    expect((await register(token.toUpperCase())).status).toBe(200);
+    expect((await register(token)).status).toBe(200);
+
+    const [stored] = await sql<{ total: number; token: string }[]>`
+      select count(*)::int as total, min(device_token) as token from device_tokens where user_id = 'push-user-1'
+    `;
+    expect(stored).toEqual({ total: 1, token });
+
+    const deleteResponse = await DELETE(
+      new Request("https://cmux.test/api/device-tokens", {
+        method: "DELETE",
+        headers,
+        body: JSON.stringify({ deviceToken: token.toUpperCase() }),
+      }),
+    );
+    expect(deleteResponse.status).toBe(200);
+
+    const [remaining] = await sql<{ total: number }[]>`
+      select count(*)::int as total from device_tokens where user_id = 'push-user-1'
+    `;
+    expect(remaining.total).toBe(0);
   });
 });

--- a/web/tests/device-tokens-route.test.ts
+++ b/web/tests/device-tokens-route.test.ts
@@ -1,0 +1,73 @@
+import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test";
+import postgres, { type Sql } from "postgres";
+
+import { closeCloudDbForTests } from "../db/client";
+
+const runDbTests = process.env.CMUX_DB_TEST === "1";
+const dbTest = runDbTests ? test : test.skip;
+
+const getUser = mock(async () => ({
+  id: "push-user-1",
+  displayName: null,
+  primaryEmail: "push@example.com",
+  selectedTeam: null,
+  listTeams: async () => [],
+}));
+
+mock.module("../app/lib/stack", () => ({
+  getStackServerApp: () => ({ getUser }),
+  isStackConfigured: () => true,
+}));
+
+const { POST } = await import("../app/api/device-tokens/route");
+
+let sql: Sql | null = null;
+
+beforeAll(() => {
+  if (!runDbTests) return;
+  const databaseURL = process.env.DIRECT_DATABASE_URL ?? process.env.DATABASE_URL;
+  if (!databaseURL) {
+    throw new Error("DATABASE_URL is required when CMUX_DB_TEST=1");
+  }
+  sql = postgres(databaseURL, { max: 1 });
+});
+
+afterAll(async () => {
+  await closeCloudDbForTests();
+  await sql?.end();
+});
+
+describe("device token route", () => {
+  dbTest("serializes registration cap enforcement per user", async () => {
+    if (!sql) throw new Error("test database not initialized");
+    await sql`truncate device_tokens restart identity cascade`;
+    getUser.mockClear();
+
+    const responses = await Promise.all(
+      Array.from({ length: 12 }, (_, index) =>
+        POST(
+          new Request("https://cmux.test/api/device-tokens", {
+            method: "POST",
+            headers: {
+              authorization: "Bearer access-token",
+              "x-stack-refresh-token": "refresh-token",
+            },
+            body: JSON.stringify({
+              deviceToken: index.toString(16).padStart(64, "0"),
+              bundleId: "dev.cmux.ios.push1",
+              platform: "ios",
+            }),
+          }),
+        )
+      ),
+    );
+
+    const statuses = responses.map((response) => response.status).sort();
+    expect(statuses).toEqual([200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 429, 429]);
+
+    const [stored] = await sql<{ total: number }[]>`
+      select count(*)::int as total from device_tokens where user_id = 'push-user-1'
+    `;
+    expect(stored.total).toBe(10);
+  });
+});

--- a/web/tests/notification-rate-limit.test.ts
+++ b/web/tests/notification-rate-limit.test.ts
@@ -1,0 +1,46 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import postgres, { type Sql } from "postgres";
+
+import { closeCloudDbForTests } from "../db/client";
+import { recordPushSendOrThrow, PushRateLimitExceededError } from "../services/apns/rateLimit";
+
+const runDbTests = process.env.CMUX_DB_TEST === "1";
+const dbTest = runDbTests ? test : test.skip;
+
+let sql: Sql | null = null;
+
+beforeAll(() => {
+  if (!runDbTests) return;
+  const databaseURL = process.env.DIRECT_DATABASE_URL ?? process.env.DATABASE_URL;
+  if (!databaseURL) {
+    throw new Error("DATABASE_URL is required when CMUX_DB_TEST=1");
+  }
+  sql = postgres(databaseURL, { max: 1 });
+});
+
+afterAll(async () => {
+  await closeCloudDbForTests();
+  await sql?.end();
+});
+
+describe("notification rate limit", () => {
+  dbTest("limits forwarded pushes per user in a sliding window", async () => {
+    if (!sql) throw new Error("test database not initialized");
+    await sql`truncate notification_send_events restart identity cascade`;
+
+    const { cloudDb } = await import("../db/client");
+    const db = cloudDb();
+    const now = new Date("2026-06-02T12:00:00Z");
+
+    for (let i = 0; i < 60; i += 1) {
+      await recordPushSendOrThrow(db, "push-user-1", 1, now);
+    }
+    await recordPushSendOrThrow(db, "push-user-2", 1, now);
+
+    await expect(recordPushSendOrThrow(db, "push-user-1", 1, now)).rejects.toBeInstanceOf(
+      PushRateLimitExceededError,
+    );
+
+    await recordPushSendOrThrow(db, "push-user-1", 1, new Date(now.getTime() + 10 * 60 * 1000 + 1));
+  });
+});

--- a/web/tests/vm-route-auth.test.ts
+++ b/web/tests/vm-route-auth.test.ts
@@ -49,6 +49,7 @@ const attachRoute = await import("../app/api/vm/[id]/attach-endpoint/route");
 const execRoute = await import("../app/api/vm/[id]/exec/route");
 const sshRoute = await import("../app/api/vm/[id]/ssh-endpoint/route");
 const { VmProviderOperationError } = await import("../services/vms/errors");
+const { verifyRequest } = await import("../services/vms/auth");
 const { withAuthedVmApiRoute } = await import("../services/vms/routeHelpers");
 
 beforeEach(() => {
@@ -665,6 +666,33 @@ describe("VM REST auth", () => {
 
     expect(response.status).toBe(200);
     expect(runVmWorkflow).toHaveBeenCalled();
+  });
+
+  test("native-only auth does not fall back to browser cookies", async () => {
+    getUser.mockResolvedValue(authedStackUser());
+
+    const nativeOnlyUser = await verifyRequest(
+      new Request("https://cmux.test/api/notifications/push", {
+        method: "POST",
+        headers: { cookie: "stack-auth-cookie=present" },
+        body: "{}",
+      }),
+      { allowCookie: false },
+    );
+
+    expect(nativeOnlyUser).toBeNull();
+    expect(getUser).not.toHaveBeenCalled();
+
+    const cookieUser = await verifyRequest(
+      new Request("https://cmux.test/api/notifications/push", {
+        method: "POST",
+        headers: { cookie: "stack-auth-cookie=present" },
+        body: "{}",
+      }),
+    );
+
+    expect(cookieUser?.id).toBe("user-1");
+    expect(getUser).toHaveBeenCalledTimes(1);
   });
 
   test("blocks VM create kill switch before workflow", async () => {


### PR DESCRIPTION
## Summary
- Adds the web APNs backend for iOS device-token registration and authenticated push sends.
- Stores only server-owned routing state, keyed by authenticated Stack user id.
- Restricts APNs bundle ids to stable prod, TestFlight, and tagged dev iOS bundle ids.
- Adds DB-backed per-user send rate limiting: 60 push send requests per 10 minutes.
- Requires native Stack bearer auth for APNs routes, so browser cookie CSRF cannot register tokens or burn a user notification quota.
- Caps APNs route JSON bodies at 8 KiB and bounds notification fields before APNs send.

## Testing
- `bun test tests/apns.test.ts`
- `bun test`
- `CMUX_PORT=9181 bash scripts/db-local.sh up`
- `CMUX_PORT=9181 bash scripts/db-local.sh migrate`
- `CMUX_PORT=9181 DATABASE_URL=$(CMUX_PORT=9181 bash scripts/db-local.sh url) CMUX_DB_TEST=1 bun test tests/notification-rate-limit.test.ts tests/db-schema.test.ts`
- `bunx tsc --noEmit`
- `bun db:check`
- `bun run lint` (passes with 9 existing unrelated warnings)
- `source scripts/load-dev-env.sh && bun run build`

## Security
- A caller cannot choose a target user; send routes only select `device_tokens.user_id = authenticated_user.id`.
- Cookie-only browser requests are rejected for APNs routes.
- Vercel firewall rate limiting is optional, but Postgres rate limiting is enforced before APNs traffic.
- APNs keys are not committed. Local dev secrets live in `~/.secrets/cmuxterm-dev.env`; the `.p8` lives in `~/.secrets/AuthKey_6M9VDKV3YF.p8` with mode 600.

## Related
- Split out from https://github.com/manaflow-ai/cmux/pull/5079

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782994808&installation_id=133855650&pr_number=5215&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5215&signature=2ac883a7edff448cbb7b06cf8485c3109c9f05c646d4076afffe14bd14acc040"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Introduces authenticated push delivery, optional APNs secrets, DB-backed rate limits, and auth behavior changes (cookie rejection on push routes)—security- and abuse-sensitive surface area.
> 
> **Overview**
> Adds a **web APNs backend** so native clients can register iOS device tokens and the macOS app can forward terminal notifications to the user’s phones.
> 
> **APIs:** `POST`/`DELETE` **`/api/device-tokens`** validate hex tokens, allowlisted bundle IDs (prod/TestFlight/tagged dev → sandbox vs production), cap **10 devices per user** with transactional advisory locking, and upsert by unique `device_token`. **`POST` `/api/notifications/push`** loads only the authenticated user’s iOS tokens, no-ops without devices, optionally applies Vercel firewall rate limiting, enforces **60 send requests per 10 minutes** in Postgres before calling APNs, sends via a Node **HTTP/2 + ES256 JWT** sender, prunes dead tokens, and returns aggregate **`sent`/`devices`/`pruned`** (no provider error leakage). Optional **`hideContent`** redacts alert text in the payload.
> 
> **Data & config:** migrations for **`device_tokens`** and **`notification_send_events`**; optional **`CMUX_APNS_*`** env vars; local dev default for **`CMUX_PUSH_RATE_LIMIT_ID`**.
> 
> **Auth hardening:** APNs routes call **`verifyRequest` with `allowCookie: false`** so browser cookies cannot register tokens or consume push quota.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fc793e6b62cd5053c5e1a64a222641160b77d93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a secure APNs backend for iOS push notifications. Routes require native Stack bearer auth (cookies rejected), enforce strict bounds and per-user limits, and return privacy-preserving summaries with unified errors.

- **New Features**
  - `POST/DELETE /api/device-tokens`: register/unregister iOS tokens with Stack bearer auth; restrict bundle IDs to prod/TestFlight/tagged dev; 8 KiB body cap; max 10 devices per user; upsert by token; cap enforced atomically.
  - `POST /api/notifications/push`: native-only auth; send to the authenticated user’s devices only and filter to iOS tokens; DB rate limit 60 requests per 10 minutes; optional `@vercel/firewall` rate limit; bounded title/body/ids and optional `hideContent`; prunes invalid tokens; Node-only APNs sender (HTTP/2 + ES256); no-op when the user has no devices; response uses a summary helper to return only aggregate counts (sent/devices/pruned); unified error handler returns `push_internal_error` on unexpected failures.
  - Data model: adds `device_tokens` and `notification_send_events` tables with supporting indexes.

- **Migration**
  - Run DB migrations.
  - Set APNs env vars (optional; route returns `apns_not_configured` until set): `CMUX_APNS_KEY_P8`, `CMUX_APNS_KEY_ID`, `CMUX_APNS_TEAM_ID`.
  - Optionally set `CMUX_PUSH_RATE_LIMIT_ID` to enable Vercel firewall rate limiting.

<sup>Written for commit 5fc793e6b62cd5053c5e1a64a222641160b77d93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * iOS push: register/unregister device tokens, send pushes with dead-token pruning, payload building (sandbox/production) and optional content redaction, per-user rate limiting and clear error responses.
* **Database**
  * Added device_tokens and notification_send_events tables with indexes for efficient lookups and send-event tracking.
* **Chores**
  * New optional APNs and rate-limit environment variables and local dev export.
* **Tests**
  * Comprehensive tests covering payloads, signing, rate limiting, routes, and handler error behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->