### PR TITLE
Preserve syntax highlighting on changed diff lines

### DIFF
--- a/CLI/cmux_open.swift
+++ b/CLI/cmux_open.swift
@@ -199,6 +199,7 @@ extension CMUXCLI {
         var pages: [DiffViewerDeferredSourcePage]
         var layout: String
         var appearance: DiffViewerAppearance
+        var runtime: DiffViewerRuntime
     }
 
     private struct DiffViewerDeferredSourcePage {
@@ -244,6 +245,13 @@ extension CMUXCLI {
         var directory: URL
         var mapper: DiffViewerURLMapper
         var groupID: String
+        var runtime: DiffViewerRuntime
+    }
+
+    private struct DiffViewerRuntime {
+        var executableURL: URL?
+
+        static let current = DiffViewerRuntime(executableURL: nil)
     }
 
     private struct DiffViewerSourceOption {
@@ -851,13 +859,15 @@ extension CMUXCLI {
             socketPath: socketPath,
             fontSizeOverride: fontSizeOverride
         )
+        let runtime = diffViewerRuntime(socketPath: socketPath)
         let viewer = try writeDiffViewer(
             rawInput: parsedArgs.inputs.first,
             source: parsedArgs.source,
             titleOverride: parsedArgs.title,
             layout: layout,
             appearance: appearance,
-            context: diffSourceContext
+            context: diffSourceContext,
+            runtime: runtime
         )
 
         try resolveTargetIfNeeded()
@@ -895,6 +905,58 @@ extension CMUXCLI {
         let surfaceText = formatHandle(payload, kind: "surface", idFormat: idFormat) ?? "unknown"
         let paneText = formatHandle(payload, kind: "pane", idFormat: idFormat) ?? "unknown"
         print("OK surface=\(surfaceText) pane=\(paneText) path=\(completedViewer.fileURL.path)")
+    }
+
+    private func diffViewerRuntime(socketPath: String) -> DiffViewerRuntime {
+        if let taggedExecutableURL = taggedDiffViewerExecutableURL(socketPath: socketPath) {
+            return DiffViewerRuntime(executableURL: taggedExecutableURL)
+        }
+        return .current
+    }
+
+    private func diffViewerExecutableURL(for runtime: DiffViewerRuntime) -> URL? {
+        runtime.executableURL ?? resolvedExecutableURL()
+    }
+
+    private func taggedDiffViewerExecutableURL(socketPath: String) -> URL? {
+        let socketName = URL(fileURLWithPath: socketPath).lastPathComponent
+        let prefix = "cmux-debug-"
+        let suffix = ".sock"
+        guard socketName.hasPrefix(prefix), socketName.hasSuffix(suffix) else {
+            return nil
+        }
+
+        let tagStart = socketName.index(socketName.startIndex, offsetBy: prefix.count)
+        let tagEnd = socketName.index(socketName.endIndex, offsetBy: -suffix.count)
+        let tag = String(socketName[tagStart..<tagEnd])
+        guard !tag.isEmpty,
+              tag.allSatisfy({ character in
+                  character.isLetter || character.isNumber || character == "-" || character == "_"
+              }) else {
+            return nil
+        }
+
+        let homePath = ProcessInfo.processInfo.environment["HOME"]
+            .flatMap { $0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : $0 }
+            ?? NSHomeDirectory()
+        let candidate = URL(fileURLWithPath: homePath, isDirectory: true)
+            .appendingPathComponent("Library/Developer/Xcode/DerivedData/cmux-\(tag)", isDirectory: true)
+            .appendingPathComponent("Build/Products/Debug/cmux DEV \(tag).app", isDirectory: true)
+            .appendingPathComponent("Contents/Resources/bin/cmux", isDirectory: false)
+            .standardizedFileURL
+
+        guard FileManager.default.isExecutableFile(atPath: candidate.path) else {
+            return nil
+        }
+        return canonicalFileURL(candidate)
+    }
+
+    private func canonicalFileURL(_ url: URL) -> URL {
+        if let resolvedPath = realpath(url.path, nil) {
+            defer { free(resolvedPath) }
+            return URL(fileURLWithPath: String(cString: resolvedPath)).standardizedFileURL
+        }
+        return url.standardizedFileURL
     }
 
     private func canonicalDiffSourceContext(
@@ -2929,7 +2991,8 @@ extension CMUXCLI {
         titleOverride: String?,
         layout: String,
         appearance: DiffViewerAppearance,
-        context: DiffSourceContext
+        context: DiffSourceContext,
+        runtime: DiffViewerRuntime
     ) throws -> DiffViewerWriteResult {
         if let source {
             return try writeGitDiffViewerHTMLSet(
@@ -2937,7 +3000,8 @@ extension CMUXCLI {
                 titleOverride: titleOverride,
                 layout: layout,
                 appearance: appearance,
-                context: context
+                context: context,
+                runtime: runtime
             )
         }
 
@@ -2951,7 +3015,7 @@ extension CMUXCLI {
 
         let title = titleOverride ?? input.defaultTitle
         let directory = try diffViewerDirectory()
-        let origin = try diffViewerHTTPServerOrigin(rootDirectory: directory)
+        let origin = try diffViewerHTTPServerOrigin(rootDirectory: directory, runtime: runtime)
         let mapper = DiffViewerURLMapper(
             token: UUID().uuidString.lowercased(),
             rootDirectory: directory,
@@ -2969,9 +3033,10 @@ extension CMUXCLI {
             remotePatchURL: input.remotePatchURL,
             layout: layout,
             appearance: appearance,
-            sourceOptions: []
+            sourceOptions: [],
+            runtime: runtime
         )
-        let assets = try ensureDiffViewerAssets(nextTo: viewerFileURL)
+        let assets = try ensureDiffViewerAssets(nextTo: viewerFileURL, runtime: runtime)
         let allowedFiles = try diffViewerAllowedFiles(
             pageURLs: [viewerFileURL],
             assets: assets,
@@ -2997,9 +3062,10 @@ extension CMUXCLI {
         titleOverride: String?,
         layout: String,
         appearance: DiffViewerAppearance,
-        context: DiffSourceContext
+        context: DiffSourceContext,
+        runtime: DiffViewerRuntime
     ) throws -> DiffViewerWriteResult {
-        let target = try makeDiffViewerGitHTMLSetTarget()
+        let target = try makeDiffViewerGitHTMLSetTarget(runtime: runtime)
         if selectedSource != .lastTurn {
             return try writeOpeningGitDiffViewerHTMLSet(
                 selectedSource: selectedSource,
@@ -3020,9 +3086,9 @@ extension CMUXCLI {
         )
     }
 
-    private func makeDiffViewerGitHTMLSetTarget() throws -> DiffViewerGitHTMLSetTarget {
+    private func makeDiffViewerGitHTMLSetTarget(runtime: DiffViewerRuntime) throws -> DiffViewerGitHTMLSetTarget {
         let directory = try diffViewerDirectory()
-        let origin = try diffViewerHTTPServerOrigin(rootDirectory: directory)
+        let origin = try diffViewerHTTPServerOrigin(rootDirectory: directory, runtime: runtime)
         let mapper = DiffViewerURLMapper(
             token: UUID().uuidString.lowercased(),
             rootDirectory: directory,
@@ -3030,7 +3096,7 @@ extension CMUXCLI {
         )
         let timestamp = Int(Date().timeIntervalSince1970)
         let groupID = "\(timestamp)-\(UUID().uuidString.prefix(8))"
-        return DiffViewerGitHTMLSetTarget(directory: directory, mapper: mapper, groupID: groupID)
+        return DiffViewerGitHTMLSetTarget(directory: directory, mapper: mapper, groupID: groupID, runtime: runtime)
     }
 
     private func diffViewerLoadingDiffMessage(_ target: String) -> String {
@@ -3074,9 +3140,10 @@ extension CMUXCLI {
             repoOptions: [],
             baseOptions: [],
             repoRoot: repoRoot,
-            branchBaseRef: selectedSource == .branch ? context.branchBaseRef : nil
+            branchBaseRef: selectedSource == .branch ? context.branchBaseRef : nil,
+            runtime: target.runtime
         )
-        let assets = try ensureDiffViewerAssets(nextTo: openingFileURL)
+        let assets = try ensureDiffViewerAssets(nextTo: openingFileURL, runtime: target.runtime)
         let allowedFiles = try diffViewerAllowedFiles(
             pageURLs: [openingFileURL],
             assets: assets,
@@ -3130,14 +3197,16 @@ extension CMUXCLI {
                         try? writeDiffViewerRedirectHTML(
                             to: openingFileURL,
                             title: title,
-                            targetURL: completed.url
+                            targetURL: completed.url,
+                            runtime: target.runtime
                         )
                         throw error
                     }
                     try writeDiffViewerRedirectHTML(
                         to: openingFileURL,
                         title: finalized.title,
-                        targetURL: finalized.url
+                        targetURL: finalized.url,
+                        runtime: target.runtime
                     )
                     _ = try completeDeferredDiffViewerSources(
                         completed.deferredSourceSet,
@@ -3160,7 +3229,8 @@ extension CMUXCLI {
                         repoOptions: [],
                         baseOptions: [],
                         repoRoot: repoRoot,
-                        branchBaseRef: selectedSource == .branch ? context.branchBaseRef : nil
+                        branchBaseRef: selectedSource == .branch ? context.branchBaseRef : nil,
+                        runtime: target.runtime
                     )
                     throw error
                 }
@@ -3340,7 +3410,8 @@ extension CMUXCLI {
                 repoOptions: selectedRepoOptions,
                 baseOptions: selectedSource == .branch ? baseOptions : [],
                 repoRoot: repoRoot,
-                branchBaseRef: selectedSource == .branch ? selectedContext.branchBaseRef : nil
+                branchBaseRef: selectedSource == .branch ? selectedContext.branchBaseRef : nil,
+                runtime: target.runtime
             )
             let sourceFallbacks = Dictionary(uniqueKeysWithValues: DiffSource.allCases.compactMap { source -> (DiffSource, DiffViewerDeferredSourceFallback)? in
                 guard source != selectedSource,
@@ -3403,7 +3474,8 @@ extension CMUXCLI {
                     repoOptions: repoOptionsForSource(source, selectedRepoRoot: repoRoot),
                     baseOptions: source == .branch ? baseOptions : [],
                     repoRoot: repoRoot,
-                    branchBaseRef: source == .branch ? pageContext.branchBaseRef : nil
+                    branchBaseRef: source == .branch ? pageContext.branchBaseRef : nil,
+                    runtime: target.runtime
                 )
                 deferredPages.append(
                     DiffViewerDeferredSourcePage(
@@ -3448,7 +3520,8 @@ extension CMUXCLI {
                     repoOptions: repoOptionsForSource(source, selectedRepoRoot: option.repoRoot),
                     baseOptions: [],
                     repoRoot: option.repoRoot,
-                    branchBaseRef: source == .branch ? explicitBranchBaseRef : nil
+                    branchBaseRef: source == .branch ? explicitBranchBaseRef : nil,
+                    runtime: target.runtime
                 )
                 deferredPages.append(
                     DiffViewerDeferredSourcePage(
@@ -3492,7 +3565,8 @@ extension CMUXCLI {
                     urls: baseURLs
                 ),
                 repoRoot: repoRoot,
-                branchBaseRef: option.ref
+                branchBaseRef: option.ref,
+                runtime: target.runtime
             )
             deferredPages.append(
                 DiffViewerDeferredSourcePage(
@@ -3526,7 +3600,8 @@ extension CMUXCLI {
                 repoOptions: selectedRepoOptions,
                 baseOptions: selectedSource == .branch ? baseOptions : [],
                 repoRoot: repoRoot,
-                branchBaseRef: selectedSource == .branch ? selectedContext.branchBaseRef : nil
+                branchBaseRef: selectedSource == .branch ? selectedContext.branchBaseRef : nil,
+                runtime: target.runtime
             )
         } else if let selectedEmptyMessage {
             // Friendly, non-error empty diff state: the panel shows plain-language
@@ -3544,10 +3619,11 @@ extension CMUXCLI {
                 repoOptions: selectedRepoOptions,
                 baseOptions: selectedSource == .branch ? baseOptions : [],
                 repoRoot: repoRoot,
-                branchBaseRef: selectedSource == .branch ? selectedContext.branchBaseRef : nil
+                branchBaseRef: selectedSource == .branch ? selectedContext.branchBaseRef : nil,
+                runtime: target.runtime
             )
         }
-        let assets = try ensureDiffViewerAssets(nextTo: selectedFileURL)
+        let assets = try ensureDiffViewerAssets(nextTo: selectedFileURL, runtime: target.runtime)
         let pageURLs = [selectedFileURL] + deferredPages.map(\.url)
         var allowedFiles = try diffViewerAllowedFiles(
             pageURLs: pageURLs,
@@ -3584,7 +3660,8 @@ extension CMUXCLI {
             deferredSourceSet: DiffViewerDeferredSourceSet(
                 pages: deferredPages,
                 layout: layout,
-                appearance: appearance
+                appearance: appearance,
+                runtime: target.runtime
             )
         )
     }
@@ -3675,7 +3752,8 @@ extension CMUXCLI {
             repoOptions: page.repoOptions,
             baseOptions: page.baseOptions,
             repoRoot: page.context.repoRoot,
-            branchBaseRef: page.source == .branch ? page.context.branchBaseRef : nil
+            branchBaseRef: page.source == .branch ? page.context.branchBaseRef : nil,
+            runtime: sourceSet.runtime
         )
     }
 
@@ -3767,7 +3845,8 @@ extension CMUXCLI {
             repoOptions: page.repoOptions,
             baseOptions: page.source == .branch ? page.baseOptions : [],
             repoRoot: page.context.repoRoot,
-            branchBaseRef: page.source == .branch ? page.context.branchBaseRef : nil
+            branchBaseRef: page.source == .branch ? page.context.branchBaseRef : nil,
+            runtime: sourceSet.runtime
         )
     }
 
@@ -3821,7 +3900,8 @@ extension CMUXCLI {
             repoOptions: repoOptions,
             baseOptions: baseOptions,
             repoRoot: pageContext.repoRoot,
-            branchBaseRef: source == .branch ? pageContext.branchBaseRef : nil
+            branchBaseRef: source == .branch ? pageContext.branchBaseRef : nil,
+            runtime: sourceSet.runtime
         )
         return DiffViewerDeferredCompletion(
             input: input,
@@ -4099,7 +4179,7 @@ extension CMUXCLI {
         try runDiffViewerHTTPServer(rootDirectory: rootDirectory)
     }
 
-    private func diffViewerHTTPServerOrigin(rootDirectory: URL) throws -> URL {
+    private func diffViewerHTTPServerOrigin(rootDirectory: URL, runtime: DiffViewerRuntime = .current) throws -> URL {
         let rootDirectory = rootDirectory.standardizedFileURL.resolvingSymlinksInPath()
         try validateSecureDiffViewerDirectory(rootDirectory, repairPermissions: false)
 
@@ -4107,7 +4187,7 @@ extension CMUXCLI {
            state.rootPath == rootDirectory.path,
            state.protocolVersion == Self.diffViewerHTTPServerProtocolVersion,
            (1...65535).contains(state.port),
-           diffViewerHTTPServerStateMatchesCurrentExecutable(state),
+           diffViewerHTTPServerStateMatchesRuntimeExecutable(state, runtime: runtime),
            diffViewerHTTPServerIsReachable(port: state.port) {
             guard let url = URL(string: "http://127.0.0.1:\(state.port)") else {
                 throw CLIError(message: "Failed to build diff viewer server URL")
@@ -4115,7 +4195,7 @@ extension CMUXCLI {
             return url
         }
 
-        return try startDiffViewerHTTPServer(rootDirectory: rootDirectory)
+        return try startDiffViewerHTTPServer(rootDirectory: rootDirectory, runtime: runtime)
     }
 
     private func readDiffViewerHTTPServerState(rootDirectory: URL) throws -> DiffViewerHTTPServerState {
@@ -4131,9 +4211,9 @@ extension CMUXCLI {
         try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
     }
 
-    private func diffViewerHTTPServerStateMatchesCurrentExecutable(_ state: DiffViewerHTTPServerState) -> Bool {
+    private func diffViewerHTTPServerStateMatchesRuntimeExecutable(_ state: DiffViewerHTTPServerState, runtime: DiffViewerRuntime) -> Bool {
         guard state.pid > 0,
-              let currentExecutablePath = resolvedExecutableURL()?.path,
+              let currentExecutablePath = diffViewerExecutableURL(for: runtime)?.path,
               let serverExecutablePath = diffViewerHTTPServerExecutablePath(pid: state.pid),
               serverExecutablePath == currentExecutablePath else {
             return false
@@ -4163,8 +4243,8 @@ extension CMUXCLI {
         return URL(fileURLWithPath: rawPath).standardizedFileURL.path
     }
 
-    private func startDiffViewerHTTPServer(rootDirectory: URL) throws -> URL {
-        guard let executableURL = resolvedExecutableURL() else {
+    private func startDiffViewerHTTPServer(rootDirectory: URL, runtime: DiffViewerRuntime = .current) throws -> URL {
+        guard let executableURL = diffViewerExecutableURL(for: runtime) else {
             throw CLIError(message: "Failed to resolve cmux executable for diff viewer server")
         }
 
@@ -5365,7 +5445,8 @@ extension CMUXCLI {
         repoOptions: [DiffViewerSourceOption] = [],
         baseOptions: [DiffViewerSourceOption] = [],
         repoRoot: String? = nil,
-        branchBaseRef: String? = nil
+        branchBaseRef: String? = nil,
+        runtime: DiffViewerRuntime = .current
     ) throws {
         try writeDiffViewerHTML(
             to: viewerURL,
@@ -5382,12 +5463,19 @@ extension CMUXCLI {
             branchBaseRef: branchBaseRef,
             statusMessage: message,
             statusIsError: isError,
-            pollForReplacement: pollForReplacement
+            pollForReplacement: pollForReplacement,
+            runtime: runtime
         )
     }
 
-    private func writeDiffViewerRedirectHTML(to viewerURL: URL, title: String, targetURL: URL) throws {
+    private func writeDiffViewerRedirectHTML(
+        to viewerURL: URL,
+        title: String,
+        targetURL: URL,
+        runtime: DiffViewerRuntime = .current
+    ) throws {
         try writeDiffViewerPatchSidecar("", for: viewerURL)
+        _ = try ensureDiffViewerAssets(nextTo: viewerURL, runtime: runtime)
         let target = targetURL.absoluteString
         let targetLiteral = try jsonStringLiteral(target)
         let escapedTitle = htmlEscaped(title)
@@ -5427,7 +5515,8 @@ extension CMUXCLI {
         branchBaseRef: String? = nil,
         statusMessage: String? = nil,
         statusIsError: Bool = false,
-        pollForReplacement: Bool = false
+        pollForReplacement: Bool = false,
+        runtime: DiffViewerRuntime = .current
     ) throws {
         if remotePatchURL == nil {
             try writeDiffViewerPatchSidecar(patch, for: viewerURL)
@@ -5462,7 +5551,7 @@ extension CMUXCLI {
         if let branchBaseRef {
             payload["branchBaseRef"] = branchBaseRef
         }
-        let assets = try ensureDiffViewerAssets(nextTo: viewerURL)
+        let assets = try ensureDiffViewerAssets(nextTo: viewerURL, runtime: runtime)
         let config: [String: Any] = [
             "payload": payload,
             "assets": [
@@ -5495,8 +5584,8 @@ extension CMUXCLI {
         try html.write(to: viewerURL, atomically: true, encoding: .utf8)
     }
 
-    private func ensureDiffViewerAssets(nextTo viewerURL: URL) throws -> DiffViewerAssets {
-        let sourceDirectory = try diffViewerBundledAssetDirectory()
+    private func ensureDiffViewerAssets(nextTo viewerURL: URL, runtime: DiffViewerRuntime = .current) throws -> DiffViewerAssets {
+        let sourceDirectory = try diffViewerBundledAssetDirectory(runtime: runtime)
         let assetDirectoryName = "pierre-diffs-1.2.7-trees-1.0.0-beta.4"
         let targetDirectory = viewerURL.deletingLastPathComponent()
             .appendingPathComponent("assets", isDirectory: true)
@@ -5628,15 +5717,15 @@ extension CMUXCLI {
         return targetDate >= sourceDate
     }
 
-    private func diffViewerBundledAssetDirectory() throws -> URL {
-        let candidates = diffViewerBundledAssetDirectoryCandidates()
+    private func diffViewerBundledAssetDirectory(runtime: DiffViewerRuntime = .current) throws -> URL {
+        let candidates = diffViewerBundledAssetDirectoryCandidates(runtime: runtime)
         if let directory = candidates.first {
             return directory
         }
         throw CLIError(message: "Bundled diff viewer assets not found")
     }
 
-    private func diffViewerBundledAssetDirectoryCandidates() -> [URL] {
+    private func diffViewerBundledAssetDirectoryCandidates(runtime: DiffViewerRuntime = .current) -> [URL] {
         let fileManager = FileManager.default
         var candidates: [URL] = []
         var seen: Set<String> = []
@@ -5659,13 +5748,7 @@ extension CMUXCLI {
             candidates.append(standardized)
         }
 
-        appendIfExisting(
-            Bundle.main.resourceURL?
-                .appendingPathComponent("markdown-viewer", isDirectory: true)
-                .appendingPathComponent("diff-viewer", isDirectory: true)
-        )
-
-        if let executableURL = resolvedExecutableURL() {
+        if let executableURL = diffViewerExecutableURL(for: runtime) {
             let execDir = executableURL.deletingLastPathComponent().standardizedFileURL
             for relativePath in [
                 "markdown-viewer/diff-viewer",
@@ -5700,6 +5783,12 @@ extension CMUXCLI {
                 current = current.deletingLastPathComponent().standardizedFileURL
             }
         }
+
+        appendIfExisting(
+            Bundle.main.resourceURL?
+                .appendingPathComponent("markdown-viewer", isDirectory: true)
+                .appendingPathComponent("diff-viewer", isDirectory: true)
+        )
 
         let devRelative = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()

--- a/CLI/cmux_open.swift
+++ b/CLI/cmux_open.swift
@@ -199,7 +199,7 @@ extension CMUXCLI {
         var pages: [DiffViewerDeferredSourcePage]
         var layout: String
         var appearance: DiffViewerAppearance
-        var runtime: DiffViewerRuntime
+        var runtime: URL?
     }
 
     private struct DiffViewerDeferredSourcePage {
@@ -245,13 +245,7 @@ extension CMUXCLI {
         var directory: URL
         var mapper: DiffViewerURLMapper
         var groupID: String
-        var runtime: DiffViewerRuntime
-    }
-
-    private struct DiffViewerRuntime {
-        var executableURL: URL?
-
-        static let current = DiffViewerRuntime(executableURL: nil)
+        var runtime: URL?
     }
 
     private struct DiffViewerSourceOption {
@@ -907,15 +901,15 @@ extension CMUXCLI {
         print("OK surface=\(surfaceText) pane=\(paneText) path=\(completedViewer.fileURL.path)")
     }
 
-    private func diffViewerRuntime(socketPath: String) -> DiffViewerRuntime {
+    private func diffViewerRuntime(socketPath: String) -> URL? {
         if let taggedExecutableURL = taggedDiffViewerExecutableURL(socketPath: socketPath) {
-            return DiffViewerRuntime(executableURL: taggedExecutableURL)
+            return taggedExecutableURL
         }
-        return .current
+        return nil
     }
 
-    private func diffViewerExecutableURL(for runtime: DiffViewerRuntime) -> URL? {
-        runtime.executableURL ?? resolvedExecutableURL()
+    private func diffViewerExecutableURL(for runtime: URL?) -> URL? {
+        runtime ?? resolvedExecutableURL()
     }
 
     private func taggedDiffViewerExecutableURL(socketPath: String) -> URL? {
@@ -2992,7 +2986,7 @@ extension CMUXCLI {
         layout: String,
         appearance: DiffViewerAppearance,
         context: DiffSourceContext,
-        runtime: DiffViewerRuntime
+        runtime: URL?
     ) throws -> DiffViewerWriteResult {
         if let source {
             return try writeGitDiffViewerHTMLSet(
@@ -3063,7 +3057,7 @@ extension CMUXCLI {
         layout: String,
         appearance: DiffViewerAppearance,
         context: DiffSourceContext,
-        runtime: DiffViewerRuntime
+        runtime: URL?
     ) throws -> DiffViewerWriteResult {
         let target = try makeDiffViewerGitHTMLSetTarget(runtime: runtime)
         if selectedSource != .lastTurn {
@@ -3086,7 +3080,7 @@ extension CMUXCLI {
         )
     }
 
-    private func makeDiffViewerGitHTMLSetTarget(runtime: DiffViewerRuntime) throws -> DiffViewerGitHTMLSetTarget {
+    private func makeDiffViewerGitHTMLSetTarget(runtime: URL?) throws -> DiffViewerGitHTMLSetTarget {
         let directory = try diffViewerDirectory()
         let origin = try diffViewerHTTPServerOrigin(rootDirectory: directory, runtime: runtime)
         let mapper = DiffViewerURLMapper(
@@ -4179,7 +4173,7 @@ extension CMUXCLI {
         try runDiffViewerHTTPServer(rootDirectory: rootDirectory)
     }
 
-    private func diffViewerHTTPServerOrigin(rootDirectory: URL, runtime: DiffViewerRuntime = .current) throws -> URL {
+    private func diffViewerHTTPServerOrigin(rootDirectory: URL, runtime: URL? = nil) throws -> URL {
         let rootDirectory = rootDirectory.standardizedFileURL.resolvingSymlinksInPath()
         try validateSecureDiffViewerDirectory(rootDirectory, repairPermissions: false)
 
@@ -4211,7 +4205,7 @@ extension CMUXCLI {
         try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
     }
 
-    private func diffViewerHTTPServerStateMatchesRuntimeExecutable(_ state: DiffViewerHTTPServerState, runtime: DiffViewerRuntime) -> Bool {
+    private func diffViewerHTTPServerStateMatchesRuntimeExecutable(_ state: DiffViewerHTTPServerState, runtime: URL?) -> Bool {
         guard state.pid > 0,
               let currentExecutablePath = diffViewerExecutableURL(for: runtime)?.path,
               let serverExecutablePath = diffViewerHTTPServerExecutablePath(pid: state.pid),
@@ -4243,7 +4237,7 @@ extension CMUXCLI {
         return URL(fileURLWithPath: rawPath).standardizedFileURL.path
     }
 
-    private func startDiffViewerHTTPServer(rootDirectory: URL, runtime: DiffViewerRuntime = .current) throws -> URL {
+    private func startDiffViewerHTTPServer(rootDirectory: URL, runtime: URL? = nil) throws -> URL {
         guard let executableURL = diffViewerExecutableURL(for: runtime) else {
             throw CLIError(message: "Failed to resolve cmux executable for diff viewer server")
         }
@@ -5446,7 +5440,7 @@ extension CMUXCLI {
         baseOptions: [DiffViewerSourceOption] = [],
         repoRoot: String? = nil,
         branchBaseRef: String? = nil,
-        runtime: DiffViewerRuntime = .current
+        runtime: URL? = nil
     ) throws {
         try writeDiffViewerHTML(
             to: viewerURL,
@@ -5472,7 +5466,7 @@ extension CMUXCLI {
         to viewerURL: URL,
         title: String,
         targetURL: URL,
-        runtime: DiffViewerRuntime = .current
+        runtime: URL? = nil
     ) throws {
         try writeDiffViewerPatchSidecar("", for: viewerURL)
         _ = try ensureDiffViewerAssets(nextTo: viewerURL, runtime: runtime)
@@ -5516,7 +5510,7 @@ extension CMUXCLI {
         statusMessage: String? = nil,
         statusIsError: Bool = false,
         pollForReplacement: Bool = false,
-        runtime: DiffViewerRuntime = .current
+        runtime: URL? = nil
     ) throws {
         if remotePatchURL == nil {
             try writeDiffViewerPatchSidecar(patch, for: viewerURL)
@@ -5584,7 +5578,7 @@ extension CMUXCLI {
         try html.write(to: viewerURL, atomically: true, encoding: .utf8)
     }
 
-    private func ensureDiffViewerAssets(nextTo viewerURL: URL, runtime: DiffViewerRuntime = .current) throws -> DiffViewerAssets {
+    private func ensureDiffViewerAssets(nextTo viewerURL: URL, runtime: URL? = nil) throws -> DiffViewerAssets {
         let sourceDirectory = try diffViewerBundledAssetDirectory(runtime: runtime)
         let assetDirectoryName = "pierre-diffs-1.2.7-trees-1.0.0-beta.4"
         let targetDirectory = viewerURL.deletingLastPathComponent()
@@ -5717,7 +5711,7 @@ extension CMUXCLI {
         return targetDate >= sourceDate
     }
 
-    private func diffViewerBundledAssetDirectory(runtime: DiffViewerRuntime = .current) throws -> URL {
+    private func diffViewerBundledAssetDirectory(runtime: URL? = nil) throws -> URL {
         let candidates = diffViewerBundledAssetDirectoryCandidates(runtime: runtime)
         if let directory = candidates.first {
             return directory
@@ -5725,7 +5719,7 @@ extension CMUXCLI {
         throw CLIError(message: "Bundled diff viewer assets not found")
     }
 
-    private func diffViewerBundledAssetDirectoryCandidates(runtime: DiffViewerRuntime = .current) -> [URL] {
+    private func diffViewerBundledAssetDirectoryCandidates(runtime: URL? = nil) -> [URL] {
         let fileManager = FileManager.default
         var candidates: [URL] = []
         var seen: Set<String> = []

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -3517,11 +3517,25 @@ class TerminalController {
             }
         }
 
-        return [
+        var result: [String: Any] = [
             "socket_path": socketPath,
             "focused": focused.isEmpty ? NSNull() : focused,
             "caller": v2OrNull(resolvedCaller)
         ]
+        if let bundleIdentifier = Bundle.main.bundleIdentifier {
+            result["bundle_identifier"] = bundleIdentifier
+        }
+        result["app_bundle_path"] = Bundle.main.bundleURL.path
+        if let executablePath = Bundle.main.executableURL?.path {
+            result["app_executable_path"] = executablePath
+        }
+        if let cliPath = Bundle.main.resourceURL?
+            .appendingPathComponent("bin", isDirectory: true)
+            .appendingPathComponent("cmux", isDirectory: false)
+            .path {
+            result["app_cli_path"] = cliPath
+        }
+        return result
     }
 
     private struct V2WindowRouting {

--- a/cmuxTests/CMUXOpenCommandTests.swift
+++ b/cmuxTests/CMUXOpenCommandTests.swift
@@ -459,6 +459,98 @@ final class CMUXOpenCommandTests: XCTestCase {
         XCTAssertTrue(darkOnlyTheme.html.contains("\"ghosttyName\":\"Unit Dark\""), darkOnlyTheme.html)
     }
 
+    func testDiffCommandUsesTaggedSocketAppAssetsAndServer() throws {
+        let cliPath = try bundledCLIPath()
+        let tag = "asset\(UUID().uuidString.replacingOccurrences(of: "-", with: "").prefix(6).lowercased())"
+        let socketPath = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("cmux-debug-\(tag).sock", isDirectory: false)
+            .path
+        unlink(socketPath)
+        let listenerFD = try bindUnixSocket(at: socketPath)
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let homeURL = rootURL.appendingPathComponent("home", isDirectory: true)
+        let targetCLIURL = homeURL
+            .appendingPathComponent("Library/Developer/Xcode/DerivedData/cmux-\(tag)", isDirectory: true)
+            .appendingPathComponent("Build/Products/Debug/cmux DEV \(tag).app", isDirectory: true)
+            .appendingPathComponent("Contents/Resources/bin/cmux", isDirectory: false)
+        let targetResourcesURL = targetCLIURL
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let patchURL = rootURL.appendingPathComponent("change.patch", isDirectory: false)
+        let state = MockSocketServerState()
+
+        try FileManager.default.createDirectory(at: targetCLIURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try FileManager.default.copyItem(at: URL(fileURLWithPath: cliPath), to: targetCLIURL)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: targetCLIURL.path)
+        try writeTestDiffViewerAssets(
+            resourcesURL: targetResourcesURL,
+            appMain: "export const cmuxTaggedSocketAssetMarker = 'target-\(tag)';\n"
+        )
+        try """
+        diff --git a/file.txt b/file.txt
+        index 1111111..2222222 100644
+        --- a/file.txt
+        +++ b/file.txt
+        @@ -1 +1 @@
+        -old
+        +new
+        """.write(to: patchURL, atomically: true, encoding: .utf8)
+
+        defer {
+            Darwin.close(listenerFD)
+            unlink(socketPath)
+            try? FileManager.default.removeItem(at: rootURL)
+        }
+
+        let serverHandled = startMockServer(listenerFD: listenerFD, state: state) { line in
+            guard let payload = Self.v2Payload(from: line),
+                  let id = payload["id"] as? String,
+                  let method = payload["method"] as? String,
+                  method == "browser.open_split",
+                  let params = payload["params"] as? [String: Any],
+                  let rawURL = params["url"] as? String else {
+                return Self.v2Response(id: "unknown", ok: false, error: ["code": "unexpected"])
+            }
+            return Self.v2Response(
+                id: id,
+                ok: true,
+                result: ["surface_id": "surface-id", "pane_id": "pane-id", "url": rawURL]
+            )
+        }
+
+        let result = runCLI(
+            cliPath: cliPath,
+            socketPath: socketPath,
+            arguments: ["diff", patchURL.path, "--title", "Tagged assets", "--focus", "false"],
+            environmentOverrides: [
+                "HOME": homeURL.path,
+                "CFFIXED_USER_HOME": homeURL.path
+            ]
+        )
+
+        wait(for: [serverHandled], timeout: 5)
+        XCTAssertFalse(result.timedOut, result.stderr)
+        XCTAssertEqual(result.status, 0, result.stderr)
+
+        let payload = try XCTUnwrap(Self.v2Payload(from: try XCTUnwrap(state.commands.first)))
+        let params = try XCTUnwrap(payload["params"] as? [String: Any])
+        let rawURL = try XCTUnwrap(params["url"] as? String)
+        let files = try diffViewerAllowedFiles(for: rawURL, from: params)
+        let appEntry = try XCTUnwrap(files.first { file in
+            (file["request_path"] as? String)?.hasSuffix("/assets/cmux-diff-viewer-app/main.mjs") == true
+        })
+        let appFilePath = try XCTUnwrap(appEntry["file_path"] as? String)
+        let appMain = try String(contentsOfFile: appFilePath, encoding: .utf8)
+        XCTAssertTrue(appMain.contains("cmuxTaggedSocketAssetMarker = 'target-\(tag)'"), appMain)
+
+        let stateURL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("cmux-diff-viewer-\(Darwin.getuid())", isDirectory: true)
+            .appendingPathComponent(".server-state", isDirectory: false)
+        let serverState = try JSONSerialization.jsonObject(with: Data(contentsOf: stateURL)) as? [String: Any]
+        XCTAssertEqual(serverState?["executablePath"] as? String, targetCLIURL.path)
+    }
+
     func testDiffCommandLinksOriginalDiffshubPRURL() throws {
         let cliPath = try bundledCLIPath()
 
@@ -2459,6 +2551,43 @@ final class CMUXOpenCommandTests: XCTestCase {
         }
 
         throw XCTSkip("Bundled cmux CLI not found in \(appBundleURL.path)")
+    }
+
+    private func writeTestDiffViewerAssets(resourcesURL: URL, appMain: String) throws {
+        let diffViewerURL = resourcesURL
+            .appendingPathComponent("markdown-viewer", isDirectory: true)
+            .appendingPathComponent("diff-viewer", isDirectory: true)
+        let appURL = resourcesURL
+            .appendingPathComponent("markdown-viewer", isDirectory: true)
+            .appendingPathComponent("diff-viewer-app", isDirectory: true)
+        let workerPoolURL = diffViewerURL.appendingPathComponent("worker-pool", isDirectory: true)
+        try FileManager.default.createDirectory(at: workerPoolURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: appURL, withIntermediateDirectories: true)
+        try "export const diffsFixture = true;\n".write(
+            to: diffViewerURL.appendingPathComponent("diffs.mjs", isDirectory: false),
+            atomically: true,
+            encoding: .utf8
+        )
+        try "export const treesFixture = true;\n".write(
+            to: diffViewerURL.appendingPathComponent("trees.mjs", isDirectory: false),
+            atomically: true,
+            encoding: .utf8
+        )
+        try "export const workerPoolFixture = true;\n".write(
+            to: workerPoolURL.appendingPathComponent("worker-pool.mjs", isDirectory: false),
+            atomically: true,
+            encoding: .utf8
+        )
+        try "self.cmuxWorkerFixture = true;\n".write(
+            to: workerPoolURL.appendingPathComponent("worker-portable.js", isDirectory: false),
+            atomically: true,
+            encoding: .utf8
+        )
+        try appMain.write(
+            to: appURL.appendingPathComponent("main.mjs", isDirectory: false),
+            atomically: true,
+            encoding: .utf8
+        )
     }
 
     private func runProcess(

--- a/diff-viewer/src/App.tsx
+++ b/diff-viewer/src/App.tsx
@@ -3,7 +3,7 @@ import { getFiletypeFromFileName, parsePatchFiles, preloadHighlighter, processFi
 import { FileTree, useFileTree } from "@pierre/trees/react";
 import { preparePresortedFileTreeInput } from "@pierre/trees";
 import { useEffect, useReducer, useRef, useState } from "react";
-import { copyGitApplyCommand, diffSourceDetail, resolveDiffNavigationURL } from "./actions";
+import { copyGitApplyCommand, resolveDiffNavigationURL } from "./actions";
 import { resolveDiffViewerAppearance } from "./appearance";
 import { fileName, type DiffItem, type FileTreeSource, type StreamMetrics, streamPatch } from "./diff-stream";
 import { applyPierreFileTreeGitStatus, planPierreFileTreeRefresh, selectPierreFileTreePath } from "./file-tree-refresh";
@@ -392,7 +392,6 @@ function SourceControls({
         options={payload.baseOptions}
         onNavigate={onNavigate}
       />
-      <span id="source-detail">{selectedSourceDetail(payload)}</span>
     </div>
   );
 }
@@ -441,13 +440,6 @@ function NavigationSelect({
       ))}
     </select>
   );
-}
-
-function selectedSourceDetail(payload: any): string {
-  const selectedSource = Array.isArray(payload.sourceOptions)
-    ? payload.sourceOptions.find((option: any) => option.selected) ?? payload.sourceOptions.find((option: any) => !option.disabled)
-    : null;
-  return selectedSource?.sourceLabel ?? diffSourceDetail(payload);
 }
 
 function JumpSelect({

--- a/diff-viewer/src/App.tsx
+++ b/diff-viewer/src/App.tsx
@@ -499,7 +499,7 @@ function OptionsMenu({
     <div id="options-menu" aria-label={label("options")}>
       <MenuButton icon="refresh" label={label("refresh")} onClick={onReload} />
       <MenuButton checked={state.options.wordWrap} icon="wrap" label={state.options.wordWrap ? label("disableWordWrap") : label("enableWordWrap")} onClick={() => toggle("wordWrap")} />
-      <MenuButton checked={state.options.collapsed} icon="collapse" label={state.options.collapsed ? label("expandAllDiffs") : label("collapseAllDiffs")} onClick={() => toggle("collapsed")} />
+      <MenuButton checked={state.options.collapsed} icon={state.options.collapsed ? "expand" : "collapse"} label={state.options.collapsed ? label("expandAllDiffs") : label("collapseAllDiffs")} onClick={() => toggle("collapsed")} />
       <div className="menu-separator" />
       <MenuButton checked={state.filesVisible} icon="files" label={state.filesVisible ? label("hideFiles") : label("showFiles")} onClick={() => dispatch({ type: "set-files-visible", visible: !state.filesVisible })} />
       <MenuButton checked={state.options.expandUnchanged} icon="document" label={state.options.expandUnchanged ? label("collapseUnchangedContext") : label("expandUnchangedContext")} onClick={() => toggle("expandUnchanged")} />

--- a/diff-viewer/src/App.tsx
+++ b/diff-viewer/src/App.tsx
@@ -656,20 +656,6 @@ function FilesSidebar({
           <div className="visually-hidden">{state.status.message}</div>
         )}
       </div>
-      <div id="files-footer" aria-label={label("diffStats")}>
-        <div className="stats-row">
-          <span>{label("files")}</span>
-          <strong id="stats-files">{state.treeSource?.diffStats.fileCount ?? 0}</strong>
-        </div>
-        <div className="stats-row">
-          <span>{label("additions")}</span>
-          <strong id="stats-added" className="stat-add">+{state.treeSource?.diffStats.addedLines ?? 0}</strong>
-        </div>
-        <div className="stats-row">
-          <span>{label("deletions")}</span>
-          <strong id="stats-deleted" className="stat-del">-{state.treeSource?.diffStats.deletedLines ?? 0}</strong>
-        </div>
-      </div>
     </aside>
   );
 }

--- a/diff-viewer/src/App.tsx
+++ b/diff-viewer/src/App.tsx
@@ -311,17 +311,6 @@ function Toolbar({
           </a>
         ) : null}
         <button
-          id="files-toggle"
-          className="toolbar-icon"
-          type="button"
-          title={state.filesVisible ? label("hideFiles") : label("showFiles")}
-          aria-label={state.filesVisible ? label("hideFiles") : label("showFiles")}
-          aria-pressed={state.filesVisible}
-          onClick={() => dispatch({ type: "set-files-visible", visible: !state.filesVisible })}
-        >
-          <Icon name="files" />
-        </button>
-        <button
           id="layout-toggle"
           className="toolbar-icon"
           type="button"
@@ -342,6 +331,17 @@ function Toolbar({
           onClick={() => dispatch({ type: "set-options-open", open: !state.optionsOpen })}
         >
           <Icon name="dots" />
+        </button>
+        <button
+          id="files-toggle"
+          className="toolbar-icon"
+          type="button"
+          title={state.filesVisible ? label("hideFiles") : label("showFiles")}
+          aria-label={state.filesVisible ? label("hideFiles") : label("showFiles")}
+          aria-pressed={state.filesVisible}
+          onClick={() => dispatch({ type: "set-files-visible", visible: !state.filesVisible })}
+        >
+          <Icon name="files" />
         </button>
         <span id="copy-feedback" className="visually-hidden" aria-live="polite">
           {state.copyFeedback}
@@ -630,15 +630,6 @@ function FilesSidebar({
           >
             <Icon name="search" />
           </button>
-          <button
-            id="file-collapse-toggle"
-            type="button"
-            title={label("hideFiles")}
-            aria-label={label("hideFiles")}
-            onClick={() => dispatch({ type: "set-files-visible", visible: false })}
-          >
-            <Icon name="sidebarCollapse" />
-          </button>
         </span>
       </div>
       <div id="file-list">
@@ -688,19 +679,6 @@ function PierreFileTree({
     searchBlurBehavior: "retain",
     stickyFolders: true,
     gitStatus: source.gitStatus as any,
-    renderRowDecoration(context: any) {
-      if (context.item.kind !== "file") {
-        return null;
-      }
-      const stats = latest.current.source.statsByPath.get(context.item.path);
-      if (stats == null || (stats.added === 0 && stats.deleted === 0)) {
-        return null;
-      }
-      return {
-        text: `+${stats.added} -${stats.deleted}`,
-        title: `${stats.added} ${latest.current.label("additions")}, ${stats.deleted} ${latest.current.label("deletions")}`,
-      };
-    },
     sort: () => 0,
     unsafeCSS: fileTreeUnsafeCSS(),
     onSelectionChange(paths: readonly string[]) {

--- a/diff-viewer/src/icons.tsx
+++ b/diff-viewer/src/icons.tsx
@@ -45,7 +45,7 @@ function IconPaths({ name }: { name: IconName }) {
   case "document":
     return <><path d="M6 3h6l4 4v10H6z" /><path d="M12 3v5h5" /></>;
   case "dots":
-    return <><path d="M5 10h.01" /><path d="M10 10h.01" /><path d="M15 10h.01" /></>;
+    return <><path d="M5 10h.01" data-precision-dot="true" /><path d="M10 10h.01" data-precision-dot="true" /><path d="M15 10h.01" data-precision-dot="true" /></>;
   case "expand":
     return <path d="M6.5 8 10 11.5 13.5 8" />;
   case "external":
@@ -53,7 +53,7 @@ function IconPaths({ name }: { name: IconName }) {
   case "eye":
     return <><path d="M2.5 10s2.75-5 7.5-5 7.5 5 7.5 5-2.75 5-7.5 5-7.5-5-7.5-5z" /><circle cx="10" cy="10" r="2.4" /></>;
   case "files":
-    return <><path d="M3 5h5l1.5 2H17v9.5H3z" /><path d="M3 7h14" /></>;
+    return <><rect x="3.5" y="4" width="13" height="12" rx="2" /><path d="M7.5 4v12" /><path d="M5.2 7h1.1" /><path d="M5.2 10h1.1" /><path d="M5.2 13h1.1" /><path d="M10 7h3.8" /><path d="M10 10h4.5" /><path d="M10 13h3.2" /></>;
   case "numbers":
     return <><path d="M5 5h2v10" /><path d="M4 15h4" /><path d="M11 6.5a2 2 0 1 1 3.2 1.6L11 12h4" /><path d="M11 15h4" /></>;
   case "refresh":

--- a/diff-viewer/src/icons.tsx
+++ b/diff-viewer/src/icons.tsx
@@ -53,7 +53,7 @@ function IconPaths({ name }: { name: IconName }) {
   case "eye":
     return <><path d="M2.5 10s2.75-5 7.5-5 7.5 5 7.5 5-2.75 5-7.5 5-7.5-5-7.5-5z" /><circle cx="10" cy="10" r="2.4" /></>;
   case "files":
-    return <><rect x="3.5" y="4" width="13" height="12" rx="2" /><path d="M11 4v12" /><path d="M13.2 7h2" /><path d="M13.2 10h2" /><path d="M13.2 13h2" /><path d="M6.2 8h2.6" /><path d="M6.2 12h2.6" /></>;
+    return <><rect x="3.5" y="4" width="13" height="12" rx="2" /><path d="M11.5 4v12" /></>;
   case "numbers":
     return <><path d="M5 5h2v10" /><path d="M4 15h4" /><path d="M11 6.5a2 2 0 1 1 3.2 1.6L11 12h4" /><path d="M11 15h4" /></>;
   case "refresh":

--- a/diff-viewer/src/icons.tsx
+++ b/diff-viewer/src/icons.tsx
@@ -63,9 +63,9 @@ function IconPaths({ name }: { name: IconName }) {
   case "sidebarCollapse":
     return <><rect x="3.5" y="4" width="13" height="12" rx="2" /><path d="M8 4v12" /><path d="m12 8 2 2-2 2" /></>;
   case "split":
-    return <><rect x="4" y="4" width="12" height="12" rx="2" /><rect x="6.2" y="5.5" width="2.8" height="9" rx=".7" data-diff-deletion="true" /><rect x="11" y="5.5" width="2.8" height="9" rx=".7" data-diff-addition="true" /></>;
+    return <><rect x="4" y="4" width="12" height="12" rx="2" /><rect x="5" y="5" width="4.5" height="10" rx="1" data-diff-deletion="true" /><rect x="10.5" y="5" width="4.5" height="10" rx="1" data-diff-addition="true" /></>;
   case "unified":
-    return <><rect x="4" y="4" width="12" height="12" rx="2" /><rect x="6" y="6.2" width="8" height="2.8" rx=".7" data-diff-deletion="true" /><rect x="6" y="11" width="8" height="2.8" rx=".7" data-diff-addition="true" /></>;
+    return <><rect x="4" y="4" width="12" height="12" rx="2" /><rect x="5" y="5" width="10" height="4.5" rx="1" data-diff-deletion="true" /><rect x="5" y="10.5" width="10" height="4.5" rx="1" data-diff-addition="true" /></>;
   case "word":
     return <><path d="M3 6h14" /><path d="M3 10h8" /><path d="M3 14h11" /><path d="M14 10h3" /></>;
   case "wrap":

--- a/diff-viewer/src/icons.tsx
+++ b/diff-viewer/src/icons.tsx
@@ -53,7 +53,7 @@ function IconPaths({ name }: { name: IconName }) {
   case "eye":
     return <><path d="M2.5 10s2.75-5 7.5-5 7.5 5 7.5 5-2.75 5-7.5 5-7.5-5-7.5-5z" /><circle cx="10" cy="10" r="2.4" /></>;
   case "files":
-    return <><rect x="3.5" y="4" width="13" height="12" rx="2" /><path d="M7.5 4v12" /><path d="M5.2 7h1.1" /><path d="M5.2 10h1.1" /><path d="M5.2 13h1.1" /><path d="M10 7h3.8" /><path d="M10 10h4.5" /><path d="M10 13h3.2" /></>;
+    return <><path d="M6.5 4.5v11" /><path d="M4.2 6.5h1.1" /><path d="M4.2 10h1.1" /><path d="M4.2 13.5h1.1" /><path d="M9 6.5h6.2" /><path d="M9 10h5.2" /><path d="M9 13.5h6.2" /></>;
   case "numbers":
     return <><path d="M5 5h2v10" /><path d="M4 15h4" /><path d="M11 6.5a2 2 0 1 1 3.2 1.6L11 12h4" /><path d="M11 15h4" /></>;
   case "refresh":

--- a/diff-viewer/src/icons.tsx
+++ b/diff-viewer/src/icons.tsx
@@ -63,9 +63,9 @@ function IconPaths({ name }: { name: IconName }) {
   case "sidebarCollapse":
     return <><rect x="3.5" y="4" width="13" height="12" rx="2" /><path d="M8 4v12" /><path d="m12 8 2 2-2 2" /></>;
   case "split":
-    return <><rect x="4" y="4" width="12" height="12" rx="2" /><rect x="5" y="5" width="4.5" height="10" rx="1" data-diff-deletion="true" /><rect x="10.5" y="5" width="4.5" height="10" rx="1" data-diff-addition="true" /></>;
+    return <><rect x="4" y="4" width="12" height="12" rx="2" /><rect x="6" y="6" width="3.5" height="8" rx="1" data-diff-deletion="true" /><rect x="10.5" y="6" width="3.5" height="8" rx="1" data-diff-addition="true" /></>;
   case "unified":
-    return <><rect x="4" y="4" width="12" height="12" rx="2" /><rect x="5" y="5" width="10" height="4.5" rx="1" data-diff-deletion="true" /><rect x="5" y="10.5" width="10" height="4.5" rx="1" data-diff-addition="true" /></>;
+    return <><rect x="4" y="4" width="12" height="12" rx="2" /><rect x="6" y="6" width="8" height="3.5" rx="1" data-diff-deletion="true" /><rect x="6" y="10.5" width="8" height="3.5" rx="1" data-diff-addition="true" /></>;
   case "word":
     return <><path d="M3 6h14" /><path d="M3 10h8" /><path d="M3 14h11" /><path d="M14 10h3" /></>;
   case "wrap":

--- a/diff-viewer/src/icons.tsx
+++ b/diff-viewer/src/icons.tsx
@@ -63,9 +63,9 @@ function IconPaths({ name }: { name: IconName }) {
   case "sidebarCollapse":
     return <><rect x="3.5" y="4" width="13" height="12" rx="2" /><path d="M8 4v12" /><path d="m12 8 2 2-2 2" /></>;
   case "split":
-    return <><rect x="3" y="4" width="14" height="12" rx="2" /><path d="M10 4v12" data-accent="true" /><path d="M6 8h2" /><path d="M6 12h2" /><path d="M12 8h2" /><path d="M12 12h2" /></>;
+    return <><rect x="4" y="4" width="12" height="12" rx="2" /><rect x="6.2" y="5.5" width="2.8" height="9" rx=".7" data-diff-deletion="true" /><rect x="11" y="5.5" width="2.8" height="9" rx=".7" data-diff-addition="true" /></>;
   case "unified":
-    return <><rect x="4" y="3.5" width="12" height="13" rx="2" /><path d="M7 7h6" /><path d="M7 10h6" data-accent="true" /><path d="M7 13h6" /></>;
+    return <><rect x="4" y="4" width="12" height="12" rx="2" /><rect x="6" y="6.2" width="8" height="2.8" rx=".7" data-diff-deletion="true" /><rect x="6" y="11" width="8" height="2.8" rx=".7" data-diff-addition="true" /></>;
   case "word":
     return <><path d="M3 6h14" /><path d="M3 10h8" /><path d="M3 14h11" /><path d="M14 10h3" /></>;
   case "wrap":

--- a/diff-viewer/src/icons.tsx
+++ b/diff-viewer/src/icons.tsx
@@ -7,6 +7,7 @@ export type IconName =
   | "clipboard"
   | "document"
   | "dots"
+  | "expand"
   | "external"
   | "eye"
   | "files"
@@ -38,13 +39,15 @@ function IconPaths({ name }: { name: IconName }) {
   case "classic":
     return <><path d="M4 5h12" /><path d="M4 10h12" /><path d="M4 15h12" /><path d="M7 3v4" /><path d="M13 8v4" /></>;
   case "collapse":
-    return <><path d="M7 3v4H3" /><path d="M3 7l5-5" /><path d="M13 17v-4h4" /><path d="M17 13l-5 5" /></>;
+    return <><path d="M13.5 11.5 10 15 6.5 11.5" /><path d="M6.5 8.5 10 5l3.5 3.5" /></>;
   case "clipboard":
     return <><rect x="5" y="4" width="10" height="13" rx="2" /><path d="M8 4a2 2 0 0 1 4 0" /><path d="M8 7h4" /></>;
   case "document":
     return <><path d="M6 3h6l4 4v10H6z" /><path d="M12 3v5h5" /></>;
   case "dots":
     return <><path d="M5 10h.01" /><path d="M10 10h.01" /><path d="M15 10h.01" /></>;
+  case "expand":
+    return <path d="M6.5 8 10 11.5 13.5 8" />;
   case "external":
     return <><path d="M7 5H5a2 2 0 0 0-2 2v8a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2v-2" /><path d="M11 3h6v6" /><path d="m10 10 7-7" /></>;
   case "eye":
@@ -58,7 +61,7 @@ function IconPaths({ name }: { name: IconName }) {
   case "search":
     return <><circle cx="8.5" cy="8.5" r="4.5" /><path d="m12 12 4 4" /></>;
   case "sidebarCollapse":
-    return <><rect x="3.5" y="4" width="13" height="12" rx="2" /><path d="M12 4v12" /><path d="m8 8-2 2 2 2" /></>;
+    return <><rect x="3.5" y="4" width="13" height="12" rx="2" /><path d="M8 4v12" /><path d="m12 8 2 2-2 2" /></>;
   case "split":
     return <><rect x="3" y="4" width="14" height="12" rx="2" /><path d="M10 4v12" data-accent="true" /><path d="M6 8h2" /><path d="M6 12h2" /><path d="M12 8h2" /><path d="M12 12h2" /></>;
   case "unified":

--- a/diff-viewer/src/icons.tsx
+++ b/diff-viewer/src/icons.tsx
@@ -53,7 +53,7 @@ function IconPaths({ name }: { name: IconName }) {
   case "eye":
     return <><path d="M2.5 10s2.75-5 7.5-5 7.5 5 7.5 5-2.75 5-7.5 5-7.5-5-7.5-5z" /><circle cx="10" cy="10" r="2.4" /></>;
   case "files":
-    return <><path d="M6.5 4.5v11" /><path d="M4.2 6.5h1.1" /><path d="M4.2 10h1.1" /><path d="M4.2 13.5h1.1" /><path d="M9 6.5h6.2" /><path d="M9 10h5.2" /><path d="M9 13.5h6.2" /></>;
+    return <><rect x="3.5" y="4" width="13" height="12" rx="2" /><path d="M11 4v12" /><path d="M13.2 7h2" /><path d="M13.2 10h2" /><path d="M13.2 13h2" /><path d="M6.2 8h2.6" /><path d="M6.2 12h2.6" /></>;
   case "numbers":
     return <><path d="M5 5h2v10" /><path d="M4 15h4" /><path d="M11 6.5a2 2 0 1 1 3.2 1.6L11 12h4" /><path d="M11 15h4" /></>;
   case "refresh":

--- a/diff-viewer/src/pierre-options.ts
+++ b/diff-viewer/src/pierre-options.ts
@@ -139,17 +139,6 @@ export function fileTreeUnsafeCSS(): string {
       flex: 1 1 auto;
       min-width: 0;
     }
-    [data-item-section='decoration'] {
-      flex: 0 0 auto;
-      min-width: 44px;
-      margin-inline-start: 2px;
-      justify-content: flex-end;
-      text-align: right;
-    }
-    [data-item-section='decoration'] > span {
-      display: inline-block;
-      font-variant-numeric: tabular-nums;
-    }
     [data-item-section='git'] {
       opacity: 0.75;
     }

--- a/diff-viewer/src/pierre-options.ts
+++ b/diff-viewer/src/pierre-options.ts
@@ -140,12 +140,14 @@ export function fileTreeUnsafeCSS(): string {
       min-width: 0;
     }
     [data-item-section='decoration'] {
-      flex: 0 0 56px;
-      width: 56px;
-      min-width: 56px;
-      margin-inline-start: 4px;
+      flex: 0 0 auto;
+      min-width: 44px;
+      margin-inline-start: 2px;
+      justify-content: flex-end;
+      text-align: right;
     }
     [data-item-section='decoration'] > span {
+      display: inline-block;
       font-variant-numeric: tabular-nums;
     }
     [data-item-section='git'] {

--- a/diff-viewer/src/pierre-options.ts
+++ b/diff-viewer/src/pierre-options.ts
@@ -55,7 +55,7 @@ export function codeViewUnsafeCSS(): string {
     :host {
       --diffs-light-bg: var(--cmux-diff-bg);
       --diffs-dark-bg: var(--cmux-diff-bg);
-      --diffs-bg-buffer-override: var(--cmux-diff-bg);
+      --diffs-bg-buffer-override: color-mix(in srgb, var(--cmux-diff-fg) 12%, transparent);
       --diffs-bg-context-override: var(--cmux-diff-bg);
       --diffs-bg-context-gutter-override: var(--cmux-diff-bg);
       --cmux-diff-surface-bg: light-dark(
@@ -88,6 +88,18 @@ export function codeViewUnsafeCSS(): string {
     }
     [data-line-type='change-deletion']:where([data-column-number], [data-gutter-buffer]) {
       color: var(--diffs-deletion-base);
+    }
+    [data-gutter-buffer='buffer'] {
+      background-position: 5px 0;
+      background-size: 8px 8px;
+      background-origin: border-box;
+      background-image: repeating-linear-gradient(
+        -45deg,
+        transparent,
+        transparent 4.242px,
+        var(--diffs-bg-buffer) 4.242px,
+        var(--diffs-bg-buffer) 5.656px
+      );
     }
     [data-separator='line-info'] {
       background-color: var(--diffs-bg-separator);

--- a/diff-viewer/src/pierre-options.ts
+++ b/diff-viewer/src/pierre-options.ts
@@ -83,10 +83,10 @@ export function codeViewUnsafeCSS(): string {
       min-height: 30px;
       background-color: var(--cmux-diff-surface-bg) !important;
     }
-    [data-line-type='change-addition'] {
+    [data-line-type='change-addition']:where([data-column-number], [data-gutter-buffer]) {
       color: var(--diffs-addition-base);
     }
-    [data-line-type='change-deletion'] {
+    [data-line-type='change-deletion']:where([data-column-number], [data-gutter-buffer]) {
       color: var(--diffs-deletion-base);
     }
     [data-separator='line-info'] {

--- a/diff-viewer/src/styles.css
+++ b/diff-viewer/src/styles.css
@@ -247,6 +247,10 @@ body {
 #layout-toggle svg [data-diff-addition] {
   fill: light-dark(var(--cmux-diff-addition-fg-light), var(--cmux-diff-addition-fg-dark));
 }
+.toolbar-icon svg [data-precision-dot],
+.menu-item svg [data-precision-dot] {
+  stroke-width: 2;
+}
 #options-menu {
   position: absolute;
   top: calc(100% + 7px);

--- a/diff-viewer/src/styles.css
+++ b/diff-viewer/src/styles.css
@@ -96,7 +96,7 @@ body {
   align-items: center;
   gap: 7px;
   min-height: 32px;
-  padding: 3px 8px;
+  padding: 3px 4px 3px 8px;
   border-bottom: 1px solid var(--cmux-diff-border);
   background: var(--cmux-diff-toolbar-bg);
   color: color-mix(in lab, var(--cmux-diff-fg) 76%, var(--cmux-diff-bg));

--- a/diff-viewer/src/styles.css
+++ b/diff-viewer/src/styles.css
@@ -107,8 +107,11 @@ body {
 .toolbar-actions {
   display: flex;
   align-items: center;
-  gap: 6px;
   min-width: 0;
+}
+.toolbar-left,
+.toolbar-middle {
+  gap: 6px;
 }
 .toolbar-left {
   justify-self: stretch;
@@ -118,6 +121,7 @@ body {
 }
 .toolbar-actions {
   justify-self: end;
+  gap: 4px;
 }
 #source-select,
 #repo-select,
@@ -202,8 +206,8 @@ body {
   }
 }
 .toolbar-icon {
-  width: 28px;
-  height: 26px;
+  width: 20px;
+  height: 20px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -228,8 +232,8 @@ body {
 }
 .toolbar-icon svg,
 .menu-item svg {
-  width: 16px;
-  height: 16px;
+  width: 14px;
+  height: 14px;
   display: block;
   fill: none;
   stroke: currentColor;

--- a/diff-viewer/src/styles.css
+++ b/diff-viewer/src/styles.css
@@ -233,7 +233,7 @@ body {
   display: block;
   fill: none;
   stroke: currentColor;
-  stroke-width: 1.75;
+  stroke-width: 1;
   stroke-linecap: round;
   stroke-linejoin: round;
 }
@@ -452,7 +452,7 @@ body[data-status-only="true"] #files-sidebar {
   height: 15px;
   fill: none;
   stroke: currentColor;
-  stroke-width: 1.75;
+  stroke-width: 1;
   stroke-linecap: round;
   stroke-linejoin: round;
 }

--- a/diff-viewer/src/styles.css
+++ b/diff-viewer/src/styles.css
@@ -429,8 +429,7 @@ body[data-status-only="true"] #files-sidebar {
   gap: 2px;
   flex: 0 0 auto;
 }
-#file-search-toggle,
-#file-collapse-toggle {
+#file-search-toggle {
   width: 24px;
   height: 24px;
   flex: 0 0 auto;
@@ -444,13 +443,11 @@ body[data-status-only="true"] #files-sidebar {
   padding: 0;
 }
 #file-search-toggle:hover,
-#file-search-toggle[aria-pressed="true"],
-#file-collapse-toggle:hover {
+#file-search-toggle[aria-pressed="true"] {
   background: var(--cmux-diff-hover-bg);
   color: var(--cmux-diff-fg);
 }
-#file-search-toggle svg,
-#file-collapse-toggle svg {
+#file-search-toggle svg {
   width: 15px;
   height: 15px;
   fill: none;

--- a/diff-viewer/src/styles.css
+++ b/diff-viewer/src/styles.css
@@ -496,24 +496,6 @@ body[data-loading="false"]:not([data-status-only="true"]) #loading-layer {
   height: 100%;
   min-height: 0;
 }
-#files-footer {
-  flex: 0 0 auto;
-  padding: 7px 10px 8px;
-  border-top: 1px solid color-mix(in lab, var(--cmux-diff-fg) 10%, transparent);
-  background: var(--cmux-diff-sidebar-bg);
-}
-.stats-row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 10px;
-  min-height: 19px;
-  color: var(--cmux-diff-text-muted);
-}
-.stats-row strong {
-  color: var(--cmux-diff-text-subtle);
-  font-weight: 600;
-}
 .file-entry {
   width: 100%;
   min-height: 30px;

--- a/diff-viewer/src/styles.css
+++ b/diff-viewer/src/styles.css
@@ -176,14 +176,6 @@ body {
   outline: 2px solid color-mix(in lab, var(--cmux-diff-fg) 36%, transparent);
   outline-offset: 1px;
 }
-#source-detail {
-  flex: 1 1 auto;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  color: var(--cmux-diff-text-muted);
-}
 @media (max-width: 760px) {
   #toolbar {
     grid-template-columns: minmax(0, 1fr) auto;
@@ -200,9 +192,6 @@ body {
   }
   .toolbar-actions {
     grid-area: actions;
-  }
-  #source-detail {
-    display: none;
   }
 }
 .toolbar-icon {

--- a/diff-viewer/src/styles.css
+++ b/diff-viewer/src/styles.css
@@ -237,8 +237,15 @@ body {
   stroke-linecap: round;
   stroke-linejoin: round;
 }
-#layout-toggle svg [data-accent] {
-  stroke: light-dark(#0a84ff, #7ab7ff);
+#layout-toggle svg [data-diff-deletion],
+#layout-toggle svg [data-diff-addition] {
+  stroke: none;
+}
+#layout-toggle svg [data-diff-deletion] {
+  fill: light-dark(var(--cmux-diff-deletion-fg-light), var(--cmux-diff-deletion-fg-dark));
+}
+#layout-toggle svg [data-diff-addition] {
+  fill: light-dark(var(--cmux-diff-addition-fg-light), var(--cmux-diff-addition-fg-dark));
 }
 #options-menu {
   position: absolute;

--- a/diff-viewer/test/app.test.tsx
+++ b/diff-viewer/test/app.test.tsx
@@ -52,6 +52,7 @@ test("App renders the React-owned shell without starting a patch fetch for statu
   );
 
   expect(dom.window.document.getElementById("toolbar")).toBeTruthy();
+  expect(dom.window.document.getElementById("source-detail")).toBeNull();
   expect(dom.window.document.getElementById("files-sidebar")).toBeTruthy();
   expect(dom.window.document.getElementById("status-text")?.textContent).toBe("Waiting for diff");
   expect(fetched).toBe(false);

--- a/diff-viewer/test/pierre-options.test.ts
+++ b/diff-viewer/test/pierre-options.test.ts
@@ -21,8 +21,10 @@ test("code view CSS gives Pierre diff body surfaces the editor background", () =
   expect(css).not.toContain("@container sticky-header scroll-state");
   expect(css).toContain("[data-separator='line-info'] {");
   expect(css).toContain("[data-separator='line-info'] [data-separator-wrapper]");
-  expect(css).not.toContain("[data-line-type='change-addition'] span");
-  expect(css).not.toContain("[data-line-type='change-deletion'] span");
+  expect(css).toContain("[data-line-type='change-addition']:where([data-column-number], [data-gutter-buffer])");
+  expect(css).toContain("[data-line-type='change-deletion']:where([data-column-number], [data-gutter-buffer])");
+  expect(css).not.toContain("[data-line-type='change-addition'] {");
+  expect(css).not.toContain("[data-line-type='change-deletion'] {");
 });
 
 test("file tree sticky overlays use a non-transparent surface", () => {

--- a/diff-viewer/test/pierre-options.test.ts
+++ b/diff-viewer/test/pierre-options.test.ts
@@ -6,6 +6,7 @@ test("code view CSS gives Pierre diff body surfaces the editor background", () =
 
   expect(css).toContain("--diffs-light-bg: var(--cmux-diff-bg)");
   expect(css).toContain("--diffs-dark-bg: var(--cmux-diff-bg)");
+  expect(css).toContain("--diffs-bg-buffer-override: color-mix(in srgb, var(--cmux-diff-fg) 12%, transparent)");
   expect(css).toContain("--diffs-bg-context-override: var(--cmux-diff-bg)");
   expect(css).toContain("--diffs-bg-context-gutter-override: var(--cmux-diff-bg)");
   expect(css).toContain("background-color: var(--cmux-diff-bg)");
@@ -23,6 +24,8 @@ test("code view CSS gives Pierre diff body surfaces the editor background", () =
   expect(css).toContain("[data-separator='line-info'] [data-separator-wrapper]");
   expect(css).toContain("[data-line-type='change-addition']:where([data-column-number], [data-gutter-buffer])");
   expect(css).toContain("[data-line-type='change-deletion']:where([data-column-number], [data-gutter-buffer])");
+  expect(css).toContain("[data-gutter-buffer='buffer']");
+  expect(css).toContain("background-image: repeating-linear-gradient(");
   expect(css).not.toContain("[data-line-type='change-addition'] {");
   expect(css).not.toContain("[data-line-type='change-deletion'] {");
 });

--- a/diff-viewer/test/styles.test.ts
+++ b/diff-viewer/test/styles.test.ts
@@ -9,5 +9,7 @@ test("toolbar and files pane use theme surfaces", () => {
   expect(styles).toMatch(/#files-header\s*\{[^}]*border-bottom: 1px solid var\(--cmux-diff-border\)[^}]*background: var\(--cmux-diff-sidebar-bg\)/s);
   expect(styles).toMatch(/#file-list\s*\{[^}]*background: var\(--cmux-diff-sidebar-bg\)/s);
   expect(styles).toContain("--trees-bg-override: var(--cmux-diff-sidebar-bg)");
+  expect(styles).toMatch(/\.toolbar-icon svg,\s*\.menu-item svg\s*\{[^}]*stroke-width: 1;/s);
+  expect(styles).toMatch(/#file-search-toggle svg\s*\{[^}]*stroke-width: 1;/s);
   expect(styles).not.toContain("box-shadow: 0 -1px 0 var(--cmux-diff-border), 0 1px 0 var(--cmux-diff-border)");
 });

--- a/diff-viewer/test/styles.test.ts
+++ b/diff-viewer/test/styles.test.ts
@@ -15,5 +15,6 @@ test("toolbar and files pane use theme surfaces", () => {
   expect(styles).toMatch(/\.toolbar-icon svg,\s*\.menu-item svg\s*\{[^}]*width: 14px;[^}]*height: 14px;/s);
   expect(styles).toMatch(/\.toolbar-icon svg,\s*\.menu-item svg\s*\{[^}]*stroke-width: 1;/s);
   expect(styles).toMatch(/#file-search-toggle svg\s*\{[^}]*stroke-width: 1;/s);
+  expect(styles).not.toContain("#source-detail");
   expect(styles).not.toContain("box-shadow: 0 -1px 0 var(--cmux-diff-border), 0 1px 0 var(--cmux-diff-border)");
 });

--- a/diff-viewer/test/styles.test.ts
+++ b/diff-viewer/test/styles.test.ts
@@ -9,6 +9,9 @@ test("toolbar and files pane use theme surfaces", () => {
   expect(styles).toMatch(/#files-header\s*\{[^}]*border-bottom: 1px solid var\(--cmux-diff-border\)[^}]*background: var\(--cmux-diff-sidebar-bg\)/s);
   expect(styles).toMatch(/#file-list\s*\{[^}]*background: var\(--cmux-diff-sidebar-bg\)/s);
   expect(styles).toContain("--trees-bg-override: var(--cmux-diff-sidebar-bg)");
+  expect(styles).toMatch(/\.toolbar-actions\s*\{[^}]*gap: 4px;/s);
+  expect(styles).toMatch(/\.toolbar-icon\s*\{[^}]*width: 20px;[^}]*height: 20px;/s);
+  expect(styles).toMatch(/\.toolbar-icon svg,\s*\.menu-item svg\s*\{[^}]*width: 14px;[^}]*height: 14px;/s);
   expect(styles).toMatch(/\.toolbar-icon svg,\s*\.menu-item svg\s*\{[^}]*stroke-width: 1;/s);
   expect(styles).toMatch(/#file-search-toggle svg\s*\{[^}]*stroke-width: 1;/s);
   expect(styles).not.toContain("box-shadow: 0 -1px 0 var(--cmux-diff-border), 0 1px 0 var(--cmux-diff-border)");

--- a/diff-viewer/test/styles.test.ts
+++ b/diff-viewer/test/styles.test.ts
@@ -5,6 +5,7 @@ test("toolbar and files pane use theme surfaces", () => {
   expect(styles).toContain("--cmux-diff-toolbar-bg: var(--cmux-diff-bg)");
   expect(styles).toContain("--cmux-diff-sidebar-bg: var(--cmux-diff-bg)");
   expect(styles).toMatch(/#toolbar\s*\{[^}]*border-bottom: 1px solid var\(--cmux-diff-border\)[^}]*background: var\(--cmux-diff-toolbar-bg\)/s);
+  expect(styles).toMatch(/#toolbar\s*\{[^}]*padding: 3px 4px 3px 8px;/s);
   expect(styles).toMatch(/#files-sidebar\s*\{[^}]*background: var\(--cmux-diff-sidebar-bg\)/s);
   expect(styles).toMatch(/#files-header\s*\{[^}]*border-bottom: 1px solid var\(--cmux-diff-border\)[^}]*background: var\(--cmux-diff-sidebar-bg\)/s);
   expect(styles).toMatch(/#file-list\s*\{[^}]*background: var\(--cmux-diff-sidebar-bg\)/s);

--- a/scripts/reload.sh
+++ b/scripts/reload.sh
@@ -52,6 +52,36 @@ write_dev_cli_shim() {
 set -euo pipefail
 
 CLI_PATH_FILE="/tmp/cmux-last-cli-path"
+SOCKET_ARG=""
+EXPECT_SOCKET_VALUE=0
+for arg in "\$@"; do
+  if [[ "\$EXPECT_SOCKET_VALUE" == "1" ]]; then
+    SOCKET_ARG="\$arg"
+    EXPECT_SOCKET_VALUE=0
+    continue
+  fi
+  case "\$arg" in
+    --socket)
+      EXPECT_SOCKET_VALUE=1
+      ;;
+    --socket=*)
+      SOCKET_ARG="\${arg#--socket=}"
+      ;;
+  esac
+done
+if [[ -n "\$SOCKET_ARG" ]]; then
+  SOCKET_NAME="\$(basename "\$SOCKET_ARG")"
+  if [[ "\$SOCKET_NAME" == cmux-debug-*.sock ]]; then
+    TAG="\${SOCKET_NAME#cmux-debug-}"
+    TAG="\${TAG%.sock}"
+    if [[ "\$TAG" =~ ^[A-Za-z0-9_-]+$ ]]; then
+      TAG_CLI="\$HOME/Library/Developer/Xcode/DerivedData/cmux-\$TAG/Build/Products/Debug/cmux DEV \$TAG.app/Contents/Resources/bin/cmux"
+      if [[ -x "\$TAG_CLI" ]] && [[ "\$TAG_CLI" != "\$0" ]]; then
+        exec "\$TAG_CLI" "\$@"
+      fi
+    fi
+  fi
+fi
 if [[ -n "\${CMUX_BUNDLED_CLI_PATH:-}" ]] && [[ -f "\$CMUX_BUNDLED_CLI_PATH" ]] && [[ -x "\$CMUX_BUNDLED_CLI_PATH" ]] && [[ "\$CMUX_BUNDLED_CLI_PATH" != "\$0" ]]; then
   exec "\$CMUX_BUNDLED_CLI_PATH" "\$@"
 fi


### PR DESCRIPTION
Follow-up to https://github.com/manaflow-ai/cmux/pull/5308.

Changed lines in the React/Pierre diff viewer were colored by a broad `[data-line-type]` selector. That flattened syntax token colors on added/deleted code.

This keeps red/green coloring scoped to Pierre gutter surfaces and lets code token spans keep their Shiki syntax colors.

Checks run:
- `bun test`
- `bun run typecheck`
- `bun run lint:ci`
- `bun run react-doctor:ci`
- `./scripts/build-diff-viewer-app.sh`
- `./scripts/build-diff-viewer-app.sh --check`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5415"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783215322&installation_id=133855650&pr_number=5415&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5415&signature=63f1684177be4a7c7dcf1fa3712b4fbaf2a4bede5ececdc7a78a4d6598273e3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local dev ergonomics for diff viewer asset/server selection; no auth or production path changes in this diff.
> 
> **Overview**
> Threads an optional **`runtime` executable URL** through diff viewer HTML generation, deferred git sources, redirects, and asset copying so the viewer can target a specific `cmux` binary instead of always using the current process.
> 
> When the client connects via a **`cmux-debug-<tag>.sock`** socket, the CLI resolves **`~/Library/Developer/Xcode/DerivedData/cmux-<tag>/.../cmux DEV <tag>.app/.../bin/cmux`** (if executable) and uses it to **start or validate** the local diff HTTP server and to **prefer bundled `markdown-viewer/diff-viewer` assets** next to that binary, with `Bundle.main` as a fallback. Redirect pages now call **`ensureDiffViewerAssets`** with the same runtime so intermediate pages load scripts correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b7c414a7062bb0329cdcf4153bd7ed8b55e6378. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves syntax highlighting on changed diff lines, restores split diff buffer stripes, and polishes the diff viewer UI. Also pins the diff viewer server and assets to the tagged app when launched via a `cmux-debug-<tag>.sock` for consistent dev builds.

- **Bug Fixes**
  - Scoped `[data-line-type='change-addition|change-deletion']:where([data-column-number], [data-gutter-buffer])` so only gutters/line-number columns get diff colors; restored split buffer stripes via `[data-gutter-buffer='buffer']` with a softer, repeating gradient; softened buffer overlay using `color-mix(...)`.
  - Updated tests to require the scoped selectors, assert buffer stripes, forbid broad `[data-line-type] {}` rules, confirm icon stroke weights/sizes, verify toolbar spacing/right inset, check menu icon metrics, and confirm the source detail label is removed.

- **UI/Dev Ergonomics**
  - UI polish: dynamic expand/expand-all icons; theme-aware `split`/`unified` icons using addition/deletion fills; precision dots; standardized toolbar icon/button sizes; simplified files icon; moved the Files toggle into toolbar actions and adjusted the toolbar right inset; removed the files sidebar collapse button, footer totals, per-file row decorations, and the source detail label/styles.
  - Dev ergonomics: when using `cmux-debug-<tag>.sock`, pin the diff viewer HTTP server and bundled assets to the matching DerivedData app/executable; server reuse is gated on that runtime executable; asset lookup prefers paths next to that executable (with `Bundle.main` fallback); redirect pages now include assets; `scripts/reload.sh` forwards to the tagged CLI; `TerminalController` returns bundle identifier and app/CLI paths; tests verify tagged asset loading and the server executable path.

<sup>Written for commit b2df05b9d7dbabf1e07da2d633c143a269b7e1a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5415?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined diff addition/deletion visuals and SVG fill/stroke behavior for more consistent rendering and selector targeting.

* **UI**
  * Toggle now swaps between expand and collapse icons; added an expand icon and adjusted collapse/sidebar icon artwork.
  * Removed the files sidebar footer that showed diff statistics.

* **Tests**
  * Updated tests to validate the refined CSS selector and styling output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->