### PR TITLE
Coalesce sidebar preview refreshes

### DIFF
--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -10540,9 +10540,6 @@ final class Workspace: Identifiable, ObservableObject {
             sidebarObservationSignal($customDescription),
             sidebarObservationSignal($isPinned),
             sidebarObservationSignal($customColor),
-            sidebarObservationSignal($latestConversationMessage),
-            sidebarObservationSignal($latestSubmittedMessage),
-            sidebarObservationSignal($latestSubmittedAt),
         ]
 
         return Publishers.MergeMany(publishers).eraseToAnyPublisher()
@@ -10561,6 +10558,9 @@ final class Workspace: Identifiable, ObservableObject {
             sidebarObservationSignal($panelDirectories),
             sidebarObservationSignal($statusEntries),
             sidebarObservationSignal($metadataBlocks),
+            sidebarObservationSignal($latestConversationMessage),
+            sidebarObservationSignal($latestSubmittedMessage),
+            sidebarObservationSignal($latestSubmittedAt),
             sidebarObservationSignal($logEntries),
             sidebarObservationSignal($progress),
             sidebarObservationSignal($gitBranch),

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -6431,6 +6431,35 @@ final class WorkspacePanelGitBranchTests: XCTestCase {
         )
     }
 
+    func testConversationPreviewChangesUseDebouncedSidebarObservationOnly() {
+        let workspace = Workspace()
+
+        var immediatePublishCount = 0
+        let immediateCancellable = workspace.sidebarImmediateObservationPublisher.sink {
+            immediatePublishCount += 1
+        }
+        defer { immediateCancellable.cancel() }
+
+        var debouncedPublishCount = 0
+        let debouncedCancellable = workspace.sidebarObservationPublisher.sink {
+            debouncedPublishCount += 1
+        }
+        defer { debouncedCancellable.cancel() }
+
+        XCTAssertTrue(workspace.recordSubmittedMessage("please implement this"))
+
+        XCTAssertEqual(
+            immediatePublishCount,
+            0,
+            "Expected agent message previews to avoid immediate sidebar row invalidations"
+        )
+        XCTAssertGreaterThan(
+            debouncedPublishCount,
+            0,
+            "Expected agent message previews to still refresh sidebar rows through the debounced observation path"
+        )
+    }
+
     @MainActor
     func testSidebarPullRequestsTrackFocusedPanelOnly() {
         let workspace = Workspace()


### PR DESCRIPTION
## Summary

- Move `latestConversationMessage`, `latestSubmittedMessage`, and `latestSubmittedAt` from `sidebarImmediateObservationPublisher` to `sidebarObservationPublisher`.
- Add a unit test proving submitted message previews no longer trigger immediate sidebar row invalidations, while still publishing through the debounced sidebar observation path.

Refs #2586.

The motivation is a live cmux 0.64.12 hang where the main thread was dominated by SwiftUI/AttributeGraph layout work and socket commands failed with `Broken pipe`. These message preview fields can update during agent activity and are sidebar-visible, but they do not need the same immediate treatment as title, description, pin, or color changes. Keeping them on the existing debounced path should reduce high-frequency row snapshot churn without delaying stable row affordances.

## Testing

- `git diff --check`
- Attempted:

```text
xcodebuild test -project cmux.xcodeproj -scheme cmux-unit -destination 'platform=macOS' -only-testing:cmuxTests/WorkspacePanelGitBranchTests/testConversationPreviewChangesUseDebouncedSidebarObservationOnly -derivedDataPath /tmp/cmux-pr-debug-dd
```

The targeted Xcode test command did not reach test execution in this environment. It spent several minutes in package/build resolution with no further output after dependency checkout, so I interrupted that `xcodebuild` process.

## Demo Video

No demo video. This is a mitigation for a captured live hang rather than a deterministic UI scenario.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [ ] I tested the change locally
- [x] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5291"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783087413&installation_id=133855650&pr_number=5291&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5291&signature=e77f0d118446b752c4e1e1b45f1b6fec2e8e07ac55c71c8370379dee6b63f944"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Coalesced sidebar preview updates by moving preview fields off the immediate observation path. This reduces sidebar row layout churn and mitigates the live hang reported in #2586.

- **Performance**
  - Moved latest conversation/submitted preview fields from sidebarImmediateObservationPublisher to the debounced sidebarObservationPublisher.
  - Added a unit test to ensure submitted message previews avoid immediate invalidations and still refresh via the debounced path.

<sup>Written for commit 517268c5fa506d28986cff43c0feb81e922aaeae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for message preview submission behavior to ensure correct sidebar invalidation handling.

* **Refactor**
  * Reorganized internal observation signal ordering for improved code structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->