### PR TITLE
Improve Claude and OpenCode notification attention

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -21390,7 +21390,12 @@ struct CMUXCLI {
                         localized: "cli.claude-hook.notification.title",
                         defaultValue: "Claude Code"
                     )
-                    let payload = notificationPayload(title: title, subtitle: completion.subtitle, body: completion.body)
+                    let payload = notificationPayload(
+                        title: title,
+                        subtitle: completion.subtitle,
+                        body: completion.body,
+                        bodyFormat: "markdown"
+                    )
                     _ = try? sendV1Command("notify_target_async \(workspaceId) \(surfaceId) \(payload)", client: client)
                 }
                 print("OK")
@@ -21535,7 +21540,12 @@ struct CMUXCLI {
                 localized: "cli.claude-hook.notification.title",
                 defaultValue: "Claude Code"
             )
-            let payload = notificationPayload(title: title, subtitle: summary.subtitle, body: summary.body)
+            let payload = notificationPayload(
+                title: title,
+                subtitle: summary.subtitle,
+                body: summary.body,
+                bodyFormat: "markdown"
+            )
 
             if let sessionId = parsedInput.sessionId {
                 try? sessionStore.upsert(
@@ -22435,7 +22445,25 @@ struct CMUXCLI {
         case "error", "codex_error_info", "codexErrorInfo", "additional_details", "additionalDetails":
             return compactClaudeHookCodexFailureValue(rawValue, key: key)
         default:
-            return compactClaudeHookStringValue(rawValue, maxLength: claudeHookCompactFieldLimit(for: key))
+            return compactClaudeHookStringValue(
+                rawValue,
+                maxLength: claudeHookCompactFieldLimit(for: key),
+                preserveWhitespace: claudeHookCompactFieldPreservesRichText(key)
+            )
+        }
+    }
+
+    private func claudeHookCompactFieldPreservesRichText(_ key: String) -> Bool {
+        switch key {
+        case "last_assistant_message", "lastAssistantMessage",
+             "assistantPreamble", "assistant_preamble",
+             "assistant_response", "assistantResponse",
+             "summary", "message", "body", "text", "prompt",
+             "description", "user_message", "userMessage",
+             "command", "plan":
+            return true
+        default:
+            return false
         }
     }
 
@@ -22475,14 +22503,17 @@ struct CMUXCLI {
     private func compactClaudeHookStringValue(
         _ rawValue: Any?,
         maxLength: Int,
-        keepSuffix: Bool = false
+        keepSuffix: Bool = false,
+        preserveWhitespace: Bool = false
     ) -> String? {
         guard let rawString = rawValue as? String else { return nil }
         let previewLength = max(maxLength, min(maxLength * 4, 1024))
         let preview = keepSuffix
             ? String(rawString.suffix(previewLength))
             : String(rawString.prefix(previewLength))
-        let normalized = normalizedSingleLine(preview)
+        let normalized = preserveWhitespace
+            ? redactClaudeSensitiveSpans(preview).trimmingCharacters(in: .whitespacesAndNewlines)
+            : normalizedSingleLine(redactClaudeSensitiveSpans(preview))
         guard !normalized.isEmpty else { return nil }
         if keepSuffix, normalized.count > maxLength {
             return "…" + String(normalized.suffix(maxLength - 1))
@@ -23931,9 +23962,8 @@ struct CMUXCLI {
             firstString(in: nested, keys: ["message", "body", "text", "prompt", "error", "description"])
         ]
         let message = messageCandidates.compactMap { $0 }.first ?? "Claude needs your input"
-        let normalizedMessage = normalizedSingleLine(message)
         let signal = signalParts.compactMap { $0 }.joined(separator: " ")
-        var classified = classifyClaudeNotification(signal: signal, message: normalizedMessage)
+        var classified = classifyClaudeNotification(signal: signal, message: message)
 
         classified.body = truncate(classified.body, maxLength: 180)
         return classified
@@ -23970,9 +24000,9 @@ struct CMUXCLI {
             firstString(in: nested, keys: ["type", "kind", "reason"]),
         ]
         let messageCandidates = [
-            firstString(in: object, keys: ["message", "body", "text", "prompt", "summary", "description", "error", "title"]),
-            firstString(in: nested, keys: ["message", "body", "text", "prompt", "summary", "description", "error", "title"]),
-            firstString(in: extra, keys: ["message", "body", "text", "prompt", "summary", "description", "error", "title"]),
+            firstString(in: object, keys: ["last_assistant_message", "lastAssistantMessage", "assistant_response", "assistantResponse", "message", "body", "text", "prompt", "summary", "description", "error", "title"]),
+            firstString(in: nested, keys: ["last_assistant_message", "lastAssistantMessage", "assistant_response", "assistantResponse", "message", "body", "text", "prompt", "summary", "description", "error", "title"]),
+            firstString(in: extra, keys: ["last_assistant_message", "lastAssistantMessage", "assistant_response", "assistantResponse", "message", "body", "text", "prompt", "summary", "description", "error", "title"]),
         ]
         let fallbackBody = String.localizedStringWithFormat(
             String(localized: "agent.generic.notification.body.sentNotification", defaultValue: "%@ sent a notification"),
@@ -24010,7 +24040,7 @@ struct CMUXCLI {
         return classifyAgentHookNotification(
             def: def,
             signal: signal,
-            message: normalizedMessage,
+            message: message,
             isFallback: message == fallbackBody
         )
     }
@@ -24034,7 +24064,7 @@ struct CMUXCLI {
         }
         return AgentHookNotificationSummary(
             subtitle: String(localized: "agent.generic.notification.subtitle.completed", defaultValue: "Completed"),
-            body: truncate(normalizedSingleLine(body), maxLength: 180),
+            body: truncate(body, maxLength: 180),
             status: .idle,
             isFallback: false
         )
@@ -24074,9 +24104,9 @@ struct CMUXCLI {
         let nested = (object["notification"] as? [String: Any]) ?? (object["data"] as? [String: Any]) ?? [:]
         let extra = (object["extra"] as? [String: Any]) ?? [:]
         let messageCandidates = [
-            firstString(in: object, keys: ["message", "body", "text", "prompt", "summary", "description", "error", "title"]),
-            firstString(in: nested, keys: ["message", "body", "text", "prompt", "summary", "description", "error", "title"]),
-            firstString(in: extra, keys: ["message", "body", "text", "prompt", "summary", "description", "error", "title"]),
+            firstString(in: object, keys: ["last_assistant_message", "lastAssistantMessage", "assistant_response", "assistantResponse", "message", "body", "text", "prompt", "summary", "description", "error", "title"]),
+            firstString(in: nested, keys: ["last_assistant_message", "lastAssistantMessage", "assistant_response", "assistantResponse", "message", "body", "text", "prompt", "summary", "description", "error", "title"]),
+            firstString(in: extra, keys: ["last_assistant_message", "lastAssistantMessage", "assistant_response", "assistantResponse", "message", "body", "text", "prompt", "summary", "description", "error", "title"]),
         ]
         return messageCandidates.compactMap { $0 }.first.map(normalizedSingleLine)
     }
@@ -24116,9 +24146,9 @@ struct CMUXCLI {
                   let text = extractMessageText(from: object) else {
                 continue
             }
-            let normalized = normalizedSingleLine(text)
-            if !normalized.isEmpty {
-                return normalized
+            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !normalizedSingleLine(trimmed).isEmpty {
+                return trimmed
             }
         }
         return nil
@@ -24409,8 +24439,35 @@ struct CMUXCLI {
             .replacingOccurrences(of: "|", with: "¦")
     }
 
-    private func notificationPayload(title: String, subtitle: String, body: String) -> String {
-        "\(sanitizeNotificationField(title))|\(sanitizeNotificationField(subtitle))|\(sanitizeNotificationField(body))"
+    private func notificationPayload(
+        title: String,
+        subtitle: String,
+        body: String,
+        bodyFormat: String = "plain"
+    ) -> String {
+        guard bodyFormat != "plain" else {
+            return "\(sanitizeNotificationField(title))|\(sanitizeNotificationField(subtitle))|\(sanitizeNotificationField(body))"
+        }
+        let object: [String: Any] = [
+            "title": sanitizeNotificationField(title),
+            "subtitle": sanitizeNotificationField(subtitle),
+            "body": body.trimmingCharacters(in: .whitespacesAndNewlines),
+            "body_format": bodyFormat,
+        ]
+        guard let data = try? JSONSerialization.data(withJSONObject: object, options: []) else {
+            return "\(sanitizeNotificationField(title))|\(sanitizeNotificationField(subtitle))|\(sanitizeNotificationField(body))"
+        }
+        return "json64:\(data.base64EncodedString())"
+    }
+
+    private func notificationBodyNeedsRichFormat(_ body: String) -> Bool {
+        let trimmed = body.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        if trimmed.contains("\n") || trimmed.contains("\r") {
+            return true
+        }
+        let markdownMarkers = ["**", "__", "`", "](", "# ", "- ", "* ", "> "]
+        return markdownMarkers.contains { trimmed.contains($0) }
     }
 
     private func redactClaudeSensitiveSpans(_ value: String) -> String {
@@ -24943,7 +25000,15 @@ struct CMUXCLI {
         environment: [String: String]?
     ) -> String {
         var commandParts: [String] = []
-        commandParts.append(contentsOf: argv)
+        let wrapped = claudeWrapperResumeCommandPartsIfNeeded(argv: argv, kind: kind)
+        if !wrapped.additionalEnvironment.isEmpty {
+            commandParts.append("env")
+            for key in wrapped.additionalEnvironment.keys.sorted() {
+                guard let value = wrapped.additionalEnvironment[key] else { continue }
+                commandParts.append("\(key)=\(value)")
+            }
+        }
+        commandParts.append(contentsOf: wrapped.argv)
 
         let cwd = normalizedHookValue(workingDirectory)
         let sanitizedCommandParts = AgentLaunchSanitizer.removingSavedWorkingDirectoryOptions(
@@ -24966,6 +25031,44 @@ struct CMUXCLI {
             return "{ cd -- \(quotedCwd) 2>/dev/null || [ ! -d \(quotedCwd) ]; } && \(command)"
         }
         return command
+    }
+
+    private func claudeWrapperResumeCommandPartsIfNeeded(
+        argv: [String],
+        kind: String
+    ) -> (argv: [String], additionalEnvironment: [String: String]) {
+        guard kind == "claude",
+              !argv.isEmpty,
+              !isClaudeTeamsCommand(argv),
+              let wrapperPath = currentBundledClaudeWrapperPath(),
+              let claudeExecutable = normalizedHookValue(argv.first),
+              claudeExecutable != wrapperPath else {
+            return (argv, [:])
+        }
+        return (
+            [wrapperPath] + Array(argv.dropFirst()),
+            ["CMUX_CUSTOM_CLAUDE_PATH": claudeExecutable]
+        )
+    }
+
+    private func isClaudeTeamsCommand(_ argv: [String]) -> Bool {
+        guard argv.count >= 2 else { return false }
+        return argv[1] == "claude-teams"
+    }
+
+    private func currentBundledClaudeWrapperPath() -> String? {
+        guard let cmuxPath = normalizedHookValue(ProcessInfo.processInfo.environment["CMUX_BUNDLED_CLI_PATH"]),
+              (cmuxPath as NSString).lastPathComponent == "cmux" else {
+            return nil
+        }
+        let wrapperPath = URL(fileURLWithPath: cmuxPath)
+            .deletingLastPathComponent()
+            .appendingPathComponent("claude", isDirectory: false)
+            .path
+        guard FileManager.default.isExecutableFile(atPath: wrapperPath) else {
+            return nil
+        }
+        return wrapperPath
     }
 
     private func hermesAgentSubrouterResumeCommand(
@@ -25411,6 +25514,95 @@ function sendHook(subcommand, ctx, event, extra = {}) {
   } catch (_) {}
 }
 
+function normalizeSDKResponse(response, fallback) {
+  if (response == null) return fallback;
+  if (Array.isArray(response)) return response;
+  if (typeof response === "object" && "data" in response && response.data != null) {
+    return response.data;
+  }
+  return fallback;
+}
+
+function textFromMessage(message) {
+  const parts = Array.isArray(message && message.parts) ? message.parts : [];
+  return parts
+    .filter((part) => part && part.type === "text" && typeof part.text === "string")
+    .map((part) => part.text.trim())
+    .filter(Boolean)
+    .join("\n");
+}
+
+function latestAssistantMessageText(messages) {
+  if (!Array.isArray(messages)) return null;
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (!message || message.info?.role !== "assistant") continue;
+    if (message.info?.error) continue;
+    const text = firstString(textFromMessage(message));
+    if (text) return text;
+  }
+  return null;
+}
+
+async function latestAssistantMessage(ctx, event) {
+  const sessionId = sessionIdFor(event);
+  if (!sessionId || typeof ctx?.client?.session?.messages !== "function") return null;
+  try {
+    const response = await ctx.client.session.messages({
+      path: { id: sessionId },
+      query: { directory: cwdFor(ctx, event) },
+    });
+    return latestAssistantMessageText(normalizeSDKResponse(response, []));
+  } catch (_) {
+    return null;
+  }
+}
+
+const CMUX_STOP_SENT_KEY = Symbol.for("cmux.opencode.stopSent");
+const CMUX_SESSION_ENDED_KEY = Symbol.for("cmux.opencode.sessionEnded");
+
+function stopSentSet() {
+  if (!globalThis[CMUX_STOP_SENT_KEY]) {
+    globalThis[CMUX_STOP_SENT_KEY] = new Set();
+  }
+  return globalThis[CMUX_STOP_SENT_KEY];
+}
+
+function endedSessionSet() {
+  if (!globalThis[CMUX_SESSION_ENDED_KEY]) {
+    globalThis[CMUX_SESSION_ENDED_KEY] = new Set();
+  }
+  return globalThis[CMUX_SESSION_ENDED_KEY];
+}
+
+function markSessionActive(event) {
+  const sessionId = sessionIdFor(event);
+  if (!sessionId) return;
+  const key = String(sessionId);
+  stopSentSet().delete(key);
+  endedSessionSet().delete(key);
+}
+
+function markSessionEnded(event) {
+  const sessionId = sessionIdFor(event);
+  if (!sessionId) return;
+  const key = String(sessionId);
+  stopSentSet().delete(key);
+  endedSessionSet().add(key);
+}
+
+async function sendStopOnce(ctx, event) {
+  const sessionId = sessionIdFor(event);
+  if (!sessionId) return;
+  const key = String(sessionId);
+  if (endedSessionSet().has(key)) return;
+  const sent = stopSentSet();
+  if (sent.has(key)) return;
+  sent.add(key);
+  const message = await latestAssistantMessage(ctx, event);
+  sendHook("stop", ctx, event, { last_assistant_message: message || undefined });
+}
+
 const CMUXSessionRestore = async (ctx) => {
   if (globalThis[CMUX_PLUGIN_INSTALLED_KEY]) return {};
   globalThis[CMUX_PLUGIN_INSTALLED_KEY] = true;
@@ -25419,25 +25611,30 @@ const CMUXSessionRestore = async (ctx) => {
       const props = eventProperties(event);
       switch (event && event.type) {
         case "session.created":
+          markSessionActive(event);
           sendHook("session-start", ctx, event);
           break;
         case "session.updated":
           if (props.info && props.info.time && props.info.time.archived) {
             sendHook("session-end", ctx, event);
+            markSessionEnded(event);
           } else {
-            sendHook("session-start", ctx, event);
+            markSessionActive(event);
           }
           break;
         case "session.status":
           if (props.status && props.status.type === "idle") {
-            sendHook("stop", ctx, event);
+            await sendStopOnce(ctx, event);
+          } else if (props.status && props.status.type) {
+            markSessionActive(event);
           }
           break;
         case "session.idle":
-          sendHook("stop", ctx, event);
+          await sendStopOnce(ctx, event);
           break;
         case "session.deleted":
           sendHook("session-end", ctx, event);
+          markSessionEnded(event);
           break;
         default:
           break;
@@ -28068,8 +28265,8 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
             }
             let body = codexFailure?.body
                 ?? antigravityFailure?.body
-                ?? lastMsg.map { truncate(normalizedSingleLine($0), maxLength: 200) }
-                ?? grokAssistantMessage.map { truncate(normalizedSingleLine($0), maxLength: 200) }
+                ?? lastMsg.map { truncate($0, maxLength: 200) }
+                ?? grokAssistantMessage.map { truncate($0, maxLength: 200) }
                 ?? String.localizedStringWithFormat(
                     String(
                         localized: "agent.codex.completion.body.sessionCompleted",
@@ -28193,7 +28390,12 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                 telemetry.breadcrumb("\(def.name)-hook.stop.subagent-notification-suppressed")
             }
             if shouldPublishStopAlert, shouldSendNotification(fingerprint: notificationFingerprint) {
-                let payload = notificationPayload(title: def.displayName, subtitle: subtitle, body: body)
+                let payload = notificationPayload(
+                    title: def.displayName,
+                    subtitle: subtitle,
+                    body: body,
+                    bodyFormat: "markdown"
+                )
                 let notifyCommand = "notify_target_async \(workspaceId) \(surfaceId) \(payload)"
 #if DEBUG
                 agentHookDebugLog(
@@ -28505,7 +28707,12 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
 
             let notificationFingerprint = notificationDedupeFingerprint(status: summary.status)
             if shouldSendNotification(fingerprint: notificationFingerprint) {
-                let payload = notificationPayload(title: def.displayName, subtitle: summary.subtitle, body: summary.body)
+                let payload = notificationPayload(
+                    title: def.displayName,
+                    subtitle: summary.subtitle,
+                    body: summary.body,
+                    bodyFormat: "markdown"
+                )
                 let notifyCommand = "notify_target_async \(workspaceId) \(surfaceId) \(payload)"
 #if DEBUG
                 agentHookDebugLog(

--- a/Resources/bin/claude
+++ b/Resources/bin/claude
@@ -479,10 +479,188 @@ fi
 # - SubagentStop: feed telemetry only. It must not run the visible Stop
 #   hook because a subagent finishing should not notify like the parent.
 HOOKS_JSON='{"preferredNotifChannel":"notifications_disabled","hooks":{"SessionStart":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude session-start","timeout":10}]}],"Stop":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude stop","timeout":10}]},{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks feed --source claude","timeout":10,"async":true}]}],"SubagentStop":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks feed --source claude","timeout":10,"async":true}]}],"SessionEnd":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude session-end","timeout":1}]}],"Notification":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude notification","timeout":10}]}],"UserPromptSubmit":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude prompt-submit","timeout":10}]}],"PreToolUse":[{"matcher":"CronCreate","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude cron-create-guard","timeout":5}]},{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude pre-tool-use","timeout":5,"async":true}]}],"PermissionRequest":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks feed --source claude","timeout":125}]}]}}'
+MERGED_USER_SETTINGS=false
+
+merge_user_claude_settings_if_present() {
+    local user_settings=""
+    local consumed_by_option=""
+    local arg
+    for arg in "$@"; do
+        if [[ -n "$consumed_by_option" ]]; then
+            if [[ "$consumed_by_option" == "--settings" && -z "$user_settings" ]]; then
+                user_settings="$arg"
+            fi
+            consumed_by_option=""
+            continue
+        fi
+        [[ "$arg" == "--" ]] && break
+        case "$arg" in
+            --settings=*)
+                if [[ -z "$user_settings" ]]; then
+                    user_settings="${arg#--settings=}"
+                fi
+                ;;
+            --settings)
+                consumed_by_option="--settings"
+                ;;
+            --*=*)
+                ;;
+            -*)
+                if claude_option_consumes_value "$arg"; then
+                    consumed_by_option="$arg"
+                fi
+                ;;
+            *)
+                break
+                ;;
+        esac
+    done
+    [[ -n "$user_settings" ]] || return 0
+    command -v node >/dev/null 2>&1 || return 0
+
+    local merged
+    merged="$(CMUX_CLAUDE_WRAPPER_SETTINGS="$HOOKS_JSON" CMUX_CLAUDE_USER_SETTINGS="$user_settings" node <<'NODE'
+const fs = require("fs");
+const path = require("path");
+
+function expandPath(value) {
+  if (value === "~") return process.env.HOME || value;
+  if (value.startsWith("~/")) return path.join(process.env.HOME || "", value.slice(2));
+  return value;
+}
+
+function parseSettings(value) {
+  const trimmed = String(value || "").trim();
+  if (!trimmed) throw new Error("empty settings");
+  try {
+    return JSON.parse(trimmed);
+  } catch (_) {
+    const data = fs.readFileSync(expandPath(trimmed), "utf8");
+    return JSON.parse(data);
+  }
+}
+
+function isObject(value) {
+  return value && typeof value === "object" && !Array.isArray(value);
+}
+
+function mergeHooks(cmuxHooks, userHooks) {
+  if (!isObject(cmuxHooks)) return isObject(userHooks) ? userHooks : cmuxHooks;
+  if (!isObject(userHooks)) return cmuxHooks;
+  const merged = { ...cmuxHooks };
+  for (const [event, userGroups] of Object.entries(userHooks)) {
+    const cmuxGroups = merged[event];
+    if (Array.isArray(cmuxGroups) && Array.isArray(userGroups)) {
+      merged[event] = [...cmuxGroups, ...userGroups];
+    } else {
+      merged[event] = userGroups;
+    }
+  }
+  return merged;
+}
+
+const cmuxSettings = JSON.parse(process.env.CMUX_CLAUDE_WRAPPER_SETTINGS || "{}");
+const userSettings = parseSettings(process.env.CMUX_CLAUDE_USER_SETTINGS || "");
+if (!isObject(userSettings)) throw new Error("settings must be an object");
+const merged = { ...userSettings, ...cmuxSettings };
+merged.hooks = mergeHooks(cmuxSettings.hooks, userSettings.hooks);
+process.stdout.write(JSON.stringify(merged));
+NODE
+)" || return 0
+    [[ -n "$merged" ]] || return 0
+    HOOKS_JSON="$merged"
+    MERGED_USER_SETTINGS=true
+}
+
+merge_user_claude_settings_if_present "$@"
+
+CLAUDE_ARGS=("$@")
+if [[ "$MERGED_USER_SETTINGS" == true ]]; then
+    stripped_settings=false
+    consumed_by_option=""
+    scan_options=true
+    rewritten_args=()
+    for arg in "$@"; do
+        if [[ -n "$consumed_by_option" ]]; then
+            if [[ "$consumed_by_option" == "--settings" && "$stripped_settings" == true ]]; then
+                consumed_by_option=""
+                continue
+            fi
+            rewritten_args+=("$arg")
+            consumed_by_option=""
+            continue
+        fi
+        if [[ "$scan_options" == true && "$stripped_settings" == false ]]; then
+            case "$arg" in
+                --settings=*)
+                    stripped_settings=true
+                    continue
+                    ;;
+                --settings)
+                    stripped_settings=true
+                    consumed_by_option="--settings"
+                    continue
+                    ;;
+            esac
+        fi
+        rewritten_args+=("$arg")
+        if [[ "$scan_options" == true ]]; then
+            if [[ "$arg" == "--" ]]; then
+                scan_options=false
+                continue
+            fi
+            case "$arg" in
+                --*=*)
+                    ;;
+                -*)
+                    if claude_option_consumes_value "$arg"; then
+                        consumed_by_option="$arg"
+                    fi
+                    ;;
+                *)
+                    scan_options=false
+                    ;;
+            esac
+        fi
+    done
+    CLAUDE_ARGS=("${rewritten_args[@]}")
+fi
+
+SETTINGS_ARG="$HOOKS_JSON"
+if [[ "$MERGED_USER_SETTINGS" == true ]]; then
+    settings_file="$(mktemp "${TMPDIR:-/tmp}/cmux-claude-settings.XXXXXX")" || {
+        echo "cmux claude wrapper: failed to create merged settings file" >&2
+        exec "$REAL_CLAUDE" "${CLAUDE_ARGS[@]}"
+    }
+    chmod 600 "$settings_file" 2>/dev/null || true
+    if ! printf '%s' "$HOOKS_JSON" > "$settings_file"; then
+        rm -f "$settings_file"
+        echo "cmux claude wrapper: failed to write merged settings file" >&2
+        exec "$REAL_CLAUDE" "${CLAUDE_ARGS[@]}"
+    fi
+    SETTINGS_ARG="$settings_file"
+fi
+
+if [[ "$MERGED_USER_SETTINGS" == true ]]; then
+    cleanup_merged_settings() {
+        rm -f "$SETTINGS_ARG"
+    }
+    trap cleanup_merged_settings EXIT INT TERM
+    if [[ "$SKIP_SESSION_ID" == true ]]; then
+        "$REAL_CLAUDE" --settings "$SETTINGS_ARG" "${CLAUDE_ARGS[@]}"
+    else
+        SESSION_ID="$(uuidgen | tr '[:upper:]' '[:lower:]')"
+        "$REAL_CLAUDE" --session-id "$SESSION_ID" --settings "$SETTINGS_ARG" "${CLAUDE_ARGS[@]}"
+    fi
+    exit_code=$?
+    cleanup_merged_settings
+    trap - EXIT INT TERM
+    exit "$exit_code"
+fi
 
 if [[ "$SKIP_SESSION_ID" == true ]]; then
-    exec "$REAL_CLAUDE" --settings "$HOOKS_JSON" "$@"
+    exec "$REAL_CLAUDE" --settings "$SETTINGS_ARG" "${CLAUDE_ARGS[@]}"
 else
     SESSION_ID="$(uuidgen | tr '[:upper:]' '[:lower:]')"
-    exec "$REAL_CLAUDE" --session-id "$SESSION_ID" --settings "$HOOKS_JSON" "$@"
+    exec "$REAL_CLAUDE" --session-id "$SESSION_ID" --settings "$SETTINGS_ARG" "${CLAUDE_ARGS[@]}"
 fi

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -11715,10 +11715,8 @@ struct VerticalTabsSidebar: View {
             remoteDisplayTarget: workspace.remoteDisplayTarget,
             remoteConnectionState: workspace.remoteConnectionState.rawValue,
             unreadCount: notificationStore.unreadCount(forTabId: workspace.id),
-            latestNotificationText: notificationStore.latestNotification(forTabId: workspace.id).flatMap {
-                let text = $0.body.isEmpty ? $0.title : $0.body
-                return text.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
-            },
+            latestNotificationText: notificationStore.latestNotification(forTabId: workspace.id)
+                .flatMap(TerminalNotificationStore.sidebarPreviewText(for:)),
             latestSubmittedMessage: workspace.latestSubmittedMessage,
             latestSubmittedAt: workspace.latestSubmittedAt,
             listeningPorts: workspace.listeningPorts,
@@ -12488,9 +12486,7 @@ struct VerticalTabsSidebar: View {
                   let notification = notificationStore.latestNotification(forTabId: tab.id) else {
                 return nil
             }
-            let text = notification.body.isEmpty ? notification.title : notification.body
-            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-            return trimmed.isEmpty ? nil : trimmed
+            return TerminalNotificationStore.sidebarPreviewText(for: notification)
         }()
         let liveShowsModifierShortcutHints = modifierKeyMonitor.isModifierPressed
         let resolvedShowsModifierShortcutHints = SidebarShortcutHintFreezePolicy.resolved(

--- a/Sources/Feed/AttentionTarget.swift
+++ b/Sources/Feed/AttentionTarget.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+struct AttentionTarget: Sendable {
+    let workspaceId: UUID
+    let surfaceId: UUID?
+    let statusKey: String
+    let previousStatusEntry: SidebarStatusEntry?
+    let previousLifecycle: AgentHibernationLifecycleState?
+}

--- a/Sources/Feed/FeedCoordinator.swift
+++ b/Sources/Feed/FeedCoordinator.swift
@@ -25,6 +25,7 @@ final class FeedCoordinator: @unchecked Sendable {
     /// handler signals the semaphore after filling the slot.
     private let waiterLock = NSLock()
     private var waiters: [String: PendingWaiter] = [:]
+    @MainActor private var attentionTargets: [String: AttentionTarget] = [:]
 
     /// One kqueue-backed DispatchSource per distinct agent PID we've
     /// ever seen. The kernel fires `.exit` the instant the process
@@ -118,6 +119,7 @@ final class FeedCoordinator: @unchecked Sendable {
                 if let ppid = event.ppid, ppid > 0 {
                     FeedCoordinator.shared.armPidWatcher(ppid: ppid)
                 }
+                FeedCoordinator.shared.surfaceBlockingDecisionAttention(event: event, requestId: requestId)
                 #if DEBUG
                 FeedCoordinatorTestHooks.afterBlockingEventIngested?(event, requestId)
                 #endif
@@ -139,14 +141,17 @@ final class FeedCoordinator: @unchecked Sendable {
         switch waitResult {
         case .success:
             if let decision = w?.decision {
+                clearBlockingDecisionAttention(requestId: requestId)
                 return .resolved(itemId: itemIdSlot.value, decision: decision)
             }
             cancelNotification(requestId: requestId)
             expireTimedOutItem(itemIdSlot.value)
+            clearBlockingDecisionAttention(requestId: requestId)
             return .timedOut(itemId: itemIdSlot.value)
         case .timedOut:
             cancelNotification(requestId: requestId)
             expireTimedOutItem(itemIdSlot.value)
+            clearBlockingDecisionAttention(requestId: requestId)
             return .timedOut(itemId: itemIdSlot.value)
         }
     }
@@ -177,6 +182,7 @@ final class FeedCoordinator: @unchecked Sendable {
         }
 
         cancelNotification(requestId: requestId)
+        clearBlockingDecisionAttention(requestId: requestId)
     }
 
     fileprivate func isAwaitingDecision(requestId: String) -> Bool {
@@ -219,6 +225,173 @@ final class FeedCoordinator: @unchecked Sendable {
         }
     }
 
+    @MainActor
+    private func surfaceBlockingDecisionAttention(event: WorkstreamEvent, requestId: String) {
+        guard Self.isBlockingDecision(event),
+              let statusKey = Self.statusKey(for: event.source),
+              let target = resolveAttentionTarget(event: event, statusKey: statusKey)
+        else { return }
+
+        #if DEBUG
+        FeedCoordinatorTestHooks.attentionObserver?(event, requestId, statusKey, target.workspaceId, target.surfaceId)
+        #endif
+
+        guard let manager = Self.tabManager(containing: target.workspaceId),
+              let workspace = manager.tabs.first(where: { $0.id == target.workspaceId })
+        else { return }
+
+        let existingWorkspaceStatusTarget = attentionTargets.values.first {
+            $0.workspaceId == target.workspaceId &&
+                $0.statusKey == target.statusKey
+        }
+        let existingPanelLifecycleTarget = attentionTargets.values.first {
+            $0.workspaceId == target.workspaceId &&
+                $0.surfaceId == target.surfaceId &&
+                $0.statusKey == target.statusKey
+        }
+        let resolvedTarget = AttentionTarget(
+            workspaceId: target.workspaceId,
+            surfaceId: target.surfaceId,
+            statusKey: target.statusKey,
+            previousStatusEntry: existingWorkspaceStatusTarget?.previousStatusEntry ?? workspace.statusEntries[statusKey],
+            previousLifecycle: existingPanelLifecycleTarget?.previousLifecycle ?? target.surfaceId.flatMap {
+                workspace.agentLifecycle(key: target.statusKey, panelId: $0)
+            }
+        )
+        attentionTargets[requestId] = resolvedTarget
+
+        workspace.statusEntries[statusKey] = SidebarStatusEntry(
+            key: statusKey,
+            value: String(localized: "feed.status.needsInput", defaultValue: "Needs input"),
+            icon: "bell.fill",
+            color: "#4C8DFF",
+            priority: 100
+        )
+        if let surfaceId = target.surfaceId {
+            workspace.setAgentLifecycle(
+                key: statusKey,
+                panelId: surfaceId,
+                lifecycle: .needsInput
+            )
+        }
+        if WorkspaceAutoReorderSettings.isEnabled() {
+            manager.moveTabToTopForNotification(target.workspaceId)
+        }
+        NSApp.requestUserAttention(.informationalRequest)
+    }
+
+    private func clearBlockingDecisionAttention(requestId: String) {
+        Task { @MainActor in
+            FeedCoordinator.shared.clearBlockingDecisionAttentionOnMain(requestId: requestId)
+        }
+    }
+
+    @MainActor
+    private func clearBlockingDecisionAttentionOnMain(requestId: String) {
+        guard let target = attentionTargets.removeValue(forKey: requestId),
+              let manager = Self.tabManager(containing: target.workspaceId),
+              let workspace = manager.tabs.first(where: { $0.id == target.workspaceId })
+        else { return }
+        let hasWorkspaceSiblingPendingDecision = attentionTargets.values.contains {
+            $0.workspaceId == target.workspaceId &&
+                $0.statusKey == target.statusKey
+        }
+        let hasPanelSiblingPendingDecision = attentionTargets.values.contains {
+            $0.workspaceId == target.workspaceId &&
+                $0.surfaceId == target.surfaceId &&
+                $0.statusKey == target.statusKey
+        }
+        if !hasWorkspaceSiblingPendingDecision,
+           let entry = workspace.statusEntries[target.statusKey],
+           entry.value == String(localized: "feed.status.needsInput", defaultValue: "Needs input"),
+           entry.icon == "bell.fill",
+           entry.color == "#4C8DFF" {
+            if let previousStatusEntry = target.previousStatusEntry {
+                workspace.statusEntries[target.statusKey] = previousStatusEntry
+            } else {
+                workspace.statusEntries.removeValue(forKey: target.statusKey)
+            }
+        }
+        if !hasPanelSiblingPendingDecision,
+           let surfaceId = target.surfaceId,
+           workspace.agentLifecycle(key: target.statusKey, panelId: surfaceId) == .needsInput {
+            if let previousLifecycle = target.previousLifecycle {
+                workspace.setAgentLifecycle(key: target.statusKey, panelId: surfaceId, lifecycle: previousLifecycle)
+            } else {
+                _ = workspace.clearAgentLifecycle(key: target.statusKey, panelId: surfaceId)
+            }
+        }
+    }
+
+    @MainActor
+    private func resolveAttentionTarget(event: WorkstreamEvent, statusKey: String) -> AttentionTarget? {
+        let resolved = FeedJumpResolver.parse(event.sessionId).flatMap {
+            FeedJumpResolver.lookup(agent: $0.agent, sessionId: $0.sessionId)
+        }
+        if let workspaceId = event.workspaceId.flatMap(UUID.init(uuidString:)) {
+            var resolvedSurfaceId: UUID?
+            if resolved?.workspaceId == workspaceId.uuidString {
+                resolvedSurfaceId = resolved.flatMap { UUID(uuidString: $0.surfaceId) }
+            }
+            return AttentionTarget(
+                workspaceId: workspaceId,
+                surfaceId: resolvedSurfaceId,
+                statusKey: statusKey,
+                previousStatusEntry: nil,
+                previousLifecycle: nil
+            )
+        }
+        let workspaceString = resolved?.workspaceId
+        guard let workspaceId = workspaceString.flatMap(UUID.init(uuidString:)) else { return nil }
+        let surfaceId = resolved.flatMap { UUID(uuidString: $0.surfaceId) }
+        return AttentionTarget(
+            workspaceId: workspaceId,
+            surfaceId: surfaceId,
+            statusKey: statusKey,
+            previousStatusEntry: nil,
+            previousLifecycle: nil
+        )
+    }
+
+    @MainActor
+    private static func tabManager(containing workspaceId: UUID) -> TabManager? {
+        guard let app = AppDelegate.shared else { return nil }
+        if let manager = app.tabManagerFor(tabId: workspaceId) {
+            return manager
+        }
+        if let manager = app.tabManager,
+           manager.tabs.contains(where: { $0.id == workspaceId }) {
+            return manager
+        }
+        return nil
+    }
+
+    private static func isBlockingDecision(_ event: WorkstreamEvent) -> Bool {
+        switch event.hookEventName {
+        case .permissionRequest, .askUserQuestion, .exitPlanMode:
+            return event.requestId != nil
+        default:
+            return false
+        }
+    }
+
+    private static func statusKey(for source: String) -> String? {
+        switch source {
+        case "claude", "claude_code":
+            return "claude_code"
+        case "agy":
+            return "antigravity"
+        case "rovo":
+            return "rovodev"
+        case "amp", "antigravity", "codebuddy", "codex", "copilot", "cursor", "factory", "gemini", "grok", "kiro", "opencode", "pi", "qoder", "rovodev":
+            return source
+        case "hermes", "hermes-agent":
+            return "hermes-agent"
+        default:
+            return nil
+        }
+    }
+
     enum IngestBlockingResult {
         case acknowledged(itemId: UUID?)
         case resolved(itemId: UUID?, decision: WorkstreamDecision)
@@ -251,6 +424,7 @@ enum FeedCoordinatorTestHooks {
     static var afterBlockingEventIngested: (@Sendable (WorkstreamEvent, String) -> Void)?
     static var isAppActiveOverride: (@Sendable () -> Bool)?
     static var notificationPostObserver: (@Sendable (WorkstreamEvent, String) -> Void)?
+    static var attentionObserver: (@Sendable (WorkstreamEvent, String, String, UUID, UUID?) -> Void)?
 }
 #endif
 
@@ -335,7 +509,37 @@ enum FeedJumpResolver {
         let surfaceId: String
     }
 
+    private static let knownAgentPrefixes = [
+        "hermes-agent",
+        "antigravity",
+        "codebuddy",
+        "claude_code",
+        "rovodev",
+        "claude",
+        "cursor",
+        "factory",
+        "gemini",
+        "opencode",
+        "codex",
+        "grok",
+        "kiro",
+        "qoder",
+        "copilot",
+        "hermes",
+        "agy",
+        "amp",
+        "rovo",
+        "pi",
+    ]
+
     static func parse(_ workstreamId: String) -> (agent: String, sessionId: String)? {
+        for agent in knownAgentPrefixes {
+            let prefix = "\(agent)-"
+            guard workstreamId.hasPrefix(prefix) else { continue }
+            let sessionId = String(workstreamId.dropFirst(prefix.count))
+            guard !sessionId.isEmpty else { return nil }
+            return (agent, sessionId)
+        }
         guard let dash = workstreamId.firstIndex(of: "-") else { return nil }
         let agent = String(workstreamId[..<dash])
         let sessionId = String(workstreamId[workstreamId.index(after: dash)...])

--- a/Sources/NotificationBodyText.swift
+++ b/Sources/NotificationBodyText.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+struct NotificationBodyText: View {
+    private static let maxMarkdownBodyCharacters = 4_096
+
+    let notification: TerminalNotification
+    let font: Font
+    let color: Color
+    let lineLimit: Int
+
+    var body: some View {
+        bodyText
+            .font(font)
+            .foregroundColor(color)
+            .lineLimit(lineLimit)
+    }
+
+    @ViewBuilder
+    private var bodyText: some View {
+        if notification.bodyFormat == .markdown,
+           notification.body.count <= Self.maxMarkdownBodyCharacters,
+           let attributed = try? AttributedString(markdown: notification.body) {
+            Text(attributed)
+        } else {
+            Text(notification.body)
+        }
+    }
+}

--- a/Sources/NotificationsPage.swift
+++ b/Sources/NotificationsPage.swift
@@ -240,10 +240,12 @@ private struct NotificationRow: View {
                         }
 
                         if !notification.body.isEmpty {
-                            Text(notification.body)
-                                .font(.subheadline)
-                                .foregroundColor(.secondary)
-                                .lineLimit(3)
+                            NotificationBodyText(
+                                notification: notification,
+                                font: .subheadline,
+                                color: .secondary,
+                                lineLimit: 3
+                            )
                         }
 
                         if let tabTitle {

--- a/Sources/ParsedNotificationPayload.swift
+++ b/Sources/ParsedNotificationPayload.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+struct ParsedNotificationPayload {
+    let title: String
+    let subtitle: String
+    let body: String
+    let bodyFormat: TerminalNotificationBodyFormat
+}

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -353,12 +353,21 @@ enum AgentResumeCommandBuilder {
         includeWorkingDirectoryPrefix: Bool
     ) -> String {
         var commandParts: [String] = []
-        let environmentParts = launchEnvironmentParts(kind: kind, environment: launchCommand?.environment)
+        let wrapped = claudeWrapperResumeCommandPartsIfNeeded(
+            argv: argv,
+            kind: kind,
+            launchCommand: launchCommand
+        )
+        let environmentParts = launchEnvironmentParts(
+            kind: kind,
+            environment: launchCommand?.environment,
+            additionalEnvironment: wrapped.additionalEnvironment
+        )
         if !environmentParts.isEmpty {
             commandParts.append("env")
             commandParts.append(contentsOf: environmentParts)
         }
-        commandParts.append(contentsOf: argv)
+        commandParts.append(contentsOf: wrapped.argv)
 
         let cwd = !includeWorkingDirectoryPrefix || customRegistration?.cwd == .ignore
             ? nil
@@ -389,15 +398,19 @@ enum AgentResumeCommandBuilder {
 
     private static func launchEnvironmentParts(
         kind: RestorableAgentKind,
-        environment: [String: String]?
+        environment: [String: String]?,
+        additionalEnvironment: [String: String] = [:]
     ) -> [String] {
-        guard let environment, !environment.isEmpty else {
+        guard environment?.isEmpty == false || !additionalEnvironment.isEmpty else {
             return []
         }
 
         var environmentParts: [String] = []
         var preservedClaudeAuthSelectionEnvironmentKeys: [String] = []
-        let selectedEnvironment = AgentLaunchEnvironmentPolicy.selectedEnvironment(from: environment, kind: kind.rawValue)
+        var selectedEnvironment = AgentLaunchEnvironmentPolicy.selectedEnvironment(from: environment ?? [:], kind: kind.rawValue)
+        for (key, value) in additionalEnvironment {
+            selectedEnvironment[key] = value
+        }
         for key in selectedEnvironment.keys.sorted() {
             guard let value = selectedEnvironment[key] else { continue }
             environmentParts.append("\(key)=\(value)")
@@ -413,6 +426,53 @@ enum AgentResumeCommandBuilder {
             )
         }
         return environmentParts
+    }
+
+    private static func claudeWrapperResumeCommandPartsIfNeeded(
+        argv: [String],
+        kind: RestorableAgentKind,
+        launchCommand: AgentLaunchCommandSnapshot?
+    ) -> (argv: [String], additionalEnvironment: [String: String]) {
+        guard kind == .claude,
+              launchCommand?.launcher != "claudeTeams",
+              !argv.isEmpty,
+              !isClaudeTeamsCommand(argv),
+              let wrapperPath = currentBundledClaudeWrapperPath(),
+              let claudeExecutable = normalized(argv.first),
+              claudeExecutable != wrapperPath else {
+            return (argv, [:])
+        }
+        return (
+            [wrapperPath] + Array(argv.dropFirst()),
+            ["CMUX_CUSTOM_CLAUDE_PATH": claudeExecutable]
+        )
+    }
+
+    private static func isClaudeTeamsCommand(_ argv: [String]) -> Bool {
+        guard argv.count >= 2 else { return false }
+        return argv[1] == "claude-teams"
+    }
+
+    private static func currentBundledClaudeWrapperPath() -> String? {
+        if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] == nil,
+           let bundlePath = normalized(Bundle.main.resourceURL?.appendingPathComponent("bin/claude").path),
+           (bundlePath as NSString).lastPathComponent == "claude",
+           FileManager.default.isExecutableFile(atPath: bundlePath) {
+            return bundlePath
+        }
+        guard let path = normalized(ProcessInfo.processInfo.environment["CMUX_BUNDLED_CLI_PATH"]),
+              (path as NSString).lastPathComponent == "cmux" else {
+            return nil
+        }
+        let wrapperPath = URL(fileURLWithPath: path)
+            .deletingLastPathComponent()
+            .appendingPathComponent("claude", isDirectory: false)
+            .path
+        guard FileManager.default.isExecutableFile(atPath: wrapperPath)
+                || ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil else {
+            return nil
+        }
+        return wrapperPath
     }
 
     private static func resumeArguments(

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -356,6 +356,92 @@ nonisolated struct SurfaceResumeBindingSnapshot: Codable, Equatable, Sendable {
         detectedBinding.isProcessDetected && (isProcessDetected || isAgentHookBinding)
     }
 
+    func replacingDirectClaudeResumeWithBundledWrapperIfNeeded() -> SurfaceResumeBindingSnapshot {
+        guard kind == "claude",
+              source == "agent-hook",
+              let wrapperPath = Self.currentBundledClaudeWrapperPath(),
+              let tokens = SurfaceResumeCommandCanonicalizer.tokens(from: command),
+              let resumeIndex = tokens.firstIndex(of: "--resume"),
+              let executableIndex = Self.claudeExecutableIndex(beforeResumeIndex: resumeIndex, in: tokens),
+              resumeIndex + 1 < tokens.count else {
+            return self
+        }
+
+        let executable = tokens[executableIndex]
+        guard (executable as NSString).lastPathComponent != "cmux",
+              executable != wrapperPath,
+              !(executableIndex > 0 && tokens[tokens.index(before: executableIndex)] == "claude-teams") else {
+            return self
+        }
+
+        let sessionId = tokens[resumeIndex + 1]
+        let preResumeArguments = Array(tokens[tokens.index(after: executableIndex)..<resumeIndex])
+        let preservedArguments = Array(tokens.dropFirst(resumeIndex + 2))
+        let wrappedParts = [wrapperPath] + preResumeArguments + ["--resume", sessionId] + preservedArguments
+        let wrappedCommand = wrappedParts.map(Self.shellSingleQuoted).joined(separator: " ")
+        let wrappedCommandWithCwd = TerminalStartupWorkingDirectoryPrefix.prefix(
+            wrappedCommand,
+            workingDirectory: cwd
+        )
+        var wrappedEnvironment = environment ?? [:]
+        for (key, value) in Self.inlineEnvironmentAssignments(beforeExecutableIndex: executableIndex, in: tokens) {
+            wrappedEnvironment[key] = value
+        }
+        wrappedEnvironment["CMUX_CUSTOM_CLAUDE_PATH"] = executable
+        return SurfaceResumeBindingSnapshot(
+            name: name,
+            kind: kind,
+            command: wrappedCommandWithCwd,
+            cwd: cwd,
+            checkpointId: checkpointId,
+            source: source,
+            environment: wrappedEnvironment,
+            autoResume: autoResume,
+            approvalPolicy: approvalPolicy,
+            approvalRecordId: approvalRecordId,
+            updatedAt: updatedAt
+        )
+    }
+
+    private static func claudeExecutableIndex(beforeResumeIndex resumeIndex: Int, in tokens: [String]) -> Int? {
+        let commandStart = tokens.lastIndex(of: "&&").map { tokens.index(after: $0) } ?? tokens.startIndex
+        guard commandStart < resumeIndex else { return nil }
+        var index = commandStart
+        if tokens[index] == "env" || tokens[index] == "/usr/bin/env" {
+            index = tokens.index(after: index)
+            while index < resumeIndex, tokens[index].contains("="), !tokens[index].hasPrefix("-") {
+                index = tokens.index(after: index)
+            }
+        }
+        guard index < resumeIndex,
+              (tokens[index] as NSString).lastPathComponent == "claude" else {
+            return nil
+        }
+        return index
+    }
+
+    private static func inlineEnvironmentAssignments(beforeExecutableIndex executableIndex: Int, in tokens: [String]) -> [String: String] {
+        let commandStart = tokens.lastIndex(of: "&&").map { tokens.index(after: $0) } ?? tokens.startIndex
+        guard commandStart < executableIndex,
+              (tokens[commandStart] == "env" || tokens[commandStart] == "/usr/bin/env") else {
+            return [:]
+        }
+
+        var result: [String: String] = [:]
+        var index = tokens.index(after: commandStart)
+        while index < executableIndex, tokens[index].contains("="), !tokens[index].hasPrefix("-") {
+            let token = tokens[index]
+            if let separator = token.firstIndex(of: "=") {
+                let key = String(token[..<separator])
+                if !key.isEmpty {
+                    result[key] = String(token[token.index(after: separator)...])
+                }
+            }
+            index = tokens.index(after: index)
+        }
+        return result
+    }
+
     static let maxInlineStartupInputBytes = SessionRestorableAgentSnapshot.maxInlineStartupInputBytes
 
     var startupInput: String? {
@@ -454,6 +540,28 @@ nonisolated struct SurfaceResumeBindingSnapshot: Codable, Equatable, Sendable {
 
     private static func isSafeEnvironmentValue(_ value: String) -> Bool {
         !value.unicodeScalars.contains { $0.value < 0x20 || $0.value == 0x7F }
+    }
+
+    private static func currentBundledClaudeWrapperPath() -> String? {
+        if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] == nil,
+           let bundlePath = normalized(Bundle.main.resourceURL?.appendingPathComponent("bin/claude").path),
+           (bundlePath as NSString).lastPathComponent == "claude",
+           FileManager.default.isExecutableFile(atPath: bundlePath) {
+            return bundlePath
+        }
+        guard let path = normalized(ProcessInfo.processInfo.environment["CMUX_BUNDLED_CLI_PATH"]),
+              (path as NSString).lastPathComponent == "cmux" else {
+            return nil
+        }
+        let wrapperPath = URL(fileURLWithPath: path)
+            .deletingLastPathComponent()
+            .appendingPathComponent("claude", isDirectory: false)
+            .path
+        guard FileManager.default.isExecutableFile(atPath: wrapperPath)
+                || ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil else {
+            return nil
+        }
+        return wrapperPath
     }
 
     private static func isSensitiveEnvironmentKey(_ key: String) -> Bool {
@@ -1636,6 +1744,7 @@ struct SessionNotificationSnapshot: Codable, Sendable {
     var title: String
     var subtitle: String
     var body: String
+    var bodyFormat: TerminalNotificationBodyFormat?
     var createdAt: TimeInterval
     var isRead: Bool
     var paneFlash: Bool?
@@ -1646,6 +1755,7 @@ struct SessionNotificationSnapshot: Codable, Sendable {
         title: String,
         subtitle: String,
         body: String,
+        bodyFormat: TerminalNotificationBodyFormat? = nil,
         createdAt: TimeInterval,
         isRead: Bool,
         paneFlash: Bool? = nil,
@@ -1655,6 +1765,7 @@ struct SessionNotificationSnapshot: Codable, Sendable {
         self.title = title
         self.subtitle = subtitle
         self.body = body
+        self.bodyFormat = bodyFormat
         self.createdAt = createdAt
         self.isRead = isRead
         self.paneFlash = paneFlash
@@ -1667,6 +1778,7 @@ struct SessionNotificationSnapshot: Codable, Sendable {
             title: notification.title,
             subtitle: notification.subtitle,
             body: notification.body,
+            bodyFormat: notification.bodyFormat == .plain ? nil : notification.bodyFormat,
             createdAt: notification.createdAt.timeIntervalSince1970,
             isRead: notification.isRead,
             paneFlash: notification.paneFlash,
@@ -1683,6 +1795,7 @@ struct SessionNotificationSnapshot: Codable, Sendable {
             title: title,
             subtitle: subtitle,
             body: body,
+            bodyFormat: bodyFormat ?? .plain,
             createdAt: Date(timeIntervalSince1970: createdAt),
             isRead: isRead,
             paneFlash: paneFlash ?? true,

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -5078,11 +5078,8 @@ class TerminalController {
         rootPath: String?,
         projectRootPath: String?
     ) -> [String: Any] {
-        let latestNotificationText = TerminalNotificationStore.shared.latestNotification(forTabId: workspace.id).flatMap {
-            let text = $0.body.isEmpty ? $0.title : $0.body
-            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-            return trimmed.isEmpty ? nil : trimmed
-        }
+        let latestNotificationText = TerminalNotificationStore.shared.latestNotification(forTabId: workspace.id)
+            .flatMap(TerminalNotificationStore.sidebarPreviewText(for:))
         return [
             "id": workspace.id.uuidString,
             "ref": v2Ref(kind: .workspace, uuid: workspace.id),
@@ -10534,6 +10531,12 @@ class TerminalController {
 
     // MARK: - V2 Notification Methods
 
+    private static func v2NotificationBodyFormat(_ value: Any?) -> TerminalNotificationBodyFormat {
+        let rawValue = ((value as? String) ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return TerminalNotificationBodyFormat(rawValue: rawValue) ?? .plain
+    }
+
     private func v2NotificationCreate(params: [String: Any]) -> V2CallResult {
         guard let tabManager = v2ResolveTabManager(params: params) else {
             return .err(code: "unavailable", message: "TabManager not available", data: nil)
@@ -10543,6 +10546,7 @@ class TerminalController {
         let title = (params["title"] as? String) ?? "Notification"
         let subtitle = (params["subtitle"] as? String) ?? ""
         let body = (params["body"] as? String) ?? ""
+        let bodyFormat = Self.v2NotificationBodyFormat(params["body_format"])
 
         var result: V2CallResult = .err(code: "internal_error", message: "Failed to notify", data: nil)
         v2MainSync {
@@ -10564,7 +10568,8 @@ class TerminalController {
                 surfaceId: surfaceId,
                 title: title,
                 subtitle: subtitle,
-                body: body
+                body: body,
+                bodyFormat: bodyFormat
             )
             result = .ok(["workspace_id": ws.id.uuidString, "surface_id": v2OrNull(surfaceId?.uuidString)])
         }
@@ -10582,6 +10587,7 @@ class TerminalController {
         let title = (params["title"] as? String) ?? "Notification"
         let subtitle = (params["subtitle"] as? String) ?? ""
         let body = (params["body"] as? String) ?? ""
+        let bodyFormat = Self.v2NotificationBodyFormat(params["body_format"])
 
         var result: V2CallResult = .err(code: "internal_error", message: "Failed to notify", data: nil)
         v2MainSync {
@@ -10598,7 +10604,8 @@ class TerminalController {
                 surfaceId: surfaceId,
                 title: title,
                 subtitle: subtitle,
-                body: body
+                body: body,
+                bodyFormat: bodyFormat
             )
             result = .ok(["workspace_id": ws.id.uuidString, "workspace_ref": v2Ref(kind: .workspace, uuid: ws.id), "surface_id": surfaceId.uuidString, "surface_ref": v2Ref(kind: .surface, uuid: surfaceId), "window_id": v2OrNull(v2ResolveWindowId(tabManager: tabManager)?.uuidString), "window_ref": v2Ref(kind: .window, uuid: v2ResolveWindowId(tabManager: tabManager))])
         }
@@ -10619,6 +10626,7 @@ class TerminalController {
         let title = (params["title"] as? String) ?? "Notification"
         let subtitle = (params["subtitle"] as? String) ?? ""
         let body = (params["body"] as? String) ?? ""
+        let bodyFormat = Self.v2NotificationBodyFormat(params["body_format"])
 
         var result: V2CallResult = .err(code: "internal_error", message: "Failed to notify", data: nil)
         v2MainSync {
@@ -10635,7 +10643,8 @@ class TerminalController {
                 surfaceId: surfaceId,
                 title: title,
                 subtitle: subtitle,
-                body: body
+                body: body,
+                bodyFormat: bodyFormat
             )
             result = .ok(["workspace_id": ws.id.uuidString, "workspace_ref": v2Ref(kind: .workspace, uuid: ws.id), "surface_id": surfaceId.uuidString, "surface_ref": v2Ref(kind: .surface, uuid: surfaceId), "window_id": v2OrNull(v2ResolveWindowId(tabManager: tabManager)?.uuidString), "window_ref": v2Ref(kind: .window, uuid: v2ResolveWindowId(tabManager: tabManager))])
         }
@@ -10854,6 +10863,7 @@ class TerminalController {
             "title": notification.title,
             "subtitle": notification.subtitle,
             "body": notification.body,
+            "body_format": notification.bodyFormat.rawValue,
             "created_at": Self.notificationCreatedAtString(notification.createdAt),
             "tab_title": v2OrNull(AppDelegate.shared?.tabTitle(for: notification.tabId)),
         ]
@@ -17871,13 +17881,14 @@ class TerminalController {
                 return
             }
             let surfaceId = tabManager.focusedSurfaceId(for: tabId)
-            let (title, subtitle, body) = parseNotificationPayload(args)
+            let parsedPayload = parseNotificationPayload(args)
             deliverNotificationSynchronously(
                 tabId: tabId,
                 surfaceId: surfaceId,
-                title: title,
-                subtitle: subtitle,
-                body: body
+                title: parsedPayload.title,
+                subtitle: parsedPayload.subtitle,
+                body: parsedPayload.body,
+                bodyFormat: parsedPayload.bodyFormat
             )
         }
         return result
@@ -17903,13 +17914,14 @@ class TerminalController {
                 result = "ERROR: Surface not found"
                 return
             }
-            let (title, subtitle, body) = parseNotificationPayload(payload)
+            let parsedPayload = parseNotificationPayload(payload)
             deliverNotificationSynchronously(
                 tabId: tabId,
                 surfaceId: surfaceId,
-                title: title,
-                subtitle: subtitle,
-                body: body
+                title: parsedPayload.title,
+                subtitle: parsedPayload.subtitle,
+                body: parsedPayload.body,
+                bodyFormat: parsedPayload.bodyFormat
             )
         }
         return result
@@ -17926,7 +17938,7 @@ class TerminalController {
         let tabArg = parts[0]
         let panelArg = parts[1]
         let payload = parts.count > 2 ? parts[2] : ""
-        let (title, subtitle, body) = parseNotificationPayload(payload)
+        let parsedPayload = parseNotificationPayload(payload)
 
         if let workspaceId = UUID(uuidString: tabArg),
            let panelId = UUID(uuidString: panelArg) {
@@ -17943,9 +17955,10 @@ class TerminalController {
                 deliverNotificationSynchronously(
                     tabId: workspaceId,
                     surfaceId: panelId,
-                    title: title,
-                    subtitle: subtitle,
-                    body: body
+                    title: parsedPayload.title,
+                    subtitle: parsedPayload.subtitle,
+                    body: parsedPayload.body,
+                    bodyFormat: parsedPayload.bodyFormat
                 )
             }
             return result
@@ -17971,9 +17984,10 @@ class TerminalController {
             deliverNotificationSynchronously(
                 tabId: tab.id,
                 surfaceId: panelId,
-                title: title,
-                subtitle: subtitle,
-                body: body
+                title: parsedPayload.title,
+                subtitle: parsedPayload.subtitle,
+                body: parsedPayload.body,
+                bodyFormat: parsedPayload.bodyFormat
             )
         }
         return result
@@ -18000,18 +18014,19 @@ class TerminalController {
         guard !payload.isEmpty else {
             return "ERROR: Usage: notify_target_async <workspace_uuid> <surface_uuid> <title>|<subtitle>|<body>"
         }
-        let (title, subtitle, body) = parseNotificationPayload(payload)
+        let parsedPayload = parseNotificationPayload(payload)
 #if DEBUG
         cmuxDebugLog(
-            "socket.notifyTargetAsync.enqueue workspace=\(tabId.uuidString.prefix(8)) surface=\(surfaceId.uuidString.prefix(8)) titleLen=\(title.count) subtitleLen=\(subtitle.count) bodyLen=\(body.count) coalesces=0"
+            "socket.notifyTargetAsync.enqueue workspace=\(tabId.uuidString.prefix(8)) surface=\(surfaceId.uuidString.prefix(8)) titleLen=\(parsedPayload.title.count) subtitleLen=\(parsedPayload.subtitle.count) bodyLen=\(parsedPayload.body.count) bodyFormat=\(parsedPayload.bodyFormat.rawValue) coalesces=0"
         )
 #endif
         TerminalMutationBus.shared.enqueueNotification(
             tabId: tabId,
             surfaceId: surfaceId,
-            title: title,
-            subtitle: subtitle,
-            body: body,
+            title: parsedPayload.title,
+            subtitle: parsedPayload.subtitle,
+            body: parsedPayload.body,
+            bodyFormat: parsedPayload.bodyFormat,
             coalesces: false
         )
         return "OK"
@@ -18025,11 +18040,22 @@ class TerminalController {
                 let readText = notification.isRead ? "read" : "unread"
                 let createdAt = Self.notificationCreatedAtString(notification.createdAt)
                 let tabTitle = Self.notificationListTrailingField(AppDelegate.shared?.tabTitle(for: notification.tabId) ?? "")
-                return "\(index):\(notification.id.uuidString)|\(notification.tabId.uuidString)|\(surfaceText)|\(readText)|\(notification.title)|\(notification.subtitle)|\(notification.body)|\(createdAt)|\(tabTitle)"
+                let title = Self.notificationListField(notification.title)
+                let subtitle = Self.notificationListField(notification.subtitle)
+                let body = Self.notificationListField(notification.body)
+                return "\(index):\(notification.id.uuidString)|\(notification.tabId.uuidString)|\(surfaceText)|\(readText)|\(title)|\(subtitle)|\(body)|\(createdAt)|\(tabTitle)"
             }
             result = lines.joined(separator: "\n")
         }
         return result.isEmpty ? "No notifications" : result
+    }
+
+    private static func notificationListField(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\r\n", with: "\\n")
+            .replacingOccurrences(of: "\r", with: "\\n")
+            .replacingOccurrences(of: "\n", with: "\\n")
+            .replacingOccurrences(of: "|", with: "%7C")
     }
 
     private func clearNotifications(_ args: String) -> String {
@@ -18778,16 +18804,42 @@ class TerminalController {
         return nil
     }
 
-    private func parseNotificationPayload(_ args: String) -> (String, String, String) {
+    private func parseNotificationPayload(_ args: String) -> ParsedNotificationPayload {
         let trimmed = args.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return ("Notification", "", "") }
+        guard !trimmed.isEmpty else {
+            return ParsedNotificationPayload(title: "Notification", subtitle: "", body: "", bodyFormat: .plain)
+        }
+        if trimmed.hasPrefix("json64:"),
+           let data = Data(base64Encoded: String(trimmed.dropFirst("json64:".count))),
+           let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            let title = ((object["title"] as? String) ?? "")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let subtitle = ((object["subtitle"] as? String) ?? "")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let body = ((object["body"] as? String) ?? "")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let rawFormat = ((object["body_format"] as? String) ?? "")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let bodyFormat = TerminalNotificationBodyFormat(rawValue: rawFormat) ?? .plain
+            return ParsedNotificationPayload(
+                title: title.isEmpty ? "Notification" : title,
+                subtitle: subtitle,
+                body: body,
+                bodyFormat: bodyFormat
+            )
+        }
         let parts = trimmed.split(separator: "|", maxSplits: 2, omittingEmptySubsequences: false).map(String.init)
         let title = parts.count > 0 ? parts[0].trimmingCharacters(in: .whitespacesAndNewlines) : ""
         let subtitle = parts.count > 2 ? parts[1].trimmingCharacters(in: .whitespacesAndNewlines) : ""
         let body = parts.count > 2
             ? parts[2].trimmingCharacters(in: .whitespacesAndNewlines)
             : (parts.count > 1 ? parts[1].trimmingCharacters(in: .whitespacesAndNewlines) : "")
-        return (title.isEmpty ? "Notification" : title, subtitle, body)
+        return ParsedNotificationPayload(
+            title: title.isEmpty ? "Notification" : title,
+            subtitle: subtitle,
+            body: body,
+            bodyFormat: .plain
+        )
     }
 
     private func closeWorkspace(_ tabId: String) -> String {

--- a/Sources/TerminalNotificationBodyFormat.swift
+++ b/Sources/TerminalNotificationBodyFormat.swift
@@ -1,0 +1,4 @@
+enum TerminalNotificationBodyFormat: String, Codable, Sendable, Hashable {
+    case plain
+    case markdown
+}

--- a/Sources/TerminalNotificationPolicy.swift
+++ b/Sources/TerminalNotificationPolicy.swift
@@ -8,6 +8,33 @@ struct TerminalNotificationPolicyPayload: Codable, Sendable, Equatable {
     var title: String
     var subtitle: String
     var body: String
+    var bodyFormat: TerminalNotificationBodyFormat = .plain
+
+    init(
+        workspaceId: String,
+        surfaceId: String?,
+        title: String,
+        subtitle: String,
+        body: String,
+        bodyFormat: TerminalNotificationBodyFormat = .plain
+    ) {
+        self.workspaceId = workspaceId
+        self.surfaceId = surfaceId
+        self.title = title
+        self.subtitle = subtitle
+        self.body = body
+        self.bodyFormat = bodyFormat
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        workspaceId = try container.decode(String.self, forKey: .workspaceId)
+        surfaceId = try container.decodeIfPresent(String.self, forKey: .surfaceId)
+        title = try container.decode(String.self, forKey: .title)
+        subtitle = try container.decode(String.self, forKey: .subtitle)
+        body = try container.decode(String.self, forKey: .body)
+        bodyFormat = try container.decodeIfPresent(TerminalNotificationBodyFormat.self, forKey: .bodyFormat) ?? .plain
+    }
 }
 
 struct TerminalNotificationPolicyContext: Codable, Sendable, Equatable {
@@ -93,6 +120,7 @@ private struct TerminalNotificationPolicyPayloadPatch: Decodable {
     var title: String?
     var subtitle: String?
     var body: String?
+    var bodyFormat: TerminalNotificationBodyFormat?
 
     private enum CodingKeys: String, CodingKey {
         case workspaceId
@@ -100,6 +128,7 @@ private struct TerminalNotificationPolicyPayloadPatch: Decodable {
         case title
         case subtitle
         case body
+        case bodyFormat
     }
 
     init(from decoder: Decoder) throws {
@@ -109,6 +138,7 @@ private struct TerminalNotificationPolicyPayloadPatch: Decodable {
         title = try container.decodeIfNonNullValuePresent(String.self, forKey: .title)
         subtitle = try container.decodeIfNonNullValuePresent(String.self, forKey: .subtitle)
         body = try container.decodeIfNonNullValuePresent(String.self, forKey: .body)
+        bodyFormat = try container.decodeIfNonNullValuePresent(TerminalNotificationBodyFormat.self, forKey: .bodyFormat)
     }
 
     func merged(into payload: TerminalNotificationPolicyPayload) -> TerminalNotificationPolicyPayload {
@@ -127,6 +157,9 @@ private struct TerminalNotificationPolicyPayloadPatch: Decodable {
         }
         if let body {
             merged.body = body
+        }
+        if let bodyFormat {
+            merged.bodyFormat = bodyFormat
         }
         return merged
     }
@@ -192,6 +225,7 @@ struct TerminalNotificationPolicyRequest: Sendable {
     let title: String
     let subtitle: String
     let body: String
+    let bodyFormat: TerminalNotificationBodyFormat
     let cwd: String?
     let isAppFocused: Bool
     let isFocusedPanel: Bool
@@ -203,6 +237,7 @@ struct TerminalNotificationPolicyRequest: Sendable {
         title: String,
         subtitle: String,
         body: String,
+        bodyFormat: TerminalNotificationBodyFormat = .plain,
         cwd: String?,
         isAppFocused: Bool,
         isFocusedPanel: Bool
@@ -213,6 +248,7 @@ struct TerminalNotificationPolicyRequest: Sendable {
         self.title = title
         self.subtitle = subtitle
         self.body = body
+        self.bodyFormat = bodyFormat
         self.cwd = cwd
         self.isAppFocused = isAppFocused
         self.isFocusedPanel = isFocusedPanel
@@ -238,7 +274,8 @@ enum TerminalNotificationPolicyEngine {
                 surfaceId: request.surfaceId?.uuidString,
                 title: request.title,
                 subtitle: request.subtitle,
-                body: request.body
+                body: request.body,
+                bodyFormat: request.bodyFormat
             ),
             context: TerminalNotificationPolicyContext(
                 cwd: request.cwd,

--- a/Sources/TerminalNotificationQueue.swift
+++ b/Sources/TerminalNotificationQueue.swift
@@ -10,6 +10,7 @@ fileprivate struct QueuedTerminalNotification: Sendable {
     let title: String
     let subtitle: String
     let body: String
+    let bodyFormat: TerminalNotificationBodyFormat
 }
 
 fileprivate enum TerminalSocketMutation {
@@ -51,13 +52,15 @@ final class TerminalMutationBus: @unchecked Sendable {
         title: String,
         subtitle: String,
         body: String,
+        bodyFormat: TerminalNotificationBodyFormat = .plain,
         coalesces: Bool = true
     ) {
         enqueueNotification(QueuedTerminalNotification(
             key: QueuedTerminalNotificationKey(tabId: tabId, surfaceId: surfaceId),
             title: title,
             subtitle: subtitle,
-            body: body
+            body: body,
+            bodyFormat: bodyFormat
         ), coalesces: coalesces)
     }
 
@@ -360,7 +363,8 @@ extension TerminalController {
         surfaceId: UUID?,
         title: String,
         subtitle: String,
-        body: String
+        body: String,
+        bodyFormat: TerminalNotificationBodyFormat = .plain
     ) {
         TerminalMutationBus.shared.discardPendingNotifications(forTabId: tabId, surfaceId: surfaceId)
 #if DEBUG
@@ -373,7 +377,8 @@ extension TerminalController {
             surfaceId: surfaceId,
             title: title,
             subtitle: subtitle,
-            body: body
+            body: body,
+            bodyFormat: bodyFormat
         )
     }
 }
@@ -398,7 +403,8 @@ extension TerminalNotificationStore {
             surfaceId: notification.key.surfaceId,
             title: notification.title,
             subtitle: notification.subtitle,
-            body: notification.body
+            body: notification.body,
+            bodyFormat: notification.bodyFormat
         )
     }
 

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -699,6 +699,7 @@ struct TerminalNotification: Identifiable, Hashable {
     let title: String
     let subtitle: String
     let body: String
+    let bodyFormat: TerminalNotificationBodyFormat
     let createdAt: Date
     var isRead: Bool
     var paneFlash: Bool = true
@@ -712,6 +713,7 @@ struct TerminalNotification: Identifiable, Hashable {
         title: String,
         subtitle: String,
         body: String,
+        bodyFormat: TerminalNotificationBodyFormat = .plain,
         createdAt: Date,
         isRead: Bool,
         paneFlash: Bool = true,
@@ -724,6 +726,7 @@ struct TerminalNotification: Identifiable, Hashable {
         self.title = title
         self.subtitle = subtitle
         self.body = body
+        self.bodyFormat = bodyFormat
         self.createdAt = createdAt
         self.isRead = isRead
         self.paneFlash = paneFlash
@@ -758,6 +761,24 @@ final class TerminalNotificationStore: ObservableObject {
 
     static let categoryIdentifier = "com.cmuxterm.app.userNotification"
     static let actionShowIdentifier = "com.cmuxterm.app.userNotification.show"
+    static let codingAgentNotificationTitles: Set<String> = [
+        "Antigravity",
+        "Amp",
+        "Claude Code",
+        "CodeBuddy",
+        "Codex",
+        "Copilot",
+        "Cursor",
+        "Factory",
+        "Gemini",
+        "Grok",
+        "Hermes Agent",
+        "Kiro",
+        "OpenCode",
+        "Pi",
+        "Qoder",
+        "Rovo Dev",
+    ]
     private enum AuthorizationRequestOrigin: String {
         case notificationDelivery = "notification_delivery"
         case settingsButton = "settings_button"
@@ -1140,6 +1161,30 @@ final class TerminalNotificationStore: ObservableObject {
         indexes.latestByTabId[tabId]
     }
 
+    static func sidebarPreviewText(for notification: TerminalNotification) -> String? {
+        let title = notification.title.trimmingCharacters(in: .whitespacesAndNewlines)
+        if codingAgentNotificationTitles.contains(title) {
+            for value in [notification.body, notification.subtitle, notification.title] {
+                let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !trimmed.isEmpty, !isGenericCodingAgentNotificationBody(trimmed) else {
+                    continue
+                }
+                return trimmed
+            }
+        }
+        let preferredText = notification.body.isEmpty ? notification.title : notification.body
+        let trimmed = preferredText.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func isGenericCodingAgentNotificationBody(_ value: String) -> Bool {
+        let lower = value.lowercased()
+        return lower == "task completed"
+            || lower == "session completed"
+            || lower.hasSuffix(" session completed")
+            || lower.hasSuffix(" sent a notification")
+    }
+
     func notifications(forTabId tabId: UUID, surfaceId: UUID?) -> [TerminalNotification] {
         notifications.filter { $0.matches(tabId: tabId, surfaceId: surfaceId) }
     }
@@ -1159,6 +1204,7 @@ final class TerminalNotificationStore: ObservableObject {
         title: String,
         subtitle: String,
         body: String,
+        bodyFormat: TerminalNotificationBodyFormat = .plain,
         cooldownKey: String? = nil,
         cooldownInterval: TimeInterval? = nil,
         clickAction: TerminalNotificationClickAction? = nil
@@ -1199,7 +1245,8 @@ final class TerminalNotificationStore: ObservableObject {
             surfaceId: surfaceId,
             title: title,
             subtitle: subtitle,
-            body: body
+            body: body,
+            bodyFormat: bodyFormat
         )
         guard !policyContext.hooks.isEmpty else {
             applyNotification(
@@ -1299,7 +1346,8 @@ final class TerminalNotificationStore: ObservableObject {
         surfaceId: UUID?,
         title: String,
         subtitle: String,
-        body: String
+        body: String,
+        bodyFormat: TerminalNotificationBodyFormat
     ) -> NotificationPolicyContext {
         let appDelegate = AppDelegate.shared
         let context = appDelegate?.contextContainingTabId(tabId)
@@ -1329,6 +1377,7 @@ final class TerminalNotificationStore: ObservableObject {
                 title: title,
                 subtitle: subtitle,
                 body: body,
+                bodyFormat: bodyFormat,
                 cwd: cwd,
                 isAppFocused: isAppFocused,
                 isFocusedPanel: isFocusedPanel
@@ -1354,6 +1403,7 @@ final class TerminalNotificationStore: ObservableObject {
                 title: payload.title,
                 subtitle: payload.subtitle,
                 body: payload.body,
+                bodyFormat: payload.bodyFormat,
                 cwd: request.cwd,
                 isAppFocused: request.isAppFocused,
                 isFocusedPanel: request.isFocusedPanel
@@ -1372,6 +1422,7 @@ final class TerminalNotificationStore: ObservableObject {
         cooldownReservation: NotificationCooldownReservation?,
         clickAction: TerminalNotificationClickAction?
     ) {
+        let subtitle = subtitleWithCodingAgentContext(for: request)
         let shouldSuppressExternalDelivery = shouldSuppressExternalDelivery(
             tabId: request.tabId,
             surfaceId: request.surfaceId
@@ -1382,8 +1433,9 @@ final class TerminalNotificationStore: ObservableObject {
             surfaceId: request.surfaceId,
             panelId: request.panelId,
             title: request.title,
-            subtitle: request.subtitle,
+            subtitle: subtitle,
             body: request.body,
+            bodyFormat: request.bodyFormat,
             createdAt: now,
             isRead: !effects.markUnread,
             paneFlash: effects.paneFlash,
@@ -1469,6 +1521,51 @@ final class TerminalNotificationStore: ObservableObject {
             shouldSuppressExternalDelivery: shouldSuppressExternalDelivery,
             effects: effects
         )
+    }
+
+    private func subtitleWithCodingAgentContext(for request: TerminalNotificationPolicyRequest) -> String {
+        let title = request.title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard Self.codingAgentNotificationTitles.contains(title) else {
+            return request.subtitle
+        }
+
+        var parts = trimmedNotificationParts(from: request.subtitle)
+        for contextPart in codingAgentContextParts(tabId: request.tabId, panelId: request.panelId) {
+            appendNotificationPart(contextPart, to: &parts)
+        }
+        return parts.joined(separator: " • ")
+    }
+
+    private func codingAgentContextParts(tabId: UUID, panelId: UUID?) -> [String] {
+        let appDelegate = AppDelegate.shared
+        let context = appDelegate?.contextContainingTabId(tabId)
+        let tabManager = context?.tabManager ?? appDelegate?.tabManagerFor(tabId: tabId) ?? appDelegate?.tabManager
+        guard let workspace = tabManager?.tabs.first(where: { $0.id == tabId }) else {
+            return []
+        }
+
+        var parts: [String] = []
+        appendNotificationPart(workspace.title, to: &parts)
+        if let panelId {
+            appendNotificationPart(workspace.panelTitle(panelId: panelId), to: &parts)
+        }
+        return parts
+    }
+
+    private func trimmedNotificationParts(from value: String) -> [String] {
+        value
+            .split(separator: "•", omittingEmptySubsequences: true)
+            .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+    }
+
+    private func appendNotificationPart(_ value: String?, to parts: inout [String]) {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else {
+            return
+        }
+        guard !parts.contains(where: { $0 == trimmed }) else { return }
+        parts.append(trimmed)
     }
 
     private func shouldSuppressExternalDelivery(tabId: UUID, surfaceId: UUID?) -> Bool {
@@ -1770,6 +1867,7 @@ final class TerminalNotificationStore: ObservableObject {
             title: notification.title,
             subtitle: notification.subtitle,
             body: notification.body,
+            bodyFormat: notification.bodyFormat,
             createdAt: notification.createdAt,
             isRead: notification.isRead,
             paneFlash: notification.paneFlash,
@@ -1850,6 +1948,7 @@ final class TerminalNotificationStore: ObservableObject {
                 title: notification.title,
                 subtitle: notification.subtitle,
                 body: notification.body,
+                bodyFormat: notification.bodyFormat,
                 createdAt: notification.createdAt,
                 isRead: notification.isRead,
                 paneFlash: notification.paneFlash,

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -2626,10 +2626,12 @@ private struct NotificationPopoverRow: View {
                 }
 
                 if !notification.body.isEmpty {
-                    Text(notification.body)
-                        .font(.system(size: 11.5))
-                        .foregroundColor(.secondary)
-                        .lineLimit(2)
+                    NotificationBodyText(
+                        notification: notification,
+                        font: .system(size: 11.5),
+                        color: .secondary,
+                        lineLimit: 2
+                    )
                         .fixedSize(horizontal: false, vertical: true)
                 }
 

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -42,7 +42,7 @@ private final class WorkspacePendingTerminalInputObserver: @unchecked Sendable {
     var observer: NSObjectProtocol?
 }
 
-struct SidebarStatusEntry: Equatable {
+struct SidebarStatusEntry: Equatable, Sendable {
     let key: String
     let value: String
     let icon: String?
@@ -80,7 +80,7 @@ struct SidebarMetadataBlock: Equatable {
     let timestamp: Date
 }
 
-enum SidebarMetadataFormat: String {
+enum SidebarMetadataFormat: String, Sendable {
     case plain
     case markdown
 }
@@ -1006,6 +1006,7 @@ extension Workspace {
             signingSecret: approvalSigningSecret
         )
         effectiveBinding = hermesAgentSubrouterBindingForStartup(effectiveBinding)
+        effectiveBinding = effectiveBinding.replacingDirectClaudeResumeWithBundledWrapperIfNeeded()
         if effectiveBinding.source == "agent-hook", !autoResumeAgentSessions {
             return nil
         }
@@ -12255,6 +12256,13 @@ final class Workspace: Identifiable, ObservableObject {
         guard let targetPanelId, panels[targetPanelId] != nil else { return }
         agentLifecycleStatesByPanelId[targetPanelId, default: [:]][key] = lifecycle
         recordAgentLifecycleChange(panelId: targetPanelId)
+    }
+
+    func agentLifecycle(
+        key: String,
+        panelId: UUID
+    ) -> AgentHibernationLifecycleState? {
+        agentLifecycleStatesByPanelId[panelId]?[key]
     }
 
     @discardableResult

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		D1320AA0D1320AA0D1320AA1 /* AppIconDockTilePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1320AA0D1320AA0D1320AA4 /* AppIconDockTilePlugin.swift */; };
 		A5001621 /* AppleScriptSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001620 /* AppleScriptSupport.swift */; };
 		A5001100 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A5001101 /* Assets.xcassets */; };
+		1DBAB2FED0E541124A1CF3EF /* AttentionTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E4CA6D3391483563434AAB2 /* AttentionTarget.swift */; };
 		36CE99ED050785B5E96B72BB /* AuthCallbackRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A19A4145F034965110CF87 /* AuthCallbackRouter.swift */; };
 		D9FEC58D5BACCF76459F1BBE /* AuthEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43430FA5929121E2EAAB3091 /* AuthEnvironment.swift */; };
 		350DAC5EBD38642A3E81471A /* AuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 312DE7503B4658DD173121B8 /* AuthManager.swift */; };
@@ -375,6 +376,7 @@
 		00C3AA443F6DA8D94E28CE17 /* MobileWorkspaceListObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F14137954A34DFFA05C88C /* MobileWorkspaceListObserver.swift */; };
 		B9000015A1B2C3D4E5F60719 /* MultiWindowNotificationsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000016A1B2C3D4E5F60719 /* MultiWindowNotificationsUITests.swift */; };
 		734F49D37E543DD01C2F4FEF /* NotificationAndMenuBarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C075029771815DD5DA1332 /* NotificationAndMenuBarTests.swift */; };
+		A3721E1E50517CB331D0B706 /* NotificationBodyText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D27CC1F236083ADD7450749 /* NotificationBodyText.swift */; };
 		A5001094 /* NotificationsPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001091 /* NotificationsPage.swift */; };
 		D36090020000000000000001 /* NSWindow+CmuxPeerWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36090020000000000000002 /* NSWindow+CmuxPeerWindow.swift */; };
 		4378399A7C0245EF8186F306 /* OmnibarAndToolsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B09C007F42697761B5F1A2AB /* OmnibarAndToolsTests.swift */; };
@@ -386,6 +388,7 @@
 		A5001405 /* PanelContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001415 /* PanelContentView.swift */; };
 		BB49DF25341706C2A892C27C /* PanelOwnedNativeViewSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE314D9700F6F1C8D4A2FE11 /* PanelOwnedNativeViewSession.swift */; };
 		C44550000000000000000001 /* PanelOwnedNativeViewSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C44550000000000000000002 /* PanelOwnedNativeViewSessionTests.swift */; };
+		0E30AB5335F62AFCC49EEF23 /* ParsedNotificationPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95A4BCE772B852B298961742 /* ParsedNotificationPayload.swift */; };
 		A5001425 /* PDFPreviewChromeDebugWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001424 /* PDFPreviewChromeDebugWindowController.swift */; };
 		D1F0A00100000000000000A1 /* PhonePushClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F0A00100000000000000A2 /* PhonePushClient.swift */; };
 		B3575000000000000000000A /* PiVaultAgentPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35750000000000000000009 /* PiVaultAgentPersistenceTests.swift */; };
@@ -538,6 +541,7 @@
 		0D56BE882EAD4B67AC44F96D /* TerminalDirectoryOpenSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8E2E03F4A64C61B729CF19 /* TerminalDirectoryOpenSupport.swift */; };
 		E5C0F1A0E5C0F1A0E5C0F1A0 /* TerminalFindEscapeRouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C0F1A1E5C0F1A1E5C0F1A1 /* TerminalFindEscapeRouting.swift */; };
 		A5001542 /* TerminalImageTransfer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001544 /* TerminalImageTransfer.swift */; };
+		B2DDBA6F5846F7E2CF35C57C /* TerminalNotificationBodyFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA0FFFAFD67D684E58EAFB9C /* TerminalNotificationBodyFormat.swift */; };
 		A5C41101A1B2C3D4E5F60718 /* TerminalNotificationCallerResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C41102A1B2C3D4E5F60718 /* TerminalNotificationCallerResolver.swift */; };
 		A5C41103A1B2C3D4E5F60718 /* TerminalNotificationCallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C41104A1B2C3D4E5F60718 /* TerminalNotificationCallerTests.swift */; };
 		A5A5A507A1B2C3D4E5F60718 /* TerminalNotificationClearAllTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5A5A508A1B2C3D4E5F60718 /* TerminalNotificationClearAllTests.swift */; };
@@ -735,6 +739,7 @@
 		D1320AA0D1320AA0D1320AA4 /* AppIconDockTilePlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconDockTilePlugin.swift; sourceTree = "<group>"; };
 		A5001620 /* AppleScriptSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleScriptSupport.swift; sourceTree = "<group>"; };
 		A5001101 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		4E4CA6D3391483563434AAB2 /* AttentionTarget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AttentionTarget.swift; path = Sources/Feed/AttentionTarget.swift; sourceTree = "<group>"; };
 		61A19A4145F034965110CF87 /* AuthCallbackRouter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AuthCallbackRouter.swift; sourceTree = "<group>"; };
 		43430FA5929121E2EAAB3091 /* AuthEnvironment.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AuthEnvironment.swift; sourceTree = "<group>"; };
 		312DE7503B4658DD173121B8 /* AuthManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AuthManager.swift; sourceTree = "<group>"; };
@@ -1040,6 +1045,7 @@
 		C9F14137954A34DFFA05C88C /* MobileWorkspaceListObserver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileWorkspaceListObserver.swift; sourceTree = "<group>"; };
 		B9000016A1B2C3D4E5F60719 /* MultiWindowNotificationsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiWindowNotificationsUITests.swift; sourceTree = "<group>"; };
 		D2C075029771815DD5DA1332 /* NotificationAndMenuBarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationAndMenuBarTests.swift; sourceTree = "<group>"; };
+		1D27CC1F236083ADD7450749 /* NotificationBodyText.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NotificationBodyText.swift; path = Sources/NotificationBodyText.swift; sourceTree = "<group>"; };
 		A5001091 /* NotificationsPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsPage.swift; sourceTree = "<group>"; };
 		D36090020000000000000002 /* NSWindow+CmuxPeerWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "App/NSWindow+CmuxPeerWindow.swift"; sourceTree = "<group>"; };
 		B09C007F42697761B5F1A2AB /* OmnibarAndToolsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OmnibarAndToolsTests.swift; sourceTree = "<group>"; };
@@ -1051,6 +1057,7 @@
 		A5001415 /* PanelContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/PanelContentView.swift; sourceTree = "<group>"; };
 		CE314D9700F6F1C8D4A2FE11 /* PanelOwnedNativeViewSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/PanelOwnedNativeViewSession.swift; sourceTree = "<group>"; };
 		C44550000000000000000002 /* PanelOwnedNativeViewSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanelOwnedNativeViewSessionTests.swift; sourceTree = "<group>"; };
+		95A4BCE772B852B298961742 /* ParsedNotificationPayload.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ParsedNotificationPayload.swift; path = Sources/ParsedNotificationPayload.swift; sourceTree = "<group>"; };
 		A5001424 /* PDFPreviewChromeDebugWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/PDFPreviewChromeDebugWindowController.swift; sourceTree = "<group>"; };
 		D1F0A00100000000000000A2 /* PhonePushClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PhonePushClient.swift; sourceTree = "<group>"; };
 		B35750000000000000000009 /* PiVaultAgentPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiVaultAgentPersistenceTests.swift; sourceTree = "<group>"; };
@@ -1195,6 +1202,7 @@
 		6B8E2E03F4A64C61B729CF19 /* TerminalDirectoryOpenSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/TerminalDirectoryOpenSupport.swift; sourceTree = "<group>"; };
 		E5C0F1A1E5C0F1A1E5C0F1A1 /* TerminalFindEscapeRouting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/TerminalFindEscapeRouting.swift; sourceTree = "<group>"; };
 		A5001544 /* TerminalImageTransfer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalImageTransfer.swift; sourceTree = "<group>"; };
+		EA0FFFAFD67D684E58EAFB9C /* TerminalNotificationBodyFormat.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TerminalNotificationBodyFormat.swift; path = Sources/TerminalNotificationBodyFormat.swift; sourceTree = "<group>"; };
 		A5C41102A1B2C3D4E5F60718 /* TerminalNotificationCallerResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalNotificationCallerResolver.swift; sourceTree = "<group>"; };
 		A5C41104A1B2C3D4E5F60718 /* TerminalNotificationCallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalNotificationCallerTests.swift; sourceTree = "<group>"; };
 		A5A5A508A1B2C3D4E5F60718 /* TerminalNotificationClearAllTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalNotificationClearAllTests.swift; sourceTree = "<group>"; };
@@ -1490,6 +1498,10 @@
 				3196C9C2D01F054C1D3385DD /* cmuxUITests */,
 				F1000003A1B2C3D4E5F60718 /* cmuxTests */,
 				A5001042 /* Products */,
+				4E4CA6D3391483563434AAB2 /* AttentionTarget.swift */,
+				1D27CC1F236083ADD7450749 /* NotificationBodyText.swift */,
+				95A4BCE772B852B298961742 /* ParsedNotificationPayload.swift */,
+				EA0FFFAFD67D684E58EAFB9C /* TerminalNotificationBodyFormat.swift */,
 			);
 			sourceTree = "<group>";
 		};
@@ -2325,6 +2337,23 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		A5001300A1B2C3D4E5F60719 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -euo pipefail\nDEST=\"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}\"\nGHOSTTY_DEST=\"${DEST}/ghostty\"\nTERMINFO_DEST=\"${DEST}/terminfo\"\nCMUX_SHELL_DEST=\"${DEST}/shell-integration\"\nBIN_DEST=\"${DEST}/bin\"\nSRC_SHARE=\"${SRCROOT}/ghostty/zig-out/share\"\nGHOSTTY_SRC=\"${SRC_SHARE}/ghostty\"\nTERMINFO_SRC=\"${SRC_SHARE}/terminfo\"\nFALLBACK_GHOSTTY=\"${SRCROOT}/Resources/ghostty\"\nFALLBACK_TERMINFO=\"${SRCROOT}/Resources/ghostty/terminfo\"\nTERMINFO_OVERLAY=\"${SRCROOT}/Resources/terminfo-overlay\"\nCMUX_SHELL_SRC=\"${SRCROOT}/Resources/shell-integration\"\nCMUX_GHOSTTY_ZSH_SRC=\"${SRCROOT}/ghostty/src/shell-integration/zsh/ghostty-integration\"\nBUILD_GHOSTTY_HELPER=\"${SRCROOT}/scripts/build-ghostty-cli-helper.sh\"\nGHOSTTY_HELPER_DEST=\"${BIN_DEST}/ghostty\"\nif [ -d \"$GHOSTTY_SRC\" ]; then\n  mkdir -p \"$GHOSTTY_DEST\"\n  rsync -a --delete \"$GHOSTTY_SRC/\" \"$GHOSTTY_DEST/\"\nelif [ -d \"$FALLBACK_GHOSTTY\" ]; then\n  mkdir -p \"$GHOSTTY_DEST\"\n  rsync -a --delete \"$FALLBACK_GHOSTTY/\" \"$GHOSTTY_DEST/\"\nfi\nif [ -d \"$TERMINFO_SRC\" ]; then\n  mkdir -p \"$TERMINFO_DEST\"\n  rsync -a --delete \"$TERMINFO_SRC/\" \"$TERMINFO_DEST/\"\nelif [ -d \"$FALLBACK_TERMINFO\" ]; then\n  mkdir -p \"$TERMINFO_DEST\"\n  rsync -a --delete \"$FALLBACK_TERMINFO/\" \"$TERMINFO_DEST/\"\nfi\n# Overlay any cmux-specific terminfo adjustments.\n# This intentionally does not use --delete so we only patch specific entries.\nif [ -d \"$TERMINFO_OVERLAY\" ]; then\n  mkdir -p \"$TERMINFO_DEST\"\n  rsync -a \"$TERMINFO_OVERLAY/\" \"$TERMINFO_DEST/\"\nfi\nif [ -d \"$CMUX_SHELL_SRC\" ]; then\n  mkdir -p \"$CMUX_SHELL_DEST\"\n  # Use '/.' so dotfiles like .zshenv/.zprofile are copied too.\n  rsync -a \"$CMUX_SHELL_SRC/.\" \"$CMUX_SHELL_DEST/\"\nfi\nif [ -f \"$CMUX_GHOSTTY_ZSH_SRC\" ]; then\n  mkdir -p \"$CMUX_SHELL_DEST\"\n  rsync -a \"$CMUX_GHOSTTY_ZSH_SRC\" \"$CMUX_SHELL_DEST/ghostty-integration.zsh\"\nfi\nif [ ! -x \"$BUILD_GHOSTTY_HELPER\" ]; then\n  echo \"error: missing Ghostty CLI helper build script at $BUILD_GHOSTTY_HELPER\" >&2\n  exit 1\nfi\nARCHS_LIST=\" ${ARCHS:-} \"\nHAS_ARM64=0\nHAS_X86_64=0\nGHOSTTY_HELPER_TARGET=\"\"\ncase \"$ARCHS_LIST\" in\n  *\" arm64 \"*) HAS_ARM64=1 ;;\nesac\ncase \"$ARCHS_LIST\" in\n  *\" x86_64 \"*) HAS_X86_64=1 ;;\nesac\nif [ \"$HAS_ARM64\" -eq 1 ] && [ \"$HAS_X86_64\" -eq 1 ]; then\n  \"$BUILD_GHOSTTY_HELPER\" --universal --output \"$GHOSTTY_HELPER_DEST\"\nelif [ \"$HAS_ARM64\" -eq 1 ]; then\n  GHOSTTY_HELPER_TARGET=\"aarch64-macos\"\nelif [ \"$HAS_X86_64\" -eq 1 ]; then\n  GHOSTTY_HELPER_TARGET=\"x86_64-macos\"\nfi\nif [ -n \"$GHOSTTY_HELPER_TARGET\" ]; then\n  \"$BUILD_GHOSTTY_HELPER\" --target \"$GHOSTTY_HELPER_TARGET\" --output \"$GHOSTTY_HELPER_DEST\"\nelif [ \"$HAS_ARM64\" -eq 0 ] || [ \"$HAS_X86_64\" -eq 0 ]; then\n  \"$BUILD_GHOSTTY_HELPER\" --output \"$GHOSTTY_HELPER_DEST\"\nfi\nif [ ! -x \"$GHOSTTY_HELPER_DEST\" ]; then\n  echo \"error: Ghostty CLI helper was not created at $GHOSTTY_HELPER_DEST\" >&2\n  exit 1\nfi\nINFO_PLIST=\"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}\"\nCOMMIT=\"$(git -C \"${SRCROOT}\" rev-parse --short=9 HEAD 2>/dev/null || true)\"\nif [ -n \"$COMMIT\" ] && [ -f \"$INFO_PLIST\" ]; then\n  /usr/libexec/PlistBuddy -c \"Set :CMUXCommit $COMMIT\" \"$INFO_PLIST\" >/dev/null 2>&1 || /usr/libexec/PlistBuddy -c \"Add :CMUXCommit string $COMMIT\" \"$INFO_PLIST\" >/dev/null 2>&1 || true\nfi\n";
+		};
 		C0DE47000000000000000003 /* Write Extension Point */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -2345,23 +2374,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/scripts/write-sidebar-extension-point.sh\"\n";
-		};
-		A5001300A1B2C3D4E5F60719 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -euo pipefail\nDEST=\"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}\"\nGHOSTTY_DEST=\"${DEST}/ghostty\"\nTERMINFO_DEST=\"${DEST}/terminfo\"\nCMUX_SHELL_DEST=\"${DEST}/shell-integration\"\nBIN_DEST=\"${DEST}/bin\"\nSRC_SHARE=\"${SRCROOT}/ghostty/zig-out/share\"\nGHOSTTY_SRC=\"${SRC_SHARE}/ghostty\"\nTERMINFO_SRC=\"${SRC_SHARE}/terminfo\"\nFALLBACK_GHOSTTY=\"${SRCROOT}/Resources/ghostty\"\nFALLBACK_TERMINFO=\"${SRCROOT}/Resources/ghostty/terminfo\"\nTERMINFO_OVERLAY=\"${SRCROOT}/Resources/terminfo-overlay\"\nCMUX_SHELL_SRC=\"${SRCROOT}/Resources/shell-integration\"\nCMUX_GHOSTTY_ZSH_SRC=\"${SRCROOT}/ghostty/src/shell-integration/zsh/ghostty-integration\"\nBUILD_GHOSTTY_HELPER=\"${SRCROOT}/scripts/build-ghostty-cli-helper.sh\"\nGHOSTTY_HELPER_DEST=\"${BIN_DEST}/ghostty\"\nif [ -d \"$GHOSTTY_SRC\" ]; then\n  mkdir -p \"$GHOSTTY_DEST\"\n  rsync -a --delete \"$GHOSTTY_SRC/\" \"$GHOSTTY_DEST/\"\nelif [ -d \"$FALLBACK_GHOSTTY\" ]; then\n  mkdir -p \"$GHOSTTY_DEST\"\n  rsync -a --delete \"$FALLBACK_GHOSTTY/\" \"$GHOSTTY_DEST/\"\nfi\nif [ -d \"$TERMINFO_SRC\" ]; then\n  mkdir -p \"$TERMINFO_DEST\"\n  rsync -a --delete \"$TERMINFO_SRC/\" \"$TERMINFO_DEST/\"\nelif [ -d \"$FALLBACK_TERMINFO\" ]; then\n  mkdir -p \"$TERMINFO_DEST\"\n  rsync -a --delete \"$FALLBACK_TERMINFO/\" \"$TERMINFO_DEST/\"\nfi\n# Overlay any cmux-specific terminfo adjustments.\n# This intentionally does not use --delete so we only patch specific entries.\nif [ -d \"$TERMINFO_OVERLAY\" ]; then\n  mkdir -p \"$TERMINFO_DEST\"\n  rsync -a \"$TERMINFO_OVERLAY/\" \"$TERMINFO_DEST/\"\nfi\nif [ -d \"$CMUX_SHELL_SRC\" ]; then\n  mkdir -p \"$CMUX_SHELL_DEST\"\n  # Use '/.' so dotfiles like .zshenv/.zprofile are copied too.\n  rsync -a \"$CMUX_SHELL_SRC/.\" \"$CMUX_SHELL_DEST/\"\nfi\nif [ -f \"$CMUX_GHOSTTY_ZSH_SRC\" ]; then\n  mkdir -p \"$CMUX_SHELL_DEST\"\n  rsync -a \"$CMUX_GHOSTTY_ZSH_SRC\" \"$CMUX_SHELL_DEST/ghostty-integration.zsh\"\nfi\nif [ ! -x \"$BUILD_GHOSTTY_HELPER\" ]; then\n  echo \"error: missing Ghostty CLI helper build script at $BUILD_GHOSTTY_HELPER\" >&2\n  exit 1\nfi\nARCHS_LIST=\" ${ARCHS:-} \"\nHAS_ARM64=0\nHAS_X86_64=0\nGHOSTTY_HELPER_TARGET=\"\"\ncase \"$ARCHS_LIST\" in\n  *\" arm64 \"*) HAS_ARM64=1 ;;\nesac\ncase \"$ARCHS_LIST\" in\n  *\" x86_64 \"*) HAS_X86_64=1 ;;\nesac\nif [ \"$HAS_ARM64\" -eq 1 ] && [ \"$HAS_X86_64\" -eq 1 ]; then\n  \"$BUILD_GHOSTTY_HELPER\" --universal --output \"$GHOSTTY_HELPER_DEST\"\nelif [ \"$HAS_ARM64\" -eq 1 ]; then\n  GHOSTTY_HELPER_TARGET=\"aarch64-macos\"\nelif [ \"$HAS_X86_64\" -eq 1 ]; then\n  GHOSTTY_HELPER_TARGET=\"x86_64-macos\"\nfi\nif [ -n \"$GHOSTTY_HELPER_TARGET\" ]; then\n  \"$BUILD_GHOSTTY_HELPER\" --target \"$GHOSTTY_HELPER_TARGET\" --output \"$GHOSTTY_HELPER_DEST\"\nelif [ \"$HAS_ARM64\" -eq 0 ] || [ \"$HAS_X86_64\" -eq 0 ]; then\n  \"$BUILD_GHOSTTY_HELPER\" --output \"$GHOSTTY_HELPER_DEST\"\nfi\nif [ ! -x \"$GHOSTTY_HELPER_DEST\" ]; then\n  echo \"error: Ghostty CLI helper was not created at $GHOSTTY_HELPER_DEST\" >&2\n  exit 1\nfi\nINFO_PLIST=\"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}\"\nCOMMIT=\"$(git -C \"${SRCROOT}\" rev-parse --short=9 HEAD 2>/dev/null || true)\"\nif [ -n \"$COMMIT\" ] && [ -f \"$INFO_PLIST\" ]; then\n  /usr/libexec/PlistBuddy -c \"Set :CMUXCommit $COMMIT\" \"$INFO_PLIST\" >/dev/null 2>&1 || /usr/libexec/PlistBuddy -c \"Add :CMUXCommit string $COMMIT\" \"$INFO_PLIST\" >/dev/null 2>&1 || true\nfi\n";
 		};
 		C0DEFF100000000000000003 /* Build Command Palette Nucleo FFI */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -2428,6 +2440,7 @@
 				A5001093 /* AppDelegate.swift in Sources */,
 				A11EAB000000000000000000 /* AppearanceSettings.swift in Sources */,
 				A5001621 /* AppleScriptSupport.swift in Sources */,
+				1DBAB2FED0E541124A1CF3EF /* AttentionTarget.swift in Sources */,
 				36CE99ED050785B5E96B72BB /* AuthCallbackRouter.swift in Sources */,
 				D9FEC58D5BACCF76459F1BBE /* AuthEnvironment.swift in Sources */,
 				350DAC5EBD38642A3E81471A /* AuthManager.swift in Sources */,
@@ -2544,12 +2557,12 @@
 				A5001429 /* FilePreviewPDFViewport.swift in Sources */,
 				DD62AFF1D95A1D5D1850AC10 /* FilePreviewQuickLookSession.swift in Sources */,
 				D0B10016A1B2C3D4E5F60001 /* FilePreviewTextEditor.swift in Sources */,
-					F11E52270000000000005227 /* FilePreviewWordWrapSettings.swift in Sources */,
+				F11E52270000000000005227 /* FilePreviewWordWrapSettings.swift in Sources */,
 				A5001445A5001445A5001445 /* FilePreviewWorkspaceOpenSupport.swift in Sources */,
 				F1A0C0DE0000000000000002 /* FindTextFieldSupport.swift in Sources */,
 				F0C05170000000000000002 /* FocusHistory.swift in Sources */,
 				C4160A020000000000000001 /* FocusHistoryMenuInvalidator.swift in Sources */,
-					C0DEFB100000000000000001 /* FocusSurfaceBroadcaster.swift in Sources */,
+				C0DEFB100000000000000001 /* FocusSurfaceBroadcaster.swift in Sources */,
 				AA5269A0C0DE0002FACE0002 /* ForeignFirstResponderPolicy.swift in Sources */,
 				D0B10012A1B2C3D4E5F60001 /* GhosttyApp+SurfaceConfigurationReload.swift in Sources */,
 				A5001004 /* GhosttyConfig.swift in Sources */,
@@ -2562,7 +2575,7 @@
 				A5001005 /* GhosttyTerminalView.swift in Sources */,
 				D0B1000AA1B2C3D4E5F60001 /* GhosttyTerminalViewSupport.swift in Sources */,
 				D3284101A1B2C3D4E5F60718 /* GhosttyTextInputSupport.swift in Sources */,
-					617C70C1617C70C1617C70C1 /* GitPollClock.swift in Sources */,
+				617C70C1617C70C1617C70C1 /* GitPollClock.swift in Sources */,
 				3865A0023865A0023865A002 /* GlobalSearchCoordinator.swift in Sources */,
 				3865A0073865A0073865A007 /* GlobalSearchDocuments.swift in Sources */,
 				3865A0083865A0083865A008 /* GlobalSearchPanelCaptureManager.swift in Sources */,
@@ -2605,23 +2618,25 @@
 				AB57F0C27BECE8EDFC6B2B97 /* MobileTerminalByteTee.swift in Sources */,
 				C9CFB398DF94D6DDEAF42D67 /* MobileTerminalRenderObserver.swift in Sources */,
 				00C3AA443F6DA8D94E28CE17 /* MobileWorkspaceListObserver.swift in Sources */,
+				A3721E1E50517CB331D0B706 /* NotificationBodyText.swift in Sources */,
 				A5001094 /* NotificationsPage.swift in Sources */,
 				D36090020000000000000001 /* NSWindow+CmuxPeerWindow.swift in Sources */,
 				D0B1001CA1B2C3D4E5F60001 /* PaneDropRoutingSupport.swift in Sources */,
 				A5001400 /* Panel.swift in Sources */,
 				A5001405 /* PanelContentView.swift in Sources */,
 				BB49DF25341706C2A892C27C /* PanelOwnedNativeViewSession.swift in Sources */,
+				0E30AB5335F62AFCC49EEF23 /* ParsedNotificationPayload.swift in Sources */,
 				A5001425 /* PDFPreviewChromeDebugWindowController.swift in Sources */,
 				D1F0A00100000000000000A1 /* PhonePushClient.swift in Sources */,
 				A5001540 /* PortScanner.swift in Sources */,
 				A5001521 /* PostHogAnalytics.swift in Sources */,
 				C47110020000000000000001 /* ProcessPipeReader.swift in Sources */,
-					A5C0DE0000000000000000BA /* ProjectBuildSettingsTabView.swift in Sources */,
-					A5C0DE0000000000000000B6 /* ProjectFilesTabView.swift in Sources */,
-					A5C0DE0000000000000000B2 /* ProjectPanel.swift in Sources */,
-					A5C0DE0000000000000000B4 /* ProjectPanelView.swift in Sources */,
-					A5C0DE0000000000000000BC /* ProjectSchemesTabView.swift in Sources */,
-					A5C0DE0000000000000000B8 /* ProjectTargetsTabView.swift in Sources */,
+				A5C0DE0000000000000000BA /* ProjectBuildSettingsTabView.swift in Sources */,
+				A5C0DE0000000000000000B6 /* ProjectFilesTabView.swift in Sources */,
+				A5C0DE0000000000000000B2 /* ProjectPanel.swift in Sources */,
+				A5C0DE0000000000000000B4 /* ProjectPanelView.swift in Sources */,
+				A5C0DE0000000000000000BC /* ProjectSchemesTabView.swift in Sources */,
+				A5C0DE0000000000000000B8 /* ProjectTargetsTabView.swift in Sources */,
 				A500RG01 /* ReactGrab.swift in Sources */,
 				A5001643 /* RemoteInteractiveShellBootstrapBuilder.swift in Sources */,
 				D0C0D0C0D0C0D0C0D0C00001 /* RemoteLoopbackProxyAlias.swift in Sources */,
@@ -2700,6 +2715,7 @@
 				0D56BE882EAD4B67AC44F96D /* TerminalDirectoryOpenSupport.swift in Sources */,
 				E5C0F1A0E5C0F1A0E5C0F1A0 /* TerminalFindEscapeRouting.swift in Sources */,
 				A5001542 /* TerminalImageTransfer.swift in Sources */,
+				B2DDBA6F5846F7E2CF35C57C /* TerminalNotificationBodyFormat.swift in Sources */,
 				A5C41101A1B2C3D4E5F60718 /* TerminalNotificationCallerResolver.swift in Sources */,
 				A5001096 /* TerminalNotificationPolicy.swift in Sources */,
 				A5A5A501A1B2C3D4E5F60718 /* TerminalNotificationQueue.swift in Sources */,
@@ -2796,7 +2812,7 @@
 				B9000048A1B2C3D4E5F60719 /* CMUXCLI+TmuxCompatHUDSupport.swift in Sources */,
 				B9000044A1B2C3D4E5F60719 /* CMUXCLI+TmuxCompatSupport.swift in Sources */,
 				B9000033A1B2C3D4E5F60719 /* CMUXCLI+TopRendering.swift in Sources */,
-					FEEDC1A50000000000000001 /* FeedEventClassifier.swift in Sources */,
+				FEEDC1A50000000000000001 /* FeedEventClassifier.swift in Sources */,
 				C0DEF0B10000000000000003 /* JSONCParser.swift in Sources */,
 				C47110020000000000000003 /* ProcessPipeReader.swift in Sources */,
 				B9000028A1B2C3D4E5F60719 /* RemoteInteractiveShellBootstrapBuilder.swift in Sources */,
@@ -2947,15 +2963,15 @@
 				4378399A7C0245EF8186F306 /* OmnibarAndToolsTests.swift in Sources */,
 				A5E01203A1B2C3D4E5F60718 /* OpenCodeHookRegressionTests.swift in Sources */,
 				C44550000000000000000001 /* PanelOwnedNativeViewSessionTests.swift in Sources */,
-					B3575000000000000000000A /* PiVaultAgentPersistenceTests.swift in Sources */,
-					D0B10008A1B2C3D4E5F60001 /* PortalTabDragRoutingTests.swift in Sources */,
-					F4100000A1B2C3D4E5F60718 /* PortScannerTests.swift in Sources */,
+				B3575000000000000000000A /* PiVaultAgentPersistenceTests.swift in Sources */,
+				D0B10008A1B2C3D4E5F60001 /* PortalTabDragRoutingTests.swift in Sources */,
+				F4100000A1B2C3D4E5F60718 /* PortScannerTests.swift in Sources */,
 				C135190000000000000000A1 /* PreferredEditorSettingsTests.swift in Sources */,
 				C47110010000000000000001 /* ProcessPipeReadCrashRegressionTests.swift in Sources */,
-					F5410004A1B2C3D4E5F60718 /* RestorableAgentHookProviderHermesTests.swift in Sources */,
-					F5410000A1B2C3D4E5F60718 /* RestorableAgentHookProviderResumeTests.swift in Sources */,
-					F5410002A1B2C3D4E5F60718 /* RestorableAgentNonInteractiveTests.swift in Sources */,
-					F5410006A1B2C3D4E5F60718 /* RestorableAgentSessionIndexTests.swift in Sources */,
+				F5410004A1B2C3D4E5F60718 /* RestorableAgentHookProviderHermesTests.swift in Sources */,
+				F5410000A1B2C3D4E5F60718 /* RestorableAgentHookProviderResumeTests.swift in Sources */,
+				F5410002A1B2C3D4E5F60718 /* RestorableAgentNonInteractiveTests.swift in Sources */,
+				F5410006A1B2C3D4E5F60718 /* RestorableAgentSessionIndexTests.swift in Sources */,
 				C3408A000000000000000003 /* RightSidebarCommandPaletteTests.swift in Sources */,
 				C46790000000000000000007 /* RosettaNativeRelaunchTests.swift in Sources */,
 				F5310000A1B2C3D4E5F60718 /* RovoDevHookConfigTests.swift in Sources */,
@@ -3466,6 +3482,10 @@
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/CmuxTerminalCopyMode;
 		};
+		C5A1FED000000000000000C4 /* XCLocalSwiftPackageReference "CmuxSwiftRender" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Packages/CmuxSwiftRender;
+		};
 		C5A1FED100000000000000D4 /* XCLocalSwiftPackageReference "CmuxSwiftRenderUI" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/CmuxSwiftRenderUI;
@@ -3474,9 +3494,13 @@
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/CmuxSidebarInterpreterService;
 		};
-		C5A1FED000000000000000C4 /* XCLocalSwiftPackageReference "CmuxSwiftRender" */ = {
+		C617000000000000000000A1 /* XCLocalSwiftPackageReference "CmuxGit" */ = {
 			isa = XCLocalSwiftPackageReference;
-			relativePath = Packages/CmuxSwiftRender;
+			relativePath = Packages/CmuxGit;
+		};
+		C750100000000000000000A1 /* XCLocalSwiftPackageReference "CmuxControlSocket" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Packages/CmuxControlSocket;
 		};
 		C8000301C8000301C8000301 /* XCLocalSwiftPackageReference "CmuxProcess" */ = {
 			isa = XCLocalSwiftPackageReference;
@@ -3485,14 +3509,6 @@
 		C8000311C8000311C8000311 /* XCLocalSwiftPackageReference "CmuxFileWatch" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/CmuxFileWatch;
-		};
-		C617000000000000000000A1 /* XCLocalSwiftPackageReference "CmuxGit" */ = {
-			isa = XCLocalSwiftPackageReference;
-			relativePath = Packages/CmuxGit;
-		};
-		C750100000000000000000A1 /* XCLocalSwiftPackageReference "CmuxControlSocket" */ = {
-			isa = XCLocalSwiftPackageReference;
-			relativePath = Packages/CmuxControlSocket;
 		};
 		CD0CFE5100000000CD0CFE51 /* XCLocalSwiftPackageReference "CmuxSettings" */ = {
 			isa = XCLocalSwiftPackageReference;
@@ -3561,130 +3577,10 @@
 			package = 40B63BB4A170F0BD2D1DEFD1 /* XCLocalSwiftPackageReference "CMUXAuthCore" */;
 			productName = CMUXAuthCore;
 		};
-		AA11BB22CC33DD44EE550002 /* CMUXWorkstream */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = AA11BB22CC33DD44EE550003 /* XCLocalSwiftPackageReference "CMUXWorkstream" */;
-			productName = CMUXWorkstream;
-		};
-		C0DE45000000000000000002 /* CmuxExtensionKit */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = C0DE45000000000000000003 /* XCLocalSwiftPackageReference "CmuxExtensionKit" */;
-			productName = CmuxExtensionKit;
-		};
-		C0DE46000000000000000002 /* CMUXExtensionHostSupport */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = C0DE46000000000000000003 /* XCLocalSwiftPackageReference "CMUXExtensionHostSupport" */;
-			productName = CMUXExtensionHostSupport;
-		};
-		C0DE49000000000000000002 /* CmuxExtensionSidebarExamples */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = C0DE49000000000000000003 /* XCLocalSwiftPackageReference "CmuxExtensionSidebarExamples" */;
-			productName = CmuxExtensionSidebarExamples;
-		};
-		C0DE4A000000000000000002 /* CmuxSidebarProviderKit */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = C0DE4A000000000000000003 /* XCLocalSwiftPackageReference "CmuxSidebarProviderKit" */;
-			productName = CmuxSidebarProviderKit;
-		};
 		3069F1D10000000000000006 /* CMUXPasteboardFidelity */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 3069F1D10000000000000007 /* XCLocalSwiftPackageReference "CMUXPasteboardFidelity" */;
 			productName = CMUXPasteboardFidelity;
-		};
-		A5C0DE0000000000000000A2 /* CMUXProjectModel */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = A5C0DE0000000000000000A1 /* XCLocalSwiftPackageReference "CMUXProjectModel" */;
-			productName = CMUXProjectModel;
-		};
-		F53000A2A1B2C3D4E5F60718 /* CMUXAgentVault */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = F53000A1A1B2C3D4E5F60718 /* XCLocalSwiftPackageReference "CMUXAgentVault" */;
-			productName = CMUXAgentVault;
-		};
-		A5B00002A1B2C3D4E5F60718 /* CMUXAgentLaunch */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = A5B00001A1B2C3D4E5F60718 /* XCLocalSwiftPackageReference "CMUXAgentLaunch" */;
-			productName = CMUXAgentLaunch;
-		};
-		A500D013A1B2C3D4E5F60718 /* CMUXDebugLog */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = A500D012A1B2C3D4E5F60718 /* XCLocalSwiftPackageReference "CMUXDebugLog" */;
-			productName = CMUXDebugLog;
-		};
-		A5354305A5354305A5354305 /* CmuxSocketControl */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = A5354304A5354304A5354304 /* XCLocalSwiftPackageReference "CmuxSocketControl" */;
-			productName = CmuxSocketControl;
-		};
-		C52830000000000000000004 /* CmuxTerminalCopyMode */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = C52830000000000000000003 /* XCLocalSwiftPackageReference "CmuxTerminalCopyMode" */;
-			productName = CmuxTerminalCopyMode;
-		};
-		C5A1FED000000000000000C3 /* CmuxSwiftRender */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = C5A1FED000000000000000C4 /* XCLocalSwiftPackageReference "CmuxSwiftRender" */;
-			productName = CmuxSwiftRender;
-		};
-		C5A1FED100000000000000D3 /* CmuxSwiftRenderUI */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = C5A1FED100000000000000D4 /* XCLocalSwiftPackageReference "CmuxSwiftRenderUI" */;
-			productName = CmuxSwiftRenderUI;
-		};
-		C5A1FED200000000000000E3 /* CmuxSidebarInterpreterClient */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = C5A1FED200000000000000E4 /* XCLocalSwiftPackageReference "CmuxSidebarInterpreterService" */;
-			productName = CmuxSidebarInterpreterClient;
-		};
-		C5A1FED200000000000000E6 /* CmuxSidebarRemoteRender */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = C5A1FED200000000000000E4 /* XCLocalSwiftPackageReference "CmuxSidebarInterpreterService" */;
-			productName = CmuxSidebarRemoteRender;
-		};
-		C8000312C8000312C8000312 /* CmuxFileWatch */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = C8000311C8000311C8000311 /* XCLocalSwiftPackageReference "CmuxFileWatch" */;
-			productName = CmuxFileWatch;
-		};
-		C617000000000000000000A2 /* CmuxGit */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = C617000000000000000000A1 /* XCLocalSwiftPackageReference "CmuxGit" */;
-			productName = CmuxGit;
-		};
-		C750100000000000000000A2 /* CmuxControlSocket */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = C750100000000000000000A1 /* XCLocalSwiftPackageReference "CmuxControlSocket" */;
-			productName = CmuxControlSocket;
-		};
-		C8000302C8000302C8000302 /* CmuxProcess */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = C8000301C8000301C8000301 /* XCLocalSwiftPackageReference "CmuxProcess" */;
-			productName = CmuxProcess;
-		};
-		CD0CFE5200000000CD0CFE52 /* CmuxSettings */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = CD0CFE5100000000CD0CFE51 /* XCLocalSwiftPackageReference "CmuxSettings" */;
-			productName = CmuxSettings;
-		};
-		CD0CFE5500000000CD0CFE55 /* CmuxSettingsUI */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = CD0CFE5400000000CD0CFE54 /* XCLocalSwiftPackageReference "CmuxSettingsUI" */;
-			productName = CmuxSettingsUI;
-		};
-		CDFEED0200000000CDFEED02 /* CmuxUpdater */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = CDFEED0100000000CDFEED01 /* XCLocalSwiftPackageReference "CmuxUpdater" */;
-			productName = CmuxUpdater;
-		};
-		CDFEED0500000000CDFEED05 /* CmuxUpdaterUI */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = CDFEED0400000000CDFEED04 /* XCLocalSwiftPackageReference "CmuxUpdaterUI" */;
-			productName = CmuxUpdaterUI;
-		};
-		CF00F00000000000000000A2 /* CmuxFoundation */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = CF00F00000000000000000A1 /* XCLocalSwiftPackageReference "CmuxFoundation" */;
-			productName = CmuxFoundation;
 		};
 		A5001231 /* Sparkle */ = {
 			isa = XCSwiftPackageProductDependency;
@@ -3711,15 +3607,135 @@
 			package = A5001292 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */;
 			productName = MarkdownUI;
 		};
