### PR TITLE
Map Pi UI prompts to needs-input status

### DIFF
--- a/CLI/CMUXCLI+AgentHookDefinitions.swift
+++ b/CLI/CMUXCLI+AgentHookDefinitions.swift
@@ -128,7 +128,7 @@ extension CMUXCLI {
     }
 
     enum AgentHookAction {
-        case sessionStart, promptSubmit, stop, notification, approvalResponse, sessionEnd, sessionFinalize, noop
+        case sessionStart, promptSubmit, stop, notification, approvalResponse, uiPromptStart, uiPromptEnd, sessionEnd, sessionFinalize, noop
     }
 
     static let subcommandActions: [String: AgentHookAction] = [
@@ -139,6 +139,8 @@ extension CMUXCLI {
         "notify": .notification,
         "agent-response": .stop,
         "approval-response": .approvalResponse,
+        "ui-prompt-start": .uiPromptStart,
+        "ui-prompt-end": .uiPromptEnd,
         "shell-exec": .promptSubmit,
         "shell-done": .noop,
         "session-end": .sessionEnd,

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -27619,7 +27619,7 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                 cwd: hookCwd ?? mapped?.cwd
             )
             let suppressVisibleMutations = shouldSuppressNestedAgentVisibleMutations(currentAgentPID: pid, env: env)
-            let shouldRestoreRunning = mapped?.runtimeStatus == .needsInput || mapped == nil
+            let shouldRestoreRunning = mapped?.runtimeStatus == .needsInput
             if !sessionId.isEmpty, !suppressVisibleMutations, shouldRestoreRunning {
                 try? store.upsert(
                     sessionId: sessionId,

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -25244,8 +25244,8 @@ export default CMUXSessionRestore;
     private static let piExtensionMarker = "cmux-pi-session-extension-marker"
     private static let piExtensionFilename = "cmux-session.ts"
     private static let piExtensionSource = #"""
-// cmux-pi-session-extension-marker v1
-// Bridges Pi session lifecycle events into cmux's restorable session store.
+// cmux-pi-session-extension-marker v2
+// Bridges Pi session lifecycle and UI prompt events into cmux's restorable session store.
 // Installed by `cmux hooks pi install` or `cmux hooks setup`.
 // DO NOT EDIT MANUALLY. cmux upgrades this file in place.
 
@@ -25330,6 +25330,10 @@ function eventName(subcommand: string): string {
       return "UserPromptSubmit";
     case "stop":
       return "Stop";
+    case "ui-prompt-start":
+      return "ui_prompt_start";
+    case "ui-prompt-end":
+      return "ui_prompt_end";
     default:
       return subcommand;
   }
@@ -25357,6 +25361,15 @@ function lastAssistantMessage(event: AgentEndEvent): string | undefined {
     if (text) return text;
   }
   return undefined;
+}
+
+function promptEventPayload(event: { kind?: unknown; title?: unknown }): Record<string, unknown> {
+  const payload: Record<string, unknown> = {};
+  const kind = firstString(event.kind);
+  const title = firstString(event.title);
+  if (kind) payload.kind = kind;
+  if (title) payload.title = title;
+  return payload;
 }
 
 function sendHook(subcommand: string, ctx: ExtensionContext, extra: Record<string, unknown> = {}): void {
@@ -25397,6 +25410,14 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
 
   pi.on("agent_end", async (event, ctx) => {
     sendHook("stop", ctx, { last_assistant_message: lastAssistantMessage(event) });
+  });
+
+  pi.on("ui_prompt_start", async (event: { kind?: unknown; title?: unknown }, ctx) => {
+    sendHook("ui-prompt-start", ctx, promptEventPayload(event));
+  });
+
+  pi.on("ui_prompt_end", async (event: { kind?: unknown; title?: unknown }, ctx) => {
+    sendHook("ui-prompt-end", ctx, promptEventPayload(event));
   });
 }
 """#
@@ -27134,6 +27155,23 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                 client: client
             )
         }
+        func setRunningStatus(workspaceId: String, surfaceId: String) {
+            let runningStatus = String(localized: "agent.generic.status.running", defaultValue: "Running")
+            _ = try? sendV1Command(
+                "set_status \(def.statusKey) \(runningStatus) --icon=bolt.fill --color=#4C8DFF --tab=\(workspaceId)\(socketPanelOption(surfaceId))",
+                client: client
+            )
+        }
+        func setNeedsInputStatus(workspaceId: String, surfaceId: String) {
+            let statusValue = String.localizedStringWithFormat(
+                String(localized: "agent.generic.notification.status.needsInput", defaultValue: "%@ needs input"),
+                def.displayName
+            )
+            _ = try? sendV1Command(
+                "set_status \(def.statusKey) \(statusValue) --icon=bell.fill --color=#4C8DFF --priority=100 --tab=\(workspaceId)\(socketPanelOption(surfaceId))",
+                client: client
+            )
+        }
         func sendAgentFeedTelemetry(workspaceId: String? = nil) {
             didSendFeedTelemetry = true
             sendFeedTelemetry(
@@ -27502,6 +27540,127 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                     env: env,
                     telemetry: telemetry
                 )
+            }
+
+        case .uiPromptStart:
+            let mapped = sessionId.isEmpty ? nil : (try? store.lookup(sessionId: sessionId))
+            guard let target = resolveAgentHookTarget(mapped: mapped) else {
+                didSendFeedTelemetry = true
+                print("{}")
+                return
+            }
+            let workspaceId = target.workspaceId
+            let surfaceId = target.surfaceId
+            let pid = mapped?.pid ?? inferredPID
+            let launchCommand = agentLaunchCommandFromEnvironment(
+                env,
+                fallbackPID: pid,
+                fallbackKind: def.name,
+                cwd: hookCwd ?? mapped?.cwd
+            )
+            let suppressVisibleMutations = shouldSuppressNestedAgentVisibleMutations(currentAgentPID: pid, env: env)
+            if !sessionId.isEmpty, !suppressVisibleMutations {
+                try? store.upsert(
+                    sessionId: sessionId,
+                    workspaceId: workspaceId,
+                    surfaceId: surfaceId,
+                    cwd: hookCwd ?? mapped?.cwd,
+                    transcriptPath: input.transcriptPath ?? mapped?.transcriptPath,
+                    pid: pid,
+                    launchCommand: launchCommand ?? mapped?.launchCommand,
+                    agentLifecycle: .needsInput,
+                    runtimeStatus: .needsInput,
+                    updateRuntimeStatus: true
+                )
+                publishAgentSurfaceResumeBinding(
+                    client: client,
+                    workspaceId: workspaceId,
+                    surfaceId: surfaceId,
+                    kind: def.name,
+                    displayName: def.displayName,
+                    sessionId: sessionId,
+                    cwd: hookCwd ?? mapped?.cwd,
+                    launchCommand: launchCommand ?? mapped?.launchCommand
+                )
+            }
+            if let pid, !suppressVisibleMutations {
+                _ = try? sendV1Command(
+                    "set_agent_pid \(pidKey) \(pid) --tab=\(workspaceId)\(socketPanelOption(surfaceId))",
+                    client: client
+                )
+            }
+            if !suppressVisibleMutations {
+                setAgentLifecycle(
+                    client: client,
+                    key: def.statusKey,
+                    lifecycle: .needsInput,
+                    workspaceId: workspaceId,
+                    surfaceId: surfaceId
+                )
+                setNeedsInputStatus(workspaceId: workspaceId, surfaceId: surfaceId)
+            } else {
+                telemetry.breadcrumb("\(def.name)-hook.ui-prompt-start.nested-suppressed")
+            }
+
+        case .uiPromptEnd:
+            let mapped = sessionId.isEmpty ? nil : (try? store.lookup(sessionId: sessionId))
+            guard let target = resolveAgentHookTarget(mapped: mapped) else {
+                didSendFeedTelemetry = true
+                print("{}")
+                return
+            }
+            let workspaceId = target.workspaceId
+            let surfaceId = target.surfaceId
+            let pid = mapped?.pid ?? inferredPID
+            let launchCommand = agentLaunchCommandFromEnvironment(
+                env,
+                fallbackPID: pid,
+                fallbackKind: def.name,
+                cwd: hookCwd ?? mapped?.cwd
+            )
+            let suppressVisibleMutations = shouldSuppressNestedAgentVisibleMutations(currentAgentPID: pid, env: env)
+            let shouldRestoreRunning = mapped?.runtimeStatus == .needsInput || mapped == nil
+            if !sessionId.isEmpty, !suppressVisibleMutations, shouldRestoreRunning {
+                try? store.upsert(
+                    sessionId: sessionId,
+                    workspaceId: workspaceId,
+                    surfaceId: surfaceId,
+                    cwd: hookCwd ?? mapped?.cwd,
+                    transcriptPath: input.transcriptPath ?? mapped?.transcriptPath,
+                    pid: pid,
+                    launchCommand: launchCommand ?? mapped?.launchCommand,
+                    agentLifecycle: .running,
+                    runtimeStatus: .running,
+                    updateRuntimeStatus: true
+                )
+                publishAgentSurfaceResumeBinding(
+                    client: client,
+                    workspaceId: workspaceId,
+                    surfaceId: surfaceId,
+                    kind: def.name,
+                    displayName: def.displayName,
+                    sessionId: sessionId,
+                    cwd: hookCwd ?? mapped?.cwd,
+                    launchCommand: launchCommand ?? mapped?.launchCommand
+                )
+            }
+            if let pid, !suppressVisibleMutations, shouldRestoreRunning {
+                _ = try? sendV1Command(
+                    "set_agent_pid \(pidKey) \(pid) --tab=\(workspaceId)\(socketPanelOption(surfaceId))",
+                    client: client
+                )
+            }
+            if !suppressVisibleMutations, shouldRestoreRunning {
+                setAgentLifecycle(
+                    client: client,
+                    key: def.statusKey,
+                    lifecycle: .running,
+                    workspaceId: workspaceId,
+                    surfaceId: surfaceId
+                )
+                setRunningStatus(workspaceId: workspaceId, surfaceId: surfaceId)
+            } else if suppressVisibleMutations {
+                telemetry.breadcrumb("\(def.name)-hook.ui-prompt-end.nested-suppressed")
             }
 
         case .stop:

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -157,6 +157,107 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         )
     }
 
+    func testPiUIPromptEndWithoutRecordedPromptDoesNotRestoreRunning() throws {
+        let context = try makeClaudeHookContext(name: "pi-ui-end-stale")
+        defer { context.cleanup() }
+
+        startAgentHookMockServerAccepting(context: context, connectionLimit: 8)
+        let sessionId = "pi-missing-session"
+        let promptEnd = runAgentHook(
+            context: context,
+            agent: "pi",
+            subcommand: "ui-prompt-end",
+            standardInput: #"{"session_id":"\#(sessionId)","cwd":"\#(context.root.path)","hook_event_name":"ui_prompt_end","kind":"select"}"#,
+            extraEnvironment: agentLaunchEnvironment(
+                context: context,
+                kind: "pi",
+                executable: "/usr/local/bin/pi",
+                arguments: ["/usr/local/bin/pi", "--model", "gpt-5.1"]
+            )
+        )
+
+        XCTAssertFalse(promptEnd.timedOut, promptEnd.stderr)
+        XCTAssertEqual(promptEnd.status, 0, promptEnd.stderr)
+        XCTAssertEqual(promptEnd.stdout, "{}\n")
+        let commands = context.state.snapshot()
+        XCTAssertFalse(
+            commands.contains { $0.contains("set_agent_lifecycle pi running") },
+            "A stale Pi UI prompt end without a recorded needsInput prompt must not create a phantom running lifecycle, saw \(commands)"
+        )
+        XCTAssertFalse(
+            commands.contains { $0.contains("set_status pi Running") },
+            "A stale Pi UI prompt end without a recorded needsInput prompt must not create a phantom running status, saw \(commands)"
+        )
+    }
+
+    func testPiUIPromptLifecycleSuppressesNestedVisibleMutations() throws {
+        let context = try makeClaudeHookContext(name: "pi-ui-nested")
+        defer { context.cleanup() }
+
+        startAgentHookMockServerAccepting(context: context, connectionLimit: 16)
+        let sessionId = "pi-nested-session"
+        var launchEnvironment = agentLaunchEnvironment(
+            context: context,
+            kind: "pi",
+            executable: "/usr/local/bin/pi",
+            arguments: ["/usr/local/bin/pi", "--model", "gpt-5.1"]
+        )
+        let start = runAgentHook(
+            context: context,
+            agent: "pi",
+            subcommand: "session-start",
+            standardInput: #"{"session_id":"\#(sessionId)","cwd":"\#(context.root.path)","hook_event_name":"SessionStart"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(start.timedOut, start.stderr)
+        XCTAssertEqual(start.status, 0, start.stderr)
+
+        launchEnvironment["CMUX_AGENT_HOOK_SUPPRESS_VISIBLE_MUTATIONS"] = "1"
+        let promptStartCommandStart = context.state.snapshot().count
+        let promptStart = runAgentHook(
+            context: context,
+            agent: "pi",
+            subcommand: "ui-prompt-start",
+            standardInput: #"{"session_id":"\#(sessionId)","cwd":"\#(context.root.path)","hook_event_name":"ui_prompt_start","kind":"confirm","title":"Nested prompt"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(promptStart.timedOut, promptStart.stderr)
+        XCTAssertEqual(promptStart.status, 0, promptStart.stderr)
+        XCTAssertEqual(promptStart.stdout, "{}\n")
+
+        let promptStartCommands = Array(context.state.snapshot().dropFirst(promptStartCommandStart))
+        XCTAssertFalse(
+            promptStartCommands.contains { $0.contains("set_agent_lifecycle pi needsInput") },
+            "Suppressed nested Pi UI prompt start must not mutate visible lifecycle, saw \(promptStartCommands)"
+        )
+        XCTAssertFalse(
+            promptStartCommands.contains { $0.contains("set_status pi Pi needs input") },
+            "Suppressed nested Pi UI prompt start must not mutate visible status, saw \(promptStartCommands)"
+        )
+
+        let promptEndCommandStart = context.state.snapshot().count
+        let promptEnd = runAgentHook(
+            context: context,
+            agent: "pi",
+            subcommand: "ui-prompt-end",
+            standardInput: #"{"session_id":"\#(sessionId)","cwd":"\#(context.root.path)","hook_event_name":"ui_prompt_end","kind":"confirm"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(promptEnd.timedOut, promptEnd.stderr)
+        XCTAssertEqual(promptEnd.status, 0, promptEnd.stderr)
+        XCTAssertEqual(promptEnd.stdout, "{}\n")
+
+        let promptEndCommands = Array(context.state.snapshot().dropFirst(promptEndCommandStart))
+        XCTAssertFalse(
+            promptEndCommands.contains { $0.contains("set_agent_lifecycle pi running") },
+            "Suppressed nested Pi UI prompt end must not mutate visible lifecycle, saw \(promptEndCommands)"
+        )
+        XCTAssertFalse(
+            promptEndCommands.contains { $0.contains("set_status pi Running") },
+            "Suppressed nested Pi UI prompt end must not mutate visible status, saw \(promptEndCommands)"
+        )
+    }
+
     func testCodexPromptSubmitRefreshesLastTurnDiffBaseline() throws {
         let context = try makeClaudeHookContext(name: "codex-prompt-baseline")
         defer { context.cleanup() }

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -73,6 +73,90 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         )
     }
 
+    func testPiUIPromptLifecycleMarksNeedsInputWithoutNotification() throws {
+        let context = try makeClaudeHookContext(name: "pi-ui-prompt")
+        defer { context.cleanup() }
+
+        startAgentHookMockServerAccepting(context: context, connectionLimit: 24)
+        let sessionId = "pi-session-123"
+        let launchEnvironment = agentLaunchEnvironment(
+            context: context,
+            kind: "pi",
+            executable: "/usr/local/bin/pi",
+            arguments: ["/usr/local/bin/pi", "--model", "gpt-5.1"]
+        )
+        let start = runAgentHook(
+            context: context,
+            agent: "pi",
+            subcommand: "session-start",
+            standardInput: #"{"session_id":"\#(sessionId)","cwd":"\#(context.root.path)","hook_event_name":"SessionStart"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(start.timedOut, start.stderr)
+        XCTAssertEqual(start.status, 0, start.stderr)
+        XCTAssertEqual(start.stdout, "{}\n")
+
+        let promptStartCommandStart = context.state.snapshot().count
+        let promptStart = runAgentHook(
+            context: context,
+            agent: "pi",
+            subcommand: "ui-prompt-start",
+            standardInput: #"{"session_id":"\#(sessionId)","cwd":"\#(context.root.path)","hook_event_name":"ui_prompt_start","kind":"select","title":"Choose one"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(promptStart.timedOut, promptStart.stderr)
+        XCTAssertEqual(promptStart.status, 0, promptStart.stderr)
+        XCTAssertEqual(promptStart.stdout, "{}\n")
+
+        let promptStartCommands = Array(context.state.snapshot().dropFirst(promptStartCommandStart))
+        XCTAssertTrue(
+            promptStartCommands.contains {
+                $0.contains("set_agent_lifecycle pi needsInput --tab=\(context.workspaceId)")
+                    && $0.contains("--panel=\(context.surfaceId)")
+            },
+            "Expected Pi UI prompt start to mark lifecycle needsInput, saw \(promptStartCommands)"
+        )
+        XCTAssertTrue(
+            promptStartCommands.contains {
+                $0.contains("set_status pi Pi needs input --icon=bell.fill --color=#4C8DFF --priority=100 --tab=\(context.workspaceId)")
+                    && $0.contains("--panel=\(context.surfaceId)")
+            },
+            "Expected Pi UI prompt start to show a needs-input status, saw \(promptStartCommands)"
+        )
+        XCTAssertFalse(
+            promptStartCommands.contains { $0.hasPrefix("notify_target_async ") },
+            "Pi UI prompt start should update lifecycle/status without publishing a notification, saw \(promptStartCommands)"
+        )
+
+        let promptEndCommandStart = context.state.snapshot().count
+        let promptEnd = runAgentHook(
+            context: context,
+            agent: "pi",
+            subcommand: "ui-prompt-end",
+            standardInput: #"{"session_id":"\#(sessionId)","cwd":"\#(context.root.path)","hook_event_name":"ui_prompt_end","kind":"select"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(promptEnd.timedOut, promptEnd.stderr)
+        XCTAssertEqual(promptEnd.status, 0, promptEnd.stderr)
+        XCTAssertEqual(promptEnd.stdout, "{}\n")
+
+        let promptEndCommands = Array(context.state.snapshot().dropFirst(promptEndCommandStart))
+        XCTAssertTrue(
+            promptEndCommands.contains {
+                $0.contains("set_agent_lifecycle pi running --tab=\(context.workspaceId)")
+                    && $0.contains("--panel=\(context.surfaceId)")
+            },
+            "Expected Pi UI prompt end to restore lifecycle running, saw \(promptEndCommands)"
+        )
+        XCTAssertTrue(
+            promptEndCommands.contains {
+                $0.contains("set_status pi Running --icon=bolt.fill --color=#4C8DFF --tab=\(context.workspaceId)")
+                    && $0.contains("--panel=\(context.surfaceId)")
+            },
+            "Expected Pi UI prompt end to restore running status, saw \(promptEndCommands)"
+        )
+    }
+
     func testCodexPromptSubmitRefreshesLastTurnDiffBaseline() throws {
         let context = try makeClaudeHookContext(name: "codex-prompt-baseline")
         defer { context.cleanup() }

--- a/docs/agent-hooks.md
+++ b/docs/agent-hooks.md
@@ -21,7 +21,7 @@ Supported agent names are `codex`, `grok`, `opencode`, `pi`, `amp`, `cursor`, `g
 | Codex | `codex` | `~/.codex/hooks.json`, `~/.codex/config.toml` | `codex resume <id>` | PreToolUse, PermissionRequest |
 | Grok | `grok` | `~/.grok/hooks/cmux-session.json` | `grok -r <id>` | PreToolUse |
 | OpenCode | `opencode` | `~/.config/opencode/plugins/cmux-session.js`, `~/.config/opencode/plugins/cmux-feed.js` | `opencode --session <id>` | plugin event bus |
-| Pi | `pi` | `~/.pi/agent/extensions/cmux-session.ts` | `pi --session <id>` | none |
+| Pi | `pi` | `~/.pi/agent/extensions/cmux-session.ts` | `pi --session <id>` | lifecycle + UI prompt status |
 | Amp | `amp` | `~/.config/amp/plugins/cmux-session.ts` | `amp threads continue <id>` | none |
 | Cursor CLI | `cursor-agent` | `~/.cursor/hooks.json` | `cursor-agent --resume <id>` | beforeShellExecution |
 | Gemini | `gemini` | `~/.gemini/settings.json` | `gemini --resume <id>` | PreToolUse |
@@ -124,7 +124,7 @@ and browser state. Restored agent terminals stay idle until you resume them manu
 | Factory | none | `CMUX_FACTORY_HOOKS_DISABLED=1` |
 | Qoder | `QODER_CONFIG_DIR` | `CMUX_QODER_HOOKS_DISABLED=1` |
 
-Pi uses Pi's extension system, not the legacy Pi hooks API. The installed extension is auto-discovered from `~/.pi/agent/extensions/` or `$PI_CODING_AGENT_DIR/extensions/`.
+Pi uses Pi's extension system, not the legacy Pi hooks API. The installed extension is auto-discovered from `~/.pi/agent/extensions/` or `$PI_CODING_AGENT_DIR/extensions/`. In Pi versions that emit `ui_prompt_start` and `ui_prompt_end`, cmux maps blocking `ctx.ui` prompts to the agent lifecycle `needsInput` state and restores `running` when the prompt closes; this is a status/lifecycle signal, not a Feed card.
 
 Kiro stores hooks inside agent configuration files. The cmux installer creates or updates a `cmux` agent config with lifecycle, tool, and completion hooks; merge the generated `hooks` block into another Kiro agent config if you want the same cmux notifications on that agent.
 

--- a/docs/feed.md
+++ b/docs/feed.md
@@ -84,7 +84,7 @@ Installs supported agent hooks whose binaries are on `PATH`. See [Agent hook int
 | CodeBuddy    | `~/.codebuddy/settings.json`              | PreToolUse               |
 | Factory      | `~/.factory/settings.json`                | PreToolUse               |
 | Qoder        | `~/.qoder/settings.json`                  | PreToolUse               |
-| Pi           | `~/.pi/agent/extensions/cmux-session.ts`  | lifecycle only           |
+| Pi           | `~/.pi/agent/extensions/cmux-session.ts`  | lifecycle + UI prompt status |
 | Rovo Dev     | `~/.rovodev/config.yml`                   | lifecycle only           |
 
 Individual agents:


### PR DESCRIPTION
## Summary

- Add Pi `ui_prompt_start` / `ui_prompt_end` handling in the generated `~/.pi/agent/extensions/cmux-session.ts` extension.
- Add lifecycle-only `cmux hooks pi ui-prompt-start` and `cmux hooks pi ui-prompt-end` subcommands.
- Map mid-turn Pi UI prompts to cmux `needsInput` lifecycle/status while the prompt is open, then restore `running` only when the stored session was explicitly in prompt `needsInput` state.
- Keep this as a status/lifecycle signal only; it does not publish Feed cards or user notifications.
- Update agent hook / Feed docs to describe Pi UI prompt status support.

This is the cmux companion change for the draft Pi lifecycle-events work. Keeping both PRs draft until the Pi-side API is accepted.

## Testing

- Added process-level CLI regression coverage:
  - `testPiUIPromptLifecycleMarksNeedsInputWithoutNotification`
    - Starts a Pi session through the real `cmux hooks pi session-start` CLI path.
    - Sends `ui-prompt-start` and verifies `set_agent_lifecycle pi needsInput` plus the `Pi needs input` status pill.
    - Verifies no `notify_target_async` notification is published.
    - Sends `ui-prompt-end` and verifies lifecycle/status return to `running`.
  - `testPiUIPromptEndWithoutRecordedPromptDoesNotRestoreRunning`
    - Sends a stale `ui-prompt-end` without a recorded prompt/session and verifies it does not create phantom `running` lifecycle/status.
  - `testPiUIPromptLifecycleSuppressesNestedVisibleMutations`
    - Exercises `CMUX_AGENT_HOOK_SUPPRESS_VISIBLE_MUTATIONS=1` and verifies nested prompt start/end do not mutate visible lifecycle/status.
- Static checks run locally:
  - `./scripts/lint-pbxproj-test-wiring.sh` passed.
  - `./scripts/check-pbxproj.sh` passed.
  - `xcrun swiftc -parse CLI/CMUXCLI+AgentHookDefinitions.swift CLI/cmux.swift cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift` passed.
- Attempted required tagged Debug build:
  - `./scripts/reload.sh --tag pi-ui-prompt`
  - Blocked immediately because Zig is not installed on this machine: `Error: zig is not installed. Install via: brew install zig`.
- Attempted compile-only fallback with tagged derived data path:
  - `xcodebuild -project cmux.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-pi-ui-prompt build`
  - First blocked by uninitialized `vendor/bonsplit`; initialized that submodule only.
  - Then blocked because local setup has no `GhosttyKit.xcframework`, which normally comes from setup/reload and requires Zig.
- Per preference, did not install Zig locally; using CI/builders for full build/test verification.

## Demo Video

Not recorded yet. This is draft until the Pi PR lands; after both sides are available in a build, the demo should show a Pi `ask`/`ctx.ui.select` prompt making the cmux agent status switch from running to needs-input and back.

- Video URL or attachment:

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [ ] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved
