### PR TITLE
Harden Git index hex parsing

### DIFF
--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -4042,9 +4042,7 @@ class TabManager: ObservableObject {
             let mtimeNanoseconds = readBigEndianUInt32(bytes, at: offset + 12)
             let mode = readBigEndianUInt32(bytes, at: offset + 24)
             let size = readBigEndianUInt32(bytes, at: offset + 36)
-            let objectID = bytes[(offset + 40)..<(offset + 60)].map {
-                String(format: "%02x", $0)
-            }.joined()
+            let objectID = gitHexString(bytes[(offset + 40)..<(offset + 60)])
             let flags = readBigEndianUInt16(bytes, at: offset + 60)
             let pathLength = Int(flags & 0x0fff)
             let hasExtendedFlags = version >= 3 && (flags & 0x4000) != 0
@@ -4112,7 +4110,7 @@ class TabManager: ObservableObject {
             }
         }
 
-        let checksum = bytes[(bytes.count - 20)..<bytes.count].map { String(format: "%02x", $0) }.joined()
+        let checksum = gitHexString(bytes[(bytes.count - 20)..<bytes.count])
         return GitIndexSnapshot(
             entries: entries,
             signature: checksum,
@@ -4150,7 +4148,7 @@ class TabManager: ObservableObject {
             appendString(entry.objectID)
             appendByte(0)
         }
-        return String(format: "%016llx", CUnsignedLongLong(hash))
+        return gitHexString(hash)
     }
 
     private nonisolated static func gitlinkWorktreeCommit(
@@ -4213,7 +4211,28 @@ class TabManager: ObservableObject {
         guard let data = try? Data(contentsOf: indexURL), data.count >= 20 else {
             return nil
         }
-        return data.suffix(20).map { String(format: "%02x", $0) }.joined()
+        return gitHexString(data.suffix(20))
+    }
+
+    private nonisolated static func gitHexString<C: Collection>(_ bytes: C) -> String where C.Element == UInt8 {
+        let table = Array("0123456789abcdef".utf8)
+        var encoded: [UInt8] = []
+        encoded.reserveCapacity(bytes.count * 2)
+        for byte in bytes {
+            encoded.append(table[Int(byte >> 4)])
+            encoded.append(table[Int(byte & 0x0f)])
+        }
+        return String(decoding: encoded, as: UTF8.self)
+    }
+
+    private nonisolated static func gitHexString(_ value: UInt64) -> String {
+        let table = Array("0123456789abcdef".utf8)
+        var encoded = Array(repeating: UInt8(ascii: "0"), count: 16)
+        for index in 0..<16 {
+            let shift = UInt64((15 - index) * 4)
+            encoded[index] = table[Int((value >> shift) & 0x0f)]
+        }
+        return String(decoding: encoded, as: UTF8.self)
     }
 
     private nonisolated static func readGitIndexV4PathStripLength(
@@ -4899,6 +4918,15 @@ class TabManager: ObservableObject {
             return []
         }
         return githubRepositorySlugs(fromGitRemoteVOutput: output)
+    }
+
+    nonisolated static func gitTrackedChangesSnapshotForTesting(
+        directory: String
+    ) -> (isDirty: Bool, indexSignature: String?, indexContentSignature: String?)? {
+        guard let repository = resolveGitRepository(containing: directory) else {
+            return nil
+        }
+        return gitTrackedChangesSnapshot(repository: repository)
     }
 #endif
 

--- a/cmuxTests/WorkspacePullRequestSidebarTests.swift
+++ b/cmuxTests/WorkspacePullRequestSidebarTests.swift
@@ -1197,6 +1197,62 @@ final class WorkspacePullRequestSidebarTests: XCTestCase {
         )
     }
 
