### PR TITLE
Fix #5321: a stale/background auxiliary window absorbs the Close shortcut so windows won't close

### DIFF
--- a/Sources/App/AuxiliaryCloseShortcutTarget.swift
+++ b/Sources/App/AuxiliaryCloseShortcutTarget.swift
@@ -1,0 +1,26 @@
+import AppKit
+
+/// Selects the auxiliary window that should own a focused-window close shortcut (Cmd+W) among
+/// `candidates` (typically the key window, the main window, and the shortcut's event window).
+///
+/// The close shortcut is a focused-window command, so an auxiliary window may only own it when it is
+/// actually the **key** window. A non-key auxiliary candidate — a stale `event.window` that AppKit
+/// preserved after another window became key, or a closed-but-reused auxiliary scene (e.g. the
+/// Settings window) lingering in the background — must be rejected; otherwise it absorbs Cmd+W and
+/// the user's focused window/tab never closes (issue #5321).
+///
+/// - Parameters:
+///   - candidates: Candidate windows in priority order; `nil` entries are skipped.
+///   - isAuxiliary: Whether a candidate is an auxiliary cmux window that can own the close shortcut.
+///   - isKey: Whether a candidate is currently the key window.
+/// - Returns: The first candidate that is both auxiliary and the key window, or `nil` to fall through
+///   to the normal focused-window/tab close.
+func auxiliaryCloseShortcutTarget<Window>(
+    candidates: [Window?],
+    isAuxiliary: (Window) -> Bool,
+    isKey: (Window) -> Bool
+) -> Window? {
+    candidates
+        .compactMap { $0 }
+        .first { isAuxiliary($0) }
+}

--- a/Sources/App/AuxiliaryCloseShortcutTarget.swift
+++ b/Sources/App/AuxiliaryCloseShortcutTarget.swift
@@ -22,5 +22,5 @@ func auxiliaryCloseShortcutTarget<Window>(
 ) -> Window? {
     candidates
         .compactMap { $0 }
-        .first { isAuxiliary($0) }
+        .first { isAuxiliary($0) && isKey($0) }
 }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -6095,13 +6095,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     private func auxiliaryWindowForFocusedCloseShortcut(event: NSEvent) -> NSWindow? {
-        [
-            NSApp.keyWindow,
-            NSApp.mainWindow,
-            resolvedShortcutEventWindow(event),
-        ]
-        .compactMap { $0 }
-        .first { cmuxWindowShouldOwnCloseShortcut($0) }
+        // Only an auxiliary window that is actually the key window may own the focused Close shortcut.
+        // A stale event window or a lingering closed auxiliary scene must not absorb Cmd+W (#5321).
+        auxiliaryCloseShortcutTarget(
+            candidates: [
+                NSApp.keyWindow,
+                NSApp.mainWindow,
+                resolvedShortcutEventWindow(event),
+            ],
+            isAuxiliary: { cmuxWindowShouldOwnCloseShortcut($0) },
+            isKey: { $0.isKeyWindow }
+        )
     }
 
     /// Re-sync app-level active window pointers from the currently focused main terminal window.

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -39,6 +39,8 @@
 		350DAC5EBD38642A3E81471A /* AuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 312DE7503B4658DD173121B8 /* AuthManager.swift */; };
 		698944F99A6ADFBA24A7BFB9 /* AuthSettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1EA8948C5F126FE63CFB4E /* AuthSettingsStore.swift */; };
 		B9000012A1B2C3D4E5F60719 /* AutomationSocketUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000011A1B2C3D4E5F60719 /* AutomationSocketUITests.swift */; };
+		BB5321A0C0DE0002FACE0002 /* AuxiliaryCloseShortcutTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB5321A0C0DE0001FACE0001 /* AuxiliaryCloseShortcutTarget.swift */; };
+		BB5321A0C0DE0004FACE0004 /* AuxiliaryCloseShortcutTargetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB5321A0C0DE0003FACE0003 /* AuxiliaryCloseShortcutTargetTests.swift */; };
 		C0DE35860000000000000001 /* BackgroundWorkspacePrimeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE35860000000000000002 /* BackgroundWorkspacePrimeCoordinator.swift */; };
 		A50012F1 /* Backport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50012F0 /* Backport.swift */; };
 		D0B10010A1B2C3D4E5F60001 /* BonsplitTabBarDebug.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B10011A1B2C3D4E5F60001 /* BonsplitTabBarDebug.swift */; };
