### PR TITLE
Fix #753: stop cmux launching under Rosetta on Apple Silicon

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -65,6 +65,10 @@
 	<string>CmuxDockTilePlugin.plugin</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
+	<key>LSArchitecturePriority</key>
+	<array>
+		<string>arm64</string>
+	</array>
 	<key>NSHumanReadableCopyright</key>
 	<string></string>
 	<key>NSMainStoryboardFile</key>

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -68,6 +68,7 @@
 	<key>LSArchitecturePriority</key>
 	<array>
 		<string>arm64</string>
+		<string>x86_64</string>
 	</array>
 	<key>NSHumanReadableCopyright</key>
 	<string></string>

--- a/Sources/App/RosettaNativeRelaunch.swift
+++ b/Sources/App/RosettaNativeRelaunch.swift
@@ -1,0 +1,137 @@
+import Darwin
+import Foundation
+import os
+
+nonisolated private let rosettaRelaunchLogger = Logger(subsystem: "com.cmuxterm.app", category: "RosettaRelaunch")
+
+/// Launch-time self-heal that re-execs cmux natively when the process is
+/// running translated under Rosetta on Apple Silicon.
+///
+/// cmux ships a universal (`x86_64 arm64`) binary so it keeps supporting Intel
+/// Macs. On Apple Silicon, a stale LaunchServices architecture preference (set
+/// once from the DMG volume copy and inherited by the `/Applications` copy) can
+/// pin the app to its `x86_64` slice, so the whole process tree — login shell,
+/// `zsh`, and every tool launched in a cmux terminal — runs translated. macOS 26
+/// then shows a Rosetta deprecation dialog. `LSArchitecturePriority = (arm64)`
+/// in the app `Info.plist` fixes future launches; this type corrects an
+/// already-mis-pinned install by re-launching the arm64 slice in place at
+/// startup, mirroring ``CLIForwardingLaunchRouter``'s re-exec shape.
+enum RosettaNativeRelaunch {
+    /// Environment guard that marks a process as the product of a native
+    /// relaunch, so a relaunch that fails to escape translation never loops.
+    private static let guardKey = "CMUX_ROSETTA_RELAUNCHED"
+
+    /// Whether the current process should re-exec itself as a native arm64
+    /// binary.
+    ///
+    /// Pure decision logic with no side effects so it is unit-testable without
+    /// launching the app: relaunch exactly when the process is translated and a
+    /// native relaunch has not already been attempted. On Intel hardware and on
+    /// natively-launched Apple Silicon processes `isTranslated` is `false`, so
+    /// this returns `false` and the app proceeds unchanged.
+    ///
+    /// - Parameters:
+    ///   - isTranslated: Whether the process is running under Rosetta
+    ///     translation (`sysctl.proc_translated == 1`).
+    ///   - hasAttemptedRelaunch: Whether a native relaunch was already attempted
+    ///     in this launch chain (the guard env var is present).
+    /// - Returns: `true` when the process should re-exec natively.
+    static func shouldRelaunchNatively(isTranslated: Bool, hasAttemptedRelaunch: Bool) -> Bool {
+        isTranslated
+    }
+
+    /// Whether this process is running under Rosetta translation.
+    ///
+    /// Reads `sysctl.proc_translated`. The key is absent on Intel Macs and on
+    /// older systems, which `sysctlbyname` reports as a failure; that case is
+    /// treated as "not translated".
+    static func isProcessTranslated() -> Bool {
+        var value: Int32 = 0
+        var size = MemoryLayout<Int32>.size
+        let result = sysctlbyname("sysctl.proc_translated", &value, &size, nil, 0)
+        if result != 0 { return false }
+        return value == 1
+    }
+
+    /// Re-exec cmux as a native arm64 process when it is running translated.
+    ///
+    /// Call this as early as possible at launch (after CLI forwarding, before
+    /// AppKit is brought up). When ``shouldRelaunchNatively(isTranslated:hasAttemptedRelaunch:)``
+    /// is `true`, it replaces the current process image in place with the
+    /// arm64 slice of the same bundle executable via `posix_spawn` configured
+    /// with `POSIX_SPAWN_SETEXEC` and an arm64 binary preference. The call only
+    /// returns when no relaunch was needed or when the relaunch failed; on
+    /// failure it logs and lets the (still translated) process continue rather
+    /// than crashing.
+    ///
+    /// - Parameters:
+    ///   - isTranslated: Translation state; defaults to a live `sysctl` read.
+    ///   - hasAttemptedRelaunch: Loop guard; defaults to the presence of the
+    ///     guard env var.
+    ///   - executablePath: The Mach-O to re-exec; defaults to the running
+    ///     bundle executable.
+    ///   - arguments: The argument vector to preserve; defaults to the current
+    ///     process arguments.
+    static func relaunchNativelyIfNeeded(
+        isTranslated: Bool = isProcessTranslated(),
+        hasAttemptedRelaunch: Bool = getenv(guardKey) != nil,
+        executablePath: String? = Bundle.main.executablePath,
+        arguments: [String] = CommandLine.arguments
+    ) {
+        guard shouldRelaunchNatively(isTranslated: isTranslated, hasAttemptedRelaunch: hasAttemptedRelaunch) else {
+            return
+        }
+        guard let executablePath else {
+            rosettaRelaunchLogger.warning("translated launch detected but bundle executable path is unavailable; continuing translated")
+            return
+        }
+
+        // Mark descendants of the relaunch so a relaunch that fails to escape
+        // translation cannot loop.
+        setenv(guardKey, "1", 1)
+
+        var attributes = posix_spawnattr_t(nil as OpaquePointer?)
+        guard posix_spawnattr_init(&attributes) == 0 else {
+            rosettaRelaunchLogger.warning("failed to init posix_spawnattr; continuing translated")
+            unsetenv(guardKey)
+            return
+        }
+        defer { posix_spawnattr_destroy(&attributes) }
+
+        // Replace the current process image in place (like exec) so there is no
+        // orphaned translated process and the PID is preserved.
+        posix_spawnattr_setflags(&attributes, Int16(POSIX_SPAWN_SETEXEC))
+
+        // Force the arm64 slice of the universal binary so the replacement
+        // process is native, not translated. Without an explicit preference the
+        // kernel would re-select the x86_64 slice that this translated process
+        // is already running.
+        var cpuPreference = cpu_type_t(CPU_TYPE_ARM64)
+        var selectedCount = 0
+        let binprefResult = posix_spawnattr_setbinpref_np(&attributes, 1, &cpuPreference, &selectedCount)
+        guard binprefResult == 0, selectedCount == 1 else {
+            rosettaRelaunchLogger.warning("failed to set arm64 binary preference; continuing translated")
+            unsetenv(guardKey)
+            return
+        }
+
+        var cArguments = arguments.map { strdup($0) }
+        cArguments.append(nil)
+        defer { for argument in cArguments where argument != nil { free(argument) } }
+
+        var pid: pid_t = 0
+        let spawnResult = executablePath.withCString { path in
+            posix_spawn(&pid, path, nil, &attributes, &cArguments, environ)
+        }
+
+        // With POSIX_SPAWN_SETEXEC a successful call never returns. Reaching
+        // here means the re-exec failed; log and fall through so the app still
+        // launches (translated) instead of dying.
+        let errorText = String(cString: strerror(spawnResult))
+        rosettaRelaunchLogger.warning("native re-exec failed; continuing translated")
+        #if DEBUG
+        rosettaRelaunchLogger.debug("native re-exec failed at \(executablePath, privacy: .public): \(errorText, privacy: .public)")
+        #endif
+        unsetenv(guardKey)
+    }
+}

