### PR TITLE
Fix important issue regressions

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2579,6 +2579,23 @@ struct ContentView: View {
         }
 
         sidebarSelectionState.selection = .tabs
+        if workspace.isRemoteWorkspace {
+            Task { [weak workspace, fileExplorerStore] in
+                guard let workspace else { return }
+                do {
+                    let localURL = try await fileExplorerStore.materializeRemoteFileForPreview(path: filePath)
+                    _ = workspace.openFileSurfaces(
+                        inPane: paneId,
+                        filePaths: [localURL.path],
+                        focus: true,
+                        reuseExisting: true
+                    )
+                } catch {
+                    NSSound.beep()
+                }
+            }
+            return
+        }
         _ = workspace.openFileSurfaces(
             inPane: paneId,
             filePaths: [filePath],
@@ -2628,6 +2645,7 @@ struct ContentView: View {
                         sshOptions: config.sshOptions
                     ),
                     displayTarget: config.displayTarget,
+                    rootPath: tab.currentDirectory,
                     isAvailable: tab.remoteConnectionState == .connected,
                     unavailableDetail: unavailableDetail
                 )

--- a/Sources/FileExplorerStore.swift
+++ b/Sources/FileExplorerStore.swift
@@ -275,6 +275,11 @@ protocol SSHFileExplorerTransport: AnyObject {
         connection: SSHFileExplorerConnection,
         showHidden: Bool
     ) async throws -> [FileExplorerEntry]
+    nonisolated func downloadFile(
+        path: String,
+        connection: SSHFileExplorerConnection,
+        to localURL: URL
+    ) async throws
 }
 
 enum FileExplorerWorkspaceRoot: Equatable {
@@ -284,6 +289,7 @@ enum FileExplorerWorkspaceRoot: Equatable {
         workspaceId: UUID,
         connection: SSHFileExplorerConnection,
         displayTarget: String,
+        rootPath: String?,
         isAvailable: Bool,
         unavailableDetail: String?
     )
@@ -403,6 +409,13 @@ final class SSHFileExplorerProvider: FileExplorerProvider, @unchecked Sendable {
         }
         return try await transport.listDirectory(path: path, connection: connection, showHidden: showHidden)
     }
+
+    func downloadFile(path: String, to localURL: URL) async throws {
+        guard isAvailable else {
+            throw FileExplorerError.providerUnavailable
+        }
+        try await transport.downloadFile(path: path, connection: connection, to: localURL)
+    }
 }
 
 final class ProcessSSHFileExplorerTransport: SSHFileExplorerTransport {
@@ -422,6 +435,33 @@ final class ProcessSSHFileExplorerTransport: SSHFileExplorerTransport {
         showHidden: Bool
     ) async throws -> [FileExplorerEntry] {
         try await Self.runSSHListCommand(path: path, connection: connection, showHidden: showHidden)
+    }
+
+    nonisolated func downloadFile(
+        path: String,
+        connection: SSHFileExplorerConnection,
+        to localURL: URL
+    ) async throws {
+        let escapedPath = Self.shellSingleQuote(path)
+        let outputURL = localURL
+        let commandProcess = SSHDownloadCommandProcess(
+            connection: connection,
+            command: "cat -- \(escapedPath)",
+            outputURL: outputURL
+        )
+        let result = try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                DispatchQueue.global(qos: .userInitiated).async {
+                    continuation.resume(with: Result { try commandProcess.run() })
+                }
+            }
+        } onCancel: {
+            commandProcess.terminate()
+        }
+        guard result.terminationStatus == 0 else {
+            try? FileManager.default.removeItem(at: outputURL)
+            throw FileExplorerError.sshCommandFailed(result.stderr)
+        }
     }
 
     private struct SSHCommandResult: Sendable {
@@ -507,6 +547,94 @@ final class ProcessSSHFileExplorerTransport: SSHFileExplorerTransport {
         }
     }
 
