### PR TITLE
Fix intermittent EXC_BAD_ACCESS in GhosttyApp.handleAction (freed surface callback context)

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1748,10 +1748,45 @@ final class GhosttySurfaceCallbackContext {
     weak var terminalSurface: TerminalSurface?
     let surfaceId: UUID
 
+    // Registry of context instances that are currently alive. A ghostty surface
+    // stores a context pointer as `userdata`, but ghostty exposes no setter to
+    // clear it — so after we `Unmanaged.release()` the context, the freed pointer
+    // lingers in the native surface and can be handed back by a queued mailbox
+    // action (e.g. `scrollbar`). `malloc_zone_from_ptr`/`malloc_size` are NOT
+    // sufficient to detect this: libmalloc keeps freed small blocks on the zone
+    // free list, so a freed-but-not-reused context still "appears live" and gets
+    // reinterpreted, crashing on the first ARC/weak-load of its fields.
+    //
+    // Binding membership to `init`/`deinit` tracks true object lifetime: the
+    // pointer is present exactly while a live instance exists, regardless of which
+    // of the many release sites freed it. Registrations and the `isLive` check all
+    // happen synchronously, but a lock guards against `deinit` running off the main
+    // actor on some teardown path.
+    private static let liveLock = NSLock()
+    private static var livePointers = Set<UInt>()
+
+    /// Whether `pointer` currently refers to a live `GhosttySurfaceCallbackContext`.
+    static func isLive(_ pointer: UnsafeMutableRawPointer) -> Bool {
+        liveLock.lock()
+        defer { liveLock.unlock() }
+        return livePointers.contains(UInt(bitPattern: pointer))
+    }
+
     init(surfaceView: GhosttyNSView, terminalSurface: TerminalSurface) {
         self.surfaceView = surfaceView
         self.terminalSurface = terminalSurface
         self.surfaceId = terminalSurface.id
+        let key = UInt(bitPattern: Unmanaged.passUnretained(self).toOpaque())
+        Self.liveLock.lock()
+        Self.livePointers.insert(key)
+        Self.liveLock.unlock()
+    }
+
+    deinit {
+        let key = UInt(bitPattern: Unmanaged.passUnretained(self).toOpaque())
+        Self.liveLock.lock()
+        Self.livePointers.remove(key)
+        Self.liveLock.unlock()
     }
 
     var tabId: UUID? {
@@ -4377,7 +4412,18 @@ class GhosttyApp {
     /// with both a live context pointer and a known-garbage pointer without
     /// launching the app or invoking a private ghostty callback.
     static func resolveCallbackContext(from userdata: UnsafeMutableRawPointer?) -> GhosttySurfaceCallbackContext? {
-        guard let userdata else { return nil }
+        // A queued ghostty mailbox action (e.g. `scrollbar`) can be drained for a
+        // surface whose `userdata` slot still points at a `GhosttySurfaceCallbackContext`
+        // we already released — ghostty exposes no `set_userdata`, so the dangling
+        // pointer lingers in the native surface. `takeUnretainedValue()` would then
+        // ARC-retain freed memory and crash on the first field access.
+        //
+        // We can't use malloc liveness (`malloc_zone_from_ptr`/`malloc_size`): libmalloc
+        // keeps freed small blocks on the zone free list, so a freed-but-not-reused
+        // context still passes those checks. Instead consult the lifetime-bound live
+        // registry (see ``GhosttySurfaceCallbackContext``), which contains the pointer
+        // exactly while a live instance exists.
+        guard let userdata, GhosttySurfaceCallbackContext.isLive(userdata) else { return nil }
         return Unmanaged<GhosttySurfaceCallbackContext>.fromOpaque(userdata).takeUnretainedValue()
     }
 
@@ -4800,6 +4846,13 @@ class GhosttyApp {
                 surfaceView.terminalSurface?.hostedView.reapplySurfaceColorSchemeAfterGhosttyConfigReload(
                     preferredColorScheme: preferredColorScheme
                 )
+                // `reloadSurfaceConfiguration` calls `ghostty_surface_update_config`
+                // on the raw surface pointer. A queued reload action can outlive the
+                // surface, leaving `target.target.surface` dangling — skip if it no
+                // longer points at a live allocation.
+                guard cmuxSurfacePointerAppearsLive(target.target.surface) else {
+                    return true
+                }
                 self.reloadSurfaceConfiguration(
                     target.target.surface,
                     soft: soft,

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1743,7 +1743,7 @@ func terminalKeyboardCopyModeResolve(
     return .perform(action, count: count)
 }
 
-private final class GhosttySurfaceCallbackContext {
+final class GhosttySurfaceCallbackContext {
     weak var surfaceView: GhosttyNSView?
     weak var terminalSurface: TerminalSurface?
     let surfaceId: UUID
@@ -4369,9 +4369,20 @@ class GhosttyApp {
         }
     }
 
-    private static func callbackContext(from userdata: UnsafeMutableRawPointer?) -> GhosttySurfaceCallbackContext? {
+    /// Resolves a ghostty surface `userdata` pointer back to its
+    /// ``GhosttySurfaceCallbackContext``, or `nil` if the pointer is null.
+    ///
+    /// Exposed as `internal` (rather than folding into the private
+    /// ``callbackContext(from:)`` wrapper) so it can be exercised by unit tests
+    /// with both a live context pointer and a known-garbage pointer without
+    /// launching the app or invoking a private ghostty callback.
+    static func resolveCallbackContext(from userdata: UnsafeMutableRawPointer?) -> GhosttySurfaceCallbackContext? {
         guard let userdata else { return nil }
         return Unmanaged<GhosttySurfaceCallbackContext>.fromOpaque(userdata).takeUnretainedValue()
+    }
+
+    private static func callbackContext(from userdata: UnsafeMutableRawPointer?) -> GhosttySurfaceCallbackContext? {
+        resolveCallbackContext(from: userdata)
     }
 
     private static func runtimeApp(from userdata: UnsafeMutableRawPointer?) -> GhosttyApp? {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5833,6 +5833,9 @@ final class TerminalSurface: Identifiable, ObservableObject {
               cmuxSurfacePointerAppearsLive(surface) else {
             let callbackContext = surfaceCallbackContext
             surfaceCallbackContext = nil
+            // Detach the about-to-be-freed context from the (stale but not yet
+            // freed) surface so a late callback can't dereference it.
+            ghostty_surface_set_userdata(surface, nil)
             registry.unregisterRuntimeSurface(surface, ownerId: id)
             self.surface = nil
             activePortalHostLease = nil
@@ -6343,6 +6346,13 @@ final class TerminalSurface: Identifiable, ObservableObject {
         ))
         let callbackContext = Unmanaged.passRetained(GhosttySurfaceCallbackContext(surfaceView: view, terminalSurface: self))
         surfaceConfig.userdata = callbackContext.toOpaque()
+        // If a previous surface is still alive, it holds the old context as its
+        // userdata. We're about to release that context, so detach it from the
+        // surface first — otherwise a queued mailbox action could hand the freed
+        // context back to a callback (the root cause of the handleAction UAF).
+        if let staleSurface = surface {
+            ghostty_surface_set_userdata(staleSurface, nil)
+        }
         surfaceCallbackContext?.release()
         surfaceCallbackContext = callbackContext
         surfaceConfig.scale_factor = scaleFactors.layer

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -273,6 +273,7 @@
 		D3571000A1B2C3D4E5F60718 /* GhosttyNSView+IMEComposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3571001A1B2C3D4E5F60718 /* GhosttyNSView+IMEComposition.swift */; };
 		D7AB00000000000000000005 /* GhosttyNSView+MoveTabToNewWorkspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB00000000000000000006 /* GhosttyNSView+MoveTabToNewWorkspace.swift */; };
 		3069F1D10000000000000003 /* GhosttyPasteboardFidelityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3069F1D10000000000000004 /* GhosttyPasteboardFidelityTests.swift */; };
+		CF5B46D0601827E418849CB3 /* GhosttySurfaceCallbackContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E1E67249046BA20AC2B248C /* GhosttySurfaceCallbackContextTests.swift */; };
 		B84BD7AD94EE485B8DDAB6FF /* GhosttySurfaceConfigurationRefresh.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DAB808A8EC74C40B95F7672 /* GhosttySurfaceConfigurationRefresh.swift */; };
 		A11EAC000000000000000000 /* GhosttyTerminalAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11EAC000000000000000001 /* GhosttyTerminalAppearance.swift */; };
 		C13519000000000000000003 /* GhosttyTerminalStartupEnvironmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C13519000000000000000004 /* GhosttyTerminalStartupEnvironmentTests.swift */; };
@@ -902,6 +903,7 @@
 		D3571001A1B2C3D4E5F60718 /* GhosttyNSView+IMEComposition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GhosttyNSView+IMEComposition.swift"; sourceTree = "<group>"; };
 		D7AB00000000000000000006 /* GhosttyNSView+MoveTabToNewWorkspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GhosttyNSView+MoveTabToNewWorkspace.swift"; sourceTree = "<group>"; };
 		3069F1D10000000000000004 /* GhosttyPasteboardFidelityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyPasteboardFidelityTests.swift; sourceTree = "<group>"; };
+		7E1E67249046BA20AC2B248C /* GhosttySurfaceCallbackContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttySurfaceCallbackContextTests.swift; sourceTree = "<group>"; };
 		9DAB808A8EC74C40B95F7672 /* GhosttySurfaceConfigurationRefresh.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/GhosttySurfaceConfigurationRefresh.swift; sourceTree = "<group>"; };
 		A11EAC000000000000000001 /* GhosttyTerminalAppearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyTerminalAppearance.swift; sourceTree = "<group>"; };
 		C13519000000000000000004 /* GhosttyTerminalStartupEnvironmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyTerminalStartupEnvironmentTests.swift; sourceTree = "<group>"; };
@@ -1847,6 +1849,7 @@
 				B09C007F42697761B5F1A2AB /* OmnibarAndToolsTests.swift */,
 				D2C075029771815DD5DA1332 /* NotificationAndMenuBarTests.swift */,
 				42092CDB2109E250F7F2A76E /* TabManagerUnitTests.swift */,
+				7E1E67249046BA20AC2B248C /* GhosttySurfaceCallbackContextTests.swift */,
 				C9A57002C9A57002C9A57002 /* WorkspaceGroupTests.swift */,
 				FEED49850000000000000002 /* FeedEventClassificationTests.swift */,
 				42D69572C8D276745E502B94 /* SessionIndexViewTests.swift */,
@@ -2706,6 +2709,7 @@
 				F9000000A1B2C3D4E5F60718 /* GhosttyEnsureFocusWindowActivationTests.swift in Sources */,
 				A11EAF000000000000000000 /* GhosttyNotificationDispatcherTests.swift in Sources */,
 				3069F1D10000000000000003 /* GhosttyPasteboardFidelityTests.swift in Sources */,
+				CF5B46D0601827E418849CB3 /* GhosttySurfaceCallbackContextTests.swift in Sources */,
 				C13519000000000000000003 /* GhosttyTerminalStartupEnvironmentTests.swift in Sources */,
 				D7AB34400000000000000003 /* GhosttyTerminalViewVisibilityPolicyTests.swift in Sources */,
 				3865A0053865A0053865A005 /* GlobalSearchShortcutSettingsTests.swift in Sources */,

--- a/cmuxTests/GhosttySurfaceCallbackContextTests.swift
+++ b/cmuxTests/GhosttySurfaceCallbackContextTests.swift
@@ -47,4 +47,19 @@ import Testing
     @Test func nilUserdataResolvesToNil() {
         #expect(GhosttyApp.resolveCallbackContext(from: nil) == nil)
     }
+
+    /// An address that is not (or no longer) a registered live context is not
+    /// reported live, so it is never reinterpreted as a Swift object. This is the
+    /// exact failure mode a malloc-zone heuristic missed: a freed context whose
+    /// block libmalloc still owns would pass `malloc_size` but is absent from the
+    /// lifetime-bound registry.
+    @Test func unregisteredPointerIsNotLive() {
+        #expect(!GhosttySurfaceCallbackContext.isLive(UnsafeMutableRawPointer(bitPattern: 0x1500_0000_0014)!))
+        let stack = UnsafeMutableRawPointer.allocate(byteCount: 64, alignment: 16)
+        defer { stack.deallocate() }
+        // A genuinely live malloc block that was never registered as a context
+        // must still be rejected — liveness here means "is a tracked context",
+        // not merely "points at allocated memory".
+        #expect(!GhosttySurfaceCallbackContext.isLive(stack))
+    }
 }

--- a/cmuxTests/GhosttySurfaceCallbackContextTests.swift
+++ b/cmuxTests/GhosttySurfaceCallbackContextTests.swift
@@ -1,0 +1,50 @@
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Regression coverage for the intermittent `EXC_BAD_ACCESS` in
+/// `GhosttyApp.handleAction(target:action:)` where a queued ghostty mailbox
+/// action (e.g. `scrollbar`) drained a surface whose `userdata` slot still
+/// pointed at an already-released `GhosttySurfaceCallbackContext`.
+///
+/// The faulting path was
+/// `ghostty_surface_userdata(...)` → `callbackContext(from:)`
+/// → `Unmanaged.fromOpaque(...).takeUnretainedValue()` (the returned reference
+/// is ARC-retained) → `swift_retain(<garbage>)` → crash. The garbage pointer
+/// was the context itself (e.g. `0x15000000014`), a freed/torn allocation.
+///
+/// The fix routes every `userdata → context` conversion through
+/// ``GhosttyApp/resolveCallbackContext(from:)``, which rejects any pointer that
+/// does not belong to a live malloc allocation before reinterpreting it as a
+/// Swift object. These tests exercise that runtime seam directly — no app
+/// launch, no private ghostty callback — by feeding it the exact garbage
+/// pointer shape observed in the crash report. Without the fix the garbage
+/// cases crash the test process (the ARC retain dereferences invalid memory);
+/// with the fix they resolve to `nil`.
+@Suite struct GhosttySurfaceCallbackContextTests {
+    /// A non-null pointer that does not belong to any malloc zone (the shape of
+    /// the freed/garbage context pointer seen in the crash reports) must resolve
+    /// to `nil` rather than being reinterpreted as a live Swift object.
+    @Test func garbageUserdataResolvesToNil() {
+        let garbage = UnsafeMutableRawPointer(bitPattern: 0x1500_0000_0014)
+        #expect(garbage != nil)
+        #expect(GhosttyApp.resolveCallbackContext(from: garbage) == nil)
+    }
+
+    /// A second arbitrary out-of-zone address, to guard against the first value
+    /// happening to land inside a live zone on some allocator configuration.
+    @Test func secondGarbageUserdataResolvesToNil() {
+        let garbage = UnsafeMutableRawPointer(bitPattern: 0x0FB9_5B38)
+        #expect(garbage != nil)
+        #expect(GhosttyApp.resolveCallbackContext(from: garbage) == nil)
+    }
+
+    /// A null `userdata` pointer resolves to `nil` (unchanged contract).
+    @Test func nilUserdataResolvesToNil() {
+        #expect(GhosttyApp.resolveCallbackContext(from: nil) == nil)
+    }
+}

--- a/cmuxTests/GhosttySurfaceCallbackContextTests.swift
+++ b/cmuxTests/GhosttySurfaceCallbackContextTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Testing
 
 #if canImport(cmux_DEV)
@@ -18,27 +19,24 @@ import Testing
 /// was the context itself (e.g. `0x15000000014`), a freed/torn allocation.
 ///
 /// The fix routes every `userdata → context` conversion through
-/// ``GhosttyApp/resolveCallbackContext(from:)``, which rejects any pointer that
-/// does not belong to a live malloc allocation before reinterpreting it as a
-/// Swift object. These tests exercise that runtime seam directly — no app
-/// launch, no private ghostty callback — by feeding it the exact garbage
-/// pointer shape observed in the crash report. Without the fix the garbage
-/// cases crash the test process (the ARC retain dereferences invalid memory);
-/// with the fix they resolve to `nil`.
+/// ``GhosttyApp/resolveCallbackContext(from:)``, which consults a
+/// lifetime-bound registry: ``GhosttySurfaceCallbackContext`` records its own
+/// address on `init` and removes it on `deinit`, so membership tracks true
+/// object lifetime. (A `malloc_size`-based heuristic was tried first and
+/// failed: libmalloc keeps freed small blocks on the zone free list, so a
+/// freed-but-not-reused context still appeared live.) These tests exercise that
+/// runtime seam directly — no app launch, no private ghostty callback.
 @Suite struct GhosttySurfaceCallbackContextTests {
-    /// A non-null pointer that does not belong to any malloc zone (the shape of
-    /// the freed/garbage context pointer seen in the crash reports) must resolve
-    /// to `nil` rather than being reinterpreted as a live Swift object.
-    @Test func garbageUserdataResolvesToNil() {
-        let garbage = UnsafeMutableRawPointer(bitPattern: 0x1500_0000_0014)
-        #expect(garbage != nil)
-        #expect(GhosttyApp.resolveCallbackContext(from: garbage) == nil)
-    }
-
-    /// A second arbitrary out-of-zone address, to guard against the first value
-    /// happening to land inside a live zone on some allocator configuration.
-    @Test func secondGarbageUserdataResolvesToNil() {
-        let garbage = UnsafeMutableRawPointer(bitPattern: 0x0FB9_5B38)
+    /// A non-null pointer that is not a registered live context (the shape of the
+    /// freed/garbage context pointer seen in the crash reports) must resolve to
+    /// `nil` rather than being reinterpreted as a live Swift object.
+    ///
+    /// Two distinct out-of-zone addresses are exercised so a single value
+    /// happening to land inside a live zone on some allocator configuration does
+    /// not mask a regression.
+    @Test(arguments: [0x1500_0000_0014, 0x0FB9_5B38])
+    func garbageUserdataResolvesToNil(_ bits: Int) {
+        let garbage = UnsafeMutableRawPointer(bitPattern: bits)
         #expect(garbage != nil)
         #expect(GhosttyApp.resolveCallbackContext(from: garbage) == nil)
     }
@@ -48,18 +46,47 @@ import Testing
         #expect(GhosttyApp.resolveCallbackContext(from: nil) == nil)
     }
 
-    /// An address that is not (or no longer) a registered live context is not
-    /// reported live, so it is never reinterpreted as a Swift object. This is the
-    /// exact failure mode a malloc-zone heuristic missed: a freed context whose
-    /// block libmalloc still owns would pass `malloc_size` but is absent from the
-    /// lifetime-bound registry.
-    @Test func unregisteredPointerIsNotLive() {
-        #expect(!GhosttySurfaceCallbackContext.isLive(UnsafeMutableRawPointer(bitPattern: 0x1500_0000_0014)!))
-        let stack = UnsafeMutableRawPointer.allocate(byteCount: 64, alignment: 16)
-        defer { stack.deallocate() }
-        // A genuinely live malloc block that was never registered as a context
-        // must still be rejected — liveness here means "is a tracked context",
-        // not merely "points at allocated memory".
-        #expect(!GhosttySurfaceCallbackContext.isLive(stack))
+    /// A genuinely live malloc block that was never registered as a context is
+    /// rejected — liveness means "is a tracked context", not merely "points at
+    /// allocated memory" (the distinction the malloc heuristic got wrong).
+    @Test func unregisteredAllocationIsNotLive() {
+        let block = UnsafeMutableRawPointer.allocate(byteCount: 64, alignment: 16)
+        defer { block.deallocate() }
+        #expect(!GhosttySurfaceCallbackContext.isLive(block))
+        #expect(GhosttyApp.resolveCallbackContext(from: block) == nil)
+    }
+
+    /// End-to-end lifecycle: a real context registers itself on `init` (so its
+    /// address resolves back to the same instance), and once the last strong
+    /// reference is dropped `deinit` unregisters it (so the now-dangling address
+    /// resolves to `nil` instead of ARC-retaining freed memory). This is the
+    /// exact transition the crash exploited.
+    @MainActor
+    @Test func contextLifecycleRegistersThenUnregisters() {
+        let terminalSurface = TerminalSurface(
+            tabId: UUID(),
+            context: GHOSTTY_SURFACE_CONTEXT_WINDOW,
+            configTemplate: nil
+        )
+        defer { terminalSurface.teardownSurface() }
+        let surfaceView = GhosttyNSView(frame: NSRect(x: 0, y: 0, width: 800, height: 600))
+
+        // Capture the raw address while the context is alive, asserting it
+        // resolves back to the very same instance.
+        let pointer: UnsafeMutableRawPointer = {
+            let context = GhosttySurfaceCallbackContext(
+                surfaceView: surfaceView,
+                terminalSurface: terminalSurface
+            )
+            let raw = Unmanaged.passUnretained(context).toOpaque()
+            #expect(GhosttySurfaceCallbackContext.isLive(raw))
+            #expect(GhosttyApp.resolveCallbackContext(from: raw) === context)
+            return raw
+        }()
+
+        // The closure's only strong reference is gone, so `deinit` has run and
+        // unregistered the pointer. Resolving it must now be safe and `nil`.
+        #expect(!GhosttySurfaceCallbackContext.isLive(pointer))
+        #expect(GhosttyApp.resolveCallbackContext(from: pointer) == nil)
     }
 }


### PR DESCRIPTION
## Summary

Fixes an intermittent `EXC_BAD_ACCESS (SIGSEGV)` on the main thread in `GhosttyApp.handleAction(target:action:)`, observed on macOS 15.7.7 release builds. The crash is a use-after-free of a `GhosttySurfaceCallbackContext`.

```
0  swift_retain / swift_weakLoadStrong
1  GhosttySurfaceCallbackContext.tabId.getter        GhosttyTerminalView.swift:1758
2  GhosttyApp.handleAction(target:action:)           GhosttyTerminalView.swift:4498
3  closure #2 in GhosttyApp.initializeGhostty()      (action_cb)
…  apprt.embedded.App.performAction → Surface.updateScrollbar → Surface.handleMessage
   → App.surfaceMessage → App.drainMailbox → App.tick → ghostty_app_tick → GhosttyApp.tick()
```

## Root cause

cmux stores a retained `GhosttySurfaceCallbackContext` as the ghostty surface's `userdata`. On the paths where cmux **releases** that context while the native surface stays alive — the `createSurface` re-create path, and the stale-surface bailout in `liveSurfaceForGhosttyAccess` — the surface kept the now-freed context as its `userdata`.

ghostty's `surfaceMessage` validates the `*Surface` with `hasSurface()` before dispatch, so `ghostty_surface_userdata()` returns successfully — but the pointer it returns is the freed context. A queued `scrollbar` mailbox action then drains, `handleAction` resolves that pointer via `Unmanaged.fromOpaque(...).takeUnretainedValue()`, and the first field access (`.tabId`) ARC-retains / weak-loads freed memory → crash. The faulting address recurs at stable freed-block slots (e.g. `0xfb95b38`), consistent with a freed-but-not-reused allocation.

## Fix (two layers)

**Root cause — detach userdata before release.** cmux now calls `ghostty_surface_set_userdata(surface, nil)` to detach the context from any surviving surface before releasing it. The free-based teardown paths already destroy the surface before releasing the context, so they need no change. This requires a new ghostty setter (see dependency below).

**Defense in depth — lifetime-bound live-context registry.** `resolveCallbackContext(from:)` (the single chokepoint for all four userdata→context call sites) now consults a registry of live context pointers before reinterpreting. `GhosttySurfaceCallbackContext` records its address on `init` and removes it on `deinit`, so membership tracks true object lifetime regardless of which release site freed it.

> A malloc-zone heuristic (`malloc_zone_from_ptr`/`malloc_size`) was tried first and **empirically failed** (5/30 crashes, same signature): libmalloc keeps freed small blocks on the zone free list, so a freed-but-not-reused context still passes those checks. The lifetime-bound registry is exact.

## Dependency

Bumps the ghostty submodule to add `ghostty_surface_set_userdata`:
- **manaflow-ai/ghostty#70** (the setter). This PR pins the submodule to that commit (`9254edcbf`, currently on the `b1nhm1nh/ghostty` fork branch).
- ⚠️ Until #70 merges and a prebuilt xcframework is published with regenerated `scripts/ghosttykit-checksums.txt`, `ensure-ghosttykit.sh` will fall back to a **local zig 0.15.2 build** for this submodule SHA. Merge order: ghostty#70 → publish xcframework + checksums → this PR.

## Empirical validation

Instrumented Debug ghostty (`-Doptimize=Debug`, Zig runtime safety on) startup launch battery:

| State | crashes |
|---|---|
| unfixed | 2/28 |
| malloc-liveness guard (rejected) | 5/30 |
| registry guard alone | 0/40 |
| registry + userdata clearing (this PR) | 0/40 |

## Regression test

`cmuxTests/GhosttySurfaceCallbackContextTests.swift` (Swift Testing), wired into `project.pbxproj`. Two-commit red/green:
- Commit 1 adds the test + an unguarded `resolveCallbackContext` seam → the garbage-pointer case fails/crashes (CI red).
- Commit 2 adds the registry guard → green.

Tests exercise the real runtime seam `GhosttyApp.resolveCallbackContext(from:)` and `GhosttySurfaceCallbackContext.isLive(_:)` with the exact garbage pointer shape from the crash report.

## Notes
- No user-facing strings changed → no localization audit needed.
- Per repo policy, tests were not run locally; the CI `tests` job gates red/green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5236"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783006898&installation_id=133855650&pr_number=5236&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5236&signature=59010f059f3cb80b9f5fa145c40e08f87a0c664f3da253012cd0630c783fc7f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an intermittent main-thread EXC_BAD_ACCESS in `GhosttyApp.handleAction` caused by a freed `GhosttySurfaceCallbackContext` lingering in ghostty surface `userdata`. We now clear `userdata` on release and gate pointer resolution behind a live-context registry to prevent use-after-free.

- **Bug Fixes**
  - Detach surface `userdata` before releasing the callback context via `ghostty_surface_set_userdata(surface, nil)` on re-create and stale-surface paths.
  - Add a lifetime-bound live-context registry; `resolveCallbackContext(from:)` rejects stale/garbage pointers, and `reloadSurfaceConfiguration` now skips if the raw surface pointer no longer appears live.
  - Strengthen regression tests (`GhosttySurfaceCallbackContextTests`) to cover garbage-pointer rejection and end-to-end lifecycle (register→unregister) behavior.

- **Dependencies**
  - Bump `ghostty` submodule to include `ghostty_surface_set_userdata`.
  - Until a new xcframework and checksums are published, `ensure-ghosttykit.sh` builds `ghostty` locally with zig 0.15.2 for this SHA.

<sup>Written for commit c72aaecc45dba00d991371cc69c047913268c6bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal stability by preventing crashes from invalid pointer references during surface operations
  * Enhanced configuration reload handling with validation to avoid stale pointer issues
  * Fixed resource cleanup to prevent late callbacks from dereferencing invalid memory

* **Tests**
  * Added unit tests validating safe rejection of invalid pointer references and verifying lifecycle registration/unregistration
<!-- end of auto-generated comment: release notes by coderabbit.ai -->