### PR TITLE
Fix TextBox IME replacement range crash

### DIFF
--- a/Sources/TextBoxInput.swift
+++ b/Sources/TextBoxInput.swift
@@ -3636,6 +3636,7 @@ final class TextBoxInputTextView: NSTextView {
     }
 
     override func insertText(_ insertString: Any, replacementRange: NSRange) {
+        let replacementRange = sanitizedTextStorageReplacementRange(replacementRange)
         queueAutomaticAttachmentFileCleanup(in: replacementRange)
         super.insertText(insertString, replacementRange: replacementRange)
         flushAutomaticAttachmentFileCleanup()
@@ -3643,7 +3644,11 @@ final class TextBoxInputTextView: NSTextView {
     }
 
     override func setMarkedText(_ string: Any, selectedRange: NSRange, replacementRange: NSRange) {
-        super.setMarkedText(string, selectedRange: selectedRange, replacementRange: replacementRange)
+        super.setMarkedText(
+            string,
+            selectedRange: Self.sanitizedRange(selectedRange, upperBound: Self.textInputStringLength(string)),
+            replacementRange: sanitizedTextStorageReplacementRange(replacementRange)
+        )
         onMarkedTextStateChanged(hasMarkedText())
     }
 
@@ -3655,6 +3660,27 @@ final class TextBoxInputTextView: NSTextView {
     override func didChangeText() {
         super.didChangeText()
         flushAutomaticAttachmentFileCleanup()
+    }
+
+    private func sanitizedTextStorageReplacementRange(_ range: NSRange) -> NSRange {
+        guard range.location != NSNotFound else { return range }
+        return Self.sanitizedRange(range, upperBound: attributedString().length)
+    }
+
+    private static func sanitizedRange(_ range: NSRange, upperBound: Int) -> NSRange {
+        guard range.location != NSNotFound else { return range }
+        let upperBound = max(0, upperBound)
+        let location = min(max(0, range.location), upperBound)
+        let length = min(max(0, range.length), upperBound - location)
+        return NSRange(location: location, length: length)
+    }
+
+    private static func textInputStringLength(_ string: Any) -> Int {
+        if let attributed = string as? NSAttributedString {
+            return attributed.length
+        }
+        let plain = (string as? String) ?? String(describing: string)
+        return (plain as NSString).length
     }
 
     override func copy(_ sender: Any?) {

--- a/Sources/TextBoxInput.swift
+++ b/Sources/TextBoxInput.swift
@@ -3644,9 +3644,10 @@ final class TextBoxInputTextView: NSTextView {
     }
 
     override func setMarkedText(_ string: Any, selectedRange: NSRange, replacementRange: NSRange) {
+        let markedTextLength = Self.textInputStringLength(string)
         super.setMarkedText(
             string,
-            selectedRange: Self.sanitizedRange(selectedRange, upperBound: Self.textInputStringLength(string)),
+            selectedRange: Self.sanitizedMarkedTextSelectionRange(selectedRange, markedTextLength: markedTextLength),
             replacementRange: sanitizedTextStorageReplacementRange(replacementRange)
         )
         onMarkedTextStateChanged(hasMarkedText())
@@ -3673,6 +3674,14 @@ final class TextBoxInputTextView: NSTextView {
         let location = min(max(0, range.location), upperBound)
         let length = min(max(0, range.length), upperBound - location)
         return NSRange(location: location, length: length)
+    }
+
+    private static func sanitizedMarkedTextSelectionRange(_ range: NSRange, markedTextLength: Int) -> NSRange {
+        let markedTextLength = max(0, markedTextLength)
+        guard range.location != NSNotFound else {
+            return NSRange(location: markedTextLength, length: 0)
+        }
+        return sanitizedRange(range, upperBound: markedTextLength)
     }
 
     private static func textInputStringLength(_ string: Any) -> Int {

--- a/cmuxTests/TextBoxMentionCompletionTests.swift
+++ b/cmuxTests/TextBoxMentionCompletionTests.swift
@@ -178,6 +178,20 @@ struct TextBoxMentionCompletionTests {
     }
 
     @Test
+    func testTextBoxSetMarkedTextNormalizesMissingSelectedRangeToMarkedTextEnd() {
+        let textView = TextBoxInputTextView(frame: NSRect(x: 0, y: 0, width: 320, height: 30))
+
+        textView.setMarkedText(
+            "日本語",
+            selectedRange: NSRange(location: NSNotFound, length: 0),
+            replacementRange: NSRange(location: NSNotFound, length: 0)
+        )
+
+        #expect(textView.string == "日本語")
+        #expect(textView.selectedRange() == NSRange(location: 3, length: 0))
+    }
+
+    @Test
     func testTextBoxPublishesCommittedIMETextBeforeClearingMarkedState() {
         var text = ""
         var attachments: [TextBoxAttachment] = []

--- a/cmuxTests/TextBoxMentionCompletionTests.swift
+++ b/cmuxTests/TextBoxMentionCompletionTests.swift
@@ -166,6 +166,18 @@ struct TextBoxMentionCompletionTests {
     }
 
     @Test
+    func testTextBoxInsertTextClampsStaleIMERangeAtUTF16End() {
+        let textView = TextBoxInputTextView(frame: NSRect(x: 0, y: 0, width: 320, height: 30))
+        textView.string = "日本語"
+        textView.setSelectedRange(NSRange(location: 3, length: 0))
+
+        textView.insertText("、", replacementRange: NSRange(location: 3, length: 1))
+
+        #expect(textView.string == "日本語、")
+        #expect(textView.selectedRange() == NSRange(location: 4, length: 0))
+    }
+
+    @Test
     func testTextBoxPublishesCommittedIMETextBeforeClearingMarkedState() {
         var text = ""
         var attachments: [TextBoxAttachment] = []


### PR DESCRIPTION
## Summary
- Clamp TextBox NSTextInput replacement ranges to current UTF-16 storage bounds before calling NSTextView.insertText/setMarkedText.
- Add a regression test for a stale IME replacement range at the Japanese text UTF-16 end boundary.

## Testing
- scripts/lint-pbxproj-test-wiring.sh: pass
- Remote AWS cmux-unit red/green attempt: invalid, runner ran out of disk during app compilation before executing the focused test.

## Issues
- Fixes Sentry CMUXTERM-MACOS-VD0: https://manaflow.sentry.io/issues/7525935721/

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5346"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783151865&installation_id=133855650&pr_number=5346&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5346&signature=86e0c2a23d01433f5f2ff1bc40d864e2ca83b852785fee6d8304c8e7745d5a4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized defensive bounds checks on text input paths; regression test added; no auth or data-layer changes.
> 
> **Overview**
> Fixes a crash when **IME** (e.g. Japanese input) passes **replacement or marked-text ranges** that extend past the current **UTF-16** text storage—such as a stale range at the end of `日本語`.
> 
> **`TextBoxInputTextView`** now clamps `replacementRange` and `selectedRange` to valid bounds before calling **`insertText`** / **`setMarkedText`**, using the attributed string length (or the incoming marked string length for selection). Attachment cleanup and marked-text callbacks use the same clamped ranges.
> 
> A unit test covers inserting with an out-of-range replacement at the UTF-16 end boundary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c8139954deb3c0e1c0dbe5acec63b5ee18b1532. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clamp and normalize IME replacement and selection ranges in `TextBoxInputTextView` to valid UTF-16 bounds to prevent NSRange crashes and ensure correct caret placement. Fixes Sentry CMUXTERM-MACOS-VD0.

- **Bug Fixes**
  - Clamp `insertText`/`setMarkedText` `replacementRange` to the current text length; sanitize `selectedRange` within marked text, defaulting to the end when `NSNotFound`.
  - Add tests for clamping a stale IME range at the Japanese end boundary and for normalizing a missing `selectedRange`.

<sup>Written for commit 57e092f86dc6f5cf3d96ebb2afc5814c09c863e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented out-of-bounds ranges during input-method (IME) interactions by sanitizing and clamping replacement/selection ranges, improving stability for international input.
  * Ensured marked-text handling no longer propagates invalid ranges, fixing cursor/selection anomalies.

* **Tests**
  * Added tests covering insertion and marked-text scenarios with international characters and IME edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->