### PR TITLE
Add deep link addressing package

### DIFF
--- a/Packages/CMUXDeepLinks/Package.swift
+++ b/Packages/CMUXDeepLinks/Package.swift
@@ -1,0 +1,30 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "CMUXDeepLinks",
+    platforms: [
+        .macOS(.v14),
+    ],
+    products: [
+        .library(
+            name: "CMUXDeepLinks",
+            targets: ["CMUXDeepLinks"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "CMUXDeepLinks",
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .enableUpcomingFeature("ExistentialAny"),
+                .enableUpcomingFeature("InternalImportsByDefault"),
+            ]
+        ),
+        .testTarget(
+            name: "CMUXDeepLinksTests",
+            dependencies: ["CMUXDeepLinks"]
+        ),
+    ]
+)

--- a/Packages/CMUXDeepLinks/Sources/CMUXDeepLinks/CMUXNavigationURLRequest.swift
+++ b/Packages/CMUXDeepLinks/Sources/CMUXDeepLinks/CMUXNavigationURLRequest.swift
@@ -1,0 +1,133 @@
+public import Foundation
+
+public enum CMUXNavigationURLParseError: Error, Equatable, Sendable {
+    case unsupportedURLShape
+    case invalidIdentifier(String)
+}
+
+public struct CMUXNavigationURLRequest: Equatable, Sendable {
+    public enum Target: Equatable, Sendable {
+        case workspace(UUID)
+        case pane(workspaceId: UUID, paneId: UUID)
+        case surface(workspaceId: UUID, surfaceId: UUID)
+    }
+
+    public let originalURL: URL
+    public let target: Target
+
+    public init(originalURL: URL, target: Target) {
+        self.originalURL = originalURL
+        self.target = target
+    }
+
+    public static func parse(
+        _ url: URL,
+        supportedSchemes: Set<String>
+    ) -> Result<CMUXNavigationURLRequest?, CMUXNavigationURLParseError> {
+        guard isSupportedScheme(url.scheme, supportedSchemes: supportedSchemes) else {
+            return .success(nil)
+        }
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            return .failure(.unsupportedURLShape)
+        }
+
+        let route = routeComponents(from: components)
+        guard route.first?.lowercased() == "workspace" else {
+            return .success(nil)
+        }
+
+        guard components.user == nil,
+              components.password == nil,
+              components.port == nil,
+              components.percentEncodedQuery == nil,
+              components.percentEncodedFragment == nil else {
+            return .failure(.unsupportedURLShape)
+        }
+
+        guard route.count == 2 || route.count == 4 else {
+            return .failure(.unsupportedURLShape)
+        }
+        guard let workspaceId = UUID(uuidString: route[1]) else {
+            return .failure(.invalidIdentifier("workspace"))
+        }
+        if route.count == 2 {
+            return .success(CMUXNavigationURLRequest(originalURL: url, target: .workspace(workspaceId)))
+        }
+
+        let childKind = route[2].lowercased()
+        guard let childId = UUID(uuidString: route[3]) else {
+            switch childKind {
+            case "pane":
+                return .failure(.invalidIdentifier("pane"))
+            case "surface", "panel", "tab":
+                return .failure(.invalidIdentifier(childKind == "tab" ? "tab" : "surface"))
+            default:
+                return .failure(.unsupportedURLShape)
+            }
+        }
+
+        switch childKind {
+        case "pane":
+            return .success(
+                CMUXNavigationURLRequest(
+                    originalURL: url,
+                    target: .pane(workspaceId: workspaceId, paneId: childId)
+                )
+            )
+        case "surface", "panel", "tab":
+            return .success(
+                CMUXNavigationURLRequest(
+                    originalURL: url,
+                    target: .surface(workspaceId: workspaceId, surfaceId: childId)
+                )
+            )
+        default:
+            return .failure(.unsupportedURLShape)
+        }
+    }
+
+    public static func workspaceLink(workspaceId: UUID, scheme: String) -> String {
+        "\(scheme)://workspace/\(workspaceId.uuidString)"
+    }
+
+    public static func paneLink(
+        workspaceId: UUID,
+        paneId: UUID,
+        scheme: String
+    ) -> String {
+        "\(scheme)://workspace/\(workspaceId.uuidString)/pane/\(paneId.uuidString)"
+    }
+
+    public static func surfaceLink(
+        workspaceId: UUID,
+        surfaceId: UUID,
+        scheme: String
+    ) -> String {
+        "\(scheme)://workspace/\(workspaceId.uuidString)/surface/\(surfaceId.uuidString)"
+    }
+
+    public static func tabLink(
+        workspaceId: UUID,
+        tabId: UUID,
+        scheme: String
+    ) -> String {
+        "\(scheme)://workspace/\(workspaceId.uuidString)/tab/\(tabId.uuidString)"
+    }
+
+    private static func isSupportedScheme(_ scheme: String?, supportedSchemes: Set<String>) -> Bool {
+        guard let scheme = scheme?.lowercased() else { return false }
+        return supportedSchemes.contains(scheme)
+    }
+
+    private static func routeComponents(from components: URLComponents) -> [String] {
+        var route: [String] = []
+        if let host = components.host?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !host.isEmpty {
+            route.append(host)
+        }
+        route += components.path
+            .split(separator: "/", omittingEmptySubsequences: true)
+            .map(String.init)
+        return route
+    }
+}

