### PR TITLE
[codex] Fix sidebar background backdrop toggles

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -3384,24 +3384,8 @@ struct ContentView: View {
                 AppDelegate.shared?.updateLog.append("ui test window accessor: id=\(windowIdentifier) visible=\(window.isVisible)")
             }
 #endif
-            let backdropResult = WindowBackdropController.apply(plan: backdropPlan, to: window)
-            if backdropResult.didChangeGlassRoot {
-                let tmuxOverlayState = tmuxWorkspacePaneWindowOverlayState(for: window)
-                tmuxWorkspacePaneWindowOverlayController(for: window, createIfNeeded: tmuxOverlayState != nil)?.update(state: tmuxOverlayState)
-                commandPaletteWindowOverlayController(for: window)
-                    .update(isVisible: isCommandPalettePresented) { AnyView(commandPaletteOverlay) }
-                TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronize(for: window)
-                BrowserWindowPortalRegistry.scheduleExternalGeometrySynchronize(for: window)
-            }
             AppDelegate.shared?.attachUpdateAccessory(to: window)
             AppDelegate.shared?.applyWindowDecorations(to: window)
-            // Let cmux supply the translucent titlebar fills. AppKit's native
-            // material otherwise blends a lighter strip over the terminal area.
-            syncNativeTitlebarBackdrop(
-                in: window,
-                enabled: true,
-                usesGlassStyle: backdropResult.usesWindowGlass
-            )
             AppDelegate.shared?.registerMainWindow(
                 window,
                 windowId: windowId,
@@ -3412,6 +3396,23 @@ struct ContentView: View {
                 cmuxConfigStore: cmuxConfigStore
             )
             installFileDropOverlayWhenReady(on: window, tabManager: tabManager)
+            WindowBackdropApplyScheduler.schedule(plan: backdropPlan, to: window, completion: { backdropResult in
+                if backdropResult.didChangeGlassRoot {
+                    let tmuxOverlayState = tmuxWorkspacePaneWindowOverlayState(for: window)
+                    tmuxWorkspacePaneWindowOverlayController(for: window, createIfNeeded: tmuxOverlayState != nil)?.update(state: tmuxOverlayState)
+                    commandPaletteWindowOverlayController(for: window)
+                        .update(isVisible: isCommandPalettePresented) { AnyView(commandPaletteOverlay) }
+                    TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronize(for: window)
+                    BrowserWindowPortalRegistry.scheduleExternalGeometrySynchronize(for: window)
+                }
+                // Let cmux supply the translucent titlebar fills. AppKit's native
+                // material otherwise blends a lighter strip over the terminal area.
+                syncNativeTitlebarBackdrop(
+                    in: window,
+                    enabled: true,
+                    usesGlassStyle: backdropResult.usesWindowGlass
+                )
+            })
         }))
 
         return AnyView(view.cmuxAppearanceColorScheme(appearanceMode))

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -4960,11 +4960,12 @@ class GhosttyApp {
         }
     }
 
