### PR TITLE
fix(zsh): propagate SIGWINCH to foreground processes after window resize

### DIFF
--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -542,21 +542,13 @@ _cmux_install_winch_guard() {
     fi
 
     TRAPWINCH() {
-        [[ -n "$CMUX_TAB_ID" ]] || return 0
-        [[ -n "$CMUX_PANEL_ID" ]] || return 0
+        [[ -n "$CMUX_TAB_ID" ]] || return 1
+        [[ -n "$CMUX_PANEL_ID" ]] || return 1
 
-        # Update $COLUMNS/$LINES after resize so the shell and any foreground
-        # program see the correct dimensions. Use zle reset-prompt instead of
-        # writing to the PTY directly to avoid making the resize look like a
-        # fresh prompt (the original concern in the comment below).
-        COLUMNS=$(tput cols 2>/dev/null || echo "$COLUMNS")
-        LINES=$(tput lines 2>/dev/null || echo "$LINES")
-        if [[ -o zle ]] && zle -l reset-prompt &>/dev/null; then
-            zle reset-prompt
-        fi
-        # Return non-zero so zsh propagates SIGWINCH to the foreground process
-        # group — this lets TUI programs (vim, htop, less, etc.) redraw to fit
-        # the new window size.
+        # Return non-zero so zsh runs its default SIGWINCH action: update
+        # $COLUMNS/$LINES via ioctl(TIOCGWINSZ), redraw the ZLE prompt, and
+        # propagate the signal to the foreground process group so TUI programs
+        # (vim, htop, less, etc.) also redraw to fit the new window size.
         return 1
     }
 

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -545,9 +545,19 @@ _cmux_install_winch_guard() {
         [[ -n "$CMUX_TAB_ID" ]] || return 0
         [[ -n "$CMUX_PANEL_ID" ]] || return 0
 
-        # Ghostty already marks prompt redraws on SIGWINCH. Writing to the PTY
-        # here grows the screen and makes resize look like a fresh prompt.
-        return 0
+        # Update $COLUMNS/$LINES after resize so the shell and any foreground
+        # program see the correct dimensions. Use zle reset-prompt instead of
+        # writing to the PTY directly to avoid making the resize look like a
+        # fresh prompt (the original concern in the comment below).
+        COLUMNS=$(tput cols 2>/dev/null || echo "$COLUMNS")
+        LINES=$(tput lines 2>/dev/null || echo "$LINES")
+        if [[ -o zle ]] && zle -l reset-prompt &>/dev/null; then
+            zle reset-prompt
+        fi
+        # Return non-zero so zsh propagates SIGWINCH to the foreground process
+        # group — this lets TUI programs (vim, htop, less, etc.) redraw to fit
+        # the new window size.
+        return 1
     }
 
     _CMUX_WINCH_GUARD_INSTALLED=1


### PR DESCRIPTION
## Summary

- `TRAPWINCH` in `cmux-zsh-integration.zsh` always returned `0`, which tells zsh the signal was fully handled and suppresses the default SIGWINCH behavior
- As a result `$COLUMNS`/`$LINES` were never updated after a resize, and foreground TUI programs (`vim`, `htop`, `less`, etc.) never received SIGWINCH to redraw themselves

## Root cause

```zsh
TRAPWINCH() {
    [[ -n "$CMUX_TAB_ID" ]] || return 0
    [[ -n "$CMUX_PANEL_ID" ]] || return 0
    # ...
    return 0   # ← always 0, swallows the signal entirely
}
```

Both guard paths and the fall-through all exit with `0`. In zsh, a `TRAPWINCH` that returns `0` means "I handled it" — zsh does not update `COLUMNS`/`LINES` or propagate SIGWINCH to the foreground process group.

## Fix

- Update `$COLUMNS`/`$LINES` via `tput` on resize
- Use `zle reset-prompt` instead of writing to the PTY directly (preserves the original motivation: avoid making resize look like a fresh prompt)
- Return `1` so zsh propagates SIGWINCH to the foreground process group

## Test plan

- [ ] Resize a cmux window while `vim` is open — editor should redraw to the new size
- [ ] Run `echo $COLUMNS` before and after resizing — value should update
- [ ] Confirm no visible "fresh prompt" flash on resize (regression guard for the original fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5417"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783216246&installation_id=133855650&pr_number=5417&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5417&signature=5da1219529496567bb4f1533f47b5533cbe9bfd5ad9bc893da13b90e096ad848"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes zsh resize handling so `$COLUMNS`/`$LINES` update and foreground TUI apps (vim, htop, less) redraw on resize without a prompt flash.

- **Bug Fixes**
  - Return `1` from `TRAPWINCH` in all paths so zsh runs its default SIGWINCH action and propagates to the foreground process, even when `CMUX_TAB_ID`/`CMUX_PANEL_ID` are unset.
  - Remove `tput` and `zle reset-prompt` calls to avoid double redraw; zsh now handles updates and prompt redraw automatically.

<sup>Written for commit 6a681427e73449a65e7dde39f846850f27369502. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed terminal resize handling so zsh's default resize behavior (prompt redraw and signal propagation to foreground processes) is preserved, preventing missed refreshes and stale prompt display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->