--- a/Sources/App/RosettaNativeRelaunch.swift
+++ b/Sources/App/RosettaNativeRelaunch.swift
@@ -37,7 +37,7 @@ enum RosettaNativeRelaunch {
     ///     in this launch chain (the guard env var is present).
     /// - Returns: `true` when the process should re-exec natively.
     static func shouldRelaunchNatively(isTranslated: Bool, hasAttemptedRelaunch: Bool) -> Bool {
-        isTranslated
+        isTranslated && !hasAttemptedRelaunch
     }
 
     /// Whether this process is running under Rosetta translation.

--- a/Sources/App/RosettaNativeRelaunch.swift
+++ b/Sources/App/RosettaNativeRelaunch.swift
@@ -99,8 +99,15 @@ enum RosettaNativeRelaunch {
         defer { posix_spawnattr_destroy(&attributes) }
 
         // Replace the current process image in place (like exec) so there is no
-        // orphaned translated process and the PID is preserved.
-        posix_spawnattr_setflags(&attributes, Int16(POSIX_SPAWN_SETEXEC))
+        // orphaned translated process and the PID is preserved. If the flag
+        // cannot be set, `posix_spawn` would fork a second process instead of
+        // replacing this one, leaving a translated parent running alongside a
+        // native child — so bail out rather than spawn without SETEXEC.
+        guard posix_spawnattr_setflags(&attributes, Int16(POSIX_SPAWN_SETEXEC)) == 0 else {
+            rosettaRelaunchLogger.warning("failed to set POSIX_SPAWN_SETEXEC; continuing translated")
+            unsetenv(guardKey)
+            return
+        }
 
         // Force the arm64 slice of the universal binary so the replacement
         // process is native, not translated. Without an explicit preference the
@@ -126,12 +133,10 @@ enum RosettaNativeRelaunch {
 
         // With POSIX_SPAWN_SETEXEC a successful call never returns. Reaching
         // here means the re-exec failed; log and fall through so the app still
-        // launches (translated) instead of dying.
-        let errorText = String(cString: strerror(spawnResult))
-        rosettaRelaunchLogger.warning("native re-exec failed; continuing translated")
-        #if DEBUG
-        rosettaRelaunchLogger.debug("native re-exec failed at \(executablePath, privacy: .public): \(errorText, privacy: .public)")
-        #endif
+        // launches (translated) instead of dying. Only the errno is logged (not
+        // the executable path) to keep user-specific install paths out of the
+        // unified log.
+        rosettaRelaunchLogger.warning("native re-exec failed (errno \(spawnResult, privacy: .public)); continuing translated")
         unsetenv(guardKey)
     }
 }

--- a/Sources/App/RosettaNativeRelaunch.swift
+++ b/Sources/App/RosettaNativeRelaunch.swift
@@ -55,8 +55,10 @@ enum RosettaNativeRelaunch {
 
     /// Re-exec cmux as a native arm64 process when it is running translated.
     ///
-    /// Call this as early as possible at launch (after CLI forwarding, before
-    /// AppKit is brought up). When ``shouldRelaunchNatively(isTranslated:hasAttemptedRelaunch:)``
+    /// Call this as early as possible at launch — before CLI forwarding and
+    /// before AppKit is brought up — so a translated launch invoked with
+    /// CLI-style arguments is re-execed natively first and the forwarded bundled
+    /// CLI inherits the native arch. When ``shouldRelaunchNatively(isTranslated:hasAttemptedRelaunch:)``
     /// is `true`, it replaces the current process image in place with the
     /// arm64 slice of the same bundle executable via `posix_spawn` configured
     /// with `POSIX_SPAWN_SETEXEC` and an arm64 binary preference. The call only

--- a/Sources/App/RosettaNativeRelaunch.swift
+++ b/Sources/App/RosettaNativeRelaunch.swift
@@ -90,7 +90,7 @@ enum RosettaNativeRelaunch {
         // translation cannot loop.
         setenv(guardKey, "1", 1)
 
-        var attributes = posix_spawnattr_t(nil as OpaquePointer?)
+        var attributes: posix_spawnattr_t?
         guard posix_spawnattr_init(&attributes) == 0 else {
             rosettaRelaunchLogger.warning("failed to init posix_spawnattr; continuing translated")
             unsetenv(guardKey)

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -104,17 +104,21 @@ struct cmuxApp: App {
         // (which happens for any shell descended from this process), bare `cmux`
         // resolves here instead of the CLI. See
         // https://github.com/manaflow-ai/cmux/issues/4678.
-        CLIForwardingLaunchRouter.forwardToBundledCLIIfNeeded()
-
         // cmux ships a universal binary so it still supports Intel Macs, but a
         // stale LaunchServices architecture preference can pin the app to its
-        // x86_64 slice on Apple Silicon, running the whole terminal process tree
-        // under Rosetta (macOS 26 deprecation dialog; translated child shells and
-        // toolchains). `LSArchitecturePriority = (arm64)` in Info.plist fixes
-        // future launches; this corrects an already-mis-pinned install by
-        // re-execing the arm64 slice in place. No-op on Intel and on native
+        // x86_64 slice on Apple Silicon, running the whole process tree under
+        // Rosetta (macOS 26 deprecation dialog; translated child shells and
+        // toolchains). `LSArchitecturePriority` in Info.plist fixes future
+        // launches; this corrects an already-mis-pinned install by re-execing the
+        // arm64 slice in place. It runs *before* CLI forwarding so a translated
+        // GUI binary invoked with CLI-style arguments is re-execed natively first
+        // and the forwarded bundled CLI then inherits the native arch too. The
+        // re-exec preserves argv and re-enters this initializer, so forwarding
+        // proceeds normally in the native process. No-op on Intel and on native
         // launches. See https://github.com/manaflow-ai/cmux/issues/753.
         RosettaNativeRelaunch.relaunchNativelyIfNeeded()
+
+        CLIForwardingLaunchRouter.forwardToBundledCLIIfNeeded()
 
         StartupBreadcrumbLog.append("app.init.begin")
         UITestLaunchManifest.applyIfPresent()

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -106,6 +106,16 @@ struct cmuxApp: App {
         // https://github.com/manaflow-ai/cmux/issues/4678.
         CLIForwardingLaunchRouter.forwardToBundledCLIIfNeeded()
 
+        // cmux ships a universal binary so it still supports Intel Macs, but a
+        // stale LaunchServices architecture preference can pin the app to its
+        // x86_64 slice on Apple Silicon, running the whole terminal process tree
+        // under Rosetta (macOS 26 deprecation dialog; translated child shells and
+        // toolchains). `LSArchitecturePriority = (arm64)` in Info.plist fixes
+        // future launches; this corrects an already-mis-pinned install by
+        // re-execing the arm64 slice in place. No-op on Intel and on native
+        // launches. See https://github.com/manaflow-ai/cmux/issues/753.
+        RosettaNativeRelaunch.relaunchNativelyIfNeeded()
+
         StartupBreadcrumbLog.append("app.init.begin")
         UITestLaunchManifest.applyIfPresent()
         StartupBreadcrumbLog.append("app.init.uiTestManifest.applied")

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -404,6 +404,8 @@
 		FE003103 /* RightSidebarPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE003003 /* RightSidebarPanelView.swift */; };
 		B37A0000000000000000000D /* RightSidebarRemoteCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = B37A0000000000000000000E /* RightSidebarRemoteCommand.swift */; };
 		FE0031A3 /* RightSidebarToolPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE0030A3 /* RightSidebarToolPanel.swift */; };
+		C46790000000000000000005 /* RosettaNativeRelaunch.swift in Sources */ = {isa = PBXBuildFile; fileRef = C46790000000000000000006 /* RosettaNativeRelaunch.swift */; };
+		C46790000000000000000007 /* RosettaNativeRelaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C46790000000000000000008 /* RosettaNativeRelaunchTests.swift */; };
 		F5310000A1B2C3D4E5F60718 /* RovoDevHookConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5310001A1B2C3D4E5F60718 /* RovoDevHookConfigTests.swift */; };
 		FE003105 /* RovoDevIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE003005 /* RovoDevIndex.swift */; };
 		F5300000A1B2C3D4E5F60718 /* RovoDevSessionIndexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5300001A1B2C3D4E5F60718 /* RovoDevSessionIndexTests.swift */; };
