### PR TITLE
Fix terminal selection mouse-up with find overlay

### DIFF
--- a/Sources/Find/TerminalSearchOverlayHostingView.swift
+++ b/Sources/Find/TerminalSearchOverlayHostingView.swift
@@ -1,0 +1,31 @@
+import AppKit
+import SwiftUI
+
+final class TerminalSearchOverlayHostingView: NSHostingView<SurfaceSearchOverlay> {
+    private weak var surfaceView: GhosttyNSView?
+
+    init(rootView: SurfaceSearchOverlay, surfaceView: GhosttyNSView) {
+        self.surfaceView = surfaceView
+        super.init(rootView: rootView)
+    }
+
+    @available(*, unavailable)
+    required init(rootView: SurfaceSearchOverlay) {
+        fatalError("init(rootView:) has not been implemented")
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        guard surfaceView?.forwardPendingLeftMouseDrag(with: event) != true else { return }
+        super.mouseDragged(with: event)
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        guard surfaceView?.completePendingLeftMouseRelease(with: event) != true else { return }
+        super.mouseUp(with: event)
+    }
+}

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -10042,7 +10042,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     }
 
     @discardableResult
-    fileprivate func forwardPendingLeftMouseDrag(with event: NSEvent) -> Bool {
+    func forwardPendingLeftMouseDrag(with event: NSEvent) -> Bool {
         guard hasPendingLeftMouseRelease, let surface else { return false }
         let eventPoint = convert(event.locationInWindow, from: nil)
         trackMousePointIfUsable(eventPoint)
@@ -10051,9 +10051,10 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     }
 
     @discardableResult
-    fileprivate func completePendingLeftMouseRelease(with event: NSEvent) -> Bool {
-        guard hasPendingLeftMouseRelease, let surface else { return false }
+    func completePendingLeftMouseRelease(with event: NSEvent) -> Bool {
+        guard hasPendingLeftMouseRelease else { return false }
         hasPendingLeftMouseRelease = false
+        guard let surface else { return false }
         let point = convert(event.locationInWindow, from: nil)
         let consumed = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, modsFromEvent(event))
         _ = handleCommandClickRelease(at: point, modifierFlags: event.modifierFlags, ghosttyConsumed: consumed)
@@ -11374,35 +11375,6 @@ private final class GhosttyFlashOverlayView: NSView {
 
     override func hitTest(_ point: NSPoint) -> NSView? {
         nil
-    }
-}
-
-private final class TerminalSearchOverlayHostingView: NSHostingView<SurfaceSearchOverlay> {
-    private weak var surfaceView: GhosttyNSView?
-
-    init(rootView: SurfaceSearchOverlay, surfaceView: GhosttyNSView) {
-        self.surfaceView = surfaceView
-        super.init(rootView: rootView)
-    }
-
-    @available(*, unavailable)
-    required init(rootView: SurfaceSearchOverlay) {
-        fatalError("init(rootView:) has not been implemented")
-    }
-
-    @available(*, unavailable)
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    override func mouseDragged(with event: NSEvent) {
-        guard surfaceView?.forwardPendingLeftMouseDrag(with: event) != true else { return }
-        super.mouseDragged(with: event)
-    }
-
-    override func mouseUp(with event: NSEvent) {
-        guard surfaceView?.completePendingLeftMouseRelease(with: event) != true else { return }
-        super.mouseUp(with: event)
     }
 }
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7828,6 +7828,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     private var deferredSurfaceSizeRetryQueued = false
     private var lastDrawableSize: CGSize = .zero
     private var isFindEscapeSuppressionArmed = false
+    private var hasPendingLeftMouseRelease = false
 #if DEBUG
     private var lastSizeSkipSignature: String?
 #endif
@@ -10030,16 +10031,33 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             ghostty_surface_mouse_pos(surface, eventPoint.x, bounds.height - eventPoint.y, modsFromEvent(event))
         }
         _ = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_LEFT, modsFromEvent(event))