+		A500D013A1B2C3D4E5F60718 /* CMUXDebugLog */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A500D012A1B2C3D4E5F60718 /* XCLocalSwiftPackageReference "CMUXDebugLog" */;
+			productName = CMUXDebugLog;
+		};
+		A5354305A5354305A5354305 /* CmuxSocketControl */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A5354304A5354304A5354304 /* XCLocalSwiftPackageReference "CmuxSocketControl" */;
+			productName = CmuxSocketControl;
+		};
+		A5B00002A1B2C3D4E5F60718 /* CMUXAgentLaunch */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A5B00001A1B2C3D4E5F60718 /* XCLocalSwiftPackageReference "CMUXAgentLaunch" */;
+			productName = CMUXAgentLaunch;
+		};
+		A5C0DE0000000000000000A2 /* CMUXProjectModel */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A5C0DE0000000000000000A1 /* XCLocalSwiftPackageReference "CMUXProjectModel" */;
+			productName = CMUXProjectModel;
+		};
 		A8BD195031FC4B82B4354297 /* StackAuth */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 28B798BB9086C8E6B60C3355 /* XCLocalSwiftPackageReference "stack-auth-swift-sdk-prerelease" */;
 			productName = StackAuth;
 		};
+		AA11BB22CC33DD44EE550002 /* CMUXWorkstream */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = AA11BB22CC33DD44EE550003 /* XCLocalSwiftPackageReference "CMUXWorkstream" */;
+			productName = CMUXWorkstream;
+		};
+		C0DE45000000000000000002 /* CmuxExtensionKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C0DE45000000000000000003 /* XCLocalSwiftPackageReference "CmuxExtensionKit" */;
+			productName = CmuxExtensionKit;
+		};
+		C0DE46000000000000000002 /* CMUXExtensionHostSupport */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C0DE46000000000000000003 /* XCLocalSwiftPackageReference "CMUXExtensionHostSupport" */;
+			productName = CMUXExtensionHostSupport;
+		};
+		C0DE49000000000000000002 /* CmuxExtensionSidebarExamples */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C0DE49000000000000000003 /* XCLocalSwiftPackageReference "CmuxExtensionSidebarExamples" */;
+			productName = CmuxExtensionSidebarExamples;
+		};
+		C0DE4A000000000000000002 /* CmuxSidebarProviderKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C0DE4A000000000000000003 /* XCLocalSwiftPackageReference "CmuxSidebarProviderKit" */;
+			productName = CmuxSidebarProviderKit;
+		};
+		C52830000000000000000004 /* CmuxTerminalCopyMode */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C52830000000000000000003 /* XCLocalSwiftPackageReference "CmuxTerminalCopyMode" */;
+			productName = CmuxTerminalCopyMode;
+		};
+		C5A1FED000000000000000C3 /* CmuxSwiftRender */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C5A1FED000000000000000C4 /* XCLocalSwiftPackageReference "CmuxSwiftRender" */;
+			productName = CmuxSwiftRender;
+		};
+		C5A1FED100000000000000D3 /* CmuxSwiftRenderUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C5A1FED100000000000000D4 /* XCLocalSwiftPackageReference "CmuxSwiftRenderUI" */;
+			productName = CmuxSwiftRenderUI;
+		};
+		C5A1FED200000000000000E3 /* CmuxSidebarInterpreterClient */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C5A1FED200000000000000E4 /* XCLocalSwiftPackageReference "CmuxSidebarInterpreterService" */;
+			productName = CmuxSidebarInterpreterClient;
+		};
+		C5A1FED200000000000000E6 /* CmuxSidebarRemoteRender */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C5A1FED200000000000000E4 /* XCLocalSwiftPackageReference "CmuxSidebarInterpreterService" */;
+			productName = CmuxSidebarRemoteRender;
+		};
+		C617000000000000000000A2 /* CmuxGit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C617000000000000000000A1 /* XCLocalSwiftPackageReference "CmuxGit" */;
+			productName = CmuxGit;
+		};
+		C750100000000000000000A2 /* CmuxControlSocket */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C750100000000000000000A1 /* XCLocalSwiftPackageReference "CmuxControlSocket" */;
+			productName = CmuxControlSocket;
+		};
+		C8000302C8000302C8000302 /* CmuxProcess */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C8000301C8000301C8000301 /* XCLocalSwiftPackageReference "CmuxProcess" */;
+			productName = CmuxProcess;
+		};
+		C8000312C8000312C8000312 /* CmuxFileWatch */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C8000311C8000311C8000311 /* XCLocalSwiftPackageReference "CmuxFileWatch" */;
+			productName = CmuxFileWatch;
+		};
+		CD0CFE5200000000CD0CFE52 /* CmuxSettings */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CD0CFE5100000000CD0CFE51 /* XCLocalSwiftPackageReference "CmuxSettings" */;
+			productName = CmuxSettings;
+		};
+		CD0CFE5500000000CD0CFE55 /* CmuxSettingsUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CD0CFE5400000000CD0CFE54 /* XCLocalSwiftPackageReference "CmuxSettingsUI" */;
+			productName = CmuxSettingsUI;
+		};
+		CDFEED0200000000CDFEED02 /* CmuxUpdater */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CDFEED0100000000CDFEED01 /* XCLocalSwiftPackageReference "CmuxUpdater" */;
+			productName = CmuxUpdater;
+		};
+		CDFEED0500000000CDFEED05 /* CmuxUpdaterUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CDFEED0400000000CDFEED04 /* XCLocalSwiftPackageReference "CmuxUpdaterUI" */;
+			productName = CmuxUpdaterUI;
+		};
+		CF00F00000000000000000A2 /* CmuxFoundation */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CF00F00000000000000000A1 /* XCLocalSwiftPackageReference "CmuxFoundation" */;
+			productName = CmuxFoundation;
+		};
 		EFB18E3B3099DFE2ECA3C263 /* CMUXMobileCore */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 0C69E6A5FA9B0513E68DF443 /* XCLocalSwiftPackageReference "CMUXMobileCore" */;
 			productName = CMUXMobileCore;
