### PR TITLE
Improve multi-workspace close dialog

### DIFF
--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -7473,12 +7473,22 @@ class TabManager: ObservableObject {
             selectedTabId = tabs[newIndex].id
         }
 
-        for workspace in indexedTargets.map(\.element) {
-            workspace.withClosedPanelHistorySuppressed {
-                workspace.teardownAllPanels()
-            }
-            workspace.teardownRemoteConnection()
+        let detachedWorkspaces = indexedTargets.map(\.element)
+        for workspace in detachedWorkspaces {
             publishCmuxWorkspaceClosed(workspace)
+        }
+        teardownDetachedWorkspacesCooperatively(detachedWorkspaces)
+    }
+
+    private func teardownDetachedWorkspacesCooperatively(_ workspaces: [Workspace]) {
+        Task { @MainActor in
+            for workspace in workspaces {
+                await workspace.withClosedPanelHistorySuppressed {
+                    await workspace.teardownAllPanelsCooperatively()
+                    workspace.teardownRemoteConnection()
+                }
+                await Task.yield()
+            }
         }
     }
 

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -7135,7 +7135,8 @@ class TabManager: ObservableObject {
             guard confirmClose(
                 title: plan.title,
                 message: plan.message,
-                acceptCmdD: plan.acceptCmdD
+                acceptCmdD: plan.acceptCmdD,
+                scrollableMessage: plan.scrollableMessage
             ) else { return }
         }
 
@@ -7151,6 +7152,7 @@ class TabManager: ObservableObject {
             }
         }
 
+        var confirmedWorkspaces: [Workspace] = []
         for workspace in plan.workspaces {
             guard tabs.contains(where: { $0.id == workspace.id }) else { continue }
             // Anchor-close confirms inside closeWorkspaceIfRunningProcess.
@@ -7167,21 +7169,10 @@ class TabManager: ObservableObject {
                 if !confirmAnchorWorkspaceClose(groupName: group.name, otherMemberCount: otherMemberCount) {
                     return
                 }
-                // Anchor confirmed (or suppressed); skip the inner re-prompt
-                // by closing without going through closeWorkspaceIfRunningProcess.
-                if tabs.count <= 1 {
-                    if let window {
-                        window.performClose(nil)
-                    } else {
-                        AppDelegate.shared?.closeMainWindowContainingTabId(workspace.id)
-                    }
-                } else {
-                    closeWorkspace(workspace)
-                }
-                continue
             }
-            closeWorkspaceIfRunningProcess(workspace, requiresConfirmation: false)
+            confirmedWorkspaces.append(workspace)
         }
+        closeWorkspacesInBatch(confirmedWorkspaces)
     }
 
     func selectWorkspace(_ workspace: Workspace) {
@@ -7208,7 +7199,7 @@ class TabManager: ObservableObject {
         }
     }
 
