### PR TITLE
Fix remote SSH file browser opening

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2579,6 +2579,23 @@ struct ContentView: View {
         }
 
         sidebarSelectionState.selection = .tabs
+        if workspace.isRemoteWorkspace {
+            Task { [weak workspace, fileExplorerStore] in
+                guard let workspace else { return }
+                do {
+                    let localURL = try await fileExplorerStore.materializeRemoteFileForPreview(path: filePath)
+                    _ = workspace.openFileSurfaces(
+                        inPane: paneId,
+                        filePaths: [localURL.path],
+                        focus: true,
+                        reuseExisting: true
+                    )
+                } catch {
+                    NSSound.beep()
+                }
+            }
+            return
+        }
         _ = workspace.openFileSurfaces(
             inPane: paneId,
             filePaths: [filePath],
@@ -2628,6 +2645,7 @@ struct ContentView: View {
                         sshOptions: config.sshOptions
                     ),
                     displayTarget: config.displayTarget,
+                    rootPath: tab.currentDirectory,
                     isAvailable: tab.remoteConnectionState == .connected,
                     unavailableDetail: unavailableDetail
                 )

--- a/Sources/FileExplorerStore.swift
+++ b/Sources/FileExplorerStore.swift
@@ -599,7 +599,7 @@ final class ProcessSSHFileExplorerTransport: SSHFileExplorerTransport {
                 process.terminate()
             }
 
-            ProcessPipeReader.copyDataToEndOfFileOrDiscard(
+            try ProcessPipeReader.copyDataToEndOfFile(
                 from: outPipe.fileHandleForReading,
                 to: outputHandle
             )
@@ -716,8 +716,8 @@ enum FileExplorerError: LocalizedError {
         switch self {
         case .providerUnavailable:
             return String(localized: "fileExplorer.error.unavailable", defaultValue: "File explorer is not available")
-        case .sshCommandFailed(let detail):
-            return String(localized: "fileExplorer.error.sshFailed", defaultValue: "SSH command failed: \(detail)")
+        case .sshCommandFailed:
+            return String(localized: "fileExplorer.error.sshFailed", defaultValue: "SSH command failed")
         }
     }
 }

--- a/Sources/FileExplorerStore.swift
+++ b/Sources/FileExplorerStore.swift
@@ -275,6 +275,11 @@ protocol SSHFileExplorerTransport: AnyObject {
         connection: SSHFileExplorerConnection,
         showHidden: Bool
     ) async throws -> [FileExplorerEntry]
+    nonisolated func downloadFile(
+        path: String,
+        connection: SSHFileExplorerConnection,
+        to localURL: URL
+    ) async throws
 }
 
 enum FileExplorerWorkspaceRoot: Equatable {
@@ -284,6 +289,7 @@ enum FileExplorerWorkspaceRoot: Equatable {
         workspaceId: UUID,
         connection: SSHFileExplorerConnection,
         displayTarget: String,
+        rootPath: String?,
         isAvailable: Bool,
         unavailableDetail: String?
     )
@@ -403,6 +409,13 @@ final class SSHFileExplorerProvider: FileExplorerProvider, @unchecked Sendable {
         }
         return try await transport.listDirectory(path: path, connection: connection, showHidden: showHidden)
     }