@@ -1032,6 +1034,8 @@
 			FE003003 /* RightSidebarPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightSidebarPanelView.swift; sourceTree = "<group>"; };
 		B37A0000000000000000000E /* RightSidebarRemoteCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightSidebarRemoteCommand.swift; sourceTree = "<group>"; };
 			FE0030A3 /* RightSidebarToolPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightSidebarToolPanel.swift; sourceTree = "<group>"; };
+		C46790000000000000000006 /* RosettaNativeRelaunch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/RosettaNativeRelaunch.swift; sourceTree = "<group>"; };
+		C46790000000000000000008 /* RosettaNativeRelaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RosettaNativeRelaunchTests.swift; sourceTree = "<group>"; };
 		F5310001A1B2C3D4E5F60718 /* RovoDevHookConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RovoDevHookConfigTests.swift; sourceTree = "<group>"; };
 		FE003005 /* RovoDevIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RovoDevIndex.swift; sourceTree = "<group>"; };
 		F5300001A1B2C3D4E5F60718 /* RovoDevSessionIndexTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RovoDevSessionIndexTests.swift; sourceTree = "<group>"; };
@@ -1416,6 +1420,7 @@
 				A11EAD000000000000000001 /* WorkspaceAppearanceResolution.swift */,
 				A5001011 /* cmuxApp.swift */,
 				C46790000000000000000004 /* CLIForwardingLaunchRouter.swift */,
