### PR TITLE
Add customizable Jupyter directory mode

### DIFF
--- a/Sources/App/DirectoryToolLaunchPanelController.swift
+++ b/Sources/App/DirectoryToolLaunchPanelController.swift
@@ -1,0 +1,226 @@
+import AppKit
+
+final class DirectoryToolLaunchPanelController: NSObject, NSWindowDelegate {
+    private let panel: NSPanel
+    private let spinner: NSProgressIndicator
+    private let messageLabel: NSTextField
+    private let outputTextView: NSTextView
+    private let allowButton: NSButton
+    private let stopButton: NSButton
+    private let noOutputText: String
+    private let launchingMessage: String
+    private let onAllow: ((DirectoryToolLaunchPanelController) -> Void)?
+    private let onStop: () -> Void
+    private var isClosed = false
+    private var didAllow = false
+
+    init(
+        title: String,
+        initialMessage: String,
+        launchingMessage: String,
+        initialOutput: String,
+        requiresApproval: Bool,
+        onAllow: ((DirectoryToolLaunchPanelController) -> Void)?,
+        onStop: @escaping () -> Void
+    ) {
+        self.launchingMessage = launchingMessage
+        self.onAllow = onAllow
+        self.onStop = onStop
+        noOutputText = String(
+            localized: "directoryTool.launchProgress.noOutput",
+            defaultValue: "No output yet."
+        )
+
+        let contentView = NSView(frame: NSRect(x: 0, y: 0, width: 520, height: 256))
+
+        spinner = NSProgressIndicator()
+        spinner.style = .spinning
+        spinner.controlSize = .regular
+        spinner.isIndeterminate = true
+        spinner.isHidden = requiresApproval
+        if !requiresApproval {
+            spinner.startAnimation(nil)
+        }
+
+        let titleLabel = NSTextField(labelWithString: title)
+        titleLabel.font = .systemFont(ofSize: NSFont.systemFontSize, weight: .semibold)
+        titleLabel.lineBreakMode = .byTruncatingTail
+
+        messageLabel = NSTextField(labelWithString: initialMessage)
+        messageLabel.font = .systemFont(ofSize: NSFont.smallSystemFontSize)
+        messageLabel.textColor = .secondaryLabelColor
+        messageLabel.lineBreakMode = .byWordWrapping
+        messageLabel.maximumNumberOfLines = 2
+
+        let headerStack = NSStackView(views: [spinner, titleLabel])
+        headerStack.orientation = .horizontal
+        headerStack.alignment = .centerY
+        headerStack.spacing = 10
+
+        outputTextView = NSTextView()
+        outputTextView.isEditable = false
+        outputTextView.isSelectable = true
+        outputTextView.drawsBackground = false
+        outputTextView.font = .monospacedSystemFont(ofSize: 11, weight: .regular)
+        outputTextView.textColor = .secondaryLabelColor
+        outputTextView.textContainerInset = NSSize(width: 8, height: 8)
+        outputTextView.string = initialOutput
+
+        let scrollView = NSScrollView()
+        scrollView.hasVerticalScroller = true
+        scrollView.drawsBackground = true
+        scrollView.backgroundColor = .textBackgroundColor.withAlphaComponent(0.65)
+        scrollView.borderType = .lineBorder
+        scrollView.documentView = outputTextView
+
+        allowButton = NSButton(title: String(
+            localized: "directoryTool.launchProgress.allow",
+            defaultValue: "Allow"
+        ), target: nil, action: nil)
+        allowButton.bezelStyle = .rounded
+        allowButton.keyEquivalent = "\r"
+        allowButton.isHidden = !requiresApproval
+
+        let stopButtonTitle: String
+        if requiresApproval {
+            stopButtonTitle = String(
+                localized: "directoryTool.launchProgress.cancel",
+                defaultValue: "Cancel"
+            )
+        } else {
+            stopButtonTitle = String(
+                localized: "directoryTool.launchProgress.stop",
+                defaultValue: "Stop"
+            )
+        }
+        stopButton = NSButton(title: stopButtonTitle, target: nil, action: nil)
+        stopButton.bezelStyle = .rounded
+
+        let footerStack = NSStackView(views: [NSView(), stopButton, allowButton])
+        footerStack.orientation = .horizontal
+        footerStack.alignment = .centerY
+        footerStack.spacing = 8
+
+        let stack = NSStackView(views: [headerStack, messageLabel, scrollView, footerStack])
+        stack.orientation = .vertical
+        stack.alignment = .leading
+        stack.spacing = 10
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(stack)
+
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+            stack.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
+            stack.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 16),
+            stack.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -14),
+            spinner.widthAnchor.constraint(equalToConstant: 18),
+            spinner.heightAnchor.constraint(equalToConstant: 18),
+            titleLabel.trailingAnchor.constraint(lessThanOrEqualTo: stack.trailingAnchor),
+            messageLabel.widthAnchor.constraint(equalTo: stack.widthAnchor),
+            scrollView.widthAnchor.constraint(equalTo: stack.widthAnchor),
+            scrollView.heightAnchor.constraint(equalToConstant: 128)
+        ])
+
+        panel = NSPanel(
+            contentRect: contentView.frame,
+            styleMask: [.titled, .closable, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.title = title
+        panel.contentView = contentView
+        panel.level = .floating
+        panel.collectionBehavior = [.moveToActiveSpace, .fullScreenAuxiliary]
+        panel.isReleasedWhenClosed = false
+
+        super.init()
+
+        panel.delegate = self
+        allowButton.target = self
+        allowButton.action = #selector(allow)
+        stopButton.target = self
+        stopButton.action = #selector(stop)
+    }
+
+    static func startingTitle(displayName: String) -> String {
+        let titleFormat = String(
+            localized: "directoryTool.launchProgress.title",
+            defaultValue: "Starting %@"
+        )
+        return String(format: titleFormat, displayName)
+    }
+
+    static func commandPreview(command: String, directoryURL: URL) -> String {
+        """
+        cd \(directoryURL.path)
+        \(command)
+        """
+    }
+
+    func show(presentingWindow: NSWindow?) {
+        guard !isClosed else { return }
+        if let presentingWindow {
+            let windowFrame = presentingWindow.frame
+            let panelFrame = panel.frame
+            let origin = NSPoint(
+                x: windowFrame.midX - panelFrame.width / 2,
+                y: windowFrame.maxY - panelFrame.height - 72
+            )
+            panel.setFrameOrigin(origin)
+        } else {
+            panel.center()
+        }
+        panel.orderFrontRegardless()
+    }
+
+    func updateOutput(_ output: String) {
+        guard !isClosed else { return }
+        let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
+        outputTextView.string = trimmed.isEmpty ? noOutputText : trimmed
+        outputTextView.scrollToEndOfDocument(nil)
+    }
+
+    func finish(message: String, stopTitle: String? = nil) {
+        guard !isClosed else { return }
+        spinner.stopAnimation(nil)
+        spinner.isHidden = true
+        messageLabel.stringValue = message
+        allowButton.isHidden = true
+        if let stopTitle {
+            stopButton.title = stopTitle
+        }
+    }
+
+    func close() {
+        guard !isClosed else { return }
+        isClosed = true
+        panel.close()
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        if !isClosed && !didAllow {
+            onStop()
+        }
+        isClosed = true
+    }
+
+    @objc private func allow() {
+        guard !didAllow, !isClosed else { return }
+        didAllow = true
+        spinner.isHidden = false
+        spinner.startAnimation(nil)
+        messageLabel.stringValue = launchingMessage
+        outputTextView.string = noOutputText
+        allowButton.isHidden = true
+        stopButton.title = String(
+            localized: "directoryTool.launchProgress.stop",
+            defaultValue: "Stop"
+        )
+        onAllow?(self)
+    }
+
+    @objc private func stop() {
+        onStop()
+        close()
+    }
+}

