### PR TITLE
Add Amp to the Vault (Session Index) sidebar

### DIFF
--- a/Assets.xcassets/AgentIcons/Amp.imageset/Amp.svg
+++ b/Assets.xcassets/AgentIcons/Amp.imageset/Amp.svg
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 800">
-  <rect width="800" height="800" rx="120" fill="#0B0B0C"/>
-  <path d="M150 400 L260 400 L330 250 L470 550 L540 400 L650 400" fill="none" stroke="#F7F7F7" stroke-width="56" stroke-linecap="round" stroke-linejoin="round"/>
+<svg width="21" height="21" viewBox="0 0 21 21" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M3.76879 18.3015L8.49839 13.505L10.2196 20.0399L12.72 19.3561L10.2288 9.86749L0.890876 7.33844L0.22594 9.89331L6.65134 11.6388L1.94138 16.4282L3.76879 18.3015Z" fill="#F34E3F"/>
+<path d="M17.4074 12.7414L19.9078 12.0575L17.4167 2.56897L8.07873 0.0399246L7.4138 2.5948L15.2992 4.73685L17.4074 12.7414Z" fill="#F34E3F"/>
+<path d="M13.8184 16.3883L16.3188 15.7044L13.8276 6.21588L4.48971 3.68683L3.82477 6.24171L11.7101 8.38376L13.8184 16.3883Z" fill="#F34E3F"/>
 </svg>

