### PR TITLE
Fix #5255: shared markdown/file-preview text editor hang (force TextKit 1)

### DIFF
--- a/Sources/Panels/FilePreviewTextEditor.swift
+++ b/Sources/Panels/FilePreviewTextEditor.swift
@@ -122,9 +122,33 @@ extension SavingTextView {
     /// be hundreds of thousands of lines. Selection responsiveness on that content is the reason
     /// this configuration is centralized; see `manaflow-ai/cmux#4576`.
     static func makeFilePreviewTextView() -> SavingTextView {
-        let textView = SavingTextView()
-        // Must run before any `textContainer` access below, or the view locks into TextKit 2.
-        textView.enableLargeDocumentSelectionPerformance()
+        // Build an EXPLICIT TextKit 1 stack so this view is never TextKit 2.
+        //
+        // A default `NSTextView()` is TextKit 2: selection/hit-testing then runs through
+        // `NSTextSelectionNavigation`, whose work is O(N) in line-fragment count, so clicking or
+        // drag-selecting in a large document pegs the main thread inside AppKit's modal
+        // mouse-tracking loop and freezes the whole app (`manaflow-ai/cmux#4576`, `#5255`).
+        //
+        // Merely *reading* `.layoutManager` afterward — the previous mitigation — only drops the
+        // view to TextKit 2 *compatibility* mode: `textLayoutManager` stays non-nil and the slow
+        // selection path remains active (confirmed by live `sample` captures of the hung process).
+        // Constructing the view from an `NSTextStorage` / `NSLayoutManager` / `NSTextContainer`
+        // stack is the only way to guarantee `textLayoutManager == nil`, i.e. a pure TextKit 1 view
+        // whose hit-testing uses `NSLayoutManager` (O(log N) with non-contiguous layout).
+        let textStorage = NSTextStorage()
+        let layoutManager = NSLayoutManager()
+        // Lazy glyph layout so multi-hundred-thousand-line documents still open instantly.
+        layoutManager.allowsNonContiguousLayout = true
+        textStorage.addLayoutManager(layoutManager)
+        let textContainer = NSTextContainer(
+            size: NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+        )
+        // No-wrap baseline; `applyFilePreviewWordWrap(_:scrollView:)` flips this live per the
+        // `fileEditor.wordWrap` setting.
+        textContainer.widthTracksTextView = false
+        layoutManager.addTextContainer(textContainer)
+
+        let textView = SavingTextView(frame: .zero, textContainer: textContainer)
         textView.isEditable = true
         textView.isSelectable = true
         textView.allowsUndo = true
@@ -138,43 +162,12 @@ extension SavingTextView {
         textView.isVerticallyResizable = true
         textView.isHorizontallyResizable = true
         textView.autoresizingMask = [.width]
-        textView.textContainer?.containerSize = NSSize(
-            width: CGFloat.greatestFiniteMagnitude,
-            height: CGFloat.greatestFiniteMagnitude
-        )
-        textView.textContainer?.widthTracksTextView = false
         textView.applyFilePreviewTextEditorInsets()
         return textView
     }
 }
 
 extension NSTextView {
-    /// Drops the text view to TextKit 1 with non-contiguous layout for large-document performance.
-    ///
-    /// TextKit 2's `NSTextSelectionNavigation` hit-tests are O(N) in line-fragment count, so
-    /// drag-selecting deep into a large file pegs the main thread (`manaflow-ai/cmux#4576`).
-    /// Accessing `layoutManager` puts the view in TextKit 1 compatibility mode, where mouse
-    /// hit-testing is roughly O(log N); `allowsNonContiguousLayout` keeps glyph layout lazy so
-    /// large files still open instantly.
-    ///
-    /// Call this before touching `textContainer`/`textLayoutManager` on a freshly created text
-    /// view, otherwise the first TextKit 2 access locks the view into TextKit 2 and
-    /// `layoutManager` returns `nil`.
-    func enableLargeDocumentSelectionPerformance() {
-        guard let layoutManager else {
-            // `layoutManager` is nil only when a TextKit 2 access already locked the view into
-            // TextKit 2, in which case non-contiguous layout was never enabled and large-document
-            // selection regresses to O(N). Release behavior is unchanged (no-op); DEBUG fails loudly
-            // so the call-order violation is caught at its source rather than as a future hang.
-            assertionFailure(
-                "enableLargeDocumentSelectionPerformance() ran after a TextKit 2 access; "
-                    + "call it before touching textContainer/textLayoutManager."
-            )
-            return
-        }
-        layoutManager.allowsNonContiguousLayout = true
-    }
-
     /// Configures the text view and its scroll view for soft line wrapping
     /// (`wrap == true`) or the no-wrap baseline with a horizontal scroller
     /// (`wrap == false`). Idempotent, so it is safe to call on every SwiftUI

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -257,6 +257,7 @@
 		DD62AFF1D95A1D5D1850AC10 /* FilePreviewQuickLookSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A02623202562490B3E88372 /* FilePreviewQuickLookSession.swift */; };
 		C0DE31390000000000000103 /* FilePreviewReviewFeedbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE31390000000000000104 /* FilePreviewReviewFeedbackTests.swift */; };
 		D0B10016A1B2C3D4E5F60001 /* FilePreviewTextEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B10017A1B2C3D4E5F60001 /* FilePreviewTextEditor.swift */; };