+				C46790000000000000000006 /* RosettaNativeRelaunch.swift */,
 				C47110020000000000000002 /* ProcessPipeReader.swift */,
 				D9CCF001D9CCF001D9CCF001 /* SettingsLazyLoadHelpers.swift */,
 				E3309A08 /* cmuxApp+EqualizeSplitsMenu.swift */,
@@ -1855,6 +1860,7 @@
 				A17110000000000000000002 /* KeyboardShortcutSpaceKeyTests.swift */,
 				1A1B2C3D4E5F607180000004 /* WorkspacePromptSubmitTests.swift */,
 				C46790000000000000000002 /* CLIForwardingLaunchArgumentTests.swift */,
+				C46790000000000000000008 /* RosettaNativeRelaunchTests.swift */,
 				C0DE31390000000000000102 /* CMUXOpenCommandTests.swift */,
 				C0DE31390000000000000106 /* CMUXCLIErrorOutputRegressionTests.swift */,
 				C47110010000000000000002 /* ProcessPipeReadCrashRegressionTests.swift */,
@@ -2486,6 +2492,7 @@
 				FE003103 /* RightSidebarPanelView.swift in Sources */,
 				B37A0000000000000000000D /* RightSidebarRemoteCommand.swift in Sources */,
 				FE0031A3 /* RightSidebarToolPanel.swift in Sources */,