+        hasPendingLeftMouseRelease = true
     }
 
     override func mouseUp(with event: NSEvent) {
         #if DEBUG
         cmuxDebugLog("terminal.mouseUp surface=\(terminalSurface?.id.uuidString.prefix(5) ?? "nil") mods=[\(debugModifierString(event.modifierFlags))]")
         #endif
-        guard let surface = surface else { return }
+        completePendingLeftMouseRelease(with: event)
+    }
+
+    @discardableResult
+    fileprivate func forwardPendingLeftMouseDrag(with event: NSEvent) -> Bool {
+        guard hasPendingLeftMouseRelease, let surface else { return false }
+        let eventPoint = convert(event.locationInWindow, from: nil)
+        trackMousePointIfUsable(eventPoint)
+        ghostty_surface_mouse_pos(surface, eventPoint.x, bounds.height - eventPoint.y, modsFromEvent(event))
+        return true
+    }
+
+    @discardableResult
+    fileprivate func completePendingLeftMouseRelease(with event: NSEvent) -> Bool {
+        guard hasPendingLeftMouseRelease, let surface else { return false }
+        hasPendingLeftMouseRelease = false
         let point = convert(event.locationInWindow, from: nil)
         let consumed = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, modsFromEvent(event))
         _ = handleCommandClickRelease(at: point, modifierFlags: event.modifierFlags, ghosttyConsumed: consumed)
+        return true
     }
 
     /// Attempt to open the word under the mouse cursor as a file path, resolved
@@ -10874,6 +10892,12 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         // the viewport rather than a cached in-bounds hover point.
         ghostty_surface_mouse_pos(surface, eventPoint.x, bounds.height - eventPoint.y, modsFromEvent(event))
     }
+
+#if DEBUG
+    func debugHasPendingLeftMouseReleaseForTesting() -> Bool {
+        hasPendingLeftMouseRelease
+    }
+#endif
 
     override func scrollWheel(with event: NSEvent) {
         NotificationCenter.default.post(name: .ghosttyDidReceiveWheelScroll, object: self)
@@ -13157,6 +13181,18 @@ final class GhosttySurfaceScrollView: NSView {
     func debugHasSearchOverlay() -> Bool {
         guard let overlay = searchOverlayHostingView else { return false }
         return overlay.superview === self && !overlay.isHidden
+    }
+
+    func debugSearchOverlayHostingViewForTesting() -> NSView? {
+        guard let overlay = searchOverlayHostingView,
+              overlay.superview === self else {
+            return nil
+        }
+        return overlay
+    }
+
+    func debugSurfaceHasPendingLeftMouseReleaseForTesting() -> Bool {
+        surfaceView.debugHasPendingLeftMouseReleaseForTesting()
     }
 
     func debugHasKeyboardCopyModeIndicator() -> Bool {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -11377,6 +11377,35 @@ private final class GhosttyFlashOverlayView: NSView {
     }
 }
 
+private final class TerminalSearchOverlayHostingView: NSHostingView<SurfaceSearchOverlay> {
+    private weak var surfaceView: GhosttyNSView?
+
+    init(rootView: SurfaceSearchOverlay, surfaceView: GhosttyNSView) {
+        self.surfaceView = surfaceView
+        super.init(rootView: rootView)
+    }
+
+    @available(*, unavailable)
+    required init(rootView: SurfaceSearchOverlay) {
+        fatalError("init(rootView:) has not been implemented")
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        guard surfaceView?.forwardPendingLeftMouseDrag(with: event) != true else { return }
+        super.mouseDragged(with: event)
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        guard surfaceView?.completePendingLeftMouseRelease(with: event) != true else { return }
+        super.mouseUp(with: event)
+    }
+}
+
 final class GhosttySurfaceScrollView: NSView {
     enum FlashStyle {
         case navigation
@@ -12711,7 +12740,7 @@ final class GhosttySurfaceScrollView: NSView {
         }
 
         searchFocusTarget = .searchField
-        let overlay = NSHostingView(rootView: rootView)
+        let overlay = TerminalSearchOverlayHostingView(rootView: rootView, surfaceView: surfaceView)
         overlay.frame = bounds
         overlay.autoresizingMask = [.width, .height]
         searchOverlayHostingView = overlay

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -525,6 +525,7 @@
 		A5001401 /* TerminalPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001411 /* TerminalPanel.swift */; };
 		A5001403 /* TerminalPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001413 /* TerminalPanelView.swift */; };
 		C0DE53350000000000000001 /* TerminalSearchOverlayHostingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE53350000000000000002 /* TerminalSearchOverlayHostingView.swift */; };
+		C0DE53360000000000000001 /* TerminalSearchOverlayMouseReleaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE53360000000000000002 /* TerminalSearchOverlayMouseReleaseTests.swift */; };
 		A5001543 /* TerminalSSHSessionDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001545 /* TerminalSSHSessionDetector.swift */; };
 		C13519000000000000000001 /* TerminalStartupEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C13519000000000000000002 /* TerminalStartupEnvironment.swift */; };
 		A5001532 /* TerminalWindowPortal.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001531 /* TerminalWindowPortal.swift */; };
