### PR TITLE
CmuxGit: align config/index/ref parsing with git semantics

### DIFF
--- a/Packages/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+Config.swift
+++ b/Packages/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+Config.swift
@@ -72,7 +72,7 @@ extension GitMetadataService {
             let parts = line.split(separator: "=", maxSplits: 1).map {
                 $0.trimmingCharacters(in: .whitespaces)
             }
-            guard parts.count == 2, parts[0] == "url" else {
+            guard parts.count == 2, parts[0].lowercased() == "url" else {
                 continue
             }
             let remoteURL = gitConfigUnquotedValue(parts[1])
@@ -108,12 +108,13 @@ extension GitMetadataService {
                 .trimmingCharacters(in: .whitespaces)
             if line.hasPrefix("[") && line.hasSuffix("]") {
                 currentRemoteName = gitConfigRemoteName(fromSectionHeader: line)
-                if line == "[include]" {
+                if line.lowercased() == "[include]" {
                     currentSectionAllowsIncludePath = true
                 } else if let condition = gitConfigIncludeIfCondition(fromSectionHeader: line) {
                     currentSectionAllowsIncludePath = gitConfigIncludeIfConditionMatches(
                         condition,
-                        repository: repository
+                        repository: repository,
+                        configURL: configURL
                     )
                 } else {
                     currentSectionAllowsIncludePath = false
@@ -127,7 +128,7 @@ extension GitMetadataService {
 
             if let currentRemoteName,
                parts.count == 2,
-               parts[0] == "url" {
+               parts[0].lowercased() == "url" {
                 let remoteURL = gitConfigUnquotedValue(parts[1])
                 guard !remoteURL.isEmpty else {
                     continue
@@ -138,7 +139,7 @@ extension GitMetadataService {
 
             guard currentSectionAllowsIncludePath,
                   parts.count == 2,
-                  parts[0] == "path",
+                  parts[0].lowercased() == "path",
                   let includeURL = gitConfigIncludeURL(
                       fromPathValue: parts[1],
                       relativeTo: configURL
@@ -168,12 +169,13 @@ extension GitMetadataService {
             let line = gitConfigLineRemovingInlineComment(rawLine)
                 .trimmingCharacters(in: .whitespaces)
             if line.hasPrefix("[") && line.hasSuffix("]") {
-                if line == "[include]" {
+                if line.lowercased() == "[include]" {
                     currentSectionAllowsPath = true
                 } else if let condition = gitConfigIncludeIfCondition(fromSectionHeader: line) {
                     currentSectionAllowsPath = gitConfigIncludeIfConditionMatches(
                         condition,
-                        repository: repository
+                        repository: repository,
+                        configURL: configURL
                     )
                 } else {
                     currentSectionAllowsPath = false
@@ -276,10 +278,14 @@ extension GitMetadataService {
     }
 
     /// The remote name from a `[remote "<name>"]` section header, or `nil`.
+    /// The section name is case-insensitive per git; the quoted subsection
+    /// (the remote name) is case-sensitive and extracted verbatim.
     nonisolated static func gitConfigRemoteName(fromSectionHeader header: String) -> String? {
         let prefix = "[remote \""
         let suffix = "\"]"
-        guard header.hasPrefix(prefix), header.hasSuffix(suffix) else {
+        guard header.count > prefix.count + suffix.count - 1,
+              header.lowercased().hasPrefix(prefix),
+              header.hasSuffix(suffix) else {
             return nil
         }
         let name = header.dropFirst(prefix.count).dropLast(suffix.count)
@@ -287,10 +293,14 @@ extension GitMetadataService {
     }
 
     /// The condition from an `[includeIf "<condition>"]` section header, or `nil`.
+    /// The section name is case-insensitive per git; the condition is extracted
+    /// verbatim (its own keyword prefixes are matched case-insensitively later).
     nonisolated static func gitConfigIncludeIfCondition(fromSectionHeader header: String) -> String? {
-        let prefix = "[includeIf \""
+        let prefix = "[includeif \""
         let suffix = "\"]"
-        guard header.hasPrefix(prefix), header.hasSuffix(suffix) else {
+        guard header.count > prefix.count + suffix.count - 1,
+              header.lowercased().hasPrefix(prefix),
+              header.hasSuffix(suffix) else {
             return nil
         }
         let condition = header.dropFirst(prefix.count).dropLast(suffix.count)
@@ -324,22 +334,33 @@ extension GitMetadataService {
     }
 
     /// Whether an `includeIf` condition (`gitdir:`, `gitdir/i:`, `onbranch:`)
-    /// matches this repository.
+    /// matches this repository. `configURL` anchors `./`-relative gitdir
+    /// patterns to the directory containing the config file, per git.
     nonisolated static func gitConfigIncludeIfConditionMatches(
         _ condition: String,
-        repository: ResolvedGitRepository
+        repository: ResolvedGitRepository,
+        configURL: URL
     ) -> Bool {
         let lowercasedCondition = condition.lowercased()
         if lowercasedCondition.hasPrefix("gitdir/i:") {
             let pattern = String(condition.dropFirst("gitdir/i:".count))
-            return gitConfigGitdirPatternMatches(pattern, repository: repository, caseInsensitive: true)
+            return gitConfigGitdirPatternMatches(
+                pattern, repository: repository, caseInsensitive: true, configURL: configURL
+            )
         }
         if lowercasedCondition.hasPrefix("gitdir:") {
             let pattern = String(condition.dropFirst("gitdir:".count))
-            return gitConfigGitdirPatternMatches(pattern, repository: repository, caseInsensitive: false)
+            return gitConfigGitdirPatternMatches(
+                pattern, repository: repository, caseInsensitive: false, configURL: configURL
+            )
         }
         if lowercasedCondition.hasPrefix("onbranch:") {
-            let pattern = String(condition.dropFirst("onbranch:".count))
+            var pattern = String(condition.dropFirst("onbranch:".count))
+            // Per git, an onbranch pattern ending in "/" matches the whole
+            // branch hierarchy under it.
+            if pattern.hasSuffix("/") {
+                pattern.append("**")
+            }
             guard let branch = gitBranchName(repository: repository) else { return false }
             return gitConfigGlobMatches(branch, pattern: pattern, caseInsensitive: false)
         }
@@ -347,14 +368,18 @@ extension GitMetadataService {
     }
 
     /// Whether a `gitdir`/`gitdir/i` glob pattern matches any of the repository's
-    /// directories, applying git's trailing-slash recursive-directory rule.
+    /// directories, applying git's pattern-expansion rules: `~`/`~/` expand to
+    /// the home directory, `./` is relative to the config file's directory, a
+    /// pattern with no leading `~/`, `./`, or `/` gets `**/` prepended, and a
+    /// trailing `/` appends `**` (the recursive-directory rule).
     nonisolated static func gitConfigGitdirPatternMatches(
         _ pattern: String,
         repository: ResolvedGitRepository,
-        caseInsensitive: Bool
+        caseInsensitive: Bool,
+        configURL: URL
     ) -> Bool {
         let isRecursiveDirectoryPattern = pattern.hasSuffix("/")
-        var expandedPattern = gitConfigExpandedPattern(pattern)
+        var expandedPattern = gitConfigExpandedPattern(pattern, configURL: configURL)
         if isRecursiveDirectoryPattern, !expandedPattern.hasSuffix("/") {
             expandedPattern.append("/")
         }
@@ -376,8 +401,11 @@ extension GitMetadataService {
         return false
     }
 
-    /// Expands `~`/`~/` and standardizes an `includeIf` gitdir pattern path.
-    nonisolated static func gitConfigExpandedPattern(_ pattern: String) -> String {
+    /// Expands an `includeIf` gitdir pattern per git's rules: `~`/`~/` to the
+    /// home directory, `./` relative to the config file's directory, absolute
+    /// paths standardized, and anything else prefixed with `**/` so a relative
+    /// pattern matches at any depth.
+    nonisolated static func gitConfigExpandedPattern(_ pattern: String, configURL: URL) -> String {
         if pattern == "~" {
             return FileManager.default.homeDirectoryForCurrentUser.standardizedFileURL.path
         }
@@ -388,7 +416,21 @@ extension GitMetadataService {
                 .standardizedFileURL
                 .path
         }
-        return URL(fileURLWithPath: pattern).standardizedFileURL.path
+        if pattern.hasPrefix("./") {
+            let relativePath = String(pattern.dropFirst(2))
+            let base = configURL.deletingLastPathComponent()
+            guard !relativePath.isEmpty else {
+                return base.standardizedFileURL.path
+            }
+            // Keep glob metacharacters intact: anchor to the config directory
+            // textually instead of routing the pattern through URL resolution.
+            return base.standardizedFileURL.path + "/" + relativePath
+        }
+        if pattern.hasPrefix("/") {
+            return URL(fileURLWithPath: pattern).standardizedFileURL.path
+        }
+        // Relative pattern: match at any depth.
+        return "**/" + pattern
     }
 
     /// Matches a value against a git glob pattern, falling back to `fnmatch`

--- a/Packages/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+Index.swift
+++ b/Packages/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+Index.swift
@@ -127,7 +127,8 @@ extension GitMetadataService {
             }
 
             let pathData = Data(pathBytes)
-            guard let path = String(data: pathData, encoding: .utf8), !path.isEmpty else {
+            guard let path = String(data: pathData, encoding: .utf8), !path.isEmpty,
+                  isValidIndexEntryPath(path) else {
                 return nil
             }
             previousPathBytes = pathBytes
@@ -233,6 +234,14 @@ extension GitMetadataService {
     /// Truncates any integer to the 32-bit field width git records in the index.
     nonisolated static func gitIndexUInt32Field<T: BinaryInteger>(_ value: T) -> UInt32 {
         UInt32(truncatingIfNeeded: UInt64(truncatingIfNeeded: value))
+    }
+
+    /// Whether an index entry path is one git would accept: repository-relative
+    /// (not absolute) and free of `..` traversal components. An index containing
+    /// anything else is treated as malformed.
+    nonisolated static func isValidIndexEntryPath(_ path: String) -> Bool {
+        guard !path.hasPrefix("/") else { return false }
+        return !path.split(separator: "/").contains("..")
     }
 
     /// The raw index trailing-20-byte checksum as hex, or `nil` when the index

--- a/Packages/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+Refs.swift
+++ b/Packages/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+Refs.swift
@@ -45,16 +45,20 @@ extension GitMetadataService {
     }
 
     /// Resolves a ref name to its value, checking the loose ref under the git
-    /// and common directories, then `packed-refs`.
+    /// and common directories, then `packed-refs`. A ref name is repo-controlled
+    /// input from `HEAD`; names whose standardized path escapes the directory
+    /// they are joined to (e.g. `../../outside`) are ignored rather than read.
     nonisolated static func gitRefValue(repository: ResolvedGitRepository, refName: String) -> String? {
-        let refURLs = [
-            URL(fileURLWithPath: repository.gitDirectory).appendingPathComponent(refName),
-            URL(fileURLWithPath: repository.commonDirectory).appendingPathComponent(refName),
+        let lookups = [
+            (base: repository.gitDirectory, refURL: URL(fileURLWithPath: repository.gitDirectory).appendingPathComponent(refName)),
+            (base: repository.commonDirectory, refURL: URL(fileURLWithPath: repository.commonDirectory).appendingPathComponent(refName)),
         ]
         var seenPaths: Set<String> = []
-        for refURL in refURLs {
+        for (base, refURL) in lookups {
+            let basePath = URL(fileURLWithPath: base).standardizedFileURL.path
             let path = refURL.standardizedFileURL.path
-            guard seenPaths.insert(path).inserted,
+            guard path.hasPrefix(basePath + "/"),
+                  seenPaths.insert(path).inserted,
                   let contents = try? String(contentsOf: refURL, encoding: .utf8) else {
                 continue
             }

--- a/Packages/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+WatchPaths.swift
+++ b/Packages/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+WatchPaths.swift
@@ -45,9 +45,18 @@ extension GitMetadataService {
     }
 
     /// The metadata paths contributed by gitlink (submodule) entries in the
-    /// index, so a submodule checkout change also wakes the watcher.
+    /// index, recursing into nested submodules so a checkout change at any
+    /// depth wakes the watcher. Cycle-safe via the visited work-tree set.
     nonisolated static func gitlinkMetadataWatchPaths(
         repository: ResolvedGitRepository
+    ) -> [String] {
+        var visitedWorkTreeRoots: Set<String> = [repository.workTreeRoot]
+        return gitlinkMetadataWatchPaths(repository: repository, visitedWorkTreeRoots: &visitedWorkTreeRoots)
+    }
+
+    private nonisolated static func gitlinkMetadataWatchPaths(
+        repository: ResolvedGitRepository,
+        visitedWorkTreeRoots: inout Set<String>
     ) -> [String] {
         let indexURL = URL(fileURLWithPath: repository.gitDirectory).appendingPathComponent("index")
         guard let indexSnapshot = gitIndexSnapshot(indexURL: indexURL) else {
@@ -60,11 +69,18 @@ extension GitMetadataService {
             let gitlinkURL = URL(fileURLWithPath: repository.workTreeRoot)
                 .appendingPathComponent(entry.path)
                 .standardizedFileURL
-            guard let submoduleRepository = resolveGitRepository(containing: gitlinkURL.path),
+            guard visitedWorkTreeRoots.insert(gitlinkURL.path).inserted,
+                  let submoduleRepository = resolveGitRepository(containing: gitlinkURL.path),
                   submoduleRepository.workTreeRoot == gitlinkURL.path else {
                 continue
             }
             paths.append(contentsOf: gitRepositoryMetadataWatchPaths(repository: submoduleRepository))
+            paths.append(
+                contentsOf: gitlinkMetadataWatchPaths(
+                    repository: submoduleRepository,
+                    visitedWorkTreeRoots: &visitedWorkTreeRoots
+                )
+            )
         }
         return paths
     }

--- a/Packages/CmuxGit/Tests/CmuxGitTests/GitMetadataServiceTests.swift
+++ b/Packages/CmuxGit/Tests/CmuxGitTests/GitMetadataServiceTests.swift
@@ -234,6 +234,73 @@ import Testing
         #expect(paths == nil)
     }
 
+    // MARK: Parsing fidelity (issue #5359)
+
+    @Test func indexWithTraversalPathIsRejected() throws {
+        let fixture = try GitRepositoryFixture()
+        try fixture.writeBranch("main")
+        try fixture.writeIndex(GitIndexFixture(version: 2, entries: [
+            GitIndexFixture.Entry(path: "ok.txt"),
+            GitIndexFixture.Entry(path: "../escape.txt"),
+        ]))
+        let indexURL = fixture.gitDirectory.appendingPathComponent("index")
+        #expect(GitMetadataService.gitIndexSnapshot(indexURL: indexURL) == nil)
+    }
+
+    @Test func indexWithAbsolutePathIsRejected() throws {
+        let fixture = try GitRepositoryFixture()
+        try fixture.writeBranch("main")
+        try fixture.writeIndex(GitIndexFixture(version: 2, entries: [
+            GitIndexFixture.Entry(path: "/etc/passwd"),
+        ]))
+        let indexURL = fixture.gitDirectory.appendingPathComponent("index")
+        #expect(GitMetadataService.gitIndexSnapshot(indexURL: indexURL) == nil)
+    }
+
+    @Test func symbolicRefEscapingGitDirectoryIsNotRead() throws {
+        let fixture = try GitRepositoryFixture()
+        try fixture.writeBranch("main")
+        // Plant a readable file OUTSIDE the git directory that an escaping ref
+        // name would resolve to; the lookup must refuse to read it.
+        let outside = fixture.root.appendingPathComponent("outside-ref")
+        try String(repeating: "e", count: 40).write(to: outside, atomically: true, encoding: .utf8)
+        let repository = try #require(GitMetadataService.resolveGitRepository(containing: fixture.root.path))
+        #expect(GitMetadataService.gitRefValue(repository: repository, refName: "../outside-ref") == nil)
+        // Sanity: a legitimate ref still resolves.
+        #expect(GitMetadataService.gitRefValue(repository: repository, refName: "refs/heads/main") != nil)
+    }
+
+    @Test func watchedPathsRecurseIntoNestedSubmodules() throws {
+        let parent = try GitRepositoryFixture()
+        try parent.writeBranch("main")
+        let commit = String(repeating: "2", count: 40)
+
+        // parent -> vendor/mid -> vendor/mid/deep (gitlinks at two depths)
+        let midRoot = parent.root.appendingPathComponent("vendor/mid", isDirectory: true)
+        let midGit = midRoot.appendingPathComponent(".git", isDirectory: true)
+        let deepRoot = midRoot.appendingPathComponent("deep", isDirectory: true)
+        let deepGit = deepRoot.appendingPathComponent(".git", isDirectory: true)
+        for dir in [midGit, deepGit] {
+            try FileManager.default.createDirectory(
+                at: dir.appendingPathComponent("refs/heads"),
+                withIntermediateDirectories: true
+            )
+            try "\(commit)\n".write(to: dir.appendingPathComponent("HEAD"), atomically: true, encoding: .utf8)
+        }
+        // mid's index records deep as a gitlink; parent's records mid.
+        try GitIndexFixture(version: 2, entries: [
+            GitIndexFixture.Entry(path: "deep", mode: 0o160000, objectID: commit, size: 0),
+        ]).data().write(to: midGit.appendingPathComponent("index"))
+        try parent.writeIndex(GitIndexFixture(version: 2, entries: [
+            GitIndexFixture.Entry(path: "vendor/mid", mode: 0o160000, objectID: commit, size: 0),
+        ]))
+
+        let paths = try #require(GitMetadataService.workspaceGitMetadataWatchedPaths(for: parent.root.path))
+        #expect(paths.contains(midGit.appendingPathComponent("HEAD").standardizedFileURL.path))
+        #expect(paths.contains(deepGit.appendingPathComponent("HEAD").standardizedFileURL.path),
+                "nested submodule metadata must be watched")
+    }
+
     // MARK: Execution contract
 
     /// Pins the SE-0338 contract the service relies on: a `nonisolated async`

--- a/Packages/CmuxGit/Tests/CmuxGitTests/GitSlugAndConfigTests.swift
+++ b/Packages/CmuxGit/Tests/CmuxGitTests/GitSlugAndConfigTests.swift
@@ -84,7 +84,85 @@ import Testing
         let condition = "gitdir:\(fixture.gitDirectory.path)/"
         #expect(GitMetadataService.gitConfigIncludeIfConditionMatches(
             condition,
-            repository: try #require(GitMetadataService.resolveGitRepository(containing: fixture.root.path))
+            repository: try #require(GitMetadataService.resolveGitRepository(containing: fixture.root.path)),
+            configURL: fixture.gitDirectory.appendingPathComponent("config")
+        ))
+    }
+
+    // MARK: Parsing fidelity (issue #5359)
+
+    private func slugs(fromConfig config: String) -> [String] {
+        GitMetadataService.githubRepositorySlugs(
+            fromGitRemoteVOutput: GitMetadataService.gitRemoteVLines(fromConfig: config).joined()
+        )
+    }
+
+    private func slugs(forDirectory directory: String) -> [String] {
+        guard let repository = GitMetadataService.resolveGitRepository(containing: directory),
+              let output = GitMetadataService.gitRemoteVOutput(repository: repository) else {
+            return []
+        }
+        return GitMetadataService.githubRepositorySlugs(fromGitRemoteVOutput: output)
+    }
+
+    @Test func configSectionAndKeyNamesAreCaseInsensitive() {
+        let config = """
+        [Remote "origin"]
+            URL = https://github.com/manaflow-ai/cmux.git
+        """
+        #expect(slugs(fromConfig: config) == ["manaflow-ai/cmux"])
+    }
+
+    @Test func includeHeaderIsCaseInsensitiveAndSubsectionCasePreserved() throws {
+        let fixture = try GitRepositoryFixture()
+        try fixture.writeBranch("main")
+        try fixture.writeConfig("""
+        [INCLUDE]
+            path = remotes.inc
+        """)
+        try """
+        [remote "MixedCase"]
+            url = https://github.com/manaflow-ai/cmux.git
+        """.write(to: fixture.gitDirectory.appendingPathComponent("remotes.inc"), atomically: true, encoding: .utf8)
+        #expect(slugs(forDirectory: fixture.root.path) == ["manaflow-ai/cmux"])
+    }
+
+    @Test func relativeGitdirPatternMatchesAtAnyDepth() throws {
+        let fixture = try GitRepositoryFixture()
+        try fixture.writeBranch("main")
+        let repository = try #require(GitMetadataService.resolveGitRepository(containing: fixture.root.path))
+        let configURL = fixture.gitDirectory.appendingPathComponent("config")
+        // Relative pattern (no leading /, ~/, ./) gets **/ prepended per git,
+        // so "<rootDirName>/.git/" matches the absolute git directory.
+        let rootDirName = fixture.root.lastPathComponent
+        #expect(GitMetadataService.gitConfigIncludeIfConditionMatches(
+            "gitdir:\(rootDirName)/.git/",
+            repository: repository,
+            configURL: configURL
+        ))
+        #expect(!GitMetadataService.gitConfigIncludeIfConditionMatches(
+            "gitdir:not-the-dir/.git/",
+            repository: repository,
+            configURL: configURL
+        ))
+    }
+
+    @Test func dotSlashGitdirPatternIsRelativeToConfigDirectory() throws {
+        let fixture = try GitRepositoryFixture()
+        try fixture.writeBranch("main")
+        let repository = try #require(GitMetadataService.resolveGitRepository(containing: fixture.root.path))
+        // "./" in the .git/config means the .git directory itself; with the
+        // trailing-slash recursion rule it matches the git directory.
+        #expect(GitMetadataService.gitConfigIncludeIfConditionMatches(
+            "gitdir:./",
+            repository: repository,
+            configURL: fixture.gitDirectory.appendingPathComponent("config")
+        ))
+        // Anchored to a different config directory, the same pattern must not match.
+        #expect(!GitMetadataService.gitConfigIncludeIfConditionMatches(
+            "gitdir:./",
+            repository: repository,
+            configURL: URL(fileURLWithPath: "/somewhere/else/config")
         ))
     }
 }


### PR DESCRIPTION
Closes https://github.com/manaflow-ai/cmux/issues/5359 — the five parsing-fidelity gaps CodeRabbit found on https://github.com/manaflow-ai/cmux/pull/5277, deferred there because they were pre-existing TabManager behavior and the extraction's contract was behavior preservation.

1. **Config case-insensitivity** — `[Remote "origin"]`, `[INCLUDE]`, `URL =` now parse (section/key names case-insensitive per git; quoted subsections verbatim).
2. **`includeIf gitdir:` expansion rules** — `./x` anchors to the config file's directory (`configURL` threaded through the matcher), bare relative patterns get `**/` prepended (match at any depth), `onbranch:` trailing-`/` appends `**`.
3. **Index path validation** — absolute or `..`-containing entry paths mark the index malformed (parser returns `nil`), as git refuses them.
4. **Symbolic-ref escape rejection** — ref names resolving outside the git/common directory are ignored before any file read (planted-file test).
5. **Nested gitlink recursion** — watch paths cover submodules at any depth, cycle-safe.

8 new targeted package tests (56 total). Single commit rather than the red/green regression split: the `configURL:` signature change means the new config tests can't compile against the old sources; the index/ref/gitlink tests do fail red against the previous logic.

`swift build` + 56 `swift test`, `cmux` (tagged reload), `cmux-unit` all green. The fixes are edge-case semantics with no expected visible change on well-formed repos — sidebar branch/dirty/PR behavior is unchanged (package tests are the real gate here).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5362"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783181374&installation_id=133855650&pr_number=5362&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5362&signature=6a337739fbce1bef5fc16499438cd793799d02c13549cc1de77975e53d1c9bdc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns `CmuxGit` parsing with git semantics to improve fidelity and safety. Fixes config includeIf matching, index path validation, ref resolution, and nested submodule watching; adds 8 targeted tests.

- **Bug Fixes**
  - Config: section/key names are case-insensitive; quoted subsections preserved. `remote.url` and `include.path` parsed case-insensitive.
  - `includeIf`: `gitdir:` expands `~`, anchors `./` to the config file’s directory, prefixes relative patterns with `**/`, and appends `**` for trailing `/`; `onbranch:` also supports trailing `/`.
  - Index: reject entries with absolute paths or `..` components (treat index as malformed).
  - Refs: ignore ref names whose paths escape the `git`/`common` directories before reading.
  - Submodules: watch paths recurse into nested gitlinks at any depth, cycle-safe.

<sup>Written for commit 63287e1386e60d1b3ce89c64e6a0fe62afa7c34b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Git configuration parsing now correctly handles include directives and case sensitivity
  * Git index entries are now validated to reject invalid paths
  * Symbolic ref resolution is hardened against directory traversal

* **Refactor**
  * Nested submodule path traversal now includes cycle detection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->