+
+    func downloadFile(path: String, to localURL: URL) async throws {
+        guard isAvailable else {
+            throw FileExplorerError.providerUnavailable
+        }
+        try await transport.downloadFile(path: path, connection: connection, to: localURL)
+    }
 }
 
 final class ProcessSSHFileExplorerTransport: SSHFileExplorerTransport {
@@ -422,6 +435,33 @@ final class ProcessSSHFileExplorerTransport: SSHFileExplorerTransport {
         showHidden: Bool
     ) async throws -> [FileExplorerEntry] {
         try await Self.runSSHListCommand(path: path, connection: connection, showHidden: showHidden)
+    }
+
+    nonisolated func downloadFile(
+        path: String,
+        connection: SSHFileExplorerConnection,
+        to localURL: URL
+    ) async throws {
+        let escapedPath = Self.shellSingleQuote(path)
+        let outputURL = localURL
+        let commandProcess = SSHDownloadCommandProcess(
+            connection: connection,
+            command: "cat -- \(escapedPath)",
+            outputURL: outputURL
+        )
+        let result = try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                DispatchQueue.global(qos: .userInitiated).async {
+                    continuation.resume(with: Result { try commandProcess.run() })
+                }
+            }
+        } onCancel: {
+            commandProcess.terminate()
+        }
+        guard result.terminationStatus == 0 else {
+            try? FileManager.default.removeItem(at: outputURL)
+            throw FileExplorerError.sshCommandFailed(result.stderr)
+        }
     }
 
     private struct SSHCommandResult: Sendable {
@@ -507,6 +547,94 @@ final class ProcessSSHFileExplorerTransport: SSHFileExplorerTransport {
         }
     }
 
+    private final class SSHDownloadCommandProcess: @unchecked Sendable {
+        private let process = Process()
+        private let outPipe = Pipe()
+        private let errPipe = Pipe()
+        private let outputURL: URL
+        private let lock = NSLock()
+        private let terminationGate = ProcessTerminationGate()
+        private var cancelled = false
+
+        init(connection: SSHFileExplorerConnection, command: String, outputURL: URL) {
+            self.outputURL = outputURL
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/ssh")
+            process.arguments = ProcessSSHFileExplorerTransport.sshArguments(connection: connection, command: command)
+            process.standardOutput = outPipe
+            process.standardError = errPipe
+        }
+
+        func run() throws -> SSHCommandResult {
+            lock.lock()
+            let wasCancelled = cancelled
+            lock.unlock()
+            if wasCancelled {
+                throw CancellationError()
+            }
+
+            try FileManager.default.createDirectory(
+                at: outputURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            FileManager.default.createFile(atPath: outputURL.path, contents: nil)
+            let outputHandle = try FileHandle(forWritingTo: outputURL)
+            defer { try? outputHandle.close() }
+
+            do {
+                try process.run()
+            } catch {
+                terminationGate.markFinished()
+                throw error
+            }
+
+            lock.lock()
+            let shouldTerminate = cancelled
+            lock.unlock()
+            if terminationGate.markLaunched() || shouldTerminate {
+                guard process.isRunning else {
+                    process.waitUntilExit()
+                    terminationGate.markFinished()
+                    throw CancellationError()
+                }
+                process.terminate()
+            }
+
+            ProcessPipeReader.copyDataToEndOfFileOrDiscard(
+                from: outPipe.fileHandleForReading,
+                to: outputHandle
+            )
+            let stderrData = ProcessPipeReader.readDataToEndOfFileOrEmpty(from: errPipe.fileHandleForReading)
+            process.waitUntilExit()
+            terminationGate.markFinished()
+            lock.lock()
+            let cancelledAfterExit = cancelled
+            lock.unlock()
+            if cancelledAfterExit {
+                throw CancellationError()
+            }
+
+            return SSHCommandResult(
+                stdout: "",
+                stderr: String(data: stderrData, encoding: .utf8) ?? "",
+                terminationStatus: process.terminationStatus
+            )
+        }
+
+        func terminate() {
+            lock.lock()
+            cancelled = true
+            lock.unlock()
+
+            guard terminationGate.requestTermination() else {
+                return
+            }
+            guard process.isRunning else {
+                return
+            }
+            process.terminate()
+        }
+    }
+
     private static func runSSHCommand(connection: SSHFileExplorerConnection, command: String) async throws -> String {
         let commandProcess = SSHCommandProcess(connection: connection, command: command)
         let result = try await withTaskCancellationHandler {
@@ -548,11 +676,11 @@ final class ProcessSSHFileExplorerTransport: SSHFileExplorerTransport {
         showHidden: Bool
     ) async throws -> [FileExplorerEntry] {
         // Escape single quotes in path for shell safety
-        let escapedPath = path.replacingOccurrences(of: "'", with: "'\\''")
+        let escapedPath = shellSingleQuote(path)
         let lsFlags = showHidden ? "-1paFA" : "-1paF"
         let output = try await runSSHCommand(
             connection: connection,
-            command: "ls \(lsFlags) '\(escapedPath)' 2>/dev/null"
+            command: "ls \(lsFlags) \(escapedPath) 2>/dev/null"
         )
 
         let normalizedPath = path.hasSuffix("/") ? path : path + "/"
@@ -573,6 +701,10 @@ final class ProcessSSHFileExplorerTransport: SSHFileExplorerTransport {
             let fullPath = normalizedPath + cleanName
             return FileExplorerEntry(name: cleanName, path: fullPath, isDirectory: isDir)
         }
+    }
+
+    private static func shellSingleQuote(_ value: String) -> String {
+        "'\(value.replacingOccurrences(of: "'", with: "'\\''"))'"
     }
 }
 
@@ -683,11 +815,12 @@ final class FileExplorerStore: ObservableObject {
             }
             setRootPath(path)
 
-        case .remoteSSH(let workspaceId, let connection, let displayTarget, let isAvailable, let unavailableDetail):
+        case .remoteSSH(let workspaceId, let connection, let displayTarget, let rootPath, let isAvailable, let unavailableDetail):
             applyRemoteSSHWorkspaceRoot(
                 workspaceId: workspaceId,
                 connection: connection,
                 displayTarget: displayTarget,
+                rootPath: rootPath,
                 isAvailable: isAvailable,
                 unavailableDetail: unavailableDetail,
                 sshTransport: sshTransport
@@ -744,6 +877,18 @@ final class FileExplorerStore: ObservableObject {
                 }
             }
         }
+    }
+
+    func materializeRemoteFileForPreview(path: String) async throws -> URL {
+        guard let sshProvider = provider as? SSHFileExplorerProvider else {
+            throw FileExplorerError.providerUnavailable
+        }
+        let cacheURL = Self.remotePreviewCacheURL(
+            displayTarget: sshProvider.displayTarget,
+            remotePath: path
+        )
+        try await sshProvider.downloadFile(path: path, to: cacheURL)
+        return cacheURL
     }
 
     private func updateDirectoryWatcher() {
@@ -976,6 +1121,7 @@ final class FileExplorerStore: ObservableObject {
         workspaceId: UUID,
         connection: SSHFileExplorerConnection,
         displayTarget: String,
+        rootPath requestedRootPath: String?,
         isAvailable: Bool,
         unavailableDetail: String?,
         sshTransport: SSHFileExplorerTransport
@@ -1016,6 +1162,14 @@ final class FileExplorerStore: ObservableObject {
                     String(localized: "fileExplorer.status.sshUnavailable", defaultValue: "SSH files unavailable")
                 )
             }
+            return
+        }
+
+        let requestedRootPath = Self.normalizedRootPath(requestedRootPath)
+        if let requestedRootPath {
+            cancelRemoteHomeResolution()
+            setRootStatusMessage(nil)
+            setRootPath(requestedRootPath)
             return
         }
 
