### PR TITLE
fix: clamp window frame when restored on same display but positioned off-screen

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -3521,10 +3521,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         } ?? false
         guard visibleMatches || frameMatches else { return false }
 
-        return frame.width.isFinite
+        guard frame.width.isFinite
             && frame.height.isFinite
             && frame.origin.x.isFinite
-            && frame.origin.y.isFinite
+            && frame.origin.y.isFinite else {
+            return false
+        }
+
+        // Even when the display ID and geometry match, the saved window position may
+        // be off-screen (e.g. the window was dragged partly off-screen, or the
+        // display was physically repositioned at the same ID/resolution). Only
+        // preserve the exact frame when enough of the top strip is accessible so the
+        // user can grab and reposition the window.
+        return shouldPreserveAccessibleFrame(frame: frame, targetDisplay: targetDisplay)
     }
 
     private nonisolated static func rectApproximatelyEqual(


### PR DESCRIPTION
## Summary

- When a cmux window was partially or fully dragged off-screen and the app was restarted, the window restored at its exact saved position — invisible, focusable but unreachable
- Root cause: `shouldPreserveExactFrame()` in `AppDelegate.swift` returned `true` (preserve exact position) whenever the saved `displayID` and display geometry matched the current display, with no check that the window was actually on-screen

## Root cause

```swift
private nonisolated static func shouldPreserveExactFrame(...) -> Bool {
    // ...display ID and geometry checks...

    // ← No visibility check! Returns true even when window is off-screen.
    return frame.width.isFinite
        && frame.height.isFinite
        && frame.origin.x.isFinite
        && frame.origin.y.isFinite
}
```

The existing `shouldPreserveAccessibleFrame()` function already implements the correct visibility check (≥120×24 px of the top strip must be visible), but `shouldPreserveExactFrame()` never called it.

## Fix

Gate the exact-frame preservation on `shouldPreserveAccessibleFrame()`. When the window's top strip is not sufficiently visible, the function returns `false` and the existing `resolvedWindowFrame()` → `clampFrame()` path runs, placing the window fully on-screen.

## How to reproduce (before fix)

1. Drag a cmux window so most of it extends beyond the right edge of the display
2. Quit cmux (`Cmd+Q`)
3. Relaunch cmux
4. The window restores off-screen: focusable but invisible, title bar unreachable

## Test plan

- [ ] Repro steps above: window should now reopen fully on-screen after relaunch
- [ ] Normal window positions (fully on-screen) restore at their exact saved position — no regression
- [ ] Window positioned mostly off-screen but with accessible top strip also restores correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5418"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783216342&installation_id=133855650&pr_number=5418&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5418&signature=cbe970ace86913a89daa9210a8d9c1def62ec704d53a7a9484b028ec0df3ebc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes windows restoring off-screen after relaunch when saved on the same display. Exact position is now preserved only if the window’s top strip is visible; otherwise the frame is clamped on-screen.

- **Bug Fixes**
  - Gate `shouldPreserveExactFrame()` on `shouldPreserveAccessibleFrame()` (requires ≥120×24 px of the top strip visible).
  - Fall back to the existing clamp/remap path when the saved frame is off-screen.
  - No change to exact-restore behavior for valid on-screen frames.

<sup>Written for commit 97ebb6fdb7ae2f434fbef91c744215402b8d1dd8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5418?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced window restoration during session recovery to validate that saved window frames are accessible on the target display, ensuring windows are always repositioned in usable screen areas rather than off-screen locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->