### PR TITLE
Fix Claude workflow resume transcript resolution

### DIFF
--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -1118,12 +1118,19 @@ struct RestorableAgentSessionIndex: Sendable {
             }
 
             for record in state.sessions.values {
-                let normalizedSessionId = record.sessionId.trimmingCharacters(in: .whitespacesAndNewlines)
+                let effectiveRecord = kind == .claude
+                    ? resolvedClaudeWorkflowRecord(
+                        record,
+                        fileManager: fileManager,
+                        lookup: claudeTranscriptLookup
+                    )
+                    : record
+                let normalizedSessionId = effectiveRecord.sessionId.trimmingCharacters(in: .whitespacesAndNewlines)
                 guard !normalizedSessionId.isEmpty,
-                      let workspaceId = UUID(uuidString: record.workspaceId),
-                      let panelId = UUID(uuidString: record.surfaceId),
+                      let workspaceId = UUID(uuidString: effectiveRecord.workspaceId),
+                      let panelId = UUID(uuidString: effectiveRecord.surfaceId),
                       hookRecordIsRestorable(
-                          record,
+                          effectiveRecord,
                           kind: kind,
                           fileManager: fileManager,
                           claudeTranscriptLookup: claudeTranscriptLookup
@@ -1135,18 +1142,18 @@ struct RestorableAgentSessionIndex: Sendable {
                     kind: kind,
                     sessionId: normalizedSessionId,
                     workingDirectory: restorableWorkingDirectory(
-                        for: record,
+                        for: effectiveRecord,
                         kind: kind,
                         fileManager: fileManager,
                         lookup: claudeTranscriptLookup
                     ),
-                    launchCommand: record.launchCommand,
+                    launchCommand: effectiveRecord.launchCommand,
                     registration: registration
                 )
                 let key = PanelKey(workspaceId: workspaceId, panelId: panelId)
                 let sessionKey = SessionKey(kind: kind, sessionId: normalizedSessionId)
                 let liveProcessID = liveScopedProcessID(
-                    for: record,
+                    for: effectiveRecord,
                     kind: kind,
                     workspaceId: workspaceId,
                     panelId: panelId,
@@ -1154,20 +1161,20 @@ struct RestorableAgentSessionIndex: Sendable {
                 )
                 let entry = Entry(
                     snapshot: snapshot,
-                    lifecycle: record.agentLifecycle,
-                    updatedAt: record.updatedAt,
+                    lifecycle: effectiveRecord.agentLifecycle,
+                    updatedAt: effectiveRecord.updatedAt,
                     processIDs: liveProcessID.map { [$0] } ?? []
                 )
-                if hookCandidatesByPanel[key]?.updatedAt ?? -Double.infinity <= record.updatedAt {
+                if hookCandidatesByPanel[key]?.updatedAt ?? -Double.infinity <= effectiveRecord.updatedAt {
                     hookCandidatesByPanel[key] = entry
                 }
-                if hookCandidatesBySession[sessionKey]?.updatedAt ?? -Double.infinity <= record.updatedAt {
+                if hookCandidatesBySession[sessionKey]?.updatedAt ?? -Double.infinity <= effectiveRecord.updatedAt {
                     hookCandidatesBySession[sessionKey] = entry
                 }
-                guard record.pid == nil || liveProcessID != nil else {
+                guard effectiveRecord.pid == nil || liveProcessID != nil else {
                     continue
                 }
-                if let existing = resolved[key], existing.updatedAt > record.updatedAt {
+                if let existing = resolved[key], existing.updatedAt > effectiveRecord.updatedAt {
                     continue
                 }
                 resolved[key] = entry
@@ -1237,6 +1244,119 @@ struct RestorableAgentSessionIndex: Sendable {
             return true
         }
         return claudeTranscriptExists(for: record, fileManager: fileManager, lookup: claudeTranscriptLookup)
+    }
+
+    private static func resolvedClaudeWorkflowRecord(
+        _ record: RestorableAgentHookSessionRecord,
+        fileManager: FileManager,
+        lookup: ClaudeTranscriptLookupCache
+    ) -> RestorableAgentHookSessionRecord {
+        guard let sessionId = normalizedNonEmptyValue(record.sessionId),
+              claudeSessionIdIsSafeFilename(sessionId) else {
+            return record
+        }
+        if let transcriptPath = normalizedNonEmptyValue(record.transcriptPath),
+           regularNonEmptyFileExists(
+               atPath: (transcriptPath as NSString).expandingTildeInPath,
+               fileManager: fileManager
+           ) {
+            return record
+        }
+
+        let roots = lookup.configRoots(for: record)
+        guard !roots.isEmpty else { return record }
+        let candidateProjectDirs = claudeWorkflowProjectDirs(
+            for: record,
+            sessionId: sessionId,
+            roots: roots,
+            fileManager: fileManager,
+            lookup: lookup
+        )
+        guard let resolved = newestClaudeSiblingTranscript(
+            in: candidateProjectDirs,
+            excludingSessionId: sessionId,
+            fileManager: fileManager
+        ) else {
+            return record
+        }
+
+        var resolvedRecord = record
+        resolvedRecord.sessionId = resolved.sessionId
+        resolvedRecord.transcriptPath = resolved.path
+        return resolvedRecord
+    }
+
+    private static func claudeWorkflowProjectDirs(
+        for record: RestorableAgentHookSessionRecord,
+        sessionId: String,
+        roots: [String],
+        fileManager: FileManager,
+        lookup: ClaudeTranscriptLookupCache
+    ) -> [String] {
+        var projectDirs: [String] = []
+        var seen: Set<String> = []
+
+        func appendIfWorkflowContainer(projectRoot: String) {
+            let workflowContainer = (projectRoot as NSString).appendingPathComponent(sessionId)
+            var isDirectory: ObjCBool = false
+            guard fileManager.fileExists(atPath: workflowContainer, isDirectory: &isDirectory),
+                  isDirectory.boolValue else {
+                return
+            }
+            let standardized = (projectRoot as NSString).standardizingPath
+            guard seen.insert(standardized).inserted else { return }
+            projectDirs.append(standardized)
+        }
+
+        let cwdCandidates = [
+            normalizedWorkingDirectory(record.launchCommand?.workingDirectory),
+            normalizedWorkingDirectory(record.cwd),
+        ].compactMap { $0 }
+        for root in roots {
+            let projectsRoot = (root as NSString).appendingPathComponent("projects")
+            for cwd in cwdCandidates {
+                appendIfWorkflowContainer(
+                    projectRoot: (projectsRoot as NSString).appendingPathComponent(encodeClaudeProjectDir(cwd))
+                )
+            }
+            for projectDir in lookup.projectDirs(configRoot: root) {
+                appendIfWorkflowContainer(
+                    projectRoot: (projectsRoot as NSString).appendingPathComponent(projectDir)
+                )
+            }
+        }
+        return projectDirs
+    }
+
+    private static func newestClaudeSiblingTranscript(
+        in projectDirs: [String],
+        excludingSessionId excludedSessionId: String,
+        fileManager: FileManager
+    ) -> (sessionId: String, path: String)? {
+        var best: (sessionId: String, path: String, modifiedAt: TimeInterval)?
+        for projectDir in projectDirs {
+            guard let children = try? fileManager.contentsOfDirectory(atPath: projectDir) else {
+                continue
+            }
+            for child in children where child.hasSuffix(".jsonl") {
+                let sessionId = String(child.dropLast(".jsonl".count))
+                guard sessionId != excludedSessionId,
+                      claudeSessionIdIsSafeFilename(sessionId) else {
+                    continue
+                }
+                let path = (projectDir as NSString).appendingPathComponent(child)
+                guard regularNonEmptyFileExists(atPath: path, fileManager: fileManager) else {
+                    continue
+                }
+                let modifiedAt = ((try? fileManager.attributesOfItem(atPath: path)[.modificationDate]) as? Date)?
+                    .timeIntervalSince1970 ?? 0
+                if best == nil || modifiedAt >= best!.modifiedAt {
+                    best = (sessionId, path, modifiedAt)
+                }
+            }
+        }
+        guard let best else { return nil }
+        return (best.sessionId, best.path)
     }
 
     private static func claudeTranscriptExists(

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -1350,7 +1350,7 @@ struct RestorableAgentSessionIndex: Sendable {
                 }
                 let modifiedAt = ((try? fileManager.attributesOfItem(atPath: path)[.modificationDate]) as? Date)?
                     .timeIntervalSince1970 ?? 0
-                if best == nil || modifiedAt >= best!.modifiedAt {
+                if best == nil || modifiedAt > best!.modifiedAt {
                     best = (sessionId, path, modifiedAt)
                 }
             }

--- a/cmuxTests/RestorableAgentSessionIndexTests.swift
+++ b/cmuxTests/RestorableAgentSessionIndexTests.swift
@@ -326,9 +326,10 @@ final class RestorableAgentSessionIndexTests: XCTestCase {
         )
         let workflowContainerSessionId = "aaaaaaaa-1111-1111-1111-aaaaaaaaaaaa"
         let resumableSessionId = "bbbbbbbb-2222-2222-2222-bbbbbbbbbbbb"
+        let workflowContainerURL = projectDir
+            .appendingPathComponent(workflowContainerSessionId, isDirectory: true)
         try fm.createDirectory(
-            at: projectDir
-                .appendingPathComponent(workflowContainerSessionId, isDirectory: true)
+            at: workflowContainerURL
                 .appendingPathComponent("subagents", isDirectory: true),
             withIntermediateDirectories: true
         )
@@ -346,6 +347,7 @@ final class RestorableAgentSessionIndexTests: XCTestCase {
                     panelId: panelId,
                     cwd: cwd.path,
                     configDir: configDir.path,
+                    transcriptPath: workflowContainerURL.path,
                     isRestorable: true,
                     updatedAt: 10
                 ),

--- a/cmuxTests/RestorableAgentSessionIndexTests.swift
+++ b/cmuxTests/RestorableAgentSessionIndexTests.swift
@@ -310,6 +310,62 @@ final class RestorableAgentSessionIndexTests: XCTestCase {
         XCTAssertEqual(snapshot.workingDirectory, launchCwd.path)
     }
 
+    func testClaudeWorkflowDirectorySessionUsesSiblingJsonlSessionForResume() throws {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory
+            .appendingPathComponent("cmux-claude-workflow-directory-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fm.removeItem(at: root) }
+
+        let configDir = root.appendingPathComponent("claude-config", isDirectory: true)
+        let projectsDir = configDir.appendingPathComponent("projects", isDirectory: true)
+        let cwd = root.appendingPathComponent("repo", isDirectory: true)
+        try fm.createDirectory(at: cwd, withIntermediateDirectories: true)
+        let projectDir = projectsDir.appendingPathComponent(
+            expectedClaudeProjectDirName(cwd.path),
+            isDirectory: true
+        )
+        let workflowContainerSessionId = "aaaaaaaa-1111-1111-1111-aaaaaaaaaaaa"
+        let resumableSessionId = "bbbbbbbb-2222-2222-2222-bbbbbbbbbbbb"
+        try fm.createDirectory(
+            at: projectDir
+                .appendingPathComponent(workflowContainerSessionId, isDirectory: true)
+                .appendingPathComponent("subagents", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        let siblingTranscriptURL = projectDir.appendingPathComponent("\(resumableSessionId).jsonl", isDirectory: false)
+        try writeClaudeTranscript(sessionId: resumableSessionId, transcriptURL: siblingTranscriptURL, cwd: cwd)
+
+        let workspaceId = UUID()
+        let panelId = UUID()
+        try writeClaudeHookStore(
+            root: root,
+            sessions: [
+                workflowContainerSessionId: hookRecord(
+                    sessionId: workflowContainerSessionId,
+                    workspaceId: workspaceId,
+                    panelId: panelId,
+                    cwd: cwd.path,
+                    configDir: configDir.path,
+                    isRestorable: true,
+                    updatedAt: 10
+                ),
+            ]
+        )
+
+        let index = RestorableAgentSessionIndex.load(homeDirectory: root.path, fileManager: fm)
+        let snapshot = try XCTUnwrap(index.snapshot(workspaceId: workspaceId, panelId: panelId))
+
+        XCTAssertEqual(snapshot.sessionId, resumableSessionId)
+        XCTAssertEqual(snapshot.workingDirectory, cwd.path)
+        XCTAssertTrue(
+            try XCTUnwrap(snapshot.resumeCommand).contains("'--resume' '\(resumableSessionId)'")
+        )
+        XCTAssertFalse(
+            try XCTUnwrap(snapshot.resumeCommand).contains(workflowContainerSessionId),
+            "The Workflow container id is not accepted by claude --resume."
+        )
+    }
+
     /// Mirrors Claude's external project-directory naming rule ("/" and "." both become "-")
     /// independently of the production `encodeClaudeProjectDir`, so these regression tests fail if
     /// that helper regresses instead of masking it by sharing the same code path.


### PR DESCRIPTION
Fixes https://github.com/manaflow-ai/cmux/issues/5224.\n\nSummary:\n- Detect Claude Workflow directory session containers during restorable-session load.\n- Resolve them to the newest sibling JSONL transcript so resume/fork uses a real Claude session id.\n- Cover the workflow-directory case in RestorableAgentSessionIndex tests.\n\nVerification:\n- git diff --cached --check before commit.\n- Local xcodebuild tests not run because repo policy forbids local test actions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5242"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783023910&installation_id=133855650&pr_number=5242&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5242&signature=fafa20d990b9f6c0b2d39de16eff20b5b6efd5b3fc02a9ec152a255744d6106d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes resume for Claude workflow directory sessions by resolving container IDs to the newest sibling `.jsonl` transcript (chosen by last-modified time) and using that real Claude session for indexing, resume, and fork. Fixes #5224.

- **Bug Fixes**
  - Map workflow-container records to the newest sibling `.jsonl` (by mtime), excluding the container ID and skipping resolution if a valid transcript already exists; propagate the resolved `sessionId`/`transcriptPath` through indexing and process matching.
  - Search config `projects` roots from encoded `launchCommand.workingDirectory`/`cwd` and known project dirs with safe filename checks; add tests confirming `--resume` uses the real Claude session ID.

<sup>Written for commit 50abbea998b9bfad244c005034561dae3f1e955c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Claude session restoration to prefer safer, more up-to-date sibling transcripts when resuming, ensuring correct session IDs, resume commands, and consistent restored metadata and process associations.

* **Tests**
  * Added a unit test verifying that restoration selects a resumable sibling transcript and configures resume commands to use that session.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->