### PR TITLE
Keep recent workspaces warm across switches

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -814,11 +814,12 @@ enum WorkspaceMountPolicy {
 
         // Ensure pinned ids (retiring handoff workspaces) are always retained at highest priority.
         // This runs after warming to prevent neighbor warming from evicting the retiring workspace.
+        let orderedTabIndexById = Dictionary(uniqueKeysWithValues: orderedTabIds.enumerated().map { ($0.element, $0.offset) })
         let prioritizedPinnedIds = pinnedIds
             .filter { existing.contains($0) && $0 != selected }
             .sorted { lhs, rhs in
-                let lhsIndex = orderedTabIds.firstIndex(of: lhs) ?? .max
-                let rhsIndex = orderedTabIds.firstIndex(of: rhs) ?? .max
+                let lhsIndex = orderedTabIndexById[lhs] ?? .max
+                let rhsIndex = orderedTabIndexById[rhs] ?? .max
                 return lhsIndex < rhsIndex
             }
         if let selected, existing.contains(selected) {
@@ -3433,6 +3434,7 @@ struct ContentView: View {
         let maxMounted = max(baseMaxMounted, selectedCount + pinnedIds.count)
         let previousMountedIds = mountedWorkspaceIds
         mountedWorkspaceIds = WorkspaceMountPolicy.nextMountedWorkspaceIds(
+            // Ordered by MRU: head is most recent, tail is evicted first.
             current: mountedWorkspaceIds,
             selected: effectiveSelectedId,
             pinnedIds: pinnedIds,

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -775,8 +775,9 @@ private func commandPaletteOwningWebView(for responder: NSResponder?) -> WKWebVi
 }
 
 enum WorkspaceMountPolicy {
-    // Keep only the selected workspace mounted to minimize layer-tree traversal.
-    static let maxMountedWorkspaces = 1
+    // Keep the selected workspace plus a small bounded MRU cache warm so revisits avoid cold terminal mounts.
+    static let maxRecentlyMountedWorkspaces = 3
+    static let maxMountedWorkspaces = 1 + maxRecentlyMountedWorkspaces
     // During workspace cycling, keep only a minimal handoff pair (selected + retiring).
     static let maxMountedWorkspacesDuringCycle = 2
 
@@ -3450,17 +3451,19 @@ struct ContentView: View {
 #if DEBUG
         if mountedWorkspaceIds != previousMountedIds {
             let added = mountedWorkspaceIds.filter { !previousMountedIds.contains($0) }
+            let debugPinnedIds = pinnedIds.sorted { $0.uuidString < $1.uuidString }
             if let snapshot = tabManager.debugCurrentWorkspaceSwitchSnapshot() {
                 let dtMs = (CACurrentMediaTime() - snapshot.startedAt) * 1000
                 cmuxDebugLog(
-                    "ws.mount.reconcile id=\(snapshot.id) dt=\(debugMsText(dtMs)) hot=\(isCycleHot ? 1 : 0) " +
-                    "selected=\(debugShortWorkspaceId(effectiveSelectedId)) " +
+                    "ws.mount.reconcile id=\(snapshot.id) dt=\(debugMsText(dtMs)) hot=\(isCycleHot ? 1 : 0) limit=\(maxMounted) " +
+                    "selected=\(debugShortWorkspaceId(effectiveSelectedId)) pinned=\(debugShortWorkspaceIds(debugPinnedIds)) " +
                     "mounted=\(debugShortWorkspaceIds(mountedWorkspaceIds)) " +
                     "added=\(debugShortWorkspaceIds(added)) removed=\(debugShortWorkspaceIds(removedIds))"
                 )
             } else {
                 cmuxDebugLog(
-                    "ws.mount.reconcile id=none hot=\(isCycleHot ? 1 : 0) selected=\(debugShortWorkspaceId(effectiveSelectedId)) " +
+                    "ws.mount.reconcile id=none hot=\(isCycleHot ? 1 : 0) limit=\(maxMounted) " +
+                    "selected=\(debugShortWorkspaceId(effectiveSelectedId)) pinned=\(debugShortWorkspaceIds(debugPinnedIds)) " +
                     "mounted=\(debugShortWorkspaceIds(mountedWorkspaceIds))"
                 )
             }

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -6987,6 +6987,26 @@ final class WorkspaceMountPolicyTests: XCTestCase {
         XCTAssertFalse(next.contains(c))
     }
 
+    func testDefaultPolicyKeepsWarmCacheBounded() {
+        let a = UUID()
+        let b = UUID()
+        let c = UUID()
+        let d = UUID()
+        let e = UUID()
+        let orderedTabIds: [UUID] = [a, b, c, d, e]
+
+        let next = WorkspaceMountPolicy.nextMountedWorkspaceIds(
+            current: [b, a, d, e],
+            selected: c,
+            pinnedIds: [],
+            orderedTabIds: orderedTabIds,
+            isCycleHot: false,
+            maxMounted: WorkspaceMountPolicy.maxMountedWorkspaces
+        )
+
+        XCTAssertEqual(next, [c, b, a, d])
+    }
+
     func testSelectedWorkspaceMovesToFrontAndMountCountIsBounded() {
         let a = UUID()
         let b = UUID()

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -6952,7 +6952,7 @@ final class WorkspacePanelGitBranchTests: XCTestCase {
 
 
 final class WorkspaceMountPolicyTests: XCTestCase {
-    func testDefaultPolicyMountsOnlySelectedWorkspace() {
+    func testDefaultPolicyKeepsRecentlyMountedWorkspaceWarm() {
         let a = UUID()
         let b = UUID()
         let orderedTabIds: [UUID] = [a, b]
@@ -6966,7 +6966,25 @@ final class WorkspaceMountPolicyTests: XCTestCase {
             maxMounted: WorkspaceMountPolicy.maxMountedWorkspaces
         )
 
-        XCTAssertEqual(next, [b])
+        XCTAssertEqual(next, [b, a])
+    }
+
+    func testDefaultPolicyDoesNotFillWarmSlotsWithUnvisitedWorkspaces() {
+        let a = UUID()
+        let b = UUID()
+        let c = UUID()
+        let orderedTabIds: [UUID] = [a, b, c]
+
+        let next = WorkspaceMountPolicy.nextMountedWorkspaceIds(
+            current: [a],
+            selected: b,
+            pinnedIds: [],
+            orderedTabIds: orderedTabIds,
+            isCycleHot: false,
+            maxMounted: WorkspaceMountPolicy.maxMountedWorkspaces
+        )
+
+        XCTAssertFalse(next.contains(c))
     }
 
     func testSelectedWorkspaceMovesToFrontAndMountCountIsBounded() {

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -6993,10 +6993,11 @@ final class WorkspaceMountPolicyTests: XCTestCase {
         let c = UUID()
         let d = UUID()
         let e = UUID()
-        let orderedTabIds: [UUID] = [a, b, c, d, e]
+        let warmCacheIds = (0...WorkspaceMountPolicy.maxMountedWorkspaces).map { _ in UUID() }
+        let orderedTabIds: [UUID] = [a, b, c, d, e] + warmCacheIds
 
         let next = WorkspaceMountPolicy.nextMountedWorkspaceIds(
-            current: [b, a, d, e],
+            current: [b, a, d, e] + warmCacheIds,
             selected: c,
             pinnedIds: [],
             orderedTabIds: orderedTabIds,
@@ -7004,7 +7005,9 @@ final class WorkspaceMountPolicyTests: XCTestCase {
             maxMounted: WorkspaceMountPolicy.maxMountedWorkspaces
         )
 
-        XCTAssertEqual(next, [c, b, a, d])
+        XCTAssertEqual(Array(next.prefix(4)), [c, b, a, d])
+        XCTAssertEqual(next.count, WorkspaceMountPolicy.maxMountedWorkspaces)
+        XCTAssertFalse(next.contains(warmCacheIds.last!))
     }
 
     func testSelectedWorkspaceMovesToFrontAndMountCountIsBounded() {


### PR DESCRIPTION
Summary:
- Raise the normal workspace mount cache from selected-only to selected + 3 recently mounted workspaces.
- Preserve the hot-cycle handoff limit at selected + retiring workspace.
- Keep the policy from filling warm slots with never-visited workspaces.
- Add DEBUG mount reconcile logs with the effective mount limit and pinned ids.

Testing:
- Added regression coverage in `cmuxTests/WorkspaceUnitTests.swift`.
- Pushed as two commits: first the failing warm-cache regression, then the implementation.
- AWS M4 Pro targeted `cmuxTests/WorkspaceMountPolicyTests` attempted in an isolated GUI-user clone, but the runner hit `No space left on device` while writing build/test output before execution completed.
- `reload-cloud.sh --tag wsfast` succeeded via local fallback because no cloud builder slot was free.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783058211&installation_id=133855650&pr_number=5280&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5280&signature=f79d489600976f717cf8d02de54f203b4ac48335ecde3e4123d7b07fc76de4f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the selected workspace plus the last 3 visited mounted to speed up switching and reduce cold mounts. Addresses slow workspace switching across quick revisits.

- **New Features**
  - Raise normal mount budget to selected + 3 MRU; keep hot-cycle handoff at 2 (selected + retiring).
  - Don’t fill warm slots with never-visited workspaces; keep the cache bounded.
  - Add DEBUG reconcile logs with effective mount limit and pinned IDs.
  - Add regression tests for warm-cache behavior and limits.

- **Refactors**
  - Precompute tab index map to prioritize pinned IDs by tab order with less overhead.

<sup>Written for commit 811a7a42066461eb70787e092c986abe8b41f472. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recently-used workspaces now remain mounted (warm cache) so additional recently visited workspaces stay available beyond the selected one.

* **Behavior**
  * Pinned workspace prioritization and mounted-ordering have been refined to produce a more consistent and predictable mount order.

* **Tests**
  * Expanded unit tests cover warm-cache behavior, bounds, and ordering.

* **Chores**
  * Debug logging format improved for clearer mount/reconcile output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->