### PR TITLE
[codex] Fix nonblocking workspace close teardown

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5377,6 +5377,8 @@ final class TerminalSurface: Identifiable, ObservableObject {
     private var runtimeSurfaceCreateAttemptCountForTesting = 0
     private let debugForceRefreshCountLock = NSLock()
     private var debugForceRefreshCountValue = 0
+    @MainActor
+    static var runtimeSurfaceFreeOverrideForTesting: (@Sendable (ghostty_surface_t) -> Void)?
 #endif
     private enum PortalLifecycleState: String {
         case live
@@ -5961,10 +5963,15 @@ final class TerminalSurface: Identifiable, ObservableObject {
         }
 #endif
 
+        let freeSurface = Self.runtimeSurfaceFreeOverrideForTesting
         Task { @MainActor in
             // Keep free behavior aligned with deinit: perform the runtime teardown on
             // the next main-actor turn so SIGHUP delivery is deterministic but non-reentrant.
-            ghostty_surface_free(surfaceToFree)
+            if let freeSurface {
+                freeSurface(surfaceToFree)
+            } else {
+                ghostty_surface_free(surfaceToFree)
+            }
             callbackContext?.release()
         }
     }
@@ -5999,8 +6006,13 @@ final class TerminalSurface: Identifiable, ObservableObject {
         )
 #endif
 
+        let freeSurface = Self.runtimeSurfaceFreeOverrideForTesting
         Task { @MainActor in
-            ghostty_surface_free(surfaceToFree)
+            if let freeSurface {
+                freeSurface(surfaceToFree)
+            } else {
+                ghostty_surface_free(surfaceToFree)
+            }
             callbackContext?.release()
         }
     }
@@ -7379,6 +7391,13 @@ final class TerminalSurface: Identifiable, ObservableObject {
         ghostty_surface_free(surfaceToFree)
         runtimeSurfaceFreedOutOfBandForTesting = true
         callbackContext?.release()
+    }
+
+    @MainActor
+    func installRuntimeSurfaceForTesting(_ runtimeSurface: ghostty_surface_t) {
+        surface = runtimeSurface
+        portalLifecycleState = .live
+        runtimeSurfaceFreedOutOfBandForTesting = false
     }
 #endif
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1713,6 +1713,137 @@ private final class GhosttySurfaceCallbackContext {
     }
 }
 