--- a/Packages/CMUXDeepLinks/Tests/CMUXDeepLinksTests/CMUXNavigationURLRequestTests.swift
+++ b/Packages/CMUXDeepLinks/Tests/CMUXDeepLinksTests/CMUXNavigationURLRequestTests.swift
@@ -1,0 +1,99 @@
+import CMUXDeepLinks
+import Foundation
+import XCTest
+
+final class CMUXNavigationURLRequestTests: XCTestCase {
+    private let supportedScheme = "cmux-test"
+    private let workspaceId = UUID(uuidString: "11111111-1111-1111-1111-111111111111")!
+    private let paneId = UUID(uuidString: "22222222-2222-2222-2222-222222222222")!
+    private let surfaceId = UUID(uuidString: "33333333-3333-3333-3333-333333333333")!
+
+    func testParsesWorkspacePaneSurfaceAndTabLinks() throws {
+        let workspaceURL = try XCTUnwrap(URL(string: "\(supportedScheme)://workspace/\(workspaceId.uuidString)"))
+        let paneURL = try XCTUnwrap(URL(string: "\(supportedScheme)://workspace/\(workspaceId.uuidString)/pane/\(paneId.uuidString)"))
+        let surfaceURL = try XCTUnwrap(URL(string: "\(supportedScheme)://workspace/\(workspaceId.uuidString)/surface/\(surfaceId.uuidString)"))
+        let panelAliasURL = try XCTUnwrap(URL(string: "\(supportedScheme)://workspace/\(workspaceId.uuidString)/panel/\(surfaceId.uuidString)"))
+        let tabAliasURL = try XCTUnwrap(URL(string: "\(supportedScheme)://workspace/\(workspaceId.uuidString)/tab/\(surfaceId.uuidString)"))
+
+        XCTAssertEqual(try parsedTarget(workspaceURL), .workspace(workspaceId))
+        XCTAssertEqual(try parsedTarget(paneURL), .pane(workspaceId: workspaceId, paneId: paneId))
+        XCTAssertEqual(try parsedTarget(surfaceURL), .surface(workspaceId: workspaceId, surfaceId: surfaceId))
+        XCTAssertEqual(try parsedTarget(panelAliasURL), .surface(workspaceId: workspaceId, surfaceId: surfaceId))
+        XCTAssertEqual(try parsedTarget(tabAliasURL), .surface(workspaceId: workspaceId, surfaceId: surfaceId))
+    }
+
+    func testGeneratedLinksRoundTrip() throws {
+        let workspaceURL = try XCTUnwrap(URL(string: CMUXNavigationURLRequest.workspaceLink(workspaceId: workspaceId, scheme: supportedScheme)))
+        let paneURL = try XCTUnwrap(URL(string: CMUXNavigationURLRequest.paneLink(workspaceId: workspaceId, paneId: paneId, scheme: supportedScheme)))
+        let surfaceURL = try XCTUnwrap(URL(string: CMUXNavigationURLRequest.surfaceLink(workspaceId: workspaceId, surfaceId: surfaceId, scheme: supportedScheme)))
+        let tabURL = try XCTUnwrap(URL(string: CMUXNavigationURLRequest.tabLink(workspaceId: workspaceId, tabId: surfaceId, scheme: supportedScheme)))
+
+        XCTAssertEqual(try parsedTarget(workspaceURL), .workspace(workspaceId))
+        XCTAssertEqual(try parsedTarget(paneURL), .pane(workspaceId: workspaceId, paneId: paneId))
+        XCTAssertEqual(try parsedTarget(surfaceURL), .surface(workspaceId: workspaceId, surfaceId: surfaceId))
+        XCTAssertEqual(try parsedTarget(tabURL), .surface(workspaceId: workspaceId, surfaceId: surfaceId))
+    }
+
+    func testIgnoresOtherCmuxRoutesAndInactiveSchemes() throws {
+        let sshURL = try XCTUnwrap(URL(string: "\(supportedScheme)://ssh?host=dev.example.com"))
+        let authURL = try XCTUnwrap(URL(string: "\(supportedScheme)://auth-callback?stack_refresh=abc"))
+        let inactiveURL = try XCTUnwrap(URL(string: "cmux-other://workspace/\(workspaceId.uuidString)"))
+
+        XCTAssertNil(try parsedOptional(sshURL))
+        XCTAssertNil(try parsedOptional(authURL))
+        XCTAssertNil(try parsedOptional(inactiveURL))
+    }
+
+    func testRejectsQueryFragmentAuthorityAndExtraPathComponents() throws {
+        let cases = [
+            "\(supportedScheme)://workspace/\(workspaceId.uuidString)?command=id",
+            "\(supportedScheme)://workspace/\(workspaceId.uuidString)#fragment",
+            "\(supportedScheme)://user@workspace/\(workspaceId.uuidString)",
+            "\(supportedScheme)://workspace:123/\(workspaceId.uuidString)",
+            "\(supportedScheme)://workspace/\(workspaceId.uuidString)/surface/\(surfaceId.uuidString)/run",
+        ]
+
+        for rawURL in cases {
+            let url = try XCTUnwrap(URL(string: rawURL))
+            switch CMUXNavigationURLRequest.parse(url, supportedSchemes: [supportedScheme]) {
+            case .failure(.unsupportedURLShape):
+                break
+            default:
+                XCTFail("Expected unsupported URL shape rejection for \(rawURL)")
+            }
+        }
+    }
+
+    func testRejectsNonUUIDIdentifiersAndRelativeRefs() throws {
+        let cases = [
+            ("\(supportedScheme)://workspace/workspace:1", "workspace"),
+            ("\(supportedScheme)://workspace/\(workspaceId.uuidString)/pane/pane:1", "pane"),
+            ("\(supportedScheme)://workspace/\(workspaceId.uuidString)/surface/surface:1", "surface"),
+            ("\(supportedScheme)://workspace/\(workspaceId.uuidString)/tab/tab:1", "tab"),
+        ]
+
+        for (rawURL, component) in cases {
+            let url = try XCTUnwrap(URL(string: rawURL))
+            switch CMUXNavigationURLRequest.parse(url, supportedSchemes: [supportedScheme]) {
+            case .failure(.invalidIdentifier(component)):
+                break
+            default:
+                XCTFail("Expected invalid \(component) rejection for \(rawURL)")
+            }
+        }
+    }
+
+    private func parsedOptional(_ url: URL) throws -> CMUXNavigationURLRequest? {
+        switch CMUXNavigationURLRequest.parse(url, supportedSchemes: [supportedScheme]) {
+        case .success(let request):
+            return request
+        case .failure(let error):
+            throw error
+        }
+    }
+
+    private func parsedTarget(_ url: URL) throws -> CMUXNavigationURLRequest.Target {
+        let request = try XCTUnwrap(parsedOptional(url))
+        return request.target
+    }
+}

