### PR TITLE
Fix terminal copy mode cursor navigation

### DIFF
--- a/Packages/CmuxTerminalCopyMode/Package.swift
+++ b/Packages/CmuxTerminalCopyMode/Package.swift
@@ -22,5 +22,14 @@ let package = Package(
                 .enableUpcomingFeature("InternalImportsByDefault"),
             ]
         ),
+        .testTarget(
+            name: "CmuxTerminalCopyModeTests",
+            dependencies: ["CmuxTerminalCopyMode"],
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .enableUpcomingFeature("ExistentialAny"),
+                .enableUpcomingFeature("InternalImportsByDefault"),
+            ]
+        ),
     ]
 )

--- a/Packages/CmuxTerminalCopyMode/Package.swift
+++ b/Packages/CmuxTerminalCopyMode/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "CmuxTerminalCopyMode",
+    platforms: [
+        .macOS(.v14),
+    ],
+    products: [
+        .library(
+            name: "CmuxTerminalCopyMode",
+            targets: ["CmuxTerminalCopyMode"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "CmuxTerminalCopyMode",
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .enableUpcomingFeature("ExistentialAny"),
+                .enableUpcomingFeature("InternalImportsByDefault"),
+            ]
+        ),
+    ]
+)

--- a/Packages/CmuxTerminalCopyMode/Sources/CmuxTerminalCopyMode/TerminalKeyboardCopyModeAction.swift
+++ b/Packages/CmuxTerminalCopyMode/Sources/CmuxTerminalCopyMode/TerminalKeyboardCopyModeAction.swift
@@ -1,4 +1,26 @@
 /// A terminal copy-mode command resolved from one keyboard input sequence.
