### PR TITLE
Fix browser address bar: single click places caret instead of selecting all (#5268)

### DIFF
--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -3846,7 +3846,6 @@ final class OmnibarNativeTextField: NSTextField {
     private struct MouseSelectionState {
         let anchor: Int
         let initialWindowLocation: NSPoint
-        let selectAllOnMouseUp: Bool
         var didDrag: Bool
     }
 
@@ -3907,7 +3906,6 @@ final class OmnibarNativeTextField: NSTextField {
         mouseSelectionState = MouseSelectionState(
             anchor: anchor,
             initialWindowLocation: event.locationInWindow,
-            selectAllOnMouseUp: !hadEditor && !event.modifierFlags.contains(.shift),
             didDrag: false
         )
     }
@@ -3930,16 +3928,16 @@ final class OmnibarNativeTextField: NSTextField {
     }
 
     override func mouseUp(with event: NSEvent) {
-        guard let state = mouseSelectionState,
-              let editor = currentEditor() as? NSTextView else {
+        guard mouseSelectionState != nil else {
             super.mouseUp(with: event)
             return
         }
 
+        // A single click leaves the caret placed in `mouseDown`; a drag leaves the
+        // range built up in `mouseDragged`. Focus-via-click never selects all — that
+        // is reserved for the keyboard path (Cmd+L), which selects the whole URL via
+        // the `selectAllRequestId` flow, independent of mouse handling.
         mouseSelectionState = nil
-        if state.selectAllOnMouseUp && !state.didDrag {
-            editor.selectAll(nil)
-        }
     }
 
     private func insertionIndex(for event: NSEvent, in editor: NSTextView) -> Int {

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -3626,3 +3626,88 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         )
     }
 }
+
+@MainActor
+final class OmnibarNativeTextFieldCaretTests: XCTestCase {
+    /// A window that hands the omnibar field a real, controllable field editor so
+    /// the click path can be exercised headlessly in CI (mirrors the probe pattern
+    /// used by the omnibar key-routing tests in `BrowserConfigTests`).
+    private final class CaretProbeWindow: NSWindow {
+        let probeFieldEditor = NSTextView(frame: NSRect(x: 0, y: 0, width: 360, height: 24))
+
+        override func fieldEditor(_ createFlag: Bool, for object: Any?) -> NSText? {
+            probeFieldEditor
+        }
+    }
+
+    private func makeMouseEvent(
+        type: NSEvent.EventType,
+        location: NSPoint,
+        window: NSWindow,
+        clickCount: Int = 1,
+        modifierFlags: NSEvent.ModifierFlags = []
+    ) -> NSEvent {
+        guard let event = NSEvent.mouseEvent(
+            with: type,
+            location: location,
+            modifierFlags: modifierFlags,
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 0,
+            clickCount: clickCount,
+            pressure: 1.0
+        ) else {
+            fatalError("Failed to create \(type) mouse event")
+        }
+        return event
+    }
+
+    /// Regression for https://github.com/manaflow-ai/cmux/issues/5268: a single,
+    /// unmodified click that focuses the omnibar must leave a caret (zero-length
+    /// selection) at the click position, not select the entire URL.
+    func testSingleClickFocusPlacesCaretInsteadOfSelectingAll() {
+        let window = CaretProbeWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 480, height: 120),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        let container = NSView(frame: window.contentRect(forFrameRect: window.frame))
+        window.contentView = container
+
+        let field = OmnibarNativeTextField(frame: NSRect(x: 12, y: 80, width: 360, height: 24))
+        field.font = .systemFont(ofSize: 12)
+        field.isEditable = true
+        field.isSelectable = true
+        field.isEnabled = true
+        field.stringValue = "https://github.com/manaflow-ai/cmux"
+        container.addSubview(field)
+
+        window.makeKeyAndOrderFront(nil)
+        defer {
+            field.removeFromSuperview()
+            window.contentView = nil
+            window.orderOut(nil)
+        }
+
+        // Do NOT pre-focus: the bug only manifests on the click that first acquires
+        // focus, where the old code forced a select-all on mouseUp.
+        let clickPoint = NSPoint(x: field.frame.midX, y: field.frame.midY)
+        let pointInWindow = container.convert(clickPoint, to: nil)
+        field.mouseDown(with: makeMouseEvent(type: .leftMouseDown, location: pointInWindow, window: window))
+        field.mouseUp(with: makeMouseEvent(type: .leftMouseUp, location: pointInWindow, window: window))
+
+        guard let editor = field.currentEditor() as? NSTextView else {
+            XCTFail("Expected a field editor after the click acquired focus")
+            return
+        }
+        let textLength = (editor.string as NSString).length
+        XCTAssertGreaterThan(textLength, 0, "Test precondition: the omnibar should contain a URL")
+        XCTAssertEqual(
+            editor.selectedRange().length,
+            0,
+            "A single click must place a caret, not select the whole URL"
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #5268. In the built-in browser, a single click in the address/search bar selected the whole URL (showing a highlighted word/host like `github.com`) and never left an editable caret, so you couldn't click between two characters to edit the URL inline.

## Root cause

`OmnibarNativeTextField.mouseUp` forced `editor.selectAll(nil)` whenever a click acquired focus:

```swift
selectAllOnMouseUp: !hadEditor && !event.modifierFlags.contains(.shift)
```

`mouseDown` correctly placed a caret at the click position, but `mouseUp` immediately replaced it with a full select-all. This also contradicted the SwiftUI focus path, which already sets `suppressNextFocusGainedSelectAll = true` on tap — i.e. the rest of the code already intended *no* select-all on click.

## Fix

Remove the mouse-driven select-all entirely (drop `selectAllOnMouseUp` from `MouseSelectionState`):

- **Single click** → caret at the click position (placed in `mouseDown`).
- **Drag** → range selection (built in `mouseDragged`).
- **Double/triple click** → word/line selection (unchanged, forwarded to the field editor).
- **Shift+click** → range extension (unchanged).
- **Cmd+L (keyboard)** → still selects the whole URL, via the independent `selectAllRequestId` flow — unaffected by this change.

## Test

Two-commit red/green: a regression test drives a real field editor through `mouseDown`/`mouseUp` on a focus-acquiring single click and asserts the resulting selection length is `0` (caret), not the full URL length. It fails on the first commit (test only) and passes after the fix.

## Localization

No user-facing strings, menus, shortcuts, or config were added or changed, so no `Localizable.xcstrings` / message-catalog updates are required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized omnibar mouse-up selection behavior plus a regression test; keyboard select-all and other selection paths are intentionally preserved.
> 
> **Overview**
> Fixes omnibar behavior where the **first click to focus** the address bar immediately **selected the entire URL** on mouse up, overriding the caret placed in `mouseDown`.
> 
> **`OmnibarNativeTextField`** no longer tracks `selectAllOnMouseUp` or calls `selectAll` in `mouseUp`. A single click leaves a **zero-length selection** at the click point; drag and modifier-driven selection are unchanged. **Select-all on focus** for keyboard paths (e.g. **Cmd+L** via `omnibarSelectAllRequestId` / focus-gained logic) is unchanged.
> 
> Adds **`OmnibarNativeTextFieldCaretTests`** with a headless field-editor probe to assert a focus-acquiring single click does not select the full URL (regression for #5268).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03be18c63df552741a469759e44352c31c89e4de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5270"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783051816&installation_id=133855650&pr_number=5270&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5270&signature=2ab625b8f1d20a75e27ed4a4a1d0ddb95d1686f4411b37cc2f0ae8254f1354bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Single-click in the browser address/search bar now places a caret where you click instead of selecting the whole URL, enabling inline edits. Fixes #5268.

- **Bug Fixes**
  - Removed mouse-driven select-all on focus in `OmnibarNativeTextField.mouseUp`.
  - Single click leaves a caret; drag/double/triple click and Shift+click behaviors are unchanged.
  - Cmd+L still selects the full URL; added a regression test to ensure single-click yields a caret.

<sup>Written for commit 03be18c63df552741a469759e44352c31c89e4de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved omnibar click behavior to place the cursor at the click position rather than selecting all text when focusing the search field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->