--- a/Sources/CmuxSSHURLRequest.swift
+++ b/Sources/CmuxSSHURLRequest.swift
@@ -1,3 +1,4 @@
+import CMUXDeepLinks
 import Foundation
 
 enum CmuxSSHURLParseError: Error, Equatable {
@@ -521,126 +522,16 @@ struct CmuxSSHURLRequest: Equatable {
     }
 }
 
-enum CmuxNavigationURLParseError: Error, Equatable {
-    case unsupportedURLShape
-    case invalidIdentifier(String)
-}
+typealias CmuxNavigationURLParseError = CMUXNavigationURLParseError
+typealias CmuxNavigationURLRequest = CMUXNavigationURLRequest
 
-struct CmuxNavigationURLRequest: Equatable {
-    enum Target: Equatable {
-        case workspace(UUID)
-        case pane(workspaceId: UUID, paneId: UUID)
-        case surface(workspaceId: UUID, surfaceId: UUID)
-    }
-
+extension CMUXNavigationURLRequest {
     static var activeSupportedSchemes: Set<String> {
         [AuthEnvironment.callbackScheme.lowercased()]
     }
 
-    let originalURL: URL
-    let target: Target
-
-    static func parse(
-        _ url: URL,
-        supportedSchemes: Set<String> = activeSupportedSchemes
-    ) -> Result<CmuxNavigationURLRequest?, CmuxNavigationURLParseError> {
-        guard isSupportedScheme(url.scheme, supportedSchemes: supportedSchemes) else {
-            return .success(nil)
-        }
-        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
-            return .failure(.unsupportedURLShape)
-        }
-
-        let route = routeComponents(from: components)
-        guard route.first?.lowercased() == "workspace" else {
-            return .success(nil)
-        }
-
-        guard components.user == nil,
-              components.password == nil,
-              components.port == nil,
-              components.percentEncodedQuery == nil,
-              components.percentEncodedFragment == nil else {
-            return .failure(.unsupportedURLShape)
-        }
-
-        guard route.count == 2 || route.count == 4 else {
-            return .failure(.unsupportedURLShape)
-        }
-        guard let workspaceId = UUID(uuidString: route[1]) else {
-            return .failure(.invalidIdentifier("workspace"))
-        }
-        if route.count == 2 {
-            return .success(CmuxNavigationURLRequest(originalURL: url, target: .workspace(workspaceId)))
-        }
-
-        let childKind = route[2].lowercased()
-        guard let childId = UUID(uuidString: route[3]) else {
-            switch childKind {
-            case "pane":
-                return .failure(.invalidIdentifier("pane"))
-            case "surface", "panel":
-                return .failure(.invalidIdentifier("surface"))
-            default:
-                return .failure(.unsupportedURLShape)
-            }
-        }
-
-        switch childKind {
-        case "pane":
-            return .success(
-                CmuxNavigationURLRequest(
-                    originalURL: url,
-                    target: .pane(workspaceId: workspaceId, paneId: childId)
-                )
-            )
-        case "surface", "panel":
-            return .success(
-                CmuxNavigationURLRequest(
-                    originalURL: url,
-                    target: .surface(workspaceId: workspaceId, surfaceId: childId)
-                )
-            )
-        default:
-            return .failure(.unsupportedURLShape)
-        }
-    }
-
-    static func workspaceLink(workspaceId: UUID, scheme: String = AuthEnvironment.callbackScheme) -> String {
-        "\(scheme)://workspace/\(workspaceId.uuidString)"
-    }
-
-    static func paneLink(
-        workspaceId: UUID,
-        paneId: UUID,
-        scheme: String = AuthEnvironment.callbackScheme
-    ) -> String {
-        "\(scheme)://workspace/\(workspaceId.uuidString)/pane/\(paneId.uuidString)"
-    }
-
-    static func surfaceLink(
-        workspaceId: UUID,
-        surfaceId: UUID,
-        scheme: String = AuthEnvironment.callbackScheme
-    ) -> String {
-        "\(scheme)://workspace/\(workspaceId.uuidString)/surface/\(surfaceId.uuidString)"
-    }
-
-    private static func isSupportedScheme(_ scheme: String?, supportedSchemes: Set<String>) -> Bool {
-        guard let scheme = scheme?.lowercased() else { return false }
-        return supportedSchemes.contains(scheme)
-    }
-
-    private static func routeComponents(from components: URLComponents) -> [String] {
-        var route: [String] = []
-        if let host = components.host?.trimmingCharacters(in: .whitespacesAndNewlines),
-           !host.isEmpty {
-            route.append(host)
-        }
-        route += components.path
-            .split(separator: "/", omittingEmptySubsequences: true)
-            .map(String.init)
-        return route
+    static func parse(_ url: URL) -> Result<CMUXNavigationURLRequest?, CMUXNavigationURLParseError> {
+        parse(url, supportedSchemes: activeSupportedSchemes)
     }
 }
 

--- a/Sources/WorkspaceSurfaceIdentifierClipboardText.swift
+++ b/Sources/WorkspaceSurfaceIdentifierClipboardText.swift
@@ -43,7 +43,10 @@ enum WorkspaceSurfaceIdentifierClipboardText {
     }
 
     static func makeWorkspaceLink(workspaceId: UUID) -> String {
-        CmuxNavigationURLRequest.workspaceLink(workspaceId: workspaceId)
+        CmuxNavigationURLRequest.workspaceLink(
+            workspaceId: workspaceId,
+            scheme: AuthEnvironment.callbackScheme
+        )
     }
 
     static func makeWorkspaceLinks(_ ids: [UUID]) -> String {
@@ -51,11 +54,27 @@ enum WorkspaceSurfaceIdentifierClipboardText {
     }
 
     static func makePaneLink(workspaceId: UUID, paneId: UUID) -> String {
-        CmuxNavigationURLRequest.paneLink(workspaceId: workspaceId, paneId: paneId)
+        CmuxNavigationURLRequest.paneLink(
+            workspaceId: workspaceId,
+            paneId: paneId,
+            scheme: AuthEnvironment.callbackScheme
+        )
     }
 
     static func makeSurfaceLink(workspaceId: UUID, surfaceId: UUID) -> String {
-        CmuxNavigationURLRequest.surfaceLink(workspaceId: workspaceId, surfaceId: surfaceId)
+        CmuxNavigationURLRequest.surfaceLink(
+            workspaceId: workspaceId,
+            surfaceId: surfaceId,
+            scheme: AuthEnvironment.callbackScheme
+        )
+    }
+
+    static func makeTabLink(workspaceId: UUID, tabId: UUID) -> String {
+        CmuxNavigationURLRequest.tabLink(
+            workspaceId: workspaceId,
+            tabId: tabId,
+            scheme: AuthEnvironment.callbackScheme
+        )
     }
 
     @MainActor

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -131,6 +131,7 @@
 		E30750000000000000000006 /* CmuxConfigNamedColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E30750000000000000000005 /* CmuxConfigNamedColorTests.swift */; };
 		C1A2B3C4D5E6F70800000001 /* CmuxConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A2B3C4D5E6F70800000002 /* CmuxConfigTests.swift */; };
 		C0DEF0A10000000000000001 /* CmuxConfigUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEF0A10000000000000002 /* CmuxConfigUI.swift */; };
