### PR TITLE
CmuxControlSocket: harden transport edges from PR #5365 review threads

### DIFF
--- a/Packages/CmuxControlSocket/Sources/CmuxControlSocket/Transport/SocketTransport+ClientSocket.swift
+++ b/Packages/CmuxControlSocket/Sources/CmuxControlSocket/Transport/SocketTransport+ClientSocket.swift
@@ -33,7 +33,10 @@ extension SocketTransport {
         let normalizedTimeout = max(timeout, 0)
         let seconds = floor(normalizedTimeout)
         let microseconds = (normalizedTimeout - seconds) * 1_000_000
-        return timeval(tv_sec: Int(seconds), tv_usec: Int32(microseconds.rounded()))
+        // Rounding can land exactly on 1_000_000, which is not a valid
+        // tv_usec; clamp to the last representable microsecond instead.
+        let clamped = min(Int32(microseconds.rounded()), 999_999)
+        return timeval(tv_sec: Int(seconds), tv_usec: clamped)
     }
 
     /// Applies `timeout` as both `SO_RCVTIMEO` and `SO_SNDTIMEO` (best effort).

--- a/Packages/CmuxControlSocket/Sources/CmuxControlSocket/Transport/SocketTransport+IO.swift
+++ b/Packages/CmuxControlSocket/Sources/CmuxControlSocket/Transport/SocketTransport+IO.swift
@@ -95,6 +95,9 @@ extension SocketTransport {
             let count = read(fd, &buffer, buffer.count)
             if count < 0 {
                 let readErrno = errno
+                if readErrno == EINTR {
+                    continue
+                }
                 if readErrno == EAGAIN || readErrno == EWOULDBLOCK {
                     break
                 }

--- a/Packages/CmuxControlSocket/Sources/CmuxControlSocket/Transport/SocketTransport+PathLock.swift
+++ b/Packages/CmuxControlSocket/Sources/CmuxControlSocket/Transport/SocketTransport+PathLock.swift
@@ -28,7 +28,7 @@ extension SocketTransport {
         var fd: Int32 = -1
         var lastErrno: Int32 = EIO
         for _ in 0..<3 {
-            fd = open(lockPath, O_CREAT | O_EXCL | O_RDWR | O_NOFOLLOW, S_IRUSR | S_IWUSR)
+            fd = open(lockPath, O_CREAT | O_EXCL | O_RDWR | O_NOFOLLOW | O_CLOEXEC, S_IRUSR | S_IWUSR)
             if fd >= 0 {
                 break
             }
@@ -38,7 +38,7 @@ extension SocketTransport {
                 return .failed(SocketStageFailure(stage: "open_lock", errnoCode: createErrno))
             }
 
-            fd = open(lockPath, O_RDWR | O_NOFOLLOW)
+            fd = open(lockPath, O_RDWR | O_NOFOLLOW | O_CLOEXEC)
             if fd >= 0 {
                 break
             }
@@ -176,7 +176,7 @@ extension SocketTransport {
         treatMissingLockAsAvailable: Bool
     ) -> Bool {
         let lockPath = pathLockPath(for: path)
-        let fd = open(lockPath, O_RDWR | O_NOFOLLOW)
+        let fd = open(lockPath, O_RDWR | O_NOFOLLOW | O_CLOEXEC)
         guard fd >= 0 else {
             return treatMissingLockAsAvailable && errno == ENOENT
         }

--- a/Packages/CmuxControlSocket/Tests/CmuxControlSocketTests/SocketTransportHardeningTests.swift
+++ b/Packages/CmuxControlSocket/Tests/CmuxControlSocketTests/SocketTransportHardeningTests.swift
@@ -1,0 +1,42 @@
+import Darwin
+import Foundation
+import Testing
+
+@testable import CmuxControlSocket
+
+@Suite struct SocketTransportHardeningTests {
+    let transport = SocketTransport()
+
+    @Test func socketTimeoutMicrosecondsNeverReachOneMillion() {
+        // 0.9999996s rounds to 1_000_000µs, which is not a valid tv_usec.
+        let nearOneSecond = transport.makeSocketTimeout(0.999_999_6)
+        #expect(nearOneSecond.tv_sec == 0)
+        #expect(nearOneSecond.tv_usec == 999_999)
+
+        let exact = transport.makeSocketTimeout(2.5)
+        #expect(exact.tv_sec == 2)
+        #expect(exact.tv_usec == 500_000)
+
+        let negative = transport.makeSocketTimeout(-1)
+        #expect(negative.tv_sec == 0)
+        #expect(negative.tv_usec == 0)
+    }
+
+    @Test func acquiredLockDescriptorIsCloseOnExec() throws {
+        let path = UnixSocketFixture.makeTempSocketPath()
+        defer {
+            unlink(path)
+            unlink(path + ".lock")
+        }
+
+        guard case .acquired(let fd, _) = transport.acquireSocketPathLock(for: path) else {
+            Issue.record("expected lock acquisition to succeed")
+            return
+        }
+        defer { transport.releaseSocketPathLock(fd) }
+
+        let flags = fcntl(fd, F_GETFD)
+        #expect(flags >= 0)
+        #expect(flags & FD_CLOEXEC != 0, "lock fd must not leak across fork/exec")
+    }
+}


### PR DESCRIPTION
Follow-ups to the cubic/Greptile threads on https://github.com/manaflow-ai/cmux/pull/5365 (merged):

- **probeCommand read-loop EINTR** (Greptile P1, cubic P2): an interrupted `read(2)` now retries instead of failing the probe. The write side was already fixed pre-merge via `writeAll`.
- **O_CLOEXEC on lock files** (cubic P1): all three lock-file `open(2)` calls take `O_CLOEXEC`, closing the window between `open` and the existing `fcntl(F_SETFD)` where a concurrently spawned child (cmux spawns terminals constantly) could inherit the descriptor and keep the advisory `flock` held after the parent dies.
- **tv_usec clamp** (cubic P2): `makeSocketTimeout(0.9999996)` rounded to `tv_usec = 1_000_000`, an invalid `timeval` that `setsockopt` rejects, silently dropping the timeout. Clamped to 999_999.

Rebutted (with replies on the original threads): backoff doubling overflow needs `acceptFailureMaxBackoffMs > Int.max/2` (default 5s; checked-before-doubled); the `stat_existing_path` fallback breadth is faithful pre-existing TabManager-era policy and falls back in the safe direction.

45 package tests (2 new: clamp boundary, acquired-lock fd carries `FD_CLOEXEC`). Live-verified on tag `ctl-fix`: fresh bind + reusable marker + ping + kill-9 reclaim.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5416"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783215707&installation_id=133855650&pr_number=5416&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5416&signature=02f1839a67fddcd4dfe881b064af4fced53c58721c538c1b20319707a9a9e551"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens `CmuxControlSocket` transport to prevent spurious probe failures, fd leaks across exec, and dropped socket timeouts. Improves reliability under signals and frequent process spawns.

- **Bug Fixes**
  - Retries `read` on `EINTR` in the probe command loop.
  - Opens lock files with `O_CLOEXEC` to avoid descriptor inheritance and stuck locks.
  - Clamps `timeval.tv_usec` to 999_999 so `setsockopt` accepts the timeout.

<sup>Written for commit a086b774aafa39ec941b4e39f5072305217e12c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5416?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed socket timeout calculation to prevent invalid values in edge cases.
  * Fixed socket read operations to properly retry when interrupted by system signals.

* **Improvements**
  * Enhanced file descriptor management to prevent resource leaks during process operations.

* **Tests**
  * Added comprehensive test coverage for socket transport hardening behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->