+    @MainActor
     private func applyBackgroundToKeyWindow() {
         guard let window = activeMainWindow() else { return }
         let snapshot = WindowAppearanceSnapshot.currentFromUserDefaults(app: self)
         let plan = snapshot.backdropPlan()
-        _ = WindowBackdropController.apply(plan: plan, to: window)
+        WindowBackdropApplyScheduler.schedule(plan: plan, to: window)
         if backgroundLogEnabled {
             logBackground(
                 "applied window backdrop phase=\(plan.hostingPhase.rawValue) opacity=\(String(format: "%.3f", defaultBackgroundOpacity)) blur=\(defaultBackgroundBlur)"
@@ -7808,7 +7809,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             .currentFromUserDefaults(app: GhosttyApp.shared)
             .replacingTerminalBackgroundColor(backgroundColor ?? GhosttyApp.shared.defaultBackgroundColor)
         let plan = snapshot.backdropPlan()
-        _ = WindowBackdropController.apply(plan: plan, to: window)
+        WindowBackdropApplyScheduler.schedule(plan: plan, to: window)
         if GhosttyApp.shared.backgroundLogEnabled {
             let signature = "\(plan.hostingPhase.rawValue):\(color.hexString()):\(String(format: "%.3f", color.alphaComponent)):\(GhosttyApp.shared.defaultBackgroundBlur)"
             if signature != lastLoggedWindowBackgroundSignature {

--- a/Sources/Windowing/WindowBackdropApplyScheduler.swift
+++ b/Sources/Windowing/WindowBackdropApplyScheduler.swift
@@ -1,0 +1,97 @@
+import AppKit
+import ObjectiveC
+
+@MainActor
+enum WindowBackdropApplyScheduler {
+    typealias ApplyHandler = (WindowBackdropPlan, NSWindow) -> WindowBackdropApplicationResult
+    typealias Completion = (WindowBackdropApplicationResult) -> Void
+    typealias Enqueue = (@escaping () -> Void) -> Void
+
+    @discardableResult
+    static func schedule(
+        plan: WindowBackdropPlan,
+        to window: NSWindow,
+        enqueue: Enqueue? = nil,
+        apply: @escaping ApplyHandler = WindowBackdropController.apply(plan:to:),
+        completion: Completion? = nil
+    ) -> Bool {
+        let existingState = state(for: window)
+        let mutationID = plan.appKitMutationID
+        guard existingState.lastAppliedMutationID != mutationID || existingState.pendingMutationID != nil else {
+            return false
+        }
+
+        existingState.generation += 1
+        let generation = existingState.generation
+        existingState.pendingMutationID = mutationID
+        existingState.pendingCompletion = completion
+
+        if let enqueue {
+            enqueue { [weak window] in
+                MainActor.assumeIsolated {
+                    applyPending(
+                        plan: plan,
+                        to: window,
+                        mutationID: mutationID,
+                        generation: generation,
+                        apply: apply
+                    )
+                }
+            }
+        } else {
+            DispatchQueue.main.async { [weak window] in
+                MainActor.assumeIsolated {
+                    applyPending(
+                        plan: plan,
+                        to: window,
+                        mutationID: mutationID,
+                        generation: generation,
+                        apply: apply
+                    )
+                }
+            }
+        }
+
+        return true
+    }
+
+    private static func applyPending(
+        plan: WindowBackdropPlan,
+        to window: NSWindow?,
+        mutationID: String,
+        generation: Int,
+        apply: ApplyHandler
+    ) {
+        guard let window else { return }
+        let currentState = state(for: window)
+        guard currentState.generation == generation,
+              currentState.pendingMutationID == mutationID else {
+            return
+        }
+
+        let result = apply(plan, window)
+        currentState.lastAppliedMutationID = mutationID
+        currentState.pendingMutationID = nil
+        let completion = currentState.pendingCompletion
+        currentState.pendingCompletion = nil
+        completion?(result)
+    }
+
+    private static func state(for window: NSWindow) -> State {
+        if let state = objc_getAssociatedObject(window, &stateKey) as? State {
+            return state
+        }
+        let state = State()
+        objc_setAssociatedObject(window, &stateKey, state, .OBJC_ASSOCIATION_RETAIN)
+        return state
+    }
+
+    private final class State: NSObject {
+        var generation = 0
+        var lastAppliedMutationID: String?
+        var pendingMutationID: String?
+        var pendingCompletion: Completion?
+    }
+}
+
+private var stateKey: UInt8 = 0

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -551,6 +551,7 @@
 		063BC42CEE257D6213A2E30C /* WindowAndDragTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEE83F8394D90ACACD8E19DD /* WindowAndDragTests.swift */; };
 		A5001700A1B2C3D4E5F60718 /* WindowAppearanceSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001701A1B2C3D4E5F60718 /* WindowAppearanceSnapshot.swift */; };
 		F4200000A1B2C3D4E5F60718 /* WindowAppearanceSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4200001A1B2C3D4E5F60718 /* WindowAppearanceSnapshotTests.swift */; };
+		A5001900A1B2C3D4E5F60718 /* WindowBackdropApplyScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001901A1B2C3D4E5F60718 /* WindowBackdropApplyScheduler.swift */; };
 		A5001800A1B2C3D4E5F60718 /* WindowBackdropController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001801A1B2C3D4E5F60718 /* WindowBackdropController.swift */; };
 		B7F9A602B7F9A602B7F9A602 /* WindowChromeMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7F9A603B7F9A603B7F9A603 /* WindowChromeMetrics.swift */; };
 		A5001240 /* WindowDecorationsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001241 /* WindowDecorationsController.swift */; };