+				C46790000000000000000005 /* RosettaNativeRelaunch.swift in Sources */,
 				FE003105 /* RovoDevIndex.swift in Sources */,
 				FE003107 /* RovoDevTranscriptPreview.swift in Sources */,
 				E8BA79E246754A8B99A0B823 /* ScreenIdentity.swift in Sources */,
@@ -2786,6 +2793,7 @@
 					F5410002A1B2C3D4E5F60718 /* RestorableAgentNonInteractiveTests.swift in Sources */,
 					F5410006A1B2C3D4E5F60718 /* RestorableAgentSessionIndexTests.swift in Sources */,
 				C3408A000000000000000003 /* RightSidebarCommandPaletteTests.swift in Sources */,
+				C46790000000000000000007 /* RosettaNativeRelaunchTests.swift in Sources */,
 				F5310000A1B2C3D4E5F60718 /* RovoDevHookConfigTests.swift in Sources */,
 					F5300000A1B2C3D4E5F60718 /* RovoDevSessionIndexTests.swift in Sources */,
 				F5300002A1B2C3D4E5F60718 /* RovoDevTranscriptPreviewTests.swift in Sources */,

--- a/cmuxTests/RosettaNativeRelaunchTests.swift
+++ b/cmuxTests/RosettaNativeRelaunchTests.swift
@@ -1,0 +1,24 @@
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+import Testing
+
+@Suite struct RosettaNativeRelaunchTests {
+    @Test func relaunchesWhenTranslatedAndNotYetAttempted() {
+        #expect(RosettaNativeRelaunch.shouldRelaunchNatively(isTranslated: true, hasAttemptedRelaunch: false))
+    }
+
+    // The loop guard: once a native relaunch has been attempted, a process that
+    // is still translated must NOT relaunch again, or it spins forever.
+    @Test func doesNotRelaunchAfterAttemptEvenIfStillTranslated() {
+        #expect(!RosettaNativeRelaunch.shouldRelaunchNatively(isTranslated: true, hasAttemptedRelaunch: true))
+    }
+
+    @Test func doesNotRelaunchWhenNativeAndNotAttempted() {
+        #expect(!RosettaNativeRelaunch.shouldRelaunchNatively(isTranslated: false, hasAttemptedRelaunch: false))
+    }
+
+    @Test func doesNotRelaunchWhenNativeAndAttempted() {
+        #expect(!RosettaNativeRelaunch.shouldRelaunchNatively(isTranslated: false, hasAttemptedRelaunch: true))
+    }
+}
+#endif


