### PR TITLE
Reland: out-of-process custom sidebars (isolated interpreter + remote rendering)

### DIFF
--- a/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/CuratedSettingEntry+Default.swift
+++ b/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/CuratedSettingEntry+Default.swift
@@ -99,6 +99,7 @@ extension Array where Element == CuratedSettingEntry {
             // Beta
             .init(section: .betaFeatures, id: "feed", title: "Feed", synonyms: "feed right sidebar agent decisions permissions questions approval beta unstable"),
             .init(section: .betaFeatures, id: "dock", title: "Dock", synonyms: "dock right sidebar terminal controls tui beta unstable"),
+            .init(section: .betaFeatures, id: "customSidebars", title: "Custom Sidebars", synonyms: "custom sidebars swift json interpreted vibe beta unstable"),
 
             // Automation
             .init(section: .automation, id: "socket-mode", title: "Socket Control Mode", synonyms: "automation.socketControlMode api socket unix domain control server auth allow password disabled"),

--- a/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/BetaFeaturesSection.swift
+++ b/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/BetaFeaturesSection.swift
@@ -2,18 +2,21 @@ import CmuxSettings
 import SwiftUI
 
 /// **Beta Features** section — a warning note followed by the
-/// experimental toggles: `Feed`, `Dock`, and `Extensions`. Each toggle
-/// gates an unstable feature that is off by default.
+/// experimental toggles: `Feed`, `Dock`, `Extensions`, and
+/// `Custom Sidebars`. Each toggle gates an unstable feature that is off
+/// by default.
 @MainActor
 public struct BetaFeaturesSection: View {
     @State private var feed: DefaultsValueModel<Bool>
     @State private var dock: DefaultsValueModel<Bool>
     @State private var extensions: DefaultsValueModel<Bool>
+    @State private var customSidebars: DefaultsValueModel<Bool>
 
     public init(defaultsStore: UserDefaultsSettingsStore, catalog: SettingCatalog) {
         _feed = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.betaFeatures.rightSidebarFeed))
         _dock = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.betaFeatures.rightSidebarDock))
         _extensions = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.betaFeatures.extensions))
+        _customSidebars = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.betaFeatures.customSidebars))
     }
 
     public var body: some View {
@@ -29,6 +32,8 @@ public struct BetaFeaturesSection: View {
                 dockRow
                 SettingsCardDivider()
                 extensionsRow
+                SettingsCardDivider()
+                customSidebarsRow
             }
         }
     }
@@ -81,6 +86,23 @@ public struct BetaFeaturesSection: View {
                 .labelsHidden()
                 .controlSize(.small)
                 .accessibilityIdentifier("SettingsBetaExtensionsToggle")
+        }
+    }
+
+    @ViewBuilder
+    private var customSidebarsRow: some View {
+        SettingsCardRow(
+            configurationReview: .settingsOnly,
+            searchAnchorID: "setting:betaFeatures:customSidebars",
+            String(localized: "settings.betaFeatures.customSidebars", defaultValue: "Custom Sidebars"),
+            subtitle: customSidebars.current
+                ? String(localized: "settings.betaFeatures.customSidebars.subtitleOn", defaultValue: "Lists your sidebars from ~/.config/cmux/sidebars in the sidebar picker, rendered in an isolated helper process.")
+                : String(localized: "settings.betaFeatures.customSidebars.subtitleOff", defaultValue: "Hides custom sidebars from the sidebar picker until you enable them here.")
+        ) {
+            Toggle("", isOn: Binding(get: { customSidebars.current }, set: { customSidebars.set($0) }))
+                .labelsHidden()
+                .controlSize(.small)
+                .accessibilityIdentifier("SettingsBetaCustomSidebarsToggle")
         }
     }
 }

--- a/Packages/CmuxSettingsUI/Tests/CmuxSettingsUITests/SettingsRowAnchorResolutionTests.swift
+++ b/Packages/CmuxSettingsUI/Tests/CmuxSettingsUITests/SettingsRowAnchorResolutionTests.swift
@@ -127,6 +127,7 @@ struct SettingsRowAnchorResolutionTests {
         "setting:account:account",
         "setting:betaFeatures:feed",
         "setting:betaFeatures:dock",
+        "setting:betaFeatures:customSidebars",
         "setting:browser:history",
         "setting:browser:http-allowlist",
         "setting:workspaceColors:palette",

--- a/Packages/CmuxSidebarInterpreterService/Package.resolved
+++ b/Packages/CmuxSidebarInterpreterService/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "54fcd85444a80bfa0b5c67ea264b852e871b3bdd84b9a08fc7e1ab77756837a3",
+  "pins" : [
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
+      "state" : {
+        "revision" : "0687f71944021d616d34d922343dcef086855920",
+        "version" : "600.0.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Packages/CmuxSidebarInterpreterService/Package.swift
+++ b/Packages/CmuxSidebarInterpreterService/Package.swift
@@ -1,0 +1,77 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "CmuxSidebarInterpreterService",
+    platforms: [
+        .macOS(.v14),
+    ],
+    products: [
+        // Host-side client + wire protocol the app links against.
+        .library(
+            name: "CmuxSidebarInterpreterClient",
+            targets: ["CmuxSidebarInterpreterClient"]
+        ),
+        // The out-of-process worker that runs the untrusted interpreter.
+        .executable(
+            name: "cmux-sidebar-interpreter",
+            targets: ["cmux-sidebar-interpreter"]
+        ),
+        // Headless protocol fixture for RenderWorkerClient supervision tests.
+        .executable(
+            name: "cmux-sidebar-render-fixture",
+            targets: ["cmux-sidebar-render-fixture"]
+        ),
+        // Remote rendering: the faceless render-worker loop and the host-side
+        // layer-hosting sidebar surface.
+        .library(
+            name: "CmuxSidebarRemoteRender",
+            targets: ["CmuxSidebarRemoteRender"]
+        ),
+    ],
+    dependencies: [
+        .package(path: "../CmuxSwiftRender"),
+        .package(path: "../CmuxSwiftRenderUI"),
+    ],
+    targets: [
+        .target(
+            name: "CmuxSidebarInterpreterClient",
+            dependencies: ["CmuxSwiftRender"],
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+            ]
+        ),
+        .executableTarget(
+            name: "cmux-sidebar-interpreter",
+            dependencies: ["CmuxSidebarInterpreterClient"],
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+            ]
+        ),
+        .executableTarget(
+            name: "cmux-sidebar-render-fixture",
+            dependencies: ["CmuxSidebarInterpreterClient"],
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+            ]
+        ),
+        .target(
+            name: "CmuxSidebarRemoteRender",
+            dependencies: [
+                "CmuxSidebarInterpreterClient",
+                .product(name: "CmuxSwiftRenderUI", package: "CmuxSwiftRenderUI"),
+            ],
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+            ]
+        ),
+        .testTarget(
+            name: "CmuxSidebarInterpreterClientTests",
+            dependencies: ["CmuxSidebarInterpreterClient"],
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+            ]
+        ),
+    ]
+)

--- a/Packages/CmuxSidebarInterpreterService/Sources/CmuxSidebarInterpreterClient/InterpreterClient+ReexecSelf.swift
+++ b/Packages/CmuxSidebarInterpreterService/Sources/CmuxSidebarInterpreterClient/InterpreterClient+ReexecSelf.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+public extension InterpreterClient {
+    /// The argv flag that puts a host binary into sidebar-interpreter worker
+    /// mode. The app's entry point checks for this *before* any AppKit/SwiftUI
+    /// setup, runs ``runSidebarInterpreterWorker()``, and exits.
+    static let workerModeArgument = "--cmux-sidebar-interpreter-worker"
+
+    /// A client that runs the worker by re-executing the current process's
+    /// binary with ``workerModeArgument``.
+    ///
+    /// This avoids bundling and signing a separate helper executable: the app
+    /// already contains the interpreter, so the worker is just the same binary
+    /// launched in worker mode. The worker process is spawned lazily on the
+    /// first render and reused for the session.
+    ///
+    /// - Parameter timeout: Per-render deadline before the worker is killed and
+    ///   the render returns `nil`.
+    static func reexecingCurrentBinary(timeout: Duration = .seconds(2)) -> InterpreterClient {
+        let binary = Bundle.main.executableURL
+            ?? URL(fileURLWithPath: CommandLine.arguments[0])
+        return InterpreterClient(
+            executableURL: binary,
+            arguments: [workerModeArgument],
+            timeout: timeout
+        )
+    }
+}

--- a/Packages/CmuxSidebarInterpreterService/Sources/CmuxSidebarInterpreterClient/InterpreterClient+SidebarInterpreting.swift
+++ b/Packages/CmuxSidebarInterpreterService/Sources/CmuxSidebarInterpreterClient/InterpreterClient+SidebarInterpreting.swift
@@ -1,0 +1,6 @@
+import CmuxSwiftRender
+
+/// ``InterpreterClient`` is the out-of-process, crash-isolating
+/// ``SidebarInterpreting``: each `render` runs in a supervised worker, so an
+/// interpreter fault returns `nil` instead of crashing the host.
+extension InterpreterClient: SidebarInterpreting {}

--- a/Packages/CmuxSidebarInterpreterService/Sources/CmuxSidebarInterpreterClient/InterpreterClient.swift
+++ b/Packages/CmuxSidebarInterpreterService/Sources/CmuxSidebarInterpreterClient/InterpreterClient.swift
@@ -1,0 +1,216 @@
+import CmuxSwiftRender
+import Foundation
+
+/// Supervises an out-of-process ``RenderInterpreterRunner`` worker and renders
+/// untrusted sidebar source through it, so an interpreter crash, hang, or
+/// runaway never takes down the host.
+///
+/// The host calls ``render(source:state:)``; the request is encoded and sent to
+/// a worker process (the `cmux-sidebar-interpreter` executable), which replies
+/// with a ``RenderNode``. If the worker crashes (its pipe closes) or fails to
+/// answer within `timeout`, the call returns `nil` and the worker is relaunched
+/// on the next render. Responses are correlated by id, so concurrent renders
+/// are safe.
+///
+/// ```swift
+/// let client = InterpreterClient(executableURL: workerURL)
+/// let node = await client.render(source: source, state: dataContext)
+/// // node == nil  ⇒  show the sidebar's error/empty state
+/// ```
+public actor InterpreterClient {
+    /// Location of the worker executable (bundled in the app, injected in tests).
+    nonisolated let executableURL: URL
+    /// Extra environment for the worker process (used by tests for fault injection).
+    nonisolated let extraEnvironment: [String: String]
+    /// How long to wait for a single response before terminating the worker.
+    nonisolated let timeout: Duration
+    /// Arguments passed to the worker process (e.g. the worker-mode flag when
+    /// re-executing the host app binary).
+    nonisolated let arguments: [String]
+
+    private var child: Child?
+    private var generation: Int = 0
+    private var nextID: UInt64 = 0
+    private var waiters: [UInt64: CheckedContinuation<InterpreterResponse?, Never>] = [:]
+
+    /// Creates a client that launches `executableURL` on demand.
+    ///
+    /// - Parameters:
+    ///   - executableURL: The worker binary to run.
+    ///   - timeout: Per-render deadline; on expiry the worker is killed and the
+    ///     render returns `nil`. Defaults to 2 seconds.
+    ///   - arguments: Arguments for the worker process (defaults to none; the
+    ///     re-exec-self factory passes the worker-mode flag).
+    ///   - extraEnvironment: Additional environment for the worker process.
+    public init(
+        executableURL: URL,
+        arguments: [String] = [],
+        timeout: Duration = .seconds(2),
+        environment extraEnvironment: [String: String] = [:]
+    ) {
+        self.executableURL = executableURL
+        self.arguments = arguments
+        self.timeout = timeout
+        self.extraEnvironment = extraEnvironment
+    }
+
+    /// Renders `source` against `state` in the worker process.
+    ///
+    /// - Returns: the interpreted ``RenderNode``, or `nil` if the worker
+    ///   produced no view, crashed, or timed out. Never throws and never
+    ///   crashes the host regardless of what the source does.
+    public func render(source: String, state: [String: SwiftValue]) async -> RenderNode? {
+        let id = nextID
+        nextID &+= 1
+        let request = InterpreterRequest(id: id, source: source, state: state)
+        guard let data = try? JSONEncoder().encode(request) else { return nil }
+
+        let channel: LengthPrefixedMessageChannel
+        do {
+            channel = try ensureRunning()
+        } catch {
+            return nil
+        }
+
+        do {
+            try channel.sendMessage(data)
+        } catch {
+            // Broken pipe: the worker died. Drop it; the next render relaunches.
+            workerEnded(generation: generation)
+            return nil
+        }
+
+        // Bounded, cancellable deadline: if no reply lands in `timeout`, fail
+        // this waiter and terminate the worker (its closing pipe ends the
+        // reader). This is a genuine timeout, not a poll/settle.
+        let deadline = timeout
+        let watchdog = Task { [weak self] in
+            try? await Task.sleep(for: deadline)
+            guard let self else { return }
+            await self.timedOut(id: id)
+        }
+        defer { watchdog.cancel() }
+
+        let response = await withCheckedContinuation { continuation in
+            waiters[id] = continuation
+        }
+        guard let response, response.id == id else { return nil }
+        return response.node
+    }
+
+    /// Terminates the worker and fails any in-flight renders. Call from the
+    /// owner's teardown (e.g. when the sidebar disappears).
+    public func shutdown() {
+        child?.process.terminate()
+        child = nil
+        failAllWaiters()
+    }
+
+    // MARK: - Worker lifecycle
+
+    private func ensureRunning() throws -> LengthPrefixedMessageChannel {
+        if let child, child.process.isRunning {
+            return child.channel
+        }
+        return try launch()
+    }
+
+    private func launch() throws -> LengthPrefixedMessageChannel {
+        generation &+= 1
+        let gen = generation
+
+        let process = Process()
+        process.executableURL = executableURL
+        if !arguments.isEmpty { process.arguments = arguments }
+        let stdin = Pipe()
+        let stdout = Pipe()
+        process.standardInput = stdin
+        process.standardOutput = stdout
+        if !extraEnvironment.isEmpty {
+            process.environment = ProcessInfo.processInfo.environment
+                .merging(extraEnvironment) { _, new in new }
+        }
+
+        let channel = LengthPrefixedMessageChannel(
+            readFD: stdout.fileHandleForReading.fileDescriptor,
+            writeFD: stdin.fileHandleForWriting.fileDescriptor
+        )
+        process.terminationHandler = { [weak self] _ in
+            guard let self else { return }
+            Task { await self.workerEnded(generation: gen) }
+        }
+
+        try process.run()
+        child = Child(process: process, channel: channel, stdin: stdin, stdout: stdout)
+
+        // Reader thread: blocks draining framed responses off the worker's
+        // stdout descriptor and hands each to the actor. The channel is fd-
+        // backed and Sendable; FileHandle is not, so we never capture it.
+        let readChannel = channel
+        let reader = Thread { [weak self] in
+            while let data = readChannel.receiveMessage() {
+                guard let response = try? JSONDecoder().decode(InterpreterResponse.self, from: data) else {
+                    continue
+                }
+                Task { [weak self] in
+                    guard let self else { return }
+                    await self.deliver(response, generation: gen)
+                }
+            }
+            Task { [weak self] in
+                guard let self else { return }
+                await self.workerEnded(generation: gen)
+            }
+        }
+        reader.stackSize = 1 << 20
+        reader.name = "cmux-sidebar-interpreter-reader"
+        reader.start()
+
+        return channel
+    }
+
+    private func deliver(_ response: InterpreterResponse, generation gen: Int) {
+        guard gen == generation else { return } // ignore a superseded worker
+        waiters.removeValue(forKey: response.id)?.resume(returning: response)
+    }
+
+    private func timedOut(id: UInt64) {
+        guard let continuation = waiters.removeValue(forKey: id) else { return }
+        continuation.resume(returning: nil)
+        // Discard the worker synchronously (not just terminate and wait for the
+        // async termination handler) so the next render relaunches a fresh one
+        // instead of reusing the dying process.
+        discardWorker()
+    }
+
+    /// Terminates the current worker and forgets it, so ``ensureRunning()``
+    /// relaunches on the next render. The old worker's reader/termination
+    /// handler run under its now-stale generation and no-op.
+    private func discardWorker() {
+        child?.process.terminate()
+        child = nil
+    }
+
+    private func workerEnded(generation gen: Int) {
+        guard gen == generation else { return }
+        child = nil
+        failAllWaiters()
+    }
+
+    private func failAllWaiters() {
+        let pending = waiters
+        waiters.removeAll()
+        for (_, continuation) in pending {
+            continuation.resume(returning: nil)
+        }
+    }
+}
+
+/// A running worker process and the channel/pipes that feed it. Held only by
+/// the ``InterpreterClient`` actor, so its non-`Sendable` members are safe.
+private struct Child {
+    let process: Process
+    let channel: LengthPrefixedMessageChannel
+    let stdin: Pipe
+    let stdout: Pipe
+}

--- a/Packages/CmuxSidebarInterpreterService/Sources/CmuxSidebarInterpreterClient/InterpreterRequest.swift
+++ b/Packages/CmuxSidebarInterpreterService/Sources/CmuxSidebarInterpreterClient/InterpreterRequest.swift
@@ -1,0 +1,22 @@
+import CmuxSwiftRender
+
+/// A request sent from the host to the out-of-process interpreter worker:
+/// interpret `source` against `state` and return the resulting ``RenderNode``.
+///
+/// `id` correlates the response to this request so the host can match replies
+/// even though the worker is a separate process and the channel is a single
+/// ordered byte stream.
+public struct InterpreterRequest: Codable, Sendable {
+    /// Monotonic per-client identifier the matching ``InterpreterResponse`` echoes.
+    public let id: UInt64
+    /// The untrusted Swift-subset sidebar source to interpret.
+    public let source: String
+    /// The live, read-only data context the interpreter binds identifiers to.
+    public let state: [String: SwiftValue]
+
+    public init(id: UInt64, source: String, state: [String: SwiftValue]) {
+        self.id = id
+        self.source = source
+        self.state = state
+    }
+}

--- a/Packages/CmuxSidebarInterpreterService/Sources/CmuxSidebarInterpreterClient/InterpreterResponse.swift
+++ b/Packages/CmuxSidebarInterpreterService/Sources/CmuxSidebarInterpreterClient/InterpreterResponse.swift
@@ -1,0 +1,20 @@
+import CmuxSwiftRender
+
+/// The worker's reply to an ``InterpreterRequest``: the interpreted
+/// ``RenderNode`` tree, or `nil` when the source produced no supported view.
+///
+/// A crash, timeout, or protocol error in the worker produces *no* response at
+/// all; the host treats the absence (its waiter failing) as "render
+/// unavailable" and shows its error/empty state, so an interpreter defect can
+/// never take down the host process.
+public struct InterpreterResponse: Codable, Sendable {
+    /// Echoes the originating ``InterpreterRequest/id``.
+    public let id: UInt64
+    /// The interpreted view tree, or `nil` if nothing supported was found.
+    public let node: RenderNode?
+
+    public init(id: UInt64, node: RenderNode?) {
+        self.id = id
+        self.node = node
+    }
+}

