### PR TITLE
Rebuild sidebar workspace reorder on a SwiftUI DragGesture

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -12334,7 +12334,6 @@ struct VerticalTabsSidebar: View {
             lastSidebarSelectionIndex: $lastSidebarSelectionIndex,
             showsModifierShortcutHints: resolvedShowsModifierShortcutHints,
             dragAutoScrollController: dragAutoScrollController,
-            isBeingDragged: isBeingDragged,
             topDropIndicatorVisible: false,
             onReorderChanged: onReorderChanged,
             onReorderEnded: onReorderEnded,
@@ -12352,13 +12351,19 @@ struct VerticalTabsSidebar: View {
         .equatable()
 
         let indent: CGFloat = tab.groupId != nil ? SidebarWorkspaceGroupingMetrics.memberIndent : 0
+        // Applying the dragged-row "invisible placeholder" opacity here in the
+        // parent (rather than inside `TabItemView`) keeps the gesture-hosting
+        // row's inputs constant during a drag, so `.equatable()` skips its body
+        // and the in-flight `DragGesture` is not torn down when the drag starts.
         if role == .dragFollower {
             row
+                .opacity(isBeingDragged ? 0 : 1)
                 .allowsHitTesting(false)
                 .accessibilityHidden(true)
                 .padding(.leading, indent)
         } else {
             row
+                .opacity(isBeingDragged ? 0 : 1)
                 .id(tab.id)
                 .accessibilityIdentifier("sidebarWorkspace.\(tab.id.uuidString)")
                 .preference(key: SidebarWorkspaceRowIdsPreferenceKey.self, value: Set([tab.id]))
@@ -14824,7 +14829,6 @@ struct TabItemView: View, Equatable {
         lhs.allRemoteContextMenuTargetsDisconnected == rhs.allRemoteContextMenuTargetsDisconnected &&
         lhs.contextMenuPinState == rhs.contextMenuPinState &&
         lhs.workspaceGroupMenuSnapshot == rhs.workspaceGroupMenuSnapshot &&
-        lhs.isBeingDragged == rhs.isBeingDragged &&
         lhs.topDropIndicatorVisible == rhs.topDropIndicatorVisible &&
         lhs.isReorderEnabled == rhs.isReorderEnabled &&
         lhs.settings == rhs.settings
@@ -14857,7 +14861,6 @@ struct TabItemView: View, Equatable {
     // (see CLAUDE.md). When drag state changes, the parent recomputes these
     // per-row snapshots and `==` skips re-render for rows whose snapshot is
     // unchanged.
-    let isBeingDragged: Bool
     let topDropIndicatorVisible: Bool
     /// Reorder gesture callbacks (start location, current location), dispatched
     /// into the shared `VerticalTabsSidebar` reorder helpers via closures so the
@@ -15520,10 +15523,6 @@ struct TabItemView: View, Equatable {
         .padding(.horizontal, 6)
         .background { rowHeightProbe }
         .contentShape(Rectangle())
-        // The row being dragged renders fully invisible: its visible copy is the
-        // floating `SidebarReorderFollowerView`, and this slot is the gap the
-        // surrounding rows animate open around.
-        .opacity(isBeingDragged ? 0 : 1)
         .overlay {
             SidebarWorkspaceRowHoverTracker(rowInteractionState: $rowInteractionState)
         }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -10203,6 +10203,13 @@ final class SidebarDragState {
     var draggedTabId: UUID?
     var dropIndicator: SidebarDropIndicator?
     var dropIndicatorUsesTopLevelRows = false
+    /// Cursor Y (in the workspace list's coordinate space) of the active
+    /// gesture-driven reorder. Read ONLY by the isolated `SidebarReorderFollowerView`
+    /// overlay so the floating follower can track the cursor every frame without
+    /// invalidating the `LazyVStack` body. The parent body and list rows must
+    /// never read this — doing so would re-run them per frame and reintroduce
+    /// the https://github.com/manaflow-ai/cmux/issues/2586 layout-thrash loop.
+    var followerCursorY: CGFloat?
     /// True while the `debug.sidebar.simulate_drag` debug-only V2 method is
     /// driving the drag state. The lifecycle observers honor this by not
     /// starting `SidebarDragFailsafeMonitor` (which would otherwise post a
@@ -10211,7 +10218,55 @@ final class SidebarDragState {
     /// release flows.
     var isSimulated: Bool = false
 
+    // MARK: Gesture-reorder geometry (not observed)
+    // These back the gesture-driven reorder hit-testing. They are
+    // `@ObservationIgnored` so updating them (including the high-frequency
+    // `rowFramesInList` push during a drag) never invalidates any view; only
+    // this type's own methods read them, and the indicator/cursor results they
+    // produce flow through the observed properties above.
+
+    /// The picked-up row's frame in list space, captured at drag start. Sizes
+    /// and positions the follower.
+    @ObservationIgnored var draggedRowFrame: CGRect?
+    /// Offset of the cursor within the picked-up row at drag start, so the
+    /// follower keeps the same grab point under the cursor.
+    @ObservationIgnored var grabOffsetY: CGFloat = 0
+    /// Live frames of the currently-rendered workspace rows + group headers,
+    /// keyed by represented workspace id, in list space.
+    @ObservationIgnored var rowFramesInList: [UUID: CGRect] = [:]
+    /// Reads the current cursor Y in list space (NSEvent-backed). Set by the
+    /// view; used by the auto-scroll tick to keep the indicator fresh while the
+    /// pointer sits still at an edge and content scrolls underneath.
+    @ObservationIgnored var cursorYProvider: (() -> CGFloat?)?
+    @ObservationIgnored private var reorderIds: [UUID] = []
+    @ObservationIgnored private var pinnedIds: Set<UUID> = []
+    /// For each reorder-scope id, the represented ids of the rendered rows that
+    /// compose its hit-test band (a single row normally; a group header plus its
+    /// members when dragging a group anchor at top level).
+    @ObservationIgnored private var scopeBandComposition: [UUID: [UUID]] = [:]
+
+    /// Dead-zone half-width around a row midpoint within which the landing edge
+    /// is held, so the gap does not flicker on sub-pixel jitter.
+    static let hysteresisMargin: CGFloat = 6
+
     init() {}
+
+    /// Pushes the latest rendered row frames. While a drag is active the
+    /// committed frames are frozen (only newly-rendered rows are added, existing
+    /// ones are not overwritten): the list reflows to preview the gap, but
+    /// hit-testing stays against the committed layout so the landing slot does
+    /// not feed back on its own preview and oscillate.
+    func updateRowFrames(_ frames: [UUID: CGRect]) {
+        guard draggedTabId != nil else {
+            rowFramesInList = frames
+            return
+        }
+        for (id, frame) in frames where rowFramesInList[id] == nil {
+            rowFramesInList[id] = frame
+        }
+    }
+
+    // MARK: simulate_drag / legacy API (drives observed state directly)
 
     func beginDragging(tabId: UUID) {
         draggedTabId = tabId
@@ -10229,7 +10284,99 @@ final class SidebarDragState {
 
     func clearDrag() {
         draggedTabId = nil
+        followerCursorY = nil
+        draggedRowFrame = nil
+        grabOffsetY = 0
+        reorderIds = []
+        pinnedIds = []
+        scopeBandComposition = [:]
         clearDropIndicator()
+    }
+
+    // MARK: Gesture-driven reorder
+
+    /// Begins a gesture-driven reorder of `tabId`.
+    func beginReorder(
+        tabId: UUID,
+        usesTopLevelRows: Bool,
+        reorderIds: [UUID],
+        pinnedIds: Set<UUID>,
+        scopeBandComposition: [UUID: [UUID]],
+        draggedRowFrame: CGRect?,
+        grabOffsetY: CGFloat,
+        cursorY: CGFloat
+    ) {
+        self.draggedTabId = tabId
+        self.dropIndicatorUsesTopLevelRows = usesTopLevelRows
+        self.reorderIds = reorderIds
+        self.pinnedIds = pinnedIds
+        self.scopeBandComposition = scopeBandComposition
+        self.draggedRowFrame = draggedRowFrame
+        self.grabOffsetY = grabOffsetY
+        self.followerCursorY = cursorY
+        recomputeIndicator(cursorY: cursorY)
+    }
+
+    /// Updates the follower position and landing slot for a moved cursor.
+    func updateReorder(cursorY: CGFloat) {
+        followerCursorY = cursorY
+        recomputeIndicator(cursorY: cursorY)
+    }
+
+    /// Re-reads the cursor from `cursorYProvider` and refreshes. Called by the
+    /// auto-scroll tick so the landing slot keeps advancing while the pointer is
+    /// stationary at an edge.
+    func refreshFromCursor() {
+        guard draggedTabId != nil, let cursorY = cursorYProvider?() else { return }
+        updateReorder(cursorY: cursorY)
+    }
+
+    /// The committed index the dragged workspace should move to on drop, or nil
+    /// for a no-op. Reads gesture geometry; call only at drop time, not in a
+    /// view body.
+    func gestureReorderTargetIndex() -> Int? {
+        guard let draggedTabId, dropIndicator != nil else { return nil }
+        return SidebarDropPlanner.targetIndex(
+            draggedTabId: draggedTabId,
+            targetTabId: dropIndicator?.tabId,
+            indicator: dropIndicator,
+            tabIds: reorderIds,
+            pinnedTabIds: pinnedIds
+        )
+    }
+
+    private func recomputeIndicator(cursorY: CGFloat) {
+        guard let draggedTabId else { return }
+        let bands = buildBands()
+        let indicator = SidebarReorderIndicatorResolver.resolve(
+            cursorY: cursorY,
+            bands: bands,
+            draggedId: draggedTabId,
+            pinnedIds: pinnedIds,
+            current: dropIndicator,
+            hysteresisMargin: Self.hysteresisMargin
+        )
+        if indicator != dropIndicator {
+            dropIndicator = indicator
+        }
+    }
+
+    private func buildBands() -> [SidebarReorderIndicatorResolver.Band] {
+        var bands: [SidebarReorderIndicatorResolver.Band] = []
+        bands.reserveCapacity(reorderIds.count)
+        for scopeId in reorderIds {
+            let composition = scopeBandComposition[scopeId] ?? [scopeId]
+            var minY = CGFloat.greatestFiniteMagnitude
+            var maxY = -CGFloat.greatestFiniteMagnitude
+            for renderedId in composition {
+                guard let frame = rowFramesInList[renderedId] else { continue }
+                minY = min(minY, frame.minY)
+                maxY = max(maxY, frame.maxY)
+            }
+            guard maxY > minY else { continue }
+            bands.append(.init(id: scopeId, minY: minY, maxY: maxY))
+        }
+        return bands.sorted { $0.minY < $1.minY }
     }
 }
 
@@ -11968,16 +12115,27 @@ struct VerticalTabsSidebar: View {
     }
 
     private func workspaceRows(renderContext: WorkspaceListRenderContext) -> some View {
-        let renderItems = SidebarWorkspaceRenderItem.renderItems(
+        let baseRenderItems = SidebarWorkspaceRenderItem.renderItems(
             tabs: renderContext.tabs,
             groupsById: renderContext.workspaceGroupById
         )
-        // LazyVStack is safe here because `dragState` is @Observable:
-        // drag mutations at 60fps invalidate only the rows/overlays that
-        // read them, never this sidebar body. See SidebarDragState and
+        // During a gesture-driven reorder the list reflows to `previewItems`
+        // (the dragged row moved to its landing slot) so the gap animates open.
+        // `dropIndicator` is discrete — it changes only when the landing slot
+        // crosses a row midpoint — so this body re-runs a handful of times per
+        // drag, never per frame. The per-frame follower position lives in the
+        // isolated `SidebarReorderFollowerView`, which alone reads
+        // `dragState.followerCursorY`. LazyVStack is safe here because
+        // `dragState` is @Observable. See SidebarDragState and
         // https://github.com/manaflow-ai/cmux/issues/2586.
+        let previewItems = SidebarWorkspaceRenderItem.dragPreviewItems(
+            baseRenderItems,
+            draggedWorkspaceId: dragState.draggedTabId,
+            dropIndicator: dragState.dropIndicator,
+            reorderWorkspaceIds: renderContext.sidebarReorderIds
+        )
         return LazyVStack(spacing: tabRowSpacing) {
-            ForEach(renderItems, id: \.id) { item in
+            ForEach(previewItems, id: \.id) { item in
                 switch item {
                 case .groupHeader(let group, let memberWorkspaceIds):
                     sidebarWorkspaceGroupHeader(
@@ -11985,13 +12143,37 @@ struct VerticalTabsSidebar: View {
                         memberWorkspaceIds: memberWorkspaceIds,
                         renderContext: renderContext
                     )
-                case .workspace(let tab):
+                case .workspace(let tab, _):
                     workspaceRow(tab, renderContext: renderContext)
                 }
             }
         }
+        .animation(Self.sidebarReorderAnimation, value: previewItems.map(\.id))
         .padding(.vertical, SidebarWorkspaceListMetrics.rowVerticalPadding)
         .frame(maxWidth: .infinity, alignment: .leading)
+        .coordinateSpace(.named(SidebarReorderListCoordinateSpace.name))
+        .onPreferenceChange(SidebarReorderRowFrameKey.self) { frames in
+            dragState.updateRowFrames(frames)
+        }
+        .overlay {
+            SidebarReorderFollowerView(
+                dragState: dragState,
+                sourceItems: baseRenderItems,
+                rowContent: { item in
+                    switch item {
+                    case .groupHeader(let group, let memberWorkspaceIds):
+                        AnyView(sidebarWorkspaceGroupHeader(
+                            group: group,
+                            memberWorkspaceIds: memberWorkspaceIds,
+                            renderContext: renderContext,
+                            role: .dragFollower
+                        ))
+                    case .workspace(let tab, _):
+                        AnyView(workspaceRow(tab, renderContext: renderContext, role: .dragFollower))
+                    }
+                }
+            )
+        }
         .overlayPreferenceValue(SidebarWorkspaceRowFramePreferenceKey.self) { anchors in
             GeometryReader { proxy in
                 SidebarBonsplitTabWorkspaceDropOverlay(
@@ -12048,9 +12230,11 @@ struct VerticalTabsSidebar: View {
         }
     }
 
+    @ViewBuilder
     private func workspaceRow(
         _ tab: Workspace,
-        renderContext: WorkspaceListRenderContext
+        renderContext: WorkspaceListRenderContext,
+        role: SidebarWorkspaceRowRenderRole = .list
     ) -> some View {
         let index = renderContext.tabIndexById[tab.id] ?? 0
         let usesSelectedContextMenuTargets = selectedTabIds.contains(tab.id)
@@ -12108,39 +12292,28 @@ struct VerticalTabsSidebar: View {
         // is intentional: the parent owns the @Observable store, and these
         // value snapshots are what get passed to the row. The row's
         // Equatable conformance ignores closures, so rows whose snapshot is
-        // unchanged skip re-render when drag state moves.
-        let isBeingDragged = dragState.draggedTabId == tab.id
-        let sidebarReorderIds = renderContext.sidebarReorderIds
-        let topDropIndicatorVisible = SidebarTabDropIndicatorPredicate.topVisible(
-            forTabId: tab.id,
-            draggedTabId: dragState.draggedTabId,
-            dropIndicator: dragState.dropIndicator,
-            tabIds: sidebarReorderIds
-        )
-        let onDragStart: () -> NSItemProvider = { [tabId = tab.id] in
-            #if DEBUG
-            cmuxDebugLog("sidebar.onDrag tab=\(tabId.uuidString.prefix(5))")
-            #endif
-            dragState.beginDragging(tabId: tabId)
-            return SidebarTabDragPayload.provider(for: tabId)
-        }
-        let tabDropDelegateFactory: (CGFloat) -> SidebarTabDropDelegate = { [
-            tabId = tab.id,
-            selectedTabIds = $selectedTabIds,
-            lastSidebarSelectionIndex = $lastSidebarSelectionIndex
-        ] rowHeight in
-            SidebarTabDropDelegate(
-                targetTabId: tabId,
-                tabManager: tabManager,
-                dragState: dragState,
-                selectedTabIds: selectedTabIds,
-                lastSidebarSelectionIndex: lastSidebarSelectionIndex,
-                targetRowHeight: rowHeight,
-                dragAutoScrollController: dragAutoScrollController
+        // unchanged skip re-render when drag state moves. The dragged row in the
+        // list reads as `isBeingDragged` and renders invisible (the floating
+        // follower carries the visible copy); the follower copy itself
+        // (`role == .dragFollower`) renders fully visible.
+        let isBeingDragged = role == .list && dragState.draggedTabId == tab.id
+        // The reorder gesture, dispatched into the shared reorder helpers. Wired
+        // into `TabItemView` so it lives below `.equatable()` and survives the
+        // parent body re-evaluations that the discrete drop-indicator changes
+        // trigger, instead of being torn down mid-drag.
+        let onReorderChanged: (CGPoint, CGPoint) -> Void = { [tabId = tab.id, renderContext] startLocation, location in
+            sidebarReorderGestureChanged(
+                draggedId: tabId,
+                startLocationY: startLocation.y,
+                cursorY: location.y,
+                renderContext: renderContext
             )
         }
+        let onReorderEnded: (CGPoint, CGPoint) -> Void = { [tabId = tab.id] _, _ in
+            sidebarReorderGestureEnded(draggedId: tabId)
+        }
 
-        return TabItemView(
+        let row = TabItemView(
             tabManager: tabManager,
             notificationStore: notificationStore,
             tab: tab,
@@ -12162,9 +12335,10 @@ struct VerticalTabsSidebar: View {
             showsModifierShortcutHints: resolvedShowsModifierShortcutHints,
             dragAutoScrollController: dragAutoScrollController,
             isBeingDragged: isBeingDragged,
-            topDropIndicatorVisible: topDropIndicatorVisible,
-            onDragStart: onDragStart,
-            tabDropDelegateFactory: tabDropDelegateFactory,
+            topDropIndicatorVisible: false,
+            onReorderChanged: onReorderChanged,
+            onReorderEnded: onReorderEnded,
+            isReorderEnabled: role == .list,
             contextMenuWorkspaceIds: contextMenuWorkspaceIds,
             remoteContextMenuWorkspaceIds: remoteContextMenuWorkspaceIds,
             allRemoteContextMenuTargetsConnecting: allRemoteContextMenuTargetsConnecting,
@@ -12176,13 +12350,23 @@ struct VerticalTabsSidebar: View {
             onContextMenuDisappear: onContextMenuDisappear
         )
         .equatable()
-        .id(tab.id)
-        .accessibilityIdentifier("sidebarWorkspace.\(tab.id.uuidString)")
-        .preference(key: SidebarWorkspaceRowIdsPreferenceKey.self, value: Set([tab.id]))
-        .anchorPreference(key: SidebarWorkspaceRowFramePreferenceKey.self, value: .bounds) { anchor in
-            [tab.id: anchor]
+
+        let indent: CGFloat = tab.groupId != nil ? SidebarWorkspaceGroupingMetrics.memberIndent : 0
+        if role == .dragFollower {
+            row
+                .allowsHitTesting(false)
+                .accessibilityHidden(true)
+                .padding(.leading, indent)
+        } else {
+            row
+                .id(tab.id)
+                .accessibilityIdentifier("sidebarWorkspace.\(tab.id.uuidString)")
+                .preference(key: SidebarWorkspaceRowIdsPreferenceKey.self, value: Set([tab.id]))
+                .anchorPreference(key: SidebarWorkspaceRowFramePreferenceKey.self, value: .bounds) { anchor in
+                    [tab.id: anchor]
+                }
+                .padding(.leading, indent)
         }
-        .padding(.leading, tab.groupId != nil ? SidebarWorkspaceGroupingMetrics.memberIndent : 0)
     }
 
     private func debugShortSidebarTabId(_ id: UUID?) -> String {
@@ -14642,6 +14826,7 @@ struct TabItemView: View, Equatable {
         lhs.workspaceGroupMenuSnapshot == rhs.workspaceGroupMenuSnapshot &&
         lhs.isBeingDragged == rhs.isBeingDragged &&
         lhs.topDropIndicatorVisible == rhs.topDropIndicatorVisible &&
+        lhs.isReorderEnabled == rhs.isReorderEnabled &&
         lhs.settings == rhs.settings
     }
 
@@ -14674,11 +14859,14 @@ struct TabItemView: View, Equatable {
     // unchanged.
     let isBeingDragged: Bool
     let topDropIndicatorVisible: Bool
-    let onDragStart: () -> NSItemProvider
-    /// Factory invoked from `body` with the row's measured `rowHeight`. Closure
-    /// captures the parent's `dragState`, so TabItemView itself never holds an
-    /// `@Observable` store reference (snapshot-boundary rule).
-    let tabDropDelegateFactory: (CGFloat) -> SidebarTabDropDelegate
+    /// Reorder gesture callbacks (start location, current location), dispatched
+    /// into the shared `VerticalTabsSidebar` reorder helpers via closures so the
+    /// row never holds an `@Observable` store reference (snapshot-boundary rule).
+    let onReorderChanged: (CGPoint, CGPoint) -> Void
+    let onReorderEnded: (CGPoint, CGPoint) -> Void
+    /// False for the floating follower copy, which is non-interactive and must
+    /// not report a row frame.
+    let isReorderEnabled: Bool
     let contextMenuWorkspaceIds: [UUID]
     let remoteContextMenuWorkspaceIds: [UUID]
     let allRemoteContextMenuTargetsConnecting: Bool
@@ -15332,7 +15520,10 @@ struct TabItemView: View, Equatable {
         .padding(.horizontal, 6)
         .background { rowHeightProbe }
         .contentShape(Rectangle())
-        .opacity(isBeingDragged ? 0.6 : 1)
+        // The row being dragged renders fully invisible: its visible copy is the
+        // floating `SidebarReorderFollowerView`, and this slot is the gap the
+        // surrounding rows animate open around.
+        .opacity(isBeingDragged ? 0 : 1)
         .overlay {
             SidebarWorkspaceRowHoverTracker(rowInteractionState: $rowInteractionState)
         }
@@ -15404,9 +15595,12 @@ struct TabItemView: View, Equatable {
         .onChange(of: settings) { _ in
             refreshWorkspaceSnapshot(force: true)
         }
-        .onDrag(onDragStart)
-        .internalOnlyTabDrag()
-        .onDrop(of: SidebarTabDragPayload.dropContentTypes, delegate: tabDropDelegateFactory(rowHeight))
+        .modifier(SidebarReorderRowModifier(
+            enabled: isReorderEnabled,
+            workspaceId: tab.id,
+            onChanged: onReorderChanged,
+            onEnded: onReorderEnded
+        ))
         .onDrop(of: BonsplitTabDragPayload.dropContentTypes, delegate: SidebarBonsplitTabDropDelegate(
             targetWorkspaceId: tab.id,
             tabManager: tabManager,

--- a/Sources/Sidebar/SidebarReorderFollowerView.swift
+++ b/Sources/Sidebar/SidebarReorderFollowerView.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+/// The floating copy of the picked-up workspace row that tracks the cursor
+/// during a gesture-driven reorder.
+///
+/// This is the ONLY view that reads `SidebarDragState.followerCursorY`, the
+/// per-frame cursor position. Because it is a sibling overlay over the list (not
+/// a row inside the `LazyVStack`/`ForEach`), its per-frame updates repaint just
+/// this one view and never invalidate the list body — the property that keeps
+/// the drag off the https://github.com/manaflow-ai/cmux/issues/2586 thrash path.
+/// Implicit animations are disabled so the follower snaps to the cursor with
+/// zero lag while the list rows animate the gap open underneath it.
+struct SidebarReorderFollowerView: View {
+    let dragState: SidebarDragState
+    /// The committed render list, used to find the picked-up row's content.
+    let sourceItems: [SidebarWorkspaceRenderItem]
+    let rowContent: (SidebarWorkspaceRenderItem) -> AnyView
+
+    var body: some View {
+        if let draggedId = dragState.draggedTabId,
+           let cursorY = dragState.followerCursorY,
+           let frame = dragState.draggedRowFrame,
+           frame.width > 0,
+           frame.height > 0,
+           let item = sourceItems.first(where: { $0.representedWorkspaceId == draggedId }) {
+            let topY = cursorY - dragState.grabOffsetY
+            rowContent(item)
+                .frame(width: frame.width, height: frame.height, alignment: .topLeading)
+                .position(x: frame.midX, y: topY + frame.height / 2)
+                .shadow(color: Color.black.opacity(0.18), radius: 11, x: 0, y: 5)
+                .opacity(0.97)
+                .allowsHitTesting(false)
+                .accessibilityHidden(true)
+                .zIndex(1000)
+                .transaction { transaction in
+                    transaction.disablesAnimations = true
+                    transaction.animation = nil
+                }
+        }
+    }
+}

--- a/Sources/Sidebar/SidebarReorderIndicatorResolver.swift
+++ b/Sources/Sidebar/SidebarReorderIndicatorResolver.swift
@@ -1,0 +1,115 @@
+import CoreGraphics
+import Foundation
+
+/// Maps a drag cursor position to a ``SidebarDropIndicator`` for the gesture
+/// driven workspace reorder, with hysteresis so the gap does not flicker when
+/// the cursor hovers exactly on a row's midpoint.
+///
+/// Pure and self-contained so it is unit-testable without a running app: the
+/// caller passes the reorder-scope rows as vertical bands (already resolved
+/// from the live row frames) plus the current cursor Y, all in one coordinate
+/// space. Edge/insertion/pinned-tier legality is delegated to
+/// ``SidebarDropPlanner``; this type only adds hit-testing and stickiness.
+enum SidebarReorderIndicatorResolver {
+    /// One reorder-scope item's vertical extent in list space. For a top-level
+    /// group drag, a band spans the group header plus all its member rows so
+    /// the whole group reads as one target.
+    struct Band: Equatable {
+        let id: UUID
+        let minY: CGFloat
+        let maxY: CGFloat
+
+        var midY: CGFloat { (minY + maxY) / 2 }
+        var height: CGFloat { max(maxY - minY, 0) }
+    }
+
+    /// Resolves the drop indicator for `cursorY`.
+    ///
+    /// - Parameters:
+    ///   - cursorY: cursor Y in the same list space as the band extents.
+    ///   - bands: reorder-scope bands in scope order, contiguous and sorted.
+    ///   - draggedId: the workspace being dragged.
+    ///   - pinnedIds: pinned ids within the scope (tier constraint).
+    ///   - current: the indicator currently shown, used for hysteresis.
+    ///   - hysteresisMargin: half-width of the dead-zone around a band midpoint
+    ///     within which the current edge is kept (points).
+    /// - Returns: the indicator to show, or nil for a no-op move.
+    static func resolve(
+        cursorY: CGFloat,
+        bands: [Band],
+        draggedId: UUID,
+        pinnedIds: Set<UUID>,
+        current: SidebarDropIndicator?,
+        hysteresisMargin: CGFloat
+    ) -> SidebarDropIndicator? {
+        guard !bands.isEmpty else { return nil }
+        let scopeIds = bands.map(\.id)
+
+        // Below every row: append to the end of the scope.
+        guard let lastBand = bands.last, cursorY <= lastBand.maxY else {
+            return SidebarDropPlanner.indicator(
+                draggedTabId: draggedId,
+                targetTabId: nil,
+                tabIds: scopeIds,
+                pinnedTabIds: pinnedIds
+            )
+        }
+
+        // First band whose bottom edge is below the cursor is the target; this
+        // also assigns the inter-row spacing gap to the lower band.
+        let targetBand = bands.first(where: { cursorY < $0.maxY }) ?? lastBand
+        let pointerY = cursorY - targetBand.minY
+
+        let effectivePointerY = stickyPointerY(
+            pointerY: pointerY,
+            band: targetBand,
+            scopeIds: scopeIds,
+            current: current,
+            margin: hysteresisMargin
+        )
+
+        return SidebarDropPlanner.indicator(
+            draggedTabId: draggedId,
+            targetTabId: targetBand.id,
+            tabIds: scopeIds,
+            pinnedTabIds: pinnedIds,
+            pointerY: effectivePointerY,
+            targetHeight: targetBand.height
+        )
+    }
+
+    /// Biases `pointerY` toward the current edge while the cursor sits within
+    /// `margin` of the band midpoint, so the indicator does not oscillate on
+    /// sub-pixel jitter at the 50% split.
+    private static func stickyPointerY(
+        pointerY: CGFloat,
+        band: Band,
+        scopeIds: [UUID],
+        current: SidebarDropIndicator?,
+        margin: CGFloat
+    ) -> CGFloat {
+        let mid = band.height / 2
+        guard margin > 0, abs(pointerY - mid) < margin else { return pointerY }
+        guard let edge = currentEdge(for: band, scopeIds: scopeIds, current: current) else {
+            return pointerY
+        }
+        return edge == .top ? mid - margin : mid + margin
+    }
+
+    /// The edge of `band` that the current indicator represents, if any. The
+    /// planner canonicalizes "after row i" to "top of row i+1" (or the end
+    /// sentinel), so both forms are matched here.
+    private static func currentEdge(
+        for band: Band,
+        scopeIds: [UUID],
+        current: SidebarDropIndicator?
+    ) -> SidebarDropEdge? {
+        guard let current else { return nil }
+        if current.tabId == band.id, current.edge == .top { return .top }
+        guard let index = scopeIds.firstIndex(of: band.id) else { return nil }
+        let afterId: UUID? = index + 1 < scopeIds.count ? scopeIds[index + 1] : nil
+        if let afterId, current.tabId == afterId, current.edge == .top { return .bottom }
+        if afterId == nil, current.tabId == nil, current.edge == .bottom { return .bottom }
+        return nil
+    }
+}

--- a/Sources/Sidebar/SidebarReorderRowFrameKey.swift
+++ b/Sources/Sidebar/SidebarReorderRowFrameKey.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+/// Collects the live frames of the workspace sidebar rows (and group headers),
+/// keyed by represented workspace id, in the list's `"sidebarReorderList"`
+/// coordinate space.
+///
+/// The gesture-driven reorder reads these via `.onPreferenceChange` to hit-test
+/// the drag cursor against the rows. Resolving concrete `CGRect`s (rather than
+/// `Anchor<CGRect>`) lets the value flow straight into `SidebarDragState`'s
+/// non-observed geometry without a `GeometryProxy`, so the push never happens
+/// inside a view-body computation.
+struct SidebarReorderRowFrameKey: PreferenceKey {
+    static let defaultValue: [UUID: CGRect] = [:]
+
+    static func reduce(value: inout [UUID: CGRect], nextValue: () -> [UUID: CGRect]) {
+        value.merge(nextValue(), uniquingKeysWith: { _, new in new })
+    }
+}
+
+extension View {
+    /// Reports this row's frame in the reorder list coordinate space under
+    /// `workspaceId`.
+    func sidebarReorderRowFrame(_ workspaceId: UUID) -> some View {
+        background(
+            GeometryReader { proxy in
+                Color.clear.preference(
+                    key: SidebarReorderRowFrameKey.self,
+                    value: [workspaceId: proxy.frame(in: .named(SidebarReorderListCoordinateSpace.name))]
+                )
+            }
+        )
+    }
+}
+
+/// The named coordinate space the reorder gesture and row frames share, so the
+/// gesture location and the measured row frames are guaranteed to align.
+enum SidebarReorderListCoordinateSpace {
+    static let name = "sidebarReorderList"
+}

--- a/Sources/Sidebar/VerticalTabsSidebar+Reorder.swift
+++ b/Sources/Sidebar/VerticalTabsSidebar+Reorder.swift
@@ -1,0 +1,168 @@
+import AppKit
+import SwiftUI
+
+/// How a sidebar workspace row / group header is being rendered.
+enum SidebarWorkspaceRowRenderRole {
+    /// A normal interactive row in the list. Carries the reorder gesture and
+    /// reports its frame; renders invisible while it is the one being dragged
+    /// (its visible copy is the floating follower).
+    case list
+    /// The floating follower copy painted over the list during a reorder drag.
+    /// Always fully visible, never interactive, reports no frame.
+    case dragFollower
+}
+
+/// Gesture-driven workspace reorder, shared by workspace rows and group-header
+/// (anchor) rows so both reorder through one path. Replaces the old
+/// `.onDrag` system-drag + `DropDelegate` reorder, whose coarse, target-gated
+/// location updates made the drag feel laggy.
+extension VerticalTabsSidebar {
+    /// The spring the list rows use to animate the gap open and to settle into
+    /// place on drop.
+    static let sidebarReorderAnimation = Animation.snappy(duration: 0.22, extraBounce: 0.02)
+
+    /// Handles a reorder drag tick: begins the drag on the first event, then
+    /// updates the follower position and landing slot.
+    ///
+    /// - Parameters:
+    ///   - draggedId: the workspace (or group anchor) being dragged.
+    ///   - startLocationY: the gesture's start Y in the reorder list space.
+    ///   - cursorY: the gesture's current Y in the reorder list space.
+    func sidebarReorderGestureChanged(
+        draggedId: UUID,
+        startLocationY: CGFloat,
+        cursorY: CGFloat,
+        renderContext: WorkspaceListRenderContext
+    ) {
+        if dragState.draggedTabId != draggedId {
+            #if DEBUG
+            cmuxDebugLog("sidebar.reorder.begin id=\(draggedId.uuidString.prefix(5)) startY=\(Int(startLocationY)) cursorY=\(Int(cursorY))")
+            #endif
+            let usesTopLevelRows = tabManager.sidebarReorderUsesTopLevelRows(
+                forDraggedWorkspaceId: draggedId,
+                targetWorkspaceId: nil
+            )
+            let reorderIds = tabManager.sidebarReorderWorkspaceIds(
+                forDraggedWorkspaceId: draggedId,
+                usesTopLevelRows: usesTopLevelRows
+            )
+            let pinnedIds = tabManager.sidebarReorderPinnedWorkspaceIds(
+                forDraggedWorkspaceId: draggedId,
+                usesTopLevelRows: usesTopLevelRows
+            )
+            let composition = sidebarReorderScopeBandComposition(
+                usesTopLevelRows: usesTopLevelRows,
+                renderContext: renderContext
+            )
+            let frame = dragState.rowFramesInList[draggedId]
+            let grabOffsetY = frame.map { startLocationY - $0.minY } ?? 0
+            dragState.beginReorder(
+                tabId: draggedId,
+                usesTopLevelRows: usesTopLevelRows,
+                reorderIds: reorderIds,
+                pinnedIds: pinnedIds,
+                scopeBandComposition: composition,
+                draggedRowFrame: frame,
+                grabOffsetY: grabOffsetY,
+                cursorY: cursorY
+            )
+        } else {
+            dragState.updateReorder(cursorY: cursorY)
+        }
+        dragAutoScrollController.updateFromDragLocation()
+    }
+
+    /// Commits the reorder on drag end, animating the list into the landing
+    /// slot, then clears the drag state.
+    func sidebarReorderGestureEnded(draggedId: UUID) {
+        defer {
+            dragState.clearDrag()
+            dragAutoScrollController.stop()
+        }
+        guard dragState.draggedTabId == draggedId,
+              let targetIndex = dragState.gestureReorderTargetIndex() else {
+            #if DEBUG
+            cmuxDebugLog("sidebar.reorder.end id=\(draggedId.uuidString.prefix(5)) target=nil (noop)")
+            #endif
+            return
+        }
+        let usesTopLevelRows = dragState.dropIndicatorUsesTopLevelRows
+        #if DEBUG
+        cmuxDebugLog("sidebar.reorder.end id=\(draggedId.uuidString.prefix(5)) target=\(targetIndex) topLevel=\(usesTopLevelRows)")
+        #endif
+        withAnimation(Self.sidebarReorderAnimation) {
+            _ = tabManager.reorderSidebarWorkspace(
+                tabId: draggedId,
+                toIndex: targetIndex,
+                isDragOperation: true,
+                usesTopLevelRows: usesTopLevelRows
+            )
+        }
+    }
+
+    /// Maps each reorder-scope id to the rendered rows that compose its hit-test
+    /// band. Empty (identity) in normal mode; in top-level mode each group
+    /// anchor's band spans its header plus its members so the group reads as one
+    /// drop target.
+    func sidebarReorderScopeBandComposition(
+        usesTopLevelRows: Bool,
+        renderContext: WorkspaceListRenderContext
+    ) -> [UUID: [UUID]] {
+        guard usesTopLevelRows else { return [:] }
+        var composition: [UUID: [UUID]] = [:]
+        for group in renderContext.workspaceGroupById.values {
+            let memberIds = renderContext.tabs
+                .filter { $0.groupId == group.id && $0.id != group.anchorWorkspaceId }
+                .map(\.id)
+            composition[group.anchorWorkspaceId] = [group.anchorWorkspaceId] + memberIds
+        }
+        return composition
+    }
+}
+
+/// Attaches the reorder `DragGesture` to a row. The gesture runs in the shared
+/// `"sidebarReorderList"` space so its location aligns with the measured row
+/// frames. A non-zero `minimumDistance` lets a plain click still select the row.
+struct SidebarReorderDragModifier: ViewModifier {
+    let onChanged: (_ startLocation: CGPoint, _ location: CGPoint) -> Void
+    let onEnded: (_ startLocation: CGPoint, _ location: CGPoint) -> Void
+
+    func body(content: Content) -> some View {
+        content.gesture(
+            DragGesture(minimumDistance: 6, coordinateSpace: .named(SidebarReorderListCoordinateSpace.name))
+                .onChanged { value in onChanged(value.startLocation, value.location) }
+                .onEnded { value in onEnded(value.startLocation, value.location) }
+        )
+    }
+}
+
+extension View {
+    func sidebarReorderDrag(
+        onChanged: @escaping (_ startLocation: CGPoint, _ location: CGPoint) -> Void,
+        onEnded: @escaping (_ startLocation: CGPoint, _ location: CGPoint) -> Void
+    ) -> some View {
+        modifier(SidebarReorderDragModifier(onChanged: onChanged, onEnded: onEnded))
+    }
+}
+
+/// Adds the reorder gesture and frame reporter to an interactive sidebar row.
+/// `enabled` is constant for a given row role, so the `if` never re-keys view
+/// identity at runtime; the follower copy passes `enabled: false` to stay
+/// non-interactive and report no frame.
+struct SidebarReorderRowModifier: ViewModifier {
+    let enabled: Bool
+    let workspaceId: UUID
+    let onChanged: (_ startLocation: CGPoint, _ location: CGPoint) -> Void
+    let onEnded: (_ startLocation: CGPoint, _ location: CGPoint) -> Void
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if enabled {
+            content
+                .sidebarReorderRowFrame(workspaceId)
+                .sidebarReorderDrag(onChanged: onChanged, onEnded: onEnded)
+        } else {
+            content
+        }
+    }
+}

--- a/Sources/SidebarWorkspaceGroupHeaderView.swift
+++ b/Sources/SidebarWorkspaceGroupHeaderView.swift
@@ -27,7 +27,8 @@ struct SidebarWorkspaceGroupHeaderView: View, Equatable {
             lhs.rowSpacing == rhs.rowSpacing &&
             lhs.isFirstRow == rhs.isFirstRow &&
             lhs.isBeingDragged == rhs.isBeingDragged &&
-            lhs.topDropIndicatorVisible == rhs.topDropIndicatorVisible
+            lhs.topDropIndicatorVisible == rhs.topDropIndicatorVisible &&
+            lhs.isReorderEnabled == rhs.isReorderEnabled
     }
 
     let groupId: UUID
@@ -51,8 +52,11 @@ struct SidebarWorkspaceGroupHeaderView: View, Equatable {
     let isFirstRow: Bool
     let isBeingDragged: Bool
     let topDropIndicatorVisible: Bool
-    let onDragStart: () -> NSItemProvider
-    let tabDropDelegateFactory: (CGFloat) -> SidebarWorkspaceGroupHeaderDropDelegate
+    /// Reorder gesture callbacks dispatched into the shared reorder helpers.
+    let onReorderChanged: (CGPoint, CGPoint) -> Void
+    let onReorderEnded: (CGPoint, CGPoint) -> Void
+    /// False for the floating follower copy.
+    let isReorderEnabled: Bool
     let onToggleCollapsed: () -> Void
     let onFocusAnchor: () -> Void
     let onTapPlus: () -> Void
@@ -220,7 +224,9 @@ struct SidebarWorkspaceGroupHeaderView: View, Equatable {
         .padding(.horizontal, 6)
         .background { rowHeightProbe }
         .shortcutHintVisibilityAnimation(value: showsShortcutHint)
-        .opacity(isBeingDragged ? 0.6 : 1)
+        // The dragged header renders invisible; its visible copy is the floating
+        // follower and this slot is the gap that opens during a reorder.
+        .opacity(isBeingDragged ? 0 : 1)
         .overlay(alignment: .top) {
             SidebarWorkspaceTopDropIndicator(
                 isVisible: topDropIndicatorVisible,
@@ -228,9 +234,12 @@ struct SidebarWorkspaceGroupHeaderView: View, Equatable {
                 rowSpacing: rowSpacing
             )
         }
-        .onDrag(onDragStart)
-        .internalOnlyTabDrag()
-        .onDrop(of: SidebarTabDragPayload.dropContentTypes, delegate: tabDropDelegateFactory(rowHeight))
+        .modifier(SidebarReorderRowModifier(
+            enabled: isReorderEnabled,
+            workspaceId: anchorWorkspaceId,
+            onChanged: onReorderChanged,
+            onEnded: onReorderEnded
+        ))
         .onHover { hovering in
             isHovered = hovering
         }

--- a/Sources/SidebarWorkspaceGroupHeaderView.swift
+++ b/Sources/SidebarWorkspaceGroupHeaderView.swift
@@ -26,7 +26,6 @@ struct SidebarWorkspaceGroupHeaderView: View, Equatable {
             lhs.newWorkspacePlacement == rhs.newWorkspacePlacement &&
             lhs.rowSpacing == rhs.rowSpacing &&
             lhs.isFirstRow == rhs.isFirstRow &&
-            lhs.isBeingDragged == rhs.isBeingDragged &&
             lhs.topDropIndicatorVisible == rhs.topDropIndicatorVisible &&
             lhs.isReorderEnabled == rhs.isReorderEnabled
     }
@@ -50,7 +49,6 @@ struct SidebarWorkspaceGroupHeaderView: View, Equatable {
     let newWorkspacePlacement: WorkspaceGroupNewPlacement?
     let rowSpacing: CGFloat
     let isFirstRow: Bool
-    let isBeingDragged: Bool
     let topDropIndicatorVisible: Bool
     /// Reorder gesture callbacks dispatched into the shared reorder helpers.
     let onReorderChanged: (CGPoint, CGPoint) -> Void
@@ -224,9 +222,6 @@ struct SidebarWorkspaceGroupHeaderView: View, Equatable {
         .padding(.horizontal, 6)
         .background { rowHeightProbe }
         .shortcutHintVisibilityAnimation(value: showsShortcutHint)
-        // The dragged header renders invisible; its visible copy is the floating
-        // follower and this slot is the gap that opens during a reorder.
-        .opacity(isBeingDragged ? 0 : 1)
         .overlay(alignment: .top) {
             SidebarWorkspaceTopDropIndicator(
                 isVisible: topDropIndicatorVisible,

--- a/Sources/SidebarWorkspaceRenderItem.swift
+++ b/Sources/SidebarWorkspaceRenderItem.swift
@@ -1,19 +1,56 @@
 import Foundation
 
 /// One drawable item in the workspace sidebar.
+///
+/// `.workspace` carries an `effectiveGroupId` so the live reorder preview can
+/// show a row indenting into (or out of) a group before the drop commits. It is
+/// the group the row currently renders as a member of, which during a drag may
+/// differ from `workspace.groupId` (the committed membership).
 @MainActor
 enum SidebarWorkspaceRenderItem {
     case groupHeader(WorkspaceGroup, memberWorkspaceIds: [UUID])
-    case workspace(Workspace)
+    case workspace(Workspace, effectiveGroupId: UUID?)
+
+    /// The workspace this item represents: the row's workspace, or a group
+    /// header's anchor workspace.
+    var representedWorkspaceId: UUID {
+        switch self {
+        case .groupHeader(let group, _):
+            return group.anchorWorkspaceId
+        case .workspace(let workspace, _):
+            return workspace.id
+        }
+    }
+
+    /// The group the row renders as a member of (nil for top-level rows and
+    /// group headers).
+    var effectiveGroupId: UUID? {
+        switch self {
+        case .groupHeader:
+            return nil
+        case .workspace(_, let groupId):
+            return groupId
+        }
+    }
 
     var id: String {
         switch self {
         case .groupHeader(let group, _):
             return "group.\(group.id.uuidString)"
-        case .workspace(let workspace):
+        case .workspace(let workspace, _):
             return "workspace.\(workspace.id.uuidString)"
         }
     }
+
+    func withEffectiveGroupId(_ groupId: UUID?) -> SidebarWorkspaceRenderItem {
+        switch self {
+        case .groupHeader:
+            return self
+        case .workspace(let workspace, _):
+            return .workspace(workspace, effectiveGroupId: groupId)
+        }
+    }
+
     static func renderItems(
         tabs: [Workspace],
         groupsById: [UUID: WorkspaceGroup]
@@ -53,9 +90,182 @@ enum SidebarWorkspaceRenderItem {
                 continue
             }
             if groupId == nil || !skipChildrenUntilNextGroup {
-                items.append(.workspace(tab))
+                items.append(.workspace(tab, effectiveGroupId: groupId))
             }
         }
         return items
+    }
+
+    /// Returns the render list reordered to where the dragged row would land,
+    /// so the `LazyVStack` can animate the gap open (and the dragged row's slot
+    /// indent into/out of a group). Pure; drives the live reorder preview.
+    ///
+    /// - Parameters:
+    ///   - items: the committed render list (`renderItems`).
+    ///   - draggedWorkspaceId: the row being dragged, or nil when idle.
+    ///   - dropIndicator: where the row would currently land.
+    ///   - reorderWorkspaceIds: the ordered id scope the reorder operates over
+    ///     (top-level rows when dragging a group anchor, otherwise every row).
+    /// - Returns: the preview-ordered list, or `items` unchanged when there is
+    ///   nothing to preview.
+    static func dragPreviewItems(
+        _ items: [SidebarWorkspaceRenderItem],
+        draggedWorkspaceId: UUID?,
+        dropIndicator: SidebarDropIndicator?,
+        reorderWorkspaceIds: [UUID]
+    ) -> [SidebarWorkspaceRenderItem] {
+        guard let draggedWorkspaceId,
+              let dropIndicator,
+              reorderWorkspaceIds.contains(draggedWorkspaceId),
+              reorderWorkspaceIds.count > 1 else {
+            return items
+        }
+
+        let topLevelMode = Set(reorderWorkspaceIds) != Set(items.map(\.representedWorkspaceId))
+        let blocks = dragPreviewBlocks(
+            items,
+            reorderWorkspaceIds: reorderWorkspaceIds,
+            draggedWorkspaceId: draggedWorkspaceId,
+            topLevelMode: topLevelMode
+        )
+        let blockIds = blocks.map(\.workspaceId)
+        let reorderIds = reorderWorkspaceIds.filter { blockIds.contains($0) }
+        guard reorderIds.count == blocks.count,
+              Set(reorderIds) == Set(blockIds),
+              reorderIds.contains(draggedWorkspaceId),
+              let nextReorderIds = dragPreviewWorkspaceIds(
+                reorderIds,
+                draggedWorkspaceId: draggedWorkspaceId,
+                dropIndicator: dropIndicator
+              ),
+              nextReorderIds != reorderIds else {
+            return items
+        }
+
+        var blocksById: [UUID: [SidebarWorkspaceRenderItem]] = [:]
+        for block in blocks {
+            guard blocksById[block.workspaceId] == nil else {
+                return items
+            }
+            blocksById[block.workspaceId] = block.items
+        }
+        let reordered = nextReorderIds.flatMap { blocksById[$0] ?? [] }
+        return applyingDraggedMembership(reordered, draggedWorkspaceId: draggedWorkspaceId)
+    }
+
+    /// Recomputes the dragged workspace's effective group membership from its
+    /// new neighbors in the preview list, matching the vertical-position rule
+    /// used at commit (`TabManager.applyDragInferredGroupMembership`): a member
+    /// only when sandwiched between two rows of the SAME group. Keeps the live
+    /// indent preview in sync with where the drop will actually land.
+    private static func applyingDraggedMembership(
+        _ renderItems: [SidebarWorkspaceRenderItem],
+        draggedWorkspaceId: UUID
+    ) -> [SidebarWorkspaceRenderItem] {
+        guard let draggedIndex = renderItems.firstIndex(where: { item in
+            if case .workspace(let workspace, _) = item { return workspace.id == draggedWorkspaceId }
+            return false
+        }) else {
+            return renderItems
+        }
+        let beforeGroup = draggedIndex > renderItems.startIndex
+            ? groupIdentity(renderItems[draggedIndex - 1])
+            : nil
+        let afterGroup = draggedIndex < renderItems.index(before: renderItems.endIndex)
+            ? groupIdentity(renderItems[draggedIndex + 1])
+            : nil
+        let membership: UUID? = (beforeGroup == afterGroup) ? beforeGroup : nil
+        guard renderItems[draggedIndex].effectiveGroupId != membership else { return renderItems }
+        var result = renderItems
+        result[draggedIndex] = result[draggedIndex].withEffectiveGroupId(membership)
+        return result
+    }
+
+    /// The group a render item counts as for neighbor-membership purposes: the
+    /// group a header anchors, or a workspace row's effective group.
+    private static func groupIdentity(_ item: SidebarWorkspaceRenderItem) -> UUID? {
+        switch item {
+        case .groupHeader(let group, _):
+            return group.id
+        case .workspace(_, let effectiveGroupId):
+            return effectiveGroupId
+        }
+    }
+
+    /// The id order after moving the dragged workspace to the indicator slot,
+    /// or nil when the move is a no-op.
+    private static func dragPreviewWorkspaceIds(
+        _ ids: [UUID],
+        draggedWorkspaceId: UUID,
+        dropIndicator: SidebarDropIndicator
+    ) -> [UUID]? {
+        guard ids.contains(draggedWorkspaceId) else { return nil }
+        if dropIndicator.tabId == draggedWorkspaceId {
+            return ids
+        }
+
+        var result = ids.filter { $0 != draggedWorkspaceId }
+        let insertionIndex: Int
+        if let targetWorkspaceId = dropIndicator.tabId {
+            guard let targetIndex = result.firstIndex(of: targetWorkspaceId) else {
+                return ids
+            }
+            insertionIndex = dropIndicator.edge == .top ? targetIndex : targetIndex + 1
+        } else {
+            insertionIndex = result.count
+        }
+
+        result.insert(draggedWorkspaceId, at: min(max(insertionIndex, 0), result.count))
+        return result
+    }
+
+    /// Groups the render list into reorderable blocks keyed by the id that
+    /// `reorderWorkspaceIds` orders. In top-level mode a group header plus its
+    /// members form one block (so the whole group moves together), except the
+    /// dragged member which is promoted to its own top-level block.
+    private static func dragPreviewBlocks(
+        _ items: [SidebarWorkspaceRenderItem],
+        reorderWorkspaceIds: [UUID],
+        draggedWorkspaceId: UUID,
+        topLevelMode: Bool
+    ) -> [(workspaceId: UUID, items: [SidebarWorkspaceRenderItem])] {
+        guard topLevelMode else {
+            return items.map { item in
+                (workspaceId: item.representedWorkspaceId, items: [item])
+            }
+        }
+
+        let reorderIdSet = Set(reorderWorkspaceIds)
+        var blocks: [(workspaceId: UUID, items: [SidebarWorkspaceRenderItem])] = []
+        var index = items.startIndex
+        while index < items.endIndex {
+            switch items[index] {
+            case .groupHeader(let group, _):
+                var groupItems = [items[index]]
+                var promotedMemberItems: [SidebarWorkspaceRenderItem] = []
+                index = items.index(after: index)
+                while index < items.endIndex {
+                    guard case .workspace(let workspace, _) = items[index],
+                          workspace.groupId == group.id else {
+                        break
+                    }
+                    if workspace.id == draggedWorkspaceId, reorderIdSet.contains(workspace.id) {
+                        promotedMemberItems.append(items[index].withEffectiveGroupId(nil))
+                    } else {
+                        groupItems.append(items[index])
+                    }
+                    index = items.index(after: index)
+                }
+                blocks.append((workspaceId: group.anchorWorkspaceId, items: groupItems))
+                for item in promotedMemberItems {
+                    blocks.append((workspaceId: item.representedWorkspaceId, items: [item]))
+                }
+
+            case .workspace(let workspace, _):
+                blocks.append((workspaceId: workspace.id, items: [items[index]]))
+                index = items.index(after: index)
+            }
+        }
+        return blocks
     }
 }

--- a/Sources/VerticalTabsSidebar+WorkspaceGroups.swift
+++ b/Sources/VerticalTabsSidebar+WorkspaceGroups.swift
@@ -6,7 +6,8 @@ extension VerticalTabsSidebar {
     func sidebarWorkspaceGroupHeader(
         group: WorkspaceGroup,
         memberWorkspaceIds: [UUID],
-        renderContext: WorkspaceListRenderContext
+        renderContext: WorkspaceListRenderContext,
+        role: SidebarWorkspaceRowRenderRole = .list
     ) -> some View {
         let settings = renderContext.tabItemSettings
         let isAnchorActive = tabManager.selectedTabId == group.anchorWorkspaceId
@@ -34,46 +35,21 @@ extension VerticalTabsSidebar {
         )
         let modifierSymbol = renderContext.workspaceNumberShortcut.numberedDigitHintPrefix
         let showsHintForAnchor = modifierKeyMonitor.isModifierPressed
-        let topDropIndicatorVisible = SidebarTabDropIndicatorPredicate.topVisible(
-            forTabId: group.anchorWorkspaceId,
-            draggedTabId: dragState.draggedTabId,
-            dropIndicator: dragState.dropIndicator,
-            tabIds: renderContext.sidebarReorderIds
-        )
-        let onDragStart: () -> NSItemProvider = { [anchorId = group.anchorWorkspaceId] in
-            #if DEBUG
-            cmuxDebugLog("sidebar.onDrag groupAnchor=\(anchorId.uuidString.prefix(5))")
-            #endif
-            dragState.beginDragging(tabId: anchorId)
-            return SidebarTabDragPayload.provider(for: anchorId)
+        // Dragging a group header reorders the whole group at top level; the
+        // shared reorder helpers handle the anchor/top-level scope.
+        let onReorderChanged: (CGPoint, CGPoint) -> Void = { [anchorId = group.anchorWorkspaceId, renderContext] startLocation, location in
+            sidebarReorderGestureChanged(
+                draggedId: anchorId,
+                startLocationY: startLocation.y,
+                cursorY: location.y,
+                renderContext: renderContext
+            )
         }
-        let tabDropDelegateFactory: (CGFloat) -> SidebarWorkspaceGroupHeaderDropDelegate = { [
-            groupId = group.id,
-            anchorId = group.anchorWorkspaceId,
-            selectedTabIds = $selectedTabIds,
-            lastSidebarSelectionIndex = $lastSidebarSelectionIndex
-        ] rowHeight in
-            let reorderDelegate = SidebarTabDropDelegate(
-                targetTabId: anchorId,
-                tabManager: tabManager,
-                dragState: dragState,
-                selectedTabIds: selectedTabIds,
-                lastSidebarSelectionIndex: lastSidebarSelectionIndex,
-                targetRowHeight: rowHeight,
-                dragAutoScrollController: dragAutoScrollController
-            )
-            return SidebarWorkspaceGroupHeaderDropDelegate(
-                targetGroupId: groupId,
-                targetAnchorWorkspaceId: anchorId,
-                tabManager: tabManager,
-                dragState: dragState,
-                targetRowHeight: rowHeight,
-                dragAutoScrollController: dragAutoScrollController,
-                reorderDelegate: reorderDelegate
-            )
+        let onReorderEnded: (CGPoint, CGPoint) -> Void = { [anchorId = group.anchorWorkspaceId] _, _ in
+            sidebarReorderGestureEnded(draggedId: anchorId)
         }
 
-        SidebarWorkspaceGroupHeaderView(
+        let header = SidebarWorkspaceGroupHeaderView(
             groupId: group.id,
             anchorWorkspaceId: group.anchorWorkspaceId,
             name: group.name,
@@ -93,10 +69,11 @@ extension VerticalTabsSidebar {
             newWorkspacePlacement: newWorkspacePlacement,
             rowSpacing: tabRowSpacing,
             isFirstRow: renderContext.sidebarReorderIds.first == group.anchorWorkspaceId,
-            isBeingDragged: dragState.draggedTabId == group.anchorWorkspaceId,
-            topDropIndicatorVisible: topDropIndicatorVisible,
-            onDragStart: onDragStart,
-            tabDropDelegateFactory: tabDropDelegateFactory,
+            isBeingDragged: role == .list && dragState.draggedTabId == group.anchorWorkspaceId,
+            topDropIndicatorVisible: false,
+            onReorderChanged: onReorderChanged,
+            onReorderEnded: onReorderEnded,
+            isReorderEnabled: role == .list,
             onToggleCollapsed: { [weak tabManager, groupId = group.id] in
                 tabManager?.toggleWorkspaceGroupCollapsed(groupId: groupId)
             },
@@ -152,11 +129,19 @@ extension VerticalTabsSidebar {
             }
         )
         .equatable()
-        .id(group.anchorWorkspaceId)
-        .accessibilityIdentifier("sidebarWorkspaceGroup.\(group.id.uuidString)")
-        .preference(key: SidebarWorkspaceRowIdsPreferenceKey.self, value: Set([group.anchorWorkspaceId]))
-        .anchorPreference(key: SidebarWorkspaceRowFramePreferenceKey.self, value: .bounds) { [anchorId = group.anchorWorkspaceId] anchor in
-            [anchorId: anchor]
+
+        if role == .dragFollower {
+            header
+                .allowsHitTesting(false)
+                .accessibilityHidden(true)
+        } else {
+            header
+                .id(group.anchorWorkspaceId)
+                .accessibilityIdentifier("sidebarWorkspaceGroup.\(group.id.uuidString)")
+                .preference(key: SidebarWorkspaceRowIdsPreferenceKey.self, value: Set([group.anchorWorkspaceId]))
+                .anchorPreference(key: SidebarWorkspaceRowFramePreferenceKey.self, value: .bounds) { [anchorId = group.anchorWorkspaceId] anchor in
+                    [anchorId: anchor]
+                }
         }
     }
 }

--- a/Sources/VerticalTabsSidebar+WorkspaceGroups.swift
+++ b/Sources/VerticalTabsSidebar+WorkspaceGroups.swift
@@ -48,6 +48,10 @@ extension VerticalTabsSidebar {
         let onReorderEnded: (CGPoint, CGPoint) -> Void = { [anchorId = group.anchorWorkspaceId] _, _ in
             sidebarReorderGestureEnded(draggedId: anchorId)
         }
+        // Computed in the parent and applied as opacity below (not passed into
+        // the header view) so the gesture-hosting header's inputs stay constant
+        // during a drag and its in-flight `DragGesture` is not torn down.
+        let isBeingDragged = role == .list && dragState.draggedTabId == group.anchorWorkspaceId
 
         let header = SidebarWorkspaceGroupHeaderView(
             groupId: group.id,
@@ -69,7 +73,6 @@ extension VerticalTabsSidebar {
             newWorkspacePlacement: newWorkspacePlacement,
             rowSpacing: tabRowSpacing,
             isFirstRow: renderContext.sidebarReorderIds.first == group.anchorWorkspaceId,
-            isBeingDragged: role == .list && dragState.draggedTabId == group.anchorWorkspaceId,
             topDropIndicatorVisible: false,
             onReorderChanged: onReorderChanged,
             onReorderEnded: onReorderEnded,
@@ -132,10 +135,12 @@ extension VerticalTabsSidebar {
 
         if role == .dragFollower {
             header
+                .opacity(isBeingDragged ? 0 : 1)
                 .allowsHitTesting(false)
                 .accessibilityHidden(true)
         } else {
             header
+                .opacity(isBeingDragged ? 0 : 1)
                 .id(group.anchorWorkspaceId)
                 .accessibilityIdentifier("sidebarWorkspaceGroup.\(group.id.uuidString)")
                 .preference(key: SidebarWorkspaceRowIdsPreferenceKey.self, value: Set([group.anchorWorkspaceId]))

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -436,6 +436,9 @@
 		C0DEF0A30000000000000001 /* SidebarPortDisplayText.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEF0A30000000000000002 /* SidebarPortDisplayText.swift */; };
 		C0DE48000000000000000001 /* SidebarProviderMenuRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE48000000000000000002 /* SidebarProviderMenuRegressionTests.swift */; };
 		B9000130A1B2C3D4E5F60719 /* SidebarPullRequestInteractivityUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000131A1B2C3D4E5F60719 /* SidebarPullRequestInteractivityUITests.swift */; };
+		D7AB34300000000000000531 /* SidebarReorderFollowerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB34300000000000000532 /* SidebarReorderFollowerView.swift */; };
+		D7AB34300000000000000511 /* SidebarReorderIndicatorResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB34300000000000000512 /* SidebarReorderIndicatorResolver.swift */; };
+		D7AB34300000000000000521 /* SidebarReorderRowFrameKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB34300000000000000522 /* SidebarReorderRowFrameKey.swift */; };
 		B8F266236A1A3D9A45BD840F /* SidebarResizeUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 818DBCD4AB69EB72573E8138 /* SidebarResizeUITests.swift */; };
 		C0DE35010000000000000001 /* SidebarScrim.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE35010000000000000002 /* SidebarScrim.swift */; };
 		E62155868BB29FEB5DAAAF25 /* SidebarSelectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AD52285508B1D6A9875E7B3 /* SidebarSelectionState.swift */; };
@@ -528,6 +531,7 @@
 		A5001204 /* UpdateViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001214 /* UpdateViewModel.swift */; };
 		B35750000000000000000006 /* VaultAgentProcessScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35750000000000000000005 /* VaultAgentProcessScanner.swift */; };
 		B35750000000000000000002 /* VaultAgentRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35750000000000000000001 /* VaultAgentRegistry.swift */; };
+		D7AB34300000000000000541 /* VerticalTabsSidebar+Reorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB34300000000000000542 /* VerticalTabsSidebar+Reorder.swift */; };
 		C9A57209C9A57209C9A57209 /* VerticalTabsSidebar+WorkspaceGroups.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A5720AC9A5720AC9A5720A /* VerticalTabsSidebar+WorkspaceGroups.swift */; };
 		ACE4FE1A8F1CC6C0B6A673AB /* VMClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CEC6EF35B71AE59FA45BA69 /* VMClient.swift */; };
 		ACE4FE2A8F1CC6C0B6A673AB /* VMClientSocketCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CEC6F0035B71AE59FA45BA7 /* VMClientSocketCommands.swift */; };
@@ -1057,6 +1061,9 @@
 		C0DEF0A30000000000000002 /* SidebarPortDisplayText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarPortDisplayText.swift; sourceTree = "<group>"; };
 		C0DE48000000000000000002 /* SidebarProviderMenuRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarProviderMenuRegressionTests.swift; sourceTree = "<group>"; };
 		B9000131A1B2C3D4E5F60719 /* SidebarPullRequestInteractivityUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarPullRequestInteractivityUITests.swift; sourceTree = "<group>"; };
+		D7AB34300000000000000532 /* SidebarReorderFollowerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarReorderFollowerView.swift; sourceTree = "<group>"; };
+		D7AB34300000000000000512 /* SidebarReorderIndicatorResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarReorderIndicatorResolver.swift; sourceTree = "<group>"; };
+		D7AB34300000000000000522 /* SidebarReorderRowFrameKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarReorderRowFrameKey.swift; sourceTree = "<group>"; };
 		818DBCD4AB69EB72573E8138 /* SidebarResizeUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarResizeUITests.swift; sourceTree = "<group>"; };
 		C0DE35010000000000000002 /* SidebarScrim.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarScrim.swift; sourceTree = "<group>"; };
 		9AD52285508B1D6A9875E7B3 /* SidebarSelectionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarSelectionState.swift; sourceTree = "<group>"; };
@@ -1147,6 +1154,7 @@
 		A5001214 /* UpdateViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Update/UpdateViewModel.swift; sourceTree = "<group>"; };
 			B35750000000000000000005 /* VaultAgentProcessScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultAgentProcessScanner.swift; sourceTree = "<group>"; };
 		B35750000000000000000001 /* VaultAgentRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultAgentRegistry.swift; sourceTree = "<group>"; };
+		D7AB34300000000000000542 /* VerticalTabsSidebar+Reorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Sidebar/VerticalTabsSidebar+Reorder.swift"; sourceTree = "<group>"; };
 		C9A5720AC9A5720AC9A5720A /* VerticalTabsSidebar+WorkspaceGroups.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VerticalTabsSidebar+WorkspaceGroups.swift"; sourceTree = "<group>"; };
 		9CEC6EF35B71AE59FA45BA69 /* VMClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VMClient.swift; sourceTree = "<group>"; };
 		9CEC6F0035B71AE59FA45BA7 /* VMClientSocketCommands.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VMClientSocketCommands.swift; sourceTree = "<group>"; };
@@ -1421,6 +1429,10 @@
 				C0DEF0A90000000000000002 /* ContentView+ForkAgentConversation.swift */,
 				D7AB00000000000000000004 /* ContentView+MoveTabToNewWorkspace.swift */,
 				D7AB34300000000000000002 /* SidebarDropPlanner.swift */,
+				D7AB34300000000000000512 /* SidebarReorderIndicatorResolver.swift */,
+				D7AB34300000000000000522 /* SidebarReorderRowFrameKey.swift */,
+				D7AB34300000000000000532 /* SidebarReorderFollowerView.swift */,
+				D7AB34300000000000000542 /* VerticalTabsSidebar+Reorder.swift */,
 				EA1F00000000000000000002 /* SidebarPathFormatter.swift */,
 				EA1F00000000000000000004 /* SidebarDirectoryText.swift */,
 				D7AB34300000000000000004 /* SidebarBonsplitTabWorkspaceDropOverlay.swift */,
@@ -2455,6 +2467,9 @@
 				D7AB34300000000000000001 /* SidebarDropPlanner.swift in Sources */,
 				EA1F00000000000000000001 /* SidebarPathFormatter.swift in Sources */,
 				C0DEF0A30000000000000001 /* SidebarPortDisplayText.swift in Sources */,
+				D7AB34300000000000000531 /* SidebarReorderFollowerView.swift in Sources */,
+				D7AB34300000000000000511 /* SidebarReorderIndicatorResolver.swift in Sources */,
+				D7AB34300000000000000521 /* SidebarReorderRowFrameKey.swift in Sources */,
 				C0DE35010000000000000001 /* SidebarScrim.swift in Sources */,
 				E62155868BB29FEB5DAAAF25 /* SidebarSelectionState.swift in Sources */,
 				F57072635F25EBCA741E125D /* SidebarState.swift in Sources */,
@@ -2519,6 +2534,7 @@
 				A5001204 /* UpdateViewModel.swift in Sources */,
 				B35750000000000000000006 /* VaultAgentProcessScanner.swift in Sources */,
 				B35750000000000000000002 /* VaultAgentRegistry.swift in Sources */,
+				D7AB34300000000000000541 /* VerticalTabsSidebar+Reorder.swift in Sources */,
 				C9A57209C9A57209C9A57209 /* VerticalTabsSidebar+WorkspaceGroups.swift in Sources */,
 				ACE4FE1A8F1CC6C0B6A673AB /* VMClient.swift in Sources */,
 				ACE4FE2A8F1CC6C0B6A673AB /* VMClientSocketCommands.swift in Sources */,

--- a/cmuxTests/WorkspaceGroupTests.swift
+++ b/cmuxTests/WorkspaceGroupTests.swift
@@ -183,7 +183,7 @@ struct WorkspaceGroupTests {
                 groupMemberIds = memberWorkspaceIds
             case .groupHeader:
                 break
-            case .workspace(let workspace):
+            case .workspace(let workspace, _):
                 visibleWorkspaceIds.append(workspace.id)
             }
         }
@@ -707,5 +707,73 @@ struct WorkspaceGroupTests {
         #expect(RenderableSystemSymbol.resolvedSurfaceTabIcon("   doc.text   ") == "doc.text")
         #expect(RenderableSystemSymbol.resolvedSurfaceTabIcon("not.an.sf.symbol") == "doc.text")
         #expect(RenderableSystemSymbol.resolvedSurfaceTabIcon("   ") == "doc.text")
+    }
+}
+
+/// Covers the gesture-driven reorder hit-testing + hysteresis that
+/// `SidebarReorderIndicatorResolver` adds on top of `SidebarDropPlanner`.
+@Suite("Sidebar reorder indicator resolver")
+struct SidebarReorderIndicatorResolverTests {
+    private func band(_ id: UUID, _ minY: CGFloat, _ maxY: CGFloat) -> SidebarReorderIndicatorResolver.Band {
+        .init(id: id, minY: minY, maxY: maxY)
+    }
+
+    @Test func cursorBelowAllRowsAppendsToEnd() {
+        let a = UUID(); let b = UUID(); let c = UUID()
+        let bands = [band(a, 0, 20), band(b, 22, 42), band(c, 44, 64)]
+        let indicator = SidebarReorderIndicatorResolver.resolve(
+            cursorY: 200, bands: bands, draggedId: a, pinnedIds: [], current: nil, hysteresisMargin: 6
+        )
+        #expect(indicator?.tabId == nil)
+        #expect(indicator?.edge == .bottom)
+    }
+
+    @Test func cursorInTopHalfOfFirstRowTargetsItsTop() {
+        let a = UUID(); let b = UUID(); let c = UUID()
+        let bands = [band(a, 0, 20), band(b, 22, 42), band(c, 44, 64)]
+        // Dragging C; hovering the top half of A should land it before A.
+        let indicator = SidebarReorderIndicatorResolver.resolve(
+            cursorY: 3, bands: bands, draggedId: c, pinnedIds: [], current: nil, hysteresisMargin: 6
+        )
+        #expect(indicator?.tabId == a)
+        #expect(indicator?.edge == .top)
+    }
+
+    @Test func hysteresisHoldsCurrentEdgeNearMidpoint() {
+        let a = UUID(); let b = UUID(); let c = UUID()
+        let bands = [band(a, 0, 20), band(b, 20, 40), band(c, 40, 60)]
+        // Dragging A. Current landing slot is "after B" (canonicalized to top of C).
+        let current = SidebarDropIndicator(tabId: c, edge: .top)
+        // Cursor just above B's midpoint (30) and within the 6pt dead-zone: the
+        // raw decision flips to "before B", but stickiness keeps the current slot.
+        let held = SidebarReorderIndicatorResolver.resolve(
+            cursorY: 29, bands: bands, draggedId: a, pinnedIds: [], current: current, hysteresisMargin: 6
+        )
+        #expect(held == current)
+        // With no hysteresis the same cursor flips the slot.
+        let flipped = SidebarReorderIndicatorResolver.resolve(
+            cursorY: 29, bands: bands, draggedId: a, pinnedIds: [], current: current, hysteresisMargin: 0
+        )
+        #expect(flipped != current)
+    }
+
+    @Test func clearMidpointCrossingFlipsEdge() {
+        let a = UUID(); let b = UUID(); let c = UUID()
+        let bands = [band(a, 0, 20), band(b, 20, 40), band(c, 40, 60)]
+        let current = SidebarDropIndicator(tabId: c, edge: .top) // after B
+        // Dragging C; cursor well into the top of B (far outside the dead-zone)
+        // lands before B.
+        let indicator = SidebarReorderIndicatorResolver.resolve(
+            cursorY: 22, bands: bands, draggedId: c, pinnedIds: [], current: current, hysteresisMargin: 6
+        )
+        #expect(indicator?.tabId == b)
+        #expect(indicator?.edge == .top)
+    }
+
+    @Test func emptyBandsResolveToNil() {
+        let indicator = SidebarReorderIndicatorResolver.resolve(
+            cursorY: 10, bands: [], draggedId: UUID(), pinnedIds: [], current: nil, hysteresisMargin: 6
+        )
+        #expect(indicator == nil)
     }
 }


### PR DESCRIPTION
## Summary
- Rebuild sidebar workspace reordering on a custom SwiftUI `DragGesture` instead of `.onDrag` -> `NSItemProvider`. The system drag session only reported pointer location coarsely (via the drop delegate, and only over a valid target), which is what made dragging feel laggy and the follower drift.
- The gesture owns the whole interaction: a 1:1 floating follower (`SidebarReorderFollowerView`), a live gap that animates open via `dragPreviewItems`, and hysteresis (`SidebarReorderIndicatorResolver`) so the landing slot does not flicker at row midpoints.
- Workspace rows and group-header (anchor) rows reorder through one shared path (`VerticalTabsSidebar+Reorder`), so dragging groups and dragging rows in/out of groups keep full parity.
- Per-frame cursor updates touch only the isolated follower overlay; the list reflows only on discrete drop-indicator changes, preserving the snapshot boundary from https://github.com/manaflow-ai/cmux/issues/2586. Committed row frames are frozen during a drag so hit-testing cannot feed back on its own preview.
- Reuses the existing group-aware data model unchanged: `SidebarDropPlanner`, `TabManager.reorderSidebarWorkspace`, the auto-scroll controller, the cross-surface pane/file `onDrop` targets, and the `debug.sidebar.simulate_drag` harness.

## Testing
- Cloud build of the `cmux` scheme: green (compiles).
- Launched the tagged build; created/renamed 6 workspaces and ran `simulate-sidebar-drag` (8 steps) with no crash, confirming the drop-indicator -> `dragPreviewItems` gap path renders.
- New unit tests for `SidebarReorderIndicatorResolver` (append-to-end, top-half targeting, hysteresis hold vs. flip, empty bands). The interaction *feel* is a manual dogfood gate (cannot be unit-tested).

## Dogfood
Tagged build is up. The reorder feel needs human verification before merge: grab a workspace row, confirm it lifts and follows the cursor 1:1, neighbors spring open a gap, and it drops cleanly into the slot. Also drag a group header and drag a row into/out of a group.

> Known v1 cut: edge auto-scroll still scrolls, but the gap/follower do not recompute while the pointer sits still at the edge (only on movement). Long-list edge polish is a planned follow-up.

## Issues
- Task: restart sidebar reordering animations from scratch (prior attempt `task-sidebar-reordering-animations` felt bad)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5226"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782999599&installation_id=133855650&pr_number=5226&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5226&signature=601ae782f61956734bc0658543550300951078a07a359f6f869362bb95218cd3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large UI interaction rewrite in the main sidebar list with careful observation boundaries; commit path reuses existing planners but reorder feel and edge auto-scroll need manual verification.
> 
> **Overview**
> Replaces sidebar workspace reordering from macOS `.onDrag` / `DropDelegate` with a custom SwiftUI `DragGesture` on workspace rows and group headers, routed through shared `VerticalTabsSidebar+Reorder` helpers.
> 
> **Interaction:** A floating `SidebarReorderFollowerView` tracks the cursor each frame via `followerCursorY` (only that overlay reads it). The list uses `dragPreviewItems` to animate the gap and group-indent preview on discrete drop-indicator changes. Hit-testing uses measured row frames (`SidebarReorderRowFrameKey`), frozen during drag, plus `SidebarReorderIndicatorResolver` hysteresis so landing slots do not flicker at row midpoints.
> 
> **State / views:** `SidebarDragState` gains gesture-reorder geometry (`@ObservationIgnored` row frames, bands, `beginReorder` / `updateReorder`). Rows hide in-list while dragged; `TabItemView` / group headers drop sidebar tab drag delegates and use `SidebarReorderRowModifier` instead. Commit still goes through `SidebarDropPlanner` and `TabManager.reorderSidebarWorkspace`.
> 
> **Tests:** New unit tests for `SidebarReorderIndicatorResolver` in `WorkspaceGroupTests.swift`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f81905fce3b2025a28336226f72ab03118a49a60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebuilt sidebar workspace reordering with a custom SwiftUI `DragGesture` to remove lag and drift, adding a 1:1 floating follower and a live gap preview. Group headers and rows now use one shared path for consistent behavior.

- **New Features**
  - Replaced `.onDrag`/`NSItemProvider` with a gesture-based reorder for workspaces and group headers.
  - Added `SidebarReorderFollowerView` for a smooth floating follower and `dragPreviewItems` for a live gap and indent preview.
  - Introduced `SidebarReorderIndicatorResolver` with hysteresis to prevent flicker near row midpoints.
  - Measured row frames in a named space via `SidebarReorderRowFrameKey`; frames freeze during drag; auto-scroll keeps the landing slot fresh.

- **Performance**
  - Per-frame updates repaint only the follower; the list reflows only on discrete indicator changes, avoiding layout thrash from #2586.
  - Eliminates system-drag pointer lag and follower drift; reuses `SidebarDropPlanner` and `TabManager.reorderSidebarWorkspace`.
  - Added unit tests for resolver behavior (append-to-end, top-half targeting, hysteresis, empty bands).

<sup>Written for commit 97a0eb35d063fcc3b5d10ee0d57854e99a1d1f6c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gesture-driven drag-and-drop reordering for sidebar workspaces with a floating follower preview and drop indicators.

* **Improvements**
  * Smoother, more stable drop targeting (reduced jitter near edges), improved auto-scroll during drags, and cleaner visuals (dragged row hidden while follower is shown; follower is non-interactive and excluded from accessibility).

* **Tests**
  * Added unit tests covering drop-indicator resolution and edge behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->