+    private final class SSHDownloadCommandProcess: @unchecked Sendable {
+        private let process = Process()
+        private let outPipe = Pipe()
+        private let errPipe = Pipe()
+        private let outputURL: URL
+        private let lock = NSLock()
+        private let terminationGate = ProcessTerminationGate()
+        private var cancelled = false
+
+        init(connection: SSHFileExplorerConnection, command: String, outputURL: URL) {
+            self.outputURL = outputURL
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/ssh")
+            process.arguments = ProcessSSHFileExplorerTransport.sshArguments(connection: connection, command: command)
+            process.standardOutput = outPipe
+            process.standardError = errPipe
+        }
+
+        func run() throws -> SSHCommandResult {
+            lock.lock()
+            let wasCancelled = cancelled
+            lock.unlock()
+            if wasCancelled {
+                throw CancellationError()
+            }
+
+            try FileManager.default.createDirectory(
+                at: outputURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            FileManager.default.createFile(atPath: outputURL.path, contents: nil)
+            let outputHandle = try FileHandle(forWritingTo: outputURL)
+            defer { try? outputHandle.close() }
+
+            do {
+                try process.run()
+            } catch {
+                terminationGate.markFinished()
+                throw error
+            }
+
+            lock.lock()
+            let shouldTerminate = cancelled
+            lock.unlock()
+            if terminationGate.markLaunched() || shouldTerminate {
+                guard process.isRunning else {
+                    process.waitUntilExit()
+                    terminationGate.markFinished()
+                    throw CancellationError()
+                }
+                process.terminate()
+            }
+
+            ProcessPipeReader.copyDataToEndOfFileOrDiscard(
+                from: outPipe.fileHandleForReading,
+                to: outputHandle
+            )
+            let stderrData = ProcessPipeReader.readDataToEndOfFileOrEmpty(from: errPipe.fileHandleForReading)
+            process.waitUntilExit()
+            terminationGate.markFinished()
+            lock.lock()
+            let cancelledAfterExit = cancelled
+            lock.unlock()
+            if cancelledAfterExit {
+                throw CancellationError()
+            }
+
+            return SSHCommandResult(
+                stdout: "",
+                stderr: String(data: stderrData, encoding: .utf8) ?? "",
+                terminationStatus: process.terminationStatus
+            )
+        }
+
+        func terminate() {
+            lock.lock()
+            cancelled = true
+            lock.unlock()
+
+            guard terminationGate.requestTermination() else {
+                return
+            }
+            guard process.isRunning else {
+                return
+            }
+            process.terminate()
+        }
+    }
+
     private static func runSSHCommand(connection: SSHFileExplorerConnection, command: String) async throws -> String {
         let commandProcess = SSHCommandProcess(connection: connection, command: command)
         let result = try await withTaskCancellationHandler {
@@ -548,11 +676,11 @@ final class ProcessSSHFileExplorerTransport: SSHFileExplorerTransport {
         showHidden: Bool
     ) async throws -> [FileExplorerEntry] {
         // Escape single quotes in path for shell safety
-        let escapedPath = path.replacingOccurrences(of: "'", with: "'\\''")
+        let escapedPath = shellSingleQuote(path)
         let lsFlags = showHidden ? "-1paFA" : "-1paF"
         let output = try await runSSHCommand(
             connection: connection,
-            command: "ls \(lsFlags) '\(escapedPath)' 2>/dev/null"
+            command: "ls \(lsFlags) \(escapedPath) 2>/dev/null"
         )
 
         let normalizedPath = path.hasSuffix("/") ? path : path + "/"
@@ -573,6 +701,10 @@ final class ProcessSSHFileExplorerTransport: SSHFileExplorerTransport {
             let fullPath = normalizedPath + cleanName
             return FileExplorerEntry(name: cleanName, path: fullPath, isDirectory: isDir)
         }
+    }
+
+    private static func shellSingleQuote(_ value: String) -> String {
+        "'\(value.replacingOccurrences(of: "'", with: "'\\''"))'"
     }
 }
 
@@ -683,11 +815,12 @@ final class FileExplorerStore: ObservableObject {
             }
             setRootPath(path)
 
-        case .remoteSSH(let workspaceId, let connection, let displayTarget, let isAvailable, let unavailableDetail):
+        case .remoteSSH(let workspaceId, let connection, let displayTarget, let rootPath, let isAvailable, let unavailableDetail):
             applyRemoteSSHWorkspaceRoot(
                 workspaceId: workspaceId,
                 connection: connection,
                 displayTarget: displayTarget,
+                rootPath: rootPath,
                 isAvailable: isAvailable,
                 unavailableDetail: unavailableDetail,
                 sshTransport: sshTransport
@@ -744,6 +877,18 @@ final class FileExplorerStore: ObservableObject {
                 }
             }
         }
+    }
+
+    func materializeRemoteFileForPreview(path: String) async throws -> URL {
+        guard let sshProvider = provider as? SSHFileExplorerProvider else {
+            throw FileExplorerError.providerUnavailable
+        }
+        let cacheURL = Self.remotePreviewCacheURL(
+            displayTarget: sshProvider.displayTarget,
+            remotePath: path
+        )
+        try await sshProvider.downloadFile(path: path, to: cacheURL)
+        return cacheURL
     }
 
     private func updateDirectoryWatcher() {
@@ -976,6 +1121,7 @@ final class FileExplorerStore: ObservableObject {
         workspaceId: UUID,
         connection: SSHFileExplorerConnection,
         displayTarget: String,
+        rootPath requestedRootPath: String?,
         isAvailable: Bool,
         unavailableDetail: String?,
         sshTransport: SSHFileExplorerTransport
@@ -1016,6 +1162,14 @@ final class FileExplorerStore: ObservableObject {
                     String(localized: "fileExplorer.status.sshUnavailable", defaultValue: "SSH files unavailable")
                 )
             }
+            return
+        }
+
+        let requestedRootPath = Self.normalizedRootPath(requestedRootPath)
+        if let requestedRootPath {
+            cancelRemoteHomeResolution()
+            setRootStatusMessage(nil)
+            setRootPath(requestedRootPath)
             return
         }
 
@@ -1104,6 +1258,32 @@ final class FileExplorerStore: ObservableObject {
             return candidate.hasPrefix("/")
         }
         return candidate == root || candidate.hasPrefix(root + "/")