--- a/Packages/CmuxSidebarInterpreterService/Sources/CmuxSidebarInterpreterClient/LengthPrefixedMessageChannel.swift
+++ b/Packages/CmuxSidebarInterpreterService/Sources/CmuxSidebarInterpreterClient/LengthPrefixedMessageChannel.swift
@@ -1,0 +1,111 @@
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+import Foundation
+
+/// A framed message channel over a pair of POSIX file descriptors.
+///
+/// Each message is a 4-byte big-endian length prefix followed by that many
+/// bytes of payload (JSON in this package's use). The channel works on raw
+/// `Int32` descriptors (which are `Sendable`) rather than `FileHandle` (which
+/// is not), so it can be shared between the supervising ``InterpreterClient``
+/// actor and its reader thread without ceremony.
+///
+/// Both ends are blocking syscalls (`read(2)` / `write(2)`): the worker reads a
+/// request, the host reads a response, each on its own descriptor. `EINTR` is
+/// retried; any other short read/`0` is treated as end-of-stream.
+public struct LengthPrefixedMessageChannel: Sendable {
+    private let readFD: Int32
+    private let writeFD: Int32
+
+    /// Creates a channel that reads from `readFD` and writes to `writeFD`.
+    public init(readFD: Int32, writeFD: Int32) {
+        self.readFD = readFD
+        self.writeFD = writeFD
+    }
+
+    /// Frames larger than this are protocol violations: real traffic is JSON
+    /// of sidebar source + data context (KBs). The cap stops a corrupted or
+    /// hostile peer's length header from forcing a giant allocation.
+    public static let maximumFrameLength = 64 * 1024 * 1024
+
+    /// Writes `payload` as one length-prefixed frame. Throws ``ChannelError``
+    /// if the descriptor is closed or errors mid-write, or if `payload`
+    /// exceeds ``maximumFrameLength``.
+    public func sendMessage(_ payload: Data) throws {
+        guard payload.count <= Self.maximumFrameLength else {
+            throw ChannelError.frameTooLarge
+        }
+        let count = UInt32(payload.count)
+        var header = Data(count: 4)
+        header[0] = UInt8((count >> 24) & 0xFF)
+        header[1] = UInt8((count >> 16) & 0xFF)
+        header[2] = UInt8((count >> 8) & 0xFF)
+        header[3] = UInt8(count & 0xFF)
+        try writeAll(header)
+        if !payload.isEmpty { try writeAll(payload) }
+    }
+
+    /// Reads the next length-prefixed frame, or `nil` at end-of-stream (the
+    /// peer closed or died) or on a read error. A `nil` is the host's signal
+    /// that the worker is gone.
+    public func receiveMessage() -> Data? {
+        guard let header = readExactly(4) else { return nil }
+        let count = (UInt32(header[0]) << 24)
+            | (UInt32(header[1]) << 16)
+            | (UInt32(header[2]) << 8)
+            | UInt32(header[3])
+        if count == 0 { return Data() }
+        // A peer-controlled length: treat an oversized header like EOF (the
+        // peer is broken or hostile) instead of allocating what it asks for.
+        guard count <= UInt32(Self.maximumFrameLength) else { return nil }
+        return readExactly(Int(count))
+    }
+
+    private func writeAll(_ data: Data) throws {
+        try data.withUnsafeBytes { (raw: UnsafeRawBufferPointer) in
+            guard let base = raw.baseAddress else { return }
+            var offset = 0
+            while offset < raw.count {
+                let written = write(writeFD, base + offset, raw.count - offset)
+                if written > 0 {
+                    offset += written
+                } else if written == -1 && errno == EINTR {
+                    continue
+                } else {
+                    throw ChannelError.writeFailed
+                }
+            }
+        }
+    }
+
+    private func readExactly(_ count: Int) -> Data? {
+        guard count > 0 else { return Data() }
+        var buffer = [UInt8](repeating: 0, count: count)
+        var filled = 0
+        while filled < count {
+            let got: Int = buffer.withUnsafeMutableBytes { (raw: UnsafeMutableRawBufferPointer) in
+                guard let base = raw.baseAddress else { return -1 }
+                return read(readFD, base + filled, count - filled)
+            }
+            if got > 0 {
+                filled += got
+            } else if got == -1 && errno == EINTR {
+                continue
+            } else {
+                return nil // 0 = clean EOF; <0 = error. Either way, peer is gone.
+            }
+        }
+        return Data(buffer)
+    }
+}
+
+/// A failure writing to a ``LengthPrefixedMessageChannel`` (a closed or broken
+/// descriptor, typically because the peer process exited).
+public enum ChannelError: Error, Sendable {
+    case writeFailed
+    /// The outbound payload exceeds ``LengthPrefixedMessageChannel/maximumFrameLength``.
+    case frameTooLarge
+}

--- a/Packages/CmuxSidebarInterpreterService/Sources/CmuxSidebarInterpreterClient/RemoteContextCache.swift
+++ b/Packages/CmuxSidebarInterpreterService/Sources/CmuxSidebarInterpreterClient/RemoteContextCache.swift
@@ -1,0 +1,15 @@
+/// Main-actor mirror of the supervised render worker's current remote context
+/// id.
+///
+/// A freshly mounted sidebar surface reads this synchronously to adopt the
+/// live worker's layer in the same frame it appears, instead of blanking for
+/// the duration of the async ``RenderWorkerClient/subscribe()`` round-trip
+/// (the stream replay still delivers the id, plus any later regenerations).
+@MainActor
+public final class RemoteContextCache {
+    /// The live worker's context id, or `nil` while no worker is alive.
+    public internal(set) var contextId: UInt32?
+
+    /// Creates an empty cache; the owning client populates it.
+    public nonisolated init() {}
+}

--- a/Packages/CmuxSidebarInterpreterService/Sources/CmuxSidebarInterpreterClient/RenderInterpreterRunner.swift
+++ b/Packages/CmuxSidebarInterpreterService/Sources/CmuxSidebarInterpreterClient/RenderInterpreterRunner.swift
@@ -1,0 +1,48 @@
+import CmuxSwiftRender
+import Foundation
+
+/// Turns an ``InterpreterRequest`` into an ``InterpreterResponse`` by running
+/// the ``SwiftViewInterpreter``.
+///
+/// This is the only logic the out-of-process worker runs. It is the worker's
+/// single-threaded read-eval-write loop, so it caches the most recent parse:
+/// the host re-renders on a timer with the same source but changing data, and
+/// re-parsing unchanged source every tick is wasteful. (Reference type because
+/// it holds that cache; it is confined to the worker's serial loop.)
+public final class RenderInterpreterRunner {
+    private let interpreter = SwiftViewInterpreter()
+    private var cachedSource: String?
+    private var cachedProgram: ParsedProgram?
+
+    public init() {}
+
+    /// Interprets `request.source` against `request.state` and returns the
+    /// matching response, reusing a cached parse when the source is unchanged.
+    public func run(_ request: InterpreterRequest) -> InterpreterResponse {
+        // Test-only fault injection, gated behind environment variables the app
+        // never sets. This lets crash/timeout isolation be verified through the
+        // real process boundary (a worker that genuinely dies/hangs), which is
+        // the property the whole package exists to provide.
+        let environment = ProcessInfo.processInfo.environment
+        if let crashToken = environment["CMUX_INTERPRETER_TEST_CRASH_TOKEN"],
+           !crashToken.isEmpty, request.source == crashToken {
+            fatalError("interpreter worker test crash sentinel")
+        }
+        if let hangToken = environment["CMUX_INTERPRETER_TEST_HANG_TOKEN"],
+           !hangToken.isEmpty, request.source == hangToken {
+            // Deterministic test-only hang to exercise the client's timeout.
+            Thread.sleep(forTimeInterval: 3600)
+        }
+
+        let program: ParsedProgram
+        if cachedSource == request.source, let cached = cachedProgram {
+            program = cached
+        } else {
+            program = interpreter.parse(request.source)
+            cachedSource = request.source
+            cachedProgram = program
+        }
+        let node = interpreter.evaluate(program, state: request.state)
+        return InterpreterResponse(id: request.id, node: node)
+    }
+}

--- a/Packages/CmuxSidebarInterpreterService/Sources/CmuxSidebarInterpreterClient/RenderPointerEvent.swift
+++ b/Packages/CmuxSidebarInterpreterService/Sources/CmuxSidebarInterpreterClient/RenderPointerEvent.swift
@@ -1,0 +1,57 @@
+/// A pointer interaction forwarded from the host's sidebar surface to the
+/// render worker, which replays it against its offscreen view tree.
+///
+/// Coordinates are in points in the surface's AppKit window space: origin at
+/// the **bottom-left** of the sidebar surface, matching the worker's offscreen
+/// window so no flipping is needed on either side.
+public struct RenderPointerEvent: Codable, Sendable, Equatable {
+    /// The interaction kind.
+    public enum Kind: String, Codable, Sendable {
+        /// Primary button pressed.
+        case down
+        /// Primary button released.
+        case up
+        /// Pointer moved with the primary button held.
+        case drag
+        /// Scroll wheel / trackpad scroll delta.
+        case scroll
+    }
+
+    /// What happened.
+    public var kind: Kind
+    /// X in surface points, from the left edge.
+    public var x: Double
+    /// Y in surface points, from the **bottom** edge (AppKit window coords).
+    public var y: Double
+    /// Horizontal scroll delta in points (``Kind/scroll`` only).
+    public var deltaX: Double
+    /// Vertical scroll delta in points (``Kind/scroll`` only).
+    public var deltaY: Double
+    /// Click multiplicity for ``Kind/down``/``Kind/up`` (double-click = 2).
+    public var clickCount: Int
+
+    /// Creates a pointer event.
+    ///
+    /// - Parameters:
+    ///   - kind: The interaction kind.
+    ///   - x: X in surface points from the left edge.
+    ///   - y: Y in surface points from the bottom edge.
+    ///   - deltaX: Horizontal scroll delta (scroll only).
+    ///   - deltaY: Vertical scroll delta (scroll only).
+    ///   - clickCount: Click multiplicity for down/up.
+    public init(
+        kind: Kind,
+        x: Double,
+        y: Double,
+        deltaX: Double = 0,
+        deltaY: Double = 0,
+        clickCount: Int = 1
+    ) {
+        self.kind = kind
+        self.x = x
+        self.y = y
+        self.deltaX = deltaX
+        self.deltaY = deltaY
+        self.clickCount = clickCount
+    }
+}

--- a/Packages/CmuxSidebarInterpreterService/Sources/CmuxSidebarInterpreterClient/RenderScene.swift
+++ b/Packages/CmuxSidebarInterpreterService/Sources/CmuxSidebarInterpreterClient/RenderScene.swift
@@ -1,0 +1,46 @@
+import CmuxSwiftRender
+
+/// A full description of what the render worker should show: which sidebar
+/// file, the live data context to interpret it against, and the host's
+/// scroll-inset chrome.
+///
+/// Sent host → worker whenever the data context (or the selected file) changes.
+/// The worker owns reading and watching the file itself; the host never parses
+/// or renders the file's contents — that is the whole point of remote
+/// rendering.
+public struct RenderScene: Codable, Sendable, Equatable {
+    /// Monotonic sequence number the worker echoes back in
+    /// ``RenderWorkerOutbound/ack(_:)`` once the scene is applied, driving the
+    /// client's hang watchdog.
+    public var seq: UInt64
+    /// Absolute path of the `.swift` or `.json` sidebar file to render.
+    public var filePath: String
+    /// Live, read-only values the interpreter binds identifiers to.
+    public var state: [String: SwiftValue]
+    /// Top scroll inset so content rests below the host titlebar accessory.
+    public var topInset: Double
+    /// Bottom scroll inset so content fades into the host's footer band.
+    public var bottomInset: Double
+
+    /// Creates a scene update.
+    ///
+    /// - Parameters:
+    ///   - seq: Monotonic sequence number echoed back in the worker's ack.
+    ///   - filePath: Absolute path of the sidebar file to render.
+    ///   - state: Live data context the interpreter binds identifiers to.
+    ///   - topInset: Top scroll inset reserved for host chrome.
+    ///   - bottomInset: Bottom scroll inset reserved for host chrome.
+    public init(
+        seq: UInt64,
+        filePath: String,
+        state: [String: SwiftValue],
+        topInset: Double,
+        bottomInset: Double
+    ) {
+        self.seq = seq
+        self.filePath = filePath
+        self.state = state
+        self.topInset = topInset
+        self.bottomInset = bottomInset
+    }
+}

--- a/Packages/CmuxSidebarInterpreterService/Sources/CmuxSidebarInterpreterClient/RenderSurfaceGeometry.swift
+++ b/Packages/CmuxSidebarInterpreterService/Sources/CmuxSidebarInterpreterClient/RenderSurfaceGeometry.swift
@@ -1,0 +1,27 @@
+/// The size and backing scale of the host's sidebar surface, in points.
+///
+/// Sent host → worker on layout and backing-scale changes (kept separate from
+/// ``RenderScene`` so live sidebar resizes don't re-send the full data
+/// context). The worker sizes its offscreen render surface to match, so the
+/// shared layer maps 1:1 onto the host view with no transform.
+public struct RenderSurfaceGeometry: Codable, Sendable, Equatable {
+    /// Surface width in points.
+    public var width: Double
+    /// Surface height in points.
+    public var height: Double
+    /// Backing scale factor of the host screen (2.0 on Retina), so the worker
+    /// rasterizes layer contents crisply.
+    public var scale: Double
+
+    /// Creates a surface geometry.
+    ///
+    /// - Parameters:
+    ///   - width: Surface width in points.
+    ///   - height: Surface height in points.
+    ///   - scale: Backing scale factor of the host screen.
+    public init(width: Double, height: Double, scale: Double) {
+        self.width = width
+        self.height = height
+        self.scale = scale
+    }
+}

--- a/Packages/CmuxSidebarInterpreterService/Sources/CmuxSidebarInterpreterClient/RenderWorkerClient+ReexecSelf.swift
+++ b/Packages/CmuxSidebarInterpreterService/Sources/CmuxSidebarInterpreterClient/RenderWorkerClient+ReexecSelf.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+public extension RenderWorkerClient {
+    /// The argv flag that puts a host binary into sidebar **render** worker
+    /// mode. The app's entry point checks for this *before* any of the app's
+    /// own AppKit/SwiftUI setup and runs the faceless render-worker loop
+    /// instead of the app.
+    static let workerModeArgument = "--cmux-sidebar-render-worker"
+
+    /// A client that runs the render worker by re-executing the current
+    /// process's binary with ``workerModeArgument``.
+    ///
+    /// Same re-exec-self model as
+    /// ``InterpreterClient/reexecingCurrentBinary(timeout:)``: no separate
+    /// helper to bundle and sign, and the worker always matches the host's
+    /// interpreter/renderer version.
+    ///
+    /// - Parameter ackTimeout: Deadline for a scene ack before the worker is
+    ///   treated as hung and discarded.
+    static func reexecingCurrentBinary(ackTimeout: Duration = .seconds(3)) -> RenderWorkerClient {
+        let binary = Bundle.main.executableURL
+            ?? URL(fileURLWithPath: CommandLine.arguments[0])
+        return RenderWorkerClient(
+            executableURL: binary,
+            arguments: [workerModeArgument],
+            ackTimeout: ackTimeout
+        )
+    }
+}

