### PR TITLE
Recover wiped keyboard shortcuts: decode legacy StoredShortcut format (#5422)

### DIFF
--- a/Packages/CmuxSettings/Sources/CmuxSettings/Values/StoredShortcut.swift
+++ b/Packages/CmuxSettings/Sources/CmuxSettings/Values/StoredShortcut.swift
@@ -24,6 +24,29 @@ public struct StoredShortcut: Sendable, Equatable, Hashable, Codable, SettingCod
         self.second = second
     }
 
+    private enum CodingKeys: String, CodingKey {
+        case first
+        case second
+    }
+
+    /// Decodes the current nested shape and transparently recovers the legacy
+    /// flat shape persisted by cmux ≤ 0.64.10 (top-level `key` / `command` / …
+    /// / `chord*` fields). Without this, every shortcut a user customized
+    /// before the move to nested ``ShortcutStroke``s fails to decode and
+    /// silently reverts to its default.
+    /// See https://github.com/manaflow-ai/cmux/issues/5422.
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        if let first = try container.decodeIfPresent(ShortcutStroke.self, forKey: .first) {
+            self.first = first
+            self.second = try container.decodeIfPresent(ShortcutStroke.self, forKey: .second)
+            return
+        }
+        let legacy = try LegacyFlatShortcut(from: decoder)
+        self.first = legacy.firstStroke
+        self.second = legacy.secondStroke
+    }
+
     /// True when this binding is the explicit "no shortcut" marker.
     public var isUnbound: Bool { first.key.isEmpty && second == nil }
 
@@ -55,5 +78,49 @@ public struct StoredShortcut: Sendable, Equatable, Hashable, Codable, SettingCod
             return NSNull()
         }
         return object
+    }
+}
+
+/// The pre-0.64.11 on-disk shape of ``StoredShortcut``: the primary stroke's
+/// fields flat at the top level plus optional `chord*` fields for a second
+/// stroke. Decoded only as a fallback by ``StoredShortcut/init(from:)`` so
+/// bindings persisted before the move to nested ``ShortcutStroke``s survive.
+/// See https://github.com/manaflow-ai/cmux/issues/5422.
+private struct LegacyFlatShortcut: Decodable {
+    let firstStroke: ShortcutStroke
+    let secondStroke: ShortcutStroke?
+
+    private enum CodingKeys: String, CodingKey {
+        case key, command, shift, option, control, keyCode
+        case chordKey, chordCommand, chordShift, chordOption, chordControl, chordKeyCode
+    }
+
+    init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        // `key` is the legacy discriminator: every legacy value has it (an
+        // unbound binding is `key == ""`). Its absence means the payload is
+        // neither the new nor the legacy shape, so decoding throws and the
+        // caller falls back to the action's default binding.
+        let key = try c.decode(String.self, forKey: .key)
+        firstStroke = ShortcutStroke(
+            key: key,
+            command: try c.decodeIfPresent(Bool.self, forKey: .command) ?? false,
+            shift: try c.decodeIfPresent(Bool.self, forKey: .shift) ?? false,
+            option: try c.decodeIfPresent(Bool.self, forKey: .option) ?? false,
+            control: try c.decodeIfPresent(Bool.self, forKey: .control) ?? false,
+            keyCode: try c.decodeIfPresent(UInt16.self, forKey: .keyCode)
+        )
+        if let chordKey = try c.decodeIfPresent(String.self, forKey: .chordKey), !chordKey.isEmpty {
+            secondStroke = ShortcutStroke(
+                key: chordKey,
+                command: try c.decodeIfPresent(Bool.self, forKey: .chordCommand) ?? false,
+                shift: try c.decodeIfPresent(Bool.self, forKey: .chordShift) ?? false,
+                option: try c.decodeIfPresent(Bool.self, forKey: .chordOption) ?? false,
+                control: try c.decodeIfPresent(Bool.self, forKey: .chordControl) ?? false,
+                keyCode: try c.decodeIfPresent(UInt16.self, forKey: .chordKeyCode)
+            )
+        } else {
+            secondStroke = nil
+        }
     }
 }