+    }
+
+    private static func normalizedRootPath(_ path: String?) -> String? {
+        guard let path else { return nil }
+        let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        return trimmed
+    }
+
+    private static func remotePreviewCacheURL(displayTarget: String, remotePath: String) -> URL {
+        let cacheRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-remote-file-previews", isDirectory: true)
+        let target = sanitizedCacheComponent(displayTarget)
+        let remote = sanitizedCacheComponent(remotePath)
+        let basename = URL(fileURLWithPath: remotePath).lastPathComponent
+        let filename = basename.isEmpty ? remote : "\(remote)-\(basename)"
+        return cacheRoot
+            .appendingPathComponent(target, isDirectory: true)
+            .appendingPathComponent(filename, isDirectory: false)
+    }
+
+    private static func sanitizedCacheComponent(_ value: String) -> String {
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "._-"))
+        let scalars = value.unicodeScalars.map { allowed.contains($0) ? Character($0) : "-" }
+        let candidate = String(scalars).trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+        return candidate.isEmpty ? UUID().uuidString : String(candidate.prefix(160))
     }
 
     deinit {

--- a/Sources/ProcessPipeReader.swift
+++ b/Sources/ProcessPipeReader.swift
@@ -94,6 +94,38 @@ enum ProcessPipeReader {
         return result.data
     }
 
+    static func copyDataToEndOfFileOrDiscard(from input: FileHandle, to output: FileHandle) {
+        var copiedBytes = 0
+        while true {
+            switch readOnce(
+                fileDescriptor: input.fileDescriptor,
+                maxLength: defaultChunkSize,
+                operation: "copyDataToEndOfFile"
+            ) {
+            case .success(let data):
+                guard !data.isEmpty else { return }
+                do {
+                    try output.write(contentsOf: data)
+                    copiedBytes += data.count
+                } catch {
+                    logReadFailure(
+                        ProcessPipeReadError(operation: "copyDataToEndOfFile.write", errnoCode: EIO),
+                        fileDescriptor: input.fileDescriptor,
+                        partialByteCount: copiedBytes
+                    )
+                    return
+                }
+            case .failure(let error):
+                logReadFailure(
+                    error,
+                    fileDescriptor: input.fileDescriptor,
+                    partialByteCount: copiedBytes
+                )
+                return
+            }
+        }
+    }
+
     static func readAvailableDataOrEndOfFile(from fileHandle: FileHandle) -> ProcessPipeAvailableRead {
         switch readAvailableData(from: fileHandle) {
         case .success(let result):

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -1118,12 +1118,19 @@ struct RestorableAgentSessionIndex: Sendable {
             }
 
             for record in state.sessions.values {
-                let normalizedSessionId = record.sessionId.trimmingCharacters(in: .whitespacesAndNewlines)
+                let effectiveRecord = kind == .claude
+                    ? resolvedClaudeWorkflowRecord(
+                        record,
+                        fileManager: fileManager,
+                        lookup: claudeTranscriptLookup
+                    )
+                    : record
+                let normalizedSessionId = effectiveRecord.sessionId.trimmingCharacters(in: .whitespacesAndNewlines)
                 guard !normalizedSessionId.isEmpty,
-                      let workspaceId = UUID(uuidString: record.workspaceId),
-                      let panelId = UUID(uuidString: record.surfaceId),
+                      let workspaceId = UUID(uuidString: effectiveRecord.workspaceId),
+                      let panelId = UUID(uuidString: effectiveRecord.surfaceId),
                       hookRecordIsRestorable(
-                          record,
+                          effectiveRecord,
                           kind: kind,
                           fileManager: fileManager,
                           claudeTranscriptLookup: claudeTranscriptLookup
@@ -1135,18 +1142,18 @@ struct RestorableAgentSessionIndex: Sendable {
                     kind: kind,
                     sessionId: normalizedSessionId,
                     workingDirectory: restorableWorkingDirectory(
-                        for: record,
+                        for: effectiveRecord,
                         kind: kind,
                         fileManager: fileManager,
                         lookup: claudeTranscriptLookup
                     ),
-                    launchCommand: record.launchCommand,
+                    launchCommand: effectiveRecord.launchCommand,
                     registration: registration
                 )
                 let key = PanelKey(workspaceId: workspaceId, panelId: panelId)
                 let sessionKey = SessionKey(kind: kind, sessionId: normalizedSessionId)
                 let liveProcessID = liveScopedProcessID(
-                    for: record,
+                    for: effectiveRecord,
                     kind: kind,
                     workspaceId: workspaceId,
                     panelId: panelId,
@@ -1154,20 +1161,20 @@ struct RestorableAgentSessionIndex: Sendable {
                 )
                 let entry = Entry(
                     snapshot: snapshot,
-                    lifecycle: record.agentLifecycle,
-                    updatedAt: record.updatedAt,
+                    lifecycle: effectiveRecord.agentLifecycle,
+                    updatedAt: effectiveRecord.updatedAt,
                     processIDs: liveProcessID.map { [$0] } ?? []
                 )
-                if hookCandidatesByPanel[key]?.updatedAt ?? -Double.infinity <= record.updatedAt {
+                if hookCandidatesByPanel[key]?.updatedAt ?? -Double.infinity <= effectiveRecord.updatedAt {
                     hookCandidatesByPanel[key] = entry
                 }
-                if hookCandidatesBySession[sessionKey]?.updatedAt ?? -Double.infinity <= record.updatedAt {
+                if hookCandidatesBySession[sessionKey]?.updatedAt ?? -Double.infinity <= effectiveRecord.updatedAt {
                     hookCandidatesBySession[sessionKey] = entry
                 }
-                guard record.pid == nil || liveProcessID != nil else {
+                guard effectiveRecord.pid == nil || liveProcessID != nil else {
                     continue
                 }
-                if let existing = resolved[key], existing.updatedAt > record.updatedAt {
+                if let existing = resolved[key], existing.updatedAt > effectiveRecord.updatedAt {
                     continue
                 }
                 resolved[key] = entry
@@ -1237,6 +1244,119 @@ struct RestorableAgentSessionIndex: Sendable {
             return true
         }
         return claudeTranscriptExists(for: record, fileManager: fileManager, lookup: claudeTranscriptLookup)
+    }
+
+    private static func resolvedClaudeWorkflowRecord(
+        _ record: RestorableAgentHookSessionRecord,
+        fileManager: FileManager,
+        lookup: ClaudeTranscriptLookupCache
+    ) -> RestorableAgentHookSessionRecord {
+        guard let sessionId = normalizedNonEmptyValue(record.sessionId),
+              claudeSessionIdIsSafeFilename(sessionId) else {
+            return record
+        }
+        if let transcriptPath = normalizedNonEmptyValue(record.transcriptPath),
+           regularNonEmptyFileExists(
+               atPath: (transcriptPath as NSString).expandingTildeInPath,
+               fileManager: fileManager
+           ) {
+            return record
+        }
+
+        let roots = lookup.configRoots(for: record)
+        guard !roots.isEmpty else { return record }
+        let candidateProjectDirs = claudeWorkflowProjectDirs(
+            for: record,
+            sessionId: sessionId,
+            roots: roots,
+            fileManager: fileManager,
+            lookup: lookup
+        )
+        guard let resolved = newestClaudeSiblingTranscript(
+            in: candidateProjectDirs,
+            excludingSessionId: sessionId,
+            fileManager: fileManager
+        ) else {
+            return record
+        }
+
+        var resolvedRecord = record
+        resolvedRecord.sessionId = resolved.sessionId
+        resolvedRecord.transcriptPath = resolved.path
+        return resolvedRecord
+    }
+
+    private static func claudeWorkflowProjectDirs(
+        for record: RestorableAgentHookSessionRecord,
+        sessionId: String,
+        roots: [String],
+        fileManager: FileManager,
+        lookup: ClaudeTranscriptLookupCache
+    ) -> [String] {
+        var projectDirs: [String] = []
+        var seen: Set<String> = []
+
+        func appendIfWorkflowContainer(projectRoot: String) {
+            let workflowContainer = (projectRoot as NSString).appendingPathComponent(sessionId)
+            var isDirectory: ObjCBool = false
+            guard fileManager.fileExists(atPath: workflowContainer, isDirectory: &isDirectory),
+                  isDirectory.boolValue else {
+                return
+            }
+            let standardized = (projectRoot as NSString).standardizingPath
+            guard seen.insert(standardized).inserted else { return }
+            projectDirs.append(standardized)
+        }
+
+        let cwdCandidates = [
+            normalizedWorkingDirectory(record.launchCommand?.workingDirectory),
+            normalizedWorkingDirectory(record.cwd),
+        ].compactMap { $0 }
+        for root in roots {
+            let projectsRoot = (root as NSString).appendingPathComponent("projects")
+            for cwd in cwdCandidates {
+                appendIfWorkflowContainer(
+                    projectRoot: (projectsRoot as NSString).appendingPathComponent(encodeClaudeProjectDir(cwd))
+                )
+            }
+            for projectDir in lookup.projectDirs(configRoot: root) {
+                appendIfWorkflowContainer(
+                    projectRoot: (projectsRoot as NSString).appendingPathComponent(projectDir)
+                )
+            }
+        }
+        return projectDirs
+    }
+
+    private static func newestClaudeSiblingTranscript(
+        in projectDirs: [String],
+        excludingSessionId excludedSessionId: String,
+        fileManager: FileManager
+    ) -> (sessionId: String, path: String)? {
+        var best: (sessionId: String, path: String, modifiedAt: TimeInterval)?
+        for projectDir in projectDirs {
+            guard let children = try? fileManager.contentsOfDirectory(atPath: projectDir) else {
+                continue
+            }
+            for child in children where child.hasSuffix(".jsonl") {
+                let sessionId = String(child.dropLast(".jsonl".count))
+                guard sessionId != excludedSessionId,
+                      claudeSessionIdIsSafeFilename(sessionId) else {
+                    continue
+                }
+                let path = (projectDir as NSString).appendingPathComponent(child)
+                guard regularNonEmptyFileExists(atPath: path, fileManager: fileManager) else {
+                    continue
+                }
+                let modifiedAt = ((try? fileManager.attributesOfItem(atPath: path)[.modificationDate]) as? Date)?
+                    .timeIntervalSince1970 ?? 0
+                if best == nil || modifiedAt >= best!.modifiedAt {
+                    best = (sessionId, path, modifiedAt)
+                }
+            }
+        }
+        guard let best else { return nil }
+        return (best.sessionId, best.path)
     }
 
     private static func claudeTranscriptExists(

--- a/Sources/RightSidebarToolPanel.swift
+++ b/Sources/RightSidebarToolPanel.swift
@@ -91,6 +91,24 @@ final class RightSidebarToolPanel: Panel, ObservableObject {
               let paneId = workspace.bonsplitController.focusedPaneId ?? workspace.bonsplitController.allPaneIds.first else {
             return
         }
+        if workspace.isRemoteWorkspace {
+            let store = fileExplorerStore
+            Task { [weak self, weak workspace, weak store] in
+                guard let self, let workspace, let store else { return }
+                do {
+                    let localURL = try await store.materializeRemoteFileForPreview(path: filePath)
+                    _ = workspace.openFileSurfaces(
+                        inPane: paneId,
+                        filePaths: [localURL.path],
+                        focus: true,
+                        reuseExisting: true
+                    )
+                } catch {
+                    NSSound.beep()
+                }
+            }
+            return
+        }
         _ = workspace.openFileSurfaces(
             inPane: paneId,
             filePaths: [filePath],
@@ -184,6 +202,7 @@ final class RightSidebarToolPanel: Panel, ObservableObject {
                         sshOptions: configuration.sshOptions
                     ),
                     displayTarget: configuration.displayTarget,
+                    rootPath: workspace.currentDirectory,
                     isAvailable: workspace.remoteConnectionState == .connected,
                     unavailableDetail: unavailableDetail
                 )

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -10001,7 +10001,9 @@ class TerminalController {
             includeScrollback = true
         }
 
-        var result: V2CallResult = .err(code: "internal_error", message: "Failed to read terminal text", data: nil)
+        var rawSnapshot: TerminalTextRawSnapshot?
+        var resolvedContext: (workspaceId: UUID, surfaceId: UUID, windowId: UUID?)?
+        var result: V2CallResult?
         v2MainSync {
             guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
                 result = .err(code: "not_found", message: "Workspace not found", data: nil)
@@ -10027,35 +10029,74 @@ class TerminalController {
                 return
             }
 
-            let response = readTerminalTextBase64(
+            rawSnapshot = readTerminalTextRawSnapshot(
                 terminalPanel: terminalPanel,
-                includeScrollback: includeScrollback,
-                lineLimit: lineLimit
+                includeScrollback: includeScrollback
             )
-            guard response.hasPrefix("OK ") else {
-                result = .err(code: "internal_error", message: response, data: nil)
-                return
-            }
-            let base64 = String(response.dropFirst(3)).trimmingCharacters(in: .whitespacesAndNewlines)
-            let decoded = Data(base64Encoded: base64).flatMap { String(data: $0, encoding: .utf8) }
-            guard let text = decoded ?? (base64.isEmpty ? "" : nil) else {
-                result = .err(code: "internal_error", message: "Failed to decode terminal text", data: nil)
-                return
-            }
-
-            let windowId = v2ResolveWindowId(tabManager: tabManager)
-            result = .ok([
-                "text": text,
-                "base64": base64,
-                "workspace_id": ws.id.uuidString,
-                "workspace_ref": v2Ref(kind: .workspace, uuid: ws.id),
-                "surface_id": surfaceId.uuidString,
-                "surface_ref": v2Ref(kind: .surface, uuid: surfaceId),
-                "window_id": v2OrNull(windowId?.uuidString),
-                "window_ref": v2Ref(kind: .window, uuid: windowId)
-            ])
+            resolvedContext = (ws.id, surfaceId, v2ResolveWindowId(tabManager: tabManager))
         }
-        return result
+        if let result {
+            return result
+        }
+        guard let rawSnapshot, let resolvedContext else {
+            return .err(code: "internal_error", message: "Failed to read terminal text", data: nil)
+        }
+        switch Self.terminalTextPayload(
+            from: rawSnapshot,
+            includeScrollback: includeScrollback,
+            lineLimit: lineLimit
+        ) {
+        case .success(let payload):
+            return .ok([
+                "text": payload.text,
+                "base64": payload.base64,
+                "workspace_id": resolvedContext.workspaceId.uuidString,
+                "workspace_ref": v2Ref(kind: .workspace, uuid: resolvedContext.workspaceId),
+                "surface_id": resolvedContext.surfaceId.uuidString,
+                "surface_ref": v2Ref(kind: .surface, uuid: resolvedContext.surfaceId),
+                "window_id": v2OrNull(resolvedContext.windowId?.uuidString),
+                "window_ref": v2Ref(kind: .window, uuid: resolvedContext.windowId)
+            ])
+        case .failure(let error):
+            return .err(code: "internal_error", message: error.message, data: nil)
+        }
+    }
+
+    struct TerminalTextRawSnapshot {
+        var viewport: String?
+        var screen: String?
+        var history: String?
+        var active: String?
+    }
+
+    struct TerminalTextPayload: Equatable {
+        let text: String
+        let base64: String
+    }
+
+    struct TerminalTextPayloadError: Error, Equatable {
+        let message: String
+    }
+
+    private func readTerminalTextRawSnapshot(
+        terminalPanel: TerminalPanel,
+        includeScrollback: Bool
+    ) -> TerminalTextRawSnapshot? {
+        guard terminalPanel.surface.surface != nil else { return nil }
+        if includeScrollback {
+            return TerminalTextRawSnapshot(
+                viewport: nil,
+                screen: readTerminalSelectionText(terminalPanel: terminalPanel, pointTag: GHOSTTY_POINT_SCREEN),
+                history: readTerminalSelectionText(terminalPanel: terminalPanel, pointTag: GHOSTTY_POINT_SURFACE),
+                active: readTerminalSelectionText(terminalPanel: terminalPanel, pointTag: GHOSTTY_POINT_ACTIVE)
+            )
+        }
+        return TerminalTextRawSnapshot(
+            viewport: readTerminalSelectionText(terminalPanel: terminalPanel, pointTag: GHOSTTY_POINT_VIEWPORT),
+            screen: nil,
+            history: nil,
+            active: nil
+        )
     }
 
     private func readTerminalSelectionText(terminalPanel: TerminalPanel, pointTag: ghostty_point_tag_e) -> String? {
@@ -10094,64 +10135,84 @@ class TerminalController {
     }
 
     private func readTerminalTextBase64(terminalPanel: TerminalPanel, includeScrollback: Bool = false, lineLimit: Int? = nil) -> String {
-        guard terminalPanel.surface.surface != nil else { return "ERROR: Terminal surface not found" }
-        func readSelectionText(pointTag: ghostty_point_tag_e) -> String? {
-            readTerminalSelectionText(terminalPanel: terminalPanel, pointTag: pointTag)
+        guard let snapshot = readTerminalTextRawSnapshot(
+            terminalPanel: terminalPanel,
+            includeScrollback: includeScrollback
+        ) else {
+            return "ERROR: Terminal surface not found"
         }
+        switch Self.terminalTextPayload(
+            from: snapshot,
+            includeScrollback: includeScrollback,
+            lineLimit: lineLimit
+        ) {
+        case .success(let payload):
+            return "OK \(payload.base64)"
+        case .failure(let error):
+            return "ERROR: \(error.message)"
+        }
+    }
 
-        var output: String
+    static func terminalTextPayload(
+        from snapshot: TerminalTextRawSnapshot,
+        includeScrollback: Bool,
+        lineLimit: Int?
+    ) -> Result<TerminalTextPayload, TerminalTextPayloadError> {
+        let output: String
         if includeScrollback {
-            func candidateScore(_ text: String) -> (lines: Int, bytes: Int) {
-                let lines = text.isEmpty ? 0 : text.split(separator: "\n", omittingEmptySubsequences: false).count
-                return (lines, text.utf8.count)
-            }
-
-            // Read all available regions and pick the most complete candidate.
-            // Different point tags can lose different rows around resize/reflow boundaries.
-            let screen = readSelectionText(pointTag: GHOSTTY_POINT_SCREEN)
-            let history = readSelectionText(pointTag: GHOSTTY_POINT_SURFACE)
-            let active = readSelectionText(pointTag: GHOSTTY_POINT_ACTIVE)
-
             var candidates: [String] = []
-            if let screen {
-                candidates.append(screen)
+            if let screen = snapshot.screen {
+                candidates.append(lineLimit.map { Self.tailTerminalLines(screen, maxLines: $0) } ?? screen)
             }
-            if history != nil || active != nil {
-                var merged = history ?? ""
-                if let active {
+            if snapshot.history != nil || snapshot.active != nil {
+                var merged = lineLimit.map {
+                    Self.tailTerminalLines(snapshot.history ?? "", maxLines: $0)
+                } ?? (snapshot.history ?? "")
+                if let active = snapshot.active {
                     if !merged.isEmpty, !merged.hasSuffix("\n"), !active.isEmpty {
                         merged.append("\n")
                     }
-                    merged.append(active)
+                    merged.append(lineLimit.map { Self.tailTerminalLines(active, maxLines: $0) } ?? active)
                 }
-                candidates.append(merged)
+                candidates.append(lineLimit.map { Self.tailTerminalLines(merged, maxLines: $0) } ?? merged)
             }
 
-            if let best = candidates.max(by: { lhs, rhs in
-                let left = candidateScore(lhs)
-                let right = candidateScore(rhs)
+            guard let best = candidates.max(by: { lhs, rhs in
+                let left = terminalTextCandidateScore(lhs)
+                let right = terminalTextCandidateScore(rhs)
                 if left.lines != right.lines {
                     return left.lines < right.lines
                 }
                 return left.bytes < right.bytes
-            }) {
-                output = best
-            } else {
-                return "ERROR: Failed to read terminal text"
+            }) else {
+                return .failure(TerminalTextPayloadError(message: "Failed to read terminal text"))
             }
+            output = best
         } else {
-            guard let viewport = readSelectionText(pointTag: GHOSTTY_POINT_VIEWPORT) else {
-                return "ERROR: Failed to read terminal text"
+            guard var viewport = snapshot.viewport else {
+                return .failure(TerminalTextPayloadError(message: "Failed to read terminal text"))
+            }
+            if let lineLimit {
+                viewport = Self.tailTerminalLines(viewport, maxLines: lineLimit)
             }
             output = viewport
         }
 
-        if let lineLimit {
-            output = tailTerminalLines(output, maxLines: lineLimit)
-        }
-
         let base64 = output.data(using: .utf8)?.base64EncodedString() ?? ""
-        return "OK \(base64)"
+        return .success(TerminalTextPayload(text: output, base64: base64))
+    }
+
+    private static func terminalTextCandidateScore(_ text: String) -> (lines: Int, bytes: Int) {
+        if text.isEmpty { return (0, 0) }
+        var newlineCount = 0
+        var byteCount = 0
+        for byte in text.utf8 {
+            byteCount += 1
+            if byte == 0x0A {
+                newlineCount += 1
+            }
+        }
+        return (newlineCount + 1, byteCount)
     }
 
     private struct PasteboardItemSnapshot {
@@ -10236,7 +10297,7 @@ class TerminalController {
             return nil
         }
         if let lineLimit {
-            output = tailTerminalLines(output, maxLines: lineLimit)
+            output = Self.tailTerminalLines(output, maxLines: lineLimit)
         }
         return output
     }
@@ -16983,11 +17044,21 @@ class TerminalController {
         )
     }
 
-    private func tailTerminalLines(_ text: String, maxLines: Int) -> String {
+    static func tailTerminalLines(_ text: String, maxLines: Int) -> String {
         guard maxLines > 0 else { return "" }
-        let lines = text.split(separator: "\n", omittingEmptySubsequences: false)
-        guard lines.count > maxLines else { return text }
-        return lines.suffix(maxLines).joined(separator: "\n")
+        var newlineCount = 0
+        var index = text.endIndex
+        while index > text.startIndex {
+            let previous = text.index(before: index)
+            if text[previous] == "\n" {
+                newlineCount += 1
+                if newlineCount == maxLines {
+                    return String(text[index...])
+                }
+            }
+            index = previous
+        }
+        return text
     }
 
     private func readTerminalTextBase64(surfaceArg: String, includeScrollback: Bool = false, lineLimit: Int? = nil) -> String {

--- a/cmuxTests/FileExplorerStoreTests.swift
+++ b/cmuxTests/FileExplorerStoreTests.swift
@@ -44,8 +44,10 @@ private final class MockFileExplorerProvider: FileExplorerProvider {
 private final class MockSSHFileExplorerTransport: SSHFileExplorerTransport {
     var homePath: Result<String, Error>
     var listings: [String: Result<[FileExplorerEntry], Error>] = [:]
+    var downloads: [String: Result<Data, Error>] = [:]
     private(set) var resolvedHomeConnections: [SSHFileExplorerConnection] = []
     private(set) var listedPaths: [String] = []
+    private(set) var downloadedPaths: [String] = []
 
     init(homePath: Result<String, Error> = .success("/home/dev")) {
         self.homePath = homePath
@@ -66,6 +68,20 @@ private final class MockSSHFileExplorerTransport: SSHFileExplorerTransport {
             return try result.get()
         }
         return []
+    }
+
+    func downloadFile(
+        path: String,
+        connection: SSHFileExplorerConnection,
+        to localURL: URL
+    ) async throws {
+        downloadedPaths.append(path)
+        let data = try downloads[path, default: .success(Data())].get()
+        try FileManager.default.createDirectory(
+            at: localURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try data.write(to: localURL)
     }
 }
 
@@ -187,6 +203,7 @@ final class FileExplorerStoreTests: XCTestCase {
                 workspaceId: UUID(),
                 connection: connection,
                 displayTarget: "dev@ubuntu-host:2222",
+                rootPath: nil,
                 isAvailable: true,
                 unavailableDetail: nil
             ),
@@ -233,6 +250,7 @@ final class FileExplorerStoreTests: XCTestCase {
                     sshOptions: []
                 ),
                 displayTarget: "dev@ubuntu-host",
+                rootPath: nil,
                 isAvailable: true,
                 unavailableDetail: nil
             ),
@@ -246,6 +264,74 @@ final class FileExplorerStoreTests: XCTestCase {
 
         XCTAssertTrue(store.provider is SSHFileExplorerProvider)
         XCTAssertEqual(transport.resolvedHomeConnections.map(\.destination), ["dev@ubuntu-host"])
+    }
+
+    func testRemoteWorkspaceRootTracksRequestedWorkingDirectory() async throws {
+        let transport = MockSSHFileExplorerTransport(homePath: .success("/home/dev"))
+        transport.listings["/srv/app"] = .success([
+            FileExplorerEntry(name: "Package.swift", path: "/srv/app/Package.swift", isDirectory: false),
+        ])
+        let store = FileExplorerStore()
+
+        store.applyWorkspaceRoot(
+            .remoteSSH(
+                workspaceId: UUID(),
+                connection: SSHFileExplorerConnection(
+                    destination: "dev@ubuntu-host",
+                    port: nil,
+                    identityFile: nil,
+                    sshOptions: []
+                ),
+                displayTarget: "dev@ubuntu-host",
+                rootPath: "/srv/app",
+                isAvailable: true,
+                unavailableDetail: nil
+            ),
+            sshTransport: transport
+        )
+
+        try await waitFor("remote requested cwd loaded") {
+            store.rootPath == "/srv/app" &&
+                store.rootNodes.map(\.name) == ["Package.swift"]
+        }
+
+        XCTAssertEqual(transport.resolvedHomeConnections, [])
+        XCTAssertEqual(transport.listedPaths, ["/srv/app"])
+        XCTAssertEqual(store.displayRootPath, "ssh://dev@ubuntu-host:/srv/app")
+    }
+
+    func testRemoteFilePreviewMaterializesThroughSSHProvider() async throws {
+        let transport = MockSSHFileExplorerTransport(homePath: .success("/home/dev"))
+        transport.listings["/srv/app"] = .success([
+            FileExplorerEntry(name: "README.md", path: "/srv/app/README.md", isDirectory: false),
+        ])
+        transport.downloads["/srv/app/README.md"] = .success(Data("# Remote\n".utf8))
+        let store = FileExplorerStore()
+        store.applyWorkspaceRoot(
+            .remoteSSH(
+                workspaceId: UUID(),
+                connection: SSHFileExplorerConnection(
+                    destination: "dev@ubuntu-host",
+                    port: nil,
+                    identityFile: nil,
+                    sshOptions: []
+                ),
+                displayTarget: "dev@ubuntu-host",
+                rootPath: "/srv/app",
+                isAvailable: true,
+                unavailableDetail: nil
+            ),
+            sshTransport: transport
+        )
+
+        try await waitFor("remote requested cwd loaded") {
+            store.rootNodes.map(\.name) == ["README.md"]
+        }
+        let localURL = try await store.materializeRemoteFileForPreview(path: "/srv/app/README.md")
+
+        XCTAssertEqual(transport.downloadedPaths, ["/srv/app/README.md"])
+        XCTAssertEqual(try String(contentsOf: localURL, encoding: .utf8), "# Remote\n")
+        XCTAssertTrue(localURL.path.contains("cmux-remote-file-previews"))
     }
 
     func testCancelledRootLoadDoesNotClearRemoteUnavailableStatus() async throws {
@@ -268,6 +354,7 @@ final class FileExplorerStoreTests: XCTestCase {
                     sshOptions: []
                 ),
                 displayTarget: "dev@ubuntu-host",
+                rootPath: nil,
                 isAvailable: false,
                 unavailableDetail: nil
             ),

--- a/cmuxTests/RestorableAgentSessionIndexTests.swift
+++ b/cmuxTests/RestorableAgentSessionIndexTests.swift
@@ -310,6 +310,62 @@ final class RestorableAgentSessionIndexTests: XCTestCase {
         XCTAssertEqual(snapshot.workingDirectory, launchCwd.path)
     }
 
+    func testClaudeWorkflowDirectorySessionUsesSiblingJsonlSessionForResume() throws {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory
+            .appendingPathComponent("cmux-claude-workflow-directory-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fm.removeItem(at: root) }
+
+        let configDir = root.appendingPathComponent("claude-config", isDirectory: true)
+        let projectsDir = configDir.appendingPathComponent("projects", isDirectory: true)
+        let cwd = root.appendingPathComponent("repo", isDirectory: true)
+        try fm.createDirectory(at: cwd, withIntermediateDirectories: true)
+        let projectDir = projectsDir.appendingPathComponent(
+            expectedClaudeProjectDirName(cwd.path),
+            isDirectory: true
+        )
+        let workflowContainerSessionId = "aaaaaaaa-1111-1111-1111-aaaaaaaaaaaa"
+        let resumableSessionId = "bbbbbbbb-2222-2222-2222-bbbbbbbbbbbb"
+        try fm.createDirectory(
+            at: projectDir
+                .appendingPathComponent(workflowContainerSessionId, isDirectory: true)
+                .appendingPathComponent("subagents", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        let siblingTranscriptURL = projectDir.appendingPathComponent("\(resumableSessionId).jsonl", isDirectory: false)
+        try writeClaudeTranscript(sessionId: resumableSessionId, transcriptURL: siblingTranscriptURL, cwd: cwd)
+
+        let workspaceId = UUID()
+        let panelId = UUID()
+        try writeClaudeHookStore(
+            root: root,
+            sessions: [
+                workflowContainerSessionId: hookRecord(
+                    sessionId: workflowContainerSessionId,
+                    workspaceId: workspaceId,
+                    panelId: panelId,
+                    cwd: cwd.path,
+                    configDir: configDir.path,
+                    isRestorable: true,
+                    updatedAt: 10
+                ),
+            ]
+        )
+
+        let index = RestorableAgentSessionIndex.load(homeDirectory: root.path, fileManager: fm)
+        let snapshot = try XCTUnwrap(index.snapshot(workspaceId: workspaceId, panelId: panelId))
+
+        XCTAssertEqual(snapshot.sessionId, resumableSessionId)
+        XCTAssertEqual(snapshot.workingDirectory, cwd.path)
+        XCTAssertTrue(
+            try XCTUnwrap(snapshot.resumeCommand).contains("'--resume' '\(resumableSessionId)'")
+        )
+        XCTAssertFalse(
+            try XCTUnwrap(snapshot.resumeCommand).contains(workflowContainerSessionId),
+            "The Workflow container id is not accepted by claude --resume."
+        )
+    }
+
     /// Mirrors Claude's external project-directory naming rule ("/" and "." both become "-")
     /// independently of the production `encodeClaudeProjectDir`, so these regression tests fail if
     /// that helper regresses instead of masking it by sharing the same code path.

--- a/cmuxTests/TerminalControllerSocketWriteTests.swift
+++ b/cmuxTests/TerminalControllerSocketWriteTests.swift
@@ -10,6 +10,30 @@ import Foundation
 
 @MainActor
 final class TerminalControllerSocketWriteTests: XCTestCase {
+    func testTailTerminalLinesPreservesSplitSuffixSemanticsWithoutFullSplit() {
+        XCTAssertEqual(TerminalController.tailTerminalLines("a\nb\nc", maxLines: 2), "b\nc")
+        XCTAssertEqual(TerminalController.tailTerminalLines("a\nb\n", maxLines: 2), "b\n")
+        XCTAssertEqual(TerminalController.tailTerminalLines("a", maxLines: 2), "a")
+        XCTAssertEqual(TerminalController.tailTerminalLines("a\nb", maxLines: 0), "")
+    }
+
+    func testTerminalTextPayloadTailsScrollbackBeforeEncoding() throws {
+        let result = TerminalController.terminalTextPayload(
+            from: TerminalController.TerminalTextRawSnapshot(
+                viewport: nil,
+                screen: "old\nscreen\nline",
+                history: "one\ntwo\nthree",
+                active: "four\nfive"
+            ),
+            includeScrollback: true,
+            lineLimit: 3
+        )
+        let payload = try result.get()
+
+        XCTAssertEqual(payload.text, "three\nfour\nfive")
+        XCTAssertEqual(payload.base64, Data("three\nfour\nfive".utf8).base64EncodedString())
+    }
+
     func testSocketWriteAllWritesCompletePayload() throws {
         let sockets = try makeSocketPair()
         defer {


### PR DESCRIPTION
Summary
- Make remote SSH file browser roots follow the workspace cwd and open remote files through an SSH-backed preview copy instead of treating remote paths as local files.
- Resolve Claude Workflow directory sessions to the sibling resumable JSONL transcript so auto-resume does not use a non-resumable container id.
- Move surface.read_text scrollback merge/tail/base64 work out of the main-actor capture path and reduce tail/scoring allocations.

Issues
- https://github.com/manaflow-ai/cmux/issues/5237
- https://github.com/manaflow-ai/cmux/issues/5224
- https://github.com/manaflow-ai/cmux/issues/5221
- https://github.com/manaflow-ai/cmux/issues/5209

Verification
- ./scripts/setup.sh
- ./scripts/reload.sh --tag bugfix

Notes
- I did not run local xcodebuild tests because local test actions are prohibited for cmux; the PR includes focused unit coverage for the changed behavior.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5240"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783023687&installation_id=133855650&pr_number=5240&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5240&signature=bcd3d941edac194f9f953661255ede1ea0329f290292b1d99f2076d534109985"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes regressions in remote SSH browsing, Claude Workflow auto-resume, and terminal text capture, addressing #5237 #5224 #5221 #5209. Remote files open reliably, sessions resume correctly, and terminal reads are faster.

- **Bug Fixes**
  - SSH file browser roots now follow the workspace cwd, and remote files open via an SSH-backed preview copy.
  - Claude Workflow directory sessions resolve to the sibling resumable `.jsonl` transcript for auto-resume.

- **Refactors**
  - Moved scrollback merge/tail/base64 work off the main actor and added a lighter tail algorithm to reduce allocations.
  - Added streaming SSH download and pipe copying to lower memory usage during remote previews.

<sup>Written for commit 48f7d9c857ad06d9eda750ce90071beefbb4e66d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for previewing files from remote SSH workspaces by materializing them locally
  * Added ability to configure a custom working directory for remote SSH workspace roots
  * Improved terminal text output handling and selection logic

* **Tests**
  * Added test coverage for remote workspace root path configuration
  * Added test coverage for remote file preview materialization
  * Added test coverage for Claude workflow session resumption

<!-- end of auto-generated comment: release notes by coderabbit.ai -->