-    func confirmClose(title: String, message: String, acceptCmdD: Bool) -> Bool {
+    func confirmClose(title: String, message: String, acceptCmdD: Bool, scrollableMessage: String? = nil) -> Bool {
         guard beginCloseConfirmationSession() else { return false }
         defer { endCloseConfirmationSession() }
 
@@ -7221,6 +7212,9 @@ class TabManager: ObservableObject {
         alert.messageText = title
         alert.informativeText = message
         alert.alertStyle = .warning
+        if let scrollableMessage {
+            alert.accessoryView = makeCloseConfirmationScrollableMessageView(scrollableMessage)
+        }
         alert.addButton(withTitle: String(localized: "dialog.closeTab.close", defaultValue: "Close"))
         alert.addButton(withTitle: String(localized: "dialog.closeTab.cancel", defaultValue: "Cancel"))
 
@@ -7237,11 +7231,40 @@ class TabManager: ObservableObject {
         #if DEBUG
         UITestRecorder.record([
             "closeConfirmationTitle": title,
-            "closeConfirmationMessage": message,
+            "closeConfirmationMessage": [message, scrollableMessage].compactMap(\.self).joined(separator: "\n"),
         ])
         #endif
 
         return runCloseConfirmationAlert(alert) == .alertFirstButtonReturn
+    }
+
+    private func makeCloseConfirmationScrollableMessageView(_ message: String) -> NSView {
+        let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: 360, height: 180))
+        scrollView.borderType = .bezelBorder
+        scrollView.hasVerticalScroller = true
+        scrollView.hasHorizontalScroller = false
+        scrollView.autohidesScrollers = false
+        scrollView.setAccessibilityLabel(String(
+            localized: "dialog.closeWorkspaces.list.accessibilityLabel",
+            defaultValue: "Workspaces that will close"
+        ))
+
+        let textView = NSTextView(frame: scrollView.bounds)
+        textView.string = message
+        textView.isEditable = false
+        textView.isSelectable = true
+        textView.drawsBackground = false
+        textView.textContainerInset = NSSize(width: 0, height: 0)
+        textView.font = .systemFont(ofSize: NSFont.systemFontSize)
+        textView.textColor = .labelColor
+        textView.textContainer?.widthTracksTextView = true
+        textView.minSize = NSSize(width: 0, height: 180)
+        textView.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+        textView.isVerticallyResizable = true
+        textView.isHorizontallyResizable = false
+
+        scrollView.documentView = textView
+        return scrollView
     }
 
     private func runCloseConfirmationAlert(_ alert: NSAlert) -> NSApplication.ModalResponse {
@@ -7289,6 +7312,7 @@ class TabManager: ObservableObject {
         let workspaces: [Workspace]
         let title: String
         let message: String
+        let scrollableMessage: String?
         let acceptCmdD: Bool
     }
 
@@ -7352,22 +7376,110 @@ class TabManager: ObservableObject {
         let titleLines = workspaces
             .map { "• \(closeWorkspaceDisplayTitle($0.title))" }
             .joined(separator: "\n")
-        let format = willCloseWindow
-            ? String(
-                localized: "dialog.closeWorkspacesWindow.message",
-                defaultValue: "This will close the current window, its %1$lld workspaces, and all of their panels:\n%2$@"
-            )
-            : String(
-                localized: "dialog.closeWorkspaces.message",
-                defaultValue: "This will close %1$lld workspaces and all of their panels:\n%2$@"
-            )
-        let message = String(format: format, locale: .current, Int64(workspaces.count), titleLines)
+        let usesScrollableList = workspaces.count > 12
+        let format: String
+        if willCloseWindow {
+            format = usesScrollableList
+                ? String(
+                    localized: "dialog.closeWorkspacesWindow.summary",
+                    defaultValue: "This will close the current window, its %1$lld workspaces, and all of their panels:"
+                )
+                : String(
+                    localized: "dialog.closeWorkspacesWindow.message",
+                    defaultValue: "This will close the current window, its %1$lld workspaces, and all of their panels:\n%2$@"
+                )
+        } else {
+            format = usesScrollableList
+                ? String(
+                    localized: "dialog.closeWorkspaces.summary",
+                    defaultValue: "This will close %1$lld workspaces and all of their panels:"
+                )
+                : String(
+                    localized: "dialog.closeWorkspaces.message",
+                    defaultValue: "This will close %1$lld workspaces and all of their panels:\n%2$@"
+                )
+        }
+        let message = usesScrollableList
+            ? String(format: format, locale: .current, Int64(workspaces.count))
+            : String(format: format, locale: .current, Int64(workspaces.count), titleLines)
         return CloseWorkspacesPlan(
             workspaces: workspaces,
             title: title,
             message: message,
+            scrollableMessage: usesScrollableList ? titleLines : nil,
             acceptCmdD: willCloseWindow
         )
+    }
+
+    private func closeWorkspacesInBatch(_ workspaces: [Workspace]) {
+        guard tabs.count > 1 else { return }
+        let requestedIds = Set(workspaces.map(\.id))
+        let indexedTargets = tabs.enumerated().filter { requestedIds.contains($0.element.id) }
+        guard !indexedTargets.isEmpty else { return }
+
+        let closingIds = Set(indexedTargets.map(\.element.id))
+        if tabs.count == closingIds.count {
+            if let firstWorkspace = indexedTargets.first?.element {
+                if let window {
+                    window.performClose(nil)
+                } else {
+                    AppDelegate.shared?.closeMainWindowContainingTabId(firstWorkspace.id)
+                }
+            }
+            return
+        }
+
+        for (index, workspace) in indexedTargets {
+            sentryBreadcrumb("workspace.close", data: ["tabCount": tabs.count - closingIds.count])
+            if workspace.isRestorableInSessionSnapshot {
+                let snapshot = workspace.sessionSnapshot(
+                    includeScrollback: true,
+                    restorableAgentIndex: RestorableAgentSessionIndex.load()
+                )
+                ClosedItemHistoryStore.shared.push(.workspace(ClosedWorkspaceHistoryEntry(
+                    workspaceId: workspace.id,
+                    windowId: AppDelegate.shared?.windowId(for: self),
+                    workspaceIndex: index,
+                    snapshot: snapshot
+                )))
+            }
+            clearWorkspaceGitProbes(workspaceId: workspace.id)
+            clearWorkspacePullRequestTracking(workspaceId: workspace.id)
+            sidebarSelectedWorkspaceIds.remove(workspace.id)
+            invalidateFocusHistoryTarget(workspaceId: workspace.id, panelId: nil)
+            AppDelegate.shared?.notificationStore?.clearNotifications(forTabId: workspace.id)
+            unwireClosedBrowserTracking(for: workspace)
+            recentlyClosedBrowsers.removeSnapshots(forWorkspaceId: workspace.id)
+            workspace.owningTabManager = nil
+        }
+
+        let firstClosedIndex = indexedTargets.map(\.offset).min() ?? 0
+        let oldSelectedTabId = selectedTabId
+        tabs = tabs.filter { !closingIds.contains($0.id) }
+
+        let dissolvedGroupIds = Set(workspaceGroups.compactMap { group in
+            closingIds.contains(group.anchorWorkspaceId) ? group.id : nil
+        })
+        if !dissolvedGroupIds.isEmpty {
+            for tab in tabs where tab.groupId.map(dissolvedGroupIds.contains) == true {
+                tab.groupId = nil
+            }
+            workspaceGroups.removeAll { dissolvedGroupIds.contains($0.id) }
+            normalizeWorkspaceGroupContiguity()
+        }
+
+        if let oldSelectedTabId, closingIds.contains(oldSelectedTabId) {
+            let newIndex = min(firstClosedIndex, max(0, tabs.count - 1))
+            selectedTabId = tabs[newIndex].id
+        }
+
+        for workspace in indexedTargets.map(\.element) {
+            workspace.withClosedPanelHistorySuppressed {
+                workspace.teardownAllPanels()
+            }
+            workspace.teardownRemoteConnection()
+            publishCmuxWorkspaceClosed(workspace)
+        }
     }
 
     private func closeWorkspaceDisplayTitle(_ title: String?) -> String {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -11372,6 +11372,13 @@ final class Workspace: Identifiable, ObservableObject {
         body()
     }
 
+    func withClosedPanelHistorySuppressed(_ body: () async -> Void) async {
+        let previous = suppressClosedPanelHistory
+        suppressClosedPanelHistory = true
+        defer { suppressClosedPanelHistory = previous }
+        await body()
+    }
+
     func markTabCloseButtonClose(surfaceId: TabID) {
         explicitUserCloseTabIds.insert(surfaceId)
         tabCloseButtonCloseTabIds.insert(surfaceId)
@@ -15233,6 +15240,50 @@ final class Workspace: Identifiable, ObservableObject {
                 requestTransferredRemoteCleanup: true,
                 cleanupControllerSurfaceState: true
             )
+        }
+        pruneSurfaceMetadata(validSurfaceIds: [])
+        syncRemotePortScanTTYs()
+        recomputeListeningPorts()
+        clearRemoteConfigurationIfWorkspaceBecameLocal()
+        restoredTerminalScrollbackByPanelId.removeAll(keepingCapacity: false)
+#if DEBUG
+        debugSessionSnapshotScrollbackFallbackPanelIds.removeAll(keepingCapacity: false)
+        debugSessionSnapshotSyntheticScrollbackByPanelId.removeAll(keepingCapacity: false)
+#endif
+        pendingTerminalInputObserversByPanelId.removeAll(keepingCapacity: false)
+        terminalInheritanceFontPointsByPanelId.removeAll(keepingCapacity: false)
+        lastTerminalConfigInheritancePanelId = nil
+        lastTerminalConfigInheritanceFontPoints = nil
+    }
+
+    /// Tear down panels from a workspace that has already been detached from
+    /// visible UI state. Yield between small chunks so closing many workspaces
+    /// cannot monopolize the main actor.
+    func teardownAllPanelsCooperatively(yieldEvery panelCount: Int = 1) async {
+        portalRenderingEnabled = false
+        clearLayoutFollowUp()
+        hideAllTerminalPortalViews()
+        hideAllBrowserPortalViews()
+        let panelEntries = Array(panels)
+        let yieldInterval = max(1, panelCount)
+        for (index, entry) in panelEntries.enumerated() {
+            let panelId = entry.key
+            let panel = entry.value
+            discardClosedPanelLifecycleState(
+                panelId: panelId,
+                tabId: surfaceIdFromPanelId(panelId),
+                paneId: paneId(forPanelId: panelId),
+                panel: panel,
+                origin: "workspace_teardown",
+                closePanel: true,
+                publishSurfaceClosedEvent: true,
+                clearSurfaceNotifications: true,
+                requestTransferredRemoteCleanup: true,
+                cleanupControllerSurfaceState: true
+            )
+            if (index + 1) % yieldInterval == 0 {
+                await Task.yield()
+            }
         }
         pruneSurfaceMetadata(validSurfaceIds: [])
         syncRemotePortScanTTYs()

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -6,6 +6,7 @@ import WebKit
 import ObjectiveC.runtime
 import Bonsplit
 import UserNotifications
+import Combine
 
 #if canImport(cmux_DEV)
 @testable import cmux_DEV
@@ -1421,6 +1422,45 @@ final class TabManagerCloseWorkspacesWithConfirmationTests: XCTestCase {
         XCTAssertEqual(prompts.first?.message, expectedMessage)
         XCTAssertEqual(prompts.first?.acceptCmdD, false)
         XCTAssertEqual(manager.tabs.map(\.title), ["Alpha", "Beta", "Gamma"])
+    }
+
+    func testCloseWorkspacesWithConfirmationUsesCompactPromptAndPublishesSingleTabsChangeForLargeSelection() {
+        let manager = TabManager()
+        while manager.tabs.count < 15 {
+            _ = manager.addWorkspace()
+        }
+        for (index, workspace) in manager.tabs.enumerated() {
+            manager.setCustomTitle(tabId: workspace.id, title: "Workspace \(index)")
+        }
+
+        let closingIds = manager.tabs.prefix(14).map(\.id)
+        var tabEmissionCounts: [Int] = []
+        let cancellable = manager.$tabs.dropFirst().sink { tabs in
+            tabEmissionCounts.append(tabs.count)
+        }
+        defer { cancellable.cancel() }
+
+        var prompts: [(title: String, message: String, acceptCmdD: Bool)] = []
+        manager.confirmCloseHandler = { title, message, acceptCmdD in
+            prompts.append((title, message, acceptCmdD))
+            return true
+        }
+
+        manager.closeWorkspacesWithConfirmation(Array(closingIds), allowPinned: true)
+
+        let expectedSummary = String(
+            format: String(
+                localized: "dialog.closeWorkspaces.summary",
+                defaultValue: "This will close %1$lld workspaces and all of their panels:"
+            ),
+            locale: .current,
+            Int64(14)
+        )
+        XCTAssertEqual(prompts.count, 1)
+        XCTAssertEqual(prompts.first?.message, expectedSummary)
+        XCTAssertFalse(prompts.first?.message.contains("Workspace 0") ?? true)
+        XCTAssertEqual(manager.tabs.map(\.title), ["Workspace 14"])
+        XCTAssertEqual(tabEmissionCounts, [1], "Expected multi-close to publish one tabs array mutation")
     }
 }
 


### PR DESCRIPTION
Summary
- Cap long multi-workspace close confirmations with a scrollable workspace list.
- Batch multi-workspace tab removal so a large close publishes one tabs array mutation.
- Add coverage for the large-selection compact prompt and single tabs publish path.

Verification
- jq empty Resources/Localizable.xcstrings
- git diff --check
- ./scripts/reload-cloud.sh --tag closews
- AWS GUI-context xcodebuild: cmux-unit, only cmuxTests/TabManagerCloseWorkspacesWithConfirmationTests, 5 tests passed

Dogfood
- Tagged build: http://127.0.0.1:17320/closews
- Check closing a large sidebar multi-selection. The previous dialog could extend below the screen and closing many workspaces could churn the sidebar once per workspace. The dialog should now stay on screen with a scrollable list, and after confirmation the selected workspaces should disappear as one batch.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5318"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783116781&installation_id=133855650&pr_number=5318&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5318&signature=c5957062dcb3d0bc537ed515ed4b5da9b476ab73392a8be3b66c7e531df7d1ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes batch workspace teardown and tab/group state on the main actor; behavior is covered by tests but affects a sensitive close path with many workspaces.
> 
> **Overview**
> Large multi-workspace close confirmations no longer embed every workspace title in the alert body. When more than **12** workspaces are selected, the dialog uses new **summary** strings (with or without closing the whole window) and shows the bullet list in a **scrollable accessory** with a dedicated accessibility label.
> 
> After confirmation, closes are **batched**: anchor checks still run per workspace, but tab removal, history, group dissolution, selection, and cooperative panel teardown happen in one pass so the sidebar gets a **single** `tabs` update instead of one mutation per workspace. **`closeWorkspacesInBatch`** and async **`teardownAllPanelsCooperatively`** on `Workspace` support that path; **`confirmClose`** optionally attaches the scroll view.
> 
> New localization keys and a unit test cover the compact prompt and single publish behavior for large selections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e6322f8afd5b86c4803fda5682bd25948f42500. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the multi-workspace close dialog with a compact, scrollable list and batches the close into a single `tabs` update to reduce UI churn. Detached workspaces now tear down cooperatively after the UI update to keep the app responsive.

- **New Features**
  - Scrollable list for large selections with an accessibility label.
  - Localized summary strings for multi-close and window-close variants.

- **Refactors**
  - Batch multi-workspace close into one `tabs` mutation; updates selection and dissolves groups in one pass.
  - Cooperative teardown of detached workspaces (suppresses closed-panel history, yields between panel cleanups); tests cover the compact prompt and single-publish path.

<sup>Written for commit 2e6322f8afd5b86c4803fda5682bd25948f42500. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5318?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced workspace closure confirmation: clearly lists workspaces to be closed and uses a scrollable list for large selections.

* **Bug Fixes**
  * Batch close now prompts once for large selections and reliably closes the chosen workspaces, preserving selection and window state.

* **Documentation**
  * Updated localized dialog text and summaries for workspace/window close confirmations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->