### PR TITLE
Persist workspace focus history permanently and add History sidebar pane

### DIFF
--- a/Sources/ContentView+RightSidebarCommandPalette.swift
+++ b/Sources/ContentView+RightSidebarCommandPalette.swift
@@ -129,6 +129,8 @@ extension ContentView {
             return "palette.showRightSidebarFind"
         case .sessions:
             return "palette.showRightSidebarSessions"
+        case .history:
+            return "palette.showRightSidebarHistory"
         case .feed:
             return "palette.showRightSidebarFeed"
         case .dock:
@@ -154,6 +156,8 @@ extension ContentView {
             return "palette.openFindPane"
         case .sessions:
             return "palette.openVaultPane"
+        case .history:
+            return "palette.openHistoryPane"
         case .feed, .dock:
             return nil
         }
@@ -167,6 +171,8 @@ extension ContentView {
             return String(localized: "command.openFindPane.title", defaultValue: "Open Find as Pane")
         case .sessions:
             return String(localized: "command.openVaultPane.title", defaultValue: "Open Vault as Pane")
+        case .history:
+            return String(localized: "command.openHistoryPane.title", defaultValue: "Open History as Pane")
         case .feed, .dock:
             return nil
         }

--- a/Sources/FocusHistory.swift
+++ b/Sources/FocusHistory.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-struct FocusHistoryEntry: Equatable {
+struct FocusHistoryEntry: Equatable, Codable, Sendable {
     let workspaceId: UUID
     let panelId: UUID?
 }
 
-struct FocusHistoryRecord: Equatable {
+struct FocusHistoryRecord: Equatable, Codable, Sendable {
     let entry: FocusHistoryEntry
     var focusedAt: Date
 

--- a/Sources/FocusHistoryStore.swift
+++ b/Sources/FocusHistoryStore.swift
@@ -1,0 +1,203 @@
+import Foundation
+import OSLog
+
+private let focusHistoryLogger = Logger(
+    subsystem: "com.cmuxterm.app",
+    category: "FocusHistoryStore"
+)
+
+/// A persisted store for focus history entries.
+///
+/// Focus history tracks which workspaces and panels the user has focused,
+/// enabling back/forward navigation and a browsable history pane.
+/// Unlike the in-memory focus history that was capped at 50 entries,
+/// this store persists permanently to disk with no capacity limit.
+@MainActor
+final class FocusHistoryStore: ObservableObject {
+    static let shared = FocusHistoryStore(
+        fileURL: defaultHistoryFileURL()
+    )
+
+    @Published private(set) var revision: UInt64 = 0
+    private var records: [FocusHistoryRecord] = []
+    private let fileURL: URL?
+    private var needsPersistenceAfterLoad = false
+    private var didFinishLoad = false
+
+    init(fileURL: URL? = nil, loadPersisted: Bool = true) {
+        self.fileURL = fileURL
+        self.didFinishLoad = !loadPersisted || fileURL == nil
+        if loadPersisted, let fileURL {
+            loadPersistedRecordsAsync(from: fileURL)
+        }
+    }
+
+    var isEmpty: Bool { records.isEmpty }
+    var count: Int { records.count }
+
+    var allRecords: [FocusHistoryRecord] { records }
+
+    func record(for index: Int) -> FocusHistoryRecord? {
+        guard records.indices.contains(index) else { return nil }
+        return records[index]
+    }
+
+    func append(_ record: FocusHistoryRecord) {
+        records.append(record)
+        revision &+= 1
+        persistRecords()
+    }
+
+    func insert(_ record: FocusHistoryRecord, at index: Int) {
+        let insertionIndex = min(max(0, index), records.count)
+        records.insert(record, at: insertionIndex)
+        revision &+= 1
+        persistRecords()
+    }
+
+    func remove(at index: Int) -> FocusHistoryRecord? {
+        guard records.indices.contains(index) else { return nil }
+        let record = records.remove(at: index)
+        revision &+= 1
+        persistRecords()
+        return record
+    }
+
+    func removeAll() {
+        guard !records.isEmpty else { return }
+        records.removeAll(keepingCapacity: false)
+        revision &+= 1
+        persistRecords()
+    }
+
+    func removeAll(where predicate: (FocusHistoryRecord) -> Bool) {
+        let oldCount = records.count
+        records.removeAll(where: predicate)
+        guard records.count != oldCount else { return }
+        revision &+= 1
+        persistRecords()
+    }
+
+    func replaceAll(_ newRecords: [FocusHistoryRecord]) {
+        records = newRecords
+        revision &+= 1
+        persistRecords()
+    }
+
+    func updateRecord(at index: Int, with record: FocusHistoryRecord) {
+        guard records.indices.contains(index) else { return }
+        records[index] = record
+        revision &+= 1
+        persistRecords()
+    }
+
+    // MARK: - Persistence
+
+    private func persistRecords() {
+        guard let fileURL else { return }
+        guard didFinishLoad else {
+            needsPersistenceAfterLoad = true
+            return
+        }
+        let snapshot = records
+        Task.detached(priority: .utility) {
+            Self.saveRecords(snapshot, fileURL: fileURL)
+        }
+    }
+
+    private func loadPersistedRecordsAsync(from fileURL: URL) {
+        Task { @MainActor [weak self] in
+            let loaded = await Self.loadRecords(fileURL: fileURL)
+            guard let self, !self.didFinishLoad else { return }
+            self.records = loaded
+            self.didFinishLoad = true
+            self.revision &+= 1
+            if self.needsPersistenceAfterLoad {
+                self.needsPersistenceAfterLoad = false
+                self.persistRecords()
+            }
+        }
+    }
+
+    nonisolated private static func loadRecords(fileURL: URL) -> [FocusHistoryRecord] {
+        guard let data = try? Data(contentsOf: fileURL) else { return [] }
+        let decoder = JSONDecoder()
+        if let snapshot = try? decoder.decode(FocusHistoryPersistenceSnapshot.self, from: data),
+           snapshot.version == FocusHistoryPersistenceSnapshot.currentVersion {
+            return snapshot.records
+        }
+        return (try? decoder.decode([FocusHistoryRecord].self, from: data)) ?? []
+    }
+
+    nonisolated private static func saveRecords(_ records: [FocusHistoryRecord], fileURL: URL) {
+        guard !records.isEmpty else {
+            do {
+                try FileManager.default.removeItem(at: fileURL)
+            } catch {
+                if FileManager.default.fileExists(atPath: fileURL.path) {
+                    focusHistoryLogger.debug(
+                        "focusHistory.remove.failed file=\(fileURL.path, privacy: .public) error=\(error.localizedDescription, privacy: .public)"
+                    )
+                }
+            }
+            return
+        }
+        let directory = fileURL.deletingLastPathComponent()
+        do {
+            try FileManager.default.createDirectory(
+                at: directory,
+                withIntermediateDirectories: true,
+                attributes: nil
+            )
+            let snapshot = FocusHistoryPersistenceSnapshot(records: records)
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.sortedKeys]
+            let data = try encoder.encode(snapshot)
+            if let existingData = try? Data(contentsOf: fileURL), existingData == data {
+                return
+            }
+            try data.write(to: fileURL, options: .atomic)
+        } catch {
+            focusHistoryLogger.debug(
+                "focusHistory.save.failed file=\(fileURL.path, privacy: .public) records=\(records.count) error=\(error.localizedDescription, privacy: .public)"
+            )
+        }
+    }
+
+    nonisolated private static func defaultHistoryFileURL(
+        bundleIdentifier: String? = Bundle.main.bundleIdentifier,
+        appSupportDirectory: URL? = nil,
+        isRunningUnderAutomatedTests: Bool = SessionRestorePolicy.isRunningUnderAutomatedTests()
+    ) -> URL? {
+        guard !isRunningUnderAutomatedTests else { return nil }
+        let resolvedAppSupport: URL
+        if let appSupportDirectory {
+            resolvedAppSupport = appSupportDirectory
+        } else if let discovered = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first {
+            resolvedAppSupport = discovered
+        } else {
+            return nil
+        }
+        let bundleId = (bundleIdentifier?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false)
+            ? bundleIdentifier!
+            : "com.cmuxterm.app"
+        let safeBundleId = bundleId.replacingOccurrences(
+            of: "[^A-Za-z0-9._-]",
+            with: "_",
+            options: .regularExpression
+        )
+        return resolvedAppSupport
+            .appendingPathComponent("cmux", isDirectory: true)
+            .appendingPathComponent("focus-history-\(safeBundleId).json", isDirectory: false)
+    }
+}
+
+private struct FocusHistoryPersistenceSnapshot: Codable {
+    static let currentVersion = 1
+
+    var version: Int = currentVersion
+    var records: [FocusHistoryRecord]
+}

--- a/Sources/HistoryPanelView.swift
+++ b/Sources/HistoryPanelView.swift
@@ -1,0 +1,150 @@
+import SwiftUI
+
+struct HistoryPanelView: View {
+    @EnvironmentObject private var tabManager: TabManager
+    @ObservedObject private var closedItemHistoryStore = ClosedItemHistoryStore.shared
+    @ObservedObject private var focusHistoryStore = FocusHistoryStore.shared
+    @State private var selectedTab: HistoryTab = .focus
+
+    enum HistoryTab: String, CaseIterable {
+        case focus
+        case closed
+
+        var label: String {
+            switch self {
+            case .focus:
+                return String(localized: "historyPane.tab.focus", defaultValue: "Focus History")
+            case .closed:
+                return String(localized: "historyPane.tab.closed", defaultValue: "Recently Closed")
+            }
+        }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            tabBar
+            Divider()
+            content
+        }
+    }
+
+    private var tabBar: some View {
+        HStack(spacing: 0) {
+            ForEach(HistoryTab.allCases, id: \.self) { tab in
+                Button(action: { selectedTab = tab }) {
+                    Text(tab.label)
+                        .font(.system(size: 12, weight: selectedTab == tab ? .semibold : .regular))
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 8)
+                        .background(selectedTab == tab ? Color.accentColor.opacity(0.15) : Color.clear)
+                        .cornerRadius(4)
+                }
+                .buttonStyle(.plain)
+                .foregroundColor(selectedTab == tab ? .accentColor : .secondary)
+            }
+            Spacer()
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch selectedTab {
+        case .focus:
+            focusHistoryList
+        case .closed:
+            closedHistoryList
+        }
+    }
+
+    private var focusHistoryList: some View {
+        let snapshot = tabManager.focusHistoryMenuSnapshot(direction: .back)
+        return Group {
+            if snapshot.items.isEmpty {
+                emptyState(message: String(localized: "historyPane.focus.empty", defaultValue: "No focus history yet"))
+            } else {
+                List {
+                    ForEach(snapshot.items, id: \.historyIndex) { item in
+                        focusHistoryRow(item: item)
+                    }
+                }
+                .listStyle(.plain)
+            }
+        }
+    }
+
+    private func focusHistoryRow(item: FocusHistoryMenuItem) -> some View {
+        Button(action: {
+            _ = tabManager.navigateToFocusHistoryMenuItem(item)
+        }) {
+            HStack(spacing: 8) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(FocusHistoryMenuFormatter.title(for: item))
+                        .font(.system(size: 12))
+                        .lineLimit(1)
+                    Text(FocusHistoryMenuFormatter.subtitle(for: item))
+                        .font(.system(size: 11))
+                        .foregroundColor(.secondary)
+                        .lineLimit(1)
+                }
+                Spacer()
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+        .disabled(!item.isNavigable)
+        .opacity(item.isNavigable ? 1.0 : 0.5)
+    }
+
+    private var closedHistoryList: some View {
+        let snapshot = closedItemHistoryStore.menuSnapshot()
+        return Group {
+            if snapshot.items.isEmpty {
+                emptyState(message: String(localized: "historyPane.closed.empty", defaultValue: "No recently closed items"))
+            } else {
+                List {
+                    ForEach(snapshot.items) { item in
+                        closedHistoryRow(item: item)
+                    }
+                }
+                .listStyle(.plain)
+            }
+        }
+    }
+
+    private func closedHistoryRow(item: ClosedItemHistoryMenuItem) -> some View {
+        Button(action: {
+            AppDelegate.shared?.reopenClosedHistoryItem(id: item.id, preferredTabManager: tabManager)
+        }) {
+            HStack(spacing: 8) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(item.title)
+                        .font(.system(size: 12))
+                        .lineLimit(1)
+                    Text(item.menuSubtitle)
+                        .font(.system(size: 11))
+                        .foregroundColor(.secondary)
+                        .lineLimit(1)
+                }
+                Spacer()
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+    }
+
+    private func emptyState(message: String) -> some View {
+        VStack {
+            Spacer()
+            Text(message)
+                .font(.system(size: 13))
+                .foregroundColor(.secondary)
+            Spacer()
+        }
+    }
+}

--- a/Sources/KeyboardShortcutContext.swift
+++ b/Sources/KeyboardShortcutContext.swift
@@ -74,7 +74,7 @@ extension KeyboardShortcutSettings.Action {
              .diffViewerScrollToTop,
              .diffViewerOpenFileSearch:
             return .browserPanel
-        case .switchRightSidebarToFiles, .switchRightSidebarToFind, .switchRightSidebarToSessions, .switchRightSidebarToFeed, .switchRightSidebarToDock:
+        case .switchRightSidebarToFiles, .switchRightSidebarToFind, .switchRightSidebarToSessions, .switchRightSidebarToHistory, .switchRightSidebarToFeed, .switchRightSidebarToDock:
             return .rightSidebarFocus
         case .renameTab, .renameWorkspace, .sendCtrlFToTerminal:
             return .nonBrowserPanel

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -86,6 +86,7 @@ enum KeyboardShortcutSettings {
         case switchRightSidebarToFiles
         case switchRightSidebarToFind
         case switchRightSidebarToSessions
+        case switchRightSidebarToHistory
         case switchRightSidebarToFeed
         case switchRightSidebarToDock
         case triggerFlash
@@ -188,6 +189,7 @@ enum KeyboardShortcutSettings {
             case .switchRightSidebarToFiles: return String(localized: "shortcut.switchRightSidebarToFiles.label", defaultValue: "Show Sidebar Files")
             case .switchRightSidebarToFind: return String(localized: "shortcut.switchRightSidebarToFind.label", defaultValue: "Show Sidebar Find")
             case .switchRightSidebarToSessions: return String(localized: "shortcut.switchRightSidebarToSessions.label", defaultValue: "Show Sidebar Vault")
+            case .switchRightSidebarToHistory: return String(localized: "shortcut.switchRightSidebarToHistory.label", defaultValue: "Show Sidebar History")
             case .switchRightSidebarToFeed: return String(localized: "shortcut.switchRightSidebarToFeed.label", defaultValue: "Show Sidebar Feed")
             case .switchRightSidebarToDock: return String(localized: "shortcut.switchRightSidebarToDock.label", defaultValue: "Show Sidebar Dock")
             case .triggerFlash: return String(localized: "shortcut.flashFocusedPanel.label", defaultValue: "Flash Focused Panel")
@@ -262,6 +264,7 @@ enum KeyboardShortcutSettings {
             case .switchRightSidebarToFiles,
                  .switchRightSidebarToFind,
                  .switchRightSidebarToSessions,
+                 .switchRightSidebarToHistory,
                  .switchRightSidebarToFeed,
                  .switchRightSidebarToDock:
                 return false
@@ -326,6 +329,8 @@ enum KeyboardShortcutSettings {
                 return StoredShortcut(key: "2", command: false, shift: false, option: false, control: true)
             case .switchRightSidebarToSessions:
                 return StoredShortcut(key: "3", command: false, shift: false, option: false, control: true)
+            case .switchRightSidebarToHistory:
+                return StoredShortcut(key: "6", command: false, shift: false, option: false, control: true)
             case .switchRightSidebarToFeed:
                 return StoredShortcut(key: "4", command: false, shift: false, option: false, control: true)
             case .switchRightSidebarToDock:

--- a/Sources/MainWindowFocusController.swift
+++ b/Sources/MainWindowFocusController.swift
@@ -109,7 +109,7 @@ final class MainWindowFocusController {
             fileExplorerHost = host
         case .find:
             fileSearchHost = host
-        case .sessions, .feed, .dock:
+        case .sessions, .history, .feed, .dock:
             break
         }
         focusRegisteredRightSidebarEndpointIfNeeded(mode: mode)
@@ -641,7 +641,7 @@ final class MainWindowFocusController {
             return .outline
         case .find:
             return .searchField
-        case .sessions:
+        case .sessions, .history:
             return .host
         case .feed:
             return focusFirstItem ? .firstItem : .host
@@ -659,7 +659,7 @@ final class MainWindowFocusController {
             return fileExplorerHost?.focusOutline() == true
         case .find:
             return fileSearchHost?.focusSearchField() == true
-        case .sessions:
+        case .sessions, .history:
             return false
         case .feed:
             if target == .firstItem {

--- a/Sources/RightSidebarMode+Availability.swift
+++ b/Sources/RightSidebarMode+Availability.swift
@@ -9,6 +9,8 @@ extension RightSidebarMode {
             return .find
         case "vault", "sessions":
             return .sessions
+        case "history":
+            return .history
         case "feed":
             return .feed
         case "dock":
@@ -38,7 +40,7 @@ extension RightSidebarMode {
 
     func isAvailable(feedEnabled: Bool, dockEnabled: Bool) -> Bool {
         switch self {
-        case .files, .find, .sessions:
+        case .files, .find, .sessions, .history:
             return true
         case .feed:
             return feedEnabled

--- a/Sources/RightSidebarPanelView.swift
+++ b/Sources/RightSidebarPanelView.swift
@@ -13,6 +13,7 @@ nonisolated enum RightSidebarMode: String, CaseIterable, Codable, Sendable {
     case files
     case find
     case sessions
+    case history
     case feed
     case dock
 
@@ -21,6 +22,7 @@ nonisolated enum RightSidebarMode: String, CaseIterable, Codable, Sendable {
         case .files: return String(localized: "rightSidebar.mode.files", defaultValue: "Files")
         case .find: return String(localized: "rightSidebar.mode.find", defaultValue: "Find")
         case .sessions: return String(localized: "rightSidebar.mode.sessions", defaultValue: "Vault")
+        case .history: return String(localized: "rightSidebar.mode.history", defaultValue: "History")
         case .feed: return String(localized: "rightSidebar.mode.feed", defaultValue: "Feed")
         case .dock: return String(localized: "rightSidebar.mode.dock", defaultValue: "Dock")
         }
@@ -31,6 +33,7 @@ nonisolated enum RightSidebarMode: String, CaseIterable, Codable, Sendable {
         case .files: return "folder"
         case .find: return "magnifyingglass"
         case .sessions: return "books.vertical"
+        case .history: return "clock.arrow.circlepath"
         case .feed: return "dot.radiowaves.left.and.right"
         case .dock: return "dock.rectangle"
         }
@@ -41,6 +44,7 @@ nonisolated enum RightSidebarMode: String, CaseIterable, Codable, Sendable {
         case .files: return .switchRightSidebarToFiles
         case .find: return .switchRightSidebarToFind
         case .sessions: return .switchRightSidebarToSessions
+        case .history: return .switchRightSidebarToHistory
         case .feed: return .switchRightSidebarToFeed
         case .dock: return .switchRightSidebarToDock
         }
@@ -48,7 +52,7 @@ nonisolated enum RightSidebarMode: String, CaseIterable, Codable, Sendable {
 }
 
 extension RightSidebarMode {
-    static let paneModes: [RightSidebarMode] = [.files, .find, .sessions]
+    static let paneModes: [RightSidebarMode] = [.files, .find, .sessions, .history]
 
     var canOpenAsPane: Bool {
         Self.paneModes.contains(self)
@@ -66,6 +70,9 @@ extension RightSidebarMode {
         }
         if KeyboardShortcutSettings.shortcut(for: .switchRightSidebarToSessions).matches(event: event) {
             return .sessions
+        }
+        if KeyboardShortcutSettings.shortcut(for: .switchRightSidebarToHistory).matches(event: event) {
+            return .history
         }
         if KeyboardShortcutSettings.shortcut(for: .switchRightSidebarToFeed).matches(event: event),
            RightSidebarMode.feed.isAvailable() {
@@ -406,6 +413,8 @@ struct RightSidebarPanelView: View {
                 .onAppear {
                     sessionIndexStore.setCurrentDirectoryIfChanged(sessionIndexDirectory)
                 }
+        case .history:
+            HistoryPanelView()
         case .feed:
             FeedPanelView()
         case .dock:

--- a/Sources/RightSidebarToolPanel.swift
+++ b/Sources/RightSidebarToolPanel.swift
@@ -81,7 +81,7 @@ final class RightSidebarToolPanel: Panel, ObservableObject {
         case .sessions:
             guard let store = sessionIndexStoreStorage else { return }
             syncSessionIndexRoot(from: workspace, store: store)
-        case .feed, .dock:
+        case .history, .feed, .dock:
             break
         }
     }
@@ -139,7 +139,7 @@ final class RightSidebarToolPanel: Panel, ObservableObject {
             guard let anchor = sessionIndexFocusAnchorView,
                   let window = anchor.window else { return }
             _ = window.makeFirstResponder(anchor)
-        case .feed, .dock:
+        case .history, .feed, .dock:
             break
         }
     }
@@ -161,7 +161,7 @@ final class RightSidebarToolPanel: Panel, ObservableObject {
         case .sessions:
             guard sessionIndexFocusAnchorView?.ownsKeyboardFocus(responder) == true else { return nil }
             return .panel
-        case .feed, .dock:
+        case .history, .feed, .dock:
             return nil
         }
     }
@@ -288,6 +288,8 @@ struct RightSidebarToolPanelView: View {
                 RightSidebarToolFocusAnchor(onViewChange: panel.attachSessionIndexFocusAnchor)
                     .frame(width: 0, height: 0)
             )
+        case .history:
+            HistoryPanelView()
         case .feed, .dock:
             EmptyView()
         }

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -1329,7 +1329,7 @@ class TabManager: ObservableObject {
     private var shouldRecordFocusHistory: Bool {
         focusHistoryRecordingSuppressionDepth == 0
     }
-    private let maxHistorySize = 50
+    private let focusHistoryStore = FocusHistoryStore.shared
     private var selectionSideEffectsGeneration: UInt64 = 0
     private var workspaceCycleGeneration: UInt64 = 0
     private var workspaceCycleCooldownTask: Task<Void, Never>?
@@ -1374,6 +1374,7 @@ class TabManager: ObservableObject {
             initialTerminalInput: initialTerminalInput,
             autoWelcomeIfNeeded: autoWelcomeIfNeeded
         )
+        loadPersistedFocusHistory()
         observers.append(NotificationCenter.default.addObserver(
             forName: .ghosttyDidSetTitle,
             object: nil,
@@ -8715,12 +8716,9 @@ class TabManager: ObservableObject {
                 }
 
                 focusHistory.insert(FocusHistoryRecord(entry: entry), at: insertionIndex)
-                let overflow = max(0, focusHistory.count - maxHistorySize)
-                if overflow > 0 {
-                    focusHistory.removeFirst(overflow)
-                }
-                historyIndex = max(-1, insertionIndex - overflow)
+                historyIndex = insertionIndex
                 focusHistoryRevision &+= 1
+                syncFocusHistoryToStore()
                 return
             } else {
                 focusHistory = Array(focusHistory.prefix(historyIndex + 1))
@@ -8737,12 +8735,9 @@ class TabManager: ObservableObject {
         }
 
         focusHistory.append(FocusHistoryRecord(entry: entry))
-        if focusHistory.count > maxHistorySize {
-            focusHistory.removeFirst(focusHistory.count - maxHistorySize)
-        }
-
         historyIndex = focusHistory.count - 1
         focusHistoryRevision &+= 1
+        syncFocusHistoryToStore()
     }
 
     private func recordFocusInHistory(
@@ -8768,6 +8763,7 @@ class TabManager: ObservableObject {
             if focusHistory[historyIndex].entry != entry {
                 focusHistory[historyIndex] = FocusHistoryRecord(entry: entry)
                 focusHistoryRevision &+= 1
+                syncFocusHistoryToStore()
             }
             return
         }
@@ -8781,6 +8777,7 @@ class TabManager: ObservableObject {
                 return
             }
             focusHistoryRevision &+= 1
+            syncFocusHistoryToStore()
             return
         }
 
@@ -8802,6 +8799,18 @@ class TabManager: ObservableObject {
             historyIndex = min(max(-1, historyIndex), focusHistory.count - 1)
         }
         focusHistoryRevision &+= 1
+        syncFocusHistoryToStore()
+    }
+
+    private func syncFocusHistoryToStore() {
+        focusHistoryStore.replaceAll(focusHistory)
+    }
+
+    private func loadPersistedFocusHistory() {
+        let persisted = focusHistoryStore.allRecords
+        guard !persisted.isEmpty else { return }
+        focusHistory = persisted
+        historyIndex = persisted.count - 1
     }
 
     private func panelIdForFocusHistorySurface(_ surfaceId: UUID, workspaceId: UUID) -> UUID {
@@ -8980,6 +8989,7 @@ class TabManager: ObservableObject {
 
         let currentEntry = currentFocusHistoryEntry
         var targetIndex = historyIndex - 1
+        var didMutate = false
         while targetIndex >= 0 {
             let entry = focusHistory[targetIndex].entry
             guard focusHistoryWorkspace(for: entry) != nil else {
@@ -8987,6 +8997,7 @@ class TabManager: ObservableObject {
                 historyIndex -= 1
                 targetIndex -= 1
                 focusHistoryRevision &+= 1
+                didMutate = true
                 continue
             }
             if focusHistoryEntryResolvesToCurrent(entry, currentEntry: currentEntry) {
@@ -8994,13 +9005,16 @@ class TabManager: ObservableObject {
                 continue
             }
             if navigateToFocusHistoryEntry(entry, targetIndex: targetIndex) {
+                if didMutate { syncFocusHistoryToStore() }
                 return true
             }
             focusHistory.remove(at: targetIndex)
             historyIndex -= 1
             targetIndex -= 1
             focusHistoryRevision &+= 1
+            didMutate = true
         }
+        if didMutate { syncFocusHistoryToStore() }
         return false
     }
 
@@ -9010,11 +9024,13 @@ class TabManager: ObservableObject {
 
         let currentEntry = currentFocusHistoryEntry
         var targetIndex = historyIndex + 1
+        var didMutate = false
         while targetIndex < focusHistory.count {
             let entry = focusHistory[targetIndex].entry
             guard focusHistoryWorkspace(for: entry) != nil else {
                 focusHistory.remove(at: targetIndex)
                 focusHistoryRevision &+= 1
+                didMutate = true
                 continue
             }
             if focusHistoryEntryResolvesToCurrent(entry, currentEntry: currentEntry) {
@@ -9022,11 +9038,14 @@ class TabManager: ObservableObject {
                 continue
             }
             if navigateToFocusHistoryEntry(entry, targetIndex: targetIndex) {
+                if didMutate { syncFocusHistoryToStore() }
                 return true
             }
             focusHistory.remove(at: targetIndex)
             focusHistoryRevision &+= 1
+            didMutate = true
         }
+        if didMutate { syncFocusHistoryToStore() }
         return false
     }
 
@@ -11259,6 +11278,7 @@ extension TabManager {
         lastFocusedPanelByTab.removeAll()
         pendingPanelTitleUpdates.removeAll()
         focusHistory.removeAll()
+        focusHistoryStore.removeAll()
         historyIndex = -1
         focusHistoryRecordingSuppressionDepth = 0
         focusHistorySuppressedSelectionSideEffectGenerations.removeAll()

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -268,6 +268,7 @@
 		F1A0C0DE0000000000000002 /* FindTextFieldSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A0C0DE0000000000000001 /* FindTextFieldSupport.swift */; };
 		F0C05170000000000000002 /* FocusHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0C05170000000000000001 /* FocusHistory.swift */; };
 		C4160A020000000000000001 /* FocusHistoryMenuInvalidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4160A020000000000000002 /* FocusHistoryMenuInvalidator.swift */; };
+		5960FFADE79B450B9E9F8B82275457C2 /* FocusHistoryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3318603CEF24BFE889D9DE362185DA9 /* FocusHistoryStore.swift */; };
 		C0DEFB100000000000000001 /* FocusSurfaceBroadcaster.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEFB100000000000000002 /* FocusSurfaceBroadcaster.swift */; };
 		C0DEFB300000000000000001 /* FocusSurfaceBroadcasterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEFB300000000000000002 /* FocusSurfaceBroadcasterTests.swift */; };
 		D0B10012A1B2C3D4E5F60001 /* GhosttyApp+SurfaceConfigurationReload.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B10013A1B2C3D4E5F60001 /* GhosttyApp+SurfaceConfigurationReload.swift */; };
@@ -297,6 +298,7 @@
 		C1ADE10002A1B2C3D4E5F719 /* grok in Copy CLI */ = {isa = PBXBuildFile; fileRef = C1ADE10001A1B2C3D4E5F719 /* grok */; };
 		C0DE34020000000000000005 /* HelpMenuUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE34020000000000000006 /* HelpMenuUITests.swift */; };
 		F5320000A1B2C3D4E5F60718 /* HermesAgentIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5320001A1B2C3D4E5F60718 /* HermesAgentIndex.swift */; };
+		DF76253CAE3C419B8AD1A5A461A89A77 /* HistoryPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D642C7CDA214289B69F421E6FED661B /* HistoryPanelView.swift */; };
 		CD0CFE6000000000CD0CFE60 /* HostAccountFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0CFE6100000000CD0CFE61 /* HostAccountFlow.swift */; };
 		CD0CFE6200000000CD0CFE62 /* HostSettingsActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0CFE6300000000CD0CFE63 /* HostSettingsActions.swift */; };
 		F1C1AA21B7E84D10A1C10001 /* InactivePaneFirstClickFocusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C1AA20B7E84D10A1C10001 /* InactivePaneFirstClickFocusTests.swift */; };
@@ -898,6 +900,7 @@
 		F1A0C0DE0000000000000001 /* FindTextFieldSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Find/FindTextFieldSupport.swift; sourceTree = "<group>"; };
 		F0C05170000000000000001 /* FocusHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusHistory.swift; sourceTree = "<group>"; };
 		C4160A020000000000000002 /* FocusHistoryMenuInvalidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusHistoryMenuInvalidator.swift; sourceTree = "<group>"; };
+		F3318603CEF24BFE889D9DE362185DA9 /* FocusHistoryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusHistoryStore.swift; sourceTree = "<group>"; };
 		C0DEFB100000000000000002 /* FocusSurfaceBroadcaster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusSurfaceBroadcaster.swift; sourceTree = "<group>"; };
 		C0DEFB300000000000000002 /* FocusSurfaceBroadcasterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusSurfaceBroadcasterTests.swift; sourceTree = "<group>"; };
 		A5001017 /* ghostty.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ghostty.h; sourceTree = "<group>"; };
@@ -928,6 +931,7 @@
 		C1ADE10001A1B2C3D4E5F719 /* grok */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = Resources/bin/grok; sourceTree = SOURCE_ROOT; };
 		C0DE34020000000000000006 /* HelpMenuUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpMenuUITests.swift; sourceTree = "<group>"; };
 		F5320001A1B2C3D4E5F60718 /* HermesAgentIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HermesAgentIndex.swift; sourceTree = "<group>"; };
+		2D642C7CDA214289B69F421E6FED661B /* HistoryPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryPanelView.swift; sourceTree = "<group>"; };
 		CD0CFE6100000000CD0CFE61 /* HostAccountFlow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HostAccountFlow.swift; sourceTree = "<group>"; };
 		CD0CFE6300000000CD0CFE63 /* HostSettingsActions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HostSettingsActions.swift; sourceTree = "<group>"; };
 		F1C1AA20B7E84D10A1C10001 /* InactivePaneFirstClickFocusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InactivePaneFirstClickFocusTests.swift; sourceTree = "<group>"; };
@@ -1496,6 +1500,8 @@
 					A50012F4 /* KeyboardLayout.swift */,
 					A5001013 /* TabManager.swift */,
 					F0C05170000000000000001 /* FocusHistory.swift */,
+				2D642C7CDA214289B69F421E6FED661B /* HistoryPanelView.swift */,
+				F3318603CEF24BFE889D9DE362185DA9 /* FocusHistoryStore.swift */,
 					C0DEFB100000000000000002 /* FocusSurfaceBroadcaster.swift */,
 					C10D51700000000000000001 /* ClosedItemHistory.swift */,
 					C3677003000000000000002 /* TabManager+CompatibilityTypes.swift */,
@@ -2383,6 +2389,7 @@
 					F1A0C0DE0000000000000002 /* FindTextFieldSupport.swift in Sources */,
 					F0C05170000000000000002 /* FocusHistory.swift in Sources */,
 				C4160A020000000000000001 /* FocusHistoryMenuInvalidator.swift in Sources */,
+			5960FFADE79B450B9E9F8B82275457C2 /* FocusHistoryStore.swift in Sources */,
 					C0DEFB100000000000000001 /* FocusSurfaceBroadcaster.swift in Sources */,
 				D0B10012A1B2C3D4E5F60001 /* GhosttyApp+SurfaceConfigurationReload.swift in Sources */,
 				A5001004 /* GhosttyConfig.swift in Sources */,
@@ -2399,6 +2406,7 @@
 				3865A0073865A0073865A007 /* GlobalSearchDocuments.swift in Sources */,
 				3865A0083865A0083865A008 /* GlobalSearchPanelCaptureManager.swift in Sources */,
 				F5320000A1B2C3D4E5F60718 /* HermesAgentIndex.swift in Sources */,
+			DF76253CAE3C419B8AD1A5A461A89A77 /* HistoryPanelView.swift in Sources */,
 				CD0CFE6000000000CD0CFE60 /* HostAccountFlow.swift in Sources */,
 				CD0CFE6200000000CD0CFE62 /* HostSettingsActions.swift in Sources */,
 				4D8B37E0E11A29997632765F /* InternalTabDragConfiguration.swift in Sources */,


### PR DESCRIPTION
## Summary
- Replace in-memory 50-entry focus history cap with FocusHistoryStore that persists to disk permanently
- Remove maxHistorySize limit for unlimited focus history
- Add new RightSidebarMode.history with HistoryPanelView sidebar pane
- History pane shows two tabs:
  - Focus History: browsable list of previously focused workspaces/panels with click-to-navigate
  - Recently Closed: browsable list of closed tabs, workspaces, and windows with click-to-restore
- Add Ctrl+6 keyboard shortcut and command palette support for History pane
- Sync all focus history mutations to persistent store after every change

## Testing
- Build verified: xcodebuild -scheme cmux -configuration Debug succeeds

## Issues
- Related to focus history persistence request

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5281"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783058229&installation_id=133855650&pr_number=5281&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5281&signature=17ee4a9b28f8205d6d679cce49c55594a29cd27c2d672b93e2a082150dc71d70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Focus/navigation state is written to disk on every history change and loaded at `TabManager` init; bugs could corrupt navigation or grow unbounded history files, but scope is localized UI state rather than auth or remote data.
> 
> **Overview**
> This PR makes workspace/panel **focus history** durable and browsable instead of a capped in-memory list.
> 
> **Persistence:** `TabManager` drops the 50-entry `maxHistorySize` trim and wires a new `FocusHistoryStore` that JSON-persists the full stack under Application Support (async load/save, versioned snapshot, skipped under UI tests). `FocusHistoryEntry` / `FocusHistoryRecord` gain `Codable` for disk encoding. Mutations (record, invalidate, back/forward cleanup, session reset) sync via `replaceAll` / `removeAll` on the store.
> 
> **History sidebar:** Adds `RightSidebarMode.history` with `HistoryPanelView`—tabs for **Focus History** (click rows via existing `TabManager` menu navigation) and **Recently Closed** (reopen via `ClosedItemHistoryStore`). Integrated into the right sidebar, tool panes, CLI mode parsing, availability, focus routing, and command palette entries.
> 
> **Shortcuts:** New `switchRightSidebarToHistory` (default **Ctrl+6**) and matching mode shortcut detection; treated like other right-sidebar mode switches in shortcut context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98aa3ff74387152b15d23a34d2c45dd0682ad4e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persists workspace focus history to disk and adds a History sidebar pane for quick navigation and restore. Removes the 50-item cap, making back/forward history durable across app restarts.

- **New Features**
  - Added `FocusHistoryStore` that saves history to Application Support and loads it on startup; unlimited entries and JSON snapshotting.
  - Introduced Right Sidebar “History” pane (`RightSidebarMode.history`) with two tabs: Focus History (click to navigate) and Recently Closed (click to restore).
  - Added Ctrl+6 shortcut and command palette actions to open the History pane.
  - Integrated persistence into `TabManager` (sync on every mutation, load on init, clear on reset); made history models `Codable`/`Sendable`.

<sup>Written for commit 98aa3ff74387152b15d23a34d2c45dd0682ad4e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5281?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new History panel in the right sidebar, accessible via Ctrl+6, displaying Focus history and Recently Closed items in separate tabs
  * Focus history is now automatically persisted across application sessions
  * History panel can be opened as a dedicated pane from the sidebar

<!-- end of auto-generated comment: release notes by coderabbit.ai -->