### PR DESCRIPTION
## Issue
Fixes #753 — on Apple Silicon, cmux.app ends up **running under Rosetta** (translated), so the app and every child process (login, zsh, and every tool launched in a cmux terminal) run as x86_64. macOS 26 (Tahoe) shows a Rosetta deprecation dialog, and x86_64 child shells silently poison dev toolchains (xcodebuild launched from a cmux terminal builds x86_64).

## Diagnosis
This is **architecture selection at launch, not a stray Intel binary.** Reproduced on the affected machine:
- Running app process has `ps -o flags = 40c4` → the `P_TRANSLATED` bit (`0x4000`) is set.
- A shell spawned inside cmux: `uname -m = x86_64`, `sysctl sysctl.proc_translated = 1`.
- `lipo -archs /Applications/cmux.app/Contents/MacOS/cmux` → `x86_64 arm64` — the binary is **universal**; LaunchServices is selecting the x86_64 slice.
- A full bundle rescan found **no** x86_64-only component; every Mach-O is universal.
- The `lsregister -u <app> && lsregister <app>` + restart workaround fixes it locally, confirming the root cause is a **LaunchServices architecture preference** (seeded by the DMG volume copy and inherited by the `/Applications` copy), not Mach-O contents.

## Fix
Two layers, both of which **keep the universal binary** so Intel support is preserved (no regression of #293 / #1661 — the app stays `x86_64 arm64`):

1. **`LSArchitecturePriority = (arm64)` in `Resources/Info.plist`** — LaunchServices prefers the arm64 slice on Apple Silicon for all future launches.
2. **`RosettaNativeRelaunch` launch-time self-heal** (`Sources/App/RosettaNativeRelaunch.swift`) — corrects an *already* mis-pinned install without waiting for a reinstall. At `cmuxApp.init()` (right after CLI forwarding, before AppKit comes up) it reads `sysctl.proc_translated`; when translated it re-execs the **same** bundle executable **in place** via `posix_spawn` with `POSIX_SPAWN_SETEXEC` + `posix_spawnattr_setbinpref_np(CPU_TYPE_ARM64)`, guarded by an env var to prevent relaunch loops. No-op on Intel and on native Apple Silicon launches; on spawn failure it logs and continues (degrades to translated rather than crashing).

Child-process spawn paths were audited: the `x86_64` strings in `Workspace.swift`/`ContentView.swift` are arch-name *mapping* only (for downloading helper binaries) — no `posix_spawn` binary-preference forces x86_64, so children correctly inherit the app's (now native) arch. The release pipeline contains no `lsregister` double-registration; `LSArchitecturePriority` covers even the system's automatic DMG-volume registration.

## Tests
The launch/LaunchServices behavior itself is **not cleanly unit-testable** (and per repo policy we do not assert Info.plist/pbxproj contents). The unit-testable part is the self-heal **decision logic**, covered by a real behavioral test (`cmuxTests/RosettaNativeRelaunchTests.swift`): relaunch iff translated **and** not already attempted, including the loop-guard case. Per the regression-test commit policy this is split red→green:
- Commit 1 adds the test with the loop guard omitted → the guard test fails.
- Commit 2 adds the guard (+ Info.plist key + call-site wiring) → green.

End-to-end verification is by launching the produced app and checking `uname -m = arm64` / `sysctl sysctl.proc_translated = 0` with no Rosetta dialog.

## Localization
No user-facing strings added — the self-heal is silent (os_log only). Nothing to localize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5306"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783111214&installation_id=133855650&pr_number=5306&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5306&signature=9a1ae54d980f7d2531f96902e3080a5d89cf8478408f7654949ad53907d75463"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes early app launch with in-process re-exec via posix_spawn, but scope is narrow, Intel/universal support is preserved, loop guards and fail-open behavior limit blast radius.
> 
> **Overview**
> Fixes Apple Silicon installs that were stuck launching cmux’s **x86_64** slice under Rosetta (terminals and child tools then run translated).
> 
> **`Info.plist`** now declares **`LSArchitecturePriority`** with **`arm64`** before **`x86_64`**, so LaunchServices prefers native on Apple Silicon while Intel still gets **x86_64**.
> 
> A new **`RosettaNativeRelaunch`** path runs at the very start of **`cmuxApp` init**, **before** bundled CLI forwarding: if **`sysctl.proc_translated`** says the process is translated and a one-shot env guard is absent, it **re-execs** the same bundle executable in place via **`posix_spawn`** with **`POSIX_SPAWN_SETEXEC`** and an **arm64** binary preference; on failure it logs and continues translated. **`RosettaNativeRelaunchTests`** cover the relaunch vs loop-guard decision only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3513f8919a0aa2d568a866673f6e1a92bfcfd480. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops cmux from launching under Rosetta on Apple Silicon so terminals run native arm64 and avoid the deprecation dialog. The app remains universal to keep Intel support. Fixes #753.

- **Bug Fixes**
  - Set `LSArchitecturePriority = (arm64, x86_64)` in Info.plist so Apple Silicon prefers arm64 while Intel still launches x86_64.
  - Add early self-heal: if translated, re-exec the same binary with `POSIX_SPAWN_SETEXEC` and an arm64 preference; guarded by an env var; bails if `SETEXEC` can’t be set to avoid forking; no-op on Intel; logs and continues on failure; uses the repo’s `posix_spawnattr_t` init pattern.
  - Run the relaunch check before CLI forwarding (and before AppKit) so forwarded CLI inherits the native arch; corrected doc comments to match.
  - Add unit tests for the relaunch decision, including the loop guard.

<sup>Written for commit 3513f8919a0aa2d568a866673f6e1a92bfcfd480. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5306?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Detects translated (Rosetta) launches and attempts to relaunch the app as a native (arm64) process on Apple Silicon when appropriate.

* **Tests**
  * Added unit tests for the relaunch decision logic and loop-guard behavior.

* **Chores**
  * Declares arm64 as preferred architecture in app metadata and updated project build entries for the relaunch feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->