### PR TITLE
Cache omnibar suggestion candidates to fix typing beachball

### DIFF
--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1742,6 +1742,13 @@ final class BrowserHistoryStore: ObservableObject {
         }
     }
 
+    // Single source of truth for history. `private(set)` + `@MainActor` means
+    // every mutation runs through this setter, so `didSet` is the one enforced
+    // invalidation point for the derived `cachedSuggestionCandidates`. It must
+    // stay `@Published` for SwiftUI observation, so a memoized cache invalidated
+    // here is the idiomatic shape. Do not add a writer that bypasses the setter
+    // (e.g. an unsafe-buffer bulk write or an external `Binding<[Entry]>`)
+    // without invalidating the cache.
     @Published private(set) var entries: [Entry] = [] {
         didSet { suggestionCandidatesDirty = true }
     }

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1742,7 +1742,9 @@ final class BrowserHistoryStore: ObservableObject {
         }
     }
 
-    @Published private(set) var entries: [Entry] = []
+    @Published private(set) var entries: [Entry] = [] {
+        didSet { suggestionCandidatesDirty = true }
+    }
 
     private let fileURL: URL?
     private var didLoad: Bool = false
@@ -1766,6 +1768,22 @@ final class BrowserHistoryStore: ObservableObject {
     private struct ScoredSuggestion {
         let entry: Entry
         let score: Double
+    }
+
+    // Precomputed, lowercased/parsed match fields for every entry. Building a
+    // SuggestionCandidate parses the URL (URLComponents) and lowercases five
+    // fields; doing that for all entries on every omnibar keystroke pegged the
+    // main thread once history grew to a few thousand rows (the typing
+    // beachball). The cache is rebuilt only when `entries` actually changes
+    // (via the didSet above), so steady-state typing reuses it and pays only
+    // the cheap substring scoring in `suggestionScore`.
+    private var cachedSuggestionCandidates: [SuggestionCandidate] = []
+    private var suggestionCandidatesDirty = true
+
+    private func refreshSuggestionCandidatesIfNeeded() {
+        guard suggestionCandidatesDirty else { return }
+        cachedSuggestionCandidates = entries.map(makeSuggestionCandidate)
+        suggestionCandidatesDirty = false
     }
 
     init(fileURL: URL? = nil) {
@@ -1911,12 +1929,12 @@ final class BrowserHistoryStore: ObservableObject {
         let queryTokens = tokenizeSuggestionQuery(q)
         let now = Date()
 
-        let matched = entries.compactMap { entry -> ScoredSuggestion? in
-            let candidate = makeSuggestionCandidate(entry: entry)
+        refreshSuggestionCandidatesIfNeeded()
+        let matched = cachedSuggestionCandidates.compactMap { candidate -> ScoredSuggestion? in
             guard let score = suggestionScore(candidate: candidate, query: q, queryTokens: queryTokens, now: now) else {
                 return nil
             }
-            return ScoredSuggestion(entry: entry, score: score)
+            return ScoredSuggestion(entry: candidate.entry, score: score)
         }
         .sorted { lhs, rhs in
             if lhs.score != rhs.score { return lhs.score > rhs.score }

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1743,14 +1743,15 @@ final class BrowserHistoryStore: ObservableObject {
     }
 
     // Single source of truth for history. `private(set)` + `@MainActor` means
-    // every mutation runs through this setter, so `didSet` is the one enforced
-    // invalidation point for the derived `cachedSuggestionCandidates`. It must
-    // stay `@Published` for SwiftUI observation, so a memoized cache invalidated
-    // here is the idiomatic shape. Do not add a writer that bypasses the setter
-    // (e.g. an unsafe-buffer bulk write or an external `Binding<[Entry]>`)
-    // without invalidating the cache.
+    // every mutation runs through this setter, so dropping the derived
+    // suggestion cache here is the one enforced invalidation point. Setting it
+    // to nil both frees the retained Entry/URL strings promptly (so clearing
+    // history does not leave browsing history resident in the cache) and forces
+    // a rebuild on next use. It must stay `@Published` for SwiftUI observation.
+    // Do not add a writer that bypasses this setter (e.g. an unsafe-buffer bulk
+    // write or an external `Binding<[Entry]>`) without dropping the cache.
     @Published private(set) var entries: [Entry] = [] {
-        didSet { suggestionCandidatesDirty = true }
+        didSet { cachedSuggestionCandidates = nil }
     }
 
     private let fileURL: URL?
@@ -1777,20 +1778,25 @@ final class BrowserHistoryStore: ObservableObject {
         let score: Double
     }
 
-    // Precomputed, lowercased/parsed match fields for every entry. Building a
+    // Lazily built, lowercased/parsed match fields for every entry. Building a
     // SuggestionCandidate parses the URL (URLComponents) and lowercases five
     // fields; doing that for all entries on every omnibar keystroke pegged the
     // main thread once history grew to a few thousand rows (the typing
-    // beachball). The cache is rebuilt only when `entries` actually changes
-    // (via the didSet above), so steady-state typing reuses it and pays only
-    // the cheap substring scoring in `suggestionScore`.
-    private var cachedSuggestionCandidates: [SuggestionCandidate] = []
-    private var suggestionCandidatesDirty = true
+    // beachball). `nil` means "not built / just invalidated"; it is rebuilt only
+    // when `entries` changes (via the didSet above), so steady-state typing
+    // reuses it and pays only the cheap substring scoring in `suggestionScore`.
+    private var cachedSuggestionCandidates: [SuggestionCandidate]?
 
-    private func refreshSuggestionCandidatesIfNeeded() {
-        guard suggestionCandidatesDirty else { return }
-        cachedSuggestionCandidates = entries.map(makeSuggestionCandidate)
-        suggestionCandidatesDirty = false
+    /// Number of suggestion candidates currently resident in the cache, or 0
+    /// when the cache has been invalidated. Used by tests to verify that
+    /// clearing history drops the retained candidates promptly.
+    var residentSuggestionCandidateCount: Int { cachedSuggestionCandidates?.count ?? 0 }
+
+    private func suggestionCandidates() -> [SuggestionCandidate] {
+        if let cached = cachedSuggestionCandidates { return cached }
+        let built = entries.map(makeSuggestionCandidate)
+        cachedSuggestionCandidates = built
+        return built
     }
 
     init(fileURL: URL? = nil) {
@@ -1936,8 +1942,7 @@ final class BrowserHistoryStore: ObservableObject {
         let queryTokens = tokenizeSuggestionQuery(q)
         let now = Date()
 
-        refreshSuggestionCandidatesIfNeeded()
-        let matched = cachedSuggestionCandidates.compactMap { candidate -> ScoredSuggestion? in
+        let matched = suggestionCandidates().compactMap { candidate -> ScoredSuggestion? in
             guard let score = suggestionScore(candidate: candidate, query: q, queryTokens: queryTokens, now: now) else {
                 return nil
             }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		A5008381 /* BrowserFindJavaScriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5008380 /* BrowserFindJavaScriptTests.swift */; };
 		B42450030000000000000001 /* BrowserHiddenWebViewDiscardManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B42450040000000000000001 /* BrowserHiddenWebViewDiscardManager.swift */; };
 		B42450010000000000000001 /* BrowserHiddenWebViewDiscardPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B42450020000000000000001 /* BrowserHiddenWebViewDiscardPolicy.swift */; };
+		4E1F28554F1B908F18559390 /* BrowserHistorySuggestionCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19D536229C6194FD62B44503 /* BrowserHistorySuggestionCacheTests.swift */; };
 		FA100000A1B2C3D4E5F60718 /* BrowserImportMappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA100001A1B2C3D4E5F60718 /* BrowserImportMappingTests.swift */; };
 		FB100000A1B2C3D4E5F60718 /* BrowserImportProfilesUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB100001A1B2C3D4E5F60718 /* BrowserImportProfilesUITests.swift */; };
 		B0A501000000000000000001 /* BrowserOmnibarAppKitBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A501000000000000000002 /* BrowserOmnibarAppKitBridge.swift */; };
@@ -736,6 +737,7 @@
 		A5008380 /* BrowserFindJavaScriptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserFindJavaScriptTests.swift; sourceTree = "<group>"; };
 		B42450040000000000000001 /* BrowserHiddenWebViewDiscardManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserHiddenWebViewDiscardManager.swift; sourceTree = "<group>"; };
 		B42450020000000000000001 /* BrowserHiddenWebViewDiscardPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserHiddenWebViewDiscardPolicy.swift; sourceTree = "<group>"; };
+		19D536229C6194FD62B44503 /* BrowserHistorySuggestionCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserHistorySuggestionCacheTests.swift; sourceTree = "<group>"; };
 		FA100001A1B2C3D4E5F60718 /* BrowserImportMappingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserImportMappingTests.swift; sourceTree = "<group>"; };
 		FB100001A1B2C3D4E5F60718 /* BrowserImportProfilesUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserImportProfilesUITests.swift; sourceTree = "<group>"; };
 		B0A501000000000000000002 /* BrowserOmnibarAppKitBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserOmnibarAppKitBridge.swift; sourceTree = "<group>"; };
@@ -1904,6 +1906,7 @@
 				D3622001A1B2C3D4E5F60718 /* BrowserArrowKeyForwardingTests.swift */,
 				D3622101A1B2C3D4E5F60718 /* EditableTextViewArrowKeyForwardingTests.swift */,
 				58C7B1B978620BE162CC057E /* BrowserPanelTests.swift */,
+				19D536229C6194FD62B44503 /* BrowserHistorySuggestionCacheTests.swift */,
 				D0B1000DA1B2C3D4E5F60001 /* CmuxWebViewDragRoutingTests.swift */,
 					D0B1000FA1B2C3D4E5F60001 /* BrowserPaneDropRoutingTests.swift */,
 					02FC74F2C27127CC565B3E8C /* TerminalAndGhosttyTests.swift */,
@@ -2803,6 +2806,7 @@
 				D3622000A1B2C3D4E5F60718 /* BrowserArrowKeyForwardingTests.swift in Sources */,
 				E12E88F82733EC42F32C36A3 /* BrowserConfigTests.swift in Sources */,
 				A5008381 /* BrowserFindJavaScriptTests.swift in Sources */,
+				4E1F28554F1B908F18559390 /* BrowserHistorySuggestionCacheTests.swift in Sources */,
 				FA100000A1B2C3D4E5F60718 /* BrowserImportMappingTests.swift in Sources */,
 					C2B6A97D1F2E4C71A8B9D001 /* BrowserOmnibarPerformanceSupportTests.swift in Sources */,
 				D0B1000EA1B2C3D4E5F60001 /* BrowserPaneDropRoutingTests.swift in Sources */,

--- a/cmuxTests/BrowserHistorySuggestionCacheTests.swift
+++ b/cmuxTests/BrowserHistorySuggestionCacheTests.swift
@@ -1,0 +1,68 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Guards the omnibar suggestion candidate cache added to ``BrowserHistoryStore``.
+///
+/// The store now precomputes each entry's lowercased/parsed match fields once
+/// and rebuilds that cache only when `entries` changes, instead of re-parsing
+/// every URL on every keystroke. These tests pin the behavioral contract that
+/// matters for correctness: the cache must invalidate whenever history mutates,
+/// so a warmed cache never hides a newly recorded visit or a stale ranking.
+@MainActor
+@Suite struct BrowserHistorySuggestionCacheTests {
+    private func makeStore() -> (store: BrowserHistoryStore, fileURL: URL) {
+        let fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-history-suggest-\(UUID().uuidString).json")
+        return (BrowserHistoryStore(fileURL: fileURL), fileURL)
+    }
+
+    @Test func suggestionsMatchHostAndTitleAfterCaching() {
+        let (store, fileURL) = makeStore()
+        defer { store.clearHistory(); try? FileManager.default.removeItem(at: fileURL) }
+
+        store.recordVisit(url: URL(string: "https://github.com/manaflow-ai/cmux/issues"), title: "cmux issues")
+        store.recordVisit(url: URL(string: "https://example.com/docs"), title: "Example Docs")
+
+        // First query warms the candidate cache.
+        let results = store.suggestions(for: "github", limit: 8).map(\.url)
+        #expect(results.contains("https://github.com/manaflow-ai/cmux/issues"))
+        #expect(!results.contains("https://example.com/docs"))
+    }
+
+    @Test func newlyRecordedVisitInvalidatesWarmedCache() {
+        let (store, fileURL) = makeStore()
+        defer { store.clearHistory(); try? FileManager.default.removeItem(at: fileURL) }
+
+        store.recordVisit(url: URL(string: "https://example.com/start"), title: "Start")
+        // Warm the candidate cache with a query that does not match the URL we
+        // are about to add.
+        _ = store.suggestions(for: "example", limit: 8)
+
+        store.recordVisit(url: URL(string: "https://manaflow.ai/pricing"), title: "Pricing")
+        let results = store.suggestions(for: "manaflow", limit: 8).map(\.url)
+        #expect(results.contains("https://manaflow.ai/pricing"))
+    }
+
+    @Test func repeatedVisitRefreshesCachedRanking() throws {
+        let (store, fileURL) = makeStore()
+        defer { store.clearHistory(); try? FileManager.default.removeItem(at: fileURL) }
+
+        store.recordVisit(url: URL(string: "https://news.ycombinator.com/news"), title: "HN")
+        // Warm the cache while the entry has visitCount == 1.
+        _ = store.suggestions(for: "news", limit: 8)
+
+        for _ in 0..<5 {
+            store.recordVisit(url: URL(string: "https://news.ycombinator.com/news"), title: "HN")
+        }
+
+        let top = try #require(store.suggestions(for: "news", limit: 8).first)
+        #expect(top.url == "https://news.ycombinator.com/news")
+        #expect(top.visitCount == 6)
+    }
+}

--- a/cmuxTests/BrowserHistorySuggestionCacheTests.swift
+++ b/cmuxTests/BrowserHistorySuggestionCacheTests.swift
@@ -65,4 +65,20 @@ import Testing
         #expect(top.url == "https://news.ycombinator.com/news")
         #expect(top.visitCount == 6)
     }
+
+    @Test func clearingHistoryDropsResidentSuggestionCache() {
+        let (store, fileURL) = makeStore()
+        defer { store.clearHistory(); try? FileManager.default.removeItem(at: fileURL) }
+
+        store.recordVisit(url: URL(string: "https://secret.example.com/private-page"), title: "secret")
+        // Warm the cache so the parsed/lowercased URL strings become resident.
+        _ = store.suggestions(for: "secret", limit: 8)
+        #expect(store.residentSuggestionCandidateCount > 0)
+
+        // Clearing history must drop the cached candidates immediately, without
+        // waiting for the next omnibar query, so cleared browsing history is not
+        // left resident in memory.
+        store.clearHistory()
+        #expect(store.residentSuggestionCandidateCount == 0)
+    }
 }

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -1,5 +1,4 @@
 import XCTest
-import Testing
 import AppKit
 import SwiftUI
 import UniformTypeIdentifiers
@@ -3932,65 +3931,5 @@ final class OmnibarNativeTextFieldCaretTests: XCTestCase {
             0,
             "A single click must place a caret, not select the whole URL"
         )
-    }
-}
-
-/// Guards the omnibar suggestion candidate cache added to ``BrowserHistoryStore``.
-///
-/// The store now precomputes each entry's lowercased/parsed match fields once
-/// and rebuilds that cache only when `entries` changes, instead of re-parsing
-/// every URL on every keystroke. These tests pin the behavioral contract that
-/// matters for correctness: the cache must invalidate whenever history mutates,
-/// so a warmed cache never hides a newly recorded visit or a stale ranking.
-@MainActor
-@Suite struct BrowserHistorySuggestionCacheTests {
-    private func makeStore() -> (store: BrowserHistoryStore, fileURL: URL) {
-        let fileURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent("cmux-history-suggest-\(UUID().uuidString).json")
-        return (BrowserHistoryStore(fileURL: fileURL), fileURL)
-    }
-
-    @Test func suggestionsMatchHostAndTitleAfterCaching() {
-        let (store, fileURL) = makeStore()
-        defer { store.clearHistory(); try? FileManager.default.removeItem(at: fileURL) }
-
-        store.recordVisit(url: URL(string: "https://github.com/manaflow-ai/cmux/issues"), title: "cmux issues")
-        store.recordVisit(url: URL(string: "https://example.com/docs"), title: "Example Docs")
-
-        // First query warms the candidate cache.
-        let results = store.suggestions(for: "github", limit: 8).map(\.url)
-        #expect(results.contains("https://github.com/manaflow-ai/cmux/issues"))
-        #expect(!results.contains("https://example.com/docs"))
-    }
-
-    @Test func newlyRecordedVisitInvalidatesWarmedCache() {
-        let (store, fileURL) = makeStore()
-        defer { store.clearHistory(); try? FileManager.default.removeItem(at: fileURL) }
-
-        store.recordVisit(url: URL(string: "https://example.com/start"), title: "Start")
-        // Warm the candidate cache with a query that does not match the URL we
-        // are about to add.
-        _ = store.suggestions(for: "example", limit: 8)
-
-        store.recordVisit(url: URL(string: "https://manaflow.ai/pricing"), title: "Pricing")
-        let results = store.suggestions(for: "manaflow", limit: 8).map(\.url)
-        #expect(results.contains("https://manaflow.ai/pricing"))
-    }
-
-    @Test func repeatedVisitRefreshesCachedRanking() throws {
-        let (store, fileURL) = makeStore()
-        defer { store.clearHistory(); try? FileManager.default.removeItem(at: fileURL) }
-
-        store.recordVisit(url: URL(string: "https://news.ycombinator.com/news"), title: "HN")
-        // Warm the cache while the entry has visitCount == 1.
-        _ = store.suggestions(for: "news", limit: 8)
-
-        for _ in 0..<5 {
-            store.recordVisit(url: URL(string: "https://news.ycombinator.com/news"), title: "HN")
-        }
-
-        let top = try #require(store.suggestions(for: "news", limit: 8).first)
-        #expect(top.url == "https://news.ycombinator.com/news")
-        #expect(top.visitCount == 6)
     }
 }

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import Testing
 import AppKit
 import SwiftUI
 import UniformTypeIdentifiers
