### PR TITLE
Open group config in the user's configured editor

### DIFF
--- a/Sources/HostSettingsActions.swift
+++ b/Sources/HostSettingsActions.swift
@@ -70,7 +70,11 @@ final class HostSettingsActions: SettingsHostActions {
     }
 
     func openConfigInExternalEditor() {
-        NSWorkspace.shared.open(configFileURL)
+        // Honor the user's configured editor (`preferredEditorCommand`),
+        // falling back to the OS default. Opening the config file directly
+        // through `NSWorkspace.shared.open` would route to the default
+        // `.json` handler and ignore the cmux setting.
+        PreferredEditorSettings.open(configFileURL)
     }
 
     func sendFeedback() {

--- a/Sources/SidebarWorkspaceGroupConfigOpener.swift
+++ b/Sources/SidebarWorkspaceGroupConfigOpener.swift
@@ -8,7 +8,7 @@ enum SidebarWorkspaceGroupConfigOpener {
     static func openCmuxConfigInEditor() {
         openCmuxConfigInEditor(
             home: FileManager.default.homeDirectoryForCurrentUser,
-            open: PreferredEditorSettings.open
+            open: { PreferredEditorSettings.open($0) }
         )
     }
 
@@ -32,7 +32,7 @@ enum SidebarWorkspaceGroupConfigOpener {
             )
             try? Data("{}\n".utf8).write(to: configURL, options: .atomic)
         }
-        NSWorkspace.shared.open(configURL)
+        open(configURL)
     }
 
     static func openWorkspaceGroupsDocs() {

--- a/Sources/SidebarWorkspaceGroupConfigOpener.swift
+++ b/Sources/SidebarWorkspaceGroupConfigOpener.swift
@@ -3,8 +3,23 @@ import Foundation
 
 /// Opens workspace-group configuration and documentation surfaces.
 enum SidebarWorkspaceGroupConfigOpener {
+    /// Opens the cmux config file (`~/.config/cmux/cmux.json`) in the user's
+    /// configured editor, materializing an empty config first if none exists.
     static func openCmuxConfigInEditor() {
-        let home = FileManager.default.homeDirectoryForCurrentUser
+        openCmuxConfigInEditor(
+            home: FileManager.default.homeDirectoryForCurrentUser,
+            open: PreferredEditorSettings.open
+        )
+    }
+
+    /// Testable seam: resolves the cmux config path under `home`, materializes
+    /// an empty config if absent, then hands the file to `open`.
+    ///
+    /// The public ``openCmuxConfigInEditor()`` entry point passes
+    /// `PreferredEditorSettings.open` so the config file honors
+    /// `preferredEditorCommand` (with an OS-default fallback). Tests inject a
+    /// capturing closure to assert the config file is routed through `open`.
+    static func openCmuxConfigInEditor(home: URL, open: (URL) -> Void) {
         let configURL = home
             .appendingPathComponent(".config", isDirectory: true)
             .appendingPathComponent("cmux", isDirectory: true)

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -357,6 +357,7 @@
 		F4100000A1B2C3D4E5F60718 /* PortScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4100001A1B2C3D4E5F60718 /* PortScannerTests.swift */; };
 		A5001270 /* PostHog in Frameworks */ = {isa = PBXBuildFile; productRef = A5001271 /* PostHog */; };
 		A5001521 /* PostHogAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001520 /* PostHogAnalytics.swift */; };
+		C135190000000000000000A1 /* PreferredEditorSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C135190000000000000000A2 /* PreferredEditorSettingsTests.swift */; };
 		C47110010000000000000001 /* ProcessPipeReadCrashRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C47110010000000000000002 /* ProcessPipeReadCrashRegressionTests.swift */; };
 		C47110020000000000000001 /* ProcessPipeReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = C47110020000000000000002 /* ProcessPipeReader.swift */; };
 		C47110020000000000000003 /* ProcessPipeReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = C47110020000000000000002 /* ProcessPipeReader.swift */; };
@@ -453,6 +454,7 @@
 		CA39C0304FE351A21C372429 /* SidebarWidthPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0171AF1F49F7547191CEE5 /* SidebarWidthPolicyTests.swift */; };
 		D7AB34300000000000000005 /* SidebarWorkspaceDropPlannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB34300000000000000006 /* SidebarWorkspaceDropPlannerTests.swift */; };
 		C9A57103C9A57103C9A57103 /* SidebarWorkspaceGroupConfigOpener.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A57104C9A57104C9A57104 /* SidebarWorkspaceGroupConfigOpener.swift */; };
