### PR TITLE
Suppress expected CLI socket Sentry telemetry

### DIFF
--- a/CLI/CLISocketErrnoProviding.swift
+++ b/CLI/CLISocketErrnoProviding.swift
@@ -1,0 +1,3 @@
+protocol CLISocketErrnoProviding {
+    var socketErrnoValue: Int32 { get }
+}

--- a/CLI/CLISocketExpectedAvailabilityError.swift
+++ b/CLI/CLISocketExpectedAvailabilityError.swift
@@ -1,0 +1,1 @@
+protocol CLISocketExpectedAvailabilityError {}

--- a/CLI/CLISocketReadEOFError.swift
+++ b/CLI/CLISocketReadEOFError.swift
@@ -1,0 +1,5 @@
+struct CLISocketReadEOFError: Error, CustomStringConvertible, CLISocketExpectedAvailabilityError {
+    let message: String
+
+    var description: String { message }
+}

--- a/CLI/CLISocketTransportError.swift
+++ b/CLI/CLISocketTransportError.swift
@@ -1,0 +1,30 @@
+import Darwin
+import Foundation
+
+struct CLISocketTransportError: Error, CustomStringConvertible, CLISocketErrnoProviding {
+    let message: String
+    let socketErrnoValue: Int32
+
+    init(message: String, errnoValue: Int32) {
+        self.message = message
+        self.socketErrnoValue = errnoValue
+    }
+
+    init(connectPath path: String, errnoValue: Int32) {
+        let format = String(
+            localized: "cli.socket.error.connectFailed",
+            defaultValue: "Failed to connect to socket at %@ (%@, errno %lld)"
+        )
+        self.init(
+            message: String.localizedStringWithFormat(
+                format,
+                path,
+                String(cString: strerror(errnoValue)),
+                Int64(errnoValue)
+            ),
+            errnoValue: errnoValue
+        )
+    }
+
+    var description: String { message }
+}

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -63,8 +63,17 @@ private struct CLISocketTransportError: Error, CustomStringConvertible, CLISocke
     }
 
     init(connectPath path: String, errnoValue: Int32) {
+        let format = String(
+            localized: "cli.socket.error.connectFailed",
+            defaultValue: "Failed to connect to socket at %@ (%@, errno %lld)"
+        )
         self.init(
-            message: "Failed to connect to socket at \(path) (\(String(cString: strerror(errnoValue))), errno \(errnoValue))",
+            message: String.localizedStringWithFormat(
+                format,
+                path,
+                String(cString: strerror(errnoValue)),
+                Int64(errnoValue)
+            ),
             errnoValue: errnoValue
         )
     }
