### PR TITLE
Web: harden production security headers

### DIFF
--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -3,11 +3,16 @@ import type { NextConfig } from "next";
 import createNextIntlPlugin from "next-intl/plugin";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { poweredByHeader, securityHeaderRules } from "./security-headers";
 
 const withNextIntl = createNextIntlPlugin("./i18n/request.ts");
 const webRoot = path.dirname(fileURLToPath(import.meta.url));
 
 const nextConfig: NextConfig = {
+  poweredByHeader,
+  async headers() {
+    return securityHeaderRules;
+  },
   turbopack: {
     root: webRoot,
   },

--- a/web/security-headers.ts
+++ b/web/security-headers.ts
@@ -1,0 +1,16 @@
+export const poweredByHeader = false;
+
+export const securityHeaders = [
+  { key: "Content-Security-Policy", value: "base-uri 'self'; object-src 'none'; frame-ancestors 'none'" },
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "X-Frame-Options", value: "DENY" },
+  { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=(), payment=()" },
+];
+
+export const securityHeaderRules = [
+  {
+    source: "/:path*",
+    headers: securityHeaders,
+  },
+];

--- a/web/tests/security-headers.test.ts
+++ b/web/tests/security-headers.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { poweredByHeader, securityHeaderRules } from "../security-headers";
+
+describe("production security headers", () => {
+  test("does not expose framework implementation details", () => {
+    expect(poweredByHeader).toBe(false);
+  });
+
+  test("applies baseline hardening headers to every route", async () => {
+    const allRoutes = securityHeaderRules.find((rule) => rule.source === "/:path*");
+    expect(allRoutes).toBeDefined();
+
+    const headers = Object.fromEntries(allRoutes!.headers.map((header) => [header.key, header.value]));
+    expect(headers).toMatchObject({
+      "Content-Security-Policy": "base-uri 'self'; object-src 'none'; frame-ancestors 'none'",
+      "Referrer-Policy": "strict-origin-when-cross-origin",
+      "X-Content-Type-Options": "nosniff",
+      "X-Frame-Options": "DENY",
+      "Permissions-Policy": "camera=(), microphone=(), geolocation=(), payment=()",
+    });
+  });
+});


### PR DESCRIPTION
Follow-up from a bounded production pentest of https://cmux.com.

Findings addressed:
- Production exposed `X-Powered-By: Next.js`.
- HTML/API responses had HSTS but lacked baseline anti-sniffing/framing/referrer/permissions headers.
- Add a narrow CSP that blocks object embedding, document base hijacking, and framing without touching script/style policy.

Changes:
- Disable Next `poweredByHeader`.
- Apply baseline security headers to all routes from `next.config.ts`:
  - `Content-Security-Policy: base-uri self; object-src none; frame-ancestors none`
  - `Referrer-Policy: strict-origin-when-cross-origin`
  - `X-Content-Type-Options: nosniff`
  - `X-Frame-Options: DENY`
  - `Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=()`
- Add a focused config test to keep these headers from regressing.

Pentest context:
- `POST /api/notifications/push` rejected no auth, cookie-only fake auth, bearer-without-refresh, and bogus bearer+refresh with `401`.
- `POST`/`DELETE /api/device-tokens` rejected no auth and cookie-only fake auth with `401`.
- Correctly sized oversized unauthenticated bodies still returned `401` before body parsing.
- Secret-file probes like `/.env`, `/.env.local`, `/api/env`, `/server.js`, `/package.json`, and source-map probes did not expose secrets.
- Vercel production env shows APNs, Stack, DB, provider, Resend, and OTEL vars as encrypted Production env vars.

Verification:
- `cd web && bun test tests/security-headers.test.ts`
- `cd web && bunx tsc --noEmit --pretty false`
- `cd web && bun run lint -- next.config.ts tests/security-headers.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5334"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783134805&installation_id=133855650&pr_number=5334&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5334&signature=660ac4ef68ddb950347f77da229215efd25e4caec81fa9954f21b14c541455b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive response headers and a narrow CSP; no auth, data, or script-policy changes, with tests guarding config.
> 
> **Overview**
> Addresses production pentest findings by **hardening HTTP responses** on the Next.js app: **`X-Powered-By` is turned off** and a shared **`security-headers`** module drives **`headers()`** so every route gets baseline protections.
> 
> **Global headers** now include a **narrow CSP** (`base-uri 'self'`, `object-src 'none'`, `frame-ancestors 'none'`) plus **`Referrer-Policy`**, **`X-Content-Type-Options: nosniff`**, **`X-Frame-Options: DENY`**, and a restrictive **`Permissions-Policy`**. Script/style CSP is intentionally untouched.
> 
> A **Bun test** locks the header config so these values do not regress.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d9a72679b3dada1c211e4d9ed3edd186d4f040f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened production response security by disabling `X-Powered-By` and applying a narrow CSP with baseline headers across all routes. Centralized the header config in `security-headers.ts` and added a test to prevent regressions.

- **New Features**
  - Disable `poweredByHeader` to remove `X-Powered-By`.
  - Set global headers via `headers()` in `next.config.ts` for `/:path*`: `Content-Security-Policy` "base-uri 'self'; object-src 'none'; frame-ancestors 'none'"; `Referrer-Policy` "strict-origin-when-cross-origin"; `X-Content-Type-Options` "nosniff"; `X-Frame-Options` "DENY"; `Permissions-Policy` "camera=(), microphone=(), geolocation=(), payment=()".

<sup>Written for commit 0d9a72679b3dada1c211e4d9ed3edd186d4f040f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Applied site-wide security headers and disabled the default "powered by" header to improve baseline HTTP hardening across all routes.

* **Tests**
  * Added automated tests that verify production security header rules are applied for all routes, asserting the expected Content-Security-Policy and baseline security header values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->