--- a/Packages/CmuxSettings/Tests/CmuxSettingsTests/StoredShortcutLegacyDecodingTests.swift
+++ b/Packages/CmuxSettings/Tests/CmuxSettingsTests/StoredShortcutLegacyDecodingTests.swift
@@ -1,0 +1,66 @@
+import Foundation
+import Testing
+@testable import CmuxSettings
+
+/// Regression coverage for https://github.com/manaflow-ai/cmux/issues/5422.
+///
+/// `StoredShortcut` used to persist as flat fields (`key`, `command`, …,
+/// `chordKey`, …). The move to nested ``ShortcutStroke``s (`first` / `second`)
+/// in the settings-package reimplement changed the serialized shape without a
+/// legacy decoder, so every keyboard shortcut a user had customized failed to
+/// decode and silently reverted to its default. These fixtures are the real
+/// pre-0.64.11 on-disk JSON (`JSONEncoder` omits nil optionals) and must keep
+/// decoding into the equivalent nested value.
+@Suite("StoredShortcut legacy decoding")
+struct StoredShortcutLegacyDecodingTests {
+    private func decode(_ json: String) throws -> StoredShortcut {
+        try JSONDecoder().decode(StoredShortcut.self, from: Data(json.utf8))
+    }
+
+    @Test func decodesLegacySingleStroke() throws {
+        // ⌘T as persisted by cmux ≤ 0.64.10.
+        let decoded = try decode(
+            #"{"key":"t","command":true,"shift":false,"option":false,"control":false,"keyCode":17,"chordCommand":false,"chordShift":false,"chordOption":false,"chordControl":false}"#
+        )
+        #expect(decoded.first == ShortcutStroke(key: "t", command: true, keyCode: 17))
+        #expect(decoded.second == nil)
+        #expect(!decoded.isUnbound)
+    }
+
+    @Test func decodesLegacyChord() throws {
+        // A tmux-style chord (Ctrl-B then C) as persisted by cmux ≤ 0.64.10.
+        let decoded = try decode(
+            #"{"key":"b","command":false,"shift":false,"option":false,"control":true,"keyCode":11,"chordKey":"c","chordCommand":false,"chordShift":false,"chordOption":false,"chordControl":false,"chordKeyCode":8}"#
+        )
+        #expect(decoded.first == ShortcutStroke(key: "b", control: true, keyCode: 11))
+        #expect(decoded.second == ShortcutStroke(key: "c", keyCode: 8))
+        #expect(decoded.hasChord)
+    }
+
+    @Test func decodesLegacyUnbound() throws {
+        // An explicit "no shortcut" binding as persisted by cmux ≤ 0.64.10.
+        let decoded = try decode(
+            #"{"key":"","command":false,"shift":false,"option":false,"control":false,"chordCommand":false,"chordShift":false,"chordOption":false,"chordControl":false}"#
+        )
+        #expect(decoded.isUnbound)
+    }
+
+    @Test func decodeFromUserDefaultsRecoversLegacyData() {
+        // The runtime reads persisted shortcuts via this path; it must recover
+        // legacy data instead of returning nil (which reverts to the default).
+        let json =
+            #"{"key":"t","command":true,"shift":false,"option":false,"control":false,"keyCode":17,"chordCommand":false,"chordShift":false,"chordOption":false,"chordControl":false}"#
+        let recovered = StoredShortcut.decodeFromUserDefaults(Data(json.utf8))
+        #expect(recovered == StoredShortcut(first: ShortcutStroke(key: "t", command: true, keyCode: 17)))
+    }
+
+    @Test func newNestedFormatStillRoundTrips() throws {
+        // The legacy fallback must not regress the current nested format.
+        let original = StoredShortcut(
+            first: ShortcutStroke(key: "p", command: true, shift: true, keyCode: 35),
+            second: ShortcutStroke(key: "k", keyCode: 40)
+        )
+        let data = try JSONEncoder().encode(original)
+        #expect(try JSONDecoder().decode(StoredShortcut.self, from: data) == original)
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/manaflow-ai/cmux/issues/5422.

Updating to v0.64.11+ silently reverted every customized keyboard shortcut to its default. The Settings SPM reimplement ([#4975](https://github.com/manaflow-ai/cmux/pull/4975)) changed `StoredShortcut`'s persisted JSON from a flat shape to nested `first`/`second` strokes, with synthesized `Codable` and no legacy decoder. The storage key (`shortcut.<action>` in `UserDefaults`) is unchanged, so the new build reads each user's existing flat JSON, fails to decode it (`keyNotFound("first")`), swallows the error, and falls back to the default.

## Fix

A custom `StoredShortcut.init(from:)` that decodes the nested shape and falls back to the legacy flat shape (mapping the flat `key`/`command`/…/`keyCode` to `first` and `chord*` to `second`). The user's data is still in `UserDefaults` under the same key, so this recovers it non-destructively — no migration write, and encoding stays the nested format. A missing `key` (neither shape) still throws so genuinely unrecognized data falls back to the default.

This one decoder fixes every read path: `KeyboardShortcutSettingsLookup`, and the package `SettingCodable` `decodeFromUserDefaults` / `decodeFromJSON`.

## Two-commit red → green

- **Commit 1** adds the regression test. Decoding the real pre-0.64.11 flat JSON throws `keyNotFound("first")`, so the `SettingCodable` path returns nil. Red.
- **Commit 2** adds the decoder. All legacy fixtures (single stroke, chord, unbound) decode to the correct nested value, and the new nested format still round-trips. Green.

Verified locally with `swift test --package-path Packages/CmuxSettings` (4 legacy tests fail on commit 1, all 44 pass on commit 2).

The general guard going forward: a round-trip / legacy-decode test for every `Codable` type persisted in `UserDefaults` or `cmux.json`, so a future serialized-shape change can't silently wipe user data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5423"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783219437&installation_id=133855650&pr_number=5423&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5423&signature=eb01078fe26d16c8b8b3b938f906f9a1f8f0f40ffe92b76e81b9b947717f2f87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit ac32c3a40c70ba65d73ae850161b7bcc9efc60c8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores users’ customized keyboard shortcuts by decoding the legacy flat `StoredShortcut` format, so upgrades to v0.64.11+ no longer reset bindings to defaults. Data is recovered on read from the same `UserDefaults` keys; encoding stays in the new nested shape.

- **Bug Fixes**
  - Added a custom `StoredShortcut.init(from:)` that decodes the nested `first`/`second` strokes and falls back to the legacy flat `key`/`command`/.../`chord*` fields; throws only if neither shape matches.
  - Added regression tests for legacy single-stroke, chord, and unbound values, plus round-trip of the new format; covers `KeyboardShortcutSettingsLookup` and `SettingCodable` decode paths.

<sup>Written for commit ac32c3a40c70ba65d73ae850161b7bcc9efc60c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5423?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a data loss issue where keyboard shortcuts customized in earlier versions were not being properly loaded, causing them to revert to default values. All previously saved user shortcuts are now correctly preserved and restored across app updates.

* **Tests**
  * Added backward compatibility tests validating the proper loading of keyboard shortcut configurations saved in previous application versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->