### PR TITLE
Fix Codex auto-resume emitting invalid `-s disabled` (#5262)

### DIFF
--- a/Sources/SessionIndexModels.swift
+++ b/Sources/SessionIndexModels.swift
@@ -331,12 +331,10 @@ struct SessionEntry: Identifiable, Hashable {
             if let model, !model.isEmpty {
                 parts.append("-m \(Self.shellQuote(model))")
             }
-            if let approval, !approval.isEmpty {
-                parts.append("-a \(Self.shellQuote(approval))")
-            }
-            if let sandbox, !sandbox.isEmpty {
-                parts.append("-s \(Self.shellQuote(sandbox))")
-            }
+            parts.append(contentsOf: Self.codexApprovalSandboxArguments(
+                approvalPolicy: approval,
+                sandboxMode: sandbox
+            ))
             if let effort, !effort.isEmpty {
                 parts.append("-c model_reasoning_effort=\(Self.shellQuote(effort))")
             }
@@ -438,6 +436,49 @@ struct SessionEntry: Identifiable, Hashable {
     /// Single-quote a value for safe shell injection. Escapes embedded single quotes.
     static func shellQuote(_ value: String) -> String {
         TerminalStartupShellQuoting.shellToken(value, allowingBareASCII: true)
+    }
+
+    /// Sandbox-policy values the Codex CLI `--sandbox` flag accepts.
+    ///
+    /// cmux captures Codex's *internal* sandbox-policy `type`, which is a
+    /// superset of the CLI vocabulary (it also includes `disabled`, `managed`,
+    /// and may grow further). Those extra types have no `--sandbox` equivalent
+    /// and must never be forwarded as `-s`, or Codex rejects the resumed command
+    /// (see https://github.com/manaflow-ai/cmux/issues/5262).
+    static let codexCLISandboxModes: Set<String> = [
+        "read-only",
+        "workspace-write",
+        "danger-full-access",
+    ]
+
+    /// Builds the approval/sandbox CLI tokens for a `codex resume` command from
+    /// the per-session policy cmux captured, always yielding a valid invocation.
+    ///
+    /// A `--dangerously-bypass-approvals-and-sandbox` launch round-trips to a
+    /// captured `(approval: "never", sandbox: "disabled")`. This reproduces that
+    /// single combined flag rather than the invalid, contradictory `-a never -s
+    /// disabled`. Sandbox types with no CLI equivalent (`disabled`, `managed`,
+    /// future values) are dropped instead of emitted as an invalid `-s`; valid
+    /// values pass through unchanged.
+    static func codexApprovalSandboxArguments(
+        approvalPolicy: String?,
+        sandboxMode: String?
+    ) -> [String] {
+        // The exact inverse of `--dangerously-bypass-approvals-and-sandbox`:
+        // emit that one flag and nothing else, since `-a`/`-s` here would be both
+        // invalid (`-s disabled`) and contradictory with the bypass flag.
+        if approvalPolicy == "never", sandboxMode == "disabled" {
+            return ["--dangerously-bypass-approvals-and-sandbox"]
+        }
+
+        var parts: [String] = []
+        if let approvalPolicy, !approvalPolicy.isEmpty {
+            parts.append("-a \(shellQuote(approvalPolicy))")
+        }
+        if let sandboxMode, !sandboxMode.isEmpty, codexCLISandboxModes.contains(sandboxMode) {
+            parts.append("-s \(shellQuote(sandboxMode))")
+        }
+        return parts
     }
 
     var displayTitle: String {

--- a/cmuxTests/SessionIndexViewTests.swift
+++ b/cmuxTests/SessionIndexViewTests.swift
@@ -137,6 +137,98 @@ final class SessionIndexViewTests: XCTestCase {
         )
     }
 
+    // Regression for https://github.com/manaflow-ai/cmux/issues/5262.
+    // cmux captures Codex's *internal* sandbox-policy `type`, which is a superset of
+    // the values the `--sandbox` CLI flag accepts. A
+    // `--dangerously-bypass-approvals-and-sandbox` launch round-trips to a captured
+    // `(approval: "never", sandbox: "disabled")`; the generator must reproduce that
+    // single combined flag rather than the invalid, contradictory `-a never -s disabled`
+    // (Codex rejects it: `error: invalid value 'disabled' for '--sandbox <SANDBOX_MODE>'`).
+    func testCodexResumeCommandReproducesBypassFlagForDisabledSandbox() {
+        let entry = makeEntry(
+            agent: .codex,
+            sessionId: "codex-session-123",
+            title: "resume me",
+            specifics: .codex(
+                model: "gpt-5.5",
+                approvalPolicy: "never",
+                sandboxMode: "disabled",
+                effort: "high"
+            )
+        )
+
+        let command = entry.resumeCommand ?? ""
+        XCTAssertEqual(
+            command,
+            "codex resume codex-session-123 -m gpt-5.5 --dangerously-bypass-approvals-and-sandbox -c model_reasoning_effort=high"
+        )
+        XCTAssertFalse(
+            command.contains("-s disabled"),
+            "Codex resume must not emit the invalid `-s disabled` flag (issue #5262)"
+        )
+        XCTAssertFalse(
+            command.contains("-a never -s"),
+            "The bypass flag must replace, not accompany, -a/-s"
+        )
+    }
+
+    // The `managed` sandbox type (ChatGPT/cloud-managed) likewise has no `--sandbox`
+    // equivalent, so it must be dropped rather than emitted as the invalid `-s managed`.
+    func testCodexResumeCommandDropsUnsupportedManagedSandbox() {
+        let entry = makeEntry(
+            agent: .codex,
+            sessionId: "codex-session-managed",
+            title: "resume me",
+            specifics: .codex(
+                model: nil,
+                approvalPolicy: "on-request",
+                sandboxMode: "managed",
+                effort: nil
+            )
+        )
+
+        let command = entry.resumeCommand ?? ""
+        XCTAssertEqual(command, "codex resume codex-session-managed -a on-request")
+        XCTAssertFalse(
+            command.contains("-s managed"),
+            "Codex resume must not emit the invalid `-s managed` flag (issue #5262)"
+        )
+    }
+
+    // Valid sandbox values still pass through unchanged, and an explicit
+    // `(never, danger-full-access)` is preserved rather than collapsed into the
+    // bypass flag (the two are semantically distinct in Codex).
+    func testCodexResumeCommandPreservesValidSandboxModes() {
+        let readOnly = makeEntry(
+            agent: .codex,
+            sessionId: "codex-ro",
+            title: "resume me",
+            specifics: .codex(
+                model: nil,
+                approvalPolicy: "untrusted",
+                sandboxMode: "read-only",
+                effort: nil
+            )
+        )
+        XCTAssertEqual(readOnly.resumeCommand, "codex resume codex-ro -a untrusted -s read-only")
+
+        let dangerFullAccess = makeEntry(
+            agent: .codex,
+            sessionId: "codex-dfa",
+            title: "resume me",
+            specifics: .codex(
+                model: "gpt-5.5",
+                approvalPolicy: "never",
+                sandboxMode: "danger-full-access",
+                effort: nil
+            )
+        )
+        XCTAssertEqual(
+            dangerFullAccess.resumeCommand,
+            "codex resume codex-dfa -m gpt-5.5 -a never -s danger-full-access"
+        )
+    }
+
     func testCurrentDirectorySetterDoesNotPublishEqualValue() {
         let store = SessionIndexStore()
         var emittedValues: [String?] = []


### PR DESCRIPTION
## Summary

Fixes #5262. cmux auto-resume generated an **invalid** Codex CLI command containing `-s disabled`, which Codex rejects:

```
error: invalid value 'disabled' for '--sandbox <SANDBOX_MODE>'
```

### Root cause

cmux captures Codex's **internal** sandbox-policy `type` (read from `~/.codex/state_5.sqlite`'s `sandbox_policy` JSON, and the rollout JSONL `turn_context`). That vocabulary is a **superset** of what the Codex CLI `--sandbox` flag accepts. Verified against `codex resume --help` (v0.136.0):

> `-s, --sandbox <SANDBOX_MODE>` — possible values: **`read-only`, `workspace-write`, `danger-full-access`**

But the captured `type` also includes `disabled` and `managed`. The old generator forwarded the captured value verbatim as `-s <type>`. A session launched with `--dangerously-bypass-approvals-and-sandbox` round-trips to `(approval: never, sandbox: disabled)`, so resume produced the invalid **and contradictory** `-a never -s disabled`. (Inspecting a real state DB: 28 rows with `{"type":"disabled"}` and several with `{"type":"managed"}` — both invalid as `--sandbox` values.)

### Fix

Translate the captured policy into a valid invocation at the CLI-generation boundary (`SessionEntry.codexApprovalSandboxArguments`):

- **`(never, disabled)` → `--dangerously-bypass-approvals-and-sandbox`** — faithfully reproduces the original YOLO launch intent, and emits that single combined flag instead of `-a never -s disabled` (which would be both invalid and contradictory with the bypass flag).
- **Validate the sandbox value against the CLI's accepted set** (`read-only`, `workspace-write`, `danger-full-access`). Any internal-only type (`disabled`, `managed`, or future additions) is **dropped** rather than emitted as an invalid `-s`. This fixes the whole class of "internal sandbox type leaks into `-s`" bugs, not just the one reported value.
- **Valid sandbox values pass through unchanged**, and an explicit `(never, danger-full-access)` is preserved (not collapsed into the bypass flag — the two are semantically distinct in Codex).

Claude/Grok/OpenCode/other agents are unaffected: only Codex reads an internal policy-type superset. Grok reads its sandbox value from Grok's own session JSON (its own CLI vocabulary), so it doesn't share the defect and is left unchanged.

## Tests

Two-commit red/green structure (per repo policy):

1. **Failing test** — `SessionIndexViewTests` gains behavioral coverage on the real `SessionEntry.resumeCommand` path: the disabled→bypass round-trip, dropping the unsupported `managed` value, and preserving valid sandbox modes. Red against the old generator.
2. **Fix** — turns them green.

These are pure-function tests on the resume-command generator (no app launch, no socket), added to an already-wired test file.

## Localization

No new user-facing UI strings — the change only affects a generated Codex CLI command (shell tokens, not localized text). No `Localizable.xcstrings` changes required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5276"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783056038&installation_id=133855650&pr_number=5276&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5276&signature=5e5eebc912879658bf161b859f698e4be04f1c758f9b7a11776b54ec2a3fc300"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to Codex resume shell string generation with unit tests; no auth, persistence, or other agents affected.
> 
> **Overview**
> Fixes **Codex auto-resume** so generated `codex resume …` commands match what the CLI accepts, instead of blindly forwarding internal sandbox policy values as `-s`.
> 
> **`SessionEntry`** now routes Codex approval/sandbox through **`codexApprovalSandboxArguments`**: captured `(never, disabled)` becomes **`--dangerously-bypass-approvals-and-sandbox`** only; `-s` is emitted only for CLI-supported modes (`read-only`, `workspace-write`, `danger-full-access`), dropping internal types like `disabled` and `managed`. Other agents are unchanged.
> 
> **Tests** on `resumeCommand` cover the bypass round-trip, dropped `managed`, and unchanged valid `-a`/`-s` combinations (regression for #5262).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b1c87a1d0fc957dcf9e5fbd2bee33fbe3c5e7bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #5262 by generating valid Codex resume commands and preventing invalid `-s disabled`/`-s managed`. Translates internal sandbox policy values to safe CLI args.

- **Bug Fixes**
  - Map `(approval: never, sandbox: disabled)` to `--dangerously-bypass-approvals-and-sandbox` only (no `-a`/`-s`).
  - Emit `-s` only for supported modes: `read-only`, `workspace-write`, `danger-full-access`; drop internal-only values like `disabled` and `managed`.
  - Route Codex resume through a safe arg builder and add regression tests for bypass, managed, and valid pass-through.

<sup>Written for commit 8b1c87a1d0fc957dcf9e5fbd2bee33fbe3c5e7bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Codex resume command generation to correctly handle sandbox and approval policy flag combinations, including special case handling and filtering of unsupported sandbox modes.

* **Tests**
  * Added regression tests validating Codex sandbox and approval flag combinations in resume commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->