### PR TITLE
Fix session resume when Workflow tool creates container directory

### DIFF
--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -1407,7 +1407,7 @@ struct RestorableAgentSessionIndex: Sendable {
         // Pick the sibling whose birthtime is closest to the Workflow container directory.
         let dirPath = (projectRoot as NSString).appendingPathComponent(excludingSessionId)
         guard let dirBirth = (try? fileManager.attributesOfItem(atPath: dirPath))?[.creationDate] as? Date else {
-            return siblings.first
+            return siblings.sorted().first
         }
         return siblings.min { a, b in
             let pathA = (projectRoot as NSString).appendingPathComponent("\(a).jsonl")

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -1122,7 +1122,7 @@ struct RestorableAgentSessionIndex: Sendable {
                 guard !normalizedSessionId.isEmpty,
                       let workspaceId = UUID(uuidString: record.workspaceId),
                       let panelId = UUID(uuidString: record.surfaceId),
-                      hookRecordIsRestorable(
+                      let effectiveSessionId = hookRecordResolvableSessionId(
                           record,
                           kind: kind,
                           fileManager: fileManager,
@@ -1133,7 +1133,7 @@ struct RestorableAgentSessionIndex: Sendable {
 
                 let snapshot = SessionRestorableAgentSnapshot(
                     kind: kind,
-                    sessionId: normalizedSessionId,
+                    sessionId: effectiveSessionId,
                     workingDirectory: restorableWorkingDirectory(
                         for: record,
                         kind: kind,
@@ -1220,60 +1220,64 @@ struct RestorableAgentSessionIndex: Sendable {
         normalizedNonEmptyValue(rawValue)
     }
 
-    private static func hookRecordIsRestorable(
+    // Returns the session ID to use for resume (may differ from record.sessionId when the stored ID
+    // is a Workflow container directory), or nil if the session cannot be resumed.
+    private static func hookRecordResolvableSessionId(
         _ record: RestorableAgentHookSessionRecord,
         kind: RestorableAgentKind,
         fileManager: FileManager,
         claudeTranscriptLookup: ClaudeTranscriptLookupCache
-    ) -> Bool {
+    ) -> String? {
         guard kind == .claude else {
-            return record.isRestorable != false
+            return record.isRestorable != false ? normalizedNonEmptyValue(record.sessionId) : nil
         }
         if let transcriptPath = normalizedNonEmptyValue(record.transcriptPath),
            regularNonEmptyFileExists(
                atPath: (transcriptPath as NSString).expandingTildeInPath,
                fileManager: fileManager
            ) {
-            return true
+            return normalizedNonEmptyValue(record.sessionId)
         }
-        return claudeTranscriptExists(for: record, fileManager: fileManager, lookup: claudeTranscriptLookup)
+        return claudeResolvedSessionId(for: record, fileManager: fileManager, lookup: claudeTranscriptLookup)
     }
 
-    private static func claudeTranscriptExists(
+    // Returns the effective session ID for resume: the stored ID if its .jsonl exists, or the
+    // sibling interactive transcript's ID when the stored ID maps to a Workflow container directory.
+    private static func claudeResolvedSessionId(
         for record: RestorableAgentHookSessionRecord,
         fileManager: FileManager,
         lookup: ClaudeTranscriptLookupCache
-    ) -> Bool {
+    ) -> String? {
         guard let sessionId = normalizedNonEmptyValue(record.sessionId),
               claudeSessionIdIsSafeFilename(sessionId) else {
-            return false
+            return nil
         }
 
         let roots = lookup.configRoots(for: record)
-        guard !roots.isEmpty else { return false }
+        guard !roots.isEmpty else { return nil }
 
         let cwd = normalizedWorkingDirectory(record.cwd)
             ?? normalizedWorkingDirectory(record.launchCommand?.workingDirectory)
         for root in roots {
             if let cwd,
-               claudeTranscriptFileExists(
+               let resolved = claudeResolvedSessionIdInProjectDir(
                    configRoot: root,
                    projectDirName: encodeClaudeProjectDir(cwd),
                    sessionId: sessionId,
                    fileManager: fileManager
                ) {
-                return true
+                return resolved
             }
-            if claudeTranscriptFileExistsInAnyProject(
+            if let resolved = claudeResolvedSessionIdInAnyProject(
                 configRoot: root,
                 sessionId: sessionId,
                 fileManager: fileManager,
                 lookup: lookup
             ) {
-                return true
+                return resolved
             }
         }
-        return false
+        return nil
     }
 
     /// The directory cmux must `cd` into to resume or fork this session.
@@ -1349,6 +1353,92 @@ struct RestorableAgentSessionIndex: Sendable {
             .replacingOccurrences(of: ".", with: "-")
     }
 
+    // Returns the resumable session ID found in a specific project dir: the stored sessionId when
+    // its .jsonl exists, or the sibling interactive transcript's ID when sessionId/ is a Workflow
+    // container directory. Returns nil when neither exists.
+    private static func claudeResolvedSessionIdInProjectDir(
+        configRoot: String,
+        projectDirName: String,
+        sessionId: String,
+        fileManager: FileManager
+    ) -> String? {
+        let projectsRoot = (configRoot as NSString).appendingPathComponent("projects")
+        let projectRoot = (projectsRoot as NSString).appendingPathComponent(projectDirName)
+        let path = (projectRoot as NSString).appendingPathComponent("\(sessionId).jsonl")
+        if regularNonEmptyFileExists(atPath: path, fileManager: fileManager) {
+            return sessionId
+        }
+        // When the stored session ID is a Workflow container directory, find the sibling
+        // interactive transcript (the actual session Claude created for the conversation).
+        var isDirectory: ObjCBool = false
+        let dirPath = (projectRoot as NSString).appendingPathComponent(sessionId)
+        guard fileManager.fileExists(atPath: dirPath, isDirectory: &isDirectory),
+              isDirectory.boolValue else {
+            return nil
+        }
+        return claudeInteractiveSiblingSessionId(
+            inProjectRoot: projectRoot,
+            excludingSessionId: sessionId,
+            fileManager: fileManager
+        )
+    }
+
+    // Scans projectRoot for a .jsonl file that is not the Workflow container's own ID.
+    // When multiple candidates exist, picks the one whose birthtime is closest to the container
+    // directory's birthtime (the interactive session was created at the same time as the Workflow).
+    private static func claudeInteractiveSiblingSessionId(
+        inProjectRoot projectRoot: String,
+        excludingSessionId: String,
+        fileManager: FileManager
+    ) -> String? {
+        guard let contents = try? fileManager.contentsOfDirectory(atPath: projectRoot) else {
+            return nil
+        }
+        let siblings = contents.compactMap { name -> String? in
+            guard name.hasSuffix(".jsonl") else { return nil }
+            let candidate = String(name.dropLast(".jsonl".count))
+            guard candidate != excludingSessionId,
+                  claudeSessionIdIsSafeFilename(candidate) else { return nil }
+            let filePath = (projectRoot as NSString).appendingPathComponent(name)
+            return regularNonEmptyFileExists(atPath: filePath, fileManager: fileManager) ? candidate : nil
+        }
+        guard !siblings.isEmpty else { return nil }
+        if siblings.count == 1 { return siblings[0] }
+        // Pick the sibling whose birthtime is closest to the Workflow container directory.
+        let dirPath = (projectRoot as NSString).appendingPathComponent(excludingSessionId)
+        guard let dirBirth = (try? fileManager.attributesOfItem(atPath: dirPath))?[.creationDate] as? Date else {
+            return siblings.first
+        }
+        return siblings.min { a, b in
+            let pathA = (projectRoot as NSString).appendingPathComponent("\(a).jsonl")
+            let pathB = (projectRoot as NSString).appendingPathComponent("\(b).jsonl")
+            let birthA = ((try? fileManager.attributesOfItem(atPath: pathA))?[.creationDate] as? Date) ?? .distantPast
+            let birthB = ((try? fileManager.attributesOfItem(atPath: pathB))?[.creationDate] as? Date) ?? .distantPast
+            return abs(birthA.timeIntervalSince(dirBirth)) < abs(birthB.timeIntervalSince(dirBirth))
+        }
+    }
+
+    private static func claudeResolvedSessionIdInAnyProject(
+        configRoot: String,
+        sessionId: String,
+        fileManager: FileManager,
+        lookup: ClaudeTranscriptLookupCache
+    ) -> String? {
+        for projectDir in lookup.projectDirs(configRoot: configRoot) {
+            if let resolved = claudeResolvedSessionIdInProjectDir(
+                configRoot: configRoot,
+                projectDirName: projectDir,
+                sessionId: sessionId,
+                fileManager: fileManager
+            ) {
+                return resolved
+            }
+        }
+        return nil
+    }
+
+    // Used by restorableWorkingDirectory to verify which candidate cwd holds the session.
+    // Returns true also for Workflow container directories so cwd resolution works correctly.
     private static func claudeTranscriptFileExists(
         configRoot: String,
         projectDirName: String,
@@ -1358,24 +1448,10 @@ struct RestorableAgentSessionIndex: Sendable {
         let projectsRoot = (configRoot as NSString).appendingPathComponent("projects")
         let projectRoot = (projectsRoot as NSString).appendingPathComponent(projectDirName)
         let path = (projectRoot as NSString).appendingPathComponent("\(sessionId).jsonl")
-        return regularNonEmptyFileExists(atPath: path, fileManager: fileManager)
-    }
-
-    private static func claudeTranscriptFileExistsInAnyProject(
-        configRoot: String,
-        sessionId: String,
-        fileManager: FileManager,
-        lookup: ClaudeTranscriptLookupCache
-    ) -> Bool {
-        let projectsRoot = (configRoot as NSString).appendingPathComponent("projects")
-        for projectDir in lookup.projectDirs(configRoot: configRoot) {
-            let projectRoot = (projectsRoot as NSString).appendingPathComponent(projectDir)
-            let path = (projectRoot as NSString).appendingPathComponent("\(sessionId).jsonl")
-            if regularNonEmptyFileExists(atPath: path, fileManager: fileManager) {
-                return true
-            }
-        }
-        return false
+        if regularNonEmptyFileExists(atPath: path, fileManager: fileManager) { return true }
+        var isDirectory: ObjCBool = false
+        let dirPath = (projectRoot as NSString).appendingPathComponent(sessionId)
+        return fileManager.fileExists(atPath: dirPath, isDirectory: &isDirectory) && isDirectory.boolValue
     }
 
     private final class ClaudeTranscriptLookupCache {

--- a/cmuxTests/RestorableAgentSessionIndexTests.swift
+++ b/cmuxTests/RestorableAgentSessionIndexTests.swift
@@ -448,8 +448,10 @@ final class RestorableAgentSessionIndexTests: XCTestCase {
         try fm.createDirectory(at: projectDir, withIntermediateDirectories: true)
 
         let workflowContainerId = "d1d1d1d1-d1d1-d1d1-d1d1-d1d1d1d1d1d1"
-        let nearSiblingId = "e2e2e2e2-e2e2-e2e2-e2e2-e2e2e2e2e2e2"
-        let farSiblingId = "f3f3f3f3-f3f3-f3f3-f3f3-f3f3f3f3f3f3"
+        // "near" sorts after "far" alphabetically ("f..." > "e...") and is written second,
+        // so only the pinned birthtimes can make nearSiblingId win.
+        let nearSiblingId = "f3f3f3f3-f3f3-f3f3-f3f3-f3f3f3f3f3f3"
+        let farSiblingId = "e2e2e2e2-e2e2-e2e2-e2e2-e2e2e2e2e2e2"
         let workspaceId = UUID()
         let panelId = UUID()
 
@@ -457,11 +459,11 @@ final class RestorableAgentSessionIndexTests: XCTestCase {
         let workflowDir = projectDir.appendingPathComponent(workflowContainerId, isDirectory: true)
         try fm.createDirectory(at: workflowDir, withIntermediateDirectories: true)
 
-        // Two sibling transcripts
+        // Two sibling transcripts — far written first so filesystem creation order also favors it.
         let nearURL = projectDir.appendingPathComponent("\(nearSiblingId).jsonl")
         let farURL = projectDir.appendingPathComponent("\(farSiblingId).jsonl")
-        try writeClaudeTranscript(sessionId: nearSiblingId, transcriptURL: nearURL, cwd: cwd)
         try writeClaudeTranscript(sessionId: farSiblingId, transcriptURL: farURL, cwd: cwd)
+        try writeClaudeTranscript(sessionId: nearSiblingId, transcriptURL: nearURL, cwd: cwd)
 
         // Pin birthtimes: container at T, near sibling 5 s after (delta 5), far sibling 60 s after (delta 60).
         let baseDate = Date(timeIntervalSince1970: 1_000_000)

--- a/cmuxTests/RestorableAgentSessionIndexTests.swift
+++ b/cmuxTests/RestorableAgentSessionIndexTests.swift
@@ -313,6 +313,122 @@ final class RestorableAgentSessionIndexTests: XCTestCase {
     /// Mirrors Claude's external project-directory naming rule ("/" and "." both become "-")
     /// independently of the production `encodeClaudeProjectDir`, so these regression tests fail if
     /// that helper regresses instead of masking it by sharing the same code path.
+    // When CMUX passes --session-id <uuid> to Claude and Claude uses the Workflow tool, Claude
+    // creates <uuid>/ (a directory) as the Workflow container rather than <uuid>.jsonl. The actual
+    // interactive transcript lands as a sibling file with a different UUID in the same project dir.
+    // CMUX must detect the directory case and use the sibling's session ID for resume.
+    func testClaudeWorkflowContainerUsesInteractiveSiblingTranscript() throws {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory
+            .appendingPathComponent("cmux-claude-workflow-sibling-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fm.removeItem(at: root) }
+
+        let configDir = root.appendingPathComponent("claude-config", isDirectory: true)
+        let projectsDir = configDir.appendingPathComponent("projects", isDirectory: true)
+        let cwd = root.appendingPathComponent("repo", isDirectory: true)
+        try fm.createDirectory(at: cwd, withIntermediateDirectories: true)
+        let projectDir = projectsDir.appendingPathComponent(
+            expectedClaudeProjectDirName(cwd.path),
+            isDirectory: true
+        )
+        try fm.createDirectory(at: projectDir, withIntermediateDirectories: true)
+
+        // UUID CMUX stored (passed as --session-id; Claude used it for the Workflow directory)
+        let workflowContainerId = "a5323ac1-b493-46d1-a031-5549577d8bf8"
+        // UUID of the actual interactive transcript Claude created internally
+        let interactiveId = "18fc1ee3-0000-0000-0000-000000000000"
+        let workspaceId = UUID()
+        let panelId = UUID()
+
+        // Workflow container directory with subagent artifacts inside
+        let workflowDir = projectDir.appendingPathComponent(workflowContainerId, isDirectory: true)
+        try fm.createDirectory(
+            at: workflowDir.appendingPathComponent("subagents", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        try "subagent data".write(
+            to: workflowDir.appendingPathComponent("subagents/agent-0001.jsonl"),
+            atomically: true, encoding: .utf8
+        )
+
+        // Actual interactive transcript — sibling of the Workflow directory
+        try writeClaudeTranscript(
+            sessionId: interactiveId,
+            transcriptURL: projectDir.appendingPathComponent("\(interactiveId).jsonl"),
+            cwd: cwd
+        )
+
+        try writeClaudeHookStore(
+            root: root,
+            sessions: [
+                workflowContainerId: hookRecord(
+                    sessionId: workflowContainerId,
+                    workspaceId: workspaceId,
+                    panelId: panelId,
+                    cwd: cwd.path,
+                    configDir: configDir.path,
+                    updatedAt: 10
+                ),
+            ]
+        )
+
+        let index = RestorableAgentSessionIndex.load(homeDirectory: root.path, fileManager: fm)
+        XCTAssertEqual(
+            index.snapshot(workspaceId: workspaceId, panelId: panelId)?.sessionId,
+            interactiveId,
+            "Workflow container directory: must resolve to the interactive sibling transcript for resume."
+        )
+    }
+
+    // When the stored session ID is a Workflow container directory but there is no sibling .jsonl,
+    // the session cannot be resumed.
+    func testClaudeWorkflowContainerWithNoSiblingIsNotRestorable() throws {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory
+            .appendingPathComponent("cmux-claude-workflow-no-sibling-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fm.removeItem(at: root) }
+
+        let configDir = root.appendingPathComponent("claude-config", isDirectory: true)
+        let projectsDir = configDir.appendingPathComponent("projects", isDirectory: true)
+        let cwd = root.appendingPathComponent("repo", isDirectory: true)
+        try fm.createDirectory(at: cwd, withIntermediateDirectories: true)
+        let projectDir = projectsDir.appendingPathComponent(
+            expectedClaudeProjectDirName(cwd.path),
+            isDirectory: true
+        )
+        try fm.createDirectory(at: projectDir, withIntermediateDirectories: true)
+
+        let workflowContainerId = "cccccccc-cccc-cccc-cccc-cccccccccccc"
+        let workspaceId = UUID()
+        let panelId = UUID()
+
+        // Only the Workflow container directory, no sibling .jsonl
+        try fm.createDirectory(
+            at: projectDir.appendingPathComponent(workflowContainerId, isDirectory: true),
+            withIntermediateDirectories: true
+        )
+
+        try writeClaudeHookStore(
+            root: root,
+            sessions: [
+                workflowContainerId: hookRecord(
+                    sessionId: workflowContainerId,
+                    workspaceId: workspaceId,
+                    panelId: panelId,
+                    cwd: cwd.path,
+                    configDir: configDir.path,
+                    updatedAt: 10
+                ),
+            ]
+        )
+
+        let index = RestorableAgentSessionIndex.load(homeDirectory: root.path, fileManager: fm)
+        XCTAssertNil(
+            index.snapshot(workspaceId: workspaceId, panelId: panelId),
+            "Workflow container directory without a sibling transcript must not be restorable."
+        )
+    }
+
     private func expectedClaudeProjectDirName(_ path: String) -> String {
         path.replacingOccurrences(of: "/", with: "-")
             .replacingOccurrences(of: ".", with: "-")

--- a/cmuxTests/RestorableAgentSessionIndexTests.swift
+++ b/cmuxTests/RestorableAgentSessionIndexTests.swift
@@ -429,6 +429,68 @@ final class RestorableAgentSessionIndexTests: XCTestCase {
         )
     }
 
+    // When there are multiple sibling .jsonl files in the project dir, the Workflow container heuristic
+    // must pick the one whose birthtime is closest to the container directory's birthtime.
+    func testClaudeWorkflowContainerPicksNearestSiblingByBirthtime() throws {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory
+            .appendingPathComponent("cmux-claude-workflow-birthtime-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fm.removeItem(at: root) }
+
+        let configDir = root.appendingPathComponent("claude-config", isDirectory: true)
+        let projectsDir = configDir.appendingPathComponent("projects", isDirectory: true)
+        let cwd = root.appendingPathComponent("repo", isDirectory: true)
+        try fm.createDirectory(at: cwd, withIntermediateDirectories: true)
+        let projectDir = projectsDir.appendingPathComponent(
+            expectedClaudeProjectDirName(cwd.path),
+            isDirectory: true
+        )
+        try fm.createDirectory(at: projectDir, withIntermediateDirectories: true)
+
+        let workflowContainerId = "d1d1d1d1-d1d1-d1d1-d1d1-d1d1d1d1d1d1"
+        let nearSiblingId = "e2e2e2e2-e2e2-e2e2-e2e2-e2e2e2e2e2e2"
+        let farSiblingId = "f3f3f3f3-f3f3-f3f3-f3f3-f3f3f3f3f3f3"
+        let workspaceId = UUID()
+        let panelId = UUID()
+
+        // Workflow container directory
+        let workflowDir = projectDir.appendingPathComponent(workflowContainerId, isDirectory: true)
+        try fm.createDirectory(at: workflowDir, withIntermediateDirectories: true)
+
+        // Two sibling transcripts
+        let nearURL = projectDir.appendingPathComponent("\(nearSiblingId).jsonl")
+        let farURL = projectDir.appendingPathComponent("\(farSiblingId).jsonl")
+        try writeClaudeTranscript(sessionId: nearSiblingId, transcriptURL: nearURL, cwd: cwd)
+        try writeClaudeTranscript(sessionId: farSiblingId, transcriptURL: farURL, cwd: cwd)
+
+        // Pin birthtimes: container at T, near sibling 5 s after (delta 5), far sibling 60 s after (delta 60).
+        let baseDate = Date(timeIntervalSince1970: 1_000_000)
+        try fm.setAttributes([.creationDate: baseDate], ofItemAtPath: workflowDir.path)
+        try fm.setAttributes([.creationDate: Date(timeIntervalSince1970: 1_000_005)], ofItemAtPath: nearURL.path)
+        try fm.setAttributes([.creationDate: Date(timeIntervalSince1970: 1_000_060)], ofItemAtPath: farURL.path)
+
+        try writeClaudeHookStore(
+            root: root,
+            sessions: [
+                workflowContainerId: hookRecord(
+                    sessionId: workflowContainerId,
+                    workspaceId: workspaceId,
+                    panelId: panelId,
+                    cwd: cwd.path,
+                    configDir: configDir.path,
+                    updatedAt: 10
+                ),
+            ]
+        )
+
+        let index = RestorableAgentSessionIndex.load(homeDirectory: root.path, fileManager: fm)
+        XCTAssertEqual(
+            index.snapshot(workspaceId: workspaceId, panelId: panelId)?.sessionId,
+            nearSiblingId,
+            "Workflow container: must pick the sibling transcript whose birthtime is closest to the container directory."
+        )
+    }
+
     private func expectedClaudeProjectDirName(_ path: String) -> String {
         path.replacingOccurrences(of: "/", with: "-")
             .replacingOccurrences(of: ".", with: "-")


### PR DESCRIPTION
## Bug

When Claude uses the Workflow tool to manage a session, the tool creates a `<session-id>/` directory in the project dir instead of the usual `<session-id>.jsonl` file. CMUX was looking for the `.jsonl` to determine if a session was resumable, so when it didn't find it, it marked the session as not resumable (`canResume = false`). However, the auto-resume logic attempted `claude --resume <session-id>` anyway and failed with "No conversation found", leaving the user with a terminal that couldn't be resumed.

## Fix

Upon detecting a `<session-id>/` that is a directory instead of a `.jsonl` file, the code now:

1. Scans sibling `.jsonl` files in the same project dir to find the actual interactive transcript.
2. Uses the session ID from the found `.jsonl` for the resume, instead of the Workflow directory ID.
3. If there are multiple `.jsonl` candidates, it picks the one with `birthtime` closest to the Workflow directory (most likely to be the interactive session that generated it).

This allows auto-resume to work correctly when the Workflow tool is involved, without breaking the normal `.jsonl` session flow.

## Commit structure

- **Commit 1** (`9d28589`): Adds regression tests that fail without the fix, demonstrating the bug.
- **Commit 2** (`be815c2`): Applies the fix; tests pass.

This two-commit structure allows verifying in CI (Commits tab) that the test genuinely fails before the fix and passes afterward.
Refs #5224

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783005162&installation_id=133855650&pr_number=5234&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5234&signature=883494a5306776bc3088197c51001c7ce2ea5d5b1c42802252da967840ad22a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes auto-resume when the Workflow tool creates a session directory instead of a `.jsonl`. CMUX now resolves the real interactive transcript and resumes with the correct session ID, including when multiple sibling transcripts exist.

- **Bug Fixes**
  - Detect `<session-id>/` directories and treat them as Workflow containers.
  - Resolve the resume session ID by scanning sibling `.jsonl` files; if multiple, pick the one with creation time closest to the container directory; if none, mark as not restorable.
  - Accept container directories in working directory checks so resume/fork works correctly.

<sup>Written for commit 056cc3b7da71dbf6c759f67710852a18562677b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Claude session restoration by validating and resolving resumable session IDs using filesystem checks, including support for sessions created by Workflow and selecting the most likely interactive transcript by file creation time.

* **Tests**
  * Added tests covering resolution to interactive transcripts, selection among multiple transcripts by closest creation time, and failure when no transcript exists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->