### PR TITLE
Route crash telemetry to cmux-errors (errors.cmux.dev) [hold for DNS]

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -64,7 +64,10 @@ private final class CLISocketSentryTelemetry {
 #if canImport(Sentry)
     private static let startupLock = NSLock()
     private static var started = false
-    private static let dsn = "https://ecba1ec90ecaee02a102fba931b6d2b3@o4507547940749312.ingest.us.sentry.io/4510796264636416"
+    // Ingest via our own GCP-hosted, Sentry-envelope-compatible backend
+    // (cmux-errors), which owns the raw data and forwards a sampled subset to
+    // sentry.io. Same project id + public key; only the host changes.
+    private static let dsn = "https://ecba1ec90ecaee02a102fba931b6d2b3@errors.cmux.dev/4510796264636416"
 
     private static func currentSentryReleaseName() -> String? {
         guard let bundleIdentifier = currentSentryBundleIdentifier(),

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1294,7 +1294,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
             StartupBreadcrumbLog.append("appDelegate.didFinish.sentry.begin")
             SentrySDK.start { options in
-                options.dsn = "https://ecba1ec90ecaee02a102fba931b6d2b3@o4507547940749312.ingest.us.sentry.io/4510796264636416"
+                // Ingest via our own GCP-hosted, Sentry-envelope-compatible
+                // backend (cmux-errors), which owns the raw data and forwards a
+                // sampled subset to sentry.io. Same project id + public key;
+                // only the host changes.
+                options.dsn = "https://ecba1ec90ecaee02a102fba931b6d2b3@errors.cmux.dev/4510796264636416"
                 #if DEBUG
                 options.environment = "development"
                 options.debug = true


### PR DESCRIPTION
Client half of the hybrid crash-pipeline cutover. Repoints the Sentry Cocoa SDK DSN host from `o4507547940749312.ingest.us.sentry.io` to **`errors.cmux.dev`** (our GCP-hosted, Sentry-envelope-compatible `cmux-errors` backend). Same project id (`4510796264636416`) and public key, so the SDK and envelope format are unchanged.

cmux-errors owns the raw data (GCS + BigQuery, no monthly event quota) and forwards a sampled subset to sentry.io for the UI / 25 uptime monitors / Seer.

**Draft / DO NOT MERGE** until:
1. `errors.cmux.dev` A-record → `8.232.45.246` (DNS-only) is added and the GCP managed cert is `ACTIVE`.
2. `cmux-errors/scripts/smoke-test.sh BASE_URL=https://errors.cmux.dev` passes (event lands in BigQuery).
3. PR #5208 (Sentry noise reduction) has shipped, so forwarded volume stays under the sponsored 5M.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5220"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782995501&installation_id=133855650&pr_number=5220&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5220&signature=c91cfe087c7da391623b9457812f916a1debd736851f49c2ce81a70c5d30b2b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route macOS app and CLI crash telemetry to errors.cmux.dev (`cmux-errors`), our Sentry-envelope-compatible backend. Only the DSN host changes; raw data goes to GCS/BigQuery and a sampled subset is forwarded to sentry.io.

- **Migration**
  - Add DNS A record: errors.cmux.dev → 8.232.45.246 (DNS-only) and wait for the GCP managed cert to be ACTIVE
  - Run `cmux-errors/scripts/smoke-test.sh BASE_URL=https://errors.cmux.dev` and verify the event in BigQuery
  - Ship PR #5208 (Sentry noise reduction) to keep forwarded volume within the 5M cap

<sup>Written for commit 5a060f3718e63b0562f8a2d09543bc914bd0bdbe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mis-timed merge or DNS/cert issues could drop crash events until rollback; otherwise it is a host-only routing change with no auth or app logic edits.
> 
> **Overview**
> Repoints **Sentry Cocoa SDK** crash/error ingest from the US `sentry.io` ingest host to **`errors.cmux.dev`** (`cmux-errors`), in both the **macOS app** (`AppDelegate`) and **CLI** (`cmux.swift`). The DSN **project id and public key are unchanged**—only the host—so envelope format and SDK behavior stay the same; comments note raw data is owned by your backend with a sampled forward to sentry.io.
> 
> No other Sentry options, sampling, or startup sequencing changes appear in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a060f3718e63b0562f8a2d09543bc914bd0bdbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated error reporting infrastructure configuration to use a dedicated custom backend service for error event ingestion. This change applies across the application's CLI and main components, improving system reliability and monitoring efficiency. The update replaces reliance on external ingestion services with an internal custom backend solution while maintaining full compatibility with existing error tracking workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->