### PR TITLE
iOS: localize push notification strings

### DIFF
--- a/Packages/CmuxMobileAuth/Sources/CmuxMobileAuth/AuthManager.swift
+++ b/Packages/CmuxMobileAuth/Sources/CmuxMobileAuth/AuthManager.swift
@@ -396,6 +396,8 @@ public final class AuthManager {
     }
 
     public func signOut() async {
+        await NotificationManager.shared.unregisterFromServer()
+
         do {
             try await stack.signOut()
         } catch {
@@ -406,7 +408,6 @@ public final class AuthManager {
         clearDebugPasswordCredentials()
         #endif
         clearAuthState()
-        await NotificationManager.shared.unregisterFromServer()
     }
 
     public func getAccessToken() async throws -> String {

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -885,6 +885,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     }
 
     private var keyboardHeight: CGFloat = 0
+    private var isDismantled = false
     /// Whether the hidden terminal input should become first responder when the surface attaches to a window.
     public var autoFocusOnWindowAttach = true
 
@@ -1065,6 +1066,11 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         liveAnchormuxLog("surface.didMoveToWindow window=\(window != nil)")
         syncSurfaceVisibility()
         if window != nil {
+            isDismantled = false
+            #if DEBUG
+            accessibilityIdentifier = "MobileTerminalSurface"
+            isAccessibilityElement = true
+            #endif
             setNeedsGeometrySync()
             setFocus(true)
             if autoFocusOnWindowAttach {
@@ -1072,9 +1078,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             }
             startDisplayLink()
         } else {
-            resignInput()
-            stopDisplayLink()
-            setFocus(false)
+            prepareForReuseAfterDetach()
         }
     }
 
@@ -1133,7 +1137,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             }
             #endif
             DispatchQueue.main.async {
-                guard let self else { return }
+                guard let self, !self.isDismantled else { return }
                 self.needsDraw = true
                 if let cursorVisibilityDelta, cursorVisibilityDelta != self.hostCursorVisible {
                     self.hostCursorVisible = cursorVisibilityDelta
@@ -1249,6 +1253,22 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         guard wasFirstResponder, keyboardHeight != 0 else { return }
         keyboardHeight = 0
         setNeedsGeometrySync()
+    }
+
+    /// Stops user-visible and accessibility output from a surface SwiftUI has removed.
+    public func prepareForDismantle() {
+        isDismantled = true
+        prepareForReuseAfterDetach()
+    }
+
+    private func prepareForReuseAfterDetach() {
+        resignInput()
+        stopDisplayLink()
+        setFocus(false)
+        #if DEBUG
+        accessibilityLabel = nil
+        isAccessibilityElement = false
+        #endif
     }
 
     func updateRemotePlatform(_ platform: RemotePlatform) {

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -885,7 +885,8 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     }
 
     private var keyboardHeight: CGFloat = 0
-    var autoFocusOnWindowAttach = true
+    /// Whether the hidden terminal input should become first responder when the surface attaches to a window.
+    public var autoFocusOnWindowAttach = true
 
     @objc private func handleKeyboardWillShow(_ notification: Notification) {
         guard let frameEnd = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect,

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -1229,10 +1229,16 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         inputProxy.becomeFirstResponder()
     }
 
+    /// Resigns the currently focused terminal input proxy, if any.
+    ///
+    /// Use before presenting SwiftUI chrome over the terminal so UIKit releases
+    /// the hidden text input and the terminal can recalculate full-height
+    /// geometry after the keyboard leaves.
     public static func resignActiveInput() {
         activeInputSurface?.resignInput()
     }
 
+    /// Resigns this surface's hidden text input and clears keyboard geometry.
     public func resignInput() {
         let wasFirstResponder = inputProxy.isFirstResponder
         inputProxy.resignFirstResponder()

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -1601,8 +1601,12 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             if lagMs > 150 { liveAnchormuxLog("oq.render.LAG \(Int(lagMs))ms") }
             ghostty_surface_render_now(surface)
             DispatchQueue.main.async {
-                guard let self, !self.isDismantled else { return }
+                guard let self else { return }
                 self.renderInFlight = false
+                guard !self.isDismantled else {
+                    self.needsAnotherRender = false
+                    return
+                }
                 if self.needsAnotherRender {
                     self.needsAnotherRender = false
                     self.requestRender()

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -1085,7 +1085,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     private var lastProcessOutputLogTime: CFTimeInterval = 0
 
     public func processOutput(_ data: Data) {
-        guard let surface else { return }
+        guard let surface, !isDismantled else { return }
         #if DEBUG
         if lastInputTimestamp > 0 {
             let elapsed = (CACurrentMediaTime() - lastInputTimestamp) * 1000.0
@@ -1585,7 +1585,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// gates this on `needsDraw`/`pendingRenderFrames`, so it is not a
     /// per-frame loop that would flood the main queue with present blocks.
     private func requestRender() {
-        guard let surface else { return }
+        guard let surface, !isDismantled else { return }
         // Coalesce: never let more than one render_now sit on the serial queue.
         // (Called on main from the display link.)
         if renderInFlight {
@@ -1601,7 +1601,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             if lagMs > 150 { liveAnchormuxLog("oq.render.LAG \(Int(lagMs))ms") }
             ghostty_surface_render_now(surface)
             DispatchQueue.main.async {
-                guard let self else { return }
+                guard let self, !self.isDismantled else { return }
                 self.renderInFlight = false
                 if self.needsAnotherRender {
                     self.needsAnotherRender = false
@@ -2073,7 +2073,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     }
 
     func drawForWakeup() {
-        guard surface != nil, window != nil else { return }
+        guard surface != nil, window != nil, !isDismantled else { return }
         // Don't call `ghostty_surface_refresh` here: that wakes the renderer
         // thread to present asynchronously (`setSurface` → `dispatch_async` to
         // main → size-guard discard), which both blanks frames and competes

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -571,6 +571,7 @@ public enum TerminalInputAccessoryAction: Int, CaseIterable {
 }
 
 public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
+    private static weak var activeInputSurface: GhosttySurfaceView?
     private weak var runtime: GhosttyRuntime?
     private weak var delegate: GhosttySurfaceViewDelegate?
     private let fontSize: Float32
@@ -796,7 +797,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             self?.performFontZoom(direction)
         }
         inputProxy.onHideKeyboard = { [weak self] in
-            self?.inputProxy.resignFirstResponder()
+            self?.resignInput()
         }
         inputProxy.accessoryLayoutInsetsProvider = { [weak self] in
             guard let self,
@@ -1070,6 +1071,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             }
             startDisplayLink()
         } else {
+            resignInput()
             stopDisplayLink()
             setFocus(false)
         }
@@ -1221,9 +1223,25 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     @objc
     func focusInput() {
         onFocusInputRequestedForTesting?()
+        Self.activeInputSurface = self
         setNeedsGeometrySync()
         inputProxy.updateAccessoryLayoutInsets()
         inputProxy.becomeFirstResponder()
+    }
+
+    public static func resignActiveInput() {
+        activeInputSurface?.resignInput()
+    }
+
+    public func resignInput() {
+        let wasFirstResponder = inputProxy.isFirstResponder
+        inputProxy.resignFirstResponder()
+        if Self.activeInputSurface === self {
+            Self.activeInputSurface = nil
+        }
+        guard wasFirstResponder, keyboardHeight != 0 else { return }
+        keyboardHeight = 0
+        setNeedsGeometrySync()
     }
 
     func updateRemotePlatform(_ platform: RemotePlatform) {

--- a/Sources/Mobile/MobileTerminalByteTee.swift
+++ b/Sources/Mobile/MobileTerminalByteTee.swift
@@ -26,7 +26,7 @@ private let mobileTerminalByteTeeLog = Logger(
 /// publish handles the hop to the main `MobileHostService.emitEvent`.
 @MainActor
 final class MobileTerminalByteTee {
-    static let shared = MobileTerminalByteTee()
+    nonisolated static let shared = MobileTerminalByteTee()
 
     private struct SurfaceState {
         /// Monotonic byte-stream sequence. Each emitted chunk advances by
@@ -45,7 +45,7 @@ final class MobileTerminalByteTee {
         qos: .userInitiated
     )
 
-    private init() {}
+    private nonisolated init() {}
 
     /// Non-isolated entry point called from the C tee trampoline. Safe
     /// to invoke from any thread.

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -10277,7 +10277,7 @@ class TerminalController {
     /// freshly-attached device gets the live screen immediately, and deeper
     /// history is a follow-up (incremental scrollback paging on scroll-to-top).
     /// Tune up to trade replay payload size for more attach-time history.
-    static let mobileReplayScrollbackLineBudget = 1
+    nonisolated static let mobileReplayScrollbackLineBudget = 1
 
     private func mobileTerminalRenderGridFrame(
         terminalPanel: TerminalPanel,

--- a/ios/cmux/CmuxAppDelegate.swift
+++ b/ios/cmux/CmuxAppDelegate.swift
@@ -33,7 +33,7 @@ final class CmuxAppDelegate: NSObject, UIApplicationDelegate, UNUserNotification
         willPresent notification: UNNotification
     ) async -> UNNotificationPresentationOptions {
         let ids = Self.cmuxIDs(from: notification.request.content.userInfo)
-        let present = await MobilePushCoordinator.shared.shouldPresentInForeground(
+        let present = MobilePushCoordinator.shared.shouldPresentInForeground(
             workspaceId: ids.workspaceId,
             surfaceId: ids.surfaceId
         )
@@ -45,7 +45,7 @@ final class CmuxAppDelegate: NSObject, UIApplicationDelegate, UNUserNotification
         didReceive response: UNNotificationResponse
     ) async {
         let ids = Self.cmuxIDs(from: response.notification.request.content.userInfo)
-        await MobilePushCoordinator.shared.handleTap(
+        MobilePushCoordinator.shared.handleTap(
             workspaceId: ids.workspaceId,
             surfaceId: ids.surfaceId
         )

--- a/ios/cmux/CmuxAppDelegate.swift
+++ b/ios/cmux/CmuxAppDelegate.swift
@@ -28,27 +28,31 @@ final class CmuxAppDelegate: NSObject, UIApplicationDelegate, UNUserNotification
         NSLog("cmux.push registration failed: %@", error.localizedDescription)
     }
 
-    func userNotificationCenter(
+    nonisolated func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         willPresent notification: UNNotification
     ) async -> UNNotificationPresentationOptions {
         let ids = Self.cmuxIDs(from: notification.request.content.userInfo)
-        let present = MobilePushCoordinator.shared.shouldPresentInForeground(
-            workspaceId: ids.workspaceId,
-            surfaceId: ids.surfaceId
-        )
+        let present = await MainActor.run {
+            MobilePushCoordinator.shared.shouldPresentInForeground(
+                workspaceId: ids.workspaceId,
+                surfaceId: ids.surfaceId
+            )
+        }
         return present ? [.banner, .sound, .badge] : []
     }
 
-    func userNotificationCenter(
+    nonisolated func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         didReceive response: UNNotificationResponse
     ) async {
         let ids = Self.cmuxIDs(from: response.notification.request.content.userInfo)
-        MobilePushCoordinator.shared.handleTap(
-            workspaceId: ids.workspaceId,
-            surfaceId: ids.surfaceId
-        )
+        await MainActor.run {
+            MobilePushCoordinator.shared.handleTap(
+                workspaceId: ids.workspaceId,
+                surfaceId: ids.surfaceId
+            )
+        }
     }
 
     private nonisolated static func cmuxIDs(

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -1,40 +1,6 @@
 {
   "sourceLanguage": "en",
   "strings": {
-    "CMUX_PUSH_REDACTED_BODY": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "An agent needs your attention"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "エージェントに確認が必要です"
-          }
-        }
-      }
-    },
-    "CMUX_PUSH_REDACTED_TITLE": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "cmux"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "cmux"
-          }
-        }
-      }
-    },
     "auth.error.apple_config": {
       "extractionState": "manual",
       "localizations": {

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -1,6 +1,40 @@
 {
   "sourceLanguage": "en",
   "strings": {
+    "CMUX_PUSH_REDACTED_BODY": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "An agent needs your attention"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エージェントに確認が必要です"
+          }
+        }
+      }
+    },
+    "CMUX_PUSH_REDACTED_TITLE": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux"
+          }
+        }
+      }
+    },
     "auth.error.apple_config": {
       "extractionState": "manual",
       "localizations": {
@@ -2445,6 +2479,40 @@
           "stringUnit": {
             "state": "translated",
             "value": "ターミナル画面を起動しています。"
+          }
+        }
+      }
+    },
+    "mobile.notifications.disable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turn Off Agent Notifications"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エージェント通知をオフにする"
+          }
+        }
+      }
+    },
+    "mobile.notifications.enable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notify Me About Agents"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エージェント通知を受け取る"
           }
         }
       }

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileShellStore.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileShellStore.swift
@@ -666,21 +666,27 @@ public final class CMUXMobileShellStore {
         selectedTerminalID = workspace.terminals.first?.id
     }
 