@@ -711,6 +713,8 @@
 		312DE7503B4658DD173121B8 /* AuthManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AuthManager.swift; sourceTree = "<group>"; };
 		5B1EA8948C5F126FE63CFB4E /* AuthSettingsStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AuthSettingsStore.swift; sourceTree = "<group>"; };
 		B9000011A1B2C3D4E5F60719 /* AutomationSocketUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomationSocketUITests.swift; sourceTree = "<group>"; };
+		BB5321A0C0DE0001FACE0001 /* AuxiliaryCloseShortcutTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/AuxiliaryCloseShortcutTarget.swift; sourceTree = "<group>"; };
+		BB5321A0C0DE0003FACE0003 /* AuxiliaryCloseShortcutTargetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuxiliaryCloseShortcutTargetTests.swift; sourceTree = "<group>"; };
 		C0DE35860000000000000002 /* BackgroundWorkspacePrimeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundWorkspacePrimeCoordinator.swift; sourceTree = "<group>"; };
 		A50012F0 /* Backport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Backport.swift; sourceTree = "<group>"; };
 		D0B10011A1B2C3D4E5F60001 /* BonsplitTabBarDebug.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BonsplitTabBarDebug.swift; sourceTree = "<group>"; };
@@ -1520,6 +1524,7 @@
 				E5C0F1A1E5C0F1A1E5C0F1A1 /* TerminalFindEscapeRouting.swift */,
 				C7934BB35B66491B1BCA8064 /* MenuBarExtraController.swift */,
 				2F0C07000000000000000001 /* CmuxMainWindow.swift */,
+				BB5321A0C0DE0001FACE0001 /* AuxiliaryCloseShortcutTarget.swift */,
 				AA5269A0C0DE0001FACE0001 /* ForeignFirstResponderPolicy.swift */,
 				2F0C06000000000000000001 /* MainWindowVisibilityController.swift */,
 				A500D011A1B2C3D4E5F60718 /* DebugLogging.swift */,
@@ -1858,6 +1863,7 @@
 				F7000001A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift */,
 				F8000001A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift */,
 				F9000001A1B2C3D4E5F60718 /* GhosttyEnsureFocusWindowActivationTests.swift */,
+				BB5321A0C0DE0003FACE0003 /* AuxiliaryCloseShortcutTargetTests.swift */,
 				AA5269A0C0DE0003FACE0003 /* ForeignFirstResponderPolicyTests.swift */,
 				F1C1AA20B7E84D10A1C10001 /* InactivePaneFirstClickFocusTests.swift */,
 				FA000001A1B2C3D4E5F60718 /* WorkspaceStressProfileTests.swift */,
@@ -2332,6 +2338,7 @@
 				D9FEC58D5BACCF76459F1BBE /* AuthEnvironment.swift in Sources */,
 				350DAC5EBD38642A3E81471A /* AuthManager.swift in Sources */,
 				698944F99A6ADFBA24A7BFB9 /* AuthSettingsStore.swift in Sources */,
+				BB5321A0C0DE0002FACE0002 /* AuxiliaryCloseShortcutTarget.swift in Sources */,
 				C0DE35860000000000000001 /* BackgroundWorkspacePrimeCoordinator.swift in Sources */,
 					A50012F1 /* Backport.swift in Sources */,
 				D0B10010A1B2C3D4E5F60001 /* BonsplitTabBarDebug.swift in Sources */,
@@ -2755,6 +2762,7 @@
 				C34670010000000000000001 /* AppDelegateRenameShortcutContextTests.swift in Sources */,
 				F6000000A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift in Sources */,
 				A11EAA000000000000000000 /* AppearanceSettingsTests.swift in Sources */,
+				BB5321A0C0DE0004FACE0004 /* AuxiliaryCloseShortcutTargetTests.swift in Sources */,
 				D3622000A1B2C3D4E5F60718 /* BrowserArrowKeyForwardingTests.swift in Sources */,
 				E12E88F82733EC42F32C36A3 /* BrowserConfigTests.swift in Sources */,
 				A5008381 /* BrowserFindJavaScriptTests.swift in Sources */,

--- a/cmuxTests/AuxiliaryCloseShortcutTargetTests.swift
+++ b/cmuxTests/AuxiliaryCloseShortcutTargetTests.swift
@@ -1,0 +1,54 @@
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Coverage for ``auxiliaryCloseShortcutTarget(candidates:isAuxiliary:isKey:)`` — the rule that an
+/// auxiliary window only owns the focused Close shortcut when it is the key window. Regression
+/// coverage for issue #5321 (a stale/background auxiliary window must not absorb Cmd+W).
+@Suite struct AuxiliaryCloseShortcutTargetTests {
+    private struct FakeWindow {
+        let id: String
+        let auxiliary: Bool
+        let key: Bool
+    }
+
+    private func target(_ windows: [FakeWindow?]) -> FakeWindow? {
+        auxiliaryCloseShortcutTarget(
+            candidates: windows,
+            isAuxiliary: { $0.auxiliary },
+            isKey: { $0.key }
+        )
+    }
+
+    @Test func selectsAuxiliaryWindowThatIsKey() {
+        let aux = FakeWindow(id: "cmux.settings", auxiliary: true, key: true)
+        #expect(target([aux])?.id == "cmux.settings")
+    }
+
+    /// The #5321 regression: a background/stale auxiliary window (not key) must not be selected.
+    /// Without the key requirement this returns the auxiliary window and absorbs Cmd+W.
+    @Test func ignoresNonKeyAuxiliaryWindow() {
+        let mainKey = FakeWindow(id: "cmux.main", auxiliary: false, key: true)
+        let staleAux = FakeWindow(id: "cmux.settings", auxiliary: true, key: false)
+        #expect(target([mainKey, staleAux])?.id == nil)
+    }
+
+    @Test func ignoresKeyNonAuxiliaryWindow() {
+        let mainKey = FakeWindow(id: "cmux.main", auxiliary: false, key: true)
+        #expect(target([mainKey])?.id == nil)
+    }
+
+    @Test func returnsNilForEmptyCandidates() {
+        #expect(target([nil, nil])?.id == nil)
+    }
+
+    @Test func picksFirstAuxiliaryKeyCandidate() {
+        let about = FakeWindow(id: "cmux.about", auxiliary: true, key: true)
+        let settings = FakeWindow(id: "cmux.settings", auxiliary: true, key: true)
+        #expect(target([about, settings])?.id == "cmux.about")
+    }
+}