@@ -1163,6 +1164,7 @@
 		A5001411 /* TerminalPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/TerminalPanel.swift; sourceTree = "<group>"; };
 		A5001413 /* TerminalPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/TerminalPanelView.swift; sourceTree = "<group>"; };
 		C0DE53350000000000000002 /* TerminalSearchOverlayHostingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Find/TerminalSearchOverlayHostingView.swift; sourceTree = "<group>"; };
+		C0DE53360000000000000002 /* TerminalSearchOverlayMouseReleaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSearchOverlayMouseReleaseTests.swift; sourceTree = "<group>"; };
 		A5001545 /* TerminalSSHSessionDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSSHSessionDetector.swift; sourceTree = "<group>"; };
 		C13519000000000000000002 /* TerminalStartupEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalStartupEnvironment.swift; sourceTree = "<group>"; };
 		A5001531 /* TerminalWindowPortal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalWindowPortal.swift; sourceTree = "<group>"; };
@@ -1881,6 +1883,7 @@
 				D0B1000DA1B2C3D4E5F60001 /* CmuxWebViewDragRoutingTests.swift */,
 					D0B1000FA1B2C3D4E5F60001 /* BrowserPaneDropRoutingTests.swift */,
 					02FC74F2C27127CC565B3E8C /* TerminalAndGhosttyTests.swift */,
+					C0DE53360000000000000002 /* TerminalSearchOverlayMouseReleaseTests.swift */,
 					C35610000000000000000002 /* FinderFileDropRegressionTests.swift */,
 					C44550000000000000000002 /* PanelOwnedNativeViewSessionTests.swift */,
 					3069F1D10000000000000004 /* GhosttyPasteboardFidelityTests.swift */,
@@ -2877,6 +2880,7 @@
 					A5A5A505A1B2C3D4E5F60718 /* TerminalNotificationDirectInteractionTests.swift in Sources */,
 				A5A5A503A1B2C3D4E5F60718 /* TerminalNotificationQueueTests.swift in Sources */,
 					A5E380700000000000000001 /* TerminalNotificationSocketActionTests.swift in Sources */,
+				C0DE53360000000000000001 /* TerminalSearchOverlayMouseReleaseTests.swift in Sources */,
 				C0DE7B300000000000000001 /* TextBoxMentionCompletionTests.swift in Sources */,
 				F50030040000000000000001 /* TitlebarInteractiveControlTests.swift in Sources */,
 				D3284001A1B2C3D4E5F60718 /* TraditionalChineseIMENumpadRegressionTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -524,6 +524,7 @@
 		D0B10000A1B2C3D4E5F60001 /* TerminalPaneDropTargetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B10001A1B2C3D4E5F60001 /* TerminalPaneDropTargetView.swift */; };
 		A5001401 /* TerminalPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001411 /* TerminalPanel.swift */; };
 		A5001403 /* TerminalPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001413 /* TerminalPanelView.swift */; };
+		C0DE53350000000000000001 /* TerminalSearchOverlayHostingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE53350000000000000002 /* TerminalSearchOverlayHostingView.swift */; };
 		A5001543 /* TerminalSSHSessionDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001545 /* TerminalSSHSessionDetector.swift */; };
 		C13519000000000000000001 /* TerminalStartupEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C13519000000000000000002 /* TerminalStartupEnvironment.swift */; };
 		A5001532 /* TerminalWindowPortal.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001531 /* TerminalWindowPortal.swift */; };
@@ -1161,6 +1162,7 @@
 		D0B10001A1B2C3D4E5F60001 /* TerminalPaneDropTargetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalPaneDropTargetView.swift; sourceTree = "<group>"; };
 		A5001411 /* TerminalPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/TerminalPanel.swift; sourceTree = "<group>"; };
 		A5001413 /* TerminalPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/TerminalPanelView.swift; sourceTree = "<group>"; };
+		C0DE53350000000000000002 /* TerminalSearchOverlayHostingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Find/TerminalSearchOverlayHostingView.swift; sourceTree = "<group>"; };
 		A5001545 /* TerminalSSHSessionDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSSHSessionDetector.swift; sourceTree = "<group>"; };
 		C13519000000000000000002 /* TerminalStartupEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalStartupEnvironment.swift; sourceTree = "<group>"; };
 		A5001531 /* TerminalWindowPortal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalWindowPortal.swift; sourceTree = "<group>"; };
@@ -1652,6 +1654,7 @@
 					A5A5A502A1B2C3D4E5F60718 /* TerminalNotificationQueue.swift */,
 				A5C41102A1B2C3D4E5F60718 /* TerminalNotificationCallerResolver.swift */,
 				A5001301 /* SurfaceSearchOverlay.swift */,
