### PR TITLE
Add daily Codex docs audit workflow

### DIFF
--- a/.github/prompts/daily-docs-codex.md
+++ b/.github/prompts/daily-docs-codex.md
@@ -1,0 +1,24 @@
+You are running in the daily cmux documentation audit workflow.
+
+Goal:
+Audit the cmux repository history and current implementation for documentation gaps. Update existing docs when behavior has changed, add new docs pages when a shipped feature deserves first-class docs, and keep docs navigation and localized strings in sync.
+
+Required context to inspect:
+- `git log --first-parent --name-status`, using `DOCS_AUDIT_COMMIT_WINDOW`. If `DOCS_AUDIT_COMMIT_WINDOW=all`, inspect the full first-parent history.
+- `CHANGELOG.md`, `README*.md`, and `docs/`.
+- The docs site under `web/app/[locale]/docs/`.
+- Docs navigation in `web/app/[locale]/components/docs-nav-items.ts`.
+- Locale files in `web/messages/*.json`.
+- Current source code for features referenced by commits or docs.
+
+Rules:
+- Only make docs-related changes. Valid targets include `docs/`, `README*.md`, `CHANGELOG.md`, `web/app/[locale]/docs/`, docs-specific components, docs search tooling, and `web/messages/*.json`.
+- Do not edit app/runtime code.
+- Do not commit, push, create branches, create issues, or open pull requests. The workflow does that after your run.
+- Prefer updating an existing page when the concept already exists. Add a new page only when it makes navigation clearer for a real user.
+- Every user-facing docs-site string must use the existing `next-intl` message pattern. Add keys to every locale file. If a precise translation is not practical, keep the meaning simple and conservative.
+- Keep copy short. Avoid marketing tone.
+- Cite concrete commit SHAs or source files in your final summary when they drove a docs change.
+- If no docs changes are needed, leave the working tree clean and explain why in the final summary.
+
+Before editing, build a short plan from the commit audit. After editing, run the narrowest useful checks you can in the available time. The workflow will run web lint/build when web files changed.