### PR DESCRIPTION
Fixes part of https://github.com/manaflow-ai/cmux/issues/5321.

## Symptom

You press the Close shortcut (Cmd+W) to close a window and it doesn't close. Confirmed via the DEBUG event log: the shortcut logs `shortcut.closeTab route=auxWindow`, no `window.closed` fires, and the main-window count is unchanged.

## Root cause

The Close-tab shortcut handler (`AppDelegate.swift`) first calls `auxiliaryWindowForFocusedCloseShortcut`, which returned the first of `[NSApp.keyWindow, NSApp.mainWindow, resolvedShortcutEventWindow(event)]` whose identifier is an auxiliary window (`cmuxWindowShouldOwnCloseShortcut` → `cmuxAuxiliaryWindowIdentifiers`: `cmux.settings`, `cmux.browser-popup`, `cmux.recentlyClosedHistory`, …), then called `performClose` on it.

`resolvedShortcutEventWindow` returns `event.window`, which AppKit can leave **stale** after another window becomes key (the sibling `mainWindowForFocusedCloseShortcut` documents exactly this). So a **background / stale auxiliary window** (or a closed-but-reused Settings scene that lingers) gets the `performClose` and refuses to close, and the user's actually-focused window/tab never closes.

## Fix

The Close shortcut is a focused-window command, so an auxiliary window may only own it when it is actually the **key** window. `auxiliaryWindowForFocusedCloseShortcut` now requires the auxiliary candidate to be `isKeyWindow`, via a small testable helper `auxiliaryCloseShortcutTarget(candidates:isAuxiliary:isKey:)`. A genuinely focused auxiliary window (e.g. a browser popup that has key) still owns Cmd+W; a non-key/stale auxiliary window falls through to the normal focused-window/tab close.

## Tests

`cmuxTests/AuxiliaryCloseShortcutTargetTests.swift`: a key auxiliary window is selected; a **non-key** auxiliary window is **not** (the #5321 regression — fails without the key requirement, see the first commit); a key non-auxiliary window is not selected; empty candidates return nil; first auxiliary+key candidate wins.

## Scope

This fixes the **close-shortcut absorption** half of #5321 (the demonstrated "can't close a window" symptom). The other half — auxiliary windows (Settings, etc.) not truly closing, so they reappear and linger in the window switcher (SwiftUI single-`Window`-scene reuse + missing `close()`/`collectionBehavior`/`isExcludedFromWindowsMenu`) — is the larger, riskier change and stays tracked in #5321 for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5322"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783120434&installation_id=133855650&pr_number=5322&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5322&signature=ffdbaf71a620e98a5dd2b7d2c69b402cc7965fc81878adda96402a6047ffefa7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow shortcut-routing change with unit tests; no auth, data, or broad architectural impact.
> 
> **Overview**
> Fixes **Cmd+W** being swallowed when a **background or stale auxiliary window** (e.g. Settings) was still considered the close target because routing only required an auxiliary identifier, not actual key focus.
> 
> **`auxiliaryWindowForFocusedCloseShortcut`** now picks the first candidate that is both an auxiliary cmux window and **`isKeyWindow`**, via a small **`auxiliaryCloseShortcutTarget`** helper, so close falls through to the focused main window/tab when the auxiliary isn’t key. A focused auxiliary (e.g. browser popup with key) still owns the shortcut.
> 
> Adds **`AuxiliaryCloseShortcutTargetTests`** for the #5321 regression (non-key auxiliary must not be selected).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6d4560028dd7575ca08b3501197efdaec39ac02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the bug where a stale/background auxiliary window (e.g. Settings) intercepted Cmd+W, so the focused window didn’t close. Only the key auxiliary window can own the Close shortcut; otherwise it falls through to the focused window/tab. Addresses the close-shortcut absorption part of #5321.

- **Bug Fixes**
  - Require auxiliary windows to be key before owning Cmd+W in `auxiliaryWindowForFocusedCloseShortcut`.
  - Add `AuxiliaryCloseShortcutTarget.swift` helper to select the correct window (key + auxiliary).
  - Add tests covering key/non-key auxiliary cases and selection order.
  - Update project to include new source and test files.

<sup>Written for commit a6d4560028dd7575ca08b3501197efdaec39ac02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5322?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed close shortcut (Cmd+W) routing to properly handle auxiliary windows and ensure only the key window owns the shortcut.

* **Tests**
  * Added comprehensive tests for close shortcut target resolution validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->