+				C0DE53350000000000000002 /* TerminalSearchOverlayHostingView.swift */,
 				A5008370 /* BrowserSearchOverlay.swift */,
 				A5008372 /* BrowserFindJavaScript.swift */,
 				3865B0013865B0013865B001 /* SearchIndex.swift */,
@@ -2596,6 +2599,7 @@
 				D0B10000A1B2C3D4E5F60001 /* TerminalPaneDropTargetView.swift in Sources */,
 				A5001401 /* TerminalPanel.swift in Sources */,
 				A5001403 /* TerminalPanelView.swift in Sources */,
+				C0DE53350000000000000001 /* TerminalSearchOverlayHostingView.swift in Sources */,
 				A5001543 /* TerminalSSHSessionDetector.swift in Sources */,
 				C13519000000000000000001 /* TerminalStartupEnvironment.swift in Sources */,
 				A5001532 /* TerminalWindowPortal.swift in Sources */,

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -3199,23 +3199,6 @@ final class GhosttySurfaceOverlayTests: XCTestCase {
         return surface
     }
 
-    private func makeMouseEvent(type: NSEvent.EventType, location: NSPoint, window: NSWindow) -> NSEvent {
-        guard let event = NSEvent.mouseEvent(
-            with: type,
-            location: location,
-            modifierFlags: [],
-            timestamp: ProcessInfo.processInfo.systemUptime,
-            windowNumber: window.windowNumber,
-            context: nil,
-            eventNumber: 0,
-            clickCount: 1,
-            pressure: 1.0
-        ) else {
-            fatalError("Failed to create \(type) mouse event")
-        }
-        return event
-    }
-
     private func findEditableTextField(in view: NSView) -> NSTextField? {
         if let field = view as? NSTextField, field.isEditable {
             return field
@@ -3238,15 +3221,6 @@ final class GhosttySurfaceOverlayTests: XCTestCase {
             return true
         }
         return false
-    }
-
-    private func surfaceView(in hostedView: GhosttySurfaceScrollView) -> NSView? {
-        hostedView.subviews
-            .compactMap { $0 as? NSScrollView }
-            .first?
-            .documentView?
-            .subviews
-            .first
     }
 
     @discardableResult
@@ -3592,106 +3566,6 @@ final class GhosttySurfaceOverlayTests: XCTestCase {
             !hostedView.debugHasSearchOverlay()
         }
         XCTAssertFalse(hostedView.debugHasSearchOverlay())
-    }
-
-    func testSearchOverlayForwardsTerminalMouseReleaseDuringSelectionDrag() throws {
-        let surface = makeTrackedTerminalSurface()
-        let hostedView = surface.hostedView
-        let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 360, height: 240),
-            styleMask: [.titled, .closable],
-            backing: .buffered,
-            defer: false
-        )
-        defer { window.orderOut(nil) }
-
-        guard let contentView = window.contentView else {
-            XCTFail("Expected content view")
-            return
-        }
-        hostedView.frame = contentView.bounds
-        hostedView.autoresizingMask = [.width, .height]
-        contentView.addSubview(hostedView)
-
-        window.makeKeyAndOrderFront(nil)
-        window.displayIfNeeded()
-        contentView.layoutSubtreeIfNeeded()
-        hostedView.layoutSubtreeIfNeeded()
-
-        hostedView.setSearchOverlay(searchState: TerminalSurface.SearchState(needle: "needle"))
-        waitUntil(description: "search overlay to mount") {
-            hostedView.debugHasSearchOverlay()
-        }
-
-        let terminalView = try XCTUnwrap(surfaceView(in: hostedView) as? GhosttyNSView)
-        let overlay = try XCTUnwrap(hostedView.debugSearchOverlayHostingViewForTesting())
-
-        let downLocation = terminalView.convert(NSPoint(x: 24, y: 24), to: nil)
-        terminalView.mouseDown(with: makeMouseEvent(type: .leftMouseDown, location: downLocation, window: window))
-        XCTAssertTrue(
-            hostedView.debugSurfaceHasPendingLeftMouseReleaseForTesting(),
-            "Terminal selection should own the left-button release after mouseDown"
-        )
-
-        let overlayLocation = overlay.convert(NSPoint(x: overlay.bounds.midX, y: overlay.bounds.midY), to: nil)
-        overlay.mouseDragged(with: makeMouseEvent(type: .leftMouseDragged, location: overlayLocation, window: window))
-        XCTAssertTrue(
-            hostedView.debugSurfaceHasPendingLeftMouseReleaseForTesting(),
-            "Dragging across the find overlay must keep terminal selection ownership until mouseUp"
-        )
-
-        overlay.mouseUp(with: makeMouseEvent(type: .leftMouseUp, location: overlayLocation, window: window))
-        XCTAssertFalse(
-            hostedView.debugSurfaceHasPendingLeftMouseReleaseForTesting(),
-            "An overlay-captured mouseUp must release the terminal selection"
-        )
-    }
-
-    func testSearchOverlayMouseReleaseClearsSelectionDragAfterSurfaceRelease() throws {
-        let surface = makeTrackedTerminalSurface()
-        let hostedView = surface.hostedView
-        let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 360, height: 240),
-            styleMask: [.titled, .closable],
-            backing: .buffered,
-            defer: false
-        )
-        defer { window.orderOut(nil) }
-
-        guard let contentView = window.contentView else {
-            XCTFail("Expected content view")
-            return
-        }
-        hostedView.frame = contentView.bounds
-        hostedView.autoresizingMask = [.width, .height]
-        contentView.addSubview(hostedView)
-
-        window.makeKeyAndOrderFront(nil)
-        window.displayIfNeeded()
-        contentView.layoutSubtreeIfNeeded()
-        hostedView.layoutSubtreeIfNeeded()
-
-        hostedView.setSearchOverlay(searchState: TerminalSurface.SearchState(needle: "needle"))
-        waitUntil(description: "search overlay to mount") {
-            hostedView.debugHasSearchOverlay()
-        }
-
-        let terminalView = try XCTUnwrap(surfaceView(in: hostedView) as? GhosttyNSView)
-        let overlay = try XCTUnwrap(hostedView.debugSearchOverlayHostingViewForTesting())
-
-        let downLocation = terminalView.convert(NSPoint(x: 24, y: 24), to: nil)
-        terminalView.mouseDown(with: makeMouseEvent(type: .leftMouseDown, location: downLocation, window: window))
-        XCTAssertTrue(hostedView.debugSurfaceHasPendingLeftMouseReleaseForTesting())
-
-        surface.releaseSurfaceForTesting()
-        XCTAssertNil(surface.surface)
-
-        let overlayLocation = overlay.convert(NSPoint(x: overlay.bounds.midX, y: overlay.bounds.midY), to: nil)
-        overlay.mouseUp(with: makeMouseEvent(type: .leftMouseUp, location: overlayLocation, window: window))
-        XCTAssertFalse(
-            hostedView.debugSurfaceHasPendingLeftMouseReleaseForTesting(),
-            "The pending terminal release state must clear even if the Ghostty surface is gone"
-        )
     }
 
     func testRapidSearchOverlayToggleDoesNotLeaveStaleOverlayMounted() {

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -3647,6 +3647,53 @@ final class GhosttySurfaceOverlayTests: XCTestCase {
         )
     }
 