+		};
+		F53000A2A1B2C3D4E5F60718 /* CMUXAgentVault */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F53000A1A1B2C3D4E5F60718 /* XCLocalSwiftPackageReference "CMUXAgentVault" */;
+			productName = CMUXAgentVault;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/tests/test_claude_hook_stop_last_assistant.py
+++ b/tests/test_claude_hook_stop_last_assistant.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import glob
+import base64
 import json
 import os
 import shutil
@@ -253,10 +254,42 @@ def main() -> int:
             return 1
 
         notify = notify_commands[-1]
-        expected_payload = f"notify_target_async {workspace_id} {surface_id} Claude Code|Completed in fun|2"
-        if notify != expected_payload:
+        prefix = f"notify_target_async {workspace_id} {surface_id} "
+        if not notify.startswith(prefix):
+            print("FAIL: expected stop notification to target workspace and surface")
+            print(f"expected_prefix={prefix!r}")
+            print(f"actual={notify!r}")
+            print(f"commands={server.commands!r}")
+            return 1
+
+        raw_payload = notify.removeprefix(prefix)
+        if raw_payload.startswith("json64:"):
+            try:
+                notification = json.loads(base64.b64decode(raw_payload.removeprefix("json64:")).decode("utf-8"))
+            except Exception as exc:
+                print("FAIL: expected stop notification json64 payload to decode")
+                print(f"error={exc}")
+                print(f"actual={notify!r}")
+                return 1
+        else:
+            parts = raw_payload.split("|", 2)
+            notification = {
+                "title": parts[0] if len(parts) > 0 else "",
+                "subtitle": parts[1] if len(parts) > 1 else "",
+                "body": parts[2] if len(parts) > 2 else "",
+                "body_format": "plain",
+            }
+
+        expected_notification = {
+            "title": "Claude Code",
+            "subtitle": "Completed in fun",
+            "body": "2",
+            "body_format": "markdown",
+        }
+        if notification != expected_notification:
             print("FAIL: expected stop notification to use final assistant text")