@@ -1175,6 +1176,7 @@
 		BEE83F8394D90ACACD8E19DD /* WindowAndDragTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowAndDragTests.swift; sourceTree = "<group>"; };
 		A5001701A1B2C3D4E5F60718 /* WindowAppearanceSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Windowing/WindowAppearanceSnapshot.swift; sourceTree = "<group>"; };
 		F4200001A1B2C3D4E5F60718 /* WindowAppearanceSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowAppearanceSnapshotTests.swift; sourceTree = "<group>"; };
+		A5001901A1B2C3D4E5F60718 /* WindowBackdropApplyScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Windowing/WindowBackdropApplyScheduler.swift; sourceTree = "<group>"; };
 		A5001801A1B2C3D4E5F60718 /* WindowBackdropController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Windowing/WindowBackdropController.swift; sourceTree = "<group>"; };
 		B7F9A603B7F9A603B7F9A603 /* WindowChromeMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowChromeMetrics.swift; sourceTree = "<group>"; };
 		A5001241 /* WindowDecorationsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowDecorationsController.swift; sourceTree = "<group>"; };
@@ -1475,6 +1477,7 @@
 				A080D1F6CCCBFBED8D95DD1D /* ShortcutHintPill.swift */,
 				0B54144FA244A0B482D2903D /* WindowGlassEffect.swift */,
 				A5001701A1B2C3D4E5F60718 /* WindowAppearanceSnapshot.swift */,
+				A5001901A1B2C3D4E5F60718 /* WindowBackdropApplyScheduler.swift */,
 				A5001801A1B2C3D4E5F60718 /* WindowBackdropController.swift */,
 				D1614EAD3CCF70A177A51BD1 /* SidebarState.swift */,
 				38A09EB2E92203B2E95923A7 /* CommandPaletteSearch.swift */,
@@ -2574,6 +2577,7 @@
 				ACE4FE2A8F1CC6C0B6A673AB /* VMClientSocketCommands.swift in Sources */,
 				A500120C /* WindowAccessor.swift in Sources */,
 				A5001700A1B2C3D4E5F60718 /* WindowAppearanceSnapshot.swift in Sources */,
+				A5001900A1B2C3D4E5F60718 /* WindowBackdropApplyScheduler.swift in Sources */,
 				A5001800A1B2C3D4E5F60718 /* WindowBackdropController.swift in Sources */,
 				B7F9A602B7F9A602B7F9A602 /* WindowChromeMetrics.swift in Sources */,
 				A5001240 /* WindowDecorationsController.swift in Sources */,

--- a/cmuxTests/WindowAppearanceSnapshotTests.swift
+++ b/cmuxTests/WindowAppearanceSnapshotTests.swift
@@ -114,6 +114,80 @@ final class WindowAppearanceSnapshotTests: XCTestCase {
         )
     }
 