+///
+/// `TerminalKeyboardCopyModeAction` is the semantic command layer between raw
+/// keyboard events and the terminal host. Resolvers such as
+/// ``terminalKeyboardCopyModeAction(keyCode:charactersIgnoringModifiers:modifiers:hasSelection:asciiCharacterProvider:)``
+/// produce these values; the AppKit integration decides how to apply the
+/// resulting viewport scroll, cursor movement, search, copy, or exit action.
+///
+/// ```swift
+/// let action: TerminalKeyboardCopyModeAction = .adjustSelection(.down)
+/// switch action {
+/// case .adjustSelection(let move):
+///     print("move cursor or selection endpoint: \(move)")
+/// case .exit:
+///     print("leave copy mode")
+/// default:
+///     break
+/// }
+/// ```
+///
+/// Use ``adjustSelection(_:)`` with ``TerminalKeyboardCopyModeSelectionMove`` for
+/// both non-visual cursor motion and visual-selection endpoint motion. The enum
+/// has no initializer parameters and does not throw.
 public enum TerminalKeyboardCopyModeAction: Equatable, Sendable {
     /// Leaves keyboard copy mode.
     case exit
@@ -43,5 +65,7 @@ public enum TerminalKeyboardCopyModeAction: Equatable, Sendable {
     case searchPrevious
 
     /// Moves the copy-mode cursor or extends visual selection.
+    ///
+    /// - Parameter move: The cursor or endpoint movement to apply.
     case adjustSelection(TerminalKeyboardCopyModeSelectionMove)
 }

--- a/Packages/CmuxTerminalCopyMode/Sources/CmuxTerminalCopyMode/TerminalKeyboardCopyModeAction.swift
+++ b/Packages/CmuxTerminalCopyMode/Sources/CmuxTerminalCopyMode/TerminalKeyboardCopyModeAction.swift
@@ -1,0 +1,47 @@
+/// A terminal copy-mode command resolved from one keyboard input sequence.
+public enum TerminalKeyboardCopyModeAction: Equatable, Sendable {
+    /// Leaves keyboard copy mode.
+    case exit
+
+    /// Starts visual selection at the current copy-mode cursor.
+    case startSelection
+
+    /// Clears the active visual selection while staying in copy mode.
+    case clearSelection
+
+    /// Copies the active visual selection and exits copy mode.
+    case copyAndExit
+
+    /// Copies one or more full viewport lines and exits copy mode.
+    case copyLineAndExit
+
+    /// Scrolls the viewport by a signed number of lines.
+    case scrollLines(Int)
+
+    /// Scrolls the viewport by a signed number of pages.
+    case scrollPage(Int)
+
+    /// Scrolls the viewport by a signed number of half pages.
+    case scrollHalfPage(Int)
+
+    /// Jumps the viewport and cursor to the top-left cell.
+    case scrollToTop
+
+    /// Jumps the viewport and cursor to the bottom-right cell.
+    case scrollToBottom
+
+    /// Jumps by a signed number of shell prompts.
+    case jumpToPrompt(Int)
+
+    /// Opens terminal search from copy mode.
+    case startSearch
+
+    /// Moves to the next search result.
+    case searchNext
+
+    /// Moves to the previous search result.
+    case searchPrevious
+
+    /// Moves the copy-mode cursor or extends visual selection.
+    case adjustSelection(TerminalKeyboardCopyModeSelectionMove)
+}

--- a/Packages/CmuxTerminalCopyMode/Sources/CmuxTerminalCopyMode/TerminalKeyboardCopyModeCount.swift
+++ b/Packages/CmuxTerminalCopyMode/Sources/CmuxTerminalCopyMode/TerminalKeyboardCopyModeCount.swift
@@ -1,0 +1,10 @@
+/// The maximum numeric prefix accepted for a keyboard copy-mode command.
+public let terminalKeyboardCopyModeMaxCount = 9_999
+
+/// Clamps a command repeat count into the range accepted by keyboard copy mode.
+///
+/// - Parameter value: The raw count parsed from user input.
+/// - Returns: A count between `1` and ``terminalKeyboardCopyModeMaxCount``.
+public func terminalKeyboardCopyModeClampCount(_ value: Int) -> Int {
+    min(max(value, 1), terminalKeyboardCopyModeMaxCount)
+}

--- a/Packages/CmuxTerminalCopyMode/Sources/CmuxTerminalCopyMode/TerminalKeyboardCopyModeCount.swift
+++ b/Packages/CmuxTerminalCopyMode/Sources/CmuxTerminalCopyMode/TerminalKeyboardCopyModeCount.swift
@@ -1,7 +1,25 @@
-/// The maximum numeric prefix accepted for a keyboard copy-mode command.
+/// The largest repeat count accepted by terminal keyboard copy mode.
+///
+/// ``terminalKeyboardCopyModeClampCount(_:)`` uses this value to keep numeric
+/// prefixes bounded before actions such as ``TerminalKeyboardCopyModeAction.adjustSelection(_:)``
+/// are applied.
+///
+/// ```swift
+/// let count = terminalKeyboardCopyModeClampCount(20_000)
+/// // count == terminalKeyboardCopyModeMaxCount
+/// ```
 public let terminalKeyboardCopyModeMaxCount = 9_999
 
-/// Clamps a command repeat count into the range accepted by keyboard copy mode.
+/// Clamps a command repeat count into the range accepted by terminal keyboard copy mode.
+///
+/// Use this at the host boundary before applying a stored numeric prefix to a
+/// ``TerminalKeyboardCopyModeAction``. Values smaller than one become `1`; values
+/// larger than ``terminalKeyboardCopyModeMaxCount`` become that maximum.
+///
+/// ```swift
+/// terminalKeyboardCopyModeClampCount(0) == 1
+/// terminalKeyboardCopyModeClampCount(20_000) == terminalKeyboardCopyModeMaxCount
+/// ```
 ///
 /// - Parameter value: The raw count parsed from user input.
 /// - Returns: A count between `1` and ``terminalKeyboardCopyModeMaxCount``.

--- a/Packages/CmuxTerminalCopyMode/Sources/CmuxTerminalCopyMode/TerminalKeyboardCopyModeCursor.swift
+++ b/Packages/CmuxTerminalCopyMode/Sources/CmuxTerminalCopyMode/TerminalKeyboardCopyModeCursor.swift
@@ -1,12 +1,36 @@
-/// The visible cursor position used while terminal keyboard copy mode is active.
+/// A viewport-relative cursor used while terminal keyboard copy mode is active.
+///
+/// `TerminalKeyboardCopyModeCursor` is the pure state model behind the visible
+/// copy-mode overlay. Hosts move it with ``move(_:count:rows:columns:)``, clamp it
+/// with ``clamp(rows:columns:)`` when the grid changes, and shift it with
+/// ``shiftForViewportScroll(lineDelta:rows:columns:)`` when the viewport scrolls.
+///
+/// ```swift
+/// var cursor = TerminalKeyboardCopyModeCursor(row: 8, column: 4)
+/// let overflow = cursor.move(.down, count: 2, rows: 10, columns: 40)
+/// cursor.shiftForViewportScroll(lineDelta: overflow, rows: 10, columns: 40)
+/// ```
 public struct TerminalKeyboardCopyModeCursor: Equatable, Sendable {
     /// The zero-based viewport row occupied by the cursor.
+    ///
+    /// The value is expected to be valid after ``clamp(rows:columns:)`` or
+    /// ``clamped(rows:columns:)`` has been applied for the current grid.
     public var row: Int
 
     /// The zero-based viewport column occupied by the cursor.
+    ///
+    /// The value is expected to be valid after ``clamp(rows:columns:)`` or
+    /// ``clamped(rows:columns:)`` has been applied for the current grid.
     public var column: Int
 
     /// Creates a cursor at a viewport cell.
+    ///
+    /// The initializer stores the supplied values as-is. Call
+    /// ``clamp(rows:columns:)`` if the values may be outside the active grid.
+    ///
+    /// ```swift
+    /// let cursor = TerminalKeyboardCopyModeCursor(row: 0, column: 0)
+    /// ```
     ///
     /// - Parameters:
     ///   - row: The zero-based viewport row.
@@ -17,6 +41,14 @@ public struct TerminalKeyboardCopyModeCursor: Equatable, Sendable {
     }
 
     /// Returns a cursor constrained to the supplied grid dimensions.
+    ///
+    /// This nonmutating counterpart to ``clamp(rows:columns:)`` is useful when
+    /// callers need a safe value without changing the original cursor.
+    ///
+    /// ```swift
+    /// let clamped = TerminalKeyboardCopyModeCursor(row: 40, column: 2)
+    ///     .clamped(rows: 24, columns: 80)
+    /// ```
     ///
     /// - Parameters:
     ///   - rows: The current terminal viewport row count.
@@ -30,6 +62,15 @@ public struct TerminalKeyboardCopyModeCursor: Equatable, Sendable {
 
     /// Constrains the cursor to the supplied grid dimensions.
     ///
+    /// Use this after terminal resize events so later
+    /// ``move(_:count:rows:columns:)`` or visual-selection anchoring starts from
+    /// a valid viewport cell.
+    ///
+    /// ```swift
+    /// var cursor = TerminalKeyboardCopyModeCursor(row: 40, column: 90)
+    /// cursor.clamp(rows: 24, columns: 80)
+    /// ```
+    ///
     /// - Parameters:
     ///   - rows: The current terminal viewport row count.
     ///   - columns: The current terminal viewport column count.
@@ -40,8 +81,18 @@ public struct TerminalKeyboardCopyModeCursor: Equatable, Sendable {
 
     /// Moves the cursor within the current grid and reports any vertical scroll overflow.
     ///
+    /// Horizontal moves stay inside the grid. Vertical moves clamp to the top or
+    /// bottom edge and return the signed overflow line count so the host can
+    /// scroll the viewport while the cursor remains visible.
+    ///
+    /// ```swift
+    /// var cursor = TerminalKeyboardCopyModeCursor(row: 23, column: 4)
+    /// let scrollDelta = cursor.move(.down, count: 3, rows: 24, columns: 80)
+    /// cursor.shiftForViewportScroll(lineDelta: scrollDelta, rows: 24, columns: 80)
+    /// ```
+    ///
     /// - Parameters:
-    ///   - direction: The movement to apply.
+    ///   - direction: The ``TerminalKeyboardCopyModeSelectionMove`` to apply.
     ///   - count: The repeat count from a numeric prefix.
     ///   - rows: The current terminal viewport row count.
     ///   - columns: The current terminal viewport column count.
@@ -95,8 +146,13 @@ public struct TerminalKeyboardCopyModeCursor: Equatable, Sendable {
     /// cursor model in step with the adjusted endpoint without asking callers to apply the
     /// overflow returned by ``move(_:count:rows:columns:)``.
     ///
+    /// ```swift
+    /// var cursor = TerminalKeyboardCopyModeCursor(row: 2, column: 1)
+    /// cursor.moveAfterTerminalSelectionAdjustment(.right, count: 1, rows: 24, columns: 80)
+    /// ```
+    ///
     /// - Parameters:
-    ///   - direction: The selection endpoint movement that Ghostty applied.
+    ///   - direction: The ``TerminalKeyboardCopyModeSelectionMove`` that Ghostty applied.
     ///   - count: The repeat count for this movement.
     ///   - rows: The current terminal viewport row count.
     ///   - columns: The current terminal viewport column count.
@@ -113,6 +169,12 @@ public struct TerminalKeyboardCopyModeCursor: Equatable, Sendable {
     ///
     /// Positive line deltas scroll the terminal viewport downward, so the same text appears on a
     /// smaller visible row. Negative deltas scroll upward, moving the same text toward the bottom.
+    ///
+    /// ```swift
+    /// var cursor = TerminalKeyboardCopyModeCursor(row: 10, column: 4)
+    /// cursor.shiftForViewportScroll(lineDelta: 3, rows: 24, columns: 80)
+    /// // cursor.row == 7
+    /// ```
     ///
     /// - Parameters:
     ///   - lineDelta: The signed viewport scroll delta applied by Ghostty.

--- a/Packages/CmuxTerminalCopyMode/Sources/CmuxTerminalCopyMode/TerminalKeyboardCopyModeCursor.swift
+++ b/Packages/CmuxTerminalCopyMode/Sources/CmuxTerminalCopyMode/TerminalKeyboardCopyModeCursor.swift
@@ -1,0 +1,109 @@
+/// The visible cursor position used while terminal keyboard copy mode is active.
+public struct TerminalKeyboardCopyModeCursor: Equatable, Sendable {
+    /// The zero-based viewport row occupied by the cursor.
+    public var row: Int
+
+    /// The zero-based viewport column occupied by the cursor.
+    public var column: Int
+
+    /// Creates a cursor at a viewport cell.
+    ///
+    /// - Parameters:
+    ///   - row: The zero-based viewport row.
+    ///   - column: The zero-based viewport column.
+    public init(row: Int, column: Int) {
+        self.row = row
+        self.column = column
+    }
+
+    /// Returns a cursor constrained to the supplied grid dimensions.
+    ///
+    /// - Parameters:
+    ///   - rows: The current terminal viewport row count.
+    ///   - columns: The current terminal viewport column count.
+    /// - Returns: A copy of this cursor clamped into the grid.
+    public func clamped(rows: Int, columns: Int) -> TerminalKeyboardCopyModeCursor {
+        var copy = self
+        copy.clamp(rows: rows, columns: columns)
+        return copy
+    }
+
+    /// Constrains the cursor to the supplied grid dimensions.
+    ///
+    /// - Parameters:
+    ///   - rows: The current terminal viewport row count.
+    ///   - columns: The current terminal viewport column count.
+    public mutating func clamp(rows: Int, columns: Int) {
+        row = Self.clamp(row, upperBound: rows)
+        column = Self.clamp(column, upperBound: columns)
+    }
+
+    /// Moves the cursor within the current grid and reports any vertical scroll overflow.
+    ///
+    /// - Parameters:
+    ///   - direction: The movement to apply.
+    ///   - count: The repeat count from a numeric prefix.
+    ///   - rows: The current terminal viewport row count.
+    ///   - columns: The current terminal viewport column count.
+    /// - Returns: A signed line delta to apply to the viewport when movement crossed a vertical edge.
+    public mutating func move(
+        _ direction: TerminalKeyboardCopyModeSelectionMove,
+        count: Int,
+        rows: Int,
+        columns: Int
+    ) -> Int {
+        let clampedRows = max(rows, 1)
+        let clampedColumns = max(columns, 1)
+        let clampedCount = terminalKeyboardCopyModeClampCount(count)
+        clamp(rows: clampedRows, columns: clampedColumns)
+
+        switch direction {
+        case .left:
+            column = max(0, column - clampedCount)
+            return 0
+        case .right:
+            column = min(clampedColumns - 1, column + clampedCount)
+            return 0
+        case .up:
+            return moveVertically(delta: -clampedCount, rows: clampedRows)
+        case .down:
+            return moveVertically(delta: clampedCount, rows: clampedRows)
+        case .pageUp:
+            return moveVertically(delta: -(clampedRows * clampedCount), rows: clampedRows)
+        case .pageDown:
+            return moveVertically(delta: clampedRows * clampedCount, rows: clampedRows)
+        case .home:
+            row = 0
+            column = 0
+            return 0
+        case .end:
+            row = clampedRows - 1
+            column = clampedColumns - 1
+            return 0
+        case .beginningOfLine:
+            column = 0
+            return 0
+        case .endOfLine:
+            column = clampedColumns - 1
+            return 0
+        }
+    }
+
+    private mutating func moveVertically(delta: Int, rows: Int) -> Int {
+        let target = row + delta
+        if target < 0 {
+            row = 0
+            return target
+        }
+        if target >= rows {
+            row = rows - 1
+            return target - (rows - 1)
+        }
+        row = target
+        return 0
+    }
+
+    private static func clamp(_ value: Int, upperBound: Int) -> Int {
+        max(0, min(max(upperBound, 1) - 1, value))
+    }
+}

--- a/Packages/CmuxTerminalCopyMode/Sources/CmuxTerminalCopyMode/TerminalKeyboardCopyModeCursor.swift
+++ b/Packages/CmuxTerminalCopyMode/Sources/CmuxTerminalCopyMode/TerminalKeyboardCopyModeCursor.swift
@@ -89,6 +89,40 @@ public struct TerminalKeyboardCopyModeCursor: Equatable, Sendable {
         }
     }
 
+    /// Moves the cursor after Ghostty has adjusted a visual-selection endpoint.
+    ///
+    /// Ghostty owns viewport scrolling for `adjust_selection`; this method keeps the visible
+    /// cursor model in step with the adjusted endpoint without asking callers to apply the
+    /// overflow returned by ``move(_:count:rows:columns:)``.
+    ///
+    /// - Parameters:
+    ///   - direction: The selection endpoint movement that Ghostty applied.
+    ///   - count: The repeat count for this movement.
+    ///   - rows: The current terminal viewport row count.
+    ///   - columns: The current terminal viewport column count.
+    public mutating func moveAfterTerminalSelectionAdjustment(
+        _ direction: TerminalKeyboardCopyModeSelectionMove,
+        count: Int,
+        rows: Int,
+        columns: Int
+    ) {
+        _ = move(direction, count: count, rows: rows, columns: columns)
+    }
+
+    /// Shifts the visible cursor row after the viewport scrolls without moving the cursor's text.
+    ///
+    /// Positive line deltas scroll the terminal viewport downward, so the same text appears on a
+    /// smaller visible row. Negative deltas scroll upward, moving the same text toward the bottom.
+    ///
+    /// - Parameters:
+    ///   - lineDelta: The signed viewport scroll delta applied by Ghostty.
+    ///   - rows: The current terminal viewport row count.
+    ///   - columns: The current terminal viewport column count.
+    public mutating func shiftForViewportScroll(lineDelta: Int, rows: Int, columns: Int) {
+        row -= lineDelta
+        clamp(rows: rows, columns: columns)
+    }
+
     private mutating func moveVertically(delta: Int, rows: Int) -> Int {
         let target = row + delta
         if target < 0 {

--- a/Packages/CmuxTerminalCopyMode/Sources/CmuxTerminalCopyMode/TerminalKeyboardCopyModeGeometry.swift
+++ b/Packages/CmuxTerminalCopyMode/Sources/CmuxTerminalCopyMode/TerminalKeyboardCopyModeGeometry.swift
@@ -1,5 +1,37 @@
 import Foundation
 
+/// Resolves the row count that is actually visible in the terminal host view.
+///
+/// Ghostty can report a backing grid that is taller than the clipped AppKit
+/// host view by a small number of rows. Vim-mode cursor movement should use the
+/// visible rows so edge scrolling begins when the cursor reaches the visible
+/// edge rather than after it moves into clipped backing rows.
+///
+/// ```swift
+/// let rows = terminalKeyboardCopyModeVisibleViewportRows(
+///     backingRows: 42,
+///     viewHeight: 720,
+///     cellHeight: 18
+/// )
+/// ```
+///
+/// - Parameters:
+///   - backingRows: The row count reported by the terminal surface.
+///   - viewHeight: The AppKit host view height in points.
+///   - cellHeight: The terminal cell height in points.
+/// - Returns: A positive row count constrained to the visible host viewport.
+public func terminalKeyboardCopyModeVisibleViewportRows(
+    backingRows: Int,
+    viewHeight: Double,
+    cellHeight: Double
+) -> Int {
+    let clampedBackingRows = max(backingRows, 1)
+    guard viewHeight > 0, cellHeight > 0 else { return clampedBackingRows }
+
+    let fittedRows = max(Int(floor(viewHeight / cellHeight)), 1)
+    return min(clampedBackingRows, fittedRows)
+}
+
 /// Resolves the initial copy-mode cursor row from Ghostty's IME point.
 ///
 /// Ghostty exposes the live cursor as an IME rectangle rather than as viewport

--- a/Packages/CmuxTerminalCopyMode/Sources/CmuxTerminalCopyMode/TerminalKeyboardCopyModeGeometry.swift
+++ b/Packages/CmuxTerminalCopyMode/Sources/CmuxTerminalCopyMode/TerminalKeyboardCopyModeGeometry.swift
@@ -2,6 +2,18 @@ import Foundation
 
 /// Resolves the initial copy-mode cursor row from Ghostty's IME point.
 ///
+/// Ghostty exposes the live cursor as an IME rectangle rather than as viewport
+/// cell coordinates. This helper converts that top-origin Y coordinate into the
+/// row used by ``TerminalKeyboardCopyModeCursor`` when keyboard copy mode starts.
+///
+/// ```swift
+/// let row = terminalKeyboardCopyModeInitialViewportRow(
+///     rows: 24,
+///     imePointY: 240,
+///     imeCellHeight: 24
+/// )
+/// ```
+///
 /// - Parameters:
 ///   - rows: The current terminal viewport row count.
 ///   - imePointY: Ghostty's top-origin IME Y coordinate.
@@ -23,6 +35,19 @@ public func terminalKeyboardCopyModeInitialViewportRow(
 
 /// Resolves the initial copy-mode cursor column from Ghostty's IME point.
 ///
+/// Ghostty reports the cursor X coordinate at the cell midpoint. This helper
+/// converts that coordinate into the zero-based column used by
+/// ``TerminalKeyboardCopyModeCursor``.
+///
+/// ```swift
+/// let column = terminalKeyboardCopyModeInitialViewportColumn(
+///     columns: 80,
+///     imePointX: 235,
+///     imeCellWidth: 10,
+///     leftPadding: 5
+/// )
+/// ```
+///
 /// - Parameters:
 ///   - columns: The current terminal viewport column count.
 ///   - imePointX: Ghostty's IME X coordinate at the cursor cell midpoint.
@@ -43,6 +68,19 @@ public func terminalKeyboardCopyModeInitialViewportColumn(
 }
 
 /// Chooses a nonzero horizontal drag range within a visible cursor cell.
+///
+/// The terminal host uses this range when it has to synthesize a drag inside the
+/// current copy-mode cursor cell. The returned range is clamped to the view
+/// bounds and keeps `startX < endX` so callers can issue a normal left-to-right
+/// drag even when the cell is partially clipped.
+///
+/// ```swift
+/// let range = terminalKeyboardCopyModeCursorSelectionXRange(
+///     rectMinX: 20,
+///     rectMaxX: 30,
+///     boundsWidth: 100
+/// )
+/// ```
 ///
 /// - Parameters:
 ///   - rectMinX: The cell's left edge in view coordinates.
@@ -71,5 +109,5 @@ public func terminalKeyboardCopyModeCursorSelectionXRange(
     }
     let fallbackEndX = max(midpointX - 1, 0)
     guard fallbackEndX < midpointX else { return nil }
-    return (midpointX, fallbackEndX)
+    return (fallbackEndX, midpointX)
 }

--- a/Packages/CmuxTerminalCopyMode/Sources/CmuxTerminalCopyMode/TerminalKeyboardCopyModeGeometry.swift
+++ b/Packages/CmuxTerminalCopyMode/Sources/CmuxTerminalCopyMode/TerminalKeyboardCopyModeGeometry.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+/// Resolves the initial copy-mode cursor row from Ghostty's IME point.
+///
+/// - Parameters:
+///   - rows: The current terminal viewport row count.
+///   - imePointY: Ghostty's top-origin IME Y coordinate.
+///   - imeCellHeight: The current terminal cell height.
+///   - topPadding: Vertical inset before the terminal grid begins.
+/// - Returns: A zero-based row clamped into the viewport.
+public func terminalKeyboardCopyModeInitialViewportRow(
+    rows: Int,
+    imePointY: Double,
+    imeCellHeight: Double,
+    topPadding: Double = 0
+) -> Int {
+    let clampedRows = max(rows, 1)
+    guard imeCellHeight > 0 else { return clampedRows - 1 }
+
+    let estimatedRow = Int(floor(((imePointY - topPadding) / imeCellHeight) - 1))
+    return max(0, min(clampedRows - 1, estimatedRow))
+}
+
+/// Resolves the initial copy-mode cursor column from Ghostty's IME point.
+///
+/// - Parameters:
+///   - columns: The current terminal viewport column count.
+///   - imePointX: Ghostty's IME X coordinate at the cursor cell midpoint.
+///   - imeCellWidth: The current terminal cell width.
+///   - leftPadding: Horizontal inset before the terminal grid begins.
+/// - Returns: A zero-based column clamped into the viewport.
+public func terminalKeyboardCopyModeInitialViewportColumn(
+    columns: Int,
+    imePointX: Double,
+    imeCellWidth: Double,
+    leftPadding: Double = 0
+) -> Int {
+    let clampedColumns = max(columns, 1)
+    guard imeCellWidth > 0 else { return 0 }
+
+    let estimatedColumn = Int(floor((imePointX - leftPadding) / imeCellWidth))
+    return max(0, min(clampedColumns - 1, estimatedColumn))
+}
+
+/// Chooses a nonzero horizontal drag range within a visible cursor cell.
+///
+/// - Parameters:
+///   - rectMinX: The cell's left edge in view coordinates.
+///   - rectMaxX: The cell's right edge in view coordinates.
+///   - boundsWidth: The containing view width.
+/// - Returns: A start/end X pair for synthetic selection, or `nil` when the view is too narrow.
+public func terminalKeyboardCopyModeCursorSelectionXRange(
+    rectMinX: Double,
+    rectMaxX: Double,
+    boundsWidth: Double
+) -> (startX: Double, endX: Double)? {
+    let maxX = boundsWidth - 1
+    guard maxX > 0 else { return nil }
+
+    let visibleMinX = min(max(rectMinX, 0), maxX)
+    let visibleMaxX = min(max(rectMaxX, 0), maxX)
+    let startX = min(max(visibleMinX + 0.5, 0), maxX)
+    let endX = min(max(visibleMaxX - 0.5, 0), maxX)
+    if endX > startX {
+        return (startX, endX)
+    }
+
+    let midpointX = min(max((visibleMinX + visibleMaxX) / 2, 0), maxX)
+    if midpointX < maxX {
+        return (midpointX, min(midpointX + 1, maxX))
+    }
+    let fallbackEndX = max(midpointX - 1, 0)
+    guard fallbackEndX < midpointX else { return nil }
+    return (midpointX, fallbackEndX)
+}

--- a/Packages/CmuxTerminalCopyMode/Sources/CmuxTerminalCopyMode/TerminalKeyboardCopyModeInputState.swift
+++ b/Packages/CmuxTerminalCopyMode/Sources/CmuxTerminalCopyMode/TerminalKeyboardCopyModeInputState.swift
@@ -1,4 +1,18 @@
 /// Incremental keyboard state for multi-key terminal copy-mode commands.
+///
+/// `TerminalKeyboardCopyModeInputState` stores the small amount of resolver
+/// state that survives between key events: numeric prefixes, `yy`, and `gg`.
+/// Pass one mutable instance into
+/// ``terminalKeyboardCopyModeResolve(keyCode:charactersIgnoringModifiers:modifiers:hasSelection:state:asciiCharacterProvider:)``
+/// for the lifetime of a copy-mode session, then call ``reset()`` when the host
+/// exits copy mode.
+///
+/// ```swift
+/// var state = TerminalKeyboardCopyModeInputState()
+/// state.countPrefix = 2
+/// state.pendingYankLine = true
+/// state.reset()
+/// ```
 public struct TerminalKeyboardCopyModeInputState: Equatable, Sendable {
     /// The numeric prefix collected before a command.
     public var countPrefix: Int?
@@ -26,6 +40,10 @@ public struct TerminalKeyboardCopyModeInputState: Equatable, Sendable {
     }
 
     /// Clears all pending multi-key command state.
+    ///
+    /// After calling this method, ``countPrefix``, ``pendingYankLine``, and
+    /// ``pendingG`` return to their initial values. The method mutates the state
+    /// in place and returns no value.
     public mutating func reset() {
         countPrefix = nil
         pendingYankLine = false

--- a/Packages/CmuxTerminalCopyMode/Sources/CmuxTerminalCopyMode/TerminalKeyboardCopyModeInputState.swift
+++ b/Packages/CmuxTerminalCopyMode/Sources/CmuxTerminalCopyMode/TerminalKeyboardCopyModeInputState.swift
@@ -1,0 +1,34 @@
+/// Incremental keyboard state for multi-key terminal copy-mode commands.
+public struct TerminalKeyboardCopyModeInputState: Equatable, Sendable {
+    /// The numeric prefix collected before a command.
+    public var countPrefix: Int?
+
+    /// Whether `y` has been pressed as a pending line-yank operator.
+    public var pendingYankLine: Bool
+
+    /// Whether `g` has been pressed as a pending jump prefix.
+    public var pendingG: Bool
+
+    /// Creates an input state snapshot.
+    ///
+    /// - Parameters:
+    ///   - countPrefix: The numeric prefix collected before a command.
+    ///   - pendingYankLine: Whether `y` is waiting for a second `y`.
+    ///   - pendingG: Whether `g` is waiting for a second `g`.
+    public init(
+        countPrefix: Int? = nil,
+        pendingYankLine: Bool = false,
+        pendingG: Bool = false
+    ) {
+        self.countPrefix = countPrefix
+        self.pendingYankLine = pendingYankLine
+        self.pendingG = pendingG
+    }
+
+    /// Clears all pending multi-key command state.
+    public mutating func reset() {
+        countPrefix = nil
+        pendingYankLine = false
+        pendingG = false
+    }
+}

--- a/Packages/CmuxTerminalCopyMode/Sources/CmuxTerminalCopyMode/TerminalKeyboardCopyModeKeyResolution.swift
+++ b/Packages/CmuxTerminalCopyMode/Sources/CmuxTerminalCopyMode/TerminalKeyboardCopyModeKeyResolution.swift
@@ -226,7 +226,8 @@ public func terminalKeyboardCopyModeResolve(
             state.reset()
             return .perform(.copyLineAndExit, count: count)
         }
-        state.pendingYankLine = false
+        state.reset()
+        return .consume
     }
 
     if state.pendingG {
@@ -236,7 +237,8 @@ public func terminalKeyboardCopyModeResolve(
             state.reset()
             return .perform(action, count: count)
         }
-        state.pendingG = false
+        state.reset()
+        return .consume
     }
 
     if normalized.isEmpty,

--- a/Packages/CmuxTerminalCopyMode/Sources/CmuxTerminalCopyMode/TerminalKeyboardCopyModeKeyResolution.swift
+++ b/Packages/CmuxTerminalCopyMode/Sources/CmuxTerminalCopyMode/TerminalKeyboardCopyModeKeyResolution.swift
@@ -227,7 +227,6 @@ public func terminalKeyboardCopyModeResolve(
             return .perform(.copyLineAndExit, count: count)
         }
         state.reset()
-        return .consume
     }
 
     if state.pendingG {
@@ -238,7 +237,6 @@ public func terminalKeyboardCopyModeResolve(
             return .perform(action, count: count)
         }
         state.reset()
-        return .consume
     }
 
     if normalized.isEmpty,

--- a/Packages/CmuxTerminalCopyMode/Sources/CmuxTerminalCopyMode/TerminalKeyboardCopyModeKeyResolution.swift
+++ b/Packages/CmuxTerminalCopyMode/Sources/CmuxTerminalCopyMode/TerminalKeyboardCopyModeKeyResolution.swift
@@ -1,0 +1,238 @@
+private func terminalKeyboardCopyModeNormalizedModifiers(
+    _ modifiers: TerminalKeyboardCopyModeModifiers
+) -> TerminalKeyboardCopyModeModifiers {
+    modifiers.subtracting([.numericPad, .function, .capsLock])
+}
+
+private func terminalKeyboardCopyModeChars(
+    _ charactersIgnoringModifiers: String?,
+    keyCode: UInt16,
+    asciiCharacterProvider: (UInt16) -> String?
+) -> String {
+    let raw = charactersIgnoringModifiers?.unicodeScalars.first.map { String($0).lowercased() } ?? ""
+    if raw.allSatisfy(\.isASCII) { return raw }
+
+    if let asciiScalar = asciiCharacterProvider(keyCode)?.unicodeScalars.first {
+        return String(asciiScalar).lowercased()
+    }
+    return raw
+}
+
+/// Returns whether copy mode should bypass an event so app-level shortcuts can handle it.
+///
+/// - Parameter modifiers: The event modifiers converted to ``TerminalKeyboardCopyModeModifiers``.
+/// - Returns: `true` when the event should stay available to app-level shortcut handling.
+public func terminalKeyboardCopyModeShouldBypassForShortcut(
+    modifiers: TerminalKeyboardCopyModeModifiers
+) -> Bool {
+    let normalized = terminalKeyboardCopyModeNormalizedModifiers(modifiers)
+    return normalized.contains(.command)
+}
+
+/// Resolves a single key event to a terminal copy-mode action.
+///
+/// - Parameters:
+///   - keyCode: The hardware key code for the event.
+///   - charactersIgnoringModifiers: The layout character reported without modifiers.
+///   - modifiers: The event modifiers converted to ``TerminalKeyboardCopyModeModifiers``.
+///   - hasSelection: Whether visual selection is currently active.
+///   - asciiCharacterProvider: A fallback physical-key lookup for non-ASCII input sources.
+/// - Returns: A copy-mode action, or `nil` when the key is not a command.
+public func terminalKeyboardCopyModeAction(
+    keyCode: UInt16,
+    charactersIgnoringModifiers: String?,
+    modifiers: TerminalKeyboardCopyModeModifiers,
+    hasSelection: Bool,
+    asciiCharacterProvider: (UInt16) -> String? = { _ in nil }
+) -> TerminalKeyboardCopyModeAction? {
+    let normalized = terminalKeyboardCopyModeNormalizedModifiers(modifiers)
+    let chars = terminalKeyboardCopyModeChars(
+        charactersIgnoringModifiers,
+        keyCode: keyCode,
+        asciiCharacterProvider: asciiCharacterProvider
+    )
+
+    if keyCode == 53 {
+        return .exit
+    }
+
+    switch keyCode {
+    case 126:
+        return .adjustSelection(.up)
+    case 125:
+        return .adjustSelection(.down)
+    case 123:
+        return .adjustSelection(.left)
+    case 124:
+        return .adjustSelection(.right)
+    case 116:
+        return hasSelection ? .adjustSelection(.pageUp) : .scrollPage(-1)
+    case 121:
+        return hasSelection ? .adjustSelection(.pageDown) : .scrollPage(1)
+    case 115:
+        return hasSelection ? .adjustSelection(.home) : .scrollToTop
+    case 119:
+        return hasSelection ? .adjustSelection(.end) : .scrollToBottom
+    default:
+        break
+    }
+
+    if normalized == [.control] {
+        if chars == "u" || chars == "\u{15}" {
+            return hasSelection ? .adjustSelection(.pageUp) : .scrollHalfPage(-1)
+        }
+        if chars == "d" || chars == "\u{04}" {
+            return hasSelection ? .adjustSelection(.pageDown) : .scrollHalfPage(1)
+        }
+        if chars == "b" || chars == "\u{02}" {
+            return hasSelection ? .adjustSelection(.pageUp) : .scrollPage(-1)
+        }
+        if chars == "f" || chars == "\u{06}" {
+            return hasSelection ? .adjustSelection(.pageDown) : .scrollPage(1)
+        }
+        if chars == "y" || chars == "\u{19}" {
+            return hasSelection ? .adjustSelection(.up) : .scrollLines(-1)
+        }
+        if chars == "e" || chars == "\u{05}" {
+            return hasSelection ? .adjustSelection(.down) : .scrollLines(1)
+        }
+        return nil
+    }
+
+    guard normalized.isEmpty || normalized == [.shift] else { return nil }
+
+    switch chars {
+    case "q":
+        return .exit
+    case "v":
+        return hasSelection ? .clearSelection : .startSelection
+    case "y":
+        if normalized == [.shift], !hasSelection {
+            return .copyLineAndExit
+        }
+        return hasSelection ? .copyAndExit : nil
+    case "j":
+        return .adjustSelection(.down)
+    case "k":
+        return .adjustSelection(.up)
+    case "h":
+        return .adjustSelection(.left)
+    case "l":
+        return .adjustSelection(.right)
+    case "g":
+        if normalized == [.shift] {
+            return hasSelection ? .adjustSelection(.end) : .scrollToBottom
+        }
+        return nil
+    case "0", "^":
+        return hasSelection ? .adjustSelection(.beginningOfLine) : nil
+    case "$", "4":
+        guard chars == "$" || normalized == [.shift] else { return nil }
+        return hasSelection ? .adjustSelection(.endOfLine) : nil
+    case "{", "[":
+        guard chars == "{" || normalized == [.shift] else { return nil }
+        return .jumpToPrompt(-1)
+    case "}", "]":
+        guard chars == "}" || normalized == [.shift] else { return nil }
+        return .jumpToPrompt(1)
+    case "/":
+        return .startSearch
+    case "n":
+        return normalized == [.shift] ? .searchPrevious : .searchNext
+    default:
+        return nil
+    }
+}
+
+/// Resolves a key event and any pending prefix state to a copy-mode command.
+///
+/// - Parameters:
+///   - keyCode: The hardware key code for the event.
+///   - charactersIgnoringModifiers: The layout character reported without modifiers.
+///   - modifiers: The event modifiers converted to ``TerminalKeyboardCopyModeModifiers``.
+///   - hasSelection: Whether visual selection is currently active.
+///   - state: The pending multi-key input state to read and update.
+///   - asciiCharacterProvider: A fallback physical-key lookup for non-ASCII input sources.
+/// - Returns: A resolution describing whether to perform or only consume the event.
+public func terminalKeyboardCopyModeResolve(
+    keyCode: UInt16,
+    charactersIgnoringModifiers: String?,
+    modifiers: TerminalKeyboardCopyModeModifiers,
+    hasSelection: Bool,
+    state: inout TerminalKeyboardCopyModeInputState,
+    asciiCharacterProvider: (UInt16) -> String? = { _ in nil }
+) -> TerminalKeyboardCopyModeResolution {
+    let normalized = terminalKeyboardCopyModeNormalizedModifiers(modifiers)
+    let chars = terminalKeyboardCopyModeChars(
+        charactersIgnoringModifiers,
+        keyCode: keyCode,
+        asciiCharacterProvider: asciiCharacterProvider
+    )
+
+    if keyCode == 53 {
+        state.reset()
+        return .perform(.exit, count: 1)
+    }
+
+    if state.pendingYankLine {
+        if chars == "y", normalized.isEmpty || normalized == [.shift] {
+            let count = terminalKeyboardCopyModeClampCount(state.countPrefix ?? 1)
+            state.reset()
+            return .perform(.copyLineAndExit, count: count)
+        }
+        state.pendingYankLine = false
+    }
+
+    if state.pendingG {
+        if chars == "g", normalized.isEmpty {
+            let count = terminalKeyboardCopyModeClampCount(state.countPrefix ?? 1)
+            let action: TerminalKeyboardCopyModeAction = hasSelection ? .adjustSelection(.home) : .scrollToTop
+            state.reset()
+            return .perform(action, count: count)
+        }
+        state.pendingG = false
+    }
+
+    if normalized.isEmpty,
+       let scalar = chars.unicodeScalars.first,
+       scalar.isASCII,
+       scalar.value >= 48,
+       scalar.value <= 57 {
+        let digit = Int(scalar.value - 48)
+        if digit == 0 {
+            if let currentCount = state.countPrefix {
+                state.countPrefix = terminalKeyboardCopyModeClampCount(currentCount * 10)
+                return .consume
+            }
+        } else {
+            let currentCount = state.countPrefix ?? 0
+            state.countPrefix = terminalKeyboardCopyModeClampCount((currentCount * 10) + digit)
+            return .consume
+        }
+    }
+
+    if !hasSelection, chars == "y", normalized.isEmpty {
+        state.pendingYankLine = true
+        return .consume
+    }
+
+    if chars == "g", normalized.isEmpty {
+        state.pendingG = true
+        return .consume
+    }
+
+    guard let action = terminalKeyboardCopyModeAction(
+        keyCode: keyCode,
+        charactersIgnoringModifiers: charactersIgnoringModifiers,
+        modifiers: modifiers,
+        hasSelection: hasSelection,
+        asciiCharacterProvider: asciiCharacterProvider
+    ) else {
+        state.reset()
+        return .consume
+    }
+
+    let count = terminalKeyboardCopyModeClampCount(state.countPrefix ?? 1)
+    state.reset()
+    return .perform(action, count: count)
+}

--- a/Packages/CmuxTerminalCopyMode/Sources/CmuxTerminalCopyMode/TerminalKeyboardCopyModeKeyResolution.swift
+++ b/Packages/CmuxTerminalCopyMode/Sources/CmuxTerminalCopyMode/TerminalKeyboardCopyModeKeyResolution.swift
@@ -20,6 +20,16 @@ private func terminalKeyboardCopyModeChars(
 
 /// Returns whether copy mode should bypass an event so app-level shortcuts can handle it.
 ///
+/// Copy mode owns ordinary navigation keys but must not swallow app-level
+/// shortcuts such as Command-C or Command-Shift-M. Use this before invoking
+/// ``terminalKeyboardCopyModeResolve(keyCode:charactersIgnoringModifiers:modifiers:hasSelection:state:asciiCharacterProvider:)``.
+///
+/// ```swift
+/// let shouldBypass = terminalKeyboardCopyModeShouldBypassForShortcut(
+///     modifiers: [.command, .shift]
+/// )
+/// ```
+///
 /// - Parameter modifiers: The event modifiers converted to ``TerminalKeyboardCopyModeModifiers``.
 /// - Returns: `true` when the event should stay available to app-level shortcut handling.
 public func terminalKeyboardCopyModeShouldBypassForShortcut(
@@ -30,6 +40,19 @@ public func terminalKeyboardCopyModeShouldBypassForShortcut(
 }
 
 /// Resolves a single key event to a terminal copy-mode action.
+///
+/// This stateless resolver handles one key at a time. For count prefixes and
+/// two-key commands such as `gg` and `yy`, use
+/// ``terminalKeyboardCopyModeResolve(keyCode:charactersIgnoringModifiers:modifiers:hasSelection:state:asciiCharacterProvider:)``.
+///
+/// ```swift
+/// let action = terminalKeyboardCopyModeAction(
+///     keyCode: 38,
+///     charactersIgnoringModifiers: "j",
+///     modifiers: [],
+///     hasSelection: false
+/// )
+/// ```
 ///
 /// - Parameters:
 ///   - keyCode: The hardware key code for the event.
@@ -125,10 +148,10 @@ public func terminalKeyboardCopyModeAction(
         }
         return nil
     case "0", "^":
-        return hasSelection ? .adjustSelection(.beginningOfLine) : nil
+        return .adjustSelection(.beginningOfLine)
     case "$", "4":
         guard chars == "$" || normalized == [.shift] else { return nil }
-        return hasSelection ? .adjustSelection(.endOfLine) : nil
+        return .adjustSelection(.endOfLine)
     case "{", "[":
         guard chars == "{" || normalized == [.shift] else { return nil }
         return .jumpToPrompt(-1)
@@ -145,6 +168,29 @@ public func terminalKeyboardCopyModeAction(
 }
 
 /// Resolves a key event and any pending prefix state to a copy-mode command.
+///
+/// This is the stateful resolver used by the terminal host. It consumes numeric
+/// prefixes, tracks pending `gg` and `yy` sequences in
+/// ``TerminalKeyboardCopyModeInputState``, and returns either a counted action or
+/// a consume-only result.
+///
+/// ```swift
+/// var state = TerminalKeyboardCopyModeInputState()
+/// _ = terminalKeyboardCopyModeResolve(
+///     keyCode: 20,
+///     charactersIgnoringModifiers: "3",
+///     modifiers: [],
+///     hasSelection: false,
+///     state: &state
+/// )
+/// let result = terminalKeyboardCopyModeResolve(
+///     keyCode: 38,
+///     charactersIgnoringModifiers: "j",
+///     modifiers: [],
+///     hasSelection: false,
+///     state: &state
+/// )
+/// ```
 ///
 /// - Parameters:
 ///   - keyCode: The hardware key code for the event.

--- a/Packages/CmuxTerminalCopyMode/Sources/CmuxTerminalCopyMode/TerminalKeyboardCopyModeModifiers.swift
+++ b/Packages/CmuxTerminalCopyMode/Sources/CmuxTerminalCopyMode/TerminalKeyboardCopyModeModifiers.swift
@@ -1,0 +1,30 @@
+/// Modifier keys relevant to terminal keyboard copy-mode command resolution.
+public struct TerminalKeyboardCopyModeModifiers: OptionSet, Equatable, Sendable {
+    /// The raw option-set storage.
+    public let rawValue: UInt8
+
+    /// Creates a modifier set from raw option bits.
+    ///
+    /// - Parameter rawValue: The raw option-set storage.
+    public init(rawValue: UInt8) {
+        self.rawValue = rawValue
+    }
+
+    /// The Command modifier.
+    public static let command = TerminalKeyboardCopyModeModifiers(rawValue: 1 << 0)
+
+    /// The Shift modifier.
+    public static let shift = TerminalKeyboardCopyModeModifiers(rawValue: 1 << 1)
+
+    /// The Control modifier.
+    public static let control = TerminalKeyboardCopyModeModifiers(rawValue: 1 << 2)
+
+    /// The numeric-pad modifier, ignored during command matching.
+    public static let numericPad = TerminalKeyboardCopyModeModifiers(rawValue: 1 << 3)
+
+    /// The function-key modifier, ignored during command matching.
+    public static let function = TerminalKeyboardCopyModeModifiers(rawValue: 1 << 4)
+
+    /// The Caps Lock modifier, ignored during command matching.
+    public static let capsLock = TerminalKeyboardCopyModeModifiers(rawValue: 1 << 5)
+}

--- a/Packages/CmuxTerminalCopyMode/Sources/CmuxTerminalCopyMode/TerminalKeyboardCopyModeModifiers.swift
+++ b/Packages/CmuxTerminalCopyMode/Sources/CmuxTerminalCopyMode/TerminalKeyboardCopyModeModifiers.swift
@@ -1,11 +1,26 @@
 /// Modifier keys relevant to terminal keyboard copy-mode command resolution.
+///
+/// `TerminalKeyboardCopyModeModifiers` is a small, platform-neutral option set
+/// that lets the copy-mode resolver avoid depending on AppKit event types. The
+/// app target maps `NSEvent.ModifierFlags` into this type before calling
+/// ``terminalKeyboardCopyModeAction(keyCode:charactersIgnoringModifiers:modifiers:hasSelection:asciiCharacterProvider:)``
+/// or
+/// ``terminalKeyboardCopyModeResolve(keyCode:charactersIgnoringModifiers:modifiers:hasSelection:state:asciiCharacterProvider:)``.
+///
+/// ```swift
+/// let modifiers: TerminalKeyboardCopyModeModifiers = [.command, .shift]
+/// if modifiers.contains(.command) {
+///     print("let the app shortcut layer handle this event")
+/// }
+/// ```
 public struct TerminalKeyboardCopyModeModifiers: OptionSet, Equatable, Sendable {
     /// The raw option-set storage.
     public let rawValue: UInt8
 
     /// Creates a modifier set from raw option bits.
     ///
-    /// - Parameter rawValue: The raw option-set storage.
+    /// - Parameter rawValue: The raw option-set storage. Unknown bits are
+    ///   preserved so callers can round-trip values produced by `OptionSet`.
     public init(rawValue: UInt8) {
         self.rawValue = rawValue
     }

--- a/Packages/CmuxTerminalCopyMode/Sources/CmuxTerminalCopyMode/TerminalKeyboardCopyModeResolution.swift
+++ b/Packages/CmuxTerminalCopyMode/Sources/CmuxTerminalCopyMode/TerminalKeyboardCopyModeResolution.swift
@@ -1,0 +1,8 @@
+/// The result of resolving a keyboard copy-mode key event.
+public enum TerminalKeyboardCopyModeResolution: Equatable, Sendable {
+    /// Performs a resolved action with a repeat count.
+    case perform(TerminalKeyboardCopyModeAction, count: Int)
+
+    /// Consumes the key event without performing an immediate action.
+    case consume
+}

--- a/Packages/CmuxTerminalCopyMode/Sources/CmuxTerminalCopyMode/TerminalKeyboardCopyModeResolution.swift
+++ b/Packages/CmuxTerminalCopyMode/Sources/CmuxTerminalCopyMode/TerminalKeyboardCopyModeResolution.swift
@@ -1,6 +1,27 @@
 /// The result of resolving a keyboard copy-mode key event.
+///
+/// Resolvers return `TerminalKeyboardCopyModeResolution` so callers can
+/// distinguish an event that should perform a counted
+/// ``TerminalKeyboardCopyModeAction`` from one that should only update pending
+/// resolver state.
+///
+/// ```swift
+/// let resolution: TerminalKeyboardCopyModeResolution = .perform(.adjustSelection(.down), count: 3)
+/// switch resolution {
+/// case .perform(let action, let count):
+///     print("perform \(action) \(count) time(s)")
+/// case .consume:
+///     print("wait for the next key")
+/// }
+/// ```
+///
+/// The enum has no initializer parameters and does not throw.
 public enum TerminalKeyboardCopyModeResolution: Equatable, Sendable {
     /// Performs a resolved action with a repeat count.
+    ///
+    /// - Parameters:
+    ///   - action: The copy-mode action to perform.
+    ///   - count: The clamped repeat count for the action.
     case perform(TerminalKeyboardCopyModeAction, count: Int)
 
     /// Consumes the key event without performing an immediate action.

--- a/Packages/CmuxTerminalCopyMode/Sources/CmuxTerminalCopyMode/TerminalKeyboardCopyModeSelectionMove.swift
+++ b/Packages/CmuxTerminalCopyMode/Sources/CmuxTerminalCopyMode/TerminalKeyboardCopyModeSelectionMove.swift
@@ -1,4 +1,16 @@
 /// A cursor or visual-selection movement supported by terminal keyboard copy mode.
+///
+/// `TerminalKeyboardCopyModeSelectionMove` describes the movement component of
+/// ``TerminalKeyboardCopyModeAction.adjustSelection(_:)``. The terminal host
+/// applies the same cases to the visible copy-mode cursor outside visual mode
+/// and to Ghostty's selection endpoint while visual mode is active.
+///
+/// ```swift
+/// let move: TerminalKeyboardCopyModeSelectionMove = .pageUp
+/// let action = TerminalKeyboardCopyModeAction.adjustSelection(move)
+/// ```
+///
+/// The enum has no initializer parameters and does not throw.
 public enum TerminalKeyboardCopyModeSelectionMove: String, Equatable, Sendable {
     /// Moves one or more cells left.
     case left

--- a/Packages/CmuxTerminalCopyMode/Sources/CmuxTerminalCopyMode/TerminalKeyboardCopyModeSelectionMove.swift
+++ b/Packages/CmuxTerminalCopyMode/Sources/CmuxTerminalCopyMode/TerminalKeyboardCopyModeSelectionMove.swift
@@ -1,0 +1,32 @@
+/// A cursor or visual-selection movement supported by terminal keyboard copy mode.
+public enum TerminalKeyboardCopyModeSelectionMove: String, Equatable, Sendable {
+    /// Moves one or more cells left.
+    case left
+
+    /// Moves one or more cells right.
+    case right
+
+    /// Moves one or more rows up.
+    case up
+
+    /// Moves one or more rows down.
+    case down
+
+    /// Moves one or more pages up.
+    case pageUp = "page_up"
+
+    /// Moves one or more pages down.
+    case pageDown = "page_down"
+
+    /// Moves to the top-left cell.
+    case home
+
+    /// Moves to the bottom-right cell.
+    case end
+
+    /// Moves to the first cell in the current row.
+    case beginningOfLine = "beginning_of_line"
+
+    /// Moves to the last cell in the current row.
+    case endOfLine = "end_of_line"
+}

--- a/Packages/CmuxTerminalCopyMode/Tests/CmuxTerminalCopyModeTests/TerminalKeyboardCopyModeTests.swift
+++ b/Packages/CmuxTerminalCopyMode/Tests/CmuxTerminalCopyModeTests/TerminalKeyboardCopyModeTests.swift
@@ -87,7 +87,7 @@ struct TerminalKeyboardCopyModeResolverTests {
         #expect(state == TerminalKeyboardCopyModeInputState())
     }
 
-    @Test func unmatchedGPrefixConsumesFollowupAndClearsCount() {
+    @Test func unmatchedGPrefixClearsCountBeforeResolvingFollowup() {
         var state = TerminalKeyboardCopyModeInputState(countPrefix: 3, pendingG: true)
 
         #expect(
@@ -97,12 +97,12 @@ struct TerminalKeyboardCopyModeResolverTests {
                 modifiers: [],
                 hasSelection: false,
                 state: &state
-            ) == .consume
+            ) == .perform(.adjustSelection(.down), count: 1)
         )
         #expect(state == TerminalKeyboardCopyModeInputState())
     }
 
-    @Test func unmatchedYankLinePrefixConsumesFollowupAndClearsCount() {
+    @Test func unmatchedYankLinePrefixClearsCountBeforeResolvingFollowup() {
         var state = TerminalKeyboardCopyModeInputState(countPrefix: 3, pendingYankLine: true)
 
         #expect(
@@ -112,7 +112,7 @@ struct TerminalKeyboardCopyModeResolverTests {
                 modifiers: [],
                 hasSelection: false,
                 state: &state
-            ) == .consume
+            ) == .perform(.adjustSelection(.up), count: 1)
         )
         #expect(state == TerminalKeyboardCopyModeInputState())
     }

--- a/Packages/CmuxTerminalCopyMode/Tests/CmuxTerminalCopyModeTests/TerminalKeyboardCopyModeTests.swift
+++ b/Packages/CmuxTerminalCopyMode/Tests/CmuxTerminalCopyModeTests/TerminalKeyboardCopyModeTests.swift
@@ -86,6 +86,36 @@ struct TerminalKeyboardCopyModeResolverTests {
         )
         #expect(state == TerminalKeyboardCopyModeInputState())
     }
+
+    @Test func unmatchedGPrefixConsumesFollowupAndClearsCount() {
+        var state = TerminalKeyboardCopyModeInputState(countPrefix: 3, pendingG: true)
+
+        #expect(
+            terminalKeyboardCopyModeResolve(
+                keyCode: 38,
+                charactersIgnoringModifiers: "j",
+                modifiers: [],
+                hasSelection: false,
+                state: &state
+            ) == .consume
+        )
+        #expect(state == TerminalKeyboardCopyModeInputState())
+    }
+
+    @Test func unmatchedYankLinePrefixConsumesFollowupAndClearsCount() {
+        var state = TerminalKeyboardCopyModeInputState(countPrefix: 3, pendingYankLine: true)
+
+        #expect(
+            terminalKeyboardCopyModeResolve(
+                keyCode: 40,
+                charactersIgnoringModifiers: "k",
+                modifiers: [],
+                hasSelection: false,
+                state: &state
+            ) == .consume
+        )
+        #expect(state == TerminalKeyboardCopyModeInputState())
+    }
 }
 
 @Suite("Terminal keyboard copy mode cursor")

--- a/Packages/CmuxTerminalCopyMode/Tests/CmuxTerminalCopyModeTests/TerminalKeyboardCopyModeTests.swift
+++ b/Packages/CmuxTerminalCopyMode/Tests/CmuxTerminalCopyModeTests/TerminalKeyboardCopyModeTests.swift
@@ -1,0 +1,130 @@
+import CmuxTerminalCopyMode
+import Testing
+
+@Suite("Terminal keyboard copy mode resolver")
+struct TerminalKeyboardCopyModeResolverTests {
+    @Test func resolvesAllVimKeysWithNonASCIILayoutFallback() {
+        let asciiProvider: (UInt16) -> String? = { keyCode in
+            switch keyCode {
+            case 4: return "h"
+            case 38: return "j"
+            case 40: return "k"
+            case 37: return "l"
+            default: return nil
+            }
+        }
+        let cases: [(keyCode: UInt16, characters: String, action: TerminalKeyboardCopyModeAction)] = [
+            (4, "ㅗ", .adjustSelection(.left)),
+            (38, "ㅓ", .adjustSelection(.down)),
+            (40, "ㅏ", .adjustSelection(.up)),
+            (37, "ㅣ", .adjustSelection(.right)),
+        ]
+
+        for testCase in cases {
+            #expect(
+                terminalKeyboardCopyModeAction(
+                    keyCode: testCase.keyCode,
+                    charactersIgnoringModifiers: testCase.characters,
+                    modifiers: [],
+                    hasSelection: false,
+                    asciiCharacterProvider: asciiProvider
+                ) == testCase.action
+            )
+        }
+    }
+
+    @Test func ignoresCapsLockForAllVimMotionKeys() {
+        let cases: [(keyCode: UInt16, characters: String, action: TerminalKeyboardCopyModeAction)] = [
+            (4, "h", .adjustSelection(.left)),
+            (38, "j", .adjustSelection(.down)),
+            (40, "k", .adjustSelection(.up)),
+            (37, "l", .adjustSelection(.right)),
+        ]
+
+        for testCase in cases {
+            #expect(
+                terminalKeyboardCopyModeAction(
+                    keyCode: testCase.keyCode,
+                    charactersIgnoringModifiers: testCase.characters,
+                    modifiers: [.capsLock],
+                    hasSelection: false
+                ) == testCase.action
+            )
+        }
+    }
+
+    @Test func lineBoundaryKeysMoveCursorOutsideVisualMode() {
+        #expect(
+            terminalKeyboardCopyModeAction(
+                keyCode: 29,
+                charactersIgnoringModifiers: "0",
+                modifiers: [],
+                hasSelection: false
+            ) == .adjustSelection(.beginningOfLine)
+        )
+        #expect(
+            terminalKeyboardCopyModeAction(
+                keyCode: 21,
+                charactersIgnoringModifiers: "4",
+                modifiers: [.shift],
+                hasSelection: false
+            ) == .adjustSelection(.endOfLine)
+        )
+    }
+
+    @Test func zeroWithoutExistingCountActsAsBeginningOfLineMotion() {
+        var state = TerminalKeyboardCopyModeInputState()
+
+        #expect(
+            terminalKeyboardCopyModeResolve(
+                keyCode: 29,
+                charactersIgnoringModifiers: "0",
+                modifiers: [],
+                hasSelection: false,
+                state: &state
+            ) == .perform(.adjustSelection(.beginningOfLine), count: 1)
+        )
+        #expect(state == TerminalKeyboardCopyModeInputState())
+    }
+}
+
+@Suite("Terminal keyboard copy mode cursor")
+struct TerminalKeyboardCopyModeCursorPackageTests {
+    @Test func motionThenVisualSelectionUsesMovedCursorAsAnchor() {
+        var cursor = TerminalKeyboardCopyModeCursor(row: 8, column: 7)
+
+        let moveAction = terminalKeyboardCopyModeAction(
+            keyCode: 38,
+            charactersIgnoringModifiers: "j",
+            modifiers: [],
+            hasSelection: false
+        )
+        #expect(moveAction == .adjustSelection(.down))
+        if case let .adjustSelection(move)? = moveAction {
+            #expect(cursor.move(move, count: 1, rows: 20, columns: 40) == 0)
+        }
+
+        #expect(
+            terminalKeyboardCopyModeAction(
+                keyCode: 9,
+                charactersIgnoringModifiers: "v",
+                modifiers: [],
+                hasSelection: false
+            ) == .startSelection
+        )
+        #expect(cursor.clamped(rows: 20, columns: 40) == TerminalKeyboardCopyModeCursor(row: 9, column: 7))
+    }
+
+    @Test func cursorSelectionXRangeKeepsLeftToRightDragAtRightEdge() throws {
+        let range = try #require(
+            terminalKeyboardCopyModeCursorSelectionXRange(
+                rectMinX: 99.5,
+                rectMaxX: 120,
+                boundsWidth: 100
+            )
+        )
+
+        #expect(abs(range.startX - 98) < 0.0001)
+        #expect(abs(range.endX - 99) < 0.0001)
+    }
+}

