### PR TITLE
Scale sidebar workspace group header with sidebar font size (#5398)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,1 @@
-{"sessionId":"9c9943de-bc79-4f2c-9b82-cbd58c3a1d51","pid":32319,"procStart":"Sun May 31 00:20:09 2026","acquiredAt":1780187614705}
+{"sessionId":"5c2a62d0-99c2-42c0-9452-f67b6fbaacda","pid":75304,"procStart":"Thu Jun  4 23:34:54 2026","acquiredAt":1780616564932}

--- a/Sources/SidebarWorkspaceGroupHeaderMetrics.swift
+++ b/Sources/SidebarWorkspaceGroupHeaderMetrics.swift
@@ -1,0 +1,76 @@
+import CoreGraphics
+
+/// Font sizes, icon/control frames, and badge padding for
+/// ``SidebarWorkspaceGroupHeaderView``, derived from the sidebar font scale.
+///
+/// The collapsible workspace group/folder header must grow proportionally with
+/// the configurable sidebar font size, just like the workspace rows below it.
+/// `TabItemView` already scales its subviews by `settings.sidebarFontScale`
+/// (see ``SidebarTabItemFontScale``); this type is the single place that
+/// applies the same scale to the group header so the two grow at the same rate
+/// from one scaling path.
+///
+/// The `base*` constants are the design sizes at the default sidebar font size,
+/// where ``SidebarTabItemFontScale/scale(for:)`` returns `1.0`. Every metric is
+/// the corresponding base value multiplied by ``fontScale``.
+///
+/// ```swift
+/// let metrics = SidebarWorkspaceGroupHeaderMetrics(fontScale: settings.sidebarFontScale)
+/// Image(systemName: "chevron.down")
+///     .font(.system(size: metrics.chevronFontSize, weight: .semibold))
+///     .frame(width: metrics.chevronFrame, height: metrics.chevronFrame)
+/// ```
+struct SidebarWorkspaceGroupHeaderMetrics: Equatable {
+    /// The sidebar font scale; `1.0` at the default sidebar font size and
+    /// proportionally larger as the configured `sidebar-font-size` grows.
+    let fontScale: CGFloat
+
+    /// Creates header metrics for the given sidebar font scale.
+    /// - Parameter fontScale: The scale from ``SidebarTabItemFontScale/scale(for:)``;
+    ///   `1.0` at the default sidebar font size.
+    init(fontScale: CGFloat) {
+        self.fontScale = fontScale
+    }
+
+    /// Chevron glyph point size at the default sidebar font size.
+    static let baseChevronFontSize: CGFloat = 9
+    /// Chevron tap-target frame edge at the default sidebar font size.
+    static let baseChevronFrame: CGFloat = 14
+    /// Folder/group icon point size at the default sidebar font size.
+    static let baseIconFontSize: CGFloat = 11
+    /// Folder/group icon frame edge at the default sidebar font size.
+    static let baseIconFrame: CGFloat = 14
+    /// Group name point size at the default sidebar font size.
+    static let baseNameFontSize: CGFloat = 11
+    /// Unread badge point size at the default sidebar font size.
+    static let baseUnreadFontSize: CGFloat = 10
+    /// Unread badge horizontal padding at the default sidebar font size.
+    static let baseUnreadHorizontalPadding: CGFloat = 5
+    /// Unread badge vertical padding at the default sidebar font size.
+    static let baseUnreadVerticalPadding: CGFloat = 1
+    /// Plus-button glyph point size at the default sidebar font size.
+    static let basePlusFontSize: CGFloat = 11
+    /// Plus-button frame edge at the default sidebar font size.
+    static let basePlusFrame: CGFloat = 18
+
+    /// Scaled chevron glyph point size.
+    var chevronFontSize: CGFloat { Self.baseChevronFontSize }
+    /// Scaled chevron tap-target frame edge.
+    var chevronFrame: CGFloat { Self.baseChevronFrame }
+    /// Scaled folder/group icon point size.
+    var iconFontSize: CGFloat { Self.baseIconFontSize }
+    /// Scaled folder/group icon frame edge.
+    var iconFrame: CGFloat { Self.baseIconFrame }
+    /// Scaled group name point size.
+    var nameFontSize: CGFloat { Self.baseNameFontSize }
+    /// Scaled unread badge point size.
+    var unreadFontSize: CGFloat { Self.baseUnreadFontSize }
+    /// Scaled unread badge horizontal padding.
+    var unreadHorizontalPadding: CGFloat { Self.baseUnreadHorizontalPadding }
+    /// Scaled unread badge vertical padding.
+    var unreadVerticalPadding: CGFloat { Self.baseUnreadVerticalPadding }
+    /// Scaled plus-button glyph point size.
+    var plusFontSize: CGFloat { Self.basePlusFontSize }
+    /// Scaled plus-button frame edge.
+    var plusFrame: CGFloat { Self.basePlusFrame }
+}

--- a/Sources/SidebarWorkspaceGroupHeaderMetrics.swift
+++ b/Sources/SidebarWorkspaceGroupHeaderMetrics.swift
@@ -54,23 +54,23 @@ struct SidebarWorkspaceGroupHeaderMetrics: Equatable {
     static let basePlusFrame: CGFloat = 18
 
     /// Scaled chevron glyph point size.
-    var chevronFontSize: CGFloat { Self.baseChevronFontSize }
+    var chevronFontSize: CGFloat { Self.baseChevronFontSize * fontScale }
     /// Scaled chevron tap-target frame edge.
-    var chevronFrame: CGFloat { Self.baseChevronFrame }
+    var chevronFrame: CGFloat { Self.baseChevronFrame * fontScale }
     /// Scaled folder/group icon point size.
-    var iconFontSize: CGFloat { Self.baseIconFontSize }
+    var iconFontSize: CGFloat { Self.baseIconFontSize * fontScale }
     /// Scaled folder/group icon frame edge.
-    var iconFrame: CGFloat { Self.baseIconFrame }
+    var iconFrame: CGFloat { Self.baseIconFrame * fontScale }
     /// Scaled group name point size.
-    var nameFontSize: CGFloat { Self.baseNameFontSize }
+    var nameFontSize: CGFloat { Self.baseNameFontSize * fontScale }
     /// Scaled unread badge point size.
-    var unreadFontSize: CGFloat { Self.baseUnreadFontSize }
+    var unreadFontSize: CGFloat { Self.baseUnreadFontSize * fontScale }
     /// Scaled unread badge horizontal padding.
-    var unreadHorizontalPadding: CGFloat { Self.baseUnreadHorizontalPadding }
+    var unreadHorizontalPadding: CGFloat { Self.baseUnreadHorizontalPadding * fontScale }
     /// Scaled unread badge vertical padding.
-    var unreadVerticalPadding: CGFloat { Self.baseUnreadVerticalPadding }
+    var unreadVerticalPadding: CGFloat { Self.baseUnreadVerticalPadding * fontScale }
     /// Scaled plus-button glyph point size.
-    var plusFontSize: CGFloat { Self.basePlusFontSize }
+    var plusFontSize: CGFloat { Self.basePlusFontSize * fontScale }
     /// Scaled plus-button frame edge.
-    var plusFrame: CGFloat { Self.basePlusFrame }
+    var plusFrame: CGFloat { Self.basePlusFrame * fontScale }
 }

--- a/Sources/SidebarWorkspaceGroupHeaderView.swift
+++ b/Sources/SidebarWorkspaceGroupHeaderView.swift
@@ -22,6 +22,7 @@ struct SidebarWorkspaceGroupHeaderView: View, Equatable {
             lhs.showsShortcutHint == rhs.showsShortcutHint &&
             lhs.shortcutHintXOffset == rhs.shortcutHintXOffset &&
             lhs.shortcutHintYOffset == rhs.shortcutHintYOffset &&
+            lhs.fontScale == rhs.fontScale &&
             lhs.cwdContextMenuItems == rhs.cwdContextMenuItems &&
             lhs.newWorkspacePlacement == rhs.newWorkspacePlacement &&
             lhs.rowSpacing == rhs.rowSpacing &&
@@ -45,6 +46,7 @@ struct SidebarWorkspaceGroupHeaderView: View, Equatable {
     let showsShortcutHint: Bool
     let shortcutHintXOffset: Double
     let shortcutHintYOffset: Double
+    let fontScale: CGFloat
     let cwdContextMenuItems: [CmuxResolvedConfigContextMenuItem]
     let newWorkspacePlacement: WorkspaceGroupNewPlacement?
     let rowSpacing: CGFloat
@@ -66,6 +68,10 @@ struct SidebarWorkspaceGroupHeaderView: View, Equatable {
 
     @State private var isHovered = false
     @State private var rowHeight: CGFloat = 1
+
+    private var metrics: SidebarWorkspaceGroupHeaderMetrics {
+        SidebarWorkspaceGroupHeaderMetrics(fontScale: fontScale)
+    }
 
     private var iconColor: Color {
         if let tintHex, let nsColor = NSColor(hex: tintHex) {
@@ -100,9 +106,9 @@ struct SidebarWorkspaceGroupHeaderView: View, Equatable {
     var body: some View {
         HStack(spacing: 4) {
             Image(systemName: isCollapsed ? "chevron.right" : "chevron.down")
-                .font(.system(size: 9, weight: .semibold))
+                .font(.system(size: metrics.chevronFontSize, weight: .semibold))
                 .foregroundStyle(.secondary)
-                .frame(width: 14, height: 14)
+                .frame(width: metrics.chevronFrame, height: metrics.chevronFrame)
                 .contentShape(Rectangle())
                 .onTapGesture { onToggleCollapsed() }
                 .accessibilityAddTraits(.isButton)
@@ -116,21 +122,21 @@ struct SidebarWorkspaceGroupHeaderView: View, Equatable {
 
             HStack(spacing: 6) {
                 Image(systemName: displayedIconSymbol)
-                    .font(.system(size: 11, weight: .semibold))
+                    .font(.system(size: metrics.iconFontSize, weight: .semibold))
                     .foregroundStyle(iconColor)
-                    .frame(width: 14, height: 14)
+                    .frame(width: metrics.iconFrame, height: metrics.iconFrame)
                     .accessibilityHidden(true)
                 Text(name)
-                    .font(.system(size: 11, weight: .semibold))
+                    .font(.system(size: metrics.nameFontSize, weight: .semibold))
                     .foregroundStyle(isAnchorActive ? Color.primary : Color.primary.opacity(0.9))
                     .lineLimit(1)
                     .truncationMode(.tail)
                 if anchorUnreadCount > 0 {
                     Text("\(anchorUnreadCount)")
-                        .font(.system(size: 10, weight: .semibold))
+                        .font(.system(size: metrics.unreadFontSize, weight: .semibold))
                         .foregroundStyle(.white)
-                        .padding(.horizontal, 5)
-                        .padding(.vertical, 1)
+                        .padding(.horizontal, metrics.unreadHorizontalPadding)
+                        .padding(.vertical, metrics.unreadVerticalPadding)
                         .background(Capsule().fill(Color.accentColor))
                         .accessibilityLabel(Text(String.localizedStringWithFormat(
                             String(localized: "workspaceGroup.unread.a11y", defaultValue: "%lld unread"),
@@ -151,14 +157,14 @@ struct SidebarWorkspaceGroupHeaderView: View, Equatable {
             let plusVisible = isHovered && !showsShortcutHint
             Button(action: onTapPlus) {
                 Image(systemName: "plus")
-                    .font(.system(size: 11, weight: .medium))
+                    .font(.system(size: metrics.plusFontSize, weight: .medium))
                     .foregroundStyle(.secondary)
-                    .frame(width: 18, height: 18)
+                    .frame(width: metrics.plusFrame, height: metrics.plusFrame)
                     .contentShape(Rectangle())
                     .opacity(plusVisible ? 1 : 0)
             }
             .buttonStyle(.plain)
-            .frame(width: 18, height: 18)
+            .frame(width: metrics.plusFrame, height: metrics.plusFrame)
             .allowsHitTesting(plusVisible)
             .accessibilityHidden(!plusVisible)
             .accessibilityLabel(Text(String(

--- a/Sources/VerticalTabsSidebar+WorkspaceGroups.swift
+++ b/Sources/VerticalTabsSidebar+WorkspaceGroups.swift
@@ -90,6 +90,7 @@ extension VerticalTabsSidebar {
             showsShortcutHint: showsHintForAnchor,
             shortcutHintXOffset: settings.sidebarShortcutHintXOffset,
             shortcutHintYOffset: settings.sidebarShortcutHintYOffset,
+            fontScale: settings.sidebarFontScale,
             cwdContextMenuItems: cwdContextMenuItems,
             newWorkspacePlacement: newWorkspacePlacement,
             rowSpacing: tabRowSpacing,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -483,6 +483,8 @@
 		C135190000000000000000B1 /* SidebarWorkspaceGroupConfigOpenerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C135190000000000000000B2 /* SidebarWorkspaceGroupConfigOpenerTests.swift */; };
 		C9A57105C9A57105C9A57105 /* SidebarWorkspaceGroupContextMenuRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A57106C9A57106C9A57106 /* SidebarWorkspaceGroupContextMenuRunner.swift */; };
 		C9A57107C9A57107C9A57107 /* SidebarWorkspaceGroupDialogs.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A57108C9A57108C9A57108 /* SidebarWorkspaceGroupDialogs.swift */; };
+		C9A57301C9A57301C9A57301 /* SidebarWorkspaceGroupHeaderMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A57302C9A57302C9A57302 /* SidebarWorkspaceGroupHeaderMetrics.swift */; };
+		C9A57303C9A57303C9A57303 /* SidebarWorkspaceGroupHeaderMetricsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A57304C9A57304C9A57304 /* SidebarWorkspaceGroupHeaderMetricsTests.swift */; };
 		C9A57101C9A57101C9A57101 /* SidebarWorkspaceGroupHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A57102C9A57102C9A57102 /* SidebarWorkspaceGroupHeaderView.swift */; };
 		C9A57109C9A57109C9A57109 /* SidebarWorkspaceGroupingMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A5710AC9A5710AC9A5710A /* SidebarWorkspaceGroupingMetrics.swift */; };
 		C9A57201C9A57201C9A57201 /* SidebarWorkspaceRenderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A57202C9A57202C9A57202 /* SidebarWorkspaceRenderItem.swift */; };
@@ -1129,6 +1131,8 @@
 		C135190000000000000000B2 /* SidebarWorkspaceGroupConfigOpenerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceGroupConfigOpenerTests.swift; sourceTree = "<group>"; };
 		C9A57106C9A57106C9A57106 /* SidebarWorkspaceGroupContextMenuRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceGroupContextMenuRunner.swift; sourceTree = "<group>"; };
 		C9A57108C9A57108C9A57108 /* SidebarWorkspaceGroupDialogs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceGroupDialogs.swift; sourceTree = "<group>"; };
+		C9A57302C9A57302C9A57302 /* SidebarWorkspaceGroupHeaderMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceGroupHeaderMetrics.swift; sourceTree = "<group>"; };
+		C9A57304C9A57304C9A57304 /* SidebarWorkspaceGroupHeaderMetricsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceGroupHeaderMetricsTests.swift; sourceTree = "<group>"; };
 		C9A57102C9A57102C9A57102 /* SidebarWorkspaceGroupHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceGroupHeaderView.swift; sourceTree = "<group>"; };
 		C9A5710AC9A5710AC9A5710A /* SidebarWorkspaceGroupingMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceGroupingMetrics.swift; sourceTree = "<group>"; };
 		C9A57202C9A57202C9A57202 /* SidebarWorkspaceRenderItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceRenderItem.swift; sourceTree = "<group>"; };
@@ -1519,6 +1523,7 @@
 				C9A57108C9A57108C9A57108 /* SidebarWorkspaceGroupDialogs.swift */,
 				CA1F0A02CA1F0A02CA1F0A02 /* CmuxModalAlertPresentation.swift */,
 				C9A57102C9A57102C9A57102 /* SidebarWorkspaceGroupHeaderView.swift */,
+				C9A57302C9A57302C9A57302 /* SidebarWorkspaceGroupHeaderMetrics.swift */,
 				C9A5710AC9A5710AC9A5710A /* SidebarWorkspaceGroupingMetrics.swift */,
 				D5037010000000000000002 /* RenderableSystemSymbol.swift */,
 				C9A57202C9A57202C9A57202 /* SidebarWorkspaceRenderItem.swift */,
@@ -1962,6 +1967,7 @@
 				FEEDC0DEC0DEC0DEC0DE0002 /* FeedCoordinatorTests.swift */,
 				1D301919B10F22B8708E8883 /* WorkspaceManualUnreadTests.swift */,
 				EE0171AF1F49F7547191CEE5 /* SidebarWidthPolicyTests.swift */,
+				C9A57304C9A57304C9A57304 /* SidebarWorkspaceGroupHeaderMetricsTests.swift */,
 				51D800000000000000000002 /* SidebarIdentifierFormattingTests.swift */,
 				C7A507000000000000000001 /* TaskManagerResourcesTests.swift */,
 				C7A507000000000000004530 /* TaskManagerViewSnapshotBoundaryTests.swift */,
@@ -2607,6 +2613,7 @@
 				C9A57103C9A57103C9A57103 /* SidebarWorkspaceGroupConfigOpener.swift in Sources */,
 				C9A57105C9A57105C9A57105 /* SidebarWorkspaceGroupContextMenuRunner.swift in Sources */,
 				C9A57107C9A57107C9A57107 /* SidebarWorkspaceGroupDialogs.swift in Sources */,
+				C9A57301C9A57301C9A57301 /* SidebarWorkspaceGroupHeaderMetrics.swift in Sources */,
 				C9A57101C9A57101C9A57101 /* SidebarWorkspaceGroupHeaderView.swift in Sources */,
 				C9A57109C9A57109C9A57109 /* SidebarWorkspaceGroupingMetrics.swift in Sources */,
 				C9A57201C9A57201C9A57201 /* SidebarWorkspaceRenderItem.swift in Sources */,
@@ -2906,6 +2913,7 @@
 				CA39C0304FE351A21C372429 /* SidebarWidthPolicyTests.swift in Sources */,
 				D7AB34300000000000000005 /* SidebarWorkspaceDropPlannerTests.swift in Sources */,
 				C135190000000000000000B1 /* SidebarWorkspaceGroupConfigOpenerTests.swift in Sources */,
+				C9A57303C9A57303C9A57303 /* SidebarWorkspaceGroupHeaderMetricsTests.swift in Sources */,
 				62270F3DCECB4787D789CCE3 /* SidebarWorkspaceSnapshotRefreshPolicyTests.swift in Sources */,
 				F8000000A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift in Sources */,
 				F6355600A1B2C3D4E5F60718 /* SSHStartupSignalLifecycleTests.swift in Sources */,

--- a/cmuxTests/SidebarWorkspaceGroupHeaderMetricsTests.swift
+++ b/cmuxTests/SidebarWorkspaceGroupHeaderMetricsTests.swift
@@ -1,0 +1,53 @@
+import CoreGraphics
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite struct SidebarWorkspaceGroupHeaderMetricsTests {
+    @Test func metricsMatchBaseSizesAtDefaultScale() {
+        let metrics = SidebarWorkspaceGroupHeaderMetrics(fontScale: 1)
+
+        #expect(metrics.chevronFontSize == SidebarWorkspaceGroupHeaderMetrics.baseChevronFontSize)
+        #expect(metrics.chevronFrame == SidebarWorkspaceGroupHeaderMetrics.baseChevronFrame)
+        #expect(metrics.iconFontSize == SidebarWorkspaceGroupHeaderMetrics.baseIconFontSize)
+        #expect(metrics.iconFrame == SidebarWorkspaceGroupHeaderMetrics.baseIconFrame)
+        #expect(metrics.nameFontSize == SidebarWorkspaceGroupHeaderMetrics.baseNameFontSize)
+        #expect(metrics.unreadFontSize == SidebarWorkspaceGroupHeaderMetrics.baseUnreadFontSize)
+        #expect(metrics.unreadHorizontalPadding == SidebarWorkspaceGroupHeaderMetrics.baseUnreadHorizontalPadding)
+        #expect(metrics.unreadVerticalPadding == SidebarWorkspaceGroupHeaderMetrics.baseUnreadVerticalPadding)
+        #expect(metrics.plusFontSize == SidebarWorkspaceGroupHeaderMetrics.basePlusFontSize)
+        #expect(metrics.plusFrame == SidebarWorkspaceGroupHeaderMetrics.basePlusFrame)
+    }
+
+    @Test func metricsScaleProportionallyWhenSidebarFontEnlarged() {
+        let scale: CGFloat = 2
+        let metrics = SidebarWorkspaceGroupHeaderMetrics(fontScale: scale)
+
+        #expect(metrics.chevronFontSize == SidebarWorkspaceGroupHeaderMetrics.baseChevronFontSize * scale)
+        #expect(metrics.chevronFrame == SidebarWorkspaceGroupHeaderMetrics.baseChevronFrame * scale)
+        #expect(metrics.iconFontSize == SidebarWorkspaceGroupHeaderMetrics.baseIconFontSize * scale)
+        #expect(metrics.iconFrame == SidebarWorkspaceGroupHeaderMetrics.baseIconFrame * scale)
+        #expect(metrics.nameFontSize == SidebarWorkspaceGroupHeaderMetrics.baseNameFontSize * scale)
+        #expect(metrics.unreadFontSize == SidebarWorkspaceGroupHeaderMetrics.baseUnreadFontSize * scale)
+        #expect(metrics.unreadHorizontalPadding == SidebarWorkspaceGroupHeaderMetrics.baseUnreadHorizontalPadding * scale)
+        #expect(metrics.unreadVerticalPadding == SidebarWorkspaceGroupHeaderMetrics.baseUnreadVerticalPadding * scale)
+        #expect(metrics.plusFontSize == SidebarWorkspaceGroupHeaderMetrics.basePlusFontSize * scale)
+        #expect(metrics.plusFrame == SidebarWorkspaceGroupHeaderMetrics.basePlusFrame * scale)
+    }
+
+    @Test func headerAndRowFontScaleShareOneScalingPath() {
+        // The header must grow at the same rate as the workspace rows, which
+        // derive their scale from SidebarTabItemFontScale. Reusing that scale
+        // keeps the two in lockstep instead of introducing a second path.
+        let enlargedSize = GhosttyConfig.defaultSidebarFontSize * 1.6
+        let rowScale = SidebarTabItemFontScale.scale(for: enlargedSize)
+        let metrics = SidebarWorkspaceGroupHeaderMetrics(fontScale: rowScale)
+
+        #expect(metrics.nameFontSize == SidebarWorkspaceGroupHeaderMetrics.baseNameFontSize * rowScale)
+        #expect(rowScale > 1)
+    }
+}

--- a/cmuxTests/SidebarWorkspaceGroupHeaderMetricsTests.swift
+++ b/cmuxTests/SidebarWorkspaceGroupHeaderMetricsTests.swift
@@ -39,6 +39,22 @@ import Testing
         #expect(metrics.plusFrame == SidebarWorkspaceGroupHeaderMetrics.basePlusFrame * scale)
     }
 
+    @Test func metricsScaleProportionallyWhenSidebarFontShrunk() {
+        let scale: CGFloat = 0.5
+        let metrics = SidebarWorkspaceGroupHeaderMetrics(fontScale: scale)
+
+        #expect(metrics.chevronFontSize == SidebarWorkspaceGroupHeaderMetrics.baseChevronFontSize * scale)
+        #expect(metrics.chevronFrame == SidebarWorkspaceGroupHeaderMetrics.baseChevronFrame * scale)
+        #expect(metrics.iconFontSize == SidebarWorkspaceGroupHeaderMetrics.baseIconFontSize * scale)
+        #expect(metrics.iconFrame == SidebarWorkspaceGroupHeaderMetrics.baseIconFrame * scale)
+        #expect(metrics.nameFontSize == SidebarWorkspaceGroupHeaderMetrics.baseNameFontSize * scale)
+        #expect(metrics.unreadFontSize == SidebarWorkspaceGroupHeaderMetrics.baseUnreadFontSize * scale)
+        #expect(metrics.unreadHorizontalPadding == SidebarWorkspaceGroupHeaderMetrics.baseUnreadHorizontalPadding * scale)
+        #expect(metrics.unreadVerticalPadding == SidebarWorkspaceGroupHeaderMetrics.baseUnreadVerticalPadding * scale)
+        #expect(metrics.plusFontSize == SidebarWorkspaceGroupHeaderMetrics.basePlusFontSize * scale)
+        #expect(metrics.plusFrame == SidebarWorkspaceGroupHeaderMetrics.basePlusFrame * scale)
+    }
+
     @Test func headerAndRowFontScaleShareOneScalingPath() {
         // The header must grow at the same rate as the workspace rows, which
         // derive their scale from SidebarTabItemFontScale. Reusing that scale


### PR DESCRIPTION
## Summary

Fixes #5398. cmux's sidebar font size is configurable via `sidebar-font-size`, and the workspace rows already scale with it — but the workspace **group/folder header** (the collapsible row with the chevron, folder icon, group name, unread badge, and `+` button) hardcoded every font size and frame, so enlarging the sidebar font left the header small and mismatched against the rows beneath it.

## Root cause

`SidebarWorkspaceGroupHeaderView` (`Sources/SidebarWorkspaceGroupHeaderView.swift`) hardcoded every font (`.system(size: 9/10/11)`) and frame (`14x14`, `18x18`) and never received the sidebar font scale. The workspace-row path threads `settings.sidebarFontScale` (= `SidebarTabItemFontScale.scale(for:)`, `1.0` at the default size) into `TabItemView` and multiplies every size by it. The header is built at `VerticalTabsSidebar+WorkspaceGroups.swift:77`, where `settings` is already in scope, but the scale was never passed in.

## Fix

- Extracted the header's sizes/frames/badge padding into a pure, testable `SidebarWorkspaceGroupHeaderMetrics` value type that multiplies each base size by `fontScale`.
- Added `let fontScale: CGFloat` to `SidebarWorkspaceGroupHeaderView` and included it in the `Equatable ==` so a font-size change invalidates the header under the `LazyVStack`.
- Threaded the existing `settings.sidebarFontScale` in at the call site — **reusing the single scaling path** that already feeds `TabItemView`, not adding a second one.
- The header and the workspace rows now grow at the same rate.

The outer/inner `HStack` spacings stay fixed, matching `TabItemView` (which also keeps fixed spacing), so the row layout stays stable while glyphs/frames scale.

## Tests

Two-commit red/green structure (`SidebarWorkspaceGroupHeaderMetricsTests`, Swift Testing):
- **Commit 1** extracts the metrics helper reflecting the current *unscaled* behavior plus a behavior-level test asserting the metrics scale at default (`1.0`) and enlarged (`2.0`) scales, and that the header reuses `SidebarTabItemFontScale` — CI goes **red**.
- **Commit 2** makes the metrics multiply by `fontScale` and wires the scale into the view + call site — CI goes **green**.

Test file is wired into the `cmux` unit test target in `project.pbxproj` (`lint-pbxproj-test-wiring` passes, 152 files).

## Localization

No new user-facing strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5401"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783208516&installation_id=133855650&pr_number=5401&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5401&signature=3fb50a8d909b3899ad29276952266f6ce828f137e605b78dfe10955dcc9e89f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized SwiftUI sizing and equatable snapshot changes for the group header, with unit tests and no auth or data-path changes.
> 
> **Overview**
> Fixes workspace **group/folder headers** staying at fixed sizes when `sidebar-font-size` is increased, so they no longer look smaller than the workspace rows below them.
> 
> Introduces **`SidebarWorkspaceGroupHeaderMetrics`** with base design sizes multiplied by `fontScale`, and wires **`SidebarWorkspaceGroupHeaderView`** to use those metrics for chevron, icon, title, unread badge, and plus control instead of hardcoded `.system(size:)` and frames. The sidebar passes **`settings.sidebarFontScale`** (same path as `TabItemView` via `SidebarTabItemFontScale`) and includes **`fontScale` in `Equatable`** so font-size changes refresh the equatable header in the `LazyVStack`. Unit tests cover default, enlarged, and shrunk scaling plus shared scaling with row font scale.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 933425b23448345e45ff6de631c9ac2ec2bef7a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the sidebar workspace group header scale with the configurable sidebar font size so it matches the workspace rows. Removes hardcoded sizes and uses the same scaling path as rows for consistent sizing.

- **Bug Fixes**
  - Pass `settings.sidebarFontScale` into `SidebarWorkspaceGroupHeaderView` and include `fontScale` in `Equatable` to re-render on font-size change.
  - Centralize sizes in `SidebarWorkspaceGroupHeaderMetrics`, multiplying base values by the scale for icons, text, badge, and plus button.
  - Update the call site in `VerticalTabsSidebar+WorkspaceGroups.swift`; keep existing HStack spacings unchanged for stable layout.
  - Add `SidebarWorkspaceGroupHeaderMetricsTests` to verify scaling at default, enlarged, and shrunk sizes, and reuse of `SidebarTabItemFontScale`.

<sup>Written for commit 933425b23448345e45ff6de631c9ac2ec2bef7a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sidebar workspace group headers accept a font scale and adjust chevrons, icons, names, unread badges, and action buttons so sizing and padding scale consistently with user font preferences.

* **Tests**
  * Added tests verifying header metric defaults and proportional scaling behavior across different font scales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->