### PR TITLE
Add Open Current Directory in Devin Command

### DIFF
--- a/Sources/App/TerminalDirectoryOpenSupport.swift
+++ b/Sources/App/TerminalDirectoryOpenSupport.swift
@@ -65,6 +65,7 @@ enum TerminalDirectoryOpenTarget: String, CaseIterable {
     case androidStudio
     case antigravity
     case cursor
+    case devin
     case finder
     case ghostty
     case intellij
@@ -112,6 +113,8 @@ enum TerminalDirectoryOpenTarget: String, CaseIterable {
             return String(localized: "menu.openInAntigravity", defaultValue: "Open Current Directory in Antigravity")
         case .cursor:
             return String(localized: "menu.openInCursor", defaultValue: "Open Current Directory in Cursor")
+        case .devin:
+            return String(localized: "menu.openInDevin", defaultValue: "Open Current Directory in Devin")
         case .finder:
             return String(localized: "menu.openInFinder", defaultValue: "Open Current Directory in Finder")
         case .ghostty:
@@ -148,6 +151,8 @@ enum TerminalDirectoryOpenTarget: String, CaseIterable {
             return common + ["antigravity"]
         case .cursor:
             return common + ["cursor"]
+        case .devin:
+            return common + ["devin", "cognition"]
         case .finder:
             return common + ["finder", "file", "manager", "reveal"]
         case .ghostty:
@@ -243,6 +248,8 @@ enum TerminalDirectoryOpenTarget: String, CaseIterable {
                 "/Applications/Cursor Preview.app",
                 "/Applications/Cursor Nightly.app",
             ]
+        case .devin:
+            return ["/Applications/Devin.app"]
         case .finder:
             return ["/System/Library/CoreServices/Finder.app"]
         case .ghostty:


### PR DESCRIPTION
## Summary

- **What changed?** Adds **Devin** as an "Open Current Directory in…" target. This introduces a new `devin` case in `TerminalDirectoryOpenTarget` (`Sources/App/TerminalDirectoryOpenSupport.swift`) with the menu label "Open Current Directory in Devin", search keywords (`devin`, `cognition`), and the app path `/Applications/Devin.app`. Localized strings for the new label were added across all supported languages in `Resources/Localizable.xcstrings`.
- **Why?** Windsurf was rebranded to Devin, so Windsurf users who now use Devin can open the current terminal directory directly in the Devin app, consistent with the existing targets (Cursor, Antigravity, IntelliJ, etc.).

## Testing

- How did you test this change? Built the Debug app locally and opened the "Open Current Directory in…" menu/command palette.
- What did you verify manually? "Open Current Directory in Devin" appears in the list, is discoverable via the `devin`/`cognition` search keywords, and launches `/Applications/Devin.app` with the current directory.

## Demo Video

For UI or behavior changes, include a short demo video (GitHub upload, Loom, or other direct link).

- Video URL or attachment:


https://github.com/user-attachments/assets/e78b85f3-63ab-4200-b671-88aa26808a4c


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783081183&installation_id=133855650&pr_number=5288&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5288&signature=ee5e346e56ad932f7a5d0385b35ba42e4d545ca7db58f0a71eef0534b97254e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to open your current directory in Devin directly from the application.
  * Comprehensive localization support added across 19+ languages including English, Japanese, Chinese, Korean, German, Spanish, French, Italian, and more.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Closes #5287