### PR TITLE
Fix copy-mode vim keys under non-ASCII layouts

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1490,6 +1490,23 @@ private func terminalKeyboardCopyModeChars(
     return String(scalar).lowercased()
 }
 
+private func terminalKeyboardCopyModeResolvedCharacters(
+    charactersIgnoringModifiers: String?,
+    normalizedCharacters: String?
+) -> (characters: String?, shouldPassIfUnmatched: Bool) {
+    let raw = charactersIgnoringModifiers ?? ""
+    if !raw.isEmpty, raw.allSatisfy(\.isASCII) {
+        return (raw, false)
+    }
+
+    let normalized = normalizedCharacters ?? ""
+    if !normalized.isEmpty, normalized.allSatisfy(\.isASCII) {
+        return (normalized, false)
+    }
+
+    return (normalized.isEmpty ? charactersIgnoringModifiers : normalized, true)
+}
+
 func terminalKeyboardCopyModeShouldBypassForShortcut(modifierFlags: NSEvent.ModifierFlags) -> Bool {
     let normalized = terminalKeyboardCopyModeNormalizedModifiers(modifierFlags)
     return normalized.contains(.command)
@@ -1606,7 +1623,11 @@ func terminalKeyboardCopyModeResolve(
     state: inout TerminalKeyboardCopyModeInputState
 ) -> TerminalKeyboardCopyModeResolution {
     let normalized = terminalKeyboardCopyModeNormalizedModifiers(modifierFlags)
-    let chars = terminalKeyboardCopyModeChars(charactersIgnoringModifiers)
+    let resolvedCharacters = terminalKeyboardCopyModeResolvedCharacters(
+        charactersIgnoringModifiers: charactersIgnoringModifiers,
+        normalizedCharacters: normalizedCharacters
+    )
+    let chars = terminalKeyboardCopyModeChars(resolvedCharacters.characters)
 
     if keyCode == 53 { // Escape
         state.reset()
@@ -1665,12 +1686,12 @@ func terminalKeyboardCopyModeResolve(
 
     guard let action = terminalKeyboardCopyModeAction(
         keyCode: keyCode,
-        charactersIgnoringModifiers: charactersIgnoringModifiers,
+        charactersIgnoringModifiers: resolvedCharacters.characters,
         modifierFlags: modifierFlags,
         hasSelection: hasSelection
     ) else {
         state.reset()
-        return .consume
+        return resolvedCharacters.shouldPassIfUnmatched ? .pass : .consume
     }
 
     let count = terminalKeyboardCopyModeClampCount(state.countPrefix ?? 1)
@@ -8403,14 +8424,26 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         let resolution = terminalKeyboardCopyModeResolve(
             keyCode: event.keyCode,
             charactersIgnoringModifiers: event.charactersIgnoringModifiers,
+            normalizedCharacters: KeyboardLayout.normalizedCharacters(for: event),
             modifierFlags: event.modifierFlags,
             hasSelection: hasSelection,
             state: &keyboardCopyModeInputState
         )
-        guard case let .perform(action, count) = resolution else {
+        switch resolution {
+        case .pass:
+            return false
+        case .consume:
             return true
+        case let .perform(action, count):
+            return performKeyboardCopyModeAction(action, count: count, surface: surface)
         }
+    }
 
+    private func performKeyboardCopyModeAction(
+        _ action: TerminalKeyboardCopyModeAction,
+        count: Int,
+        surface: ghostty_surface_t
+    ) -> Bool {
         switch action {
         case .exit:
             _ = ghostty_surface_clear_selection_compat(surface)

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1421,6 +1421,7 @@ struct TerminalKeyboardCopyModeInputState: Equatable {
 enum TerminalKeyboardCopyModeResolution: Equatable {
     case perform(TerminalKeyboardCopyModeAction, count: Int)
     case consume
+    case pass
 }
 
 private let terminalKeyboardCopyModeMaxCount = 9_999
@@ -1599,6 +1600,7 @@ func terminalKeyboardCopyModeAction(
 func terminalKeyboardCopyModeResolve(
     keyCode: UInt16,
     charactersIgnoringModifiers: String?,
+    normalizedCharacters: String?,
     modifierFlags: NSEvent.ModifierFlags,
     hasSelection: Bool,
     state: inout TerminalKeyboardCopyModeInputState
@@ -1674,6 +1676,23 @@ func terminalKeyboardCopyModeResolve(
     let count = terminalKeyboardCopyModeClampCount(state.countPrefix ?? 1)
     state.reset()
     return .perform(action, count: count)
+}
+
+func terminalKeyboardCopyModeResolve(
+    keyCode: UInt16,
+    charactersIgnoringModifiers: String?,
+    modifierFlags: NSEvent.ModifierFlags,
+    hasSelection: Bool,
+    state: inout TerminalKeyboardCopyModeInputState
+) -> TerminalKeyboardCopyModeResolution {
+    terminalKeyboardCopyModeResolve(
+        keyCode: keyCode,
+        charactersIgnoringModifiers: charactersIgnoringModifiers,
+        normalizedCharacters: charactersIgnoringModifiers,
+        modifierFlags: modifierFlags,
+        hasSelection: hasSelection,
+        state: &state
+    )
 }
 
 private final class GhosttySurfaceCallbackContext {

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -1581,6 +1581,7 @@ final class TerminalKeyboardCopyModeResolveTests: XCTestCase {
     private func resolve(
         _ keyCode: UInt16,
         chars: String,
+        normalizedChars: String? = nil,
         modifiers: NSEvent.ModifierFlags = [],
         hasSelection: Bool,
         state: inout TerminalKeyboardCopyModeInputState
@@ -1588,10 +1589,81 @@ final class TerminalKeyboardCopyModeResolveTests: XCTestCase {
         terminalKeyboardCopyModeResolve(
             keyCode: keyCode,
             charactersIgnoringModifiers: chars,
+            normalizedCharacters: normalizedChars ?? chars,
             modifierFlags: modifiers,
             hasSelection: hasSelection,
             state: &state
         )
+    }
+
+    func testNonASCIILettersUseLayoutNormalizedCharacters() {
+        let cases: [
+            (
+                name: String,
+                keyCode: UInt16,
+                rawChars: String,
+                normalizedChars: String,
+                modifiers: NSEvent.ModifierFlags,
+                hasSelection: Bool,
+                expected: TerminalKeyboardCopyModeResolution
+            )
+        ] = [
+            ("j under Korean 2-set", 38, "ㅓ", "j", [], false, .perform(.scrollLines(1), count: 1)),
+            ("k under Korean 2-set", 40, "ㅏ", "k", [], false, .perform(.scrollLines(-1), count: 1)),
+            ("h under Korean 2-set", 4, "ㅗ", "h", [], true, .perform(.adjustSelection(.left), count: 1)),
+            ("l under Korean 2-set", 37, "ㅣ", "l", [], true, .perform(.adjustSelection(.right), count: 1)),
+            ("v under Korean 2-set", 9, "ㅍ", "v", [], false, .perform(.startSelection, count: 1)),
+            ("y under Korean 2-set", 16, "ㅛ", "y", [], true, .perform(.copyAndExit, count: 1)),
+            ("n under Korean 2-set", 45, "ㅜ", "n", [], false, .perform(.searchNext, count: 1)),
+            ("G under Korean 2-set", 5, "ㅎ", "g", [.shift], false, .perform(.scrollToBottom, count: 1)),
+        ]
+
+        for testCase in cases {
+            var state = TerminalKeyboardCopyModeInputState()
+            XCTAssertEqual(
+                resolve(
+                    testCase.keyCode,
+                    chars: testCase.rawChars,
+                    normalizedChars: testCase.normalizedChars,
+                    modifiers: testCase.modifiers,
+                    hasSelection: testCase.hasSelection,
+                    state: &state
+                ),
+                testCase.expected,
+                testCase.name
+            )
+            XCTAssertEqual(state, TerminalKeyboardCopyModeInputState(), testCase.name)
+        }
+    }
+
+    func testNonASCIIGGUsesLayoutNormalizedCharacters() {
+        var state = TerminalKeyboardCopyModeInputState()
+        XCTAssertEqual(
+            resolve(5, chars: "ㅎ", normalizedChars: "g", hasSelection: false, state: &state),
+            .consume
+        )
+        XCTAssertEqual(
+            resolve(5, chars: "ㅎ", normalizedChars: "g", hasSelection: false, state: &state),
+            .perform(.scrollToTop, count: 1)
+        )
+        XCTAssertEqual(state, TerminalKeyboardCopyModeInputState())
+    }
+
+    func testASCIICharactersTakePrecedenceOverLayoutFallback() {
+        var state = TerminalKeyboardCopyModeInputState()
+        XCTAssertEqual(
+            resolve(38, chars: "h", normalizedChars: "j", hasSelection: true, state: &state),
+            .perform(.adjustSelection(.left), count: 1)
+        )
+    }
+
+    func testUnmatchedNonASCIIKeyPassesThrough() {
+        var state = TerminalKeyboardCopyModeInputState(countPrefix: 3)
+        XCTAssertEqual(
+            resolve(104, chars: "한", normalizedChars: "한", hasSelection: false, state: &state),
+            .pass
+        )
+        XCTAssertEqual(state, TerminalKeyboardCopyModeInputState())
     }
 
     func testCountPrefixAppliesToMotion() {

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -1619,7 +1619,8 @@ final class TerminalKeyboardCopyModeResolveTests: XCTestCase {
         normalizedChars: String? = nil,
         modifiers: NSEvent.ModifierFlags = [],
         hasSelection: Bool,
-        state: inout TerminalKeyboardCopyModeInputState
+        state: inout TerminalKeyboardCopyModeInputState,
+        asciiCharacterProvider: (UInt16, NSEvent.ModifierFlags) -> String? = { _, _ in nil }
     ) -> TerminalKeyboardCopyModeResolution {
         terminalKeyboardCopyModeResolve(
             keyCode: keyCode,
@@ -1627,7 +1628,8 @@ final class TerminalKeyboardCopyModeResolveTests: XCTestCase {
             normalizedCharacters: normalizedChars ?? chars,
             modifierFlags: modifiers,
             hasSelection: hasSelection,
-            state: &state
+            state: &state,
+            asciiCharacterProvider: asciiCharacterProvider
         )
     }
 


### PR DESCRIPTION
Fixes #5290.

## Summary
- Adds deterministic copy-mode resolver coverage for non-ASCII keyboard layouts.
- Resolves copy-mode vim keys through a layout-aware key identity: raw ASCII first, then `KeyboardLayout.normalizedCharacters(for:)`, then ASCII-capable key lookup.
- Returns `.pass` for unresolved non-ASCII/no-identity events so input-source toggle keys are not swallowed.
- Adds English and Japanese localization entries for the copy-mode/key-table indicators already referenced by the UI.

## Testing
- CI regression structure: commit `44da7563f` adds the failing tests first; commit `d2d58bcd4` adds the fix.
- GitHub Actions is the verification path per repo policy; no local `xcodebuild`, local app launch, or `reload.sh` was run.
- `scripts/normalize-pbxproj.py cmux.xcodeproj/project.pbxproj` and `scripts/check-pbxproj.sh` were run after syncing with `origin/main`.
- `python3 -m json.tool Resources/Localizable.xcstrings` verified the string catalog parses after localization updates.

## Demo Video
Not recorded. The repro is covered by deterministic resolver tests, and the local tagged app launch is intentionally deferred until explicit approval.

## Localization
Updated `Resources/Localizable.xcstrings` for `ghostty.copy-mode.indicator`, `ghostty.key-table.indicator`, and `ghostty.key-table.icon.accessibility` in English and Japanese.

## Review Trigger
Automated reviewers have run on the branch; no manual re-trigger requested.

## Checklist
- [x] Two-commit red/green regression structure used.
- [x] Branch pushed to `origin` only.
- [x] PR review threads addressed/resolved.
- [x] Local app build/launch intentionally not run before user approval.

<!-- codesmith:footer -->
---
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches terminal keyboard routing and copy-mode state; behavior change is localized but affects all copy-mode key handling.
> 
> **Overview**
> **Copy-mode vim navigation** now maps keys using layout-aware identity: prefer raw ASCII from the event, then `KeyboardLayout.normalizedCharacters(for:)`, then ASCII key-code fallback—so motions like `j`/`k`/`h`/`l` work when the active input source reports Hangul or other non-Latin characters.
> 
> When a key still cannot be resolved to a copy-mode action, the resolver returns **`.pass`** instead of swallowing the event, so IME/input-source toggles and unrelated keys are not blocked.
> 
> Adds **English/Japanese** strings for copy-mode and key-table indicator labels already used in the UI, plus **unit tests** for Korean-layout cases, `gg`, ASCII precedence, and pass-through behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afd7d98467fd4262c9a34b0ead17a751c1c82add. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localization support for copy-mode and key-table interface elements in English and Japanese.

* **Improvements**
  * Enhanced copy-mode keyboard handling for international keyboard layouts, including better support for non-ASCII character input.

* **Tests**
  * Expanded test coverage for copy-mode keyboard behavior with various international keyboard layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->