### PR TITLE
Fix #5303: stop browser pane re-running one-time setup on every CoreAnimation commit

### DIFF
--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -4243,10 +4243,15 @@ final class BrowserPanel: Panel, ObservableObject {
     /// pane, and a view-scoped `@State` guard resets whenever the view changes
     /// identity (a remount re-runs it). A process-scoped guard runs the work once
     /// regardless of how many panels or view instances come and go.
-    static func bootstrapBrowserDefaultsIfNeeded(defaults: UserDefaults = .standard) {
+    ///
+    /// Always targets `UserDefaults.standard`: the guard is process-wide, so an
+    /// injectable suite here would silently no-op for every caller after the first.
+    /// Tests exercise ``normalizeBrowserDefaults(defaults:)`` directly with a
+    /// scratch suite instead.
+    static func bootstrapBrowserDefaultsIfNeeded() {
         guard !hasBootstrappedBrowserDefaults else { return }
         hasBootstrappedBrowserDefaults = true
-        normalizeBrowserDefaults(defaults: defaults)
+        normalizeBrowserDefaults(defaults: .standard)
     }
 
     /// Registers fallback defaults and writes back canonical values for any stored

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -4231,6 +4231,77 @@ final class BrowserPanel: Panel, ObservableObject {
         return instanceID == webViewInstanceID
     }
 
+    /// Tracks whether the process-once browser defaults bootstrap has run.
+    private static var hasBootstrappedBrowserDefaults = false
+
+    /// Registers browser fallback defaults and normalizes any legacy/out-of-range
+    /// stored settings to their canonical form, exactly once per process.
+    ///
+    /// This is app-once work, not per-view work. Keeping it out of
+    /// `BrowserPanelView.onAppear` is what fixes the issue #5303 render loop:
+    /// `.onAppear` can re-fire on every CoreAnimation commit for a portal-hosted
+    /// pane, and a view-scoped `@State` guard resets whenever the view changes
+    /// identity (a remount re-runs it). A process-scoped guard runs the work once
+    /// regardless of how many panels or view instances come and go.
+    static func bootstrapBrowserDefaultsIfNeeded(defaults: UserDefaults = .standard) {
+        guard !hasBootstrappedBrowserDefaults else { return }
+        hasBootstrappedBrowserDefaults = true
+        normalizeBrowserDefaults(defaults: defaults)
+    }
+
+    /// Registers fallback defaults and writes back canonical values for any stored
+    /// browser setting whose raw value is legacy or out of range.
+    ///
+    /// Pure with respect to the injected `defaults`, so it is unit-testable against
+    /// a scratch `UserDefaults(suiteName:)` without touching `UserDefaults.standard`.
+    static func normalizeBrowserDefaults(defaults: UserDefaults) {
+        defaults.register(defaults: [
+            BrowserSearchSettings.searchEngineKey: BrowserSearchSettings.defaultSearchEngine.rawValue,
+            BrowserSearchSettings.customSearchEngineNameKey: BrowserSearchSettings.defaultCustomSearchEngineName,
+            BrowserSearchSettings.customSearchEngineURLTemplateKey: BrowserSearchSettings.defaultCustomSearchEngineURLTemplate,
+            BrowserSearchSettings.searchSuggestionsEnabledKey: BrowserSearchSettings.defaultSearchSuggestionsEnabled,
+            BrowserToolbarAccessorySpacingDebugSettings.key: BrowserToolbarAccessorySpacingDebugSettings.defaultSpacing,
+            BrowserProfilePopoverDebugSettings.horizontalPaddingKey: BrowserProfilePopoverDebugSettings.defaultHorizontalPadding,
+            BrowserProfilePopoverDebugSettings.verticalPaddingKey: BrowserProfilePopoverDebugSettings.defaultVerticalPadding,
+            BrowserThemeSettings.modeKey: BrowserThemeSettings.defaultMode.rawValue,
+        ])
+
+        let resolvedThemeMode = BrowserThemeSettings.mode(defaults: defaults)
+        let currentThemeRaw = defaults.string(forKey: BrowserThemeSettings.modeKey)
+            ?? BrowserThemeSettings.defaultMode.rawValue
+        if currentThemeRaw != resolvedThemeMode.rawValue {
+            defaults.set(resolvedThemeMode.rawValue, forKey: BrowserThemeSettings.modeKey)
+        }
+
+        let resolvedHintVariant = BrowserImportHintSettings.variant(defaults: defaults)
+        let currentHintRaw = defaults.string(forKey: BrowserImportHintSettings.variantKey)
+            ?? BrowserImportHintSettings.defaultVariant.rawValue
+        if currentHintRaw != resolvedHintVariant.rawValue {
+            defaults.set(resolvedHintVariant.rawValue, forKey: BrowserImportHintSettings.variantKey)
+        }
+
+        let resolvedToolbarSpacing = BrowserToolbarAccessorySpacingDebugSettings.current(defaults: defaults)
+        let currentToolbarSpacing = (defaults.object(forKey: BrowserToolbarAccessorySpacingDebugSettings.key) as? Int)
+            ?? BrowserToolbarAccessorySpacingDebugSettings.defaultSpacing
+        if currentToolbarSpacing != resolvedToolbarSpacing {
+            defaults.set(resolvedToolbarSpacing, forKey: BrowserToolbarAccessorySpacingDebugSettings.key)
+        }
+
+        let resolvedHorizontalPadding = BrowserProfilePopoverDebugSettings.currentHorizontalPadding(defaults: defaults)
+        let currentHorizontalPadding = (defaults.object(forKey: BrowserProfilePopoverDebugSettings.horizontalPaddingKey) as? NSNumber)?.doubleValue
+            ?? BrowserProfilePopoverDebugSettings.defaultHorizontalPadding
+        if currentHorizontalPadding != resolvedHorizontalPadding {
+            defaults.set(resolvedHorizontalPadding, forKey: BrowserProfilePopoverDebugSettings.horizontalPaddingKey)
+        }
+
+        let resolvedVerticalPadding = BrowserProfilePopoverDebugSettings.currentVerticalPadding(defaults: defaults)
+        let currentVerticalPadding = (defaults.object(forKey: BrowserProfilePopoverDebugSettings.verticalPaddingKey) as? NSNumber)?.doubleValue
+            ?? BrowserProfilePopoverDebugSettings.defaultVerticalPadding
+        if currentVerticalPadding != resolvedVerticalPadding {
+            defaults.set(resolvedVerticalPadding, forKey: BrowserProfilePopoverDebugSettings.verticalPaddingKey)
+        }
+    }
+
     init(
         workspaceId: UUID,
         profileID: UUID? = nil,
@@ -4246,6 +4317,9 @@ final class BrowserPanel: Panel, ObservableObject {
         isRemoteWorkspace: Bool = false,
         remoteWebsiteDataStoreIdentifier: UUID? = nil
     ) {
+        // Register fallback defaults and normalize legacy/out-of-range settings once
+        // per process, before any setting is read below or by the SwiftUI view.
+        Self.bootstrapBrowserDefaultsIfNeeded()
         self.id = UUID()
         self.workspaceId = workspaceId
         let requestedProfileID = profileID ?? BrowserProfileStore.shared.effectiveLastUsedProfileID

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -459,6 +459,11 @@ struct BrowserPanelView: View {
     @State private var suppressNextFocusGainedSelectAll: Bool = false
     @State private var isBrowserProfileMenuPresented = false
     @State private var isBrowserThemeMenuPresented = false
+    // `.onAppear` is not a reliable once-signal for a portal-hosted pane: it can
+    // re-fire on every CoreAnimation commit (issue #5303). This guards the one-time
+    // setup so default registration, settings normalization, and the initial
+    // empty-state populate run exactly once per view instance instead of per commit.
+    @State private var didCompleteInitialBrowserPanelSetup = false
     @State private var browserChromeStyle = BrowserChromeStyle.resolve(
         for: .light,
         themeBackgroundColor: GhosttyBackgroundTheme.currentColor()
@@ -755,7 +760,45 @@ struct BrowserPanelView: View {
     }
 
     private func handleBrowserPanelAppear() {
+        // One-time setup must not re-run on every commit; `.onAppear` can re-fire
+        // repeatedly for a portal-hosted pane (issue #5303). Everything below the
+        // setup call is idempotent and cheap, and genuine state transitions are
+        // already handled by the dedicated `.onChange` observers on `body`, so
+        // re-running this per appear is harmless once the heavy/one-time work is
+        // gated out.
+        performInitialBrowserPanelSetupIfNeeded()
         startOmnibarSuggestionRefreshConsumer()
+        refreshBrowserChromeStyle()
+        panel.noteWebViewVisibility(
+            isVisibleInUI && isCurrentPaneOwner,
+            reason: "view.onAppear"
+        )
+        panel.refreshAppearanceDrivenColors()
+        panel.setBrowserThemeMode(browserThemeMode)
+        applyPendingAddressBarFocusRequestIfNeeded()
+        syncURLFromPanel()
+        // If the browser surface is focused but has no URL loaded yet, auto-focus the omnibar.
+        autoFocusOmnibarIfBlank()
+        syncWebViewResponderPolicyWithViewState(reason: "onAppear")
+        panel.historyStore.loadIfNeeded()
+#if DEBUG
+        logBrowserFocusState(event: "view.onAppear")
+#endif
+        focusModeShortcutHintMonitor.start()
+    }
+
+    /// Runs the work that must execute exactly once per `BrowserPanelView` instance,
+    /// independent of how many times SwiftUI fires `.onAppear`.
+    ///
+    /// `.onAppear` is not a reliable once-or-on-transition signal for a portal-hosted
+    /// browser pane — it can re-fire on every CoreAnimation commit. Default
+    /// registration, settings normalization (which writes `@AppStorage` and would
+    /// otherwise re-enter the commit pass), and the initial empty-state import
+    /// populate all belong here so a spurious appear does no work (issue #5303).
+    private func performInitialBrowserPanelSetupIfNeeded() {
+        guard !didCompleteInitialBrowserPanelSetup else { return }
+        didCompleteInitialBrowserPanelSetup = true
+
         UserDefaults.standard.register(defaults: [
             BrowserSearchSettings.searchEngineKey: BrowserSearchSettings.defaultSearchEngine.rawValue,
             BrowserSearchSettings.customSearchEngineNameKey: BrowserSearchSettings.defaultCustomSearchEngineName,
@@ -766,7 +809,7 @@ struct BrowserPanelView: View {
             BrowserProfilePopoverDebugSettings.verticalPaddingKey: BrowserProfilePopoverDebugSettings.defaultVerticalPadding,
             BrowserThemeSettings.modeKey: BrowserThemeSettings.defaultMode.rawValue,
         ])
-        refreshBrowserChromeStyle()
+
         let resolvedThemeMode = BrowserThemeSettings.mode(defaults: .standard)
         if browserThemeModeRaw != resolvedThemeMode.rawValue {
             browserThemeModeRaw = resolvedThemeMode.rawValue
@@ -787,23 +830,10 @@ struct BrowserPanelView: View {
         if browserProfilePopoverVerticalPaddingRaw != resolvedProfilePopoverVerticalPadding {
             browserProfilePopoverVerticalPaddingRaw = resolvedProfilePopoverVerticalPadding
         }
-        panel.noteWebViewVisibility(
-            isVisibleInUI && isCurrentPaneOwner,
-            reason: "view.onAppear"
-        )
-        panel.refreshAppearanceDrivenColors()
-        panel.setBrowserThemeMode(browserThemeMode)
-        applyPendingAddressBarFocusRequestIfNeeded()
-        syncURLFromPanel()
-        // If the browser surface is focused but has no URL loaded yet, auto-focus the omnibar.
-        autoFocusOmnibarIfBlank()
-        syncWebViewResponderPolicyWithViewState(reason: "onAppear")
+
+        // Populate the empty-state import list once; `handleCurrentURLChange`
+        // refreshes it on subsequent new-tab navigations.
         refreshEmptyStateImportBrowsers()
-        panel.historyStore.loadIfNeeded()
-#if DEBUG
-        logBrowserFocusState(event: "view.onAppear")
-#endif
-        focusModeShortcutHintMonitor.start()
     }
 
     private func handleOmnibarVisibilityChange(_ isVisible: Bool) {

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -794,7 +794,7 @@ struct BrowserPanelView: View {
     /// `.onAppear` is not a reliable once-or-on-transition signal for a portal-hosted
     /// browser pane — it can re-fire on every CoreAnimation commit (issue #5303).
     /// Default registration and settings normalization are app-once work and live in
-    /// ``BrowserPanel/bootstrapBrowserDefaultsIfNeeded(defaults:)`` (run from the model
+    /// ``BrowserPanel/bootstrapBrowserDefaultsIfNeeded()`` (run from the model
     /// init), not here. This method only seeds view-local state: the initial
     /// empty-state import list, which `handleCurrentURLChange` refreshes on subsequent
     /// new-tab navigations.

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -460,9 +460,9 @@ struct BrowserPanelView: View {
     @State private var isBrowserProfileMenuPresented = false
     @State private var isBrowserThemeMenuPresented = false
     // `.onAppear` is not a reliable once-signal for a portal-hosted pane: it can
-    // re-fire on every CoreAnimation commit (issue #5303). This guards the one-time
-    // setup so default registration, settings normalization, and the initial
-    // empty-state populate run exactly once per view instance instead of per commit.
+    // re-fire on every CoreAnimation commit (issue #5303). This guards the first-
+    // appearance view-state seed (the empty-state import list) so a spurious appear
+    // does no work. App-once settings work lives in the model bootstrap, not here.
     @State private var didCompleteInitialBrowserPanelSetup = false
     @State private var browserChromeStyle = BrowserChromeStyle.resolve(
         for: .light,
@@ -787,52 +787,20 @@ struct BrowserPanelView: View {
         focusModeShortcutHintMonitor.start()
     }
 
-    /// Runs the work that must execute exactly once per `BrowserPanelView` instance,
-    /// independent of how many times SwiftUI fires `.onAppear`.
+    /// Runs the view-state initialization that should happen on first appearance,
+    /// independent of how many times SwiftUI fires `.onAppear` for the same view
+    /// instance.
     ///
     /// `.onAppear` is not a reliable once-or-on-transition signal for a portal-hosted
-    /// browser pane — it can re-fire on every CoreAnimation commit. Default
-    /// registration, settings normalization (which writes `@AppStorage` and would
-    /// otherwise re-enter the commit pass), and the initial empty-state import
-    /// populate all belong here so a spurious appear does no work (issue #5303).
+    /// browser pane — it can re-fire on every CoreAnimation commit (issue #5303).
+    /// Default registration and settings normalization are app-once work and live in
+    /// ``BrowserPanel/bootstrapBrowserDefaultsIfNeeded(defaults:)`` (run from the model
+    /// init), not here. This method only seeds view-local state: the initial
+    /// empty-state import list, which `handleCurrentURLChange` refreshes on subsequent
+    /// new-tab navigations.
     private func performInitialBrowserPanelSetupIfNeeded() {
         guard !didCompleteInitialBrowserPanelSetup else { return }
         didCompleteInitialBrowserPanelSetup = true
-
-        UserDefaults.standard.register(defaults: [
-            BrowserSearchSettings.searchEngineKey: BrowserSearchSettings.defaultSearchEngine.rawValue,
-            BrowserSearchSettings.customSearchEngineNameKey: BrowserSearchSettings.defaultCustomSearchEngineName,
-            BrowserSearchSettings.customSearchEngineURLTemplateKey: BrowserSearchSettings.defaultCustomSearchEngineURLTemplate,
-            BrowserSearchSettings.searchSuggestionsEnabledKey: BrowserSearchSettings.defaultSearchSuggestionsEnabled,
-            BrowserToolbarAccessorySpacingDebugSettings.key: BrowserToolbarAccessorySpacingDebugSettings.defaultSpacing,
-            BrowserProfilePopoverDebugSettings.horizontalPaddingKey: BrowserProfilePopoverDebugSettings.defaultHorizontalPadding,
-            BrowserProfilePopoverDebugSettings.verticalPaddingKey: BrowserProfilePopoverDebugSettings.defaultVerticalPadding,
-            BrowserThemeSettings.modeKey: BrowserThemeSettings.defaultMode.rawValue,
-        ])
-
-        let resolvedThemeMode = BrowserThemeSettings.mode(defaults: .standard)
-        if browserThemeModeRaw != resolvedThemeMode.rawValue {
-            browserThemeModeRaw = resolvedThemeMode.rawValue
-        }
-        let resolvedHintVariant = BrowserImportHintSettings.variant(for: browserImportHintVariantRaw)
-        if browserImportHintVariantRaw != resolvedHintVariant.rawValue {
-            browserImportHintVariantRaw = resolvedHintVariant.rawValue
-        }
-        let resolvedToolbarAccessorySpacing = BrowserToolbarAccessorySpacingDebugSettings.resolved(browserToolbarAccessorySpacingRaw)
-        if browserToolbarAccessorySpacingRaw != resolvedToolbarAccessorySpacing {
-            browserToolbarAccessorySpacingRaw = resolvedToolbarAccessorySpacing
-        }
-        let resolvedProfilePopoverHorizontalPadding = BrowserProfilePopoverDebugSettings.resolvedHorizontalPadding(browserProfilePopoverHorizontalPaddingRaw)
-        if browserProfilePopoverHorizontalPaddingRaw != resolvedProfilePopoverHorizontalPadding {
-            browserProfilePopoverHorizontalPaddingRaw = resolvedProfilePopoverHorizontalPadding
-        }
-        let resolvedProfilePopoverVerticalPadding = BrowserProfilePopoverDebugSettings.resolvedVerticalPadding(browserProfilePopoverVerticalPaddingRaw)
-        if browserProfilePopoverVerticalPaddingRaw != resolvedProfilePopoverVerticalPadding {
-            browserProfilePopoverVerticalPaddingRaw = resolvedProfilePopoverVerticalPadding
-        }
-
-        // Populate the empty-state import list once; `handleCurrentURLChange`
-        // refreshes it on subsequent new-tab navigations.
         refreshEmptyStateImportBrowsers()
     }
 

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -2205,6 +2205,57 @@ final class BrowserPanelWebViewLifecycleTests: XCTestCase {
         XCTAssertEqual(panel.webViewLifecycleState, .liveVisible)
     }
 
+    /// Regression guard for the issue #5303 render loop: `BrowserPanelView.onAppear`
+    /// re-fired on every CoreAnimation commit and re-asserted webview visibility,
+    /// which restored + re-navigated the webview repeatedly. Once the webview is live
+    /// and visible, redundant visibility notifications (the shape a spurious appear
+    /// produces) must be no-ops: no lifecycle churn and no webview replacement, so no
+    /// re-navigation is issued.
+    func testRedundantVisibleNotificationsDoNotChurnLiveWebView() {
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            initialURL: URL(string: "about:blank")!,
+            isRemoteWorkspace: false
+        )
+        defer { panel.close() }
+
+        let deadline = Date().addingTimeInterval(1.0)
+        while panel.webView.isLoading,
+              RunLoop.main.run(mode: .default, before: deadline),
+              Date() < deadline {}
+
+        panel.noteWebViewVisibility(true, reason: "test.visible.first")
+        XCTAssertEqual(panel.webViewLifecycleState, .liveVisible)
+
+        let webViewAfterFirst = panel.webView
+        let instanceIDAfterFirst = panel.webViewInstanceID
+        let reasonAfterFirst = panel.webViewLastVisibilityChangeReason
+        let changeAtAfterFirst = panel.webViewLastVisibilityChangeAt
+
+        var observedStates: [BrowserWebViewLifecycleState] = []
+        var cancellable: AnyCancellable?
+        cancellable = panel.$webViewLifecycleState.dropFirst().sink { state in
+            observedStates.append(state)
+        }
+        defer { cancellable?.cancel() }
+
+        // Simulate `.onAppear` re-firing many times in one commit storm.
+        for index in 0..<32 {
+            panel.noteWebViewVisibility(true, reason: "test.visible.spurious-\(index)")
+        }
+
+        XCTAssertEqual(panel.webViewLifecycleState, .liveVisible)
+        XCTAssertTrue(observedStates.isEmpty, "Redundant visible notes churned lifecycle: \(observedStates)")
+        XCTAssertTrue(panel.webView === webViewAfterFirst, "A live webview must not be replaced by redundant visibility notes")
+        XCTAssertEqual(panel.webViewInstanceID, instanceIDAfterFirst)
+        XCTAssertEqual(
+            panel.webViewLastVisibilityChangeReason,
+            reasonAfterFirst,
+            "Redundant visible notes must early-return without recording a new transition"
+        )
+        XCTAssertEqual(panel.webViewLastVisibilityChangeAt, changeAtAfterFirst)
+    }
+
     func testRestoredHistoryBackDoesNotEmitNewTabLifecycleState() {
         let discardedAt = Date(timeIntervalSince1970: 300)
         let panel = BrowserPanel(

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -2336,12 +2336,16 @@ final class BrowserDefaultsNormalizationTests: XCTestCase {
         defer { defaults.removePersistentDomain(forName: suiteName) }
 
         let validSpacing = BrowserToolbarAccessorySpacingDebugSettings.supportedValues.last ?? BrowserToolbarAccessorySpacingDebugSettings.defaultSpacing
-        defaults.set(BrowserThemeMode.dark.rawValue, forKey: BrowserThemeSettings.modeKey)
+        // Resolve the app-target theme mode via the app-only settings type; the bare
+        // `BrowserThemeMode` is ambiguous here because this file also imports
+        // `CmuxSettings`, which declares a same-named enum.
+        let validThemeRaw = BrowserThemeSettings.mode(for: "dark").rawValue
+        defaults.set(validThemeRaw, forKey: BrowserThemeSettings.modeKey)
         defaults.set(validSpacing, forKey: BrowserToolbarAccessorySpacingDebugSettings.key)
 
         BrowserPanel.normalizeBrowserDefaults(defaults: defaults)
 
-        XCTAssertEqual(defaults.string(forKey: BrowserThemeSettings.modeKey), BrowserThemeMode.dark.rawValue)
+        XCTAssertEqual(defaults.string(forKey: BrowserThemeSettings.modeKey), validThemeRaw)
         XCTAssertEqual(defaults.integer(forKey: BrowserToolbarAccessorySpacingDebugSettings.key), validSpacing)
     }
 }

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -2223,6 +2223,7 @@ final class BrowserPanelWebViewLifecycleTests: XCTestCase {
         while panel.webView.isLoading,
               RunLoop.main.run(mode: .default, before: deadline),
               Date() < deadline {}
+        XCTAssertFalse(panel.webView.isLoading, "Timed out waiting for about:blank to finish loading")
 
         panel.noteWebViewVisibility(true, reason: "test.visible.first")
         XCTAssertEqual(panel.webViewLifecycleState, .liveVisible)
@@ -2293,6 +2294,55 @@ final class BrowserPanelWebViewLifecycleTests: XCTestCase {
 
         XCTAssertFalse(observedStates.contains(.newTab), "Back restore emitted unexpected states: \(observedStates)")
         XCTAssertEqual(panel.webViewLifecycleState, .liveHidden)
+    }
+}
+
+@MainActor
+final class BrowserDefaultsNormalizationTests: XCTestCase {
+    /// Moving default registration + settings normalization out of
+    /// `BrowserPanelView.onAppear` into the model bootstrap (issue #5303) keeps the
+    /// canonicalization behavior: an out-of-range or legacy raw value stored in
+    /// defaults is rewritten to its canonical form, and registered fallbacks are
+    /// available for unset keys.
+    func testNormalizeRewritesOutOfRangeAndLegacyValues() throws {
+        let suiteName = "cmux.browserDefaultsNormalizationTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        // Out-of-range / invalid raw values that must be canonicalized.
+        defaults.set("not-a-real-mode", forKey: BrowserThemeSettings.modeKey)
+        defaults.set("not-a-real-variant", forKey: BrowserImportHintSettings.variantKey)
+        defaults.set(999, forKey: BrowserToolbarAccessorySpacingDebugSettings.key)
+        defaults.set(999.0, forKey: BrowserProfilePopoverDebugSettings.horizontalPaddingKey)
+        defaults.set(-5.0, forKey: BrowserProfilePopoverDebugSettings.verticalPaddingKey)
+
+        BrowserPanel.normalizeBrowserDefaults(defaults: defaults)
+
+        XCTAssertEqual(defaults.string(forKey: BrowserThemeSettings.modeKey), BrowserThemeSettings.defaultMode.rawValue)
+        XCTAssertEqual(defaults.string(forKey: BrowserImportHintSettings.variantKey), BrowserImportHintSettings.defaultVariant.rawValue)
+        XCTAssertEqual(defaults.integer(forKey: BrowserToolbarAccessorySpacingDebugSettings.key), BrowserToolbarAccessorySpacingDebugSettings.defaultSpacing)
+        XCTAssertEqual(defaults.double(forKey: BrowserProfilePopoverDebugSettings.horizontalPaddingKey), BrowserProfilePopoverDebugSettings.defaultHorizontalPadding, accuracy: 0.0001)
+        XCTAssertEqual(defaults.double(forKey: BrowserProfilePopoverDebugSettings.verticalPaddingKey), BrowserProfilePopoverDebugSettings.defaultVerticalPadding, accuracy: 0.0001)
+
+        // Registered fallbacks are available for keys that were never set.
+        XCTAssertEqual(defaults.string(forKey: BrowserSearchSettings.searchEngineKey), BrowserSearchSettings.defaultSearchEngine.rawValue)
+    }
+
+    /// Already-canonical, in-range values must be left untouched (no clobbering of
+    /// valid user settings during normalization).
+    func testNormalizePreservesValidValues() throws {
+        let suiteName = "cmux.browserDefaultsNormalizationTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let validSpacing = BrowserToolbarAccessorySpacingDebugSettings.supportedValues.last ?? BrowserToolbarAccessorySpacingDebugSettings.defaultSpacing
+        defaults.set(BrowserThemeMode.dark.rawValue, forKey: BrowserThemeSettings.modeKey)
+        defaults.set(validSpacing, forKey: BrowserToolbarAccessorySpacingDebugSettings.key)
+
+        BrowserPanel.normalizeBrowserDefaults(defaults: defaults)
+
+        XCTAssertEqual(defaults.string(forKey: BrowserThemeSettings.modeKey), BrowserThemeMode.dark.rawValue)
+        XCTAssertEqual(defaults.integer(forKey: BrowserToolbarAccessorySpacingDebugSettings.key), validSpacing)
     }
 }
 


### PR DESCRIPTION
Fixes #5303.

## Problem

A live 3-second `sample` of production cmux showed the **main thread spending ~39% of on-CPU time** re-evaluating `BrowserPanelView.body` and re-running `handleBrowserPanelAppear()` inside CoreAnimation commit handlers. For the portal-hosted browser pane, `.onAppear` re-fires on essentially every `CA::Transaction::commit`, and `handleBrowserPanelAppear()` was doing **process-once work on every call**:

- `UserDefaults.standard.register(defaults:)` — re-registering the whole defaults dictionary every commit.
- Five settings-normalization blocks that **write `@AppStorage`** (theme mode, import-hint variant, toolbar spacing, two profile-popover paddings) — writing state during the commit pass, which feeds SwiftUI invalidation.
- `refreshEmptyStateImportBrowsers()` — cancelling and respawning a detached browser-detection `Task` every commit.

In addition, the repeated visibility re-assertion drove `noteWebViewVisibility → restoreDiscardedWebViewIfNeeded → performNavigation → browserLoadRequest`, re-navigating the WKWebView and churning the WebContent helper process (a plausible engine for the leak in #5302).

## Root cause

`.onAppear` is being treated as a "run once / on transition" signal, but it is not reliable for a portal-hosted pane — it re-fires every commit. Doing one-time setup and `@AppStorage` writes in that path makes every spurious appear expensive and re-entrant.

## Fix

Move the one-time work to where it belongs and gate the rest:

- **Process-once settings work moved to the model.** `UserDefaults.register(defaults:)` and the five settings-normalization writes now live in `BrowserPanel.normalizeBrowserDefaults(defaults:)`, run once per process via `BrowserPanel.bootstrapBrowserDefaultsIfNeeded()` from `BrowserPanel.init`. The process-scoped guard survives view remounts (a view-scoped flag would reset on identity change), and the injected `UserDefaults` makes the normalization unit-testable.
- **View-local first-appear seed gated by `@State`.** `performInitialBrowserPanelSetupIfNeeded()` runs at most once per `BrowserPanelView` instance and only seeds view-local state (the empty-state import list).
- `handleBrowserPanelAppear()` keeps only cheap, already-idempotent calls. Genuine state transitions (visibility, focus, URL, omnibar, profile, color scheme) are independently handled by the dedicated `.onChange` observers on `body`, so re-running the slim per-appear path is harmless.

This removes the heavy per-commit work **and** the `@AppStorage`-write-during-commit invalidation edge, eliminating the whole class of "appear re-fires every commit → re-does one-time setup / re-writes state / re-navigates the webview." A live webview is no longer restored and re-navigated by redundant appears (`restoreDiscardedWebViewIfNeeded` already guards on `isDiscardedForMemory`, and `noteWebViewVisibility` early-returns when visibility is unchanged).

## Verification

- **Mechanism confirmed in code** against the issue's live `sample` call tree.
- After a build, the fix is verifiable by opening a browser pane and running `sample <cmux-pid> 3`: the `BrowserPanelView.body` / `handleBrowserPanelAppear` / `browserLoadRequest` frames under `CA::Transaction::commit` should be gone and main-thread CPU should drop.

## Tests

Adds `testRedundantVisibleNotificationsDoNotChurnLiveWebView` to `BrowserPanelWebViewLifecycleTests`: once a webview is live and visible, 32 redundant `noteWebViewVisibility(true, …)` calls (the shape a spurious appear produces) must not churn lifecycle, replace the webview, or record a new transition — so no re-navigation is issued.

Adds `BrowserDefaultsNormalizationTests`: against a scratch `UserDefaults(suiteName:)`, out-of-range/legacy stored values are rewritten to canonical form, registered fallbacks are available for unset keys, and already-valid values are left untouched.

Related performance evidence: https://github.com/manaflow-ai/cmux/issues/5305 (tracking audit; this PR removes the render-loop CPU engine documented there).

The view-level run-once gating itself is not cleanly unit-testable without SwiftUI hosting in the unit target, so there is no red-first commit for that piece; it is verified via the issue's sample and the behavioral guard above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5311"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783112063&installation_id=133855650&pr_number=5311&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5311&signature=adaaaf67ef43d1083644d6a1728e8ab9898eb7ab86e62fa4d8b1cbf1b7bee49e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches hot-path browser panel lifecycle and UserDefaults on every panel init, but behavior is narrowed to idempotent normalization and existing visibility early-returns; regression coverage was added.
> 
> **Overview**
> Fixes **#5303** by stopping portal-hosted `BrowserPanelView` from treating every repeated `.onAppear` (CoreAnimation commits) as first-time setup.
> 
> **Process-once work** moves out of `handleBrowserPanelAppear()`: `UserDefaults` fallback registration and canonicalization of legacy/out-of-range browser settings now run via `BrowserPanel.bootstrapBrowserDefaultsIfNeeded()` / `normalizeBrowserDefaults(defaults:)` from **`BrowserPanel` init**, guarded once per process. The view no longer re-registers defaults or re-syncs theme/import-hint/toolbar/profile debug keys on each appear (removing `@AppStorage`-write-driven invalidation during commits).
> 
> **View-once work** is limited to `performInitialBrowserPanelSetupIfNeeded()` with `didCompleteInitialBrowserPanelSetup`, which only seeds the empty-state import browser list; per-appear handling keeps idempotent visibility/chrome/focus/history calls.
> 
> **Tests** add `BrowserDefaultsNormalizationTests` (scratch `UserDefaults`) and `testRedundantVisibleNotificationsDoNotChurnLiveWebView` to ensure redundant `noteWebViewVisibility(true, …)` does not replace the live `WKWebView` or churn lifecycle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dfefa4745a487f919d9404f9fec59b42284f726. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the browser panel from re-running one-time setup on every CoreAnimation commit, fixing #5303. Defaults registration and settings normalization now run once per process in the model; the view’s appear path stays light, avoiding render-loop churn and redundant `WKWebView` navigation.

- Bug Fixes
  - Moved browser defaults/bootstrap to a process-once model init (`bootstrapBrowserDefaultsIfNeeded()`), which now always targets `UserDefaults.standard`; normalization remains in `normalizeBrowserDefaults(defaults:)` for unit tests.
  - Limited the view’s run-once guard to seeding the initial empty-state import list; `.onAppear` now does only cheap, idempotent work.
  - Added tests: `BrowserDefaultsNormalizationTests` and `testRedundantVisibleNotificationsDoNotChurnLiveWebView`; fixed test build by disambiguating the `BrowserThemeMode` enum in the normalization test.

<sup>Written for commit 5dfefa4745a487f919d9404f9fec59b42284f726. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented redundant WebView recreation when the browser panel re-appears.
  * Ensured browser preferences are initialized and normalized once per launch to correct legacy or out-of-range values.
  * Added a view-level one-time guard to avoid repeated initial-appearance work for portal-hosted panes.

* **Tests**
  * Added tests verifying visibility notifications no longer churn WebView lifecycle.
  * Added tests for defaults normalization and preservation of valid values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
