### PR TITLE
Fix #5269: recover terminal focus when first responder is stranded in another window

### DIFF
--- a/Sources/App/ForeignFirstResponderPolicy.swift
+++ b/Sources/App/ForeignFirstResponderPolicy.swift
@@ -39,5 +39,8 @@ func shouldRespectForeignFirstResponder(
     in window: NSWindow,
     isRightSidebarOwner: (NSResponder) -> Bool
 ) -> Bool {
+    // A stranded responder (detached, or reparented into another window without resigning) no longer
+    // belongs to this window and must not block the terminal from reclaiming first responder.
+    guard (firstResponder as? NSView)?.window === window else { return false }
     return firstResponder is NSText || isRightSidebarOwner(firstResponder)
 }

--- a/Sources/App/ForeignFirstResponderPolicy.swift
+++ b/Sources/App/ForeignFirstResponderPolicy.swift
@@ -1,0 +1,43 @@
+import AppKit
+
+/// Whether an active terminal surface should *yield* to `firstResponder` instead of taking first
+/// responder itself when reconciling focus (used by `GhosttySurfaceScrollView.ensureFocus` and the
+/// find-overlay focus apply).
+///
+/// A terminal yields only to a *legitimate* in-window focus owner: a focused text editor
+/// (`NSText` field editor) or a right-sidebar / dock / feed host. Crucially it must also still
+/// belong to `window`. cmux hosts terminal surfaces through a portal that reparents views between
+/// windows; a focus owner can be reparented out of a window without resigning, leaving
+/// `window.firstResponder` pointing at a view that no longer belongs to the window (a "stranded"
+/// responder, see issue #5269). The previous guard checked responder *type* only, so it treated a
+/// stranded `NSText` / sidebar responder as legitimate and the terminal never reclaimed focus —
+/// making the pane unfocusable by click or by programmatic `focus-pane` until the workspace was
+/// moved to a fresh window. Requiring window membership lets the terminal reclaim focus from a
+/// stranded responder while still respecting a genuine in-window focus owner.
+///
+/// - Parameters:
+///   - firstResponder: The window's current first responder.
+///   - window: The window whose focus is being reconciled.
+///   - isRightSidebarOwner: Predicate identifying right-sidebar / dock / feed focus hosts (injected
+///     so this policy is testable without `AppDelegate`).
+/// - Returns: `true` only when `firstResponder` is a legitimate focus owner that genuinely belongs
+///   to `window`; `false` when the terminal should reclaim first responder (including when the
+///   responder is stranded in another window or detached).
+///
+/// ```swift
+/// if respectForeignFirstResponder,
+///    let firstResponder = window.firstResponder,
+///    shouldRespectForeignFirstResponder(firstResponder, in: window, isRightSidebarOwner: {
+///        AppDelegate.shared?.isRightSidebarFocusResponder($0, in: window) == true
+///    }) {
+///     return // a real in-window focus owner is active; do not steal focus
+/// }
+/// ```
+@MainActor
+func shouldRespectForeignFirstResponder(
+    _ firstResponder: NSResponder,
+    in window: NSWindow,
+    isRightSidebarOwner: (NSResponder) -> Bool
+) -> Bool {
+    return firstResponder is NSText || isRightSidebarOwner(firstResponder)
+}

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -5238,7 +5238,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // never re-route the keystroke to the terminal. Symmetric with
         // applyFirstResponderIfNeeded's foreign focus guard.
         if let firstResponder = window.firstResponder,
