### PR TITLE
Bump all packages to swift-tools-version 6.2

### DIFF
--- a/Packages/CMUXAgentLaunch/Package.swift
+++ b/Packages/CMUXAgentLaunch/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.2
 import PackageDescription
 
 let package = Package(

--- a/Packages/CMUXAgentVault/Package.swift
+++ b/Packages/CMUXAgentVault/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.2
 import PackageDescription
 
 let package = Package(

--- a/Packages/CMUXAuthCore/Package.swift
+++ b/Packages/CMUXAuthCore/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.2
 import PackageDescription
 
 let package = Package(

--- a/Packages/CMUXDebugLog/Package.swift
+++ b/Packages/CMUXDebugLog/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.2
 
 import PackageDescription
 
@@ -16,12 +16,18 @@ let package = Package(
     targets: [
         .target(
             name: "CMUXDebugLog",
-            path: "Sources/CMUXDebugLog"
+            path: "Sources/CMUXDebugLog",
+            // Bumped tools-version to 6.2 with the rest of the packages, but pin
+            // the Swift 5 language mode this package has always built under: its
+            // shared DebugEventLog singleton is not Swift 6 strict-concurrency
+            // clean, and modernizing it is separate from the version bump.
+            swiftSettings: [.swiftLanguageMode(.v5)]
         ),
         .testTarget(
             name: "CMUXDebugLogTests",
             dependencies: ["CMUXDebugLog"],
-            path: "Tests/CMUXDebugLogTests"
+            path: "Tests/CMUXDebugLogTests",
+            swiftSettings: [.swiftLanguageMode(.v5)]
         ),
     ]
 )

--- a/Packages/CMUXExtensionHostSupport/Package.swift
+++ b/Packages/CMUXExtensionHostSupport/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.2
 import PackageDescription
 
 let package = Package(

--- a/Packages/CMUXPasteboardFidelity/Package.swift
+++ b/Packages/CMUXPasteboardFidelity/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.2
 import PackageDescription
 
 let package = Package(

--- a/Packages/CMUXProjectModel/Package.swift
+++ b/Packages/CMUXProjectModel/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.2
 import PackageDescription
 
 let package = Package(

--- a/Packages/CMUXWorkstream/Package.swift
+++ b/Packages/CMUXWorkstream/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.2
 import PackageDescription
 
 let package = Package(

--- a/Packages/CmuxExtensionKit/Package.swift
+++ b/Packages/CmuxExtensionKit/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.2
 import PackageDescription
 
 let package = Package(

--- a/Packages/CmuxFileWatch/Package.swift
+++ b/Packages/CmuxFileWatch/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.2
 
 import PackageDescription
 

--- a/Packages/CmuxFoundation/Package.swift
+++ b/Packages/CmuxFoundation/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.2
 
 import PackageDescription
 

--- a/Packages/CmuxProcess/Package.swift
+++ b/Packages/CmuxProcess/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.2
 
 import PackageDescription
 

--- a/Packages/CmuxSettings/Package.swift
+++ b/Packages/CmuxSettings/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.2
 
 import PackageDescription
 

--- a/Packages/CmuxSettingsUI/Package.swift
+++ b/Packages/CmuxSettingsUI/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.2
 
 import PackageDescription
 

--- a/Packages/CmuxSidebarProviderKit/Package.swift
+++ b/Packages/CmuxSidebarProviderKit/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.2
 import PackageDescription
 
 let package = Package(

--- a/Packages/CmuxSocketControl/Package.swift
+++ b/Packages/CmuxSocketControl/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.2
 
 import PackageDescription
 

--- a/Packages/CmuxSwiftRender/Package.swift
+++ b/Packages/CmuxSwiftRender/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.2
 
 import PackageDescription
 

--- a/Packages/CmuxSwiftRenderUI/Package.swift
+++ b/Packages/CmuxSwiftRenderUI/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.2
 
 import PackageDescription
 

--- a/Packages/CmuxUpdater/Package.swift
+++ b/Packages/CmuxUpdater/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.2
 
 import PackageDescription
 

--- a/Packages/CmuxUpdaterUI/Package.swift
+++ b/Packages/CmuxUpdaterUI/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.2
 
 import PackageDescription
 


### PR DESCRIPTION
Standardize every package under `Packages/` on `swift-tools-version: 6.2`. The team is pinned to Xcode 26 (`.xcode-version` → `26.0`) and CI builds the cmux project on Xcode 26, so the packages can declare 6.2 and use 6.2 features (e.g. `@concurrent`) without per-declaration `#if compiler(>=6.2)` guards.

## CI supports 6.2

The `tests` / `tests-build-and-lag` / `ui-regressions` / `release-build` jobs build the Xcode project on the `warp-macos-15-arm64-6x` runner with Xcode 26 selected — they already compile `@concurrent` (which requires a ≥6.2 compiler), so that runner's SwiftPM parses a 6.2 manifest. The one Xcode-16 CI path (the ghostty-cli-helper) builds a standalone Zig/Ghostty binary and does not resolve the Swift packages. `ci-macos-compat.yml` is `workflow_dispatch`-only and runs on macOS 15/26 runners (both Xcode-26-capable), so it's unaffected too.

## Compile impact: essentially none

19 of 20 packages were at `6.0` and already build in **Swift 6 language mode** (either an explicit `.swiftLanguageMode(.v6)` or the 6.0 default), so bumping them to `6.2` is a pure manifest-version change — it does not alter how they compile.

The exception is **CMUXDebugLog**, which was `5.9` (default Swift **5** language mode). Its shared `DebugEventLog` singleton is not Swift 6 strict-concurrency clean, so it's pinned to `.swiftLanguageMode(.v5)` to preserve its current behavior. Migrating it to Swift 6 is deliberately **not** part of this version bump.

## Verification

`swift build` of CMUXDebugLog (the only package whose compilation could change) and a representative leaf (CmuxFoundation) at 6.2 — both green. Full-project resolution/build is gated by CI on Xcode 26 (the `tests`/`release-build` jobs).

Note: `CmuxGit` is bumped to 6.2 in its own PR (#5277) since it doesn't exist on `main` yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5293"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783095596&installation_id=133855650&pr_number=5293&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5293&signature=21b69d31f8d5c9c73e12f505ce402088114f82500831f71ba1b41a6575137347"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized all packages under `Packages/` to `swift-tools-version: 6.2` to align with Xcode 26 in CI. This enables Swift 6.2 features like `@concurrent` without `#if` guards and has no behavior change for most packages.

- **Refactors**
  - Bumped 19 packages from 6.0 to 6.2; they already compile in Swift 6, so no compile-mode change.
  - Updated `CMUXDebugLog` manifest to 6.2 but pinned targets to `.swiftLanguageMode(.v5)` to keep current concurrency behavior.
  - Verified `swift build` locally for `CMUXDebugLog` and a leaf package; CI on macOS 15/Xcode 26 already builds with 6.2.

<sup>Written for commit 16e1b5bdb34e54b551e430abe35d17a68a4334b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Swift tools version requirement from 6.0 to 6.2 across all packages for improved compiler compatibility
  * Added language compatibility settings to one package to ensure consistent compilation behavior with newer Swift versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->