+		DD1100010000000000000001 /* CMUXDeepLinks in Frameworks */ = {isa = PBXBuildFile; productRef = DD1100030000000000000001 /* CMUXDeepLinks */; };
 		D1320AA0D1320AA0D1320AA2 /* CmuxDockTilePlugin.plugin in Copy Dock Tile Plugin */ = {isa = PBXBuildFile; fileRef = D1320AA0D1320AA0D1320AA5 /* CmuxDockTilePlugin.plugin */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		E7E000000000000000000005 /* CmuxEventBus.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7E000000000000000000006 /* CmuxEventBus.swift */; };
 		E7E000000000000000000003 /* CmuxEventBusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7E000000000000000000004 /* CmuxEventBusTests.swift */; };
@@ -1199,6 +1200,7 @@
 				A5B00003A1B2C3D4E5F60718 /* CMUXAgentLaunch in Frameworks */,
 				F53000A0A1B2C3D4E5F60718 /* CMUXAgentVault in Frameworks */,
 				5EDB6027B346C46521A93C74 /* CMUXAuthCore in Frameworks */,
+				DD1100010000000000000001 /* CMUXDeepLinks in Frameworks */,
 				C0DE46000000000000000001 /* CMUXExtensionClient in Frameworks */,
 				C0DE45000000000000000001 /* CmuxExtensionKit in Frameworks */,
 				CF00F00000000000000000A3 /* CmuxFoundation in Frameworks */,
