### PR TITLE
Fix copy-mode vim keys swallowed under non-ASCII input sources (Korean, Japanese Kana, Zhuyin)

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1483,18 +1483,21 @@ private func terminalKeyboardCopyModeNormalizedModifiers(
 private func terminalKeyboardCopyModeChars(
     _ charactersIgnoringModifiers: String?,
     keyCode: UInt16,
-    modifierFlags: NSEvent.ModifierFlags
+    asciiCharacterProvider: (UInt16, NSEvent.ModifierFlags) -> String?
 ) -> String {
     let raw = charactersIgnoringModifiers?.unicodeScalars.first.map { String($0).lowercased() } ?? ""
     if raw.allSatisfy(\.isASCII) { return raw }
     // Non-ASCII input sources (Korean 두벌식, Japanese Kana, Zhuyin) translate the
     // physical key to a layout character, so a vim key like `j` arrives as `ㅓ` and
     // never matches the ASCII `switch chars` cases. Fall back to the ASCII-capable
-    // layout — the same `KeyboardLayout` helper the keyDown shortcut path already
-    // uses — so copy-mode vim keys resolve regardless of the active input source.
-    // ASCII-emitting IMEs (Pinyin, romaji) keep `raw` and skip the fallback.
-    if let asciiScalar = KeyboardLayout.character(forKeyCode: keyCode, modifierFlags: modifierFlags)?
-        .unicodeScalars.first {
+    // layout lookup (the same one the keyDown shortcut path uses) so copy-mode vim
+    // keys resolve regardless of the active input source. ASCII-emitting IMEs
+    // (Pinyin, romaji) keep `raw` and skip the fallback. The provider is injected
+    // so tests can supply a deterministic mapping without depending on the runner's
+    // input source. Pass [] like KeyboardLayout.normalizedCharacters does: the
+    // lookup lowercases its output and only honors shift/command, so modifiers are
+    // irrelevant for letter keys and this stays consistent with the shortcut path.
+    if let asciiScalar = asciiCharacterProvider(keyCode, [])?.unicodeScalars.first {
         return String(asciiScalar).lowercased()
     }
     return raw
@@ -1509,10 +1512,11 @@ func terminalKeyboardCopyModeAction(
     keyCode: UInt16,
     charactersIgnoringModifiers: String?,
     modifierFlags: NSEvent.ModifierFlags,
-    hasSelection: Bool
+    hasSelection: Bool,
+    asciiCharacterProvider: (UInt16, NSEvent.ModifierFlags) -> String? = KeyboardLayout.character(forKeyCode:modifierFlags:)
 ) -> TerminalKeyboardCopyModeAction? {
     let normalized = terminalKeyboardCopyModeNormalizedModifiers(modifierFlags)
-    let chars = terminalKeyboardCopyModeChars(charactersIgnoringModifiers, keyCode: keyCode, modifierFlags: modifierFlags)
+    let chars = terminalKeyboardCopyModeChars(charactersIgnoringModifiers, keyCode: keyCode, asciiCharacterProvider: asciiCharacterProvider)
 
     if keyCode == 53 { // Escape
         return .exit
@@ -1612,10 +1616,11 @@ func terminalKeyboardCopyModeResolve(
     charactersIgnoringModifiers: String?,
     modifierFlags: NSEvent.ModifierFlags,
     hasSelection: Bool,
-    state: inout TerminalKeyboardCopyModeInputState
+    state: inout TerminalKeyboardCopyModeInputState,
+    asciiCharacterProvider: (UInt16, NSEvent.ModifierFlags) -> String? = KeyboardLayout.character(forKeyCode:modifierFlags:)
 ) -> TerminalKeyboardCopyModeResolution {
     let normalized = terminalKeyboardCopyModeNormalizedModifiers(modifierFlags)
-    let chars = terminalKeyboardCopyModeChars(charactersIgnoringModifiers, keyCode: keyCode, modifierFlags: modifierFlags)
+    let chars = terminalKeyboardCopyModeChars(charactersIgnoringModifiers, keyCode: keyCode, asciiCharacterProvider: asciiCharacterProvider)
 
     if keyCode == 53 { // Escape
         state.reset()
@@ -1676,7 +1681,8 @@ func terminalKeyboardCopyModeResolve(
         keyCode: keyCode,
         charactersIgnoringModifiers: charactersIgnoringModifiers,
         modifierFlags: modifierFlags,
-        hasSelection: hasSelection
+        hasSelection: hasSelection,
+        asciiCharacterProvider: asciiCharacterProvider
     ) else {
         state.reset()
         return .consume

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1481,12 +1481,23 @@ private func terminalKeyboardCopyModeNormalizedModifiers(
 }
 
 private func terminalKeyboardCopyModeChars(
-    _ charactersIgnoringModifiers: String?
+    _ charactersIgnoringModifiers: String?,
+    keyCode: UInt16,
+    modifierFlags: NSEvent.ModifierFlags
 ) -> String {
-    guard let scalar = charactersIgnoringModifiers?.unicodeScalars.first else {
-        return ""
+    let raw = charactersIgnoringModifiers?.unicodeScalars.first.map { String($0).lowercased() } ?? ""
+    if raw.allSatisfy(\.isASCII) { return raw }
+    // Non-ASCII input sources (Korean 두벌식, Japanese Kana, Zhuyin) translate the
+    // physical key to a layout character, so a vim key like `j` arrives as `ㅓ` and
+    // never matches the ASCII `switch chars` cases. Fall back to the ASCII-capable
+    // layout — the same `KeyboardLayout` helper the keyDown shortcut path already
+    // uses — so copy-mode vim keys resolve regardless of the active input source.
+    // ASCII-emitting IMEs (Pinyin, romaji) keep `raw` and skip the fallback.
+    if let asciiScalar = KeyboardLayout.character(forKeyCode: keyCode, modifierFlags: modifierFlags)?
+        .unicodeScalars.first {
+        return String(asciiScalar).lowercased()
     }
-    return String(scalar).lowercased()
+    return raw
 }
 
 func terminalKeyboardCopyModeShouldBypassForShortcut(modifierFlags: NSEvent.ModifierFlags) -> Bool {
@@ -1501,7 +1512,7 @@ func terminalKeyboardCopyModeAction(
     hasSelection: Bool
 ) -> TerminalKeyboardCopyModeAction? {
     let normalized = terminalKeyboardCopyModeNormalizedModifiers(modifierFlags)
-    let chars = terminalKeyboardCopyModeChars(charactersIgnoringModifiers)
+    let chars = terminalKeyboardCopyModeChars(charactersIgnoringModifiers, keyCode: keyCode, modifierFlags: modifierFlags)
 
     if keyCode == 53 { // Escape
         return .exit
@@ -1604,7 +1615,7 @@ func terminalKeyboardCopyModeResolve(
     state: inout TerminalKeyboardCopyModeInputState
 ) -> TerminalKeyboardCopyModeResolution {
     let normalized = terminalKeyboardCopyModeNormalizedModifiers(modifierFlags)
-    let chars = terminalKeyboardCopyModeChars(charactersIgnoringModifiers)
+    let chars = terminalKeyboardCopyModeChars(charactersIgnoringModifiers, keyCode: keyCode, modifierFlags: modifierFlags)
 
     if keyCode == 53 { // Escape
         state.reset()

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -1289,6 +1289,31 @@ final class TerminalKeyboardCopyModeActionTests: XCTestCase {
         )
     }
 
+    func testVimKeysResolveUnderNonASCIIKeyboardLayout() {
+        // Korean 2-set (두벌식) reports "ㅓ" for the physical 'j' key (keyCode 38)
+        // and "ㅏ" for 'k' (keyCode 40). Copy-mode vim keys must still resolve to a
+        // scroll action via the ASCII-capable layout fallback, exactly as they do on
+        // an ASCII layout — without forcing the user to switch input sources.
+        XCTAssertEqual(
+            terminalKeyboardCopyModeAction(
+                keyCode: 38,
+                charactersIgnoringModifiers: "ㅓ",
+                modifierFlags: [],
+                hasSelection: false
+            ),
+            .scrollLines(1)
+        )
+        XCTAssertEqual(
+            terminalKeyboardCopyModeAction(
+                keyCode: 40,
+                charactersIgnoringModifiers: "ㅏ",
+                modifierFlags: [],
+                hasSelection: false
+            ),
+            .scrollLines(-1)
+        )
+    }
+
     func testCapsLockDoesNotBlockLetterMappings() {
         XCTAssertEqual(
             terminalKeyboardCopyModeAction(

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -1292,14 +1292,23 @@ final class TerminalKeyboardCopyModeActionTests: XCTestCase {
     func testVimKeysResolveUnderNonASCIIKeyboardLayout() {
         // Korean 2-set (두벌식) reports "ㅓ" for the physical 'j' key (keyCode 38)
         // and "ㅏ" for 'k' (keyCode 40). Copy-mode vim keys must still resolve to a
-        // scroll action via the ASCII-capable layout fallback, exactly as they do on
-        // an ASCII layout — without forcing the user to switch input sources.
+        // scroll action via the ASCII-capable layout fallback, without forcing the
+        // user to switch input sources. The character provider is injected so this
+        // test is deterministic and independent of the CI runner's input source.
+        let asciiProvider: (UInt16, NSEvent.ModifierFlags) -> String? = { keyCode, _ in
+            switch keyCode {
+            case 38: return "j"
+            case 40: return "k"
+            default: return nil
+            }
+        }
         XCTAssertEqual(
             terminalKeyboardCopyModeAction(
                 keyCode: 38,
                 charactersIgnoringModifiers: "ㅓ",
                 modifierFlags: [],
-                hasSelection: false
+                hasSelection: false,
+                asciiCharacterProvider: asciiProvider
             ),
             .scrollLines(1)
         )
@@ -1308,7 +1317,8 @@ final class TerminalKeyboardCopyModeActionTests: XCTestCase {
                 keyCode: 40,
                 charactersIgnoringModifiers: "ㅏ",
                 modifierFlags: [],
-                hasSelection: false
+                hasSelection: false,
+                asciiCharacterProvider: asciiProvider
             ),
             .scrollLines(-1)
         )


### PR DESCRIPTION
## Summary
- Copy-mode vim keys (j/k/h/l/g/v) were swallowed on non-ASCII keyboard layouts (Korean 두벌식, Japanese Kana, Zhuyin): resolution matched on `charactersIgnoringModifiers`, which reflects the active input source's layout, so physical `j` arrives as `ㅓ` and matches no case. Arrow/Home/End were unaffected because they match on keyCode.
- Routes the chars lookup through the existing `KeyboardLayout` ASCII-capable fallback (already used by the keyDown shortcut path in `GhosttyTerminalView.swift`), so vim keys resolve regardless of input source. ASCII-emitting IMEs (Pinyin, romaji) short-circuit on the ASCII check and keep prior behavior.

## Test plan
- `testVimKeysResolveUnderNonASCIIKeyboardLayout` added per the repo's two-commit regression policy: commit 1 = failing test (red), commit 2 = fix (green), so CI proves the test catches the bug.
- Manually verified on macOS 26.2 with Korean 2-set active: `Cmd+Shift+M` then `j`/`k`/`v`/`g`/`G`/`y` all work; ABC layout + arrows/Home/End unaffected (no regression).

Fixes #5290

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5292"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783088206&installation_id=133855650&pr_number=5292&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5292&signature=1222e5d03b051c36b56b0a452ab2592fb006b73826fa6aaecd0a51bfe8d336d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes copy-mode vim keys (j/k/h/l/g/v) not working under non-ASCII input sources (Korean 2-set, Japanese Kana, Zhuyin) (fixes #5290). Keys now resolve via the ASCII-capable `KeyboardLayout` fallback so copy-mode works regardless of the active input source.

- **Bug Fixes**
  - Root cause: matching on `charactersIgnoringModifiers` used the active layout, so physical `j` arrived as `ㅓ` and matched nothing.
  - Change: route char lookup through `KeyboardLayout.character(forKeyCode:modifierFlags:)` and inject an ASCII character provider into copy-mode resolution (defaults to that method, passing [] modifiers) for deterministic behavior. Added a regression test covering the Korean layout.

<sup>Written for commit 2d2343d67434732f1fb7b73e961f1d57fb4681b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved copy-mode keyboard handling so commands resolve correctly on non-ASCII keyboard layouts by falling back to an ASCII-capable mapping when needed (e.g., Korean IME), preventing incorrect key actions.

* **Tests**
  * Added a regression test to ensure Vim-style navigation keys resolve correctly under non-ASCII keyboard layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->