--- a/Packages/CmuxTerminalCopyMode/Tests/CmuxTerminalCopyModeTests/TerminalKeyboardCopyModeTests.swift
+++ b/Packages/CmuxTerminalCopyMode/Tests/CmuxTerminalCopyModeTests/TerminalKeyboardCopyModeTests.swift
@@ -127,4 +127,12 @@ struct TerminalKeyboardCopyModeCursorPackageTests {
         #expect(abs(range.startX - 98) < 0.0001)
         #expect(abs(range.endX - 99) < 0.0001)
     }
+
+    @Test func viewportOffsetDeltaKeepsCursorOnSameTextAfterJump() {
+        var cursor = TerminalKeyboardCopyModeCursor(row: 10, column: 4)
+
+        cursor.shiftForViewportScroll(lineDelta: 3, rows: 20, columns: 8)
+
+        #expect(cursor == TerminalKeyboardCopyModeCursor(row: 7, column: 4))
+    }
 }

--- a/Packages/CmuxTerminalCopyMode/Tests/CmuxTerminalCopyModeTests/TerminalKeyboardCopyModeTests.swift
+++ b/Packages/CmuxTerminalCopyMode/Tests/CmuxTerminalCopyModeTests/TerminalKeyboardCopyModeTests.swift
@@ -165,4 +165,17 @@ struct TerminalKeyboardCopyModeCursorPackageTests {
 
         #expect(cursor == TerminalKeyboardCopyModeCursor(row: 7, column: 4))
     }
+
+    @Test func clippedBackingRowsDoNotDelayEdgeScroll() {
+        let rows = terminalKeyboardCopyModeVisibleViewportRows(
+            backingRows: 12,
+            viewHeight: 100,
+            cellHeight: 10
+        )
+        var cursor = TerminalKeyboardCopyModeCursor(row: rows - 1, column: 4)
+
+        #expect(rows == 10)
+        #expect(cursor.move(.down, count: 1, rows: rows, columns: 8) == 1)
+        #expect(cursor == TerminalKeyboardCopyModeCursor(row: rows - 1, column: 4))
+    }
 }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1394,6 +1394,7 @@ enum TerminalKeyboardCopyModeAction: Equatable {
     case clearSelection
     case copyAndExit
     case copyLineAndExit
+    case scrollLines(Int)
     case scrollPage(Int)
     case scrollHalfPage(Int)
     case scrollToTop
@@ -1638,10 +1639,10 @@ func terminalKeyboardCopyModeAction(
             return hasSelection ? .adjustSelection(.pageDown) : .scrollPage(1)
         }
         if chars == "y" || chars == "\u{19}" {
-            return .adjustSelection(.up)
+            return hasSelection ? .adjustSelection(.up) : .scrollLines(-1)
         }
         if chars == "e" || chars == "\u{05}" {
-            return .adjustSelection(.down)
+            return hasSelection ? .adjustSelection(.down) : .scrollLines(1)
         }
         return nil
     }
@@ -8505,6 +8506,22 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         syncKeyboardCopyModeCursorOverlay(surface: surface)
     }
 
+    private func updateKeyboardCopyModeCursorModel(
+        _ direction: TerminalKeyboardCopyModeSelectionMove,
+        count: Int,
+        surface: ghostty_surface_t
+    ) {
+        guard let metrics = keyboardCopyModeGridMetrics(surface: surface) else { return }
+        var cursor = keyboardCopyModeCursor ?? keyboardCopyModeInitialCursor(surface: surface)
+        _ = cursor.move(
+            direction,
+            count: count,
+            rows: metrics.rows,
+            columns: metrics.columns
+        )
+        keyboardCopyModeCursor = cursor
+    }
+
     private func selectKeyboardCopyModeCursorCell(surface: ghostty_surface_t) -> Bool {
         guard let cursor = keyboardCopyModeCursor,
               let metrics = keyboardCopyModeGridMetrics(surface: surface) else {
@@ -8520,13 +8537,15 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         _ = ghostty_surface_clear_selection_compat(surface)
         ghostty_surface_mouse_pos(surface, Double(startX), Double(y), mods)
         guard ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_LEFT, mods) else {
-            return false
+            return ghostty_surface_select_cursor_cell_compat(surface)
         }
         ghostty_surface_mouse_pos(surface, Double(endX), Double(y), mods)
-        defer {
-            _ = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, mods)
+        let selectedCursorCell = ghostty_surface_has_selection(surface)
+        _ = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, mods)
+        guard selectedCursorCell else {
+            return ghostty_surface_select_cursor_cell_compat(surface)
         }
-        return ghostty_surface_has_selection(surface)
+        return true
     }
 
     private func copyCurrentViewportLinesToClipboard(
@@ -8617,6 +8636,8 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             )
             _ = ghostty_surface_clear_selection_compat(surface)
             setKeyboardCopyModeActive(false)