+    func testGitIndexParserHexEncodingIsStableUnderConcurrentSnapshots() async throws {
+        let repoURL = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "cmux-sidebar-index-hex-concurrency-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: repoURL, withIntermediateDirectories: true)
+        try writeMinimalGitRepository(at: repoURL)
+        let trackedURL = repoURL.appendingPathComponent("tracked.txt")
+        try "seed\n".write(to: trackedURL, atomically: true, encoding: .utf8)
+        let objectIDBytes = Array(UInt8(0)...UInt8(19))
+        try writeGitIndexVersion2EntryFromStat(
+            at: repoURL,
+            trackedPath: "tracked.txt",
+            indexMode: 0o100644,
+            signatureByte: 0xab,
+            objectIDBytes: objectIDBytes
+        )
+        defer {
+            try? FileManager.default.removeItem(at: repoURL)
+        }
+
+        let baseline = try XCTUnwrap(
+            TabManager.gitTrackedChangesSnapshotForTesting(directory: repoURL.path)
+        )
+        XCTAssertFalse(baseline.isDirty)
+        XCTAssertEqual(
+            baseline.indexSignature,
+            "abababababababababababababababababababab",
+            "Git index checksums should be encoded as stable lowercase two-character hex bytes."
+        )
+        let baselineContentSignature = try XCTUnwrap(baseline.indexContentSignature)
+
+        let mismatchCount = await withTaskGroup(of: Int.self) { group in
+            for _ in 0..<32 {
+                group.addTask {
+                    var mismatches = 0
+                    for _ in 0..<128 {
+                        let snapshot = TabManager.gitTrackedChangesSnapshotForTesting(directory: repoURL.path)
+                        if snapshot?.isDirty != false ||
+                            snapshot?.indexSignature != baseline.indexSignature ||
+                            snapshot?.indexContentSignature != baselineContentSignature {
+                            mismatches += 1
+                        }
+                    }
+                    return mismatches
+                }
+            }
+            var total = 0
+            for await mismatches in group {
+                total += mismatches
+            }
+            return total
+        }
+        XCTAssertEqual(mismatchCount, 0)
+    }
+
     func testIndexContentChangeAfterWorktreeDirtyRemainsDirty() throws {
         let defaults = UserDefaults.standard
         let previousWatchGitStatus = defaults.object(forKey: SidebarWorkspaceDetailDefaults.watchGitStatusKey)


### PR DESCRIPTION
## Summary
- Replace Git index byte-to-hex formatting in `TabManager.gitIndexSnapshot` with a pure Swift encoder.
- Add focused coverage for stable Git index signatures and concurrent parser snapshots.

## Testing
- `xcodebuild -project cmux.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/cmux-sentgit-build build` passed locally.
- `./scripts/lint-pbxproj-test-wiring.sh` passed locally.
- AWS `cmux-unit` focused test passed: `WorkspacePullRequestSidebarTests/testGitIndexParserHexEncodingIsStableUnderConcurrentSnapshots`, 1 test, 0 failures.

## Issues
- Related: https://manaflow.sentry.io/issues/7524984838/

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5347"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783152146&installation_id=133855650&pr_number=5347&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5347&signature=fc034060df84b54444d7051c3a6332da45b3fa2c4eed212c4b57ef9e4f9a230a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how index signatures are computed for workspace dirty-state detection; incorrect encoding could mis-report clean/dirty, but scope is limited to hex formatting with new regression coverage.
> 
> **Overview**
> **Replaces** `String(format:)`-based Git index hex encoding in `TabManager` with dedicated **`gitHexString`** helpers for byte collections and `UInt64`, used when parsing object IDs, index checksums, content signatures, and file signatures.
> 
> **Adds** a test-only `gitTrackedChangesSnapshotForTesting` entry point and **`testGitIndexParserHexEncodingIsStableUnderConcurrentSnapshots`**, which asserts lowercase stable hex and runs many concurrent snapshot reads to guard against flaky or non-deterministic encoding (related Sentry issue).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fb3c2c853046b9646e1683b6117c9287ec6157f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced Git index hex encoding with a pure Swift encoder to ensure stable, lowercase hex for object IDs and checksums and to avoid concurrency-related crashes in `TabManager.gitIndexSnapshot`. Added a focused test to verify stability under concurrent snapshots.

- **Bug Fixes**
  - Replaced per-byte `String(format: "%02x")` with `gitHexString(...)` for object IDs, trailing index checksum, and content hash formatting.
  - Added a UInt64 hex encoder to remove remaining `String(format:)` usage in signature paths.
  - Exposed `gitTrackedChangesSnapshotForTesting(...)` and added a concurrency test to confirm hex stability and checksum consistency.

<sup>Written for commit 1fb3c2c853046b9646e1683b6117c9287ec6157f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized internal hex encoding generation for improved consistency.

* **Tests**
  * Added test coverage to verify snapshot stability under concurrent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->