-    public func createTerminal() {
+    public func createTerminal(in workspaceID: MobileWorkspacePreview.ID? = nil) {
+        let targetWorkspaceID = workspaceID ?? selectedWorkspace?.id
         guard remoteClient == nil else {
+            guard let targetWorkspaceID else { return }
             guard createTerminalTask == nil else { return }
+            selectedWorkspaceID = targetWorkspaceID
+            syncSelectedTerminalForWorkspace()
             let taskID = UUID()
             createTerminalTaskID = taskID
             createTerminalTask = Task { @MainActor [weak self] in
                 defer { self?.clearCreateTerminalTask(id: taskID) }
                 guard let self else { return }
-                await self.createRemoteTerminal()
+                await self.createRemoteTerminal(in: targetWorkspaceID)
             }
             return
         }
-        guard let workspaceIndex = workspaces.firstIndex(where: { $0.id == selectedWorkspace?.id }) else {
+        guard let targetWorkspaceID,
+              let workspaceIndex = workspaces.firstIndex(where: { $0.id == targetWorkspaceID }) else {
             return
         }
+        selectedWorkspaceID = targetWorkspaceID
         let terminalIndex = workspaces[workspaceIndex].terminals.count + 1
         let terminal = MobileTerminalPreview(
             id: .init(rawValue: "\(workspaces[workspaceIndex].id.rawValue)-terminal-\(terminalIndex)"),
@@ -1148,10 +1154,9 @@ public final class CMUXMobileShellStore {
         }
     }
 
-    private func createRemoteTerminal() async {
-        guard let client = remoteClient,
-              let workspaceID = selectedWorkspace?.id.rawValue else { return }
-        let requestedWorkspaceID = MobileWorkspacePreview.ID(rawValue: workspaceID)
+    private func createRemoteTerminal(in requestedWorkspaceID: MobileWorkspacePreview.ID) async {
+        guard let client = remoteClient else { return }
+        let workspaceID = requestedWorkspaceID.rawValue
         let generation = connectionGeneration
         do {
             let resultData = try await client.sendRequest(
@@ -2087,4 +2092,3 @@ private extension MobileWorkspacePreview {
         terminals.contains(where: \.isReady)
     }
 }
-

--- a/ios/cmuxPackage/Sources/cmuxFeature/Terminal/GhosttySurfaceRepresentable.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/Terminal/GhosttySurfaceRepresentable.swift
@@ -45,6 +45,7 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
     }
 
     static func dismantleUIView(_ uiView: UIView, coordinator: Coordinator) {
+        (uiView as? GhosttySurfaceView)?.resignInput()
         coordinator.detach()
     }
 

--- a/ios/cmuxPackage/Sources/cmuxFeature/Terminal/GhosttySurfaceRepresentable.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/Terminal/GhosttySurfaceRepresentable.swift
@@ -14,6 +14,7 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
     let surfaceID: String
     let store: CMUXMobileShellStore
     let fontSize: Float32
+    let autoFocusOnWindowAttach: Bool
 
     func makeCoordinator() -> Coordinator {
         Coordinator(surfaceID: surfaceID, store: store)
@@ -36,12 +37,13 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
             delegate: context.coordinator,
             fontSize: fontSize
         )
+        view.autoFocusOnWindowAttach = autoFocusOnWindowAttach
         context.coordinator.attach(surfaceView: view)
         return view
     }
 
     func updateUIView(_ uiView: UIView, context: Context) {
-        // No prop-driven mutations yet; bytes flow via the byte sink.
+        (uiView as? GhosttySurfaceView)?.autoFocusOnWindowAttach = autoFocusOnWindowAttach
     }
 
     static func dismantleUIView(_ uiView: UIView, coordinator: Coordinator) {

--- a/ios/cmuxPackage/Sources/cmuxFeature/Terminal/GhosttySurfaceRepresentable.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/Terminal/GhosttySurfaceRepresentable.swift
@@ -47,7 +47,7 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
     }
 
     static func dismantleUIView(_ uiView: UIView, coordinator: Coordinator) {
-        (uiView as? GhosttySurfaceView)?.resignInput()
+        (uiView as? GhosttySurfaceView)?.prepareForDismantle()
         coordinator.detach()
     }
 

--- a/ios/cmuxPackage/Sources/cmuxFeature/WorkspaceViews.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/WorkspaceViews.swift
@@ -20,6 +20,8 @@ struct WorkspaceShellView: View {
     @State private var pendingCompactCreateNavigationWorkspaceIDs: Set<MobileWorkspacePreview.ID>?
     @State private var hasPresentedSplitDetail = false
     @State private var splitColumnVisibility: NavigationSplitViewVisibility = .automatic
+    @State private var suppressNextTerminalAutoFocus = false
+    @State private var terminalAutoFocusSuppressedSurfaceIDs: Set<String> = []
     #if os(iOS)
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Environment(\.verticalSizeClass) private var verticalSizeClass
@@ -133,6 +135,7 @@ struct WorkspaceShellView: View {
 
     private func selectWorkspace(_ id: MobileWorkspacePreview.ID) {
         pendingCompactCreateNavigationWorkspaceIDs = nil
+        suppressNextTerminalAutoFocus = false
         store.selectedWorkspaceID = id
         if usesCompactStack, compactNavigationPath.last != id {
             compactNavigationPath = [id]
@@ -175,7 +178,9 @@ struct WorkspaceShellView: View {
             store: store,
             workspaceID: workspaceID,
             createWorkspace: createWorkspace,
-            safeAreaContext: safeAreaContext
+            safeAreaContext: safeAreaContext,
+            suppressNextTerminalAutoFocus: $suppressNextTerminalAutoFocus,
+            terminalAutoFocusSuppressedSurfaceIDs: $terminalAutoFocusSuppressedSurfaceIDs
         )
     }
 }
@@ -233,6 +238,8 @@ private struct WorkspaceDetailContainer: View {
     let workspaceID: MobileWorkspacePreview.ID?
     let createWorkspace: () -> Void
     let safeAreaContext: MobileTerminalSafeAreaContext
+    @Binding var suppressNextTerminalAutoFocus: Bool
+    @Binding var terminalAutoFocusSuppressedSurfaceIDs: Set<String>
 
     private var workspace: MobileWorkspacePreview? {
         if let workspaceID {
@@ -255,7 +262,9 @@ private struct WorkspaceDetailContainer: View {
                 createTerminal: store.createTerminal,
                 reportTerminalViewport: store.reportTerminalViewport,
                 sendTerminalInput: store.sendTerminalRawInput,
-                safeAreaContext: safeAreaContext
+                safeAreaContext: safeAreaContext,
+                suppressNextTerminalAutoFocus: $suppressNextTerminalAutoFocus,
+                terminalAutoFocusSuppressedSurfaceIDs: $terminalAutoFocusSuppressedSurfaceIDs
             )
             .onAppear {
                 if store.selectedWorkspaceID != workspace.id {
@@ -587,9 +596,9 @@ struct WorkspaceDetailView: View {
     let reportTerminalViewport: (MobileWorkspacePreview.ID, MobileTerminalPreview.ID, MobileTerminalViewportSize) -> Void
     let sendTerminalInput: (String) -> Void
     let safeAreaContext: MobileTerminalSafeAreaContext
+    @Binding var suppressNextTerminalAutoFocus: Bool
+    @Binding var terminalAutoFocusSuppressedSurfaceIDs: Set<String>
     @State private var isTerminalPickerPresented = false
-    @State private var suppressNextTerminalAutoFocus = false
-    @State private var terminalAutoFocusSuppressedSurfaceIDs: Set<String> = []
 
     private var selectedTerminal: MobileTerminalPreview? {
         workspace.terminals.first { $0.id == selectedTerminalID } ?? workspace.terminals.first

--- a/ios/cmuxPackage/Sources/cmuxFeature/WorkspaceViews.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/WorkspaceViews.swift
@@ -259,7 +259,7 @@ private struct WorkspaceDetailContainer: View {
                     set: { store.selectTerminal($0) }
                 ),
                 createWorkspace: createWorkspace,
-                createTerminal: store.createTerminal,
+                createTerminal: { store.createTerminal(in: workspace.id) },
                 reportTerminalViewport: store.reportTerminalViewport,
                 sendTerminalInput: store.sendTerminalRawInput,
                 safeAreaContext: safeAreaContext,

--- a/ios/cmuxPackage/Sources/cmuxFeature/WorkspaceViews.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/WorkspaceViews.swift
@@ -794,6 +794,7 @@ struct WorkspaceDetailView: View {
     }
 
     private func dismissTerminalKeyboardForChrome() {
+        GhosttySurfaceView.resignActiveInput()
         dismissKeyboard()
     }
 }

--- a/ios/cmuxPackage/Sources/cmuxFeature/WorkspaceViews.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/WorkspaceViews.swift
@@ -606,6 +606,7 @@ struct WorkspaceDetailView: View {
                     store: store,
                     fontSize: MobileTerminalFontPreference.defaultSize
                 )
+                .id(terminalID)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
                 .background(TerminalPalette.background)
             } else {

--- a/ios/cmuxPackage/Sources/cmuxFeature/WorkspaceViews.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/WorkspaceViews.swift
@@ -583,6 +583,8 @@ struct WorkspaceDetailView: View {
     let sendTerminalInput: (String) -> Void
     let safeAreaContext: MobileTerminalSafeAreaContext
     @State private var isTerminalPickerPresented = false
+    @State private var suppressNextTerminalAutoFocus = false
+    @State private var terminalAutoFocusSuppressedSurfaceIDs: Set<String> = []
 
     private var selectedTerminal: MobileTerminalPreview? {
         workspace.terminals.first { $0.id == selectedTerminalID } ?? workspace.terminals.first
@@ -604,7 +606,8 @@ struct WorkspaceDetailView: View {
                 GhosttySurfaceRepresentable(
                     surfaceID: terminalID,
                     store: store,
-                    fontSize: MobileTerminalFontPreference.defaultSize
+                    fontSize: MobileTerminalFontPreference.defaultSize,
+                    autoFocusOnWindowAttach: !terminalAutoFocusSuppressedSurfaceIDs.contains(terminalID)
                 )
                 .id(terminalID)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
@@ -632,6 +635,9 @@ struct WorkspaceDetailView: View {
         .background(TerminalPalette.background)
         #endif
         .navigationTitle(workspace.name)
+        .onChange(of: selectedTerminal?.id) { _, terminalID in
+            suppressPendingTerminalAutoFocusIfNeeded(for: terminalID)
+        }
         .mobileTerminalNavigationChrome()
         .toolbar {
             #if os(iOS)
@@ -772,29 +778,41 @@ struct WorkspaceDetailView: View {
 
     private func createWorkspaceFromToolbar() {
         dismissTerminalKeyboardForChrome()
+        suppressNextTerminalAutoFocus = true
         createWorkspace()
     }
 
     private func createWorkspaceFromTerminalPicker() {
         dismissTerminalKeyboardForChrome()
         isTerminalPickerPresented = false
+        suppressNextTerminalAutoFocus = true
         createWorkspace()
     }
 
     private func createTerminalFromToolbar() {
         dismissTerminalKeyboardForChrome()
         isTerminalPickerPresented = false
+        suppressNextTerminalAutoFocus = true
         createTerminal()
     }
 
     private func selectTerminalFromPicker(_ terminalID: MobileTerminalPreview.ID) {
         dismissTerminalKeyboardForChrome()
         isTerminalPickerPresented = false
+        terminalAutoFocusSuppressedSurfaceIDs.insert(terminalID.rawValue)
+        suppressNextTerminalAutoFocus = false
         selectedTerminalID = terminalID
     }
 
     private func dismissTerminalKeyboardForChrome() {
         GhosttySurfaceView.resignActiveInput()
         dismissKeyboard()
+    }
+
+    private func suppressPendingTerminalAutoFocusIfNeeded(for terminalID: MobileTerminalPreview.ID?) {
+        guard suppressNextTerminalAutoFocus,
+              let terminalID else { return }
+        terminalAutoFocusSuppressedSurfaceIDs.insert(terminalID.rawValue)
+        suppressNextTerminalAutoFocus = false
     }
 }

--- a/ios/cmuxPackage/Sources/cmuxFeature/WorkspaceViews.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/WorkspaceViews.swift
@@ -649,6 +649,9 @@ struct WorkspaceDetailView: View {
         .background(TerminalPalette.background)
         #endif
         .navigationTitle(workspace.name)
+        .onAppear {
+            suppressPendingTerminalAutoFocusIfNeeded(for: selectedTerminal?.id)
+        }
         .onChange(of: selectedTerminal?.id) { _, terminalID in
             suppressPendingTerminalAutoFocusIfNeeded(for: terminalID)
         }

--- a/ios/cmuxPackage/Sources/cmuxFeature/WorkspaceViews.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/WorkspaceViews.swift
@@ -288,6 +288,7 @@ struct WorkspaceListView: View {
     var signOut: (() -> Void)?
     @State private var searchText = ""
     @State private var showingShortcutsSettings = false
+    @State private var notificationsEnabled = false
 
     private var filteredWorkspaces: [MobileWorkspacePreview] {
         let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -340,6 +341,9 @@ struct WorkspaceListView: View {
         .sheet(isPresented: $showingShortcutsSettings) {
             TerminalShortcutsSettingsView()
         }
+        .onAppear {
+            notificationsEnabled = MobilePushCoordinator.shared.isEnabled
+        }
         #endif
     }
 
@@ -365,18 +369,19 @@ struct WorkspaceListView: View {
             #if os(iOS)
             Button {
                 Task {
-                    if MobilePushCoordinator.shared.isEnabled {
+                    if notificationsEnabled {
                         await MobilePushCoordinator.shared.disable()
+                        notificationsEnabled = false
                     } else {
-                        _ = await MobilePushCoordinator.shared.enable()
+                        notificationsEnabled = await MobilePushCoordinator.shared.enable()
                     }
                 }
             } label: {
                 Label(
-                    MobilePushCoordinator.shared.isEnabled
+                    notificationsEnabled
                         ? L10n.string("mobile.notifications.disable", defaultValue: "Turn Off Agent Notifications")
                         : L10n.string("mobile.notifications.enable", defaultValue: "Notify Me About Agents"),
-                    systemImage: MobilePushCoordinator.shared.isEnabled ? "bell.slash" : "bell"
+                    systemImage: notificationsEnabled ? "bell.slash" : "bell"
                 )
             }
             .accessibilityIdentifier("MobileWorkspaceNotificationsMenuItem")

--- a/ios/cmuxPackage/Sources/cmuxFeature/WorkspaceViews.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/WorkspaceViews.swift
@@ -607,7 +607,7 @@ struct WorkspaceDetailView: View {
                     surfaceID: terminalID,
                     store: store,
                     fontSize: MobileTerminalFontPreference.defaultSize,
-                    autoFocusOnWindowAttach: !terminalAutoFocusSuppressedSurfaceIDs.contains(terminalID)
+                    autoFocusOnWindowAttach: shouldAutoFocusTerminalSurface(terminalID)
                 )
                 .id(terminalID)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
@@ -807,6 +807,11 @@ struct WorkspaceDetailView: View {
     private func dismissTerminalKeyboardForChrome() {
         GhosttySurfaceView.resignActiveInput()
         dismissKeyboard()
+    }
+
+    private func shouldAutoFocusTerminalSurface(_ terminalID: String) -> Bool {
+        !suppressNextTerminalAutoFocus
+            && !terminalAutoFocusSuppressedSurfaceIDs.contains(terminalID)
     }
 
     private func suppressPendingTerminalAutoFocusIfNeeded(for terminalID: MobileTerminalPreview.ID?) {

--- a/ios/cmuxPackage/Sources/cmuxFeature/WorkspaceViews.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/WorkspaceViews.swift
@@ -624,6 +624,9 @@ struct WorkspaceDetailView: View {
                     autoFocusOnWindowAttach: shouldAutoFocusTerminalSurface(terminalID)
                 )
                 .id(terminalID)
+                .onAppear {
+                    clearConsumedTerminalAutoFocusSuppression(for: terminalID)
+                }
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
                 .background(TerminalPalette.background)
             } else {
@@ -816,7 +819,9 @@ struct WorkspaceDetailView: View {
     private func selectTerminalFromPicker(_ terminalID: MobileTerminalPreview.ID) {
         dismissTerminalKeyboardForChrome()
         isTerminalPickerPresented = false
-        terminalAutoFocusSuppressedSurfaceIDs.insert(terminalID.rawValue)
+        if selectedTerminal?.id != terminalID {
+            terminalAutoFocusSuppressedSurfaceIDs.insert(terminalID.rawValue)
+        }
         suppressNextTerminalAutoFocus = false
         selectedTerminalID = terminalID
     }
@@ -829,6 +834,10 @@ struct WorkspaceDetailView: View {
     private func shouldAutoFocusTerminalSurface(_ terminalID: String) -> Bool {
         !suppressNextTerminalAutoFocus
             && !terminalAutoFocusSuppressedSurfaceIDs.contains(terminalID)
+    }
+
+    private func clearConsumedTerminalAutoFocusSuppression(for terminalID: String) {
+        terminalAutoFocusSuppressedSurfaceIDs.remove(terminalID)
     }
 
     private func suppressPendingTerminalAutoFocusIfNeeded(for terminalID: MobileTerminalPreview.ID?) {

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/cmuxFeatureTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/cmuxFeatureTests.swift
@@ -1810,6 +1810,22 @@ import UIKit
 }
 
 @MainActor
+@Test func createTerminalUsesExplicitWorkspaceContextWhenSelectionIsStale() {
+    let store = CMUXMobileShellStore.preview()
+    store.signIn()
+    store.pairingCode = "debug"
+    store.connectPreviewHost()
+    store.createWorkspace()
+
+    store.selectedWorkspaceID = "workspace-main"
+    store.createTerminal(in: "workspace-3")
+
+    #expect(store.selectedWorkspace?.id.rawValue == "workspace-3")
+    #expect(store.selectedWorkspace?.terminals.map(\.name) == ["Terminal 1", "Terminal 2"])
+    #expect(store.selectedTerminalID?.rawValue == "workspace-3-terminal-2")
+}
+
+@MainActor
 @Test func remoteCreateTerminalKeepsOtherWorkspacesWhenMacReturnsScopedList() async throws {
     let route = try CmxAttachRoute(
         id: "debug_loopback",


### PR DESCRIPTION
Follow-up iOS notification readiness PR on top of `feat-ios-mobile-spm-replay`.

Changes:
- Localizes the iOS notification menu strings in `Localizable.xcstrings` for English and Japanese.
- Tracks the notification opt-in state in the menu so the label/icon update immediately after enable or disable.
- Deletes the APNs token from the web backend before mobile sign-out clears auth, so unregister still has a valid access token.
- Hardens `CmuxAppDelegate` notification delegate methods for Swift 6 by extracting Sendable IDs before hopping to `MainActor`.
- Fixes terminal remount behavior by keying the Ghostty surface by terminal ID and dismantling detached UIKit surfaces.
- Creates new terminals in the currently displayed workspace even when store selection is stale.
- Suppresses keyboard autofocus after chrome actions such as new workspace, new terminal, and terminal picker selection, while preserving tap-to-focus.
- Consumes terminal focus suppression once so a later normal remount can focus again.
- Clears render in-flight state even when a surface is dismantled while a render completion is returning.

Verification:
- `xcodebuildmcp simulator build --workspace-path ios/cmux.xcworkspace --scheme cmux --simulator-id 5E1A1E60-52E0-4ACE-B75B-67CFB27EECAB --configuration Debug --derived-data-path /tmp/cmux-ios-followup-build --output json`
- `jq empty ios/cmux/Resources/Localizable.xcstrings`
- `git diff --check`
- `swift test --package-path ios/cmuxPackage` was attempted but is not a valid local host test for this package because `CmuxMobileTerminal` imports UIKit; simulator/hosted iOS tests cover it instead.

Preview:
- https://cmux-git-feat-ios-push-localization-manaflow.vercel.app

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Sign-out ordering and terminal render/input teardown affect session cleanup and on-screen behavior; changes are targeted UX and concurrency fixes rather than broad auth redesign.
> 
> **Overview**
> This PR improves **iOS agent notifications**, **sign-out push cleanup**, and **terminal UI lifecycle** on top of the mobile replay work.
> 
> **Notifications:** Adds localized enable/disable menu strings (EN/JA). The workspace settings menu keeps a local `notificationsEnabled` flag so labels and icons update right after toggling push. `CmuxAppDelegate` notification delegate methods are `nonisolated` for Swift 6; workspace/surface IDs are parsed on the callback thread and policy runs on `MainActor`.
> 
> **Auth:** `signOut()` now calls `NotificationManager.shared.unregisterFromServer()` **before** `stack.signOut()` so the backend can delete the APNs token while the access token is still valid.
> 
> **Terminal:** `GhosttySurfaceView` tracks the active hidden input surface, exposes `resignActiveInput()` / `resignInput()`, and uses an `isDismantled` flag so detached surfaces stop processing output and rendering. SwiftUI wires `autoFocusOnWindowAttach`, keys the representable by terminal ID, and calls `prepareForDismantle()` on teardown. Workspace chrome dismisses the keyboard and suppresses autofocus after actions like new workspace, new terminal, or picker selection, while tap-to-focus still works.
> 
> **Store:** `createTerminal(in:)` creates terminals in an explicit workspace when selection is stale (with a test).
> 
> **Mac host:** `MobileTerminalByteTee` and replay scrollback budget are `nonisolated` where C callbacks or cross-actor access require it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ebfd757d070444b164e6131aeca54f8f2b699d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