+    func testSearchOverlayMouseReleaseClearsSelectionDragAfterSurfaceRelease() throws {
+        let surface = makeTrackedTerminalSurface()
+        let hostedView = surface.hostedView
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 360, height: 240),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+        hostedView.frame = contentView.bounds
+        hostedView.autoresizingMask = [.width, .height]
+        contentView.addSubview(hostedView)
+
+        window.makeKeyAndOrderFront(nil)
+        window.displayIfNeeded()
+        contentView.layoutSubtreeIfNeeded()
+        hostedView.layoutSubtreeIfNeeded()
+
+        hostedView.setSearchOverlay(searchState: TerminalSurface.SearchState(needle: "needle"))
+        waitUntil(description: "search overlay to mount") {
+            hostedView.debugHasSearchOverlay()
+        }
+
+        let terminalView = try XCTUnwrap(surfaceView(in: hostedView) as? GhosttyNSView)
+        let overlay = try XCTUnwrap(hostedView.debugSearchOverlayHostingViewForTesting())
+
+        let downLocation = terminalView.convert(NSPoint(x: 24, y: 24), to: nil)
+        terminalView.mouseDown(with: makeMouseEvent(type: .leftMouseDown, location: downLocation, window: window))
+        XCTAssertTrue(hostedView.debugSurfaceHasPendingLeftMouseReleaseForTesting())
+
+        surface.releaseSurfaceForTesting()
+        XCTAssertNil(surface.surface)
+
+        let overlayLocation = overlay.convert(NSPoint(x: overlay.bounds.midX, y: overlay.bounds.midY), to: nil)
+        overlay.mouseUp(with: makeMouseEvent(type: .leftMouseUp, location: overlayLocation, window: window))
+        XCTAssertFalse(
+            hostedView.debugSurfaceHasPendingLeftMouseReleaseForTesting(),
+            "The pending terminal release state must clear even if the Ghostty surface is gone"
+        )
+    }
+
     func testRapidSearchOverlayToggleDoesNotLeaveStaleOverlayMounted() {
         let surface = makeTrackedTerminalSurface()
         let hostedView = surface.hostedView

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -3199,6 +3199,23 @@ final class GhosttySurfaceOverlayTests: XCTestCase {
         return surface
     }
 
+    private func makeMouseEvent(type: NSEvent.EventType, location: NSPoint, window: NSWindow) -> NSEvent {
+        guard let event = NSEvent.mouseEvent(
+            with: type,
+            location: location,
+            modifierFlags: [],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 1.0
+        ) else {
+            fatalError("Failed to create \(type) mouse event")
+        }
+        return event
+    }
+
     private func findEditableTextField(in view: NSView) -> NSTextField? {
         if let field = view as? NSTextField, field.isEditable {
             return field
@@ -3221,6 +3238,15 @@ final class GhosttySurfaceOverlayTests: XCTestCase {
             return true
         }
         return false
+    }
+
+    private func surfaceView(in hostedView: GhosttySurfaceScrollView) -> NSView? {
+        hostedView.subviews
+            .compactMap { $0 as? NSScrollView }
+            .first?
+            .documentView?
+            .subviews
+            .first
     }
 
     @discardableResult
@@ -3566,6 +3592,59 @@ final class GhosttySurfaceOverlayTests: XCTestCase {
             !hostedView.debugHasSearchOverlay()
         }
         XCTAssertFalse(hostedView.debugHasSearchOverlay())
+    }
+
+    func testSearchOverlayForwardsTerminalMouseReleaseDuringSelectionDrag() throws {
+        let surface = makeTrackedTerminalSurface()
+        let hostedView = surface.hostedView
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 360, height: 240),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+        hostedView.frame = contentView.bounds
+        hostedView.autoresizingMask = [.width, .height]
+        contentView.addSubview(hostedView)
+
+        window.makeKeyAndOrderFront(nil)
+        window.displayIfNeeded()
+        contentView.layoutSubtreeIfNeeded()
+        hostedView.layoutSubtreeIfNeeded()
+
+        hostedView.setSearchOverlay(searchState: TerminalSurface.SearchState(needle: "needle"))
+        waitUntil(description: "search overlay to mount") {
+            hostedView.debugHasSearchOverlay()
+        }
+
+        let terminalView = try XCTUnwrap(surfaceView(in: hostedView) as? GhosttyNSView)
+        let overlay = try XCTUnwrap(hostedView.debugSearchOverlayHostingViewForTesting())
+
+        let downLocation = terminalView.convert(NSPoint(x: 24, y: 24), to: nil)
+        terminalView.mouseDown(with: makeMouseEvent(type: .leftMouseDown, location: downLocation, window: window))
+        XCTAssertTrue(
+            hostedView.debugSurfaceHasPendingLeftMouseReleaseForTesting(),
+            "Terminal selection should own the left-button release after mouseDown"
+        )
+
+        let overlayLocation = overlay.convert(NSPoint(x: overlay.bounds.midX, y: overlay.bounds.midY), to: nil)
+        overlay.mouseDragged(with: makeMouseEvent(type: .leftMouseDragged, location: overlayLocation, window: window))
+        XCTAssertTrue(
+            hostedView.debugSurfaceHasPendingLeftMouseReleaseForTesting(),
+            "Dragging across the find overlay must keep terminal selection ownership until mouseUp"
+        )
+
+        overlay.mouseUp(with: makeMouseEvent(type: .leftMouseUp, location: overlayLocation, window: window))
+        XCTAssertFalse(
+            hostedView.debugSurfaceHasPendingLeftMouseReleaseForTesting(),
+            "An overlay-captured mouseUp must release the terminal selection"
+        )
     }
 
     func testRapidSearchOverlayToggleDoesNotLeaveStaleOverlayMounted() {

--- a/cmuxTests/TerminalSearchOverlayMouseReleaseTests.swift
+++ b/cmuxTests/TerminalSearchOverlayMouseReleaseTests.swift
@@ -1,0 +1,151 @@
+import AppKit
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+@Suite("Terminal search overlay mouse release")
+struct TerminalSearchOverlayMouseReleaseTests {
+    @Test("Search overlay forwards terminal mouse release during selection drag")
+    func searchOverlayForwardsTerminalMouseReleaseDuringSelectionDrag() throws {
+        let surface = makeTerminalSurface()
+        defer { surface.releaseSurfaceForTesting() }
+
+        let (hostedView, window) = try attachToWindow(surface: surface)
+        defer { window.orderOut(nil) }
+
+        hostedView.setSearchOverlay(searchState: TerminalSurface.SearchState(needle: "needle"))
+        #expect(waitUntil(description: "search overlay to mount") {
+            hostedView.debugHasSearchOverlay()
+        })
+
+        let terminalView = try #require(surfaceView(in: hostedView) as? GhosttyNSView)
+        let overlay = try #require(hostedView.debugSearchOverlayHostingViewForTesting())
+
+        let downLocation = terminalView.convert(NSPoint(x: 24, y: 24), to: nil)
+        terminalView.mouseDown(with: makeMouseEvent(type: .leftMouseDown, location: downLocation, window: window))
+        #expect(
+            hostedView.debugSurfaceHasPendingLeftMouseReleaseForTesting(),
+            "Terminal selection should own the left-button release after mouseDown"
+        )
+
+        let overlayLocation = overlay.convert(NSPoint(x: overlay.bounds.midX, y: overlay.bounds.midY), to: nil)
+        overlay.mouseDragged(with: makeMouseEvent(type: .leftMouseDragged, location: overlayLocation, window: window))
+        #expect(
+            hostedView.debugSurfaceHasPendingLeftMouseReleaseForTesting(),
+            "Dragging across the find overlay must keep terminal selection ownership until mouseUp"
+        )
+
+        overlay.mouseUp(with: makeMouseEvent(type: .leftMouseUp, location: overlayLocation, window: window))
+        #expect(
+            !hostedView.debugSurfaceHasPendingLeftMouseReleaseForTesting(),
+            "An overlay-captured mouseUp must release the terminal selection"
+        )
+    }
+
+    @Test("Search overlay release clears pending selection after surface release")
+    func searchOverlayMouseReleaseClearsSelectionDragAfterSurfaceRelease() throws {
+        let surface = makeTerminalSurface()
+        defer { surface.releaseSurfaceForTesting() }
+
+        let (hostedView, window) = try attachToWindow(surface: surface)
+        defer { window.orderOut(nil) }
+
+        hostedView.setSearchOverlay(searchState: TerminalSurface.SearchState(needle: "needle"))
+        #expect(waitUntil(description: "search overlay to mount") {
+            hostedView.debugHasSearchOverlay()
+        })
+
+        let terminalView = try #require(surfaceView(in: hostedView) as? GhosttyNSView)
+        let overlay = try #require(hostedView.debugSearchOverlayHostingViewForTesting())
+
+        let downLocation = terminalView.convert(NSPoint(x: 24, y: 24), to: nil)
+        terminalView.mouseDown(with: makeMouseEvent(type: .leftMouseDown, location: downLocation, window: window))
+        #expect(hostedView.debugSurfaceHasPendingLeftMouseReleaseForTesting())
+
+        surface.releaseSurfaceForTesting()
+        #expect(surface.surface == nil)
+
+        let overlayLocation = overlay.convert(NSPoint(x: overlay.bounds.midX, y: overlay.bounds.midY), to: nil)
+        overlay.mouseUp(with: makeMouseEvent(type: .leftMouseUp, location: overlayLocation, window: window))
+        #expect(
+            !hostedView.debugSurfaceHasPendingLeftMouseReleaseForTesting(),
+            "The pending terminal release state must clear even if the Ghostty surface is gone"
+        )
+    }
+
+    private func makeTerminalSurface() -> TerminalSurface {
+        TerminalSurface(
+            tabId: UUID(),
+            context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
+            configTemplate: nil,
+            workingDirectory: nil
+        )
+    }
+
+    private func attachToWindow(surface: TerminalSurface) throws -> (GhosttySurfaceScrollView, NSWindow) {
+        let hostedView = surface.hostedView
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 360, height: 240),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        let contentView = try #require(window.contentView)
+        hostedView.frame = contentView.bounds
+        hostedView.autoresizingMask = [.width, .height]
+        contentView.addSubview(hostedView)
+
+        window.makeKeyAndOrderFront(nil)
+        window.displayIfNeeded()
+        contentView.layoutSubtreeIfNeeded()
+        hostedView.layoutSubtreeIfNeeded()
+
+        return (hostedView, window)
+    }
+
+    private func makeMouseEvent(type: NSEvent.EventType, location: NSPoint, window: NSWindow) -> NSEvent {
+        guard let event = NSEvent.mouseEvent(
+            with: type,
+            location: location,
+            modifierFlags: [],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 1.0
+        ) else {
+            preconditionFailure("Failed to create \(type) mouse event")
+        }
+        return event
+    }
+
+    private func surfaceView(in hostedView: GhosttySurfaceScrollView) -> NSView? {
+        hostedView.subviews
+            .compactMap { $0 as? NSScrollView }
+            .first?
+            .documentView?
+            .subviews
+            .first
+    }
+
+    private func waitUntil(
+        timeout: TimeInterval = 1.0,
+        description: String,
+        _ condition: @escaping () -> Bool
+    ) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if condition() {
+                return true
+            }
+            _ = RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.01))
+        }
+        return condition()
+    }
+}