+		C0DEFC100000000000000001 /* FilePreviewTextEditorTextKitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEFC100000000000000002 /* FilePreviewTextEditorTextKitTests.swift */; };
 		F11E52270000000000005227 /* FilePreviewWordWrapSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11E52270000000000005228 /* FilePreviewWordWrapSettings.swift */; };
 		A5001445A5001445A5001445 /* FilePreviewWorkspaceOpenSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001444A5001444A5001444 /* FilePreviewWorkspaceOpenSupport.swift */; };
 		FE002103 /* FileSearchRipgrepParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE002003 /* FileSearchRipgrepParserTests.swift */; };
@@ -884,6 +885,7 @@
 		0A02623202562490B3E88372 /* FilePreviewQuickLookSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/FilePreviewQuickLookSession.swift; sourceTree = "<group>"; };
 		C0DE31390000000000000104 /* FilePreviewReviewFeedbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePreviewReviewFeedbackTests.swift; sourceTree = "<group>"; };
 		D0B10017A1B2C3D4E5F60001 /* FilePreviewTextEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/FilePreviewTextEditor.swift; sourceTree = "<group>"; };
+		C0DEFC100000000000000002 /* FilePreviewTextEditorTextKitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePreviewTextEditorTextKitTests.swift; sourceTree = "<group>"; };
 		F11E52270000000000005228 /* FilePreviewWordWrapSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/FilePreviewWordWrapSettings.swift; sourceTree = "<group>"; };
 		A5001444A5001444A5001444 /* FilePreviewWorkspaceOpenSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/FilePreviewWorkspaceOpenSupport.swift; sourceTree = "<group>"; };
 			FE002003 /* FileSearchRipgrepParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSearchRipgrepParserTests.swift; sourceTree = "<group>"; };
@@ -1839,6 +1841,7 @@
 				A5001435A5001435A5001435 /* FilePreviewPDFThumbnailSidebarTests.swift */,
 				D3664001D3664001D3664001 /* MarkdownPanelTests.swift */,
 				C0DE31390000000000000104 /* FilePreviewReviewFeedbackTests.swift */,
+				C0DEFC100000000000000002 /* FilePreviewTextEditorTextKitTests.swift */,
 				D7AB00000000000000000010 /* AppDelegateMoveTabToNewWorkspaceTests.swift */,
 				17C9F5BA0DD14EDC8C3E5002 /* MainWindowVisibilityControllerTests.swift */,
 				A11EAA000000000000000001 /* AppearanceSettingsTests.swift */,
@@ -2708,6 +2711,7 @@
 				C0DE49950000000000000001 /* FilePreviewKindResolverTests.swift in Sources */,
 				A5001436A5001436A5001436 /* FilePreviewPDFThumbnailSidebarTests.swift in Sources */,
 				C0DE31390000000000000103 /* FilePreviewReviewFeedbackTests.swift in Sources */,
+				C0DEFC100000000000000001 /* FilePreviewTextEditorTextKitTests.swift in Sources */,
 				FE002103 /* FileSearchRipgrepParserTests.swift in Sources */,
 				C35610000000000000000001 /* FinderFileDropRegressionTests.swift in Sources */,
 				C0DEFB300000000000000001 /* FocusSurfaceBroadcasterTests.swift in Sources */,