+		C135190000000000000000B1 /* SidebarWorkspaceGroupConfigOpenerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C135190000000000000000B2 /* SidebarWorkspaceGroupConfigOpenerTests.swift */; };
 		C9A57105C9A57105C9A57105 /* SidebarWorkspaceGroupContextMenuRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A57106C9A57106C9A57106 /* SidebarWorkspaceGroupContextMenuRunner.swift */; };
 		C9A57107C9A57107C9A57107 /* SidebarWorkspaceGroupDialogs.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A57108C9A57108C9A57108 /* SidebarWorkspaceGroupDialogs.swift */; };
 		C9A57101C9A57101C9A57101 /* SidebarWorkspaceGroupHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A57102C9A57102C9A57102 /* SidebarWorkspaceGroupHeaderView.swift */; };
@@ -978,6 +980,7 @@
 		A5001541 /* PortScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortScanner.swift; sourceTree = "<group>"; };
 		F4100001A1B2C3D4E5F60718 /* PortScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortScannerTests.swift; sourceTree = "<group>"; };
 		A5001520 /* PostHogAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogAnalytics.swift; sourceTree = "<group>"; };
+		C135190000000000000000A2 /* PreferredEditorSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferredEditorSettingsTests.swift; sourceTree = "<group>"; };
 		C47110010000000000000002 /* ProcessPipeReadCrashRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessPipeReadCrashRegressionTests.swift; sourceTree = "<group>"; };
 		C47110020000000000000002 /* ProcessPipeReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessPipeReader.swift; sourceTree = "<group>"; };
 		A5C0DE0000000000000000B9 /* ProjectBuildSettingsTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/ProjectBuildSettingsTabView.swift; sourceTree = "<group>"; };
@@ -1069,6 +1072,7 @@
 		EE0171AF1F49F7547191CEE5 /* SidebarWidthPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWidthPolicyTests.swift; sourceTree = "<group>"; };
 		D7AB34300000000000000006 /* SidebarWorkspaceDropPlannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceDropPlannerTests.swift; sourceTree = "<group>"; };
 		C9A57104C9A57104C9A57104 /* SidebarWorkspaceGroupConfigOpener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceGroupConfigOpener.swift; sourceTree = "<group>"; };
+		C135190000000000000000B2 /* SidebarWorkspaceGroupConfigOpenerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceGroupConfigOpenerTests.swift; sourceTree = "<group>"; };
 		C9A57106C9A57106C9A57106 /* SidebarWorkspaceGroupContextMenuRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceGroupContextMenuRunner.swift; sourceTree = "<group>"; };
 		C9A57108C9A57108C9A57108 /* SidebarWorkspaceGroupDialogs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceGroupDialogs.swift; sourceTree = "<group>"; };
 		C9A57102C9A57102C9A57102 /* SidebarWorkspaceGroupHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceGroupHeaderView.swift; sourceTree = "<group>"; };
@@ -1748,6 +1752,8 @@
 				A11EB0000000000000000001 /* GhosttyConfigPathResolverTests.swift */,
 				C13519000000000000000004 /* GhosttyTerminalStartupEnvironmentTests.swift */,
 				C13519000000000000000008 /* ClaudeConfigDirectoryPathTests.swift */,
+				C135190000000000000000A2 /* PreferredEditorSettingsTests.swift */,
+				C135190000000000000000B2 /* SidebarWorkspaceGroupConfigOpenerTests.swift */,
 				A11EAE000000000000000001 /* WorkspaceAppearanceConfigResolutionTests.swift */,
 				A11EAF000000000000000001 /* GhosttyNotificationDispatcherTests.swift */,
 				F4200001A1B2C3D4E5F60718 /* WindowAppearanceSnapshotTests.swift */,
@@ -2720,6 +2726,7 @@
 					B3575000000000000000000A /* PiVaultAgentPersistenceTests.swift in Sources */,
 					D0B10008A1B2C3D4E5F60001 /* PortalTabDragRoutingTests.swift in Sources */,
 					F4100000A1B2C3D4E5F60718 /* PortScannerTests.swift in Sources */,
