### PR TITLE
Fix markdown/browser Cmd zoom on non-US keyboard layouts

### DIFF
--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -1818,6 +1818,20 @@ struct ShortcutStroke: Equatable, Hashable {
         eventKeyCode: UInt16
     ) -> String {
         let lowered = eventCharacter.lowercased()
+
+        // "+" -> "=" and "_" -> "-" are normalized regardless of Shift. On US
+        // layouts these symbols only exist as Shift variants, so the Shift gate
+        // below historically sufficed. On European layouts (German QWERTZ, French
+        // AZERTY, Nordic) "+" and "-" are dedicated keys typed WITHOUT Shift, so a
+        // bare "+"/"_" can only originate from such a key. Mapping them to their
+        // base zoom key ("=", "-") unconditionally is therefore safe (no shortcut
+        // key is ever stored as "+"/"_") and is what makes Cmd zoom work there.
+        switch lowered {
+        case "+": return "="
+        case "_": return "-"
+        default: break
+        }
+
         guard applyShiftSymbolNormalization else { return lowered }
 
         switch lowered {
@@ -1830,8 +1844,6 @@ struct ShortcutStroke: Equatable, Hashable {
         case "\"": return "'"
         case "|": return "\\"
         case "~": return "`"
-        case "+": return "="
-        case "_": return "-"
         case "!": return eventKeyCode == 18 ? "1" : lowered // kVK_ANSI_1
         case "@": return eventKeyCode == 19 ? "2" : lowered // kVK_ANSI_2
         case "#": return eventKeyCode == 20 ? "3" : lowered // kVK_ANSI_3

--- a/cmuxTests/KeyboardShortcutContextTests.swift
+++ b/cmuxTests/KeyboardShortcutContextTests.swift
@@ -253,6 +253,34 @@ final class KeyboardShortcutContextTests: XCTestCase {
         )
     }
 
+    // The "_" -> "-" normalization was also moved out of the Shift gate, so a
+    // bare "_" (no Shift) from a layout where "_" is a dedicated key must match
+    // the "-" zoom-out chord. Without this, a future refactor could re-gate "_"
+    // behind Shift with no failing test to catch it.
+    func testZoomOutMatchesBareUnderscoreOnNonUSLayout() {
+        let markdownZoomOut = KeyboardShortcutSettings.Action.markdownZoomOut.defaultShortcut
+        XCTAssertTrue(
+            markdownZoomOut.matches(
+                keyCode: 27,
+                modifierFlags: [.command],
+                eventCharacter: "_",
+                layoutCharacterProvider: { _, _ in "_" }
+            ),
+            "Cmd and a dedicated _ key should zoom markdown out (\"_\" normalizes to \"-\")"
+        )
+
+        let browserZoomOut = KeyboardShortcutSettings.Action.browserZoomOut.defaultShortcut
+        XCTAssertTrue(
+            browserZoomOut.matches(
+                keyCode: 27,
+                modifierFlags: [.command],
+                eventCharacter: "_",
+                layoutCharacterProvider: { _, _ in "_" }
+            ),
+            "Cmd and a dedicated _ key should zoom the browser out (\"_\" normalizes to \"-\")"
+        )
+    }
+
     func testZoomInDoesNotMatchUnrelatedKeyOnNonUSLayout() {
         // Guard: the layout-aware "+" handling must not make Cmd-= match keys that
         // legitimately produce other characters (e.g. a bare letter key).

--- a/cmuxTests/KeyboardShortcutContextTests.swift
+++ b/cmuxTests/KeyboardShortcutContextTests.swift
@@ -197,6 +197,76 @@ final class KeyboardShortcutContextTests: XCTestCase {
         XCTAssertTrue(nonBrowser.overlaps(markdown))
     }
 
+    // Regression: on European layouts (German QWERTZ, French AZERTY, Nordic, ...)
+    // "+" and "-" are dedicated keys typed WITHOUT Shift, so the event reports
+    // character "+"/"-" with no Shift flag and a keyCode that is not the US
+    // kVK_ANSI_Equal (24) / kVK_ANSI_Minus (27). The Cmd-=/Cmd-- zoom chords must
+    // still match from those keys. See https://github.com/manaflow-ai/cmux/pull/5163.
+    func testMarkdownZoomMatchesDedicatedPlusMinusKeysOnNonUSLayout() {
+        // German QWERTZ: dedicated "+" key sits at the US RightBracket position
+        // (keyCode 30) and produces "+" with no Shift; "-" sits at the US Slash
+        // position (keyCode 44) and produces "-" with no Shift.
+        let zoomIn = KeyboardShortcutSettings.Action.markdownZoomIn.defaultShortcut
+        XCTAssertTrue(
+            zoomIn.matches(
+                keyCode: 30,
+                modifierFlags: [.command],
+                eventCharacter: "+",
+                layoutCharacterProvider: { _, _ in "+" }
+            ),
+            "Cmd and the dedicated + key should zoom markdown in on non-US layouts"
+        )
+
+        let zoomOut = KeyboardShortcutSettings.Action.markdownZoomOut.defaultShortcut
+        XCTAssertTrue(
+            zoomOut.matches(
+                keyCode: 44,
+                modifierFlags: [.command],
+                eventCharacter: "-",
+                layoutCharacterProvider: { _, _ in "-" }
+            ),
+            "Cmd and the dedicated - key should zoom markdown out on non-US layouts"
+        )
+    }
+
+    func testBrowserZoomMatchesDedicatedPlusMinusKeysOnNonUSLayout() {
+        let zoomIn = KeyboardShortcutSettings.Action.browserZoomIn.defaultShortcut
+        XCTAssertTrue(
+            zoomIn.matches(
+                keyCode: 30,
+                modifierFlags: [.command],
+                eventCharacter: "+",
+                layoutCharacterProvider: { _, _ in "+" }
+            ),
+            "Cmd and the dedicated + key should zoom the browser in on non-US layouts"
+        )
+
+        let zoomOut = KeyboardShortcutSettings.Action.browserZoomOut.defaultShortcut
+        XCTAssertTrue(
+            zoomOut.matches(
+                keyCode: 44,
+                modifierFlags: [.command],
+                eventCharacter: "-",
+                layoutCharacterProvider: { _, _ in "-" }
+            ),
+            "Cmd and the dedicated - key should zoom the browser out on non-US layouts"
+        )
+    }
+
+    func testZoomInDoesNotMatchUnrelatedKeyOnNonUSLayout() {
+        // Guard: the layout-aware "+" handling must not make Cmd-= match keys that
+        // legitimately produce other characters (e.g. a bare letter key).
+        let zoomIn = KeyboardShortcutSettings.Action.browserZoomIn.defaultShortcut
+        XCTAssertFalse(
+            zoomIn.matches(
+                keyCode: 45,
+                modifierFlags: [.command],
+                eventCharacter: "n",
+                layoutCharacterProvider: { _, _ in "n" }
+            )
+        )
+    }
+
     func testFocusHistoryMenuShortcutsSuppressDuplicateBrowserHistoryKeys() throws {
         let originalSettingsFileStore = KeyboardShortcutSettings.settingsFileStore
         let directoryURL = try makeTemporaryDirectory()


### PR DESCRIPTION
## Problem

The markdown viewer's zoom shortcuts (Cmd-= zoom in, Cmd-- zoom out, Cmd-0 reset) from #5163 do not work on European / non-US keyboard layouts (German QWERTZ, French AZERTY, Nordic). A European user cannot trigger markdown zoom from the keys they would naturally press. Browser zoom (browserZoomIn/Out/Reset) has the same defect. Terminal panes still zoom because Ghostty does its own layout-aware font zoom, which is why only the markdown viewer was reported.

## Root cause

Markdown and browser zoom both resolve through the unified `ShortcutStroke` matcher in `Sources/KeyboardShortcutSettings.swift`. Its symbol normalization (`normalizedShortcutEventCharacter`) mapped `+` -> `=` and `_` -> `-` only when Shift was held (`applyShiftSymbolNormalization`).

That gate is US-centric. On US layouts `+`/`-` only exist as the Shift variants of the `=`/`-` key, so requiring Shift was fine. On European layouts `+` and `-` are dedicated keys typed WITHOUT Shift: the event reports character `+`/`-` with no Shift flag and a keyCode that is not US `kVK_ANSI_Equal` (24) / `kVK_ANSI_Minus` (27). So the normalization never ran, the layout-character fallback (also passing `applyShiftSymbolNormalization: false`) failed, and the final ANSI keyCode fallback compared against US physical keycodes that the `+`/`-` keys do not sit on. Net: Cmd-+ / Cmd-- from a European keyboard never matched the `=`/`-` zoom chord.

This is the same class of bug a dedicated `browserZoomShortcutAction` once handled (#680) before shortcuts became configurable and that path was removed.

## Fix

Move the `+` -> `=` and `_` -> `-` normalization out of the Shift gate so it runs unconditionally in the shared matcher. A bare `+`/`_` can only originate from a dedicated key on a non-US layout (it requires Shift on US), and no shortcut key is ever stored as `+`/`_`, so the mapping is always safe and US behavior is unchanged. Because the fix lives in the one matcher every configurable shortcut flows through, it repairs markdown zoom, browser zoom, and any other `=`/`-` symbol chord at once, and it follows the actually-bound key so user rebindings are respected. Keypad plus/minus (character `+`/`-`) are now covered too.

No new or renamed shortcuts, so Settings UI and docs are unchanged.

## Tests

Two-commit red/green structure per repo policy:
1. Adds matcher tests in `cmuxTests/KeyboardShortcutContextTests.swift` that simulate the dedicated `+`/`-` keys (character `+`/`-`, no Shift, non-24/27 keyCode, layout provider returning `+`/`-`) and assert they match `markdownZoomIn`/`Out` AND `browserZoomIn`/`Out`. Plus a guard that a bare letter key does not match the zoom chord. This commit is red.
2. The fix. This commit is green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5394"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783205714&installation_id=133855650&pr_number=5394&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5394&signature=c13594de5d2ca73dc6c41389602cba99b0a214f326931fb283b37e1f83f6b673"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to keyboard event character normalization with regression tests; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes **markdown and browser zoom** (Cmd-= / Cmd--) on **non-US keyboards** by changing shared shortcut matching in `normalizedShortcutEventCharacter`.
> 
> **`+` → `=`** and **`_` → `-`** now run **before** the Shift-only symbol normalization. On layouts where `+` and `-` are dedicated keys without Shift, events no longer fail to match zoom chords stored as `=` and `-`. US behavior stays the same because those symbols still map correctly when Shift is used.
> 
> Adds **regression tests** that simulate European dedicated `+`/`-`/`_` keys (non-US key codes, no Shift) for markdown and browser zoom, plus a guard that unrelated keys do not match zoom-in.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7eb1275e91a0cf865a9859de585f54836ff7be6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix markdown and browser zoom shortcuts on non‑US keyboards by normalizing '+' and '_' to their base '=' and '-' keys regardless of Shift. Users on German, French, and Nordic layouts can use Cmd-+ and Cmd-- to zoom; keypad +/- also work.

- **Bug Fixes**
  - Normalize `+` -> `=` and `_` -> `-` unconditionally in the shared `ShortcutStroke` matcher.
  - Restore Cmd-+/Cmd-- matching for markdown and browser zoom; US behavior unchanged.
  - Add regression tests for dedicated plus/minus keys, bare `_` normalization, and a guard against unrelated keys.

<sup>Written for commit c7eb1275e91a0cf865a9859de585f54836ff7be6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Keyboard zoom in/out shortcuts now correctly recognize "+" and "-" (and dedicated "_" where appropriate) on non-US European layouts (e.g., German QWERTZ, AZERTY, Nordic), so zoom shortcuts work as expected on those keyboards.

* **Tests**
  * Added regression tests covering non-US layout behavior and an edge-case guard to prevent unrelated key matches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->