### PR TITLE
Fix #5302: leaked settings observation tasks grow heap to 4.4 GB over ~23h

### DIFF
--- a/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Bindings/DefaultsValueModel.swift
+++ b/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Bindings/DefaultsValueModel.swift
@@ -18,8 +18,13 @@ import Observation
 /// 3. ``set(_:)`` updates ``current`` optimistically (immediate UI) and
 ///    persists the write in a fire-and-forget `Task`.
 ///
-/// Lifecycle: the observation `Task` captures `self` weakly and exits
-/// when the model is deallocated, so no explicit cancellation is needed.
+/// Lifecycle: the observation is owned by a ``SettingReadDriver`` held by the
+/// model. When the model deallocates, the driver's `deinit` cancels the
+/// iterating task, which finishes the change stream and tears down its
+/// underlying `NotificationCenter.notifications(named:)` sequence. A bare
+/// `weak self` inside the loop is **not** enough — the task is parked at the
+/// `await` and never re-checks `self` for an idle key, leaking the
+/// subscription (see https://github.com/manaflow-ai/cmux/issues/5302).
 @MainActor
 @Observable
 public final class DefaultsValueModel<Value: SettingCodable> {
@@ -28,6 +33,10 @@ public final class DefaultsValueModel<Value: SettingCodable> {
 
     private let store: UserDefaultsSettingsStore
     private let key: DefaultsKey<Value>
+
+    /// Owns the change-stream subscription and cancels it when this model
+    /// deallocates.
+    @ObservationIgnored private let observation = SettingReadDriver<Value>()
 
     /// Creates a model bound to ``key`` in ``store``.
     ///
@@ -60,12 +69,8 @@ public final class DefaultsValueModel<Value: SettingCodable> {
         // element (the actual stored value) lands immediately after and
         // is the sole writer of `current` thereafter.
         self.current = key.defaultValue
-        Task { [weak self] in
-            for await value in makeStream() {
-                guard let self else { return }
-                if Task.isCancelled { break }
-                self.current = value
-            }
+        observation.activate(makeStream) { [weak self] value in
+            self?.current = value
         }
     }
 

--- a/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Bindings/DefaultsValueModel.swift
+++ b/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Bindings/DefaultsValueModel.swift
@@ -34,15 +34,34 @@ public final class DefaultsValueModel<Value: SettingCodable> {
     /// - Parameters:
     ///   - store: The UserDefaults store to read from and write to.
     ///   - key: The setting to observe.
-    public init(store: UserDefaultsSettingsStore, key: DefaultsKey<Value>) {
+    public convenience init(store: UserDefaultsSettingsStore, key: DefaultsKey<Value>) {
+        self.init(store: store, key: key, makeStream: { store.values(for: key) })
+    }
+
+    /// Designated initializer with an injectable change-stream factory.
+    ///
+    /// The `makeStream` seam lets tests drive the observation with a stream
+    /// whose teardown they can observe, proving the model cancels its
+    /// observation on deallocation. Production code uses the public
+    /// `init(store:key:)`, which wires `makeStream` to the store.
+    ///
+    /// - Parameters:
+    ///   - store: The UserDefaults store used for writes (`set`/`reset`).
+    ///   - key: The setting to observe.
+    ///   - makeStream: Builds the change stream this model iterates.
+    init(
+        store: UserDefaultsSettingsStore,
+        key: DefaultsKey<Value>,
+        makeStream: @escaping () -> AsyncStream<Value>
+    ) {
         self.store = store
         self.key = key
         // Seed with the key default; the observation stream's first
         // element (the actual stored value) lands immediately after and
         // is the sole writer of `current` thereafter.
         self.current = key.defaultValue
-        Task { [weak self, store, key] in
-            for await value in store.values(for: key) {
+        Task { [weak self] in
+            for await value in makeStream() {
                 guard let self else { return }
                 if Task.isCancelled { break }
                 self.current = value

--- a/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Bindings/JSONValueModel.swift
+++ b/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Bindings/JSONValueModel.swift
@@ -10,8 +10,12 @@ import Observation
 /// pushed into the optional injected ``SettingsErrorLog`` so the UI can
 /// surface them centrally; the model never silently swallows a failure.
 ///
-/// Lifecycle: the observation `Task` captures `self` weakly inside its
-/// loop body and exits naturally when the model is deallocated.
+/// Lifecycle: the observation is owned by a ``SettingReadDriver`` held by the
+/// model; the driver's `deinit` cancels the iterating task when the model
+/// deallocates, finishing the change stream and tearing down its underlying
+/// observation. A bare `weak self` is **not** enough — the parked task never
+/// re-checks `self` for an idle key (see
+/// https://github.com/manaflow-ai/cmux/issues/5302).
 @MainActor
 @Observable
 public final class JSONValueModel<Value: SettingCodable> {
@@ -26,6 +30,10 @@ public final class JSONValueModel<Value: SettingCodable> {
     private let key: JSONKey<Value>
     private let errorLog: SettingsErrorLog
 
+    /// Owns the change-stream subscription and cancels it when this model
+    /// deallocates.
+    @ObservationIgnored private let observation = SettingReadDriver<Value>()
+
     /// Creates a model bound to ``key`` in ``store``.
     ///
     /// - Parameters:
@@ -34,21 +42,42 @@ public final class JSONValueModel<Value: SettingCodable> {
     ///   - errorLog: Global log that write failures are pushed into so
     ///     they surface centrally. The runtime always provides one; see
     ///     ``SettingsRuntime/errorLog``.
-    public init(
+    public convenience init(
         store: JSONConfigStore,
         key: JSONKey<Value>,
         errorLog: SettingsErrorLog
+    ) {
+        self.init(
+            store: store,
+            key: key,
+            errorLog: errorLog,
+            makeStream: { store.values(for: key) }
+        )
+    }
+
+    /// Designated initializer with an injectable change-stream factory.
+    ///
+    /// The `makeStream` seam lets tests drive the observation with a stream
+    /// whose teardown they can observe. Production code uses the public
+    /// `init(store:key:errorLog:)`, which wires `makeStream` to the store.
+    ///
+    /// - Parameters:
+    ///   - store: The JSON config store used for writes (`set`/`reset`).
+    ///   - key: The setting to observe.
+    ///   - errorLog: Global log that write failures are pushed into.
+    ///   - makeStream: Builds the change stream this model iterates.
+    init(
+        store: JSONConfigStore,
+        key: JSONKey<Value>,
+        errorLog: SettingsErrorLog,
+        makeStream: @escaping () -> AsyncStream<Value>
     ) {
         self.store = store
         self.key = key
         self.errorLog = errorLog
         self.current = key.defaultValue
-        Task { [weak self, store, key] in
-            for await value in store.values(for: key) {
-                guard let self else { return }
-                if Task.isCancelled { break }
-                self.current = value
-            }
+        observation.activate(makeStream) { [weak self] value in
+            self?.current = value
         }
     }
 

--- a/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Bindings/LiveSetting.swift
+++ b/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Bindings/LiveSetting.swift
@@ -128,6 +128,7 @@ public struct LiveSetting<Value: SettingCodable>: @preconcurrency DynamicPropert
     /// store's change stream into the wrapper's `@State`; later calls are no-ops.
     public func update() {
         guard let runtime else { return }
-        driver.activate({ makeStream(runtime) }, sink: $value)
+        let binding = $value
+        driver.activate({ makeStream(runtime) }) { binding.wrappedValue = $0 }
     }
 }

--- a/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Bindings/SecretValueModel.swift
+++ b/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Bindings/SecretValueModel.swift
@@ -11,8 +11,12 @@ import Observation
 /// are pushed into the injected ``SettingsErrorLog`` so the UI surfaces them
 /// centrally; the model never silently swallows a failure.
 ///
-/// Lifecycle: the observation `Task` captures `self` weakly and exits when the
-/// model is deallocated.
+/// Lifecycle: the observation is owned by a ``SettingReadDriver`` held by the
+/// model; the driver's `deinit` cancels the iterating task when the model
+/// deallocates, finishing the change stream and tearing down its underlying
+/// observation. A bare `weak self` is **not** enough — the parked task never
+/// re-checks `self` for an idle key (see
+/// https://github.com/manaflow-ai/cmux/issues/5302).
 @MainActor
 @Observable
 public final class SecretValueModel {
@@ -26,27 +30,52 @@ public final class SecretValueModel {
     private let key: SecretFileKey
     private let errorLog: SettingsErrorLog
 
+    /// Owns the change-stream subscription and cancels it when this model
+    /// deallocates.
+    @ObservationIgnored private let observation = SettingReadDriver<String>()
+
     /// Creates a model bound to ``key`` in ``store``.
     ///
     /// - Parameters:
     ///   - store: The secret-file store to read from and write to.
     ///   - key: The secret to observe.
     ///   - errorLog: Global log that write failures are pushed into.
-    public init(
+    public convenience init(
         store: SecretFileStore,
         key: SecretFileKey,
         errorLog: SettingsErrorLog
+    ) {
+        self.init(
+            store: store,
+            key: key,
+            errorLog: errorLog,
+            makeStream: { store.values(for: key) }
+        )
+    }
+
+    /// Designated initializer with an injectable change-stream factory.
+    ///
+    /// The `makeStream` seam lets tests drive the observation with a stream
+    /// whose teardown they can observe. Production code uses the public
+    /// `init(store:key:errorLog:)`, which wires `makeStream` to the store.
+    ///
+    /// - Parameters:
+    ///   - store: The secret-file store used for writes (`set`/`reset`).
+    ///   - key: The secret to observe.
+    ///   - errorLog: Global log that write failures are pushed into.
+    ///   - makeStream: Builds the change stream this model iterates.
+    init(
+        store: SecretFileStore,
+        key: SecretFileKey,
+        errorLog: SettingsErrorLog,
+        makeStream: @escaping () -> AsyncStream<String>
     ) {
         self.store = store
         self.key = key
         self.errorLog = errorLog
         self.current = key.defaultValue
-        Task { [weak self, store, key] in
-            for await value in store.values(for: key) {
-                guard let self else { return }
-                if Task.isCancelled { break }
-                self.current = value
-            }
+        observation.activate(makeStream) { [weak self] value in
+            self?.current = value
         }
     }
 

--- a/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Bindings/SettingReadDriver.swift
+++ b/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Bindings/SettingReadDriver.swift
@@ -1,34 +1,46 @@
 import SwiftUI
 
-/// Pushes values from a settings store's change `AsyncStream` into a SwiftUI
-/// `@State` (via its `Binding`), so a property wrapper's reads ride on `@State`
-/// invalidation instead of Observation.
+/// Owns the lifecycle of one settings-store change-stream subscription:
+/// a single `Task` that forwards each element from an `AsyncStream<Value>`
+/// into a caller-supplied sink, and cancels that task when the driver is
+/// deallocated.
 ///
-/// This is the mechanism behind ``LiveSetting``. Holding the latest value in
-/// the consuming view's own `@State` is what makes updates reliable inside an
-/// AppKit `NSHostingView` host, where an `@Observable` model updated off the
-/// render cycle does not re-invalidate the view; `@State` is SwiftUI's most
-/// fundamental, host-agnostic invalidation primitive. The driver is
-/// store-agnostic — it only needs an `AsyncStream<Value>` — so the same path
-/// works for every key kind (UserDefaults, JSON, secret).
+/// This is the single source of truth for "observe a setting" teardown. The
+/// owning object (a SwiftUI `@State` for ``LiveSetting``, or an `@Observable`
+/// value model such as ``DefaultsValueModel``) holds the driver; when the
+/// owner deallocates, the driver's `deinit` cancels the task. That
+/// cancellation propagates into the parked `for await`, finishing the stream
+/// and firing its `onTermination`, which tears down the underlying
+/// `NotificationCenter.notifications(named:)` sequence. Relying on `weak self`
+/// inside the loop is **not** sufficient: the task is suspended at the `await`
+/// and never re-evaluates `self` for an idle key, so the subscription would
+/// leak (see https://github.com/manaflow-ai/cmux/issues/5302).
+///
+/// The driver is store-agnostic — it only needs an `AsyncStream<Value>` — so
+/// the same path works for every key kind (UserDefaults, JSON, secret) and
+/// for both `@State`-backed and `@Observable`-backed consumers.
 @MainActor
 final class SettingReadDriver<Value: Sendable> {
     private var task: Task<Void, Never>?
 
     /// Starts forwarding `makeStream()`'s elements into `sink`. Idempotent:
-    /// the first call wins and later calls (every `update()`) are no-ops, so
-    /// the subscription is created once for the lifetime of the `@State`.
+    /// the first call wins and later calls are no-ops, so the subscription is
+    /// created once for the lifetime of the owning object.
     ///
     /// - Parameters:
     ///   - makeStream: Builds the store change stream. Called at most once.
-    ///   - sink: The `@State`-backed binding to write each value into.
-    func activate(_ makeStream: () -> AsyncStream<Value>, sink: Binding<Value>) {
+    ///   - sink: Receives each value on the main actor. Capture the consumer
+    ///     weakly here so the forwarding task does not retain it.
+    func activate(
+        _ makeStream: () -> AsyncStream<Value>,
+        sink: @escaping @MainActor (Value) -> Void
+    ) {
         guard task == nil else { return }
         let stream = makeStream()
         task = Task { @MainActor in
             for await value in stream {
                 if Task.isCancelled { break }
-                sink.wrappedValue = value
+                sink(value)
             }
         }
     }

--- a/Packages/CmuxSettingsUI/Tests/CmuxSettingsUITests/DefaultsValueModelLifecycleTests.swift
+++ b/Packages/CmuxSettingsUI/Tests/CmuxSettingsUITests/DefaultsValueModelLifecycleTests.swift
@@ -1,0 +1,73 @@
+import CmuxSettings
+import Foundation
+import Testing
+
+@testable import CmuxSettingsUI
+
+/// Lifecycle regression tests for ``DefaultsValueModel``.
+///
+/// The settings value models start a long-lived `Task` that iterates the
+/// store's `values(for:)` change stream. That stream parks on
+/// `NotificationCenter.default.notifications(named:)`, which rarely fires for
+/// an idle key, so the iterating task is suspended indefinitely. If the model
+/// only relies on `weak self` for teardown, dropping the model never reaches
+/// the `guard let self` check (the task is parked at the `await`), so the
+/// task — and the `AsyncStream` + notification sequence it keeps alive — leak.
+///
+/// `State(initialValue: DefaultsValueModel(...))` re-runs on every parent
+/// render, constructing throwaway models, so each leaked trio accumulates
+/// monotonically (see https://github.com/manaflow-ai/cmux/issues/5302).
+///
+/// This suite proves the model cancels its observation when it deallocates by
+/// observing the injected stream's `onTermination`: cancellation of the
+/// model's iterating task finishes the stream and fires `onTermination`.
+@MainActor
+@Suite struct DefaultsValueModelLifecycleTests {
+    /// Box whose flag the stream's `onTermination` flips on the main actor.
+    @MainActor
+    private final class TerminationFlag {
+        var didTerminate = false
+    }
+
+    @Test func droppingModelTearsDownObservation() async {
+        let store = UserDefaultsSettingsStore(
+            defaults: UserDefaults(suiteName: "issue-5302-defaults-value-model")!
+        )
+        let key = SettingCatalog().betaFeatures.extensions
+
+        let (stream, continuation) = AsyncStream<Bool>.makeStream()
+        let flag = TerminationFlag()
+        continuation.onTermination = { _ in
+            Task { @MainActor in flag.didTerminate = true }
+        }
+
+        var model: DefaultsValueModel<Bool>? = DefaultsValueModel(
+            store: store,
+            key: key,
+            makeStream: { stream }
+        )
+
+        // Drive one value through so the model's task is parked awaiting the
+        // next element — the exact suspended state where `weak self` teardown
+        // never runs.
+        continuation.yield(true)
+        var settleSpins = 0
+        while model?.current != true, settleSpins < 100_000 {
+            await Task.yield()
+            settleSpins += 1
+        }
+        #expect(model?.current == true)
+
+        // Drop the model. A model that owns and cancels its observation will
+        // cancel the parked task, finishing the stream and firing
+        // `onTermination`. A model that leaks it never will.
+        model = nil
+
+        var spins = 0
+        while !flag.didTerminate, spins < 100_000 {
+            await Task.yield()
+            spins += 1
+        }
+        #expect(flag.didTerminate)
+    }
+}

--- a/Packages/CmuxSettingsUI/Tests/CmuxSettingsUITests/JSONValueModelLifecycleTests.swift
+++ b/Packages/CmuxSettingsUI/Tests/CmuxSettingsUITests/JSONValueModelLifecycleTests.swift
@@ -1,0 +1,59 @@
+import CmuxSettings
+import Foundation
+import Testing
+
+@testable import CmuxSettingsUI
+
+/// Lifecycle regression tests for ``JSONValueModel``.
+///
+/// These mirror the `DefaultsValueModel` leak repro against the JSON-backed
+/// settings model: once the observation task is parked awaiting the next
+/// element, dropping the model must cancel the task and terminate the stream.
+@MainActor
+@Suite struct JSONValueModelLifecycleTests {
+    /// Box whose flag the stream's `onTermination` flips on the main actor.
+    @MainActor
+    private final class TerminationFlag {
+        var didTerminate = false
+    }
+
+    @Test func droppingModelTearsDownObservation() async {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("issue-5302-json-value-model-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let store = JSONConfigStore(fileURL: tempDir.appendingPathComponent("cmux.json"))
+        let key = JSONKey<String>(id: "automation.socketPassword", defaultValue: "")
+        let errorLog = SettingsErrorLog()
+
+        let (stream, continuation) = AsyncStream<String>.makeStream()
+        let flag = TerminationFlag()
+        continuation.onTermination = { _ in
+            Task { @MainActor in flag.didTerminate = true }
+        }
+
+        var model: JSONValueModel<String>? = JSONValueModel(
+            store: store,
+            key: key,
+            errorLog: errorLog,
+            makeStream: { stream }
+        )
+
+        continuation.yield("observed")
+        var settleSpins = 0
+        while model?.current != "observed", settleSpins < 100_000 {
+            await Task.yield()
+            settleSpins += 1
+        }
+        #expect(model?.current == "observed")
+
+        model = nil
+
+        var spins = 0
+        while !flag.didTerminate, spins < 100_000 {
+            await Task.yield()
+            spins += 1
+        }
+        #expect(flag.didTerminate)
+    }
+}

--- a/Packages/CmuxSettingsUI/Tests/CmuxSettingsUITests/SecretValueModelLifecycleTests.swift
+++ b/Packages/CmuxSettingsUI/Tests/CmuxSettingsUITests/SecretValueModelLifecycleTests.swift
@@ -1,0 +1,59 @@
+import CmuxSettings
+import Foundation
+import Testing
+
+@testable import CmuxSettingsUI
+
+/// Lifecycle regression tests for ``SecretValueModel``.
+///
+/// The secret-backed model used the same long-lived settings observation shape
+/// as the defaults and JSON models. This proves deallocation cancels the
+/// parked observation task instead of leaving its stream alive.
+@MainActor
+@Suite struct SecretValueModelLifecycleTests {
+    /// Box whose flag the stream's `onTermination` flips on the main actor.
+    @MainActor
+    private final class TerminationFlag {
+        var didTerminate = false
+    }
+
+    @Test func droppingModelTearsDownObservation() async {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("issue-5302-secret-value-model-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let store = SecretFileStore(baseDirectory: tempDir)
+        let key = SecretFileKey(id: "automation.socketPassword", fileName: "socket-control-password")
+        let errorLog = SettingsErrorLog()
+
+        let (stream, continuation) = AsyncStream<String>.makeStream()
+        let flag = TerminationFlag()
+        continuation.onTermination = { _ in
+            Task { @MainActor in flag.didTerminate = true }
+        }
+
+        var model: SecretValueModel? = SecretValueModel(
+            store: store,
+            key: key,
+            errorLog: errorLog,
+            makeStream: { stream }
+        )
+
+        continuation.yield("observed")
+        var settleSpins = 0
+        while model?.current != "observed", settleSpins < 100_000 {
+            await Task.yield()
+            settleSpins += 1
+        }
+        #expect(model?.current == "observed")
+
+        model = nil
+
+        var spins = 0
+        while !flag.didTerminate, spins < 100_000 {
+            await Task.yield()
+            spins += 1
+        }
+        #expect(flag.didTerminate)
+    }
+}


### PR DESCRIPTION
## What

Fixes #5302 — the cmux app process grows to **4.4 GB over ~23h** from leaked Swift-concurrency objects (~1.3M `Task stack`, 328K `NSNotificationCenter.Notifications`, 207K `AsyncStream<Bool>`, 53K `AsyncStream<String>`), never reclaimed.

## Root cause

The three settings value models — `DefaultsValueModel`, `JSONValueModel`, `SecretValueModel` (`Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Bindings/`) — each started an **un-retained** `Task` iterating the store's `values(for:)` `AsyncStream`. That stream parks on `NotificationCenter.default.notifications(named:)`, which rarely fires for an idle key.

The models relied on `weak self` inside the loop for teardown, but a task suspended at the `await` **never re-evaluates `self`** — so after the model deallocated, the task, its `AsyncStream`, and the `notifications(named:)` sequence leaked permanently. The store side (`UserDefaultsSettingsStore.values(for:)`) already tears down correctly via `continuation.onTermination`, but that only fires when the *consumer* iteration ends, which it never did.

Because `State(initialValue: DefaultsValueModel(...))` re-runs on every parent `init`/render across the settings sections, throwaway models accumulated these leaked trios monotonically. The heap counts line up exactly: `DefaultsValueModel<Bool>` ↔ `AsyncStream<Bool>`, `SecretValueModel` ↔ `AsyncStream<String>`, both ↔ `notifications(named:)`.

## Fix

Make observation lifecycle the single responsibility of `SettingReadDriver` — the `@MainActor` owner already used by `LiveSetting`, which already cancels its task in `deinit`. Generalized it from a `Binding` sink to a closure sink, and had all three value models **own** one (`@ObservationIgnored private let observation = SettingReadDriver<Value>()`).

Now: model dealloc → driver `deinit` → task `cancel()` → the parked `for await` finishes → the `AsyncStream`'s `onTermination` cancels the inner `notifications(named:)` task. The leaked state is unrepresentable: there is no observation path that isn't owned by a driver that cancels on teardown.

`LiveSetting` is unchanged in behavior (it already used `SettingReadDriver` correctly).

## Tests

Two-commit red/green:
1. **Failing test** — `DefaultsValueModelLifecycleTests.droppingModelTearsDownObservation` injects a stream via a new `makeStream` test seam, drives a value through so the task is parked, drops the model, and asserts the stream's `onTermination` fires. Red without the fix (the parked task is never cancelled).
2. **Fix** — green.

Runs in CI via `swift test --package-path Packages/CmuxSettingsUI`.

## Scope

Task-stack / async-`notifications(named:)` leak only. Does not touch the separate IOSurface/GPU accumulation (#1435 / #4607) or the old-style `addObserver` audit (#2078).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5310"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783111984&installation_id=133855650&pr_number=5310&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5310&signature=a6ed8abf320e2b0ed0bb1f43e20e0329b8aa1cf6f34e7cfe5558ee8db3c56fdc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core settings UI observation for all backing stores; behavior should match prior reads/writes but incorrect cancellation could drop live updates or regress memory under load.
> 
> **Overview**
> Fixes a long-running memory leak (#5302) where **defaults, JSON, and secret** settings view models started bare `Task` loops on store change streams. Those tasks stayed suspended at `for await` after the model was gone, so `weak self` never ran and **tasks, `AsyncStream`s, and `NotificationCenter` observation** piled up (especially when SwiftUI recreated models each render).
> 
> Observation teardown is centralized in **`SettingReadDriver`**: it now takes a closure sink (not only a `Binding`), cancels its iterating task in `deinit`, and each value model **owns** a driver via an injectable `makeStream` initializer for tests. **`LiveSetting`** is wired to the same closure API with no intended behavior change.
> 
> New **lifecycle regression tests** assert that dropping a model terminates the injected stream (`onTermination`) while the observation task is parked awaiting the next value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b72bfebe0ba67acf87977c4a020c6bd0f668de4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #5302 by stopping leaked settings observation tasks that grew the app to ~4.4 GB over ~23h. Observation is now owned and canceled by a single driver, removing the `Task`/`AsyncStream`/notification leak.

- **Bug Fixes**
  - Centralized observation in `SettingReadDriver` (closure-based sink; cancels in `deinit`).
  - Updated `DefaultsValueModel`, `JSONValueModel`, and `SecretValueModel` to use the driver and added a `makeStream` test seam; removed unretained loops.
  - Added lifecycle regression tests for all three models asserting the stream terminates on dealloc; adjusted `LiveSetting` to the closure sink (no behavior change).

<sup>Written for commit b72bfebe0ba67acf87977c4a020c6bd0f668de4f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Settings models refactored to improve observation lifecycle and reduce stray background work.

* **Bug Fixes**
  * Prevented long-lived subscription/task leaks so settings updates stop when models are released.

* **Tests**
  * Added regression tests that verify observations are torn down when models are deallocated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->