### PR TITLE
fix(web): disable ligatures in code blocks to prevent -- swallowing preceding space

### DIFF
--- a/web/app/[locale]/components/code-block.tsx
+++ b/web/app/[locale]/components/code-block.tsx
@@ -31,7 +31,7 @@ export async function CodeBlock({
           </div>
         )}
         <div
-          className={`[&_pre]:m-0 [&_pre]:bg-code-bg [&_pre]:border [&_pre]:border-border [&_pre]:px-4 [&_pre]:py-3 [&_pre]:overflow-x-auto [&_pre]:text-[13px] ${shikiLineHeightClass} [&_pre]:font-mono ${
+          className={`[&_pre]:m-0 [&_pre]:bg-code-bg [&_pre]:border [&_pre]:border-border [&_pre]:px-4 [&_pre]:py-3 [&_pre]:overflow-x-auto [&_pre]:text-[13px] ${shikiLineHeightClass} [&_pre]:font-mono [&_pre]:[font-variant-ligatures:none] ${
             title
               ? "[&_pre]:rounded-b-lg [&_pre]:border-t-0"
               : "[&_pre]:rounded-lg"
@@ -51,7 +51,7 @@ export async function CodeBlock({
       )}
       <pre
         className={`bg-code-bg border border-border px-4 py-3 overflow-x-auto text-[13px] ${plainLineHeightClass} ${
-          variant === "ascii" ? "" : "font-mono "
+          variant === "ascii" ? "" : "font-mono [font-variant-ligatures:none] "
         }${title ? "rounded-b-lg" : "rounded-lg"}`}
         style={
           variant === "ascii"


### PR DESCRIPTION
## Problem

SF Mono (`ui-monospace` on macOS) has a `--` ligature that collapses the whitespace immediately preceding it. This makes CLI flags like `--title` appear visually joined to the preceding word in code blocks — e.g. `rename-workspace--title` instead of `rename-workspace --title`.

The bug affects any code block containing double-dash flags anywhere on the site.

## Fix

Add `font-variant-ligatures: none` to the `<pre>` elements in both render paths of `CodeBlock`. This is the standard CSS property for suppressing ligatures and has no other visual impact on code rendering.

## Testing

Reproduced locally with `CMUX_DEV_START_DB=0 bun dev`. Space renders correctly before `--` flags after the change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782999521&installation_id=133855650&pr_number=5225&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5225&signature=bbfa45f1400cacbb47b4006d04e6c826d56d4c327679569dda91c96ed2133dad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable ligatures in all code blocks to stop the SF Mono `--` ligature from swallowing the space before it, so flags like `--title` render correctly. Applied `font-variant-ligatures: none` to `<pre>` elements in both `CodeBlock` render paths.

<sup>Written for commit 366083bf7ae06d1fcdd95d949bb4227d271dba12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated code block typography to disable ligatures for improved readability in non-ASCII text rendering while maintaining consistent styling across all code block variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->