--- a/.github/workflows/daily-docs-codex.yml
+++ b/.github/workflows/daily-docs-codex.yml
@@ -1,0 +1,211 @@
+name: Daily Codex docs audit
+
+on:
+  schedule:
+    - cron: "23 12 * * *"
+  workflow_dispatch:
+    inputs:
+      commit_window:
+        description: Git commit window to audit, for example "30 days" or "all"
+        required: false
+        default: all
+      model:
+        description: Codex model
+        required: false
+        default: ""
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: daily-codex-docs-audit
+  cancel-in-progress: false
+
+jobs:
+  docs-audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    env:
+      CODEX_VERSION: "0.136.0"
+      CODEX_MODEL: ${{ github.event.inputs.model || vars.DAILY_DOCS_CODEX_MODEL || 'gpt-5.5' }}
+      DOCS_AUDIT_COMMIT_WINDOW: ${{ github.event.inputs.commit_window || vars.DAILY_DOCS_COMMIT_WINDOW || 'all' }}
+      SUBROUTER_BASE_URL: ${{ vars.SUBROUTER_BASE_URL || 'http://subrouter-team:31415' }}
+      SUBROUTER_OPENAI_BASE_URL: ${{ vars.SUBROUTER_OPENAI_BASE_URL }}
+      SUBROUTER_CHATGPT_BASE_URL: ${{ vars.SUBROUTER_CHATGPT_BASE_URL }}
+      SUBROUTER_API_KEY: ${{ secrets.SUBROUTER_API_KEY }}
+      OPENAI_API_KEY: ${{ secrets.SUBROUTER_API_KEY }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+
+      - name: Install Codex CLI
+        run: |
+          set -euo pipefail
+          npm install -g "@openai/codex@${CODEX_VERSION}"
+          codex --version
+
+      - name: Configure Codex for subrouter
+        run: |
+          set -euo pipefail
+          if [ -z "${SUBROUTER_API_KEY:-}" ]; then
+            echo "::error::Missing SUBROUTER_API_KEY secret. Daily Codex docs audit must use subrouter."
+            exit 1
+          fi
+
+          root="${SUBROUTER_BASE_URL%/}"
+          openai_base="${SUBROUTER_OPENAI_BASE_URL:-}"
+          chatgpt_base="${SUBROUTER_CHATGPT_BASE_URL:-}"
+          if [ -z "$openai_base" ]; then
+            if [[ "$root" == */v1 ]]; then
+              openai_base="$root"
+              root="${root%/v1}"
+            else
+              openai_base="$root/v1"
+            fi
+          fi
+          if [ -z "$chatgpt_base" ]; then
+            chatgpt_base="$root/backend-api"
+          fi
+
+          {
+            echo "CODEX_HOME=${RUNNER_TEMP}/codex-home"
+            echo "SUBROUTER_OPENAI_BASE_URL_RESOLVED=${openai_base}"
+            echo "SUBROUTER_CHATGPT_BASE_URL_RESOLVED=${chatgpt_base}"
+          } >> "$GITHUB_ENV"
+
+          mkdir -p "${RUNNER_TEMP}/codex-home"
+          cat > "${RUNNER_TEMP}/codex-home/config.toml" <<EOF
+          model = "${CODEX_MODEL}"
+          model_reasoning_effort = "high"
+          openai_base_url = "${openai_base}"
+          chatgpt_base_url = "${chatgpt_base}"
+          experimental_realtime_ws_base_url = "${openai_base}"
+
+          [projects."${GITHUB_WORKSPACE}"]
+          trust_level = "trusted"
+          EOF
+
+      - name: Create dated branch
+        id: branch
+        run: |
+          set -euo pipefail
+          run_date="$(date -u +%Y%m%d)"
+          branch="automation/daily-docs-codex-${run_date}"
+          git switch -c "$branch"
+          git config user.name "cmux docs automation"
+          git config user.email "actions@github.com"
+          echo "name=$branch" >> "$GITHUB_OUTPUT"
+          echo "date=$run_date" >> "$GITHUB_OUTPUT"
+
+      - name: Run Codex docs audit through subrouter
+        run: |
+          set -euo pipefail
+          {
+            cat .github/prompts/daily-docs-codex.md
+            printf '\n\nWorkflow context:\n'
+            printf 'DOCS_AUDIT_COMMIT_WINDOW=%s\n' "$DOCS_AUDIT_COMMIT_WINDOW"
+            printf 'SUBROUTER_OPENAI_BASE_URL=%s\n' "$SUBROUTER_OPENAI_BASE_URL_RESOLVED"
+            printf 'SUBROUTER_CHATGPT_BASE_URL=%s\n' "$SUBROUTER_CHATGPT_BASE_URL_RESOLVED"
+          } | codex exec \
+            --cd "$GITHUB_WORKSPACE" \
+            --model "$CODEX_MODEL" \
+            --sandbox workspace-write \
+            --ask-for-approval never \
+            --output-last-message "$RUNNER_TEMP/codex-docs-audit-summary.md" \
+            -
+
+      - name: Stop if Codex made no changes
+        id: changes
+        run: |
+          set -euo pipefail
+          if [ -z "$(git status --porcelain=v1 --untracked-files=all)" ]; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "No docs changes needed."
+            if [ -f "$RUNNER_TEMP/codex-docs-audit-summary.md" ]; then
+              sed -n '1,120p' "$RUNNER_TEMP/codex-docs-audit-summary.md"
+            fi
+            exit 0
+          fi
+
+          changed="$(git status --porcelain=v1 --untracked-files=all | cut -c4- | sed 's/.* -> //')"
+          bad="$(
+            printf '%s\n' "$changed" \
+              | grep -Ev '^(CHANGELOG\.md|README(\.[^.]+)?\.md|docs/|web/app/\[locale\]/docs/|web/app/\[locale\]/components/docs-|web/messages/|web/tools/build-docs-search\.mjs$)' \
+              || true
+          )"
+          if [ -n "$bad" ]; then
+            echo "::error::Codex changed files outside the docs surface:"
+            printf '%s\n' "$bad"
+            exit 1
+          fi
+
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
+
+      - name: Verify web docs changes
+        if: steps.changes.outputs.has_changes == 'true'
+        run: |
+          set -euo pipefail
+          if git status --porcelain=v1 --untracked-files=all | cut -c4- | sed 's/.* -> //' | grep -q '^web/'; then
+            cd web
+            bun install --frozen-lockfile
+            bun run lint
+            bun run build
+          fi
+
+      - name: Commit and push docs changes
+        if: steps.changes.outputs.has_changes == 'true'
+        run: |
+          set -euo pipefail
+          git add -A
+          git commit -m "Update docs from daily Codex audit"
+          git push --force-with-lease origin "HEAD:refs/heads/${{ steps.branch.outputs.name }}"
+
+      - name: Open pull request
+        if: steps.changes.outputs.has_changes == 'true'
+        env:
+          BRANCH_NAME: ${{ steps.branch.outputs.name }}
+          RUN_DATE: ${{ steps.branch.outputs.date }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## Summary"
+            echo "- Daily Codex audit reviewed cmux commit history and updated docs where needed."
+            echo "- Codex ran through subrouter at ${SUBROUTER_OPENAI_BASE_URL_RESOLVED}."
+            echo
+            echo "## Codex notes"
+            if [ -f "$RUNNER_TEMP/codex-docs-audit-summary.md" ]; then
+              sed -n '1,160p' "$RUNNER_TEMP/codex-docs-audit-summary.md"
+            else
+              echo "- Codex did not write a final summary file."
+            fi
+            echo
+            echo "## Testing"
+            if git show --name-only --pretty='' HEAD | grep -q '^web/'; then
+              echo "- cd web && bun install --frozen-lockfile"
+              echo "- cd web && bun run lint"
+              echo "- cd web && bun run build"
+            else
+              echo "- Docs-only change outside web; no runtime tests run."
+            fi
+          } > "$RUNNER_TEMP/pr-body.md"
+
+          existing="$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$BRANCH_NAME" --json number --jq '.[0].number // empty')"
+          if [ -n "$existing" ]; then
+            gh pr edit "$existing" --repo "$GITHUB_REPOSITORY" \
+              --title "Update docs from daily Codex audit (${RUN_DATE})" \
+              --body-file "$RUNNER_TEMP/pr-body.md"
+            gh pr view "$existing" --repo "$GITHUB_REPOSITORY" --json url --jq .url
+          else
+            gh pr create --repo "$GITHUB_REPOSITORY" \
+              --base main \
+              --head "$BRANCH_NAME" \
+              --title "Update docs from daily Codex audit (${RUN_DATE})" \
+              --body-file "$RUNNER_TEMP/pr-body.md"
+          fi