-            print(f"expected={expected_payload!r}")
+            print(f"expected={expected_notification!r}")
+            print(f"actual_notification={notification!r}")
             print(f"actual={notify!r}")
             print(f"commands={server.commands!r}")
             return 1

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 SOURCE_WRAPPER = ROOT / "Resources" / "bin" / "claude"
+LAST_SETTINGS_CONTENT = ""
 
 
 def make_executable(path: Path, content: str) -> None:
@@ -31,12 +32,25 @@ def read_lines(path: Path) -> list[str]:
 
 
 def parse_settings_arg(argv: list[str]) -> dict:
-    if "--settings" not in argv:
+    value = settings_arg_value(argv)
+    if not value:
         return {}
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        path = Path(value)
+        if path.exists():
+            return json.loads(path.read_text(encoding="utf-8"))
+        return json.loads(LAST_SETTINGS_CONTENT)
+
+
+def settings_arg_value(argv: list[str]) -> str:
+    if "--settings" not in argv:
+        return ""
     index = argv.index("--settings")
     if index + 1 >= len(argv):
-        return {}
-    return json.loads(argv[index + 1])
+        return ""
+    return argv[index + 1]
 
 
 def run_wrapper(
@@ -81,6 +95,21 @@ printf '%s\\n' "${CMUX_AGENT_LAUNCH_ARGV_B64-__UNSET__}" > "$FAKE_REAL_LAUNCH_AR
 printf '%s\\n' "${CMUX_CLAUDE_HOOK_CMUX_BIN-__UNSET__}" > "$FAKE_HOOK_CMUX_BIN_LOG"
 for arg in "$@"; do
   printf '%s\\n' "$arg" >> "$FAKE_REAL_ARGS_LOG"
+done
+settings_next=false
+for arg in "$@"; do
+  if [[ "$settings_next" == true ]]; then
+    if [[ -f "$arg" ]]; then
+      printf '__CMUX_SETTINGS_CONTENT__=%s\\n' "$(cat "$arg")" >> "$FAKE_REAL_ARGS_LOG"
+    else
+      printf '__CMUX_SETTINGS_CONTENT__=%s\\n' "$arg" >> "$FAKE_REAL_ARGS_LOG"
+    fi
+    settings_next=false
+    continue
+  fi
+  if [[ "$arg" == "--settings" ]]; then
+    settings_next=true
+  fi
 done
 if [[ "${1:-}" == "--help" ]]; then
   cat <<'HELP'
@@ -214,9 +243,15 @@ exit 0
         child_node_options_value = child_node_options_lines[0] if child_node_options_lines else ""
         hook_cmux_bin_value = hook_cmux_bin_lines[0] if hook_cmux_bin_lines else ""
         launch_argv_b64_value = launch_argv_b64_lines[0] if launch_argv_b64_lines else ""
+        global LAST_SETTINGS_CONTENT
+        real_args_lines = read_lines(real_args_log)
+        settings_prefix = "__CMUX_SETTINGS_CONTENT__="
+        settings_lines = [line.removeprefix(settings_prefix) for line in real_args_lines if line.startswith(settings_prefix)]
+        LAST_SETTINGS_CONTENT = settings_lines[-1] if settings_lines else ""
+        real_args_lines = [line for line in real_args_lines if not line.startswith(settings_prefix)]
         return (
             proc.returncode,
-            read_lines(real_args_log),
+            real_args_lines,
             read_lines(cmux_log),
             proc.stderr.strip(),
             claudecode_value,
@@ -574,6 +609,214 @@ def test_live_socket_injects_supported_hooks_without_unlocking_bypass(failures: 
     expect(
         any(h.get("timeout", 999) <= 2 for h in session_end_hooks),
         f"SessionEnd hook should have short timeout, got {session_end_hooks}",
+        failures,
+    )
+
+def test_live_socket_merges_user_settings_file_into_first_settings(failures: list[str]) -> None:
+    with tempfile.TemporaryDirectory(prefix="cmux-claude-user-settings-") as td:
+        settings_path = Path(td) / "settings.json"
+        settings_path.write_text(
+            json.dumps({
+                "model": "opus",
+                "preferredNotifChannel": "terminal_bell",
+                "hooks": {
+                    "Stop": [
+                        {
+                            "matcher": "",
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": "echo user-stop",
+                                    "timeout": 3,
+                                }
+                            ],
+                        }
+                    ]
+                },
+            }),
+            encoding="utf-8",
+        )
+        code, real_argv, *_ = run_wrapper(
+            socket_state="live",
+            argv=["--settings", str(settings_path), "hello"],
+        )
+
+    expect(code == 0, f"user settings file: wrapper exited {code}", failures)
+    settings_arg = settings_arg_value(real_argv)
+    expect(
+        settings_arg and not settings_arg.lstrip().startswith("{"),
+        f"user settings file: merged settings should be passed as a file path, got {settings_arg!r}",
+        failures,
+    )
+    expect(
+        settings_arg and not Path(settings_arg).exists(),
+        f"user settings file: merged settings temp file should be removed after Claude exits, got {settings_arg!r}",
+        failures,
+    )
+    settings = parse_settings_arg(real_argv)
+    expect(settings.get("model") == "opus", f"user settings file: expected model to survive, got {settings}", failures)
+    expect(
+        settings.get("preferredNotifChannel") == "notifications_disabled",
+        f"user settings file: expected cmux to keep Claude native notifications disabled, got {settings}",
+        failures,
+    )
+    stop_groups = settings.get("hooks", {}).get("Stop", [])
+    stop_commands = [
+        hook.get("command", "")
+        for group in stop_groups
+        for hook in group.get("hooks", [])
+    ]
+    expect(
+        any("hooks claude stop" in command for command in stop_commands),
+        f"user settings file: expected cmux Stop hook to survive, got {stop_commands}",
+        failures,
+    )
+    expect(
+        "echo user-stop" in stop_commands,
+        f"user settings file: expected user Stop hook to be appended, got {stop_commands}",
+        failures,
+    )
+    expect(
+        str(settings_path) not in real_argv,
+        f"user settings file: merged settings file should not be passed again, got {real_argv}",
+        failures,
+    )
+
+
+def test_live_socket_merges_inline_settings_form(failures: list[str]) -> None:
+    inline = json.dumps({
+        "permissionMode": "acceptEdits",
+        "hooks": {
+            "Notification": [
+                {
+                    "matcher": "",
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": "echo user-notify",
+                            "timeout": 2,
+                        }
+                    ],
+                }
+            ]
+        },
+    })
+    code, real_argv, *_ = run_wrapper(
+        socket_state="live",
+        argv=[f"--settings={inline}", "hello"],
+    )
+
+    expect(code == 0, f"inline settings: wrapper exited {code}", failures)
+    settings = parse_settings_arg(real_argv)
+    expect(
+        settings.get("permissionMode") == "acceptEdits",
+        f"inline settings: expected permissionMode to survive, got {settings}",
+        failures,
+    )
+    notification_groups = settings.get("hooks", {}).get("Notification", [])
+    notification_commands = [
+        hook.get("command", "")
+        for group in notification_groups
+        for hook in group.get("hooks", [])
+    ]
+    expect(
+        any("hooks claude notification" in command for command in notification_commands),
+        f"inline settings: expected cmux Notification hook to survive, got {notification_commands}",
+        failures,
+    )
+    expect(
+        "echo user-notify" in notification_commands,
+        f"inline settings: expected user Notification hook to be appended, got {notification_commands}",
+        failures,
+    )
+    expect(
+        not any(arg == f"--settings={inline}" for arg in real_argv),
+        f"inline settings: merged settings should not be passed again, got {real_argv}",
+        failures,
+    )
+
+
+def test_live_socket_does_not_merge_settings_after_double_dash(failures: list[str]) -> None:
+    inline = json.dumps({"model": "opus"})
+    code, real_argv, *_ = run_wrapper(
+        socket_state="live",
+        argv=["--", f"--settings={inline}", "hello"],
+    )
+
+    expect(code == 0, f"settings after --: wrapper exited {code}", failures)
+    settings = parse_settings_arg(real_argv)
+    expect(
+        settings.get("model") != "opus",
+        f"settings after --: positional settings-like text should not merge, got {settings}",
+        failures,
+    )
+    expect(
+        real_argv[-3:] == ["--", f"--settings={inline}", "hello"],
+        f"settings after --: expected positional args preserved, got {real_argv}",
+        failures,
+    )
+
+
+def test_live_socket_does_not_merge_settings_like_option_value(failures: list[str]) -> None:
+    inline = json.dumps({"model": "opus"})
+    code, real_argv, *_ = run_wrapper(
+        socket_state="live",
+        argv=["--append-system-prompt", f"--settings={inline}", "hello"],
+    )
+
+    expect(code == 0, f"settings-like option value: wrapper exited {code}", failures)
+    settings = parse_settings_arg(real_argv)
+    expect(
+        settings.get("model") != "opus",
+        f"settings-like option value: option value should not merge, got {settings}",
+        failures,
+    )
+    expect(
+        real_argv[-3:] == ["--append-system-prompt", f"--settings={inline}", "hello"],
+        f"settings-like option value: expected original args preserved, got {real_argv}",
+        failures,
+    )
+
+
+def test_live_socket_merges_settings_after_common_value_options(failures: list[str]) -> None:
+    inline = json.dumps({"model": "opus"})
+    for option in ("--allowedTools", "--plugin-dir"):
+        code, real_argv, *_ = run_wrapper(
+            socket_state="live",
+            argv=[option, "Read", f"--settings={inline}", "hello"],
+        )
+
+        expect(code == 0, f"settings after {option}: wrapper exited {code}", failures)
+        settings = parse_settings_arg(real_argv)
+        expect(
+            settings.get("model") == "opus",
+            f"settings after {option}: expected settings to merge after option value, got {settings}",
+            failures,
+        )
+        expect(
+            real_argv[-3:] == [option, "Read", "hello"],
+            f"settings after {option}: expected consumed settings stripped and other args preserved, got {real_argv}",
+            failures,
+        )
+
+
+def test_live_socket_does_not_merge_settings_after_prompt(failures: list[str]) -> None:
+    inline = json.dumps({"model": "opus"})
+    code, real_argv, *_ = run_wrapper(
+        socket_state="live",
+        argv=["hello", f"--settings={inline}"],
+    )
+
+    expect(code == 0, f"settings after prompt: wrapper exited {code}", failures)
+    settings = parse_settings_arg(real_argv)
+    expect(
+        settings.get("model") != "opus",
+        f"settings after prompt: prompt text should not merge, got {settings}",
+        failures,
+    )
+    expect(
+        real_argv[-2:] == ["hello", f"--settings={inline}"],
+        f"settings after prompt: expected prompt args preserved, got {real_argv}",
         failures,
     )
 