--- a/Sources/App/DirectoryToolLaunchPanelController.swift
+++ b/Sources/App/DirectoryToolLaunchPanelController.swift
@@ -9,6 +9,7 @@ final class DirectoryToolLaunchPanelController: NSObject, NSWindowDelegate {
     private let stopButton: NSButton
     private let noOutputText: String
     private let launchingMessage: String
+    private let launchingOutputText: String
     private let onAllow: ((DirectoryToolLaunchPanelController) -> Void)?
     private let onStop: () -> Void
     private var isClosed = false
@@ -29,6 +30,10 @@ final class DirectoryToolLaunchPanelController: NSObject, NSWindowDelegate {
         noOutputText = String(
             localized: "directoryTool.launchProgress.noOutput",
             defaultValue: "No output yet."
+        )
+        launchingOutputText = String(
+            localized: "directoryTool.launchProgress.launching",
+            defaultValue: "Launching..."
         )
 
         let contentView = NSView(frame: NSRect(x: 0, y: 0, width: 520, height: 256))
@@ -198,7 +203,7 @@ final class DirectoryToolLaunchPanelController: NSObject, NSWindowDelegate {
     }
 
     func windowWillClose(_ notification: Notification) {
-        if !isClosed && !didAllow {
+        if !isClosed {
             onStop()
         }
         isClosed = true
@@ -210,16 +215,19 @@ final class DirectoryToolLaunchPanelController: NSObject, NSWindowDelegate {
         spinner.isHidden = false
         spinner.startAnimation(nil)
         messageLabel.stringValue = launchingMessage
-        outputTextView.string = noOutputText
+        outputTextView.string = launchingOutputText
         allowButton.isHidden = true
         stopButton.title = String(
             localized: "directoryTool.launchProgress.stop",
             defaultValue: "Stop"
         )
+        panel.contentView?.layoutSubtreeIfNeeded()
+        panel.displayIfNeeded()
         onAllow?(self)
     }
 
     @objc private func stop() {
+        stopButton.isEnabled = false
         onStop()
         close()
     }

--- a/Sources/App/TerminalDirectoryOpenSupport.swift
+++ b/Sources/App/TerminalDirectoryOpenSupport.swift
@@ -879,6 +879,10 @@ final class DirectoryToolWebServerController {
         case failed(LaunchFailure)
     }
 
+    struct LaunchProgress: Sendable, Equatable {
+        var output: String
+    }
+
     struct LaunchFailure: Sendable, Equatable {
         enum Reason: Sendable, Equatable {
             case invalidConfiguration
@@ -903,6 +907,7 @@ final class DirectoryToolWebServerController {
     func ensureWebServerURL(
         tool: CmuxResolvedDirectoryTool,
         directoryURL: URL,
+        progress: ((LaunchProgress) -> Void)? = nil,
         completion: @escaping (LaunchResult) -> Void
     ) {
         let normalizedDirectoryURL = directoryURL.standardizedFileURL
@@ -917,7 +922,11 @@ final class DirectoryToolWebServerController {
             }
             self.serversByKey.removeValue(forKey: key)
             self.launchQueue.async {
-                let result = self.launchWebServer(tool: tool, directoryURL: normalizedDirectoryURL)
+                let result = self.launchWebServer(
+                    tool: tool,
+                    directoryURL: normalizedDirectoryURL,
+                    progress: progress
+                )
                 self.queue.async {
                     if case .opened(let process, let url) = result {
                         self.serversByKey[key] = (process, url)
@@ -942,7 +951,8 @@ final class DirectoryToolWebServerController {
 
     private func launchWebServer(
         tool: CmuxResolvedDirectoryTool,
-        directoryURL: URL
+        directoryURL: URL,
+        progress: ((LaunchProgress) -> Void)?
     ) -> InternalLaunchResult {
         guard tool.kind == .shellWebServer,
               let command = tool.command,
@@ -967,7 +977,14 @@ final class DirectoryToolWebServerController {
         process.standardOutput = stdoutPipe
         process.standardError = stderrPipe
 
-        let collector = DirectoryToolWebServerOutputCollector(urlPattern: tool.urlRegex)
+        let collector = DirectoryToolWebServerOutputCollector(
+            urlPattern: tool.urlRegex
+        ) { output in
+            guard let progress else { return }
+            DispatchQueue.main.async {
+                progress(LaunchProgress(output: output))
+            }
+        }
         let outputReader: (FileHandle) -> Void = { fileHandle in
             switch ProcessPipeReader.readAvailableDataOrEndOfFile(from: fileHandle) {
             case .data(let data):
@@ -1045,15 +1062,19 @@ final class DirectoryToolWebServerController {
 }
 
 final class DirectoryToolWebServerOutputCollector {
+    private static let maxOutputSnippetLength = 800
+
     private let lock = NSLock()
     private let semaphore = DispatchSemaphore(value: 0)
     private let urlPattern: String?
+    private let outputHandler: ((String) -> Void)?
     private var outputBuffer = ""
     private var resolvedURL: URL?
     private var didSignal = false
 
-    init(urlPattern: String?) {
+    init(urlPattern: String?, outputHandler: ((String) -> Void)? = nil) {
         self.urlPattern = urlPattern
+        self.outputHandler = outputHandler
     }
 
     var webServerURL: URL? {
@@ -1065,39 +1086,67 @@ final class DirectoryToolWebServerOutputCollector {
     var outputSnippet: String {
         lock.lock()
         defer { lock.unlock() }
-        let trimmed = outputBuffer.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard trimmed.count > 800 else { return trimmed }
-        let suffix = trimmed.suffix(800)
+        return Self.snippet(from: outputBuffer)
+    }
+
+    private static func snippet(from output: String) -> String {
+        let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.count > maxOutputSnippetLength else { return trimmed }
+        let suffix = trimmed.suffix(maxOutputSnippetLength)
         return "..." + suffix
     }
 
     func append(_ data: Data) {
         guard let text = String(data: data, encoding: .utf8), !text.isEmpty else { return }
+        var outputToReport: String?
+        var shouldSignal = false
+
         lock.lock()
-        defer { lock.unlock() }
-        guard resolvedURL == nil else { return }
-        outputBuffer.append(text)
-        if let parsedURL = DirectoryToolWebServerURLBuilder.extractURL(from: outputBuffer, pattern: urlPattern) {
-            resolvedURL = parsedURL
-            outputBuffer.removeAll(keepingCapacity: false)
-            if !didSignal {
-                didSignal = true
-                semaphore.signal()
+        if resolvedURL == nil {
+            outputBuffer.append(text)
+            outputToReport = Self.snippet(from: outputBuffer)
+            if let parsedURL = DirectoryToolWebServerURLBuilder.extractURL(from: outputBuffer, pattern: urlPattern) {
+                resolvedURL = parsedURL
+                outputBuffer.removeAll(keepingCapacity: false)
+                if !didSignal {
+                    didSignal = true
+                    shouldSignal = true
+                }
             }
+        }
+        lock.unlock()
+
+        if let outputToReport {
+            outputHandler?(outputToReport)
+        }
+        if shouldSignal {
+            semaphore.signal()
         }
     }
 
     func markProcessExited() {
+        var outputToReport: String?
+        var shouldSignal = false
+
         lock.lock()
-        defer { lock.unlock() }
         if resolvedURL == nil,
            let parsedURL = DirectoryToolWebServerURLBuilder.extractURL(from: outputBuffer, pattern: urlPattern) {
             resolvedURL = parsedURL
             outputBuffer.removeAll(keepingCapacity: false)
+            outputToReport = Self.snippet(from: outputBuffer)
         }
-        guard !didSignal else { return }
-        didSignal = true
-        semaphore.signal()
+        if !didSignal {
+            didSignal = true
+            shouldSignal = true
+        }
+        lock.unlock()
+
+        if let outputToReport {
+            outputHandler?(outputToReport)
+        }
+        if shouldSignal {
+            semaphore.signal()
+        }
     }
 
     func waitForURL(timeoutSeconds: TimeInterval) -> Bool {

--- a/Sources/App/TerminalDirectoryOpenSupport.swift
+++ b/Sources/App/TerminalDirectoryOpenSupport.swift
@@ -872,7 +872,24 @@ enum DirectoryToolWebServerURLBuilder {
 
 final class DirectoryToolWebServerController {
     static let shared = DirectoryToolWebServerController()
-    private static let startupTimeoutSeconds: TimeInterval = 60
+    private static let defaultStartupTimeoutSeconds: TimeInterval = 20
+
+    enum LaunchResult {
+        case opened(URL)
+        case failed(LaunchFailure)
+    }
+
+    struct LaunchFailure: Sendable, Equatable {
+        enum Reason: Sendable, Equatable {
+            case invalidConfiguration
+            case launchFailed
+            case exitedWithoutURL(status: Int32)
+            case timedOut
+        }
+
+        var reason: Reason
+        var output: String
+    }
 
     private struct ServerKey: Hashable {
         let toolID: String
@@ -886,7 +903,7 @@ final class DirectoryToolWebServerController {
     func ensureWebServerURL(
         tool: CmuxResolvedDirectoryTool,
         directoryURL: URL,
-        completion: @escaping (URL?) -> Void
+        completion: @escaping (LaunchResult) -> Void
     ) {
         let normalizedDirectoryURL = directoryURL.standardizedFileURL
         let key = ServerKey(toolID: tool.id, directoryPath: normalizedDirectoryURL.path)
@@ -894,7 +911,7 @@ final class DirectoryToolWebServerController {
             if let server = self.serversByKey[key],
                server.process.isRunning {
                 DispatchQueue.main.async {
-                    completion(server.url)
+                    completion(.opened(server.url))
                 }
                 return
             }
@@ -902,25 +919,35 @@ final class DirectoryToolWebServerController {
             self.launchQueue.async {
                 let result = self.launchWebServer(tool: tool, directoryURL: normalizedDirectoryURL)
                 self.queue.async {
-                    if let result {
-                        self.serversByKey[key] = result
+                    if case .opened(let process, let url) = result {
+                        self.serversByKey[key] = (process, url)
                     }
                     DispatchQueue.main.async {
-                        completion(result?.url)
+                        switch result {
+                        case .opened(_, let url):
+                            completion(.opened(url))
+                        case .failed(let failure):
+                            completion(.failed(failure))
+                        }
                     }
                 }
             }
         }
     }
 
+    private enum InternalLaunchResult {
+        case opened(process: Process, url: URL)
+        case failed(LaunchFailure)
+    }
+
     private func launchWebServer(
         tool: CmuxResolvedDirectoryTool,
         directoryURL: URL
-    ) -> (process: Process, url: URL)? {
+    ) -> InternalLaunchResult {
         guard tool.kind == .shellWebServer,
               let command = tool.command,
               !command.isEmpty else {
-            return nil
+            return .failed(LaunchFailure(reason: .invalidConfiguration, output: ""))
         }
         let executablePath = tool.resolvedExecutablePath() ?? ""
         let cwdURL = resolvedCwdURL(template: tool.cwd, directoryURL: directoryURL)
@@ -970,20 +997,27 @@ final class DirectoryToolWebServerController {
         } catch {
             stdoutPipe.fileHandleForReading.readabilityHandler = nil
             stderrPipe.fileHandleForReading.readabilityHandler = nil
-            return nil
+            return .failed(LaunchFailure(reason: .launchFailed, output: error.localizedDescription))
         }
 
-        guard collector.waitForURL(timeoutSeconds: Self.startupTimeoutSeconds),
+        let configuredStartupTimeoutSeconds = tool.startupTimeoutSeconds
+            ?? Self.defaultStartupTimeoutSeconds
+        let startupTimeoutSeconds = max(1, TimeInterval(configuredStartupTimeoutSeconds))
+        guard collector.waitForURL(timeoutSeconds: startupTimeoutSeconds),
               let url = collector.webServerURL else {
             stdoutPipe.fileHandleForReading.readabilityHandler = nil
             stderrPipe.fileHandleForReading.readabilityHandler = nil
             if process.isRunning {
                 process.terminate()
+                return .failed(LaunchFailure(reason: .timedOut, output: collector.outputSnippet))
             }
-            return nil
+            return .failed(LaunchFailure(
+                reason: .exitedWithoutURL(status: process.terminationStatus),
+                output: collector.outputSnippet
+            ))
         }
 
-        return (process, url)
+        return .opened(process: process, url: url)
     }
 
     private func resolvedCwdURL(template: String?, directoryURL: URL) -> URL {
@@ -1026,6 +1060,15 @@ final class DirectoryToolWebServerOutputCollector {
         lock.lock()
         defer { lock.unlock() }
         return resolvedURL
+    }
+
+    var outputSnippet: String {
+        lock.lock()
+        defer { lock.unlock() }
+        let trimmed = outputBuffer.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.count > 800 else { return trimmed }
+        let suffix = trimmed.suffix(800)
+        return "..." + suffix
     }
 
     func append(_ data: Data) {

--- a/Sources/App/TerminalDirectoryOpenSupport.swift
+++ b/Sources/App/TerminalDirectoryOpenSupport.swift
@@ -310,10 +310,7 @@ extension CmuxResolvedDirectoryTool {
                 isExecutableAtPath: environment.isExecutableFileAtPath
             ) != nil
         case .shellWebServer:
-            if executablePathCandidates.isEmpty {
-                return command?.isEmpty == false
-            }
-            return resolvedExecutablePath(in: environment) != nil
+            return command?.isEmpty == false
         }
     }
 
@@ -926,9 +923,6 @@ final class DirectoryToolWebServerController {
             return nil
         }
         let executablePath = tool.resolvedExecutablePath() ?? ""
-        guard !executablePath.isEmpty || tool.executablePathCandidates.isEmpty else {
-            return nil
-        }
         let cwdURL = resolvedCwdURL(template: tool.cwd, directoryURL: directoryURL)
 
         let process = Process()

--- a/Sources/App/TerminalDirectoryOpenSupport.swift
+++ b/Sources/App/TerminalDirectoryOpenSupport.swift
@@ -1015,6 +1015,19 @@ final class DirectoryToolWebServerController {
         return true
     }
 
+    func isWebServerRunning(tool: CmuxResolvedDirectoryTool, directoryURL: URL) -> Bool {
+        let normalizedDirectoryURL = directoryURL.standardizedFileURL
+        let key = ServerKey(toolID: tool.id, directoryPath: normalizedDirectoryURL.path)
+        return queue.sync {
+            guard let server = self.serversByKey[key] else { return false }
+            if server.process.isRunning {
+                return true
+            }
+            self.serversByKey.removeValue(forKey: key)
+            return false
+        }
+    }
+
     private enum InternalLaunchResult {
         case opened(process: Process, url: URL)
         case failed(LaunchFailure)

--- a/Sources/App/TerminalDirectoryOpenSupport.swift
+++ b/Sources/App/TerminalDirectoryOpenSupport.swift
@@ -93,7 +93,7 @@ enum TerminalDirectoryOpenTarget: String, CaseIterable {
     }
 
     static var commandPaletteShortcutTargets: [Self] {
-        Array(allCases)
+        allCases.filter { $0 != .vscodeInline }
     }
 
     static func availableTargets(in environment: DetectionEnvironment = .live) -> Set<Self> {
@@ -291,6 +291,96 @@ enum TerminalDirectoryOpenTarget: String, CaseIterable {
         }
         return deduped
     }
+}
+
+extension CmuxResolvedDirectoryTool {
+    static func availableTools(
+        _ tools: [CmuxResolvedDirectoryTool],
+        in environment: TerminalDirectoryOpenTarget.DetectionEnvironment = .live
+    ) -> Set<String> {
+        Set(tools.filter { $0.isAvailable(in: environment) }.map(\.id))
+    }
+
+    func isAvailable(in environment: TerminalDirectoryOpenTarget.DetectionEnvironment = .live) -> Bool {
+        switch kind {
+        case .vscodeServeWeb:
+            guard let applicationURL = applicationURL(in: environment) else { return false }
+            return VSCodeCLILaunchConfigurationBuilder.launchConfiguration(
+                vscodeApplicationURL: applicationURL,
+                isExecutableAtPath: environment.isExecutableFileAtPath
+            ) != nil
+        case .shellWebServer:
+            if executablePathCandidates.isEmpty {
+                return command?.isEmpty == false
+            }
+            return resolvedExecutablePath(in: environment) != nil
+        }
+    }
+
+    func applicationURL(in environment: TerminalDirectoryOpenTarget.DetectionEnvironment = .live) -> URL? {
+        guard let path = applicationPath(in: environment) else { return nil }
+        return URL(fileURLWithPath: path, isDirectory: true)
+    }
+
+    func resolvedExecutablePath(in environment: TerminalDirectoryOpenTarget.DetectionEnvironment = .live) -> String? {
+        for path in expandedCandidatePaths(executablePathCandidates, environment: environment)
+            where environment.isExecutableFileAtPath(path) {
+            return path
+        }
+        return nil
+    }
+
+    private func applicationPath(in environment: TerminalDirectoryOpenTarget.DetectionEnvironment) -> String? {
+        for path in expandedCandidatePaths(applicationBundlePathCandidates, environment: environment)
+            where environment.fileExistsAtPath(path) {
+            return path
+        }
+        for applicationName in applicationSearchNames {
+            guard let resolvedPath = environment.applicationPathForName(applicationName),
+                  environment.fileExistsAtPath(resolvedPath) else {
+                continue
+            }
+            return resolvedPath
+        }
+        return nil
+    }
+
+    private var applicationSearchNames: [String] {
+        directoryToolUniquePreservingOrder(
+            applicationBundlePathCandidates.map {
+                URL(fileURLWithPath: $0).deletingPathExtension().lastPathComponent
+            }
+        )
+    }
+
+    private func expandedCandidatePaths(
+        _ candidates: [String],
+        environment: TerminalDirectoryOpenTarget.DetectionEnvironment
+    ) -> [String] {
+        let globalPrefix = "/Applications/"
+        let userPrefix = "\(environment.homeDirectoryPath)/Applications/"
+        var expanded: [String] = []
+
+        for candidate in candidates {
+            let expandedCandidate = (candidate as NSString).expandingTildeInPath
+            expanded.append(expandedCandidate)
+            if expandedCandidate.hasPrefix(globalPrefix) {
+                let suffix = String(expandedCandidate.dropFirst(globalPrefix.count))
+                expanded.append(userPrefix + suffix)
+            }
+        }
+
+        return directoryToolUniquePreservingOrder(expanded)
+    }
+}
+
+private func directoryToolUniquePreservingOrder(_ values: [String]) -> [String] {
+    var seen: Set<String> = []
+    var deduped: [String] = []
+    for value in values where seen.insert(value).inserted {
+        deduped.append(value)
+    }
+    return deduped
 }
 
 enum VSCodeServeWebURLBuilder {
@@ -758,6 +848,225 @@ final class ServeWebOutputCollector {
         if webUIURL != nil { return true }
         _ = semaphore.wait(timeout: .now() + timeoutSeconds)
         return webUIURL != nil
+    }
+}
+
+enum DirectoryToolWebServerURLBuilder {
+    private static let defaultURLPattern = #"(https?://(?:127\.0\.0\.1|localhost):[^\s]+)"#
+
+    static func extractURL(from output: String, pattern: String?) -> URL? {
+        let regexPattern = pattern?.isEmpty == false ? pattern! : defaultURLPattern
+        guard let regex = try? NSRegularExpression(pattern: regexPattern) else {
+            return extractURL(from: output, pattern: nil)
+        }
+        let nsRange = NSRange(output.startIndex..<output.endIndex, in: output)
+        guard let match = regex.firstMatch(in: output, range: nsRange) else { return nil }
+        let captureRange = match.numberOfRanges > 1 ? match.range(at: 1) : match.range(at: 0)
+        guard captureRange.location != NSNotFound,
+              let range = Range(captureRange, in: output) else {
+            return nil
+        }
+        let rawURL = String(output[range])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "'\""))
+        return URL(string: rawURL)
+    }
+}
+
+final class DirectoryToolWebServerController {
+    static let shared = DirectoryToolWebServerController()
+    private static let startupTimeoutSeconds: TimeInterval = 60
+
+    private struct ServerKey: Hashable {
+        let toolID: String
+        let directoryPath: String
+    }
+
+    private let queue = DispatchQueue(label: "cmux.directoryTool.webServer")
+    private let launchQueue = DispatchQueue(label: "cmux.directoryTool.webServer.launch")
+    private var serversByKey: [ServerKey: (process: Process, url: URL)] = [:]
+
+    func ensureWebServerURL(
+        tool: CmuxResolvedDirectoryTool,
+        directoryURL: URL,
+        completion: @escaping (URL?) -> Void
+    ) {
+        let normalizedDirectoryURL = directoryURL.standardizedFileURL
+        let key = ServerKey(toolID: tool.id, directoryPath: normalizedDirectoryURL.path)
+        queue.async {
+            if let server = self.serversByKey[key],
+               server.process.isRunning {
+                DispatchQueue.main.async {
+                    completion(server.url)
+                }
+                return
+            }
+            self.serversByKey.removeValue(forKey: key)
+            self.launchQueue.async {
+                let result = self.launchWebServer(tool: tool, directoryURL: normalizedDirectoryURL)
+                self.queue.async {
+                    if let result {
+                        self.serversByKey[key] = result
+                    }
+                    DispatchQueue.main.async {
+                        completion(result?.url)
+                    }
+                }
+            }
+        }
+    }
+
+    private func launchWebServer(
+        tool: CmuxResolvedDirectoryTool,
+        directoryURL: URL
+    ) -> (process: Process, url: URL)? {
+        guard tool.kind == .shellWebServer,
+              let command = tool.command,
+              !command.isEmpty else {
+            return nil
+        }
+        let executablePath = tool.resolvedExecutablePath() ?? ""
+        guard !executablePath.isEmpty || tool.executablePathCandidates.isEmpty else {
+            return nil
+        }
+        let cwdURL = resolvedCwdURL(template: tool.cwd, directoryURL: directoryURL)
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/zsh")
+        process.arguments = ["-lc", command]
+        process.currentDirectoryURL = cwdURL
+        var environment = ProcessInfo.processInfo.environment
+        environment["CMUX_DIRECTORY"] = directoryURL.path
+        environment["CMUX_TOOL_ID"] = tool.id
+        environment["CMUX_TOOL_EXECUTABLE"] = executablePath
+        process.environment = environment
+
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        let collector = DirectoryToolWebServerOutputCollector(urlPattern: tool.urlRegex)
+        let outputReader: (FileHandle) -> Void = { fileHandle in
+            switch ProcessPipeReader.readAvailableDataOrEndOfFile(from: fileHandle) {
+            case .data(let data):
+                collector.append(data)
+            case .wouldBlock:
+                return
+            case .endOfFile:
+                fileHandle.readabilityHandler = nil
+            }
+        }
+        stdoutPipe.fileHandleForReading.readabilityHandler = outputReader
+        stderrPipe.fileHandleForReading.readabilityHandler = outputReader
+
+        process.terminationHandler = { terminatedProcess in
+            stdoutPipe.fileHandleForReading.readabilityHandler = nil
+            stderrPipe.fileHandleForReading.readabilityHandler = nil
+            Self.drainAvailableOutput(from: stdoutPipe.fileHandleForReading, collector: collector)
+            Self.drainAvailableOutput(from: stderrPipe.fileHandleForReading, collector: collector)
+            collector.markProcessExited()
+            self.queue.async {
+                self.serversByKey = self.serversByKey.filter { $0.value.process !== terminatedProcess }
+            }
+        }
+
+        do {
+            try process.run()
+        } catch {
+            stdoutPipe.fileHandleForReading.readabilityHandler = nil
+            stderrPipe.fileHandleForReading.readabilityHandler = nil
+            return nil
+        }
+
+        guard collector.waitForURL(timeoutSeconds: Self.startupTimeoutSeconds),
+              let url = collector.webServerURL else {
+            stdoutPipe.fileHandleForReading.readabilityHandler = nil
+            stderrPipe.fileHandleForReading.readabilityHandler = nil
+            if process.isRunning {
+                process.terminate()
+            }
+            return nil
+        }
+
+        return (process, url)
+    }
+
+    private func resolvedCwdURL(template: String?, directoryURL: URL) -> URL {
+        let raw = template?.replacingOccurrences(of: "{directory}", with: directoryURL.path) ?? directoryURL.path
+        let expanded = (raw as NSString).expandingTildeInPath
+        let path = (expanded as NSString).isAbsolutePath
+            ? expanded
+            : (directoryURL.path as NSString).appendingPathComponent(expanded)
+        return URL(fileURLWithPath: path, isDirectory: true)
+    }
+
+    private static func drainAvailableOutput(
+        from fileHandle: FileHandle,
+        collector: DirectoryToolWebServerOutputCollector
+    ) {
+        while true {
+            switch ProcessPipeReader.readAvailableDataOrEndOfFile(from: fileHandle) {
+            case .data(let data):
+                collector.append(data)
+            case .wouldBlock, .endOfFile:
+                return
+            }
+        }
+    }
+}
+
+final class DirectoryToolWebServerOutputCollector {
+    private let lock = NSLock()
+    private let semaphore = DispatchSemaphore(value: 0)
+    private let urlPattern: String?
+    private var outputBuffer = ""
+    private var resolvedURL: URL?
+    private var didSignal = false
+
+    init(urlPattern: String?) {
+        self.urlPattern = urlPattern
+    }
+
+    var webServerURL: URL? {
+        lock.lock()
+        defer { lock.unlock() }
+        return resolvedURL
+    }
+
+    func append(_ data: Data) {
+        guard let text = String(data: data, encoding: .utf8), !text.isEmpty else { return }
+        lock.lock()
+        defer { lock.unlock() }
+        guard resolvedURL == nil else { return }
+        outputBuffer.append(text)
+        if let parsedURL = DirectoryToolWebServerURLBuilder.extractURL(from: outputBuffer, pattern: urlPattern) {
+            resolvedURL = parsedURL
+            outputBuffer.removeAll(keepingCapacity: false)
+            if !didSignal {
+                didSignal = true
+                semaphore.signal()
+            }
+        }
+    }
+
+    func markProcessExited() {
+        lock.lock()
+        defer { lock.unlock() }
+        if resolvedURL == nil,
+           let parsedURL = DirectoryToolWebServerURLBuilder.extractURL(from: outputBuffer, pattern: urlPattern) {
+            resolvedURL = parsedURL
+            outputBuffer.removeAll(keepingCapacity: false)
+        }
+        guard !didSignal else { return }
+        didSignal = true
+        semaphore.signal()
+    }
+
+    func waitForURL(timeoutSeconds: TimeInterval) -> Bool {
+        if webServerURL != nil { return true }
+        _ = semaphore.wait(timeout: .now() + timeoutSeconds)
+        return webServerURL != nil
     }
 }
 

--- a/Sources/App/TerminalDirectoryOpenSupport.swift
+++ b/Sources/App/TerminalDirectoryOpenSupport.swift
@@ -490,7 +490,11 @@ final class VSCodeServeWebController {
     }
 #endif
 
-    func ensureServeWebURL(vscodeApplicationURL: URL, completion: @escaping (URL?) -> Void) {
+    func ensureServeWebURL(
+        vscodeApplicationURL: URL,
+        progress: ((String) -> Void)? = nil,
+        completion: @escaping (URL?) -> Void
+    ) {
         queue.async {
             if let process = self.serveWebProcess,
                process.isRunning,
@@ -523,7 +527,8 @@ final class VSCodeServeWebController {
                 }
                 let launchResult = self.launchServeWebProcess(
                     vscodeApplicationURL: vscodeApplicationURL,
-                    expectedGeneration: launchGeneration
+                    expectedGeneration: launchGeneration,
+                    progress: progress
                 )
                 self.queue.async {
                     guard self.activeLaunchGeneration == launchGeneration else {
@@ -626,7 +631,8 @@ final class VSCodeServeWebController {
 
     private func launchServeWebProcess(
         vscodeApplicationURL: URL,
-        expectedGeneration: UInt64
+        expectedGeneration: UInt64,
+        progress: ((String) -> Void)?
     ) -> (process: Process, url: URL)? {
         if let launchProcessOverride {
             return launchProcessOverride(vscodeApplicationURL, expectedGeneration)
@@ -656,7 +662,12 @@ final class VSCodeServeWebController {
         process.standardOutput = stdoutPipe
         process.standardError = stderrPipe
 
-        let collector = ServeWebOutputCollector()
+        let collector = ServeWebOutputCollector { output in
+            guard let progress else { return }
+            DispatchQueue.main.async {
+                progress(output)
+            }
+        }
         let outputReader: (FileHandle) -> Void = { fileHandle in
             switch ProcessPipeReader.readAvailableDataOrEndOfFile(from: fileHandle) {
             case .data(let data):
@@ -794,11 +805,18 @@ final class VSCodeServeWebController {
 }
 
 final class ServeWebOutputCollector {
+    private static let maxOutputSnippetLength = 800
+
     private let lock = NSLock()
     private let semaphore = DispatchSemaphore(value: 0)
+    private let outputHandler: ((String) -> Void)?
     private var outputBuffer = ""
     private var resolvedURL: URL?
     private var didSignal = false
+
+    init(outputHandler: ((String) -> Void)? = nil) {
+        self.outputHandler = outputHandler
+    }
 
     var webUIURL: URL? {
         lock.lock()
@@ -806,39 +824,76 @@ final class ServeWebOutputCollector {
         return resolvedURL
     }
 
-    func append(_ data: Data) {
-        guard let text = String(data: data, encoding: .utf8), !text.isEmpty else { return }
+    var outputSnippet: String {
         lock.lock()
         defer { lock.unlock() }
-        guard resolvedURL == nil else { return }
-        outputBuffer.append(text)
-        while let newlineIndex = outputBuffer.firstIndex(where: \.isNewline) {
-            let line = String(outputBuffer[..<newlineIndex])
-            outputBuffer.removeSubrange(...newlineIndex)
-            guard let parsedURL = VSCodeServeWebURLBuilder.extractWebUIURL(from: line) else {
-                continue
+        return Self.snippet(from: outputBuffer)
+    }
+
+    private static func snippet(from output: String) -> String {
+        let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.count > maxOutputSnippetLength else { return trimmed }
+        let suffix = trimmed.suffix(maxOutputSnippetLength)
+        return "..." + suffix
+    }
+
+    func append(_ data: Data) {
+        guard let text = String(data: data, encoding: .utf8), !text.isEmpty else { return }
+        var outputToReport: String?
+        var shouldSignal = false
+
+        lock.lock()
+        if resolvedURL == nil {
+            outputBuffer.append(text)
+            outputToReport = Self.snippet(from: outputBuffer)
+            while let newlineIndex = outputBuffer.firstIndex(where: \.isNewline) {
+                let line = String(outputBuffer[..<newlineIndex])
+                outputBuffer.removeSubrange(...newlineIndex)
+                guard let parsedURL = VSCodeServeWebURLBuilder.extractWebUIURL(from: line) else {
+                    continue
+                }
+                resolvedURL = parsedURL
+                outputBuffer.removeAll(keepingCapacity: false)
+                if !didSignal {
+                    didSignal = true
+                    shouldSignal = true
+                }
+                break
             }
-            resolvedURL = parsedURL
-            outputBuffer.removeAll(keepingCapacity: false)
-            if !didSignal {
-                didSignal = true
-                semaphore.signal()
-            }
-            return
+        }
+        lock.unlock()
+
+        if let outputToReport {
+            outputHandler?(outputToReport)
+        }
+        if shouldSignal {
+            semaphore.signal()
         }
     }
 
     func markProcessExited() {
+        var outputToReport: String?
+        var shouldSignal = false
+
         lock.lock()
-        defer { lock.unlock() }
         if resolvedURL == nil, !outputBuffer.isEmpty,
            let parsedURL = VSCodeServeWebURLBuilder.extractWebUIURL(from: outputBuffer) {
             resolvedURL = parsedURL
+            outputToReport = Self.snippet(from: outputBuffer)
             outputBuffer.removeAll(keepingCapacity: false)
         }
-        guard !didSignal else { return }
-        didSignal = true
-        semaphore.signal()
+        if !didSignal {
+            didSignal = true
+            shouldSignal = true
+        }
+        lock.unlock()
+
+        if let outputToReport {
+            outputHandler?(outputToReport)
+        }
+        if shouldSignal {
+            semaphore.signal()
+        }
     }
 
     func waitForURL(timeoutSeconds: TimeInterval) -> Bool {
@@ -1189,8 +1244,8 @@ final class DirectoryToolWebServerOutputCollector {
         if resolvedURL == nil,
            let parsedURL = DirectoryToolWebServerURLBuilder.extractURL(from: outputBuffer, pattern: urlPattern) {
             resolvedURL = parsedURL
-            outputBuffer.removeAll(keepingCapacity: false)
             outputToReport = Self.snippet(from: outputBuffer)
+            outputBuffer.removeAll(keepingCapacity: false)
         }
         if !didSignal {
             didSignal = true

--- a/Sources/App/TerminalDirectoryOpenSupport.swift
+++ b/Sources/App/TerminalDirectoryOpenSupport.swift
@@ -907,6 +907,7 @@ final class DirectoryToolWebServerController {
     func ensureWebServerURL(
         tool: CmuxResolvedDirectoryTool,
         directoryURL: URL,
+        launchHandle: DirectoryToolWebServerLaunchHandle? = nil,
         progress: ((LaunchProgress) -> Void)? = nil,
         completion: @escaping (LaunchResult) -> Void
     ) {
@@ -925,6 +926,7 @@ final class DirectoryToolWebServerController {
                 let result = self.launchWebServer(
                     tool: tool,
                     directoryURL: normalizedDirectoryURL,
+                    launchHandle: launchHandle,
                     progress: progress
                 )
                 self.queue.async {
@@ -944,6 +946,20 @@ final class DirectoryToolWebServerController {
         }
     }
 
+    func stopWebServer(tool: CmuxResolvedDirectoryTool, directoryURL: URL) -> Bool {
+        let normalizedDirectoryURL = directoryURL.standardizedFileURL
+        let key = ServerKey(toolID: tool.id, directoryPath: normalizedDirectoryURL.path)
+        let process: Process? = queue.sync {
+            guard let server = self.serversByKey.removeValue(forKey: key) else { return nil }
+            return server.process
+        }
+        guard let process else { return false }
+        if process.isRunning {
+            process.terminate()
+        }
+        return true
+    }
+
     private enum InternalLaunchResult {
         case opened(process: Process, url: URL)
         case failed(LaunchFailure)
@@ -952,6 +968,7 @@ final class DirectoryToolWebServerController {
     private func launchWebServer(
         tool: CmuxResolvedDirectoryTool,
         directoryURL: URL,
+        launchHandle: DirectoryToolWebServerLaunchHandle?,
         progress: ((LaunchProgress) -> Void)?
     ) -> InternalLaunchResult {
         guard tool.kind == .shellWebServer,
@@ -1011,6 +1028,7 @@ final class DirectoryToolWebServerController {
 
         do {
             try process.run()
+            launchHandle?.attach(process)
         } catch {
             stdoutPipe.fileHandleForReading.readabilityHandler = nil
             stderrPipe.fileHandleForReading.readabilityHandler = nil
@@ -1057,6 +1075,45 @@ final class DirectoryToolWebServerController {
             case .wouldBlock, .endOfFile:
                 return
             }
+        }
+    }
+}
+
+final class DirectoryToolWebServerLaunchHandle {
+    private let lock = NSLock()
+    private var process: Process?
+    private var isCancelled = false
+
+    var cancelled: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return isCancelled
+    }
+
+    func attach(_ process: Process) {
+        var shouldTerminate = false
+        lock.lock()
+        if isCancelled {
+            shouldTerminate = true
+        } else {
+            self.process = process
+        }
+        lock.unlock()
+
+        if shouldTerminate, process.isRunning {
+            process.terminate()
+        }
+    }
+
+    func cancel() {
+        let processToTerminate: Process?
+        lock.lock()
+        isCancelled = true
+        processToTerminate = process
+        lock.unlock()
+
+        if let processToTerminate, processToTerminate.isRunning {
+            processToTerminate.terminate()
         }
     }
 }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -7262,9 +7262,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     @discardableResult
     func openDirectoryInInlineVSCode(
         _ directoryURL: URL,
+        vscodeApplicationURL preferredVSCodeApplicationURL: URL? = nil,
         tabManager preferredTabManager: TabManager? = nil
     ) -> Bool {
-        guard let vscodeApplicationURL = TerminalDirectoryOpenTarget.vscodeInline.applicationURL() else {
+        guard let vscodeApplicationURL = preferredVSCodeApplicationURL
+            ?? TerminalDirectoryOpenTarget.vscodeInline.applicationURL() else {
             return false
         }
 
@@ -7302,8 +7304,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return true
     }
 
-    func showOpenFolderInInlineVSCodePanel(tabManager preferredTabManager: TabManager? = nil) {
-        guard TerminalDirectoryOpenTarget.vscodeInline.isAvailable() else {
+    func showOpenFolderInInlineVSCodePanel(
+        vscodeApplicationURL preferredVSCodeApplicationURL: URL? = nil,
+        tabManager preferredTabManager: TabManager? = nil
+    ) {
+        guard preferredVSCodeApplicationURL != nil || TerminalDirectoryOpenTarget.vscodeInline.isAvailable() else {
             NSSound.beep()
             return
         }
@@ -7334,7 +7339,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         if panel.runModal() == .OK,
            let url = panel.url,
-           !openDirectoryInInlineVSCode(url, tabManager: targetTabManager) {
+           !openDirectoryInInlineVSCode(
+               url,
+               vscodeApplicationURL: preferredVSCodeApplicationURL,
+               tabManager: targetTabManager
+           ) {
             NSSound.beep()
         }
     }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -7281,15 +7281,54 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             ?? targetTabManager.addWorkspace(select: true).id
         let normalizedDirectoryURL = directoryURL.standardizedFileURL
 
-        VSCodeServeWebController.shared.ensureServeWebURL(vscodeApplicationURL: vscodeApplicationURL) { serveWebURL in
+        var progressController: DirectoryToolLaunchPanelController!
+        progressController = DirectoryToolLaunchPanelController(
+            title: DirectoryToolLaunchPanelController.startingTitle(displayName: "VS Code"),
+            initialMessage: String(
+                localized: "directoryTool.launchProgress.message",
+                defaultValue: "Waiting for the tool to print a local URL."
+            ),
+            launchingMessage: String(
+                localized: "directoryTool.launchProgress.message",
+                defaultValue: "Waiting for the tool to print a local URL."
+            ),
+            initialOutput: String(
+                localized: "directoryTool.launchProgress.noOutput",
+                defaultValue: "No output yet."
+            ),
+            requiresApproval: false,
+            onAllow: nil,
+            onStop: {
+                VSCodeServeWebController.shared.stop()
+            }
+        )
+        progressController.show(presentingWindow: NSApp.keyWindow ?? NSApp.mainWindow)
+
+        VSCodeServeWebController.shared.ensureServeWebURL(
+            vscodeApplicationURL: vscodeApplicationURL,
+            progress: { output in
+                progressController.updateOutput(output)
+            }
+        ) { serveWebURL in
             guard let serveWebURL,
                   let openFolderURL = VSCodeServeWebURLBuilder.openFolderURL(
                       baseWebUIURL: serveWebURL,
                       directoryPath: normalizedDirectoryURL.path
                   ) else {
+                progressController.finish(
+                    message: String(
+                        localized: "directoryTool.launchProgress.failed",
+                        defaultValue: "The server did not start."
+                    ),
+                    stopTitle: String(
+                        localized: "directoryTool.launchProgress.hide",
+                        defaultValue: "Hide"
+                    )
+                )
                 NSSound.beep()
                 return
             }
+            progressController.close()
 
             guard targetTabManager.openBrowser(
                 inWorkspace: targetWorkspaceId,

--- a/Sources/CmuxConfig.swift
+++ b/Sources/CmuxConfig.swift
@@ -503,7 +503,8 @@ struct CmuxDirectoryToolDefinition: Codable, Sendable, Hashable {
             command: """
             TOOL="${CMUX_TOOL_EXECUTABLE:-$(command -v jupyter || true)}"; \
             if [ -z "$TOOL" ]; then TOOL="$(command -v jupyter-lab || true)"; fi; \
-            if [ -z "$TOOL" ]; then echo "Jupyter is not installed or is not on PATH." >&2; exit 127; fi; \
+            if [ -z "$TOOL" ] && command -v uvx >/dev/null 2>&1; then exec uvx --from jupyterlab jupyter lab --no-browser --ip=127.0.0.1 --port=8888 --ServerApp.port_retries=50; fi; \
+            if [ -z "$TOOL" ]; then echo "Jupyter is not installed and uvx is not on PATH." >&2; exit 127; fi; \
             if [ "$(basename "$TOOL")" = "jupyter-lab" ]; then exec "$TOOL" --no-browser --ip=127.0.0.1 --port=8888 --ServerApp.port_retries=50; fi; \
             exec "$TOOL" lab --no-browser --ip=127.0.0.1 --port=8888 --ServerApp.port_retries=50
             """,
@@ -511,9 +512,9 @@ struct CmuxDirectoryToolDefinition: Codable, Sendable, Hashable {
             urlRegex: "(http://(?:127\\.0\\.0\\.1|localhost):[^\\s]+)",
             failureMessage: String(
                 localized: "directoryTool.jupyter.failureMessage",
-                defaultValue: "Jupyter is not installed or did not print a local URL. Install JupyterLab, then run this command again."
+                defaultValue: "Jupyter is not installed, uvx is not available, or the tool did not print a local URL. Install uv, then run this command again."
             ),
-            installCommand: "python3 -m pip install --user jupyterlab",
+            installCommand: "if command -v brew >/dev/null 2>&1; then brew install uv; else curl -LsSf https://astral.sh/uv/install.sh | sh; fi",
             startupTimeoutSeconds: 20
         ),
     ]

--- a/Sources/CmuxConfig.swift
+++ b/Sources/CmuxConfig.swift
@@ -479,7 +479,13 @@ struct CmuxDirectoryToolDefinition: Codable, Sendable, Hashable {
                 "/usr/local/bin/jupyter",
                 "/usr/bin/jupyter",
             ],
-            command: "exec \"$CMUX_TOOL_EXECUTABLE\" lab --no-browser --ip=127.0.0.1 --port=0",
+            command: """
+            TOOL="${CMUX_TOOL_EXECUTABLE:-$(command -v jupyter || true)}"; \
+            if [ -z "$TOOL" ]; then TOOL="$(command -v jupyter-lab || true)"; fi; \
+            if [ -z "$TOOL" ]; then exit 127; fi; \
+            if [ "$(basename "$TOOL")" = "jupyter-lab" ]; then exec "$TOOL" --no-browser --ip=127.0.0.1 --port=0; fi; \
+            exec "$TOOL" lab --no-browser --ip=127.0.0.1 --port=0
+            """,
             cwd: "{directory}",
             urlRegex: "(http://127\\.0\\.0\\.1:[^\\s]+)"
         ),

--- a/Sources/CmuxConfig.swift
+++ b/Sources/CmuxConfig.swift
@@ -501,12 +501,24 @@ struct CmuxDirectoryToolDefinition: Codable, Sendable, Hashable {
                 "~/.asdf/shims/jupyter",
             ],
             command: """
-            TOOL="${CMUX_TOOL_EXECUTABLE:-$(command -v jupyter || true)}"; \
-            if [ -z "$TOOL" ]; then TOOL="$(command -v jupyter-lab || true)"; fi; \
-            if [ -z "$TOOL" ] && command -v uvx >/dev/null 2>&1; then exec uvx --from jupyterlab jupyter lab --no-browser --ip=127.0.0.1 --port=8888 --ServerApp.port_retries=50; fi; \
-            if [ -z "$TOOL" ]; then echo "Jupyter is not installed and uvx is not on PATH." >&2; exit 127; fi; \
-            if [ "$(basename "$TOOL")" = "jupyter-lab" ]; then exec "$TOOL" --no-browser --ip=127.0.0.1 --port=8888 --ServerApp.port_retries=50; fi; \
-            exec "$TOOL" lab --no-browser --ip=127.0.0.1 --port=8888 --ServerApp.port_retries=50
+            jupyter="${CMUX_TOOL_EXECUTABLE:-}"
+            if [ -z "$jupyter" ]; then
+              jupyter="$(command -v jupyter || command -v jupyter-lab || true)"
+            fi
+
+            if [ -n "$jupyter" ]; then
+              if [ "$(basename "$jupyter")" = "jupyter-lab" ]; then
+                exec "$jupyter" --no-browser --ip=127.0.0.1 --port=8888 --ServerApp.port_retries=50
+              fi
+              exec "$jupyter" lab --no-browser --ip=127.0.0.1 --port=8888 --ServerApp.port_retries=50
+            fi
+
+            if command -v uvx >/dev/null 2>&1; then
+              exec uvx --from jupyterlab jupyter lab --no-browser --ip=127.0.0.1 --port=8888 --ServerApp.port_retries=50
+            fi
+
+            echo "Jupyter is not installed and uvx is not on PATH." >&2
+            exit 127
             """,
             cwd: "{directory}",
             urlRegex: "(http://(?:127\\.0\\.0\\.1|localhost):[^\\s]+)",

--- a/Sources/CmuxConfig.swift
+++ b/Sources/CmuxConfig.swift
@@ -9,6 +9,7 @@ extension CodingUserInfoKey {
 
 struct CmuxConfigFile: Codable, Sendable {
     var actions: [String: CmuxConfigActionDefinition]
+    var directoryTools: [CmuxDirectoryToolDefinition]?
     var ui: CmuxConfigUIDefinition?
     var notifications: CmuxNotificationConfigDefinition?
     var newWorkspaceCommand: String?
@@ -18,11 +19,12 @@ struct CmuxConfigFile: Codable, Sendable {
     var workspaceGroups: CmuxConfigWorkspaceGroupsDefinition?
 
     private enum CodingKeys: String, CodingKey {
-        case actions, ui, notifications, newWorkspaceCommand, surfaceTabBarButtons, commands, vault, workspaceGroups
+        case actions, directoryTools, ui, notifications, newWorkspaceCommand, surfaceTabBarButtons, commands, vault, workspaceGroups
     }
 
     init(
         actions: [String: CmuxConfigActionDefinition] = [:],
+        directoryTools: [CmuxDirectoryToolDefinition]? = nil,
         ui: CmuxConfigUIDefinition? = nil,
         notifications: CmuxNotificationConfigDefinition? = nil,
         newWorkspaceCommand: String? = nil,
@@ -32,6 +34,7 @@ struct CmuxConfigFile: Codable, Sendable {
         workspaceGroups: CmuxConfigWorkspaceGroupsDefinition? = nil
     ) {
         self.actions = actions
+        self.directoryTools = directoryTools
         self.ui = ui
         self.notifications = notifications
         self.newWorkspaceCommand = newWorkspaceCommand
@@ -51,6 +54,7 @@ struct CmuxConfigFile: Codable, Sendable {
             decodedActions,
             codingPath: decoder.codingPath + [CodingKeys.actions]
         )
+        directoryTools = try container.decodeIfPresent([CmuxDirectoryToolDefinition].self, forKey: .directoryTools)
         ui = try container.decodeIfPresent(CmuxConfigUIDefinition.self, forKey: .ui)
         notifications = try container.decodeIfPresent(CmuxNotificationConfigDefinition.self, forKey: .notifications)
 
@@ -320,6 +324,243 @@ struct CmuxResolvedNotificationHook: Sendable, Hashable {
         hasher.combine(sourcePath)
         hasher.combine(cwd)
         hasher.combine(trustDescriptor?.fingerprint)
+    }
+}
+
+enum CmuxDirectoryToolKind: String, Codable, Sendable, Hashable {
+    case vscodeServeWeb
+    case shellWebServer
+}
+
+struct CmuxDirectoryToolDefinition: Codable, Sendable, Hashable {
+    var id: String
+    var title: String
+    var subtitle: String?
+    var keywords: [String]
+    var enabled: Bool
+    var kind: CmuxDirectoryToolKind
+    var applicationBundlePathCandidates: [String]
+    var executablePathCandidates: [String]
+    var command: String?
+    var cwd: String?
+    var urlRegex: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case title
+        case subtitle
+        case keywords
+        case enabled
+        case kind
+        case applicationBundlePathCandidates
+        case executablePathCandidates
+        case command
+        case cwd
+        case urlRegex
+    }
+
+    init(
+        id: String,
+        title: String,
+        subtitle: String? = nil,
+        keywords: [String] = [],
+        enabled: Bool = true,
+        kind: CmuxDirectoryToolKind,
+        applicationBundlePathCandidates: [String] = [],
+        executablePathCandidates: [String] = [],
+        command: String? = nil,
+        cwd: String? = nil,
+        urlRegex: String? = nil
+    ) {
+        self.id = id
+        self.title = title
+        self.subtitle = subtitle
+        self.keywords = keywords
+        self.enabled = enabled
+        self.kind = kind
+        self.applicationBundlePathCandidates = applicationBundlePathCandidates
+        self.executablePathCandidates = executablePathCandidates
+        self.command = command
+        self.cwd = cwd
+        self.urlRegex = urlRegex
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try Self.requiredTrimmedString(forKey: .id, in: container)
+        enabled = try container.decodeIfPresent(Bool.self, forKey: .enabled) ?? true
+        if let decodedTitle = try Self.optionalTrimmedString(forKey: .title, in: container) {
+            title = decodedTitle
+        } else if enabled == false {
+            title = id
+        } else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .title,
+                in: container,
+                debugDescription: "title must not be blank"
+            )
+        }
+        subtitle = try Self.optionalTrimmedString(forKey: .subtitle, in: container)
+        keywords = try container.decodeIfPresent([String].self, forKey: .keywords)?
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty } ?? []
+        kind = try container.decodeIfPresent(CmuxDirectoryToolKind.self, forKey: .kind) ?? .shellWebServer
+        applicationBundlePathCandidates = try Self.trimmedStringArray(
+            forKey: .applicationBundlePathCandidates,
+            in: container
+        )
+        executablePathCandidates = try Self.trimmedStringArray(
+            forKey: .executablePathCandidates,
+            in: container
+        )
+        command = try Self.optionalTrimmedString(forKey: .command, in: container)
+        cwd = try Self.optionalTrimmedString(forKey: .cwd, in: container)
+        urlRegex = try Self.optionalTrimmedString(forKey: .urlRegex, in: container)
+
+        switch kind {
+        case .vscodeServeWeb:
+            if applicationBundlePathCandidates.isEmpty {
+                applicationBundlePathCandidates = Self.defaultVSCodeApplicationBundlePathCandidates
+            }
+        case .shellWebServer:
+            if enabled, command == nil {
+                throw DecodingError.dataCorruptedError(
+                    forKey: .command,
+                    in: container,
+                    debugDescription: "shellWebServer directory tools require command"
+                )
+            }
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(title, forKey: .title)
+        try container.encodeIfPresent(subtitle, forKey: .subtitle)
+        if !keywords.isEmpty {
+            try container.encode(keywords, forKey: .keywords)
+        }
+        try container.encode(enabled, forKey: .enabled)
+        try container.encode(kind, forKey: .kind)
+        if !applicationBundlePathCandidates.isEmpty {
+            try container.encode(applicationBundlePathCandidates, forKey: .applicationBundlePathCandidates)
+        }
+        if !executablePathCandidates.isEmpty {
+            try container.encode(executablePathCandidates, forKey: .executablePathCandidates)
+        }
+        try container.encodeIfPresent(command, forKey: .command)
+        try container.encodeIfPresent(cwd, forKey: .cwd)
+        try container.encodeIfPresent(urlRegex, forKey: .urlRegex)
+    }
+
+    static let defaultVSCodeApplicationBundlePathCandidates = [
+        "/Applications/Visual Studio Code.app",
+        "/Applications/Code.app",
+    ]
+
+    static let defaultDefinitions: [CmuxDirectoryToolDefinition] = [
+        CmuxDirectoryToolDefinition(
+            id: "vscode-inline",
+            title: String(localized: "menu.openInVSCode", defaultValue: "Open Current Directory in VS Code (Inline)"),
+            subtitle: String(localized: "command.openFolderInVSCodeInline.subtitle", defaultValue: "VS Code Inline"),
+            keywords: ["terminal", "directory", "open", "ide", "vs", "code", "visual", "studio", "inline", "browser", "serve-web"],
+            kind: .vscodeServeWeb,
+            applicationBundlePathCandidates: defaultVSCodeApplicationBundlePathCandidates
+        ),
+        CmuxDirectoryToolDefinition(
+            id: "jupyter",
+            title: String(localized: "menu.openInJupyter", defaultValue: "Open Current Directory in Jupyter"),
+            subtitle: String(localized: "command.openFolderInJupyter.subtitle", defaultValue: "Jupyter"),
+            keywords: ["terminal", "directory", "open", "notebook", "jupyter", "lab", "python", "browser"],
+            kind: .shellWebServer,
+            executablePathCandidates: [
+                "/opt/homebrew/bin/jupyter",
+                "/usr/local/bin/jupyter",
+                "/usr/bin/jupyter",
+            ],
+            command: "exec \"$CMUX_TOOL_EXECUTABLE\" lab --no-browser --ip=127.0.0.1 --port=0",
+            cwd: "{directory}",
+            urlRegex: "(http://127\\.0\\.0\\.1:[^\\s]+)"
+        ),
+    ]
+
+    private static func requiredTrimmedString(
+        forKey key: CodingKeys,
+        in container: KeyedDecodingContainer<CodingKeys>
+    ) throws -> String {
+        let value = try container.decode(String.self, forKey: key)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.isEmpty else {
+            throw DecodingError.dataCorruptedError(
+                forKey: key,
+                in: container,
+                debugDescription: "\(key.stringValue) must not be blank"
+            )
+        }
+        return value
+    }
+
+    private static func optionalTrimmedString(
+        forKey key: CodingKeys,
+        in container: KeyedDecodingContainer<CodingKeys>
+    ) throws -> String? {
+        guard let value = try container.decodeIfPresent(String.self, forKey: key)?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty else {
+            return nil
+        }
+        return value
+    }
+
+    private static func trimmedStringArray(
+        forKey key: CodingKeys,
+        in container: KeyedDecodingContainer<CodingKeys>
+    ) throws -> [String] {
+        try container.decodeIfPresent([String].self, forKey: key)?
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty } ?? []
+    }
+}
+
+struct CmuxResolvedDirectoryTool: Sendable, Hashable, Identifiable {
+    var id: String
+    var title: String
+    var subtitle: String?
+    var keywords: [String]
+    var kind: CmuxDirectoryToolKind
+    var applicationBundlePathCandidates: [String]
+    var executablePathCandidates: [String]
+    var command: String?
+    var cwd: String?
+    var urlRegex: String?
+    var sourcePath: String?
+
+    var commandPaletteCommandId: String {
+        "palette.terminalDirectoryTool.\(id)"
+    }
+
+    var displayCommand: String {
+        switch kind {
+        case .vscodeServeWeb:
+            return "code-tunnel serve-web"
+        case .shellWebServer:
+            return command ?? ""
+        }
+    }
+
+    init(definition: CmuxDirectoryToolDefinition, sourcePath: String?) {
+        id = definition.id
+        title = definition.title
+        subtitle = definition.subtitle
+        keywords = definition.keywords
+        kind = definition.kind
+        applicationBundlePathCandidates = definition.applicationBundlePathCandidates
+        executablePathCandidates = definition.executablePathCandidates
+        command = definition.command
+        cwd = definition.cwd
+        urlRegex = definition.urlRegex
+        self.sourcePath = sourcePath
     }
 }
 
@@ -1884,6 +2125,9 @@ final class CmuxConfigStore: ObservableObject {
 
     @Published private(set) var loadedCommands: [CmuxCommandDefinition] = []
     @Published private(set) var loadedActions: [CmuxResolvedConfigAction] = []
+    @Published private(set) var loadedDirectoryTools: [CmuxResolvedDirectoryTool] = CmuxDirectoryToolDefinition.defaultDefinitions.map {
+        CmuxResolvedDirectoryTool(definition: $0, sourcePath: nil)
+    }
     @Published private(set) var newWorkspaceCommandName: String?
     @Published private(set) var newWorkspaceActionID: String?
     @Published private(set) var newWorkspaceContextMenuItems: [CmuxResolvedConfigContextMenuItem] = []
@@ -2174,6 +2418,11 @@ final class CmuxConfigStore: ObservableObject {
         }
         let localActions = localConfig.map { actionEntries(from: $0.actions, sourcePath: localPath) } ?? [:]
         let globalActions = globalConfig.map { actionEntries(from: $0.actions, sourcePath: globalConfigPath) } ?? [:]
+        let directoryTools = resolvedDirectoryTools(
+            globalDefinitions: globalConfig?.directoryTools,
+            localDefinitions: localConfig?.directoryTools,
+            localPath: localPath
+        )
 
         // Local config takes precedence
         if let localConfig {
@@ -2293,6 +2542,7 @@ final class CmuxConfigStore: ObservableObject {
 
         loadedCommands = commands
         loadedActions = resolvedActions
+        loadedDirectoryTools = directoryTools
         commandSourcePaths = sourcePaths
         actionLookup = resolvedActionLookup
         newWorkspaceActionID = configuredNewWorkspaceActionID
@@ -2418,6 +2668,57 @@ final class CmuxConfigStore: ObservableObject {
         fallback: [String: ActionEntry]
     ) -> [String: ActionEntry] {
         fallback.merging(primary) { _, primary in primary }
+    }
+
+    private func resolvedDirectoryTools(
+        globalDefinitions: [CmuxDirectoryToolDefinition]?,
+        localDefinitions: [CmuxDirectoryToolDefinition]?,
+        localPath: String?
+    ) -> [CmuxResolvedDirectoryTool] {
+        struct Entry {
+            let definition: CmuxDirectoryToolDefinition
+            let sourcePath: String?
+            let order: Int
+        }
+
+        var entriesByID: [String: Entry] = [:]
+        var nextOrder = 0
+
+        func normalizedID(_ id: String) -> String {
+            id.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        func apply(_ definitions: [CmuxDirectoryToolDefinition], sourcePath: String?) {
+            for definition in definitions {
+                let id = normalizedID(definition.id)
+                guard !id.isEmpty else { continue }
+                let order = entriesByID[id]?.order ?? nextOrder
+                if entriesByID[id] == nil {
+                    nextOrder += 1
+                }
+                entriesByID[id] = Entry(definition: definition, sourcePath: sourcePath, order: order)
+            }
+        }
+
+        apply(CmuxDirectoryToolDefinition.defaultDefinitions, sourcePath: nil)
+        if let globalDefinitions {
+            apply(globalDefinitions, sourcePath: globalConfigPath)
+        }
+        if let localDefinitions {
+            apply(localDefinitions, sourcePath: localPath)
+        }
+
+        return entriesByID.values
+            .filter { $0.definition.enabled }
+            .sorted { lhs, rhs in
+                if lhs.order != rhs.order {
+                    return lhs.order < rhs.order
+                }
+                return lhs.definition.id < rhs.definition.id
+            }
+            .map { entry in
+                CmuxResolvedDirectoryTool(definition: entry.definition, sourcePath: entry.sourcePath)
+            }
     }
 
     private func sanitizeConfigText(_ text: String) -> String {

--- a/Sources/CmuxConfig.swift
+++ b/Sources/CmuxConfig.swift
@@ -344,6 +344,9 @@ struct CmuxDirectoryToolDefinition: Codable, Sendable, Hashable {
     var command: String?
     var cwd: String?
     var urlRegex: String?
+    var failureMessage: String?
+    var installCommand: String?
+    var startupTimeoutSeconds: Double?
 
     private enum CodingKeys: String, CodingKey {
         case id
@@ -357,6 +360,9 @@ struct CmuxDirectoryToolDefinition: Codable, Sendable, Hashable {
         case command
         case cwd
         case urlRegex
+        case failureMessage
+        case installCommand
+        case startupTimeoutSeconds
     }
 
     init(
@@ -370,7 +376,10 @@ struct CmuxDirectoryToolDefinition: Codable, Sendable, Hashable {
         executablePathCandidates: [String] = [],
         command: String? = nil,
         cwd: String? = nil,
-        urlRegex: String? = nil
+        urlRegex: String? = nil,
+        failureMessage: String? = nil,
+        installCommand: String? = nil,
+        startupTimeoutSeconds: Double? = nil
     ) {
         self.id = id
         self.title = title
@@ -383,6 +392,9 @@ struct CmuxDirectoryToolDefinition: Codable, Sendable, Hashable {
         self.command = command
         self.cwd = cwd
         self.urlRegex = urlRegex
+        self.failureMessage = failureMessage
+        self.installCommand = installCommand
+        self.startupTimeoutSeconds = startupTimeoutSeconds
     }
 
     init(from decoder: Decoder) throws {
@@ -416,6 +428,9 @@ struct CmuxDirectoryToolDefinition: Codable, Sendable, Hashable {
         command = try Self.optionalTrimmedString(forKey: .command, in: container)
         cwd = try Self.optionalTrimmedString(forKey: .cwd, in: container)
         urlRegex = try Self.optionalTrimmedString(forKey: .urlRegex, in: container)
+        failureMessage = try Self.optionalTrimmedString(forKey: .failureMessage, in: container)
+        installCommand = try Self.optionalTrimmedString(forKey: .installCommand, in: container)
+        startupTimeoutSeconds = try container.decodeIfPresent(Double.self, forKey: .startupTimeoutSeconds)
 
         switch kind {
         case .vscodeServeWeb:
@@ -452,6 +467,9 @@ struct CmuxDirectoryToolDefinition: Codable, Sendable, Hashable {
         try container.encodeIfPresent(command, forKey: .command)
         try container.encodeIfPresent(cwd, forKey: .cwd)
         try container.encodeIfPresent(urlRegex, forKey: .urlRegex)
+        try container.encodeIfPresent(failureMessage, forKey: .failureMessage)
+        try container.encodeIfPresent(installCommand, forKey: .installCommand)
+        try container.encodeIfPresent(startupTimeoutSeconds, forKey: .startupTimeoutSeconds)
     }
 
     static let defaultVSCodeApplicationBundlePathCandidates = [
@@ -478,16 +496,25 @@ struct CmuxDirectoryToolDefinition: Codable, Sendable, Hashable {
                 "/opt/homebrew/bin/jupyter",
                 "/usr/local/bin/jupyter",
                 "/usr/bin/jupyter",
+                "~/.local/bin/jupyter",
+                "~/.pyenv/shims/jupyter",
+                "~/.asdf/shims/jupyter",
             ],
             command: """
             TOOL="${CMUX_TOOL_EXECUTABLE:-$(command -v jupyter || true)}"; \
             if [ -z "$TOOL" ]; then TOOL="$(command -v jupyter-lab || true)"; fi; \
-            if [ -z "$TOOL" ]; then exit 127; fi; \
-            if [ "$(basename "$TOOL")" = "jupyter-lab" ]; then exec "$TOOL" --no-browser --ip=127.0.0.1 --port=0; fi; \
-            exec "$TOOL" lab --no-browser --ip=127.0.0.1 --port=0
+            if [ -z "$TOOL" ]; then echo "Jupyter is not installed or is not on PATH." >&2; exit 127; fi; \
+            if [ "$(basename "$TOOL")" = "jupyter-lab" ]; then exec "$TOOL" --no-browser --ip=127.0.0.1 --port=8888 --ServerApp.port_retries=50; fi; \
+            exec "$TOOL" lab --no-browser --ip=127.0.0.1 --port=8888 --ServerApp.port_retries=50
             """,
             cwd: "{directory}",
-            urlRegex: "(http://127\\.0\\.0\\.1:[^\\s]+)"
+            urlRegex: "(http://(?:127\\.0\\.0\\.1|localhost):[^\\s]+)",
+            failureMessage: String(
+                localized: "directoryTool.jupyter.failureMessage",
+                defaultValue: "Jupyter is not installed or did not print a local URL. Install JupyterLab, then run this command again."
+            ),
+            installCommand: "python3 -m pip install --user jupyterlab",
+            startupTimeoutSeconds: 20
         ),
     ]
 
@@ -540,6 +567,9 @@ struct CmuxResolvedDirectoryTool: Sendable, Hashable, Identifiable {
     var command: String?
     var cwd: String?
     var urlRegex: String?
+    var failureMessage: String?
+    var installCommand: String?
+    var startupTimeoutSeconds: Double?
     var sourcePath: String?
 
     var commandPaletteCommandId: String {
@@ -566,6 +596,9 @@ struct CmuxResolvedDirectoryTool: Sendable, Hashable, Identifiable {
         command = definition.command
         cwd = definition.cwd
         urlRegex = definition.urlRegex
+        failureMessage = definition.failureMessage
+        installCommand = definition.installCommand
+        startupTimeoutSeconds = definition.startupTimeoutSeconds
         self.sourcePath = sourcePath
     }
 }

--- a/Sources/CmuxConfig.swift
+++ b/Sources/CmuxConfig.swift
@@ -577,6 +577,10 @@ struct CmuxResolvedDirectoryTool: Sendable, Hashable, Identifiable {
         "palette.terminalDirectoryTool.\(id)"
     }
 
+    var stopCommandPaletteCommandId: String {
+        "\(commandPaletteCommandId).stop"
+    }
+
     var displayCommand: String {
         switch kind {
         case .vscodeServeWeb:

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1133,6 +1133,7 @@ struct ContentView: View {
     @State private var commandPaletteResolvedSearchFingerprint: Int?
     @State private var commandPaletteResolvedMatchingQuery = ""
     @State private var commandPaletteTerminalOpenTargetAvailability: Set<TerminalDirectoryOpenTarget> = []
+    @State private var commandPaletteDirectoryToolAvailability: Set<String> = []
     @State private var commandPaletteForkableAgentActivePanelKey: String?
     @State private var commandPaletteForkableAgentProbeIDsByPanelKey: [String: UUID] = [:]
     @State var commandPaletteForkableAgentSupportedPanelKeys: Set<String> = []
@@ -1492,6 +1493,10 @@ struct ContentView: View {
         static let browserDisabled = "browser.disabled"
         static func terminalOpenTargetAvailable(_ target: TerminalDirectoryOpenTarget) -> String {
             "terminal.openTarget.\(target.rawValue).available"
+        }
+
+        static func directoryToolAvailable(_ tool: CmuxResolvedDirectoryTool) -> String {
+            "terminal.directoryTool.\(tool.id).available"
         }
     }
 
@@ -5103,9 +5108,17 @@ struct ContentView: View {
         if commandPaletteTerminalOpenTargetAvailability != terminalOpenTargets {
             commandPaletteTerminalOpenTargetAvailability = terminalOpenTargets
         }
+        let directoryToolIDs = resolveCommandPaletteDirectoryTools(for: scope)
+        if commandPaletteDirectoryToolAvailability != directoryToolIDs {
+            commandPaletteDirectoryToolAvailability = directoryToolIDs
+        }
         refreshCommandPaletteForkableAgentAvailabilityIfNeeded(scope: scope)
         let commandsContext = scope == .commands
-            ? commandPaletteCommandsContext(terminalOpenTargets: terminalOpenTargets)
+            ? commandPaletteCommandsContext(
+                terminalOpenTargets: terminalOpenTargets,
+                directoryTools: cmuxConfigStore.loadedDirectoryTools,
+                availableDirectoryToolIDs: directoryToolIDs
+            )
             : nil
         let fingerprint = commandPaletteEntriesFingerprint(
             for: scope,
@@ -5923,7 +5936,9 @@ struct ContentView: View {
 
     private func commandPaletteCachedCommandsContext() -> CommandPaletteCommandsContext {
         commandPaletteCommandsContext(
-            terminalOpenTargets: commandPaletteTerminalOpenTargetAvailability
+            terminalOpenTargets: commandPaletteTerminalOpenTargetAvailability,
+            directoryTools: cmuxConfigStore.loadedDirectoryTools,
+            availableDirectoryToolIDs: commandPaletteDirectoryToolAvailability
         )
     }
 
@@ -5935,6 +5950,16 @@ struct ContentView: View {
             return []
         }
         return TerminalDirectoryOpenTarget.availableTargets()
+    }
+
+    private func resolveCommandPaletteDirectoryTools(
+        for scope: CommandPaletteListScope
+    ) -> Set<String> {
+        guard scope == .commands,
+              focusedPanelContext?.panel.panelType == .terminal else {
+            return []
+        }
+        return CmuxResolvedDirectoryTool.availableTools(cmuxConfigStore.loadedDirectoryTools)
     }
 
     static func commandPaletteForkableAgentPanelKey(workspaceId: UUID, panelId: UUID) -> String {
@@ -6353,10 +6378,16 @@ struct ContentView: View {
     }
 
     private func commandPaletteCommandsContext(
-        terminalOpenTargets: Set<TerminalDirectoryOpenTarget>
+        terminalOpenTargets: Set<TerminalDirectoryOpenTarget>,
+        directoryTools: [CmuxResolvedDirectoryTool],
+        availableDirectoryToolIDs: Set<String>
     ) -> CommandPaletteCommandsContext {
         let cliInstalledInPATH = AppDelegate.shared?.isCmuxCLIInstalledInPATH() ?? false
-        var snapshot = commandPaletteContextSnapshot(terminalOpenTargets: terminalOpenTargets)
+        var snapshot = commandPaletteContextSnapshot(
+            terminalOpenTargets: terminalOpenTargets,
+            directoryTools: directoryTools,
+            availableDirectoryToolIDs: availableDirectoryToolIDs
+        )
         snapshot.setBool(CommandPaletteContextKeys.cliInstalledInPATH, cliInstalledInPATH)
         snapshot.setBool(
             CommandPaletteContextKeys.defaultTerminalIsDefault,
@@ -6501,7 +6532,9 @@ struct ContentView: View {
     }
 
     private func commandPaletteContextSnapshot(
-        terminalOpenTargets: Set<TerminalDirectoryOpenTarget>? = nil
+        terminalOpenTargets: Set<TerminalDirectoryOpenTarget>? = nil,
+        directoryTools: [CmuxResolvedDirectoryTool]? = nil,
+        availableDirectoryToolIDs: Set<String>? = nil
     ) -> CommandPaletteContextSnapshot {
         var snapshot = CommandPaletteContextSnapshot()
         snapshot.setBool(CommandPaletteContextKeys.workspaceMinimalModeEnabled, isMinimalMode)
@@ -6592,6 +6625,18 @@ struct ContentView: View {
                         availableTargets.contains(target)
                     )
                 }
+                let tools = directoryTools ?? cmuxConfigStore.loadedDirectoryTools
+                let availableToolIDs = availableDirectoryToolIDs ?? CmuxResolvedDirectoryTool.availableTools(tools)
+                for tool in tools {
+                    snapshot.setBool(
+                        CommandPaletteContextKeys.directoryToolAvailable(tool),
+                        availableToolIDs.contains(tool.id)
+                    )
+                }
+                snapshot.setBool(
+                    CommandPaletteContextKeys.terminalOpenTargetAvailable(.vscodeInline),
+                    tools.contains { $0.kind == .vscodeServeWeb && availableToolIDs.contains($0.id) }
+                )
             }
         }
 
@@ -6720,7 +6765,7 @@ struct ContentView: View {
                     )
                 ),
                 keywords: ["open", "folder", "directory", "project", "vs", "code", "inline", "editor", "browser"],
-                when: { _ in TerminalDirectoryOpenTarget.vscodeInline.isAvailable() }
+                when: { _ in configuredInlineVSCodeApplicationURL() != nil }
             )
         )
         contributions.append(
@@ -7477,6 +7522,22 @@ struct ContentView: View {
                 )
             )
         }
+        for tool in cmuxConfigStore.loadedDirectoryTools {
+            contributions.append(
+                CommandPaletteCommandContribution(
+                    commandId: tool.commandPaletteCommandId,
+                    title: constant(tool.title),
+                    subtitle: { context in
+                        tool.subtitle ?? terminalPanelSubtitle(context)
+                    },
+                    keywords: ["terminal", "directory", "open", "browser"] + tool.keywords,
+                    when: { context in
+                        context.bool(CommandPaletteContextKeys.panelIsTerminal)
+                            && context.bool(CommandPaletteContextKeys.directoryToolAvailable(tool))
+                    }
+                )
+            )
+        }
         contributions.append(
             CommandPaletteCommandContribution(
                 commandId: "palette.vscodeServeWebStop",
@@ -7883,7 +7944,14 @@ struct ContentView: View {
         }
         registry.register(commandId: "palette.openFolderInVSCodeInline") {
             DispatchQueue.main.async {
-                AppDelegate.shared?.showOpenFolderInInlineVSCodePanel(tabManager: tabManager)
+                if let vscodeApplicationURL = configuredInlineVSCodeApplicationURL() {
+                    AppDelegate.shared?.showOpenFolderInInlineVSCodePanel(
+                        vscodeApplicationURL: vscodeApplicationURL,
+                        tabManager: tabManager
+                    )
+                } else {
+                    NSSound.beep()
+                }
             }
         }
         registry.register(commandId: "palette.reopenPreviousSession") {
@@ -8287,6 +8355,14 @@ struct ContentView: View {
         for target in TerminalDirectoryOpenTarget.commandPaletteShortcutTargets {
             registry.register(commandId: target.commandPaletteCommandId) {
                 if !openFocusedDirectory(in: target) {
+                    NSSound.beep()
+                }
+            }
+        }
+        for tool in cmuxConfigStore.loadedDirectoryTools {
+            let captured = tool
+            registry.register(commandId: tool.commandPaletteCommandId) {
+                if !openFocusedDirectory(with: captured) {
                     NSSound.beep()
                 }
             }
@@ -9776,6 +9852,11 @@ struct ContentView: View {
         return openFocusedDirectory(directoryURL, in: target)
     }
 
+    private func openFocusedDirectory(with tool: CmuxResolvedDirectoryTool) -> Bool {
+        guard let directoryURL = focusedTerminalDirectoryURL() else { return false }
+        return openFocusedDirectory(directoryURL, with: tool)
+    }
+
     private func openFocusedDirectory(_ directoryURL: URL, in target: TerminalDirectoryOpenTarget) -> Bool {
         switch target {
         case .finder:
@@ -9791,8 +9872,87 @@ struct ContentView: View {
         }
     }
 
-    private func openFocusedDirectoryInInlineVSCode(_ directoryURL: URL) -> Bool {
-        AppDelegate.shared?.openDirectoryInInlineVSCode(directoryURL, tabManager: tabManager) ?? false
+    private func openFocusedDirectory(_ directoryURL: URL, with tool: CmuxResolvedDirectoryTool) -> Bool {
+        guard tool.isAvailable() else { return false }
+        switch tool.kind {
+        case .vscodeServeWeb:
+            guard let vscodeApplicationURL = tool.applicationURL() else { return false }
+            return openFocusedDirectoryInInlineVSCode(directoryURL, vscodeApplicationURL: vscodeApplicationURL)
+        case .shellWebServer:
+            return openFocusedDirectoryInShellDirectoryTool(directoryURL, tool: tool)
+        }
+    }
+
+    private func openFocusedDirectoryInInlineVSCode(
+        _ directoryURL: URL,
+        vscodeApplicationURL: URL? = nil
+    ) -> Bool {
+        AppDelegate.shared?.openDirectoryInInlineVSCode(
+            directoryURL,
+            vscodeApplicationURL: vscodeApplicationURL,
+            tabManager: tabManager
+        ) ?? false
+    }
+
+    private func configuredInlineVSCodeApplicationURL() -> URL? {
+        cmuxConfigStore.loadedDirectoryTools
+            .first { $0.kind == .vscodeServeWeb && $0.isAvailable() }?
+            .applicationURL()
+    }
+
+    private func openFocusedDirectoryInShellDirectoryTool(
+        _ directoryURL: URL,
+        tool: CmuxResolvedDirectoryTool
+    ) -> Bool {
+        let targetWorkspaceId = tabManager.selectedWorkspace?.id
+            ?? tabManager.tabs.first?.id
+            ?? tabManager.addWorkspace(select: true).id
+        return authorizeDirectoryToolIfNeeded(tool) {
+            DirectoryToolWebServerController.shared.ensureWebServerURL(
+                tool: tool,
+                directoryURL: directoryURL.standardizedFileURL
+            ) { webServerURL in
+                guard let webServerURL,
+                      tabManager.openBrowser(
+                          inWorkspace: targetWorkspaceId,
+                          url: webServerURL,
+                          preferSplitRight: true
+                      ) != nil else {
+                    NSSound.beep()
+                    return
+                }
+            }
+        }
+    }
+
+    private func authorizeDirectoryToolIfNeeded(
+        _ tool: CmuxResolvedDirectoryTool,
+        onAuthorized: @escaping () -> Void
+    ) -> Bool {
+        let descriptor = CmuxActionTrustDescriptor(
+            actionID: "directoryTool.\(tool.id)",
+            kind: "directoryTool",
+            command: tool.displayCommand,
+            target: "browserSplit",
+            workspaceCommand: nil,
+            configPath: tool.sourcePath.map(canonicalConfigPath),
+            projectRoot: tool.sourcePath.map { canonicalConfigPath(CmuxButtonIcon.projectRoot(forConfigPath: $0)) },
+            iconFingerprint: nil
+        )
+        return CmuxConfigExecutor.authorizeProjectAutomationIfNeeded(
+            descriptor: descriptor,
+            confirm: false,
+            configSourcePath: tool.sourcePath,
+            globalConfigPath: cmuxConfigStore.globalConfigPath,
+            displayCommand: tool.displayCommand,
+            displayTitle: tool.title,
+            presentingWindow: NSApp.keyWindow ?? NSApp.mainWindow,
+            onAuthorized: onAuthorized
+        )
+    }
+
+    private func canonicalConfigPath(_ path: String) -> String {
+        URL(fileURLWithPath: path).resolvingSymlinksInPath().standardizedFileURL.path
     }
 
     private func stopInlineVSCodeServeWeb() {
@@ -9800,7 +9960,8 @@ struct ContentView: View {
     }
 
     private func restartInlineVSCodeServeWeb() -> Bool {
-        guard let vscodeApplicationURL = TerminalDirectoryOpenTarget.vscodeInline.applicationURL() else {
+        guard let vscodeApplicationURL = configuredInlineVSCodeApplicationURL()
+            ?? TerminalDirectoryOpenTarget.vscodeInline.applicationURL() else {
             return false
         }
         VSCodeServeWebController.shared.restart(vscodeApplicationURL: vscodeApplicationURL) { serveWebURL in

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -9908,10 +9908,13 @@ struct ContentView: View {
             ?? tabManager.tabs.first?.id
             ?? tabManager.addWorkspace(select: true).id
         return authorizeDirectoryToolIfNeeded(tool) {
+            let progressController = DirectoryToolLaunchProgressController(tool: tool)
+            progressController.show(presentingWindow: NSApp.keyWindow ?? NSApp.mainWindow)
             DirectoryToolWebServerController.shared.ensureWebServerURL(
                 tool: tool,
                 directoryURL: directoryURL.standardizedFileURL
             ) { result in
+                progressController.close()
                 switch result {
                 case .opened(let webServerURL):
                     guard tabManager.openBrowser(
@@ -9929,6 +9932,57 @@ struct ContentView: View {
                         directoryURL: directoryURL
                     )
                 }
+            }
+        }
+    }
+
+    private final class DirectoryToolLaunchProgressController {
+        private let alert: NSAlert
+        private var isClosed = false
+
+        init(tool: CmuxResolvedDirectoryTool) {
+            alert = NSAlert()
+            alert.alertStyle = .informational
+            let titleFormat = String(
+                localized: "directoryTool.launchProgress.title",
+                defaultValue: "Starting %@"
+            )
+            alert.messageText = String(format: titleFormat, tool.subtitle ?? tool.title)
+            alert.informativeText = String(
+                localized: "directoryTool.launchProgress.message",
+                defaultValue: "Waiting for the tool to print a local URL."
+            )
+
+            let spinner = NSProgressIndicator(frame: NSRect(x: 0, y: 0, width: 24, height: 24))
+            spinner.style = .spinning
+            spinner.controlSize = .regular
+            spinner.isIndeterminate = true
+            spinner.startAnimation(nil)
+            alert.accessoryView = spinner
+            alert.addButton(withTitle: String(
+                localized: "directoryTool.launchProgress.hide",
+                defaultValue: "Hide"
+            ))
+        }
+
+        func show(presentingWindow: NSWindow?) {
+            guard !isClosed else { return }
+            if let presentingWindow {
+                alert.beginSheetModal(for: presentingWindow) { [weak self] _ in
+                    self?.isClosed = true
+                }
+            } else {
+                alert.window.makeKeyAndOrderFront(nil)
+            }
+        }
+
+        func close() {
+            guard !isClosed else { return }
+            isClosed = true
+            if let sheetParent = alert.window.sheetParent {
+                sheetParent.endSheet(alert.window)
+            } else {
+                alert.window.close()
             }
         }
     }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -9945,9 +9945,12 @@ struct ContentView: View {
             defaultValue: "Couldn't Start %@"
         )
         alert.messageText = String(format: titleFormat, tool.subtitle ?? tool.title)
-        alert.informativeText = directoryToolLaunchFailureMessage(tool: tool, failure: failure)
-
         let installCommand = tool.installCommand?.trimmingCharacters(in: .whitespacesAndNewlines)
+        alert.informativeText = directoryToolLaunchFailureMessage(
+            tool: tool,
+            failure: failure,
+            installCommand: installCommand
+        )
         if installCommand?.isEmpty == false {
             alert.addButton(withTitle: String(
                 localized: "directoryTool.launchFailure.runInstall",
@@ -9979,7 +9982,8 @@ struct ContentView: View {
 
     private func directoryToolLaunchFailureMessage(
         tool: CmuxResolvedDirectoryTool,
-        failure: DirectoryToolWebServerController.LaunchFailure
+        failure: DirectoryToolWebServerController.LaunchFailure,
+        installCommand: String?
     ) -> String {
         let baseMessage: String
         if let configuredMessage = tool.failureMessage?.trimmingCharacters(in: .whitespacesAndNewlines),
@@ -10010,13 +10014,22 @@ struct ContentView: View {
             }
         }
 
+        var message = baseMessage
+        if let installCommand, !installCommand.isEmpty {
+            let installFormat = String(
+                localized: "directoryTool.launchFailure.installCommandFormat",
+                defaultValue: "%@\n\nInstall command:\n%@"
+            )
+            message = String(format: installFormat, message, installCommand)
+        }
+
         let output = failure.output.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !output.isEmpty else { return baseMessage }
+        guard !output.isEmpty else { return message }
         let outputFormat = String(
             localized: "directoryTool.launchFailure.outputFormat",
             defaultValue: "%@\n\nOutput:\n%@"
         )
-        return String(format: outputFormat, baseMessage, output)
+        return String(format: outputFormat, message, output)
     }
 
     private func runDirectoryToolInstallCommand(

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -9912,7 +9912,10 @@ struct ContentView: View {
             progressController.show(presentingWindow: NSApp.keyWindow ?? NSApp.mainWindow)
             DirectoryToolWebServerController.shared.ensureWebServerURL(
                 tool: tool,
-                directoryURL: directoryURL.standardizedFileURL
+                directoryURL: directoryURL.standardizedFileURL,
+                progress: { progress in
+                    progressController.updateOutput(progress.output)
+                }
             ) { result in
                 progressController.close()
                 switch result {
@@ -9936,54 +9939,150 @@ struct ContentView: View {
         }
     }
 
-    private final class DirectoryToolLaunchProgressController {
-        private let alert: NSAlert
+    private final class DirectoryToolLaunchProgressController: NSObject, NSWindowDelegate {
+        private let panel: NSPanel
+        private let outputTextView: NSTextView
+        private let noOutputText: String
         private var isClosed = false
 
         init(tool: CmuxResolvedDirectoryTool) {
-            alert = NSAlert()
-            alert.alertStyle = .informational
             let titleFormat = String(
                 localized: "directoryTool.launchProgress.title",
                 defaultValue: "Starting %@"
             )
-            alert.messageText = String(format: titleFormat, tool.subtitle ?? tool.title)
-            alert.informativeText = String(
+            let title = String(format: titleFormat, tool.subtitle ?? tool.title)
+            let message = String(
                 localized: "directoryTool.launchProgress.message",
                 defaultValue: "Waiting for the tool to print a local URL."
             )
+            noOutputText = String(
+                localized: "directoryTool.launchProgress.noOutput",
+                defaultValue: "No output yet."
+            )
 
-            let spinner = NSProgressIndicator(frame: NSRect(x: 0, y: 0, width: 24, height: 24))
+            let contentView = NSView(frame: NSRect(x: 0, y: 0, width: 520, height: 256))
+
+            let spinner = NSProgressIndicator()
             spinner.style = .spinning
             spinner.controlSize = .regular
             spinner.isIndeterminate = true
             spinner.startAnimation(nil)
-            alert.accessoryView = spinner
-            alert.addButton(withTitle: String(
+
+            let titleLabel = NSTextField(labelWithString: title)
+            titleLabel.font = .systemFont(ofSize: NSFont.systemFontSize, weight: .semibold)
+            titleLabel.lineBreakMode = .byTruncatingTail
+
+            let messageLabel = NSTextField(labelWithString: message)
+            messageLabel.font = .systemFont(ofSize: NSFont.smallSystemFontSize)
+            messageLabel.textColor = .secondaryLabelColor
+            messageLabel.lineBreakMode = .byWordWrapping
+            messageLabel.maximumNumberOfLines = 2
+
+            let headerStack = NSStackView(views: [spinner, titleLabel])
+            headerStack.orientation = .horizontal
+            headerStack.alignment = .centerY
+            headerStack.spacing = 10
+
+            outputTextView = NSTextView()
+            outputTextView.isEditable = false
+            outputTextView.isSelectable = true
+            outputTextView.drawsBackground = false
+            outputTextView.font = .monospacedSystemFont(ofSize: 11, weight: .regular)
+            outputTextView.textColor = .secondaryLabelColor
+            outputTextView.textContainerInset = NSSize(width: 8, height: 8)
+            outputTextView.string = noOutputText
+
+            let scrollView = NSScrollView()
+            scrollView.hasVerticalScroller = true
+            scrollView.drawsBackground = true
+            scrollView.backgroundColor = .textBackgroundColor.withAlphaComponent(0.65)
+            scrollView.borderType = .lineBorder
+            scrollView.documentView = outputTextView
+
+            let hideButton = NSButton(title: String(
                 localized: "directoryTool.launchProgress.hide",
                 defaultValue: "Hide"
-            ))
+            ), target: nil, action: nil)
+            hideButton.bezelStyle = .rounded
+
+            let footerStack = NSStackView(views: [NSView(), hideButton])
+            footerStack.orientation = .horizontal
+            footerStack.alignment = .centerY
+
+            let stack = NSStackView(views: [headerStack, messageLabel, scrollView, footerStack])
+            stack.orientation = .vertical
+            stack.alignment = .leading
+            stack.spacing = 10
+            stack.translatesAutoresizingMaskIntoConstraints = false
+            contentView.addSubview(stack)
+
+            NSLayoutConstraint.activate([
+                stack.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+                stack.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
+                stack.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 16),
+                stack.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -14),
+                spinner.widthAnchor.constraint(equalToConstant: 18),
+                spinner.heightAnchor.constraint(equalToConstant: 18),
+                titleLabel.trailingAnchor.constraint(lessThanOrEqualTo: stack.trailingAnchor),
+                messageLabel.widthAnchor.constraint(equalTo: stack.widthAnchor),
+                scrollView.widthAnchor.constraint(equalTo: stack.widthAnchor),
+                scrollView.heightAnchor.constraint(equalToConstant: 128)
+            ])
+
+            panel = NSPanel(
+                contentRect: contentView.frame,
+                styleMask: [.titled, .closable, .nonactivatingPanel],
+                backing: .buffered,
+                defer: false
+            )
+            panel.title = title
+            panel.contentView = contentView
+            panel.level = .floating
+            panel.collectionBehavior = [.moveToActiveSpace, .fullScreenAuxiliary]
+            panel.isReleasedWhenClosed = false
+
+            super.init()
+
+            panel.delegate = self
+            hideButton.target = self
+            hideButton.action = #selector(hide)
         }
 
         func show(presentingWindow: NSWindow?) {
             guard !isClosed else { return }
             if let presentingWindow {
-                alert.beginSheetModal(for: presentingWindow) { [weak self] _ in
-                    self?.isClosed = true
-                }
+                let windowFrame = presentingWindow.frame
+                let panelFrame = panel.frame
+                let origin = NSPoint(
+                    x: windowFrame.midX - panelFrame.width / 2,
+                    y: windowFrame.maxY - panelFrame.height - 72
+                )
+                panel.setFrameOrigin(origin)
             } else {
-                alert.window.makeKeyAndOrderFront(nil)
+                panel.center()
             }
+            panel.orderFrontRegardless()
+        }
+
+        func updateOutput(_ output: String) {
+            guard !isClosed else { return }
+            let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
+            outputTextView.string = trimmed.isEmpty ? noOutputText : trimmed
+            outputTextView.scrollToEndOfDocument(nil)
         }
 
         func close() {
             guard !isClosed else { return }
             isClosed = true
-            if let sheetParent = alert.window.sheetParent {
-                sheetParent.endSheet(alert.window)
-            } else {
-                alert.window.close()
-            }
+            panel.close()
+        }
+
+        func windowWillClose(_ notification: Notification) {
+            isClosed = true
+        }
+
+        @objc private func hide() {
+            close()
         }
     }
 

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -7537,6 +7537,24 @@ struct ContentView: View {
                     }
                 )
             )
+            if tool.kind == .shellWebServer {
+                let titleFormat = String(
+                    localized: "command.directoryTool.stop.title",
+                    defaultValue: "Stop %@"
+                )
+                contributions.append(
+                    CommandPaletteCommandContribution(
+                        commandId: tool.stopCommandPaletteCommandId,
+                        title: constant(String(format: titleFormat, tool.subtitle ?? tool.title)),
+                        subtitle: terminalPanelSubtitle,
+                        keywords: ["terminal", "directory", "stop", "server"] + tool.keywords,
+                        when: { context in
+                            context.bool(CommandPaletteContextKeys.panelIsTerminal)
+                                && context.bool(CommandPaletteContextKeys.directoryToolAvailable(tool))
+                        }
+                    )
+                )
+            }
         }
         contributions.append(
             CommandPaletteCommandContribution(
@@ -8364,6 +8382,13 @@ struct ContentView: View {
             registry.register(commandId: tool.commandPaletteCommandId) {
                 if !openFocusedDirectory(with: captured) {
                     NSSound.beep()
+                }
+            }
+            if tool.kind == .shellWebServer {
+                registry.register(commandId: tool.stopCommandPaletteCommandId) {
+                    if !stopFocusedDirectoryShellDirectoryTool(tool: captured) {
+                        NSSound.beep()
+                    }
                 }
             }
         }
@@ -9908,50 +9933,83 @@ struct ContentView: View {
             ?? tabManager.tabs.first?.id
             ?? tabManager.addWorkspace(select: true).id
         return authorizeDirectoryToolIfNeeded(tool) {
-            let progressController = DirectoryToolLaunchProgressController(tool: tool)
-            progressController.show(presentingWindow: NSApp.keyWindow ?? NSApp.mainWindow)
-            DirectoryToolWebServerController.shared.ensureWebServerURL(
+            let launchHandle = DirectoryToolWebServerLaunchHandle()
+            var progressController: DirectoryToolLaunchProgressController!
+            progressController = DirectoryToolLaunchProgressController(
                 tool: tool,
-                directoryURL: directoryURL.standardizedFileURL,
-                progress: { progress in
-                    progressController.updateOutput(progress.output)
-                }
-            ) { result in
-                progressController.close()
-                switch result {
-                case .opened(let webServerURL):
-                    guard tabManager.openBrowser(
-                          inWorkspace: targetWorkspaceId,
-                          url: webServerURL,
-                          preferSplitRight: true
-                    ) != nil else {
-                        NSSound.beep()
-                        return
-                    }
-                case .failed(let failure):
-                    showDirectoryToolLaunchFailureAlert(
+                command: tool.command ?? "",
+                directoryURL: directoryURL,
+                onAllow: { progressController in
+                    DirectoryToolWebServerController.shared.ensureWebServerURL(
                         tool: tool,
-                        failure: failure,
-                        directoryURL: directoryURL
-                    )
+                        directoryURL: directoryURL.standardizedFileURL,
+                        launchHandle: launchHandle,
+                        progress: { progress in
+                            progressController.updateOutput(progress.output)
+                        }
+                    ) { result in
+                        guard !launchHandle.cancelled else { return }
+                        progressController.close()
+                        switch result {
+                        case .opened(let webServerURL):
+                            guard tabManager.openBrowser(
+                                  inWorkspace: targetWorkspaceId,
+                                  url: webServerURL,
+                                  preferSplitRight: true
+                            ) != nil else {
+                                NSSound.beep()
+                                return
+                            }
+                        case .failed(let failure):
+                            showDirectoryToolLaunchFailureAlert(
+                                tool: tool,
+                                failure: failure,
+                                directoryURL: directoryURL
+                            )
+                        }
+                    }
+                },
+                onStop: {
+                    launchHandle.cancel()
                 }
-            }
+            )
+            progressController.show(presentingWindow: NSApp.keyWindow ?? NSApp.mainWindow)
         }
     }
 
     private final class DirectoryToolLaunchProgressController: NSObject, NSWindowDelegate {
         private let panel: NSPanel
+        private let spinner: NSProgressIndicator
+        private let messageLabel: NSTextField
         private let outputTextView: NSTextView
+        private let allowButton: NSButton
+        private let stopButton: NSButton
         private let noOutputText: String
+        private let launchingMessage: String
+        private let onAllow: (DirectoryToolLaunchProgressController) -> Void
+        private let onStop: () -> Void
         private var isClosed = false
+        private var didAllow = false
 
-        init(tool: CmuxResolvedDirectoryTool) {
+        init(
+            tool: CmuxResolvedDirectoryTool,
+            command: String,
+            directoryURL: URL,
+            onAllow: @escaping (DirectoryToolLaunchProgressController) -> Void,
+            onStop: @escaping () -> Void
+        ) {
+            self.onAllow = onAllow
+            self.onStop = onStop
             let titleFormat = String(
                 localized: "directoryTool.launchProgress.title",
                 defaultValue: "Starting %@"
             )
             let title = String(format: titleFormat, tool.subtitle ?? tool.title)
             let message = String(
+                localized: "directoryTool.launchProgress.reviewCommand",
+                defaultValue: "Review the command before running it."
+            )
+            launchingMessage = String(
                 localized: "directoryTool.launchProgress.message",
                 defaultValue: "Waiting for the tool to print a local URL."
             )
@@ -9962,17 +10020,17 @@ struct ContentView: View {
 
             let contentView = NSView(frame: NSRect(x: 0, y: 0, width: 520, height: 256))
 
-            let spinner = NSProgressIndicator()
+            spinner = NSProgressIndicator()
             spinner.style = .spinning
             spinner.controlSize = .regular
             spinner.isIndeterminate = true
-            spinner.startAnimation(nil)
+            spinner.isHidden = true
 
             let titleLabel = NSTextField(labelWithString: title)
             titleLabel.font = .systemFont(ofSize: NSFont.systemFontSize, weight: .semibold)
             titleLabel.lineBreakMode = .byTruncatingTail
 
-            let messageLabel = NSTextField(labelWithString: message)
+            messageLabel = NSTextField(labelWithString: message)
             messageLabel.font = .systemFont(ofSize: NSFont.smallSystemFontSize)
             messageLabel.textColor = .secondaryLabelColor
             messageLabel.lineBreakMode = .byWordWrapping
@@ -9990,7 +10048,7 @@ struct ContentView: View {
             outputTextView.font = .monospacedSystemFont(ofSize: 11, weight: .regular)
             outputTextView.textColor = .secondaryLabelColor
             outputTextView.textContainerInset = NSSize(width: 8, height: 8)
-            outputTextView.string = noOutputText
+            outputTextView.string = Self.commandPreview(command: command, directoryURL: directoryURL)
 
             let scrollView = NSScrollView()
             scrollView.hasVerticalScroller = true
@@ -9999,15 +10057,23 @@ struct ContentView: View {
             scrollView.borderType = .lineBorder
             scrollView.documentView = outputTextView
 
-            let hideButton = NSButton(title: String(
-                localized: "directoryTool.launchProgress.hide",
-                defaultValue: "Hide"
+            allowButton = NSButton(title: String(
+                localized: "directoryTool.launchProgress.allow",
+                defaultValue: "Allow"
             ), target: nil, action: nil)
-            hideButton.bezelStyle = .rounded
+            allowButton.bezelStyle = .rounded
+            allowButton.keyEquivalent = "\r"
 
-            let footerStack = NSStackView(views: [NSView(), hideButton])
+            stopButton = NSButton(title: String(
+                localized: "directoryTool.launchProgress.cancel",
+                defaultValue: "Cancel"
+            ), target: nil, action: nil)
+            stopButton.bezelStyle = .rounded
+
+            let footerStack = NSStackView(views: [NSView(), stopButton, allowButton])
             footerStack.orientation = .horizontal
             footerStack.alignment = .centerY
+            footerStack.spacing = 8
 
             let stack = NSStackView(views: [headerStack, messageLabel, scrollView, footerStack])
             stack.orientation = .vertical
@@ -10044,8 +10110,17 @@ struct ContentView: View {
             super.init()
 
             panel.delegate = self
-            hideButton.target = self
-            hideButton.action = #selector(hide)
+            allowButton.target = self
+            allowButton.action = #selector(allow)
+            stopButton.target = self
+            stopButton.action = #selector(stop)
+        }
+
+        private static func commandPreview(command: String, directoryURL: URL) -> String {
+            """
+            cd \(directoryURL.path)
+            \(command)
+            """
         }
 
         func show(presentingWindow: NSWindow?) {
@@ -10078,10 +10153,29 @@ struct ContentView: View {
         }
 
         func windowWillClose(_ notification: Notification) {
+            if !isClosed && !didAllow {
+                onStop()
+            }
             isClosed = true
         }
 
-        @objc private func hide() {
+        @objc private func allow() {
+            guard !didAllow, !isClosed else { return }
+            didAllow = true
+            spinner.isHidden = false
+            spinner.startAnimation(nil)
+            messageLabel.stringValue = launchingMessage
+            outputTextView.string = noOutputText
+            allowButton.isHidden = true
+            stopButton.title = String(
+                localized: "directoryTool.launchProgress.stop",
+                defaultValue: "Stop"
+            )
+            onAllow(self)
+        }
+
+        @objc private func stop() {
+            onStop()
             close()
         }
     }
@@ -10244,6 +10338,17 @@ struct ContentView: View {
 
     private func stopInlineVSCodeServeWeb() {
         VSCodeServeWebController.shared.stop()
+    }
+
+    private func stopFocusedDirectoryShellDirectoryTool(tool: CmuxResolvedDirectoryTool) -> Bool {
+        guard tool.kind == .shellWebServer,
+              let directoryURL = focusedTerminalDirectoryURL() else {
+            return false
+        }
+        return DirectoryToolWebServerController.shared.stopWebServer(
+            tool: tool,
+            directoryURL: directoryURL
+        )
     }
 
     private func restartInlineVSCodeServeWeb() -> Bool {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -9934,11 +9934,22 @@ struct ContentView: View {
             ?? tabManager.addWorkspace(select: true).id
         return authorizeDirectoryToolIfNeeded(tool) {
             let launchHandle = DirectoryToolWebServerLaunchHandle()
-            var progressController: DirectoryToolLaunchProgressController!
-            progressController = DirectoryToolLaunchProgressController(
-                tool: tool,
-                command: tool.command ?? "",
-                directoryURL: directoryURL,
+            var progressController: DirectoryToolLaunchPanelController!
+            progressController = DirectoryToolLaunchPanelController(
+                title: DirectoryToolLaunchPanelController.startingTitle(displayName: tool.subtitle ?? tool.title),
+                initialMessage: String(
+                    localized: "directoryTool.launchProgress.reviewCommand",
+                    defaultValue: "Review the command before running it."
+                ),
+                launchingMessage: String(
+                    localized: "directoryTool.launchProgress.message",
+                    defaultValue: "Waiting for the tool to print a local URL."
+                ),
+                initialOutput: DirectoryToolLaunchPanelController.commandPreview(
+                    command: tool.command ?? "",
+                    directoryURL: directoryURL
+                ),
+                requiresApproval: true,
                 onAllow: { progressController in
                     DirectoryToolWebServerController.shared.ensureWebServerURL(
                         tool: tool,
@@ -9949,9 +9960,9 @@ struct ContentView: View {
                         }
                     ) { result in
                         guard !launchHandle.cancelled else { return }
-                        progressController.close()
                         switch result {
                         case .opened(let webServerURL):
+                            progressController.close()
                             guard tabManager.openBrowser(
                                   inWorkspace: targetWorkspaceId,
                                   url: webServerURL,
@@ -9961,6 +9972,13 @@ struct ContentView: View {
                                 return
                             }
                         case .failed(let failure):
+                            progressController.finish(
+                                message: directoryToolLaunchProgressFailureMessage(failure),
+                                stopTitle: String(
+                                    localized: "directoryTool.launchProgress.hide",
+                                    defaultValue: "Hide"
+                                )
+                            )
                             showDirectoryToolLaunchFailureAlert(
                                 tool: tool,
                                 failure: failure,
@@ -9974,209 +9992,6 @@ struct ContentView: View {
                 }
             )
             progressController.show(presentingWindow: NSApp.keyWindow ?? NSApp.mainWindow)
-        }
-    }
-
-    private final class DirectoryToolLaunchProgressController: NSObject, NSWindowDelegate {
-        private let panel: NSPanel
-        private let spinner: NSProgressIndicator
-        private let messageLabel: NSTextField
-        private let outputTextView: NSTextView
-        private let allowButton: NSButton
-        private let stopButton: NSButton
-        private let noOutputText: String
-        private let launchingMessage: String
-        private let onAllow: (DirectoryToolLaunchProgressController) -> Void
-        private let onStop: () -> Void
-        private var isClosed = false
-        private var didAllow = false
-
-        init(
-            tool: CmuxResolvedDirectoryTool,
-            command: String,
-            directoryURL: URL,
-            onAllow: @escaping (DirectoryToolLaunchProgressController) -> Void,
-            onStop: @escaping () -> Void
-        ) {
-            self.onAllow = onAllow
-            self.onStop = onStop
-            let titleFormat = String(
-                localized: "directoryTool.launchProgress.title",
-                defaultValue: "Starting %@"
-            )
-            let title = String(format: titleFormat, tool.subtitle ?? tool.title)
-            let message = String(
-                localized: "directoryTool.launchProgress.reviewCommand",
-                defaultValue: "Review the command before running it."
-            )
-            launchingMessage = String(
-                localized: "directoryTool.launchProgress.message",
-                defaultValue: "Waiting for the tool to print a local URL."
-            )
-            noOutputText = String(
-                localized: "directoryTool.launchProgress.noOutput",
-                defaultValue: "No output yet."
-            )
-
-            let contentView = NSView(frame: NSRect(x: 0, y: 0, width: 520, height: 256))
-
-            spinner = NSProgressIndicator()
-            spinner.style = .spinning
-            spinner.controlSize = .regular
-            spinner.isIndeterminate = true
-            spinner.isHidden = true
-
-            let titleLabel = NSTextField(labelWithString: title)
-            titleLabel.font = .systemFont(ofSize: NSFont.systemFontSize, weight: .semibold)
-            titleLabel.lineBreakMode = .byTruncatingTail
-
-            messageLabel = NSTextField(labelWithString: message)
-            messageLabel.font = .systemFont(ofSize: NSFont.smallSystemFontSize)
-            messageLabel.textColor = .secondaryLabelColor
-            messageLabel.lineBreakMode = .byWordWrapping
-            messageLabel.maximumNumberOfLines = 2
-
-            let headerStack = NSStackView(views: [spinner, titleLabel])
-            headerStack.orientation = .horizontal
-            headerStack.alignment = .centerY
-            headerStack.spacing = 10
-
-            outputTextView = NSTextView()
-            outputTextView.isEditable = false
-            outputTextView.isSelectable = true
-            outputTextView.drawsBackground = false
-            outputTextView.font = .monospacedSystemFont(ofSize: 11, weight: .regular)
-            outputTextView.textColor = .secondaryLabelColor
-            outputTextView.textContainerInset = NSSize(width: 8, height: 8)
-            outputTextView.string = Self.commandPreview(command: command, directoryURL: directoryURL)
-
-            let scrollView = NSScrollView()
-            scrollView.hasVerticalScroller = true
-            scrollView.drawsBackground = true
-            scrollView.backgroundColor = .textBackgroundColor.withAlphaComponent(0.65)
-            scrollView.borderType = .lineBorder
-            scrollView.documentView = outputTextView
-
-            allowButton = NSButton(title: String(
-                localized: "directoryTool.launchProgress.allow",
-                defaultValue: "Allow"
-            ), target: nil, action: nil)
-            allowButton.bezelStyle = .rounded
-            allowButton.keyEquivalent = "\r"
-
-            stopButton = NSButton(title: String(
-                localized: "directoryTool.launchProgress.cancel",
-                defaultValue: "Cancel"
-            ), target: nil, action: nil)
-            stopButton.bezelStyle = .rounded
-
-            let footerStack = NSStackView(views: [NSView(), stopButton, allowButton])
-            footerStack.orientation = .horizontal
-            footerStack.alignment = .centerY
-            footerStack.spacing = 8
-
-            let stack = NSStackView(views: [headerStack, messageLabel, scrollView, footerStack])
-            stack.orientation = .vertical
-            stack.alignment = .leading
-            stack.spacing = 10
-            stack.translatesAutoresizingMaskIntoConstraints = false
-            contentView.addSubview(stack)
-
-            NSLayoutConstraint.activate([
-                stack.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
-                stack.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
-                stack.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 16),
-                stack.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -14),
-                spinner.widthAnchor.constraint(equalToConstant: 18),
-                spinner.heightAnchor.constraint(equalToConstant: 18),
-                titleLabel.trailingAnchor.constraint(lessThanOrEqualTo: stack.trailingAnchor),
-                messageLabel.widthAnchor.constraint(equalTo: stack.widthAnchor),
-                scrollView.widthAnchor.constraint(equalTo: stack.widthAnchor),
-                scrollView.heightAnchor.constraint(equalToConstant: 128)
-            ])
-
-            panel = NSPanel(
-                contentRect: contentView.frame,
-                styleMask: [.titled, .closable, .nonactivatingPanel],
-                backing: .buffered,
-                defer: false
-            )
-            panel.title = title
-            panel.contentView = contentView
-            panel.level = .floating
-            panel.collectionBehavior = [.moveToActiveSpace, .fullScreenAuxiliary]
-            panel.isReleasedWhenClosed = false
-
-            super.init()
-
-            panel.delegate = self
-            allowButton.target = self
-            allowButton.action = #selector(allow)
-            stopButton.target = self
-            stopButton.action = #selector(stop)
-        }
-
-        private static func commandPreview(command: String, directoryURL: URL) -> String {
-            """
-            cd \(directoryURL.path)
-            \(command)
-            """
-        }
-
-        func show(presentingWindow: NSWindow?) {
-            guard !isClosed else { return }
-            if let presentingWindow {
-                let windowFrame = presentingWindow.frame
-                let panelFrame = panel.frame
-                let origin = NSPoint(
-                    x: windowFrame.midX - panelFrame.width / 2,
-                    y: windowFrame.maxY - panelFrame.height - 72
-                )
-                panel.setFrameOrigin(origin)
-            } else {
-                panel.center()
-            }
-            panel.orderFrontRegardless()
-        }
-
-        func updateOutput(_ output: String) {
-            guard !isClosed else { return }
-            let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
-            outputTextView.string = trimmed.isEmpty ? noOutputText : trimmed
-            outputTextView.scrollToEndOfDocument(nil)
-        }
-
-        func close() {
-            guard !isClosed else { return }
-            isClosed = true
-            panel.close()
-        }
-
-        func windowWillClose(_ notification: Notification) {
-            if !isClosed && !didAllow {
-                onStop()
-            }
-            isClosed = true
-        }
-
-        @objc private func allow() {
-            guard !didAllow, !isClosed else { return }
-            didAllow = true
-            spinner.isHidden = false
-            spinner.startAnimation(nil)
-            messageLabel.stringValue = launchingMessage
-            outputTextView.string = noOutputText
-            allowButton.isHidden = true
-            stopButton.title = String(
-                localized: "directoryTool.launchProgress.stop",
-                defaultValue: "Stop"
-            )
-            onAllow(self)
-        }
-
-        @objc private func stop() {
-            onStop()
-            close()
         }
     }
 
@@ -10270,13 +10085,34 @@ struct ContentView: View {
             message = String(format: installFormat, message, installCommand)
         }
 
-        let output = failure.output.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !output.isEmpty else { return message }
-        let outputFormat = String(
-            localized: "directoryTool.launchFailure.outputFormat",
-            defaultValue: "%@\n\nOutput:\n%@"
-        )
-        return String(format: outputFormat, message, output)
+        return message
+    }
+
+    private func directoryToolLaunchProgressFailureMessage(
+        _ failure: DirectoryToolWebServerController.LaunchFailure
+    ) -> String {
+        switch failure.reason {
+        case .invalidConfiguration:
+            return String(
+                localized: "directoryTool.launchFailure.invalidConfiguration",
+                defaultValue: "This directory tool is missing a command."
+            )
+        case .launchFailed:
+            return String(
+                localized: "directoryTool.launchFailure.launchFailed",
+                defaultValue: "cmux could not launch this directory tool."
+            )
+        case .exitedWithoutURL:
+            return String(
+                localized: "directoryTool.launchFailure.exitedWithoutURL",
+                defaultValue: "The directory tool exited before printing a local URL."
+            )
+        case .timedOut:
+            return String(
+                localized: "directoryTool.launchFailure.timedOut",
+                defaultValue: "The directory tool did not print a local URL before the startup timeout."
+            )
+        }
     }
 
     private func runDirectoryToolInstallCommand(

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1498,6 +1498,10 @@ struct ContentView: View {
         static func directoryToolAvailable(_ tool: CmuxResolvedDirectoryTool) -> String {
             "terminal.directoryTool.\(tool.id).available"
         }
+
+        static func directoryToolRunning(_ tool: CmuxResolvedDirectoryTool) -> String {
+            "terminal.directoryTool.\(tool.id).running"
+        }
     }
 
     struct CommandPaletteCommandContribution {
@@ -6627,11 +6631,22 @@ struct ContentView: View {
                 }
                 let tools = directoryTools ?? cmuxConfigStore.loadedDirectoryTools
                 let availableToolIDs = availableDirectoryToolIDs ?? CmuxResolvedDirectoryTool.availableTools(tools)
+                let directoryURL = focusedTerminalDirectoryURL()
                 for tool in tools {
                     snapshot.setBool(
                         CommandPaletteContextKeys.directoryToolAvailable(tool),
                         availableToolIDs.contains(tool.id)
                     )
+                    if tool.kind == .shellWebServer,
+                       let directoryURL {
+                        snapshot.setBool(
+                            CommandPaletteContextKeys.directoryToolRunning(tool),
+                            DirectoryToolWebServerController.shared.isWebServerRunning(
+                                tool: tool,
+                                directoryURL: directoryURL
+                            )
+                        )
+                    }
                 }
                 snapshot.setBool(
                     CommandPaletteContextKeys.terminalOpenTargetAvailable(.vscodeInline),
@@ -7550,7 +7565,7 @@ struct ContentView: View {
                         keywords: ["terminal", "directory", "stop", "server"] + tool.keywords,
                         when: { context in
                             context.bool(CommandPaletteContextKeys.panelIsTerminal)
-                                && context.bool(CommandPaletteContextKeys.directoryToolAvailable(tool))
+                                && context.bool(CommandPaletteContextKeys.directoryToolRunning(tool))
                         }
                     )
                 )

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -9911,16 +9911,137 @@ struct ContentView: View {
             DirectoryToolWebServerController.shared.ensureWebServerURL(
                 tool: tool,
                 directoryURL: directoryURL.standardizedFileURL
-            ) { webServerURL in
-                guard let webServerURL,
-                      tabManager.openBrowser(
+            ) { result in
+                switch result {
+                case .opened(let webServerURL):
+                    guard tabManager.openBrowser(
                           inWorkspace: targetWorkspaceId,
                           url: webServerURL,
                           preferSplitRight: true
-                      ) != nil else {
-                    NSSound.beep()
-                    return
+                    ) != nil else {
+                        NSSound.beep()
+                        return
+                    }
+                case .failed(let failure):
+                    showDirectoryToolLaunchFailureAlert(
+                        tool: tool,
+                        failure: failure,
+                        directoryURL: directoryURL
+                    )
                 }
+            }
+        }
+    }
+
+    private func showDirectoryToolLaunchFailureAlert(
+        tool: CmuxResolvedDirectoryTool,
+        failure: DirectoryToolWebServerController.LaunchFailure,
+        directoryURL: URL
+    ) {
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        let titleFormat = String(
+            localized: "directoryTool.launchFailure.title",
+            defaultValue: "Couldn't Start %@"
+        )
+        alert.messageText = String(format: titleFormat, tool.subtitle ?? tool.title)
+        alert.informativeText = directoryToolLaunchFailureMessage(tool: tool, failure: failure)
+
+        let installCommand = tool.installCommand?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if installCommand?.isEmpty == false {
+            alert.addButton(withTitle: String(
+                localized: "directoryTool.launchFailure.runInstall",
+                defaultValue: "Run Install Command"
+            ))
+            alert.addButton(withTitle: String(
+                localized: "directoryTool.launchFailure.copyInstall",
+                defaultValue: "Copy Install Command"
+            ))
+        }
+        alert.addButton(withTitle: String(
+            localized: "directoryTool.launchFailure.ok",
+            defaultValue: "OK"
+        ))
+
+        let response = alert.runModal()
+        guard let installCommand, !installCommand.isEmpty else { return }
+        if response == .alertFirstButtonReturn {
+            runDirectoryToolInstallCommand(
+                installCommand,
+                tool: tool,
+                directoryURL: directoryURL
+            )
+        } else if response == .alertSecondButtonReturn {
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(installCommand, forType: .string)
+        }
+    }
+
+    private func directoryToolLaunchFailureMessage(
+        tool: CmuxResolvedDirectoryTool,
+        failure: DirectoryToolWebServerController.LaunchFailure
+    ) -> String {
+        let baseMessage: String
+        if let configuredMessage = tool.failureMessage?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !configuredMessage.isEmpty {
+            baseMessage = configuredMessage
+        } else {
+            switch failure.reason {
+            case .invalidConfiguration:
+                baseMessage = String(
+                    localized: "directoryTool.launchFailure.invalidConfiguration",
+                    defaultValue: "This directory tool is missing a command."
+                )
+            case .launchFailed:
+                baseMessage = String(
+                    localized: "directoryTool.launchFailure.launchFailed",
+                    defaultValue: "cmux could not launch this directory tool."
+                )
+            case .exitedWithoutURL:
+                baseMessage = String(
+                    localized: "directoryTool.launchFailure.exitedWithoutURL",
+                    defaultValue: "The directory tool exited before printing a local URL."
+                )
+            case .timedOut:
+                baseMessage = String(
+                    localized: "directoryTool.launchFailure.timedOut",
+                    defaultValue: "The directory tool did not print a local URL before the startup timeout."
+                )
+            }
+        }
+
+        let output = failure.output.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !output.isEmpty else { return baseMessage }
+        let outputFormat = String(
+            localized: "directoryTool.launchFailure.outputFormat",
+            defaultValue: "%@\n\nOutput:\n%@"
+        )
+        return String(format: outputFormat, baseMessage, output)
+    }
+
+    private func runDirectoryToolInstallCommand(
+        _ command: String,
+        tool: CmuxResolvedDirectoryTool,
+        directoryURL: URL
+    ) {
+        _ = CmuxConfigExecutor.prepareShellInputIfAuthorized(
+            command,
+            confirm: true,
+            actionID: "directoryTool.\(tool.id).install",
+            target: .newTabInCurrentPane,
+            configSourcePath: tool.sourcePath,
+            globalConfigPath: cmuxConfigStore.globalConfigPath,
+            displayTitle: String(
+                localized: "directoryTool.install.title",
+                defaultValue: "Install Directory Tool"
+            ),
+            presentingWindow: NSApp.keyWindow ?? NSApp.mainWindow
+        ) { shellInput in
+            if let workspace = tabManager.selectedWorkspace {
+                workspace.clearSplitZoom()
+                workspace.newTerminalSurfaceInFocusedPane(focus: true, initialInput: shellInput)
+            } else {
+                tabManager.newSurface(initialInput: shellInput)
             }
         }
     }

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -642,9 +642,11 @@ struct cmuxApp: App {
                         defaultValue: "Open Folder in VS Code (Inline)…"
                     )
                 ) {
-                    AppDelegate.shared?.showOpenFolderInInlineVSCodePanel()
+                    AppDelegate.shared?.showOpenFolderInInlineVSCodePanel(
+                        vscodeApplicationURL: configuredInlineVSCodeApplicationURL()
+                    )
                 }
-                .disabled(!TerminalDirectoryOpenTarget.vscodeInline.isAvailable())
+                .disabled(configuredInlineVSCodeApplicationURL() == nil)
             }
 
             // Close tab/workspace
@@ -1030,6 +1032,17 @@ struct cmuxApp: App {
         AppDelegate.shared?.activeTabManagerForCommands(
             preferredWindow: NSApp.keyWindow ?? NSApp.mainWindow
         ) ?? tabManager
+    }
+
+    private func configuredInlineVSCodeApplicationURL() -> URL? {
+        guard let configStore = AppDelegate.shared?.mainWindowContexts.values
+            .first(where: { $0.tabManager === activeTabManager })?
+            .cmuxConfigStore else {
+            return TerminalDirectoryOpenTarget.vscodeInline.applicationURL()
+        }
+        return configStore.loadedDirectoryTools
+            .first { $0.kind == .vscodeServeWeb && $0.isAvailable() }?
+            .applicationURL()
     }
 
     private func notificationMenuItemTitle(for notification: TerminalNotification) -> String {

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -200,6 +200,7 @@
 		C0DE32470000000000000001 /* ContentViewIdentifierCopyCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE32470000000000000002 /* ContentViewIdentifierCopyCommands.swift */; };
 		A500D010A1B2C3D4E5F60718 /* DebugLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = A500D011A1B2C3D4E5F60718 /* DebugLogging.swift */; };
 		A5001F000000000000000001 /* DetachedFolderDragIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001F000000000000000002 /* DetachedFolderDragIcon.swift */; };
+		0D6B2C472EF17C9D004B3A12 /* DirectoryToolLaunchPanelController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D6B2C462EF17C9D004B3A12 /* DirectoryToolLaunchPanelController.swift */; };
 		B8F266266A1A3D9A45BD840F /* DisplayResolutionRegressionUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F266276A1A3D9A45BD840F /* DisplayResolutionRegressionUITests.swift */; };
 		D0C0D0C0D0C0D0C0D0C0D003 /* DockEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C0D0C0D0C0D0C0D0C0D004 /* DockEmptyView.swift */; };
 		D0C0D0C0D0C0D0C0D0C0D001 /* DockPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C0D0C0D0C0D0C0D0C0D002 /* DockPanelView.swift */; };
@@ -828,6 +829,7 @@
 		C0DE32470000000000000002 /* ContentViewIdentifierCopyCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentViewIdentifierCopyCommands.swift; sourceTree = "<group>"; };
 		A500D011A1B2C3D4E5F60718 /* DebugLogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/DebugLogging.swift; sourceTree = "<group>"; };
 		A5001F000000000000000002 /* DetachedFolderDragIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetachedFolderDragIcon.swift; sourceTree = "<group>"; };
+		0D6B2C462EF17C9D004B3A12 /* DirectoryToolLaunchPanelController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/DirectoryToolLaunchPanelController.swift; sourceTree = "<group>"; };
 		B8F266276A1A3D9A45BD840F /* DisplayResolutionRegressionUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayResolutionRegressionUITests.swift; sourceTree = "<group>"; };
 		D0C0D0C0D0C0D0C0D0C0D004 /* DockEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockEmptyView.swift; sourceTree = "<group>"; };
 		D0C0D0C0D0C0D0C0D0C0D002 /* DockPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockPanelView.swift; sourceTree = "<group>"; };
@@ -1451,6 +1453,7 @@
 				C0DEFF300000000000000002 /* CommandPaletteSearchOrchestrator.swift */,
 				C0DEF4110000000000000002 /* CommandPaletteSettingsToggle.swift */,
 				9DAB808A8EC74C40B95F7672 /* GhosttySurfaceConfigurationRefresh.swift */,
+				0D6B2C462EF17C9D004B3A12 /* DirectoryToolLaunchPanelController.swift */,
 				6B8E2E03F4A64C61B729CF19 /* TerminalDirectoryOpenSupport.swift */,
 				8A4FE96C3F394FC6A6D4B018 /* CmuxCLIPathInstaller.swift */,
 				47D5AA7D29C94F5CA865B2BF /* ScreenIdentity.swift */,
@@ -2312,6 +2315,7 @@
 				C0DE32470000000000000001 /* ContentViewIdentifierCopyCommands.swift in Sources */,
 				A500D010A1B2C3D4E5F60718 /* DebugLogging.swift in Sources */,
 				A5001F000000000000000001 /* DetachedFolderDragIcon.swift in Sources */,
+				0D6B2C472EF17C9D004B3A12 /* DirectoryToolLaunchPanelController.swift in Sources */,
 				D0C0D0C0D0C0D0C0D0C0D003 /* DockEmptyView.swift in Sources */,
 				D0C0D0C0D0C0D0C0D0C0D001 /* DockPanelView.swift in Sources */,
 				D0B10014A1B2C3D4E5F60001 /* DragOverlayRoutingPolicy.swift in Sources */,

--- a/cmuxTests/CmuxConfigTests.swift
+++ b/cmuxTests/CmuxConfigTests.swift
@@ -133,6 +133,47 @@ final class CmuxConfigDecodingTests: XCTestCase {
         XCTAssertThrowsError(try decode(json))
     }
 
+    func testDecodeDirectoryTool() throws {
+        let json = """
+        {
+          "directoryTools": [{
+            "id": "notebook",
+            "title": "Open Current Directory in Notebook",
+            "subtitle": "Notebook",
+            "keywords": ["notebook", "python"],
+            "kind": "shellWebServer",
+            "executablePathCandidates": ["/opt/homebrew/bin/notebook"],
+            "command": "notebook --no-browser",
+            "cwd": "{directory}",
+            "urlRegex": "(http://127\\\\.0\\\\.0\\\\.1:[^\\\\s]+)"
+          }]
+        }
+        """
+        let config = try decode(json)
+        let tool = try XCTUnwrap(config.directoryTools?.first)
+        XCTAssertEqual(tool.id, "notebook")
+        XCTAssertEqual(tool.title, "Open Current Directory in Notebook")
+        XCTAssertEqual(tool.subtitle, "Notebook")
+        XCTAssertEqual(tool.keywords, ["notebook", "python"])
+        XCTAssertEqual(tool.kind, .shellWebServer)
+        XCTAssertEqual(tool.executablePathCandidates, ["/opt/homebrew/bin/notebook"])
+        XCTAssertEqual(tool.command, "notebook --no-browser")
+        XCTAssertEqual(tool.cwd, "{directory}")
+    }
+
+    func testShellDirectoryToolRequiresCommand() {
+        let json = """
+        {
+          "directoryTools": [{
+            "id": "broken",
+            "title": "Broken",
+            "kind": "shellWebServer"
+          }]
+        }
+        """
+        XCTAssertThrowsError(try decode(json))
+    }
+
     func testDecodeNewWorkspaceCommandTrimsWhitespace() throws {
         let json = """
         {
@@ -671,6 +712,66 @@ final class CmuxConfigDecodingTests: XCTestCase {
 
         XCTAssertTrue(store.configurationIssues.isEmpty)
         XCTAssertNotNil(store.resolvedAction(id: "bad"))
+    }
+
+    @MainActor
+    func testConfigStoreLoadsDefaultDirectoryTools() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-config-store-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let store = CmuxConfigStore(
+            globalConfigPath: root.appendingPathComponent("missing-global.json").path,
+            startFileWatchers: false
+        )
+        store.loadAll()
+
+        XCTAssertEqual(store.loadedDirectoryTools.map(\.id), ["vscode-inline", "jupyter"])
+        XCTAssertEqual(store.loadedDirectoryTools.first?.kind, .vscodeServeWeb)
+        XCTAssertEqual(store.loadedDirectoryTools.last?.kind, .shellWebServer)
+    }
+
+    @MainActor
+    func testLocalDirectoryToolsOverrideAndDisableDefaults() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-config-store-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let globalURL = root.appendingPathComponent("global.json")
+        let localURL = root.appendingPathComponent("cmux.json")
+        try """
+        {
+          "directoryTools": [{
+            "id": "custom",
+            "title": "Open in Custom",
+            "kind": "shellWebServer",
+            "command": "custom-server"
+          }]
+        }
+        """.write(to: globalURL, atomically: true, encoding: .utf8)
+        try """
+        {
+          "directoryTools": [
+            { "id": "jupyter", "enabled": false },
+            { "id": "custom", "title": "Open in Local Custom", "kind": "shellWebServer", "command": "local-server" }
+          ]
+        }
+        """.write(to: localURL, atomically: true, encoding: .utf8)
+
+        let store = CmuxConfigStore(
+            globalConfigPath: globalURL.path,
+            localConfigPath: localURL.path,
+            startFileWatchers: false
+        )
+        store.loadAll()
+
+        XCTAssertEqual(store.loadedDirectoryTools.map(\.id), ["vscode-inline", "custom"])
+        let custom = try XCTUnwrap(store.loadedDirectoryTools.first { $0.id == "custom" })
+        XCTAssertEqual(custom.title, "Open in Local Custom")
+        XCTAssertEqual(custom.command, "local-server")
+        XCTAssertEqual(custom.sourcePath, localURL.path)
     }
 
     @MainActor

--- a/cmuxTests/CmuxConfigTests.swift
+++ b/cmuxTests/CmuxConfigTests.swift
@@ -145,7 +145,10 @@ final class CmuxConfigDecodingTests: XCTestCase {
             "executablePathCandidates": ["/opt/homebrew/bin/notebook"],
             "command": "notebook --no-browser",
             "cwd": "{directory}",
-            "urlRegex": "(http://127\\\\.0\\\\.0\\\\.1:[^\\\\s]+)"
+            "urlRegex": "(http://127\\\\.0\\\\.0\\\\.1:[^\\\\s]+)",
+            "failureMessage": "Notebook is missing",
+            "installCommand": "python3 -m pip install notebook",
+            "startupTimeoutSeconds": 7
           }]
         }
         """
@@ -159,6 +162,10 @@ final class CmuxConfigDecodingTests: XCTestCase {
         XCTAssertEqual(tool.executablePathCandidates, ["/opt/homebrew/bin/notebook"])
         XCTAssertEqual(tool.command, "notebook --no-browser")
         XCTAssertEqual(tool.cwd, "{directory}")
+        XCTAssertEqual(tool.urlRegex, "(http://127\\.0\\.0\\.1:[^\\s]+)")
+        XCTAssertEqual(tool.failureMessage, "Notebook is missing")
+        XCTAssertEqual(tool.installCommand, "python3 -m pip install notebook")
+        XCTAssertEqual(tool.startupTimeoutSeconds, 7)
     }
 
     func testShellDirectoryToolRequiresCommand() {

--- a/cmuxTests/OmnibarAndToolsTests.swift
+++ b/cmuxTests/OmnibarAndToolsTests.swift
@@ -308,6 +308,21 @@ final class ServeWebOutputCollectorTests: XCTestCase {
         XCTAssertTrue(collector.waitForURL(timeoutSeconds: 0.1))
         XCTAssertEqual(collector.webUIURL?.absoluteString, "http://127.0.0.1:9001?tkn=final-token")
     }
+
+    func testReportsOutputSnippetAsTextArrives() {
+        var snippets: [String] = []
+        let collector = ServeWebOutputCollector { snippet in
+            snippets.append(snippet)
+        }
+
+        collector.append(Data("Starting VS Code server\n".utf8))
+        collector.append(Data("Preparing web UI\n".utf8))
+
+        XCTAssertEqual(snippets, [
+            "Starting VS Code server",
+            "Starting VS Code server\nPreparing web UI"
+        ])
+    }
 }
 
 

--- a/cmuxTests/OmnibarAndToolsTests.swift
+++ b/cmuxTests/OmnibarAndToolsTests.swift
@@ -339,6 +339,21 @@ final class DirectoryToolWebServerOutputCollectorTests: XCTestCase {
         XCTAssertTrue(collector.waitForURL(timeoutSeconds: 0.1))
         XCTAssertEqual(collector.webServerURL?.absoluteString, "http://localhost:8888/lab?token=test-token")
     }
+
+    func testReportsOutputSnippetAsTextArrives() {
+        var snippets: [String] = []
+        let collector = DirectoryToolWebServerOutputCollector(urlPattern: nil) { snippet in
+            snippets.append(snippet)
+        }
+
+        collector.append(Data("Resolving packages\n".utf8))
+        collector.append(Data("Installed jupyterlab\n".utf8))
+
+        XCTAssertEqual(snippets, [
+            "Resolving packages",
+            "Resolving packages\nInstalled jupyterlab"
+        ])
+    }
 }
 
 

--- a/cmuxTests/OmnibarAndToolsTests.swift
+++ b/cmuxTests/OmnibarAndToolsTests.swift
@@ -311,6 +311,37 @@ final class ServeWebOutputCollectorTests: XCTestCase {
 }
 
 
+final class DirectoryToolWebServerOutputCollectorTests: XCTestCase {
+    func testWaitForURLReturnsFalseAfterProcessExitSignal() {
+        let collector = DirectoryToolWebServerOutputCollector(urlPattern: nil)
+
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.05) {
+            collector.append(Data("Jupyter is not installed\n".utf8))
+            collector.markProcessExited()
+        }
+
+        let start = Date()
+        let resolved = collector.waitForURL(timeoutSeconds: 1)
+        let elapsed = Date().timeIntervalSince(start)
+
+        XCTAssertFalse(resolved)
+        XCTAssertLessThan(elapsed, 0.5)
+        XCTAssertEqual(collector.outputSnippet, "Jupyter is not installed")
+    }
+
+    func testCustomRegexParsesLocalhostJupyterURL() {
+        let collector = DirectoryToolWebServerOutputCollector(
+            urlPattern: "(http://(?:127\\.0\\.0\\.1|localhost):[^\\s]+)"
+        )
+
+        collector.append(Data("http://localhost:8888/lab?token=test-token\n".utf8))
+
+        XCTAssertTrue(collector.waitForURL(timeoutSeconds: 0.1))
+        XCTAssertEqual(collector.webServerURL?.absoluteString, "http://localhost:8888/lab?token=test-token")
+    }
+}
+
+
 final class VSCodeServeWebControllerTests: XCTestCase {
     func testStopDuringInFlightLaunchDoesNotDropNextGenerationCompletion() {
         let firstLaunchStarted = expectation(description: "first launch started")

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -2196,6 +2196,8 @@ final class TerminalDirectoryOpenTargetAvailabilityTests: XCTestCase {
         let definition = try XCTUnwrap(CmuxDirectoryToolDefinition.defaultDefinitions.first { $0.id == "jupyter" })
         let command = try XCTUnwrap(definition.command)
         XCTAssertTrue(command.contains("uvx --from jupyterlab jupyter lab"))
+        XCTAssertTrue(command.contains("jupyter=\"${CMUX_TOOL_EXECUTABLE:-}\""))
+        XCTAssertTrue(command.contains("command -v jupyter || command -v jupyter-lab"))
         XCTAssertEqual(
             definition.installCommand,
             "if command -v brew >/dev/null 2>&1; then brew install uv; else curl -LsSf https://astral.sh/uv/install.sh | sh; fi"

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -2155,7 +2155,24 @@ final class TerminalDirectoryOpenTargetAvailabilityTests: XCTestCase {
 
         let availableTargets = TerminalDirectoryOpenTarget.availableTargets(in: env)
         XCTAssertTrue(availableTargets.contains(.vscode))
-        XCTAssertTrue(availableTargets.contains(.vscodeInline))
+        XCTAssertFalse(availableTargets.contains(.vscodeInline))
+    }
+
+    func testDefaultDirectoryToolsDetectVSCodeInlineAndJupyter() {
+        let env = environment(
+            existingPaths: [
+                "/Applications/Visual Studio Code.app",
+                "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code-tunnel",
+                "/opt/homebrew/bin/jupyter",
+            ]
+        )
+        let tools = CmuxDirectoryToolDefinition.defaultDefinitions.map {
+            CmuxResolvedDirectoryTool(definition: $0, sourcePath: nil)
+        }
+
+        let availableTools = CmuxResolvedDirectoryTool.availableTools(tools, in: env)
+        XCTAssertTrue(availableTools.contains("vscode-inline"))
+        XCTAssertTrue(availableTools.contains("jupyter"))
     }
 
     func testTowerDetectedViaApplicationLookupOutsideApplications() {

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -2192,6 +2192,15 @@ final class TerminalDirectoryOpenTargetAvailabilityTests: XCTestCase {
         XCTAssertEqual(availableTools, ["notebook"])
     }
 
+    func testDefaultJupyterUsesUVXFallbackAndInstallCommand() throws {
+        let definition = try XCTUnwrap(CmuxDirectoryToolDefinition.defaultDefinitions.first { $0.id == "jupyter" })
+        XCTAssertTrue(definition.command.contains("uvx --from jupyterlab jupyter lab"))
+        XCTAssertEqual(
+            definition.installCommand,
+            "if command -v brew >/dev/null 2>&1; then brew install uv; else curl -LsSf https://astral.sh/uv/install.sh | sh; fi"
+        )
+    }
+
     func testTowerDetectedViaApplicationLookupOutsideApplications() {
         let towerPath = "/Volumes/Setapp/Tower.app"
         let env = environment(

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -2163,7 +2163,6 @@ final class TerminalDirectoryOpenTargetAvailabilityTests: XCTestCase {
             existingPaths: [
                 "/Applications/Visual Studio Code.app",
                 "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code-tunnel",
-                "/opt/homebrew/bin/jupyter",
             ]
         )
         let tools = CmuxDirectoryToolDefinition.defaultDefinitions.map {
@@ -2173,6 +2172,24 @@ final class TerminalDirectoryOpenTargetAvailabilityTests: XCTestCase {
         let availableTools = CmuxResolvedDirectoryTool.availableTools(tools, in: env)
         XCTAssertTrue(availableTools.contains("vscode-inline"))
         XCTAssertTrue(availableTools.contains("jupyter"))
+    }
+
+    func testShellDirectoryToolsArePaletteAvailableWithoutStaticExecutableMatch() {
+        let env = environment(existingPaths: [])
+        let tool = CmuxDirectoryToolDefinition(
+            id: "notebook",
+            title: "Open Notebook",
+            kind: .shellWebServer,
+            executablePathCandidates: ["/opt/homebrew/bin/notebook"],
+            command: "notebook --port=0"
+        )
+
+        let availableTools = CmuxResolvedDirectoryTool.availableTools(
+            [CmuxResolvedDirectoryTool(definition: tool, sourcePath: nil)],
+            in: env
+        )
+
+        XCTAssertEqual(availableTools, ["notebook"])
     }
 
     func testTowerDetectedViaApplicationLookupOutsideApplications() {

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -2194,7 +2194,8 @@ final class TerminalDirectoryOpenTargetAvailabilityTests: XCTestCase {
 
     func testDefaultJupyterUsesUVXFallbackAndInstallCommand() throws {
         let definition = try XCTUnwrap(CmuxDirectoryToolDefinition.defaultDefinitions.first { $0.id == "jupyter" })
-        XCTAssertTrue(definition.command.contains("uvx --from jupyterlab jupyter lab"))
+        let command = try XCTUnwrap(definition.command)
+        XCTAssertTrue(command.contains("uvx --from jupyterlab jupyter lab"))
         XCTAssertEqual(
             definition.installCommand,
             "if command -v brew >/dev/null 2>&1; then brew install uv; else curl -LsSf https://astral.sh/uv/install.sh | sh; fi"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,3 +21,36 @@ Controls what the tab right-click `Fork Conversation` item does. The submenu sti
 Values: `right`, `left`, `top`, `bottom`, `newTab`, `newWorkspace`.
 
 Default: `right`.
+
+## `directoryTools`
+
+Adds Command Palette tools that open the focused terminal directory in a cmux browser split.
+
+Built-in ids:
+
+- `vscode-inline`: starts VS Code `code-tunnel serve-web` and opens the directory inline.
+- `jupyter`: starts `jupyter lab` in the focused directory and opens the printed local URL.
+
+Use the same id to override a built-in. Set `enabled` to `false` to hide one.
+
+Example:
+
+```json
+{
+  "directoryTools": [
+    {
+      "id": "notebook",
+      "title": "Open Current Directory in Notebook",
+      "subtitle": "Notebook",
+      "keywords": ["notebook", "python"],
+      "kind": "shellWebServer",
+      "executablePathCandidates": ["/opt/homebrew/bin/jupyter"],
+      "command": "exec \"$CMUX_TOOL_EXECUTABLE\" lab --no-browser --ip=127.0.0.1 --port=0",
+      "cwd": "{directory}",
+      "urlRegex": "(http://127\\.0\\.0\\.1:[^\\s]+)"
+    }
+  ]
+}
+```
+
+For `shellWebServer`, cmux sets `CMUX_DIRECTORY`, `CMUX_TOOL_ID`, and `CMUX_TOOL_EXECUTABLE`. Project-local tools are prompted through the same trust flow as project-local custom commands.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,7 +29,7 @@ Adds Command Palette tools that open the focused terminal directory in a cmux br
 Built-in ids:
 
 - `vscode-inline`: starts VS Code `code-tunnel serve-web` and opens the directory inline.
-- `jupyter`: starts `jupyter lab` in the focused directory and opens the printed local URL.
+- `jupyter`: starts local `jupyter lab` in the focused directory, or uses `uvx --from jupyterlab` when `uvx` is available, and opens the printed local URL.
 
 Use the same id to override a built-in. Set `enabled` to `false` to hide one.
 
@@ -45,15 +45,15 @@ Example:
       "keywords": ["notebook", "python"],
       "kind": "shellWebServer",
       "executablePathCandidates": ["/opt/homebrew/bin/jupyter"],
-      "command": "TOOL=\"${CMUX_TOOL_EXECUTABLE:-$(command -v jupyter || true)}\"; if [ -z \"$TOOL\" ]; then echo \"Notebook is not installed\" >&2; exit 127; fi; exec \"$TOOL\" lab --no-browser --ip=127.0.0.1 --port=8888 --ServerApp.port_retries=50",
+      "command": "TOOL=\"${CMUX_TOOL_EXECUTABLE:-$(command -v jupyter || true)}\"; if [ -z \"$TOOL\" ] && command -v uvx >/dev/null 2>&1; then exec uvx --from jupyterlab jupyter lab --no-browser --ip=127.0.0.1 --port=8888 --ServerApp.port_retries=50; fi; if [ -z \"$TOOL\" ]; then echo \"Notebook is not installed and uvx is not on PATH\" >&2; exit 127; fi; exec \"$TOOL\" lab --no-browser --ip=127.0.0.1 --port=8888 --ServerApp.port_retries=50",
       "cwd": "{directory}",
       "urlRegex": "(http://(?:127\\.0\\.0\\.1|localhost):[^\\s]+)",
       "failureMessage": "Notebook is not installed or did not print a local URL.",
-      "installCommand": "python3 -m pip install --user jupyterlab",
+      "installCommand": "if command -v brew >/dev/null 2>&1; then brew install uv; else curl -LsSf https://astral.sh/uv/install.sh | sh; fi",
       "startupTimeoutSeconds": 20
     }
   ]
 }
 ```
 
-For `shellWebServer`, cmux sets `CMUX_DIRECTORY`, `CMUX_TOOL_ID`, and `CMUX_TOOL_EXECUTABLE`. If startup fails, cmux shows `failureMessage`, captured output, and an optional `installCommand` button. Install commands run in a visible terminal tab after the user clicks the button. Project-local tools are prompted through the same trust flow as project-local custom commands.
+For `shellWebServer`, cmux sets `CMUX_DIRECTORY`, `CMUX_TOOL_ID`, and `CMUX_TOOL_EXECUTABLE`. If startup fails, cmux shows `failureMessage`, captured output, and the exact optional `installCommand` before offering to run or copy it. Install commands run in a visible terminal tab after the user clicks the button. Project-local tools are prompted through the same trust flow as project-local custom commands.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -45,12 +45,15 @@ Example:
       "keywords": ["notebook", "python"],
       "kind": "shellWebServer",
       "executablePathCandidates": ["/opt/homebrew/bin/jupyter"],
-      "command": "exec \"$CMUX_TOOL_EXECUTABLE\" lab --no-browser --ip=127.0.0.1 --port=0",
+      "command": "TOOL=\"${CMUX_TOOL_EXECUTABLE:-$(command -v jupyter || true)}\"; if [ -z \"$TOOL\" ]; then echo \"Notebook is not installed\" >&2; exit 127; fi; exec \"$TOOL\" lab --no-browser --ip=127.0.0.1 --port=8888 --ServerApp.port_retries=50",
       "cwd": "{directory}",
-      "urlRegex": "(http://127\\.0\\.0\\.1:[^\\s]+)"
+      "urlRegex": "(http://(?:127\\.0\\.0\\.1|localhost):[^\\s]+)",
+      "failureMessage": "Notebook is not installed or did not print a local URL.",
+      "installCommand": "python3 -m pip install --user jupyterlab",
+      "startupTimeoutSeconds": 20
     }
   ]
 }
 ```
 
-For `shellWebServer`, cmux sets `CMUX_DIRECTORY`, `CMUX_TOOL_ID`, and `CMUX_TOOL_EXECUTABLE`. Project-local tools are prompted through the same trust flow as project-local custom commands.
+For `shellWebServer`, cmux sets `CMUX_DIRECTORY`, `CMUX_TOOL_ID`, and `CMUX_TOOL_EXECUTABLE`. If startup fails, cmux shows `failureMessage`, captured output, and an optional `installCommand` button. Install commands run in a visible terminal tab after the user clicks the button. Project-local tools are prompted through the same trust flow as project-local custom commands.

--- a/web/data/cmux.schema.json
+++ b/web/data/cmux.schema.json
@@ -103,6 +103,19 @@
           "urlRegex": {
             "type": "string",
             "description": "Optional regular expression used to capture the browser URL from stdout/stderr. If it has a capture group, group 1 is used."
+          },
+          "failureMessage": {
+            "type": "string",
+            "description": "Optional message shown when the tool exits, times out, or does not print a URL."
+          },
+          "installCommand": {
+            "type": "string",
+            "description": "Optional shell command offered in the failure alert. cmux runs it in a visible terminal tab only after the user clicks Run Install Command."
+          },
+          "startupTimeoutSeconds": {
+            "type": "number",
+            "minimum": 1,
+            "description": "Seconds to wait for the tool to print a URL before showing the failure alert."
           }
         },
         "allOf": [

--- a/web/data/cmux.schema.json
+++ b/web/data/cmux.schema.json
@@ -39,6 +39,86 @@
         "additionalProperties": true
       }
     },
+    "directoryTools": {
+      "title": "directoryTools",
+      "description": "Browser-backed tools that open the focused terminal directory inside cmux. Built-ins provide VS Code Inline and Jupyter; entries with the same id override defaults, and enabled false disables a default.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9._-]+$",
+            "description": "Stable id used for Command Palette commands. Use vscode-inline or jupyter to override built-in tools."
+          },
+          "title": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Command Palette title, for example Open Current Directory in Notebook."
+          },
+          "subtitle": {
+            "type": "string",
+            "description": "Optional Command Palette subtitle."
+          },
+          "keywords": {
+            "type": "array",
+            "items": { "type": "string" },
+            "default": [],
+            "description": "Extra search keywords for the Command Palette."
+          },
+          "enabled": {
+            "type": "boolean",
+            "default": true,
+            "description": "Set false to remove a built-in or configured tool."
+          },
+          "kind": {
+            "type": "string",
+            "enum": ["vscodeServeWeb", "shellWebServer"],
+            "default": "shellWebServer",
+            "description": "vscodeServeWeb runs VS Code's code-tunnel serve-web backend. shellWebServer runs command and opens the first local URL matched in output."
+          },
+          "applicationBundlePathCandidates": {
+            "type": "array",
+            "items": { "type": "string" },
+            "default": [],
+            "description": "Application bundle candidates for vscodeServeWeb. /Applications entries are also checked under ~/Applications."
+          },
+          "executablePathCandidates": {
+            "type": "array",
+            "items": { "type": "string" },
+            "default": [],
+            "description": "Executable candidates for shellWebServer availability. The resolved path is exposed to command as CMUX_TOOL_EXECUTABLE."
+          },
+          "command": {
+            "type": "string",
+            "description": "Shell command for shellWebServer. cmux sets CMUX_DIRECTORY, CMUX_TOOL_ID, and CMUX_TOOL_EXECUTABLE."
+          },
+          "cwd": {
+            "type": "string",
+            "default": "{directory}",
+            "description": "Working directory for shellWebServer. Supports {directory}; relative paths resolve from the focused directory."
+          },
+          "urlRegex": {
+            "type": "string",
+            "description": "Optional regular expression used to capture the browser URL from stdout/stderr. If it has a capture group, group 1 is used."
+          }
+        },
+        "allOf": [
+          {
+            "if": {
+              "properties": {
+                "kind": { "const": "shellWebServer" },
+                "enabled": { "not": { "const": false } }
+              }
+            },
+            "then": { "required": ["command"] }
+          }
+        ]
+      },
+      "default": []
+    },
     "vault": {
       "title": "vault",
       "description": "Vault session restore agent registrations. cmux includes Pi by default; use this section to add or override JSONL-backed coding agents without an app update.",

--- a/web/data/cmux.schema.json
+++ b/web/data/cmux.schema.json
@@ -110,7 +110,7 @@
           },
           "installCommand": {
             "type": "string",
-            "description": "Optional shell command offered in the failure alert. cmux runs it in a visible terminal tab only after the user clicks Run Install Command."
+            "description": "Optional shell command shown in the failure alert. cmux runs it in a visible terminal tab only after the user clicks Run Install Command."
           },
           "startupTimeoutSeconds": {
             "type": "number",


### PR DESCRIPTION
## Summary
- Add configurable browser-backed directory tools with VS Code Inline and Jupyter defaults
- Route terminal directory commands through the new tool registry and generic shell web-server launcher
- Document directoryTools in cmux.json and add schema/test coverage

## Testing
- jq empty Resources/Localizable.xcstrings web/data/cmux.schema.json
- git diff --check
- ./scripts/reload-cloud.sh --tag jupmode

## Issues
- Task: make cmux jupyter mode similar to inline vscode mode with a customizable abstraction

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5222"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782995971&installation_id=133855650&pr_number=5222&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5222&signature=6491f0a7eef170eecd90993cbd6c8756c6615bab9f4964e52c4c036c2ab72a60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Runs user-configurable shell commands and subprocesses to bind localhost services and open URLs in-app; mitigated by trust prompts and localhost-focused URL parsing, but misconfiguration or command injection in config remains a concern.
> 
> **Overview**
> Introduces configurable **`directoryTools`** so terminal “open directory” actions can launch **browser splits** via VS Code `serve-web` or arbitrary **shell web servers** (built-in **Jupyter** plus overrides in `cmux.json`).
> 
> **Config & registry:** `CmuxConfig`/`CmuxConfigStore` load and merge default + global/local tool definitions; the command palette registers open/stop commands per tool and drops **VS Code Inline** from the legacy `TerminalDirectoryOpenTarget` shortcut list in favor of the tool registry.
> 
> **Launch UX:** New **`DirectoryToolLaunchPanelController`** shows command review (**Allow**), live log output, and **Stop/Cancel**; inline VS Code and shell tools stream stdout/stderr while waiting for a local URL. Failures surface **`failureMessage`**, captured output, and optional **Run/Copy install** commands; project-local tools use the existing automation trust flow.
> 
> **Runtime:** **`DirectoryToolWebServerController`** runs `zsh -lc` with `CMUX_DIRECTORY` / `CMUX_TOOL_*`, parses URLs via regex, caches one server per tool+directory, and reuses **`ServeWebOutputCollector`** progress hooks for VS Code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c3c80154cabd8d401dcfed400c6bf2073c60c90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds customizable directory tools to open the focused terminal directory in a browser split, with built‑in `vscode-inline` and `jupyter`. Aligns Jupyter mode with inline VS Code via a customizable abstraction.

- New `directoryTools` in `cmux.json` (kinds: `vscodeServeWeb`, `shellWebServer`); built-ins: `vscode-inline`, `jupyter`. Override or disable defaults by id.
- `shellWebServer` runs a command in the directory, captures a local URL via default/custom `urlRegex`, exports `CMUX_DIRECTORY`, `CMUX_TOOL_ID`, `CMUX_TOOL_EXECUTABLE`, reuses servers per tool+directory, and supports `startupTimeoutSeconds`.
- Built-in `jupyter` tries local `jupyter`/`jupyter-lab`, falls back to `uvx --from jupyterlab jupyter lab`, includes an `installCommand` for `uv`, and has refined launch controls (clearer progress and Stop behavior).
- Command Palette auto-generates open/stop commands; VS Code Inline uses the first available configured `vscodeServeWeb`. The old `.vscodeInline` target is removed from generic open-directory shortcuts, and the menu item is disabled unless configured.
- Launch/trust UX uses a shared review panel with Allow and Stop, then a progress view with streaming output; failures show an alert with captured output and “Run/Copy Install Command”. Project-local tools use the existing trust prompt. Docs, schema, localization, and tests updated.

<sup>Written for commit 8c3c80154cabd8d401dcfed400c6bf2073c60c90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Command palette/UI exposes configurable "directory tools" to open focused terminal directories (built-ins: Jupyter, Inline VS Code). Tools can launch web servers, parse served URLs, and surface install/copy/run CTAs on failures; inline VS Code may use an explicit configured application URL.

* **Documentation**
  * Added docs and examples for directoryTools configuration, env vars, failure UI, and usage.

* **Localization**
  * Added en/ja strings for Jupyter, directory-tool install/launch flows, errors, CTAs, and menu text.

* **Tests**
  * Added tests for config decoding, tool availability, web-server output parsing, and launch behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->