-           firstResponder is NSText || isRightSidebarFocusResponder(firstResponder, in: window) {
+           shouldRespectForeignFirstResponder(firstResponder, in: window, isRightSidebarOwner: {
+               isRightSidebarFocusResponder($0, in: window)
+           }) {
             return
         }
         guard let context = contextForMainWindow(window) ?? contextForMainTerminalWindow(window),
@@ -6475,7 +6477,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     func isRightSidebarFocusResponder(_ responder: NSResponder, in window: NSWindow?) -> Bool {
-        keyboardFocusCoordinator(for: window)?.ownsRightSidebarFocus(responder) == true
+        // A responder reparented out of `window` (stranded) is not this window's right-sidebar focus
+        // owner even when its type matches `ownsRightSidebarFocus`. Requiring window membership keeps a
+        // stranded host from being treated as a legitimate focus owner that blocks focus recovery
+        // (issue #5269).
+        guard let window, (responder as? NSView)?.window === window else { return false }
+        return keyboardFocusCoordinator(for: window)?.ownsRightSidebarFocus(responder) == true
     }
 
     func shouldRouteRightSidebarModeShortcut(in window: NSWindow?) -> Bool {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -13108,7 +13108,9 @@ final class GhosttySurfaceScrollView: NSView {
             }
             if respectForeignFirstResponder,
                let firstResponder = window.firstResponder,
-               firstResponder is NSText || AppDelegate.shared?.isRightSidebarFocusResponder(firstResponder, in: window) == true {
+               shouldRespectForeignFirstResponder(firstResponder, in: window, isRightSidebarOwner: {
+               AppDelegate.shared?.isRightSidebarFocusResponder($0, in: window) == true
+           }) {
 #if DEBUG
                 let reason = firstResponder is NSText ? "textEditorFocused" : "rightSidebarFocused"
                 dlog("focus.ensure.skip surface=\(surfaceView.terminalSurface?.id.uuidString.prefix(5) ?? "nil") reason=dock.\(reason)")
@@ -13182,7 +13184,9 @@ final class GhosttySurfaceScrollView: NSView {
         // surface already owns focus.
         if respectForeignFirstResponder,
            let firstResponder = window.firstResponder,
-           firstResponder is NSText || AppDelegate.shared?.isRightSidebarFocusResponder(firstResponder, in: window) == true {
+           shouldRespectForeignFirstResponder(firstResponder, in: window, isRightSidebarOwner: {
+               AppDelegate.shared?.isRightSidebarFocusResponder($0, in: window) == true
+           }) {
 #if DEBUG
             let reason = firstResponder is NSText ? "textEditorFocused" : "rightSidebarFocused"
             dlog("focus.ensure.skip surface=\(surfaceView.terminalSurface?.id.uuidString.prefix(5) ?? "nil") reason=\(reason)")
@@ -13473,7 +13477,9 @@ final class GhosttySurfaceScrollView: NSView {
         // own GhosttyNSView for input, so NSText and the feed focus host are always foreign focus
         // owners that should survive deferred terminal visibility applies.
         if let firstResponder = window.firstResponder,
-           firstResponder is NSText || AppDelegate.shared?.isRightSidebarFocusResponder(firstResponder, in: window) == true {
+           shouldRespectForeignFirstResponder(firstResponder, in: window, isRightSidebarOwner: {
+               AppDelegate.shared?.isRightSidebarFocusResponder($0, in: window) == true
+           }) {
 #if DEBUG
             let reason = firstResponder is NSText ? "textEditorFocused" : "rightSidebarFocused"
             cmuxDebugLog("find.applyFirstResponder SKIP surface=\(surfaceShort) reason=\(reason)")

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -275,6 +275,8 @@
 		C4160A020000000000000001 /* FocusHistoryMenuInvalidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4160A020000000000000002 /* FocusHistoryMenuInvalidator.swift */; };
 		C0DEFB100000000000000001 /* FocusSurfaceBroadcaster.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEFB100000000000000002 /* FocusSurfaceBroadcaster.swift */; };
 		C0DEFB300000000000000001 /* FocusSurfaceBroadcasterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEFB300000000000000002 /* FocusSurfaceBroadcasterTests.swift */; };
+		AA5269A0C0DE0002FACE0002 /* ForeignFirstResponderPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA5269A0C0DE0001FACE0001 /* ForeignFirstResponderPolicy.swift */; };
+		AA5269A0C0DE0004FACE0004 /* ForeignFirstResponderPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA5269A0C0DE0003FACE0003 /* ForeignFirstResponderPolicyTests.swift */; };
 		D0B10012A1B2C3D4E5F60001 /* GhosttyApp+SurfaceConfigurationReload.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B10013A1B2C3D4E5F60001 /* GhosttyApp+SurfaceConfigurationReload.swift */; };
 		1718C0DE1718C0DE17180002 /* GhosttyCommandShiftForwardingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1718C0DE1718C0DE17180001 /* GhosttyCommandShiftForwardingTests.swift */; };
 		A5001004 /* GhosttyConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001014 /* GhosttyConfig.swift */; };
@@ -906,6 +908,8 @@
 		C4160A020000000000000002 /* FocusHistoryMenuInvalidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusHistoryMenuInvalidator.swift; sourceTree = "<group>"; };
 		C0DEFB100000000000000002 /* FocusSurfaceBroadcaster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusSurfaceBroadcaster.swift; sourceTree = "<group>"; };
 		C0DEFB300000000000000002 /* FocusSurfaceBroadcasterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusSurfaceBroadcasterTests.swift; sourceTree = "<group>"; };
+		AA5269A0C0DE0001FACE0001 /* ForeignFirstResponderPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/ForeignFirstResponderPolicy.swift; sourceTree = "<group>"; };
+		AA5269A0C0DE0003FACE0003 /* ForeignFirstResponderPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForeignFirstResponderPolicyTests.swift; sourceTree = "<group>"; };
 		A5001017 /* ghostty.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ghostty.h; sourceTree = "<group>"; };
 		D0B10013A1B2C3D4E5F60001 /* GhosttyApp+SurfaceConfigurationReload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GhosttyApp+SurfaceConfigurationReload.swift"; sourceTree = "<group>"; };
 		1718C0DE1718C0DE17180001 /* GhosttyCommandShiftForwardingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyCommandShiftForwardingTests.swift; sourceTree = "<group>"; };
@@ -1488,6 +1492,7 @@
 				E5C0F1A1E5C0F1A1E5C0F1A1 /* TerminalFindEscapeRouting.swift */,
 				C7934BB35B66491B1BCA8064 /* MenuBarExtraController.swift */,
 				2F0C07000000000000000001 /* CmuxMainWindow.swift */,
+				AA5269A0C0DE0001FACE0001 /* ForeignFirstResponderPolicy.swift */,
 				2F0C06000000000000000001 /* MainWindowVisibilityController.swift */,
 				A500D011A1B2C3D4E5F60718 /* DebugLogging.swift */,
 				D35B71010000000000000002 /* StartupBreadcrumbLog.swift */,
@@ -1812,6 +1817,7 @@
 				F7000001A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift */,
 				F8000001A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift */,
 				F9000001A1B2C3D4E5F60718 /* GhosttyEnsureFocusWindowActivationTests.swift */,
+				AA5269A0C0DE0003FACE0003 /* ForeignFirstResponderPolicyTests.swift */,
 				F1C1AA20B7E84D10A1C10001 /* InactivePaneFirstClickFocusTests.swift */,
 				FA000001A1B2C3D4E5F60718 /* WorkspaceStressProfileTests.swift */,
 					A5008380 /* BrowserFindJavaScriptTests.swift */,
@@ -2402,6 +2408,7 @@
 					F0C05170000000000000002 /* FocusHistory.swift in Sources */,
 				C4160A020000000000000001 /* FocusHistoryMenuInvalidator.swift in Sources */,
 					C0DEFB100000000000000001 /* FocusSurfaceBroadcaster.swift in Sources */,
+				AA5269A0C0DE0002FACE0002 /* ForeignFirstResponderPolicy.swift in Sources */,
 				D0B10012A1B2C3D4E5F60001 /* GhosttyApp+SurfaceConfigurationReload.swift in Sources */,
 				A5001004 /* GhosttyConfig.swift in Sources */,
 				C3873001C3873001C3873001 /* GhosttyCrashBreadcrumb.swift in Sources */,
@@ -2746,6 +2753,7 @@
 				FE002103 /* FileSearchRipgrepParserTests.swift in Sources */,
 				C35610000000000000000001 /* FinderFileDropRegressionTests.swift in Sources */,
 				C0DEFB300000000000000001 /* FocusSurfaceBroadcasterTests.swift in Sources */,
+				AA5269A0C0DE0004FACE0004 /* ForeignFirstResponderPolicyTests.swift in Sources */,
 				1718C0DE1718C0DE17180002 /* GhosttyCommandShiftForwardingTests.swift in Sources */,
 				A11EB0000000000000000000 /* GhosttyConfigPathResolverTests.swift in Sources */,
 				F4000000A1B2C3D4E5F60718 /* GhosttyConfigTests.swift in Sources */,

--- a/cmuxTests/ForeignFirstResponderPolicyTests.swift
+++ b/cmuxTests/ForeignFirstResponderPolicyTests.swift
@@ -1,0 +1,74 @@
+import AppKit
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Coverage for ``shouldRespectForeignFirstResponder(_:in:isRightSidebarOwner:)`` — the policy that
+/// decides whether an active terminal yields to the window's current first responder or reclaims
+/// focus. Regression coverage for issue #5269 (a stranded responder must not block focus).
+@MainActor
+@Suite struct ForeignFirstResponderPolicyTests {
+    private func makeWindow() -> NSWindow {
+        NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 200, height: 200),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+    }
+
+    private let neverSidebarOwner: (NSResponder) -> Bool = { _ in false }
+    private let alwaysSidebarOwner: (NSResponder) -> Bool = { _ in true }
+
+    @Test func respectsInWindowTextEditor() {
+        let window = makeWindow()
+        let textView = NSTextView(frame: .zero)
+        window.contentView?.addSubview(textView)
+        #expect(shouldRespectForeignFirstResponder(textView, in: window, isRightSidebarOwner: neverSidebarOwner))
+    }
+
+    /// The #5269 regression: a text responder stranded in another window must NOT be respected, so
+    /// the terminal can reclaim focus. Without the window-membership check this returns `true`.
+    @Test func reclaimsFromStrandedTextEditorInAnotherWindow() {
+        let windowA = makeWindow()
+        let windowB = makeWindow()
+        let textView = NSTextView(frame: .zero)
+        windowB.contentView?.addSubview(textView) // belongs to windowB, not windowA
+        #expect(!shouldRespectForeignFirstResponder(textView, in: windowA, isRightSidebarOwner: neverSidebarOwner))
+    }
+
+    @Test func respectsInWindowRightSidebarOwner() {
+        let window = makeWindow()
+        let view = NSView(frame: .zero)
+        window.contentView?.addSubview(view)
+        #expect(shouldRespectForeignFirstResponder(view, in: window, isRightSidebarOwner: alwaysSidebarOwner))
+    }
+
+    /// The #5269 regression for the sidebar/dock flavor: a sidebar host stranded in another window
+    /// must NOT be respected. Without the window-membership check this returns `true`.
+    @Test func reclaimsFromStrandedRightSidebarOwner() {
+        let windowA = makeWindow()
+        let windowB = makeWindow()
+        let view = NSView(frame: .zero)
+        windowB.contentView?.addSubview(view)
+        #expect(!shouldRespectForeignFirstResponder(view, in: windowA, isRightSidebarOwner: alwaysSidebarOwner))
+    }
+
+    @Test func reclaimsFromDetachedResponder() {
+        let window = makeWindow()
+        let textView = NSTextView(frame: .zero) // never added to a window -> .window is nil
+        #expect(!shouldRespectForeignFirstResponder(textView, in: window, isRightSidebarOwner: alwaysSidebarOwner))
+    }
+
+    @Test func doesNotRespectPlainInWindowView() {
+        let window = makeWindow()
+        let view = NSView(frame: .zero)
+        window.contentView?.addSubview(view)
+        // Neither a text editor nor a sidebar owner: the terminal reclaims focus (existing behavior).
+        #expect(!shouldRespectForeignFirstResponder(view, in: window, isRightSidebarOwner: neverSidebarOwner))
+    }
+}


### PR DESCRIPTION
Fixes part of https://github.com/manaflow-ai/cmux/issues/5269.

## Symptom

A window can get into a state where clicking a terminal/browser **pane body** does not focus it (only clicking the pane **tab** works), and you cannot type into it. It also resists **programmatic** focus (`cmux focus-pane` / `surface.focus` / `refresh-surfaces` no-op), and persists until the workspace is moved to a fresh window.

## Root cause

cmux hosts terminal surfaces through a portal that reparents views between windows/panes. When a view that is a window's first responder is reparented out of that window without resigning, `window.firstResponder` is left pointing at a view that no longer belongs to the window (a **stranded** responder).

A bare terminal recovers from this on the next focus attempt. The unrecoverable case is a guard bug: `GhosttySurfaceScrollView.ensureFocus` (and the find-overlay focus apply) **yields** to the current first responder when it is an `NSText` field editor or a right-sidebar/dock host — but it checked the responder's **type only, never whether it still belongs to the window**:

```swift
firstResponder is NSText || AppDelegate.shared?.isRightSidebarFocusResponder(firstResponder, in: window) == true
```

So a **stranded** `NSText` (e.g. a Settings field editor) or sidebar/dock host was mis-classified as a legitimate in-window focus owner, and the terminal never called `makeFirstResponder` to reclaim focus. Clicking the pane (which routes through `ensureFocus`) and programmatic `focus-pane` both no-op.

## Fix

Add a window-membership check to the three foreign-first-responder guards in `GhosttyTerminalView.swift`, via a small testable policy:

```swift
@MainActor
func shouldRespectForeignFirstResponder(_ firstResponder: NSResponder, in window: NSWindow,
                                        isRightSidebarOwner: (NSResponder) -> Bool) -> Bool {
    guard (firstResponder as? NSView)?.window === window else { return false } // stranded -> reclaim
    return firstResponder is NSText || isRightSidebarOwner(firstResponder)
}
```

A genuine in-window text editor / sidebar host is still respected; a stranded responder no longer blocks the terminal from reclaiming first responder, so clicking the pane (and `focus-pane`) recovers it.

## Tests

`cmuxTests/ForeignFirstResponderPolicyTests.swift` covers: in-window text editor and sidebar host are respected; **stranded** text editor / sidebar host in another window and a detached responder are **not** respected (the #5269 regression); and a plain in-window view is reclaimed (existing behavior). The two stranded-responder cases fail without the membership check (see the first commit) and pass with it.

## Scope / coordination

This is the **recovery-blocker** half. @austinywang's `issue-5269-pane-click-focus` branch fixes the pane-body **click→focus pointer path** (the `paneBodyPointer` trigger + portal hit-test fallback); that path still ends in `focusPanel → ensureFocus`, so it benefits from this guard fix too. The two changes touch different code (this PR only `GhosttyTerminalView.swift` `ensureFocus`) and are complementary.

Honest limit: the exact GUI gesture that produces the stranded responder (most likely the Settings field-editor flavor the reporter described) was not reproduced live; the recovery-blocker is verified from source, and this fix makes the terminal reclaim focus from any stranded responder regardless of how it was stranded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783105132&installation_id=133855650&pr_number=5296&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5296&signature=02d27e3af22972ab75e70efc5bb05dc53a2d6bb964240b19998c54bf8d424f30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches AppKit first-responder and keyboard-routing paths across terminal focus and AppDelegate; behavior change is narrow but user-visible if membership checks are wrong.
> 
> **Overview**
> Fixes **#5269** by centralizing “foreign first responder” handling in `shouldRespectForeignFirstResponder`, which only yields when the current first responder is an in-window `NSText` or right-sidebar/dock host—not when portal reparenting left a **stranded** responder still referenced by `window.firstResponder`.
> 
> **`GhosttyTerminalView`** replaces type-only guards in `ensureFocus` (dock + main paths) and find-overlay `applyFirstResponder` with that policy. **`AppDelegate`** applies the same check before routing key events to the terminal and adds a window-membership guard in `isRightSidebarFocusResponder`.
> 
> **`ForeignFirstResponderPolicyTests`** cover in-window respect vs stranded/detached reclaim behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74c08be86884bcce937c7e30e4ae31b1931e1fa5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes pane focus getting stuck when the window’s first responder is stranded in another window (#5269). The terminal now reclaims focus on click and via `focus-pane`, and avoids routing keys to a stranded responder.

- **Bug Fixes**
  - Added `shouldRespectForeignFirstResponder(...)` requiring same-window membership; still respects in-window `NSText` and right-sidebar/dock owners.
  - Applied the policy in `GhosttyTerminalView` (`ensureFocus` paths and find overlay) and in AppKit keyboard-repair; `isRightSidebarFocusResponder` now also requires window membership.
  - Added `ForeignFirstResponderPolicyTests` covering in-window, stranded (other window), and detached responders.

<sup>Written for commit 74c08be86884bcce937c7e30e4ae31b1931e1fa5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal focus management to prevent stranded or reparented responders from incorrectly retaining focus. The terminal now yields to active text editors and legitimate sidebar/dock components only when they still belong to the same window, ensuring reliable focus restoration.

* **Tests**
  * Added comprehensive tests covering focus-responder policies, including regression scenarios for detached or cross-window responders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->