@@ -1166,6 +1409,12 @@ def test_stale_socket_skips_hook_injection(failures: list[str]) -> None:
 def main() -> int:
     failures: list[str] = []
     test_live_socket_injects_supported_hooks_without_unlocking_bypass(failures)
+    test_live_socket_merges_user_settings_file_into_first_settings(failures)
+    test_live_socket_merges_inline_settings_form(failures)
+    test_live_socket_does_not_merge_settings_after_double_dash(failures)
+    test_live_socket_does_not_merge_settings_like_option_value(failures)
+    test_live_socket_merges_settings_after_common_value_options(failures)
+    test_live_socket_does_not_merge_settings_after_prompt(failures)
     test_plain_claude_launch_argv_has_no_empty_argument(failures)
     test_command_like_invocations_bypass_hook_injection(failures)
     test_passthrough_flags_bypass_hook_injection(failures)

--- a/tests/test_opencode_plugin_install.py
+++ b/tests/test_opencode_plugin_install.py
@@ -171,8 +171,34 @@ if (typeof mod.CMUXSessionRestore !== "function") {
 if (typeof mod.default !== "function") {
   throw new Error("missing default export");
 }
-const hooks = await mod.default({ directory: "/tmp/opencode-project" });
-const duplicateHooks = await duplicateMod.default({ directory: "/tmp/opencode-project" });
+const fakeMessages = [
+  {
+    info: { role: "user" },
+    parts: [{ type: "text", text: "3+3" }],
+  },
+  {
+    info: { role: "assistant" },
+    parts: [{ type: "text", text: "6" }],
+  },
+];
+const hookContext = {
+  directory: "/tmp/opencode-project",
+  client: {
+    session: {
+      messages: async ({ path, query }) => {
+        if (path.id !== "opencode-session-test") {
+          return { data: [] };
+        }
+        if (query.directory !== "/tmp/opencode-project") {
+          throw new Error("missing directory query");
+        }
+        return { data: fakeMessages };
+      },
+    },
+  },
+};
+const hooks = await mod.default(hookContext);
+const duplicateHooks = await duplicateMod.default(hookContext);
 if (!hooks || typeof hooks.event !== "function") {
   throw new Error("missing event hook");
 }
@@ -194,6 +220,119 @@ await hooks.event({
       info: {
         id: "opencode-session-test",
         directory: "/tmp/opencode-project"
+      }
+    }
+  }
+});
+await hooks.event({
+  event: {
+    type: "session.updated",
+    properties: {
+      info: {
+        id: "opencode-session-test",
+        directory: "/tmp/opencode-project"
+      }
+    }
+  }
+});
+await hooks.event({
+  event: {
+    type: "session.status",
+    properties: {
+      sessionID: "opencode-session-test",
+      status: { type: "idle" }
+    }
+  }
+});
+await hooks.event({
+  event: {
+    type: "session.idle",
+    properties: {
+      sessionID: "opencode-session-test"
+    }
+  }
+});
+await hooks.event({
+  event: {
+    type: "session.status",
+    properties: {
+      sessionID: "opencode-session-test",
+      status: { type: "busy" }
+    }
+  }
+});
+await hooks.event({
+  event: {
+    type: "session.status",
+    properties: {
+      sessionID: "opencode-session-test",
+      status: { type: "idle" }
+    }
+  }
+});
+await hooks.event({
+  event: {
+    type: "session.updated",
+    properties: {
+      info: {
+        id: "opencode-session-test",
+        directory: "/tmp/opencode-project"
+      }
+    }
+  }
+});
+await hooks.event({
+  event: {
+    type: "session.status",
+    properties: {
+      sessionID: "opencode-session-test",
+      status: { type: "idle" }
+    }
+  }
+});
+await hooks.event({
+  event: {
+    type: "session.created",
+    properties: {
+      info: {
+        id: "opencode-idle-only-session-test",
+        directory: "/tmp/opencode-project"
+      }
+    }
+  }
+});
+await hooks.event({
+  event: {
+    type: "session.idle",
+    properties: {
+      sessionID: "opencode-idle-only-session-test"
+    }
+  }
+});
+await hooks.event({
+  event: {
+    type: "session.deleted",
+    properties: {
+      sessionID: "opencode-idle-only-session-test"
+    }
+  }
+});
+await hooks.event({
+  event: {
+    type: "session.idle",
+    properties: {
+      sessionID: "opencode-idle-only-session-test"
+    }
+  }
+});
+await hooks.event({
+  event: {
+    type: "session.updated",
+    properties: {
+      info: {
+        id: "opencode-session-test",
+        directory: "/tmp/opencode-project",
+        time: { archived: 1710000000000 }
       }
     }
   }
@@ -221,11 +360,20 @@ await hooks.event({
         if "hooks opencode session-start" not in args_log:
             print(f"FAIL: plugin did not invoke hooks opencode session-start, got {args_log!r}")
             return 1
-        if args_log.count("hooks opencode session-start") != 1:
-            print(f"FAIL: plugin invoked duplicate session-start hooks, got {args_log!r}")
+        if args_log.count("hooks opencode session-start") != 2:
+            print(f"FAIL: plugin did not start both test sessions, got {args_log!r}")
+            return 1
+        if args_log.count("hooks opencode stop") != 4:
+            print(f"FAIL: plugin did not reset active stop dedupe or ignore ended sessions, got {args_log!r}")
+            return 1
+        if args_log.count("hooks opencode session-end") != 2:
+            print(f"FAIL: plugin did not invoke archived and deleted session-end hooks, got {args_log!r}")
             return 1
         if '"session_id":"opencode-session-test"' not in stdin_log or '"/tmp/opencode-project"' not in stdin_log:
             print(f"FAIL: plugin did not pass expected session payload, got {stdin_log!r}")
+            return 1
+        if '"last_assistant_message":"6"' not in stdin_log:
+            print(f"FAIL: plugin did not pass latest assistant message on stop, got {stdin_log!r}")
             return 1
         if "kind=opencode" not in env_log or "cwd=/tmp/opencode-project" not in env_log or "argv=" not in env_log:
             print(f"FAIL: plugin did not pass launch metadata environment, got {env_log!r}")


### PR DESCRIPTION
## Summary
- surface blocking feed decisions as workspace Needs input status/lifecycle for Claude, OpenCode, Codex, Grok, and other supported agents
- make agent notification bodies rich text end-to-end: markdown-aware payloads, persisted body format, socket list output, and SwiftUI rendering in the notification list and titlebar popover
- preserve multiline markdown bodies through hook parsing/redaction instead of flattening them before notify
- merge user Claude --settings into cmux hook settings so user config and cmux notifications both survive Claude's first-settings behavior
- stop duplicate OpenCode lifecycle notifications from session.updated and deprecated session.idle events

## Learned from related unmerged PRs
- took the feed-routed attention path from the strongest blocking-decision PR
- kept the Claude settings merge narrow instead of replacing the wrapper wholesale
- kept OpenCode lifecycle dedupe minimal instead of pulling in the larger stale plugin rewrites
- kept legacy pipe notification payloads for plain one-line bodies, and added encoded markdown payloads only when the body needs rich text

## Verification
- python3 tests/test_claude_wrapper_hooks.py
- python3 tests/test_claude_hook_stop_last_assistant.py
- CMUX_CLI_BIN="$HOME/Library/Developer/Xcode/DerivedData/cmux-agnotif/Build/Products/Debug/cmux DEV agnotif.app/Contents/Resources/bin/cmux" python3 tests/test_opencode_plugin_install.py
- git diff --check
- ./scripts/reload-cloud.sh --tag agnotif
- dogfood: restarted cmux DEV agnotif and verified the restored Claude pane launches through the bundled Claude wrapper with --settings, notifications_disabled, the agnotif hook CLI, and /tmp/cmux-debug-agnotif.sock
- dogfood: launched cmux DEV agnotif, pushed a Claude PermissionRequest through feed.push, replied with feed.permission.reply, and received the expected inline permission decision
- dogfood: sent a Claude hook notification with body `**Approve shell command?**\n\n- inspect generated diff\n- rerun smoke tests`; notification.list returned `body_format: markdown` and preserved the blank line plus bullet list

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches notification delivery, feed blocking UX, and Claude launch/resume wrapping across CLI and app; settings merge and payload format changes could affect edge-case hook or resume behavior.
> 
> **Overview**
> Improves how agent notifications and blocking prompts show up in cmux: **richer notification bodies**, **feed-driven “Needs input” attention**, and **more reliable Claude/OpenCode hook integration**.
> 
> **Notifications** now support an explicit `body_format` (plain vs **markdown**) end-to-end. Hook and agent stop/notification paths send `bodyFormat: "markdown"` and can use **json64** payloads so multiline and formatted text is not flattened. Hook compaction **preserves whitespace** for assistant/message fields; classification uses raw messages where appropriate. The app persists `bodyFormat`, parses json64 on the socket, renders markdown in notification UI via `NotificationBodyText`, and improves sidebar preview text for coding-agent titles. Session snapshots and policy/queue plumbing carry the new field.
> 
> **Feed blocking decisions** set workspace sidebar status to localized **“Needs input”**, panel lifecycle to `.needsInput`, optionally bump the tab, and request dock attention—restored when the decision completes or times out (`AttentionTarget` + `FeedJumpResolver` agent-prefix fixes).
> 
> **Claude wrapper** merges user `--settings` (file or inline) with cmux hook settings (hooks appended), writes merged settings to a temp file when needed, and strips the consumed `--settings` from argv. **Resume** paths rewrite direct `claude` invocations to the **bundled wrapper** with `CMUX_CUSTOM_CLAUDE_PATH` (CLI, restorable sessions, persisted surface bindings).
> 
> **OpenCode plugin** dedupes stop hooks per session, fetches **latest assistant message** for stop payloads, and tracks session active/ended across lifecycle events.
> 
> Tests updated for markdown/json64 stop notifications, settings merge edge cases, and OpenCode stop/session-end behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f6cdd6115404169b2331120f63be2af6b938d52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notifications now carry explicit body format (plain/markdown) with richer JSON64 payloads; UI renders Markdown when present.
  * CLI wrapper accepts and merges user-provided --settings.
  * Resume commands can be rewritten to use a bundled CLI wrapper when appropriate.
  * Feed shows a “Needs input” sidebar status and requests user attention for blocking decisions.

* **Bug Fixes**
  * Session lifecycle hooks refined so archived sessions emit session-end and idle/stop flows behave correctly.

* **Localization**
  * Added Japanese translation for “Needs input”.

* **Tests**
  * New/updated tests covering settings merge, rich notification payloads, resume-wrapping, session flows, and attention surfacing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->