+// The native pointer has been removed from all main-thread owner state before
+// this request is created; this wrapper only transports the one-shot free.
+private struct TerminalSurfaceRuntimeTeardownRequest: @unchecked Sendable {
+    let id: UUID
+    let workspaceId: UUID
+    let reason: String
+    let surface: ghostty_surface_t
+    let callbackContext: Unmanaged<GhosttySurfaceCallbackContext>?
+    let freeSurface: @Sendable (ghostty_surface_t) -> Void
+#if DEBUG
+    let surfaceToken: String
+    let workspaceToken: String
+#endif
+
+    init(
+        id: UUID,
+        workspaceId: UUID,
+        reason: String,
+        surface: ghostty_surface_t,
+        callbackContext: Unmanaged<GhosttySurfaceCallbackContext>?,
+        freeSurface: @escaping @Sendable (ghostty_surface_t) -> Void
+    ) {
+        self.id = id
+        self.workspaceId = workspaceId
+        self.reason = reason
+        self.surface = surface
+        self.callbackContext = callbackContext
+        self.freeSurface = freeSurface
+#if DEBUG
+        self.surfaceToken = String(id.uuidString.prefix(5))
+        self.workspaceToken = String(workspaceId.uuidString.prefix(5))
+#endif
+    }
+}
+
+private actor TerminalSurfaceRuntimeTeardownCoordinator {
+    static let shared = TerminalSurfaceRuntimeTeardownCoordinator()
+
+    private let timeout: Duration = .seconds(5)
+    private var pendingReasonsById: [UUID: String] = [:]
+
+    func enqueue(_ request: TerminalSurfaceRuntimeTeardownRequest) {
+        pendingReasonsById[request.id] = request.reason
+        let task = Task.detached(priority: .utility) {
+#if DEBUG
+            cmuxDebugLog(
+                "surface.lifecycle.nativeFree.begin surface=\(request.surfaceToken) " +
+                "workspace=\(request.workspaceToken) reason=\(request.reason)"
+            )
+#endif
+            request.freeSurface(request.surface)
+            if let callbackContext = request.callbackContext {
+                await MainActor.run {
+                    callbackContext.release()
+                }
+            }
+#if DEBUG
+            cmuxDebugLog(
+                "surface.lifecycle.nativeFree.end surface=\(request.surfaceToken) " +
+                "workspace=\(request.workspaceToken) reason=\(request.reason)"
+            )
+#endif
+        }
+        Task {
+            await observeCompletion(id: request.id, task: task)
+        }
+        Task {
+            await observeTimeout(id: request.id)
+        }
+    }
+
+    private func observeCompletion(id: UUID, task: Task<Void, Never>) async {
+        await task.value
+        pendingReasonsById.removeValue(forKey: id)
+    }
+
+    private func observeTimeout(id: UUID) async {
+        do {
+            // Genuine teardown deadline: report a stuck native free without blocking close.
+            try await Task.sleep(for: timeout)
+        } catch {
+            return
+        }
+        guard let reason = pendingReasonsById[id] else { return }
+#if DEBUG
+        cmuxDebugLog(
+            "surface.lifecycle.nativeFree.timeout surface=\(id.uuidString.prefix(5)) " +
+            "reason=\(reason)"
+        )
+#endif
+    }
+}
+
+private func enqueueTerminalSurfaceRuntimeTeardown(
+    id: UUID,
+    workspaceId: UUID,
+    reason: String,
+    surface: ghostty_surface_t,
+    callbackContext: Unmanaged<GhosttySurfaceCallbackContext>?,
+    freeSurface: @escaping @Sendable (ghostty_surface_t) -> Void
+) {
+    let request = TerminalSurfaceRuntimeTeardownRequest(
+        id: id,
+        workspaceId: workspaceId,
+        reason: reason,
+        surface: surface,
+        callbackContext: callbackContext,
+        freeSurface: freeSurface
+    )
+    Task {
+        await TerminalSurfaceRuntimeTeardownCoordinator.shared.enqueue(request)
+    }
+}
+
+private func enqueueTerminalSurfaceRuntimeTeardown(
+    id: UUID,
+    workspaceId: UUID,
+    reason: String,
+    surface: ghostty_surface_t,
+    callbackContext: Unmanaged<GhosttySurfaceCallbackContext>?
+) {
+    enqueueTerminalSurfaceRuntimeTeardown(
+        id: id,
+        workspaceId: workspaceId,
+        reason: reason,
+        surface: surface,
+        callbackContext: callbackContext,
+        freeSurface: { surface in ghostty_surface_free(surface) }
+    )
+}
+
 // Minimal Ghostty wrapper for terminal rendering
 // This uses libghostty (GhosttyKit.xcframework) for actual terminal emulation
 
@@ -5963,17 +6094,26 @@ final class TerminalSurface: Identifiable, ObservableObject {
         }
 #endif
 
-        let freeSurface = Self.runtimeSurfaceFreeOverrideForTesting
-        Task { @MainActor in
-            // Keep free behavior aligned with deinit: perform the runtime teardown on
-            // the next main-actor turn so SIGHUP delivery is deterministic but non-reentrant.
-            if let freeSurface {
-                freeSurface(surfaceToFree)
-            } else {
-                ghostty_surface_free(surfaceToFree)
-            }
-            callbackContext?.release()
+#if DEBUG
+        if let freeSurface = Self.runtimeSurfaceFreeOverrideForTesting {
+            enqueueTerminalSurfaceRuntimeTeardown(
+                id: id,
+                workspaceId: tabId,
+                reason: "teardown",
+                surface: surfaceToFree,
+                callbackContext: callbackContext,
+                freeSurface: freeSurface
+            )
+            return
         }
+#endif
+        enqueueTerminalSurfaceRuntimeTeardown(
+            id: id,
+            workspaceId: tabId,
+            reason: "teardown",
+            surface: surfaceToFree,
+            callbackContext: callbackContext
+        )
     }
 
     @MainActor