+				C135190000000000000000A1 /* PreferredEditorSettingsTests.swift in Sources */,
 				C47110010000000000000001 /* ProcessPipeReadCrashRegressionTests.swift in Sources */,
 					F5410004A1B2C3D4E5F60718 /* RestorableAgentHookProviderHermesTests.swift in Sources */,
 					F5410000A1B2C3D4E5F60718 /* RestorableAgentHookProviderResumeTests.swift in Sources */,
@@ -2743,6 +2750,7 @@
 				D7AB34300000000000000105 /* SidebarTabDropIndicatorPredicateTests.swift in Sources */,
 				CA39C0304FE351A21C372429 /* SidebarWidthPolicyTests.swift in Sources */,
 				D7AB34300000000000000005 /* SidebarWorkspaceDropPlannerTests.swift in Sources */,
+				C135190000000000000000B1 /* SidebarWorkspaceGroupConfigOpenerTests.swift in Sources */,
 				62270F3DCECB4787D789CCE3 /* SidebarWorkspaceSnapshotRefreshPolicyTests.swift in Sources */,
 				F8000000A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift in Sources */,
 				F6355600A1B2C3D4E5F60718 /* SSHStartupSignalLifecycleTests.swift in Sources */,

--- a/cmuxTests/PreferredEditorSettingsTests.swift
+++ b/cmuxTests/PreferredEditorSettingsTests.swift
@@ -1,0 +1,50 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Behavioral coverage for the editor-command resolver shared by every
+/// cmux config-file opener (the workspace-group "Edit Group Configuration"
+/// action, the "Open Cmux Settings File" action, and the Settings config
+/// window). Verifies that a configured `preferredEditorCommand` is honored
+/// and that an unset/blank value falls back to `nil` (the OS-default path).
+@Suite struct PreferredEditorSettingsTests {
+    private func makeDefaults() -> UserDefaults {
+        let suiteName = "cmux-preferred-editor-tests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+
+    @Test func returnsNilWhenUnset() {
+        let defaults = makeDefaults()
+        #expect(PreferredEditorSettings.resolvedCommand(defaults: defaults) == nil)
+    }
+
+    @Test func returnsNilForEmptyOrWhitespaceCommand() {
+        for raw in ["", "   ", "\n\t "] {
+            let defaults = makeDefaults()
+            defaults.set(raw, forKey: PreferredEditorSettings.key)
+            #expect(
+                PreferredEditorSettings.resolvedCommand(defaults: defaults) == nil,
+                "blank command \(raw.debugDescription) should fall back to OS default"
+            )
+        }
+    }
+
+    @Test func returnsConfiguredCommandWhenSet() {
+        let defaults = makeDefaults()
+        defaults.set("code", forKey: PreferredEditorSettings.key)
+        #expect(PreferredEditorSettings.resolvedCommand(defaults: defaults) == "code")
+    }
+
+    @Test func trimsSurroundingWhitespaceFromConfiguredCommand() {
+        let defaults = makeDefaults()
+        defaults.set("  code -w  \n", forKey: PreferredEditorSettings.key)
+        #expect(PreferredEditorSettings.resolvedCommand(defaults: defaults) == "code -w")
+    }
+}

--- a/cmuxTests/SidebarWorkspaceGroupConfigOpenerTests.swift
+++ b/cmuxTests/SidebarWorkspaceGroupConfigOpenerTests.swift
@@ -1,0 +1,38 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Regression coverage for the workspace-group "Edit Group Configuration…"
+/// action. The opener must route the cmux config file through the same
+/// editor-resolving path the rest of the app uses (so `preferredEditorCommand`
+/// is honored) rather than handing it to `NSWorkspace.shared.open`, which
+/// routes to the OS default `.json` handler and ignores the cmux setting.
+///
+/// Before the fix the opener called `NSWorkspace.shared.open(configURL)`
+/// directly, so the injected opener was never invoked and this test fails.
+@Suite struct SidebarWorkspaceGroupConfigOpenerTests {
+    @Test func routesConfigFileThroughInjectedOpener() throws {
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-group-config-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        var opened: [URL] = []
+        SidebarWorkspaceGroupConfigOpener.openCmuxConfigInEditor(home: home) { opened.append($0) }
+
+        #expect(opened.count == 1)
+        let url = try #require(opened.first)
+        #expect(url.lastPathComponent == "cmux.json")
+        // Resolved beneath the injected home, under .config/cmux.
+        #expect(url.path.hasPrefix(home.path))
+        #expect(url.deletingLastPathComponent().lastPathComponent == "cmux")
+
+        // The opener materializes an empty config when none exists, scoped to
+        // the injected home (no real-filesystem side effects).
+        #expect(FileManager.default.fileExists(atPath: url.path))
+    }
+}