+        case let .scrollLines(delta):
+            _ = performBindingAction("scroll_page_lines:\(delta * count)")
         case let .scrollPage(delta):
             performBindingAction(delta > 0 ? "scroll_page_down" : "scroll_page_up", repeatCount: count)
         case let .scrollHalfPage(delta):
@@ -8653,6 +8674,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         case let .adjustSelection(direction):
             if keyboardCopyModeVisualActive {
                 performBindingAction("adjust_selection:\(direction.rawValue)", repeatCount: count)
+                updateKeyboardCopyModeCursorModel(direction, count: count, surface: surface)
             } else {
                 moveKeyboardCopyModeCursor(direction, count: count, surface: surface)
             }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -8222,6 +8222,19 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         keyboardCopyModeCursor = cursor
     }
 
+    private func adjustKeyboardCopyModeSelection(
+        _ direction: TerminalKeyboardCopyModeSelectionMove,
+        count: Int,
+        surface: ghostty_surface_t
+    ) {
+        let action = "adjust_selection:\(direction.rawValue)"
+        let clampedCount = terminalKeyboardCopyModeClampCount(count)
+        for _ in 0 ..< clampedCount {
+            _ = performBindingAction(action)
+            updateKeyboardCopyModeCursorModel(direction, count: 1, surface: surface)
+        }
+    }
+
     private func selectKeyboardCopyModeCursorCell(surface: ghostty_surface_t) -> Bool {
         guard let metrics = keyboardCopyModeGridMetrics(surface: surface) else { return false }
 
@@ -8393,8 +8406,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             syncKeyboardCopyModeCursorOverlay(surface: surface)
         case let .adjustSelection(direction):
             if keyboardCopyModeVisualActive {
-                performBindingAction("adjust_selection:\(direction.rawValue)", repeatCount: count)
-                updateKeyboardCopyModeCursorModel(direction, count: count, surface: surface)
+                adjustKeyboardCopyModeSelection(direction, count: count, surface: surface)
             } else {
                 moveKeyboardCopyModeCursor(direction, count: count, surface: surface)
             }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7402,6 +7402,8 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     private var keyboardCopyModePendingViewportJumpSync = false
     private var keyboardCopyModePendingViewportJumpScrollbarOffset: UInt64?
     private var keyboardCopyModePendingViewportJumpGeneration = 0
+    private var keyboardCopyModePendingViewportJumpFallbackLineDelta: Int?
+    private var keyboardCopyModePendingViewportJumpAppliedFallbackLineDelta = 0
     /// Tracks whether the user has explicitly entered visual selection mode (v).
     /// Separate from Ghostty's `has_selection` because non-visual copy mode keeps
     /// the cursor in AppKit overlay state until visual selection starts.
@@ -8083,6 +8085,8 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         keyboardCopyModePendingViewportJumpGeneration += 1
         keyboardCopyModePendingViewportJumpSync = false
         keyboardCopyModePendingViewportJumpScrollbarOffset = nil
+        keyboardCopyModePendingViewportJumpFallbackLineDelta = nil
+        keyboardCopyModePendingViewportJumpAppliedFallbackLineDelta = 0
         keyboardCopyModeActive = active
         if active, let surface {
             _ = ghostty_surface_clear_selection_compat(surface)
@@ -8231,10 +8235,12 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         syncKeyboardCopyModeCursorOverlay(surface: surface)
     }
 
-    private func beginKeyboardCopyModeViewportJumpCursorSync() {
+    private func beginKeyboardCopyModeViewportJumpCursorSync(fallbackLineDelta: Int? = nil) {
         keyboardCopyModePendingViewportJumpGeneration += 1
         keyboardCopyModePendingViewportJumpSync = true
         keyboardCopyModePendingViewportJumpScrollbarOffset = scrollbar?.offset
+        keyboardCopyModePendingViewportJumpFallbackLineDelta = fallbackLineDelta
+        keyboardCopyModePendingViewportJumpAppliedFallbackLineDelta = 0
     }
 
     private func scheduleKeyboardCopyModeViewportJumpCursorSyncFallback() {
@@ -8257,6 +8263,14 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             return
         }
 
+        if let lineDelta = keyboardCopyModePendingViewportJumpFallbackLineDelta,
+           lineDelta != 0,
+           keyboardCopyModePendingViewportJumpAppliedFallbackLineDelta == 0 {
+            shiftKeyboardCopyModeCursorForViewportScroll(lineDelta: lineDelta, surface: surface)
+            keyboardCopyModePendingViewportJumpAppliedFallbackLineDelta = lineDelta
+            return
+        }
+
         clampKeyboardCopyModeCursor(surface: surface)
     }
 
@@ -8266,12 +8280,18 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
         keyboardCopyModePendingViewportJumpSync = false
         keyboardCopyModePendingViewportJumpScrollbarOffset = nil
+        keyboardCopyModePendingViewportJumpFallbackLineDelta = nil
+        keyboardCopyModePendingViewportJumpAppliedFallbackLineDelta = 0
     }
 
     private func finishKeyboardCopyModeViewportJumpCursorSyncIfNeeded(newScrollbar: GhosttyScrollbar? = nil) {
         guard keyboardCopyModePendingViewportJumpSync else { return }
         keyboardCopyModePendingViewportJumpSync = false
-        defer { keyboardCopyModePendingViewportJumpScrollbarOffset = nil }
+        defer {
+            keyboardCopyModePendingViewportJumpScrollbarOffset = nil
+            keyboardCopyModePendingViewportJumpFallbackLineDelta = nil
+            keyboardCopyModePendingViewportJumpAppliedFallbackLineDelta = 0
+        }
 
         guard keyboardCopyModeActive, let surface else { return }
         let resolvedNewOffset = newScrollbar?.offset ?? scrollbar?.offset
@@ -8281,8 +8301,9 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                 from: previousOffset,
                 to: resolvedNewOffset
             )
-            if lineDelta != 0 {
-                shiftKeyboardCopyModeCursorForViewportScroll(lineDelta: lineDelta, surface: surface)
+            let remainingLineDelta = lineDelta - keyboardCopyModePendingViewportJumpAppliedFallbackLineDelta
+            if remainingLineDelta != 0 {
+                shiftKeyboardCopyModeCursorForViewportScroll(lineDelta: remainingLineDelta, surface: surface)
                 return
             }
         }
@@ -8463,28 +8484,25 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             setKeyboardCopyModeActive(false)
         case let .scrollLines(delta):
             let lineDelta = delta * terminalKeyboardCopyModeClampCount(count)
+            beginKeyboardCopyModeViewportJumpCursorSync(fallbackLineDelta: lineDelta)
             _ = performBindingAction("scroll_page_lines:\(lineDelta)")
-            shiftKeyboardCopyModeCursorForViewportScroll(lineDelta: lineDelta, surface: surface)
+            scheduleKeyboardCopyModeViewportJumpCursorSyncFallback()
         case let .scrollPage(delta):
             let clampedCount = terminalKeyboardCopyModeClampCount(count)
-            performBindingAction(delta > 0 ? "scroll_page_down" : "scroll_page_up", repeatCount: clampedCount)
             let rows = keyboardCopyModeGridMetrics(surface: surface)?.rows
                 ?? max(Int(ghostty_surface_size(surface).rows), 1)
-            shiftKeyboardCopyModeCursorForViewportScroll(
-                lineDelta: delta * rows * clampedCount,
-                surface: surface
-            )
+            beginKeyboardCopyModeViewportJumpCursorSync(fallbackLineDelta: delta * rows * clampedCount)
+            performBindingAction(delta > 0 ? "scroll_page_down" : "scroll_page_up", repeatCount: clampedCount)
+            scheduleKeyboardCopyModeViewportJumpCursorSyncFallback()
         case let .scrollHalfPage(delta):
             let clampedCount = terminalKeyboardCopyModeClampCount(count)
             let fraction = delta > 0 ? 0.5 : -0.5
-            performBindingAction("scroll_page_fractional:\(fraction)", repeatCount: clampedCount)
             let rows = keyboardCopyModeGridMetrics(surface: surface)?.rows
                 ?? max(Int(ghostty_surface_size(surface).rows), 1)
             let linesPerScroll = Int((Double(rows) * 0.5).rounded(.towardZero))