@@ -1104,6 +1258,32 @@ final class FileExplorerStore: ObservableObject {
             return candidate.hasPrefix("/")
         }
         return candidate == root || candidate.hasPrefix(root + "/")
+    }
+
+    private static func normalizedRootPath(_ path: String?) -> String? {
+        guard let path else { return nil }
+        let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        return trimmed
+    }
+
+    private static func remotePreviewCacheURL(displayTarget: String, remotePath: String) -> URL {
+        let cacheRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-remote-file-previews", isDirectory: true)
+        let target = sanitizedCacheComponent(displayTarget)
+        let remote = sanitizedCacheComponent(remotePath)
+        let basename = URL(fileURLWithPath: remotePath).lastPathComponent
+        let filename = basename.isEmpty ? remote : "\(remote)-\(basename)"
+        return cacheRoot
+            .appendingPathComponent(target, isDirectory: true)
+            .appendingPathComponent(filename, isDirectory: false)
+    }
+
+    private static func sanitizedCacheComponent(_ value: String) -> String {
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "._-"))
+        let scalars = value.unicodeScalars.map { allowed.contains($0) ? Character($0) : "-" }
+        let candidate = String(scalars).trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+        return candidate.isEmpty ? UUID().uuidString : String(candidate.prefix(160))
     }
 
     deinit {

--- a/Sources/ProcessPipeReader.swift
+++ b/Sources/ProcessPipeReader.swift
@@ -94,6 +94,38 @@ enum ProcessPipeReader {
         return result.data
     }
 
+    static func copyDataToEndOfFileOrDiscard(from input: FileHandle, to output: FileHandle) {
+        var copiedBytes = 0
+        while true {
+            switch readOnce(
+                fileDescriptor: input.fileDescriptor,
+                maxLength: defaultChunkSize,
+                operation: "copyDataToEndOfFile"
+            ) {
+            case .success(let data):
+                guard !data.isEmpty else { return }
+                do {
+                    try output.write(contentsOf: data)
+                    copiedBytes += data.count
+                } catch {
+                    logReadFailure(
+                        ProcessPipeReadError(operation: "copyDataToEndOfFile.write", errnoCode: EIO),
+                        fileDescriptor: input.fileDescriptor,
+                        partialByteCount: copiedBytes
+                    )
+                    return
+                }
+            case .failure(let error):
+                logReadFailure(
+                    error,
+                    fileDescriptor: input.fileDescriptor,
+                    partialByteCount: copiedBytes
+                )
+                return
+            }
+        }
+    }
+
     static func readAvailableDataOrEndOfFile(from fileHandle: FileHandle) -> ProcessPipeAvailableRead {
         switch readAvailableData(from: fileHandle) {
         case .success(let result):

--- a/Sources/ProcessPipeReader.swift
+++ b/Sources/ProcessPipeReader.swift
@@ -94,7 +94,7 @@ enum ProcessPipeReader {
         return result.data
     }
 
-    static func copyDataToEndOfFileOrDiscard(from input: FileHandle, to output: FileHandle) {
+    static func copyDataToEndOfFile(from input: FileHandle, to output: FileHandle) throws {
         var copiedBytes = 0
         while true {
             switch readOnce(
@@ -113,7 +113,7 @@ enum ProcessPipeReader {
                         fileDescriptor: input.fileDescriptor,
                         partialByteCount: copiedBytes
                     )
-                    return
+                    throw error
                 }
             case .failure(let error):
                 logReadFailure(
@@ -121,7 +121,7 @@ enum ProcessPipeReader {
                     fileDescriptor: input.fileDescriptor,
                     partialByteCount: copiedBytes
                 )
-                return
+                throw error
             }
         }
     }

--- a/Sources/RightSidebarToolPanel.swift
+++ b/Sources/RightSidebarToolPanel.swift
@@ -93,8 +93,8 @@ final class RightSidebarToolPanel: Panel, ObservableObject {
         }
         if workspace.isRemoteWorkspace {
             let store = fileExplorerStore
-            Task { [weak self, weak workspace, weak store] in
-                guard let self, let workspace, let store else { return }
+            Task { [weak workspace, weak store] in
+                guard let workspace, let store else { return }
                 do {
                     let localURL = try await store.materializeRemoteFileForPreview(path: filePath)
                     _ = workspace.openFileSurfaces(

--- a/Sources/RightSidebarToolPanel.swift
+++ b/Sources/RightSidebarToolPanel.swift
@@ -91,6 +91,24 @@ final class RightSidebarToolPanel: Panel, ObservableObject {
               let paneId = workspace.bonsplitController.focusedPaneId ?? workspace.bonsplitController.allPaneIds.first else {
             return
         }
+        if workspace.isRemoteWorkspace {
+            let store = fileExplorerStore
+            Task { [weak self, weak workspace, weak store] in
+                guard let self, let workspace, let store else { return }
+                do {
+                    let localURL = try await store.materializeRemoteFileForPreview(path: filePath)
+                    _ = workspace.openFileSurfaces(
+                        inPane: paneId,
+                        filePaths: [localURL.path],
+                        focus: true,
+                        reuseExisting: true
+                    )
+                } catch {
+                    NSSound.beep()
+                }
+            }
+            return
+        }
         _ = workspace.openFileSurfaces(
             inPane: paneId,
             filePaths: [filePath],
@@ -184,6 +202,7 @@ final class RightSidebarToolPanel: Panel, ObservableObject {
                         sshOptions: configuration.sshOptions
                     ),
                     displayTarget: configuration.displayTarget,
+                    rootPath: workspace.currentDirectory,
                     isAvailable: workspace.remoteConnectionState == .connected,
                     unavailableDetail: unavailableDetail
                 )

--- a/cmuxTests/FileExplorerStoreTests.swift
+++ b/cmuxTests/FileExplorerStoreTests.swift
@@ -44,8 +44,10 @@ private final class MockFileExplorerProvider: FileExplorerProvider {
 private final class MockSSHFileExplorerTransport: SSHFileExplorerTransport {
     var homePath: Result<String, Error>
     var listings: [String: Result<[FileExplorerEntry], Error>] = [:]
+    var downloads: [String: Result<Data, Error>] = [:]
     private(set) var resolvedHomeConnections: [SSHFileExplorerConnection] = []
     private(set) var listedPaths: [String] = []
+    private(set) var downloadedPaths: [String] = []
 
     init(homePath: Result<String, Error> = .success("/home/dev")) {
         self.homePath = homePath
@@ -66,6 +68,20 @@ private final class MockSSHFileExplorerTransport: SSHFileExplorerTransport {
             return try result.get()
         }
         return []
+    }
+
+    func downloadFile(
+        path: String,
+        connection: SSHFileExplorerConnection,
+        to localURL: URL
+    ) async throws {
+        downloadedPaths.append(path)
+        let data = try downloads[path, default: .success(Data())].get()
+        try FileManager.default.createDirectory(
+            at: localURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try data.write(to: localURL)
     }
 }
 
@@ -187,6 +203,7 @@ final class FileExplorerStoreTests: XCTestCase {
                 workspaceId: UUID(),
                 connection: connection,
                 displayTarget: "dev@ubuntu-host:2222",
+                rootPath: nil,
                 isAvailable: true,
                 unavailableDetail: nil
             ),
@@ -233,6 +250,7 @@ final class FileExplorerStoreTests: XCTestCase {
                     sshOptions: []
                 ),
                 displayTarget: "dev@ubuntu-host",
+                rootPath: nil,
                 isAvailable: true,
                 unavailableDetail: nil
             ),
@@ -246,6 +264,74 @@ final class FileExplorerStoreTests: XCTestCase {
 
         XCTAssertTrue(store.provider is SSHFileExplorerProvider)
         XCTAssertEqual(transport.resolvedHomeConnections.map(\.destination), ["dev@ubuntu-host"])
+    }
+
+    func testRemoteWorkspaceRootTracksRequestedWorkingDirectory() async throws {
+        let transport = MockSSHFileExplorerTransport(homePath: .success("/home/dev"))
+        transport.listings["/srv/app"] = .success([
+            FileExplorerEntry(name: "Package.swift", path: "/srv/app/Package.swift", isDirectory: false),
+        ])
+        let store = FileExplorerStore()
+
+        store.applyWorkspaceRoot(
+            .remoteSSH(
+                workspaceId: UUID(),
+                connection: SSHFileExplorerConnection(
+                    destination: "dev@ubuntu-host",
+                    port: nil,
+                    identityFile: nil,
+                    sshOptions: []
+                ),
+                displayTarget: "dev@ubuntu-host",
+                rootPath: "/srv/app",
+                isAvailable: true,
+                unavailableDetail: nil
+            ),
+            sshTransport: transport
+        )
+
+        try await waitFor("remote requested cwd loaded") {
+            store.rootPath == "/srv/app" &&
+                store.rootNodes.map(\.name) == ["Package.swift"]
+        }
+
+        XCTAssertEqual(transport.resolvedHomeConnections, [])
+        XCTAssertEqual(transport.listedPaths, ["/srv/app"])
+        XCTAssertEqual(store.displayRootPath, "ssh://dev@ubuntu-host:/srv/app")
+    }
+
+    func testRemoteFilePreviewMaterializesThroughSSHProvider() async throws {
+        let transport = MockSSHFileExplorerTransport(homePath: .success("/home/dev"))
+        transport.listings["/srv/app"] = .success([
+            FileExplorerEntry(name: "README.md", path: "/srv/app/README.md", isDirectory: false),
+        ])
+        transport.downloads["/srv/app/README.md"] = .success(Data("# Remote\n".utf8))
+        let store = FileExplorerStore()
+        store.applyWorkspaceRoot(
+            .remoteSSH(
+                workspaceId: UUID(),
+                connection: SSHFileExplorerConnection(
+                    destination: "dev@ubuntu-host",
+                    port: nil,
+                    identityFile: nil,
+                    sshOptions: []
+                ),
+                displayTarget: "dev@ubuntu-host",
+                rootPath: "/srv/app",
+                isAvailable: true,
+                unavailableDetail: nil
+            ),
+            sshTransport: transport
+        )
+
+        try await waitFor("remote requested cwd loaded") {
+            store.rootNodes.map(\.name) == ["README.md"]
+        }
+        let localURL = try await store.materializeRemoteFileForPreview(path: "/srv/app/README.md")
+
+        XCTAssertEqual(transport.downloadedPaths, ["/srv/app/README.md"])
+        XCTAssertEqual(try String(contentsOf: localURL, encoding: .utf8), "# Remote\n")
+        XCTAssertTrue(localURL.path.contains("cmux-remote-file-previews"))
     }
 
     func testCancelledRootLoadDoesNotClearRemoteUnavailableStatus() async throws {
@@ -268,6 +354,7 @@ final class FileExplorerStoreTests: XCTestCase {
                     sshOptions: []
                 ),
                 displayTarget: "dev@ubuntu-host",
+                rootPath: nil,
                 isAvailable: false,
                 unavailableDetail: nil
             ),


### PR DESCRIPTION
Fixes https://github.com/manaflow-ai/cmux/issues/5237.\n\nSummary:\n- Use the active remote workspace cwd as the remote file browser root.\n- Materialize remote files through SSH into a local preview copy before opening them.\n- Cover remote root selection and preview materialization in FileExplorerStore tests.\n\nVerification:\n- git diff --cached --check before commit.\n- Local xcodebuild tests not run because repo policy forbids local test actions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5241"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783023910&installation_id=133855650&pr_number=5241&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5241&signature=40d3b98e9b6177ccf6f0b4da319d9aeef4b071f0cd81059ff68f1f9def4a2a6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix remote SSH file opening in the file explorer and right sidebar by rooting at the active remote cwd and materializing a local preview before open. Improves reliability and error messages in remote workspaces.

- **Bug Fixes**
  - Root the remote browser to the workspace’s current directory when provided (skip home resolution).
  - Download files via `ssh cat` into a temp preview cache and open the local copy; beep on failure and remove partial files on SSH errors.
  - Harden SSH I/O and UX: single-quote paths, propagate download write failures, show a generic localized “SSH command failed” (en/ja/ko); add tests for cwd-rooting and preview materialization; remove an unused sidebar capture.

<sup>Written for commit 88beca2c000e6099ff107245fa203d44b547f640. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remote file preview: remote files are downloaded into a deterministic local cache for fast, viewable previews; previewing a remote file will materialize it first.
  * Remote explorer now respects and starts from the workspace's current working directory when using SSH.

* **Bug Fixes**
  * SSH failure messages use a generic, localized error string.
  * If remote preview materialization fails, the app beeps and does not open a preview.

* **Tests**
  * Added tests for remote preview materialization and remote workspace root handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->