@@ -3931,5 +3932,65 @@ final class OmnibarNativeTextFieldCaretTests: XCTestCase {
             0,
             "A single click must place a caret, not select the whole URL"
         )
+    }
+}
+
+/// Guards the omnibar suggestion candidate cache added to ``BrowserHistoryStore``.
+///
+/// The store now precomputes each entry's lowercased/parsed match fields once
+/// and rebuilds that cache only when `entries` changes, instead of re-parsing
+/// every URL on every keystroke. These tests pin the behavioral contract that
+/// matters for correctness: the cache must invalidate whenever history mutates,
+/// so a warmed cache never hides a newly recorded visit or a stale ranking.
+@MainActor
+@Suite struct BrowserHistorySuggestionCacheTests {
+    private func makeStore() -> (store: BrowserHistoryStore, fileURL: URL) {
+        let fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-history-suggest-\(UUID().uuidString).json")
+        return (BrowserHistoryStore(fileURL: fileURL), fileURL)
+    }
+
+    @Test func suggestionsMatchHostAndTitleAfterCaching() {
+        let (store, fileURL) = makeStore()
+        defer { store.clearHistory(); try? FileManager.default.removeItem(at: fileURL) }
+
+        store.recordVisit(url: URL(string: "https://github.com/manaflow-ai/cmux/issues"), title: "cmux issues")
+        store.recordVisit(url: URL(string: "https://example.com/docs"), title: "Example Docs")
+
+        // First query warms the candidate cache.
+        let results = store.suggestions(for: "github", limit: 8).map(\.url)
+        #expect(results.contains("https://github.com/manaflow-ai/cmux/issues"))
+        #expect(!results.contains("https://example.com/docs"))
+    }
+
+    @Test func newlyRecordedVisitInvalidatesWarmedCache() {
+        let (store, fileURL) = makeStore()
+        defer { store.clearHistory(); try? FileManager.default.removeItem(at: fileURL) }
+
+        store.recordVisit(url: URL(string: "https://example.com/start"), title: "Start")
+        // Warm the candidate cache with a query that does not match the URL we
+        // are about to add.
+        _ = store.suggestions(for: "example", limit: 8)
+
+        store.recordVisit(url: URL(string: "https://manaflow.ai/pricing"), title: "Pricing")
+        let results = store.suggestions(for: "manaflow", limit: 8).map(\.url)
+        #expect(results.contains("https://manaflow.ai/pricing"))
+    }
+
+    @Test func repeatedVisitRefreshesCachedRanking() throws {
+        let (store, fileURL) = makeStore()
+        defer { store.clearHistory(); try? FileManager.default.removeItem(at: fileURL) }
+
+        store.recordVisit(url: URL(string: "https://news.ycombinator.com/news"), title: "HN")
+        // Warm the cache while the entry has visitCount == 1.
+        _ = store.suggestions(for: "news", limit: 8)
+
+        for _ in 0..<5 {
+            store.recordVisit(url: URL(string: "https://news.ycombinator.com/news"), title: "HN")
+        }
+
+        let top = try #require(store.suggestions(for: "news", limit: 8).first)
+        #expect(top.url == "https://news.ycombinator.com/news")
+        #expect(top.visitCount == 6)
     }
 }


