### PR TITLE
Fix TextBox teardown crash when toggling sidebar background

### DIFF
--- a/Sources/Panels/TerminalPanel.swift
+++ b/Sources/Panels/TerminalPanel.swift
@@ -224,16 +224,14 @@ final class TerminalPanel: Panel, ObservableObject {
 
     func registerTextBoxInputView(_ view: TextBoxInputTextView) {
         textBoxInputView = view
+        // Registration runs from NSViewRepresentable.makeNSView; restoring drafts here must not
+        // write SwiftUI/Combine bindings while SwiftUI is constructing the subtree.
         if let restoredTextBoxDraft {
             self.restoredTextBoxDraft = nil
-            view.installSessionDraft(restoredTextBoxDraft)
-            textBoxContent = view.plainText()
-            textBoxAttachments = view.inlineAttachments()
+            view.installSessionDraft(restoredTextBoxDraft, notifyingTextChange: false)
         } else if let preservedTextBoxAttributedContent {
             self.preservedTextBoxAttributedContent = nil
-            view.installPreservedContent(preservedTextBoxAttributedContent)
-            textBoxContent = view.plainText()
-            textBoxAttachments = view.inlineAttachments()
+            view.installPreservedContent(preservedTextBoxAttributedContent, notifyingTextChange: false)
         }
         focusTextBoxIfNeeded()
 #if DEBUG
@@ -345,8 +343,10 @@ final class TerminalPanel: Panel, ObservableObject {
     }
 
     func preserveTextBoxContentForUnmount(from textBoxInputView: TextBoxInputTextView) {
-        guard !isClosingPanel else {
-            discardTextBoxContentForClose(from: textBoxInputView)
+        // Dismantle can run while AttributeGraph is destroying this subtree. Cache only
+        // non-published draft state here; normal editing keeps the published bindings current.
+        if isClosingPanel {
+            recordTextBoxViewUnmounted(textBoxInputView)
             return
         }
         let preservedContent = textBoxInputView.attributedContentForPreservation()
@@ -354,8 +354,12 @@ final class TerminalPanel: Panel, ObservableObject {
         preservedTextBoxAttributedContent = NSAttributedString(
             attributedString: preservedContent
         )
-        textBoxContent = textBoxInputView.plainText()
-        textBoxAttachments = textBoxInputView.inlineAttachments()
+        recordTextBoxViewUnmounted(textBoxInputView)
+    }
+
+    private func recordTextBoxViewUnmounted(_ textBoxInputView: TextBoxInputTextView) {
+        guard self.textBoxInputView === textBoxInputView else { return }
+        self.textBoxInputView = nil
     }
 
     private func discardTextBoxContentForClose(from textBoxInputView: TextBoxInputTextView? = nil) {

--- a/Sources/Panels/TerminalPanel.swift
+++ b/Sources/Panels/TerminalPanel.swift
@@ -65,6 +65,7 @@ final class TerminalPanel: Panel, ObservableObject {
     private var preservedTextBoxAttributedContent: NSAttributedString?
     private var restoredTextBoxDraft: SessionTextBoxInputDraftSnapshot?
     private var isClosingPanel = false
+    private var didDiscardTextBoxContentForClose = false
 #if DEBUG
     private struct DebugTextBoxInlineFixture {
         let localURL: URL?
@@ -346,6 +347,10 @@ final class TerminalPanel: Panel, ObservableObject {
         // Dismantle can run while AttributeGraph is destroying this subtree. Cache only
         // non-published draft state here; normal editing keeps the published bindings current.
         if isClosingPanel {
+            assert(
+                didDiscardTextBoxContentForClose,
+                "close() must discard TextBox content before SwiftUI dismantles the TextBox view"
+            )
             recordTextBoxViewUnmounted(textBoxInputView)
             return
         }
@@ -363,6 +368,7 @@ final class TerminalPanel: Panel, ObservableObject {
     }
 
     private func discardTextBoxContentForClose(from textBoxInputView: TextBoxInputTextView? = nil) {
+        didDiscardTextBoxContentForClose = true
         let currentTextView = textBoxInputView ?? self.textBoxInputView
         let attachmentsToCleanup = currentTextView?.inlineAttachments() ?? textBoxAttachments
         if let currentTextView {

--- a/Sources/TextBoxInput.swift
+++ b/Sources/TextBoxInput.swift
@@ -3702,6 +3702,7 @@ struct TextBoxInputView: NSViewRepresentable {
 
         updateTextView(textView, context: context)
         onTextViewCreated(textView)
+        context.coordinator.queuePendingAttachmentUploadStateSync(from: textView)
         return scrollView
     }
 
@@ -3763,9 +3764,15 @@ struct TextBoxInputView: NSViewRepresentable {
 
     final class Coordinator: NSObject, NSTextViewDelegate {
         var parent: TextBoxInputView
+        private var pendingAttachmentUploadStateForNextLayout: Bool?
 
         init(parent: TextBoxInputView) {
             self.parent = parent
+        }
+
+        /// Captures pending-upload state once after representable construction restores AppKit storage.
+        func queuePendingAttachmentUploadStateSync(from textView: TextBoxInputTextView) {
+            pendingAttachmentUploadStateForNextLayout = textView.hasPendingAttachmentUploadPlaceholder()
         }
 
         func textDidChange(_ notification: Notification) {
@@ -3799,7 +3806,7 @@ struct TextBoxInputView: NSViewRepresentable {
                   let textContainer = textView.textContainer else { return }
             if let textBoxView = textView as? TextBoxInputTextView {
                 textBoxView.recenterSingleLineTextContainer()
-                syncPendingAttachmentUploadState(from: textBoxView)
+                applyPendingAttachmentUploadStateSyncIfNeeded()
             }
             layoutManager.ensureLayout(for: textContainer)
             let lineFragmentCount = (textView as? TextBoxInputTextView)?.visualLineFragmentCount()
@@ -3839,12 +3846,13 @@ struct TextBoxInputView: NSViewRepresentable {
             }
         }
 
-        /// Synchronizes pending-upload UI state from AppKit after the text view has entered its layout cycle.
-        private func syncPendingAttachmentUploadState(from textView: TextBoxInputTextView) {
+        /// Applies the one-shot pending-upload state captured during representable construction.
+        private func applyPendingAttachmentUploadStateSyncIfNeeded() {
             // Silent restore skips textDidChange to avoid publishing through TerminalPanel while
             // SwiftUI constructs the representable. Layout completion is the post-construction
             // bridge point that keeps this binding aligned without mutating state from makeNSView.
-            let hasPendingUpload = textView.hasPendingAttachmentUploadPlaceholder()
+            guard let hasPendingUpload = pendingAttachmentUploadStateForNextLayout else { return }
+            pendingAttachmentUploadStateForNextLayout = nil
             guard parent.hasPendingAttachmentUpload != hasPendingUpload else { return }
             parent.hasPendingAttachmentUpload = hasPendingUpload
         }

--- a/Sources/TextBoxInput.swift
+++ b/Sources/TextBoxInput.swift
@@ -3399,6 +3399,15 @@ struct TextBoxInputContainer: View {
     private func registerTextView(_ textView: TextBoxInputTextView) {
         textViewReference.textView = textView
         onTextViewCreated(textView)
+        syncPendingAttachmentUploadState(from: textView)
+    }
+
+    private func syncPendingAttachmentUploadState(from textView: TextBoxInputTextView) {
+        // Restoring preserved content during makeNSView intentionally skips textDidChange to
+        // avoid publishing through TerminalPanel. Keep this container-only state in sync here.
+        let hasPendingUpload = textView.hasPendingAttachmentUploadPlaceholder()
+        guard hasPendingAttachmentUpload != hasPendingUpload else { return }
+        hasPendingAttachmentUpload = hasPendingUpload
     }
 
     private func chooseFiles() {

--- a/Sources/TextBoxInput.swift
+++ b/Sources/TextBoxInput.swift
@@ -4006,10 +4006,20 @@ final class TextBoxInputTextView: NSTextView {
         discardUndoHistoryAndCleanupPendingAttachmentFiles()
     }
 
+    /// Installs preserved attributed content into the text view.
+    ///
+    /// Pass `false` for `notifyingTextChange` only from representable construction paths where
+    /// the owning panel already has the current draft state. That restores AppKit storage without
+    /// running delegate or binding side effects during SwiftUI lifecycle work.
     func installPreservedContent(_ content: NSAttributedString, notifyingTextChange: Bool = true) {
         installAttributedContent(content, notifyingTextChange: notifyingTextChange)
     }
 
+    /// Installs a saved session draft into the text view.
+    ///
+    /// Pass `false` for `notifyingTextChange` only from representable construction paths where
+    /// the owning panel already has the current draft state. That restores AppKit storage without
+    /// running delegate or binding side effects during SwiftUI lifecycle work.
     func installSessionDraft(_ draft: SessionTextBoxInputDraftSnapshot, notifyingTextChange: Bool = true) {
         installAttributedContent(
             attributedContent(from: draft),

--- a/Sources/TextBoxInput.swift
+++ b/Sources/TextBoxInput.swift
@@ -3396,12 +3396,14 @@ struct TextBoxInputContainer: View {
         )
     }
 
+    /// Records the newly constructed text view, lets the panel restore draft state, then syncs container-only state.
     private func registerTextView(_ textView: TextBoxInputTextView) {
         textViewReference.textView = textView
         onTextViewCreated(textView)
         syncPendingAttachmentUploadState(from: textView)
     }
 
+    /// Synchronizes pending-upload state without invoking the TextBox delegate or published panel bindings.
     private func syncPendingAttachmentUploadState(from textView: TextBoxInputTextView) {
         // Restoring preserved content during makeNSView intentionally skips textDidChange to
         // avoid publishing through TerminalPanel. Keep this container-only state in sync here.

--- a/Sources/TextBoxInput.swift
+++ b/Sources/TextBoxInput.swift
@@ -3396,20 +3396,10 @@ struct TextBoxInputContainer: View {
         )
     }
 
-    /// Records the newly constructed text view, lets the panel restore draft state, then syncs container-only state.
+    /// Records the newly constructed text view and lets the panel restore draft state.
     private func registerTextView(_ textView: TextBoxInputTextView) {
         textViewReference.textView = textView
         onTextViewCreated(textView)
-        syncPendingAttachmentUploadState(from: textView)
-    }
-
-    /// Synchronizes pending-upload state without invoking the TextBox delegate or published panel bindings.
-    private func syncPendingAttachmentUploadState(from textView: TextBoxInputTextView) {
-        // Restoring preserved content during makeNSView intentionally skips textDidChange to
-        // avoid publishing through TerminalPanel. Keep this container-only state in sync here.
-        let hasPendingUpload = textView.hasPendingAttachmentUploadPlaceholder()
-        guard hasPendingAttachmentUpload != hasPendingUpload else { return }
-        hasPendingAttachmentUpload = hasPendingUpload
     }
 
     private func chooseFiles() {
@@ -3807,7 +3797,10 @@ struct TextBoxInputView: NSViewRepresentable {
         func recalculateHeight(_ textView: NSTextView) {
             guard let layoutManager = textView.layoutManager,
                   let textContainer = textView.textContainer else { return }
-            (textView as? TextBoxInputTextView)?.recenterSingleLineTextContainer()
+            if let textBoxView = textView as? TextBoxInputTextView {
+                textBoxView.recenterSingleLineTextContainer()
+                syncPendingAttachmentUploadState(from: textBoxView)
+            }
             layoutManager.ensureLayout(for: textContainer)
             let lineFragmentCount = (textView as? TextBoxInputTextView)?.visualLineFragmentCount()
                 ?? TextBoxInputTextView.visualLineFragmentCount(
@@ -3844,6 +3837,16 @@ struct TextBoxInputView: NSViewRepresentable {
             if abs(parent.textViewHeight - preferredHeight) > 0.5 {
                 parent.textViewHeight = preferredHeight
             }
+        }
+
+        /// Synchronizes pending-upload UI state from AppKit after the text view has entered its layout cycle.
+        private func syncPendingAttachmentUploadState(from textView: TextBoxInputTextView) {
+            // Silent restore skips textDidChange to avoid publishing through TerminalPanel while
+            // SwiftUI constructs the representable. Layout completion is the post-construction
+            // bridge point that keeps this binding aligned without mutating state from makeNSView.
+            let hasPendingUpload = textView.hasPendingAttachmentUploadPlaceholder()
+            guard parent.hasPendingAttachmentUpload != hasPendingUpload else { return }
+            parent.hasPendingAttachmentUpload = hasPendingUpload
         }
     }
 }

--- a/Sources/TextBoxInput.swift
+++ b/Sources/TextBoxInput.swift
@@ -4006,15 +4006,18 @@ final class TextBoxInputTextView: NSTextView {
         discardUndoHistoryAndCleanupPendingAttachmentFiles()
     }
 
-    func installPreservedContent(_ content: NSAttributedString) {
-        installAttributedContent(content)
+    func installPreservedContent(_ content: NSAttributedString, notifyingTextChange: Bool = true) {
+        installAttributedContent(content, notifyingTextChange: notifyingTextChange)
     }
 
-    func installSessionDraft(_ draft: SessionTextBoxInputDraftSnapshot) {
-        installAttributedContent(attributedContent(from: draft))
+    func installSessionDraft(_ draft: SessionTextBoxInputDraftSnapshot, notifyingTextChange: Bool = true) {
+        installAttributedContent(
+            attributedContent(from: draft),
+            notifyingTextChange: notifyingTextChange
+        )
     }
 
-    private func installAttributedContent(_ content: NSAttributedString) {
+    private func installAttributedContent(_ content: NSAttributedString, notifyingTextChange: Bool) {
         invalidatePendingAttachmentUploads()
         dismissMentionCompletions()
         clearAttachmentFocus(dismissPreview: true)
@@ -4029,7 +4032,11 @@ final class TextBoxInputTextView: NSTextView {
             layoutManager?.ensureLayout(for: textContainer)
         }
         recenterSingleLineTextContainer()
-        didChangeText()
+        if notifyingTextChange {
+            didChangeText()
+        } else {
+            flushAutomaticAttachmentFileCleanup()
+        }
     }
 
     func attributedContentForPreservation() -> NSAttributedString {

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 import AppKit
 import Carbon.HIToolbox
+import Combine
 import SwiftUI
 
 #if canImport(cmux_DEV)
@@ -9668,6 +9669,30 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
             remountedTextView.submissionText(),
             expectedImageSubmission(before: "hello ", url: originalURL, after: " world")
         )
+    }
+
+    func testTerminalPanelPreservesTextBoxDraftForUnmountWithoutPublishing() throws {
+        let workspace = Workspace()
+        let panelId = try XCTUnwrap(workspace.focusedPanelId)
+        let terminalPanel = try XCTUnwrap(workspace.terminalPanel(for: panelId))
+        let originalTextView = TextBoxInputTextView(frame: NSRect(x: 0, y: 0, width: 320, height: 30))
+        originalTextView.string = "preserve this"
+
+        var objectWillChangeCount = 0
+        let cancellable = terminalPanel.objectWillChange.sink {
+            objectWillChangeCount += 1
+        }
+
+        terminalPanel.preserveTextBoxContentForUnmount(from: originalTextView)
+
+        let draft = try XCTUnwrap(terminalPanel.sessionTextBoxDraftSnapshot())
+        XCTAssertEqual(textBoxSessionDraftPartSummaries(draft.parts), [.text("preserve this")])
+        XCTAssertEqual(
+            objectWillChangeCount,
+            0,
+            "TextBox unmount preservation runs from NSViewRepresentable.dismantleNSView and must not publish during SwiftUI teardown"
+        )
+        withExtendedLifetime(cancellable) {}
     }
 
     func testTerminalPanelCloseDisposesTextBoxAttachmentDrafts() throws {


### PR DESCRIPTION
Closes #5245

## Summary
- Adds a regression test proving TextBox unmount preservation does not publish `objectWillChange` during representable teardown.
- Stops `TerminalPanel.preserveTextBoxContentForUnmount(from:)` from mutating `@Published` TextBox bindings from `NSViewRepresentable.dismantleNSView`.
- Keeps remount/session preservation through the existing private attributed-draft path and restores drafts without notifying bindings during `makeNSView` registration.

## Crash Stack
Reproduced in the tagged local dev build by mounting an active TextBox, then toggling `sidebarAppearance.matchTerminalBackground` on/off via the same app-side settings reload path. The crash is a Swift exclusivity abort while Combine publishes during AttributeGraph teardown:

```
Exception Type: EXC_CRASH (SIGABRT)
Triggered by Thread: 0, Dispatch Queue: com.apple.main-thread
5   libswiftCore.dylib      swift::fatalErrorv
7   libswiftCore.dylib      swift::runtime::AccessSet::insert
15  Combine                 ObservableObjectPublisher.Inner.send()
17  Combine                 PublishedSubject.send(_:)
22  cmux DEV.debug.dylib    TerminalPanel.textBoxContent.setter
23  cmux DEV.debug.dylib    TerminalPanel.preserveTextBoxContentForUnmount(from:) (TerminalPanel.swift:357)
24  cmux DEV.debug.dylib    closure #7 in TerminalPanelView.terminalBody.getter (TerminalPanelView.swift:118)
25  cmux DEV.debug.dylib    static TextBoxInputView.dismantleNSView(_:coordinator:) (TextBoxInput.swift:3709)
30  AttributeGraph          AG::Node::destroy
32  AttributeGraph          AG::Subgraph::invalidate_now
```

## Repro Notes
Before fix: confirmed crash in tagged dev build `issue-5245-sidebar-bg-toggle-crash`; process exited during rapid match-terminal-background reload while TextBox was active.

After fix: rebuilt with `CMUX_SKIP_ZIG_BUILD=1 ./scripts/reload.sh --tag issue-5245-sidebar-bg-toggle-crash --launch`, relaunched the tagged app when the debug socket was stale, mounted an active TextBox fixture, flipped `sidebarAppearance.matchTerminalBackground` true/false eight times through app-side `reload-config`, restored config, and confirmed the process stayed alive.

Verified app path:
`/Users/austinwang/Library/Developer/Xcode/DerivedData/cmux-issue-5245-sidebar-bg-toggle-crash/Build/Products/Debug/cmux DEV issue-5245-sidebar-bg-toggle-crash.app`

## Tests
- Added `testTerminalPanelPreservesTextBoxDraftForUnmountWithoutPublishing` as the failing regression test in its own commit.
- Local unit-test command not run because this task forbids local `xcodebuild test` / full local tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches terminal TextBox lifecycle and Combine publishing during SwiftUI teardown; behavior is narrow but easy to regress on remount/close paths.
> 
> **Overview**
> Fixes a Swift exclusivity crash when the TextBox `NSViewRepresentable` is torn down during SwiftUI/AttributeGraph updates (e.g. toggling sidebar background while the TextBox is active).
> 
> **`TerminalPanel`** no longer assigns `@Published` `textBoxContent` / `textBoxAttachments` from `preserveTextBoxContentForUnmount` during dismantle; it only caches private attributed draft state and clears the view reference. Panel close now asserts that draft discard happened before dismantle via `didDiscardTextBoxContentForClose`.
> 
> **`TextBoxInput`** restores preserved/session drafts with `notifyingTextChange: false` on registration so `didChangeText` does not publish during `makeNSView`. Pending attachment-upload state is synced once on the next layout pass instead of from construction. A regression test asserts unmount preservation does not emit `objectWillChange`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b220adff300c669f357496b0672eadba0931c7a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve and restore terminal panel text drafts without triggering UI-change notifications during teardown or registration.
  * Avoid publishing drafts when a panel is closing and prevent unnecessary immediate state copies; keep attachment/upload state consistent during input lifecycle.

* **Tests**
  * Added a test verifying draft preservation during panel transitions does not emit UI-change events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->