### PR DESCRIPTION
## Summary

The workspace-group **Edit Group Configuration…** action handed `~/.config/cmux/cmux.json` to `NSWorkspace.shared.open`, which routes through Launch Services to the default `.json` handler (e.g. Antigravity) and ignores the user's `preferredEditorCommand` setting. The **Open Config in External Editor** Settings action had the same gap.

Both now route through the existing `PreferredEditorSettings.open(_:)` helper — already the single source of truth used by **Open Cmux Settings File** (`openCmuxSettingsFileInEditor`) and the Settings config window (`ConfigSettingsView.openCurrentSourceInEditor`) — so every cmux-config opener honors the configured editor and falls back to the OS default identically. This eliminates the "this opener forgot to honor the editor setting" class of bug.

`openWorkspaceGroupsDocs()` (web docs → browser) and `revealCurrentSourceInFinder()` (folder → Finder) are intentionally left on `NSWorkspace.shared.open`.

## Tests

Adds `PreferredEditorSettingsTests` (Swift Testing) covering `PreferredEditorSettings.resolvedCommand(defaults:)` through its injected `UserDefaults` seam: returns the configured command (trimmed) when set, and `nil` when unset or blank (the OS-default fallback path). The actual `open` dispatch is Launch-Services/UI level and not unit-testable.

## Localization

No user-facing strings changed — menu/Settings labels are untouched; the change only reroutes the open path and adds internal comments. No `Localizable.xcstrings` update needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5250"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783029272&installation_id=133855650&pr_number=5250&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5250&signature=3b13cfdd1f11e5addb1555a906d3cf793468afbc4a204a24f4d48ac5b001acca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavior fix aligning two open actions with existing editor routing; no auth, data, or security surface changes.
> 
> **Overview**
> **Edit Group Configuration…** and **Open Config in External Editor** no longer call `NSWorkspace.shared.open` on `cmux.json`. They now use **`PreferredEditorSettings.open`**, so `preferredEditorCommand` is honored instead of the system default `.json` app.
> 
> The sidebar opener gains a **`openCmuxConfigInEditor(home:open:)`** seam (production passes `PreferredEditorSettings.open`) so tests can assert the config URL is handed to the editor path. **Docs** and other non-config opens stay on `NSWorkspace`.
> 
> New **`PreferredEditorSettingsTests`** cover `resolvedCommand` (unset/blank → OS default, trimmed command when set). **`SidebarWorkspaceGroupConfigOpenerTests`** verify routing through the injected opener and empty-config materialization under a temp home.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e6f8c3fbea891731499260eb16a042c6701c300. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Group and settings config files now open in the user's preferred editor instead of the OS `.json` default. This aligns all config openers and fixes the "opens in wrong app" bug.

- **Bug Fixes**
  - Route “Edit Group Configuration…” and “Open Config in External Editor” through `PreferredEditorSettings.open(_:)` with OS-default fallback.
  - Add seam `SidebarWorkspaceGroupConfigOpener.openCmuxConfigInEditor(home:open:)` (defaults to `PreferredEditorSettings.open`) to ensure editor routing.
  - Keep docs (`openWorkspaceGroupsDocs`) and Finder reveal (`revealCurrentSourceInFinder`) on `NSWorkspace.shared.open`.
  - Tests: add `PreferredEditorSettingsTests` for `resolvedCommand` and `SidebarWorkspaceGroupConfigOpenerTests` to verify routing.

<sup>Written for commit 6e6f8c3fbea891731499260eb16a042c6701c300. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configuration files now open using your preferred editor (honors configured editor) and will create an empty config file if none exists.

* **Tests**
  * Added tests covering editor preference resolution, trimming/validation of configured commands, and routing the config file open operation through the selected editor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->