+    @MainActor
+    func testRapidWindowBackdropSchedulesOnlyApplyLatestPlan() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 640, height: 420),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        let firstPlan = makeSnapshot(
+            unifySurfaceBackdrops: true,
+            backgroundHex: "#101820",
+            backgroundOpacity: 0.6
+        ).backdropPlan(glassEffectAvailable: false)
+        let latestPlan = makeSnapshot(
+            unifySurfaceBackdrops: false,
+            backgroundHex: "#F8F8F2",
+            backgroundOpacity: 1.0
+        ).backdropPlan(glassEffectAvailable: false)
+        var queued: [() -> Void] = []
+        var appliedMutationIDs: [String] = []
+        var completionMutationIDs: [String] = []
+
+        let firstScheduled = WindowBackdropApplyScheduler.schedule(
+            plan: firstPlan,
+            to: window,
+            enqueue: { queued.append($0) },
+            apply: { plan, _ in
+                appliedMutationIDs.append(plan.appKitMutationID)
+                return WindowBackdropApplicationResult(
+                    didChangeGlassRoot: false,
+                    usesWindowGlass: plan.usesWindowGlass
+                )
+            },
+            completion: { _ in completionMutationIDs.append(firstPlan.appKitMutationID) }
+        )
+        let latestScheduled = WindowBackdropApplyScheduler.schedule(
+            plan: latestPlan,
+            to: window,
+            enqueue: { queued.append($0) },
+            apply: { plan, _ in
+                appliedMutationIDs.append(plan.appKitMutationID)
+                return WindowBackdropApplicationResult(
+                    didChangeGlassRoot: false,
+                    usesWindowGlass: plan.usesWindowGlass
+                )
+            },
+            completion: { _ in completionMutationIDs.append(latestPlan.appKitMutationID) }
+        )
+
+        XCTAssertTrue(firstScheduled)
+        XCTAssertTrue(latestScheduled)
+        XCTAssertEqual(queued.count, 2)
+        XCTAssertTrue(appliedMutationIDs.isEmpty)
+
+        queued.forEach { $0() }
+
+        XCTAssertEqual(appliedMutationIDs, [latestPlan.appKitMutationID])
+        XCTAssertEqual(completionMutationIDs, [latestPlan.appKitMutationID])
+        XCTAssertFalse(
+            WindowBackdropApplyScheduler.schedule(
+                plan: latestPlan,
+                to: window,
+                enqueue: { queued.append($0) },
+                apply: { plan, _ in
+                    appliedMutationIDs.append(plan.appKitMutationID)
+                    return WindowBackdropApplicationResult(
+                        didChangeGlassRoot: false,
+                        usesWindowGlass: plan.usesWindowGlass
+                    )
+                }
+            )
+        )
+    }
+
     func testChromeColorSchemeFollowsTerminalBackground() {
         XCTAssertEqual(
             makeSnapshot(unifySurfaceBackdrops: true, backgroundHex: "#F8F8F2").chromeColorScheme,


### PR DESCRIPTION
## Summary

Fixes #5245.

- Coalesce per-window backdrop applications through `WindowBackdropApplyScheduler` so rapid `Match Terminal Background` flips only apply the latest pending AppKit mutation.
- Move the ContentView window backdrop mutation out of the SwiftUI `WindowAccessor` update pass and run portal/titlebar follow-up work after the scheduled mutation completes.
- Route Ghostty background-triggered window backdrop refreshes through the same scheduler.
- Add behavior coverage for rapid on/off backdrop scheduling in the existing appearance tests.

## Root Cause

`sidebarAppearance.matchTerminalBackground` changes both the SwiftUI sidebar backdrop shape and the AppKit window backdrop plan. The old path applied `WindowBackdropController.apply` directly from SwiftUI update/change flows. That can remove/reinstall `WindowGlassEffect` and reparent `window.contentView` while SwiftUI is still reconciling the same window tree. Rapid toggles a few seconds apart could leave stale window mutations or completions racing the latest sidebar/window state.

## Validation

- `./scripts/setup.sh`
- `scripts/check-pbxproj.sh`
- `./scripts/reload.sh --tag issue-5245-sidebar-bg`

Per request, I did not run local `xcodebuild test`.

## Localization

No user-facing strings were added or changed. I audited the touched files for new localized/UI string surfaces; the string scan only found pre-existing localized strings in large touched files.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783115226&installation_id=133855650&pr_number=5314&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5314&signature=0d317f38d073ea90dd3219bfb8a8583bef1443494f7caceebeaf98ea74539a27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes crash and state corruption when rapidly toggling “Match Terminal Background” in the sidebar (#5245). Coalesces window backdrop updates so only the latest plan applies and follow-up UI work runs safely on the main actor.

- **Bug Fixes**
  - Added WindowBackdropApplyScheduler to coalesce per-window backdrop mutations and apply only the latest on the main actor, with a completion for follow-up work.
  - Moved the ContentView backdrop apply out of SwiftUI; overlay controllers, portal sync, and titlebar backdrop now update in the scheduler completion.
  - Routed Ghostty background-triggered backdrop refreshes through the scheduler and marked the entry point @MainActor.
  - Added a test that confirms rapid schedules only apply the latest plan and skip redundant reschedules.

<sup>Written for commit 293481f388b30e2eae7efa711d239b1bc1fa409d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

