### PR TITLE
Add SSH agent forwarding support for cmux ssh

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -7977,7 +7977,14 @@ struct CMUXCLI {
               !trimmed.isEmpty else {
             return nil
         }
-        return trimmed
+        guard trimmed.hasPrefix("~") else {
+            return trimmed
+        }
+        let expanded = (trimmed as NSString).expandingTildeInPath
+        guard !expanded.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return trimmed
+        }
+        return expanded
     }
 
     /// Returns whether an SSH option value enables a boolean-style OpenSSH setting.

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -7953,10 +7953,13 @@ struct CMUXCLI {
             let variableName = String(trimmed.dropFirst())
             return normalizedSSHAgentSocketPath(ProcessInfo.processInfo.environment[variableName])
         }
-        guard Self.isSSHYesValue(trimmed) else {
+        if Self.isSSHYesValue(trimmed) {
+            return normalizedSSHAgentSocketPath(ProcessInfo.processInfo.environment["SSH_AUTH_SOCK"])
+        }
+        guard !Self.isSSHNoValue(trimmed) else {
             return nil
         }
-        return normalizedSSHAgentSocketPath(ProcessInfo.processInfo.environment["SSH_AUTH_SOCK"])
+        return normalizedSSHAgentSocketPath(trimmed)
     }
 
     private func normalizedSSHAgentSocketPath(_ value: String?) -> String? {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -7272,6 +7272,7 @@ struct CMUXCLI {
         let noFocus: Bool
         let sshOptions: [String]
         let extraArguments: [String]
+        let agentSocketPath: String?
         let localSocketPath: String
         let remoteRelayPort: Int
         /// True when the remote is a cloud VM with cmuxd-remote pre-baked in the image.
@@ -7288,6 +7289,7 @@ struct CMUXCLI {
             noFocus: Bool,
             sshOptions: [String],
             extraArguments: [String],
+            agentSocketPath: String? = nil,
             localSocketPath: String,
             remoteRelayPort: Int,
             skipDaemonBootstrap: Bool = false
@@ -7301,6 +7303,7 @@ struct CMUXCLI {
             self.noFocus = noFocus
             self.sshOptions = sshOptions
             self.extraArguments = extraArguments
+            self.agentSocketPath = agentSocketPath
             self.localSocketPath = localSocketPath
             self.remoteRelayPort = remoteRelayPort
             self.skipDaemonBootstrap = skipDaemonBootstrap
@@ -7558,6 +7561,11 @@ struct CMUXCLI {
         var workspaceCreateParams: [String: Any] = [
             "initial_command": initialSSHStartupCommand,
         ]
+        if let agentSocketPath = sshOptions.agentSocketPath {
+            workspaceCreateParams["initial_env"] = [
+                "SSH_AUTH_SOCK": agentSocketPath,
+            ]
+        }
         try applyWindowOrCallerContext(to: &workspaceCreateParams, client: client, windowRaw: sshOptions.windowRaw)
 
         let workspaceCreateStartedAt = Date()
@@ -7621,6 +7629,9 @@ struct CMUXCLI {
             }
             if !remoteSSHOptions.isEmpty {
                 configureParams["ssh_options"] = remoteSSHOptions
+            }
+            if let agentSocketPath = sshOptions.agentSocketPath {
+                configureParams["ssh_auth_sock"] = agentSocketPath
             }
             if sshOptions.remoteRelayPort > 0 {
                 configureParams["relay_port"] = sshOptions.remoteRelayPort
@@ -7731,6 +7742,7 @@ struct CMUXCLI {
         var noFocus = false
         var sshOptions: [String] = []
         var extraArguments: [String] = []
+        var forwardAgentOverride: Bool?
 
         var passthrough = false
         var index = 0
@@ -7776,6 +7788,12 @@ struct CMUXCLI {
             case "--no-focus":
                 noFocus = true
                 index += 1
+            case "-A", "--forward-agent":
+                forwardAgentOverride = true
+                index += 1
+            case "-a", "--no-forward-agent":
+                forwardAgentOverride = false
+                index += 1
             case "--ssh-option":
                 guard index + 1 < commandArgs.count else {
                     throw CLIError(message: "ssh: --ssh-option requires a value")
@@ -7806,6 +7824,13 @@ struct CMUXCLI {
         guard let destination else {
             throw CLIError(message: "ssh requires a destination (example: cmux ssh user@host)")
         }
+        let agentForwarding = resolvedSSHAgentForwarding(
+            destination: destination,
+            port: port,
+            identityFile: identityFile,
+            sshOptions: sshOptions,
+            override: forwardAgentOverride
+        )
         return SSHCommandOptions(
             destination: destination,
             port: port,
@@ -7813,11 +7838,151 @@ struct CMUXCLI {
             workspaceName: workspaceName,
             windowRaw: windowRaw ?? windowOverride,
             noFocus: noFocus,
-            sshOptions: sshOptions,
+            sshOptions: agentForwarding.sshOptions,
             extraArguments: extraArguments,
+            agentSocketPath: agentForwarding.agentSocketPath,
             localSocketPath: localSocketPath,
             remoteRelayPort: remoteRelayPort
         )
+    }
+
+    private func resolvedSSHAgentForwarding(
+        destination: String,
+        port: Int?,
+        identityFile: String?,
+        sshOptions: [String],
+        override: Bool?
+    ) -> (sshOptions: [String], agentSocketPath: String?) {
+        let forwardAgentValue: String?
+        var resolvedOptions = sshOptions
+
+        if let override {
+            resolvedOptions = sshOptionsRemovingForwardAgent(resolvedOptions)
+            resolvedOptions.append("ForwardAgent=\(override ? "yes" : "no")")
+            forwardAgentValue = override ? "yes" : nil
+        } else if let explicitForwardAgent = sshForwardAgentValue(in: resolvedOptions) {
+            forwardAgentValue = Self.isSSHNoValue(explicitForwardAgent) ? nil : explicitForwardAgent
+        } else if let configuredForwardAgent = effectiveSSHConfigForwardAgent(
+            destination: destination,
+            port: port,
+            identityFile: identityFile,
+            sshOptions: resolvedOptions
+        ), !Self.isSSHNoValue(configuredForwardAgent) {
+            resolvedOptions.append("ForwardAgent=\(configuredForwardAgent)")
+            forwardAgentValue = configuredForwardAgent
+        } else {
+            forwardAgentValue = nil
+        }
+
+        let agentSocketPath = forwardAgentValue.flatMap(defaultSSHAgentSocketPath(forForwardAgentValue:))
+        return (resolvedOptions, agentSocketPath)
+    }
+
+    private func effectiveSSHConfigForwardAgent(
+        destination: String,
+        port: Int?,
+        identityFile: String?,
+        sshOptions: [String]
+    ) -> String? {
+#if DEBUG
+        if let fixture = ProcessInfo.processInfo.environment["CMUX_TEST_SSH_G_OUTPUT"] {
+            return sshForwardAgentValue(fromSSHConfigDump: fixture)
+        }
+#endif
+
+        var arguments = ["-G"]
+        if let port {
+            arguments += ["-p", String(port)]
+        }
+        if let identityFile = normalizedSSHIdentityPath(identityFile) {
+            arguments += ["-i", identityFile]
+        }
+        for option in sshOptions {
+            arguments += ["-o", option]
+        }
+        arguments.append(destination)
+
+        let result = runProcess(executablePath: "/usr/bin/ssh", arguments: arguments, timeout: 3)
+        guard result.status == 0 else {
+            cliDebugLog(
+                "cli.ssh.forwardAgent.resolve.failed target=\(destination) " +
+                "status=\(result.status) stderr=\(result.stderr.trimmingCharacters(in: .whitespacesAndNewlines))"
+            )
+            return nil
+        }
+
+        return sshForwardAgentValue(fromSSHConfigDump: result.stdout)
+    }
+
+    private func sshForwardAgentValue(fromSSHConfigDump output: String) -> String? {
+        for line in output.split(whereSeparator: \.isNewline) {
+            let parts = line.split(maxSplits: 1, whereSeparator: \.isWhitespace)
+            guard parts.count == 2,
+                  parts[0].lowercased() == "forwardagent" else {
+                continue
+            }
+            let value = String(parts[1]).trimmingCharacters(in: .whitespacesAndNewlines)
+            return value.isEmpty ? nil : value
+        }
+        return nil
+    }
+
+    private func sshOptionsRemovingForwardAgent(_ options: [String]) -> [String] {
+        options.filter { option in
+            sshOptionKey(option) != "forwardagent"
+        }
+    }
+
+    private func sshOptionKey(_ option: String) -> String? {
+        let trimmed = option.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        return trimmed
+            .split(whereSeparator: { $0 == "=" || $0.isWhitespace })
+            .first
+            .map(String.init)?
+            .lowercased()
+    }
+
+    private func sshForwardAgentValue(in options: [String]) -> String? {
+        sshOptionValue(named: "ForwardAgent", in: options)
+    }
+
+    private func defaultSSHAgentSocketPath(forForwardAgentValue value: String) -> String? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.hasPrefix("$") {
+            let variableName = String(trimmed.dropFirst())
+            return normalizedSSHAgentSocketPath(ProcessInfo.processInfo.environment[variableName])
+        }
+        guard Self.isSSHYesValue(trimmed) else {
+            return nil
+        }
+        return normalizedSSHAgentSocketPath(ProcessInfo.processInfo.environment["SSH_AUTH_SOCK"])
+    }
+
+    private func normalizedSSHAgentSocketPath(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else {
+            return nil
+        }
+        return trimmed
+    }
+
+    private static func isSSHYesValue(_ value: String) -> Bool {
+        switch value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "yes", "true", "on", "1":
+            return true
+        default:
+            return false
+        }
+    }
+
+    private static func isSSHNoValue(_ value: String) -> Bool {
+        switch value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "no", "false", "off", "0":
+            return true
+        default:
+            return false
+        }
     }
 
     func buildSSHCommandText(
@@ -13318,7 +13483,7 @@ struct CMUXCLI {
             via Settings → Keyboard.
             """
         case "ssh":
-            return """
+            return String(localized: "cli.help.ssh", defaultValue: """
             Usage: cmux ssh <destination> [flags] [-- <remote-command-args>]
 
             Create a new workspace, mark it as remote-SSH, and start an SSH session in that workspace.
@@ -13328,6 +13493,8 @@ struct CMUXCLI {
               --name <title>          Optional workspace title
               --port <n>              SSH port
               --identity <path>       SSH identity file path
+              -A, --forward-agent     Forward the caller's SSH agent; also honors ForwardAgent yes from ssh_config
+              -a, --no-forward-agent  Disable SSH agent forwarding for this workspace
               --ssh-option <opt>      Extra SSH -o option (repeatable)
               --window <id|ref|index> Target window for the managed workspace
               --no-focus              Create workspace without switching to it
@@ -13335,8 +13502,9 @@ struct CMUXCLI {
             Example:
               cmux ssh dev@my-host
               cmux ssh dev@my-host --name "gpu-box" --port 2222 --identity ~/.ssh/id_ed25519
+              cmux ssh dev@my-host --forward-agent
               cmux ssh dev@my-host --ssh-option UserKnownHostsFile=/dev/null --ssh-option StrictHostKeyChecking=no
-            """
+            """)
         case "ssh-session-list":
             return """
             Usage: cmux ssh-session-list [--workspace <id|ref|index> | --all-workspaces]
@@ -31363,7 +31531,7 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
           move-tab-to-new-workspace [--tab <id|ref|index>] [--surface <id|ref|index>] [--workspace <id|ref|index>] [--window <id|ref|index>] [--title <text>] [--focus <true|false>]
           list-workspaces [--window <id|ref|index>]
           new-workspace [--name <title>] [--description <text>] [--cwd <path>] [--command <text>] [--layout <json>] [--window <id|ref|index>] [--focus <true|false>]
-          ssh <destination> [--name <title>] [--port <n>] [--identity <path>] [--ssh-option <opt>] [--window <id|ref|index>] [--no-focus] [-- <remote-command-args>]
+          ssh <destination> [--name <title>] [--port <n>] [--identity <path>] [-A|--forward-agent] [-a|--no-forward-agent] [--ssh-option <opt>] [--window <id|ref|index>] [--no-focus] [-- <remote-command-args>]
           ssh-session-list [--workspace <id|ref|index> | --all-workspaces]
           ssh-session-attach --session-id <id> [--workspace <id|ref|index>] [--pane <id|ref|index> | --split <left|right|up|down>]
           ssh-session-cleanup [--workspace <id|ref|index> | --all-workspaces] (--session-id <id> | --all)

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -1,5 +1,6 @@
 import Foundation
 import CMUXAgentLaunch
+import CmuxFoundation
 import CmuxSocketControl
 import CoreFoundation
 import CryptoKit
@@ -7855,103 +7856,35 @@ struct CMUXCLI {
             resolvedOptions.append("ForwardAgent=\(override ? "yes" : "no")")
             forwardAgentValue = override ? "yes" : nil
         } else if let explicitForwardAgent = sshForwardAgentValue(in: resolvedOptions) {
-            forwardAgentValue = Self.isSSHNoValue(explicitForwardAgent) ? nil : explicitForwardAgent
+            forwardAgentValue = explicitForwardAgent
         } else {
             forwardAgentValue = nil
         }
 
-        let agentSocketPath = forwardAgentValue.flatMap(defaultSSHAgentSocketPath(forForwardAgentValue:))
+        let resolver = SSHAgentSocketResolver()
+        let explicitAgentSocketPath = forwardAgentValue
+            .flatMap(resolver.agentSocketPath(forForwardAgentValue:))
+            .flatMap(existingSSHAgentSocketPath)
+        let agentSocketPath = explicitAgentSocketPath
             ?? existingSSHAgentSocketPath(ProcessInfo.processInfo.environment["SSH_AUTH_SOCK"])
         return (resolvedOptions, agentSocketPath)
     }
 
     private func sshOptionsRemovingForwardAgent(_ options: [String]) -> [String] {
-        options.filter { option in
-            sshOptionKey(option) != "forwardagent"
-        }
-    }
-
-    private func sshOptionKey(_ option: String) -> String? {
-        let trimmed = option.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return nil }
-        return trimmed
-            .split(whereSeparator: { $0 == "=" || $0.isWhitespace })
-            .first
-            .map(String.init)?
-            .lowercased()
+        SSHAgentSocketResolver().removingOptions(named: "ForwardAgent", from: options)
     }
 
     private func sshForwardAgentValue(in options: [String]) -> String? {
-        sshOptionValue(named: "ForwardAgent", in: options)
-    }
-
-    /// Resolves a supported `ForwardAgent` value into the local socket path to inject into the remote workspace.
-    private func defaultSSHAgentSocketPath(forForwardAgentValue value: String) -> String? {
-        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.hasPrefix("$") {
-            let variableName = String(trimmed.dropFirst())
-            return existingSSHAgentSocketPath(ProcessInfo.processInfo.environment[variableName])
-        }
-        if Self.isSSHYesValue(trimmed) {
-            return existingSSHAgentSocketPath(ProcessInfo.processInfo.environment["SSH_AUTH_SOCK"])
-        }
-        guard !Self.isSSHNoValue(trimmed) else {
-            return nil
-        }
-        guard isPathLikeSSHAgentSocketValue(trimmed) else {
-            return nil
-        }
-        return existingSSHAgentSocketPath(trimmed)
-    }
-
-    /// Returns whether a literal `ForwardAgent` value looks like a socket path rather than a mode such as `ask`.
-    private func isPathLikeSSHAgentSocketValue(_ value: String) -> Bool {
-        value.hasPrefix("/") || value.hasPrefix("~")
-    }
-
-    /// Normalizes a candidate SSH agent socket path while preserving the original path spelling.
-    private func normalizedSSHAgentSocketPath(_ value: String?) -> String? {
-        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
-              !trimmed.isEmpty else {
-            return nil
-        }
-        guard trimmed.hasPrefix("~") else {
-            return trimmed
-        }
-        let expanded = (trimmed as NSString).expandingTildeInPath
-        guard !expanded.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            return trimmed
-        }
-        return expanded
+        SSHAgentSocketResolver().optionValue(named: "ForwardAgent", in: options)
     }
 
     /// Returns a normalized agent socket path only when it currently exists.
     private func existingSSHAgentSocketPath(_ value: String?) -> String? {
-        guard let path = normalizedSSHAgentSocketPath(value),
+        guard let path = SSHAgentSocketResolver().normalizedAgentSocketPath(value),
               FileManager.default.fileExists(atPath: path) else {
             return nil
         }
         return path
-    }
-
-    /// Returns whether an SSH option value enables a boolean-style OpenSSH setting.
-    private static func isSSHYesValue(_ value: String) -> Bool {
-        switch value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
-        case "yes", "true", "on", "1":
-            return true
-        default:
-            return false
-        }
-    }
-
-    /// Returns whether an SSH option value disables agent socket injection for cmux-managed environments.
-    private static func isSSHNoValue(_ value: String) -> Bool {
-        switch value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
-        case "no", "false", "off", "0", "ask":
-            return true
-        default:
-            return false
-        }
     }
 
     func buildSSHCommandText(
@@ -10660,16 +10593,7 @@ struct CMUXCLI {
     }
 
     private func hasSSHOptionKey(_ options: [String], key: String) -> Bool {
-        let loweredKey = key.lowercased()
-        for option in options {
-            let trimmed = option.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !trimmed.isEmpty else { continue }
-            let token = trimmed.split(whereSeparator: { $0 == "=" || $0.isWhitespace }).first.map(String.init)?.lowercased()
-            if token == loweredKey {
-                return true
-            }
-        }
-        return false
+        SSHAgentSocketResolver().hasOptionKey(options, key: key)
     }
 
     private func deferredRemoteReconnectLocalCommandScript(
@@ -10800,23 +10724,7 @@ struct CMUXCLI {
     }
 
     private func sshOptionValue(named key: String, in options: [String]) -> String? {
-        let loweredKey = key.lowercased()
-        for option in options.reversed() {
-            let trimmed = option.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !trimmed.isEmpty else { continue }
-            let parts = trimmed.split(
-                maxSplits: 1,
-                omittingEmptySubsequences: true,
-                whereSeparator: { $0 == "=" || $0.isWhitespace }
-            )
-            if parts.count == 2, parts[0].lowercased() == loweredKey {
-                let value = parts[1].trimmingCharacters(in: .whitespacesAndNewlines)
-                if !value.isEmpty {
-                    return value
-                }
-            }
-        }
-        return nil
+        SSHAgentSocketResolver().optionValue(named: key, in: options)
     }
 
     private func cliDebugLog(_ message: @autoclosure () -> String) {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -7825,9 +7825,6 @@ struct CMUXCLI {
             throw CLIError(message: "ssh requires a destination (example: cmux ssh user@host)")
         }
         let agentForwarding = resolvedSSHAgentForwarding(
-            destination: destination,
-            port: port,
-            identityFile: identityFile,
             sshOptions: sshOptions,
             override: forwardAgentOverride
         )
@@ -7847,9 +7844,6 @@ struct CMUXCLI {
     }
 
     private func resolvedSSHAgentForwarding(
-        destination: String,
-        port: Int?,
-        identityFile: String?,
         sshOptions: [String],
         override: Bool?
     ) -> (sshOptions: [String], agentSocketPath: String?) {
@@ -7862,69 +7856,13 @@ struct CMUXCLI {
             forwardAgentValue = override ? "yes" : nil
         } else if let explicitForwardAgent = sshForwardAgentValue(in: resolvedOptions) {
             forwardAgentValue = Self.isSSHNoValue(explicitForwardAgent) ? nil : explicitForwardAgent
-        } else if let configuredForwardAgent = effectiveSSHConfigForwardAgent(
-            destination: destination,
-            port: port,
-            identityFile: identityFile,
-            sshOptions: resolvedOptions
-        ), !Self.isSSHNoValue(configuredForwardAgent) {
-            resolvedOptions.append("ForwardAgent=\(configuredForwardAgent)")
-            forwardAgentValue = configuredForwardAgent
         } else {
             forwardAgentValue = nil
         }
 
         let agentSocketPath = forwardAgentValue.flatMap(defaultSSHAgentSocketPath(forForwardAgentValue:))
+            ?? existingSSHAgentSocketPath(ProcessInfo.processInfo.environment["SSH_AUTH_SOCK"])
         return (resolvedOptions, agentSocketPath)
-    }
-
-    private func effectiveSSHConfigForwardAgent(
-        destination: String,
-        port: Int?,
-        identityFile: String?,
-        sshOptions: [String]
-    ) -> String? {
-#if DEBUG
-        if let fixture = ProcessInfo.processInfo.environment["CMUX_TEST_SSH_G_OUTPUT"] {
-            return sshForwardAgentValue(fromSSHConfigDump: fixture)
-        }
-#endif
-
-        var arguments = ["-G"]
-        if let port {
-            arguments += ["-p", String(port)]
-        }
-        if let identityFile = normalizedSSHIdentityPath(identityFile) {
-            arguments += ["-i", identityFile]
-        }
-        for option in sshOptions {
-            arguments += ["-o", option]
-        }
-        arguments.append(destination)
-
-        let result = runProcess(executablePath: "/usr/bin/ssh", arguments: arguments, timeout: 3)
-        guard result.status == 0 else {
-            cliDebugLog(
-                "cli.ssh.forwardAgent.resolve.failed target=\(destination) " +
-                "status=\(result.status) stderr=\(result.stderr.trimmingCharacters(in: .whitespacesAndNewlines))"
-            )
-            return nil
-        }
-
-        return sshForwardAgentValue(fromSSHConfigDump: result.stdout)
-    }
-
-    private func sshForwardAgentValue(fromSSHConfigDump output: String) -> String? {
-        for line in output.split(whereSeparator: \.isNewline) {
-            let parts = line.split(maxSplits: 1, whereSeparator: \.isWhitespace)
-            guard parts.count == 2,
-                  parts[0].lowercased() == "forwardagent" else {
-                continue
-            }
-            let value = String(parts[1]).trimmingCharacters(in: .whitespacesAndNewlines)
-            return value.isEmpty ? nil : value
-        }
-        return nil
     }
 
     private func sshOptionsRemovingForwardAgent(_ options: [String]) -> [String] {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -7947,6 +7947,7 @@ struct CMUXCLI {
         sshOptionValue(named: "ForwardAgent", in: options)
     }
 
+    /// Resolves a supported `ForwardAgent` value into the local socket path to inject into the remote workspace.
     private func defaultSSHAgentSocketPath(forForwardAgentValue value: String) -> String? {
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmed.hasPrefix("$") {
@@ -7959,9 +7960,18 @@ struct CMUXCLI {
         guard !Self.isSSHNoValue(trimmed) else {
             return nil
         }
+        guard isPathLikeSSHAgentSocketValue(trimmed) else {
+            return nil
+        }
         return normalizedSSHAgentSocketPath(trimmed)
     }
 
+    /// Returns whether a literal `ForwardAgent` value looks like a socket path rather than a mode such as `ask`.
+    private func isPathLikeSSHAgentSocketValue(_ value: String) -> Bool {
+        value.hasPrefix("/") || value.hasPrefix("~")
+    }
+
+    /// Normalizes a candidate SSH agent socket path while preserving the original path spelling.
     private func normalizedSSHAgentSocketPath(_ value: String?) -> String? {
         guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
               !trimmed.isEmpty else {
@@ -7970,6 +7980,7 @@ struct CMUXCLI {
         return trimmed
     }
 
+    /// Returns whether an SSH option value enables a boolean-style OpenSSH setting.
     private static func isSSHYesValue(_ value: String) -> Bool {
         switch value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
         case "yes", "true", "on", "1":
@@ -7979,9 +7990,10 @@ struct CMUXCLI {
         }
     }
 
+    /// Returns whether an SSH option value disables agent socket injection for cmux-managed environments.
     private static func isSSHNoValue(_ value: String) -> Bool {
         switch value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
-        case "no", "false", "off", "0":
+        case "no", "false", "off", "0", "ask":
             return true
         default:
             return false

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -10854,7 +10854,7 @@ struct CMUXCLI {
 
     private func sshOptionValue(named key: String, in options: [String]) -> String? {
         let loweredKey = key.lowercased()
-        for option in options {
+        for option in options.reversed() {
             let trimmed = option.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !trimmed.isEmpty else { continue }
             let parts = trimmed.split(

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -7952,10 +7952,10 @@ struct CMUXCLI {
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmed.hasPrefix("$") {
             let variableName = String(trimmed.dropFirst())
-            return normalizedSSHAgentSocketPath(ProcessInfo.processInfo.environment[variableName])
+            return existingSSHAgentSocketPath(ProcessInfo.processInfo.environment[variableName])
         }
         if Self.isSSHYesValue(trimmed) {
-            return normalizedSSHAgentSocketPath(ProcessInfo.processInfo.environment["SSH_AUTH_SOCK"])
+            return existingSSHAgentSocketPath(ProcessInfo.processInfo.environment["SSH_AUTH_SOCK"])
         }
         guard !Self.isSSHNoValue(trimmed) else {
             return nil
@@ -7963,7 +7963,7 @@ struct CMUXCLI {
         guard isPathLikeSSHAgentSocketValue(trimmed) else {
             return nil
         }
-        return normalizedSSHAgentSocketPath(trimmed)
+        return existingSSHAgentSocketPath(trimmed)
     }
 
     /// Returns whether a literal `ForwardAgent` value looks like a socket path rather than a mode such as `ask`.
@@ -7985,6 +7985,15 @@ struct CMUXCLI {
             return trimmed
         }
         return expanded
+    }
+
+    /// Returns a normalized agent socket path only when it currently exists.
+    private func existingSSHAgentSocketPath(_ value: String?) -> String? {
+        guard let path = normalizedSSHAgentSocketPath(value),
+              FileManager.default.fileExists(atPath: path) else {
+            return nil
+        }
+        return path
     }
 
     /// Returns whether an SSH option value enables a boolean-style OpenSSH setting.

--- a/Packages/CmuxFoundation/README.md
+++ b/Packages/CmuxFoundation/README.md
@@ -14,6 +14,7 @@ so call sites read naturally (`value.javaScriptStringLiteral`, not `f(value)`).
 ## Contents
 
 - `String.javaScriptStringLiteral` — the string encoded as a quoted JavaScript string literal.
+- `SSHAgentSocketResolver` — OpenSSH option parsing and SSH agent socket path normalization.
 
 ## Usage
 

--- a/Packages/CmuxFoundation/Sources/CmuxFoundation/SSHAgentSocketResolver.swift
+++ b/Packages/CmuxFoundation/Sources/CmuxFoundation/SSHAgentSocketResolver.swift
@@ -1,0 +1,160 @@
+import Foundation
+
+/// Resolves OpenSSH option values that influence local SSH agent socket usage.
+///
+/// Use this type when code needs to interpret `ForwardAgent` or inspect
+/// OpenSSH-style `-o key=value` arguments without depending on app-level remote
+/// workspace types.
+public struct SSHAgentSocketResolver: Sendable {
+    /// The environment used when a `ForwardAgent` value references `$SSH_AUTH_SOCK` or another variable.
+    public let environment: [String: String]
+
+    /// Creates a resolver that reads agent socket references from an environment snapshot.
+    ///
+    /// - Parameter environment: Environment variables visible to the OpenSSH process.
+    public init(environment: [String: String] = ProcessInfo.processInfo.environment) {
+        self.environment = environment
+    }
+
+    /// Returns the lowercased key from an OpenSSH-style option string.
+    ///
+    /// - Parameter option: An option such as `ForwardAgent=yes` or `ForwardAgent yes`.
+    /// - Returns: The normalized option key, or `nil` when the option has no key.
+    public func optionKey(_ option: String) -> String? {
+        let trimmed = option.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        return trimmed
+            .split(whereSeparator: { $0 == "=" || $0.isWhitespace })
+            .first
+            .map(String.init)?
+            .lowercased()
+    }
+
+    /// Reads the last non-empty value for an OpenSSH-style option.
+    ///
+    /// OpenSSH applies the last repeated `-o` value, so this method scans in
+    /// reverse order.
+    ///
+    /// - Parameters:
+    ///   - key: The option key to read.
+    ///   - options: Option strings such as `ForwardAgent=yes`.
+    /// - Returns: The last non-empty matching option value, or `nil`.
+    public func optionValue(named key: String, in options: [String]) -> String? {
+        let loweredKey = key.lowercased()
+        for option in options.reversed() {
+            let trimmed = option.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { continue }
+            let parts = trimmed.split(
+                maxSplits: 1,
+                omittingEmptySubsequences: true,
+                whereSeparator: { $0 == "=" || $0.isWhitespace }
+            )
+            if parts.count == 2, parts[0].lowercased() == loweredKey {
+                let value = parts[1].trimmingCharacters(in: .whitespacesAndNewlines)
+                if !value.isEmpty {
+                    return value
+                }
+            }
+        }
+        return nil
+    }
+
+    /// Returns whether an option list contains a key.
+    ///
+    /// - Parameters:
+    ///   - options: Option strings to inspect.
+    ///   - key: The key to match case-insensitively.
+    /// - Returns: `true` when any option has the requested key.
+    public func hasOptionKey(_ options: [String], key: String) -> Bool {
+        let loweredKey = key.lowercased()
+        return options.contains { option in
+            optionKey(option) == loweredKey
+        }
+    }
+
+    /// Removes all options with the requested key.
+    ///
+    /// - Parameters:
+    ///   - key: The option key to remove.
+    ///   - options: Option strings to filter.
+    /// - Returns: The options whose key does not match `key`.
+    public func removingOptions(named key: String, from options: [String]) -> [String] {
+        let loweredKey = key.lowercased()
+        return options.filter { option in
+            optionKey(option) != loweredKey
+        }
+    }
+
+    /// Normalizes a candidate SSH agent socket path and expands `~`.
+    ///
+    /// - Parameter value: A raw socket path value.
+    /// - Returns: A trimmed, tilde-expanded path, or `nil` for empty input.
+    public func normalizedAgentSocketPath(_ value: String?) -> String? {
+        guard let trimmed = normalizedOptional(value) else { return nil }
+        guard trimmed.hasPrefix("~") else { return trimmed }
+        return normalizedOptional((trimmed as NSString).expandingTildeInPath) ?? trimmed
+    }
+
+    /// Resolves the last `ForwardAgent` option into an agent socket path candidate.
+    ///
+    /// - Parameter options: OpenSSH-style option strings.
+    /// - Returns: A socket path candidate, or `nil` when no usable `ForwardAgent` value exists.
+    public func agentSocketPath(for options: [String]) -> String? {
+        guard let forwardAgentValue = optionValue(named: "ForwardAgent", in: options) else {
+            return nil
+        }
+        return agentSocketPath(forForwardAgentValue: forwardAgentValue)
+    }
+
+    /// Resolves a `ForwardAgent` value into an agent socket path candidate.
+    ///
+    /// Supported values are boolean yes-like values, `$VARIABLE` references,
+    /// and literal absolute or tilde-prefixed socket paths. No-like values and
+    /// `ask` do not identify a socket by themselves.
+    ///
+    /// - Parameter value: The `ForwardAgent` value to resolve.
+    /// - Returns: A normalized socket path candidate, or `nil`.
+    public func agentSocketPath(forForwardAgentValue value: String) -> String? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.hasPrefix("$") {
+            let variableName = String(trimmed.dropFirst())
+            return normalizedAgentSocketPath(environment[variableName])
+        }
+        if Self.isSSHYesValue(trimmed) {
+            return normalizedAgentSocketPath(environment["SSH_AUTH_SOCK"])
+        }
+        guard !Self.isSSHNoValue(trimmed),
+              Self.isPathLikeSSHAgentSocketValue(trimmed) else {
+            return nil
+        }
+        return normalizedAgentSocketPath(trimmed)
+    }
+
+    private func normalizedOptional(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func isSSHYesValue(_ value: String) -> Bool {
+        switch value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "yes", "true", "on", "1":
+            return true
+        default:
+            return false
+        }
+    }
+
+    private static func isSSHNoValue(_ value: String) -> Bool {
+        switch value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "no", "false", "off", "0", "ask":
+            return true
+        default:
+            return false
+        }
+    }
+
+    private static func isPathLikeSSHAgentSocketValue(_ value: String) -> Bool {
+        value.hasPrefix("/") || value.hasPrefix("~")
+    }
+}

--- a/Packages/CmuxFoundation/Sources/CmuxFoundation/SSHAgentSocketResolver.swift
+++ b/Packages/CmuxFoundation/Sources/CmuxFoundation/SSHAgentSocketResolver.swift
@@ -9,10 +9,15 @@ public struct SSHAgentSocketResolver: Sendable {
     /// The environment used when a `ForwardAgent` value references `$SSH_AUTH_SOCK` or another variable.
     public let environment: [String: String]
 
+    /// Creates a resolver that reads agent socket references from the current process environment.
+    public init() {
+        self.init(environment: ProcessInfo.processInfo.environment)
+    }
+
     /// Creates a resolver that reads agent socket references from an environment snapshot.
     ///
     /// - Parameter environment: Environment variables visible to the OpenSSH process.
-    public init(environment: [String: String] = ProcessInfo.processInfo.environment) {
+    public init(environment: [String: String]) {
         self.environment = environment
     }
 

--- a/Sources/ContentView+ForkAgentConversation.swift
+++ b/Sources/ContentView+ForkAgentConversation.swift
@@ -105,6 +105,7 @@ extension ContentView {
                     workingDirectory: launch.terminalWorkingDirectory,
                     initialTerminalCommand: launch.initialTerminalCommand,
                     initialTerminalInput: launch.initialTerminalInput,
+                    initialTerminalEnvironment: launch.initialTerminalEnvironment,
                     inheritWorkingDirectory: launch.terminalWorkingDirectory != nil,
                     autoWelcomeIfNeeded: false
                 )

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -6878,6 +6878,7 @@ class TerminalController {
         let foregroundAuthToken = v2RawString(params, "foreground_auth_token")?
             .trimmingCharacters(in: .whitespacesAndNewlines)
         let localSocketPath = v2RawString(params, "local_socket_path")
+        let hasExplicitAgentSocketPath = v2HasNonNullParam(params, "ssh_auth_sock")
         let agentSocketPath = v2RawString(params, "ssh_auth_sock")?
             .trimmingCharacters(in: .whitespacesAndNewlines)
         let terminalStartupCommand = v2RawString(params, "terminal_startup_command")?
@@ -6999,7 +7000,8 @@ class TerminalController {
                 foregroundAuthToken: foregroundAuthToken?.isEmpty == true ? nil : foregroundAuthToken,
                 agentSocketPath: WorkspaceRemoteConfiguration.resolvedAgentSocketPath(
                     sshOptions: sshOptions,
-                    explicitAgentSocketPath: agentSocketPath
+                    explicitAgentSocketPath: agentSocketPath,
+                    explicitAgentSocketPathIsSet: hasExplicitAgentSocketPath
                 ),
                 daemonWebSocketEndpoint: daemonWebSocketEndpoint,
                 preserveAfterTerminalExit: preserveAfterTerminalExit,

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -6878,6 +6878,8 @@ class TerminalController {
         let foregroundAuthToken = v2RawString(params, "foreground_auth_token")?
             .trimmingCharacters(in: .whitespacesAndNewlines)
         let localSocketPath = v2RawString(params, "local_socket_path")
+        let agentSocketPath = v2RawString(params, "ssh_auth_sock")?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
         let terminalStartupCommand = v2RawString(params, "terminal_startup_command")?
             .trimmingCharacters(in: .whitespacesAndNewlines)
         var persistentDaemonSlot = v2RawString(params, "persistent_daemon_slot")?
@@ -6966,6 +6968,7 @@ class TerminalController {
             "target=\(destination) transport=\(transport.rawValue) port=\(sshPort.map(String.init) ?? "nil") " +
             "autoConnect=\(autoConnect ? 1 : 0) relayPort=\(relayPort.map(String.init) ?? "nil") " +
             "localSocket=\(localSocketPath?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false ? localSocketPath! : "nil") " +
+            "sshAuthSock=\(agentSocketPath?.isEmpty == false ? 1 : 0) " +
             "sshOptions=\(sshOptions.joined(separator: "|"))"
         )
 #endif
@@ -6994,6 +6997,7 @@ class TerminalController {
                 localSocketPath: localSocketPath,
                 terminalStartupCommand: terminalStartupCommand?.isEmpty == true ? nil : terminalStartupCommand,
                 foregroundAuthToken: foregroundAuthToken?.isEmpty == true ? nil : foregroundAuthToken,
+                agentSocketPath: agentSocketPath?.isEmpty == true ? nil : agentSocketPath,
                 daemonWebSocketEndpoint: daemonWebSocketEndpoint,
                 preserveAfterTerminalExit: preserveAfterTerminalExit,
                 persistentDaemonSlot: persistentDaemonSlot?.isEmpty == true ? nil : persistentDaemonSlot,

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -6997,7 +6997,10 @@ class TerminalController {
                 localSocketPath: localSocketPath,
                 terminalStartupCommand: terminalStartupCommand?.isEmpty == true ? nil : terminalStartupCommand,
                 foregroundAuthToken: foregroundAuthToken?.isEmpty == true ? nil : foregroundAuthToken,
-                agentSocketPath: agentSocketPath?.isEmpty == true ? nil : agentSocketPath,
+                agentSocketPath: WorkspaceRemoteConfiguration.resolvedAgentSocketPath(
+                    sshOptions: sshOptions,
+                    explicitAgentSocketPath: agentSocketPath
+                ),
                 daemonWebSocketEndpoint: daemonWebSocketEndpoint,
                 preserveAfterTerminalExit: preserveAfterTerminalExit,
                 persistentDaemonSlot: persistentDaemonSlot?.isEmpty == true ? nil : persistentDaemonSlot,

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -17806,7 +17806,8 @@ final class Workspace: Identifiable, ObservableObject {
         return remoteConfiguration?.sessionSnapshot(sshOptionsOverride: forkedSSHOptions)?.workspaceConfiguration(
             localSocketPath: TerminalController.shared.currentSocketPathForRemoteRestore(),
             allowPersistentPTYRestore: false,
-            preserveSSHOptions: true
+            preserveSSHOptions: true,
+            agentSocketPath: remoteConfiguration?.agentSocketPath
         ) ?? remoteConfiguration
     }
 

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -2644,6 +2644,7 @@ private final class WorkspaceRemoteDaemonRPCClient {
 
         process.executableURL = URL(fileURLWithPath: "/usr/bin/ssh")
         process.arguments = Self.daemonArguments(configuration: configuration, remotePath: remotePath)
+        process.environment = configuration.sshProcessEnvironment
         process.standardInput = stdinPipe
         process.standardOutput = stdoutPipe
         process.standardError = stderrPipe
@@ -2712,6 +2713,7 @@ private final class WorkspaceRemoteDaemonRPCClient {
             localPort: localPort,
             remoteSocketPath: Self.bakedVMDaemonSocketPath
         )
+        process.environment = configuration.sshProcessEnvironment
         process.standardInput = FileHandle.nullDevice
         process.standardOutput = FileHandle.nullDevice
         process.standardError = stderrPipe
@@ -6949,6 +6951,7 @@ final class WorkspaceRemoteSessionController {
             let stderrPipe = Pipe()
             process.executableURL = URL(fileURLWithPath: "/usr/bin/ssh")
             process.arguments = reverseRelayArguments(relayPort: relayPort, localRelayPort: localRelayPort)
+            process.environment = configuration.sshProcessEnvironment
             process.standardInput = FileHandle.nullDevice
             process.standardOutput = FileHandle.nullDevice
             process.standardError = stderrPipe
@@ -7567,6 +7570,7 @@ final class WorkspaceRemoteSessionController {
         try runProcess(
             executable: "/usr/bin/ssh",
             arguments: arguments,
+            environment: configuration.sshProcessEnvironment,
             stdin: stdin,
             timeout: timeout
         )
@@ -7580,6 +7584,7 @@ final class WorkspaceRemoteSessionController {
         try runProcess(
             executable: "/usr/bin/scp",
             arguments: arguments,
+            environment: configuration.sshProcessEnvironment,
             stdin: nil,
             timeout: timeout,
             operation: operation
@@ -13277,6 +13282,21 @@ final class Workspace: Identifiable, ObservableObject {
         maybeDemoteRemoteWorkspaceAfterSSHSessionEnded()
     }
 
+    private func terminalStartupEnvironment(
+        base: [String: String],
+        remoteStartupCommand: String?
+    ) -> [String: String] {
+        guard remoteStartupCommand != nil,
+              let remoteEnvironment = remoteConfiguration?.sshTerminalStartupEnvironment else {
+            return base
+        }
+        var environment = base
+        for (key, value) in remoteEnvironment {
+            environment[key] = value
+        }
+        return environment
+    }
+
     private func normalizedRemotePTYSessionID(_ value: String?) -> String? {
         guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
               !trimmed.isEmpty else {
@@ -13777,6 +13797,7 @@ final class Workspace: Identifiable, ObservableObject {
             let process = Process()
             process.executableURL = URL(fileURLWithPath: "/usr/bin/ssh")
             process.arguments = arguments
+            process.environment = configuration.sshProcessEnvironment
             process.standardInput = FileHandle.nullDevice
             process.standardOutput = FileHandle.nullDevice
             process.standardError = FileHandle.nullDevice
@@ -14217,6 +14238,11 @@ final class Workspace: Identifiable, ObservableObject {
         let explicitInitialCommand = (requestedInitialCommand?.isEmpty == false) ? requestedInitialCommand : nil
         let remoteTerminalStartupCommand = remoteTerminalStartupCommand()
         let startupCommand = explicitInitialCommand ?? remoteTerminalStartupCommand
+        let remoteStartupCommandForEnvironment = explicitInitialCommand == nil ? remoteTerminalStartupCommand : nil
+        let effectiveStartupEnvironment = terminalStartupEnvironment(
+            base: startupEnvironment,
+            remoteStartupCommand: remoteStartupCommandForEnvironment
+        )
         // Hold the pane open after the remote session ends so the user can read the
         // "ssh exited …" message the startup script prints. Otherwise Ghostty silently
         // respawns a local login shell when the command exits (the PTY falls through
@@ -14271,7 +14297,7 @@ final class Workspace: Identifiable, ObservableObject {
             portOrdinal: portOrdinal,
             initialCommand: startupCommand,
             tmuxStartCommand: tmuxStartCommand,
-            additionalEnvironment: startupEnvironment
+            additionalEnvironment: effectiveStartupEnvironment
         )
         configureNewTerminalPanel(newPanel)
         panels[newPanel.id] = newPanel
@@ -14395,6 +14421,11 @@ final class Workspace: Identifiable, ObservableObject {
         let explicitInitialCommand = (requestedInitialCommand?.isEmpty == false) ? requestedInitialCommand : nil
         let remoteTerminalStartupCommand = suppressWorkspaceRemoteStartupCommand ? nil : remoteTerminalStartupCommand()
         let startupCommand = explicitInitialCommand ?? remoteTerminalStartupCommand
+        let remoteStartupCommandForEnvironment = explicitInitialCommand == nil ? remoteTerminalStartupCommand : nil
+        let effectiveStartupEnvironment = terminalStartupEnvironment(
+            base: startupEnvironment,
+            remoteStartupCommand: remoteStartupCommandForEnvironment
+        )
         // See the comment at the other call site: hold the PTY open after the remote
         // command exits so the user sees the error rather than a silently-respawned
         // local login shell.
@@ -14414,7 +14445,7 @@ final class Workspace: Identifiable, ObservableObject {
             initialCommand: startupCommand,
             tmuxStartCommand: tmuxStartCommand,
             initialInput: initialInput,
-            additionalEnvironment: startupEnvironment
+            additionalEnvironment: effectiveStartupEnvironment
         )
         configureNewTerminalPanel(newPanel)
         panels[newPanel.id] = newPanel
@@ -17525,6 +17556,10 @@ final class Workspace: Identifiable, ObservableObject {
         var inheritedConfig = inheritedTerminalConfig(inPane: paneId)
         let requestedRemoteStartupCommand = remoteStartupCommand?.trimmingCharacters(in: .whitespacesAndNewlines)
         let startupCommand = requestedRemoteStartupCommand?.isEmpty == false ? requestedRemoteStartupCommand : nil
+        let effectiveStartupEnvironment = terminalStartupEnvironment(
+            base: [:],
+            remoteStartupCommand: startupCommand
+        )
         if startupCommand != nil {
             var template = inheritedConfig ?? CmuxSurfaceConfigTemplate()
             template.waitAfterCommand = true
@@ -17538,7 +17573,8 @@ final class Workspace: Identifiable, ObservableObject {
             workingDirectory: workingDirectory,
             portOrdinal: portOrdinal,
             initialCommand: startupCommand,
-            initialInput: initialInput
+            initialInput: initialInput,
+            additionalEnvironment: effectiveStartupEnvironment
         )
         configureNewTerminalPanel(newPanel)
         panels[newPanel.id] = newPanel
@@ -17581,6 +17617,7 @@ final class Workspace: Identifiable, ObservableObject {
         var terminalWorkingDirectory: String?
         var initialTerminalCommand: String?
         var initialTerminalInput: String
+        var initialTerminalEnvironment: [String: String]
         var remoteConfiguration: WorkspaceRemoteConfiguration?
         var autoConnectRemoteConfiguration: Bool
     }
@@ -17611,6 +17648,7 @@ final class Workspace: Identifiable, ObservableObject {
             terminalWorkingDirectory: isRemoteFork ? nil : workingDirectory,
             initialTerminalCommand: remoteConfiguration?.terminalStartupCommand ?? remoteStartupCommand,
             initialTerminalInput: startupInput,
+            initialTerminalEnvironment: isRemoteFork ? (remoteConfiguration?.sshTerminalStartupEnvironment ?? [:]) : [:],
             remoteConfiguration: remoteConfiguration,
             autoConnectRemoteConfiguration: remoteConfiguration != nil
         )
@@ -19229,6 +19267,7 @@ extension Workspace: BonsplitDelegate {
             workingDirectory: launch.terminalWorkingDirectory,
             initialTerminalCommand: launch.initialTerminalCommand,
             initialTerminalInput: launch.initialTerminalInput,
+            initialTerminalEnvironment: launch.initialTerminalEnvironment,
             inheritWorkingDirectory: launch.terminalWorkingDirectory != nil,
             autoWelcomeIfNeeded: false
         )

--- a/Sources/WorkspaceRemoteConfiguration.swift
+++ b/Sources/WorkspaceRemoteConfiguration.swift
@@ -397,7 +397,6 @@ struct WorkspaceRemoteConfiguration: Equatable {
         let normalizedIdentity = WorkspaceRemoteSSHOptionFilter.normalizedIdentityPath(identityFile) ?? ""
         let normalizedLocalProxyPort = localProxyPort.map(String.init) ?? ""
         let normalizedOptions = Self.proxyBrokerSSHOptions(sshOptions).joined(separator: "\u{1f}")
-        let normalizedAgentSocketPath = self.agentSocketPath ?? ""
         let normalizedWebSocketDaemon = daemonWebSocketEndpoint?.proxyBrokerKeyComponent ?? ""
         let normalizedRequiredCapabilities = preserveAfterTerminalExit ? "pty.session" : ""
         let normalizedPersistentDaemonSlot = persistentDaemonSlot ?? ""
@@ -408,7 +407,6 @@ struct WorkspaceRemoteConfiguration: Equatable {
             normalizedPort,
             normalizedIdentity,
             normalizedOptions,
-            normalizedAgentSocketPath,
             normalizedLocalProxyPort,
             normalizedWebSocketDaemon,
             normalizedRequiredCapabilities,

--- a/Sources/WorkspaceRemoteConfiguration.swift
+++ b/Sources/WorkspaceRemoteConfiguration.swift
@@ -88,6 +88,7 @@ nonisolated struct SessionRemoteWorkspaceSnapshot: Codable, Equatable, Sendable 
     var skipDaemonBootstrap: Bool?
     var relayPort: Int? = nil
     var persistentDaemonSlot: String? = nil
+    var agentSocketPath: String? = nil
 }
 
 struct WorkspaceRemoteWebSocketDaemonEndpoint: Equatable {
@@ -450,7 +451,7 @@ extension SessionRemoteWorkspaceSnapshot {
         localSocketPath: String? = nil,
         allowPersistentPTYRestore: Bool = true,
         preserveSSHOptions: Bool = false,
-        agentSocketPath: String? = nil
+        agentSocketPath overrideAgentSocketPath: String? = nil
     ) -> WorkspaceRemoteConfiguration? {
         guard transport == .ssh else { return nil }
         let normalizedDestination = destination.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -527,7 +528,7 @@ extension SessionRemoteWorkspaceSnapshot {
                     sshOptions: restoredSSHOptions
                 ),
             foregroundAuthToken: foregroundAuthToken,
-            agentSocketPath: agentSocketPath,
+            agentSocketPath: overrideAgentSocketPath ?? agentSocketPath,
             daemonWebSocketEndpoint: nil,
             preserveAfterTerminalExit: preservePTYSession,
             persistentDaemonSlot: preservePTYSession ? normalizedPersistentDaemonSlot : nil,
@@ -626,7 +627,8 @@ extension WorkspaceRemoteConfiguration {
             preserveAfterTerminalExit: preserveAfterTerminalExit ? true : nil,
             skipDaemonBootstrap: skipDaemonBootstrap,
             relayPort: preserveAfterTerminalExit ? relayPort : nil,
-            persistentDaemonSlot: preserveAfterTerminalExit ? persistentDaemonSlot : nil
+            persistentDaemonSlot: preserveAfterTerminalExit ? persistentDaemonSlot : nil,
+            agentSocketPath: agentSocketPath
         )
     }
 }

--- a/Sources/WorkspaceRemoteConfiguration.swift
+++ b/Sources/WorkspaceRemoteConfiguration.swift
@@ -399,7 +399,7 @@ struct WorkspaceRemoteConfiguration: Equatable {
         let normalizedIdentity = WorkspaceRemoteSSHOptionFilter.normalizedIdentityPath(identityFile) ?? ""
         let normalizedLocalProxyPort = localProxyPort.map(String.init) ?? ""
         let normalizedOptions = Self.proxyBrokerSSHOptions(sshOptions).joined(separator: "\u{1f}")
-        let normalizedAgentSocketPath = WorkspaceRemoteSSHOptionFilter.normalizedOptional(agentSocketPath) ?? ""
+        let normalizedAgentSocketPath = self.agentSocketPath ?? ""
         let normalizedWebSocketDaemon = daemonWebSocketEndpoint?.proxyBrokerKeyComponent ?? ""
         let normalizedRequiredCapabilities = preserveAfterTerminalExit ? "pty.session" : ""
         let normalizedPersistentDaemonSlot = persistentDaemonSlot ?? ""
@@ -440,8 +440,7 @@ struct WorkspaceRemoteConfiguration: Equatable {
             && WorkspaceRemoteSSHOptionFilter.normalizedIdentityPath(identityFile)
                 == WorkspaceRemoteSSHOptionFilter.normalizedIdentityPath(other.identityFile)
             && Self.proxyBrokerSSHOptions(sshOptions) == Self.proxyBrokerSSHOptions(other.sshOptions)
-            && WorkspaceRemoteSSHOptionFilter.normalizedOptional(agentSocketPath)
-                == WorkspaceRemoteSSHOptionFilter.normalizedOptional(other.agentSocketPath)
+            && self.agentSocketPath == other.agentSocketPath
             && daemonWebSocketEndpoint?.proxyBrokerKeyComponent == other.daemonWebSocketEndpoint?.proxyBrokerKeyComponent
     }
 }
@@ -594,14 +593,14 @@ extension SessionRemoteWorkspaceSnapshot {
 
 extension WorkspaceRemoteConfiguration {
     var sshTerminalStartupEnvironment: [String: String]? {
-        guard let agentSocketPath = WorkspaceRemoteSSHOptionFilter.normalizedOptional(agentSocketPath) else {
+        guard let agentSocketPath = self.agentSocketPath else {
             return nil
         }
         return ["SSH_AUTH_SOCK": agentSocketPath]
     }
 
     var sshProcessEnvironment: [String: String]? {
-        guard let agentSocketPath = WorkspaceRemoteSSHOptionFilter.normalizedOptional(agentSocketPath) else {
+        guard let agentSocketPath = self.agentSocketPath else {
             return nil
         }
         var environment = ProcessInfo.processInfo.environment

--- a/Sources/WorkspaceRemoteConfiguration.swift
+++ b/Sources/WorkspaceRemoteConfiguration.swift
@@ -62,6 +62,15 @@ private enum WorkspaceRemoteSSHOptionFilter {
         return normalizedOptional((trimmed as NSString).expandingTildeInPath) ?? trimmed
     }
 
+    /// Returns a normalized agent socket path only when it currently exists.
+    static func existingAgentSocketPath(_ value: String?) -> String? {
+        guard let path = normalizedAgentSocketPath(value),
+              FileManager.default.fileExists(atPath: path) else {
+            return nil
+        }
+        return path
+    }
+
     static func hasOptionKey(_ options: [String], key: String) -> Bool {
         let loweredKey = key.lowercased()
         return options.contains { option in
@@ -465,9 +474,18 @@ struct WorkspaceRemoteConfiguration: Equatable {
     }
 
     /// Resolves the SSH agent socket to use for a remote configuration from an explicit socket or durable options.
-    static func resolvedAgentSocketPath(sshOptions: [String], explicitAgentSocketPath: String? = nil) -> String? {
-        WorkspaceRemoteSSHOptionFilter.normalizedAgentSocketPath(explicitAgentSocketPath)
-            ?? WorkspaceRemoteSSHOptionFilter.sshAgentSocketPath(for: sshOptions)
+    static func resolvedAgentSocketPath(
+        sshOptions: [String],
+        explicitAgentSocketPath: String? = nil,
+        explicitAgentSocketPathIsSet: Bool = false
+    ) -> String? {
+        if explicitAgentSocketPathIsSet {
+            return WorkspaceRemoteSSHOptionFilter.existingAgentSocketPath(explicitAgentSocketPath)
+        }
+        return WorkspaceRemoteSSHOptionFilter.existingAgentSocketPath(explicitAgentSocketPath)
+            ?? WorkspaceRemoteSSHOptionFilter.existingAgentSocketPath(
+                WorkspaceRemoteSSHOptionFilter.sshAgentSocketPath(for: sshOptions)
+            )
     }
 
     var displayTarget: String {

--- a/Sources/WorkspaceRemoteConfiguration.swift
+++ b/Sources/WorkspaceRemoteConfiguration.swift
@@ -62,6 +62,77 @@ private enum WorkspaceRemoteSSHOptionFilter {
         }
     }
 
+    /// Resolves a durable `ForwardAgent` SSH option into the current local agent socket path, when one is usable.
+    static func sshAgentSocketPath(for options: [String]) -> String? {
+        guard let forwardAgentValue = optionValue(named: "ForwardAgent", in: options) else {
+            return nil
+        }
+        return sshAgentSocketPath(forForwardAgentValue: forwardAgentValue)
+    }
+
+    /// Maps OpenSSH `ForwardAgent` forms to a socket path without treating modes like `ask` as paths.
+    private static func sshAgentSocketPath(forForwardAgentValue value: String) -> String? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.hasPrefix("$") {
+            let variableName = String(trimmed.dropFirst())
+            return normalizedOptional(ProcessInfo.processInfo.environment[variableName])
+        }
+        if isSSHYesValue(trimmed) {
+            return normalizedOptional(ProcessInfo.processInfo.environment["SSH_AUTH_SOCK"])
+        }
+        guard !isSSHNoValue(trimmed),
+              isPathLikeSSHAgentSocketValue(trimmed) else {
+            return nil
+        }
+        return normalizedOptional(trimmed)
+    }
+
+    /// Reads the first non-empty value for an OpenSSH-style `-o key=value` or `-o key value` option.
+    private static func optionValue(named key: String, in options: [String]) -> String? {
+        let loweredKey = key.lowercased()
+        for option in options {
+            let trimmed = option.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { continue }
+            let parts = trimmed.split(
+                maxSplits: 1,
+                omittingEmptySubsequences: true,
+                whereSeparator: { $0 == "=" || $0.isWhitespace }
+            )
+            if parts.count == 2, parts[0].lowercased() == loweredKey {
+                let value = parts[1].trimmingCharacters(in: .whitespacesAndNewlines)
+                if !value.isEmpty {
+                    return value
+                }
+            }
+        }
+        return nil
+    }
+
+    /// Returns whether an SSH option value enables a boolean-style OpenSSH setting.
+    private static func isSSHYesValue(_ value: String) -> Bool {
+        switch value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "yes", "true", "on", "1":
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// Returns whether an SSH option value should avoid cmux-managed agent socket injection.
+    private static func isSSHNoValue(_ value: String) -> Bool {
+        switch value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "no", "false", "off", "0", "ask":
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// Returns whether a literal `ForwardAgent` value looks like a socket path rather than a mode.
+    private static func isPathLikeSSHAgentSocketValue(_ value: String) -> Bool {
+        value.hasPrefix("/") || value.hasPrefix("~")
+    }
+
     private static func optionKey(_ option: String) -> String? {
         let trimmed = option.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
@@ -88,7 +159,6 @@ nonisolated struct SessionRemoteWorkspaceSnapshot: Codable, Equatable, Sendable 
     var skipDaemonBootstrap: Bool?
     var relayPort: Int? = nil
     var persistentDaemonSlot: String? = nil
-    var agentSocketPath: String? = nil
 }
 
 struct WorkspaceRemoteWebSocketDaemonEndpoint: Equatable {
@@ -528,7 +598,7 @@ extension SessionRemoteWorkspaceSnapshot {
                     sshOptions: restoredSSHOptions
                 ),
             foregroundAuthToken: foregroundAuthToken,
-            agentSocketPath: overrideAgentSocketPath ?? agentSocketPath,
+            agentSocketPath: overrideAgentSocketPath ?? WorkspaceRemoteSSHOptionFilter.sshAgentSocketPath(for: restoredSSHOptions),
             daemonWebSocketEndpoint: nil,
             preserveAfterTerminalExit: preservePTYSession,
             persistentDaemonSlot: preservePTYSession ? normalizedPersistentDaemonSlot : nil,
@@ -627,8 +697,7 @@ extension WorkspaceRemoteConfiguration {
             preserveAfterTerminalExit: preserveAfterTerminalExit ? true : nil,
             skipDaemonBootstrap: skipDaemonBootstrap,
             relayPort: preserveAfterTerminalExit ? relayPort : nil,
-            persistentDaemonSlot: preserveAfterTerminalExit ? persistentDaemonSlot : nil,
-            agentSocketPath: agentSocketPath
+            persistentDaemonSlot: preserveAfterTerminalExit ? persistentDaemonSlot : nil
         )
     }
 }

--- a/Sources/WorkspaceRemoteConfiguration.swift
+++ b/Sources/WorkspaceRemoteConfiguration.swift
@@ -94,10 +94,10 @@ private enum WorkspaceRemoteSSHOptionFilter {
         return normalizedAgentSocketPath(trimmed)
     }
 
-    /// Reads the first non-empty value for an OpenSSH-style `-o key=value` or `-o key value` option.
+    /// Reads the last non-empty value for an OpenSSH-style `-o key=value` or `-o key value` option.
     private static func optionValue(named key: String, in options: [String]) -> String? {
         let loweredKey = key.lowercased()
-        for option in options {
+        for option in options.reversed() {
             let trimmed = option.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !trimmed.isEmpty else { continue }
             let parts = trimmed.split(
@@ -367,7 +367,7 @@ nonisolated enum SSHPTYAttachStartupCommandBuilder {
 
     private static func sshOptionValue(named name: String, in options: [String]) -> String? {
         let loweredName = name.lowercased()
-        for option in options {
+        for option in options.reversed() {
             let trimmed = option.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !trimmed.isEmpty else { continue }
             if let equals = trimmed.firstIndex(of: "=") {
@@ -524,7 +524,6 @@ struct WorkspaceRemoteConfiguration: Equatable {
             && WorkspaceRemoteSSHOptionFilter.normalizedIdentityPath(identityFile)
                 == WorkspaceRemoteSSHOptionFilter.normalizedIdentityPath(other.identityFile)
             && Self.proxyBrokerSSHOptions(sshOptions) == Self.proxyBrokerSSHOptions(other.sshOptions)
-            && self.agentSocketPath == other.agentSocketPath
             && daemonWebSocketEndpoint?.proxyBrokerKeyComponent == other.daemonWebSocketEndpoint?.proxyBrokerKeyComponent
     }
 }

--- a/Sources/WorkspaceRemoteConfiguration.swift
+++ b/Sources/WorkspaceRemoteConfiguration.swift
@@ -450,7 +450,8 @@ extension SessionRemoteWorkspaceSnapshot {
     func workspaceConfiguration(
         localSocketPath: String? = nil,
         allowPersistentPTYRestore: Bool = true,
-        preserveSSHOptions: Bool = false
+        preserveSSHOptions: Bool = false,
+        agentSocketPath: String? = nil
     ) -> WorkspaceRemoteConfiguration? {
         guard transport == .ssh else { return nil }
         let normalizedDestination = destination.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -527,6 +528,7 @@ extension SessionRemoteWorkspaceSnapshot {
                     sshOptions: restoredSSHOptions
                 ),
             foregroundAuthToken: foregroundAuthToken,
+            agentSocketPath: agentSocketPath,
             daemonWebSocketEndpoint: nil,
             preserveAfterTerminalExit: preservePTYSession,
             persistentDaemonSlot: preservePTYSession ? normalizedPersistentDaemonSlot : nil,

--- a/Sources/WorkspaceRemoteConfiguration.swift
+++ b/Sources/WorkspaceRemoteConfiguration.swift
@@ -55,6 +55,13 @@ private enum WorkspaceRemoteSSHOptionFilter {
         return normalizedOptional((trimmed as NSString).expandingTildeInPath) ?? trimmed
     }
 
+    /// Normalizes an SSH agent socket path and expands `~` so environment injection receives a usable path.
+    static func normalizedAgentSocketPath(_ value: String?) -> String? {
+        guard let trimmed = normalizedOptional(value) else { return nil }
+        guard trimmed.hasPrefix("~") else { return trimmed }
+        return normalizedOptional((trimmed as NSString).expandingTildeInPath) ?? trimmed
+    }
+
     static func hasOptionKey(_ options: [String], key: String) -> Bool {
         let loweredKey = key.lowercased()
         return options.contains { option in
@@ -75,16 +82,16 @@ private enum WorkspaceRemoteSSHOptionFilter {
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmed.hasPrefix("$") {
             let variableName = String(trimmed.dropFirst())
-            return normalizedOptional(ProcessInfo.processInfo.environment[variableName])
+            return normalizedAgentSocketPath(ProcessInfo.processInfo.environment[variableName])
         }
         if isSSHYesValue(trimmed) {
-            return normalizedOptional(ProcessInfo.processInfo.environment["SSH_AUTH_SOCK"])
+            return normalizedAgentSocketPath(ProcessInfo.processInfo.environment["SSH_AUTH_SOCK"])
         }
         guard !isSSHNoValue(trimmed),
               isPathLikeSSHAgentSocketValue(trimmed) else {
             return nil
         }
-        return normalizedOptional(trimmed)
+        return normalizedAgentSocketPath(trimmed)
     }
 
     /// Reads the first non-empty value for an OpenSSH-style `-o key=value` or `-o key value` option.
@@ -448,13 +455,19 @@ struct WorkspaceRemoteConfiguration: Equatable {
         self.localSocketPath = localSocketPath
         self.terminalStartupCommand = terminalStartupCommand
         self.foregroundAuthToken = foregroundAuthToken
-        self.agentSocketPath = WorkspaceRemoteSSHOptionFilter.normalizedOptional(agentSocketPath)
+        self.agentSocketPath = WorkspaceRemoteSSHOptionFilter.normalizedAgentSocketPath(agentSocketPath)
         self.daemonWebSocketEndpoint = daemonWebSocketEndpoint
         self.preserveAfterTerminalExit = preserveAfterTerminalExit
         self.persistentDaemonSlot = preserveAfterTerminalExit
             ? WorkspaceRemoteSSHOptionFilter.normalizedPersistentDaemonSlot(persistentDaemonSlot)
             : nil
         self.skipDaemonBootstrap = skipDaemonBootstrap
+    }
+
+    /// Resolves the SSH agent socket to use for a remote configuration from an explicit socket or durable options.
+    static func resolvedAgentSocketPath(sshOptions: [String], explicitAgentSocketPath: String? = nil) -> String? {
+        WorkspaceRemoteSSHOptionFilter.normalizedAgentSocketPath(explicitAgentSocketPath)
+            ?? WorkspaceRemoteSSHOptionFilter.sshAgentSocketPath(for: sshOptions)
     }
 
     var displayTarget: String {
@@ -598,7 +611,10 @@ extension SessionRemoteWorkspaceSnapshot {
                     sshOptions: restoredSSHOptions
                 ),
             foregroundAuthToken: foregroundAuthToken,
-            agentSocketPath: overrideAgentSocketPath ?? WorkspaceRemoteSSHOptionFilter.sshAgentSocketPath(for: restoredSSHOptions),
+            agentSocketPath: WorkspaceRemoteConfiguration.resolvedAgentSocketPath(
+                sshOptions: restoredSSHOptions,
+                explicitAgentSocketPath: overrideAgentSocketPath
+            ),
             daemonWebSocketEndpoint: nil,
             preserveAfterTerminalExit: preservePTYSession,
             persistentDaemonSlot: preservePTYSession ? normalizedPersistentDaemonSlot : nil,

--- a/Sources/WorkspaceRemoteConfiguration.swift
+++ b/Sources/WorkspaceRemoteConfiguration.swift
@@ -1,5 +1,6 @@
 import Darwin
 import Foundation
+import CmuxFoundation
 #if canImport(Security)
 import Security
 #endif
@@ -28,7 +29,7 @@ private enum WorkspaceRemoteSSHOptionFilter {
             let trimmed = option.trimmingCharacters(in: .whitespacesAndNewlines)
             return trimmed.isEmpty ? nil : trimmed
         }.filter { option in
-            guard let key = optionKey(option) else { return true }
+            guard let key = SSHAgentSocketResolver().optionKey(option) else { return true }
             return !keys.contains(key)
         }
     }
@@ -57,9 +58,7 @@ private enum WorkspaceRemoteSSHOptionFilter {
 
     /// Normalizes an SSH agent socket path and expands `~` so environment injection receives a usable path.
     static func normalizedAgentSocketPath(_ value: String?) -> String? {
-        guard let trimmed = normalizedOptional(value) else { return nil }
-        guard trimmed.hasPrefix("~") else { return trimmed }
-        return normalizedOptional((trimmed as NSString).expandingTildeInPath) ?? trimmed
+        SSHAgentSocketResolver().normalizedAgentSocketPath(value)
     }
 
     /// Returns a normalized agent socket path only when it currently exists.
@@ -72,91 +71,12 @@ private enum WorkspaceRemoteSSHOptionFilter {
     }
 
     static func hasOptionKey(_ options: [String], key: String) -> Bool {
-        let loweredKey = key.lowercased()
-        return options.contains { option in
-            optionKey(option) == loweredKey
-        }
+        SSHAgentSocketResolver().hasOptionKey(options, key: key)
     }
 
     /// Resolves a durable `ForwardAgent` SSH option into the current local agent socket path, when one is usable.
     static func sshAgentSocketPath(for options: [String]) -> String? {
-        guard let forwardAgentValue = optionValue(named: "ForwardAgent", in: options) else {
-            return nil
-        }
-        return sshAgentSocketPath(forForwardAgentValue: forwardAgentValue)
-    }
-
-    /// Maps OpenSSH `ForwardAgent` forms to a socket path without treating modes like `ask` as paths.
-    private static func sshAgentSocketPath(forForwardAgentValue value: String) -> String? {
-        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.hasPrefix("$") {
-            let variableName = String(trimmed.dropFirst())
-            return normalizedAgentSocketPath(ProcessInfo.processInfo.environment[variableName])
-        }
-        if isSSHYesValue(trimmed) {
-            return normalizedAgentSocketPath(ProcessInfo.processInfo.environment["SSH_AUTH_SOCK"])
-        }
-        guard !isSSHNoValue(trimmed),
-              isPathLikeSSHAgentSocketValue(trimmed) else {
-            return nil
-        }
-        return normalizedAgentSocketPath(trimmed)
-    }
-
-    /// Reads the last non-empty value for an OpenSSH-style `-o key=value` or `-o key value` option.
-    private static func optionValue(named key: String, in options: [String]) -> String? {
-        let loweredKey = key.lowercased()
-        for option in options.reversed() {
-            let trimmed = option.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !trimmed.isEmpty else { continue }
-            let parts = trimmed.split(
-                maxSplits: 1,
-                omittingEmptySubsequences: true,
-                whereSeparator: { $0 == "=" || $0.isWhitespace }
-            )
-            if parts.count == 2, parts[0].lowercased() == loweredKey {
-                let value = parts[1].trimmingCharacters(in: .whitespacesAndNewlines)
-                if !value.isEmpty {
-                    return value
-                }
-            }
-        }
-        return nil
-    }
-
-    /// Returns whether an SSH option value enables a boolean-style OpenSSH setting.
-    private static func isSSHYesValue(_ value: String) -> Bool {
-        switch value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
-        case "yes", "true", "on", "1":
-            return true
-        default:
-            return false
-        }
-    }
-
-    /// Returns whether an SSH option value should avoid cmux-managed agent socket injection.
-    private static func isSSHNoValue(_ value: String) -> Bool {
-        switch value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
-        case "no", "false", "off", "0", "ask":
-            return true
-        default:
-            return false
-        }
-    }
-
-    /// Returns whether a literal `ForwardAgent` value looks like a socket path rather than a mode.
-    private static func isPathLikeSSHAgentSocketValue(_ value: String) -> Bool {
-        value.hasPrefix("/") || value.hasPrefix("~")
-    }
-
-    private static func optionKey(_ option: String) -> String? {
-        let trimmed = option.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return nil }
-        return trimmed
-            .split(whereSeparator: { $0 == "=" || $0.isWhitespace })
-            .first
-            .map(String.init)?
-            .lowercased()
+        SSHAgentSocketResolver().agentSocketPath(for: options)
     }
 }
 
@@ -363,35 +283,11 @@ nonisolated enum SSHPTYAttachStartupCommandBuilder {
     }
 
     private static func hasSSHOptionKey(_ options: [String], key: String) -> Bool {
-        let loweredKey = key.lowercased()
-        return options.contains { option in
-            option
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-                .split(whereSeparator: { $0 == "=" || $0.isWhitespace })
-                .first
-                .map(String.init)?
-                .lowercased() == loweredKey
-        }
+        SSHAgentSocketResolver().hasOptionKey(options, key: key)
     }
 
     private static func sshOptionValue(named name: String, in options: [String]) -> String? {
-        let loweredName = name.lowercased()
-        for option in options.reversed() {
-            let trimmed = option.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !trimmed.isEmpty else { continue }
-            if let equals = trimmed.firstIndex(of: "=") {
-                let key = String(trimmed[..<equals]).trimmingCharacters(in: .whitespacesAndNewlines)
-                guard key.lowercased() == loweredName else { continue }
-                let value = String(trimmed[trimmed.index(after: equals)...]).trimmingCharacters(in: .whitespacesAndNewlines)
-                return value.isEmpty ? nil : String(value)
-            }
-            let parts = trimmed.split(maxSplits: 1, whereSeparator: { $0.isWhitespace })
-            guard parts.first.map({ String($0).lowercased() }) == loweredName else { continue }
-            guard parts.count > 1 else { return nil }
-            let value = String(parts[1]).trimmingCharacters(in: .whitespacesAndNewlines)
-            return value.isEmpty ? nil : value
-        }
-        return nil
+        SSHAgentSocketResolver().optionValue(named: name, in: options)
     }
 
     private static func sshOptionValueIsDisabled(_ rawValue: String?, zeroIsDisabled: Bool = true) -> Bool {

--- a/Sources/WorkspaceRemoteConfiguration.swift
+++ b/Sources/WorkspaceRemoteConfiguration.swift
@@ -336,6 +336,7 @@ struct WorkspaceRemoteConfiguration: Equatable {
     let localSocketPath: String?
     let terminalStartupCommand: String?
     let foregroundAuthToken: String?
+    let agentSocketPath: String?
     let daemonWebSocketEndpoint: WorkspaceRemoteWebSocketDaemonEndpoint?
     let preserveAfterTerminalExit: Bool
     let persistentDaemonSlot: String?
@@ -358,6 +359,7 @@ struct WorkspaceRemoteConfiguration: Equatable {
         localSocketPath: String?,
         terminalStartupCommand: String?,
         foregroundAuthToken: String? = nil,
+        agentSocketPath: String? = nil,
         daemonWebSocketEndpoint: WorkspaceRemoteWebSocketDaemonEndpoint? = nil,
         preserveAfterTerminalExit: Bool = false,
         persistentDaemonSlot: String? = nil,
@@ -375,6 +377,7 @@ struct WorkspaceRemoteConfiguration: Equatable {
         self.localSocketPath = localSocketPath
         self.terminalStartupCommand = terminalStartupCommand
         self.foregroundAuthToken = foregroundAuthToken
+        self.agentSocketPath = WorkspaceRemoteSSHOptionFilter.normalizedOptional(agentSocketPath)
         self.daemonWebSocketEndpoint = daemonWebSocketEndpoint
         self.preserveAfterTerminalExit = preserveAfterTerminalExit
         self.persistentDaemonSlot = preserveAfterTerminalExit
@@ -396,6 +399,7 @@ struct WorkspaceRemoteConfiguration: Equatable {
         let normalizedIdentity = WorkspaceRemoteSSHOptionFilter.normalizedIdentityPath(identityFile) ?? ""
         let normalizedLocalProxyPort = localProxyPort.map(String.init) ?? ""
         let normalizedOptions = Self.proxyBrokerSSHOptions(sshOptions).joined(separator: "\u{1f}")
+        let normalizedAgentSocketPath = WorkspaceRemoteSSHOptionFilter.normalizedOptional(agentSocketPath) ?? ""
         let normalizedWebSocketDaemon = daemonWebSocketEndpoint?.proxyBrokerKeyComponent ?? ""
         let normalizedRequiredCapabilities = preserveAfterTerminalExit ? "pty.session" : ""
         let normalizedPersistentDaemonSlot = persistentDaemonSlot ?? ""
@@ -406,6 +410,7 @@ struct WorkspaceRemoteConfiguration: Equatable {
             normalizedPort,
             normalizedIdentity,
             normalizedOptions,
+            normalizedAgentSocketPath,
             normalizedLocalProxyPort,
             normalizedWebSocketDaemon,
             normalizedRequiredCapabilities,
@@ -435,6 +440,8 @@ struct WorkspaceRemoteConfiguration: Equatable {
             && WorkspaceRemoteSSHOptionFilter.normalizedIdentityPath(identityFile)
                 == WorkspaceRemoteSSHOptionFilter.normalizedIdentityPath(other.identityFile)
             && Self.proxyBrokerSSHOptions(sshOptions) == Self.proxyBrokerSSHOptions(other.sshOptions)
+            && WorkspaceRemoteSSHOptionFilter.normalizedOptional(agentSocketPath)
+                == WorkspaceRemoteSSHOptionFilter.normalizedOptional(other.agentSocketPath)
             && daemonWebSocketEndpoint?.proxyBrokerKeyComponent == other.daemonWebSocketEndpoint?.proxyBrokerKeyComponent
     }
 }
@@ -584,6 +591,22 @@ extension SessionRemoteWorkspaceSnapshot {
 }
 
 extension WorkspaceRemoteConfiguration {
+    var sshTerminalStartupEnvironment: [String: String]? {
+        guard let agentSocketPath = WorkspaceRemoteSSHOptionFilter.normalizedOptional(agentSocketPath) else {
+            return nil
+        }
+        return ["SSH_AUTH_SOCK": agentSocketPath]
+    }
+
+    var sshProcessEnvironment: [String: String]? {
+        guard let agentSocketPath = WorkspaceRemoteSSHOptionFilter.normalizedOptional(agentSocketPath) else {
+            return nil
+        }
+        var environment = ProcessInfo.processInfo.environment
+        environment["SSH_AUTH_SOCK"] = agentSocketPath
+        return environment
+    }
+
     static func forkedAgentSSHOptions(_ options: [String]) -> [String] {
         WorkspaceRemoteSSHOptionFilter.forkedWorkspaceOptions(options)
     }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -144,6 +144,7 @@
 		C8000313C8000313C8000313 /* CmuxFileWatch in Frameworks */ = {isa = PBXBuildFile; productRef = C8000312C8000312C8000312 /* CmuxFileWatch */; };
 		C8000314C8000314C8000314 /* CmuxFileWatch in Frameworks */ = {isa = PBXBuildFile; productRef = C8000312C8000312C8000312 /* CmuxFileWatch */; };
 		CF00F00000000000000000A3 /* CmuxFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = CF00F00000000000000000A2 /* CmuxFoundation */; };
+		CF00F00000000000000000A4 /* CmuxFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = CF00F00000000000000000A2 /* CmuxFoundation */; };
 		C0DE34020000000000000001 /* CmuxHelpCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE34020000000000000003 /* CmuxHelpCommands.swift */; };
 		C0DE34020000000000000002 /* CmuxHelpResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE34020000000000000004 /* CmuxHelpResource.swift */; };
 		C0DE46010000000000000001 /* CMUXInstalledExtensionSidebarHostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE46010000000000000002 /* CMUXInstalledExtensionSidebarHostView.swift */; };
@@ -1263,6 +1264,7 @@
 			files = (
 				A5B00004A1B2C3D4E5F60718 /* CMUXAgentLaunch in Frameworks */,
 				C8000314C8000314C8000314 /* CmuxFileWatch in Frameworks */,
+				CF00F00000000000000000A4 /* CmuxFoundation in Frameworks */,
 				C8000304C8000304C8000304 /* CmuxProcess in Frameworks */,
 				B900004CA1B2C3D4E5F60719 /* CmuxSocketControl in Frameworks */,
 				C5A1FED000000000000000C2 /* CmuxSwiftRender in Frameworks */,
@@ -1997,6 +1999,7 @@
 				C5A1FED100000000000000D3 /* CmuxSwiftRenderUI */,
 				C8000302C8000302C8000302 /* CmuxProcess */,
 				C8000312C8000312C8000312 /* CmuxFileWatch */,
+				CF00F00000000000000000A2 /* CmuxFoundation */,
 			);
 			productName = cmux;
 			productReference = B9000004A1B2C3D4E5F60719 /* cmux */;

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -2557,6 +2557,24 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         XCTAssertEqual(configureParams["ssh_auth_sock"] as? String, agentSocketPath)
     }
 
+    func testSSHForwardAgentConfigLiteralSocketPathPropagatesSocketPath() throws {
+        let agentSocketPath = "/tmp/cmux-test-agent-\(UUID().uuidString).sock"
+        let run = try runMockedSSH(
+            arguments: [],
+            environmentOverrides: [
+                "CMUX_TEST_SSH_G_OUTPUT": "forwardagent \(agentSocketPath)\n",
+            ]
+        )
+        let createParams = try XCTUnwrap(params(for: "workspace.create", in: run.requests))
+        let configureParams = try XCTUnwrap(params(for: "workspace.remote.configure", in: run.requests))
+        let sshOptions = try XCTUnwrap(configureParams["ssh_options"] as? [String])
+        let initialEnv = try XCTUnwrap(createParams["initial_env"] as? [String: String])
+
+        XCTAssertTrue(sshOptions.contains("ForwardAgent=\(agentSocketPath)"), "ssh_options: \(sshOptions)")
+        XCTAssertEqual(initialEnv["SSH_AUTH_SOCK"], agentSocketPath)
+        XCTAssertEqual(configureParams["ssh_auth_sock"] as? String, agentSocketPath)
+    }
+
     func testSSHNoForwardAgentFlagOverridesConfig() throws {
         let run = try runMockedSSH(
             arguments: ["--no-forward-agent"],

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -2517,7 +2517,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         let sshOptions = try XCTUnwrap(configureParams["ssh_options"] as? [String])
         let initialEnv = try XCTUnwrap(createParams["initial_env"] as? [String: String])
 
-        XCTAssertTrue(sshOptions.contains("ForwardAgent=yes"), sshOptions)
+        XCTAssertTrue(sshOptions.contains("ForwardAgent=yes"), "ssh_options: \(sshOptions)")
         XCTAssertEqual(initialEnv["SSH_AUTH_SOCK"], agentSocketPath)
         XCTAssertEqual(configureParams["ssh_auth_sock"] as? String, agentSocketPath)
     }
@@ -2533,7 +2533,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         let sshOptions = try XCTUnwrap(configureParams["ssh_options"] as? [String])
         let initialEnv = try XCTUnwrap(createParams["initial_env"] as? [String: String])
 
-        XCTAssertTrue(sshOptions.contains("ForwardAgent=yes"), sshOptions)
+        XCTAssertTrue(sshOptions.contains("ForwardAgent=yes"), "ssh_options: \(sshOptions)")
         XCTAssertEqual(initialEnv["SSH_AUTH_SOCK"], agentSocketPath)
         XCTAssertEqual(configureParams["ssh_auth_sock"] as? String, agentSocketPath)
     }
@@ -2552,7 +2552,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         let sshOptions = try XCTUnwrap(configureParams["ssh_options"] as? [String])
         let initialEnv = try XCTUnwrap(createParams["initial_env"] as? [String: String])
 
-        XCTAssertTrue(sshOptions.contains("ForwardAgent=yes"), sshOptions)
+        XCTAssertTrue(sshOptions.contains("ForwardAgent=yes"), "ssh_options: \(sshOptions)")
         XCTAssertEqual(initialEnv["SSH_AUTH_SOCK"], agentSocketPath)
         XCTAssertEqual(configureParams["ssh_auth_sock"] as? String, agentSocketPath)
     }
@@ -2569,7 +2569,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         let configureParams = try XCTUnwrap(params(for: "workspace.remote.configure", in: run.requests))
         let sshOptions = try XCTUnwrap(configureParams["ssh_options"] as? [String])
 
-        XCTAssertTrue(sshOptions.contains("ForwardAgent=no"), sshOptions)
+        XCTAssertTrue(sshOptions.contains("ForwardAgent=no"), "ssh_options: \(sshOptions)")
         XCTAssertNil(createParams["initial_env"])
         XCTAssertNil(configureParams["ssh_auth_sock"])
     }

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -2506,6 +2506,74 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         XCTAssertNotNil(UUID(uuidString: String(persistentDaemonSlot.dropFirst(4))))
     }
 
+    func testSSHForwardAgentFlagPropagatesCallerAgentSocket() throws {
+        let agentSocketPath = "/tmp/cmux-test-agent-\(UUID().uuidString).sock"
+        let run = try runMockedSSH(
+            arguments: ["--forward-agent"],
+            environmentOverrides: ["SSH_AUTH_SOCK": agentSocketPath]
+        )
+        let createParams = try XCTUnwrap(params(for: "workspace.create", in: run.requests))
+        let configureParams = try XCTUnwrap(params(for: "workspace.remote.configure", in: run.requests))
+        let sshOptions = try XCTUnwrap(configureParams["ssh_options"] as? [String])
+        let initialEnv = try XCTUnwrap(createParams["initial_env"] as? [String: String])
+
+        XCTAssertTrue(sshOptions.contains("ForwardAgent=yes"), sshOptions)
+        XCTAssertEqual(initialEnv["SSH_AUTH_SOCK"], agentSocketPath)
+        XCTAssertEqual(configureParams["ssh_auth_sock"] as? String, agentSocketPath)
+    }
+
+    func testSSHForwardAgentOptionPropagatesCallerAgentSocket() throws {
+        let agentSocketPath = "/tmp/cmux-test-agent-\(UUID().uuidString).sock"
+        let run = try runMockedSSH(
+            arguments: ["--ssh-option", "ForwardAgent=yes"],
+            environmentOverrides: ["SSH_AUTH_SOCK": agentSocketPath]
+        )
+        let createParams = try XCTUnwrap(params(for: "workspace.create", in: run.requests))
+        let configureParams = try XCTUnwrap(params(for: "workspace.remote.configure", in: run.requests))
+        let sshOptions = try XCTUnwrap(configureParams["ssh_options"] as? [String])
+        let initialEnv = try XCTUnwrap(createParams["initial_env"] as? [String: String])
+
+        XCTAssertTrue(sshOptions.contains("ForwardAgent=yes"), sshOptions)
+        XCTAssertEqual(initialEnv["SSH_AUTH_SOCK"], agentSocketPath)
+        XCTAssertEqual(configureParams["ssh_auth_sock"] as? String, agentSocketPath)
+    }
+
+    func testSSHForwardAgentConfigPropagatesCallerAgentSocket() throws {
+        let agentSocketPath = "/tmp/cmux-test-agent-\(UUID().uuidString).sock"
+        let run = try runMockedSSH(
+            arguments: [],
+            environmentOverrides: [
+                "CMUX_TEST_SSH_G_OUTPUT": "forwardagent yes\n",
+                "SSH_AUTH_SOCK": agentSocketPath,
+            ]
+        )
+        let createParams = try XCTUnwrap(params(for: "workspace.create", in: run.requests))
+        let configureParams = try XCTUnwrap(params(for: "workspace.remote.configure", in: run.requests))
+        let sshOptions = try XCTUnwrap(configureParams["ssh_options"] as? [String])
+        let initialEnv = try XCTUnwrap(createParams["initial_env"] as? [String: String])
+
+        XCTAssertTrue(sshOptions.contains("ForwardAgent=yes"), sshOptions)
+        XCTAssertEqual(initialEnv["SSH_AUTH_SOCK"], agentSocketPath)
+        XCTAssertEqual(configureParams["ssh_auth_sock"] as? String, agentSocketPath)
+    }
+
+    func testSSHNoForwardAgentFlagOverridesConfig() throws {
+        let run = try runMockedSSH(
+            arguments: ["--no-forward-agent"],
+            environmentOverrides: [
+                "CMUX_TEST_SSH_G_OUTPUT": "forwardagent yes\n",
+                "SSH_AUTH_SOCK": "/tmp/cmux-test-agent-\(UUID().uuidString).sock",
+            ]
+        )
+        let createParams = try XCTUnwrap(params(for: "workspace.create", in: run.requests))
+        let configureParams = try XCTUnwrap(params(for: "workspace.remote.configure", in: run.requests))
+        let sshOptions = try XCTUnwrap(configureParams["ssh_options"] as? [String])
+
+        XCTAssertTrue(sshOptions.contains("ForwardAgent=no"), sshOptions)
+        XCTAssertNil(createParams["initial_env"])
+        XCTAssertNil(configureParams["ssh_auth_sock"])
+    }
+
     private func assertSSHPersistentPTYUsesReusableForegroundAuthControlConnection(
         run: MockedSSHRun,
         file: StaticString = #filePath,
@@ -8091,6 +8159,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         arguments sshArguments: [String],
         jsonOutput: Bool = false,
         omitWorkspaceCreateSurfaceID: Bool = false,
+        environmentOverrides: [String: String] = [:],
         file: StaticString = #filePath,
         line: UInt = #line
     ) throws -> MockedSSHRun {
@@ -8164,6 +8233,9 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         }
         environment["CMUX_SOCKET_PATH"] = socketPath
         environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
+        for (key, value) in environmentOverrides {
+            environment[key] = value
+        }
 
         let commandArguments = jsonOutput
             ? ["--json", "--id-format", "uuids", "ssh", "example.test", "--no-focus"] + sshArguments

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -2538,6 +2538,28 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         XCTAssertEqual(configureParams["ssh_auth_sock"] as? String, agentSocketPath)
     }
 
+    func testSSHForwardAgentRepeatedOptionUsesLastValue() throws {
+        let run = try runMockedSSH(
+            arguments: [
+                "--ssh-option", "ForwardAgent=yes",
+                "--ssh-option", "ForwardAgent=no",
+            ],
+            environmentOverrides: [
+                "SSH_AUTH_SOCK": "/tmp/cmux-test-agent-\(UUID().uuidString).sock",
+            ]
+        )
+        let createParams = try XCTUnwrap(params(for: "workspace.create", in: run.requests))
+        let configureParams = try XCTUnwrap(params(for: "workspace.remote.configure", in: run.requests))
+        let sshOptions = try XCTUnwrap(configureParams["ssh_options"] as? [String])
+
+        XCTAssertEqual(sshOptions.filter { $0.hasPrefix("ForwardAgent=") }, [
+            "ForwardAgent=yes",
+            "ForwardAgent=no",
+        ])
+        XCTAssertNil(createParams["initial_env"])
+        XCTAssertNil(configureParams["ssh_auth_sock"])
+    }
+
     func testSSHForwardAgentConfigPropagatesCallerAgentSocket() throws {
         let agentSocketPath = "/tmp/cmux-test-agent-\(UUID().uuidString).sock"
         let run = try runMockedSSH(

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -2575,6 +2575,22 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         XCTAssertEqual(configureParams["ssh_auth_sock"] as? String, agentSocketPath)
     }
 
+    func testSSHForwardAgentAskDoesNotPropagateInvalidSocketPath() throws {
+        let run = try runMockedSSH(
+            arguments: ["--ssh-option", "ForwardAgent=ask"],
+            environmentOverrides: [
+                "SSH_AUTH_SOCK": "/tmp/cmux-test-agent-\(UUID().uuidString).sock",
+            ]
+        )
+        let createParams = try XCTUnwrap(params(for: "workspace.create", in: run.requests))
+        let configureParams = try XCTUnwrap(params(for: "workspace.remote.configure", in: run.requests))
+        let sshOptions = try XCTUnwrap(configureParams["ssh_options"] as? [String])
+
+        XCTAssertTrue(sshOptions.contains("ForwardAgent=ask"), "ssh_options: \(sshOptions)")
+        XCTAssertNil(createParams["initial_env"])
+        XCTAssertNil(configureParams["ssh_auth_sock"])
+    }
+
     func testSSHNoForwardAgentFlagOverridesConfig() throws {
         let run = try runMockedSSH(
             arguments: ["--no-forward-agent"],

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -2575,6 +2575,25 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         XCTAssertEqual(configureParams["ssh_auth_sock"] as? String, agentSocketPath)
     }
 
+    func testSSHForwardAgentConfigTildeSocketPathExpandsSocketPath() throws {
+        let tildeSocketPath = "~/.ssh/cmux-test-agent.sock"
+        let expandedSocketPath = (tildeSocketPath as NSString).expandingTildeInPath
+        let run = try runMockedSSH(
+            arguments: [],
+            environmentOverrides: [
+                "CMUX_TEST_SSH_G_OUTPUT": "forwardagent \(tildeSocketPath)\n",
+            ]
+        )
+        let createParams = try XCTUnwrap(params(for: "workspace.create", in: run.requests))
+        let configureParams = try XCTUnwrap(params(for: "workspace.remote.configure", in: run.requests))
+        let sshOptions = try XCTUnwrap(configureParams["ssh_options"] as? [String])
+        let initialEnv = try XCTUnwrap(createParams["initial_env"] as? [String: String])
+
+        XCTAssertTrue(sshOptions.contains("ForwardAgent=\(tildeSocketPath)"), "ssh_options: \(sshOptions)")
+        XCTAssertEqual(initialEnv["SSH_AUTH_SOCK"], expandedSocketPath)
+        XCTAssertEqual(configureParams["ssh_auth_sock"] as? String, expandedSocketPath)
+    }
+
     func testSSHForwardAgentAskDoesNotPropagateInvalidSocketPath() throws {
         let run = try runMockedSSH(
             arguments: ["--ssh-option", "ForwardAgent=ask"],

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -2560,32 +2560,27 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         XCTAssertNil(configureParams["ssh_auth_sock"])
     }
 
-    func testSSHForwardAgentConfigPropagatesCallerAgentSocket() throws {
+    func testSSHPreservesCallerAgentSocketForOpenSSHConfigResolution() throws {
         let agentSocketPath = try makeExistingAgentSocketPath()
         let run = try runMockedSSH(
             arguments: [],
             environmentOverrides: [
-                "CMUX_TEST_SSH_G_OUTPUT": "forwardagent yes\n",
                 "SSH_AUTH_SOCK": agentSocketPath,
             ]
         )
         let createParams = try XCTUnwrap(params(for: "workspace.create", in: run.requests))
         let configureParams = try XCTUnwrap(params(for: "workspace.remote.configure", in: run.requests))
-        let sshOptions = try XCTUnwrap(configureParams["ssh_options"] as? [String])
         let initialEnv = try XCTUnwrap(createParams["initial_env"] as? [String: String])
 
-        XCTAssertTrue(sshOptions.contains("ForwardAgent=yes"), "ssh_options: \(sshOptions)")
+        XCTAssertNil(configureParams["ssh_options"])
         XCTAssertEqual(initialEnv["SSH_AUTH_SOCK"], agentSocketPath)
         XCTAssertEqual(configureParams["ssh_auth_sock"] as? String, agentSocketPath)
     }
 
-    func testSSHForwardAgentConfigLiteralSocketPathPropagatesSocketPath() throws {
+    func testSSHForwardAgentLiteralSocketPathPropagatesSocketPath() throws {
         let agentSocketPath = try makeExistingAgentSocketPath()
         let run = try runMockedSSH(
-            arguments: [],
-            environmentOverrides: [
-                "CMUX_TEST_SSH_G_OUTPUT": "forwardagent \(agentSocketPath)\n",
-            ]
+            arguments: ["--ssh-option", "ForwardAgent=\(agentSocketPath)"]
         )
         let createParams = try XCTUnwrap(params(for: "workspace.create", in: run.requests))
         let configureParams = try XCTUnwrap(params(for: "workspace.remote.configure", in: run.requests))
@@ -2597,15 +2592,14 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         XCTAssertEqual(configureParams["ssh_auth_sock"] as? String, agentSocketPath)
     }
 
-    func testSSHForwardAgentConfigTildeSocketPathExpandsSocketPath() throws {
+    func testSSHForwardAgentTildeSocketPathExpandsSocketPath() throws {
         let homeURL = try makeTemporaryDirectory(prefix: "cmux-ssh-home")
         let tildeSocketPath = "~/.ssh/cmux-test-agent.sock"
         let expandedSocketURL = homeURL.appendingPathComponent(".ssh/cmux-test-agent.sock")
         try createExistingFile(at: expandedSocketURL)
         let run = try runMockedSSH(
-            arguments: [],
+            arguments: ["--ssh-option", "ForwardAgent=\(tildeSocketPath)"],
             environmentOverrides: [
-                "CMUX_TEST_SSH_G_OUTPUT": "forwardagent \(tildeSocketPath)\n",
                 "HOME": homeURL.path,
             ]
         )
@@ -2636,20 +2630,21 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
     }
 
     func testSSHNoForwardAgentFlagOverridesConfig() throws {
+        let agentSocketPath = try makeExistingAgentSocketPath()
         let run = try runMockedSSH(
             arguments: ["--no-forward-agent"],
             environmentOverrides: [
-                "CMUX_TEST_SSH_G_OUTPUT": "forwardagent yes\n",
-                "SSH_AUTH_SOCK": "/tmp/cmux-test-agent-\(UUID().uuidString).sock",
+                "SSH_AUTH_SOCK": agentSocketPath,
             ]
         )
         let createParams = try XCTUnwrap(params(for: "workspace.create", in: run.requests))
         let configureParams = try XCTUnwrap(params(for: "workspace.remote.configure", in: run.requests))
         let sshOptions = try XCTUnwrap(configureParams["ssh_options"] as? [String])
+        let initialEnv = try XCTUnwrap(createParams["initial_env"] as? [String: String])
 
         XCTAssertTrue(sshOptions.contains("ForwardAgent=no"), "ssh_options: \(sshOptions)")
-        XCTAssertNil(createParams["initial_env"])
-        XCTAssertNil(configureParams["ssh_auth_sock"])
+        XCTAssertEqual(initialEnv["SSH_AUTH_SOCK"], agentSocketPath)
+        XCTAssertEqual(configureParams["ssh_auth_sock"] as? String, agentSocketPath)
     }
 
     private func assertSSHPersistentPTYUsesReusableForegroundAuthControlConnection(

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -2507,7 +2507,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
     }
 
     func testSSHForwardAgentFlagPropagatesCallerAgentSocket() throws {
-        let agentSocketPath = "/tmp/cmux-test-agent-\(UUID().uuidString).sock"
+        let agentSocketPath = try makeExistingAgentSocketPath()
         let run = try runMockedSSH(
             arguments: ["--forward-agent"],
             environmentOverrides: ["SSH_AUTH_SOCK": agentSocketPath]
@@ -2523,7 +2523,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
     }
 
     func testSSHForwardAgentOptionPropagatesCallerAgentSocket() throws {
-        let agentSocketPath = "/tmp/cmux-test-agent-\(UUID().uuidString).sock"
+        let agentSocketPath = try makeExistingAgentSocketPath()
         let run = try runMockedSSH(
             arguments: ["--ssh-option", "ForwardAgent=yes"],
             environmentOverrides: ["SSH_AUTH_SOCK": agentSocketPath]
@@ -2561,7 +2561,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
     }
 
     func testSSHForwardAgentConfigPropagatesCallerAgentSocket() throws {
-        let agentSocketPath = "/tmp/cmux-test-agent-\(UUID().uuidString).sock"
+        let agentSocketPath = try makeExistingAgentSocketPath()
         let run = try runMockedSSH(
             arguments: [],
             environmentOverrides: [
@@ -2580,7 +2580,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
     }
 
     func testSSHForwardAgentConfigLiteralSocketPathPropagatesSocketPath() throws {
-        let agentSocketPath = "/tmp/cmux-test-agent-\(UUID().uuidString).sock"
+        let agentSocketPath = try makeExistingAgentSocketPath()
         let run = try runMockedSSH(
             arguments: [],
             environmentOverrides: [
@@ -2598,12 +2598,15 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
     }
 
     func testSSHForwardAgentConfigTildeSocketPathExpandsSocketPath() throws {
+        let homeURL = try makeTemporaryDirectory(prefix: "cmux-ssh-home")
         let tildeSocketPath = "~/.ssh/cmux-test-agent.sock"
-        let expandedSocketPath = (tildeSocketPath as NSString).expandingTildeInPath
+        let expandedSocketURL = homeURL.appendingPathComponent(".ssh/cmux-test-agent.sock")
+        try createExistingFile(at: expandedSocketURL)
         let run = try runMockedSSH(
             arguments: [],
             environmentOverrides: [
                 "CMUX_TEST_SSH_G_OUTPUT": "forwardagent \(tildeSocketPath)\n",
+                "HOME": homeURL.path,
             ]
         )
         let createParams = try XCTUnwrap(params(for: "workspace.create", in: run.requests))
@@ -2612,8 +2615,8 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         let initialEnv = try XCTUnwrap(createParams["initial_env"] as? [String: String])
 
         XCTAssertTrue(sshOptions.contains("ForwardAgent=\(tildeSocketPath)"), "ssh_options: \(sshOptions)")
-        XCTAssertEqual(initialEnv["SSH_AUTH_SOCK"], expandedSocketPath)
-        XCTAssertEqual(configureParams["ssh_auth_sock"] as? String, expandedSocketPath)
+        XCTAssertEqual(initialEnv["SSH_AUTH_SOCK"], expandedSocketURL.path)
+        XCTAssertEqual(configureParams["ssh_auth_sock"] as? String, expandedSocketURL.path)
     }
 
     func testSSHForwardAgentAskDoesNotPropagateInvalidSocketPath() throws {
@@ -8240,6 +8243,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
     ) throws -> MockedSSHRun {
         let cliPath = try bundledCLIPath()
         let socketPath = makeSocketPath("ssh")
+        let homeURL = try makeTemporaryDirectory(prefix: "cmux-ssh-home")
         let listenerFD = try bindUnixSocket(at: socketPath)
         let state = MockSocketServerState()
         let workspaceId = "11111111-1111-1111-1111-111111111111"
@@ -8308,6 +8312,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         }
         environment["CMUX_SOCKET_PATH"] = socketPath
         environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
+        environment["HOME"] = homeURL.path
         for (key, value) in environmentOverrides {
             environment[key] = value
         }
@@ -8336,6 +8341,34 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
             stdout: result.stdout,
             workspaceId: workspaceId,
             surfaceId: surfaceId
+        )
+    }
+
+    private func makeExistingAgentSocketPath() throws -> String {
+        let directory = try makeTemporaryDirectory(prefix: "cmux-agent")
+        let url = directory.appendingPathComponent("agent.sock")
+        try createExistingFile(at: url)
+        return url.path
+    }
+
+    private func makeTemporaryDirectory(prefix: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(prefix)-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: url)
+        }
+        return url
+    }
+
+    private func createExistingFile(at url: URL) throws {
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        XCTAssertTrue(
+            FileManager.default.createFile(atPath: url.path, contents: Data()),
+            "Expected to create \(url.path)"
         )
     }
 

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -2565,6 +2565,43 @@ final class WorkspaceRemoteConfigurationTransportKeyTests: XCTestCase {
         XCTAssertEqual(first.proxyBrokerTransportKey, second.proxyBrokerTransportKey)
     }
 
+    func testProxyBrokerTransportKeyIgnoresEphemeralAgentSocketPath() {
+        let first = WorkspaceRemoteConfiguration(
+            destination: "cmux-macmini",
+            port: 22,
+            identityFile: "~/.ssh/id_ed25519",
+            sshOptions: [
+                "ForwardAgent=yes",
+                "ControlMaster=auto",
+            ],
+            localProxyPort: 9000,
+            relayPort: 64000,
+            relayID: "relay-a",
+            relayToken: "token-a",
+            localSocketPath: "/tmp/cmux-a.sock",
+            terminalStartupCommand: "ssh cmux-macmini",
+            agentSocketPath: "/tmp/cmux-agent-a.sock"
+        )
+        let second = WorkspaceRemoteConfiguration(
+            destination: "cmux-macmini",
+            port: 22,
+            identityFile: "~/.ssh/id_ed25519",
+            sshOptions: [
+                "ForwardAgent=yes",
+                "ControlMaster=auto",
+            ],
+            localProxyPort: 9000,
+            relayPort: 64000,
+            relayID: "relay-b",
+            relayToken: "token-b",
+            localSocketPath: "/tmp/cmux-b.sock",
+            terminalStartupCommand: "ssh cmux-macmini",
+            agentSocketPath: "/tmp/cmux-agent-b.sock"
+        )
+
+        XCTAssertEqual(first.proxyBrokerTransportKey, second.proxyBrokerTransportKey)
+    }
+
     func testPersistentPTYIdentityRequiresSameRelayPort() {
         let first = WorkspaceRemoteConfiguration(
             destination: "cmux-macmini",

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -2606,6 +2606,48 @@ final class WorkspaceRemoteConfigurationTransportKeyTests: XCTestCase {
         XCTAssertFalse(first.hasSamePersistentPTYIdentity(as: second))
         XCTAssertFalse(second.hasSamePersistentPTYIdentity(as: first))
     }
+
+    func testPersistentPTYIdentityIgnoresEphemeralAgentSocketPath() {
+        let first = WorkspaceRemoteConfiguration(
+            destination: "cmux-macmini",
+            port: 22,
+            identityFile: "~/.ssh/id_ed25519",
+            sshOptions: [
+                "ForwardAgent=yes",
+                "ControlMaster=auto",
+            ],
+            localProxyPort: nil,
+            relayPort: 64000,
+            relayID: "relay-a",
+            relayToken: "token-a",
+            localSocketPath: "/tmp/cmux-a.sock",
+            terminalStartupCommand: "ssh cmux-macmini",
+            agentSocketPath: "/tmp/cmux-agent-a.sock",
+            preserveAfterTerminalExit: true,
+            persistentDaemonSlot: "ssh-test-slot"
+        )
+        let second = WorkspaceRemoteConfiguration(
+            destination: "cmux-macmini",
+            port: 22,
+            identityFile: "~/.ssh/id_ed25519",
+            sshOptions: [
+                "ForwardAgent=yes",
+                "ControlMaster=auto",
+            ],
+            localProxyPort: nil,
+            relayPort: 64000,
+            relayID: "relay-b",
+            relayToken: "token-b",
+            localSocketPath: "/tmp/cmux-b.sock",
+            terminalStartupCommand: "ssh cmux-macmini",
+            agentSocketPath: "/tmp/cmux-agent-b.sock",
+            preserveAfterTerminalExit: true,
+            persistentDaemonSlot: "ssh-test-slot"
+        )
+
+        XCTAssertTrue(first.hasSamePersistentPTYIdentity(as: second))
+        XCTAssertTrue(second.hasSamePersistentPTYIdentity(as: first))
+    }
 }
 
 final class WorkspaceRemoteSSHCleanupTests: XCTestCase {

--- a/cmuxTests/TabManagerSessionSnapshotTests.swift
+++ b/cmuxTests/TabManagerSessionSnapshotTests.swift
@@ -1956,6 +1956,7 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
         remoteWorkspace.setCustomTitle("Remote Mac mini")
         let identityFile = "~/.ssh/id_ed25519"
         let expandedIdentityFile = (identityFile as NSString).expandingTildeInPath
+        let agentSocketPath = "/tmp/cmux-restore-agent.sock"
         let configuration = WorkspaceRemoteConfiguration(
             destination: "dev@example.com",
             port: 2222,
@@ -1965,13 +1966,15 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
                 "ControlMaster=auto",
                 "ControlPersist=60s",
                 "StrictHostKeyChecking=accept-new",
+                "ForwardAgent=yes",
             ],
             localProxyPort: nil,
             relayPort: 64002,
             relayID: "relay-restore-test",
             relayToken: String(repeating: "d", count: 64),
             localSocketPath: "/tmp/cmux-restore-test.sock",
-            terminalStartupCommand: "ssh dev@example.com"
+            terminalStartupCommand: "ssh dev@example.com",
+            agentSocketPath: agentSocketPath
         )
         remoteWorkspace.configureRemoteConnection(configuration, autoConnect: false)
         let remotePanelId = try XCTUnwrap(remoteWorkspace.focusedPanelId)
@@ -2004,7 +2007,9 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
         XCTAssertEqual(remoteSnapshot.identityFile, expandedIdentityFile)
         XCTAssertEqual(remoteSnapshot.sshOptions, [
             "StrictHostKeyChecking=accept-new",
+            "ForwardAgent=yes",
         ])
+        XCTAssertEqual(remoteSnapshot.agentSocketPath, agentSocketPath)
 
         let restored = TabManager()
         restored.restoreSessionSnapshot(persistedTabManager)
@@ -2020,8 +2025,11 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
         XCTAssertNil(restoredWorkspace.terminalPanel(for: restoredPanelId)?.requestedWorkingDirectory)
         XCTAssertEqual(
             restoredWorkspace.remoteConfiguration?.terminalStartupCommand,
-            "ssh -p 2222 -i \(expandedIdentityFile) -o StrictHostKeyChecking=accept-new -tt dev@example.com"
+            "ssh -p 2222 -i \(expandedIdentityFile) -o StrictHostKeyChecking=accept-new -o ForwardAgent=yes -tt dev@example.com"
         )
+        XCTAssertEqual(restoredWorkspace.remoteConfiguration?.agentSocketPath, agentSocketPath)
+        XCTAssertEqual(restoredWorkspace.remoteConfiguration?.sshTerminalStartupEnvironment?["SSH_AUTH_SOCK"], agentSocketPath)
+        XCTAssertEqual(restoredWorkspace.remoteConfiguration?.sshProcessEnvironment?["SSH_AUTH_SOCK"], agentSocketPath)
     }
 
     func testSessionSnapshotRestoresPersistentSSHPTYSessionAfterRelaunch() throws {

--- a/cmuxTests/TabManagerSessionSnapshotTests.swift
+++ b/cmuxTests/TabManagerSessionSnapshotTests.swift
@@ -1956,7 +1956,17 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
         remoteWorkspace.setCustomTitle("Remote Mac mini")
         let identityFile = "~/.ssh/id_ed25519"
         let expandedIdentityFile = (identityFile as NSString).expandingTildeInPath
-        let agentSocketPath = "/tmp/cmux-restore-agent.sock"
+        let originalAgentSocketPath = "/tmp/cmux-original-restore-agent.sock"
+        let restoredAgentSocketPath = "/tmp/cmux-current-restore-agent.sock"
+        let previousAgentSocketPath = getenv("SSH_AUTH_SOCK").map { String(cString: $0) }
+        setenv("SSH_AUTH_SOCK", restoredAgentSocketPath, 1)
+        defer {
+            if let previousAgentSocketPath {
+                setenv("SSH_AUTH_SOCK", previousAgentSocketPath, 1)
+            } else {
+                unsetenv("SSH_AUTH_SOCK")
+            }
+        }
         let configuration = WorkspaceRemoteConfiguration(
             destination: "dev@example.com",
             port: 2222,
@@ -1974,7 +1984,7 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
             relayToken: String(repeating: "d", count: 64),
             localSocketPath: "/tmp/cmux-restore-test.sock",
             terminalStartupCommand: "ssh dev@example.com",
-            agentSocketPath: agentSocketPath
+            agentSocketPath: originalAgentSocketPath
         )
         remoteWorkspace.configureRemoteConnection(configuration, autoConnect: false)
         let remotePanelId = try XCTUnwrap(remoteWorkspace.focusedPanelId)
@@ -2009,7 +2019,6 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
             "StrictHostKeyChecking=accept-new",
             "ForwardAgent=yes",
         ])
-        XCTAssertEqual(remoteSnapshot.agentSocketPath, agentSocketPath)
 
         let restored = TabManager()
         restored.restoreSessionSnapshot(persistedTabManager)
@@ -2027,9 +2036,9 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
             restoredWorkspace.remoteConfiguration?.terminalStartupCommand,
             "ssh -p 2222 -i \(expandedIdentityFile) -o StrictHostKeyChecking=accept-new -o ForwardAgent=yes -tt dev@example.com"
         )
-        XCTAssertEqual(restoredWorkspace.remoteConfiguration?.agentSocketPath, agentSocketPath)
-        XCTAssertEqual(restoredWorkspace.remoteConfiguration?.sshTerminalStartupEnvironment?["SSH_AUTH_SOCK"], agentSocketPath)
-        XCTAssertEqual(restoredWorkspace.remoteConfiguration?.sshProcessEnvironment?["SSH_AUTH_SOCK"], agentSocketPath)
+        XCTAssertEqual(restoredWorkspace.remoteConfiguration?.agentSocketPath, restoredAgentSocketPath)
+        XCTAssertEqual(restoredWorkspace.remoteConfiguration?.sshTerminalStartupEnvironment?["SSH_AUTH_SOCK"], restoredAgentSocketPath)
+        XCTAssertEqual(restoredWorkspace.remoteConfiguration?.sshProcessEnvironment?["SSH_AUTH_SOCK"], restoredAgentSocketPath)
     }
 
     func testSessionSnapshotRestoresPersistentSSHPTYSessionAfterRelaunch() throws {

--- a/cmuxTests/TabManagerSessionSnapshotTests.swift
+++ b/cmuxTests/TabManagerSessionSnapshotTests.swift
@@ -1957,7 +1957,9 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
         let identityFile = "~/.ssh/id_ed25519"
         let expandedIdentityFile = (identityFile as NSString).expandingTildeInPath
         let originalAgentSocketPath = "/tmp/cmux-original-restore-agent.sock"
-        let restoredAgentSocketPath = "/tmp/cmux-current-restore-agent.sock"
+        let restoredAgentSocketPath = "/tmp/cmux-current-restore-agent-\(UUID().uuidString).sock"
+        XCTAssertTrue(FileManager.default.createFile(atPath: restoredAgentSocketPath, contents: Data()))
+        defer { try? FileManager.default.removeItem(atPath: restoredAgentSocketPath) }
         let previousAgentSocketPath = getenv("SSH_AUTH_SOCK").map { String(cString: $0) }
         setenv("SSH_AUTH_SOCK", restoredAgentSocketPath, 1)
         defer {

--- a/cmuxTests/TabManagerSessionSnapshotTests.swift
+++ b/cmuxTests/TabManagerSessionSnapshotTests.swift
@@ -2041,6 +2041,58 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
         XCTAssertEqual(restoredWorkspace.remoteConfiguration?.sshProcessEnvironment?["SSH_AUTH_SOCK"], restoredAgentSocketPath)
     }
 
+    func testSessionSnapshotRestoreOmitsSSHAgentEnvironmentWhenSocketUnavailable() throws {
+        let manager = TabManager()
+        let remoteWorkspace = manager.addWorkspace(select: true)
+        remoteWorkspace.setCustomTitle("Remote Without Agent")
+        let originalAgentSocketPath = "/tmp/cmux-original-missing-agent.sock"
+        let previousAgentSocketPath = getenv("SSH_AUTH_SOCK").map { String(cString: $0) }
+        defer {
+            if let previousAgentSocketPath {
+                setenv("SSH_AUTH_SOCK", previousAgentSocketPath, 1)
+            } else {
+                unsetenv("SSH_AUTH_SOCK")
+            }
+        }
+        let configuration = WorkspaceRemoteConfiguration(
+            destination: "dev@example.com",
+            port: 2222,
+            identityFile: nil,
+            sshOptions: [
+                "ForwardAgent=yes",
+            ],
+            localProxyPort: nil,
+            relayPort: 64002,
+            relayID: "relay-missing-agent-test",
+            relayToken: String(repeating: "f", count: 64),
+            localSocketPath: "/tmp/cmux-missing-agent-test.sock",
+            terminalStartupCommand: "ssh dev@example.com",
+            agentSocketPath: originalAgentSocketPath
+        )
+        remoteWorkspace.configureRemoteConnection(configuration, autoConnect: false)
+
+        let snapshot = manager.sessionSnapshot(includeScrollback: false)
+        let remoteSnapshot = try XCTUnwrap(
+            snapshot.workspaces.first { $0.customTitle == "Remote Without Agent" }?.remote
+        )
+        XCTAssertEqual(remoteSnapshot.sshOptions, ["ForwardAgent=yes"])
+
+        unsetenv("SSH_AUTH_SOCK")
+        let restored = TabManager()
+        restored.restoreSessionSnapshot(snapshot)
+
+        let restoredWorkspace = try XCTUnwrap(
+            restored.tabs.first { $0.customTitle == "Remote Without Agent" }
+        )
+        XCTAssertEqual(
+            restoredWorkspace.remoteConfiguration?.terminalStartupCommand,
+            "ssh -p 2222 -o ForwardAgent=yes -tt dev@example.com"
+        )
+        XCTAssertNil(restoredWorkspace.remoteConfiguration?.agentSocketPath)
+        XCTAssertNil(restoredWorkspace.remoteConfiguration?.sshTerminalStartupEnvironment?["SSH_AUTH_SOCK"])
+        XCTAssertNil(restoredWorkspace.remoteConfiguration?.sshProcessEnvironment?["SSH_AUTH_SOCK"])
+    }
+
     func testSessionSnapshotRestoresPersistentSSHPTYSessionAfterRelaunch() throws {
         let manager = TabManager()
         let remoteWorkspace = manager.addWorkspace(select: true)

--- a/cmuxTests/TerminalControllerSocketSecurityTests.swift
+++ b/cmuxTests/TerminalControllerSocketSecurityTests.swift
@@ -301,6 +301,49 @@ final class TerminalControllerSocketSecurityTests: XCTestCase {
         XCTAssertEqual(workspace.remoteConfiguration?.sshProcessEnvironment?["SSH_AUTH_SOCK"], agentSocketPath)
     }
 
+    func testRemoteConfigureUsesLastForwardAgentOption() throws {
+        let previousAgentSocketPath = getenv("SSH_AUTH_SOCK").map { String(cString: $0) }
+        setenv("SSH_AUTH_SOCK", "/tmp/cmux-configure-agent.sock", 1)
+        defer {
+            if let previousAgentSocketPath {
+                setenv("SSH_AUTH_SOCK", previousAgentSocketPath, 1)
+            } else {
+                unsetenv("SSH_AUTH_SOCK")
+            }
+        }
+
+        let previousAppDelegate = AppDelegate.shared
+        let appDelegate = AppDelegate()
+        AppDelegate.shared = appDelegate
+        defer { AppDelegate.shared = previousAppDelegate }
+
+        let manager = TabManager()
+        let workspace = manager.addWorkspace(select: false, eagerLoadTerminal: false)
+        let windowId = appDelegate.registerMainWindowContextForTesting(tabManager: manager)
+        defer {
+            appDelegate.unregisterMainWindowContextForTesting(windowId: windowId)
+            if manager.tabs.contains(where: { $0.id == workspace.id }) {
+                manager.closeWorkspace(workspace)
+            }
+        }
+
+        let response = try handleV2Request(
+            method: "workspace.remote.configure",
+            params: [
+                "workspace_id": workspace.id.uuidString,
+                "transport": "ssh",
+                "destination": "example.com",
+                "ssh_options": ["ForwardAgent=yes", "ForwardAgent=no"],
+                "auto_connect": false,
+            ]
+        )
+
+        XCTAssertEqual(response["ok"] as? Bool, true, "Unexpected JSON-RPC response: \(response)")
+        XCTAssertNil(workspace.remoteConfiguration?.agentSocketPath)
+        XCTAssertNil(workspace.remoteConfiguration?.sshTerminalStartupEnvironment?["SSH_AUTH_SOCK"])
+        XCTAssertNil(workspace.remoteConfiguration?.sshProcessEnvironment?["SSH_AUTH_SOCK"])
+    }
+
     func testRemoteConfigureRejectsPersistentDaemonSlotWithoutPreserve() throws {
         let response = try handleV2Request(
             method: "workspace.remote.configure",

--- a/cmuxTests/TerminalControllerSocketSecurityTests.swift
+++ b/cmuxTests/TerminalControllerSocketSecurityTests.swift
@@ -257,6 +257,50 @@ final class TerminalControllerSocketSecurityTests: XCTestCase {
         )
     }
 
+    func testRemoteConfigureDerivesAgentSocketPathFromForwardAgentOption() throws {
+        let previousAgentSocketPath = getenv("SSH_AUTH_SOCK").map { String(cString: $0) }
+        let agentSocketPath = "/tmp/cmux-configure-agent.sock"
+        setenv("SSH_AUTH_SOCK", agentSocketPath, 1)
+        defer {
+            if let previousAgentSocketPath {
+                setenv("SSH_AUTH_SOCK", previousAgentSocketPath, 1)
+            } else {
+                unsetenv("SSH_AUTH_SOCK")
+            }
+        }
+
+        let previousAppDelegate = AppDelegate.shared
+        let appDelegate = AppDelegate()
+        AppDelegate.shared = appDelegate
+        defer { AppDelegate.shared = previousAppDelegate }
+
+        let manager = TabManager()
+        let workspace = manager.addWorkspace(select: false, eagerLoadTerminal: false)
+        let windowId = appDelegate.registerMainWindowContextForTesting(tabManager: manager)
+        defer {
+            appDelegate.unregisterMainWindowContextForTesting(windowId: windowId)
+            if manager.tabs.contains(where: { $0.id == workspace.id }) {
+                manager.closeWorkspace(workspace)
+            }
+        }
+
+        let response = try handleV2Request(
+            method: "workspace.remote.configure",
+            params: [
+                "workspace_id": workspace.id.uuidString,
+                "transport": "ssh",
+                "destination": "example.com",
+                "ssh_options": ["ForwardAgent=yes"],
+                "auto_connect": false,
+            ]
+        )
+
+        XCTAssertEqual(response["ok"] as? Bool, true, "Unexpected JSON-RPC response: \(response)")
+        XCTAssertEqual(workspace.remoteConfiguration?.agentSocketPath, agentSocketPath)
+        XCTAssertEqual(workspace.remoteConfiguration?.sshTerminalStartupEnvironment?["SSH_AUTH_SOCK"], agentSocketPath)
+        XCTAssertEqual(workspace.remoteConfiguration?.sshProcessEnvironment?["SSH_AUTH_SOCK"], agentSocketPath)
+    }
+
     func testRemoteConfigureRejectsPersistentDaemonSlotWithoutPreserve() throws {
         let response = try handleV2Request(
             method: "workspace.remote.configure",

--- a/cmuxTests/TerminalControllerSocketSecurityTests.swift
+++ b/cmuxTests/TerminalControllerSocketSecurityTests.swift
@@ -259,7 +259,7 @@ final class TerminalControllerSocketSecurityTests: XCTestCase {
 
     func testRemoteConfigureDerivesAgentSocketPathFromForwardAgentOption() throws {
         let previousAgentSocketPath = getenv("SSH_AUTH_SOCK").map { String(cString: $0) }
-        let agentSocketPath = "/tmp/cmux-configure-agent.sock"
+        let agentSocketPath = try makeExistingAgentSocketPath()
         setenv("SSH_AUTH_SOCK", agentSocketPath, 1)
         defer {
             if let previousAgentSocketPath {
@@ -301,9 +301,55 @@ final class TerminalControllerSocketSecurityTests: XCTestCase {
         XCTAssertEqual(workspace.remoteConfiguration?.sshProcessEnvironment?["SSH_AUTH_SOCK"], agentSocketPath)
     }
 
+    func testRemoteConfigureExplicitEmptyAgentSocketSuppressesForwardAgentFallback() throws {
+        let previousAgentSocketPath = getenv("SSH_AUTH_SOCK").map { String(cString: $0) }
+        let agentSocketPath = try makeExistingAgentSocketPath()
+        setenv("SSH_AUTH_SOCK", agentSocketPath, 1)
+        defer {
+            if let previousAgentSocketPath {
+                setenv("SSH_AUTH_SOCK", previousAgentSocketPath, 1)
+            } else {
+                unsetenv("SSH_AUTH_SOCK")
+            }
+        }
+
+        let previousAppDelegate = AppDelegate.shared
+        let appDelegate = AppDelegate()
+        AppDelegate.shared = appDelegate
+        defer { AppDelegate.shared = previousAppDelegate }
+
+        let manager = TabManager()
+        let workspace = manager.addWorkspace(select: false, eagerLoadTerminal: false)
+        let windowId = appDelegate.registerMainWindowContextForTesting(tabManager: manager)
+        defer {
+            appDelegate.unregisterMainWindowContextForTesting(windowId: windowId)
+            if manager.tabs.contains(where: { $0.id == workspace.id }) {
+                manager.closeWorkspace(workspace)
+            }
+        }
+
+        let response = try handleV2Request(
+            method: "workspace.remote.configure",
+            params: [
+                "workspace_id": workspace.id.uuidString,
+                "transport": "ssh",
+                "destination": "example.com",
+                "ssh_options": ["ForwardAgent=yes"],
+                "ssh_auth_sock": "",
+                "auto_connect": false,
+            ]
+        )
+
+        XCTAssertEqual(response["ok"] as? Bool, true, "Unexpected JSON-RPC response: \(response)")
+        XCTAssertNil(workspace.remoteConfiguration?.agentSocketPath)
+        XCTAssertNil(workspace.remoteConfiguration?.sshTerminalStartupEnvironment?["SSH_AUTH_SOCK"])
+        XCTAssertNil(workspace.remoteConfiguration?.sshProcessEnvironment?["SSH_AUTH_SOCK"])
+    }
+
     func testRemoteConfigureUsesLastForwardAgentOption() throws {
         let previousAgentSocketPath = getenv("SSH_AUTH_SOCK").map { String(cString: $0) }
-        setenv("SSH_AUTH_SOCK", "/tmp/cmux-configure-agent.sock", 1)
+        let agentSocketPath = try makeExistingAgentSocketPath()
+        setenv("SSH_AUTH_SOCK", agentSocketPath, 1)
         defer {
             if let previousAgentSocketPath {
                 setenv("SSH_AUTH_SOCK", previousAgentSocketPath, 1)
@@ -1624,6 +1670,21 @@ final class TerminalControllerSocketSecurityTests: XCTestCase {
             ])
         }
         return line
+    }
+
+    private func makeExistingAgentSocketPath() throws -> String {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-agent-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: directory)
+        }
+        let url = directory.appendingPathComponent("agent.sock")
+        XCTAssertTrue(
+            FileManager.default.createFile(atPath: url.path, contents: Data()),
+            "Expected to create \(url.path)"
+        )
+        return url.path
     }
 
     private nonisolated func posixError(_ operation: String) -> NSError {

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -5881,18 +5881,20 @@ final class WorkspacePanelGitBranchTests: XCTestCase {
 
     func testForkAgentWorkspaceLaunchInRemoteWorkspacePreservesRemoteContext() throws {
         let workspace = Workspace()
+        let agentSocketPath = "/tmp/cmux-fork-agent.sock"
         workspace.configureRemoteConnection(
             WorkspaceRemoteConfiguration(
                 destination: "cmux-macmini",
                 port: 2222,
                 identityFile: "/Users/example/.ssh/cmux",
-                sshOptions: ["ServerAliveInterval=30"],
+                sshOptions: ["ServerAliveInterval=30", "ForwardAgent=yes"],
                 localProxyPort: nil,
                 relayPort: 64000,
                 relayID: "relay-fork",
                 relayToken: String(repeating: "a", count: 64),
                 localSocketPath: "/tmp/cmux-fork-remote.sock",
-                terminalStartupCommand: "ssh -p 2222 -i /Users/example/.ssh/cmux -o ServerAliveInterval=30 -tt cmux-macmini"
+                terminalStartupCommand: "ssh -p 2222 -i /Users/example/.ssh/cmux -o ServerAliveInterval=30 -o ForwardAgent=yes -tt cmux-macmini",
+                agentSocketPath: agentSocketPath
             ),
             autoConnect: false
         )
@@ -5923,14 +5925,18 @@ final class WorkspacePanelGitBranchTests: XCTestCase {
         XCTAssertNil(launch.terminalWorkingDirectory)
         XCTAssertEqual(
             launch.initialTerminalCommand,
-            "ssh -p 2222 -i /Users/example/.ssh/cmux -o ServerAliveInterval=30 -tt cmux-macmini"
+            "ssh -p 2222 -i /Users/example/.ssh/cmux -o ServerAliveInterval=30 -o ForwardAgent=yes -tt cmux-macmini"
         )
         XCTAssertEqual(launch.initialTerminalInput, snapshot.forkCommand.map { $0 + "\n" })
+        XCTAssertEqual(launch.initialTerminalEnvironment["SSH_AUTH_SOCK"], agentSocketPath)
         XCTAssertTrue(launch.autoConnectRemoteConfiguration)
         XCTAssertEqual(launch.remoteConfiguration?.destination, "cmux-macmini")
         XCTAssertEqual(launch.remoteConfiguration?.port, 2222)
         XCTAssertEqual(launch.remoteConfiguration?.identityFile, "/Users/example/.ssh/cmux")
-        XCTAssertEqual(launch.remoteConfiguration?.sshOptions, ["ServerAliveInterval=30"])
+        XCTAssertEqual(launch.remoteConfiguration?.sshOptions, ["ServerAliveInterval=30", "ForwardAgent=yes"])
+        XCTAssertEqual(launch.remoteConfiguration?.agentSocketPath, agentSocketPath)
+        XCTAssertEqual(launch.remoteConfiguration?.sshTerminalStartupEnvironment?["SSH_AUTH_SOCK"], agentSocketPath)
+        XCTAssertEqual(launch.remoteConfiguration?.sshProcessEnvironment?["SSH_AUTH_SOCK"], agentSocketPath)
         XCTAssertNil(launch.remoteConfiguration?.relayPort)
         XCTAssertNil(launch.remoteConfiguration?.localSocketPath)
     }

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -98,7 +98,7 @@ Environment:
 | `move-tab-to-new-workspace` | Move a tab or surface into a newly created workspace. |
 | `list-workspaces` | List workspaces. |
 | `new-workspace` | Create a workspace, optionally with cwd, command, description, and layout. |
-| `ssh` | Open an SSH-backed workspace. Supports `-A` / `--forward-agent` to forward the caller's SSH agent, honors `ForwardAgent yes` from OpenSSH config, and supports `-a` / `--no-forward-agent` to disable forwarding for a workspace. Agent forwarding remains opt-in because forwarded agents can be used by processes on the remote host while the SSH session is active. |
+| `ssh` | Open an SSH-backed workspace. Preserves the caller's live `SSH_AUTH_SOCK` for app-launched OpenSSH processes so `ForwardAgent yes` from ssh_config works normally. Supports `-A` / `--forward-agent` to request forwarding and `-a` / `--no-forward-agent` to disable forwarding for a workspace. Agent forwarding remains opt-in because forwarded agents can be used by processes on the remote host while the SSH session is active. |
 | `remote-daemon-status` | Print bundled remote daemon version, asset, checksum, and cache status. |
 | `ssh-session-list` | List persisted SSH PTY sessions for one remote workspace or all remote workspaces. Supports `--json`. |
 | `ssh-session-attach` | Create a local terminal surface that reattaches to an existing persisted SSH PTY session. |

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -436,6 +436,7 @@ the expected text without connecting to a cmux socket.
 - `cmux new-workspace --help` -> `Usage: cmux new-workspace`
 - `cmux list-workspaces --help` -> `Usage: cmux list-workspaces`
 - `cmux ssh --help` -> `Usage: cmux ssh <destination>`
+  - Supports `-A` / `--forward-agent` to forward the caller's SSH agent, honors `ForwardAgent yes` from OpenSSH config, and supports `-a` / `--no-forward-agent` to disable forwarding for a workspace. Agent forwarding remains opt-in because forwarded agents can be used by processes on the remote host while the SSH session is active.
 - `cmux ssh-session-list --help` -> `Usage: cmux ssh-session-list`
 - `cmux ssh-session-attach --help` -> `Usage: cmux ssh-session-attach --session-id <id>`
 - `cmux ssh-session-cleanup --help` -> `Usage: cmux ssh-session-cleanup`

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -98,7 +98,7 @@ Environment:
 | `move-tab-to-new-workspace` | Move a tab or surface into a newly created workspace. |
 | `list-workspaces` | List workspaces. |
 | `new-workspace` | Create a workspace, optionally with cwd, command, description, and layout. |
-| `ssh` | Open an SSH-backed workspace. |
+| `ssh` | Open an SSH-backed workspace. Supports `-A` / `--forward-agent` to forward the caller's SSH agent, honors `ForwardAgent yes` from OpenSSH config, and supports `-a` / `--no-forward-agent` to disable forwarding for a workspace. Agent forwarding remains opt-in because forwarded agents can be used by processes on the remote host while the SSH session is active. |
 | `remote-daemon-status` | Print bundled remote daemon version, asset, checksum, and cache status. |
 | `ssh-session-list` | List persisted SSH PTY sessions for one remote workspace or all remote workspaces. Supports `--json`. |
 | `ssh-session-attach` | Create a local terminal surface that reattaches to an existing persisted SSH PTY session. |
@@ -436,7 +436,7 @@ the expected text without connecting to a cmux socket.
 - `cmux new-workspace --help` -> `Usage: cmux new-workspace`
 - `cmux list-workspaces --help` -> `Usage: cmux list-workspaces`
 - `cmux ssh --help` -> `Usage: cmux ssh <destination>`
-  - Supports `-A` / `--forward-agent` to forward the caller's SSH agent, honors `ForwardAgent yes` from OpenSSH config, and supports `-a` / `--no-forward-agent` to disable forwarding for a workspace. Agent forwarding remains opt-in because forwarded agents can be used by processes on the remote host while the SSH session is active.
+- `cmux ssh --help` -> `--forward-agent`
 - `cmux ssh-session-list --help` -> `Usage: cmux ssh-session-list`
 - `cmux ssh-session-attach --help` -> `Usage: cmux ssh-session-attach --session-id <id>`
 - `cmux ssh-session-cleanup --help` -> `Usage: cmux ssh-session-cleanup`

--- a/docs/remote-daemon-spec.md
+++ b/docs/remote-daemon-spec.md
@@ -1,6 +1,6 @@
 # Remote SSH Living Spec
 
-Last updated: May 26, 2026
+Last updated: June 3, 2026
 Tracking issue: https://github.com/manaflow-ai/cmux/issues/151
 Primary PR: https://github.com/manaflow-ai/cmux/pull/1296
 CLI relay PR: https://github.com/manaflow-ai/cmux/pull/374
@@ -54,6 +54,7 @@ This is a **living implementation spec** (also called an **execution spec**): a 
 - `DONE` session snapshots persist the relay port for persistent SSH PTYs and mint fresh relay credentials on restore, so a reattached remote shell can keep using its existing `CMUX_SOCKET_PATH=127.0.0.1:<relay_port>` after app relaunch.
 - `DONE` relay startup writes `~/.cmux/relay/<relay_port>.daemon_path`; remote `cmux` wrapper uses this to select the right daemon binary per session, including mixed local cmux versions.
 - `DONE` relay startup writes `~/.cmux/relay/<relay_port>.auth` with a relay ID and token; the local relay requires HMAC-SHA256 challenge-response before forwarding any command to the real local socket.
+- `DONE` SSH agent forwarding is opt-in. `cmux ssh` honors `ForwardAgent yes` from OpenSSH config and accepts `-A` / `--forward-agent`; when enabled, the CLI passes its live `SSH_AUTH_SOCK` to the app so app-launched SSH transports can forward the same local agent.
 - `DONE` ephemeral port range (49152-65535) filtered from probe results to exclude relay ports from other workspaces.
 - `DONE` multi-workspace port conflict detection uses TCP connect check (`isLoopbackPortReachable`) so ports already forwarded by another workspace are silently skipped instead of flagged as conflicts.
 - `DONE` orphaned relay SSH processes from previous app sessions are cleaned up before starting a new relay.

--- a/docs/remote-daemon-spec.md
+++ b/docs/remote-daemon-spec.md
@@ -54,7 +54,7 @@ This is a **living implementation spec** (also called an **execution spec**): a 
 - `DONE` session snapshots persist the relay port for persistent SSH PTYs and mint fresh relay credentials on restore, so a reattached remote shell can keep using its existing `CMUX_SOCKET_PATH=127.0.0.1:<relay_port>` after app relaunch.
 - `DONE` relay startup writes `~/.cmux/relay/<relay_port>.daemon_path`; remote `cmux` wrapper uses this to select the right daemon binary per session, including mixed local cmux versions.
 - `DONE` relay startup writes `~/.cmux/relay/<relay_port>.auth` with a relay ID and token; the local relay requires HMAC-SHA256 challenge-response before forwarding any command to the real local socket.
-- `DONE` SSH agent forwarding is opt-in. `cmux ssh` honors `ForwardAgent yes` from OpenSSH config and accepts `-A` / `--forward-agent`; when enabled, the CLI passes its live `SSH_AUTH_SOCK` to the app so app-launched SSH transports can forward the same local agent.
+- `DONE` SSH agent forwarding is opt-in. `cmux ssh` preserves its live `SSH_AUTH_SOCK` for app-launched OpenSSH transports so `ForwardAgent yes` from ssh_config works normally, and accepts `-A` / `--forward-agent` or `-a` / `--no-forward-agent` for explicit forwarding control.
 - `DONE` ephemeral port range (49152-65535) filtered from probe results to exclude relay ports from other workspaces.
 - `DONE` multi-workspace port conflict detection uses TCP connect check (`isLoopbackPortReachable`) so ports already forwarded by another workspace are silently skipped instead of flagged as conflicts.
 - `DONE` orphaned relay SSH processes from previous app sessions are cleaned up before starting a new relay.


### PR DESCRIPTION
## Summary
- honor OpenSSH ForwardAgent settings for cmux ssh and add explicit -A/--forward-agent plus -a/--no-forward-agent flags
- pass the caller's live SSH_AUTH_SOCK through first terminal startup, app-launched SSH transports, and remote workspace forks
- document the opt-in security behavior and localize cmux ssh help

Closes #5289

## Testing
- Not run locally per task instructions; CI will run tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5301"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783108530&installation_id=133855650&pr_number=5301&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5301&signature=f17b1d08ca0b4c899801d87b6a404c4e4f1d0570822ddef0abb929c97d213cd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how local SSH credentials reach remote hosts via agent forwarding and environment injection; behavior is opt-in but misconfiguration could expose keys to remote processes while sessions are active.
> 
> **Overview**
> **`cmux ssh` now wires SSH agent forwarding end-to-end** so remote workspaces can use the caller’s local agent when forwarding is enabled.
> 
> The CLI adds **`-A` / `--forward-agent`** and **`-a` / `--no-forward-agent`**, resolves `ForwardAgent` from flags and `--ssh-option` (last value wins), and centralizes OpenSSH option parsing in **`CmuxFoundation.SSHAgentSocketResolver`**. When a usable local socket exists, it passes **`SSH_AUTH_SOCK`** via `workspace.create` `initial_env` and **`ssh_auth_sock`** on `workspace.remote.configure`.
> 
> **`WorkspaceRemoteConfiguration`** gains an **`agentSocketPath`** (only if the socket file exists), injects it into **app-launched `ssh`/`scp` environments** and **remote terminal startup**, and re-resolves on session restore from current `SSH_AUTH_SOCK` when `ForwardAgent=yes` is durable. Agent forks and new-workspace flows preserve the same env. Ephemeral agent paths stay out of **proxy broker / persistent PTY identity** keys.
> 
> Help is localized (`cli.help.ssh`) and **CLI / remote-daemon docs** note opt-in forwarding and security implications. Broad integration tests cover precedence, `ask`, tilde paths, and explicit empty `ssh_auth_sock`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 121197d3e928384fdf37b78a08aaadb2cb9a4af5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds SSH agent forwarding to `cmux ssh` so remote sessions can use your local keys. Respects `ForwardAgent`, forwards `SSH_AUTH_SOCK` into SSH/client processes and terminals, preserves it across forks and restore, and skips when the socket is missing or `ask`; no longer probes `ssh -G` to decide forwarding.

- New Features
  - Adds `-A/--forward-agent`, `-a/--no-forward-agent`, and `-o ForwardAgent=…` handling (last wins); expands `~` and env vars; avoids `ssh -G` config probes for forwarding.
  - Propagates the agent via `initial_env` on `workspace.create` and `ssh_auth_sock` on `workspace.remote.configure`; derives from `ssh_options` when omitted; injects into SSH, relay, and terminal startup; re-resolves on restore; preserves across remote forks; excludes ephemeral agent paths from persistent PTY identity and proxy broker transport keys.

- Refactors
  - Centralizes OpenSSH option parsing and agent socket normalization in `CmuxFoundation` (`SSHAgentSocketResolver`) and adopts it across CLI and remote configuration; exposes a public initializer for external use.

<sup>Written for commit 121197d3e928384fdf37b78a08aaadb2cb9a4af5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SSH agent forwarding for cmux ssh with -A/--forward-agent and -a/--no-forward-agent; respects CLI flags, explicit ForwardAgent ssh-options, and user SSH config precedence. When enabled, SSH_AUTH_SOCK is injected into created workspaces, remote session environments, and session snapshots/restores.

* **Documentation**
  * CLI help, reference docs, and examples updated to document forwarding flags and behavior.

* **Tests**
  * New integration and unit tests covering precedence, propagation, session restore, and repeated-option behavior.

* **Localization**
  * Added localized CLI help strings for the ssh command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->