### PR TITLE
Inject FocusLogStore instead of a shared singleton

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -866,6 +866,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private var browserAddressBarBlurObserver: NSObjectProtocol?
     private var browserWebViewFirstResponderObserver: NSObjectProtocol?
     let updateLog = UpdateLogStore()
+    let focusLog = FocusLogStore()
     private lazy var updateController = UpdateController(log: updateLog)
     private lazy var titlebarAccessoryController = UpdateTitlebarAccessoryController(updateLog: updateLog)
     private let windowDecorationsController = WindowDecorationsController()
@@ -1123,7 +1124,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let mainWindowNumber = NSApp.mainWindow?.windowNumber ?? -1
         let ws = workspaceId.map { String($0.uuidString.prefix(8)) } ?? "nil"
         let wd = workingDirectory.map { String($0.prefix(120)) } ?? "-"
-        FocusLogStore.shared.append(
+        focusLog.append(
             "cmdn.route phase=\(phase) src=\(source) reason=\(reason) eventWin=\(eventWindowNumber) eventNum=\(eventNumber) keyCode=\(eventKeyCode) chars=\(eventChars) keyWin=\(keyWindowNumber) mainWin=\(mainWindowNumber) activeTM=\(pointerString(tabManager)) chosen={\(summarizeContextForWorkspaceRouting(chosenContext))} ws=\(ws) wd=\(wd) contexts=[\(summarizeAllContextsForWorkspaceRouting())]"
         )
     }
@@ -7817,7 +7818,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private func synchronizeShortcutRoutingContext(event: NSEvent) -> Bool {
         guard let context = preferredMainWindowContextForShortcutRouting(event: event) else {
 #if DEBUG
-            FocusLogStore.shared.append(
+            focusLog.append(
                 "shortcut.route reason=no_context_no_fallback eventWin=\(event.windowNumber) keyCode=\(event.keyCode)"
             )
 #endif
@@ -7841,7 +7842,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
 
 #if DEBUG
-        FocusLogStore.shared.append(
+        focusLog.append(
             "shortcut.route reason=sync activeTM=\(pointerString(tabManager)) chosen={\(summarizeContextForWorkspaceRouting(context))}"
         )
 #endif
@@ -8590,12 +8591,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         pasteboard.setString(payload, forType: .string)
     }
     @objc func copyFocusLogs(_ sender: Any?) {
-        let logText = FocusLogStore.shared.snapshot()
+        let logText = focusLog.snapshot()
         let payload: String
         if logText.isEmpty {
-            payload = "No focus logs captured.\nLog file: \(FocusLogStore.shared.logPath())"
+            payload = "No focus logs captured.\nLog file: \(focusLog.logPath())"
         } else {
-            payload = logText + "\nLog file: \(FocusLogStore.shared.logPath())"
+            payload = logText + "\nLog file: \(focusLog.logPath())"
         }
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7488,7 +7488,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
     fileprivate static func focusLog(_ message: String) {
         guard focusDebugEnabled else { return }
-        FocusLogStore.shared.append(message)
+        AppDelegate.shared?.focusLog.append(message)
         NSLog("[FOCUSDBG] %@", message)
     }
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7489,7 +7489,9 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     fileprivate static func focusLog(_ message: String) {
         guard focusDebugEnabled else { return }
         AppDelegate.shared?.focusLog.append(message)
+        #if DEBUG
         NSLog("[FOCUSDBG] %@", message)
+        #endif
     }
 
     weak var terminalSurface: TerminalSurface?

--- a/Sources/Update/UpdateLogStore.swift
+++ b/Sources/Update/UpdateLogStore.swift
@@ -66,16 +66,17 @@ final class UpdateLogStore: UpdateLogging, @unchecked Sendable {
     }
 }
 
-final class FocusLogStore {
-    static let shared = FocusLogStore()
-
+// @unchecked Sendable: all mutable state (`entries`) is confined to the serial `queue`; the other
+// stored properties are immutable. Owned and injected by `AppDelegate` (see `AppDelegate.focusLog`)
+// rather than self-vending a global, so its lifecycle has a single composition root.
+final class FocusLogStore: @unchecked Sendable {
     private let queue = DispatchQueue(label: "cmux.focus.log")
     private var entries: [String] = []
     private let maxEntries = 400
     private let logURL: URL
     private let formatter: ISO8601DateFormatter
 
-    private init() {
+    init() {
         formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         let logsDir = FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask).first

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -16043,7 +16043,7 @@ final class Workspace: Identifiable, ObservableObject {
         let pane = bonsplitController.focusedPaneId?.id.uuidString.prefix(5) ?? "nil"
         let triggerLabel = trigger == .terminalFirstResponder ? "firstResponder" : "standard"
         cmuxDebugLog("focus.panel panel=\(panelId.uuidString.prefix(5)) pane=\(pane) trigger=\(triggerLabel)")
-        FocusLogStore.shared.append(
+        AppDelegate.shared?.focusLog.append(
             "Workspace.focusPanel panelId=\(panelId.uuidString) focusedPane=\(pane) trigger=\(triggerLabel)"
         )
 #endif
@@ -18661,7 +18661,7 @@ extension Workspace: BonsplitDelegate {
         // When a pane is focused, focus its selected tab's panel
         guard let tab = controller.selectedTab(inPane: pane) else { return }
 #if DEBUG
-        FocusLogStore.shared.append(
+        AppDelegate.shared?.focusLog.append(
             "Workspace.didFocusPane paneId=\(pane.id.uuidString) tabId=\(tab.id) focusedPane=\(controller.focusedPaneId?.id.uuidString ?? "nil")"
         )
 #endif


### PR DESCRIPTION
Follow-up to the CmuxUpdater extraction (https://github.com/manaflow-ai/cmux/pull/5132), which de-singletoned `UpdateLogStore`. `FocusLogStore` (the DEBUG-only focus-event diagnostic logger that lives in the same file) still self-vended a `static let shared`.

This applies the same fix: `AppDelegate` owns the single `FocusLogStore` instance next to `updateLog`, so its lifecycle has one composition root. The in-`AppDelegate` call sites use the instance directly; the `GhosttyTerminalView` and `Workspace` sites reach it via `AppDelegate.shared?.focusLog`, mirroring the existing `AppDelegate.shared?.updateLog` precedent. The type is now a plain injectable class with a documented `@unchecked Sendable` (its mutable state stays confined to the serial queue, unchanged).

The second commit compile-time guards the `FOCUSDBG` `NSLog` in `GhosttyNSView.focusLog` behind `#if DEBUG` (it was runtime-gated only), per the repo debug-log requirement.

No production behavior change. `FocusLogStore.append` is already `#if DEBUG`; this only moves ownership.

## Testing

- `./scripts/reload.sh --tag focuslog-di` builds green.
- Verified no test target references the removed `FocusLogStore.shared` symbol.
- CI `tests-build-and-lag` and the CoreAnimation main-thread startup regression pass on the build.
- No new behavior to exercise at runtime: focus logging (`~/Library/Logs/cmux-focus.log`, the Copy Focus Logs menu action) works exactly as before, now sourced from the AppDelegate-owned instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)