### PR TITLE
Fix settings-observer memory leak (#5329)

### DIFF
--- a/Packages/CmuxSettings/Sources/CmuxSettings/Stores/NotificationObserverHandle.swift
+++ b/Packages/CmuxSettings/Sources/CmuxSettings/Stores/NotificationObserverHandle.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// Owns a single block-based `NotificationCenter` observer registration and
+/// removes it on `deinit`.
+///
+/// Storing one of these instead of the raw observer token lets an `actor`
+/// register an observer without ever touching the non-`Sendable` token from its
+/// own `nonisolated deinit`: when the owning actor is deallocated, ARC releases
+/// the handle and the handle's `deinit` removes the observer. The block is the
+/// only `NotificationCenter` surface the store exposes — the leak-prone
+/// `NotificationCenter.notifications(named:)` async iterator (#5329 / #5309) is
+/// never used.
+final class NotificationObserverHandle {
+    private let center: NotificationCenter
+    private let token: any NSObjectProtocol
+
+    /// Registers `block` for `name` on `center` (any object, no specific queue).
+    /// - Parameters:
+    ///   - center: The center to observe. Defaults to `.default`.
+    ///   - name: The notification name to observe.
+    ///   - block: Invoked for each matching notification. Must be `@Sendable`
+    ///     because `NotificationCenter` may deliver on any thread.
+    init(
+        center: NotificationCenter = .default,
+        name: Notification.Name,
+        using block: @escaping @Sendable (Notification) -> Void
+    ) {
+        self.center = center
+        self.token = center.addObserver(forName: name, object: nil, queue: nil, using: block)
+    }
+
+    deinit {
+        center.removeObserver(token)
+    }
+}

--- a/Packages/CmuxSettings/Sources/CmuxSettings/Stores/SecretFileStore.swift
+++ b/Packages/CmuxSettings/Sources/CmuxSettings/Stores/SecretFileStore.swift
@@ -35,11 +35,30 @@ public actor SecretFileStore {
     /// The directory secret files are resolved under.
     public nonisolated let baseDirectory: URL
 
+    /// Per-consumer change signals. One entry per live ``values(for:)`` stream;
+    /// a single ``didChangeNotification`` fans out one `()` to each.
+    private var subscribers: [UUID: AsyncStream<Void>.Continuation] = [:]
+
+    /// The block-observer registration, created lazily on the first subscriber.
+    /// Releasing it (when this actor is deallocated) removes the observer.
+    private var observerHandle: NotificationObserverHandle?
+
+    /// The single long-lived task draining the bridged notification stream and
+    /// fanning out to ``subscribers``. Created lazily with ``observerHandle``.
+    private var observerTask: Task<Void, Never>?
+
     /// Creates a store rooted at `baseDirectory`.
     /// - Parameter baseDirectory: The directory holding the secret files
     ///   (created on first write if absent). The app uses `~/.config/cmux`.
     public init(baseDirectory: URL) {
         self.baseDirectory = baseDirectory
+    }
+
+    deinit {
+        // The observer is removed by `observerHandle`'s own deinit via ARC; we
+        // only stop the long-lived fan-out task here (Task is Sendable, so this
+        // is legal from a nonisolated deinit).
+        observerTask?.cancel()
     }
 
     /// The current secret for `key`, or its ``SecretFileKey/defaultValue`` when absent/empty.
@@ -106,8 +125,12 @@ public actor SecretFileStore {
     /// An `AsyncStream` yielding the current secret and every later change.
     ///
     /// The first element is the current value; subsequent elements arrive when
-    /// ``didChangeNotification`` fires for this key. Buffering is
-    /// `.bufferingNewest(1)`. Cancelling the consuming `Task` ends the stream.
+    /// ``didChangeNotification`` fires. Each signal re-reads the key's value and
+    /// dedups, so a change to an unrelated key never yields here. Buffering is
+    /// `.bufferingNewest(1)`. Cancelling the consuming `Task` synchronously
+    /// deregisters its subscriber and ends the stream — teardown never waits on
+    /// a future notification, so observers do not leak across remounts (the
+    /// #5329 / #5309 leak).
     public nonisolated func values(for key: SecretFileKey) -> AsyncStream<String> {
         AsyncStream<String>(bufferingPolicy: .bufferingNewest(1)) { continuation in
             let task = Task { [weak self] in
@@ -118,21 +141,21 @@ public actor SecretFileStore {
                 var lastYielded = (try? await self.value(for: key)) ?? key.defaultValue
                 continuation.yield(lastYielded)
 
-                let notifications = NotificationCenter.default.notifications(
-                    named: SecretFileStore.didChangeNotification
+                let id = UUID()
+                let (signal, signalContinuation) = AsyncStream<Void>.makeStream(
+                    bufferingPolicy: .bufferingNewest(1)
                 )
-                for await note in notifications {
+                await self.addSubscriber(id: id, continuation: signalContinuation)
+
+                for await _ in signal {
                     if Task.isCancelled { break }
-                    if let changedID = note.userInfo?[SecretFileStore.changedKeyIDKey] as? String,
-                       changedID != key.id {
-                        continue
-                    }
                     let current = (try? await self.value(for: key)) ?? key.defaultValue
                     if current != lastYielded {
                         lastYielded = current
                         continuation.yield(current)
                     }
                 }
+                await self.removeSubscriber(id: id)
                 continuation.finish()
             }
             continuation.onTermination = { _ in task.cancel() }
@@ -142,6 +165,52 @@ public actor SecretFileStore {
     /// The on-disk URL backing `key`.
     public nonisolated func fileURL(for key: SecretFileKey) -> URL {
         baseDirectory.appendingPathComponent(key.fileName, isDirectory: false)
+    }
+
+    /// Number of live ``values(for:)`` subscribers. Test seam: lets a test
+    /// assert that consumer teardown deregisters its subscriber so observers do
+    /// not accumulate across remounts (the #5329 / #5309 leak).
+    var activeSubscriberCount: Int { subscribers.count }
+
+    // MARK: - Private
+
+    private func addSubscriber(id: UUID, continuation: AsyncStream<Void>.Continuation) {
+        subscribers[id] = continuation
+        ensureObserver()
+    }
+
+    private func removeSubscriber(id: UUID) {
+        subscribers.removeValue(forKey: id)?.finish()
+    }
+
+    /// Registers the single block observer on the first subscribe. The observer
+    /// is removed synchronously in `deinit`, so nothing is parked inside a
+    /// non-cancellation-aware notification iterator.
+    private func ensureObserver() {
+        guard observerHandle == nil else { return }
+        let (rawSignal, rawContinuation) = AsyncStream<Void>.makeStream(
+            bufferingPolicy: .bufferingNewest(1)
+        )
+        // Block-based observer (not NSObject KVO), bridged into a bounded
+        // AsyncStream. The handle removes the observer when this actor is
+        // released; callers never see NotificationCenter.
+        observerHandle = NotificationObserverHandle(
+            name: SecretFileStore.didChangeNotification
+        ) { _ in
+            rawContinuation.yield(())
+        }
+        observerTask = Task { [weak self] in
+            for await _ in rawSignal {
+                guard let self else { break }
+                await self.fanOutChange()
+            }
+        }
+    }
+
+    private func fanOutChange() {
+        for continuation in subscribers.values {
+            continuation.yield(())
+        }
     }
 
     private func postChange(for key: SecretFileKey) {

--- a/Packages/CmuxSettings/Sources/CmuxSettings/Stores/SecretFileStore.swift
+++ b/Packages/CmuxSettings/Sources/CmuxSettings/Stores/SecretFileStore.swift
@@ -138,14 +138,18 @@ public actor SecretFileStore {
                     continuation.finish()
                     return
                 }
-                var lastYielded = (try? await self.value(for: key)) ?? key.defaultValue
-                continuation.yield(lastYielded)
-
+                // Subscribe before the first read so a set/reset landing in the
+                // gap signals this consumer (it would be missed if we yielded the
+                // initial value before registering). A change between subscribe
+                // and read buffers a signal that re-reads and dedups below.
                 let id = UUID()
                 let (signal, signalContinuation) = AsyncStream<Void>.makeStream(
                     bufferingPolicy: .bufferingNewest(1)
                 )
                 await self.addSubscriber(id: id, continuation: signalContinuation)
+
+                var lastYielded = (try? await self.value(for: key)) ?? key.defaultValue
+                continuation.yield(lastYielded)
 
                 for await _ in signal {
                     if Task.isCancelled { break }

--- a/Packages/CmuxSettings/Sources/CmuxSettings/Stores/UserDefaultsSettingsStore.swift
+++ b/Packages/CmuxSettings/Sources/CmuxSettings/Stores/UserDefaultsSettingsStore.swift
@@ -132,9 +132,10 @@ public actor UserDefaultsSettingsStore {
                     continuation.finish()
                     return
                 }
-                var lastYielded = await self.value(for: key)
-                continuation.yield(lastYielded)
-
+                // Subscribe before the first read so a write landing in the gap
+                // signals this consumer (it would be missed if we yielded the
+                // initial value before registering). A change between subscribe
+                // and read buffers a signal that re-reads and dedups below.
                 let id = UUID()
                 // bufferingNewest(1): the signal carries no payload, so a burst
                 // of UserDefaults writes coalesces to a single wake; the typed
@@ -143,6 +144,9 @@ public actor UserDefaultsSettingsStore {
                     bufferingPolicy: .bufferingNewest(1)
                 )
                 await self.addSubscriber(id: id, continuation: signalContinuation)
+
+                var lastYielded = await self.value(for: key)
+                continuation.yield(lastYielded)
 
                 for await _ in signal {
                     if Task.isCancelled { break }

--- a/Packages/CmuxSettings/Sources/CmuxSettings/Stores/UserDefaultsSettingsStore.swift
+++ b/Packages/CmuxSettings/Sources/CmuxSettings/Stores/UserDefaultsSettingsStore.swift
@@ -8,10 +8,15 @@ import Foundation
 /// The store only accepts ``DefaultsKey``; a ``JSONKey`` would be rejected at
 /// compile time. There are no runtime store/key-mismatch traps.
 ///
-/// Observation uses `NotificationCenter.default.notifications(named:)` as the
-/// modern AsyncSequence-based KVO replacement. Each ``values(for:)`` consumer
-/// owns a `Task` that watches the global notification stream and yields when
-/// the typed value at this key changes.
+/// Observation is driven by a single, store-owned block observer of
+/// `UserDefaults.didChangeNotification`. The observer is bridged into a bounded
+/// `AsyncStream<Void>` and fanned out to one bounded signal per active
+/// ``values(for:)`` consumer; each consumer re-reads its typed value on a
+/// signal and dedups. Cancelling a consumer's `Task` synchronously deregisters
+/// its subscriber and ends its stream, so teardown never waits on a future
+/// notification. This mirrors ``JSONConfigStore``'s subscriber fan-out and
+/// avoids parking an uncancellable `Task` inside
+/// `NotificationCenter.notifications(named:)` (the leak in issue #5329 / #5309).
 ///
 /// ```swift
 /// let catalog = SettingCatalog()
@@ -27,6 +32,18 @@ import Foundation
 public actor UserDefaultsSettingsStore {
     /// The `UserDefaults` suite this store reads and writes.
     public let underlyingDefaults: UserDefaults
+
+    /// Per-consumer change signals. One entry per live ``values(for:)`` stream;
+    /// a single `UserDefaults` change fans out one `()` to each.
+    private var subscribers: [UUID: AsyncStream<Void>.Continuation] = [:]
+
+    /// The block-observer registration, created lazily on the first subscriber.
+    /// Releasing it (when this actor is deallocated) removes the observer.
+    private var observerHandle: NotificationObserverHandle?
+
+    /// The single long-lived task draining the bridged notification stream and
+    /// fanning out to ``subscribers``. Created lazily with ``observerHandle``.
+    private var observerTask: Task<Void, Never>?
 
     /// Creates a store backed by the given `UserDefaults` instance.
     ///
@@ -48,6 +65,13 @@ public actor UserDefaultsSettingsStore {
         for key in migrating {
             key.migrateUserDefaultsLegacyKeys(defaults)
         }
+    }
+
+    deinit {
+        // The observer is removed by `observerHandle`'s own deinit via ARC; we
+        // only stop the long-lived fan-out task here (Task is Sendable, so this
+        // is legal from a nonisolated deinit).
+        observerTask?.cancel()
     }
 
     /// Returns the current value for the key.
@@ -111,10 +135,16 @@ public actor UserDefaultsSettingsStore {
                 var lastYielded = await self.value(for: key)
                 continuation.yield(lastYielded)
 
-                let notifications = NotificationCenter.default.notifications(
-                    named: UserDefaults.didChangeNotification
+                let id = UUID()
+                // bufferingNewest(1): the signal carries no payload, so a burst
+                // of UserDefaults writes coalesces to a single wake; the typed
+                // value is re-read and deduped below on each consumed signal.
+                let (signal, signalContinuation) = AsyncStream<Void>.makeStream(
+                    bufferingPolicy: .bufferingNewest(1)
                 )
-                for await _ in notifications {
+                await self.addSubscriber(id: id, continuation: signalContinuation)
+
+                for await _ in signal {
                     if Task.isCancelled { break }
                     let current = await self.value(for: key)
                     if current != lastYielded {
@@ -122,9 +152,58 @@ public actor UserDefaultsSettingsStore {
                         continuation.yield(current)
                     }
                 }
+                await self.removeSubscriber(id: id)
                 continuation.finish()
             }
             continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+
+    /// Number of live ``values(for:)`` subscribers. Test seam: lets a test
+    /// assert that consumer teardown deregisters its subscriber so observers do
+    /// not accumulate across remounts (the #5329 / #5309 leak).
+    var activeSubscriberCount: Int { subscribers.count }
+
+    // MARK: - Private
+
+    private func addSubscriber(id: UUID, continuation: AsyncStream<Void>.Continuation) {
+        subscribers[id] = continuation
+        ensureObserver()
+    }
+
+    private func removeSubscriber(id: UUID) {
+        subscribers.removeValue(forKey: id)?.finish()
+    }
+
+    /// Registers the single block observer on the first subscribe. The observer
+    /// is removed synchronously in `deinit`, so nothing is parked inside a
+    /// non-cancellation-aware notification iterator.
+    private func ensureObserver() {
+        guard observerHandle == nil else { return }
+        // bufferingNewest(1): the raw notification stream carries no payload;
+        // bursts coalesce to one fan-out. Bounded buffering caps growth.
+        let (rawSignal, rawContinuation) = AsyncStream<Void>.makeStream(
+            bufferingPolicy: .bufferingNewest(1)
+        )
+        // Block-based observer (not NSObject KVO), bridged into a bounded
+        // AsyncStream. The handle removes the observer when this actor is
+        // released; callers never see NotificationCenter.
+        observerHandle = NotificationObserverHandle(
+            name: UserDefaults.didChangeNotification
+        ) { _ in
+            rawContinuation.yield(())
+        }
+        observerTask = Task { [weak self] in
+            for await _ in rawSignal {
+                guard let self else { break }
+                await self.fanOutChange()
+            }
+        }
+    }
+
+    private func fanOutChange() {
+        for continuation in subscribers.values {
+            continuation.yield(())
         }
     }
 

--- a/Packages/CmuxSettings/Tests/CmuxSettingsTests/SettingsObserverLeakTests.swift
+++ b/Packages/CmuxSettings/Tests/CmuxSettingsTests/SettingsObserverLeakTests.swift
@@ -50,13 +50,19 @@ import Testing
         let catalog = SettingCatalog()
 
         // Simulate many host-view remounts: spin a consumer up and tear it down.
-        for _ in 0..<50 {
+        for cycle in 0..<50 {
             let consumer = Task {
                 for await _ in store.values(for: catalog.app.appearance) {}
             }
-            _ = await eventually { await store.activeSubscriberCount >= 1 }
+            #expect(
+                await eventually { await store.activeSubscriberCount >= 1 },
+                "cycle \(cycle): consumer never registered"
+            )
             consumer.cancel()
-            _ = await eventually { await store.activeSubscriberCount == 0 }
+            #expect(
+                await eventually { await store.activeSubscriberCount == 0 },
+                "cycle \(cycle): consumer did not deregister on cancel"
+            )
         }
 
         #expect(await eventually { await store.activeSubscriberCount == 0 })

--- a/Packages/CmuxSettings/Tests/CmuxSettingsTests/SettingsObserverLeakTests.swift
+++ b/Packages/CmuxSettings/Tests/CmuxSettingsTests/SettingsObserverLeakTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+import Testing
+
+@testable import CmuxSettings
+
+/// Guards against the settings-observation leak in #5329 / #5309: each
+/// `values(for:)` consumer used to park an uncancellable `Task` inside
+/// `NotificationCenter.notifications(named:)`, so tearing a consumer down (e.g.
+/// a view remount) left the `Task`, `AsyncStream`, and notification sequence
+/// alive until the next matching notification fired — which, for a quiet key,
+/// could be never. Over a long session those trios accumulated into tens of GB.
+///
+/// These tests assert the teardown contract through `activeSubscriberCount`:
+/// cancelling a consumer must deregister its subscriber promptly, and repeated
+/// create/teardown cycles must not accumulate subscribers.
+@Suite struct SettingsObserverLeakTests {
+    /// Polls `condition` until it holds or the deadline passes, without relying
+    /// on a fixed sleep. Returns whether the condition was met.
+    private func eventually(
+        timeout: Duration = .seconds(2),
+        _ condition: @Sendable () async -> Bool
+    ) async -> Bool {
+        let start = ContinuousClock.now
+        while ContinuousClock.now - start < timeout {
+            if await condition() { return true }
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        return await condition()
+    }
+
+    @Test func userDefaultsConsumerDeregistersOnCancel() async {
+        let store = UserDefaultsSettingsStore(defaults: UserDefaults(suiteName: "cmux.tests.\(UUID().uuidString)")!)
+        let catalog = SettingCatalog()
+
+        let consumer = Task {
+            for await _ in store.values(for: catalog.app.appearance) {
+                // Hold the subscription open until cancelled.
+            }
+        }
+
+        #expect(await eventually { await store.activeSubscriberCount == 1 })
+
+        consumer.cancel()
+
+        #expect(await eventually { await store.activeSubscriberCount == 0 })
+    }
+
+    @Test func userDefaultsSubscribersDoNotAccumulateAcrossChurn() async {
+        let store = UserDefaultsSettingsStore(defaults: UserDefaults(suiteName: "cmux.tests.\(UUID().uuidString)")!)
+        let catalog = SettingCatalog()
+
+        // Simulate many host-view remounts: spin a consumer up and tear it down.
+        for _ in 0..<50 {
+            let consumer = Task {
+                for await _ in store.values(for: catalog.app.appearance) {}
+            }
+            _ = await eventually { await store.activeSubscriberCount >= 1 }
+            consumer.cancel()
+            _ = await eventually { await store.activeSubscriberCount == 0 }
+        }
+
+        #expect(await eventually { await store.activeSubscriberCount == 0 })
+    }
+
+    @Test func secretConsumerDeregistersOnCancel() async {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-secret-leak-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = SecretFileStore(baseDirectory: dir)
+        let key = SecretFileKey(id: "automation.socketPassword", fileName: "socket-control-password")
+
+        let consumer = Task {
+            for await _ in store.values(for: key) {}
+        }
+
+        #expect(await eventually { await store.activeSubscriberCount == 1 })
+
+        consumer.cancel()
+
+        #expect(await eventually { await store.activeSubscriberCount == 0 })
+    }
+}


### PR DESCRIPTION
## What this fixes

`UserDefaultsSettingsStore.values(for:)` and `SecretFileStore.values(for:)` each started a `Task` that parked inside `NotificationCenter.notifications(named:)` and only checked `Task.isCancelled` *after* a notification woke it. `continuation.onTermination` calls `task.cancel()`, but `cancel()` can't unblock that await — so every time a settings consumer is torn down (a view remount, a settings panel close, a `@LiveSetting` host losing identity) the `Task`, its `AsyncStream`, and the `NSNotificationCenter.Notifications` sequence stay alive until the named notification next fires. For a quiet key — the secret-store change notification, or any `UserDefaults` key on an idle store — that's never, so the trio leaks permanently.

Over a long session these accumulate badly. The report in #5329 captured a **53 GB physical footprint / 61 GB peak** with **~216M live allocations** dominated by `Task stack` / `NSNotificationCenter.Notifications` / `AsyncStream<Bool>`. This is the same root cause already analyzed in #5309.

## The fix

Both stores now run off a single store-owned **block** observer (`addObserver(forName:object:queue:using:)`), bridged into a bounded `AsyncStream<Void>` and fanned out to one bounded signal per live consumer — exactly the subscriber pattern `JSONConfigStore.values(for:)` already uses. Because the internal signal stream is a real, cancellation-aware `AsyncStream`, cancelling a consumer now breaks its loop immediately, deregisters its subscriber, and finishes the stream. No per-consumer notification iterator, nothing parked.

The block registration is wrapped in a small `NotificationObserverHandle` whose own `deinit` removes the observer, so the actor never has to touch the non-`Sendable` observer token from its `nonisolated deinit`.

Net effect: one observer + one fan-out task per store (not per consumer), and teardown reclaims everything synchronously.

## Tests

`SettingsObserverLeakTests` exercises the teardown contract through a new `activeSubscriberCount` seam:
- cancelling a consumer drops the subscriber count back to 0 promptly (UserDefaults + secret store)
- 50 mount/teardown cycles don't accumulate subscribers

`swift test` for the package is green except for one **pre-existing, unrelated** failure — `SettingCatalogTests.userDefaultsStorageKeysAreUnique` (126 keys, 11 duplicates) — which fails on `main` and has nothing to do with these stores.

Closes #5329. Related: #5309, #5303 (remount loop that multiplies the leak).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5332"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783131462&installation_id=133855650&pr_number=5332&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5332&signature=459af449242e533d42023008947ce4c83cdd1179201da1241134c289dc4bca1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a severe memory leak in settings observers by replacing per-consumer `NotificationCenter.notifications(named:)` loops with a single store-owned block observer and bounded `AsyncStream` fan-out. Streams now subscribe before the first read and cancel cleanly, preventing parked tasks and stale initial values. Closes #5329.

- **Bug Fixes**
  - `UserDefaultsSettingsStore.values(for:)` and `SecretFileStore.values(for:)` use one block-based observer per store with bounded fan-out; subscribers register before the initial read; no per-consumer notification iterators.
  - Added `NotificationObserverHandle` to own and remove the observer in `deinit` safely.
  - Added `SettingsObserverLeakTests` and an `activeSubscriberCount` seam to verify prompt deregistration and no accumulation across 50 remount cycles; strengthened churn assertions.

<sup>Written for commit 3de17f220b0f720dd72e7301dfcbb50491611f46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved subscriber/observer cleanup issues so subscriptions are removed promptly and do not accumulate.

* **Refactor**
  * Centralized and optimized change-notification delivery with bounded buffering and deduplication to reduce redundant updates.

* **Tests**
  * Added cancellation and churn tests verifying subscriber counts return to zero after consumer cancellation.

* **Documentation**
  * Updated docs to describe the new single-observer, fan-out, and buffering/deduplication behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->