### PR DESCRIPTION
## Summary
- Keep terminal Ghostty mouse-button state owned by `GhosttyNSView` while selection is active.
- Forward drag and mouse-up events from the portal-hosted terminal find overlay back to the terminal when the terminal has a pending left-button release.
- Add regression coverage for the find-overlay-captured mouse-up path.

## Testing
- `xcodebuild -project cmux.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-task-selection-mouseup-find-overlay build` passed
- AWS targeted unit test attempted with `cmux-unit` and `-only-testing:cmuxTests/GhosttySurfaceOverlayTests/testSearchOverlayForwardsTerminalMouseReleaseDuringSelectionDrag`, but the runner failed during package checkout with `No space left on device` before running tests.

## Issues
- Plain-text task: fix terminal selection mouse-up loss when Cmd+F find overlay is open

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5335"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783135766&installation_id=133855650&pr_number=5335&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5335&signature=5503828e1c055b2ea0ad9af47947b1975acae7faa0003844f15956e69a76d29f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized AppKit mouse routing for find overlay and terminal selection; covered by new unit tests with no auth or data-path changes.
> 
> **Overview**
> Fixes **stuck terminal text selection** when the user releases the mouse over the **Cmd+F find overlay** instead of the terminal surface.
> 
> `GhosttyNSView` now tracks **`hasPendingLeftMouseRelease`** after left `mouseDown` and routes release handling through **`completePendingLeftMouseRelease`**, which still clears the flag if the Ghostty surface is already gone. **`forwardPendingLeftMouseDrag`** keeps pointer updates flowing during drags that cross the overlay.
> 
> The find UI is hosted in a new **`TerminalSearchOverlayHostingView`** that forwards **`mouseDragged`** / **`mouseUp`** to the terminal when a pending release exists. Regression tests cover overlay-captured release and cleanup after surface teardown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a18ba507a84feca3c2c90d8c7323b180c2feb83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes lost terminal selection mouse-up when the Cmd+F find overlay is open. Selections finish even if the mouse is released over the overlay, and the pending-release state now clears reliably.

- **Bug Fixes**
  - Track left-button ownership in `GhosttyNSView` with a pending-release flag; forward drag via `forwardPendingLeftMouseDrag` and centralize release in `completePendingLeftMouseRelease`.
  - Use `TerminalSearchOverlayHostingView` to forward drag/up to the terminal when a release is pending.
  - Add Swift Testing regressions for overlay-captured release and cleanup when the `Ghostty` surface is gone.

<sup>Written for commit 4a18ba507a84feca3c2c90d8c7323b180c2feb83. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed mouse event handling in the search overlay to properly defer and resolve command-click operations in the correct sequence.
  * Improved state management for mouse button release events during search overlay interactions.

* **Tests**
  * Added test suite for mouse release event forwarding in the search overlay, validating correct behavior during active searches and edge cases involving surface cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->