### PR DESCRIPTION
## Summary
- Add a scheduled daily GitHub Actions workflow that runs Codex against full git history/docs context and opens a dated docs PR when changes are needed.
- Configure Codex to use subrouter base URLs and fail closed without the SUBROUTER_API_KEY secret.
- Add a checked-in prompt that limits Codex to docs-related changes and requires docs navigation/locales to stay in sync.

## Testing
- actionlint .github/workflows/daily-docs-codex.yml
- git diff --cached --check

## Issues
- Related task: daily Codex docs audit workflow setup

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5219"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782995219&installation_id=133855650&pr_number=5219&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5219&signature=8d290ddfe9cefbe6c1e2161cfb213fdf1881be88a3864e0ba139775aa3ff75c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Grants contents/write and pull-requests/write to an agent with workspace-write sandbox; mitigated by subrouter secret gate, docs-only path allowlist, and web lint/build checks, but still introduces automated doc PRs to main.
> 
> **Overview**
> Adds **scheduled and manual** GitHub Actions automation that runs **Codex** on a daily cadence to audit commit history against docs and open a dated PR when updates are needed.
> 
> The workflow installs Codex, **requires `SUBROUTER_API_KEY`**, resolves OpenAI/ChatGPT base URLs for **subrouter**, runs `codex exec` with a checked-in prompt (`.github/prompts/daily-docs-codex.md`), and only proceeds if the working tree changed. It **rejects edits outside** an allowlisted docs surface (`docs/`, README/CHANGELOG, `web/.../docs/`, locales, docs search tooling). When `web/` changes, it runs **Bun lint/build** before commit/push to `automation/daily-docs-codex-YYYYMMDD` and creates or updates the matching PR.
> 
> The prompt scopes Codex to **docs-only** work: audit `git log`, sync markdown and the localized docs site/nav/messages, and leave commits/PRs to the workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e789e6d2fb25d6fcd5ca10c03c60522badb3ff8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a daily GitHub Actions workflow that runs Codex through the team subrouter to audit docs and open a dated PR when updates are needed. Configures Codex to only touch docs and to fail closed without `SUBROUTER_API_KEY`. Aligns with the Linear task to set up the daily Codex docs audit.

- **New Features**
  - New workflow: `.github/workflows/daily-docs-codex.yml` runs at 12:23 UTC and supports manual runs with `commit_window` and `model` inputs.
  - Uses `@openai/codex` CLI v0.136.0 via subrouter; model defaults to gpt-5.5 and can be overridden by inputs or `vars.DAILY_DOCS_CODEX_MODEL`.
  - Enforces docs-only changes; verifies `web` changes with Bun lint/build when the docs site is touched.
  - Creates `automation/daily-docs-codex-YYYYMMDD` and opens a PR with Codex’s summary if changes exist; exits cleanly if none.
  - Adds prompt at `.github/prompts/daily-docs-codex.md` that limits scope to docs, keeps nav/locales in sync, and requires `next-intl` message keys.

- **Migration**
  - Add repo secret: `SUBROUTER_API_KEY`.
  - Set `vars.SUBROUTER_BASE_URL` (and optionally `SUBROUTER_OPENAI_BASE_URL`, `SUBROUTER_CHATGPT_BASE_URL`).
  - Optionally set `vars.DAILY_DOCS_CODEX_MODEL` and `vars.DAILY_DOCS_COMMIT_WINDOW`.

<sup>Written for commit e789e6d2fb25d6fcd5ca10c03c60522badb3ff8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated daily documentation audit workflow that reviews documentation sources, applies updates, and generates pull requests with built-in validation to ensure changes remain documentation-only and includes linting/build checks when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->