-            shiftKeyboardCopyModeCursorForViewportScroll(
-                lineDelta: delta * linesPerScroll * clampedCount,
-                surface: surface
-            )
+            beginKeyboardCopyModeViewportJumpCursorSync(fallbackLineDelta: delta * linesPerScroll * clampedCount)
+            performBindingAction("scroll_page_fractional:\(fraction)", repeatCount: clampedCount)
+            scheduleKeyboardCopyModeViewportJumpCursorSyncFallback()
         case .scrollToTop:
             if var cursor = keyboardCopyModeCursor {
                 if let metrics = keyboardCopyModeGridMetrics(surface: surface) {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7336,6 +7336,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
         guard let pending else { return }
         scrollbar = pending
+        finishKeyboardCopyModeViewportJumpCursorSyncIfNeeded(newScrollbar: pending)
         NotificationCenter.default.post(
             name: .ghosttyDidUpdateScrollbar,
             object: self,
@@ -7388,6 +7389,8 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     private var imeConsumedKeyUps: Set<UInt16> = []
     private var keyboardCopyModeInputState = TerminalKeyboardCopyModeInputState()
     private var keyboardCopyModeCursor: TerminalKeyboardCopyModeCursor?
+    private var keyboardCopyModePendingViewportJumpSync = false
+    private var keyboardCopyModePendingViewportJumpScrollbarOffset: UInt64?
     /// Tracks whether the user has explicitly entered visual selection mode (v).
     /// Separate from Ghostty's `has_selection` because non-visual copy mode keeps
     /// the cursor in AppKit overlay state until visual selection starts.
@@ -8214,6 +8217,46 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         syncKeyboardCopyModeCursorOverlay(surface: surface)
     }
 
+    private func beginKeyboardCopyModeViewportJumpCursorSync() {
+        keyboardCopyModePendingViewportJumpSync = true
+        keyboardCopyModePendingViewportJumpScrollbarOffset = scrollbar?.offset
+    }
+
+    private func scheduleKeyboardCopyModeViewportJumpCursorSyncFallback() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(100)) { [weak self] in
+            self?.finishKeyboardCopyModeViewportJumpCursorSyncIfNeeded()
+        }
+    }
+
+    private func finishKeyboardCopyModeViewportJumpCursorSyncIfNeeded(newScrollbar: GhosttyScrollbar? = nil) {
+        guard keyboardCopyModePendingViewportJumpSync else { return }
+        keyboardCopyModePendingViewportJumpSync = false
+        defer { keyboardCopyModePendingViewportJumpScrollbarOffset = nil }
+
+        guard keyboardCopyModeActive, let surface else { return }
+        let resolvedNewOffset = newScrollbar?.offset ?? scrollbar?.offset
+        if let previousOffset = keyboardCopyModePendingViewportJumpScrollbarOffset,
+           let resolvedNewOffset {
+            let lineDelta = keyboardCopyModeViewportLineDelta(
+                from: previousOffset,
+                to: resolvedNewOffset
+            )
+            if lineDelta != 0 {
+                shiftKeyboardCopyModeCursorForViewportScroll(lineDelta: lineDelta, surface: surface)
+                return
+            }
+        }
+
+        clampKeyboardCopyModeCursor(surface: surface)
+    }
+
+    private func keyboardCopyModeViewportLineDelta(from previousOffset: UInt64, to currentOffset: UInt64) -> Int {
+        if currentOffset >= previousOffset {
+            return Int(clamping: currentOffset - previousOffset)
+        }
+        return -Int(clamping: previousOffset - currentOffset)
+    }
+
     private func updateKeyboardCopyModeCursorModel(
         _ direction: TerminalKeyboardCopyModeSelectionMove,
         count: Int,
@@ -8428,16 +8471,19 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             _ = performBindingAction("scroll_to_bottom")
             syncKeyboardCopyModeCursorOverlay(surface: surface)
         case let .jumpToPrompt(delta):
+            beginKeyboardCopyModeViewportJumpCursorSync()
             _ = performBindingAction("jump_to_prompt:\(delta * count)")
-            clampKeyboardCopyModeCursor(surface: surface)
+            scheduleKeyboardCopyModeViewportJumpCursorSyncFallback()
         case .startSearch:
             _ = performBindingAction("start_search")
         case .searchNext:
+            beginKeyboardCopyModeViewportJumpCursorSync()
             performBindingAction("navigate_search:next", repeatCount: count)
-            clampKeyboardCopyModeCursor(surface: surface)
+            scheduleKeyboardCopyModeViewportJumpCursorSyncFallback()
         case .searchPrevious:
+            beginKeyboardCopyModeViewportJumpCursorSync()
             performBindingAction("navigate_search:previous", repeatCount: count)
-            clampKeyboardCopyModeCursor(surface: surface)
+            scheduleKeyboardCopyModeViewportJumpCursorSyncFallback()
         case let .adjustSelection(direction):
             if keyboardCopyModeVisualActive {
                 adjustKeyboardCopyModeSelection(direction, count: count, surface: surface)

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -8206,6 +8206,14 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         syncKeyboardCopyModeCursorOverlay(surface: surface)
     }
 
+    private func clampKeyboardCopyModeCursor(surface: ghostty_surface_t) {
+        guard let metrics = keyboardCopyModeGridMetrics(surface: surface) else { return }
+        let cursor = (keyboardCopyModeCursor ?? keyboardCopyModeInitialCursor(surface: surface))
+            .clamped(rows: metrics.rows, columns: metrics.columns)
+        keyboardCopyModeCursor = cursor
+        syncKeyboardCopyModeCursorOverlay(surface: surface)
+    }
+
     private func updateKeyboardCopyModeCursorModel(
         _ direction: TerminalKeyboardCopyModeSelectionMove,
         count: Int,
@@ -8421,18 +8429,15 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             syncKeyboardCopyModeCursorOverlay(surface: surface)
         case let .jumpToPrompt(delta):
             _ = performBindingAction("jump_to_prompt:\(delta * count)")
-            keyboardCopyModeCursor = keyboardCopyModeInitialCursor(surface: surface)
-            syncKeyboardCopyModeCursorOverlay(surface: surface)
+            clampKeyboardCopyModeCursor(surface: surface)
         case .startSearch:
             _ = performBindingAction("start_search")
         case .searchNext:
             performBindingAction("navigate_search:next", repeatCount: count)
-            keyboardCopyModeCursor = keyboardCopyModeInitialCursor(surface: surface)
-            syncKeyboardCopyModeCursorOverlay(surface: surface)
+            clampKeyboardCopyModeCursor(surface: surface)
         case .searchPrevious:
             performBindingAction("navigate_search:previous", repeatCount: count)
-            keyboardCopyModeCursor = keyboardCopyModeInitialCursor(surface: surface)
-            syncKeyboardCopyModeCursorOverlay(surface: surface)
+            clampKeyboardCopyModeCursor(surface: surface)
         case let .adjustSelection(direction):
             if keyboardCopyModeVisualActive {
                 adjustKeyboardCopyModeSelection(direction, count: count, surface: surface)

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -8213,13 +8213,25 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     ) {
         guard let metrics = keyboardCopyModeGridMetrics(surface: surface) else { return }
         var cursor = keyboardCopyModeCursor ?? keyboardCopyModeInitialCursor(surface: surface)
-        _ = cursor.move(
+        cursor.moveAfterTerminalSelectionAdjustment(
             direction,
             count: count,
             rows: metrics.rows,
             columns: metrics.columns
         )
         keyboardCopyModeCursor = cursor
+    }
+
+    private func shiftKeyboardCopyModeCursorForViewportScroll(
+        lineDelta: Int,
+        surface: ghostty_surface_t
+    ) {
+        guard lineDelta != 0,
+              let metrics = keyboardCopyModeGridMetrics(surface: surface) else { return }
+        var cursor = keyboardCopyModeCursor ?? keyboardCopyModeInitialCursor(surface: surface)
+        cursor.shiftForViewportScroll(lineDelta: lineDelta, rows: metrics.rows, columns: metrics.columns)
+        keyboardCopyModeCursor = cursor
+        syncKeyboardCopyModeCursorOverlay(surface: surface)
     }
 
     private func adjustKeyboardCopyModeSelection(
@@ -8359,12 +8371,29 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             _ = ghostty_surface_clear_selection_compat(surface)
             setKeyboardCopyModeActive(false)
         case let .scrollLines(delta):
-            _ = performBindingAction("scroll_page_lines:\(delta * count)")
+            let lineDelta = delta * terminalKeyboardCopyModeClampCount(count)
+            _ = performBindingAction("scroll_page_lines:\(lineDelta)")
+            shiftKeyboardCopyModeCursorForViewportScroll(lineDelta: lineDelta, surface: surface)
         case let .scrollPage(delta):
-            performBindingAction(delta > 0 ? "scroll_page_down" : "scroll_page_up", repeatCount: count)
+            let clampedCount = terminalKeyboardCopyModeClampCount(count)
+            performBindingAction(delta > 0 ? "scroll_page_down" : "scroll_page_up", repeatCount: clampedCount)
+            let rows = keyboardCopyModeGridMetrics(surface: surface)?.rows
+                ?? max(Int(ghostty_surface_size(surface).rows), 1)
+            shiftKeyboardCopyModeCursorForViewportScroll(
+                lineDelta: delta * rows * clampedCount,
+                surface: surface
+            )
         case let .scrollHalfPage(delta):
+            let clampedCount = terminalKeyboardCopyModeClampCount(count)
             let fraction = delta > 0 ? 0.5 : -0.5
-            performBindingAction("scroll_page_fractional:\(fraction)", repeatCount: count)
+            performBindingAction("scroll_page_fractional:\(fraction)", repeatCount: clampedCount)
+            let rows = keyboardCopyModeGridMetrics(surface: surface)?.rows
+                ?? max(Int(ghostty_surface_size(surface).rows), 1)
+            let linesPerScroll = Int((Double(rows) * 0.5).rounded(.towardZero))
+            shiftKeyboardCopyModeCursorForViewportScroll(
+                lineDelta: delta * linesPerScroll * clampedCount,
+                surface: surface
+            )
         case .scrollToTop:
             if var cursor = keyboardCopyModeCursor {
                 if let metrics = keyboardCopyModeGridMetrics(surface: surface) {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7344,6 +7344,16 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         )
     }
 
+    private func flushPendingScrollbarIfAvailable() -> Bool {
+        _scrollbarLock.lock()
+        let hasPending = _pendingScrollbar != nil
+        _scrollbarLock.unlock()
+
+        guard hasPending else { return false }
+        flushPendingScrollbar()
+        return true
+    }
+
     func enqueueRenderedFrameUpdate() {
         guard GhosttyRenderedFrameNotificationDemand.isActive else { return }
 
@@ -7391,6 +7401,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     private var keyboardCopyModeCursor: TerminalKeyboardCopyModeCursor?
     private var keyboardCopyModePendingViewportJumpSync = false
     private var keyboardCopyModePendingViewportJumpScrollbarOffset: UInt64?
+    private var keyboardCopyModePendingViewportJumpGeneration = 0
     /// Tracks whether the user has explicitly entered visual selection mode (v).
     /// Separate from Ghostty's `has_selection` because non-visual copy mode keeps
     /// the cursor in AppKit overlay state until visual selection starts.
@@ -8069,6 +8080,9 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     private func setKeyboardCopyModeActive(_ active: Bool) {
         keyboardCopyModeInputState.reset()
         keyboardCopyModeVisualActive = false
+        keyboardCopyModePendingViewportJumpGeneration += 1
+        keyboardCopyModePendingViewportJumpSync = false
+        keyboardCopyModePendingViewportJumpScrollbarOffset = nil
         keyboardCopyModeActive = active
         if active, let surface {
             _ = ghostty_surface_clear_selection_compat(surface)
@@ -8218,14 +8232,40 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     }
 
     private func beginKeyboardCopyModeViewportJumpCursorSync() {
+        keyboardCopyModePendingViewportJumpGeneration += 1
         keyboardCopyModePendingViewportJumpSync = true
         keyboardCopyModePendingViewportJumpScrollbarOffset = scrollbar?.offset
     }
 
     private func scheduleKeyboardCopyModeViewportJumpCursorSyncFallback() {
+        let generation = keyboardCopyModePendingViewportJumpGeneration
         DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(100)) { [weak self] in
-            self?.finishKeyboardCopyModeViewportJumpCursorSyncIfNeeded()
+            self?.previewKeyboardCopyModeViewportJumpCursorSyncIfNeeded(generation: generation)
         }
+        DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(2)) { [weak self] in
+            self?.expireKeyboardCopyModeViewportJumpCursorSyncIfNeeded(generation: generation)
+        }
+    }
+
+    private func previewKeyboardCopyModeViewportJumpCursorSyncIfNeeded(generation: Int) {
+        guard keyboardCopyModePendingViewportJumpSync,
+              generation == keyboardCopyModePendingViewportJumpGeneration,
+              keyboardCopyModeActive,
+              let surface else { return }
+
+        if flushPendingScrollbarIfAvailable() {
+            return
+        }
+
+        clampKeyboardCopyModeCursor(surface: surface)
+    }
+
+    private func expireKeyboardCopyModeViewportJumpCursorSyncIfNeeded(generation: Int) {
+        guard keyboardCopyModePendingViewportJumpSync,
+              generation == keyboardCopyModePendingViewportJumpGeneration else { return }
+
+        keyboardCopyModePendingViewportJumpSync = false
+        keyboardCopyModePendingViewportJumpScrollbarOffset = nil
     }
 
     private func finishKeyboardCopyModeViewportJumpCursorSyncIfNeeded(newScrollbar: GhosttyScrollbar? = nil) {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1419,6 +1419,17 @@ struct TerminalKeyboardCopyModeCursor: Equatable {
     var row: Int
     var column: Int
 
+    func clamped(rows: Int, columns: Int) -> TerminalKeyboardCopyModeCursor {
+        var copy = self
+        copy.clamp(rows: rows, columns: columns)
+        return copy
+    }
+
+    mutating func clamp(rows: Int, columns: Int) {
+        row = Self.clamp(row, upperBound: rows)
+        column = Self.clamp(column, upperBound: columns)
+    }
+
     mutating func move(
         _ direction: TerminalKeyboardCopyModeSelectionMove,
         count: Int,
@@ -1428,8 +1439,7 @@ struct TerminalKeyboardCopyModeCursor: Equatable {
         let clampedRows = max(rows, 1)
         let clampedColumns = max(columns, 1)
         let clampedCount = terminalKeyboardCopyModeClampCount(count)
-        row = Self.clamp(row, upperBound: clampedRows)
-        column = Self.clamp(column, upperBound: clampedColumns)
+        clamp(rows: clampedRows, columns: clampedColumns)
 
         switch direction {
         case .left:
@@ -8503,7 +8513,12 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             return
         }
 
-        keyboardCopyModeCursorOverlayView.frame = metrics.appKitRect(for: cursor)
+        let clampedCursor = cursor.clamped(rows: metrics.rows, columns: metrics.columns)
+        if clampedCursor != cursor {
+            keyboardCopyModeCursor = clampedCursor
+        }
+
+        keyboardCopyModeCursorOverlayView.frame = metrics.appKitRect(for: clampedCursor)
         keyboardCopyModeCursorOverlayView.isHidden = false
     }
 
@@ -8546,7 +8561,8 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     private func selectKeyboardCopyModeCursorCell(surface: ghostty_surface_t) -> Bool {
         guard let metrics = keyboardCopyModeGridMetrics(surface: surface) else { return false }
 
-        let cursor = keyboardCopyModeCursor ?? keyboardCopyModeInitialCursor(surface: surface)
+        let cursor = (keyboardCopyModeCursor ?? keyboardCopyModeInitialCursor(surface: surface))
+            .clamped(rows: metrics.rows, columns: metrics.columns)
         keyboardCopyModeCursor = cursor
 
         let rect = metrics.topOriginRect(for: cursor)
@@ -8674,14 +8690,25 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             performBindingAction("scroll_page_fractional:\(fraction)", repeatCount: count)
         case .scrollToTop:
             if var cursor = keyboardCopyModeCursor {
-                cursor.row = 0
+                if let metrics = keyboardCopyModeGridMetrics(surface: surface) {
+                    _ = cursor.move(.home, count: 1, rows: metrics.rows, columns: metrics.columns)
+                } else {
+                    cursor.row = 0
+                    cursor.column = 0
+                }
                 keyboardCopyModeCursor = cursor
             }
             _ = performBindingAction("scroll_to_top")
             syncKeyboardCopyModeCursorOverlay(surface: surface)
         case .scrollToBottom:
             if var cursor = keyboardCopyModeCursor {
-                cursor.row = max(Int(ghostty_surface_size(surface).rows) - 1, 0)
+                if let metrics = keyboardCopyModeGridMetrics(surface: surface) {
+                    _ = cursor.move(.end, count: 1, rows: metrics.rows, columns: metrics.columns)
+                } else {
+                    let size = ghostty_surface_size(surface)
+                    cursor.row = max(Int(size.rows) - 1, 0)
+                    cursor.column = max(Int(size.columns) - 1, 0)
+                }
                 keyboardCopyModeCursor = cursor
             }
             _ = performBindingAction("scroll_to_bottom")

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CmuxTerminalCopyMode
 import CmuxSocketControl
 import SwiftUI
 import AppKit
@@ -1372,133 +1373,6 @@ func resolveTerminalOpenURLTarget(_ rawValue: String) -> TerminalOpenURLTarget? 
     return .external(fallback)
 }
 
-enum TerminalKeyboardCopyModeSelectionMove: String, Equatable {
-    case left
-    case right
-    case up
-    case down
-    case pageUp = "page_up"
-    case pageDown = "page_down"
-    case home
-    case end
-    case beginningOfLine = "beginning_of_line"
-    case endOfLine = "end_of_line"
-}
-
-enum TerminalKeyboardCopyModeAction: Equatable {
-    case exit
-    case startSelection
-    case clearSelection
-    case copyAndExit
-    case copyLineAndExit
-    case scrollLines(Int)
-    case scrollPage(Int)
-    case scrollHalfPage(Int)
-    case scrollToTop
-    case scrollToBottom
-    case jumpToPrompt(Int)
-    case startSearch
-    case searchNext
-    case searchPrevious
-    case adjustSelection(TerminalKeyboardCopyModeSelectionMove)
-}
-
-struct TerminalKeyboardCopyModeInputState: Equatable {
-    var countPrefix: Int?
-    var pendingYankLine = false
-    var pendingG = false
-
-    mutating func reset() {
-        countPrefix = nil
-        pendingYankLine = false
-        pendingG = false
-    }
-}
-
-struct TerminalKeyboardCopyModeCursor: Equatable {
-    var row: Int
-    var column: Int
-
-    func clamped(rows: Int, columns: Int) -> TerminalKeyboardCopyModeCursor {
-        var copy = self
-        copy.clamp(rows: rows, columns: columns)
-        return copy
-    }
-
-    mutating func clamp(rows: Int, columns: Int) {
-        row = Self.clamp(row, upperBound: rows)
-        column = Self.clamp(column, upperBound: columns)
-    }
-
-    mutating func move(
-        _ direction: TerminalKeyboardCopyModeSelectionMove,
-        count: Int,
-        rows: Int,
-        columns: Int
-    ) -> Int {
-        let clampedRows = max(rows, 1)
-        let clampedColumns = max(columns, 1)
-        let clampedCount = terminalKeyboardCopyModeClampCount(count)
-        clamp(rows: clampedRows, columns: clampedColumns)
-
-        switch direction {
-        case .left:
-            column = max(0, column - clampedCount)
-            return 0
-        case .right:
-            column = min(clampedColumns - 1, column + clampedCount)
-            return 0
-        case .up:
-            return moveVertically(delta: -clampedCount, rows: clampedRows)
-        case .down:
-            return moveVertically(delta: clampedCount, rows: clampedRows)
-        case .pageUp:
-            return moveVertically(delta: -(clampedRows * clampedCount), rows: clampedRows)
-        case .pageDown:
-            return moveVertically(delta: clampedRows * clampedCount, rows: clampedRows)
-        case .home:
-            row = 0
-            column = 0
-            return 0
-        case .end:
-            row = clampedRows - 1
-            column = clampedColumns - 1
-            return 0
-        case .beginningOfLine:
-            column = 0
-            return 0
-        case .endOfLine:
-            column = clampedColumns - 1
-            return 0
-        }
-    }
-
-    private mutating func moveVertically(delta: Int, rows: Int) -> Int {
-        let target = row + delta
-        if target < 0 {
-            row = 0
-            return target
-        }
-        if target >= rows {
-            row = rows - 1
-            return target - (rows - 1)
-        }
-        row = target
-        return 0
-    }
-
-    private static func clamp(_ value: Int, upperBound: Int) -> Int {
-        max(0, min(max(upperBound, 1) - 1, value))
-    }
-}
-
-enum TerminalKeyboardCopyModeResolution: Equatable {
-    case perform(TerminalKeyboardCopyModeAction, count: Int)
-    case consume
-}
-
-private let terminalKeyboardCopyModeMaxCount = 9_999
-
 private var terminalKeyboardCopyModeIndicatorText: String {
     String(localized: "ghostty.copy-mode.indicator", defaultValue: "vim")
 }
@@ -1509,10 +1383,6 @@ private var terminalKeyTableIndicatorDefaultText: String {
 
 private var terminalKeyTableIndicatorAccessibilityLabel: String {
     String(localized: "ghostty.key-table.icon.accessibility", defaultValue: "Key table")
-}
-
-private func terminalKeyboardCopyModeClampCount(_ value: Int) -> Int {
-    min(max(value, 1), terminalKeyboardCopyModeMaxCount)
 }
 
 private func terminalKeyTableIndicatorText(_ name: String) -> String {
@@ -1531,95 +1401,36 @@ private func terminalKeyTableIndicatorText(_ name: String) -> String {
     }
 }
 
-func terminalKeyboardCopyModeInitialViewportRow(
-    rows: Int,
-    imePointY: Double,
-    imeCellHeight: Double,
-    topPadding: Double = 0
-) -> Int {
-    let clampedRows = max(rows, 1)
-    guard imeCellHeight > 0 else { return clampedRows - 1 }
-
-    // `ghostty_surface_ime_point` returns a top-origin Y coordinate at the
-    // cursor baseline plus one cell-height. Convert that to a zero-based row.
-    let estimatedRow = Int(floor(((imePointY - topPadding) / imeCellHeight) - 1))
-    return max(0, min(clampedRows - 1, estimatedRow))
-}
-
-func terminalKeyboardCopyModeInitialViewportColumn(
-    columns: Int,
-    imePointX: Double,
-    imeCellWidth: Double,
-    leftPadding: Double = 0
-) -> Int {
-    let clampedColumns = max(columns, 1)
-    guard imeCellWidth > 0 else { return 0 }
-
-    // `ghostty_surface_ime_point` returns the horizontal midpoint of the
-    // terminal cursor cell, so flooring by cell width recovers its column.
-    let estimatedColumn = Int(floor((imePointX - leftPadding) / imeCellWidth))
-    return max(0, min(clampedColumns - 1, estimatedColumn))
-}
-
-func terminalKeyboardCopyModeCursorSelectionXRange(
-    rectMinX: Double,
-    rectMaxX: Double,
-    boundsWidth: Double
-) -> (startX: Double, endX: Double)? {
-    let maxX = boundsWidth - 1
-    guard maxX > 0 else { return nil }
-
-    let visibleMinX = min(max(rectMinX, 0), maxX)
-    let visibleMaxX = min(max(rectMaxX, 0), maxX)
-    let startX = min(max(visibleMinX + 0.5, 0), maxX)
-    let endX = min(max(visibleMaxX - 0.5, 0), maxX)
-    if endX > startX {
-        return (startX, endX)
-    }
-
-    let midpointX = min(max((visibleMinX + visibleMaxX) / 2, 0), maxX)
-    if midpointX < maxX {
-        return (midpointX, min(midpointX + 1, maxX))
-    }
-    let fallbackEndX = max(midpointX - 1, 0)
-    guard fallbackEndX < midpointX else { return nil }
-    return (midpointX, fallbackEndX)
-}
-
-private func terminalKeyboardCopyModeNormalizedModifiers(
+private func terminalKeyboardCopyModeModifiers(
     _ modifierFlags: NSEvent.ModifierFlags
-) -> NSEvent.ModifierFlags {
-    modifierFlags
-        .intersection(.deviceIndependentFlagsMask)
-        .subtracting([.numericPad, .function, .capsLock])
-}
-
-private func terminalKeyboardCopyModeChars(
-    _ charactersIgnoringModifiers: String?,
-    keyCode: UInt16,
-    asciiCharacterProvider: (UInt16, NSEvent.ModifierFlags) -> String?
-) -> String {
-    let raw = charactersIgnoringModifiers?.unicodeScalars.first.map { String($0).lowercased() } ?? ""
-    if raw.allSatisfy(\.isASCII) { return raw }
-    // Non-ASCII input sources (Korean 두벌식, Japanese Kana, Zhuyin) translate the
-    // physical key to a layout character, so a vim key like `j` arrives as `ㅓ` and
-    // never matches the ASCII `switch chars` cases. Fall back to the ASCII-capable
-    // layout lookup (the same one the keyDown shortcut path uses) so copy-mode vim
-    // keys resolve regardless of the active input source. ASCII-emitting IMEs
-    // (Pinyin, romaji) keep `raw` and skip the fallback. The provider is injected
-    // so tests can supply a deterministic mapping without depending on the runner's
-    // input source. Pass [] like KeyboardLayout.normalizedCharacters does: the
-    // lookup lowercases its output and only honors shift/command, so modifiers are
-    // irrelevant for letter keys and this stays consistent with the shortcut path.
-    if let asciiScalar = asciiCharacterProvider(keyCode, [])?.unicodeScalars.first {
-        return String(asciiScalar).lowercased()
+) -> TerminalKeyboardCopyModeModifiers {
+    let normalized = modifierFlags.intersection(.deviceIndependentFlagsMask)
+    var modifiers: TerminalKeyboardCopyModeModifiers = []
+    if normalized.contains(.command) {
+        modifiers.insert(.command)
     }
-    return raw
+    if normalized.contains(.shift) {
+        modifiers.insert(.shift)
+    }
+    if normalized.contains(.control) {
+        modifiers.insert(.control)
+    }
+    if normalized.contains(.numericPad) {
+        modifiers.insert(.numericPad)
+    }
+    if normalized.contains(.function) {
+        modifiers.insert(.function)
+    }
+    if normalized.contains(.capsLock) {
+        modifiers.insert(.capsLock)
+    }
+    return modifiers
 }
 
 func terminalKeyboardCopyModeShouldBypassForShortcut(modifierFlags: NSEvent.ModifierFlags) -> Bool {
-    let normalized = terminalKeyboardCopyModeNormalizedModifiers(modifierFlags)
-    return normalized.contains(.command)
+    CmuxTerminalCopyMode.terminalKeyboardCopyModeShouldBypassForShortcut(
+        modifiers: terminalKeyboardCopyModeModifiers(modifierFlags)
+    )
 }
 
 func terminalKeyboardCopyModeAction(
@@ -1629,100 +1440,15 @@ func terminalKeyboardCopyModeAction(
     hasSelection: Bool,
     asciiCharacterProvider: (UInt16, NSEvent.ModifierFlags) -> String? = KeyboardLayout.character(forKeyCode:modifierFlags:)
 ) -> TerminalKeyboardCopyModeAction? {
-    let normalized = terminalKeyboardCopyModeNormalizedModifiers(modifierFlags)
-    let chars = terminalKeyboardCopyModeChars(charactersIgnoringModifiers, keyCode: keyCode, asciiCharacterProvider: asciiCharacterProvider)
-
-    if keyCode == 53 { // Escape
-        return .exit
-    }
-
-    switch keyCode {
-    case 126: // Up
-        return .adjustSelection(.up)
-    case 125: // Down
-        return .adjustSelection(.down)
-    case 123: // Left
-        return .adjustSelection(.left)
-    case 124: // Right
-        return .adjustSelection(.right)
-    case 116: // Page Up
-        return hasSelection ? .adjustSelection(.pageUp) : .scrollPage(-1)
-    case 121: // Page Down
-        return hasSelection ? .adjustSelection(.pageDown) : .scrollPage(1)
-    case 115: // Home
-        return hasSelection ? .adjustSelection(.home) : .scrollToTop
-    case 119: // End
-        return hasSelection ? .adjustSelection(.end) : .scrollToBottom
-    default:
-        break
-    }
-
-    if normalized == [.control] {
-        if chars == "u" || chars == "\u{15}" {
-            return hasSelection ? .adjustSelection(.pageUp) : .scrollHalfPage(-1)
+    CmuxTerminalCopyMode.terminalKeyboardCopyModeAction(
+        keyCode: keyCode,
+        charactersIgnoringModifiers: charactersIgnoringModifiers,
+        modifiers: terminalKeyboardCopyModeModifiers(modifierFlags),
+        hasSelection: hasSelection,
+        asciiCharacterProvider: { keyCode in
+            asciiCharacterProvider(keyCode, [])
         }
-        if chars == "d" || chars == "\u{04}" {
-            return hasSelection ? .adjustSelection(.pageDown) : .scrollHalfPage(1)
-        }
-        if chars == "b" || chars == "\u{02}" {
-            return hasSelection ? .adjustSelection(.pageUp) : .scrollPage(-1)
-        }
-        if chars == "f" || chars == "\u{06}" {
-            return hasSelection ? .adjustSelection(.pageDown) : .scrollPage(1)
-        }
-        if chars == "y" || chars == "\u{19}" {
-            return hasSelection ? .adjustSelection(.up) : .scrollLines(-1)
-        }
-        if chars == "e" || chars == "\u{05}" {
-            return hasSelection ? .adjustSelection(.down) : .scrollLines(1)
-        }
-        return nil
-    }
-
-    guard normalized.isEmpty || normalized == [.shift] else { return nil }
-
-    switch chars {
-    case "q":
-        return .exit
-    case "v":
-        return hasSelection ? .clearSelection : .startSelection
-    case "y":
-        if normalized == [.shift], !hasSelection {
-            return .copyLineAndExit
-        }
-        return hasSelection ? .copyAndExit : nil
-    case "j":
-        return .adjustSelection(.down)
-    case "k":
-        return .adjustSelection(.up)
-    case "h":
-        return .adjustSelection(.left)
-    case "l":
-        return .adjustSelection(.right)
-    case "g":
-        if normalized == [.shift] {
-            return hasSelection ? .adjustSelection(.end) : .scrollToBottom
-        }
-        // Bare "g" is a prefix key (e.g. gg); handled in resolve.
-        return nil
-    case "0", "^":
-        return hasSelection ? .adjustSelection(.beginningOfLine) : nil
-    case "$", "4":
-        guard chars == "$" || normalized == [.shift] else { return nil }
-        return hasSelection ? .adjustSelection(.endOfLine) : nil
-    case "{", "[":
-        guard chars == "{" || normalized == [.shift] else { return nil }
-        return .jumpToPrompt(-1)
-    case "}", "]":
-        guard chars == "}" || normalized == [.shift] else { return nil }
-        return .jumpToPrompt(1)
-    case "/":
-        return .startSearch
-    case "n":
-        return normalized == [.shift] ? .searchPrevious : .searchNext
-    default:
-        return nil
-    }
+    )
 }
 
 func terminalKeyboardCopyModeResolve(
@@ -1733,78 +1459,16 @@ func terminalKeyboardCopyModeResolve(
     state: inout TerminalKeyboardCopyModeInputState,
     asciiCharacterProvider: (UInt16, NSEvent.ModifierFlags) -> String? = KeyboardLayout.character(forKeyCode:modifierFlags:)
 ) -> TerminalKeyboardCopyModeResolution {
-    let normalized = terminalKeyboardCopyModeNormalizedModifiers(modifierFlags)
-    let chars = terminalKeyboardCopyModeChars(charactersIgnoringModifiers, keyCode: keyCode, asciiCharacterProvider: asciiCharacterProvider)
-
-    if keyCode == 53 { // Escape
-        state.reset()
-        return .perform(.exit, count: 1)
-    }
-
-    if state.pendingYankLine {
-        if chars == "y", normalized.isEmpty || normalized == [.shift] {
-            let count = terminalKeyboardCopyModeClampCount(state.countPrefix ?? 1)
-            state.reset()
-            return .perform(.copyLineAndExit, count: count)
-        }
-        // Only `yy`/`Y` are supported as line-yank operators, so cancel the
-        // pending yank and treat this key as a fresh command.
-        state.pendingYankLine = false
-    }
-
-    if state.pendingG {
-        if chars == "g", normalized.isEmpty {
-            let count = terminalKeyboardCopyModeClampCount(state.countPrefix ?? 1)
-            let action: TerminalKeyboardCopyModeAction = hasSelection ? .adjustSelection(.home) : .scrollToTop
-            state.reset()
-            return .perform(action, count: count)
-        }
-        // Not `gg`, cancel and treat as fresh command.
-        state.pendingG = false
-    }
-
-    if normalized.isEmpty,
-       let scalar = chars.unicodeScalars.first,
-       scalar.isASCII,
-       scalar.value >= 48,
-       scalar.value <= 57 {
-        let digit = Int(scalar.value - 48)
-        if digit == 0 {
-            if let currentCount = state.countPrefix {
-                state.countPrefix = terminalKeyboardCopyModeClampCount(currentCount * 10)
-                return .consume
-            }
-        } else {
-            let currentCount = state.countPrefix ?? 0
-            state.countPrefix = terminalKeyboardCopyModeClampCount((currentCount * 10) + digit)
-            return .consume
-        }
-    }
-
-    if !hasSelection, chars == "y", normalized.isEmpty {
-        state.pendingYankLine = true
-        return .consume
-    }
-
-    if chars == "g", normalized.isEmpty {
-        state.pendingG = true
-        return .consume
-    }
-
-    guard let action = terminalKeyboardCopyModeAction(
+    CmuxTerminalCopyMode.terminalKeyboardCopyModeResolve(
         keyCode: keyCode,
         charactersIgnoringModifiers: charactersIgnoringModifiers,
-        modifierFlags: modifierFlags,
+        modifiers: terminalKeyboardCopyModeModifiers(modifierFlags),
         hasSelection: hasSelection,
-        asciiCharacterProvider: asciiCharacterProvider
-    ) else {
-        state.reset()
-        return .consume
-    }
-
-    let count = terminalKeyboardCopyModeClampCount(state.countPrefix ?? 1)
-    state.reset()
-    return .perform(action, count: count)
+        state: &state,
+        asciiCharacterProvider: { keyCode in
+            asciiCharacterProvider(keyCode, [])
+        }
+    )
 }
 
 private final class GhosttySurfaceCallbackContext {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -19,9 +19,6 @@ import UniformTypeIdentifiers
 @_silgen_name("ghostty_surface_clear_selection")
 private func ghostty_surface_clear_selection_compat(_ surface: ghostty_surface_t) -> Bool
 
-@_silgen_name("ghostty_surface_select_cursor_cell")
-private func ghostty_surface_select_cursor_cell_compat(_ surface: ghostty_surface_t) -> Bool
-
 enum GhosttyStartupAppearancePreviewProfile: String, CaseIterable, Identifiable {
     case realUserConfig
     case freshInstall
@@ -8523,10 +8520,10 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     }
 
     private func selectKeyboardCopyModeCursorCell(surface: ghostty_surface_t) -> Bool {
-        guard let cursor = keyboardCopyModeCursor,
-              let metrics = keyboardCopyModeGridMetrics(surface: surface) else {
-            return ghostty_surface_select_cursor_cell_compat(surface)
-        }
+        guard let metrics = keyboardCopyModeGridMetrics(surface: surface) else { return false }
+
+        let cursor = keyboardCopyModeCursor ?? keyboardCopyModeInitialCursor(surface: surface)
+        keyboardCopyModeCursor = cursor
 
         let rect = metrics.topOriginRect(for: cursor)
         let y = min(max(rect.midY, 0), max(bounds.height - 1, 0))
@@ -8537,13 +8534,15 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         _ = ghostty_surface_clear_selection_compat(surface)
         ghostty_surface_mouse_pos(surface, Double(startX), Double(y), mods)
         guard ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_LEFT, mods) else {
-            return ghostty_surface_select_cursor_cell_compat(surface)
+            _ = ghostty_surface_clear_selection_compat(surface)
+            return false
         }
         ghostty_surface_mouse_pos(surface, Double(endX), Double(y), mods)
         let selectedCursorCell = ghostty_surface_has_selection(surface)
         _ = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, mods)
         guard selectedCursorCell else {
-            return ghostty_surface_select_cursor_cell_compat(surface)
+            _ = ghostty_surface_clear_selection_compat(surface)
+            return false
         }
         return true
     }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -8272,7 +8272,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             _ = ghostty_surface_clear_selection_compat(surface)
             return false
         }
-        let mods = ghostty_input_mods_e(rawValue: GHOSTTY_MODS_NONE.rawValue) ?? GHOSTTY_MODS_NONE
+        let mods = GHOSTTY_MODS_NONE
 
         _ = ghostty_surface_clear_selection_compat(surface)
         ghostty_surface_mouse_pos(surface, xRange.startX, Double(y), mods)
@@ -8316,7 +8316,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         let startX = min(metrics.xInset + 0.5, xMax)
         let endX = min(metrics.xInset + (CGFloat(metrics.columns) * metrics.cellWidth) - 0.5, xMax)
 
-        let mods = ghostty_input_mods_e(rawValue: GHOSTTY_MODS_NONE.rawValue) ?? GHOSTTY_MODS_NONE
+        let mods = GHOSTTY_MODS_NONE
         ghostty_surface_mouse_pos(surface, Double(startX), Double(startY), mods)
         guard ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_LEFT, mods) else {
             return false

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1394,7 +1394,6 @@ enum TerminalKeyboardCopyModeAction: Equatable {
     case clearSelection
     case copyAndExit
     case copyLineAndExit
-    case scrollLines(Int)
     case scrollPage(Int)
     case scrollHalfPage(Int)
     case scrollToTop
@@ -1415,6 +1414,73 @@ struct TerminalKeyboardCopyModeInputState: Equatable {
         countPrefix = nil
         pendingYankLine = false
         pendingG = false
+    }
+}
+
+struct TerminalKeyboardCopyModeCursor: Equatable {
+    var row: Int
+    var column: Int
+
+    mutating func move(
+        _ direction: TerminalKeyboardCopyModeSelectionMove,
+        count: Int,
+        rows: Int,
+        columns: Int
+    ) -> Int {
+        let clampedRows = max(rows, 1)
+        let clampedColumns = max(columns, 1)
+        let clampedCount = terminalKeyboardCopyModeClampCount(count)
+        row = Self.clamp(row, upperBound: clampedRows)
+        column = Self.clamp(column, upperBound: clampedColumns)
+
+        switch direction {
+        case .left:
+            column = max(0, column - clampedCount)
+            return 0
+        case .right:
+            column = min(clampedColumns - 1, column + clampedCount)
+            return 0
+        case .up:
+            return moveVertically(delta: -clampedCount, rows: clampedRows)
+        case .down:
+            return moveVertically(delta: clampedCount, rows: clampedRows)
+        case .pageUp:
+            return moveVertically(delta: -(clampedRows * clampedCount), rows: clampedRows)
+        case .pageDown:
+            return moveVertically(delta: clampedRows * clampedCount, rows: clampedRows)
+        case .home:
+            row = 0
+            column = 0
+            return 0
+        case .end:
+            row = clampedRows - 1
+            column = clampedColumns - 1
+            return 0
+        case .beginningOfLine:
+            column = 0
+            return 0
+        case .endOfLine:
+            column = clampedColumns - 1
+            return 0
+        }
+    }
+
+    private mutating func moveVertically(delta: Int, rows: Int) -> Int {
+        let target = row + delta
+        if target < 0 {
+            row = 0
+            return target
+        }
+        if target >= rows {
+            row = rows - 1
+            return target - (rows - 1)
+        }
+        row = target
+        return 0
+    }
+
+    private static func clamp(_ value: Int, upperBound: Int) -> Int {
+        max(0, min(max(upperBound, 1) - 1, value))
     }
 }
 
@@ -1472,6 +1538,21 @@ func terminalKeyboardCopyModeInitialViewportRow(
     return max(0, min(clampedRows - 1, estimatedRow))
 }
 
+func terminalKeyboardCopyModeInitialViewportColumn(
+    columns: Int,
+    imePointX: Double,
+    imeCellWidth: Double,
+    leftPadding: Double = 0
+) -> Int {
+    let clampedColumns = max(columns, 1)
+    guard imeCellWidth > 0 else { return 0 }
+
+    // `ghostty_surface_ime_point` returns the horizontal midpoint of the
+    // terminal cursor cell, so flooring by cell width recovers its column.
+    let estimatedColumn = Int(floor((imePointX - leftPadding) / imeCellWidth))
+    return max(0, min(clampedColumns - 1, estimatedColumn))
+}
+
 private func terminalKeyboardCopyModeNormalizedModifiers(
     _ modifierFlags: NSEvent.ModifierFlags
 ) -> NSEvent.ModifierFlags {
@@ -1524,13 +1605,13 @@ func terminalKeyboardCopyModeAction(
 
     switch keyCode {
     case 126: // Up
-        return hasSelection ? .adjustSelection(.up) : .scrollLines(-1)
+        return .adjustSelection(.up)
     case 125: // Down
-        return hasSelection ? .adjustSelection(.down) : .scrollLines(1)
+        return .adjustSelection(.down)
     case 123: // Left
-        return hasSelection ? .adjustSelection(.left) : nil
+        return .adjustSelection(.left)
     case 124: // Right
-        return hasSelection ? .adjustSelection(.right) : nil
+        return .adjustSelection(.right)
     case 116: // Page Up
         return hasSelection ? .adjustSelection(.pageUp) : .scrollPage(-1)
     case 121: // Page Down
@@ -1557,10 +1638,10 @@ func terminalKeyboardCopyModeAction(
             return hasSelection ? .adjustSelection(.pageDown) : .scrollPage(1)
         }
         if chars == "y" || chars == "\u{19}" {
-            return hasSelection ? .adjustSelection(.up) : .scrollLines(-1)
+            return .adjustSelection(.up)
         }
         if chars == "e" || chars == "\u{05}" {
-            return hasSelection ? .adjustSelection(.down) : .scrollLines(1)
+            return .adjustSelection(.down)
         }
         return nil
     }
@@ -1578,13 +1659,13 @@ func terminalKeyboardCopyModeAction(
         }
         return hasSelection ? .copyAndExit : nil
     case "j":
-        return hasSelection ? .adjustSelection(.down) : .scrollLines(1)
+        return .adjustSelection(.down)
     case "k":
-        return hasSelection ? .adjustSelection(.up) : .scrollLines(-1)
+        return .adjustSelection(.up)
     case "h":
-        return hasSelection ? .adjustSelection(.left) : nil
+        return .adjustSelection(.left)
     case "l":
-        return hasSelection ? .adjustSelection(.right) : nil
+        return .adjustSelection(.right)
     case "g":
         if normalized == [.shift] {
             return hasSelection ? .adjustSelection(.end) : .scrollToBottom
@@ -7609,12 +7690,12 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     private var keyboardCopyModeConsumedKeyUps: Set<UInt16> = []
     private var imeConsumedKeyUps: Set<UInt16> = []
     private var keyboardCopyModeInputState = TerminalKeyboardCopyModeInputState()
-    private var keyboardCopyModeViewportRow: Int?
+    private var keyboardCopyModeCursor: TerminalKeyboardCopyModeCursor?
     /// Tracks whether the user has explicitly entered visual selection mode (v).
-    /// Separate from Ghostty's `has_selection` because copy mode always maintains
-    /// a 1-cell selection as a visible cursor. This flag determines whether
-    /// movements should extend the selection (visual) or scroll the viewport.
+    /// Separate from Ghostty's `has_selection` because non-visual copy mode keeps
+    /// the cursor in AppKit overlay state until visual selection starts.
     private var keyboardCopyModeVisualActive = false
+    private let keyboardCopyModeCursorOverlayView = GhosttyFlashOverlayView(frame: .zero)
     fileprivate var isKeyboardCopyModeActive: Bool { keyboardCopyModeActive }
     fileprivate var currentKeyStateIndicatorText: String? {
         if let name = keyTables.last {
@@ -7708,9 +7789,23 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         // input sequencing that needs to wait for terminal redraws.
         wantsLayer = true
         layer?.masksToBounds = true
+        setupKeyboardCopyModeCursorOverlay()
         installEventMonitor()
         updateTrackingAreas()
         registerForDraggedTypes(Array(Self.dropTypes))
+    }
+
+    private func setupKeyboardCopyModeCursorOverlay() {
+        keyboardCopyModeCursorOverlayView.wantsLayer = true
+        keyboardCopyModeCursorOverlayView.layer?.backgroundColor = NSColor.controlAccentColor
+            .withAlphaComponent(0.45)
+            .cgColor
+        keyboardCopyModeCursorOverlayView.layer?.borderColor = NSColor.white
+            .withAlphaComponent(0.70)
+            .cgColor
+        keyboardCopyModeCursorOverlayView.layer?.borderWidth = 1
+        keyboardCopyModeCursorOverlayView.isHidden = true
+        addSubview(keyboardCopyModeCursorOverlayView, positioned: .above, relativeTo: nil)
     }
 
     private func effectiveBackgroundColor() -> NSColor {
@@ -7970,6 +8065,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     override func layout() {
         super.layout()
         updateSurfaceSize()
+        syncKeyboardCopyModeCursorOverlay()
         invalidateTextInputCoordinates()
     }
 
@@ -8275,16 +8371,12 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         keyboardCopyModeVisualActive = false
         keyboardCopyModeActive = active
         if active, let surface {
-            keyboardCopyModeViewportRow = keyboardCopyModeSelectionAnchor(surface: surface)?.row
             _ = ghostty_surface_clear_selection_compat(surface)
-            if keyboardCopyModeViewportRow == nil {
-                keyboardCopyModeViewportRow = keyboardCopyModeImeViewportRow(surface: surface)
-            }
-            // Create a 1-cell selection at the terminal cursor to serve as a
-            // visible cursor indicator in copy mode.
-            _ = ghostty_surface_select_cursor_cell_compat(surface)
+            keyboardCopyModeCursor = keyboardCopyModeInitialCursor(surface: surface)
+            syncKeyboardCopyModeCursorOverlay(surface: surface)
         } else {
-            keyboardCopyModeViewportRow = nil
+            keyboardCopyModeCursor = nil
+            syncKeyboardCopyModeCursorOverlay()
         }
         terminalSurface?.setKeyboardCopyModeActive(active)
     }
@@ -8299,48 +8391,142 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     private func currentKeyboardCopyModeViewportRow(surface: ghostty_surface_t) -> Int {
         let rows = max(Int(ghostty_surface_size(surface).rows), 1)
         let fallback = rows - 1
-        return max(0, min(rows - 1, keyboardCopyModeViewportRow ?? fallback))
+        return max(0, min(rows - 1, keyboardCopyModeCursor?.row ?? fallback))
     }
 
-    private func keyboardCopyModeImeViewportRow(surface: ghostty_surface_t) -> Int {
-        let rows = max(Int(ghostty_surface_size(surface).rows), 1)
+    private struct KeyboardCopyModeGridMetrics {
+        let rows: Int
+        let columns: Int
+        let cellWidth: CGFloat
+        let cellHeight: CGFloat
+        let xInset: CGFloat
+        let yInset: CGFloat
+        let viewHeight: CGFloat
+
+        func topOriginRect(for cursor: TerminalKeyboardCopyModeCursor) -> CGRect {
+            CGRect(
+                x: xInset + (CGFloat(cursor.column) * cellWidth),
+                y: yInset + (CGFloat(cursor.row) * cellHeight),
+                width: cellWidth,
+                height: cellHeight
+            )
+        }
+
+        func appKitRect(for cursor: TerminalKeyboardCopyModeCursor) -> CGRect {
+            let topOrigin = topOriginRect(for: cursor)
+            return CGRect(
+                x: topOrigin.minX,
+                y: viewHeight - topOrigin.maxY,
+                width: topOrigin.width,
+                height: topOrigin.height
+            )
+        }
+    }
+
+    private func keyboardCopyModeGridMetrics(surface: ghostty_surface_t) -> KeyboardCopyModeGridMetrics? {
+        let size = ghostty_surface_size(surface)
+        let rows = max(Int(size.rows), 1)
+        let columns = max(Int(size.columns), 1)
+        let resolvedCellWidth = cellSize.width > 0 ? cellSize.width : CGFloat(size.cell_width_px)
+        let resolvedCellHeight = cellSize.height > 0 ? cellSize.height : CGFloat(size.cell_height_px)
+        guard resolvedCellWidth > 0, resolvedCellHeight > 0 else { return nil }
+
+        let terminalWidth = CGFloat(columns) * resolvedCellWidth
+        let terminalHeight = CGFloat(rows) * resolvedCellHeight
+        return KeyboardCopyModeGridMetrics(
+            rows: rows,
+            columns: columns,
+            cellWidth: resolvedCellWidth,
+            cellHeight: resolvedCellHeight,
+            xInset: max(0, (bounds.width - terminalWidth) / 2),
+            yInset: max(0, (bounds.height - terminalHeight) / 2),
+            viewHeight: bounds.height
+        )
+    }
+
+    private func keyboardCopyModeInitialCursor(surface: ghostty_surface_t) -> TerminalKeyboardCopyModeCursor {
+        guard let metrics = keyboardCopyModeGridMetrics(surface: surface) else {
+            return TerminalKeyboardCopyModeCursor(row: 0, column: 0)
+        }
+
         var x: Double = 0
         var y: Double = 0
         var width: Double = 0
         var height: Double = 0
         ghostty_surface_ime_point(surface, &x, &y, &width, &height)
-        return terminalKeyboardCopyModeInitialViewportRow(
-            rows: rows,
+
+        let row = terminalKeyboardCopyModeInitialViewportRow(
+            rows: metrics.rows,
             imePointY: y,
-            imeCellHeight: height
+            imeCellHeight: Double(metrics.cellHeight),
+            topPadding: Double(metrics.yInset)
         )
+        let column = terminalKeyboardCopyModeInitialViewportColumn(
+            columns: metrics.columns,
+            imePointX: x,
+            imeCellWidth: Double(metrics.cellWidth),
+            leftPadding: Double(metrics.xInset)
+        )
+        return TerminalKeyboardCopyModeCursor(row: row, column: column)
     }
 
-    private func keyboardCopyModeSelectionAnchor(surface: ghostty_surface_t) -> (row: Int, y: Double)? {
-        let size = ghostty_surface_size(surface)
-        guard size.rows > 0, size.columns > 0 else { return nil }
-        guard ghostty_surface_select_cursor_cell_compat(surface) else { return nil }
+    private func syncKeyboardCopyModeCursorOverlay(surface explicitSurface: ghostty_surface_t? = nil) {
+        guard keyboardCopyModeActive,
+              !keyboardCopyModeVisualActive,
+              let surface = explicitSurface ?? self.surface,
+              let cursor = keyboardCopyModeCursor,
+              let metrics = keyboardCopyModeGridMetrics(surface: surface) else {
+            keyboardCopyModeCursorOverlayView.isHidden = true
+            return
+        }
 
-        var text = ghostty_text_s()
-        guard ghostty_surface_read_selection(surface, &text) else { return nil }
-        defer { ghostty_surface_free_text(surface, &text) }
-
-        let rows = max(Int(size.rows), 1)
-        let cols = max(Int(size.columns), 1)
-        let rawRow = Int(text.offset_start) / cols
-        let clampedRow = max(0, min(rows - 1, rawRow))
-        return (row: clampedRow, y: text.tl_px_y)
+        keyboardCopyModeCursorOverlayView.frame = metrics.appKitRect(for: cursor)
+        keyboardCopyModeCursorOverlayView.isHidden = false
+        addSubview(keyboardCopyModeCursorOverlayView, positioned: .above, relativeTo: nil)
     }
 
-    private func refreshKeyboardCopyModeViewportRowFromVisibleAnchor(surface: ghostty_surface_t) {
-        // In visual mode the user owns the selection range; don't disturb it.
-        // Outside visual mode we keep a 1-cell cursor selection for visibility,
-        // so we still need to refresh the viewport row after scrolling.
-        guard !keyboardCopyModeVisualActive else { return }
-        guard let anchor = keyboardCopyModeSelectionAnchor(surface: surface) else { return }
-        keyboardCopyModeViewportRow = anchor.row
-        // Preserve the visible cursor indicator.
-        _ = ghostty_surface_select_cursor_cell_compat(surface)
+    private func moveKeyboardCopyModeCursor(
+        _ direction: TerminalKeyboardCopyModeSelectionMove,
+        count: Int,
+        surface: ghostty_surface_t
+    ) {
+        guard let metrics = keyboardCopyModeGridMetrics(surface: surface) else { return }
+        var cursor = keyboardCopyModeCursor ?? keyboardCopyModeInitialCursor(surface: surface)
+        let scrollDelta = cursor.move(
+            direction,
+            count: count,
+            rows: metrics.rows,
+            columns: metrics.columns
+        )
+        keyboardCopyModeCursor = cursor
+        if scrollDelta != 0 {
+            _ = performBindingAction("scroll_page_lines:\(scrollDelta)")
+        }
+        syncKeyboardCopyModeCursorOverlay(surface: surface)
+    }
+
+    private func selectKeyboardCopyModeCursorCell(surface: ghostty_surface_t) -> Bool {
+        guard let cursor = keyboardCopyModeCursor,
+              let metrics = keyboardCopyModeGridMetrics(surface: surface) else {
+            return ghostty_surface_select_cursor_cell_compat(surface)
+        }
+
+        let rect = metrics.topOriginRect(for: cursor)
+        let y = min(max(rect.midY, 0), max(bounds.height - 1, 0))
+        let startX = min(max(rect.minX + 0.5, 0), max(bounds.width - 1, 0))
+        let endX = min(max(rect.maxX - 0.5, startX), max(bounds.width - 1, 0))
+        let mods = ghostty_input_mods_e(rawValue: GHOSTTY_MODS_NONE.rawValue) ?? GHOSTTY_MODS_NONE
+
+        _ = ghostty_surface_clear_selection_compat(surface)
+        ghostty_surface_mouse_pos(surface, Double(startX), Double(y), mods)
+        guard ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_LEFT, mods) else {
+            return false
+        }
+        ghostty_surface_mouse_pos(surface, Double(endX), Double(y), mods)
+        defer {
+            _ = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, mods)
+        }
+        return ghostty_surface_has_selection(surface)
     }
 
     private func copyCurrentViewportLinesToClipboard(
@@ -8348,40 +8534,36 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         startRow: Int,
         lineCount: Int
     ) -> Bool {
+        guard let metrics = keyboardCopyModeGridMetrics(surface: surface) else { return false }
         let clampedCount = terminalKeyboardCopyModeClampCount(lineCount)
-        let rows = max(Int(ghostty_surface_size(surface).rows), 1)
+        let rows = metrics.rows
         let targetRow = max(0, min(rows - 1, startRow))
         let endRow = min(rows - 1, targetRow + clampedCount - 1)
-        guard let anchor = keyboardCopyModeSelectionAnchor(surface: surface) else {
-            return false
-        }
         _ = ghostty_surface_clear_selection_compat(surface)
 
-        var imeX: Double = 0
-        var imeY: Double = 0
-        var imeWidth: Double = 0
-        var imeHeight: Double = 0
-        ghostty_surface_ime_point(surface, &imeX, &imeY, &imeWidth, &imeHeight)
-        let cellHeight = imeHeight > 0 ? imeHeight : max(bounds.height / Double(rows), 1)
         let yMax = max(bounds.height - 1, 0)
 
-        let startRawY = anchor.y + (Double(targetRow - anchor.row) * cellHeight)
-        let endRawY = anchor.y + (Double(endRow - anchor.row) * cellHeight)
+        let startRawY = metrics.topOriginRect(
+            for: TerminalKeyboardCopyModeCursor(row: targetRow, column: 0)
+        ).midY
+        let endRawY = metrics.topOriginRect(
+            for: TerminalKeyboardCopyModeCursor(row: endRow, column: max(metrics.columns - 1, 0))
+        ).midY
         let startY = max(0, min(startRawY, yMax))
         let endY = max(0, min(endRawY, yMax))
         let xMax = max(bounds.width - 1, 0)
-        let startX = min(1, xMax)
-        let endX = xMax
+        let startX = min(metrics.xInset + 0.5, xMax)
+        let endX = min(metrics.xInset + (CGFloat(metrics.columns) * metrics.cellWidth) - 0.5, xMax)
 
         let mods = ghostty_input_mods_e(rawValue: GHOSTTY_MODS_NONE.rawValue) ?? GHOSTTY_MODS_NONE
-        ghostty_surface_mouse_pos(surface, startX, startY, mods)
+        ghostty_surface_mouse_pos(surface, Double(startX), Double(startY), mods)
         guard ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_LEFT, mods) else {
             return false
         }
         defer {
             _ = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, mods)
         }
-        ghostty_surface_mouse_pos(surface, endX, endY, mods)
+        ghostty_surface_mouse_pos(surface, Double(endX), Double(endY), mods)
         guard ghostty_surface_has_selection(surface) else { return false }
 
         return performBindingAction("copy_to_clipboard")
@@ -8395,8 +8577,8 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             return false
         }
 
-        // Use the visual-mode flag instead of raw has_selection so that the
-        // 1-cell cursor selection doesn't make every motion behave as visual.
+        // Use the visual-mode flag instead of raw has_selection; non-visual
+        // cursor state is owned by the copy-mode cursor model.
         let hasSelection = keyboardCopyModeVisualActive
         let resolution = terminalKeyboardCopyModeResolve(
             keyCode: event.keyCode,
@@ -8414,12 +8596,14 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             _ = ghostty_surface_clear_selection_compat(surface)
             setKeyboardCopyModeActive(false)
         case .startSelection:
-            keyboardCopyModeVisualActive = true
+            if selectKeyboardCopyModeCursorCell(surface: surface) {
+                keyboardCopyModeVisualActive = true
+                syncKeyboardCopyModeCursorOverlay(surface: surface)
+            }
         case .clearSelection:
             keyboardCopyModeVisualActive = false
             _ = ghostty_surface_clear_selection_compat(surface)
-            // Re-create 1-cell cursor at terminal cursor position.
-            _ = ghostty_surface_select_cursor_cell_compat(surface)
+            syncKeyboardCopyModeCursorOverlay(surface: surface)
         case .copyAndExit:
             _ = performBindingAction("copy_to_clipboard")
             _ = ghostty_surface_clear_selection_compat(surface)
@@ -8433,35 +8617,45 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             )
             _ = ghostty_surface_clear_selection_compat(surface)
             setKeyboardCopyModeActive(false)
-        case let .scrollLines(delta):
-            _ = performBindingAction("scroll_page_lines:\(delta * count)")
-            refreshKeyboardCopyModeViewportRowFromVisibleAnchor(surface: surface)
         case let .scrollPage(delta):
             performBindingAction(delta > 0 ? "scroll_page_down" : "scroll_page_up", repeatCount: count)
-            refreshKeyboardCopyModeViewportRowFromVisibleAnchor(surface: surface)
         case let .scrollHalfPage(delta):
             let fraction = delta > 0 ? 0.5 : -0.5
             performBindingAction("scroll_page_fractional:\(fraction)", repeatCount: count)
-            refreshKeyboardCopyModeViewportRowFromVisibleAnchor(surface: surface)
         case .scrollToTop:
-            keyboardCopyModeViewportRow = 0
+            if var cursor = keyboardCopyModeCursor {
+                cursor.row = 0
+                keyboardCopyModeCursor = cursor
+            }
             _ = performBindingAction("scroll_to_top")
+            syncKeyboardCopyModeCursorOverlay(surface: surface)
         case .scrollToBottom:
-            keyboardCopyModeViewportRow = max(Int(ghostty_surface_size(surface).rows) - 1, 0)
+            if var cursor = keyboardCopyModeCursor {
+                cursor.row = max(Int(ghostty_surface_size(surface).rows) - 1, 0)
+                keyboardCopyModeCursor = cursor
+            }
             _ = performBindingAction("scroll_to_bottom")
+            syncKeyboardCopyModeCursorOverlay(surface: surface)
         case let .jumpToPrompt(delta):
             _ = performBindingAction("jump_to_prompt:\(delta * count)")
-            refreshKeyboardCopyModeViewportRowFromVisibleAnchor(surface: surface)
+            keyboardCopyModeCursor = keyboardCopyModeInitialCursor(surface: surface)
+            syncKeyboardCopyModeCursorOverlay(surface: surface)
         case .startSearch:
             _ = performBindingAction("start_search")
         case .searchNext:
             performBindingAction("navigate_search:next", repeatCount: count)
-            refreshKeyboardCopyModeViewportRowFromVisibleAnchor(surface: surface)
+            keyboardCopyModeCursor = keyboardCopyModeInitialCursor(surface: surface)
+            syncKeyboardCopyModeCursorOverlay(surface: surface)
         case .searchPrevious:
             performBindingAction("navigate_search:previous", repeatCount: count)
-            refreshKeyboardCopyModeViewportRowFromVisibleAnchor(surface: surface)
+            keyboardCopyModeCursor = keyboardCopyModeInitialCursor(surface: surface)
+            syncKeyboardCopyModeCursorOverlay(surface: surface)
         case let .adjustSelection(direction):
-            performBindingAction("adjust_selection:\(direction.rawValue)", repeatCount: count)
+            if keyboardCopyModeVisualActive {
+                performBindingAction("adjust_selection:\(direction.rawValue)", repeatCount: count)
+            } else {
+                moveKeyboardCopyModeCursor(direction, count: count, surface: surface)
+            }
         }
         return true
     }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1551,6 +1551,31 @@ func terminalKeyboardCopyModeInitialViewportColumn(
     return max(0, min(clampedColumns - 1, estimatedColumn))
 }
 
+func terminalKeyboardCopyModeCursorSelectionXRange(
+    rectMinX: Double,
+    rectMaxX: Double,
+    boundsWidth: Double
+) -> (startX: Double, endX: Double)? {
+    let maxX = boundsWidth - 1
+    guard maxX > 0 else { return nil }
+
+    let visibleMinX = min(max(rectMinX, 0), maxX)
+    let visibleMaxX = min(max(rectMaxX, 0), maxX)
+    let startX = min(max(visibleMinX + 0.5, 0), maxX)
+    let endX = min(max(visibleMaxX - 0.5, 0), maxX)
+    if endX > startX {
+        return (startX, endX)
+    }
+
+    let midpointX = min(max((visibleMinX + visibleMaxX) / 2, 0), maxX)
+    if midpointX < maxX {
+        return (midpointX, min(midpointX + 1, maxX))
+    }
+    let fallbackEndX = max(midpointX - 1, 0)
+    guard fallbackEndX < midpointX else { return nil }
+    return (midpointX, fallbackEndX)
+}
+
 private func terminalKeyboardCopyModeNormalizedModifiers(
     _ modifierFlags: NSEvent.ModifierFlags
 ) -> NSEvent.ModifierFlags {
@@ -8480,7 +8505,6 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
         keyboardCopyModeCursorOverlayView.frame = metrics.appKitRect(for: cursor)
         keyboardCopyModeCursorOverlayView.isHidden = false
-        addSubview(keyboardCopyModeCursorOverlayView, positioned: .above, relativeTo: nil)
     }
 
     private func moveKeyboardCopyModeCursor(
@@ -8527,17 +8551,23 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
         let rect = metrics.topOriginRect(for: cursor)
         let y = min(max(rect.midY, 0), max(bounds.height - 1, 0))
-        let startX = min(max(rect.minX + 0.5, 0), max(bounds.width - 1, 0))
-        let endX = min(max(rect.maxX - 0.5, startX), max(bounds.width - 1, 0))
+        guard let xRange = terminalKeyboardCopyModeCursorSelectionXRange(
+            rectMinX: Double(rect.minX),
+            rectMaxX: Double(rect.maxX),
+            boundsWidth: Double(bounds.width)
+        ) else {
+            _ = ghostty_surface_clear_selection_compat(surface)
+            return false
+        }
         let mods = ghostty_input_mods_e(rawValue: GHOSTTY_MODS_NONE.rawValue) ?? GHOSTTY_MODS_NONE
 
         _ = ghostty_surface_clear_selection_compat(surface)
-        ghostty_surface_mouse_pos(surface, Double(startX), Double(y), mods)
+        ghostty_surface_mouse_pos(surface, xRange.startX, Double(y), mods)
         guard ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_LEFT, mods) else {
             _ = ghostty_surface_clear_selection_compat(surface)
             return false
         }
-        ghostty_surface_mouse_pos(surface, Double(endX), Double(y), mods)
+        ghostty_surface_mouse_pos(surface, xRange.endX, Double(y), mods)
         let selectedCursorCell = ghostty_surface_has_selection(surface)
         _ = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, mods)
         guard selectedCursorCell else {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -8107,7 +8107,8 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     }
 
     private func currentKeyboardCopyModeViewportRow(surface: ghostty_surface_t) -> Int {
-        let rows = max(Int(ghostty_surface_size(surface).rows), 1)
+        let rows = keyboardCopyModeGridMetrics(surface: surface)?.rows
+            ?? max(Int(ghostty_surface_size(surface).rows), 1)
         let fallback = rows - 1
         return max(0, min(rows - 1, keyboardCopyModeCursor?.row ?? fallback))
     }
@@ -8132,9 +8133,11 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
         func appKitRect(for cursor: TerminalKeyboardCopyModeCursor) -> CGRect {
             let topOrigin = topOriginRect(for: cursor)
+            let rawY = viewHeight - topOrigin.maxY
+            let maxY = max(viewHeight - topOrigin.height, 0)
             return CGRect(
                 x: topOrigin.minX,
-                y: viewHeight - topOrigin.maxY,
+                y: min(max(rawY, 0), maxY),
                 width: topOrigin.width,
                 height: topOrigin.height
             )
@@ -8143,12 +8146,17 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
     private func keyboardCopyModeGridMetrics(surface: ghostty_surface_t) -> KeyboardCopyModeGridMetrics? {
         let size = ghostty_surface_size(surface)
-        let rows = max(Int(size.rows), 1)
+        let backingRows = max(Int(size.rows), 1)
         let columns = max(Int(size.columns), 1)
         let resolvedCellWidth = cellSize.width > 0 ? cellSize.width : CGFloat(size.cell_width_px)
         let resolvedCellHeight = cellSize.height > 0 ? cellSize.height : CGFloat(size.cell_height_px)
         guard resolvedCellWidth > 0, resolvedCellHeight > 0 else { return nil }
 
+        let rows = terminalKeyboardCopyModeVisibleViewportRows(
+            backingRows: backingRows,
+            viewHeight: Double(bounds.height),
+            cellHeight: Double(resolvedCellHeight)
+        )
         let terminalWidth = CGFloat(columns) * resolvedCellWidth
         let terminalHeight = CGFloat(rows) * resolvedCellHeight
         return KeyboardCopyModeGridMetrics(

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -172,6 +172,8 @@
 		C5A1FED000000000000000C2 /* CmuxSwiftRender in Frameworks */ = {isa = PBXBuildFile; productRef = C5A1FED000000000000000C3 /* CmuxSwiftRender */; };
 		C5A1FED100000000000000D1 /* CmuxSwiftRenderUI in Frameworks */ = {isa = PBXBuildFile; productRef = C5A1FED100000000000000D3 /* CmuxSwiftRenderUI */; };
 		C5A1FED100000000000000D2 /* CmuxSwiftRenderUI in Frameworks */ = {isa = PBXBuildFile; productRef = C5A1FED100000000000000D3 /* CmuxSwiftRenderUI */; };
+		C52830000000000000000001 /* CmuxTerminalCopyMode in Frameworks */ = {isa = PBXBuildFile; productRef = C52830000000000000000004 /* CmuxTerminalCopyMode */; };
+		C52830000000000000000002 /* CmuxTerminalCopyMode in Frameworks */ = {isa = PBXBuildFile; productRef = C52830000000000000000004 /* CmuxTerminalCopyMode */; };
 		C7A510000000000000000002 /* CmuxTopMemoryDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A510000000000000000001 /* CmuxTopMemoryDiagnostics.swift */; };
 		B35750000000000000000004 /* CmuxTopProcessArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35750000000000000000003 /* CmuxTopProcessArguments.swift */; };
 		C7A50C000000000000000002 /* CmuxTopProcessCPUTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A50C000000000000000001 /* CmuxTopProcessCPUTests.swift */; };
@@ -1269,6 +1271,7 @@
 				A5354303A5354303A5354303 /* CmuxSocketControl in Frameworks */,
 				C5A1FED000000000000000C1 /* CmuxSwiftRender in Frameworks */,
 				C5A1FED100000000000000D1 /* CmuxSwiftRenderUI in Frameworks */,
+				C52830000000000000000001 /* CmuxTerminalCopyMode in Frameworks */,
 				CDFEED0300000000CDFEED03 /* CmuxUpdater in Frameworks */,
 				CDFEED0600000000CDFEED06 /* CmuxUpdaterUI in Frameworks */,
 				AA11BB22CC33DD44EE550001 /* CMUXWorkstream in Frameworks */,
@@ -1315,6 +1318,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C52830000000000000000002 /* CmuxTerminalCopyMode in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2008,6 +2012,7 @@
 				F53000A2A1B2C3D4E5F60718 /* CMUXAgentVault */,
 				A5B00002A1B2C3D4E5F60718 /* CMUXAgentLaunch */,
 				A5354305A5354305A5354305 /* CmuxSocketControl */,
+				C52830000000000000000004 /* CmuxTerminalCopyMode */,
 				C5A1FED000000000000000C3 /* CmuxSwiftRender */,
 				C5A1FED100000000000000D3 /* CmuxSwiftRenderUI */,
 				C8000302C8000302C8000302 /* CmuxProcess */,
@@ -2101,6 +2106,7 @@
 			name = cmuxTests;
 			packageProductDependencies = (
 				A5B00002A1B2C3D4E5F60718 /* CMUXAgentLaunch */,
+				C52830000000000000000004 /* CmuxTerminalCopyMode */,
 			);
 			productName = cmuxTests;
 			productReference = F1000002A1B2C3D4E5F60718 /* cmuxTests.xctest */;
@@ -2160,6 +2166,7 @@
 				A5B00001A1B2C3D4E5F60718 /* XCLocalSwiftPackageReference "CMUXAgentLaunch" */,
 				A500D012A1B2C3D4E5F60718 /* XCLocalSwiftPackageReference "CMUXDebugLog" */,
 				A5354304A5354304A5354304 /* XCLocalSwiftPackageReference "CmuxSocketControl" */,
+				C52830000000000000000003 /* XCLocalSwiftPackageReference "CmuxTerminalCopyMode" */,
 				C5A1FED000000000000000C4 /* XCLocalSwiftPackageReference "CmuxSwiftRender" */,
 				C5A1FED100000000000000D4 /* XCLocalSwiftPackageReference "CmuxSwiftRenderUI" */,
 				C8000301C8000301C8000301 /* XCLocalSwiftPackageReference "CmuxProcess" */,
@@ -3338,6 +3345,10 @@
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/CmuxSocketControl;
 		};
+		C52830000000000000000003 /* XCLocalSwiftPackageReference "CmuxTerminalCopyMode" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Packages/CmuxTerminalCopyMode;
+		};
 		C5A1FED100000000000000D4 /* XCLocalSwiftPackageReference "CmuxSwiftRenderUI" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/CmuxSwiftRenderUI;
@@ -3475,6 +3486,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = A5354304A5354304A5354304 /* XCLocalSwiftPackageReference "CmuxSocketControl" */;
 			productName = CmuxSocketControl;
+		};
+		C52830000000000000000004 /* CmuxTerminalCopyMode */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C52830000000000000000003 /* XCLocalSwiftPackageReference "CmuxTerminalCopyMode" */;
+			productName = CmuxTerminalCopyMode;
 		};
 		C5A1FED000000000000000C3 /* CmuxSwiftRender */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -1420,7 +1420,16 @@ final class TerminalKeyboardCopyModeActionTests: XCTestCase {
                 modifierFlags: [.control],
                 hasSelection: false
             ),
-            .adjustSelection(.up)
+            .scrollLines(-1)
+        )
+        XCTAssertEqual(
+            terminalKeyboardCopyModeAction(
+                keyCode: 0,
+                charactersIgnoringModifiers: "\u{05}",
+                modifierFlags: [.control],
+                hasSelection: false
+            ),
+            .scrollLines(1)
         )
         XCTAssertEqual(
             terminalKeyboardCopyModeAction(

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -1892,6 +1892,26 @@ final class TerminalKeyboardCopyModeViewportRowTests: XCTestCase {
         XCTAssertEqual(cursor, TerminalKeyboardCopyModeCursor(row: 0, column: 3))
     }
 
+    func testCursorClampKeepsStoredCursorInsideResizedGrid() {
+        var cursor = TerminalKeyboardCopyModeCursor(row: 25, column: 90)
+        cursor.clamp(rows: 10, columns: 20)
+        XCTAssertEqual(cursor, TerminalKeyboardCopyModeCursor(row: 9, column: 19))
+
+        cursor = TerminalKeyboardCopyModeCursor(row: -4, column: -2)
+        cursor.clamp(rows: 0, columns: 0)
+        XCTAssertEqual(cursor, TerminalKeyboardCopyModeCursor(row: 0, column: 0))
+    }
+
+    func testCursorHomeAndEndResetBothAxes() {
+        var cursor = TerminalKeyboardCopyModeCursor(row: 5, column: 3)
+        XCTAssertEqual(cursor.move(.home, count: 1, rows: 10, columns: 8), 0)
+        XCTAssertEqual(cursor, TerminalKeyboardCopyModeCursor(row: 0, column: 0))
+
+        cursor = TerminalKeyboardCopyModeCursor(row: 5, column: 3)
+        XCTAssertEqual(cursor.move(.end, count: 1, rows: 10, columns: 8), 0)
+        XCTAssertEqual(cursor, TerminalKeyboardCopyModeCursor(row: 9, column: 7))
+    }
+
     func testCursorSelectionXRangeUsesCellInteriorWhenAvailable() throws {
         let range = try XCTUnwrap(
             terminalKeyboardCopyModeCursorSelectionXRange(

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -1310,7 +1310,7 @@ final class TerminalKeyboardCopyModeActionTests: XCTestCase {
     func testVimKeysResolveUnderNonASCIIKeyboardLayout() {
         // Korean 2-set (두벌식) reports "ㅓ" for the physical 'j' key (keyCode 38)
         // and "ㅏ" for 'k' (keyCode 40). Copy-mode vim keys must still resolve to a
-        // scroll action via the ASCII-capable layout fallback, without forcing the
+        // cursor motion via the ASCII-capable layout fallback, without forcing the
         // user to switch input sources. The character provider is injected so this
         // test is deterministic and independent of the CI runner's input source.
         let asciiProvider: (UInt16, NSEvent.ModifierFlags) -> String? = { keyCode, _ in
@@ -1328,7 +1328,7 @@ final class TerminalKeyboardCopyModeActionTests: XCTestCase {
                 hasSelection: false,
                 asciiCharacterProvider: asciiProvider
             ),
-            .scrollLines(1)
+            .adjustSelection(.down)
         )
         XCTAssertEqual(
             terminalKeyboardCopyModeAction(
@@ -1338,7 +1338,7 @@ final class TerminalKeyboardCopyModeActionTests: XCTestCase {
                 hasSelection: false,
                 asciiCharacterProvider: asciiProvider
             ),
-            .scrollLines(-1)
+            .adjustSelection(.up)
         )
     }
 
@@ -1350,7 +1350,7 @@ final class TerminalKeyboardCopyModeActionTests: XCTestCase {
                 modifierFlags: [.capsLock],
                 hasSelection: false
             ),
-            .scrollLines(1)
+            .adjustSelection(.down)
         )
     }
 
@@ -1420,7 +1420,7 @@ final class TerminalKeyboardCopyModeActionTests: XCTestCase {
                 modifierFlags: [.control],
                 hasSelection: false
             ),
-            .scrollLines(-1)
+            .adjustSelection(.up)
         )
         XCTAssertEqual(
             terminalKeyboardCopyModeAction(
@@ -1650,7 +1650,7 @@ final class TerminalKeyboardCopyModeResolveTests: XCTestCase {
     func testCountPrefixAppliesToMotion() {
         var state = TerminalKeyboardCopyModeInputState()
         XCTAssertEqual(resolve(20, chars: "3", hasSelection: false, state: &state), .consume)
-        XCTAssertEqual(resolve(38, chars: "j", hasSelection: false, state: &state), .perform(.scrollLines(1), count: 3))
+        XCTAssertEqual(resolve(38, chars: "j", hasSelection: false, state: &state), .perform(.adjustSelection(.down), count: 3))
         XCTAssertEqual(state, TerminalKeyboardCopyModeInputState())
     }
 
@@ -1658,7 +1658,7 @@ final class TerminalKeyboardCopyModeResolveTests: XCTestCase {
         var state = TerminalKeyboardCopyModeInputState()
         XCTAssertEqual(resolve(19, chars: "2", hasSelection: false, state: &state), .consume)
         XCTAssertEqual(resolve(29, chars: "0", hasSelection: false, state: &state), .consume)
-        XCTAssertEqual(resolve(40, chars: "k", hasSelection: false, state: &state), .perform(.scrollLines(-1), count: 20))
+        XCTAssertEqual(resolve(40, chars: "k", hasSelection: false, state: &state), .perform(.adjustSelection(.up), count: 20))
 
         var selectionState = TerminalKeyboardCopyModeInputState()
         XCTAssertEqual(
@@ -1688,7 +1688,7 @@ final class TerminalKeyboardCopyModeResolveTests: XCTestCase {
     func testPendingYankLineDoesNotSwallowNextCommand() {
         var state = TerminalKeyboardCopyModeInputState()
         XCTAssertEqual(resolve(16, chars: "y", hasSelection: false, state: &state), .consume)
-        XCTAssertEqual(resolve(38, chars: "j", hasSelection: false, state: &state), .perform(.scrollLines(1), count: 1))
+        XCTAssertEqual(resolve(38, chars: "j", hasSelection: false, state: &state), .perform(.adjustSelection(.down), count: 1))
         XCTAssertEqual(state, TerminalKeyboardCopyModeInputState())
     }
 
@@ -1738,7 +1738,7 @@ final class TerminalKeyboardCopyModeResolveTests: XCTestCase {
     func testPendingGCancelledByOtherKey() {
         var state = TerminalKeyboardCopyModeInputState()
         XCTAssertEqual(resolve(5, chars: "g", hasSelection: false, state: &state), .consume)
-        XCTAssertEqual(resolve(38, chars: "j", hasSelection: false, state: &state), .perform(.scrollLines(1), count: 1))
+        XCTAssertEqual(resolve(38, chars: "j", hasSelection: false, state: &state), .perform(.adjustSelection(.down), count: 1))
         XCTAssertEqual(state, TerminalKeyboardCopyModeInputState())
     }
 
@@ -1841,6 +1841,46 @@ final class TerminalKeyboardCopyModeViewportRowTests: XCTestCase {
             ),
             23
         )
+    }
+
+    func testInitialViewportColumnUsesImePointMidpoint() {
+        XCTAssertEqual(
+            terminalKeyboardCopyModeInitialViewportColumn(
+                columns: 80,
+                imePointX: 5,
+                imeCellWidth: 10
+            ),
+            0
+        )
+        XCTAssertEqual(
+            terminalKeyboardCopyModeInitialViewportColumn(
+                columns: 80,
+                imePointX: 235,
+                imeCellWidth: 10,
+                leftPadding: 5
+            ),
+            23
+        )
+        XCTAssertEqual(
+            terminalKeyboardCopyModeInitialViewportColumn(
+                columns: 80,
+                imePointX: 9999,
+                imeCellWidth: 10
+            ),
+            79
+        )
+    }
+
+    func testCursorMovementReturnsScrollDeltaOnlyAtVerticalEdges() {
+        var cursor = TerminalKeyboardCopyModeCursor(row: 5, column: 3)
+        XCTAssertEqual(cursor.move(.down, count: 2, rows: 10, columns: 8), 0)
+        XCTAssertEqual(cursor, TerminalKeyboardCopyModeCursor(row: 7, column: 3))
+
+        XCTAssertEqual(cursor.move(.down, count: 4, rows: 10, columns: 8), 2)
+        XCTAssertEqual(cursor, TerminalKeyboardCopyModeCursor(row: 9, column: 3))
+
+        XCTAssertEqual(cursor.move(.up, count: 12, rows: 10, columns: 8), -3)
+        XCTAssertEqual(cursor, TerminalKeyboardCopyModeCursor(row: 0, column: 3))
     }
 }
 

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -1268,7 +1268,7 @@ final class TerminalKeyboardCopyModeActionTests: XCTestCase {
         XCTAssertFalse(terminalKeyboardCopyModeShouldBypassForShortcut(modifierFlags: [.control]))
     }
 
-    func testJKWithoutSelectionScrollByLine() {
+    func testVimMotionsWithoutSelectionMoveCursorInsteadOfViewport() {
         XCTAssertEqual(
             terminalKeyboardCopyModeAction(
                 keyCode: 38,
@@ -1276,7 +1276,7 @@ final class TerminalKeyboardCopyModeActionTests: XCTestCase {
                 modifierFlags: [],
                 hasSelection: false
             ),
-            .scrollLines(1)
+            .adjustSelection(.down)
         )
         XCTAssertEqual(
             terminalKeyboardCopyModeAction(
@@ -1285,7 +1285,25 @@ final class TerminalKeyboardCopyModeActionTests: XCTestCase {
                 modifierFlags: [],
                 hasSelection: false
             ),
-            .scrollLines(-1)
+            .adjustSelection(.up)
+        )
+        XCTAssertEqual(
+            terminalKeyboardCopyModeAction(
+                keyCode: 4,
+                charactersIgnoringModifiers: "h",
+                modifierFlags: [],
+                hasSelection: false
+            ),
+            .adjustSelection(.left)
+        )
+        XCTAssertEqual(
+            terminalKeyboardCopyModeAction(
+                keyCode: 37,
+                charactersIgnoringModifiers: "l",
+                modifierFlags: [],
+                hasSelection: false
+            ),
+            .adjustSelection(.right)
         )
     }
 

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -1891,6 +1891,55 @@ final class TerminalKeyboardCopyModeViewportRowTests: XCTestCase {
         XCTAssertEqual(cursor.move(.up, count: 12, rows: 10, columns: 8), -3)
         XCTAssertEqual(cursor, TerminalKeyboardCopyModeCursor(row: 0, column: 3))
     }
+
+    func testCursorSelectionXRangeUsesCellInteriorWhenAvailable() throws {
+        let range = try XCTUnwrap(
+            terminalKeyboardCopyModeCursorSelectionXRange(
+                rectMinX: 20,
+                rectMaxX: 30,
+                boundsWidth: 100
+            )
+        )
+
+        XCTAssertEqual(range.startX, 20.5, accuracy: 0.0001)
+        XCTAssertEqual(range.endX, 29.5, accuracy: 0.0001)
+    }
+
+    func testCursorSelectionXRangeKeepsNonzeroDragAtRightEdge() throws {
+        let range = try XCTUnwrap(
+            terminalKeyboardCopyModeCursorSelectionXRange(
+                rectMinX: 99.5,
+                rectMaxX: 120,
+                boundsWidth: 100
+            )
+        )
+
+        XCTAssertEqual(range.startX, 99, accuracy: 0.0001)
+        XCTAssertEqual(range.endX, 98, accuracy: 0.0001)
+    }
+
+    func testCursorSelectionXRangeKeepsNonzeroDragForCollapsedCellWidth() throws {
+        let range = try XCTUnwrap(
+            terminalKeyboardCopyModeCursorSelectionXRange(
+                rectMinX: 50,
+                rectMaxX: 50.4,
+                boundsWidth: 100
+            )
+        )
+
+        XCTAssertEqual(range.startX, 50.2, accuracy: 0.0001)
+        XCTAssertEqual(range.endX, 51.2, accuracy: 0.0001)
+    }
+
+    func testCursorSelectionXRangeReturnsNilWhenViewCannotExpressHorizontalDrag() {
+        XCTAssertNil(
+            terminalKeyboardCopyModeCursorSelectionXRange(
+                rectMinX: 0,
+                rectMaxX: 10,
+                boundsWidth: 1
+            )
+        )
+    }
 }
 
 

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import CmuxTerminalCopyMode
 import CmuxSocketControl
 import AppKit
 import SwiftUI

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -1310,50 +1310,60 @@ final class TerminalKeyboardCopyModeActionTests: XCTestCase {
     }
 
     func testVimKeysResolveUnderNonASCIIKeyboardLayout() {
-        // Korean 2-set (두벌식) reports "ㅓ" for the physical 'j' key (keyCode 38)
-        // and "ㅏ" for 'k' (keyCode 40). Copy-mode vim keys must still resolve to a
+        // Korean 2-set (두벌식) reports non-ASCII characters for physical vim keys.
+        // Copy-mode vim keys must still resolve to a
         // cursor motion via the ASCII-capable layout fallback, without forcing the
         // user to switch input sources. The character provider is injected so this
         // test is deterministic and independent of the CI runner's input source.
         let asciiProvider: (UInt16, NSEvent.ModifierFlags) -> String? = { keyCode, _ in
             switch keyCode {
+            case 4: return "h"
             case 38: return "j"
             case 40: return "k"
+            case 37: return "l"
             default: return nil
             }
         }
-        XCTAssertEqual(
-            terminalKeyboardCopyModeAction(
-                keyCode: 38,
-                charactersIgnoringModifiers: "ㅓ",
-                modifierFlags: [],
-                hasSelection: false,
-                asciiCharacterProvider: asciiProvider
-            ),
-            .adjustSelection(.down)
-        )
-        XCTAssertEqual(
-            terminalKeyboardCopyModeAction(
-                keyCode: 40,
-                charactersIgnoringModifiers: "ㅏ",
-                modifierFlags: [],
-                hasSelection: false,
-                asciiCharacterProvider: asciiProvider
-            ),
-            .adjustSelection(.up)
-        )
+        let cases: [(keyCode: UInt16, characters: String, move: TerminalKeyboardCopyModeSelectionMove)] = [
+            (4, "ㅗ", .left),
+            (38, "ㅓ", .down),
+            (40, "ㅏ", .up),
+            (37, "ㅣ", .right),
+        ]
+
+        for testCase in cases {
+            XCTAssertEqual(
+                terminalKeyboardCopyModeAction(
+                    keyCode: testCase.keyCode,
+                    charactersIgnoringModifiers: testCase.characters,
+                    modifierFlags: [],
+                    hasSelection: false,
+                    asciiCharacterProvider: asciiProvider
+                ),
+                .adjustSelection(testCase.move)
+            )
+        }
     }
 
     func testCapsLockDoesNotBlockLetterMappings() {
-        XCTAssertEqual(
-            terminalKeyboardCopyModeAction(
-                keyCode: 38,
-                charactersIgnoringModifiers: "j",
-                modifierFlags: [.capsLock],
-                hasSelection: false
-            ),
-            .adjustSelection(.down)
-        )
+        let cases: [(keyCode: UInt16, characters: String, move: TerminalKeyboardCopyModeSelectionMove)] = [
+            (4, "h", .left),
+            (38, "j", .down),
+            (40, "k", .up),
+            (37, "l", .right),
+        ]
+
+        for testCase in cases {
+            XCTAssertEqual(
+                terminalKeyboardCopyModeAction(
+                    keyCode: testCase.keyCode,
+                    charactersIgnoringModifiers: testCase.characters,
+                    modifierFlags: [.capsLock],
+                    hasSelection: false
+                ),
+                .adjustSelection(testCase.move)
+            )
+        }
     }
 
     func testJKWithSelectionAdjustSelection() {
@@ -1501,6 +1511,15 @@ final class TerminalKeyboardCopyModeActionTests: XCTestCase {
                 keyCode: 29,
                 charactersIgnoringModifiers: "0",
                 modifierFlags: [],
+                hasSelection: false
+            ),
+            .adjustSelection(.beginningOfLine)
+        )
+        XCTAssertEqual(
+            terminalKeyboardCopyModeAction(
+                keyCode: 29,
+                charactersIgnoringModifiers: "0",
+                modifierFlags: [],
                 hasSelection: true
             ),
             .adjustSelection(.beginningOfLine)
@@ -1513,6 +1532,15 @@ final class TerminalKeyboardCopyModeActionTests: XCTestCase {
                 hasSelection: true
             ),
             .adjustSelection(.beginningOfLine)
+        )
+        XCTAssertEqual(
+            terminalKeyboardCopyModeAction(
+                keyCode: 21,
+                charactersIgnoringModifiers: "4",
+                modifierFlags: [.shift],
+                hasSelection: false
+            ),
+            .adjustSelection(.endOfLine)
         )
         XCTAssertEqual(
             terminalKeyboardCopyModeAction(
@@ -1670,6 +1698,12 @@ final class TerminalKeyboardCopyModeResolveTests: XCTestCase {
         XCTAssertEqual(resolve(19, chars: "2", hasSelection: false, state: &state), .consume)
         XCTAssertEqual(resolve(29, chars: "0", hasSelection: false, state: &state), .consume)
         XCTAssertEqual(resolve(40, chars: "k", hasSelection: false, state: &state), .perform(.adjustSelection(.up), count: 20))
+
+        var zeroMotionState = TerminalKeyboardCopyModeInputState()
+        XCTAssertEqual(
+            resolve(29, chars: "0", hasSelection: false, state: &zeroMotionState),
+            .perform(.adjustSelection(.beginningOfLine), count: 1)
+        )
 
         var selectionState = TerminalKeyboardCopyModeInputState()
         XCTAssertEqual(
@@ -1916,8 +1950,8 @@ final class TerminalKeyboardCopyModeViewportRowTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(range.startX, 99, accuracy: 0.0001)
-        XCTAssertEqual(range.endX, 98, accuracy: 0.0001)
+        XCTAssertEqual(range.startX, 98, accuracy: 0.0001)
+        XCTAssertEqual(range.endX, 99, accuracy: 0.0001)
     }
 
     func testCursorSelectionXRangeKeepsNonzeroDragForCollapsedCellWidth() throws {
@@ -1994,6 +2028,31 @@ struct TerminalKeyboardCopyModeCursorSwiftTests {
         cursor = TerminalKeyboardCopyModeCursor(row: 0, column: 3)
         cursor.moveAfterTerminalSelectionAdjustment(.up, count: 1, rows: 10, columns: 8)
         #expect(cursor == TerminalKeyboardCopyModeCursor(row: 0, column: 3))
+    }
+
+    @Test func visualSelectionAnchorFollowsMovedCursor() {
+        var cursor = TerminalKeyboardCopyModeCursor(row: 8, column: 7)
+
+        let moveAction = terminalKeyboardCopyModeAction(
+            keyCode: 38,
+            charactersIgnoringModifiers: "j",
+            modifierFlags: [],
+            hasSelection: false
+        )
+        #expect(moveAction == .adjustSelection(.down))
+        if case let .adjustSelection(move)? = moveAction {
+            #expect(cursor.move(move, count: 1, rows: 20, columns: 40) == 0)
+        }
+
+        #expect(
+            terminalKeyboardCopyModeAction(
+                keyCode: 9,
+                charactersIgnoringModifiers: "v",
+                modifierFlags: [],
+                hasSelection: false
+            ) == .startSelection
+        )
+        #expect(cursor.clamped(rows: 20, columns: 40) == TerminalKeyboardCopyModeCursor(row: 9, column: 7))
     }
 }
 

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -1966,6 +1966,35 @@ struct TerminalKeyboardCopyModeCursorSwiftTests {
         #expect(cursor.move(.end, count: 1, rows: 10, columns: 8) == 0)
         #expect(cursor == TerminalKeyboardCopyModeCursor(row: 9, column: 7))
     }
+
+    @Test func viewportScrollShiftsCursorToStayOnSameText() {
+        var cursor = TerminalKeyboardCopyModeCursor(row: 5, column: 3)
+        cursor.shiftForViewportScroll(lineDelta: 2, rows: 10, columns: 8)
+        #expect(cursor == TerminalKeyboardCopyModeCursor(row: 3, column: 3))
+
+        cursor.shiftForViewportScroll(lineDelta: -4, rows: 10, columns: 8)
+        #expect(cursor == TerminalKeyboardCopyModeCursor(row: 7, column: 3))
+    }
+
+    @Test func viewportScrollShiftClampsAtEdges() {
+        var cursor = TerminalKeyboardCopyModeCursor(row: 1, column: 99)
+        cursor.shiftForViewportScroll(lineDelta: 5, rows: 10, columns: 8)
+        #expect(cursor == TerminalKeyboardCopyModeCursor(row: 0, column: 7))
+
+        cursor = TerminalKeyboardCopyModeCursor(row: 8, column: -2)
+        cursor.shiftForViewportScroll(lineDelta: -5, rows: 10, columns: 8)
+        #expect(cursor == TerminalKeyboardCopyModeCursor(row: 9, column: 0))
+    }
+
+    @Test func terminalSelectionAdjustmentKeepsEndpointAtViewportEdge() {
+        var cursor = TerminalKeyboardCopyModeCursor(row: 9, column: 3)
+        cursor.moveAfterTerminalSelectionAdjustment(.down, count: 1, rows: 10, columns: 8)
+        #expect(cursor == TerminalKeyboardCopyModeCursor(row: 9, column: 3))
+
+        cursor = TerminalKeyboardCopyModeCursor(row: 0, column: 3)
+        cursor.moveAfterTerminalSelectionAdjustment(.up, count: 1, rows: 10, columns: 8)
+        #expect(cursor == TerminalKeyboardCopyModeCursor(row: 0, column: 3))
+    }
 }
 
 

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import Testing
 import CmuxTerminalCopyMode
 import CmuxSocketControl
 import AppKit
@@ -1893,26 +1894,6 @@ final class TerminalKeyboardCopyModeViewportRowTests: XCTestCase {
         XCTAssertEqual(cursor, TerminalKeyboardCopyModeCursor(row: 0, column: 3))
     }
 
-    func testCursorClampKeepsStoredCursorInsideResizedGrid() {
-        var cursor = TerminalKeyboardCopyModeCursor(row: 25, column: 90)
-        cursor.clamp(rows: 10, columns: 20)
-        XCTAssertEqual(cursor, TerminalKeyboardCopyModeCursor(row: 9, column: 19))
-
-        cursor = TerminalKeyboardCopyModeCursor(row: -4, column: -2)
-        cursor.clamp(rows: 0, columns: 0)
-        XCTAssertEqual(cursor, TerminalKeyboardCopyModeCursor(row: 0, column: 0))
-    }
-
-    func testCursorHomeAndEndResetBothAxes() {
-        var cursor = TerminalKeyboardCopyModeCursor(row: 5, column: 3)
-        XCTAssertEqual(cursor.move(.home, count: 1, rows: 10, columns: 8), 0)
-        XCTAssertEqual(cursor, TerminalKeyboardCopyModeCursor(row: 0, column: 0))
-
-        cursor = TerminalKeyboardCopyModeCursor(row: 5, column: 3)
-        XCTAssertEqual(cursor.move(.end, count: 1, rows: 10, columns: 8), 0)
-        XCTAssertEqual(cursor, TerminalKeyboardCopyModeCursor(row: 9, column: 7))
-    }
-
     func testCursorSelectionXRangeUsesCellInteriorWhenAvailable() throws {
         let range = try XCTUnwrap(
             terminalKeyboardCopyModeCursorSelectionXRange(
@@ -1960,6 +1941,30 @@ final class TerminalKeyboardCopyModeViewportRowTests: XCTestCase {
                 boundsWidth: 1
             )
         )
+    }
+}
+
+
+@Suite("Terminal keyboard copy mode cursor")
+struct TerminalKeyboardCopyModeCursorSwiftTests {
+    @Test func clampKeepsStoredCursorInsideResizedGrid() {
+        var cursor = TerminalKeyboardCopyModeCursor(row: 25, column: 90)
+        cursor.clamp(rows: 10, columns: 20)
+        #expect(cursor == TerminalKeyboardCopyModeCursor(row: 9, column: 19))
+
+        cursor = TerminalKeyboardCopyModeCursor(row: -4, column: -2)
+        cursor.clamp(rows: 0, columns: 0)
+        #expect(cursor == TerminalKeyboardCopyModeCursor(row: 0, column: 0))
+    }
+
+    @Test func homeAndEndResetBothAxes() {
+        var cursor = TerminalKeyboardCopyModeCursor(row: 5, column: 3)
+        #expect(cursor.move(.home, count: 1, rows: 10, columns: 8) == 0)
+        #expect(cursor == TerminalKeyboardCopyModeCursor(row: 0, column: 0))
+
+        cursor = TerminalKeyboardCopyModeCursor(row: 5, column: 3)
+        #expect(cursor.move(.end, count: 1, rows: 10, columns: 8) == 0)
+        #expect(cursor == TerminalKeyboardCopyModeCursor(row: 9, column: 7))
     }
 }
 


### PR DESCRIPTION
## Summary
- add a regression expectation that non-visual copy-mode `h/j/k/l` resolve as cursor motion, not viewport scrolling
- keep an explicit copy-mode cursor row/column and render it as a visible pass-through overlay
- anchor `v` visual selection at the current copy-mode cursor before handing selection extension to Ghostty

Fixes #5283

## Reproduction
- Read issue #5283 with `gh issue view 5283 --repo manaflow-ai/cmux`.
- Cloud Mac provisioning was attempted first, but the local cloud setup could not resolve the required Tailscale/macfleet token.
- Fallback local repro used released `/Applications/cmux NIGHTLY.app` without building a dev app. Cmd+Shift+M showed the `vim` copy-mode badge with no visible copy-mode cursor, matching the visible-cursor failure from the issue. Local automation for the subsequent `j/k/v` anchor video was not reliable enough to claim as verified.
- Local repro recording: `cmux-assets/issue-5283-vim-mode/cloud-mac/20260603-173939/local-repro/copy-mode-broken-local-nightly.mov`.

## Tests
- Not run locally per task instruction; CI only.

## Demo Video
- Cloud Mac video was not available because provisioning was blocked by the missing local Tailscale/macfleet token.
- Local released-NIGHTLY repro recording: `cmux-assets/issue-5283-vim-mode/cloud-mac/20260603-173939/local-repro/copy-mode-broken-local-nightly.mov`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5328"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783127533&installation_id=133855650&pr_number=5328&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5328&signature=b051337c9e7b8244170925fe97e219ba73979df80b6ab64633e8ba24e12a8a90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large, user-visible changes to terminal keyboard input, selection anchoring, and scroll/cursor synchronization; mitigated by extracted pure logic and broad tests but still easy to regress edge cases (IME, layouts, async scrollbar).
> 
> **Overview**
> Adds a **`CmuxTerminalCopyMode`** Swift package and rewires **`GhosttyTerminalView`** so keyboard copy mode keeps an explicit viewport **row/column cursor** with a visible AppKit overlay instead of relying on Ghostty’s one-cell selection as the cursor.
> 
> **Behavior changes:** Outside visual mode, **`h`/`j`/`k`/`l` and arrow keys** now resolve to **cursor motion** (`.adjustSelection`) rather than scrolling the viewport; vertical moves at the grid edge trigger line scroll. **`v`** starts visual selection by **synthetic drag** at the overlay cursor cell; the overlay hides in visual mode. Scroll, page/half-page, prompt jump, and search actions **sync the cursor** to viewport changes (including deferred scrollbar updates). Initial cursor position comes from **IME geometry** and **visible row** math (clipped backing grid). Copy-mode key resolution, counts, and geometry move into the package; the app maps **`NSEvent`** modifiers and thin wrappers.
> 
> Also adds **localized** copy-mode / key-table indicator strings and **expanded tests** (package + app).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 728c023219b2f21baeffa6081415658ac3496d92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes terminal copy mode so h/j/k/l and arrow keys move a visible overlay cursor (not the viewport), and v anchors visual selection to it. Keeps the cursor in sync across scrolls and jumps, clamps on resize/grid changes, reconciles after page scrolls, and now uses visible viewport rows so edge scrolling starts at the screen edge; fixes #5283.

- **Bug Fixes**
  - Added a real overlay cursor (IME-seeded, hides in visual mode, clamps on resize); indicator strings are localized.
  - Mapped arrows and h/j/k/l to cursor motion with edge-overflow scrolling; v anchors selection via a bounded drag; copy mode bypasses app shortcuts.
  - Preserved and clamped the cursor across line/page/half-page scrolls, prompt/search jumps, and viewport jumps; deferred sync for late scrollbars; ASCII fallback fixes vim keys on non-ASCII layouts; numeric counts clamp to 9,999; preserved the key after an invalid numeric prefix; motion and edge detection use visible viewport rows with a new regression test.

- **Refactors**
  - Extracted key resolution, cursor model, geometry, input state, and count clamp into `CmuxTerminalCopyMode`; added `TerminalKeyboardCopyModeModifiers` and a shortcut-bypass helper.
  - `GhosttyTerminalView` hosts the overlay and delegates motions; tests updated via `Testing` to cover motions, visible-row edge behavior, and sync across scroll/search/viewport jumps.

<sup>Written for commit 728c023219b2f21baeffa6081415658ac3496d92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent non‑visual cursor overlay during keyboard copy‑mode
  * New modular keyboard copy‑mode component for improved behavior

* **Improvements**
  * Refined keyboard-driven copy‑mode: cursor model, selection anchoring, IME-aware initial positioning, and viewport sync
  * Mouse selection and clipboard copy align precisely to terminal cell geometry
  * Count‑prefixed motions and shortcut handling made more consistent

* **Localization**
  * Added copy‑mode and key‑table UI localization entries

* **Tests**
  * Expanded tests for key resolution, cursor, selection, and viewport behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