--- a/Assets.xcassets/AgentIcons/Amp.imageset/Amp.svg
+++ b/Assets.xcassets/AgentIcons/Amp.imageset/Amp.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 800">
+  <rect width="800" height="800" rx="120" fill="#0B0B0C"/>
+  <path d="M150 400 L260 400 L330 250 L470 550 L540 400 L650 400" fill="none" stroke="#F7F7F7" stroke-width="56" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/Assets.xcassets/AgentIcons/Amp.imageset/Contents.json
+++ b/Assets.xcassets/AgentIcons/Amp.imageset/Contents.json
@@ -1,0 +1,15 @@
+{
+  "images" : [
+    {
+      "filename" : "Amp.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
+  }
+}

--- a/CLI/CMUXCLI+AmpExtension.swift
+++ b/CLI/CMUXCLI+AmpExtension.swift
@@ -482,9 +482,12 @@ export default function (amp: PluginAPI) {
     return title ? { title } : {};
   }
 
-  // Amp usually generates the title during/after the first turn, so reading it
-  // on session.start/agent.start misses it for single-turn threads. Subscribe
-  // once per thread and push each new title through to cmux as it lands.
+  // Amp usually generates the title mid-turn, so reading it on
+  // session.start/agent.start misses it. Subscribe once per thread and push each
+  // new title to cmux as it lands. The push reuses the session-start hook, which
+  // also marks the session running, so it must only fire while a turn is active —
+  // otherwise a title that finalizes after the turn ends would revive a session
+  // cmux has already marked idle.
   const titleSubs = new Map<string, { unsubscribe?: () => void }>();
   function watchThreadTitle(threadID: string, ctx?: AmpThreadContext): void {
     const observable = ctx?.thread?.title;
@@ -492,6 +495,7 @@ export default function (amp: PluginAPI) {
     let lastSent: string | null = null;
     try {
       const sub = observable.subscribe((value) => {
+        if (!turnActive) return;
         const title = value?.trim();
         if (!title || title === lastSent) return;
         lastSent = title;

--- a/CLI/CMUXCLI+AmpExtension.swift
+++ b/CLI/CMUXCLI+AmpExtension.swift
@@ -4,7 +4,7 @@ extension CMUXCLI {
     private static let ampExtensionMarker = "cmux-amp-session-extension-marker"
     private static let ampExtensionFilename = "cmux-session.ts"
     private static let ampExtensionSource = #"""
-// cmux-amp-session-extension-marker v2
+// cmux-amp-session-extension-marker v3
 // Bridges Amp session lifecycle events into cmux's restorable session store
 // AND reports live agent status (idle/thinking/tool calls/done/error) into
 // the cmux tab status bar.
@@ -42,6 +42,18 @@ function resolveExecutable(name: string): string {
     } catch (_) {}
   }
   return name;
+}
+
+// Prefer the CLI bundled with the cmux app that launched this terminal
+// (CMUX_BUNDLED_CLI_PATH) over whatever `cmux` is on PATH, so the plugin always
+// talks to the matching app/CLI version — PATH may point at a different build
+// (e.g. an installed release while running a dev/tagged app).
+function cmuxBin(): string {
+  return (
+    process.env.CMUX_AMP_CMUX_BIN ||
+    process.env.CMUX_BUNDLED_CLI_PATH ||
+    "cmux"
+  );
 }
 
 function looksLikeAmpExecutable(value: string): boolean {
@@ -124,7 +136,7 @@ function sendHook(
     event: eventName(subcommand),
     ...extra,
   };
-  const cmux = process.env.CMUX_AMP_CMUX_BIN || "cmux";
+  const cmux = cmuxBin();
   try {
     const child = spawn(cmux, ["hooks", "amp", subcommand], {
       env: hookEnvironment(cwd),
@@ -138,7 +150,16 @@ function sendHook(
   } catch (_) {}
 }
 
-type AmpThreadContext = { thread?: { id?: string } };
+type AmpTitleObservable = {
+  get?: () => Promise<string | null>;
+  subscribe?: (onNext: (value: string | null) => void) => {
+    unsubscribe?: () => void;
+  };
+};
+
+type AmpThreadContext = {
+  thread?: { id?: string; title?: AmpTitleObservable };
+};
 
 function threadIdFrom(event: { thread?: { id?: string } } | undefined, ctx?: AmpThreadContext): string | null {
   return firstString(event?.thread?.id, ctx?.thread?.id);
@@ -259,7 +280,7 @@ function statusEnvironment(): NodeJS.ProcessEnv {
 function runCmux(args: string[]): void {
   if (process.env.CMUX_AMP_HOOKS_DISABLED === "1") return;
   if (!process.env.CMUX_SURFACE_ID) return;
-  const cmux = process.env.CMUX_AMP_CMUX_BIN || "cmux";
+  const cmux = cmuxBin();
   try {
     const child = spawn(cmux, args, {
       env: statusEnvironment(),
@@ -397,11 +418,107 @@ export default function (amp: PluginAPI) {
     } catch (_) {}
   });
 
+  // cmux just stores whatever `title` it receives. Prefer the thread title the
+  // user/agent set via the plugin API; fall back to the first user message for
+  // Amp versions whose API predates `thread.title`.
+  // Cached per thread so we resolve at most once.
+  const capturedTitles = new Map<string, string>();
+  async function resolveSessionTitle(
+    threadID: string,
+    ctx?: AmpThreadContext,
+  ): Promise<string | null> {
+    // Always try the real thread title first (cheap, and lets cmux upgrade the
+    // stored title once Amp assigns/refines it on a later turn).
+    try {
+      const threadTitle = (await ctx?.thread?.title?.get?.())?.trim();
+      if (threadTitle) return threadTitle;
+    } catch (_) {}
+    const cached = capturedTitles.get(threadID);
+    if (cached) return cached;
+    try {
+      const threads = (
+        amp as unknown as {
+          experimental?: {
+            threads?: {
+              get?: (id: string) => {
+                messages?: (options?: unknown) => Promise<unknown[]>;
+              };
+            };
+          };
+        }
+      ).experimental?.threads;
+      const handle = threads?.get?.(threadID);
+      if (!handle?.messages) return null;
+      const messages = await handle.messages({
+        from: "start",
+        limit: 1,
+        roles: ["user"],
+      });
+      if (!Array.isArray(messages)) return null;
+      for (const message of messages) {
+        const m = message as { role?: string; content?: unknown };
+        if (m.role !== "user" || !Array.isArray(m.content)) continue;
+        const text = m.content
+          .filter(
+            (block) =>
+              (block as { type?: string }).type === "text" &&
+              typeof (block as { text?: unknown }).text === "string",
+          )
+          .map((block) => (block as { text: string }).text)
+          .join(" ")
+          .replace(/\s+/g, " ")
+          .trim();
+        if (text) {
+          const title = text.length > 200 ? text.slice(0, 199) + "…" : text;
+          capturedTitles.set(threadID, title);
+          return title;
+        }
+      }
+    } catch (_) {}
+    return null;
+  }
+
+  function titleExtra(title: string | null): Record<string, unknown> {
+    return title ? { title } : {};
+  }
+
+  // Amp usually generates the title during/after the first turn, so reading it
+  // on session.start/agent.start misses it for single-turn threads. Subscribe
+  // once per thread and push each new title through to cmux as it lands.
+  const titleSubs = new Map<string, { unsubscribe?: () => void }>();
+  function watchThreadTitle(threadID: string, ctx?: AmpThreadContext): void {
+    const observable = ctx?.thread?.title;
+    if (!observable?.subscribe || titleSubs.has(threadID)) return;
+    let lastSent: string | null = null;
+    try {
+      const sub = observable.subscribe((value) => {
+        const title = value?.trim();
+        if (!title || title === lastSent) return;
+        lastSent = title;
+        sendHook("session-start", threadID, cwdFromEnv(), { title });
+      });
+      titleSubs.set(threadID, sub);
+    } catch (_) {}
+  }
+
+  process.on("exit", () => {
+    for (const sub of titleSubs.values()) {
+      try {
+        sub.unsubscribe?.();
+      } catch (_) {}
+    }
+    titleSubs.clear();
+  });
+
   amp.on("session.start", async (event: SessionStartEvent, ctx) => {
     setStatus("idle", "circle", COLOR.idle);
     const sessionId = threadIdFrom(event, ctx);
     if (!sessionId) return;
-    sendHook("session-start", sessionId, cwdFromEnv());
+    watchThreadTitle(sessionId, ctx);
+    // Backfills a title for reopened threads; null for brand-new threads until
+    // the first prompt arrives (agent.start).
+    const title = await resolveSessionTitle(sessionId, ctx);
+    sendHook("session-start", sessionId, cwdFromEnv(), titleExtra(title));
   });
 
   amp.on("agent.start", async (event: AgentStartEvent, ctx) => {
@@ -411,7 +528,9 @@ export default function (amp: PluginAPI) {
     wsLog("prompt received");
     const sessionId = threadIdFrom(event, ctx);
     if (!sessionId) return;
-    sendHook("prompt-submit", sessionId, cwdFromEnv());
+    watchThreadTitle(sessionId, ctx);
+    const title = await resolveSessionTitle(sessionId, ctx);
+    sendHook("prompt-submit", sessionId, cwdFromEnv(), titleExtra(title));
   });
 
   amp.on("tool.call", async (event: ToolCallEvent) => {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -338,6 +338,7 @@ private struct ClaudeHookParsedInput {
     let turnId: String?
     let cwd: String?
     let transcriptPath: String?
+    let title: String?
 }
 
 private enum AgentHookNotificationStatus: String, Codable {
@@ -427,6 +428,7 @@ private struct ClaudeHookSessionRecord: Codable {
     var workspaceId: String
     var surfaceId: String
     var cwd: String?
+    var title: String? = nil
     var transcriptPath: String?
     var pid: Int?
     var launchCommand: AgentHookLaunchCommandRecord?
@@ -564,7 +566,8 @@ private final class ClaudeHookSessionStore {
         launchCommand: AgentHookLaunchCommandRecord?,
         agentLifecycle: AgentHibernationLifecycleState? = nil,
         runtimeStatus: AgentHookRuntimeStatus? = nil,
-        updateRuntimeStatus: Bool = false
+        updateRuntimeStatus: Bool = false,
+        title: String? = nil
     ) throws -> Bool {
         let normalized = normalizeSessionId(sessionId)
         guard !normalized.isEmpty else { return false }
@@ -593,6 +596,7 @@ private final class ClaudeHookSessionStore {
                 updateLastNotificationStatus: false,
                 runtimeStatus: runtimeStatus,
                 updateRuntimeStatus: updateRuntimeStatus,
+                title: title,
                 now: now
             )
             let normalizedTurnId = normalizeOptional(turnId)
@@ -814,7 +818,8 @@ private final class ClaudeHookSessionStore {
         updateRuntimeStatus: Bool = false,
         markActive: Bool = false,
         turnId: String? = nil,
-        allowsNewSessionReplacement: Bool = false
+        allowsNewSessionReplacement: Bool = false,
+        title: String? = nil
     ) throws {
         let normalized = normalizeSessionId(sessionId)
         guard !normalized.isEmpty else { return }
@@ -860,6 +865,7 @@ private final class ClaudeHookSessionStore {
                 updateLastNotificationStatus: updateLastNotificationStatus,
                 runtimeStatus: runtimeStatus,
                 updateRuntimeStatus: updateRuntimeStatus,
+                title: title,
                 now: now
             )
             state.sessions[normalized] = record
@@ -1028,6 +1034,7 @@ private final class ClaudeHookSessionStore {
         updateLastNotificationStatus: Bool,
         runtimeStatus: AgentHookRuntimeStatus?,
         updateRuntimeStatus: Bool,
+        title: String? = nil,
         now: TimeInterval
     ) {
         record.workspaceId = workspaceId
@@ -1036,6 +1043,11 @@ private final class ClaudeHookSessionStore {
         }
         if let cwd = normalizeOptional(cwd) {
             record.cwd = cwd
+        }
+        // Only set when non-empty so an event without a title can't wipe one
+        // that was already stored.
+        if let title = normalizeOptional(title) {
+            record.title = title
         }
         if let transcriptPath = normalizeOptional(transcriptPath) {
             record.transcriptPath = transcriptPath
@@ -22298,7 +22310,8 @@ struct CMUXCLI {
                 sessionId: nil,
                 turnId: nil,
                 cwd: nil,
-                transcriptPath: nil
+                transcriptPath: nil,
+                title: nil
             )
         }
 
@@ -22306,6 +22319,7 @@ struct CMUXCLI {
         let turnId = firstString(in: object, keys: ["turn_id", "turnId"])
         let cwd = extractClaudeHookCWD(from: object)
         let transcriptPath = extractHookTranscriptPath(from: object)
+        let title = firstString(in: object, keys: ["title"])
         let compactObject = compactClaudeHookObject(object)
         return ClaudeHookParsedInput(
             rawObject: object,
@@ -22314,7 +22328,8 @@ struct CMUXCLI {
             sessionId: sessionId,
             turnId: turnId,
             cwd: cwd,
-            transcriptPath: transcriptPath
+            transcriptPath: transcriptPath,
+            title: title
         )
     }
 
@@ -27795,7 +27810,8 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                     launchCommand: launchCommand,
                     agentLifecycle: .unknown,
                     runtimeStatus: suppressVisibleMutations ? nil : .running,
-                    updateRuntimeStatus: !suppressVisibleMutations
+                    updateRuntimeStatus: !suppressVisibleMutations,
+                    title: input.title
                 )
                 if suppressVisibleMutations {
                     telemetry.breadcrumb("\(def.name)-hook.session-start.nested-suppressed")
@@ -27880,7 +27896,8 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                     terminalActivePromptTurnIds: terminalActivePromptTurnIds,
                     pid: pid,
                     launchCommand: launchCommand,
-                    agentLifecycle: .running
+                    agentLifecycle: .running,
+                    title: input.title
                 )) ?? false
             } else {
                 nestedPromptSubmit = false
@@ -27914,7 +27931,8 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                     launchCommand: launchCommand,
                     agentLifecycle: .running,
                     runtimeStatus: .running,
-                    updateRuntimeStatus: true
+                    updateRuntimeStatus: true,
+                    title: input.title
                 )
                 try? store.clearNotificationEmission(sessionId: sessionId)
                 publishAgentSurfaceResumeBinding(

--- a/Sources/AmpSessionIndex.swift
+++ b/Sources/AmpSessionIndex.swift
@@ -15,8 +15,6 @@ private struct AmpHookSessionRecord: Decodable {
     var cwd: String?
     var startedAt: TimeInterval?
     var updatedAt: TimeInterval?
-    /// Forward-compatible: cmux's Amp plugin does not capture a human thread
-    /// title today, but if a future plugin/hook adds one we prefer it.
     var title: String?
     var launchCommand: LaunchCommand?
 
@@ -124,8 +122,8 @@ extension SessionIndexStore {
         return entries
     }
 
-    /// Amp's hook store has no conversation title, so synthesize a readable one
-    /// from the working directory; fall back to a generic label.
+    /// Use the stored title when present; otherwise synthesize a readable label
+    /// from the working directory, falling back to a generic one.
     private nonisolated static func ampDisplayTitle(recordTitle: String?, cwd: String?) -> String {
         if let recordTitle = recordTitle?.trimmingCharacters(in: .whitespacesAndNewlines),
            !recordTitle.isEmpty {

--- a/Sources/AmpSessionIndex.swift
+++ b/Sources/AmpSessionIndex.swift
@@ -1,0 +1,178 @@
+import Foundation
+
+// Amp (Sourcegraph Amp CLI) no longer keeps a stable local thread store: thread
+// content now lives server-side and the legacy `~/.local/share/amp/threads/*.json`
+// files are abandoned. The authoritative local record of Amp sessions is cmux's
+// own per-agent hook store at `~/.cmuxterm/amp-hook-sessions.json`, written by the
+// bundled Amp plugin via `cmux hooks amp`. We read that store (read-only) to list
+// resumable Amp sessions, independent of Amp's server migration.
+
+/// One Amp session record as written by `cmux hooks amp`. Decoding is tolerant:
+/// every field beyond the dictionary key is optional so a CLI schema bump never
+/// breaks the Session Index listing.
+private struct AmpHookSessionRecord: Decodable {
+    var sessionId: String?
+    var cwd: String?
+    var startedAt: TimeInterval?
+    var updatedAt: TimeInterval?
+    /// Forward-compatible: cmux's Amp plugin does not capture a human thread
+    /// title today, but if a future plugin/hook adds one we prefer it.
+    var title: String?
+    var launchCommand: LaunchCommand?
+
+    struct LaunchCommand: Decodable {
+        var workingDirectory: String?
+    }
+}
+
+private struct AmpHookSessionStoreFile: Decodable {
+    var sessions: [String: AmpHookSessionRecord]
+
+    private enum CodingKeys: String, CodingKey { case sessions }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        sessions = try container.decodeIfPresent(
+            [String: AmpHookSessionRecord].self,
+            forKey: .sessions
+        ) ?? [:]
+    }
+}
+
+private struct AmpIndexedSession {
+    let sessionId: String
+    let title: String
+    let cwd: String?
+    let modified: Date
+}
+
+extension SessionIndexStore {
+    nonisolated static func loadAmpEntries(
+        needle: String,
+        cwdFilter: String?,
+        offset: Int,
+        limit: Int,
+        errorBag: ErrorBag,
+        storeURL: URL = RestorableAgentKind.amp.hookStoreFileURL()
+    ) -> [SessionEntry] {
+        guard limit > 0, offset >= 0 else { return [] }
+        let (target, overflow) = offset.addingReportingOverflow(limit)
+        guard !overflow else { return [] }
+
+        let fileManager = FileManager.default
+        guard fileManager.fileExists(atPath: storeURL.path) else { return [] }
+
+        let store: AmpHookSessionStoreFile
+        do {
+            let data = try Data(contentsOf: storeURL)
+            store = try JSONDecoder().decode(AmpHookSessionStoreFile.self, from: data)
+        } catch {
+            errorBag.add("Amp: cannot read session store \(storeURL.path) (\(error.localizedDescription))")
+            return []
+        }
+
+        var indexed: [AmpIndexedSession] = []
+        indexed.reserveCapacity(store.sessions.count)
+        for (key, record) in store.sessions {
+            let sessionId = (record.sessionId ?? key).trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !sessionId.isEmpty else { continue }
+
+            let cwd = Self.ampNormalizedCwd(record.cwd ?? record.launchCommand?.workingDirectory)
+            // Prefer updatedAt, then startedAt; epoch seconds.
+            let modified = Date(timeIntervalSince1970: record.updatedAt ?? record.startedAt ?? 0)
+            indexed.append(AmpIndexedSession(
+                sessionId: sessionId,
+                title: Self.ampDisplayTitle(recordTitle: record.title, cwd: cwd),
+                cwd: cwd,
+                modified: modified
+            ))
+        }
+
+        indexed.sort { $0.modified > $1.modified }
+
+        let normalizedNeedle = needle.lowercased()
+        let normalizedFilter = cwdFilter.flatMap { Self.ampNormalizedCwd($0) }
+        var matchedCount = 0
+        var entries: [SessionEntry] = []
+        entries.reserveCapacity(limit)
+
+        for session in indexed {
+            if matchedCount >= target { break }
+            if let normalizedFilter, session.cwd != normalizedFilter { continue }
+            if !normalizedNeedle.isEmpty {
+                let haystack = [session.sessionId, session.title, session.cwd ?? ""]
+                    .joined(separator: " ")
+                    .lowercased()
+                guard haystack.range(of: normalizedNeedle, options: [.literal]) != nil else { continue }
+            }
+            if matchedCount >= offset {
+                entries.append(SessionEntry(
+                    id: "amp:" + session.sessionId,
+                    agent: .amp,
+                    sessionId: session.sessionId,
+                    title: session.title,
+                    cwd: session.cwd,
+                    gitBranch: nil,
+                    pullRequest: nil,
+                    modified: session.modified,
+                    fileURL: nil,
+                    specifics: .amp
+                ))
+            }
+            matchedCount += 1
+        }
+        return entries
+    }
+
+    /// Amp's hook store has no conversation title, so synthesize a readable one
+    /// from the working directory; fall back to a generic label.
+    private nonisolated static func ampDisplayTitle(recordTitle: String?, cwd: String?) -> String {
+        if let recordTitle = recordTitle?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !recordTitle.isEmpty {
+            return recordTitle
+        }
+        if let cwd {
+            let basename = (cwd as NSString).lastPathComponent
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            if !basename.isEmpty {
+                return String(
+                    localized: "sessionIndex.amp.titleInDirectory",
+                    defaultValue: "Amp session in \(basename)"
+                )
+            }
+        }
+        return String(localized: "sessionIndex.amp.title", defaultValue: "Amp session")
+    }
+
+    private nonisolated static func ampNormalizedCwd(_ path: String?) -> String? {
+        guard let trimmed = path?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else {
+            return nil
+        }
+        return URL(fileURLWithPath: NSString(string: trimmed).expandingTildeInPath)
+            .resolvingSymlinksInPath()
+            .standardizedFileURL
+            .path
+    }
+
+    #if DEBUG
+    nonisolated static func loadAmpEntriesForTesting(
+        storeURL: URL,
+        needle: String = "",
+        cwdFilter: String? = nil,
+        offset: Int = 0,
+        limit: Int = 100
+    ) -> SearchOutcome {
+        let bag = ErrorBag()
+        let entries = loadAmpEntries(
+            needle: needle,
+            cwdFilter: cwdFilter,
+            offset: offset,
+            limit: limit,
+            errorBag: bag,
+            storeURL: storeURL
+        )
+        return SearchOutcome(entries: entries, errors: bag.snapshot())
+    }
+    #endif
+}

--- a/Sources/AmpSessionIndex.swift
+++ b/Sources/AmpSessionIndex.swift
@@ -65,7 +65,7 @@ extension SessionIndexStore {
             let data = try Data(contentsOf: storeURL)
             store = try JSONDecoder().decode(AmpHookSessionStoreFile.self, from: data)
         } catch {
-            errorBag.add("Amp: cannot read \(storeURL.lastPathComponent) (\(error.localizedDescription))")
+            errorBag.add("Amp: cannot read \(storeURL.lastPathComponent)")
             return []
         }
 

--- a/Sources/AmpSessionIndex.swift
+++ b/Sources/AmpSessionIndex.swift
@@ -65,7 +65,7 @@ extension SessionIndexStore {
             let data = try Data(contentsOf: storeURL)
             store = try JSONDecoder().decode(AmpHookSessionStoreFile.self, from: data)
         } catch {
-            errorBag.add("Amp: cannot read session store \(storeURL.path) (\(error.localizedDescription))")
+            errorBag.add("Amp: cannot read \(storeURL.lastPathComponent) (\(error.localizedDescription))")
             return []
         }
 
@@ -142,15 +142,19 @@ extension SessionIndexStore {
         return String(localized: "sessionIndex.amp.title", defaultValue: "Amp session")
     }
 
+    // Match SessionIndexStore.normalizedDirectory: standardizingPath (no symlink
+    // resolution) so Amp cwds bucket and scope-filter the same way as every other
+    // agent's entries.
     private nonisolated static func ampNormalizedCwd(_ path: String?) -> String? {
         guard let trimmed = path?.trimmingCharacters(in: .whitespacesAndNewlines),
               !trimmed.isEmpty else {
             return nil
         }
-        return URL(fileURLWithPath: NSString(string: trimmed).expandingTildeInPath)
-            .resolvingSymlinksInPath()
-            .standardizedFileURL
-            .path
+        var normalized = (NSString(string: trimmed).expandingTildeInPath as NSString).standardizingPath
+        if normalized.count > 1 && normalized.hasSuffix("/") {
+            normalized.removeLast()
+        }
+        return normalized
     }
 
     #if DEBUG

--- a/Sources/SessionAgentPresentation.swift
+++ b/Sources/SessionAgentPresentation.swift
@@ -5,6 +5,7 @@ extension SessionAgent {
         switch self {
         case .claude: return String(localized: "sessionIndex.agent.claude", defaultValue: "Claude Code")
         case .codex: return String(localized: "sessionIndex.agent.codex", defaultValue: "Codex")
+        case .amp: return String(localized: "sessionIndex.agent.amp", defaultValue: "Amp")
         case .grok: return String(localized: "sessionIndex.agent.grok", defaultValue: "Grok")
         case .opencode: return String(localized: "sessionIndex.agent.opencode", defaultValue: "OpenCode")
         case .rovodev: return String(localized: "sessionIndex.agent.rovodev", defaultValue: "Rovo Dev")
@@ -19,6 +20,7 @@ extension SessionAgent {
         switch self {
         case .claude: return "AgentIcons/Claude"
         case .codex: return "AgentIcons/Codex"
+        case .amp: return "AgentIcons/Amp"
         case .grok: return "AgentIcons/Grok"
         case .opencode: return "AgentIcons/OpenCode"
         case .rovodev: return "AgentIcons/RovoDev"

--- a/Sources/SessionIndexModels.swift
+++ b/Sources/SessionIndexModels.swift
@@ -37,6 +37,7 @@ struct RegisteredSessionAgent: Hashable, Sendable {
 enum SessionAgent: Identifiable, Codable, Sendable, Hashable {
     case claude
     case codex
+    case amp
     case grok
     case opencode
     case rovodev
@@ -45,13 +46,14 @@ enum SessionAgent: Identifiable, Codable, Sendable, Hashable {
 
     var id: String { rawValue }
 
-    static let builtInCases: [SessionAgent] = [.claude, .codex, .grok, .opencode, .rovodev, .hermesAgent]
+    static let builtInCases: [SessionAgent] = [.claude, .codex, .amp, .grok, .opencode, .rovodev, .hermesAgent]
 
     init?(rawValue: String) {
         let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
         switch value {
         case "claude": self = .claude
         case "codex": self = .codex
+        case "amp": self = .amp
         case "grok": self = .grok
         case "opencode": self = .opencode
         case "rovodev": self = .rovodev
@@ -66,6 +68,7 @@ enum SessionAgent: Identifiable, Codable, Sendable, Hashable {
         switch self {
         case .claude: return "claude"
         case .codex: return "codex"
+        case .amp: return "amp"
         case .grok: return "grok"
         case .opencode: return "opencode"
         case .rovodev: return "rovodev"
@@ -201,6 +204,7 @@ enum AgentSpecifics: Hashable {
     case grok(model: String?, permissionMode: String?, sandboxMode: String?, grokHome: String?)
     case opencode(providerModel: String?, agentName: String?)
     case rovodev
+    case amp
     case hermesAgent(source: String?, model: String?, hermesHome: String?)
     case registered(CmuxVaultAgentRegistration)
 }
@@ -366,6 +370,8 @@ struct SessionEntry: Identifiable, Hashable {
             return parts.joined(separator: " ")
         case .rovodev:
             return "acli rovodev run --restore \(Self.shellQuote(sessionId))"
+        case .amp:
+            return "amp threads continue \(Self.shellQuote(sessionId))"
         case let .hermesAgent(source, model, hermesHome):
             return Self.hermesResumeCommand(
                 sessionId: sessionId,

--- a/Sources/SessionIndexStore.swift
+++ b/Sources/SessionIndexStore.swift
@@ -1274,6 +1274,7 @@ final class SessionIndexStore: ObservableObject {
             )
         case .opencode: return loadOpenCodeEntries(needle: needle, cwdFilter: cwdFilter, offset: offset, limit: limit, errorBag: errorBag)
         case .rovodev: return loadRovoDevEntries(needle: needle, cwdFilter: cwdFilter, offset: offset, limit: limit, errorBag: errorBag)
+        case .amp: return loadAmpEntries(needle: needle, cwdFilter: cwdFilter, offset: offset, limit: limit, errorBag: errorBag)
         case .hermesAgent: return loadHermesAgentEntries(needle: needle, cwdFilter: cwdFilter, offset: offset, limit: limit, errorBag: errorBag)
         case .registered(let agent):
             guard let registration = registry.registration(id: agent.id) else {

--- a/Sources/SessionIndexView.swift
+++ b/Sources/SessionIndexView.swift
@@ -1496,7 +1496,7 @@ private enum SessionTranscriptLoader {
                 usesGrokTranscriptLayout: usesGrokTranscriptLayout,
                 id: id
             )
-        case .hermesAgent:
+        case .amp, .hermesAgent:
             return nil
         }
     }
@@ -1827,7 +1827,7 @@ private enum SessionTranscriptLoader {
             return containsAny(data, needles: genericRoleNeedles)
         case .registered:
             return true
-        case .hermesAgent:
+        case .amp, .hermesAgent:
             return false
         }
     }
@@ -1860,7 +1860,7 @@ private enum SessionTranscriptLoader {
             }
         case .grok:
             return inferredGrokRole(from: data)
-        case .hermesAgent:
+        case .amp, .hermesAgent:
             return nil
         }
         return nil

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -418,6 +418,8 @@
 		C46790000000000000000007 /* RosettaNativeRelaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C46790000000000000000008 /* RosettaNativeRelaunchTests.swift */; };
 		F5310000A1B2C3D4E5F60718 /* RovoDevHookConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5310001A1B2C3D4E5F60718 /* RovoDevHookConfigTests.swift */; };
 		FE003105 /* RovoDevIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE003005 /* RovoDevIndex.swift */; };
+		FEA00002 /* AmpSessionIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEA00001 /* AmpSessionIndex.swift */; };
+		FEA00004 /* AmpSessionIndexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEA00003 /* AmpSessionIndexTests.swift */; };
 		F5300000A1B2C3D4E5F60718 /* RovoDevSessionIndexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5300001A1B2C3D4E5F60718 /* RovoDevSessionIndexTests.swift */; };
 		FE003107 /* RovoDevTranscriptPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE003007 /* RovoDevTranscriptPreview.swift */; };
 		F5300002A1B2C3D4E5F60718 /* RovoDevTranscriptPreviewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5300003A1B2C3D4E5F60718 /* RovoDevTranscriptPreviewTests.swift */; };
@@ -1066,6 +1068,8 @@
 		C46790000000000000000008 /* RosettaNativeRelaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RosettaNativeRelaunchTests.swift; sourceTree = "<group>"; };
 		F5310001A1B2C3D4E5F60718 /* RovoDevHookConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RovoDevHookConfigTests.swift; sourceTree = "<group>"; };
 		FE003005 /* RovoDevIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RovoDevIndex.swift; sourceTree = "<group>"; };
+		FEA00001 /* AmpSessionIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmpSessionIndex.swift; sourceTree = "<group>"; };
+		FEA00003 /* AmpSessionIndexTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmpSessionIndexTests.swift; sourceTree = "<group>"; };
 		F5300001A1B2C3D4E5F60718 /* RovoDevSessionIndexTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RovoDevSessionIndexTests.swift; sourceTree = "<group>"; };
 		FE003007 /* RovoDevTranscriptPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RovoDevTranscriptPreview.swift; sourceTree = "<group>"; };
 		F5300003A1B2C3D4E5F60718 /* RovoDevTranscriptPreviewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RovoDevTranscriptPreviewTests.swift; sourceTree = "<group>"; };
@@ -1779,6 +1783,7 @@
 				B35750000000000000000005 /* VaultAgentProcessScanner.swift */,
 				FE003004 /* SessionIndexStore+CodexSQL.swift */,
 				FE003005 /* RovoDevIndex.swift */,
+				FEA00001 /* AmpSessionIndex.swift */,
 				F5320001A1B2C3D4E5F60718 /* HermesAgentIndex.swift */,
 				FE003006 /* SessionAgentPresentation.swift */,
 				FE003007 /* RovoDevTranscriptPreview.swift */,
@@ -1868,6 +1873,7 @@
 					F5410003A1B2C3D4E5F60718 /* RestorableAgentNonInteractiveTests.swift */,
 					F5410007A1B2C3D4E5F60718 /* RestorableAgentSessionIndexTests.swift */,
 					F5300001A1B2C3D4E5F60718 /* RovoDevSessionIndexTests.swift */,
+					FEA00003 /* AmpSessionIndexTests.swift */,
 				3865B0043865B0043865B004 /* SearchIndexTests.swift */,
 				F5300003A1B2C3D4E5F60718 /* RovoDevTranscriptPreviewTests.swift */,
 				F5310001A1B2C3D4E5F60718 /* RovoDevHookConfigTests.swift */,
@@ -2573,6 +2579,7 @@
 				FE0031A3 /* RightSidebarToolPanel.swift in Sources */,
 				C46790000000000000000005 /* RosettaNativeRelaunch.swift in Sources */,
 				FE003105 /* RovoDevIndex.swift in Sources */,
+				FEA00002 /* AmpSessionIndex.swift in Sources */,
 				FE003107 /* RovoDevTranscriptPreview.swift in Sources */,
 				E8BA79E246754A8B99A0B823 /* ScreenIdentity.swift in Sources */,
 				3865A0013865A0013865A001 /* SearchIndex.swift in Sources */,
@@ -2890,6 +2897,7 @@
 				C46790000000000000000007 /* RosettaNativeRelaunchTests.swift in Sources */,
 				F5310000A1B2C3D4E5F60718 /* RovoDevHookConfigTests.swift in Sources */,
 					F5300000A1B2C3D4E5F60718 /* RovoDevSessionIndexTests.swift in Sources */,
+					FEA00004 /* AmpSessionIndexTests.swift in Sources */,
 				F5300002A1B2C3D4E5F60718 /* RovoDevTranscriptPreviewTests.swift in Sources */,
 				3865A0043865A0043865A004 /* SearchIndexTests.swift in Sources */,
 				8A3392FE64E0605D942213D1 /* SessionIndexViewTests.swift in Sources */,

--- a/cmuxTests/AmpSessionIndexTests.swift
+++ b/cmuxTests/AmpSessionIndexTests.swift
@@ -42,22 +42,24 @@ final class AmpSessionIndexTests: XCTestCase {
         XCTAssertEqual(entry.title, "Amp session in amp repo")
         let resume = try XCTUnwrap(entry.resumeCommand)
         XCTAssertTrue(
-            resume.hasSuffix("amp threads continue \(SessionEntry.shellQuote("T-newer"))"),
+            resume.hasSuffix("amp threads continue T-newer"),
             "unexpected resume command: \(resume)"
         )
         XCTAssertTrue(resume.contains("/tmp/amp repo"), "resume should cd into the cwd: \(resume)")
     }
 
     func testResumeCommandWithoutCwd() throws {
+        // Whitespace-containing id so the assertion independently verifies
+        // shell-quoting rather than echoing SessionEntry.shellQuote back.
         let storeURL = try writeStore([
-            "T-nocwd": ["sessionId": "T-nocwd", "updatedAt": 50.0],
+            "T nocwd": ["sessionId": "T nocwd", "updatedAt": 50.0],
         ])
         defer { try? FileManager.default.removeItem(at: storeURL.deletingLastPathComponent()) }
 
         let entry = try XCTUnwrap(SessionIndexStore.loadAmpEntriesForTesting(storeURL: storeURL).entries.first)
         XCTAssertNil(entry.cwd)
         XCTAssertEqual(entry.title, "Amp session")
-        XCTAssertEqual(entry.resumeCommand, "amp threads continue \(SessionEntry.shellQuote("T-nocwd"))")
+        XCTAssertEqual(entry.resumeCommand, "amp threads continue 'T nocwd'")
     }
 
     func testPrefersRecordTitleWhenPresent() throws {
@@ -86,7 +88,9 @@ final class AmpSessionIndexTests: XCTestCase {
         let outcome = SessionIndexStore.loadAmpEntriesForTesting(storeURL: storeURL)
         XCTAssertEqual(outcome.entries, [])
         XCTAssertEqual(outcome.errors.count, 1)
-        XCTAssertTrue(outcome.errors[0].contains("Amp: cannot read session store"))
+        // Sanitized: filename only, no absolute path.
+        XCTAssertTrue(outcome.errors[0].contains("Amp: cannot read amp-hook-sessions.json"))
+        XCTAssertFalse(outcome.errors[0].contains(storeURL.path))
     }
 
     func testMissingStoreIsEmptyWithoutError() throws {

--- a/cmuxTests/AmpSessionIndexTests.swift
+++ b/cmuxTests/AmpSessionIndexTests.swift
@@ -1,0 +1,111 @@
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+final class AmpSessionIndexTests: XCTestCase {
+    func testReadsHookStoreSortedFilteredWithResumeCommand() throws {
+        let storeURL = try writeStore([
+            "T-older": [
+                "sessionId": "T-older",
+                "cwd": "/tmp/other repo",
+                "updatedAt": 100.0,
+            ],
+            "T-newer": [
+                "sessionId": "T-newer",
+                "cwd": "/tmp/amp repo",
+                "updatedAt": 200.0,
+            ],
+        ])
+        defer { try? FileManager.default.removeItem(at: storeURL.deletingLastPathComponent()) }
+
+        // No filter: newest first.
+        let all = SessionIndexStore.loadAmpEntriesForTesting(storeURL: storeURL)
+        XCTAssertEqual(all.errors, [])
+        XCTAssertEqual(all.entries.map(\.sessionId), ["T-newer", "T-older"])
+        XCTAssertTrue(all.entries.allSatisfy { $0.agent == .amp })
+
+        // cwd filter narrows to a single session and builds the documented resume command.
+        let filtered = SessionIndexStore.loadAmpEntriesForTesting(
+            storeURL: storeURL,
+            cwdFilter: "/tmp/amp repo"
+        )
+        let entry = try XCTUnwrap(filtered.entries.first)
+        XCTAssertEqual(filtered.entries.count, 1)
+        XCTAssertEqual(entry.sessionId, "T-newer")
+        XCTAssertEqual(entry.cwd, "/tmp/amp repo")
+        XCTAssertNil(entry.fileURL)
+        // Title is synthesized from the cwd basename (Amp has no local title).
+        XCTAssertEqual(entry.title, "Amp session in amp repo")
+        let resume = try XCTUnwrap(entry.resumeCommand)
+        XCTAssertTrue(
+            resume.hasSuffix("amp threads continue \(SessionEntry.shellQuote("T-newer"))"),
+            "unexpected resume command: \(resume)"
+        )
+        XCTAssertTrue(resume.contains("/tmp/amp repo"), "resume should cd into the cwd: \(resume)")
+    }
+
+    func testResumeCommandWithoutCwd() throws {
+        let storeURL = try writeStore([
+            "T-nocwd": ["sessionId": "T-nocwd", "updatedAt": 50.0],
+        ])
+        defer { try? FileManager.default.removeItem(at: storeURL.deletingLastPathComponent()) }
+
+        let entry = try XCTUnwrap(SessionIndexStore.loadAmpEntriesForTesting(storeURL: storeURL).entries.first)
+        XCTAssertNil(entry.cwd)
+        XCTAssertEqual(entry.title, "Amp session")
+        XCTAssertEqual(entry.resumeCommand, "amp threads continue \(SessionEntry.shellQuote("T-nocwd"))")
+    }
+
+    func testPrefersRecordTitleWhenPresent() throws {
+        let storeURL = try writeStore([
+            "T-titled": [
+                "sessionId": "T-titled",
+                "cwd": "/tmp/repo",
+                "title": "Ship Amp Session Index",
+                "updatedAt": 10.0,
+            ],
+        ])
+        defer { try? FileManager.default.removeItem(at: storeURL.deletingLastPathComponent()) }
+
+        let entry = try XCTUnwrap(SessionIndexStore.loadAmpEntriesForTesting(storeURL: storeURL).entries.first)
+        XCTAssertEqual(entry.title, "Ship Amp Session Index")
+    }
+
+    func testMalformedStoreReportsErrorWithoutCrashing() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-amp-index-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storeURL = dir.appendingPathComponent("amp-hook-sessions.json")
+        try Data("{".utf8).write(to: storeURL)
+
+        let outcome = SessionIndexStore.loadAmpEntriesForTesting(storeURL: storeURL)
+        XCTAssertEqual(outcome.entries, [])
+        XCTAssertEqual(outcome.errors.count, 1)
+        XCTAssertTrue(outcome.errors[0].contains("Amp: cannot read session store"))
+    }
+
+    func testMissingStoreIsEmptyWithoutError() throws {
+        let storeURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-amp-missing-\(UUID().uuidString)")
+            .appendingPathComponent("amp-hook-sessions.json")
+        let outcome = SessionIndexStore.loadAmpEntriesForTesting(storeURL: storeURL)
+        XCTAssertEqual(outcome.entries, [])
+        XCTAssertEqual(outcome.errors, [])
+    }
+
+    private func writeStore(_ sessions: [String: [String: Any]]) throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-amp-index-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let storeURL = dir.appendingPathComponent("amp-hook-sessions.json")
+        let payload: [String: Any] = ["version": 1, "sessions": sessions]
+        let data = try JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])
+        try data.write(to: storeURL)
+        return storeURL
+    }
+}

--- a/cmuxTests/CLIGenericHookPersistenceTests.swift
+++ b/cmuxTests/CLIGenericHookPersistenceTests.swift
@@ -3696,4 +3696,76 @@ extension CLINotifyProcessIntegrationRegressionTests {
             )
         }
     }
+
+    /// A `title` in the prompt-submit payload must be persisted to the hook
+    /// session store so the Vault can show it instead of a cwd-synthesized
+    /// label. (The Amp plugin supplies the title; how it derives it is its
+    /// own concern.)
+    func testAmpPromptSubmitPersistsTitle() throws {
+        let cliPath = try bundledCLIPath()
+        let socketPath = makeSocketPath("hook-amp-title")
+        let listenerFD = try bindUnixSocket(at: socketPath)
+        let state = MockSocketServerState()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-amp-title-\(UUID().uuidString)", isDirectory: true)
+        let workspace = root.appendingPathComponent("repo", isDirectory: true)
+        let workspaceId = "11111111-1111-1111-1111-111111111111"
+        let surfaceId = "22222222-2222-2222-2222-222222222222"
+        let sessionId = "T-amp-title-123"
+        let title = "Add Amp to the Vault sidebar"
+
+        try FileManager.default.createDirectory(at: workspace, withIntermediateDirectories: true)
+        defer {
+            Darwin.close(listenerFD)
+            unlink(socketPath)
+            try? FileManager.default.removeItem(at: root)
+        }
+
+        let serverHandled = startMockServer(listenerFD: listenerFD, state: state) { line in
+            guard let payload = self.jsonObject(line) else { return "OK" }
+            guard let id = payload["id"] as? String, let method = payload["method"] as? String else {
+                return self.malformedRequestResponse(id: payload["id"] as? String, raw: line)
+            }
+            switch method {
+            case "surface.list":
+                return self.surfaceListResponse(id: id, surfaceId: surfaceId)
+            case "surface.resume.set":
+                return self.v2Response(id: id, ok: true, result: ["ok": true])
+            case "feed.push":
+                return self.v2Response(id: id, ok: true, result: [:])
+            default:
+                return self.v2Response(id: id, ok: true, result: [:])
+            }
+        }
+
+        let environment: [String: String] = [
+            "HOME": root.path,
+            "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+            "PWD": workspace.path,
+            "CMUX_SOCKET_PATH": socketPath,
+            "CMUX_WORKSPACE_ID": workspaceId,
+            "CMUX_SURFACE_ID": surfaceId,
+            "CMUX_AGENT_HOOK_STATE_DIR": root.path,
+            "CMUX_CLI_SENTRY_DISABLED": "1",
+        ]
+
+        let result = runProcess(
+            executablePath: cliPath,
+            arguments: ["hooks", "amp", "prompt-submit"],
+            environment: environment,
+            standardInput: #"{"session_id":"\#(sessionId)","cwd":"\#(workspace.path)","hook_event_name":"UserPromptSubmit","title":"\#(title)"}"#,
+            timeout: 5
+        )
+
+        wait(for: [serverHandled], timeout: 5)
+        XCTAssertFalse(result.timedOut, result.stderr)
+        XCTAssertEqual(result.status, 0, result.stderr)
+
+        let storeURL = root.appendingPathComponent("amp-hook-sessions.json", isDirectory: false)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(contentsOf: storeURL)) as? [String: Any])
+        let sessions = try XCTUnwrap(json["sessions"] as? [String: Any])
+        let session = try XCTUnwrap(sessions[sessionId] as? [String: Any])
+        XCTAssertEqual(session["title"] as? String, title)
+        XCTAssertEqual(session["cwd"] as? String, workspace.path)
+    }
 }

--- a/cmuxTests/CLIGenericHookPersistenceTests.swift
+++ b/cmuxTests/CLIGenericHookPersistenceTests.swift
@@ -3734,7 +3734,10 @@ extension CLINotifyProcessIntegrationRegressionTests {
             case "feed.push":
                 return self.v2Response(id: id, ok: true, result: [:])
             default:
-                return self.v2Response(id: id, ok: true, result: [:])
+                return self.v2Response(
+                    id: id, ok: false,
+                    error: ["code": "unrecognized_method", "message": "unexpected method: \(method)"]
+                )
             }
         }
 

--- a/cmuxTests/SessionIndexViewTests.swift
+++ b/cmuxTests/SessionIndexViewTests.swift
@@ -578,6 +578,8 @@ private extension SessionAgent {
             )
         case .codex:
             return .codex(model: nil, approvalPolicy: nil, sandboxMode: nil, effort: nil)
+        case .amp:
+            return .amp
         case .grok:
             return .grok(model: nil, permissionMode: nil, sandboxMode: nil, grokHome: nil)
         case .opencode:


### PR DESCRIPTION
## Summary

Adds **Amp** (Sourcegraph Amp CLI) to the **Vault** (Session Index) sidebar, so Amp threads can be browsed, searched, and resumed alongside Claude Code, Codex, Grok, OpenCode, Rovo Dev, and Hermes. Amp was already a restorable agent (auto-relaunch on app start); this brings it to parity in the past-sessions UI.

<img width="483" height="691" alt="image" src="https://github.com/user-attachments/assets/34587325-dad7-4311-94fe-6ab0d853ebda" />

Demo image illustrates the progression from fallback -> first message -> title observing

## Why the hook store (not Amp's thread files)

Amp threads now live server-side. The legacy `~/.local/share/amp/threads/*.json` store is abandoned (stale for over a month locally), so this reads Amp sessions from **cmux's own hook store** `~/.cmuxterm/amp-hook-sessions.json` — written by the bundled Amp plugin via `cmux hooks amp`. That store is current, cmux-owned, and already powers the restore flow.

## Titles

The hook store carries no conversation title on its own, so the bundled Amp plugin supplies one. It reads the **real thread title** from the Amp plugin API (`ctx.thread.title`) and **subscribes** to it, so a title that Amp generates asynchronously reaches cmux even for single-turn threads. It falls back to the first user message on older Amp versions whose plugin API predates `thread.title`, and finally to a cwd-derived label (`Amp session in <dir>`). The CLI persists whatever `title` it receives and the Vault prefers it — where the title comes from is the plugin's concern. This avoids parsing Amp's unstable debug logs.

## Changes

- `Sources/AmpSessionIndex.swift` — read-only scanner for the Amp hook store (sort, needle + cwd filtering, pagination), preferring the stored `title` and synthesizing a cwd label otherwise
- `SessionAgent.amp` + `AgentSpecifics.amp` with resume `amp threads continue <id>`
- Store dispatch, presentation (display name + official Amp icon asset), localized strings (en/ja)
- `CLI/CMUXCLI+AmpExtension.swift` — plugin resolves the thread title via `ctx.thread.title` (get + subscribe) with first-message/cwd fallback, and prefers the app-bundled `cmux` for hooks
- `CLI/cmux.swift` — persists a generic `title` field on the hook session record without clobbering an existing one
- Tests: scanner parsing/sorting/cwd-filter/resume/malformed-store (`cmuxTests/AmpSessionIndexTests.swift`) and end-to-end `title` persistence (`cmuxTests/CLIGenericHookPersistenceTests.swift`)

## Verification

- Rebased on latest `main`; `cmux` app target and `cmux-unit` test target both compile (`build-for-testing` → `TEST BUILD SUCCEEDED`).
- Title flow (real title, subscription upgrade for single-turn threads, and cwd fallback) verified end-to-end in a local tagged dev build.
- Tests not run locally per repo policy — relying on CI.

🤖 Authored with AI assistance.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5366"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783189427&installation_id=133855650&pr_number=5366&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5366&signature=f2268200669f438247fe0765bb7e4e887a5d78bd8ca35b42513671725cba9e5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Amp to the Vault (Session Index) so you can browse, search, and resume Amp threads alongside other agents. Sessions are read from `cmux`’s Amp hook store and show the real thread title when available, falling back to the first user message or cwd.

- New Features
  - Added `SessionAgent.amp` and `AgentSpecifics.amp`; resume via `amp threads continue <id>`.
  - Scanner reads `~/.cmuxterm/amp-hook-sessions.json` with sort, search, cwd filter, and pagination.
  - Amp plugin subscribes to `thread.title`; CLI persists `title`, and the sidebar prefers it over cwd; added localized labels and the official icon; the plugin now prefers the app-bundled `cmux`; tests cover the scanner, resume command, malformed/missing-store handling, and title persistence.

- Bug Fixes
  - Title subscription gated to active turns to avoid reviving idle sessions.
  - Normalized Amp cwd with `standardizingPath` to match other agents’ bucketing and filters.
  - Read errors now show only the filename (no absolute path), consistent with other agents.

<sup>Written for commit e35caa7dc6c0d6978480070581585898e18c2b61. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->








<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Amp agent support: session indexing, search, resume command, and transcript preview parsing
  * Session title capture, backfill, watching, and propagation to hooks and session state
  * Added Amp icon asset and localized strings for Amp sessions
  * UI now shows Amp display name and asset

* **Tests**
  * Added tests for Amp session indexing, search, resume command, transcript parsing, and title persistence
<!-- end of auto-generated comment: release notes by coderabbit.ai -->