@@ -1916,6 +1918,7 @@
 				A5C0DE0000000000000000A2 /* CMUXProjectModel */,
 				F53000A2A1B2C3D4E5F60718 /* CMUXAgentVault */,
 				A5B00002A1B2C3D4E5F60718 /* CMUXAgentLaunch */,
+				DD1100030000000000000001 /* CMUXDeepLinks */,
 				A5354305A5354305A5354305 /* CmuxSocketControl */,
 				C8000302C8000302C8000302 /* CmuxProcess */,
 				A500D013A1B2C3D4E5F60718 /* CMUXDebugLog */,
@@ -2056,6 +2059,7 @@
 				A5C0DE0000000000000000A1 /* XCLocalSwiftPackageReference "CMUXProjectModel" */,
 				F53000A1A1B2C3D4E5F60718 /* XCLocalSwiftPackageReference "CMUXAgentVault" */,
 				A5B00001A1B2C3D4E5F60718 /* XCLocalSwiftPackageReference "CMUXAgentLaunch" */,
+				DD1100020000000000000001 /* XCLocalSwiftPackageReference "CMUXDeepLinks" */,
 				A500D012A1B2C3D4E5F60718 /* XCLocalSwiftPackageReference "CMUXDebugLog" */,
 				A5354304A5354304A5354304 /* XCLocalSwiftPackageReference "CmuxSocketControl" */,
 				C8000301C8000301C8000301 /* XCLocalSwiftPackageReference "CmuxProcess" */,
