### PR TITLE
Fix Node-based Gemini session restore command parsing

### DIFF
--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentResumeArgv.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentResumeArgv.swift
@@ -288,9 +288,57 @@ public struct AgentResumeArgv: Sendable, Equatable {
         arguments: [String],
         fallbackExecutable: String
     ) -> (executable: String, tail: [String]) {
-        let executable = normalized(executablePath) ?? normalized(arguments.first) ?? fallbackExecutable
-        let tail = arguments.isEmpty ? [] : Array(arguments.dropFirst())
+        var executable = normalized(executablePath) ?? normalized(arguments.first) ?? fallbackExecutable
+        var tail = arguments.isEmpty ? [] : Array(arguments.dropFirst())
+        if isNodeExecutable(executable), let jsIndex = nodeScriptEntrypointIndex(in: arguments) {
+            executable = fallbackExecutable
+            tail = Array(arguments.suffix(from: arguments.index(after: jsIndex)))
+        }
         return (executable, tail)
+    }
+
+    private func isNodeExecutable(_ executable: String) -> Bool {
+        let executableName = URL(fileURLWithPath: executable).lastPathComponent.lowercased()
+        return executableName == "node" || executableName == "node.exe"
+    }
+
+    private func nodeScriptEntrypointIndex(in arguments: [String]) -> [String].Index? {
+        var index = arguments.startIndex
+        while index < arguments.endIndex {
+            let argument = arguments[index]
+            if nodeOptionConsumesNextValue(argument) {
+                index = arguments.index(after: index)
+                if index < arguments.endIndex {
+                    index = arguments.index(after: index)
+                }
+                continue
+            }
+            if nodeOptionHasInlineValue(argument) {
+                index = arguments.index(after: index)
+                continue
+            }
+            if argument.hasSuffix(".js"), !argument.hasPrefix("-") {
+                return index
+            }
+            index = arguments.index(after: index)
+        }
+        return nil
+    }
+
+    private func nodeOptionConsumesNextValue(_ argument: String) -> Bool {
+        argument == "-r" ||
+            argument == "--require" ||
+            argument == "--import" ||
+            argument == "--loader" ||
+            argument == "--experimental-loader"
+    }
+
+    private func nodeOptionHasInlineValue(_ argument: String) -> Bool {
+        argument.hasPrefix("-r") ||
+            argument.hasPrefix("--require=") ||
+            argument.hasPrefix("--import=") ||
+            argument.hasPrefix("--loader=") ||
+            argument.hasPrefix("--experimental-loader=")
     }
 
     private func normalized(_ value: String?) -> String? {

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentResumeArgvTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentResumeArgvTests.swift
@@ -121,6 +121,63 @@ struct AgentResumeArgvTests {
         )
     }
 
+    @Test("Node-backed launchers resume through fallback executable after the real script entrypoint")
+    func nodeWrapperEntrypointUsesFallbackExecutable() {
+        #expect(
+            AgentResumeArgv().builtInKind(
+                kind: "gemini",
+                sessionId: "SID",
+                executablePath: "/Users/example/.nvm/versions/node/v22.0.0/bin/node",
+                arguments: [
+                    "/Users/example/.nvm/versions/node/v22.0.0/bin/node",
+                    "-r",
+                    "/tmp/cmux/preload.js",
+                    "/Users/example/.npm/lib/node_modules/@google/gemini-cli/dist/gemini.js",
+                    "--model",
+                    "gemini-2.5-pro",
+                    "--resume",
+                    "old-session",
+                    "--sandbox",
+                    "danger-full-access",
+                ]
+            ) == [
+                "gemini",
+                "--resume",
+                "SID",
+                "--model",
+                "gemini-2.5-pro",
+                "--sandbox",
+                "danger-full-access",
+            ]
+        )
+    }
+
+    @Test("Non-Node executables ending with node are not rewritten")
+    func nonNodeExecutableEndingWithNodeIsPreserved() {
+        #expect(
+            AgentResumeArgv().builtInKind(
+                kind: "gemini",
+                sessionId: "SID",
+                executablePath: "/usr/local/bin/pandanode",
+                arguments: [
+                    "/usr/local/bin/pandanode",
+                    "--model",
+                    "gemini-2.5-pro",
+                    "--config=app.js",
+                    "--resume",
+                    "old-session",
+                ]
+            ) == [
+                "/usr/local/bin/pandanode",
+                "--resume",
+                "SID",
+                "--model",
+                "gemini-2.5-pro",
+                "--config=app.js",
+            ]
+        )
+    }
+
     @Test("cmux wrapper launchers resolve before per-kind verbs")
     func launcherWrappers() {
         #expect(


### PR DESCRIPTION
This PR fixes a bug where cmux fails to correctly restore a Gemini CLI terminal session pane because it captures the raw underlying Node command line (e.g. `node --max-old-space-size=12288 /path/to/gemini.js --resume <uuid>`) instead of using the correct wrapper executable binary (`gemini`).

### Changes
* Updates `agentSurfaceResumeCommandParts` inside `CLI/cmux.swift` to check if the captured binary path is Node or ends in `node`.
* If true, it scans the arguments for the first entrypoint ending in `.js` (e.g., `gemini.js` or `claude.js`).
* It sets the executable to the proper `fallbackExecutable` (e.g., `"gemini"`) and slices the arguments tail after the `.js` script path.

This allows `cmux` to cleanly restore Node-based CLI agent sessions under their wrapper binaries directly.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5266"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783047693&installation_id=133855650&pr_number=5266&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5266&signature=08427cbcfaf84d28b523137b0dbcbb846a1f06922d961dee25dd9f7622ca62c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes resume of Node-launched Gemini sessions by rewriting Node invocations to the `gemini` wrapper and keeping only args after the `.js` entrypoint, even when preload/loader flags are present.

- **Bug Fixes**
  - Detect Node only when the basename is exactly `node` or `node.exe` (ignore `pandanode`-like names).
  - Skip Node flags that take values when scanning for the first `.js` entrypoint, including `-r`, `--require`, `--import`, `--loader`, `--experimental-loader`, and `=value` forms.

<sup>Written for commit f041af5cccd747d17f5a3cb9eeefaba1500aff54. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI command normalization for Node.js-based launches, ensuring the correct script/entrypoint is detected and processed with the right trailing arguments.
  * Enhanced Gemini resume-command handling so Node wrappers are removed only when appropriate, and non-Node executables with “node” in the name are no longer mistakenly rewritten.
* **Tests**
  * Added coverage for the Gemini resume-command behavior around Node wrapper dropping and non-Node executable preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->