--- a/cmuxTests/FilePreviewTextEditorTextKitTests.swift
+++ b/cmuxTests/FilePreviewTextEditorTextKitTests.swift
@@ -1,0 +1,48 @@
+import AppKit
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Regression coverage for the note / file-preview editor TextKit hang (issue #5255,
+/// same root-cause family as #4576).
+///
+/// The freeze is an AppKit modal mouse-tracking loop: `NSTextView.mouseDown` ->
+/// `_bellerophonTrackMouseWithMouseDownEvent` -> `NSTextSelectionNavigation`
+/// `.textSelectionsInteractingAtPoint` (TextKit 2) -> recursive O(N)
+/// `synchronizeTextLayoutManagers`, which pegs the main thread at 100% CPU and freezes
+/// the whole app. That TextKit 2 selection path is taken whenever the view has a live
+/// `textLayoutManager`.
+///
+/// The previous mitigation only *read* `.layoutManager`, which merely puts the view in
+/// TextKit 2 *compatibility* mode — `textLayoutManager` stays non-nil and the slow
+/// selection path remains active (proven by live `sample` captures of the hung process).
+/// The structural invariant that actually prevents the hang is that the editor must be a
+/// **pure TextKit 1** view, i.e. `textLayoutManager == nil`.
+///
+/// Note: the existing timing test (`testLargeFileSelectionHitTestStaysResponsive`)
+/// exercises `characterIndexForInsertion`, which uses the fast `NSLayoutManager` path
+/// even in compatibility mode, so it cannot detect a regression back to the TextKit 2
+/// selection path. This invariant test can, with no UI or timing dependency.
+@MainActor
+@Suite("File preview editor TextKit backing")
+struct FilePreviewTextEditorTextKitTests {
+    @Test("makeFilePreviewTextView is a pure TextKit 1 view (no TextKit 2 selection path)")
+    func editorIsPureTextKit1() {
+        let textView = SavingTextView.makeFilePreviewTextView()
+
+        // Primary invariant. A TextKit 2 view — or one only dropped to TextKit 2
+        // compatibility mode by reading `.layoutManager` — exposes a non-nil
+        // `textLayoutManager`, and its selection runs through NSTextSelectionNavigation:
+        // the O(N)-per-hit-test main-thread hang. A pure TextKit 1 view has nil here.
+        #expect(textView.textLayoutManager == nil)
+
+        // The TextKit 1 stack must be live, with lazy (non-contiguous) glyph layout so
+        // multi-hundred-thousand-line documents still open instantly.
+        #expect(textView.layoutManager != nil)
+        #expect(textView.layoutManager?.allowsNonContiguousLayout == true)
+    }
+}


### PR DESCRIPTION
## Issue

Fixes #5255 (same root-cause family as the closed #4576).

Clicking or drag-selecting in the shared plain-text editor hard-hangs the **entire app**: main thread pegs at ~100% CPU inside AppKit's **modal** mouse-tracking loop (`_bellerophonTrackMouseWithMouseDownEvent`), UI frozen, force-quit required. Live `sample` captures show the hot path is TextKit 2 selection: `NSTextView.mouseDown` → `NSTextSelectionNavigation.textSelectionsInteractingAtPoint` → recursive O(N) `NSTextContentStorage.synchronizeTextLayoutManagers`.

## This is a general editor bug, not a notes bug

The hang lives in the **shared** `SavingTextView` / `FilePreviewTextEditor`, which backs three surfaces — all reproduce the same freeze:

1. **Markdown** panel in text/edit mode (`MarkdownPanel.setDisplayMode(.text)`) — any `.md` doc
2. **Note** surface — a note is just a `MarkdownPanel` (with a `noteSlug`), so it inherits the bug
3. **File preview** of a large text file (`FilePreviewPanel`, the original #4576 surface)

A note is one *trigger*, not the cause. This PR is based on `main` and is independent of the note-surface branch (#4332); the change is confined to `Sources/Panels/FilePreviewTextEditor.swift`.

## Root cause

`makeFilePreviewTextView()` created a default `NSTextView()` — which is **TextKit 2** — then called `enableLargeDocumentSelectionPerformance()`, which merely *reads* `.layoutManager`. That only drops the view to TextKit 2 **compatibility mode**: `textLayoutManager` stays non-nil and selection keeps using `NSTextSelectionNavigation` (O(N) per hit-test). The #4576 mitigation therefore never actually engaged — proven by the live hung-stack still running TextKit 2 selection.

## Fix

Construct `SavingTextView` from an **explicit TextKit 1 stack** (`NSTextStorage` → `NSLayoutManager` → `NSTextContainer` → `init(frame:textContainer:)`) so `textLayoutManager == nil` is **guaranteed**. Hit-testing then routes through `NSLayoutManager` (O(log N) with non-contiguous layout). `allowsNonContiguousLayout` is kept so large docs still open instantly; `applyFilePreviewWordWrap` still drives wrapping. The now-dead `.layoutManager`-read mitigation is removed.

Because the fix is in the shared editor factory, it covers all three surfaces at once and does not touch `MarkdownPanel.swift` / `MarkdownPanelView.swift`.

## Tests (two-commit red/green)

`cmuxTests/FilePreviewTextEditorTextKitTests.swift` (Swift Testing, wired into the test target) asserts the structural invariant:

```
SavingTextView.makeFilePreviewTextView().textLayoutManager == nil
```

- **Commit 1 (red):** test only — fails on current code (compatibility mode → `textLayoutManager` non-nil).
- **Commit 2 (green):** the explicit TextKit 1 fix — test passes.

Unlike the existing `testLargeFileSelectionHitTestStaysResponsive`, which exercises the fast `characterIndexForInsertion` path (cheap even in compatibility mode) and so **cannot** detect a regression to TextKit 2 selection, this invariant catches it directly, with no UI or timing dependency.

> Note: TextKit compatibility-mode semantics can vary by macOS version; the post-fix invariant (`textLayoutManager == nil` from an explicit TextKit 1 stack) holds unconditionally regardless.

## Verification

Real-app verification (open a large markdown doc in edit mode / a big file preview, click + drag-select, confirm no freeze) will happen when the dev build is launched. By construction, `makeFilePreviewTextView().textLayoutManager == nil`, so selection uses the TextKit 1 `NSLayoutManager` path — no `NSTextSelectionNavigation`, no `synchronizeTextLayoutManagers`, no O(N) main-thread hang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5257"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783040145&installation_id=133855650&pr_number=5257&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5257&signature=b7dbea5ccb1217fdc95255dabb016b5a9d4e5d64802fc1c839a8128c8aaf9c2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core AppKit text view construction for all markdown/notes/file-preview editing; behavior change is narrow but user-facing if TextKit 1 semantics differ from TK2 on some macOS versions.
> 
> **Overview**
> Fixes a **main-thread freeze** when clicking or drag-selecting in large plain-text editors (file preview, markdown edit mode, notes) by ensuring the shared `SavingTextView` factory builds a **pure TextKit 1** view instead of a default TextKit 2 `NSTextView`.
> 
> **`makeFilePreviewTextView()`** now wires `NSTextStorage` → `NSLayoutManager` (with `allowsNonContiguousLayout`) → `NSTextContainer` → `SavingTextView(frame:textContainer:)`, so `textLayoutManager` stays nil and selection uses the fast `NSLayoutManager` path. The old **`enableLargeDocumentSelectionPerformance()`** helper (reading `.layoutManager` only for TK2 compatibility mode) is **removed**.
> 
> Adds **`FilePreviewTextEditorTextKitTests`** asserting `textLayoutManager == nil` and non-contiguous layout—structural regression coverage the existing timing hit-test test cannot provide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a86c58363f8f93aee9b1915112748613390c048a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #5255 by forcing the shared plain‑text editor (markdown text mode, notes, and file preview) to use TextKit 1, removing the hang when clicking or drag‑selecting in large files. Adds an invariant test to ensure the editor stays on TextKit 1.

- **Bug Fixes**
  - Build an explicit TextKit 1 stack (`NSTextStorage` + `NSLayoutManager` + `NSTextContainer`) in `SavingTextView.makeFilePreviewTextView()` so `textLayoutManager` is nil and selection uses `NSLayoutManager` (fast).
  - Keep `allowsNonContiguousLayout` and existing word‑wrap behavior; remove `enableLargeDocumentSelectionPerformance()` which only put the view in TextKit 2 compatibility mode.

<sup>Written for commit a86c58363f8f93aee9b1915112748613390c048a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file preview text editor performance and reliability by ensuring consistent TextKit implementation and optimized layout handling for large documents.

* **Tests**
  * Added regression test to verify text editor rendering stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->