@@ -3191,6 +3195,10 @@
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/CMUXAgentLaunch;
 		};
+		DD1100020000000000000001 /* XCLocalSwiftPackageReference "CMUXDeepLinks" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Packages/CMUXDeepLinks;
+		};
 		A500D012A1B2C3D4E5F60718 /* XCLocalSwiftPackageReference "CMUXDebugLog" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/CMUXDebugLog;
@@ -3296,6 +3304,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = A5B00001A1B2C3D4E5F60718 /* XCLocalSwiftPackageReference "CMUXAgentLaunch" */;
 			productName = CMUXAgentLaunch;
+		};
+		DD1100030000000000000001 /* CMUXDeepLinks */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = DD1100020000000000000001 /* XCLocalSwiftPackageReference "CMUXDeepLinks" */;
+			productName = CMUXDeepLinks;
 		};
 		A500D013A1B2C3D4E5F60718 /* CMUXDebugLog */ = {
 			isa = XCSwiftPackageProductDependency;


### PR DESCRIPTION
Summary:
- Added `CMUXDeepLinks`, a standalone Swift package for cmux navigation route parsing and link generation.
- Moved workspace, pane, and surface route parsing behind the package while preserving the app-local compatibility names.
- Added `/tab/<uuid>` as a generated and parsed alias for surface-level tab links so session summaries can link to tabs directly.

Acceptance criteria:
- `cmux://workspace/<uuid>` still parses and focuses a workspace.
- `cmux://workspace/<uuid>/pane/<uuid>` still parses and focuses a pane.
- `cmux://workspace/<uuid>/surface/<uuid>` still parses and focuses a surface.
- `cmux://workspace/<uuid>/tab/<uuid>` parses to the same surface target so generated docs can use tab wording.
- Unsupported routes, query strings, fragments, userinfo, and relative refs are rejected or ignored as before.

Verification:
- `swift test --package-path Packages/CMUXDeepLinks` passed, 5 tests.
- `scripts/normalize-pbxproj.py cmux.xcodeproj/project.pbxproj --check` passed.
- `./scripts/reload.sh --tag deeplink` passed.

Dogfood build:
- macOS tag: deeplink

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5231"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783004318&installation_id=133855650&pr_number=5231&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5231&signature=11afa87b2e67734a59c51f04018067dacec86dc1151dc585052201187f5ce476"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces `CMUXDeepLinks`, a standalone Swift package for deep-link parsing and link generation for workspace navigation. Adds a `/tab/<uuid>` alias that resolves to the same surface target, enabling direct tab links in generated docs.

- **New Features**
  - Adds parsing and builders for `workspace`, `pane`, `surface`, and tab-as-surface (`/tab/<uuid>`).
  - Enforces strict URL shape: rejects unsupported routes, queries, fragments, userinfo, ports, and extra path parts; ignores inactive schemes and non-navigation routes.

- **Refactors**
  - Moves navigation parsing into `CMUXDeepLinks`; keeps app-local names via typealiases to avoid churn.
  - Updates clipboard helpers to use package builders and adds `makeTabLink`.
  - Links the new package in the Xcode project and adds unit tests to cover parsing and link round-trips.

<sup>Written for commit 7eedb796c23b71077d2d63bc96bd69a665acbd3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for parsing and generating navigation URLs with validation
  * Handles workspace, pane, surface, and tab navigation targets
  * Includes scheme validation and error handling for invalid URLs

* **Tests**
  * Added comprehensive test coverage for navigation URL parsing and link generation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->