### PR TITLE
Route cmux://prompt and cmux://rules into an agent

### DIFF
--- a/Sources/AppDelegate+CmuxSSHURL.swift
+++ b/Sources/AppDelegate+CmuxSSHURL.swift
@@ -698,9 +698,24 @@ extension AppDelegate {
         if !request.noFocus {
             NSApp.activate(ignoringOtherApps: true)
         }
+        let preferredWindow = NSApp.keyWindow ?? NSApp.mainWindow
+        // Prefer landing the text in an agent: open a new workspace running the
+        // user's configured default agent and deliver the text unsent, so a
+        // `cmux://prompt` / `cmux://rules` link reaches a real agent instead of
+        // sitting at a shell prompt. Falls back to the plain focused-pane paste
+        // when no default-agent command is configured.
+        let routedToAgent = routeExternalLinkTextIntoNewAgentWorkspace(
+            request.pasteText,
+            title: request.title,
+            noFocus: request.noFocus,
+            preferredWindow: preferredWindow
+        )
+        if routedToAgent {
+            return
+        }
         let didPaste = pasteTextInPreferredMainWindowFromExternalLink(
             request.pasteText,
-            preferredWindow: NSApp.keyWindow ?? NSApp.mainWindow,
+            preferredWindow: preferredWindow,
             shouldBringToFront: !request.noFocus,
             debugSource: "textURL.\(request.kind.rawValue)",
             onSendFailure: { [weak self] in

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -7491,6 +7491,63 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return true
     }
 
+    /// Routes externally-linked text (a `cmux://prompt` / `cmux://rules` deep link)
+    /// into a freshly created workspace that launches the user's configured default
+    /// agent, delivering the text **unsent** so it lands in the agent's input box
+    /// and never auto-executes.
+    ///
+    /// The agent launch command comes from the user's own trusted
+    /// `newWorkspaceCommand` config (run via `initialTerminalCommand`); the untrusted
+    /// link text is passed as the surface's `initialTerminalInput` with no trailing
+    /// newline, so it is typed into the agent but not submitted.
+    ///
+    /// - Returns: `true` when an agent workspace was created; `false` when no
+    ///   default-agent command is configured, so the caller can fall back to the
+    ///   plain focused-pane paste path.
+    @discardableResult
+    func routeExternalLinkTextIntoNewAgentWorkspace(
+        _ text: String,
+        title: String? = nil,
+        noFocus: Bool = false,
+        preferredWindow: NSWindow? = nil
+    ) -> Bool {
+        let context: MainWindowContext? = {
+            if let existing = preferredRegisteredMainWindowContext(preferredWindow: preferredWindow) {
+                return existing
+            }
+            let windowId = createMainWindow(initialTerminalInput: "", shouldActivate: !noFocus)
+            return mainWindowContexts.values.first { $0.windowId == windowId }
+        }()
+        guard let context else { return false }
+
+        guard
+            let agentCommand = context.cmuxConfigStore?
+                .resolvedNewWorkspaceCommand()?.command.command?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+            !agentCommand.isEmpty
+        else {
+            return false
+        }
+
+        if !noFocus, let window = context.window ?? windowForMainWindowId(context.windowId) {
+            bringToFront(window)
+            setActiveMainWindow(window)
+        }
+
+        let trimmedTitle = title?.trimmingCharacters(in: .whitespacesAndNewlines)
+        _ = context.tabManager.addWorkspace(
+            title: (trimmedTitle?.isEmpty == false) ? trimmedTitle : nil,
+            initialTerminalCommand: agentCommand,
+            initialTerminalInput: text,
+            select: !noFocus,
+            autoWelcomeIfNeeded: false
+        )
+#if DEBUG
+        cmuxDebugLog("textURL.agentRoute created agent workspace chars=\(text.count) noFocus=\(noFocus)")
+#endif
+        return true
+    }
+
     @discardableResult
     func openFilePreviewInPreferredMainWindow(
         filePath: String,

--- a/Sources/CmuxSSHURLRequest.swift
+++ b/Sources/CmuxSSHURLRequest.swift
@@ -679,8 +679,22 @@ struct CmuxTextURLRequest: Equatable {
     let title: String?
     let noFocus: Bool
 
+    /// The text delivered into the target agent or terminal.
+    ///
+    /// Prompt links deliver the user's text verbatim. Rules links wrap it in a
+    /// standing-instruction preamble so the agent treats it as session guidance
+    /// instead of a one-shot task, which is what differentiates a rules link
+    /// from a prompt link at the destination. No trailing newline is added, so
+    /// the text never auto-submits.
     var pasteText: String {
-        text
+        switch kind {
+        case .prompt:
+            return text
+        case .rules:
+            let trimmedName = name?.trimmingCharacters(in: .whitespacesAndNewlines)
+            let label = (trimmedName?.isEmpty == false) ? " (\(trimmedName!))" : ""
+            return "Follow these rules for this session\(label):\n\n\(text)"
+        }
     }
 
     private struct ParsedQueryItem {

--- a/cmuxTests/CmuxSSHURLRequestTests.swift
+++ b/cmuxTests/CmuxSSHURLRequestTests.swift
@@ -687,6 +687,51 @@ final class CmuxSSHURLRequestTests: XCTestCase {
         }
     }
 
+    func testRulesPasteTextWrapsTextInStandingInstructionPreamble() throws {
+        let url = try XCTUnwrap(textURL(host: "rules", queryItems: [
+            URLQueryItem(name: "name", value: "freestyle"),
+            URLQueryItem(name: "text", value: "Prefer commas, colons, and small PRs.")
+        ]))
+
+        switch CmuxTextURLRequest.parse(url) {
+        case .success(.some(let request)):
+            XCTAssertEqual(request.kind, .rules)
+            XCTAssertEqual(request.text, "Prefer commas, colons, and small PRs.")
+            // Rules differ from prompts: the delivered text is wrapped in a
+            // standing-instruction preamble (named), and is never the verbatim text.
+            XCTAssertNotEqual(request.pasteText, request.text)
+            XCTAssertEqual(
+                request.pasteText,
+                "Follow these rules for this session (freestyle):\n\nPrefer commas, colons, and small PRs."
+            )
+            // No trailing newline, so the text never auto-submits.
+            XCTAssertFalse(request.pasteText.hasSuffix("\n"))
+        case .success(nil):
+            XCTFail("Expected rules URL request")
+        case .failure(let error):
+            XCTFail("Unexpected parse error: \(error)")
+        }
+    }
+
+    func testRulesPasteTextOmitsLabelWhenNameAbsent() throws {
+        let url = try XCTUnwrap(textURL(host: "rules", queryItems: [
+            URLQueryItem(name: "text", value: "Keep diffs small.")
+        ]))
+
+        switch CmuxTextURLRequest.parse(url) {
+        case .success(.some(let request)):
+            XCTAssertEqual(request.kind, .rules)
+            XCTAssertEqual(
+                request.pasteText,
+                "Follow these rules for this session:\n\nKeep diffs small."
+            )
+        case .success(nil):
+            XCTFail("Expected rules URL request")
+        case .failure(let error):
+            XCTFail("Unexpected parse error: \(error)")
+        }
+    }
+
     func testPreservesPromptURLTextWhitespace() throws {
         let url = try XCTUnwrap(textURL(host: "prompt", queryItems: [
             URLQueryItem(name: "text", value: "  indented prompt  ")


### PR DESCRIPTION
## Problem

`cmux://prompt` and `cmux://rules` both pasted their text into the focused terminal pane. When that pane was a shell (common when the link is clicked from a browser), an external prompt landed as raw shell text, and prompt and rules behaved identically. This is the friction Freestyle hit wiring the links into their dashboard ("not into a claude or default agent, just text in a terminal... prompt + rules both seem to do the same thing").

## Change

Both links now open a **new workspace running the user's configured default agent** (`newWorkspaceCommand`) and deliver the link text as the surface's `initialTerminalInput` (Ghostty `initial_input`, the same path agent-fork uses) with **no trailing newline**, so the text lands in the agent's input box **unsent**. Falls back to the previous focused-pane paste when no default agent is configured, so behavior is never worse than today.

Rules are now distinct from prompts: `pasteText` wraps rules in a standing-instruction preamble (`Follow these rules for this session (name):\n\n…`); prompts stay verbatim.

## Security

The security floor is unchanged: the existing confirm dialog, the can't-verify-origin warning, and the no-auto-execute contract all still apply. The untrusted link text only ever reaches the agent's input box (never `eval`'d, never submitted); the agent **launch** command comes from the user's own trusted config, not the link.

## Deliberately out of scope

Durable rules (writing the agent's `AGENTS.md`) are not implemented: that only works for local-mac agents, since an SSH/Freestyle-VM agent runs remotely and never sees a local file, while this paste approach works in both. Tracked as an open decision in the cmuxterm-hq design doc.

## Tests

Two unit tests added to `CmuxSSHURLRequestTests` covering the rules preamble (named and unnamed) and the no-trailing-newline invariant. Existing prompt tests already assert `pasteText == text` and still pass.

## Localization

No new UI strings. The only new string is the rules preamble, which is instruction content delivered to an AI agent (which operates in English), not UI chrome, so it is intentionally not localized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5264"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783045657&installation_id=133855650&pr_number=5264&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5264&signature=01142564af50af1e32a1587f2b40d87ae27c00fb649b3cc6d1f4ab43045c68ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes external URL handling and workspace creation using user config plus untrusted link text, though launch commands stay config-trusted and text remains unsent with existing confirmation.
> 
> **Overview**
> **`cmux://prompt` and `cmux://rules` now prefer a new agent workspace** instead of only pasting into the focused pane. After the existing confirm flow, the app tries `routeExternalLinkTextIntoNewAgentWorkspace`, which adds a workspace using the user's configured **`newWorkspaceCommand`** as `initialTerminalCommand` and puts link text in **`initialTerminalInput` without a trailing newline** (unsent). If no default agent command is set, behavior **falls back** to the previous focused-pane paste path.
> 
> **Rules links are differentiated from prompts** at delivery time: `CmuxTextURLRequest.pasteText` stays verbatim for `.prompt` and wraps `.rules` in a standing-instruction preamble (`Follow these rules for this session` plus optional name). Unit tests cover the rules preamble and the no-auto-submit newline rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22127853bd36e359d478442976470f7fa7e54ca6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route cmux://prompt and cmux://rules deep links into a new workspace running the user's default agent, instead of pasting into the focused terminal. The text lands in the agent’s input box unsent (no trailing newline), with fallback to the old paste behavior when no default agent is configured.

- **New Features**
  - Starts the default agent via `newWorkspaceCommand` and injects text as `initialTerminalInput` without auto-submit.
  - Makes rules distinct from prompts: rules wrap text with "Follow these rules for this session (name):" while prompts stay verbatim.
  - Preserves safety: existing confirm/origin warnings remain; the launch command comes from the user’s config.

<sup>Written for commit 22127853bd36e359d478442976470f7fa7e54ca6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * External deep-link text can now be routed into newly launched agent workspaces when available.
  * Rules-based links now include a standing-instruction preamble and session label in pasted content, while prompt links remain unchanged.

* **Tests**
  * Added test coverage for rules-link paste-text generation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->