--- a/Packages/CmuxSidebarInterpreterService/Sources/CmuxSidebarInterpreterClient/RenderWorkerClient.swift
+++ b/Packages/CmuxSidebarInterpreterService/Sources/CmuxSidebarInterpreterClient/RenderWorkerClient.swift
@@ -1,0 +1,329 @@
+import CmuxSwiftRender
+import Foundation
+
+/// Supervises an out-of-process sidebar **render** worker and relays the
+/// host's scene/geometry/pointer traffic to it, so neither an interpreter
+/// fault nor a renderer fault from untrusted sidebar source can crash the
+/// host.
+///
+/// Unlike ``InterpreterClient`` (request/response, returns a `RenderNode` the
+/// host renders), the render worker interprets *and renders* the file in its
+/// own process and shares the resulting layer tree with the window server;
+/// the host only ever receives the remote context id and ``ButtonAction``
+/// values via ``events``.
+///
+/// Supervision model:
+/// - The worker spawns lazily on the first send and is reused.
+/// - On spawn, the cached last geometry and scene are replayed, so a crashed
+///   worker comes back showing the current sidebar without host involvement.
+/// - Every scene carries a sequence number the worker acks after committing;
+///   if an ack misses the deadline the worker is presumed hung and discarded
+///   (the next send relaunches it).
+/// - A worker death (EOF on its pipe) just drops the child; the host's
+///   periodic scene updates relaunch it within a tick.
+public actor RenderWorkerClient {
+    /// Location of the worker executable (the app re-executes its own binary).
+    nonisolated let executableURL: URL
+    /// Arguments for the worker process (the render-worker mode flag).
+    nonisolated let arguments: [String]
+    /// Extra environment for the worker process (used by tests for fault injection).
+    nonisolated let extraEnvironment: [String: String]
+    /// How long to wait for a scene ack before declaring the worker hung.
+    nonisolated let ackTimeout: Duration
+    /// Synchronously readable mirror of the live worker's context id, so a
+    /// remounting sidebar surface can adopt the layer without an async hop.
+    public nonisolated let contextCache = RemoteContextCache()
+
+    private var subscribers: [Int: AsyncStream<RenderWorkerEvent>.Continuation] = [:]
+    private var nextSubscriberID = 0
+    /// The live worker's announced context id, replayed to late subscribers so
+    /// a remounted sidebar surface picks the layer back up immediately.
+    private var currentContextId: UInt32?
+
+    private var child: RenderChild?
+    private var generation = 0
+    private var nextSceneSeq: UInt64 = 1
+    /// Highest scene seq we are still waiting on an ack for, with its watchdog.
+    private var pendingAckSeq: UInt64?
+    private var ackWatchdog: Task<Void, Never>?
+    /// Replayed on every (re)spawn so the worker can rebuild the current view.
+    private var lastScene: RenderScene?
+    private var lastGeometry: RenderSurfaceGeometry?
+
+    /// Creates a client that launches `executableURL` on demand.
+    ///
+    /// - Parameters:
+    ///   - executableURL: The worker binary to run.
+    ///   - arguments: Arguments for the worker process (the re-exec-self
+    ///     factory passes the render-worker mode flag).
+    ///   - ackTimeout: Deadline for a scene ack before the worker is treated
+    ///     as hung and discarded. Defaults to 3 seconds.
+    ///   - extraEnvironment: Additional environment for the worker process.
+    public init(
+        executableURL: URL,
+        arguments: [String] = [],
+        ackTimeout: Duration = .seconds(3),
+        environment extraEnvironment: [String: String] = [:]
+    ) {
+        self.executableURL = executableURL
+        self.arguments = arguments
+        self.ackTimeout = ackTimeout
+        self.extraEnvironment = extraEnvironment
+    }
+
+    /// Subscribes to context announcements and button actions.
+    ///
+    /// Each call returns an independent stream, so sidebar surfaces can come
+    /// and go (SwiftUI remounts on provider/file switches) without tearing
+    /// down event delivery for everyone else. A new subscriber immediately
+    /// receives the live worker's current context id, if any.
+    public func subscribe() -> AsyncStream<RenderWorkerEvent> {
+        let id = nextSubscriberID
+        nextSubscriberID += 1
+        let (stream, continuation) = AsyncStream.makeStream(of: RenderWorkerEvent.self)
+        continuation.onTermination = { [weak self] _ in
+            Task { [weak self] in await self?.unsubscribe(id) }
+        }
+        subscribers[id] = continuation
+        if let currentContextId {
+            continuation.yield(.context(currentContextId))
+        }
+        return stream
+    }
+
+    private func unsubscribe(_ id: Int) {
+        subscribers.removeValue(forKey: id)
+    }
+
+    private func broadcast(_ event: RenderWorkerEvent) {
+        for continuation in subscribers.values {
+            continuation.yield(event)
+        }
+    }
+
+    /// Sends the current scene (file + data context + insets) to the worker,
+    /// spawning or respawning it if needed. Never throws and never blocks on
+    /// the worker: a dead pipe just drops the child for the next send.
+    public func updateScene(
+        filePath: String,
+        state: [String: SwiftValue],
+        topInset: Double,
+        bottomInset: Double
+    ) {
+        let scene = RenderScene(
+            seq: nextSceneSeq,
+            filePath: filePath,
+            state: state,
+            topInset: topInset,
+            bottomInset: bottomInset
+        )
+        nextSceneSeq &+= 1
+        lastScene = scene
+        send(.scene(scene))
+        armAckWatchdog(for: scene.seq)
+    }
+
+    /// Tells the worker the host surface's size or backing scale changed.
+    public func resize(_ geometry: RenderSurfaceGeometry) {
+        guard geometry != lastGeometry else { return }
+        lastGeometry = geometry
+        send(.resize(geometry))
+    }
+
+    /// Forwards a pointer interaction to be replayed in the worker.
+    public func forward(_ event: RenderPointerEvent) {
+        send(.pointer(event))
+    }
+
+    /// Forwards an explicit reload request (host notifications don't cross
+    /// the process boundary).
+    public func requestReload(names: [String]?) {
+        send(.reloadSidebars(names))
+    }
+
+    /// Terminates the worker. The next send relaunches it. Call from the
+    /// owner's teardown (e.g. when the sidebar disappears).
+    public func shutdown() {
+        discardWorker()
+    }
+
+    // MARK: - Sending
+
+    private func send(_ message: RenderWorkerInbound) {
+        guard let data = try? JSONEncoder().encode(message) else { return }
+        // One retry: a worker that died since the last send surfaces here as a
+        // broken pipe (its Process may still read as running before the
+        // termination handler lands), so relaunch once and re-deliver instead
+        // of dropping the message until the next tick.
+        for _ in 0..<2 {
+            let channel: LengthPrefixedMessageChannel
+            do {
+                channel = try ensureRunning()
+            } catch {
+                return
+            }
+            do {
+                try channel.sendMessage(data)
+                return
+            } catch {
+                discardWorker()
+            }
+        }
+    }
+
+    /// Arms (or extends) the hang watchdog for `seq`.
+    ///
+    /// Bounded, cancellable deadline (mirrors ``InterpreterClient``'s render
+    /// watchdog): if the worker hasn't acked by `ackTimeout` it is hung —
+    /// discard it so the next scene update relaunches a fresh one. Cancelled
+    /// by the matching ack; not a poll.
+    private func armAckWatchdog(for seq: UInt64) {
+        pendingAckSeq = seq
+        guard ackWatchdog == nil else { return } // oldest deadline stands
+        ackWatchdog = Task { [weak self, ackTimeout] in
+            try? await Task.sleep(for: ackTimeout)
+            guard !Task.isCancelled, let self else { return }
+            await self.ackDeadlineExpired()
+        }
+    }
+
+    private func ackDeadlineExpired() {
+        ackWatchdog = nil
+        guard pendingAckSeq != nil else { return }
+        pendingAckSeq = nil
+        discardWorker()
+    }
+
+    private func acked(_ seq: UInt64, generation gen: Int) {
+        guard gen == generation else { return }
+        guard let pending = pendingAckSeq, seq >= pending else { return }
+        pendingAckSeq = nil
+        ackWatchdog?.cancel()
+        ackWatchdog = nil
+    }
+
+    // MARK: - Worker lifecycle
+
+    private func ensureRunning() throws -> LengthPrefixedMessageChannel {
+        if let child, child.process.isRunning {
+            return child.channel
+        }
+        return try launch()
+    }
+
+    private func launch() throws -> LengthPrefixedMessageChannel {
+        generation &+= 1
+        let gen = generation
+        pendingAckSeq = nil
+        ackWatchdog?.cancel()
+        ackWatchdog = nil
+
+        let process = Process()
+        process.executableURL = executableURL
+        if !arguments.isEmpty { process.arguments = arguments }
+        let stdin = Pipe()
+        let stdout = Pipe()
+        process.standardInput = stdin
+        process.standardOutput = stdout
+        if !extraEnvironment.isEmpty {
+            process.environment = ProcessInfo.processInfo.environment
+                .merging(extraEnvironment) { _, new in new }
+        }
+
+        let channel = LengthPrefixedMessageChannel(
+            readFD: stdout.fileHandleForReading.fileDescriptor,
+            writeFD: stdin.fileHandleForWriting.fileDescriptor
+        )
+        process.terminationHandler = { [weak self] _ in
+            guard let self else { return }
+            Task { await self.workerEnded(generation: gen) }
+        }
+
+        try process.run()
+        child = RenderChild(process: process, channel: channel, stdin: stdin, stdout: stdout)
+
+        // Reader thread: blocks draining framed worker messages off the
+        // worker's stdout descriptor and hands each to the actor. The channel
+        // is fd-backed and Sendable; FileHandle is not, so we never capture
+        // it. (Same justified pattern as InterpreterClient's reader.)
+        let readChannel = channel
+        let reader = Thread { [weak self] in
+            let decoder = JSONDecoder()
+            while let data = readChannel.receiveMessage() {
+                guard let message = try? decoder.decode(RenderWorkerOutbound.self, from: data) else {
+                    continue
+                }
+                Task { [weak self] in
+                    guard let self else { return }
+                    await self.deliver(message, generation: gen)
+                }
+            }
+            Task { [weak self] in
+                guard let self else { return }
+                await self.workerEnded(generation: gen)
+            }
+        }
+        reader.stackSize = 1 << 20
+        reader.name = "cmux-sidebar-render-reader"
+        reader.start()
+
+        // Replay the current state so a respawned worker rebuilds the sidebar
+        // without the host having to notice the crash.
+        if let lastGeometry, let data = try? JSONEncoder().encode(RenderWorkerInbound.resize(lastGeometry)) {
+            try? channel.sendMessage(data)
+        }
+        if let lastScene, let data = try? JSONEncoder().encode(RenderWorkerInbound.scene(lastScene)) {
+            try? channel.sendMessage(data)
+            armAckWatchdog(for: lastScene.seq)
+        }
+
+        return channel
+    }
+
+    private func deliver(_ message: RenderWorkerOutbound, generation gen: Int) {
+        guard gen == generation else { return } // ignore a superseded worker
+        switch message {
+        case let .context(contextId):
+            currentContextId = contextId
+            Task { @MainActor [contextCache] in contextCache.contextId = contextId }
+            broadcast(.context(contextId))
+        case let .ack(seq):
+            acked(seq, generation: gen)
+        case let .action(action):
+            broadcast(.action(action))
+        }
+    }
+
+    /// Terminates the current worker and forgets it, so the next send
+    /// relaunches a fresh one. The old worker's reader/termination handler
+    /// run under its now-stale generation and no-op.
+    private func discardWorker() {
+        child?.process.terminate()
+        child = nil
+        ackWatchdog?.cancel()
+        ackWatchdog = nil
+        pendingAckSeq = nil
+        currentContextId = nil // the layer died with the worker
+        Task { @MainActor [contextCache] in contextCache.contextId = nil }
+    }
+
+    private func workerEnded(generation gen: Int) {
+        guard gen == generation else { return }
+        child = nil
+        ackWatchdog?.cancel()
+        ackWatchdog = nil
+        pendingAckSeq = nil
+        currentContextId = nil // the layer died with the worker
+        Task { @MainActor [contextCache] in contextCache.contextId = nil }
+    }
+}
+
+/// A running render worker process and the channel/pipes that feed it. Held
+/// only by the ``RenderWorkerClient`` actor, so its non-`Sendable` members are
+/// safe. (Named distinctly from ``InterpreterClient``'s file-private `Child`.)
+private struct RenderChild {
+    let process: Process
+    let channel: LengthPrefixedMessageChannel
+    let stdin: Pipe
+    let stdout: Pipe
+}

--- a/Packages/CmuxSidebarInterpreterService/Sources/CmuxSidebarInterpreterClient/RenderWorkerEvent.swift
+++ b/Packages/CmuxSidebarInterpreterService/Sources/CmuxSidebarInterpreterClient/RenderWorkerEvent.swift
@@ -1,0 +1,14 @@
+import CmuxSwiftRender
+
+/// An asynchronous notification surfaced by ``RenderWorkerClient/subscribe()``.
+///
+/// `ack` frames are consumed internally by the client's hang watchdog; only
+/// the events the host must react to are surfaced.
+public enum RenderWorkerEvent: Sendable, Equatable {
+    /// A (re)spawned worker announced its remote CoreAnimation context. The
+    /// host swaps its `CALayerHost` to this id — this is also how the sidebar
+    /// reappears after a worker crash.
+    case context(UInt32)
+    /// A button in the worker-rendered sidebar fired.
+    case action(ButtonAction)
+}

--- a/Packages/CmuxSidebarInterpreterService/Sources/CmuxSidebarInterpreterClient/RenderWorkerInbound.swift
+++ b/Packages/CmuxSidebarInterpreterService/Sources/CmuxSidebarInterpreterClient/RenderWorkerInbound.swift
@@ -1,0 +1,17 @@
+/// A host → render-worker message on the framed stdin channel.
+///
+/// The render worker (see `runSidebarRenderWorker()` in
+/// `CmuxSidebarRemoteRender`) applies messages strictly in arrival order: a
+/// scene update re-interprets and re-renders, a resize re-frames the offscreen
+/// surface, and a pointer event is replayed into the worker's view tree.
+public enum RenderWorkerInbound: Codable, Sendable, Equatable {
+    /// Show this file against this data context (see ``RenderScene``).
+    case scene(RenderScene)
+    /// The host surface was resized or changed backing scale.
+    case resize(RenderSurfaceGeometry)
+    /// A pointer interaction on the host surface to replay.
+    case pointer(RenderPointerEvent)
+    /// The host received an explicit reload request (CLI `sidebar reload`);
+    /// `nil`/empty names mean "all sidebars".
+    case reloadSidebars([String]?)
+}

--- a/Packages/CmuxSidebarInterpreterService/Sources/CmuxSidebarInterpreterClient/RenderWorkerOutbound.swift
+++ b/Packages/CmuxSidebarInterpreterService/Sources/CmuxSidebarInterpreterClient/RenderWorkerOutbound.swift
@@ -1,0 +1,19 @@
+import CmuxSwiftRender
+
+/// A render-worker → host message on the framed stdout channel.
+///
+/// The only data that ever crosses back into the host is the CoreAnimation
+/// remote context id (a plain integer the window server resolves) and
+/// ``ButtonAction`` command values — host-side cmux commands by design. No
+/// view structure derived from the untrusted sidebar file reaches the host.
+public enum RenderWorkerOutbound: Codable, Sendable, Equatable {
+    /// The worker (re)created its remote CoreAnimation context; the host
+    /// should display `CALayerHost` with this context id.
+    case context(UInt32)
+    /// The scene with this ``RenderScene/seq`` was applied and committed;
+    /// answers the client's hang watchdog.
+    case ack(UInt64)
+    /// A button in the worker-rendered view fired; the host dispatches its
+    /// commands on the real command surface.
+    case action(ButtonAction)
+}

--- a/Packages/CmuxSidebarInterpreterService/Sources/CmuxSidebarInterpreterClient/SidebarInterpreterWorker.swift
+++ b/Packages/CmuxSidebarInterpreterService/Sources/CmuxSidebarInterpreterClient/SidebarInterpreterWorker.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// The worker side of the out-of-process interpreter: a read-eval-write loop
+/// over a length-prefixed stdin/stdout channel.
+///
+/// Shared by both entry points that run the worker:
+/// - the standalone `cmux-sidebar-interpreter` executable, and
+/// - the host app re-executing its own binary in worker mode (see
+///   ``InterpreterClient/workerModeArgument``), which avoids bundling a
+///   separate helper.
+///
+/// Returns when stdin reaches end-of-stream (the host closed the pipe). The
+/// caller should `exit` afterwards; this must run before any AppKit/SwiftUI
+/// initialization in the re-exec case.
+public func runSidebarInterpreterWorker() {
+    let channel = LengthPrefixedMessageChannel(readFD: 0, writeFD: 1)
+    let runner = RenderInterpreterRunner()
+    let decoder = JSONDecoder()
+    let encoder = JSONEncoder()
+
+    while let data = channel.receiveMessage() {
+        guard let request = try? decoder.decode(InterpreterRequest.self, from: data) else {
+            continue // skip an undecodable frame rather than tear down the worker
+        }
+        let response = runner.run(request)
+        guard let payload = try? encoder.encode(response) else { continue }
+        try? channel.sendMessage(payload)
+    }
+}

