### PR TITLE
Fix WebKit post-wake crash: sleep/wake-aware hidden-webview discard scheduling

### DIFF
--- a/Sources/Panels/BrowserHiddenWebViewDiscardManager.swift
+++ b/Sources/Panels/BrowserHiddenWebViewDiscardManager.swift
@@ -66,6 +66,7 @@ final class BrowserHiddenWebViewDiscardManager {
     func blockers(for snapshot: BlockerSnapshot) -> [String] {
         var blockers: [String] = []
         if !BrowserHiddenWebViewDiscardPolicy.isEnabled { blockers.append("policy_disabled") }
+        if isSystemSleeping { blockers.append("system_sleeping") }
         if snapshot.isClosing { blockers.append("closing") }
         if isDiscardedForMemory { blockers.append("already_discarded") }
         if snapshot.isVisibleInUI { blockers.append("visible") }
@@ -90,7 +91,6 @@ final class BrowserHiddenWebViewDiscardManager {
         discardTimer?.cancel()
         discardTimer = nil
 
-        guard !isSystemSleeping else { return }
         guard let delegate else { return }
         guard blockers(for: delegate.hiddenWebViewDiscardSnapshot).isEmpty else { return }
 
@@ -139,12 +139,15 @@ final class BrowserHiddenWebViewDiscardManager {
         guard systemSleepObservers.isEmpty else { return }
         systemSleepObserverCenter = center
         systemSleepObservers = [
+            // Synchronous main-actor delivery (no Task hop): a countdown with
+            // milliseconds of mach time left must see isSystemSleeping before
+            // its timer can fire.
             center.addObserver(
                 forName: NSWorkspace.willSleepNotification,
                 object: nil,
                 queue: .main
             ) { [weak self] _ in
-                Task { @MainActor [weak self] in
+                MainActor.assumeIsolated {
                     self?.noteSystemWillSleep()
                 }
             },
@@ -153,7 +156,7 @@ final class BrowserHiddenWebViewDiscardManager {
                 object: nil,
                 queue: .main
             ) { [weak self] _ in
-                Task { @MainActor [weak self] in
+                MainActor.assumeIsolated {
                     self?.noteSystemDidWake()
                 }
             }

--- a/Sources/Panels/BrowserHiddenWebViewDiscardManager.swift
+++ b/Sources/Panels/BrowserHiddenWebViewDiscardManager.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 
 @MainActor
@@ -26,6 +27,7 @@ final class BrowserHiddenWebViewDiscardManager {
         let hasCurrentURL: Bool
         let isLoading: Bool
         let webViewIsLoading: Bool
+        let hasActiveMainFrameProvisionalNavigation: Bool
         let isDownloading: Bool
         let activeDownloadCount: Int
         let preferredDeveloperToolsVisible: Bool
@@ -40,8 +42,15 @@ final class BrowserHiddenWebViewDiscardManager {
 
     private var discardTimer: DispatchSourceTimer?
     private var policyObserver: NSObjectProtocol?
+    private var systemSleepObservers: [NSObjectProtocol] = []
+    private var systemSleepObserverCenter: NotificationCenter?
     private var policyState = BrowserHiddenWebViewDiscardPolicy.resolved()
     private var scheduleGeneration: UInt64 = 0
+
+    /// Sleep/wake state used to keep a hidden-webview discard from running in
+    /// the fragile window right after system wake (see issue #5261).
+    private(set) var isSystemSleeping = false
+    private(set) var lastSystemWakeAt: Date?
 
     private(set) var isDiscardedForMemory: Bool = false
     private(set) var discardedAt: Date?
@@ -113,6 +122,42 @@ final class BrowserHiddenWebViewDiscardManager {
         scheduleGeneration &+= 1
         discardTimer?.cancel()
         discardTimer = nil
+    }
+
+    /// Tracks system sleep/wake so discard countdowns armed before sleep do not
+    /// fire shortly after wake. Injectable center for tests.
+    func installSystemSleepObservers(center: NotificationCenter = NSWorkspace.shared.notificationCenter) {
+        guard systemSleepObservers.isEmpty else { return }
+        systemSleepObserverCenter = center
+        systemSleepObservers = [
+            center.addObserver(
+                forName: NSWorkspace.willSleepNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                Task { @MainActor [weak self] in
+                    self?.noteSystemWillSleep()
+                }
+            },
+            center.addObserver(
+                forName: NSWorkspace.didWakeNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                Task { @MainActor [weak self] in
+                    self?.noteSystemDidWake()
+                }
+            }
+        ]
+    }
+
+    func noteSystemWillSleep() {
+        isSystemSleeping = true
+    }
+
+    func noteSystemDidWake(now: Date = Date()) {
+        isSystemSleeping = false
+        lastSystemWakeAt = now
     }
 
     func installPolicyObserver() {
@@ -197,5 +242,12 @@ final class BrowserHiddenWebViewDiscardManager {
             NotificationCenter.default.removeObserver(policyObserver)
             self.policyObserver = nil
         }
+        if let center = systemSleepObserverCenter {
+            for observer in systemSleepObservers {
+                center.removeObserver(observer)
+            }
+        }
+        systemSleepObservers.removeAll()
+        systemSleepObserverCenter = nil
     }
 }

--- a/Sources/Panels/BrowserHiddenWebViewDiscardManager.swift
+++ b/Sources/Panels/BrowserHiddenWebViewDiscardManager.swift
@@ -48,7 +48,8 @@ final class BrowserHiddenWebViewDiscardManager {
     private var scheduleGeneration: UInt64 = 0
 
     /// Sleep/wake state used to keep a hidden-webview discard from running in
-    /// the fragile window right after system wake (see issue #5261).
+    /// the fragile window right after system wake
+    /// (https://github.com/manaflow-ai/cmux/issues/5261).
     private(set) var isSystemSleeping = false
     private(set) var lastSystemWakeAt: Date?
 
@@ -72,6 +73,7 @@ final class BrowserHiddenWebViewDiscardManager {
         if snapshot.hasPendingRemoteNavigation { blockers.append("pending_remote_navigation") }
         if !snapshot.hasCurrentURL { blockers.append("no_url") }
         if snapshot.isLoading || snapshot.webViewIsLoading { blockers.append("loading") }
+        if snapshot.hasActiveMainFrameProvisionalNavigation { blockers.append("provisional_navigation") }
         if snapshot.isDownloading || snapshot.activeDownloadCount != 0 { blockers.append("download") }
         if snapshot.isCapturingMedia { blockers.append("media_capture") }
         if snapshot.preferredDeveloperToolsVisible || snapshot.isDeveloperToolsVisible {
@@ -88,13 +90,19 @@ final class BrowserHiddenWebViewDiscardManager {
         discardTimer?.cancel()
         discardTimer = nil
 
+        guard !isSystemSleeping else { return }
         guard let delegate else { return }
         guard blockers(for: delegate.hiddenWebViewDiscardSnapshot).isEmpty else { return }
 
         let observedWebViewInstanceID = delegate.hiddenWebViewDiscardWebViewInstanceID
         let generation = scheduleGeneration
         let hiddenAt = delegate.hiddenWebViewDiscardHiddenAt ?? Date()
-        let elapsed = Date().timeIntervalSince(hiddenAt)
+        // Restart the countdown from the latest wake: WebKit pages reconnect and
+        // re-navigate right after wake, and replacing/releasing a WKWebView in
+        // that window crashed in WebPageProxy::updateActivityState
+        // (https://github.com/manaflow-ai/cmux/issues/5261).
+        let effectiveHiddenAt = lastSystemWakeAt.map { max(hiddenAt, $0) } ?? hiddenAt
+        let elapsed = Date().timeIntervalSince(effectiveHiddenAt)
         let remaining = max(0, BrowserHiddenWebViewDiscardPolicy.hiddenDelay - elapsed)
         if remaining <= 0 {
             delegate.hiddenWebViewDiscardManagerDidRequestDiscard(self, reason: reason)
@@ -106,6 +114,7 @@ final class BrowserHiddenWebViewDiscardManager {
         timer.setEventHandler { [weak self] in
             MainActor.assumeIsolated {
                 guard let self else { return }
+                guard !self.isSystemSleeping else { return }
                 guard self.scheduleGeneration == generation else { return }
                 guard let delegate = self.delegate else { return }
                 guard delegate.hiddenWebViewDiscardWebViewInstanceID == observedWebViewInstanceID else { return }
@@ -153,11 +162,22 @@ final class BrowserHiddenWebViewDiscardManager {
 
     func noteSystemWillSleep() {
         isSystemSleeping = true
+        let hadScheduledDiscard = hasScheduledDiscard
+        cancel()
+#if DEBUG
+        if hadScheduledDiscard {
+            cmuxDebugLog("browser.discard.sleep canceledArmedTimer=1")
+        }
+#endif
     }
 
     func noteSystemDidWake(now: Date = Date()) {
         isSystemSleeping = false
         lastSystemWakeAt = now
+        scheduleIfNeeded(reason: "system_did_wake")
+#if DEBUG
+        cmuxDebugLog("browser.discard.wake rearmed=\(hasScheduledDiscard ? 1 : 0)")
+#endif
     }
 
     func installPolicyObserver() {

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -3763,6 +3763,7 @@ final class BrowserPanel: Panel, ObservableObject {
 
     private func installHiddenWebViewDiscardPolicyObserver() {
         hiddenWebViewDiscardManager.installPolicyObserver()
+        hiddenWebViewDiscardManager.installSystemSleepObservers()
     }
 
     @discardableResult
@@ -6098,6 +6099,7 @@ extension BrowserPanel: BrowserHiddenWebViewDiscardManagerDelegate {
             hasCurrentURL: (currentURL ?? Self.remoteProxyDisplayURL(for: webView.url)) != nil,
             isLoading: isLoading,
             webViewIsLoading: webView.isLoading,
+            hasActiveMainFrameProvisionalNavigation: isMainFrameProvisionalNavigationActive,
             isDownloading: isDownloading,
             activeDownloadCount: activeDownloadCount,
             preferredDeveloperToolsVisible: preferredDeveloperToolsVisible,

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -209,6 +209,7 @@ final class BrowserHiddenWebViewDiscardManagerTests: XCTestCase {
 
         manager.noteSystemWillSleep()
         XCTAssertFalse(manager.hasScheduledDiscard)
+        XCTAssertEqual(manager.blockers(for: snapshot), ["system_sleeping"])
 
         manager.scheduleIfNeeded(reason: "test.whileSleeping")
         XCTAssertFalse(manager.hasScheduledDiscard)
@@ -216,6 +217,7 @@ final class BrowserHiddenWebViewDiscardManagerTests: XCTestCase {
 
         manager.noteSystemDidWake(now: Date())
         XCTAssertTrue(manager.hasScheduledDiscard)
+        XCTAssertEqual(manager.blockers(for: snapshot), [])
         XCTAssertEqual(delegate.discardRequestCount, 0)
     }
 }

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -97,36 +97,53 @@ private final class BrowserHiddenWebViewDiscardTestDelegate: BrowserHiddenWebVie
 }
 
 @MainActor
-final class BrowserHiddenWebViewDiscardManagerTests: XCTestCase {
-    func testActiveMediaCaptureBlocksHiddenWebViewDiscardScheduling() {
-        let defaults = UserDefaults.standard
-        let previousEnabled = defaults.object(forKey: BrowserHiddenWebViewDiscardPolicy.enabledKey)
-        defaults.set(true, forKey: BrowserHiddenWebViewDiscardPolicy.enabledKey)
-        defer {
-            if let previousEnabled {
-                defaults.set(previousEnabled, forKey: BrowserHiddenWebViewDiscardPolicy.enabledKey)
-            } else {
-                defaults.removeObject(forKey: BrowserHiddenWebViewDiscardPolicy.enabledKey)
-            }
-        }
+private func makeHiddenWebViewDiscardBlockerSnapshot(
+    hasActiveMainFrameProvisionalNavigation: Bool = false,
+    isCapturingMedia: Bool = false
+) -> BrowserHiddenWebViewDiscardManager.BlockerSnapshot {
+    BrowserHiddenWebViewDiscardManager.BlockerSnapshot(
+        isClosing: false,
+        isVisibleInUI: false,
+        shouldRenderWebView: true,
+        hasPendingRemoteNavigation: false,
+        hasCurrentURL: true,
+        isLoading: false,
+        webViewIsLoading: false,
+        hasActiveMainFrameProvisionalNavigation: hasActiveMainFrameProvisionalNavigation,
+        isDownloading: false,
+        activeDownloadCount: 0,
+        preferredDeveloperToolsVisible: false,
+        isDeveloperToolsVisible: false,
+        isElementFullscreenActive: false,
+        isReactGrabActive: false,
+        hasPopups: false,
+        isCapturingMedia: isCapturingMedia
+    )
+}
 
-        let snapshot = BrowserHiddenWebViewDiscardManager.BlockerSnapshot(
-            isClosing: false,
-            isVisibleInUI: false,
-            shouldRenderWebView: true,
-            hasPendingRemoteNavigation: false,
-            hasCurrentURL: true,
-            isLoading: false,
-            webViewIsLoading: false,
-            isDownloading: false,
-            activeDownloadCount: 0,
-            preferredDeveloperToolsVisible: false,
-            isDeveloperToolsVisible: false,
-            isElementFullscreenActive: false,
-            isReactGrabActive: false,
-            hasPopups: false,
-            isCapturingMedia: true
-        )
+@MainActor
+final class BrowserHiddenWebViewDiscardManagerTests: XCTestCase {
+    private var previousEnabled: Any?
+
+    override func setUp() {
+        super.setUp()
+        let defaults = UserDefaults.standard
+        previousEnabled = defaults.object(forKey: BrowserHiddenWebViewDiscardPolicy.enabledKey)
+        defaults.set(true, forKey: BrowserHiddenWebViewDiscardPolicy.enabledKey)
+    }
+
+    override func tearDown() {
+        let defaults = UserDefaults.standard
+        if let previousEnabled {
+            defaults.set(previousEnabled, forKey: BrowserHiddenWebViewDiscardPolicy.enabledKey)
+        } else {
+            defaults.removeObject(forKey: BrowserHiddenWebViewDiscardPolicy.enabledKey)
+        }
+        super.tearDown()
+    }
+
+    func testActiveMediaCaptureBlocksHiddenWebViewDiscardScheduling() {
+        let snapshot = makeHiddenWebViewDiscardBlockerSnapshot(isCapturingMedia: true)
         let manager = BrowserHiddenWebViewDiscardManager()
         let delegate = BrowserHiddenWebViewDiscardTestDelegate(snapshot: snapshot, hiddenAt: Date())
         manager.delegate = delegate
@@ -136,6 +153,69 @@ final class BrowserHiddenWebViewDiscardManagerTests: XCTestCase {
         manager.scheduleIfNeeded(reason: "test.hidden")
 
         XCTAssertFalse(manager.hasScheduledDiscard)
+        XCTAssertEqual(delegate.discardRequestCount, 0)
+    }
+
+    // Regression coverage for https://github.com/manaflow-ai/cmux/issues/5261:
+    // a main-frame provisional navigation (e.g. a cross-origin process swap in
+    // flight) must block a hidden-webview discard from replacing the WKWebView.
+    func testMainFrameProvisionalNavigationBlocksHiddenWebViewDiscardScheduling() {
+        let snapshot = makeHiddenWebViewDiscardBlockerSnapshot(
+            hasActiveMainFrameProvisionalNavigation: true
+        )
+        let manager = BrowserHiddenWebViewDiscardManager()
+        let delegate = BrowserHiddenWebViewDiscardTestDelegate(snapshot: snapshot, hiddenAt: Date())
+        manager.delegate = delegate
+
+        XCTAssertEqual(manager.blockers(for: snapshot), ["provisional_navigation"])
+
+        manager.scheduleIfNeeded(reason: "test.provisional")
+
+        XCTAssertFalse(manager.hasScheduledDiscard)
+        XCTAssertEqual(delegate.discardRequestCount, 0)
+    }
+
+    // Regression coverage for https://github.com/manaflow-ai/cmux/issues/5261:
+    // a discard countdown that elapsed across system sleep must restart from
+    // wake instead of discarding the webview immediately after wake, while
+    // WebKit pages are still reconnecting/renavigating.
+    func testSystemWakeRestartsHiddenWebViewDiscardCountdown() {
+        let snapshot = makeHiddenWebViewDiscardBlockerSnapshot()
+        let manager = BrowserHiddenWebViewDiscardManager()
+        let delegate = BrowserHiddenWebViewDiscardTestDelegate(
+            snapshot: snapshot,
+            hiddenAt: Date(timeIntervalSinceNow: -7200)
+        )
+        manager.delegate = delegate
+
+        manager.noteSystemDidWake(now: Date())
+        manager.scheduleIfNeeded(reason: "test.postWake")
+
+        XCTAssertEqual(delegate.discardRequestCount, 0)
+        XCTAssertTrue(manager.hasScheduledDiscard)
+    }
+
+    // Regression coverage for https://github.com/manaflow-ai/cmux/issues/5261:
+    // sleep cancels an armed discard countdown and blocks re-arming until wake,
+    // and wake re-arms a fresh countdown without discarding.
+    func testSystemSleepCancelsArmedHiddenWebViewDiscard() {
+        let snapshot = makeHiddenWebViewDiscardBlockerSnapshot()
+        let manager = BrowserHiddenWebViewDiscardManager()
+        let delegate = BrowserHiddenWebViewDiscardTestDelegate(snapshot: snapshot, hiddenAt: Date())
+        manager.delegate = delegate
+
+        manager.scheduleIfNeeded(reason: "test.hidden")
+        XCTAssertTrue(manager.hasScheduledDiscard)
+
+        manager.noteSystemWillSleep()
+        XCTAssertFalse(manager.hasScheduledDiscard)
+
+        manager.scheduleIfNeeded(reason: "test.whileSleeping")
+        XCTAssertFalse(manager.hasScheduledDiscard)
+        XCTAssertEqual(delegate.discardRequestCount, 0)
+
+        manager.noteSystemDidWake(now: Date())
+        XCTAssertTrue(manager.hasScheduledDiscard)
         XCTAssertEqual(delegate.discardRequestCount, 0)
     }
 }


### PR DESCRIPTION
Fixes https://github.com/manaflow-ai/cmux/issues/5261

## Crash

cmux 0.64.11 crashed with the app in the background 223 seconds after macOS wake, on the main thread inside WebKit while committing a provisional page:

```
WebKit::WebPageProxy::updateActivityState + 152          (KERN_INVALID_ADDRESS at 0x0)
WebKit::WebPageProxy::finishAttachingToWebProcess
WebKit::WebPageProxy::commitProvisionalPage
WebKit::ProvisionalPageProxy::didCommitLoadForFrame
```

A provisional page commit means a cross-origin (process-swap) navigation was in flight in an embedded `WKWebView` while cmux was backgrounded shortly after wake.

## Why the discard timer is the prime suspect

Browser Memory Saver (`BrowserHiddenWebViewDiscardManager`) arms a `DispatchSourceTimer` with a `DispatchTime` deadline (default 300s after a panel is hidden). `DispatchTime` is mach time, which is suspended during system sleep on Apple Silicon. So a countdown armed before sleep does not expire during sleep; it fires its *remaining* seconds after wake. A countdown with ~223s left at sleep fires exactly 223s after wake, matching the crash report's "Time Since Wake: 223 seconds".

When that timer fires, `discardHiddenWebViewForMemory` tears down and releases the live `WKWebView` (stops loading, nils delegates, detaches it, swaps in a fresh instance). Right after wake is the worst possible moment for that: pages are reconnecting and re-navigating (auto-refresh, redirects, reconnect logic), so a cross-origin provisional navigation can be racing the teardown. The blocker re-check guards on `webView.isLoading`, but it did not cover the explicit main-frame provisional navigation window, and nothing prevented the discard from landing in the immediate post-wake recovery window at all.

## Fix

`BrowserHiddenWebViewDiscardManager` is now sleep/wake aware (observers on `NSWorkspace.willSleepNotification` / `didWakeNotification`, wired per panel next to the existing policy observer):

- **Sleep cancels any armed discard countdown** and blocks re-arming until wake, so a pre-sleep countdown can never fire mid-wake-recovery.
- **Wake restarts the countdown from the wake timestamp** (`hiddenAt` is clamped to `lastSystemWakeAt`), so a hidden webview is never discarded sooner than the full configured delay after wake, and a stale `hiddenAt` can no longer trigger an *immediate* discard when scheduling re-evaluates post-wake.
- **An active main-frame provisional navigation is now an explicit discard blocker** (`provisional_navigation` in the blocker snapshot), closing the window where a process-swap navigation is in flight while `webView.isLoading` flickers.

DEBUG builds log `browser.discard.sleep` / `browser.discard.wake` transitions to the unified debug event log for future diagnosis.

## Commits (red/green)

1. Failing tests + inert API surface (sleep/wake plumbing that records state only, new blocker snapshot field). The `tests` job goes red, proving the tests catch the bug.
2. The enforcement: sleep cancel, wake clamp + reschedule, provisional-navigation blocker. Tests go green.

## Tests

`BrowserHiddenWebViewDiscardManagerTests` (cmuxTests/BrowserPanelTests.swift):
- `testMainFrameProvisionalNavigationBlocksHiddenWebViewDiscardScheduling`
- `testSystemWakeRestartsHiddenWebViewDiscardCountdown` (stale `hiddenAt` + wake must arm a fresh countdown, not discard immediately)
- `testSystemSleepCancelsArmedHiddenWebViewDiscard` (sleep cancels and blocks arming; wake re-arms without discarding)

The crash itself is not reliably reproducible (single crash log from a real session), so this is defensive hardening of the only lifecycle path in the app that destroys/replaces a live background `WKWebView` on a timer that demonstrably fires in the post-wake window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5315"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783115414&installation_id=133855650&pr_number=5315&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5315&signature=b3b3a4b49135a846b50622f9b86d29604890333701027b59de61f27a8a46a611"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #5261 by preventing a post-wake WebKit crash: hidden-webview discards are now sleep/wake-aware and safe around provisional navigations. This keeps the discard from replacing the `WKWebView` during the fragile post-wake window and waits the full delay after wake.

- **Bug Fixes**
  - Cancel any armed discard timer on `NSWorkspace.willSleepNotification`; block re-arming until wake.
  - On `NSWorkspace.didWakeNotification`, restart the countdown from wake by clamping `hiddenAt` to `lastSystemWakeAt` (no immediate discard).
  - Block discard during an active main-frame provisional navigation (`provisional_navigation`).
  - Deliver sleep/wake notifications synchronously on the main queue and surface `system_sleeping` in blockers to close the race and keep gating consistent.

<sup>Written for commit ab5df8bd181f94d6d53e4f5713409982a1017410. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Suppress hidden-webview discard countdowns during system sleep and resume correctly on wake; track sleep/wake times.

* **Bug Fixes**
  * Prevented immediate discard after system wake.
  * Improved provisional navigation tracking to avoid premature discard.

* **Tests**
  * Added regression tests for sleep/wake and provisional-navigation scenarios.
  * Refactored tests with a shared snapshot helper.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->