### PR TITLE
Fix omnibar caret preservation on click focus

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -13668,13 +13668,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     private func focusBrowserAddressBar(in panel: BrowserPanel) {
 #if DEBUG
-        let requestId = panel.requestAddressBarFocus()
+        let requestId = panel.requestAddressBarFocus(selectionIntent: .selectAll)
         cmuxDebugLog(
             "browser.focus.addressBar.request panel=\(panel.id.uuidString.prefix(5)) " +
             "request=\(requestId.uuidString.prefix(8)) \(browserFocusStateSnapshot())"
         )
 #else
-        _ = panel.requestAddressBarFocus()
+        _ = panel.requestAddressBarFocus(selectionIntent: .selectAll)
 #endif
         browserAddressBarFocusedPanelId = panel.id
 #if DEBUG

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -9772,7 +9772,7 @@ struct ContentView: View {
 
     private func focusFocusedBrowserAddressBar() -> Bool {
         guard let panel = tabManager.focusedBrowserPanel else { return false }
-        _ = panel.requestAddressBarFocus()
+        _ = panel.requestAddressBarFocus(selectionIntent: .selectAll)
         NotificationCenter.default.post(name: .browserFocusAddressBar, object: panel.id)
         return true
     }

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -15,6 +15,15 @@ import CommonCrypto
 import Security
 #endif
 
+enum BrowserAddressBarFocusSelectionIntent: Equatable {
+    case preserveFieldEditorSelection
+    case selectAll
+
+    var shouldSelectAll: Bool {
+        self == .selectAll
+    }
+}
+
 fileprivate func dedupedCanonicalURLs(_ urls: [URL]) -> [URL] {
     var seen = Set<String>()
     var result: [URL] = []
@@ -3448,6 +3457,7 @@ final class BrowserPanel: Panel, ObservableObject {
     /// Sticky omnibar-focus intent. This survives view mount timing races and is
     /// cleared only after BrowserPanelView acknowledges handling it.
     @Published private(set) var pendingAddressBarFocusRequestId: UUID?
+    private(set) var pendingAddressBarFocusSelectionIntent: BrowserAddressBarFocusSelectionIntent = .preserveFieldEditorSelection
 
     /// Per-surface browser chrome visibility. Diff and artifact viewers can hide
     /// the omnibar without changing the global browser default.
@@ -6268,6 +6278,7 @@ extension BrowserPanel {
         abandonRestoredSessionHistoryIfNeeded()
 
         pendingAddressBarFocusRequestId = nil
+        pendingAddressBarFocusSelectionIntent = .preserveFieldEditorSelection
         preferredFocusIntent = .addressBar
         suppressOmnibarAutofocusUntil = nil
         suppressWebViewFocusUntil = nil
@@ -7275,6 +7286,7 @@ extension BrowserPanel {
         if created { searchState = BrowserSearchState(needle: recoveredNeedle) }
         let shouldSelectAll = created && !recoveredNeedle.isEmpty
         pendingAddressBarFocusRequestId = nil
+        pendingAddressBarFocusSelectionIntent = .preserveFieldEditorSelection
         NotificationCenter.default.post(name: .browserDidBlurAddressBar, object: id)
         let generation = beginSearchFocusRequest(reason: "startFind")
         postBrowserSearchFocusNotification(reason: "immediate", generation: generation, selectAll: shouldSelectAll)
@@ -7376,6 +7388,7 @@ extension BrowserPanel {
         }
 
         pendingAddressBarFocusRequestId = nil
+        pendingAddressBarFocusSelectionIntent = .preserveFieldEditorSelection
         isBrowserFocusModeActive = true
         clearBrowserFocusModeEscapeArms(reason: "\(reason).activate")
         preferredFocusIntent = .webView
@@ -7628,27 +7641,35 @@ extension BrowserPanel {
     }
 
     @discardableResult
-    func requestAddressBarFocus() -> UUID {
+    func requestAddressBarFocus(
+        selectionIntent: BrowserAddressBarFocusSelectionIntent = .selectAll
+    ) -> UUID {
         clearBrowserFocusMode(reason: "requestAddressBarFocus")
         setOmnibarVisible(true)
         preferredFocusIntent = .addressBar
         invalidateSearchFocusRequests(reason: "requestAddressBarFocus")
         beginSuppressWebViewFocusForAddressBar()
         if let pendingAddressBarFocusRequestId {
+            if selectionIntent == .selectAll {
+                pendingAddressBarFocusSelectionIntent = .selectAll
+            }
 #if DEBUG
             cmuxDebugLog(
                 "browser.focus.addressBar.request panel=\(id.uuidString.prefix(5)) " +
-                "request=\(pendingAddressBarFocusRequestId.uuidString.prefix(8)) result=reuse_pending"
+                "request=\(pendingAddressBarFocusRequestId.uuidString.prefix(8)) result=reuse_pending " +
+                "selection=\(String(describing: pendingAddressBarFocusSelectionIntent))"
             )
 #endif
             return pendingAddressBarFocusRequestId
         }
         let requestId = UUID()
+        pendingAddressBarFocusSelectionIntent = selectionIntent
         pendingAddressBarFocusRequestId = requestId
 #if DEBUG
         cmuxDebugLog(
             "browser.focus.addressBar.request panel=\(id.uuidString.prefix(5)) " +
-            "request=\(requestId.uuidString.prefix(8)) result=new"
+            "request=\(requestId.uuidString.prefix(8)) result=new " +
+            "selection=\(String(describing: selectionIntent))"
         )
 #endif
         return requestId
@@ -7660,6 +7681,7 @@ extension BrowserPanel {
         isOmnibarVisible = visible
         if !visible {
             pendingAddressBarFocusRequestId = nil
+            pendingAddressBarFocusSelectionIntent = .preserveFieldEditorSelection
             if preferredFocusIntent == .addressBar {
                 preferredFocusIntent = .webView
             }
@@ -7765,7 +7787,7 @@ extension BrowserPanel {
             focus()
             return true
         case .addressBar:
-            let requestId = requestAddressBarFocus()
+            let requestId = requestAddressBarFocus(selectionIntent: .preserveFieldEditorSelection)
             NotificationCenter.default.post(name: .browserFocusAddressBar, object: id)
 #if DEBUG
             cmuxDebugLog(
@@ -7869,6 +7891,7 @@ extension BrowserPanel {
             return
         }
         pendingAddressBarFocusRequestId = nil
+        pendingAddressBarFocusSelectionIntent = .preserveFieldEditorSelection
 #if DEBUG
         cmuxDebugLog(
             "browser.focus.addressBar.requestAck panel=\(id.uuidString.prefix(5)) " +

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -7642,7 +7642,7 @@ extension BrowserPanel {
 
     @discardableResult
     func requestAddressBarFocus(
-        selectionIntent: BrowserAddressBarFocusSelectionIntent = .selectAll
+        selectionIntent: BrowserAddressBarFocusSelectionIntent = .preserveFieldEditorSelection
     ) -> UUID {
         clearBrowserFocusMode(reason: "requestAddressBarFocus")
         setOmnibarVisible(true)

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -7650,8 +7650,18 @@ extension BrowserPanel {
         invalidateSearchFocusRequests(reason: "requestAddressBarFocus")
         beginSuppressWebViewFocusForAddressBar()
         if let pendingAddressBarFocusRequestId {
-            if selectionIntent == .selectAll {
+            if selectionIntent == .selectAll,
+               pendingAddressBarFocusSelectionIntent != .selectAll {
+                let requestId = UUID()
                 pendingAddressBarFocusSelectionIntent = .selectAll
+                self.pendingAddressBarFocusRequestId = requestId
+#if DEBUG
+                cmuxDebugLog(
+                    "browser.focus.addressBar.request panel=\(id.uuidString.prefix(5)) " +
+                    "request=\(requestId.uuidString.prefix(8)) result=upgrade_to_select_all"
+                )
+#endif
+                return requestId
             }
 #if DEBUG
             cmuxDebugLog(

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -7,15 +7,6 @@ import ObjectiveC
 private var cmuxBrowserPanelNeedsRenderingStateReattachKey: UInt8 = 0
 let browserOmnibarTextFieldIdentifier = NSUserInterfaceItemIdentifier("cmux.browserOmnibarTextField")
 
-private enum OmnibarFocusGainedSelectionIntent {
-    case preserveFieldEditorSelection
-    case selectAll
-
-    var shouldSelectAll: Bool {
-        self == .selectAll
-    }
-}
-
 private func browserPanelViewObjectID(_ object: AnyObject?) -> String {
     guard let object else { return "nil" }
     return String(describing: Unmanaged.passUnretained(object).toOpaque())
@@ -465,7 +456,7 @@ struct BrowserPanelView: View {
     @State private var focusModeShortcutHintMonitor = WindowScopedShortcutHintModifierMonitor(activation: .commandOnly)
     @State private var lastHandledAddressBarFocusRequestId: UUID?
     @State private var omnibarSelectAllRequestId: UInt64 = 0
-    @State private var pendingFocusGainedSelectionIntent: OmnibarFocusGainedSelectionIntent = .preserveFieldEditorSelection
+    @State private var pendingFocusGainedSelectionIntent: BrowserAddressBarFocusSelectionIntent = .preserveFieldEditorSelection
     @State private var isBrowserProfileMenuPresented = false
     @State private var isBrowserThemeMenuPresented = false
     // `.onAppear` is not a reliable once-signal for a portal-hosted pane: it can
@@ -1864,7 +1855,7 @@ struct BrowserPanelView: View {
     private func setAddressBarFocused(
         _ focused: Bool,
         reason: String,
-        focusGainedSelectionIntent: OmnibarFocusGainedSelectionIntent = .preserveFieldEditorSelection
+        focusGainedSelectionIntent: BrowserAddressBarFocusSelectionIntent = .preserveFieldEditorSelection
     ) {
 #if DEBUG
         if addressBarFocused == focused {
@@ -2033,22 +2024,24 @@ struct BrowserPanelView: View {
             return
         }
         lastHandledAddressBarFocusRequestId = requestId
+        let selectionIntent = panel.pendingAddressBarFocusSelectionIntent
         panel.beginSuppressWebViewFocusForAddressBar()
 #if DEBUG
         logBrowserFocusState(
             event: "addressBarFocus.request.apply",
-            detail: "request=\(requestId.uuidString.prefix(8))"
+            detail: "request=\(requestId.uuidString.prefix(8)) selection=\(String(describing: selectionIntent))"
         )
 #endif
 
         if addressBarFocused {
-            // Re-run selection behavior when focus is explicitly requested again
-            // while already focused, without replacing an in-progress edit.
+            // Re-run explicit selection behavior only for requests that own it
+            // (Cmd+L), without replacing a caret from focus restoration.
             let effects = omnibarReduce(
                 state: &omnibarState,
                 event: .focusReasserted(
                     shouldSelectAll: browserOmnibarShouldSelectAllOnFocusReassertion(
-                        isUserEditing: omnibarState.isUserEditing
+                        isUserEditing: omnibarState.isUserEditing,
+                        selectionIntent: selectionIntent
                     )
                 )
             )
@@ -2064,7 +2057,7 @@ struct BrowserPanelView: View {
             setAddressBarFocused(
                 true,
                 reason: "request.apply",
-                focusGainedSelectionIntent: .selectAll
+                focusGainedSelectionIntent: selectionIntent
             )
 #if DEBUG
             logBrowserFocusState(
@@ -3848,8 +3841,11 @@ func browserOmnibarShouldReacquireFocusAfterEndEditing(
     desiredOmnibarFocus && !nextResponderIsOtherTextField
 }
 
-func browserOmnibarShouldSelectAllOnFocusReassertion(isUserEditing: Bool) -> Bool {
-    !isUserEditing
+func browserOmnibarShouldSelectAllOnFocusReassertion(
+    isUserEditing: Bool,
+    selectionIntent: BrowserAddressBarFocusSelectionIntent
+) -> Bool {
+    selectionIntent.shouldSelectAll && !isUserEditing
 }
 
 final class OmnibarNativeTextField: NSTextField {

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -456,7 +456,6 @@ struct BrowserPanelView: View {
     @State private var focusModeShortcutHintMonitor = WindowScopedShortcutHintModifierMonitor(activation: .commandOnly)
     @State private var lastHandledAddressBarFocusRequestId: UUID?
     @State private var omnibarSelectAllRequestId: UInt64 = 0
-    @State private var suppressNextFocusGainedSelectAll: Bool = false
     @State private var isBrowserProfileMenuPresented = false
     @State private var isBrowserThemeMenuPresented = false
     // `.onAppear` is not a reliable once-signal for a portal-hosted pane: it can
@@ -976,16 +975,13 @@ struct BrowserPanelView: View {
 #endif
                 onRequestPanelFocus()
             }
-            let shouldSelectAll = !suppressNextFocusGainedSelectAll
-            suppressNextFocusGainedSelectAll = false
             let effects = omnibarReduce(
                 state: &omnibarState,
-                event: .focusGained(currentURLString: urlString, shouldSelectAll: shouldSelectAll)
+                event: .focusGained(currentURLString: urlString)
             )
             applyOmnibarEffects(effects)
             refreshInlineCompletion()
         } else {
-            suppressNextFocusGainedSelectAll = false
             panel.endSuppressWebViewFocusForAddressBar()
             NotificationCenter.default.post(name: .browserDidBlurAddressBar, object: panel.id)
             if suppressNextFocusLostRevert {
@@ -2043,6 +2039,13 @@ struct BrowserPanelView: View {
             )
 #endif
         } else {
+            let urlString = panel.preferredURLStringForOmnibar() ?? ""
+            let effects = omnibarReduce(
+                state: &omnibarState,
+                event: .focusGained(currentURLString: urlString, shouldSelectAll: true)
+            )
+            applyOmnibarEffects(effects)
+            refreshInlineCompletion()
             setAddressBarFocused(true, reason: "request.apply")
 #if DEBUG
             logBrowserFocusState(
@@ -2319,7 +2322,6 @@ struct BrowserPanelView: View {
         if !wasAddressBarFocused {
             // Mark focused before pane selection converges so WebKit focus is not
             // briefly re-acquired during `focusPane`.
-            suppressNextFocusGainedSelectAll = true
             setAddressBarFocused(true, reason: "omnibar.tap")
         }
         if shouldRequestPanelFocus && wasAddressBarFocused {
@@ -3515,7 +3517,7 @@ struct OmnibarState: Equatable {
 }
 
 enum OmnibarEvent: Equatable {
-    case focusGained(currentURLString: String, shouldSelectAll: Bool = true)
+    case focusGained(currentURLString: String, shouldSelectAll: Bool = false)
     case focusReasserted(shouldSelectAll: Bool = true)
     case focusLostRevertBuffer(currentURLString: String)
     case focusLostPreserveBuffer(currentURLString: String)

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -2005,6 +2005,17 @@ struct BrowserPanelView: View {
         guard let requestId = panel.pendingAddressBarFocusRequestId else {
             return
         }
+        guard panel.panelType == .browser else {
+            lastHandledAddressBarFocusRequestId = requestId
+            panel.acknowledgeAddressBarFocusRequest(requestId)
+#if DEBUG
+            logBrowserFocusState(
+                event: "addressBarFocus.request.apply.skip",
+                detail: "reason=chrome_hidden request=\(requestId.uuidString.prefix(8))"
+            )
+#endif
+            return
+        }
         guard !isCommandPaletteVisibleForPanelWindow() else {
 #if DEBUG
             logBrowserFocusState(

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -7,6 +7,15 @@ import ObjectiveC
 private var cmuxBrowserPanelNeedsRenderingStateReattachKey: UInt8 = 0
 let browserOmnibarTextFieldIdentifier = NSUserInterfaceItemIdentifier("cmux.browserOmnibarTextField")
 
+private enum OmnibarFocusGainedSelectionIntent {
+    case preserveFieldEditorSelection
+    case selectAll
+
+    var shouldSelectAll: Bool {
+        self == .selectAll
+    }
+}
+
 private func browserPanelViewObjectID(_ object: AnyObject?) -> String {
     guard let object else { return "nil" }
     return String(describing: Unmanaged.passUnretained(object).toOpaque())
@@ -456,6 +465,7 @@ struct BrowserPanelView: View {
     @State private var focusModeShortcutHintMonitor = WindowScopedShortcutHintModifierMonitor(activation: .commandOnly)
     @State private var lastHandledAddressBarFocusRequestId: UUID?
     @State private var omnibarSelectAllRequestId: UInt64 = 0
+    @State private var pendingFocusGainedSelectionIntent: OmnibarFocusGainedSelectionIntent = .preserveFieldEditorSelection
     @State private var isBrowserProfileMenuPresented = false
     @State private var isBrowserThemeMenuPresented = false
     // `.onAppear` is not a reliable once-signal for a portal-hosted pane: it can
@@ -965,6 +975,8 @@ struct BrowserPanelView: View {
 #endif
         let urlString = panel.preferredURLStringForOmnibar() ?? ""
         if focused {
+            let selectionIntent = pendingFocusGainedSelectionIntent
+            pendingFocusGainedSelectionIntent = .preserveFieldEditorSelection
             panel.beginSuppressWebViewFocusForAddressBar()
             NotificationCenter.default.post(name: .browserDidFocusAddressBar, object: panel.id)
             // Only request panel focus if this pane isn't currently focused. When already
@@ -977,11 +989,12 @@ struct BrowserPanelView: View {
             }
             let effects = omnibarReduce(
                 state: &omnibarState,
-                event: .focusGained(currentURLString: urlString)
+                event: .focusGained(currentURLString: urlString, shouldSelectAll: selectionIntent.shouldSelectAll)
             )
             applyOmnibarEffects(effects)
             refreshInlineCompletion()
         } else {
+            pendingFocusGainedSelectionIntent = .preserveFieldEditorSelection
             panel.endSuppressWebViewFocusForAddressBar()
             NotificationCenter.default.post(name: .browserDidBlurAddressBar, object: panel.id)
             if suppressNextFocusLostRevert {
@@ -1848,7 +1861,11 @@ struct BrowserPanelView: View {
         canHandleOmnibarSelectionNavigation() && hasActionableOmnibarSuggestions
     }
 
-    private func setAddressBarFocused(_ focused: Bool, reason: String) {
+    private func setAddressBarFocused(
+        _ focused: Bool,
+        reason: String,
+        focusGainedSelectionIntent: OmnibarFocusGainedSelectionIntent = .preserveFieldEditorSelection
+    ) {
 #if DEBUG
         if addressBarFocused == focused {
             logBrowserFocusState(
@@ -1862,6 +1879,11 @@ struct BrowserPanelView: View {
             )
         }
 #endif
+        if focused, !addressBarFocused {
+            pendingFocusGainedSelectionIntent = focusGainedSelectionIntent
+        } else if !focused {
+            pendingFocusGainedSelectionIntent = .preserveFieldEditorSelection
+        }
         addressBarFocused = focused
         if focused {
             panel.noteAddressBarFocused()
@@ -2039,14 +2061,11 @@ struct BrowserPanelView: View {
             )
 #endif
         } else {
-            let urlString = panel.preferredURLStringForOmnibar() ?? ""
-            let effects = omnibarReduce(
-                state: &omnibarState,
-                event: .focusGained(currentURLString: urlString, shouldSelectAll: true)
+            setAddressBarFocused(
+                true,
+                reason: "request.apply",
+                focusGainedSelectionIntent: .selectAll
             )
-            applyOmnibarEffects(effects)
-            refreshInlineCompletion()
-            setAddressBarFocused(true, reason: "request.apply")
 #if DEBUG
             logBrowserFocusState(
                 event: "addressBarFocus.request.apply",

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -2040,7 +2040,6 @@ struct BrowserPanelView: View {
                 state: &omnibarState,
                 event: .focusReasserted(
                     shouldSelectAll: browserOmnibarShouldSelectAllOnFocusReassertion(
-                        isUserEditing: omnibarState.isUserEditing,
                         selectionIntent: selectionIntent
                     )
                 )
@@ -3842,10 +3841,9 @@ func browserOmnibarShouldReacquireFocusAfterEndEditing(
 }
 
 func browserOmnibarShouldSelectAllOnFocusReassertion(
-    isUserEditing: Bool,
     selectionIntent: BrowserAddressBarFocusSelectionIntent
 ) -> Bool {
-    selectionIntent.shouldSelectAll && !isUserEditing
+    selectionIntent.shouldSelectAll
 }
 
 final class OmnibarNativeTextField: NSTextField {

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -3885,6 +3885,48 @@ final class OmnibarNativeTextFieldCaretTests: XCTestCase {
         )
     }
 
+    /// Pane focus reconciliation can reassert omnibar focus after the click has
+    /// already placed the caret. That restore path must not treat the click as
+    /// Cmd+L and select the full URL.
+    func testFocusRestoreReassertionDoesNotClobberSingleClickCaret() {
+        let window = makeCaretProbeWindow()
+        let field = installOmnibarField(in: window)
+        window.makeKeyAndOrderFront(nil)
+        defer {
+            cleanup(window: window, field: field)
+        }
+
+        singleClick(field: field, in: window)
+
+        guard let editor = field.currentEditor() as? NSTextView else {
+            XCTFail("Expected a field editor after the click acquired focus")
+            return
+        }
+        XCTAssertEqual(editor.selectedRange().length, 0, "Test precondition: native click should place a caret")
+
+        var state = OmnibarState()
+        _ = omnibarReduce(state: &state, event: .focusGained(currentURLString: field.stringValue))
+        let effects = omnibarReduce(
+            state: &state,
+            event: .focusReasserted(
+                shouldSelectAll: browserOmnibarShouldSelectAllOnFocusReassertion(isUserEditing: state.isUserEditing)
+            )
+        )
+
+        let coordinator = makeCoordinator()
+        coordinator.parentField = field
+        if effects.shouldSelectAll {
+            coordinator.queueSelectAllRequest(1)
+            _ = coordinator.applyPendingSelectAllIfPossible(field: field)
+        }
+
+        XCTAssertEqual(
+            editor.selectedRange().length,
+            0,
+            "Focus-restore reassertion must preserve the caret placed by the focusing click"
+        )
+    }
+
     func testExplicitSelectAllRequestStillSelectsWholeURL() {
         let window = makeCaretProbeWindow()
         let field = installOmnibarField(in: window)

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -722,10 +722,12 @@ final class BrowserPanelAddressBarFocusRequestTests: XCTestCase {
 
         let requestId = panel.requestAddressBarFocus()
         XCTAssertEqual(panel.pendingAddressBarFocusRequestId, requestId)
+        XCTAssertEqual(panel.pendingAddressBarFocusSelectionIntent, .selectAll)
         XCTAssertTrue(panel.shouldSuppressWebViewFocus())
 
         panel.acknowledgeAddressBarFocusRequest(requestId)
         XCTAssertNil(panel.pendingAddressBarFocusRequestId)
+        XCTAssertEqual(panel.pendingAddressBarFocusSelectionIntent, .preserveFieldEditorSelection)
 
         // Acknowledgement only clears the durable request; focus suppression follows
         // explicit blur state transitions.
@@ -736,11 +738,12 @@ final class BrowserPanelAddressBarFocusRequestTests: XCTestCase {
 
     func testRequestCoalescesWhilePending() {
         let panel = BrowserPanel(workspaceId: UUID())
-        let firstRequest = panel.requestAddressBarFocus()
+        let firstRequest = panel.requestAddressBarFocus(selectionIntent: .preserveFieldEditorSelection)
         let secondRequest = panel.requestAddressBarFocus()
 
         XCTAssertEqual(firstRequest, secondRequest)
         XCTAssertEqual(panel.pendingAddressBarFocusRequestId, firstRequest)
+        XCTAssertEqual(panel.pendingAddressBarFocusSelectionIntent, .selectAll)
     }
 
     func testStaleAcknowledgementDoesNotClearNewestRequest() {
@@ -3909,7 +3912,10 @@ final class OmnibarNativeTextFieldCaretTests: XCTestCase {
         let effects = omnibarReduce(
             state: &state,
             event: .focusReasserted(
-                shouldSelectAll: browserOmnibarShouldSelectAllOnFocusReassertion(isUserEditing: state.isUserEditing)
+                shouldSelectAll: browserOmnibarShouldSelectAllOnFocusReassertion(
+                    isUserEditing: state.isUserEditing,
+                    selectionIntent: .preserveFieldEditorSelection
+                )
             )
         )
 

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -3745,40 +3745,94 @@ final class OmnibarNativeTextFieldCaretTests: XCTestCase {
         return event
     }
 
-    /// Regression for https://github.com/manaflow-ai/cmux/issues/5268: a single,
-    /// unmodified click that focuses the omnibar must leave a caret (zero-length
-    /// selection) at the click position, not select the entire URL.
-    func testSingleClickFocusPlacesCaretInsteadOfSelectingAll() {
+    private func makeCoordinator(
+        panelId: UUID = UUID(),
+        isFocused: Bool = true
+    ) -> OmnibarTextFieldRepresentable.Coordinator {
+        var text = ""
+        var focused = isFocused
+        return OmnibarTextFieldRepresentable.Coordinator(
+            parent: OmnibarTextFieldRepresentable(
+                panelId: panelId,
+                text: Binding(
+                    get: { text },
+                    set: { text = $0 }
+                ),
+                isFocused: Binding(
+                    get: { focused },
+                    set: { focused = $0 }
+                ),
+                selectAllRequestId: 0,
+                inlineCompletion: nil,
+                placeholder: "",
+                onTap: {},
+                onSubmit: {},
+                onEscape: {},
+                onFieldLostFocus: {},
+                onMoveSelection: { _ in },
+                onDeleteSelectedSuggestion: {},
+                onAcceptInlineCompletion: {},
+                onDeleteBackwardWithInlineSelection: {},
+                onClearTypedPrefixWithInlineSelection: {},
+                onDeleteWordBackwardWithInlineSelection: {},
+                onSelectionChanged: { _, _ in },
+                shouldSuppressWebViewFocus: { false }
+            )
+        )
+    }
+
+    private func makeCaretProbeWindow() -> CaretProbeWindow {
         let window = CaretProbeWindow(
             contentRect: NSRect(x: 0, y: 0, width: 480, height: 120),
             styleMask: [.titled, .closable],
             backing: .buffered,
             defer: false
         )
-        let container = NSView(frame: window.contentRect(forFrameRect: window.frame))
-        window.contentView = container
+        window.contentView = NSView(frame: window.contentRect(forFrameRect: window.frame))
+        return window
+    }
 
+    private func installOmnibarField(
+        in window: NSWindow,
+        stringValue: String = "https://github.com/manaflow-ai/cmux"
+    ) -> OmnibarNativeTextField {
         let field = OmnibarNativeTextField(frame: NSRect(x: 12, y: 80, width: 360, height: 24))
         field.font = .systemFont(ofSize: 12)
         field.isEditable = true
         field.isSelectable = true
         field.isEnabled = true
-        field.stringValue = "https://github.com/manaflow-ai/cmux"
-        container.addSubview(field)
+        field.stringValue = stringValue
+        window.contentView?.addSubview(field)
+        return field
+    }
 
+    private func cleanup(window: NSWindow, field: OmnibarNativeTextField) {
+        field.removeFromSuperview()
+        window.contentView = nil
+        window.orderOut(nil)
+    }
+
+    private func singleClick(field: OmnibarNativeTextField, in window: NSWindow) {
+        let clickPoint = NSPoint(x: field.frame.midX, y: field.frame.midY)
+        let pointInWindow = window.contentView?.convert(clickPoint, to: nil) ?? clickPoint
+        field.mouseDown(with: makeMouseEvent(type: .leftMouseDown, location: pointInWindow, window: window))
+        field.mouseUp(with: makeMouseEvent(type: .leftMouseUp, location: pointInWindow, window: window))
+    }
+
+    /// Regression for https://github.com/manaflow-ai/cmux/issues/5268: a single,
+    /// unmodified click that focuses the omnibar must leave a caret (zero-length
+    /// selection) at the click position, not select the entire URL.
+    func testSingleClickFocusPlacesCaretInsteadOfSelectingAll() {
+        let window = makeCaretProbeWindow()
+        let field = installOmnibarField(in: window)
         window.makeKeyAndOrderFront(nil)
         defer {
-            field.removeFromSuperview()
-            window.contentView = nil
-            window.orderOut(nil)
+            cleanup(window: window, field: field)
         }
 
         // Do NOT pre-focus: the bug only manifests on the click that first acquires
         // focus, where the old code forced a select-all on mouseUp.
-        let clickPoint = NSPoint(x: field.frame.midX, y: field.frame.midY)
-        let pointInWindow = container.convert(clickPoint, to: nil)
-        field.mouseDown(with: makeMouseEvent(type: .leftMouseDown, location: pointInWindow, window: window))
-        field.mouseUp(with: makeMouseEvent(type: .leftMouseUp, location: pointInWindow, window: window))
+        singleClick(field: field, in: window)
 
         guard let editor = field.currentEditor() as? NSTextView else {
             XCTFail("Expected a field editor after the click acquired focus")
@@ -3790,6 +3844,72 @@ final class OmnibarNativeTextFieldCaretTests: XCTestCase {
             editor.selectedRange().length,
             0,
             "A single click must place a caret, not select the whole URL"
+        )
+    }
+
+    /// The native single-click path can place a caret correctly and still be
+    /// clobbered later by the SwiftUI focus-gained effect. This exercises that
+    /// full behavior path instead of only checking the field's mouse handlers.
+    func testSwiftUIFocusGainedEffectDoesNotClobberSingleClickCaret() {
+        let window = makeCaretProbeWindow()
+        let field = installOmnibarField(in: window)
+        window.makeKeyAndOrderFront(nil)
+        defer {
+            cleanup(window: window, field: field)
+        }
+
+        singleClick(field: field, in: window)
+
+        guard let editor = field.currentEditor() as? NSTextView else {
+            XCTFail("Expected a field editor after the click acquired focus")
+            return
+        }
+        XCTAssertEqual(editor.selectedRange().length, 0, "Test precondition: native click should place a caret")
+
+        var state = OmnibarState()
+        let effects = omnibarReduce(
+            state: &state,
+            event: .focusGained(currentURLString: field.stringValue)
+        )
+        let coordinator = makeCoordinator()
+        coordinator.parentField = field
+        if effects.shouldSelectAll {
+            coordinator.queueSelectAllRequest(1)
+            _ = coordinator.applyPendingSelectAllIfPossible(field: field)
+        }
+
+        XCTAssertEqual(
+            editor.selectedRange().length,
+            0,
+            "Focus-gained handling must preserve the caret placed by the focusing click"
+        )
+    }
+
+    func testExplicitSelectAllRequestStillSelectsWholeURL() {
+        let window = makeCaretProbeWindow()
+        let field = installOmnibarField(in: window)
+        window.makeKeyAndOrderFront(nil)
+        defer {
+            cleanup(window: window, field: field)
+        }
+
+        XCTAssertTrue(window.makeFirstResponder(field))
+        guard let editor = field.currentEditor() as? NSTextView else {
+            XCTFail("Expected a field editor after focusing text field")
+            return
+        }
+        let textLength = (editor.string as NSString).length
+        editor.setSelectedRange(NSRange(location: textLength, length: 0))
+
+        let coordinator = makeCoordinator()
+        coordinator.parentField = field
+        coordinator.queueSelectAllRequest(1)
+
+        XCTAssertTrue(coordinator.applyPendingSelectAllIfPossible(field: field))
+        XCTAssertEqual(
+            editor.selectedRange(),
+            NSRange(location: 0, length: textLength),
+            "Explicit omnibar focus requests such as Cmd+L must still select the whole URL"
         )
     }
 }

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -722,7 +722,7 @@ final class BrowserPanelAddressBarFocusRequestTests: XCTestCase {
 
         let requestId = panel.requestAddressBarFocus()
         XCTAssertEqual(panel.pendingAddressBarFocusRequestId, requestId)
-        XCTAssertEqual(panel.pendingAddressBarFocusSelectionIntent, .selectAll)
+        XCTAssertEqual(panel.pendingAddressBarFocusSelectionIntent, .preserveFieldEditorSelection)
         XCTAssertTrue(panel.shouldSuppressWebViewFocus())
 
         panel.acknowledgeAddressBarFocusRequest(requestId)
@@ -740,6 +740,16 @@ final class BrowserPanelAddressBarFocusRequestTests: XCTestCase {
         let panel = BrowserPanel(workspaceId: UUID())
         let firstRequest = panel.requestAddressBarFocus(selectionIntent: .preserveFieldEditorSelection)
         let secondRequest = panel.requestAddressBarFocus()
+
+        XCTAssertEqual(firstRequest, secondRequest)
+        XCTAssertEqual(panel.pendingAddressBarFocusRequestId, firstRequest)
+        XCTAssertEqual(panel.pendingAddressBarFocusSelectionIntent, .preserveFieldEditorSelection)
+    }
+
+    func testExplicitSelectAllRequestUpgradesPendingPreserveRequest() {
+        let panel = BrowserPanel(workspaceId: UUID())
+        let firstRequest = panel.requestAddressBarFocus(selectionIntent: .preserveFieldEditorSelection)
+        let secondRequest = panel.requestAddressBarFocus(selectionIntent: .selectAll)
 
         XCTAssertEqual(firstRequest, secondRequest)
         XCTAssertEqual(panel.pendingAddressBarFocusRequestId, firstRequest)

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -751,8 +751,8 @@ final class BrowserPanelAddressBarFocusRequestTests: XCTestCase {
         let firstRequest = panel.requestAddressBarFocus(selectionIntent: .preserveFieldEditorSelection)
         let secondRequest = panel.requestAddressBarFocus(selectionIntent: .selectAll)
 
-        XCTAssertEqual(firstRequest, secondRequest)
-        XCTAssertEqual(panel.pendingAddressBarFocusRequestId, firstRequest)
+        XCTAssertNotEqual(firstRequest, secondRequest)
+        XCTAssertEqual(panel.pendingAddressBarFocusRequestId, secondRequest)
         XCTAssertEqual(panel.pendingAddressBarFocusSelectionIntent, .selectAll)
     }
 
@@ -3923,7 +3923,6 @@ final class OmnibarNativeTextFieldCaretTests: XCTestCase {
             state: &state,
             event: .focusReasserted(
                 shouldSelectAll: browserOmnibarShouldSelectAllOnFocusReassertion(
-                    isUserEditing: state.isUserEditing,
                     selectionIntent: .preserveFieldEditorSelection
                 )
             )

--- a/cmuxTests/OmnibarAndToolsTests.swift
+++ b/cmuxTests/OmnibarAndToolsTests.swift
@@ -447,7 +447,7 @@ final class OmnibarStateMachineTests: XCTestCase {
         XCTAssertTrue(state.isFocused)
         XCTAssertEqual(state.buffer, "https://example.com/")
         XCTAssertFalse(state.isUserEditing)
-        XCTAssertTrue(effects.shouldSelectAll)
+        XCTAssertFalse(effects.shouldSelectAll)
 
         effects = omnibarReduce(state: &state, event: .bufferChanged("exam"))
         XCTAssertTrue(state.isUserEditing)

--- a/cmuxTests/OmnibarAndToolsTests.swift
+++ b/cmuxTests/OmnibarAndToolsTests.swift
@@ -412,7 +412,7 @@ final class OmnibarStateMachineTests: XCTestCase {
         XCTAssertFalse(effects.shouldSelectAll)
     }
 
-    func testRefocusRequestPreservesEditingBuffer() throws {
+    func testExplicitRefocusRequestPreservesEditingBufferAndSelectsAll() throws {
         var state = OmnibarState()
 
         _ = omnibarReduce(
@@ -425,7 +425,6 @@ final class OmnibarStateMachineTests: XCTestCase {
             state: &state,
             event: .focusReasserted(
                 shouldSelectAll: browserOmnibarShouldSelectAllOnFocusReassertion(
-                    isUserEditing: state.isUserEditing,
                     selectionIntent: .selectAll
                 )
             )
@@ -435,25 +434,17 @@ final class OmnibarStateMachineTests: XCTestCase {
         XCTAssertTrue(state.isUserEditing)
         XCTAssertEqual(state.currentURLString, "https://example.com/")
         XCTAssertEqual(state.buffer, "abcdef")
-        XCTAssertFalse(effects.shouldSelectAll)
+        XCTAssertTrue(effects.shouldSelectAll)
     }
 
-    func testFocusReassertionDoesNotSelectAllDuringUserEdit() throws {
-        XCTAssertFalse(
-            browserOmnibarShouldSelectAllOnFocusReassertion(
-                isUserEditing: true,
-                selectionIntent: .selectAll
-            )
-        )
+    func testFocusReassertionHonorsSelectionIntent() throws {
         XCTAssertTrue(
             browserOmnibarShouldSelectAllOnFocusReassertion(
-                isUserEditing: false,
                 selectionIntent: .selectAll
             )
         )
         XCTAssertFalse(
             browserOmnibarShouldSelectAllOnFocusReassertion(
-                isUserEditing: false,
                 selectionIntent: .preserveFieldEditorSelection
             )
         )

--- a/cmuxTests/OmnibarAndToolsTests.swift
+++ b/cmuxTests/OmnibarAndToolsTests.swift
@@ -424,7 +424,10 @@ final class OmnibarStateMachineTests: XCTestCase {
         let effects = omnibarReduce(
             state: &state,
             event: .focusReasserted(
-                shouldSelectAll: browserOmnibarShouldSelectAllOnFocusReassertion(isUserEditing: state.isUserEditing)
+                shouldSelectAll: browserOmnibarShouldSelectAllOnFocusReassertion(
+                    isUserEditing: state.isUserEditing,
+                    selectionIntent: .selectAll
+                )
             )
         )
 
@@ -436,8 +439,24 @@ final class OmnibarStateMachineTests: XCTestCase {
     }
 
     func testFocusReassertionDoesNotSelectAllDuringUserEdit() throws {
-        XCTAssertFalse(browserOmnibarShouldSelectAllOnFocusReassertion(isUserEditing: true))
-        XCTAssertTrue(browserOmnibarShouldSelectAllOnFocusReassertion(isUserEditing: false))
+        XCTAssertFalse(
+            browserOmnibarShouldSelectAllOnFocusReassertion(
+                isUserEditing: true,
+                selectionIntent: .selectAll
+            )
+        )
+        XCTAssertTrue(
+            browserOmnibarShouldSelectAllOnFocusReassertion(
+                isUserEditing: false,
+                selectionIntent: .selectAll
+            )
+        )
+        XCTAssertFalse(
+            browserOmnibarShouldSelectAllOnFocusReassertion(
+                isUserEditing: false,
+                selectionIntent: .preserveFieldEditorSelection
+            )
+        )
     }
 
     func testEscapeRevertsWhenEditingThenBlursOnSecondEscape() throws {


### PR DESCRIPTION
Fixes #5268.

## Summary
- Adds behavior-level coverage for the path the previous test missed: native single-click caret placement followed by the SwiftUI focus-gained select-all effect.
- Makes generic omnibar focus gain preserve the field editor selection by default.
- Keeps explicit address-bar focus requests, including Cmd+L, selecting the full URL through the existing selectAllRequestId flow.

## Verification
- Added a failing-test-first commit: e6db210ef test: cover omnibar focus caret clobber.
- Did not run local tests or reload.sh per task instructions.
- Attempted cloud-mac preflight for visual reproduction, but it was blocked by missing macfleet auth token on this machine.

## Localization
- No user-facing strings changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5352"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783167957&installation_id=133855650&pr_number=5352&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5352&signature=b623ef5c14f95908a9c025a253905e7813af5058ba5dd8963bd136c8be6b6dc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized browser omnibar focus/selection behavior with added regression tests; no auth, data, or network changes.
> 
> **Overview**
> Fixes omnibar focus so a **single click** leaves a caret at the click site instead of selecting the whole URL (#5268), while **Cmd+L** and similar explicit focus commands still **select all**.
> 
> The change introduces **`BrowserAddressBarFocusSelectionIntent`** (`preserveFieldEditorSelection` vs `selectAll`) on sticky address-bar focus requests in `BrowserPanel`, with **`requestAddressBarFocus(selectionIntent:)`** able to **upgrade** a pending preserve request to select-all (new request id). `BrowserPanelView` applies that intent on focus gain and on reassert when the bar is already focused; **`OmnibarEvent.focusGained`** now defaults **`shouldSelectAll` to false**, and focus-reassert select-all follows the intent instead of “not user editing.” **`AppDelegate`** / **`ContentView`** pass **`.selectAll`** for explicit address-bar focus. Tests cover caret preservation through SwiftUI focus-gained and restore paths, request upgrade, and explicit select-all.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ae7088a32f2aa6fa0ab1bef42f667d8b04faff1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the omnibar caret on single‑click focus and on focus restore, preventing SwiftUI focus effects from selecting all, fixing #5268. Explicit focus requests (e.g., Cmd+L) still select the full URL, and focus requests are ignored when the omnibar chrome is hidden.

- **Bug Fixes**
  - Added selection intent (`preserveFieldEditorSelection` vs `selectAll`): `BrowserPanel` stores it, `BrowserPanelView` consumes it once; `requestAddressBarFocus(selectionIntent:)` coalesces and can upgrade to `.selectAll`; `AppDelegate`/`ContentView` pass `.selectAll` for explicit commands.
  - `OmnibarEvent.focusGained` now defaults to not select all; focus reassert uses `browserOmnibarShouldSelectAllOnFocusReassertion(selectionIntent)`; `BrowserPanelView` skips address‑bar focus requests when browser chrome is hidden.

<sup>Written for commit 6ae7088a32f2aa6fa0ab1bef42f667d8b04faff1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Address bar focus now respects an explicit selection intent: focus restoration can preserve the caret/selection or select all text depending on context.
  * Casual focus gains no longer force select-all by default; explicit select-all is honored when requested.
  * Focus requests that coalesce now preserve the intended selection behavior across reassertions.

* **Bug Fixes**
  * Prevented accidental clobbering of a native single-click caret selection during focus/restore flows.

* **Tests**
  * Added and updated tests covering selection-intent behavior and regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->