--- a/Packages/CmuxSidebarInterpreterService/Sources/CmuxSidebarRemoteRender/RemoteCustomSidebarHost.swift
+++ b/Packages/CmuxSidebarInterpreterService/Sources/CmuxSidebarRemoteRender/RemoteCustomSidebarHost.swift
@@ -17,10 +17,19 @@ public struct RemoteCustomSidebarHost: View {
     private let dispatch: SidebarActionDispatch
     private let contentInsets: CustomSidebarContentInsets
 
-    @State private var client = RenderWorkerClient.reexecingCurrentBinary()
+    /// Created once on mount (never in the initializer: this view sits
+    /// inside a per-second TimelineView, and a function-call `@State`
+    /// default would evaluate — allocating a client — on every re-init).
+    @State private var client: RenderWorkerClient?
 
-    /// Creates the host; see ``RemoteCustomSidebarView`` for parameter
-    /// semantics.
+    /// Creates the host.
+    ///
+    /// - Parameters:
+    ///   - fileURL: The `.swift` or `.json` sidebar file the worker renders
+    ///     and watches.
+    ///   - dataContext: Live, read-only values the worker's interpreter binds.
+    ///   - dispatch: Runs button/tap actions against the host command surface.
+    ///   - contentInsets: Top/bottom scroll insets for the host chrome.
     public init(
         fileURL: URL,
         dataContext: [String: SwiftValue],
@@ -34,20 +43,32 @@ public struct RemoteCustomSidebarHost: View {
     }
 
     public var body: some View {
-        RemoteCustomSidebarView(
-            fileURL: fileURL,
-            dataContext: dataContext,
-            dispatch: dispatch,
-            contentInsets: contentInsets,
-            client: client
-        )
+        Group {
+            if let client {
+                RemoteCustomSidebarView(
+                    fileURL: fileURL,
+                    dataContext: dataContext,
+                    dispatch: dispatch,
+                    contentInsets: contentInsets,
+                    client: client
+                )
+            } else {
+                Color.clear
+            }
+        }
+        .task {
+            if client == nil {
+                client = RenderWorkerClient.reexecingCurrentBinary()
+            }
+        }
         .onDisappear {
             // The branch unmounted (provider switch or sidebar hidden); the
             // discarded @State client would orphan its worker until window
             // close, so reap it here. Re-entering custom sidebars respawns
             // within a scene tick.
-            let client = client
-            Task { await client.shutdown() }
+            if let client {
+                Task { await client.shutdown() }
+            }
         }
     }
 }

--- a/Packages/CmuxSidebarInterpreterService/Sources/CmuxSidebarRemoteRender/RemoteCustomSidebarHost.swift
+++ b/Packages/CmuxSidebarInterpreterService/Sources/CmuxSidebarRemoteRender/RemoteCustomSidebarHost.swift
@@ -1,0 +1,53 @@
+import CmuxSidebarInterpreterClient
+import CmuxSwiftRender
+import CmuxSwiftRenderUI
+import SwiftUI
+
+/// Owns the render-worker client for a mounted custom sidebar.
+///
+/// The client (and therefore the worker process) exists only while a custom
+/// sidebar is actually selected: creating it eagerly in the sidebar host
+/// meant every sidebar render in every window evaluated the client
+/// initializer, and the re-land bisect implicated that wiring in host-wide
+/// test interference. The worker still spawns lazily on the first scene and
+/// is terminated by the surface's window-close reaper.
+public struct RemoteCustomSidebarHost: View {
+    private let fileURL: URL
+    private let dataContext: [String: SwiftValue]
+    private let dispatch: SidebarActionDispatch
+    private let contentInsets: CustomSidebarContentInsets
+
+    @State private var client = RenderWorkerClient.reexecingCurrentBinary()
+
+    /// Creates the host; see ``RemoteCustomSidebarView`` for parameter
+    /// semantics.
+    public init(
+        fileURL: URL,
+        dataContext: [String: SwiftValue],
+        dispatch: SidebarActionDispatch,
+        contentInsets: CustomSidebarContentInsets = .zero
+    ) {
+        self.fileURL = fileURL
+        self.dataContext = dataContext
+        self.dispatch = dispatch
+        self.contentInsets = contentInsets
+    }
+
+    public var body: some View {
+        RemoteCustomSidebarView(
+            fileURL: fileURL,
+            dataContext: dataContext,
+            dispatch: dispatch,
+            contentInsets: contentInsets,
+            client: client
+        )
+        .onDisappear {
+            // The branch unmounted (provider switch or sidebar hidden); the
+            // discarded @State client would orphan its worker until window
+            // close, so reap it here. Re-entering custom sidebars respawns
+            // within a scene tick.
+            let client = client
+            Task { await client.shutdown() }
+        }
+    }
+}

--- a/Packages/CmuxSidebarInterpreterService/Sources/CmuxSidebarRemoteRender/RemoteCustomSidebarView.swift
+++ b/Packages/CmuxSidebarInterpreterService/Sources/CmuxSidebarRemoteRender/RemoteCustomSidebarView.swift
@@ -1,0 +1,96 @@
+import CmuxSidebarInterpreterClient
+import CmuxSwiftRender
+import CmuxSwiftRenderUI
+import SwiftUI
+
+/// Renders a custom sidebar **fully out-of-process**: interpretation and
+/// rendering both happen in the supervised render worker, and this view only
+/// hosts the worker's remote layer and forwards input.
+///
+/// Drop-in counterpart of `CustomSidebarView` (the in-process fallback): same
+/// inputs, same look (the worker mounts the shared `CustomSidebarContentView`
+/// presentation), but no code or data derived from the user's sidebar file is
+/// ever turned into views in the host process.
+///
+/// Do **not** key the view by file URL: the worker swaps files in place on the
+/// next scene message, so the surface (and its hosted remote layer) should stay
+/// mounted across sidebar switches to avoid flashing the previous content.
+///
+/// ```swift
+/// RemoteCustomSidebarView(
+///     fileURL: url,
+///     dataContext: context,
+///     dispatch: dispatch,
+///     contentInsets: insets,
+///     client: renderWorkerClient
+/// )
+/// ```
+public struct RemoteCustomSidebarView: View {
+    private let fileURL: URL
+    private let dataContext: [String: SwiftValue]
+    private let dispatch: SidebarActionDispatch
+    private let contentInsets: CustomSidebarContentInsets
+    private let client: RenderWorkerClient
+
+    /// Creates a remote sidebar surface bound to a file, a live data context,
+    /// an action dispatch, and a supervised render-worker client.
+    ///
+    /// - Parameters:
+    ///   - fileURL: The `.swift` or `.json` sidebar file the worker renders
+    ///     and watches.
+    ///   - dataContext: Live, read-only values the worker's interpreter binds.
+    ///   - dispatch: Runs button/tap actions against the host command surface.
+    ///   - contentInsets: Top/bottom scroll insets for the host chrome.
+    ///   - client: The render-worker supervisor (one per sidebar host; the
+    ///     worker is spawned lazily and survives provider switches).
+    public init(
+        fileURL: URL,
+        dataContext: [String: SwiftValue],
+        dispatch: SidebarActionDispatch,
+        contentInsets: CustomSidebarContentInsets = .zero,
+        client: RenderWorkerClient
+    ) {
+        self.fileURL = fileURL
+        self.dataContext = dataContext
+        self.dispatch = dispatch
+        self.contentInsets = contentInsets
+        self.client = client
+    }
+
+    public var body: some View {
+        RemoteSidebarSurface(
+            fileURL: fileURL,
+            dataContext: dataContext,
+            dispatch: dispatch,
+            contentInsets: contentInsets,
+            client: client
+        )
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+/// Bridges the AppKit surface view into SwiftUI and pushes scene updates on
+/// every relevant SwiftUI update.
+private struct RemoteSidebarSurface: NSViewRepresentable {
+    let fileURL: URL
+    let dataContext: [String: SwiftValue]
+    let dispatch: SidebarActionDispatch
+    let contentInsets: CustomSidebarContentInsets
+    let client: RenderWorkerClient
+
+    func makeNSView(context: Context) -> RemoteSidebarSurfaceView {
+        let view = RemoteSidebarSurfaceView(client: client)
+        view.dispatch = dispatch
+        view.pushScene(filePath: fileURL.path, state: dataContext, insets: contentInsets)
+        return view
+    }
+
+    func updateNSView(_ view: RemoteSidebarSurfaceView, context: Context) {
+        view.dispatch = dispatch
+        view.pushScene(filePath: fileURL.path, state: dataContext, insets: contentInsets)
+    }
+
+    static func dismantleNSView(_ view: RemoteSidebarSurfaceView, coordinator: ()) {
+        view.teardown()
+    }
+}

--- a/Packages/CmuxSidebarInterpreterService/Sources/CmuxSidebarRemoteRender/RemoteHostedLayer.swift
+++ b/Packages/CmuxSidebarInterpreterService/Sources/CmuxSidebarRemoteRender/RemoteHostedLayer.swift
@@ -1,0 +1,14 @@
+import QuartzCore
+
+/// Creates the host-side layer that displays a worker's remote context:
+/// a private `CALayerHost` whose `contextId` points at the worker's
+/// `RemoteRenderContext`. Returns `nil` when the class is unavailable.
+///
+/// Counterpart of ``RemoteRenderContext``; same user-authorized private seam.
+@MainActor
+func makeRemoteHostedLayer(contextId: UInt32) -> CALayer? {
+    guard let hostClass = NSClassFromString("CALayerHost") as? CALayer.Type else { return nil }
+    let layer = hostClass.init()
+    layer.setValue(NSNumber(value: contextId), forKey: "contextId")
+    return layer
+}

--- a/Packages/CmuxSidebarInterpreterService/Sources/CmuxSidebarRemoteRender/RemoteRenderContext.swift
+++ b/Packages/CmuxSidebarInterpreterService/Sources/CmuxSidebarRemoteRender/RemoteRenderContext.swift
@@ -1,0 +1,39 @@
+import AppKit
+import QuartzCore
+
+/// The worker's connection to the window server for cross-process layer
+/// sharing: wraps the private `CAContext.remoteContextWithOptions:` SPI (the
+/// mechanism WebKit/Chromium use for out-of-process compositing).
+///
+/// This is the one non-public seam in the remote-sidebar pipeline, explicitly
+/// user-authorized for this feature. The public `CARemoteLayerServer`/
+/// `CARemoteLayerClient` API renders blank on current macOS (verified through
+/// every documented usage variant in `docs/remote-sidebar-rendering/spike/`),
+/// so the context-id route is the working substrate. The id is a plain
+/// `UInt32` resolved by the window server, so no mach-port handoff is needed.
+@MainActor
+final class RemoteRenderContext {
+    private let context: NSObject
+    /// The window-server context id the host displays via `CALayerHost`.
+    let contextId: UInt32
+
+    /// Creates a remote context, or `nil` when the SPI is unavailable (the
+    /// worker then simply renders nothing; the host shows its empty state).
+    init?() {
+        guard let contextClass = NSClassFromString("CAContext") as? NSObject.Type else { return nil }
+        let selector = NSSelectorFromString("remoteContextWithOptions:")
+        guard contextClass.responds(to: selector),
+              let unmanaged = contextClass.perform(selector, with: [:] as NSDictionary),
+              let context = unmanaged.takeUnretainedValue() as? NSObject,
+              let contextId = (context.value(forKey: "contextId") as? NSNumber)?.uint32Value
+        else { return nil }
+        self.context = context
+        self.contextId = contextId
+    }
+
+    /// The root layer shared with the host (KVC onto the private context).
+    var layer: CALayer? {
+        get { context.value(forKey: "layer") as? CALayer }
+        set { context.setValue(newValue, forKey: "layer") }
+    }
+}

--- a/Packages/CmuxSidebarInterpreterService/Sources/CmuxSidebarRemoteRender/RemoteSidebarSurfaceView.swift
+++ b/Packages/CmuxSidebarInterpreterService/Sources/CmuxSidebarRemoteRender/RemoteSidebarSurfaceView.swift
@@ -1,0 +1,247 @@
+import AppKit
+import CmuxSidebarInterpreterClient
+import CmuxSwiftRender
+import CmuxSwiftRenderUI
+import QuartzCore
+
+/// The host-side AppKit surface for a remotely rendered custom sidebar:
+/// displays the worker's layer tree via a hosted remote layer and forwards
+/// pointer interactions back over the worker channel.
+///
+/// Nothing derived from the sidebar file exists in this view — it holds a
+/// `CALayerHost` pointing at the worker's context id and a pipe. Worker
+/// crashes surface as a fresh `.context` event; the view swaps the hosted
+/// layer and the sidebar reappears.
+@MainActor
+final class RemoteSidebarSurfaceView: NSView {
+    private let client: RenderWorkerClient
+    /// Runs interpreted-button actions on the host command surface.
+    var dispatch: SidebarActionDispatch = .noop
+
+    private var hostedLayer: CALayer?
+    private var eventsTask: Task<Void, Never>?
+    private var outboxTask: Task<Void, Never>?
+    private var reloadObserver: NSObjectProtocol?
+    private var windowCloseObserver: NSObjectProtocol?
+    private let outbox: AsyncStream<RenderWorkerInbound>.Continuation
+    private var lastPushedScene: PushedScene?
+
+    init(client: RenderWorkerClient) {
+        self.client = client
+        let (stream, continuation) = AsyncStream.makeStream(of: RenderWorkerInbound.self)
+        self.outbox = continuation
+        super.init(frame: .zero)
+        wantsLayer = true
+
+        // Adopt the live worker's layer synchronously so a remounting surface
+        // (provider switches, sidebar toggles) shows the last rendered frame
+        // immediately; the subscription below swaps in any newer context.
+        if let contextId = client.contextCache.contextId {
+            adopt(contextId: contextId)
+        }
+
+        // Single ordered pipe to the actor: synchronous yields from the main
+        // thread keep scene/geometry/pointer ordering intact (independent
+        // `Task { await client... }` hops would not guarantee FIFO).
+        outboxTask = Task { [client] in
+            for await message in stream {
+                switch message {
+                case let .scene(scene):
+                    await client.updateScene(
+                        filePath: scene.filePath,
+                        state: scene.state,
+                        topInset: scene.topInset,
+                        bottomInset: scene.bottomInset
+                    )
+                case let .resize(geometry):
+                    await client.resize(geometry)
+                case let .pointer(event):
+                    await client.forward(event)
+                case let .reloadSidebars(names):
+                    await client.requestReload(names: names)
+                }
+            }
+        }
+
+        // The CLI's `sidebar reload` posts a host-process notification; the
+        // worker can't observe it across the process boundary, so forward it.
+        // Token-based observer (same pattern as CustomSidebarModel): the
+        // notifications async stream trips CI Swift 6.1's non-Sendable
+        // `Notification` check from any actor-adjacent context.
+        reloadObserver = NotificationCenter.default.addObserver(
+            forName: .customSidebarReloadRequested,
+            object: nil,
+            queue: .main
+        ) { [outbox] notification in
+            let names = notification.userInfo?["names"] as? [String]
+            outbox.yield(.reloadSidebars(names))
+        }
+
+        eventsTask = Task { @MainActor [weak self, client] in
+            for await event in await client.subscribe() {
+                guard let self else { return }
+                switch event {
+                case let .context(contextId):
+                    self.adopt(contextId: contextId)
+                case let .action(action):
+                    self.dispatch.run(action)
+                }
+            }
+        }
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("not used")
+    }
+
+    /// Stops the event/outbox pipes. Call from the representable's dismantle;
+    /// the worker itself stays alive for the next mount (cheap, and keeps
+    /// provider switches snappy).
+    func teardown() {
+        if let windowCloseObserver {
+            NotificationCenter.default.removeObserver(windowCloseObserver)
+            self.windowCloseObserver = nil
+        }
+        if let reloadObserver {
+            NotificationCenter.default.removeObserver(reloadObserver)
+            self.reloadObserver = nil
+        }
+        eventsTask?.cancel()
+        eventsTask = nil
+        outboxTask?.cancel()
+        outboxTask = nil
+        outbox.finish()
+    }
+
+    // MARK: - Scene pushes (from the representable)
+
+    /// Sends the current scene when anything in it actually changed.
+    func pushScene(
+        filePath: String,
+        state: [String: SwiftValue],
+        insets: CustomSidebarContentInsets
+    ) {
+        let scene = PushedScene(filePath: filePath, state: state, insets: insets)
+        guard scene != lastPushedScene else { return }
+        lastPushedScene = scene
+        // seq is assigned by the client; 0 here is a placeholder the client
+        // overwrites via its own counter.
+        outbox.yield(.scene(RenderScene(
+            seq: 0,
+            filePath: filePath,
+            state: state,
+            topInset: insets.top,
+            bottomInset: insets.bottom
+        )))
+    }
+
+    // MARK: - Geometry
+
+    override func layout() {
+        super.layout()
+        hostedLayer?.frame = bounds
+        pushGeometry()
+    }
+
+    override func viewDidChangeBackingProperties() {
+        super.viewDidChangeBackingProperties()
+        pushGeometry()
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        pushGeometry()
+        armWindowCloseReaper()
+    }
+
+    /// Terminates the worker when this surface's window closes. Provider
+    /// switches and sidebar toggles keep the worker warm (the client outlives
+    /// the surface), so without this a closed window's worker would idle until
+    /// app exit.
+    private func armWindowCloseReaper() {
+        if let windowCloseObserver {
+            NotificationCenter.default.removeObserver(windowCloseObserver)
+            self.windowCloseObserver = nil
+        }
+        guard let window else { return }
+        windowCloseObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.willCloseNotification,
+            object: window,
+            queue: .main
+        ) { [client] _ in
+            Task { await client.shutdown() }
+        }
+    }
+
+    private func pushGeometry() {
+        guard bounds.width > 0, bounds.height > 0 else { return }
+        let scale = window?.backingScaleFactor ?? 2
+        outbox.yield(.resize(RenderSurfaceGeometry(
+            width: bounds.width,
+            height: bounds.height,
+            scale: scale
+        )))
+    }
+
+    private func adopt(contextId: UInt32) {
+        hostedLayer?.removeFromSuperlayer()
+        guard let remote = makeRemoteHostedLayer(contextId: contextId) else { return }
+        remote.frame = bounds
+        layer?.addSublayer(remote)
+        hostedLayer = remote
+    }
+
+    // MARK: - Input forwarding
+
+    override var acceptsFirstResponder: Bool { true }
+
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
+
+    override func mouseDown(with event: NSEvent) {
+        forward(event, kind: .down)
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        forward(event, kind: .drag)
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        forward(event, kind: .up)
+    }
+
+    override func scrollWheel(with event: NSEvent) {
+        let location = convert(event.locationInWindow, from: nil)
+        outbox.yield(.pointer(RenderPointerEvent(
+            kind: .scroll,
+            x: location.x,
+            y: surfaceY(location),
+            deltaX: event.scrollingDeltaX,
+            deltaY: event.scrollingDeltaY
+        )))
+    }
+
+    private func forward(_ event: NSEvent, kind: RenderPointerEvent.Kind) {
+        let location = convert(event.locationInWindow, from: nil)
+        outbox.yield(.pointer(RenderPointerEvent(
+            kind: kind,
+            x: location.x,
+            y: surfaceY(location),
+            clickCount: event.clickCount
+        )))
+    }
+
+    /// Worker window coordinates are bottom-left-origin points of a window
+    /// exactly this view's size, so only a flip (if any) is needed.
+    private func surfaceY(_ point: NSPoint) -> CGFloat {
+        isFlipped ? bounds.height - point.y : point.y
+    }
+}
+
+/// Equality snapshot of the last pushed scene, so per-frame SwiftUI updates
+/// don't spam identical scenes over the pipe.
+private struct PushedScene: Equatable {
+    let filePath: String
+    let state: [String: SwiftValue]
+    let insets: CustomSidebarContentInsets
+}

--- a/Packages/CmuxSidebarInterpreterService/Sources/CmuxSidebarRemoteRender/RemoteWorkerRootView.swift
+++ b/Packages/CmuxSidebarInterpreterService/Sources/CmuxSidebarRemoteRender/RemoteWorkerRootView.swift
@@ -1,0 +1,20 @@
+import CmuxSwiftRenderUI
+import SwiftUI
+
+/// The worker's SwiftUI root: the shared sidebar presentation plus collection
+/// of the rendered tree's tap targets, so the coordinator can hit-test
+/// forwarded clicks geometrically.
+struct RemoteWorkerRootView: View {
+    let content: CustomSidebarContentView
+    /// Receives the rendered tree's tappable regions after each layout pass.
+    let onTapTargetsChange: @MainActor @Sendable ([SidebarTapTarget]) -> Void
+
+    var body: some View {
+        content
+            .onPreferenceChange(SidebarTapTargetsKey.self) { targets in
+                Task { @MainActor in
+                    onTapTargetsChange(targets)
+                }
+            }
+    }
+}

--- a/Packages/CmuxSidebarInterpreterService/Sources/CmuxSidebarRemoteRender/RemoteWorkerWindow.swift
+++ b/Packages/CmuxSidebarInterpreterService/Sources/CmuxSidebarRemoteRender/RemoteWorkerWindow.swift
@@ -1,0 +1,16 @@
+import AppKit
+
+/// The worker's offscreen layout/coordinate shell.
+///
+/// **Never ordered onto the screen**: an on-screen window's own CoreAnimation
+/// context claims the layer tree and the shared remote context renders blank
+/// (spike-verified; the coordinator also steals the layer back after every
+/// layout pass). The window exists so AppKit/SwiftUI have a real window for
+/// layout and coordinate spaces; forwarded input is hit-tested geometrically,
+/// not routed through the window.
+final class RemoteWorkerWindow: NSWindow {
+    /// Allow future focus forwarding; nothing orders this window in, so key
+    /// status never affects the user's real windows.
+    override var canBecomeKey: Bool { true }
+    override var canBecomeMain: Bool { true }
+}

--- a/Packages/CmuxSidebarInterpreterService/Sources/CmuxSidebarRemoteRender/RenderWorkerCoordinator.swift
+++ b/Packages/CmuxSidebarInterpreterService/Sources/CmuxSidebarRemoteRender/RenderWorkerCoordinator.swift
@@ -1,0 +1,373 @@
+import AppKit
+import CmuxSidebarInterpreterClient
+import CmuxSwiftRender
+import CmuxSwiftRenderUI
+import Observation
+import SwiftUI
+
+/// The render worker's main-actor state machine: owns the offscreen surface
+/// (window + `NSHostingView`), the shared remote context, the watched sidebar
+/// file, and the interpreter, and applies host messages strictly in arrival
+/// order.
+///
+/// Rendering model (spike-verified): the hosting view's backing layer is the
+/// remote context's root and the window is **never ordered in**, so SwiftUI
+/// has no display-link driver. Every state change therefore flows through an
+/// explicit pump — mutate `rootView`, force layout, commit — which is exactly
+/// right for a sidebar that only changes when the host sends data, the file
+/// changes on disk, or a forwarded pointer event lands.
+@MainActor
+final class RenderWorkerCoordinator {
+    private let channel: LengthPrefixedMessageChannel
+    private let encoder = JSONEncoder()
+    /// Parse-caching interpreter (same engine and fault-injection hooks as the
+    /// stage-1 interpreter worker).
+    private let runner = RenderInterpreterRunner()
+
+    private var remoteContext: RemoteRenderContext?
+    private var window: RemoteWorkerWindow?
+    private var hosting: NSHostingView<RemoteWorkerRootView>?
+    /// Tappable regions of the current render, in the root coordinate space
+    /// (top-left origin), refreshed by the root view's preference observer.
+    private var tapTargets: [SidebarTapTarget] = []
+
+    /// Loads and watches the sidebar file (hot reload), reusing the exact
+    /// in-process semantics.
+    private var model: CustomSidebarModel?
+    /// The scene's file path as sent by the host. Tracked separately from
+    /// `model.fileURL`, which the model may re-resolve to a sibling extension
+    /// (`name.swift` <-> `name.json`).
+    private var scenePath: String?
+    private var dataState: [String: SwiftValue] = [:]
+    private var insets = CustomSidebarContentInsets.zero
+    private var geometry = RenderSurfaceGeometry(width: 280, height: 600, scale: 2)
+    private var swiftRender: RenderNode?
+    private var hasRendered = false
+    /// The most recent file state that produced a working view, kept so a
+    /// broken mid-edit save (or an atomic save's transient delete) does NOT
+    /// replace a working sidebar. Reset when the selected file changes.
+    private var lastGoodState: CustomSidebarModel.State?
+    private var lastGoodRender: RenderNode?
+
+    /// Sends interpreted-button actions back to the host for dispatch.
+    private lazy var dispatch = SidebarActionDispatch { [weak self] action in
+        self?.send(.action(action))
+    }
+
+    init(channel: LengthPrefixedMessageChannel) {
+        self.channel = channel
+        ensureSurface()
+    }
+
+    /// Stderr diagnostics, enabled with `CMUX_RENDER_WORKER_DEBUG=1` in the
+    /// worker environment (inherited from the host). The worker has no log
+    /// sink of its own; stderr lands in the host's console/session log.
+    private let debugEnabled = ProcessInfo.processInfo.environment["CMUX_RENDER_WORKER_DEBUG"] == "1"
+
+    private func debugLog(_ message: @autoclosure () -> String) {
+        guard debugEnabled else { return }
+        FileHandle.standardError.write(Data("render-worker: \(message())\n".utf8))
+    }
+
+    /// Applies one host message. Called from a single FIFO consumer, so
+    /// ordering matches the wire.
+    func handle(_ message: RenderWorkerInbound) {
+        switch message {
+        case let .scene(scene):
+            apply(scene)
+            send(.ack(scene.seq))
+        case let .resize(geometry):
+            apply(geometry)
+        case let .pointer(event):
+            deliver(event)
+            pump()
+        case let .reloadSidebars(names):
+            // Forwarded from the host's CLI reload notification; the model's
+            // state change re-renders via the observation hook.
+            model?.requestReload(names: names)
+        }
+    }
+
+    // MARK: - Surface
+
+    private func ensureSurface() {
+        guard window == nil else { return }
+        guard let context = RemoteRenderContext() else { return }
+        remoteContext = context
+
+        let frame = NSRect(x: 0, y: 0, width: geometry.width, height: geometry.height)
+        let hosting = NSHostingView(rootView: currentContent())
+        // The host dictates the surface size; don't let SwiftUI fight it.
+        hosting.sizingOptions = []
+        hosting.frame = frame
+
+        let window = RemoteWorkerWindow(
+            contentRect: frame,
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.isReleasedWhenClosed = false
+        window.contentView = hosting
+        hosting.wantsLayer = true
+
+        self.window = window
+        self.hosting = hosting
+
+        window.layoutIfNeeded()
+        hosting.layoutSubtreeIfNeeded()
+        // Re-parent the backing layer as the remote context's root. The window
+        // stays offscreen forever, so no window context competes for it.
+        context.layer = hosting.layer
+        CATransaction.flush()
+        debugLog("surface ready: contextId=\(context.contextId)")
+
+        send(.context(context.contextId))
+    }
+
+    // MARK: - Scene / geometry
+
+    private func apply(_ scene: RenderScene) {
+        ensureSurface()
+        dataState = scene.state
+        insets = CustomSidebarContentInsets(top: scene.topInset, bottom: scene.bottomInset)
+
+        if scenePath != scene.filePath {
+            scenePath = scene.filePath
+            let url = URL(fileURLWithPath: scene.filePath)
+            model?.stop()
+            swiftRender = nil
+            hasRendered = false
+            lastGoodState = nil
+            lastGoodRender = nil
+            let model = CustomSidebarModel(fileURL: url)
+            self.model = model
+            model.start()
+            observe(model)
+        }
+        refresh()
+    }
+
+    private func apply(_ geometry: RenderSurfaceGeometry) {
+        ensureSurface()
+        self.geometry = geometry
+        guard let window, let hosting else { return }
+        let size = NSSize(width: geometry.width, height: geometry.height)
+        window.setContentSize(size)
+        hosting.frame = NSRect(origin: .zero, size: size)
+        pump()
+    }
+
+    /// Re-arms Observation on the model so disk reloads (kqueue → model state
+    /// change) re-render and pump even though no SwiftUI view observes the
+    /// model in this process.
+    private func observe(_ model: CustomSidebarModel) {
+        withObservationTracking {
+            _ = model.state
+            _ = model.sourceRevision
+        } onChange: { [weak self] in
+            Task { @MainActor [weak self] in
+                guard let self, self.model === model else { return }
+                self.refresh()
+                self.observe(model)
+            }
+        }
+    }
+
+    /// Re-interprets (when showing Swift source) and republishes the root
+    /// view, then pumps a commit so the host sees it.
+    ///
+    /// Hot reload is **last-good sticky**: a save only replaces what's on
+    /// screen when it actually interprets to a view (or decodes, for JSON).
+    /// Broken intermediate saves — the editor writing mid-edit states, or an
+    /// atomic save's transient missing file — keep the previous working
+    /// render. Error states still show when a file is broken from the start
+    /// (no good version to fall back to).
+    private func refresh() {
+        guard let model, let hosting else { return }
+        var displayState = model.state
+        switch model.state {
+        case let .swiftSource(source):
+            let response = runner.run(InterpreterRequest(id: 0, source: source, state: dataState))
+            if let node = response.node {
+                swiftRender = node
+                hasRendered = true
+                lastGoodState = model.state
+                lastGoodRender = node
+            } else if let lastGoodState {
+                displayState = lastGoodState
+                // Keep live data flowing while the on-disk file is broken:
+                // re-interpret the last GOOD source against the fresh data
+                // context (falling back to the cached render if even that
+                // stops producing a view).
+                if case let .swiftSource(goodSource) = lastGoodState,
+                   let liveNode = runner.run(InterpreterRequest(id: 0, source: goodSource, state: dataState)).node {
+                    swiftRender = liveNode
+                    lastGoodRender = liveNode
+                } else {
+                    swiftRender = lastGoodRender
+                }
+            } else {
+                swiftRender = nil
+                hasRendered = true
+            }
+        case .json:
+            lastGoodState = model.state
+            lastGoodRender = nil
+        case .missing, .failed:
+            if let lastGoodState {
+                displayState = lastGoodState
+                swiftRender = lastGoodRender
+            }
+        }
+        hosting.rootView = currentContent(state: displayState)
+        pump()
+    }
+
+    private func currentContent(state: CustomSidebarModel.State? = nil) -> RemoteWorkerRootView {
+        RemoteWorkerRootView(
+            content: CustomSidebarContentView(
+                state: state ?? model?.state ?? .missing,
+                swiftRender: swiftRender,
+                hasRenderedSwift: hasRendered,
+                dispatch: dispatch,
+                contentInsets: insets
+            ),
+            onTapTargetsChange: { [weak self] targets in
+                self?.tapTargets = targets
+            }
+        )
+    }
+
+    /// Forces the offscreen view tree through layout and commits the layer
+    /// tree to the window server. The explicit flush is the worker's display
+    /// driver — there is no on-screen window to drive one.
+    private func pump() {
+        guard let window, let hosting else { return }
+        window.layoutIfNeeded()
+        hosting.layoutSubtreeIfNeeded()
+        if let layer = hosting.layer, geometry.scale != 1 {
+            applyContentsScale(layer, scale: CGFloat(geometry.scale))
+        }
+        // AppKit re-parents the contentView's backing layer back into the
+        // window's frame-view layer tree on every window layout pass, which
+        // silently detaches it from the remote context (the never-shown window
+        // has no render destination, so the host goes blank). Steal it back
+        // after layout, before committing.
+        if let layer = hosting.layer, let remoteContext, remoteContext.layer !== layer {
+            layer.removeFromSuperlayer()
+            remoteContext.layer = layer
+        }
+        CATransaction.flush()
+    }
+
+    // MARK: - Input
+
+    private func deliver(_ event: RenderPointerEvent) {
+        guard let hosting else { return }
+        let location = NSPoint(x: event.x, y: event.y)
+        switch event.kind {
+        case .scroll:
+            scroll(by: event, at: location, in: hosting)
+        case .up:
+            // Geometric activation: forwarded clicks are hit-tested against
+            // the rendered tree's reported tap targets. Synthesized NSEvents
+            // route correctly (verified down to the SwiftUI container view)
+            // but SwiftUI control gestures never fire in a never-on-screen
+            // window, and its AX tree only materializes for assistive
+            // clients — the registry is deterministic and testable instead.
+            press(at: location)
+        case .down, .drag:
+            // The press fires on up; an in-progress press has no offscreen
+            // visual feedback to drive.
+            break
+        }
+    }
+
+    /// Fires the innermost tap target containing `location` (window coords,
+    /// bottom-left origin), sending its action to the host.
+    private func press(at location: NSPoint) {
+        // Tap targets are in the root view's top-left-origin space.
+        let point = CGPoint(x: location.x, y: CGFloat(geometry.height) - location.y)
+        let hit = tapTargets
+            .filter { $0.frame.contains(point) }
+            .min { $0.frame.width * $0.frame.height < $1.frame.width * $1.frame.height }
+        guard let hit else {
+            debugLog("press: no tap target at \(point) targets=\(tapTargets.map { "\($0.frame)" }.joined(separator: " | "))")
+            return
+        }
+        debugLog("press: firing action at \(point)")
+        send(.action(hit.action))
+    }
+
+    /// Scrolls the deepest `NSScrollView` under the point directly. SwiftUI's
+    /// macOS `ScrollView` is `NSScrollView`-backed, so adjusting the clip
+    /// view's origin is the reliable windowless equivalent of a wheel event.
+    private func scroll(by event: RenderPointerEvent, at location: NSPoint, in hosting: NSView) {
+        guard let scrollView = scrollView(at: location, in: hosting) else { return }
+        let clip = scrollView.contentView
+        var target = clip.bounds
+        let isFlipped = scrollView.documentView?.isFlipped ?? true
+        // Natural scrolling deltas: positive deltaY means content moves down
+        // (reveal earlier content).
+        if isFlipped {
+            target.origin.y -= CGFloat(event.deltaY)
+        } else {
+            target.origin.y += CGFloat(event.deltaY)
+        }
+        target.origin.x -= CGFloat(event.deltaX)
+        // Clamp through the clip view itself: the resting origin is NOT (0,0)
+        // when SwiftUI applies safe-area insets (it is -topInset), so a naive
+        // max(0, …) clamp pins content up under the host's titlebar chrome and
+        // never lets it scroll back. constrainBoundsRect honors content
+        // insets and the document bounds exactly like a real wheel event.
+        let constrained = clip.constrainBoundsRect(target)
+        clip.scroll(to: constrained.origin)
+        scrollView.reflectScrolledClipView(clip)
+    }
+
+    private func scrollView(at location: NSPoint, in root: NSView) -> NSScrollView? {
+        // `location` is in window coords; the hosting view fills a borderless
+        // window at origin zero, so its superview (frame view) space matches.
+        guard let hit = root.hitTest(location) else {
+            return firstScrollView(in: root)
+        }
+        var view: NSView? = hit
+        while let current = view {
+            if let scrollView = current as? NSScrollView { return scrollView }
+            view = current.superview
+        }
+        return firstScrollView(in: root)
+    }
+
+    private func firstScrollView(in view: NSView) -> NSScrollView? {
+        if let scrollView = view as? NSScrollView { return scrollView }
+        for subview in view.subviews {
+            if let found = firstScrollView(in: subview) { return found }
+        }
+        return nil
+    }
+
+    // MARK: - Outbound
+
+    private func send(_ message: RenderWorkerOutbound) {
+        guard let data = try? encoder.encode(message) else { return }
+        try? channel.sendMessage(data)
+    }
+}
+
+/// Recursively pins `contentsScale` so text and shapes rasterize crisply for
+/// the host's screen; the offscreen window has no screen to derive it from.
+/// Only touched layers are redisplayed.
+@MainActor
+private func applyContentsScale(_ layer: CALayer, scale: CGFloat) {
+    if layer.contentsScale != scale {
+        layer.contentsScale = scale
+        layer.setNeedsDisplay()
+    }
+    if let sublayers = layer.sublayers {
+        for sublayer in sublayers {
+            applyContentsScale(sublayer, scale: scale)
+        }
+    }
+}

--- a/Packages/CmuxSidebarInterpreterService/Sources/CmuxSidebarRemoteRender/RunSidebarRenderWorker.swift
+++ b/Packages/CmuxSidebarInterpreterService/Sources/CmuxSidebarRemoteRender/RunSidebarRenderWorker.swift
@@ -1,0 +1,55 @@
+import AppKit
+import CmuxSidebarInterpreterClient
+import Foundation
+
+/// The render-worker process entry point: a faceless AppKit process that
+/// interprets AND renders the untrusted sidebar file, sharing the resulting
+/// layer tree with the host via a remote CoreAnimation context.
+///
+/// The host app re-executes its own binary with
+/// ``RenderWorkerClient/workerModeArgument``; `CmuxMain` routes here *before*
+/// any of the app's own startup. Never returns: exits when the host closes
+/// stdin (or dies, which closes it too).
+public func runSidebarRenderWorker() -> Never {
+    let channel = LengthPrefixedMessageChannel(readFD: 0, writeFD: 1)
+    let (messages, continuation) = AsyncStream.makeStream(of: RenderWorkerInbound.self)
+
+    // Reader thread: blocking framed reads off stdin (same justified pattern
+    // as the clients' reader threads — the fd is the only wake-up source).
+    // Yields preserve arrival order into the stream; the single main-actor
+    // consumer below applies them in that order.
+    let reader = Thread {
+        let decoder = JSONDecoder()
+        while let data = channel.receiveMessage() {
+            guard let message = try? decoder.decode(RenderWorkerInbound.self, from: data) else {
+                continue
+            }
+            continuation.yield(message)
+        }
+        continuation.finish()
+    }
+    reader.stackSize = 1 << 20
+    reader.name = "cmux-sidebar-render-worker-reader"
+    reader.start()
+
+    // The process entry point runs on the main thread by definition.
+    MainActor.assumeIsolated {
+        let app = NSApplication.shared
+        // Faceless: no Dock icon, no focus stealing, no windows on screen.
+        app.setActivationPolicy(.prohibited)
+
+        let coordinator = RenderWorkerCoordinator(channel: channel)
+        Task { @MainActor in
+            for await message in messages {
+                coordinator.handle(message)
+            }
+            // EOF: the host closed the pipe or died. Nothing left to render.
+            exit(0)
+        }
+
+        app.run()
+    }
+    // Backstop satisfying `-> Never`: reached only if something stops the run
+    // loop (the EOF path above exits directly).
+    exit(0)
+}

--- a/Packages/CmuxSidebarInterpreterService/Sources/cmux-sidebar-interpreter/main.swift
+++ b/Packages/CmuxSidebarInterpreterService/Sources/cmux-sidebar-interpreter/main.swift
@@ -1,0 +1,8 @@
+import CmuxSidebarInterpreterClient
+
+// The standalone out-of-process sidebar interpreter worker. The shared loop
+// lives in the library so the host app can run the same worker by re-executing
+// its own binary (see InterpreterClient.workerModeArgument). Crashing, hanging,
+// or exhausting resources here only kills this process; the supervising
+// InterpreterClient detects the closed pipe and recovers.
+runSidebarInterpreterWorker()

--- a/Packages/CmuxSidebarInterpreterService/Sources/cmux-sidebar-render-fixture/main.swift
+++ b/Packages/CmuxSidebarInterpreterService/Sources/cmux-sidebar-render-fixture/main.swift
@@ -1,0 +1,53 @@
+import CmuxSidebarInterpreterClient
+import CmuxSwiftRender
+import Foundation
+
+// Test fixture for RenderWorkerClient supervision tests: speaks the render-
+// worker wire protocol without any AppKit/CoreAnimation, so the client's
+// spawn/replay/ack/crash behavior is testable headless via `swift test`.
+//
+// Behavior:
+// - announces a fake context id derived from its pid on startup, so tests can
+//   tell worker generations apart;
+// - acks every scene, unless the scene's file path matches the hang token
+//   (then it never acks, exercising the ack watchdog) or the crash token
+//   (then it dies hard, exercising respawn + replay);
+// - replies to any pointer event with a canned action, exercising the
+//   worker → host action path.
+
+let environment = ProcessInfo.processInfo.environment
+let crashToken = environment["CMUX_RENDER_FIXTURE_CRASH_TOKEN"]
+let hangToken = environment["CMUX_RENDER_FIXTURE_HANG_TOKEN"]
+
+let channel = LengthPrefixedMessageChannel(readFD: 0, writeFD: 1)
+let decoder = JSONDecoder()
+let encoder = JSONEncoder()
+
+func send(_ message: RenderWorkerOutbound) {
+    guard let payload = try? encoder.encode(message) else { return }
+    try? channel.sendMessage(payload)
+}
+
+send(.context(UInt32(truncatingIfNeeded: ProcessInfo.processInfo.processIdentifier)))
+
+while let data = channel.receiveMessage() {
+    guard let message = try? decoder.decode(RenderWorkerInbound.self, from: data) else {
+        continue
+    }
+    switch message {
+    case let .scene(scene):
+        if let crashToken, !crashToken.isEmpty, scene.filePath == crashToken {
+            fatalError("render fixture crash sentinel")
+        }
+        if let hangToken, !hangToken.isEmpty, scene.filePath == hangToken {
+            continue // swallow the scene: never ack, simulating a hung renderer
+        }
+        send(.ack(scene.seq))
+    case .resize:
+        continue
+    case .pointer:
+        send(.action(ButtonAction(commands: [])))
+    case .reloadSidebars:
+        continue
+    }
+}

--- a/Packages/CmuxSidebarInterpreterService/Tests/CmuxSidebarInterpreterClientTests/InterpreterClientTests.swift
+++ b/Packages/CmuxSidebarInterpreterService/Tests/CmuxSidebarInterpreterClientTests/InterpreterClientTests.swift
@@ -1,0 +1,67 @@
+import CmuxSwiftRender
+import Foundation
+import Testing
+@testable import CmuxSidebarInterpreterClient
+
+@Suite struct InterpreterClientTests {
+    @Test func rendersValidSourceOutOfProcess() async {
+        let client = InterpreterClient(executableURL: interpreterWorkerURL(), timeout: .seconds(10))
+        let node = await client.render(source: "Text(\"hello\")", state: [:])
+        await client.shutdown()
+        #expect(node?.kind == .text)
+        #expect(node?.text == "hello")
+    }
+
+    @Test func bindsHostDataContextInTheWorker() async {
+        let client = InterpreterClient(executableURL: interpreterWorkerURL(), timeout: .seconds(10))
+        let node = await client.render(source: "Text(title)", state: ["title": .string("from-host")])
+        await client.shutdown()
+        #expect(node?.text == "from-host")
+    }
+
+    /// The headline guarantee: a worker that crashes mid-interpret returns
+    /// `nil` to the host (it does NOT crash this test process), and the client
+    /// transparently relaunches the worker for the next render.
+    @Test func survivesAWorkerCrashAndRecovers() async {
+        let crashToken = "__CRASH_THE_WORKER__"
+        let client = InterpreterClient(
+            executableURL: interpreterWorkerURL(),
+            timeout: .seconds(10),
+            environment: ["CMUX_INTERPRETER_TEST_CRASH_TOKEN": crashToken]
+        )
+
+        let crashed = await client.render(source: crashToken, state: [:])
+        #expect(crashed == nil)
+
+        let recovered = await client.render(source: "Text(\"still alive\")", state: [:])
+        await client.shutdown()
+        #expect(recovered?.text == "still alive")
+    }
+
+    /// A worker that hangs is killed at the deadline; the render returns `nil`
+    /// and the next render relaunches a fresh worker.
+    @Test func timesOutAHangingWorkerAndRecovers() async {
+        let hangToken = "__HANG_THE_WORKER__"
+        let client = InterpreterClient(
+            executableURL: interpreterWorkerURL(),
+            timeout: .milliseconds(400),
+            environment: ["CMUX_INTERPRETER_TEST_HANG_TOKEN": hangToken]
+        )
+
+        let timedOut = await client.render(source: hangToken, state: [:])
+        #expect(timedOut == nil)
+
+        let recovered = await client.render(source: "Text(\"after timeout\")", state: [:])
+        await client.shutdown()
+        #expect(recovered?.text == "after timeout")
+    }
+
+    @Test func reusesOneWorkerAcrossManyRenders() async {
+        let client = InterpreterClient(executableURL: interpreterWorkerURL(), timeout: .seconds(10))
+        for index in 0..<8 {
+            let node = await client.render(source: "Text(\"row \\(index)\")", state: ["index": .int(index)])
+            #expect(node?.text == "row \(index)")
+        }
+        await client.shutdown()
+    }
+}

--- a/Packages/CmuxSidebarInterpreterService/Tests/CmuxSidebarInterpreterClientTests/InterpreterWorkerLocator.swift
+++ b/Packages/CmuxSidebarInterpreterService/Tests/CmuxSidebarInterpreterClientTests/InterpreterWorkerLocator.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// Locates the built `cmux-sidebar-interpreter` worker executable so the client
+/// tests can spawn the real worker process.
+///
+/// Two runners place the binary differently:
+/// - `xcodebuild test` loads a `.xctest` bundle; the worker is its sibling.
+/// - `swift test` runs via an out-of-tree `swiftpm-testing-helper` and loads no
+///   `.xctest`, so we derive the package root from `#filePath` and use the
+///   `.build/<config>` products directory (the `.build/debug` symlink resolves
+///   regardless of the host triple).
+///
+/// The first candidate that is an executable file wins.
+func interpreterWorkerURL() -> URL {
+    builtExecutableURL(named: "cmux-sidebar-interpreter")
+}
+
+/// Locates the built `cmux-sidebar-render-fixture` protocol fixture for the
+/// `RenderWorkerClient` supervision tests (same lookup rules as the worker).
+func renderFixtureURL() -> URL {
+    builtExecutableURL(named: "cmux-sidebar-render-fixture")
+}
+
+private func builtExecutableURL(named workerName: String) -> URL {
+    let fileManager = FileManager.default
+    var candidates: [URL] = []
+
+    #if os(macOS)
+    for bundle in Bundle.allBundles where bundle.bundlePath.hasSuffix(".xctest") {
+        candidates.append(bundle.bundleURL.deletingLastPathComponent().appendingPathComponent(workerName))
+    }
+    #endif
+
+    // <package>/Tests/CmuxSidebarInterpreterClientTests/<thisFile>
+    let packageRoot = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+    let buildDirectory = packageRoot.appendingPathComponent(".build")
+    candidates.append(buildDirectory.appendingPathComponent("debug").appendingPathComponent(workerName))
+    candidates.append(buildDirectory.appendingPathComponent("release").appendingPathComponent(workerName))
+    if let triples = try? fileManager.contentsOfDirectory(at: buildDirectory, includingPropertiesForKeys: nil) {
+        for triple in triples {
+            candidates.append(triple.appendingPathComponent("debug").appendingPathComponent(workerName))
+            candidates.append(triple.appendingPathComponent("release").appendingPathComponent(workerName))
+        }
+    }
+
+    for candidate in candidates where fileManager.isExecutableFile(atPath: candidate.path) {
+        return candidate
+    }
+    return candidates.first ?? URL(fileURLWithPath: workerName)
+}

--- a/Packages/CmuxSidebarInterpreterService/Tests/CmuxSidebarInterpreterClientTests/LengthPrefixedMessageChannelTests.swift
+++ b/Packages/CmuxSidebarInterpreterService/Tests/CmuxSidebarInterpreterClientTests/LengthPrefixedMessageChannelTests.swift
@@ -1,0 +1,70 @@
+import Foundation
+import Testing
+@testable import CmuxSidebarInterpreterClient
+
+@Suite struct LengthPrefixedMessageChannelTests {
+    @Test func roundTripsAFramedMessage() throws {
+        let pipe = Pipe()
+        let channel = LengthPrefixedMessageChannel(
+            readFD: pipe.fileHandleForReading.fileDescriptor,
+            writeFD: pipe.fileHandleForWriting.fileDescriptor
+        )
+        let payload = Data("hello, framed world".utf8)
+        try channel.sendMessage(payload)
+        #expect(channel.receiveMessage() == payload)
+    }
+
+    @Test func roundTripsAnEmptyMessage() throws {
+        let pipe = Pipe()
+        let channel = LengthPrefixedMessageChannel(
+            readFD: pipe.fileHandleForReading.fileDescriptor,
+            writeFD: pipe.fileHandleForWriting.fileDescriptor
+        )
+        try channel.sendMessage(Data())
+        #expect(channel.receiveMessage() == Data())
+    }
+
+    @Test func returnsNilWhenWriterClosed() throws {
+        let pipe = Pipe()
+        let channel = LengthPrefixedMessageChannel(
+            readFD: pipe.fileHandleForReading.fileDescriptor,
+            writeFD: pipe.fileHandleForWriting.fileDescriptor
+        )
+        try pipe.fileHandleForWriting.close()
+        #expect(channel.receiveMessage() == nil)
+    }
+}
+
+@Suite struct LengthPrefixedFrameGuardTests {
+    /// An inbound length header beyond the cap reads as end-of-stream instead
+    /// of an allocation the peer controls.
+    @Test func oversizedInboundHeaderReadsAsEOF() throws {
+        let inbound = Pipe()
+        let channel = LengthPrefixedMessageChannel(
+            readFD: inbound.fileHandleForReading.fileDescriptor,
+            writeFD: FileHandle.nullDevice.fileDescriptor
+        )
+        let oversize = UInt32(LengthPrefixedMessageChannel.maximumFrameLength) + 1
+        var header = Data(count: 4)
+        header[0] = UInt8((oversize >> 24) & 0xFF)
+        header[1] = UInt8((oversize >> 16) & 0xFF)
+        header[2] = UInt8((oversize >> 8) & 0xFF)
+        header[3] = UInt8(oversize & 0xFF)
+        try inbound.fileHandleForWriting.write(contentsOf: header)
+        #expect(channel.receiveMessage() == nil)
+    }
+
+    /// An outbound payload beyond the cap throws instead of writing a frame
+    /// the peer would reject.
+    @Test func oversizedOutboundPayloadThrows() {
+        let outbound = Pipe()
+        let channel = LengthPrefixedMessageChannel(
+            readFD: FileHandle.nullDevice.fileDescriptor,
+            writeFD: outbound.fileHandleForWriting.fileDescriptor
+        )
+        let payload = Data(count: LengthPrefixedMessageChannel.maximumFrameLength + 1)
+        #expect(throws: ChannelError.self) {
+            try channel.sendMessage(payload)
+        }
+    }
+}

--- a/Packages/CmuxSidebarInterpreterService/Tests/CmuxSidebarInterpreterClientTests/RenderWorkerClientTests.swift
+++ b/Packages/CmuxSidebarInterpreterService/Tests/CmuxSidebarInterpreterClientTests/RenderWorkerClientTests.swift
@@ -1,0 +1,179 @@
+import CmuxSwiftRender
+import Foundation
+import Testing
+@testable import CmuxSidebarInterpreterClient
+
+/// Supervision tests for ``RenderWorkerClient`` against the headless
+/// `cmux-sidebar-render-fixture` (announces a pid-derived context id, acks
+/// scenes, answers pointers with a canned action, and crashes/hangs on env
+/// tokens), so the spawn → announce → ack → crash → respawn cycle is verified
+/// through a real process boundary without AppKit.
+@Suite struct RenderWorkerClientTests {
+    @Test func announcesContextOnSpawn() async {
+        let client = RenderWorkerClient(executableURL: renderFixtureURL())
+        let collector = RenderEventCollector(stream: await client.subscribe())
+        await client.updateScene(filePath: "/tmp/sidebar.swift", state: [:], topInset: 0, bottomInset: 0)
+        let events = await collector.waitForEvents(count: 1)
+        await client.shutdown()
+        guard case .context = events.first else {
+            Issue.record("expected a context announcement, got \(events)")
+            return
+        }
+    }
+
+    @Test func forwardsPointerEventsAndSurfacesActions() async {
+        let client = RenderWorkerClient(executableURL: renderFixtureURL())
+        let collector = RenderEventCollector(stream: await client.subscribe())
+        await client.updateScene(filePath: "/tmp/sidebar.swift", state: [:], topInset: 0, bottomInset: 0)
+        await client.forward(RenderPointerEvent(kind: .down, x: 10, y: 10))
+        let events = await collector.waitForEvents(count: 2)
+        await client.shutdown()
+        #expect(events.count == 2)
+        guard case .context = events.first else {
+            Issue.record("expected context first, got \(events)")
+            return
+        }
+        #expect(events.last == .action(ButtonAction(commands: [])))
+    }
+
+    /// A pointer interaction with no prior scene must still spawn the worker
+    /// (the host can race a click against the first data tick) and surface the
+    /// resulting action.
+    @Test func pointerBeforeAnySceneSpawnsWorker() async {
+        let client = RenderWorkerClient(executableURL: renderFixtureURL())
+        let collector = RenderEventCollector(stream: await client.subscribe())
+        await client.forward(RenderPointerEvent(kind: .down, x: 1, y: 1))
+        let events = await collector.waitForEvents(count: 2)
+        await client.shutdown()
+        guard case .context = events.first else {
+            Issue.record("expected spawn context, got \(events)")
+            return
+        }
+        #expect(events.last == .action(ButtonAction(commands: [])))
+    }
+
+    /// The headline guarantee: a renderer crash kills only the worker. The
+    /// next scene update relaunches a fresh worker, which re-announces a new
+    /// context id the host swaps to.
+    @Test func survivesAWorkerCrashAndReannouncesContext() async {
+        let crashToken = "/tmp/__CRASH_THE_RENDER_WORKER__.swift"
+        let client = RenderWorkerClient(
+            executableURL: renderFixtureURL(),
+            environment: ["CMUX_RENDER_FIXTURE_CRASH_TOKEN": crashToken]
+        )
+        let collector = RenderEventCollector(stream: await client.subscribe())
+
+        await client.updateScene(filePath: crashToken, state: [:], topInset: 0, bottomInset: 0)
+        let first = await collector.waitForEvents(count: 1)
+
+        // The host sends scene ticks every second; relaunch happens on the
+        // next send after the death is noticed. Tick until recovery.
+        var all = [RenderWorkerEvent]()
+        for _ in 0..<20 where all.count < 2 {
+            await client.updateScene(filePath: "/tmp/recovered.swift", state: [:], topInset: 0, bottomInset: 0)
+            all = await collector.waitForEvents(count: 2, deadline: .milliseconds(500))
+        }
+        await client.shutdown()
+
+        guard case let .context(firstContext) = first.first,
+              all.count >= 2, case let .context(secondContext) = all[1] else {
+            Issue.record("expected two context announcements, got \(all)")
+            return
+        }
+        #expect(firstContext != secondContext, "a respawned worker must announce a fresh context")
+    }
+
+    /// A renderer that never acks a scene is presumed hung: the watchdog
+    /// discards it, and the next scene update relaunches a fresh worker that
+    /// replays the latest scene.
+    @Test func discardsAHungWorkerAndRecovers() async throws {
+        let hangToken = "/tmp/__HANG_THE_RENDER_WORKER__.swift"
+        let client = RenderWorkerClient(
+            executableURL: renderFixtureURL(),
+            ackTimeout: .milliseconds(300),
+            environment: ["CMUX_RENDER_FIXTURE_HANG_TOKEN": hangToken]
+        )
+        let collector = RenderEventCollector(stream: await client.subscribe())
+
+        await client.updateScene(filePath: hangToken, state: [:], topInset: 0, bottomInset: 0)
+        let first = await collector.waitForEvents(count: 1)
+
+        // Let the ack watchdog expire and discard the (simulated) hung worker.
+        // Deterministic test-only delay past the 300ms deadline.
+        try await Task.sleep(for: .milliseconds(700))
+
+        // Tick like the host until the fresh worker announces itself.
+        var all = [RenderWorkerEvent]()
+        for _ in 0..<20 where all.count < 2 {
+            await client.updateScene(filePath: "/tmp/after-hang.swift", state: [:], topInset: 0, bottomInset: 0)
+            all = await collector.waitForEvents(count: 2, deadline: .milliseconds(500))
+        }
+        await client.shutdown()
+
+        guard case let .context(firstContext) = first.first,
+              all.count >= 2, case let .context(secondContext) = all[1] else {
+            Issue.record("expected recovery context after hang, got \(all)")
+            return
+        }
+        #expect(firstContext != secondContext, "recovery must come from a fresh worker process")
+    }
+}
+
+/// Drains a ``RenderWorkerClient/subscribe()`` stream into an ordered log and lets
+/// tests await "at least N events" with a bounded deadline.
+///
+/// A single long-lived consumer per test, because `AsyncStream` is unicast and
+/// terminates when an iterator is cancelled — racing short-lived `for await`
+/// loops against deadlines would tear the stream down after the first wait.
+private actor RenderEventCollector {
+    private var events: [RenderWorkerEvent] = []
+    private var nextWaiterID = 0
+    private var waiters: [Int: (threshold: Int, continuation: CheckedContinuation<[RenderWorkerEvent], Never>)] = [:]
+    private var pump: Task<Void, Never>?
+
+    init(stream: AsyncStream<RenderWorkerEvent>) {
+        Task { await self.start(stream) }
+    }
+
+    private func start(_ stream: AsyncStream<RenderWorkerEvent>) {
+        guard pump == nil else { return }
+        pump = Task {
+            for await event in stream {
+                await self.ingest(event)
+            }
+        }
+    }
+
+    private func ingest(_ event: RenderWorkerEvent) {
+        events.append(event)
+        let satisfied = waiters.filter { $0.value.threshold <= events.count }
+        for (id, waiter) in satisfied {
+            waiters.removeValue(forKey: id)
+            waiter.continuation.resume(returning: events)
+        }
+    }
+
+    /// Returns the full event log once it holds at least `count` events, or
+    /// whatever has arrived when `deadline` expires (bounded, cancellable
+    /// test-only deadline).
+    func waitForEvents(count: Int, deadline: Duration = .seconds(10)) async -> [RenderWorkerEvent] {
+        if events.count >= count { return events }
+        let id = nextWaiterID
+        nextWaiterID += 1
+        let expiry = Task { [weak self] in
+            try? await Task.sleep(for: deadline)
+            guard !Task.isCancelled else { return }
+            await self?.expire(id)
+        }
+        let result = await withCheckedContinuation { continuation in
+            waiters[id] = (count, continuation)
+        }
+        expiry.cancel()
+        return result
+    }
+
+    private func expire(_ id: Int) {
+        guard let waiter = waiters.removeValue(forKey: id) else { return }
+        waiter.continuation.resume(returning: events)
+    }
+}

--- a/Packages/CmuxSwiftRender/Sources/CmuxSwiftRender/ActionCommand.swift
+++ b/Packages/CmuxSwiftRender/Sources/CmuxSwiftRender/ActionCommand.swift
@@ -3,7 +3,7 @@
 /// The interpreter records the call shape; a host runtime executes it. The
 /// `cmux` case maps onto cmux's socket command dispatcher (`method` + string
 /// arguments), giving interpreted buttons the breadth of the cmux CLI.
-public enum ActionCommand: Sendable, Equatable {
+public enum ActionCommand: Codable, Sendable, Equatable {
     /// A cmux command: a dispatcher method plus named string params, e.g.
     /// `cmux("workspace.select", workspace_id: w.id)` →
     /// `.cmux("workspace.select", ["workspace_id": "<uuid>"])`. Maps directly

--- a/Packages/CmuxSwiftRender/Sources/CmuxSwiftRender/ButtonAction.swift
+++ b/Packages/CmuxSwiftRender/Sources/CmuxSwiftRender/ButtonAction.swift
@@ -1,6 +1,6 @@
 /// The captured behavior of a `Button`, evaluated when the button is tapped
 /// by a host runtime.
-public struct ButtonAction: Sendable, Equatable {
+public struct ButtonAction: Codable, Sendable, Equatable {
     public let commands: [ActionCommand]
 
     public init(commands: [ActionCommand]) {

--- a/Packages/CmuxSwiftRender/Sources/CmuxSwiftRender/InProcessSidebarInterpreter.swift
+++ b/Packages/CmuxSwiftRender/Sources/CmuxSwiftRender/InProcessSidebarInterpreter.swift
@@ -1,0 +1,16 @@
+/// A ``SidebarInterpreting`` that runs the ``SwiftViewInterpreter`` in the host
+/// process.
+///
+/// This is the non-isolated implementation: simplest and lowest-latency, but a
+/// bug in the interpreter crashes the host. Use it where the source is trusted
+/// or isolation is not required; use an out-of-process implementation to guard
+/// against interpreter faults from untrusted sidebars.
+public struct InProcessSidebarInterpreter: SidebarInterpreting {
+    private let interpreter = SwiftViewInterpreter()
+
+    public init() {}
+
+    public func render(source: String, state: [String: SwiftValue]) async -> RenderNode? {
+        interpreter.evaluate(source, state: state)
+    }
+}

--- a/Packages/CmuxSwiftRender/Sources/CmuxSwiftRender/ModifierArg.swift
+++ b/Packages/CmuxSwiftRender/Sources/CmuxSwiftRender/ModifierArg.swift
@@ -1,7 +1,7 @@
 /// One argument of a ``RenderModifier``: an optional label and a resolved
 /// string value (evaluated where possible, else the source token like
 /// `.infinity` or `.leading`).
-public struct ModifierArg: Sendable, Equatable {
+public struct ModifierArg: Codable, Sendable, Equatable {
     public let label: String?
     public let value: String
 

--- a/Packages/CmuxSwiftRender/Sources/CmuxSwiftRender/RenderModifier.swift
+++ b/Packages/CmuxSwiftRender/Sources/CmuxSwiftRender/RenderModifier.swift
@@ -1,7 +1,7 @@
 /// A modifier applied to a ``RenderNode`` (e.g. `.frame(maxWidth: .infinity)`),
 /// captured with its labeled argument list so multi-argument modifiers like
 /// `.frame` can be applied precisely.
-public struct RenderModifier: Sendable, Equatable {
+public struct RenderModifier: Codable, Sendable, Equatable {
     public let name: String
     public let args: [ModifierArg]
 

--- a/Packages/CmuxSwiftRender/Sources/CmuxSwiftRender/RenderNode.swift
+++ b/Packages/CmuxSwiftRender/Sources/CmuxSwiftRender/RenderNode.swift
@@ -6,9 +6,9 @@
 /// layer maps each ``Kind`` to the real compiled view initializer. The set
 /// of kinds is the framework bridge that grows over time; the language
 /// coverage is what makes the approach general.
-public struct RenderNode: Sendable, Equatable {
+public struct RenderNode: Codable, Sendable, Equatable {
     /// The view primitive this node represents.
-    public enum Kind: String, Sendable {
+    public enum Kind: String, Codable, Sendable {
         case vstack
         case hstack
         case zstack

--- a/Packages/CmuxSwiftRender/Sources/CmuxSwiftRender/ReorderSpec.swift
+++ b/Packages/CmuxSwiftRender/Sources/CmuxSwiftRender/ReorderSpec.swift
@@ -4,7 +4,7 @@
 /// children). The host runs `method` with `[idParam: movedId, indexParam:
 /// targetIndex]`, so for workspaces the cmux `workspace.reorder` command both
 /// reorders and persists.
-public struct ReorderSpec: Sendable, Equatable {
+public struct ReorderSpec: Codable, Sendable, Equatable {
     public let method: String
     public let idParam: String
     public let indexParam: String

--- a/Packages/CmuxSwiftRender/Sources/CmuxSwiftRender/SidebarInterpreting.swift
+++ b/Packages/CmuxSwiftRender/Sources/CmuxSwiftRender/SidebarInterpreting.swift
@@ -1,0 +1,20 @@
+/// Renders interpreted-sidebar source into a ``RenderNode`` tree, abstracting
+/// over *where* interpretation happens.
+///
+/// The UI layer depends on this seam, not on a concrete interpreter, so the app
+/// can inject either ``InProcessSidebarInterpreter`` (interprets in the host
+/// process) or an out-of-process, crash-isolating implementation. The async
+/// signature accommodates both: in-process returns immediately; an
+/// out-of-process implementation awaits a worker round-trip.
+///
+/// A `nil` result means "no view to show" for any reason — unsupported source,
+/// or (for an isolating implementation) a worker crash or timeout. The caller
+/// renders its error/empty state and never has to reason about interpreter
+/// faults.
+public protocol SidebarInterpreting: Sendable {
+    /// Interprets `source` against the live `state` data context.
+    ///
+    /// - Returns: the interpreted view tree, or `nil` when no view could be
+    ///   produced (including isolated worker crash/timeout).
+    func render(source: String, state: [String: SwiftValue]) async -> RenderNode?
+}

--- a/Packages/CmuxSwiftRender/Sources/CmuxSwiftRender/SwiftValue.swift
+++ b/Packages/CmuxSwiftRender/Sources/CmuxSwiftRender/SwiftValue.swift
@@ -6,7 +6,7 @@ import Foundation
 /// booleans, and ranges (the result of `0..<n`). The interpreter resolves
 /// identifiers, string interpolations, loop sequences, and `if` conditions
 /// to these.
-public enum SwiftValue: Sendable, Equatable {
+public enum SwiftValue: Codable, Sendable, Equatable {
     case int(Int)
     case double(Double)
     case string(String)

--- a/Packages/CmuxSwiftRenderUI/Package.swift
+++ b/Packages/CmuxSwiftRenderUI/Package.swift
@@ -4,6 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "CmuxSwiftRenderUI",
+    defaultLocalization: "en",
     platforms: [
         .macOS(.v14),
     ],
@@ -25,6 +26,9 @@ let package = Package(
                 .product(name: "CmuxSwiftRender", package: "CmuxSwiftRender"),
                 .product(name: "CmuxSettings", package: "CmuxSettings"),
                 .product(name: "CmuxFileWatch", package: "CmuxFileWatch"),
+            ],
+            resources: [
+                .process("Resources"),
             ]
         ),
         .testTarget(

--- a/Packages/CmuxSwiftRenderUI/Sources/CmuxSwiftRenderUI/JSON/DSLDocument.swift
+++ b/Packages/CmuxSwiftRenderUI/Sources/CmuxSwiftRenderUI/JSON/DSLDocument.swift
@@ -1,7 +1,13 @@
 import Foundation
 
 /// The top-level declarative JSON sidebar document loaded from disk.
-struct DSLDocument: Codable, Equatable, Sendable {
+///
+/// Public so ``CustomSidebarModel/State`` (whose `.json` case carries it) can
+/// cross the package boundary to the out-of-process render worker; the fields
+/// stay internal — only this package decodes and renders documents.
+public struct DSLDocument: Codable, Equatable, Sendable {
+    /// Document schema version.
     var version: Int
+    /// The root declarative node.
     var root: DSLNode
 }

--- a/Packages/CmuxSwiftRenderUI/Sources/CmuxSwiftRenderUI/JSON/DSLSidebarRenderer.swift
+++ b/Packages/CmuxSwiftRenderUI/Sources/CmuxSwiftRenderUI/JSON/DSLSidebarRenderer.swift
@@ -33,6 +33,7 @@ struct DSLSidebarRenderer: View {
             Button(node.title ?? "") {
                 if let action = node.action { onAction(action) }
             }
+            .reportTapTarget(node.action?.buttonAction)
         case .image:
             Image(systemName: node.systemName ?? "questionmark.square.dashed")
                 .font(resolvedFont)

--- a/Packages/CmuxSwiftRenderUI/Sources/CmuxSwiftRenderUI/Rendering/RenderNodeView.swift
+++ b/Packages/CmuxSwiftRenderUI/Sources/CmuxSwiftRenderUI/Rendering/RenderNodeView.swift
@@ -20,6 +20,7 @@ struct RenderNodeView: View {
             return AnyView(
                 view.contentShape(Rectangle())
                     .onTapGesture { dispatch.run(action) }
+                    .reportTapTarget(action)
             )
         }
         return view
@@ -47,6 +48,7 @@ struct RenderNodeView: View {
                 Button(node.text ?? "") {
                     if let action = node.action { dispatch.run(action) }
                 }
+                .reportTapTarget(node.action)
             } else {
                 // Rich label form: `Button(action:){ label }`. Plain style so
                 // the label renders as authored, not as default button chrome.
@@ -56,6 +58,7 @@ struct RenderNodeView: View {
                     VStack(alignment: .leading, spacing: 0) { children }
                 }
                 .buttonStyle(.plain)
+                .reportTapTarget(node.action)
             }
         case .spacer:
             Spacer(minLength: node.spacing.map { CGFloat($0) })

--- a/Packages/CmuxSwiftRenderUI/Sources/CmuxSwiftRenderUI/Rendering/SidebarTapTarget.swift
+++ b/Packages/CmuxSwiftRenderUI/Sources/CmuxSwiftRenderUI/Rendering/SidebarTapTarget.swift
@@ -1,0 +1,46 @@
+import CmuxSwiftRender
+import SwiftUI
+
+/// A tappable region reported by the rendered sidebar tree: the global frame
+/// (root coordinate space, top-left origin) of a `Button` or tap-gesture node
+/// and the ``ButtonAction`` it fires.
+///
+/// Collected via ``SidebarTapTargetsKey`` so an out-of-process render host can
+/// hit-test forwarded clicks geometrically instead of synthesizing AppKit
+/// events (SwiftUI control gestures don't fire in a never-on-screen window).
+public struct SidebarTapTarget: Equatable, Sendable {
+    /// The region's frame in the root (`.global`) coordinate space.
+    public let frame: CGRect
+    /// The action a tap inside ``frame`` fires.
+    public let action: ButtonAction
+
+    /// Creates a tap target.
+    ///
+    /// - Parameters:
+    ///   - frame: The region's frame in the root coordinate space.
+    ///   - action: The action a tap inside the frame fires.
+    public init(frame: CGRect, action: ButtonAction) {
+        self.frame = frame
+        self.action = action
+    }
+}
+
+extension View {
+    /// Reports this view's global frame as a tappable region firing `action`.
+    /// No-op when `action` is `nil`.
+    @ViewBuilder
+    func reportTapTarget(_ action: ButtonAction?) -> some View {
+        if let action {
+            background(
+                GeometryReader { proxy in
+                    Color.clear.preference(
+                        key: SidebarTapTargetsKey.self,
+                        value: [SidebarTapTarget(frame: proxy.frame(in: .global), action: action)]
+                    )
+                }
+            )
+        } else {
+            self
+        }
+    }
+}

--- a/Packages/CmuxSwiftRenderUI/Sources/CmuxSwiftRenderUI/Rendering/SidebarTapTargetsKey.swift
+++ b/Packages/CmuxSwiftRenderUI/Sources/CmuxSwiftRenderUI/Rendering/SidebarTapTargetsKey.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+/// Accumulates every ``SidebarTapTarget`` in the rendered sidebar.
+public struct SidebarTapTargetsKey: PreferenceKey {
+    /// No targets until the render tree reports some.
+    public static let defaultValue: [SidebarTapTarget] = []
+
+    /// Concatenates targets from sibling subtrees.
+    public static func reduce(value: inout [SidebarTapTarget], nextValue: () -> [SidebarTapTarget]) {
+        value.append(contentsOf: nextValue())
+    }
+}

--- a/Packages/CmuxSwiftRenderUI/Sources/CmuxSwiftRenderUI/Resources/Localizable.xcstrings
+++ b/Packages/CmuxSwiftRenderUI/Sources/CmuxSwiftRenderUI/Resources/Localizable.xcstrings
@@ -1,0 +1,57 @@
+{
+  "sourceLanguage": "en",
+  "strings": {
+    "sidebar.custom.error": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sidebar error"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サイドバーエラー"
+          }
+        }
+      }
+    },
+    "sidebar.custom.missing": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sidebar file is empty or missing."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サイドバーファイルが空か見つかりません。"
+          }
+        }
+      }
+    },
+    "sidebar.custom.noView": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No supported SwiftUI view found."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "対応するSwiftUIビューが見つかりません。"
+          }
+        }
+      }
+    }
+  },
+  "version": "1.0"
+}

--- a/Packages/CmuxSwiftRenderUI/Sources/CmuxSwiftRenderUI/Sidebar/CustomSidebarContentView.swift
+++ b/Packages/CmuxSwiftRenderUI/Sources/CmuxSwiftRenderUI/Sidebar/CustomSidebarContentView.swift
@@ -1,0 +1,130 @@
+import CmuxSwiftRender
+import SwiftUI
+
+/// The pure presentation of a custom sidebar: file state in, pixels out.
+///
+/// Shared by both render paths so they cannot drift visually:
+/// - ``CustomSidebarView`` (in-process fallback) feeds it from its observed
+///   ``CustomSidebarModel``;
+/// - the out-of-process render worker feeds it value snapshots it computed
+///   itself and hosts it in an offscreen `NSHostingView` whose layer tree is
+///   shared with the host window.
+///
+/// Holds no model reference and runs no tasks; everything arrives as values,
+/// so it renders identically wherever it is mounted.
+public struct CustomSidebarContentView: View {
+    private let state: CustomSidebarModel.State
+    private let swiftRender: RenderNode?
+    private let hasRenderedSwift: Bool
+    private let dispatch: SidebarActionDispatch
+    private let contentInsets: CustomSidebarContentInsets
+
+    /// Creates the sidebar presentation for a loaded file state.
+    ///
+    /// - Parameters:
+    ///   - state: The loaded sidebar file state (see ``CustomSidebarModel/State``).
+    ///   - swiftRender: The latest interpreted view tree for
+    ///     ``CustomSidebarModel/State/swiftSource(_:)``, if any.
+    ///   - hasRenderedSwift: Whether a first interpret has completed, so the
+    ///     view can distinguish "still rendering" from "rendered, no view".
+    ///   - dispatch: Runs button/tap actions against the host command surface.
+    ///   - contentInsets: Top/bottom scroll insets reserved for the host's
+    ///     titlebar accessory and footer chrome.
+    public init(
+        state: CustomSidebarModel.State,
+        swiftRender: RenderNode?,
+        hasRenderedSwift: Bool,
+        dispatch: SidebarActionDispatch,
+        contentInsets: CustomSidebarContentInsets
+    ) {
+        self.state = state
+        self.swiftRender = swiftRender
+        self.hasRenderedSwift = hasRenderedSwift
+        self.dispatch = dispatch
+        self.contentInsets = contentInsets
+    }
+
+    public var body: some View {
+        content
+            .environment(\.sidebarActionDispatch, dispatch)
+            .environment(\.customSidebarContentInsets, contentInsets)
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch state {
+        case .missing:
+            scrollWrap(
+                Text(String(localized: "sidebar.custom.missing", defaultValue: "Sidebar file is empty or missing.", bundle: .module))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            )
+        case let .json(document):
+            // Route JSON node actions through the same host dispatch the
+            // interpreted path uses, so taps in a declarative sidebar run
+            // instead of being silently dropped.
+            scrollWrap(DSLSidebarRenderer(node: document.root) { action in
+                dispatch.run(action.buttonAction)
+            })
+        case .swiftSource:
+            // Keep showing the last interpreted result until the next one
+            // lands so live re-renders don't flicker.
+            if let node = swiftRender {
+                // A split root owns its own per-column scrolling and fills the
+                // sidebar height, so it is not wrapped in the outer ScrollView.
+                if node.kind == .hsplit {
+                    RenderNodeView(node: node)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else {
+                    scrollWrap(RenderNodeView(node: node))
+                }
+            } else if hasRenderedSwift {
+                scrollWrap(errorView(String(localized: "sidebar.custom.noView", defaultValue: "No supported SwiftUI view found.", bundle: .module)))
+            } else {
+                // First render in flight; an empty placeholder avoids flashing
+                // the error state before the interpreter has answered.
+                scrollWrap(Color.clear.frame(height: 1))
+            }
+        case let .failed(message):
+            scrollWrap(errorView(message))
+        }
+    }
+
+    /// Wraps non-split content in the scrolling container with host-owned
+    /// outer insets (authors control inner spacing).
+    ///
+    /// The top/bottom `safeAreaInset`s reserve the titlebar-accessory and
+    /// footer bands so content rests below the chrome and scrolls up into the
+    /// host's edge-fade mask rather than clipping against it. This mirrors the
+    /// default workspace sidebar's scroll treatment.
+    private func scrollWrap(_ view: some View) -> some View {
+        ScrollView {
+            view
+                .frame(maxWidth: .infinity, alignment: .topLeading)
+                .padding(.horizontal, 12)
+                .padding(.top, 8)
+                .padding(.bottom, 16)
+        }
+        .safeAreaInset(edge: .top, spacing: 0) {
+            Color.clear.frame(height: contentInsets.top).allowsHitTesting(false)
+        }
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            Color.clear.frame(height: contentInsets.bottom).allowsHitTesting(false)
+        }
+    }
+
+    private func errorView(_ message: String) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Label(
+                String(localized: "sidebar.custom.error", defaultValue: "Sidebar error", bundle: .module),
+                systemImage: "exclamationmark.triangle.fill"
+            )
+            .font(.caption.bold())
+            .foregroundStyle(.orange)
+            Text(message)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}

--- a/Packages/CmuxSwiftRenderUI/Sources/CmuxSwiftRenderUI/Sidebar/CustomSidebarModel.swift
+++ b/Packages/CmuxSwiftRenderUI/Sources/CmuxSwiftRenderUI/Sidebar/CustomSidebarModel.swift
@@ -1,93 +1,173 @@
+import CmuxFileWatch
 import CmuxSettings
 import CmuxSwiftRender
 import Foundation
 
-/// Loads a named custom sidebar file and reloads it on explicit request.
+/// Loads a named custom sidebar file, hot-reloads it on change, and reloads it
+/// on explicit request.
 ///
 /// The file is either an interpreted `.swift` view or a declarative `.json`
-/// document. The model stores raw Swift source so the view can re-interpret it
-/// against the live data context without re-reading the file on every render.
+/// document, resolved by name (`.swift` preferred when both exist). Reload
+/// triggers:
+/// - the file changing on disk, via ``CmuxFileWatch/FileWatcher``
+///   (kqueue-backed) — safe to act on because rendering is last-good sticky
+///   (a broken mid-edit save never replaces a working sidebar; see
+///   ``renderSwift(dataContext:)`` and the remote worker's refresh);
+/// - an explicit `customSidebarReloadRequested` notification (posted for the
+///   CLI's `sidebar reload`), optionally filtered by sidebar name.
 @MainActor
 @Observable
-final class CustomSidebarModel {
+public final class CustomSidebarModel {
     /// The loaded state of the sidebar file.
-    enum State: Equatable {
+    public enum State: Equatable, Sendable {
+        /// The file does not exist (or is empty).
         case missing
+        /// A declarative JSON sidebar document.
         case json(DSLDocument)
+        /// Raw interpreted-Swift sidebar source.
         case swiftSource(String)
+        /// The file exists but could not be loaded/decoded.
         case failed(String)
     }
 
-    private(set) var state: State = .missing
-    private var fileURL: URL
+    /// The current loaded state of the watched file.
+    public private(set) var state: State = .missing
+    /// The currently resolved sidebar file (extension can flip between
+    /// `.swift`/`.json` across reloads when both exist by name).
+    public private(set) var fileURL: URL
     private let directoryURL: URL
     private let sidebarName: String
     private let fileManager: FileManager
 
+    private var watchTask: Task<Void, Never>?
+    private var watcher: FileWatcher?
     private var reloadObserver: NSObjectProtocol?
 
-    private let interpreter = SwiftViewInterpreter()
-    // Cache the parsed Swift program so re-rendering against live data (the
-    // host re-evaluates each `TimelineView` tick) does not re-parse unchanged
-    // source. Keyed by the source string; `reload()` swaps in new source on
-    // file change, which invalidates the cache on the next `renderNode` call.
-    private var cachedSource: String?
-    private var cachedProgram: ParsedProgram?
+    /// The interpreter the source is rendered through. Defaults to the
+    /// in-process implementation; the app injects an out-of-process,
+    /// crash-isolating ``SidebarInterpreting`` so an interpreter fault from an
+    /// untrusted sidebar can't take down the host.
+    private let interpreter: any SidebarInterpreting
 
-    init(fileURL: URL, fileManager: FileManager = .default) {
+    /// Latest interpreted view for `.swiftSource`, updated only when a render
+    /// completes so live re-renders don't flash empty between ticks.
+    public private(set) var swiftRender: RenderNode?
+    /// True once the first `.swiftSource` render completes, letting the view
+    /// distinguish "still rendering" from "rendered, no view" (error state).
+    public private(set) var hasRenderedSwift = false
+    /// Bumps when the loaded source changes, so the view's render trigger
+    /// re-fires on file reload even when the data context is unchanged.
+    public private(set) var sourceRevision = 0
+
+    /// Creates a model for `fileURL` rendering through `interpreter`.
+    public init(
+        fileURL: URL,
+        interpreter: any SidebarInterpreting = InProcessSidebarInterpreter(),
+        fileManager: FileManager = .default
+    ) {
         self.fileURL = fileURL
         directoryURL = fileURL.deletingLastPathComponent()
         sidebarName = fileURL.deletingPathExtension().lastPathComponent
+        self.interpreter = interpreter
         self.fileManager = fileManager
     }
 
-    /// Interprets the current Swift source against `dataContext`, reusing a
-    /// cached parse so the expensive AST parse/fold runs only when the source
-    /// changes (not on every render).
+    /// Interprets the current `.swiftSource` against `dataContext` through the
+    /// injected interpreter and publishes the result. No-op for other states.
     ///
-    /// Returns `nil` when the current state is not `.swiftSource` or the source
-    /// produces no supported view. The view layer maps `nil` to its error UI.
-    func renderNode(dataContext: [String: SwiftValue]) -> RenderNode? {
-        guard case let .swiftSource(source) = state else { return nil }
-        let program: ParsedProgram
-        if cachedSource == source, let cached = cachedProgram {
-            program = cached
-        } else {
-            program = interpreter.parse(source)
-            cachedSource = source
-            cachedProgram = program
+    /// Drive this from the view's `.task(id:)` so it re-runs on each data-
+    /// context change and on source reload; cancellation (a newer trigger
+    /// superseding this one) discards the stale result instead of publishing it.
+    public func renderSwift(dataContext: [String: SwiftValue]) async {
+        guard case let .swiftSource(source) = state else { return }
+        let node = await interpreter.render(source: source, state: dataContext)
+        if Task.isCancelled { return }
+        // Last-good sticky: a broken mid-edit save (nil node) keeps the
+        // previous working render instead of flashing the error state; the
+        // error still shows when there was never a good render.
+        if node != nil || swiftRender == nil {
+            swiftRender = node
         }
-        return interpreter.evaluate(program, state: dataContext)
+        hasRenderedSwift = true
     }
 
-    /// Loads the file once and listens for explicit reload requests.
-    /// Idempotent.
-    func start() {
+    /// Loads the file once, starts watching it, and listens for explicit
+    /// reload requests. Idempotent.
+    public func start() {
         reload()
-        guard reloadObserver == nil else { return }
-        reloadObserver = NotificationCenter.default.addObserver(
-            forName: .customSidebarReloadRequested,
-            object: nil,
-            queue: .main
-        ) { [weak self] notification in
-            let names = notification.userInfo?["names"] as? [String]
-            Task { @MainActor [weak self] in
-                guard let self else { return }
-                guard self.matchesReloadRequest(names: names) else { return }
-                self.reload()
+        startWatcher()
+        if reloadObserver == nil {
+            reloadObserver = NotificationCenter.default.addObserver(
+                forName: .customSidebarReloadRequested,
+                object: nil,
+                queue: .main
+            ) { [weak self] notification in
+                let names = notification.userInfo?["names"] as? [String]
+                Task { @MainActor [weak self] in
+                    self?.requestReload(names: names)
+                }
             }
         }
     }
 
-    func stop() {
+    /// Stops watching the file and listening for reloads. Safe to call
+    /// repeatedly.
+    public func stop() {
+        stopWatcher()
         if let reloadObserver {
             NotificationCenter.default.removeObserver(reloadObserver)
             self.reloadObserver = nil
         }
     }
 
+    /// Reloads when `names` is empty/absent or contains this sidebar's name.
+    /// The explicit-reload entry point shared by the in-process notification
+    /// path and the out-of-process worker (which receives forwarded reload
+    /// requests over its channel; host notifications don't cross processes).
+    public func requestReload(names: [String]?) {
+        if let names, !names.isEmpty, !names.contains(sidebarName) { return }
+        reload()
+    }
+
+    /// (Re)arms the kqueue watcher on the currently resolved file. Reload can
+    /// flip the resolved extension (`name.swift` <-> `name.json`); the watcher
+    /// must follow or hot reload silently stops after a flip.
+    private var watchedPath: String?
+
+    private func startWatcher() {
+        let path = fileURL.path
+        guard watchedPath != path else { return }
+        stopWatcher()
+        watchedPath = path
+        // Leading-edge throttle coalesces the burst of kqueue events an
+        // atomic save emits into one reload.
+        let watcher = FileWatcher(path: path, throttle: .milliseconds(150))
+        self.watcher = watcher
+        watchTask = Task { [weak self] in
+            for await _ in watcher.events {
+                guard let self else { return }
+                self.reload()
+            }
+        }
+    }
+
+    private func stopWatcher() {
+        watchTask?.cancel()
+        watchTask = nil
+        watchedPath = nil
+        if let watcher {
+            self.watcher = nil
+            Task { await watcher.stop() }
+        }
+    }
+
     /// Re-reads the file: stores `.swift` source verbatim, decodes `.json`.
-    func reload() {
+    public func reload() {
+        defer {
+            sourceRevision += 1 // re-fire the view's render trigger
+            // Follow extension flips with the watcher; no-op when unchanged.
+            if watchTask != nil || watchedPath != nil { startWatcher() }
+        }
         fileURL = preferredFileURL()
         guard fileManager.fileExists(atPath: fileURL.path) else {
             state = .missing
@@ -108,13 +188,6 @@ final class CustomSidebarModel {
         } catch {
             state = .failed(CustomSidebarValidator().describe(error))
         }
-    }
-
-    private func matchesReloadRequest(names: [String]?) -> Bool {
-        guard let names, !names.isEmpty else {
-            return true
-        }
-        return names.contains(sidebarName)
     }
 
     private func preferredFileURL() -> URL {

--- a/Packages/CmuxSwiftRenderUI/Sources/CmuxSwiftRenderUI/Sidebar/CustomSidebarView.swift
+++ b/Packages/CmuxSwiftRenderUI/Sources/CmuxSwiftRenderUI/Sidebar/CustomSidebarView.swift
@@ -30,98 +30,48 @@ public struct CustomSidebarView: View {
     ///     window titlebar accessory and fades into the host's top mask when
     ///     scrolled, instead of underlapping it. Defaults to
     ///     ``CustomSidebarContentInsets/zero``.
+    ///   - interpreter: The interpreter the `.swift` source renders through.
+    ///     Defaults to the in-process implementation; the app injects an
+    ///     out-of-process, crash-isolating ``SidebarInterpreting`` so an
+    ///     interpreter fault from an untrusted sidebar can't crash the host.
     public init(
         fileURL: URL,
         dataContext: [String: SwiftValue],
         dispatch: SidebarActionDispatch,
-        contentInsets: CustomSidebarContentInsets = .zero
+        contentInsets: CustomSidebarContentInsets = .zero,
+        interpreter: any SidebarInterpreting = InProcessSidebarInterpreter()
     ) {
-        _model = State(initialValue: CustomSidebarModel(fileURL: fileURL))
+        _model = State(initialValue: CustomSidebarModel(fileURL: fileURL, interpreter: interpreter))
         self.dataContext = dataContext
         self.dispatch = dispatch
         self.contentInsets = contentInsets
     }
 
     public var body: some View {
-        content
-            .environment(\.sidebarActionDispatch, dispatch)
-            .environment(\.customSidebarContentInsets, contentInsets)
-            .onAppear { model.start() }
-            .onDisappear { model.stop() }
+        // The pure presentation is shared with the out-of-process render
+        // worker (see CustomSidebarContentView), so the two paths can't drift.
+        CustomSidebarContentView(
+            state: model.state,
+            swiftRender: model.swiftRender,
+            hasRenderedSwift: model.hasRenderedSwift,
+            dispatch: dispatch,
+            contentInsets: contentInsets
+        )
+        .onAppear { model.start() }
+        .onDisappear { model.stop() }
+        // Re-interpret whenever the live data changes or the source
+        // reloads. `.task(id:)` cancels the prior render, so a superseded
+        // tick's result is discarded rather than published stale.
+        .task(id: SwiftRenderTrigger(sourceRevision: model.sourceRevision, dataContext: dataContext)) {
+            await model.renderSwift(dataContext: dataContext)
+        }
     }
+}
 
-    @ViewBuilder
-    private var content: some View {
-        switch model.state {
-        case .missing:
-            scrollWrap(
-                Text(String(localized: "sidebar.custom.missing", defaultValue: "Sidebar file is empty or missing."))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            )
-        case let .json(document):
-            // Route JSON node actions through the same host dispatch the
-            // interpreted path uses, so taps in a declarative sidebar run
-            // instead of being silently dropped.
-            scrollWrap(DSLSidebarRenderer(node: document.root) { action in
-                dispatch.run(action.buttonAction)
-            })
-        case .swiftSource:
-            // The model caches the parsed AST and re-evaluates only against
-            // `dataContext`, so live workspace state still drives re-renders
-            // without re-parsing the source on every tick.
-            if let node = model.renderNode(dataContext: dataContext) {
-                // A split root owns its own per-column scrolling and fills the
-                // sidebar height, so it is not wrapped in the outer ScrollView.
-                if node.kind == .hsplit {
-                    RenderNodeView(node: node)
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                } else {
-                    scrollWrap(RenderNodeView(node: node))
-                }
-            } else {
-                scrollWrap(errorView(String(localized: "sidebar.custom.noView", defaultValue: "No supported SwiftUI view found.")))
-            }
-        case let .failed(message):
-            scrollWrap(errorView(message))
-        }
-    }
-
-    /// Wraps non-split content in the scrolling container with host-owned
-    /// outer insets (authors control inner spacing).
-    ///
-    /// The top/bottom `safeAreaInset`s reserve the titlebar-accessory and
-    /// footer bands so content rests below the chrome and scrolls up into the
-    /// host's edge-fade mask rather than clipping against it. This mirrors the
-    /// default workspace sidebar's scroll treatment.
-    private func scrollWrap(_ view: some View) -> some View {
-        ScrollView {
-            view
-                .frame(maxWidth: .infinity, alignment: .topLeading)
-                .padding(.horizontal, 12)
-                .padding(.top, 8)
-                .padding(.bottom, 16)
-        }
-        .safeAreaInset(edge: .top, spacing: 0) {
-            Color.clear.frame(height: contentInsets.top).allowsHitTesting(false)
-        }
-        .safeAreaInset(edge: .bottom, spacing: 0) {
-            Color.clear.frame(height: contentInsets.bottom).allowsHitTesting(false)
-        }
-    }
-
-    private func errorView(_ message: String) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Label(
-                String(localized: "sidebar.custom.error", defaultValue: "Sidebar error"),
-                systemImage: "exclamationmark.triangle.fill"
-            )
-            .font(.caption.bold())
-            .foregroundStyle(.orange)
-            Text(message)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-    }
+/// The value the sidebar's interpret `.task(id:)` keys on. It changes when the
+/// loaded source reloads (`sourceRevision`) or the live `dataContext` changes,
+/// re-running the render. `Equatable` is enough for `.task(id:)`.
+private struct SwiftRenderTrigger: Equatable {
+    let sourceRevision: Int
+    let dataContext: [String: SwiftValue]
 }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -7,7 +7,6 @@ import CmuxSidebarProviderKit
 import CmuxExtensionSidebarExamples
 import CmuxSettings
 import CmuxSettingsUI
-import CmuxSidebarInterpreterClient
 import CmuxSidebarRemoteRender
 import CmuxSwiftRender
 import CmuxSwiftRenderUI
@@ -10484,14 +10483,6 @@ struct VerticalTabsSidebar: View {
     @State private var collapsedExtensionSidebarSectionIds: Set<String> = []
     @State private var extensionSidebarWorktreeCreationInFlightSectionIds: Set<String> = []
     @State private var extensionSidebarUpdateToken: UInt64 = 0
-    /// Out-of-process render worker for custom sidebars: interprets AND
-    /// renders untrusted vibe-coded source in a supervised worker (this app
-    /// re-executing its own binary in render-worker mode) and shares the
-    /// resulting layer tree, so neither an interpreter nor a renderer fault
-    /// can crash the host. Created once per sidebar host; the worker spawns
-    /// lazily on the first scene and is reused, relaunching transparently
-    /// after a crash or hang.
-    @State private var sidebarRenderWorkerClient = RenderWorkerClient.reexecingCurrentBinary()
     /// Bumped whenever any workspace's currentDirectory changes; the group
     /// header's resolved cwd-based config (color/icon/context menu /
     /// newWorkspacePlacement) reads it through the body, so a state
@@ -11181,15 +11172,14 @@ struct VerticalTabsSidebar: View {
                 // No .id(customSidebarURL): the worker swaps files in place on
                 // the next scene message, so remounting the surface would only
                 // flash the previous sidebar's pixels during the switch.
-                RemoteCustomSidebarView(
+                RemoteCustomSidebarHost(
                     fileURL: customSidebarURL,
                     dataContext: customSidebarDataContext(now: timeline.date),
                     dispatch: makeCmuxSidebarActionDispatch(),
                     contentInsets: CustomSidebarContentInsets(
                         top: SidebarWorkspaceScrollInsets.workspaceList.top,
                         bottom: SidebarWorkspaceScrollInsets.workspaceList.bottom
-                    ),
-                    client: sidebarRenderWorkerClient
+                    )
                 )
             }
             .mask(

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -7,6 +7,8 @@ import CmuxSidebarProviderKit
 import CmuxExtensionSidebarExamples
 import CmuxSettings
 import CmuxSettingsUI
+import CmuxSidebarInterpreterClient
+import CmuxSidebarRemoteRender
 import CmuxSwiftRender
 import CmuxSwiftRenderUI
 import CmuxUpdater
@@ -10482,6 +10484,14 @@ struct VerticalTabsSidebar: View {
     @State private var collapsedExtensionSidebarSectionIds: Set<String> = []
     @State private var extensionSidebarWorktreeCreationInFlightSectionIds: Set<String> = []
     @State private var extensionSidebarUpdateToken: UInt64 = 0
+    /// Out-of-process render worker for custom sidebars: interprets AND
+    /// renders untrusted vibe-coded source in a supervised worker (this app
+    /// re-executing its own binary in render-worker mode) and shares the
+    /// resulting layer tree, so neither an interpreter nor a renderer fault
+    /// can crash the host. Created once per sidebar host; the worker spawns
+    /// lazily on the first scene and is reused, relaunching transparently
+    /// after a crash or hang.
+    @State private var sidebarRenderWorkerClient = RenderWorkerClient.reexecingCurrentBinary()
     /// Bumped whenever any workspace's currentDirectory changes; the group
     /// header's resolved cwd-based config (color/icon/context menu /
     /// newWorkspacePlacement) reads it through the body, so a state
@@ -11164,17 +11174,23 @@ struct VerticalTabsSidebar: View {
             // Periodic tick so the custom sidebar re-renders live (clock,
             // countdowns, and refreshed workspace/data context), mirroring the
             // default sidebar's TimelineView. No banned timers involved.
+            // Fully out-of-process: the render worker interprets AND renders
+            // the file; this view only hosts the worker's remote layer and
+            // forwards input, so no file-derived view code runs in the host.
             TimelineView(.periodic(from: .now, by: 1)) { timeline in
-                CustomSidebarView(
+                // No .id(customSidebarURL): the worker swaps files in place on
+                // the next scene message, so remounting the surface would only
+                // flash the previous sidebar's pixels during the switch.
+                RemoteCustomSidebarView(
                     fileURL: customSidebarURL,
                     dataContext: customSidebarDataContext(now: timeline.date),
                     dispatch: makeCmuxSidebarActionDispatch(),
                     contentInsets: CustomSidebarContentInsets(
                         top: SidebarWorkspaceScrollInsets.workspaceList.top,
                         bottom: SidebarWorkspaceScrollInsets.workspaceList.bottom
-                    )
+                    ),
+                    client: sidebarRenderWorkerClient
                 )
-                    .id(customSidebarURL)
             }
             .mask(
                 SidebarWorkspaceScrollEdgeFadeMask(

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -1,4 +1,6 @@
 import AppKit
+import CmuxSidebarInterpreterClient
+import CmuxSidebarRemoteRender
 import CmuxSocketControl
 import CmuxSettings
 import CmuxSettingsUI
@@ -8,7 +10,29 @@ import Observation
 import Darwin
 import Bonsplit
 import UniformTypeIdentifiers
+
+/// The process entry point. When the binary is launched with a sidebar worker
+/// flag (the app re-executes its own binary that way so a crash in the
+/// interpreter or renderer kills only the worker process), run that worker
+/// loop instead of the app:
+/// - the render worker hosts its own faceless AppKit session and shares the
+///   rendered layer tree with the host;
+/// - the interpreter worker (stage-1 fallback path) runs before any
+///   AppKit/SwiftUI setup.
 @main
+enum CmuxMain {
+    static func main() {
+        if CommandLine.arguments.contains(RenderWorkerClient.workerModeArgument) {
+            runSidebarRenderWorker()
+        }
+        if CommandLine.arguments.contains(InterpreterClient.workerModeArgument) {
+            runSidebarInterpreterWorker()
+            exit(0)
+        }
+        cmuxApp.main()
+    }
+}
+
 struct cmuxApp: App {
     /// Dependency container for the new settings packages. Constructed
     /// once at app launch and injected into the SwiftUI environment via

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -163,7 +163,10 @@
 		CD0CFE5600000000CD0CFE56 /* CmuxSettingsUI in Frameworks */ = {isa = PBXBuildFile; productRef = CD0CFE5500000000CD0CFE55 /* CmuxSettingsUI */; };
 		DC5DC5DC0000000000000001 /* CmuxSidebarActionDispatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC5DC5DC0000000000000002 /* CmuxSidebarActionDispatch.swift */; };
 		C0DE46030000000000000001 /* CMUXSidebarExtensionBrowserPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE46030000000000000002 /* CMUXSidebarExtensionBrowserPanel.swift */; };
+		C5A1FED200000000000000E1 /* CmuxSidebarInterpreterClient in Frameworks */ = {isa = PBXBuildFile; productRef = C5A1FED200000000000000E3 /* CmuxSidebarInterpreterClient */; };
+		C5A1FED200000000000000E2 /* CmuxSidebarInterpreterClient in Frameworks */ = {isa = PBXBuildFile; productRef = C5A1FED200000000000000E3 /* CmuxSidebarInterpreterClient */; };
 		C0DE4A000000000000000001 /* CmuxSidebarProviderKit in Frameworks */ = {isa = PBXBuildFile; productRef = C0DE4A000000000000000002 /* CmuxSidebarProviderKit */; };
+		C5A1FED200000000000000E5 /* CmuxSidebarRemoteRender in Frameworks */ = {isa = PBXBuildFile; productRef = C5A1FED200000000000000E6 /* CmuxSidebarRemoteRender */; };
 		A5354303A5354303A5354303 /* CmuxSocketControl in Frameworks */ = {isa = PBXBuildFile; productRef = A5354305A5354305A5354305 /* CmuxSocketControl */; };
 		B900004CA1B2C3D4E5F60719 /* CmuxSocketControl in Frameworks */ = {isa = PBXBuildFile; productRef = A5354305A5354305A5354305 /* CmuxSocketControl */; };
 		E7E000000000000000000009 /* CmuxSocketEventMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7E00000000000000000000A /* CmuxSocketEventMapper.swift */; };
@@ -1283,7 +1286,9 @@
 				A5C0DE0000000000000000A3 /* CMUXProjectModel in Frameworks */,
 				CD0CFE5300000000CD0CFE53 /* CmuxSettings in Frameworks */,
 				CD0CFE5600000000CD0CFE56 /* CmuxSettingsUI in Frameworks */,
+				C5A1FED200000000000000E1 /* CmuxSidebarInterpreterClient in Frameworks */,
 				C0DE4A000000000000000001 /* CmuxSidebarProviderKit in Frameworks */,
+				C5A1FED200000000000000E5 /* CmuxSidebarRemoteRender in Frameworks */,
 				A5354303A5354303A5354303 /* CmuxSocketControl in Frameworks */,
 				C5A1FED000000000000000C1 /* CmuxSwiftRender in Frameworks */,
 				C5A1FED100000000000000D1 /* CmuxSwiftRenderUI in Frameworks */,
@@ -1315,6 +1320,7 @@
 				C8000314C8000314C8000314 /* CmuxFileWatch in Frameworks */,
 				CF00F00000000000000000A4 /* CmuxFoundation in Frameworks */,
 				C8000304C8000304C8000304 /* CmuxProcess in Frameworks */,
+				C5A1FED200000000000000E2 /* CmuxSidebarInterpreterClient in Frameworks */,
 				B900004CA1B2C3D4E5F60719 /* CmuxSocketControl in Frameworks */,
 				C5A1FED000000000000000C2 /* CmuxSwiftRender in Frameworks */,
 				C5A1FED100000000000000D2 /* CmuxSwiftRenderUI in Frameworks */,
@@ -2038,6 +2044,8 @@
 				C52830000000000000000004 /* CmuxTerminalCopyMode */,
 				C5A1FED000000000000000C3 /* CmuxSwiftRender */,
 				C5A1FED100000000000000D3 /* CmuxSwiftRenderUI */,
+				C5A1FED200000000000000E3 /* CmuxSidebarInterpreterClient */,
+				C5A1FED200000000000000E6 /* CmuxSidebarRemoteRender */,
 				C8000302C8000302C8000302 /* CmuxProcess */,
 				C8000312C8000312C8000312 /* CmuxFileWatch */,
 				C617000000000000000000A2 /* CmuxGit */,
@@ -2071,6 +2079,7 @@
 				A5354305A5354305A5354305 /* CmuxSocketControl */,
 				C5A1FED000000000000000C3 /* CmuxSwiftRender */,
 				C5A1FED100000000000000D3 /* CmuxSwiftRenderUI */,
+				C5A1FED200000000000000E3 /* CmuxSidebarInterpreterClient */,
 				C8000302C8000302C8000302 /* CmuxProcess */,
 				C8000312C8000312C8000312 /* CmuxFileWatch */,
 				CF00F00000000000000000A2 /* CmuxFoundation */,
@@ -2193,6 +2202,7 @@
 				C52830000000000000000003 /* XCLocalSwiftPackageReference "CmuxTerminalCopyMode" */,
 				C5A1FED000000000000000C4 /* XCLocalSwiftPackageReference "CmuxSwiftRender" */,
 				C5A1FED100000000000000D4 /* XCLocalSwiftPackageReference "CmuxSwiftRenderUI" */,
+				C5A1FED200000000000000E4 /* XCLocalSwiftPackageReference "CmuxSidebarInterpreterService" */,
 				C8000301C8000301C8000301 /* XCLocalSwiftPackageReference "CmuxProcess" */,
 				C8000311C8000311C8000311 /* XCLocalSwiftPackageReference "CmuxFileWatch" */,
 				C617000000000000000000A1 /* XCLocalSwiftPackageReference "CmuxGit" */,
@@ -3385,6 +3395,10 @@
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/CmuxSwiftRenderUI;
 		};
+		C5A1FED200000000000000E4 /* XCLocalSwiftPackageReference "CmuxSidebarInterpreterService" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Packages/CmuxSidebarInterpreterService;
+		};
 		C5A1FED000000000000000C4 /* XCLocalSwiftPackageReference "CmuxSwiftRender" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/CmuxSwiftRender;
@@ -3537,6 +3551,16 @@
 			isa = XCSwiftPackageProductDependency;
 			package = C5A1FED100000000000000D4 /* XCLocalSwiftPackageReference "CmuxSwiftRenderUI" */;
 			productName = CmuxSwiftRenderUI;
+		};
+		C5A1FED200000000000000E3 /* CmuxSidebarInterpreterClient */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C5A1FED200000000000000E4 /* XCLocalSwiftPackageReference "CmuxSidebarInterpreterService" */;
+			productName = CmuxSidebarInterpreterClient;
+		};
+		C5A1FED200000000000000E6 /* CmuxSidebarRemoteRender */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C5A1FED200000000000000E4 /* XCLocalSwiftPackageReference "CmuxSidebarInterpreterService" */;
+			productName = CmuxSidebarRemoteRender;
 		};
 		C8000312C8000312C8000312 /* CmuxFileWatch */ = {
 			isa = XCSwiftPackageProductDependency;


### PR DESCRIPTION
Re-lands https://github.com/manaflow-ai/cmux/pull/5294 (reverted in https://github.com/manaflow-ai/cmux/pull/5372 because the `tests` job went red exactly at its merge commit — https://github.com/manaflow-ai/cmux/issues/5367).

The original branch was green on `tests` before merging main, and main was green without it; the combination fails a cluster of `AppDelegateShortcutRoutingTests` cases whose files the PR does not touch. Three CI probes are bisecting which slice triggers the interaction (packages/pbxproj only; + CmuxMain entry change; full ContentView wiring). The root-cause fix lands on this branch.

**Hard merge gate: this PR does not merge until the `tests` job passes on its final head.** Draft until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5382"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783197231&installation_id=133855650&pr_number=5382&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5382&signature=b92795681a96a332d1732c98c91447fb5145df78b467934fad87afdc97cde18f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs custom sidebar interpretation and rendering out-of-process and hosts the result via a remote layer, so crashes or hangs in user-authored sidebars cannot crash the app. Adds a beta toggle and worker flags; creates the render client once on mount when a custom sidebar is selected and registers the settings search anchor.

- New Features
  - Out-of-process workers in `CmuxSidebarInterpreterService`: `InterpreterClient` + `cmux-sidebar-interpreter`; remote rendering via `RenderWorkerClient` (spawned with `--cmux-sidebar-interpreter-worker` / `--cmux-sidebar-render-worker`).
  - Remote rendering: worker interprets and renders, shares a CoreAnimation context id; host shows it with a `CALayerHost` surface and forwards pointer/scroll; button actions flow back over the pipe.
  - Shared UI: `CustomSidebarContentView`; `CustomSidebarModel` watches files and supports explicit reloads with last-good stickiness; in-process fallback via the `SidebarInterpreting` seam.
  - App wiring: adds the “Custom Sidebars” beta toggle; `cmuxApp` handles worker flags; `ContentView` mounts `RemoteCustomSidebarHost` so the client is created lazily and reaped on unmount.

- Bug Fixes
  - Registered the “Custom Sidebars” settings row anchor to satisfy `SettingsRowAnchorResolutionTests`.
  - Create `RenderWorkerClient` only once on mount inside `RemoteCustomSidebarHost` (initialized in `.task`), avoiding per-tick re-inits from `TimelineView` and only running a worker while the sidebar is mounted.

<sup>Written for commit 8061d96d7b214ce179427f89b63da8c8d0d306d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Beta toggle for "Custom Sidebars" enabled.
  * Out-of-process custom sidebar rendering for safer, isolated sidebar extensions.
  * Hot-reload with resilient "last-good" rendering for custom sidebars.
  * In-process interpreter option for lower-latency rendering.
  * Tap-target reporting to improve button/tap reliability.

* **Localization**
  * English and Japanese strings for custom sidebar UI and errors.

* **Tests**
  * Added tests for worker supervision and framed messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->