@@ -1845,10 +1854,20 @@ final class SocketClient {
                 operation.sawNewline = sawNewline
                 recordOperation(operation)
                 if data.isEmpty {
-                    throw CLISocketReadEOFError(message: "Socket closed before reply")
+                    throw CLISocketReadEOFError(
+                        message: String(
+                            localized: "cli.socket.error.closedBeforeReply",
+                            defaultValue: "Socket closed before reply"
+                        )
+                    )
                 }
                 if !sawNewline {
-                    throw CLISocketReadEOFError(message: "Socket closed before complete reply")
+                    throw CLISocketReadEOFError(
+                        message: String(
+                            localized: "cli.socket.error.closedBeforeCompleteReply",
+                            defaultValue: "Socket closed before complete reply"
+                        )
+                    )
                 }
                 receivedCompleteResponse = true
                 break

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -235,29 +235,7 @@ private final class CLISocketSentryTelemetry {
 
         let description = String(describing: error).lowercased()
         return description == "socket closed before reply" ||
-            description == "socket closed before complete reply" ||
-            Self.description(description, containsExactErrno: ENOENT) ||
-            Self.description(description, containsExactErrno: ECONNREFUSED) ||
-            Self.description(description, containsExactErrno: EPIPE)
-    }
-
-    private static func description(_ description: String, containsExactErrno expectedErrno: Int32) -> Bool {
-        let marker = "errno "
-        var searchStart = description.startIndex
-        while let range = description.range(of: marker, range: searchStart..<description.endIndex) {
-            var cursor = range.upperBound
-            let numberStart = cursor
-            while cursor < description.endIndex, description[cursor].isNumber {
-                cursor = description.index(after: cursor)
-            }
-            if numberStart != cursor,
-               let errnoValue = Int32(description[numberStart..<cursor]),
-               errnoValue == expectedErrno {
-                return true
-            }
-            searchStart = cursor
-        }
-        return false
+            description == "socket closed before complete reply"
     }
 
     private func isSocketTransportStage(stage: String, data: [String: Any]) -> Bool {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -142,6 +142,7 @@ private final class CLISocketSentryTelemetry {
 
     func captureError(stage: String, error: Error, data: [String: Any] = [:]) {
         guard shouldEmit else { return }
+        recordCaptureProbe(stage: stage, error: error)
 #if canImport(Sentry)
         Self.ensureStarted()
         flushPendingBreadcrumbs()
@@ -169,6 +170,15 @@ private final class CLISocketSentryTelemetry {
 
     private var shouldEmit: Bool {
         !disabledByEnv
+    }
+
+    private func recordCaptureProbe(stage: String, error: Error) {
+        guard let path = processEnv["CMUX_CLI_SENTRY_CAPTURE_PROBE_PATH"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !path.isEmpty else {
+            return
+        }
+        let payload = "stage=\(stage)\nerror=\(String(describing: error))\n"
+        try? payload.write(toFile: NSString(string: path).expandingTildeInPath, atomically: true, encoding: .utf8)
     }
 
 #if canImport(Sentry)

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -47,6 +47,29 @@ private enum CLISocketEnvironment {
     }
 }
 
+private protocol CLISocketErrnoProviding {
+    var socketErrnoValue: Int32 { get }
+}
+
+private struct CLISocketTransportError: Error, CustomStringConvertible, CLISocketErrnoProviding {
+    let message: String
+    let socketErrnoValue: Int32
+
+    init(message: String, errnoValue: Int32) {
+        self.message = message
+        self.socketErrnoValue = errnoValue
+    }
+
+    init(connectPath path: String, errnoValue: Int32) {
+        self.init(
+            message: "Failed to connect to socket at \(path) (\(String(cString: strerror(errnoValue))), errno \(errnoValue))",
+            errnoValue: errnoValue
+        )
+    }
+
+    var description: String { message }
+}
+
 private final class CLISocketSentryTelemetry {
     private struct PendingBreadcrumb {
         let message: String
@@ -143,7 +166,9 @@ private final class CLISocketSentryTelemetry {
     func captureError(stage: String, error: Error, data: [String: Any] = [:]) {
         guard shouldEmit else { return }
         guard !shouldSuppressCapture(stage: stage, error: error, data: data) else { return }
+#if DEBUG
         recordCaptureProbe(stage: stage, error: error)
+#endif
 #if canImport(Sentry)
         Self.ensureStarted()
         flushPendingBreadcrumbs()
@@ -178,10 +203,21 @@ private final class CLISocketSentryTelemetry {
             return false
         }
 
+        if let errnoProvider = error as? CLISocketErrnoProviding {
+            switch errnoProvider.socketErrnoValue {
+            case ENOENT, ECONNREFUSED, EPIPE:
+                return true
+            default:
+                return false
+            }
+        }
+
         let description = String(describing: error).lowercased()
-        return description.contains("socket not found at") ||
+        return description.contains("no such file or directory") ||
+            description.contains("socket not found at") ||
             description.contains("connection refused") ||
             description.contains("broken pipe") ||
+            description.contains("errno 2") ||
             description.contains("errno 32") ||
             description.contains("errno 61")
     }
@@ -191,15 +227,6 @@ private final class CLISocketSentryTelemetry {
             stage.hasPrefix("socket_command") ||
             data["socket_phase"] != nil ||
             data["socket_operation"] != nil
-    }
-
-    private func recordCaptureProbe(stage: String, error: Error) {
-        guard let path = processEnv["CMUX_CLI_SENTRY_CAPTURE_PROBE_PATH"]?.trimmingCharacters(in: .whitespacesAndNewlines),
-              !path.isEmpty else {
-            return
-        }
-        let payload = "stage=\(stage)\nerror=\(String(describing: error))\n"
-        try? payload.write(toFile: NSString(string: path).expandingTildeInPath, atomically: true, encoding: .utf8)
     }
 
 #if canImport(Sentry)
@@ -219,6 +246,17 @@ private final class CLISocketSentryTelemetry {
         crumb.message = message
         crumb.data = payload
         SentrySDK.addBreadcrumb(crumb)
+    }
+#endif
+
+#if DEBUG
+    private func recordCaptureProbe(stage: String, error: Error) {
+        guard let path = processEnv["CMUX_CLI_SENTRY_CAPTURE_PROBE_PATH"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !path.isEmpty else {
+            return
+        }
+        let payload = "stage=\(stage)\nerror=\(String(describing: error))\n"
+        try? payload.write(toFile: NSString(string: path).expandingTildeInPath, atomically: true, encoding: .utf8)
     }
 #endif
 
@@ -1568,15 +1606,6 @@ final class SocketClient {
         let port: UInt16
     }
 
-    private struct SocketConnectError: Error, CustomStringConvertible {
-        let path: String
-        let errnoValue: Int32
-
-        var description: String {
-            "Failed to connect to socket at \(path) (\(String(cString: strerror(errnoValue))), errno \(errnoValue))"
-        }
-    }
-
     private struct RelayCredentials {
         let relayID: String
         let relayToken: Data
@@ -1830,7 +1859,7 @@ final class SocketClient {
         // Verify socket is owned by the current user to prevent fake-socket attacks.
         var st = stat()
         guard stat(path, &st) == 0 else {
-            throw CLIError(message: "Socket not found at \(path)")
+            throw CLISocketTransportError(connectPath: path, errnoValue: errno)
         }
         guard (st.st_mode & mode_t(S_IFMT)) == mode_t(S_IFSOCK) else {
             throw CLIError(message: "Path exists at \(path) but is not a Unix socket")
@@ -1873,14 +1902,14 @@ final class SocketClient {
         let connectErrno = errno
         Darwin.close(socketFD)
         socketFD = -1
-        throw SocketConnectError(path: path, errnoValue: connectErrno)
+        throw CLISocketTransportError(connectPath: path, errnoValue: connectErrno)
     }
 
     private static func shouldRetryConnect(_ error: Error) -> Bool {
-        guard let error = error as? SocketConnectError else {
+        guard let error = error as? CLISocketErrnoProviding else {
             return false
         }
-        switch error.errnoValue {
+        switch error.socketErrnoValue {
         case ECONNREFUSED, EAGAIN, EWOULDBLOCK:
             return true
         default:
@@ -2058,8 +2087,9 @@ final class SocketClient {
                         throw CLIError(message: timeoutMessage)
                     }
                     let reason = String(cString: strerror(errorCode))
-                    throw CLIError(
-                        message: "\(failureMessage) (\(reason), errno \(errorCode))"
+                    throw CLISocketTransportError(
+                        message: "\(failureMessage) (\(reason), errno \(errorCode))",
+                        errnoValue: errorCode
                     )
                 }
                 if written == 0 {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -227,10 +227,6 @@ private final class CLISocketSentryTelemetry {
         let description = String(describing: error).lowercased()
         return description == "socket closed before reply" ||
             description == "socket closed before complete reply" ||
-            description.contains("no such file or directory") ||
-            description.contains("socket not found at") ||
-            description.contains("connection refused") ||
-            description.contains("broken pipe") ||
             Self.description(description, containsExactErrno: ENOENT) ||
             Self.description(description, containsExactErrno: ECONNREFUSED) ||
             Self.description(description, containsExactErrno: EPIPE)

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -47,46 +47,6 @@ private enum CLISocketEnvironment {
     }
 }
 
-private protocol CLISocketErrnoProviding {
-    var socketErrnoValue: Int32 { get }
-}
-
-private protocol CLISocketExpectedAvailabilityError {}
-
-private struct CLISocketTransportError: Error, CustomStringConvertible, CLISocketErrnoProviding {
-    let message: String
-    let socketErrnoValue: Int32
-
-    init(message: String, errnoValue: Int32) {
-        self.message = message
-        self.socketErrnoValue = errnoValue
-    }
-
-    init(connectPath path: String, errnoValue: Int32) {
-        let format = String(
-            localized: "cli.socket.error.connectFailed",
-            defaultValue: "Failed to connect to socket at %@ (%@, errno %lld)"
-        )
-        self.init(
-            message: String.localizedStringWithFormat(
-                format,
-                path,
-                String(cString: strerror(errnoValue)),
-                Int64(errnoValue)
-            ),
-            errnoValue: errnoValue
-        )
-    }
-
-    var description: String { message }
-}
-
-private struct CLISocketReadEOFError: Error, CustomStringConvertible, CLISocketExpectedAvailabilityError {
-    let message: String
-
-    var description: String { message }
-}
-
 private final class CLISocketSentryTelemetry {
     private struct PendingBreadcrumb {
         let message: String
@@ -104,6 +64,8 @@ private final class CLISocketSentryTelemetry {
     private var pendingBreadcrumbs: [PendingBreadcrumb] = []
 
 #if canImport(Sentry)
+    // Sentry initialization is a process-wide one-time side effect; this lock
+    // serializes only the startup flag and does not guard hot socket I/O.
     private static let startupLock = NSLock()
     private static var started = false
     private static let dsn = "https://ecba1ec90ecaee02a102fba931b6d2b3@o4507547940749312.ingest.us.sentry.io/4510796264636416"

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -142,6 +142,7 @@ private final class CLISocketSentryTelemetry {
 
     func captureError(stage: String, error: Error, data: [String: Any] = [:]) {
         guard shouldEmit else { return }
+        guard !shouldSuppressCapture(stage: stage, error: error, data: data) else { return }
         recordCaptureProbe(stage: stage, error: error)
 #if canImport(Sentry)
         Self.ensureStarted()
@@ -170,6 +171,26 @@ private final class CLISocketSentryTelemetry {
 
     private var shouldEmit: Bool {
         !disabledByEnv
+    }
+
+    private func shouldSuppressCapture(stage: String, error: Error, data: [String: Any]) -> Bool {
+        guard isSocketTransportStage(stage: stage, data: data) else {
+            return false
+        }
+
+        let description = String(describing: error).lowercased()
+        return description.contains("socket not found at") ||
+            description.contains("connection refused") ||
+            description.contains("broken pipe") ||
+            description.contains("errno 32") ||
+            description.contains("errno 61")
+    }
+
+    private func isSocketTransportStage(stage: String, data: [String: Any]) -> Bool {
+        stage == "socket_connect" ||
+            stage.hasPrefix("socket_command") ||
+            data["socket_phase"] != nil ||
+            data["socket_operation"] != nil
     }
 
     private func recordCaptureProbe(stage: String, error: Error) {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -51,6 +51,8 @@ private protocol CLISocketErrnoProviding {
     var socketErrnoValue: Int32 { get }
 }
 
+private protocol CLISocketExpectedAvailabilityError {}
+
 private struct CLISocketTransportError: Error, CustomStringConvertible, CLISocketErrnoProviding {
     let message: String
     let socketErrnoValue: Int32
@@ -66,6 +68,12 @@ private struct CLISocketTransportError: Error, CustomStringConvertible, CLISocke
             errnoValue: errnoValue
         )
     }
+
+    var description: String { message }
+}
+
+private struct CLISocketReadEOFError: Error, CustomStringConvertible, CLISocketExpectedAvailabilityError {
+    let message: String
 
     var description: String { message }
 }
@@ -203,6 +211,10 @@ private final class CLISocketSentryTelemetry {
             return false
         }
 
+        if error is CLISocketExpectedAvailabilityError {
+            return true
+        }
+
         if let errnoProvider = error as? CLISocketErrnoProviding {
             switch errnoProvider.socketErrnoValue {
             case ENOENT, ECONNREFUSED, EPIPE:
@@ -213,13 +225,34 @@ private final class CLISocketSentryTelemetry {
         }
 
         let description = String(describing: error).lowercased()
-        return description.contains("no such file or directory") ||
+        return description == "socket closed before reply" ||
+            description == "socket closed before complete reply" ||
+            description.contains("no such file or directory") ||
             description.contains("socket not found at") ||
             description.contains("connection refused") ||
             description.contains("broken pipe") ||
-            description.contains("errno 2") ||
-            description.contains("errno 32") ||
-            description.contains("errno 61")
+            Self.description(description, containsExactErrno: ENOENT) ||
+            Self.description(description, containsExactErrno: ECONNREFUSED) ||
+            Self.description(description, containsExactErrno: EPIPE)
+    }
+
+    private static func description(_ description: String, containsExactErrno expectedErrno: Int32) -> Bool {
+        let marker = "errno "
+        var searchStart = description.startIndex
+        while let range = description.range(of: marker, range: searchStart..<description.endIndex) {
+            var cursor = range.upperBound
+            let numberStart = cursor
+            while cursor < description.endIndex, description[cursor].isNumber {
+                cursor = description.index(after: cursor)
+            }
+            if numberStart != cursor,
+               let errnoValue = Int32(description[numberStart..<cursor]),
+               errnoValue == expectedErrno {
+                return true
+            }
+            searchStart = cursor
+        }
+        return false
     }
 
     private func isSocketTransportStage(stage: String, data: [String: Any]) -> Bool {
@@ -1816,10 +1849,10 @@ final class SocketClient {
                 operation.sawNewline = sawNewline
                 recordOperation(operation)
                 if data.isEmpty {
-                    throw CLIError(message: "Socket closed before reply")
+                    throw CLISocketReadEOFError(message: "Socket closed before reply")
                 }
                 if !sawNewline {
-                    throw CLIError(message: "Socket closed before complete reply")
+                    throw CLISocketReadEOFError(message: "Socket closed before complete reply")
                 }
                 receivedCompleteResponse = true
                 break

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -174,10 +174,10 @@ private final class CLISocketSentryTelemetry {
     func captureError(stage: String, error: Error, data: [String: Any] = [:]) {
         guard shouldEmit else { return }
         guard !shouldSuppressCapture(stage: stage, error: error, data: data) else { return }
+#if canImport(Sentry)
 #if DEBUG
         recordCaptureProbe(stage: stage, error: error)
 #endif
-#if canImport(Sentry)
         Self.ensureStarted()
         flushPendingBreadcrumbs()
         var context = baseContext()

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -85,7 +85,11 @@
 		A5D41203A1B2C3D4E5F60718 /* CLINotifyProcessIntegrationRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D41204A1B2C3D4E5F60718 /* CLINotifyProcessIntegrationRegressionTests.swift */; };
 		A5D41205A1B2C3D4E5F60718 /* CLINotifyProcessTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D41206A1B2C3D4E5F60718 /* CLINotifyProcessTestSupport.swift */; };
 		A5D41209A1B2C3D4E5F60718 /* CLIRovoDevHookPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D4120AA1B2C3D4E5F60718 /* CLIRovoDevHookPersistenceTests.swift */; };
+		C5343003A1B2C3D4E5F60719 /* CLISocketErrnoProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5343004A1B2C3D4E5F60719 /* CLISocketErrnoProviding.swift */; };
+		C5343005A1B2C3D4E5F60719 /* CLISocketExpectedAvailabilityError.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5343006A1B2C3D4E5F60719 /* CLISocketExpectedAvailabilityError.swift */; };
 		B900004AA1B2C3D4E5F60719 /* CLISocketPathResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = B900004BA1B2C3D4E5F60719 /* CLISocketPathResolver.swift */; };
+		C5343007A1B2C3D4E5F60719 /* CLISocketReadEOFError.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5343008A1B2C3D4E5F60719 /* CLISocketReadEOFError.swift */; };
+		C5343001A1B2C3D4E5F60719 /* CLISocketTransportError.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5343002A1B2C3D4E5F60719 /* CLISocketTransportError.swift */; };
 		C10D51700000000000000002 /* ClosedItemHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = C10D51700000000000000001 /* ClosedItemHistory.swift */; };
 		B9000025A1B2C3D4E5F60719 /* CloseWindowConfirmDialogUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000026A1B2C3D4E5F60719 /* CloseWindowConfirmDialogUITests.swift */; };
 		B9000023A1B2C3D4E5F60719 /* CloseWorkspaceCmdDUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000022A1B2C3D4E5F60719 /* CloseWorkspaceCmdDUITests.swift */; };
@@ -759,7 +763,11 @@
 		A5D41204A1B2C3D4E5F60718 /* CLINotifyProcessIntegrationRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLINotifyProcessIntegrationRegressionTests.swift; sourceTree = "<group>"; };
 		A5D41206A1B2C3D4E5F60718 /* CLINotifyProcessTestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLINotifyProcessTestSupport.swift; sourceTree = "<group>"; };
 		A5D4120AA1B2C3D4E5F60718 /* CLIRovoDevHookPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIRovoDevHookPersistenceTests.swift; sourceTree = "<group>"; };
+		C5343004A1B2C3D4E5F60719 /* CLISocketErrnoProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLISocketErrnoProviding.swift; sourceTree = "<group>"; };
+		C5343006A1B2C3D4E5F60719 /* CLISocketExpectedAvailabilityError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLISocketExpectedAvailabilityError.swift; sourceTree = "<group>"; };
 		B900004BA1B2C3D4E5F60719 /* CLISocketPathResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLISocketPathResolver.swift; sourceTree = "<group>"; };
+		C5343008A1B2C3D4E5F60719 /* CLISocketReadEOFError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLISocketReadEOFError.swift; sourceTree = "<group>"; };
+		C5343002A1B2C3D4E5F60719 /* CLISocketTransportError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLISocketTransportError.swift; sourceTree = "<group>"; };
 		C10D51700000000000000001 /* ClosedItemHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosedItemHistory.swift; sourceTree = "<group>"; };
 		B9000026A1B2C3D4E5F60719 /* CloseWindowConfirmDialogUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseWindowConfirmDialogUITests.swift; sourceTree = "<group>"; };
 		B9000022A1B2C3D4E5F60719 /* CloseWorkspaceCmdDUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseWorkspaceCmdDUITests.swift; sourceTree = "<group>"; };
@@ -1793,7 +1801,11 @@
 			children = (
 				B9000001A1B2C3D4E5F60719 /* cmux.swift */,
 				FEEDC1A50000000000000002 /* FeedEventClassifier.swift */,
+				C5343004A1B2C3D4E5F60719 /* CLISocketErrnoProviding.swift */,
+				C5343006A1B2C3D4E5F60719 /* CLISocketExpectedAvailabilityError.swift */,
 				B900004BA1B2C3D4E5F60719 /* CLISocketPathResolver.swift */,
+				C5343008A1B2C3D4E5F60719 /* CLISocketReadEOFError.swift */,
+				C5343002A1B2C3D4E5F60719 /* CLISocketTransportError.swift */,
 				C510C1E00000000000000001 /* SocketOperationTelemetry.swift */,
 				B9000030A1B2C3D4E5F60719 /* cmux_open.swift */,
 						B9000040A1B2C3D4E5F60719 /* CMUXCLI+SSHCommandSupport.swift */,
@@ -2669,7 +2681,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				D36A00030000000000000003 /* AgentHibernationLifecycleState.swift in Sources */,
+				C5343003A1B2C3D4E5F60719 /* CLISocketErrnoProviding.swift in Sources */,
+				C5343005A1B2C3D4E5F60719 /* CLISocketExpectedAvailabilityError.swift in Sources */,
 				B900004AA1B2C3D4E5F60719 /* CLISocketPathResolver.swift in Sources */,
+				C5343007A1B2C3D4E5F60719 /* CLISocketReadEOFError.swift in Sources */,
+				C5343001A1B2C3D4E5F60719 /* CLISocketTransportError.swift in Sources */,
 					B9000002A1B2C3D4E5F60719 /* cmux.swift in Sources */,
 				B9000034A1B2C3D4E5F60719 /* cmux_open.swift in Sources */,
 				D35110010000000000000003 /* CmuxApplicationSupportDirectories.swift in Sources */,

--- a/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
+++ b/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
@@ -663,6 +663,42 @@ final class CMUXCLIErrorOutputRegressionTests: XCTestCase {
         )
     }
 
+    func testSocketEOFDoesNotCaptureSentryTelemetry() throws {
+        let cliPath = try bundledCLIPath()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-cli-sentry-eof-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let socketPath = root.appendingPathComponent("cmux.sock", isDirectory: false).path
+        let responder = try UnixSocketResponder(path: socketPath, response: nil)
+        defer { responder.stop() }
+
+        let probePath = root.appendingPathComponent("sentry-probe.txt", isDirectory: false).path
+        var environment = ProcessInfo.processInfo.environment
+        for key in Array(environment.keys) where key.hasPrefix("CMUX_") {
+            environment.removeValue(forKey: key)
+        }
+        environment["CMUX_SOCKET_PATH"] = socketPath
+        environment["CMUX_CLI_SENTRY_CAPTURE_PROBE_PATH"] = probePath
+        environment["CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC"] = "0.1"
+
+        let result = runProcess(
+            executablePath: cliPath,
+            arguments: ["ping"],
+            environment: environment,
+            timeout: 5
+        )
+
+        XCTAssertFalse(result.timedOut, result.stdout)
+        XCTAssertNotEqual(result.status, 0, result.stdout)
+        XCTAssertTrue(result.stdout.lowercased().contains("socket closed before reply"), result.stdout)
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: probePath),
+            (try? String(contentsOfFile: probePath, encoding: .utf8)) ?? result.stdout
+        )
+    }
+
     func testThemesSetReloadsRunningAppAfterEveryThemeWrite() throws {
         let cliPath = try bundledCLIPath()
         let fileManager = FileManager.default
@@ -1669,7 +1705,7 @@ final class CMUXCLIErrorOutputRegressionTests: XCTestCase {
 
 private final class UnixSocketResponder {
     let path: String
-    private let response: String
+    private let response: String?
     private let responseDelay: TimeInterval
     private let queue = DispatchQueue(label: "com.cmux.tests.unix-socket-responder")
     private let lock = NSLock()
@@ -1677,7 +1713,7 @@ private final class UnixSocketResponder {
     private var requests: [String] = []
     private var listenerFD: Int32 = -1
 
-    init(path: String, response: String, responseDelay: TimeInterval = 0) throws {
+    init(path: String, response: String?, responseDelay: TimeInterval = 0) throws {
         self.path = path
         self.response = response
         self.responseDelay = responseDelay
@@ -1800,6 +1836,9 @@ private final class UnixSocketResponder {
         }
         if responseDelay > 0 {
             Thread.sleep(forTimeInterval: responseDelay)
+        }
+        guard let response else {
+            return
         }
         let payload = response + "\n"
         payload.withCString { pointer in

--- a/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
+++ b/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
@@ -699,6 +699,41 @@ final class CMUXCLIErrorOutputRegressionTests: XCTestCase {
         )
     }
 
+    func testNonSocketPathWithTransientTextStillCapturesSentryTelemetry() throws {
+        let cliPath = try bundledCLIPath()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-cli-sentry-fake-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let socketPath = root.appendingPathComponent("connection refused.sock", isDirectory: false).path
+        FileManager.default.createFile(atPath: socketPath, contents: Data())
+
+        let probePath = root.appendingPathComponent("sentry-probe.txt", isDirectory: false).path
+        var environment = ProcessInfo.processInfo.environment
+        for key in Array(environment.keys) where key.hasPrefix("CMUX_") {
+            environment.removeValue(forKey: key)
+        }
+        environment["CMUX_SOCKET_PATH"] = socketPath
+        environment["CMUX_CLI_SENTRY_CAPTURE_PROBE_PATH"] = probePath
+        environment["CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC"] = "0.1"
+
+        let result = runProcess(
+            executablePath: cliPath,
+            arguments: ["ping"],
+            environment: environment,
+            timeout: 5
+        )
+
+        XCTAssertFalse(result.timedOut, result.stdout)
+        XCTAssertNotEqual(result.status, 0, result.stdout)
+        XCTAssertTrue(result.stdout.contains("is not a Unix socket"), result.stdout)
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: probePath),
+            result.stdout
+        )
+    }
+
     func testThemesSetReloadsRunningAppAfterEveryThemeWrite() throws {
         let cliPath = try bundledCLIPath()
         let fileManager = FileManager.default

--- a/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
+++ b/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
@@ -593,6 +593,76 @@ final class CMUXCLIErrorOutputRegressionTests: XCTestCase {
         )
     }
 
+    func testMissingSocketDoesNotCaptureSentryTelemetry() throws {
+        let cliPath = try bundledCLIPath()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-cli-sentry-missing-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let socketPath = root.appendingPathComponent("missing.sock", isDirectory: false).path
+        let probePath = root.appendingPathComponent("sentry-probe.txt", isDirectory: false).path
+        var environment = ProcessInfo.processInfo.environment
+        for key in Array(environment.keys) where key.hasPrefix("CMUX_") {
+            environment.removeValue(forKey: key)
+        }
+        environment["CMUX_SOCKET_PATH"] = socketPath
+        environment["CMUX_CLI_SENTRY_CAPTURE_PROBE_PATH"] = probePath
+        environment["CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC"] = "0.1"
+
+        let result = runProcess(
+            executablePath: cliPath,
+            arguments: ["ping"],
+            environment: environment,
+            timeout: 5
+        )
+
+        XCTAssertFalse(result.timedOut, result.stdout)
+        XCTAssertNotEqual(result.status, 0, result.stdout)
+        XCTAssertTrue(result.stdout.lowercased().contains("no such file or directory"), result.stdout)
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: probePath),
+            (try? String(contentsOfFile: probePath, encoding: .utf8)) ?? result.stdout
+        )
+    }
+
+    func testBrokenPipeSocketWriteDoesNotCaptureSentryTelemetry() throws {
+        let cliPath = try bundledCLIPath()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-cli-sentry-pipe-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let socketPath = root.appendingPathComponent("cmux.sock", isDirectory: false).path
+        let responder = try ImmediateCloseUnixSocketResponder(path: socketPath)
+        defer { responder.stop() }
+
+        let probePath = root.appendingPathComponent("sentry-probe.txt", isDirectory: false).path
+        var environment = ProcessInfo.processInfo.environment
+        for key in Array(environment.keys) where key.hasPrefix("CMUX_") {
+            environment.removeValue(forKey: key)
+        }
+        environment["CMUX_SOCKET_PATH"] = socketPath
+        environment["CMUX_CLI_SENTRY_CAPTURE_PROBE_PATH"] = probePath
+        environment["CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC"] = "0.1"
+
+        let payload = String(repeating: "x", count: 128 * 1024)
+        let result = runProcess(
+            executablePath: cliPath,
+            arguments: ["display-message", payload],
+            environment: environment,
+            timeout: 5
+        )
+
+        XCTAssertFalse(result.timedOut, result.stdout)
+        XCTAssertNotEqual(result.status, 0, result.stdout)
+        XCTAssertTrue(result.stdout.lowercased().contains("broken pipe"), result.stdout)
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: probePath),
+            (try? String(contentsOfFile: probePath, encoding: .utf8)) ?? result.stdout
+        )
+    }
+
     func testThemesSetReloadsRunningAppAfterEveryThemeWrite() throws {
         let cliPath = try bundledCLIPath()
         let fileManager = FileManager.default
@@ -1734,6 +1804,112 @@ private final class UnixSocketResponder {
         let payload = response + "\n"
         payload.withCString { pointer in
             _ = write(clientFD, pointer, strlen(pointer))
+        }
+    }
+
+    private static func posixError(_ operation: String) -> NSError {
+        NSError(
+            domain: NSPOSIXErrorDomain,
+            code: Int(errno),
+            userInfo: [NSLocalizedDescriptionKey: "\(operation) failed: \(String(cString: strerror(errno)))"]
+        )
+    }
+}
+
+private final class ImmediateCloseUnixSocketResponder {
+    let path: String
+    private let queue = DispatchQueue(label: "com.cmux.tests.immediate-close-unix-socket-responder")
+    private let lock = NSLock()
+    private var stopped = false
+    private var listenerFD: Int32 = -1
+
+    init(path: String) throws {
+        self.path = path
+
+        unlink(path)
+        listenerFD = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard listenerFD >= 0 else {
+            throw Self.posixError("socket")
+        }
+
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        let maxLength = MemoryLayout.size(ofValue: address.sun_path)
+        guard path.utf8.count < maxLength else {
+            throw NSError(
+                domain: NSPOSIXErrorDomain,
+                code: Int(ENAMETOOLONG),
+                userInfo: [NSLocalizedDescriptionKey: "Unix socket path is too long: \(path)"]
+            )
+        }
+        path.withCString { pointer in
+            withUnsafeMutablePointer(to: &address.sun_path) { tuplePointer in
+                let buffer = UnsafeMutableRawPointer(tuplePointer).assumingMemoryBound(to: CChar.self)
+                strncpy(buffer, pointer, maxLength - 1)
+            }
+        }
+
+        let bindResult = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { socketPointer in
+                Darwin.bind(listenerFD, socketPointer, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard bindResult == 0 else {
+            let error = Self.posixError("bind")
+            close(listenerFD)
+            listenerFD = -1
+            throw error
+        }
+        guard listen(listenerFD, 8) == 0 else {
+            let error = Self.posixError("listen")
+            close(listenerFD)
+            listenerFD = -1
+            throw error
+        }
+
+        let fd = listenerFD
+        queue.async { [weak self] in
+            self?.acceptLoop(listenerFD: fd)
+        }
+    }
+
+    deinit {
+        stop()
+    }
+
+    func stop() {
+        lock.lock()
+        guard !stopped else {
+            lock.unlock()
+            return
+        }
+        stopped = true
+        let fd = listenerFD
+        listenerFD = -1
+        lock.unlock()
+
+        if fd >= 0 {
+            close(fd)
+        }
+        unlink(path)
+    }
+
+    private var isStopped: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return stopped
+    }
+
+    private func acceptLoop(listenerFD: Int32) {
+        while !isStopped {
+            let clientFD = accept(listenerFD, nil, nil)
+            if clientFD < 0 {
+                if isStopped {
+                    return
+                }
+                continue
+            }
+            close(clientFD)
         }
     }
 

--- a/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
+++ b/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
@@ -557,6 +557,42 @@ final class CMUXCLIErrorOutputRegressionTests: XCTestCase {
         )
     }
 
+    func testStaleSocketConnectRefusalDoesNotCaptureSentryTelemetry() throws {
+        let cliPath = try bundledCLIPath()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-cli-sentry-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let socketPath = root.appendingPathComponent("cmux.sock", isDirectory: false).path
+        try createStaleSocketFile(at: socketPath)
+        defer { unlink(socketPath) }
+
+        let probePath = root.appendingPathComponent("sentry-probe.txt", isDirectory: false).path
+        var environment = ProcessInfo.processInfo.environment
+        for key in Array(environment.keys) where key.hasPrefix("CMUX_") {
+            environment.removeValue(forKey: key)
+        }
+        environment["CMUX_SOCKET_PATH"] = socketPath
+        environment["CMUX_CLI_SENTRY_CAPTURE_PROBE_PATH"] = probePath
+        environment["CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC"] = "0.1"
+
+        let result = runProcess(
+            executablePath: cliPath,
+            arguments: ["ping"],
+            environment: environment,
+            timeout: 5
+        )
+
+        XCTAssertFalse(result.timedOut, result.stdout)
+        XCTAssertNotEqual(result.status, 0, result.stdout)
+        XCTAssertTrue(result.stdout.lowercased().contains("connection refused"), result.stdout)
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: probePath),
+            (try? String(contentsOfFile: probePath, encoding: .utf8)) ?? result.stdout
+        )
+    }
+
     func testThemesSetReloadsRunningAppAfterEveryThemeWrite() throws {
         let cliPath = try bundledCLIPath()
         let fileManager = FileManager.default
@@ -1399,6 +1435,49 @@ final class CMUXCLIErrorOutputRegressionTests: XCTestCase {
     private func lstatPathExists(_ path: String) -> Bool {
         var st = stat()
         return lstat(path, &st) == 0
+    }
+
+    private func createStaleSocketFile(at path: String) throws {
+        unlink(path)
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else {
+            throw NSError(
+                domain: NSPOSIXErrorDomain,
+                code: Int(errno),
+                userInfo: [NSLocalizedDescriptionKey: "socket failed: \(String(cString: strerror(errno)))"]
+            )
+        }
+        defer { close(fd) }
+
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        let maxLength = MemoryLayout.size(ofValue: address.sun_path)
+        guard path.utf8.count < maxLength else {
+            throw NSError(
+                domain: NSPOSIXErrorDomain,
+                code: Int(ENAMETOOLONG),
+                userInfo: [NSLocalizedDescriptionKey: "Unix socket path is too long: \(path)"]
+            )
+        }
+        path.withCString { pointer in
+            withUnsafeMutablePointer(to: &address.sun_path) { tuplePointer in
+                let buffer = UnsafeMutableRawPointer(tuplePointer).assumingMemoryBound(to: CChar.self)
+                strncpy(buffer, pointer, maxLength - 1)
+            }
+        }
+
+        let bindResult = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { socketPointer in
+                Darwin.bind(fd, socketPointer, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard bindResult == 0 else {
+            throw NSError(
+                domain: NSPOSIXErrorDomain,
+                code: Int(errno),
+                userInfo: [NSLocalizedDescriptionKey: "bind failed: \(String(cString: strerror(errno)))"]
+            )
+        }
     }
 
     private func runShell(_ command: String, timeout: TimeInterval) -> ProcessRunResult {

--- a/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
+++ b/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
@@ -706,7 +706,7 @@ final class CMUXCLIErrorOutputRegressionTests: XCTestCase {
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: root) }
 
-        let socketPath = root.appendingPathComponent("connection refused.sock", isDirectory: false).path
+        let socketPath = root.appendingPathComponent("connection refused errno 61.sock", isDirectory: false).path
         FileManager.default.createFile(atPath: socketPath, contents: Data())
 
         let probePath = root.appendingPathComponent("sentry-probe.txt", isDirectory: false).path


### PR DESCRIPTION
## Summary
- suppress CLI Sentry captures for expected socket transport availability failures: missing socket, connection refused, and broken pipe
- add a regression probe/test for stale cmux.sock connection refusal telemetry

## Testing
- git diff --check
- Not run locally: xcodebuild tests are prohibited on the user Mac because they launch cmux DEV

## Issues
- Related: Sentry CMUXTERM-MACOS-DW

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5343"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783151220&installation_id=133855650&pr_number=5343&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5343&signature=4cb5fce250da55936ff7c48cf372d9b0cf35f2312caf92a2d400ae81f975a687"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CLI error typing, Sentry filtering for known socket errno/EOF cases, and test harnesses; user-visible errors stay similar and real socket misconfigurations still report.
> 
> **Overview**
> Stops **Sentry** from reporting routine CLI socket failures when the app is down or the socket closes early, while still capturing genuine misconfiguration (e.g. path exists but is not a Unix socket).
> 
> `captureError` now skips socket-transport stages (`socket_connect`, `socket_command*`, or telemetry keys `socket_phase` / `socket_operation`) when the error is typed as expected availability (`CLISocketReadEOFError`), carries suppressible errno (`ENOENT`, `ECONNREFUSED`, `EPIPE` via `CLISocketErrnoProviding`), or matches the exact EOF user messages. **DEBUG** builds can write a capture probe file via `CMUX_CLI_SENTRY_CAPTURE_PROBE_PATH` only when a capture actually runs (after suppression).
> 
> **SocketClient** replaces ad hoc connect/EOF/write failures with `CLISocketTransportError` and `CLISocketReadEOFError`, uses localized strings for connect/EOF, and keeps connect retry logic on errno via the shared protocol. Regression tests exercise missing socket, stale bind/refused, broken pipe, EOF, and a negative case where misleading path text still triggers Sentry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 505746530a298d0a256df16c34023c8e9b2f5f87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppress Sentry errors for expected CLI socket failures (missing socket, connection refused, broken pipe, EOF) during socket transport to cut noise without hiding real issues. Localizes CLI socket connect/EOF error messages, and moves socket transport error types out of `cmux.swift` for simpler typing and suppression.

- **Bug Fixes**
  - Suppression only in socket-transport stages (`socket_connect`, `socket_command*`, or when `socket_phase`/`socket_operation` is set).
  - Typed and errno-aware detection: `CLISocketReadEOFError`; `CLISocketTransportError` with `CLISocketErrnoProviding`; suppress `ENOENT`, `ECONNREFUSED`, `EPIPE`. Removed message-based errno text suppression; fallbacks match only exact EOF strings.
  - DEBUG probe writes only on actual captures; tests cover missing/refused/broken-pipe/EOF and ensure non-socket paths with misleading names still capture.

- **Refactors**
  - Moved `CLISocketTransportError`, `CLISocketReadEOFError`, `CLISocketErrnoProviding`, and `CLISocketExpectedAvailabilityError` into dedicated CLI files.
  - Replaced `SocketConnectError` with `CLISocketTransportError` and unified connect/write/EOF handling to simplify suppression and retry logic.

<sup>Written for commit 505746530a298d0a256df16c34023c8e9b2f5f87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of socket closure and transport failures; suppressed noisy telemetry for expected socket/connect/read errors (EOF, missing socket, connection refused, broken pipe and common errno-derived messages).

* **New Features**
  * DEBUG-only probe file support via env var for local capture debugging; probes are skipped for suppressed socket errors.

* **Tests**
  * Added regression tests for stale/missing/closed/broken-pipe socket scenarios verifying telemetry suppression and probe behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->