### PR TITLE
Fix session restore resuming agents in the wrong directory (drifted cwd)

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -24352,11 +24352,20 @@ struct CMUXCLI {
         launchCommand: AgentHookLaunchCommandRecord?
     ) {
         let resumeEnvironment = agentSurfaceResumeEnvironment(kind: kind, environment: launchCommand?.environment)
+        // Pin the resume binding to the directory the agent was *launched* in, not the drift-prone
+        // runtime cwd: cwd-namespaced agents (Claude, Grok, Gemini, …) file their session under the
+        // launch dir, so resuming from a worktree the agent later `cd`'d into fails with "No
+        // conversation found".
+        let resumeWorkingDirectory = AgentResumeWorkingDirectory.resolve(
+            kind: kind,
+            runtimeCwd: cwd,
+            launchWorkingDirectory: launchCommand?.workingDirectory
+        )
         guard let command = agentSurfaceResumeCommand(
             kind: kind,
             sessionId: sessionId,
             launchCommand: launchCommand,
-            workingDirectory: cwd,
+            workingDirectory: resumeWorkingDirectory,
             environment: resumeEnvironment
         ) else {
             clearAgentSurfaceResumeBinding(
@@ -24376,8 +24385,8 @@ struct CMUXCLI {
             "command": command,
             "auto_resume": true
         ]
-        if let cwd = normalizedHookValue(cwd) ?? normalizedHookValue(launchCommand?.workingDirectory) {
-            params["cwd"] = cwd
+        if let resumeWorkingDirectory {
+            params["cwd"] = resumeWorkingDirectory
         }
         if let resumeEnvironment, !resumeEnvironment.isEmpty {
             params["environment"] = resumeEnvironment

--- a/Packages/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentCwdNamespacing.swift
+++ b/Packages/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentCwdNamespacing.swift
@@ -1,0 +1,17 @@
+/// Whether an agent's session store is keyed by the directory the agent was launched in.
+///
+/// This decides whether `<agent> --resume <id>` is sensitive to the directory it runs from, which in
+/// turn drives how cmux chooses the working directory when it restores a session.
+public enum AgentCwdNamespacing: Sendable, Equatable {
+    /// The store is keyed by a directory derived from the launch cwd (Claude `projects/<encode(cwd)>/`,
+    /// plus the Grok/Pi/Gemini/Cursor/Qoder cwd-keyed buckets). Resuming from a different directory
+    /// looks in the wrong namespace and fails with "No conversation found". Kinds whose layout has not
+    /// been verified are treated as ``byDirectory`` because preferring the launch cwd is never worse
+    /// for resume lookup.
+    case byDirectory
+
+    /// Sessions are addressed by id and the cwd is recorded inside the session file (Codex, OpenCode,
+    /// Amp, Antigravity, Rovo Dev, Hermes). Resume works from any directory, so the runtime cwd can be
+    /// kept and the agent reopens where it was working.
+    case cwdInFile
+}

--- a/Packages/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentResumeWorkingDirectory.swift
+++ b/Packages/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentResumeWorkingDirectory.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// Resolves the working directory a restored agent session should run in.
+///
+/// This is the single source of truth shared by the app-side resolver
+/// (``RestorableAgentSessionIndex`` in the app target) and the CLI surface-resume-binding publisher
+/// (`publishAgentSurfaceResumeBinding` in the standalone `cmux-cli` target), so both apply one
+/// policy: directory-namespaced agents pin the launch cwd, id-keyed agents keep the runtime cwd.
+///
+/// ```swift
+/// // A Claude session launched in /repo that drifted into /repo/worktrees/x:
+/// AgentResumeWorkingDirectory.resolve(
+///     kind: "claude",
+///     runtimeCwd: "/repo/worktrees/x",
+///     launchWorkingDirectory: "/repo"
+/// ) // == "/repo"  (so `claude --resume` finds the transcript filed under /repo)
+/// ```
+public enum AgentResumeWorkingDirectory {
+    /// Classifies an agent by its raw kind id (e.g. `"claude"`, `"codex"`, `"hermes-agent"`).
+    ///
+    /// - Parameter kind: the agent's raw kind identifier (``RestorableAgentKind/rawValue`` in the app).
+    /// - Returns: ``AgentCwdNamespacing/cwdInFile`` for id-keyed agents that record the cwd in the
+    ///   session file; ``AgentCwdNamespacing/byDirectory`` for everything else (including unknown
+    ///   kinds, which prefer the launch cwd).
+    public static func cwdNamespacing(forKind kind: String) -> AgentCwdNamespacing {
+        switch kind {
+        case "codex", "opencode", "amp", "antigravity", "rovodev", "hermes-agent":
+            return .cwdInFile
+        default:
+            return .byDirectory
+        }
+    }
+
+    /// The directory a resumed agent session should `cd` into.
+    ///
+    /// Directory-namespaced agents prefer the launch working directory: it is captured once at launch,
+    /// matches the session store's namespace, and does not drift when the agent `cd`s into a
+    /// subdirectory (e.g. a worktree) mid-session. Id-keyed agents keep the runtime cwd so they reopen
+    /// where the agent was working. Inputs are trimmed and empty values are treated as absent.
+    ///
+    /// - Parameters:
+    ///   - kind: the agent's raw kind identifier.
+    ///   - runtimeCwd: the agent's last-reported runtime cwd (may have drifted).
+    ///   - launchWorkingDirectory: the directory the agent was launched in.
+    /// - Returns: the directory to `cd` into, or `nil` when neither input is usable.
+    public static func resolve(
+        kind: String,
+        runtimeCwd: String?,
+        launchWorkingDirectory: String?
+    ) -> String? {
+        let runtime = normalized(runtimeCwd)
+        let launch = normalized(launchWorkingDirectory)
+        switch cwdNamespacing(forKind: kind) {
+        case .cwdInFile:
+            return runtime ?? launch
+        case .byDirectory:
+            return launch ?? runtime
+        }
+    }
+
+    private static func normalized(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else {
+            return nil
+        }
+        return trimmed
+    }
+}

--- a/Packages/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentResumeWorkingDirectoryTests.swift
+++ b/Packages/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentResumeWorkingDirectoryTests.swift
@@ -1,0 +1,61 @@
+import CMUXAgentLaunch
+import Testing
+
+@Suite("AgentResumeWorkingDirectory")
+struct AgentResumeWorkingDirectoryTests {
+    @Test("Directory-namespaced agents pin the launch cwd over a drifted runtime cwd")
+    func directoryNamespacedPrefersLaunch() {
+        #expect(
+            AgentResumeWorkingDirectory.resolve(
+                kind: "claude",
+                runtimeCwd: "/Users/x/repo/worktrees/feature",
+                launchWorkingDirectory: "/Users/x/repo"
+            ) == "/Users/x/repo"
+        )
+        for kind in ["gemini", "cursor", "grok", "pi", "qoder"] {
+            #expect(AgentResumeWorkingDirectory.cwdNamespacing(forKind: kind) == .byDirectory)
+            #expect(
+                AgentResumeWorkingDirectory.resolve(
+                    kind: kind,
+                    runtimeCwd: "/Users/x/repo/sub",
+                    launchWorkingDirectory: "/Users/x/repo"
+                ) == "/Users/x/repo"
+            )
+        }
+    }
+
+    @Test("Id-keyed cwd-in-file agents keep the runtime cwd")
+    func cwdInFileKeepsRuntime() {
+        for kind in ["codex", "opencode", "amp", "antigravity", "rovodev", "hermes-agent"] {
+            #expect(AgentResumeWorkingDirectory.cwdNamespacing(forKind: kind) == .cwdInFile)
+            #expect(
+                AgentResumeWorkingDirectory.resolve(
+                    kind: kind,
+                    runtimeCwd: "/Users/x/repo/worktrees/feature",
+                    launchWorkingDirectory: "/Users/x/repo"
+                ) == "/Users/x/repo/worktrees/feature"
+            )
+        }
+    }
+
+    @Test("Falls back across inputs and treats empty as absent")
+    func fallbacksAndEmpty() {
+        #expect(
+            AgentResumeWorkingDirectory.resolve(
+                kind: "claude", runtimeCwd: "/Users/x/repo", launchWorkingDirectory: nil
+            ) == "/Users/x/repo"
+        )
+        #expect(
+            AgentResumeWorkingDirectory.resolve(
+                kind: "claude", runtimeCwd: "/Users/x/repo", launchWorkingDirectory: "   "
+            ) == "/Users/x/repo"
+        )
+        #expect(
+            AgentResumeWorkingDirectory.resolve(
+                kind: "claude", runtimeCwd: nil, launchWorkingDirectory: ""
+            ) == nil
+        )
+        // Unknown kinds prefer the launch cwd (never worse for resume lookup).
+        #expect(AgentResumeWorkingDirectory.cwdNamespacing(forKind: "some-future-agent") == .byDirectory)
+    }
+}

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -1398,14 +1398,15 @@ struct RestorableAgentSessionIndex: Sendable {
 
     /// The directory cmux must `cd` into to resume or fork this session.
     ///
-    /// Claude stores a transcript under the project directory derived from the cwd the session
-    /// was *created* in, and `claude --resume` / `--fork-session` only locate it from that same
-    /// directory. The hook-reported `cwd` drifts when the agent `cd`s elsewhere mid-session
-    /// (e.g. starting in a repo root, then moving into a worktree for the rest of the session),
-    /// so trusting it makes fork/resume fail with "No conversation found". For Claude, prefer the
-    /// candidate directory whose project folder actually holds the transcript: the launch cwd or
-    /// the recorded cwd, matched first against the transcript's known storage path, then against
-    /// the config directory on disk. Falls back to the recorded cwd when neither can be verified.
+    /// Many agents store their session under a directory derived from the cwd the session was
+    /// *launched* in (Claude `projects/<encode(cwd)>/`, plus the Grok/Pi/Gemini/Cursor/Qoder
+    /// cwd-keyed buckets), and `--resume` / `--fork` only locate it from that same directory. The
+    /// hook-reported `cwd` drifts when the agent `cd`s elsewhere mid-session (e.g. starting in a
+    /// repo root, then moving into a worktree), so trusting it makes resume fail with "No
+    /// conversation found". For directory-namespaced kinds, prefer the stable launch cwd (it matches
+    /// the namespace and never drifts); for Claude, first verify which candidate actually holds the
+    /// transcript. For kinds that key sessions by id and record the cwd inside the session file
+    /// (Codex, OpenCode, Amp, …), keep the recorded cwd so the resumed agent reopens where it was.
     private static func restorableWorkingDirectory(
         for record: RestorableAgentHookSessionRecord,
         kind: RestorableAgentKind,
@@ -1413,12 +1414,44 @@ struct RestorableAgentSessionIndex: Sendable {
         lookup: ClaudeTranscriptLookupCache
     ) -> String? {
         let recordedCwd = normalizedWorkingDirectory(record.cwd)
-        guard kind == .claude else { return recordedCwd }
-
         let launchCwd = normalizedWorkingDirectory(record.launchCommand?.workingDirectory)
+
+        switch kind.cwdNamespacing {
+        case .cwdInFile:
+            // Resume is addressed by id and the cwd lives inside the record, so the runtime cwd is
+            // fine — keeping it preserves the directory the agent was working in.
+            return recordedCwd ?? launchCwd
+        case .byDirectory:
+            if kind == .claude,
+               let verified = claudeVerifiedRestorableWorkingDirectory(
+                   record: record,
+                   recordedCwd: recordedCwd,
+                   launchCwd: launchCwd,
+                   fileManager: fileManager,
+                   lookup: lookup
+               ) {
+                return verified
+            }
+            // The launch cwd matches the session namespace and never drifts; fall back to the
+            // recorded cwd only when no launch cwd was captured.
+            return launchCwd ?? recordedCwd
+        }
+    }
+
+    /// For Claude, returns the candidate directory whose project folder actually holds the
+    /// transcript — matched first against the transcript's known storage path, then against the
+    /// config directory on disk — or `nil` when neither can be verified (so the caller prefers the
+    /// launch cwd instead of the drift-prone recorded cwd).
+    private static func claudeVerifiedRestorableWorkingDirectory(
+        record: RestorableAgentHookSessionRecord,
+        recordedCwd: String?,
+        launchCwd: String?,
+        fileManager: FileManager,
+        lookup: ClaudeTranscriptLookupCache
+    ) -> String? {
         guard let sessionId = normalizedNonEmptyValue(record.sessionId),
               claudeSessionIdIsSafeFilename(sessionId) else {
-            return recordedCwd ?? launchCwd
+            return nil
         }
         let candidates = [launchCwd, recordedCwd].compactMap { $0 }
 
@@ -1436,7 +1469,7 @@ struct RestorableAgentSessionIndex: Sendable {
             }
         }
 
-        // No transcript path on record: probe the config directory for the candidate that holds it.
+        // Probe the config directory for the candidate that holds the transcript on disk.
         let roots = lookup.configRoots(for: record)
         if !roots.isEmpty {
             for candidate in candidates {
@@ -1451,7 +1484,7 @@ struct RestorableAgentSessionIndex: Sendable {
                 }
             }
         }
-        return recordedCwd ?? launchCwd
+        return nil
     }
 
     private static func claudeSessionIdIsSafeFilename(_ sessionId: String) -> Bool {

--- a/Sources/RestorableAgentTypes.swift
+++ b/Sources/RestorableAgentTypes.swift
@@ -1,3 +1,4 @@
+import CMUXAgentLaunch
 import Foundation
 
 enum RestorableAgentKind: Codable, Hashable, Sendable {
@@ -113,6 +114,14 @@ enum RestorableAgentKind: Codable, Hashable, Sendable {
         case .qoder: return "Qoder"
         case .custom(let id): return id
         }
+    }
+
+    /// How an agent's session store is keyed, which decides whether `<agent> --resume <id>` is
+    /// sensitive to the directory it is launched from. Derived from the shared
+    /// ``AgentResumeWorkingDirectory/cwdNamespacing(forKind:)`` so the app and the standalone CLI
+    /// apply one classification.
+    var cwdNamespacing: AgentCwdNamespacing {
+        AgentResumeWorkingDirectory.cwdNamespacing(forKind: rawValue)
     }
 
     init(from decoder: Decoder) throws {

--- a/cmuxTests/RestorableAgentSessionIndexTests.swift
+++ b/cmuxTests/RestorableAgentSessionIndexTests.swift
@@ -1,3 +1,4 @@
+import CMUXAgentLaunch
 import Foundation
 import XCTest
 
@@ -419,6 +420,19 @@ final class RestorableAgentSessionIndexTests: XCTestCase {
             resumeCommand.contains(driftedCwd.path),
             "resume must not cd into the drifted cwd; got: \(resumeCommand)"
         )
+    }
+
+    // RestorableAgentKind.cwdNamespacing delegates to the shared AgentResumeWorkingDirectory
+    // classifier (in CMUXAgentLaunch) so the app-side resolver and the CLI surface-restore publisher
+    // apply one policy. The shared resolver's own behavior is covered in CMUXAgentLaunchTests.
+    func testRestorableAgentKindCwdNamespacingMatchesSharedClassifier() {
+        for kind in RestorableAgentKind.allCases {
+            XCTAssertEqual(
+                kind.cwdNamespacing,
+                AgentResumeWorkingDirectory.cwdNamespacing(forKind: kind.rawValue),
+                "\(kind.rawValue) namespacing must match the shared classifier"
+            )
+        }
     }
 
     func testClaudeWorkflowDirectorySessionUsesSiblingJsonlSessionForResume() throws {

--- a/cmuxTests/RestorableAgentSessionIndexTests.swift
+++ b/cmuxTests/RestorableAgentSessionIndexTests.swift
@@ -310,6 +310,117 @@ final class RestorableAgentSessionIndexTests: XCTestCase {
         XCTAssertEqual(snapshot.workingDirectory, launchCwd.path)
     }
 
+    // The transcript exists but its project directory encodes to neither the launch cwd nor the
+    // drifted cwd (an out-of-tree transcript_path), and the config dir holds no matching project
+    // folder, so neither verifier can confirm a candidate. Resolution must still prefer the launch
+    // cwd (the session namespace) over the drift-prone recorded cwd, instead of falling back to the
+    // drift. This is the exact shape that made a build *with* the #5154 fix still fail to resume.
+    func testClaudeResumePrefersLaunchCwdWhenTranscriptUnverifiable() throws {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory
+            .appendingPathComponent("cmux-claude-fallback-prefers-launch-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fm.removeItem(at: root) }
+
+        let configDir = root.appendingPathComponent("claude-config", isDirectory: true)
+        try fm.createDirectory(
+            at: configDir.appendingPathComponent("projects", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        let launchCwd = root.appendingPathComponent("repo-main", isDirectory: true)
+        let driftedCwd = root.appendingPathComponent("worktree", isDirectory: true)
+        try fm.createDirectory(at: launchCwd, withIntermediateDirectories: true)
+        try fm.createDirectory(at: driftedCwd, withIntermediateDirectories: true)
+
+        // A real transcript whose parent directory name encodes to neither candidate.
+        let sessionId = "cccccccc-cccc-cccc-cccc-cccccccccccc"
+        let outOfTreeDir = root.appendingPathComponent("elsewhere", isDirectory: true)
+        try fm.createDirectory(at: outOfTreeDir, withIntermediateDirectories: true)
+        let transcriptURL = outOfTreeDir.appendingPathComponent("\(sessionId).jsonl", isDirectory: false)
+        try writeClaudeTranscript(sessionId: sessionId, transcriptURL: transcriptURL, cwd: launchCwd)
+
+        let workspaceId = UUID()
+        let panelId = UUID()
+        try writeClaudeHookStore(
+            root: root,
+            sessions: [
+                sessionId: driftedHookRecord(
+                    sessionId: sessionId,
+                    workspaceId: workspaceId,
+                    panelId: panelId,
+                    recordedCwd: driftedCwd.path,
+                    launchCwd: launchCwd.path,
+                    configDir: configDir.path,
+                    transcriptPath: transcriptURL.path,
+                    updatedAt: 10
+                ),
+            ]
+        )
+
+        let index = RestorableAgentSessionIndex.load(homeDirectory: root.path, fileManager: fm)
+        let snapshot = try XCTUnwrap(index.snapshot(workspaceId: workspaceId, panelId: panelId))
+
+        XCTAssertEqual(snapshot.workingDirectory, launchCwd.path)
+        let resumeCommand = try XCTUnwrap(snapshot.resumeCommand)
+        XCTAssertTrue(
+            resumeCommand.contains("cd -- '\(launchCwd.path)'"),
+            "resume must cd into the launch cwd; got: \(resumeCommand)"
+        )
+        XCTAssertFalse(
+            resumeCommand.contains(driftedCwd.path),
+            "resume must not cd into the drifted cwd; got: \(resumeCommand)"
+        )
+    }
+
+    // A directory-namespaced non-Claude agent (Gemini files its session under the launch cwd) whose
+    // hook-reported cwd drifted into a subdirectory must still resume from the launch cwd. Before
+    // the fix the resolver short-circuited every non-Claude kind straight to the drifted recorded
+    // cwd via `guard kind == .claude else { return recordedCwd }`.
+    func testDirectoryNamespacedNonClaudeAgentResolvesDriftToLaunchCwd() throws {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory
+            .appendingPathComponent("cmux-gemini-drift-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fm.removeItem(at: root) }
+
+        let launchCwd = root.appendingPathComponent("repo-main", isDirectory: true)
+        let driftedCwd = root.appendingPathComponent("worktree", isDirectory: true)
+        try fm.createDirectory(at: launchCwd, withIntermediateDirectories: true)
+        try fm.createDirectory(at: driftedCwd, withIntermediateDirectories: true)
+
+        let sessionId = "dddddddd-dddd-dddd-dddd-dddddddddddd"
+        let workspaceId = UUID()
+        let panelId = UUID()
+        try writeHookStore(
+            root: root,
+            storeFilename: "gemini-hook-sessions.json",
+            sessions: [
+                sessionId: driftedAgentHookRecord(
+                    launcher: "gemini",
+                    sessionId: sessionId,
+                    workspaceId: workspaceId,
+                    panelId: panelId,
+                    recordedCwd: driftedCwd.path,
+                    launchCwd: launchCwd.path,
+                    updatedAt: 10
+                ),
+            ]
+        )
+
+        let index = RestorableAgentSessionIndex.load(homeDirectory: root.path, fileManager: fm)
+        let snapshot = try XCTUnwrap(index.snapshot(workspaceId: workspaceId, panelId: panelId))
+
+        XCTAssertEqual(snapshot.kind, .gemini)
+        XCTAssertEqual(snapshot.workingDirectory, launchCwd.path)
+        let resumeCommand = try XCTUnwrap(snapshot.resumeCommand)
+        XCTAssertTrue(
+            resumeCommand.contains("cd -- '\(launchCwd.path)'"),
+            "resume must cd into the launch cwd; got: \(resumeCommand)"
+        )
+        XCTAssertFalse(
+            resumeCommand.contains(driftedCwd.path),
+            "resume must not cd into the drifted cwd; got: \(resumeCommand)"
+        )
+    }
+
     func testClaudeWorkflowDirectorySessionUsesSiblingJsonlSessionForResume() throws {
         let fm = FileManager.default
         let root = fm.temporaryDirectory
@@ -409,6 +520,36 @@ final class RestorableAgentSessionIndexTests: XCTestCase {
         return record
     }
 
+    // A drifted hook record for an arbitrary (non-Claude) agent: the recorded runtime cwd differs
+    // from the frozen launch working directory, mirroring the production drift in CLI/cmux.swift.
+    private func driftedAgentHookRecord(
+        launcher: String,
+        sessionId: String,
+        workspaceId: UUID,
+        panelId: UUID,
+        recordedCwd: String,
+        launchCwd: String,
+        updatedAt: TimeInterval
+    ) -> [String: Any] {
+        [
+            "sessionId": sessionId,
+            "workspaceId": workspaceId.uuidString,
+            "surfaceId": panelId.uuidString,
+            "cwd": recordedCwd,
+            "pid": NSNull(),
+            "isRestorable": true,
+            "updatedAt": updatedAt,
+            "launchCommand": [
+                "launcher": launcher,
+                "executablePath": "/usr/local/bin/\(launcher)",
+                "arguments": ["/usr/local/bin/\(launcher)"],
+                "workingDirectory": launchCwd,
+                "capturedAt": updatedAt,
+                "source": "test",
+            ],
+        ]
+    }
+
     private func hookRecord(
         sessionId: String,
         workspaceId: UUID,
@@ -501,6 +642,14 @@ final class RestorableAgentSessionIndexTests: XCTestCase {
     }
 
     private func writeClaudeHookStore(root: URL, sessions: [String: [String: Any]]) throws {
+        try writeHookStore(root: root, storeFilename: "claude-hook-sessions.json", sessions: sessions)
+    }
+
+    private func writeHookStore(
+        root: URL,
+        storeFilename: String,
+        sessions: [String: [String: Any]]
+    ) throws {
         let stateDir = root.appendingPathComponent(".cmuxterm", isDirectory: true)
         try FileManager.default.createDirectory(at: stateDir, withIntermediateDirectories: true)
         let data = try JSONSerialization.data(
@@ -511,7 +660,7 @@ final class RestorableAgentSessionIndexTests: XCTestCase {
             options: [.prettyPrinted, .sortedKeys]
         )
         try data.write(
-            to: stateDir.appendingPathComponent("claude-hook-sessions.json", isDirectory: false),
+            to: stateDir.appendingPathComponent(storeFilename, isDirectory: false),
             options: .atomic
         )
     }


### PR DESCRIPTION
## Summary

Session restore was running `<agent> --resume <id>` from the wrong directory, so agents failed with "No conversation found with session ID …" and the terminal fell back to a fresh login shell.

Agent session/transcript stores are namespaced by the directory the agent was **launched** in. cmux was resuming from the agent's **drifted runtime cwd** (the dir it `cd`'d into mid-session, e.g. a worktree), so `--resume` looked in the wrong namespace. The launch working directory (frozen at launch) matches the namespace and is the correct `cd` target.

PR #5154 fixed this for Claude in one of two parallel resume mechanisms. This generalizes it to every cwd-namespaced agent and to the mechanism that actually re-runs the agent on a restored surface.

Two independent carriers of the drift, both fixed:

1. **CLI surface resume binding** (`CLI/cmux.swift`, the path that re-runs the agent on a restored surface). `publishAgentSurfaceResumeBinding` preferred the hook-reported runtime cwd over the launch cwd for both the baked `cd` and the binding cwd. Now prefers the launch cwd via a shared, unit-tested `agentResumeBindingWorkingDirectory` helper. Agent-agnostic, so it fixes restore for every agent type. This is the path that produced the reported failure on a build that already had #5154.

2. **App-side resolver** (`restorableWorkingDirectory`, used by fork / command palette / relaunch index). It was Claude-only (`guard kind == .claude else { return recordedCwd }`) and both unverified fallbacks returned the drifted recorded cwd. Now classifies each kind via a new `RestorableAgentKind.cwdNamespacing`:
   - directory-namespaced (Claude, Gemini, Cursor, Grok, Pi, Qoder) → prefer the launch cwd (Claude still verifies against the transcript's project dir first);
   - id-keyed / cwd-in-file (Codex, OpenCode, Amp, Antigravity, Rovo Dev, Hermes) → keep the recorded cwd, so they reopen where they were and nothing regresses.

Investigated with a multi-agent workflow that classified all 16 agent kinds against cmux's own resume code and on-disk stores, and confirmed the subagent-hook angle is not involved (Claude's `SubagentStop` is wired to telemetry only and subagent events carry the parent session id).

## Testing

Regression tests in `cmuxTests/RestorableAgentSessionIndexTests.swift`, two-commit red→green (failing tests first commit, fix second):

- `testClaudeResumePrefersLaunchCwdWhenTranscriptUnverifiable` — Claude, out-of-tree transcript that verifies against neither candidate: must prefer the launch cwd, not the drift.
- `testDirectoryNamespacedNonClaudeAgentResolvesDriftToLaunchCwd` — Gemini drift resolves to the launch cwd (was short-circuited to the drift by the Claude-only gate).
- `testAgentResumeBindingWorkingDirectoryPrefersLaunchOverRuntimeCwd` — the CLI helper prefers the launch working directory over the runtime cwd.

CI `tests` job compiles + runs the unit bundle. Tagged dogfood build provided for manual restore verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5300"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783108407&installation_id=133855650&pr_number=5300&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5300&signature=f48f354e5f27cd23d96f1c8b850c714b19ffce3612dad6420c4819a2566132eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches all agent resume/restore paths and per-kind cwd heuristics; wrong classification could break resume for some agents, but behavior is centralized, documented, and covered by new unit/integration tests.
> 
> **Overview**
> Fixes agent session restore choosing the wrong working directory when the hook-reported **runtime cwd** drifts (e.g. into a worktree) while the session store is keyed by the **launch** directory—so `--resume` failed with "No conversation found."
> 
> Introduces shared **`CMUXAgentLaunch`** policy (`AgentCwdNamespacing`, `AgentResumeWorkingDirectory.resolve`): **directory-namespaced** agents (Claude, Gemini, Cursor, Grok, Pi, Qoder, unknown) prefer **launch cwd**; **id-keyed / cwd-in-file** agents (Codex, OpenCode, Amp, etc.) keep **runtime cwd**.
> 
> **CLI** `publishAgentSurfaceResumeBinding` now uses that resolver for resume commands and `surface.resume.set` `cwd` instead of favoring drifted runtime cwd.
> 
> **App** `restorableWorkingDirectory` applies the same classification; non-Claude directory agents no longer return recorded cwd only; Claude still verifies transcript location when possible, but **falls back to launch cwd** when verification fails (not drift).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49babcf72fcf723beaab6c667f5b04a4453e8d50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes session restore resuming agents from a drifted runtime cwd. Resume now picks the correct directory per agent kind so `--resume <id>` finds the right namespace.

- **Bug Fixes**
  - Shared resolver: added `CMUXAgentLaunch` with `AgentResumeWorkingDirectory` and `AgentCwdNamespacing`. Directory‑namespaced kinds (Claude, Gemini, Cursor, Grok, Pi, Qoder) prefer the launch cwd; id‑keyed/cwd‑in‑file kinds (Codex, OpenCode, Amp, Antigravity, Rovo Dev, Hermes) keep the runtime cwd; unknown kinds default to launch cwd.
  - CLI and app: `publishAgentSurfaceResumeBinding` and `restorableWorkingDirectory` both delegate to the shared resolver; Claude still verifies the transcript location and falls back to the launch cwd when unverifiable.
  - Tests: added package and app coverage for kind‑aware cwd selection, Claude unverifiable transcripts, Gemini drift resolving to launch cwd, and classifier parity between app and shared logic.

<sup>Written for commit 49babcf72fcf723beaab6c667f5b04a4453e8d50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced kind-aware resume classification so agents are treated as directory-sensitive or cwd-stored when determining resume working directory.

* **Bug Fixes**
  * Resume now prefers the stable launch directory when recorded cwd is unreliable.
  * Claude resume verification probes storage locations and avoids using drifted recorded cwd if transcript can’t be verified.

* **Tests**
  * Added tests for kind-aware resume behavior and Claude unverifiable-transcript scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->