@@ -6006,15 +6146,26 @@ final class TerminalSurface: Identifiable, ObservableObject {
         )
 #endif
 
-        let freeSurface = Self.runtimeSurfaceFreeOverrideForTesting
-        Task { @MainActor in
-            if let freeSurface {
-                freeSurface(surfaceToFree)
-            } else {
-                ghostty_surface_free(surfaceToFree)
-            }
-            callbackContext?.release()
+#if DEBUG
+        if let freeSurface = Self.runtimeSurfaceFreeOverrideForTesting {
+            enqueueTerminalSurfaceRuntimeTeardown(
+                id: id,
+                workspaceId: tabId,
+                reason: reason,
+                surface: surfaceToFree,
+                callbackContext: callbackContext,
+                freeSurface: freeSurface
+            )
+            return
         }
+#endif
+        enqueueTerminalSurfaceRuntimeTeardown(
+            id: id,
+            workspaceId: tabId,
+            reason: reason,
+            surface: surfaceToFree,
+            callbackContext: callbackContext
+        )
     }
 
 #if DEBUG
@@ -7439,11 +7590,9 @@ final class TerminalSurface: Identifiable, ObservableObject {
 #endif
 
 #if DEBUG
-        let surfaceToken = String(id.uuidString.prefix(5))
-        let workspaceToken = String(tabId.uuidString.prefix(5))
         cmuxDebugLog(
-            "surface.lifecycle.deinit.begin surface=\(surfaceToken) " +
-            "workspace=\(workspaceToken) hasAttachedView=\(attachedView != nil ? 1 : 0) " +
+            "surface.lifecycle.deinit.begin surface=\(id.uuidString.prefix(5)) " +
+            "workspace=\(tabId.uuidString.prefix(5)) hasAttachedView=\(attachedView != nil ? 1 : 0) " +
             "hostedInWindow=\(hostedView.window != nil ? 1 : 0)"
         )
 #endif
@@ -7451,16 +7600,13 @@ final class TerminalSurface: Identifiable, ObservableObject {
         // Keep teardown asynchronous to avoid re-entrant close/deinit loops, but retain
         // callback userdata until surface free completes so callbacks never dereference
         // a deallocated view pointer.
-        Task { @MainActor in
-            ghostty_surface_free(surfaceToFree)
-            callbackContext?.release()
-#if DEBUG
-            cmuxDebugLog(
-                "surface.lifecycle.deinit.end surface=\(surfaceToken) " +
-                "workspace=\(workspaceToken) freed=1"
-            )
-#endif
-        }
+        enqueueTerminalSurfaceRuntimeTeardown(
+            id: id,
+            workspaceId: tabId,
+            reason: "deinit",
+            surface: surfaceToFree,
+            callbackContext: callbackContext
+        )
     }
 }
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1762,18 +1762,14 @@ private actor TerminalSurfaceRuntimeTeardownCoordinator {
         if !isWorkerRunning {
             isWorkerRunning = true
             Task.detached(priority: .utility) {
-                await self.runSerialWorker()
+                while let request = await self.nextRequestForWorker() {
+                    Task {
+                        await self.observeTimeout(id: request.id)
+                    }
+                    await Self.free(request)
+                    await self.complete(id: request.id)
+                }
             }
-        }
-        Task {
-            await observeTimeout(id: request.id)
-        }
-    }
-
-    private nonisolated func runSerialWorker() async {
-        while let request = await nextRequestForWorker() {
-            await Self.free(request)
-            await complete(id: request.id)
         }
     }
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1753,39 +1753,60 @@ private actor TerminalSurfaceRuntimeTeardownCoordinator {
 
     private let timeout: Duration = .seconds(5)
     private var pendingReasonsById: [UUID: String] = [:]
+    private var queuedRequests: [TerminalSurfaceRuntimeTeardownRequest] = []
+    private var isWorkerRunning = false
 
     func enqueue(_ request: TerminalSurfaceRuntimeTeardownRequest) {
         pendingReasonsById[request.id] = request.reason
-        let task = Task.detached(priority: .utility) {
-#if DEBUG
-            cmuxDebugLog(
-                "surface.lifecycle.nativeFree.begin surface=\(request.surfaceToken) " +
-                "workspace=\(request.workspaceToken) reason=\(request.reason)"
-            )
-#endif
-            request.freeSurface(request.surface)
-            if let callbackContext = request.callbackContext {
-                await MainActor.run {
-                    callbackContext.release()
-                }
+        queuedRequests.append(request)
+        if !isWorkerRunning {
+            isWorkerRunning = true
+            Task.detached(priority: .utility) {
+                await self.runSerialWorker()
             }
-#if DEBUG
-            cmuxDebugLog(
-                "surface.lifecycle.nativeFree.end surface=\(request.surfaceToken) " +
-                "workspace=\(request.workspaceToken) reason=\(request.reason)"
-            )
-#endif
-        }
-        Task {
-            await observeCompletion(id: request.id, task: task)
         }
         Task {
             await observeTimeout(id: request.id)
         }
     }
 
-    private func observeCompletion(id: UUID, task: Task<Void, Never>) async {
-        await task.value
+    private nonisolated func runSerialWorker() async {
+        while let request = await nextRequestForWorker() {
+            await Self.free(request)
+            await complete(id: request.id)
+        }
+    }
+
+    private func nextRequestForWorker() -> TerminalSurfaceRuntimeTeardownRequest? {
+        guard !queuedRequests.isEmpty else {
+            isWorkerRunning = false
+            return nil
+        }
+        return queuedRequests.removeFirst()
+    }
+
+    private nonisolated static func free(_ request: TerminalSurfaceRuntimeTeardownRequest) async {
+#if DEBUG
+        cmuxDebugLog(
+            "surface.lifecycle.nativeFree.begin surface=\(request.surfaceToken) " +
+            "workspace=\(request.workspaceToken) reason=\(request.reason)"
+        )
+#endif
+        request.freeSurface(request.surface)
+        if let callbackContext = request.callbackContext {
+            await MainActor.run {
+                callbackContext.release()
+            }
+        }
+#if DEBUG
+        cmuxDebugLog(
+            "surface.lifecycle.nativeFree.end surface=\(request.surfaceToken) " +
+            "workspace=\(request.workspaceToken) reason=\(request.reason)"
+        )
+#endif
+    }
+
+    private func complete(id: UUID) {
         pendingReasonsById.removeValue(forKey: id)
     }
 

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -1460,6 +1460,40 @@ final class TabManagerCloseCurrentTabSpamTests: XCTestCase {
         XCTAssertEqual(manager.tabs.count, 5, "Expected only one workspace to close after the first accepted confirmation")
     }
 
+    func testCloseWorkspaceEnqueuesTerminalRuntimeTeardownOffMainThread() {
+        let manager = TabManager()
+        let workspace = manager.addWorkspace()
+        manager.selectWorkspace(workspace)
+
+        guard let panelId = workspace.focusedPanelId,
+              let terminalPanel = workspace.terminalPanel(for: panelId) else {
+            XCTFail("Expected focused terminal panel")
+            return
+        }
+
+        let fakeSurface: ghostty_surface_t = UnsafeMutableRawPointer(bitPattern: 0x5282)!
+        terminalPanel.surface.installRuntimeSurfaceForTesting(fakeSurface)
+        terminalPanel.surface.setNeedsConfirmCloseOverrideForTesting(true)
+
+        let nativeFreeStarted = expectation(description: "native free started")
+        TerminalSurface.runtimeSurfaceFreeOverrideForTesting = { _ in
+            XCTAssertFalse(Thread.isMainThread, "Native surface free must not run on the main thread")
+            nativeFreeStarted.fulfill()
+        }
+        defer {
+            TerminalSurface.runtimeSurfaceFreeOverrideForTesting = nil
+        }
+
+        manager.confirmCloseHandler = { _, _, _ in true }
+
+        XCTAssertTrue(manager.closeWorkspaceWithConfirmation(workspace))
+        XCTAssertEqual(manager.tabs.count, 1)
+        XCTAssertFalse(manager.tabs.contains(where: { $0.id == workspace.id }))
+        XCTAssertNil(terminalPanel.surface.surface)
+
+        wait(for: [nativeFreeStarted], timeout: 3.0)
+    }
+
     func testCloseCurrentTabSpamWithConfirmationDisabledClosesEveryRequestedWorkspace() {
         let manager = TabManager()
         while manager.tabs.count < 6 {


### PR DESCRIPTION
## Summary

Fixes #5282.

This moves Ghostty runtime surface teardown out of the main-actor close path. Workspace close now clears Swift/UI ownership synchronously, unregisters the runtime pointer, and hands the blocking `ghostty_surface_free` call to a small teardown coordinator that runs native free work off the main thread. The coordinator keeps callback userdata retained until native free finishes and logs a DEBUG timeout if native teardown remains stuck.

## Root Cause

After confirming Close Workspace, `TerminalPanel.close()` / `TerminalSurface.teardownSurface()` cleared UI state but still scheduled `ghostty_surface_free` back onto the main actor. If Ghostty surface destruction blocked while waiting on the IO thread, the app could hang immediately after the confirmation dialog.

## Regression Proof

Two-commit structure:

1. `Add regression test for workspace close teardown` adds a DEBUG seam and a test proving native surface free must not execute on the main thread during confirmed workspace close.
2. `Fix nonblocking workspace close teardown` moves the native free to the teardown coordinator so the regression passes.

## Verification

- `./scripts/setup.sh`
- `scripts/check-pbxproj.sh`
- `./scripts/reload.sh --tag issue-5282-close-workspace-hang`

I did not run local `xcodebuild test`, per request.

## Localization

No user-facing UI strings were added or changed. Audit checked the touched Swift files for newly introduced localized/UI string surfaces; changes are DEBUG logs and test assertion text only.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5316"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783115430&installation_id=133855650&pr_number=5316&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5316&signature=cc99ddda2dd63c7d7c9f090e4eac49e8d8da13af6aeb95ba0130466f42256898"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #5282 by moving Ghostty surface frees off the main thread and serializing teardown to prevent hangs during Close Workspace and deinit. The coordinator now starts the 5s timeout when native free begins, and UI state clears immediately.

- **Bug Fixes**
  - Run `ghostty_surface_free` via a serialized coordinator off the main thread; release callback userdata on the main actor after free; add DEBUG begin/end logs and start the 5s timeout when free starts.
  - Clear Swift/UI ownership and unregister the runtime pointer synchronously before close; route both confirmed close and deinit through the coordinator; add a regression test (with a test-only free override) to ensure native free never runs on the main thread.

<sup>Written for commit 54af50ab7ae93470f30b28553d4e8d3cf818cc22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Terminal resource teardown is now coordinated asynchronously off the main thread, enqueued to a single-worker coordinator for non-blocking, ordered cleanup.

* **Tests**
  * Added a unit test verifying terminal teardown is performed off the main thread when closing a workspace.

* **Chores**
  * Added debug-only testing hooks to observe and override teardown behavior during tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->