### PR DESCRIPTION
## Problem
Typing in the browser omnibar beachballs once browsing history grows large (repro: ~3000 history entries makes every keystroke janky on the main thread).

## Root cause
`refreshSuggestions()` runs on the main thread and calls `BrowserHistoryStore.suggestions(for:)`, which rebuilt a `SuggestionCandidate` for every history entry on every keystroke. Building one candidate runs `URLComponents(string:)` (a full URL parse) plus five `.lowercased()` allocations. At ~3000 entries that is thousands of URL parses and tens of thousands of allocations per keystroke, with zero caching, and it scales toward the 5000-entry cap.

## Fix
Precompute each entry's lowercased/parsed match fields once and cache them. The cache rebuilds only when `entries` actually changes (a `didSet` dirty flag), so typing a query (which does not mutate history) reuses it and pays only the cheap substring scoring. The expensive URL parsing now happens once per history mutation instead of once per keystroke.

Matching and ranking output are identical. Added regression tests pin the cache-invalidation contract: a newly recorded visit and a repeated visit are both reflected after a prior query warmed the cache.

This is a performance fix with unchanged suggestion output, so there is no red/green behavioral regression to stage; the tests guard the cache's invalidation correctness, the only new failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5397"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783206520&installation_id=133855650&pr_number=5397&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5397&signature=400f24d4fbc8c851440bdcef3db992e4bd765730c2c11ce93e8d3b43f35b8414"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance-only change with unchanged suggestion matching; risk is limited to cache invalidation bugs, covered by new unit tests.
> 
> **Overview**
> Fixes omnibar typing jank when history is large by **caching pre-parsed, lowercased suggestion match fields** in `BrowserHistoryStore` instead of rebuilding them on every keystroke.
> 
> `entries` now clears `cachedSuggestionCandidates` in `didSet`, so the cache rebuilds only when history mutates; `suggestions(for:)` scores against the cached list with the same ranking behavior as before. A test-only `residentSuggestionCandidateCount` checks that **clearing history drops cached data immediately**.
> 
> Adds **`BrowserHistorySuggestionCacheTests`** (Swift Testing) for match correctness, invalidation on new/repeated visits, and cache release on clear, wired into the Xcode test target.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit beac3bd8429f799f4c6becac85df95173af139a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caches omnibar suggestion candidates to remove the typing beachball, and now drops the cache immediately when history is cleared so cleared URLs aren’t kept in memory. Matching and ranking remain unchanged.

- **Performance**
  - Cache precomputed candidates and rebuild only when `entries` changes via `didSet`; steady-state typing reuses the cache and only does substring scoring.

- **Bug Fixes**
  - Eagerly nil the cache on history clear to free retained URL/title strings; add regression tests for clear-history drop and invalidation after new and repeated visits, with tests in `BrowserHistorySuggestionCacheTests.swift`.

<sup>Written for commit beac3bd8429f799f4c6becac85df95173af139a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved omnibar suggestion responsiveness and scoring by adding an optimized, lazily-updated suggestion cache.

* **Tests**
  * Added tests validating suggestion cache correctness: warming, invalidation after visits, ranking refresh on repeat visits, and immediate clearing of cached suggestions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->