### PR TITLE
Reduce terminal typing hot-path work

### DIFF
--- a/Sources/GhosttyTerminalAppearance.swift
+++ b/Sources/GhosttyTerminalAppearance.swift
@@ -89,6 +89,76 @@ final class GhosttyDefaultBackgroundNotificationDispatcher {
     }
 }
 
+/// Coalesces terminal title notifications at the producer so tmux/title bursts
+/// don't fan out through every NotificationCenter observer per escape sequence.
+final class GhosttyTitleNotificationDispatcher {
+    static let shared = GhosttyTitleNotificationDispatcher()
+
+    private struct SurfaceKey: Hashable {
+        let tabId: UUID
+        let surfaceId: UUID
+    }
+
+    private struct PendingTitle {
+        let object: Any?
+        let title: String
+    }
+
+    private let coalescer: NotificationBurstCoalescer
+    private let postNotification: (Any?, [AnyHashable: Any]) -> Void
+    private var pendingTitles: [SurfaceKey: PendingTitle] = [:]
+    private var lastPostedTitleBySurface: [SurfaceKey: String] = [:]
+
+    init(
+        delay: TimeInterval = 1.0 / 60.0,
+        postNotification: @escaping (Any?, [AnyHashable: Any]) -> Void = { object, userInfo in
+            NotificationCenter.default.post(
+                name: .ghosttyDidSetTitle,
+                object: object,
+                userInfo: userInfo
+            )
+        }
+    ) {
+        coalescer = NotificationBurstCoalescer(delay: delay)
+        self.postNotification = postNotification
+    }
+
+    func signal(object: Any?, tabId: UUID, surfaceId: UUID, title: String) {
+        let signalOnMain = { [self] in
+            let key = SurfaceKey(tabId: tabId, surfaceId: surfaceId)
+            pendingTitles[key] = PendingTitle(object: object, title: title)
+            coalescer.signal { [self] in
+                flushPendingTitles()
+            }
+        }
+
+        if Thread.isMainThread {
+            signalOnMain()
+        } else {
+            DispatchQueue.main.async(execute: signalOnMain)
+        }
+    }
+
+    private func flushPendingTitles() {
+        guard !pendingTitles.isEmpty else { return }
+        let titles = pendingTitles
+        pendingTitles.removeAll(keepingCapacity: true)
+
+        for (key, pendingTitle) in titles {
+            guard lastPostedTitleBySurface[key] != pendingTitle.title else { continue }
+            lastPostedTitleBySurface[key] = pendingTitle.title
+            postNotification(
+                pendingTitle.object,
+                [
+                    GhosttyNotificationKey.tabId: key.tabId,
+                    GhosttyNotificationKey.surfaceId: key.surfaceId,
+                    GhosttyNotificationKey.title: pendingTitle.title,
+                ]
+            )
+        }
+    }
+}
+
 enum GhosttyNotificationKey {
     static let scrollbar = "ghostty.scrollbar"
     static let cellSize = "ghostty.cellSize"

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -4546,17 +4546,12 @@ class GhosttyApp {
                 .flatMap { String(cString: $0) } ?? ""
             if let tabId = surfaceView.tabId,
                let surfaceId = surfaceView.terminalSurface?.id {
-                DispatchQueue.main.async {
-                    NotificationCenter.default.post(
-                        name: .ghosttyDidSetTitle,
-                        object: surfaceView,
-                        userInfo: [
-                            GhosttyNotificationKey.tabId: tabId,
-                            GhosttyNotificationKey.surfaceId: surfaceId,
-                            GhosttyNotificationKey.title: title,
-                        ]
-                    )
-                }
+                GhosttyTitleNotificationDispatcher.shared.signal(
+                    object: surfaceView,
+                    tabId: tabId,
+                    surfaceId: surfaceId,
+                    title: title
+                )
             }
             return true
         case GHOSTTY_ACTION_PWD:
@@ -9299,18 +9294,26 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 #if DEBUG
         ensureSurfaceMs = (ProcessInfo.processInfo.systemUptime - ensureSurfaceStart) * 1000.0
 #endif
-        if let mode = RightSidebarMode.modeShortcut(for: event), let window, AppDelegate.shared?.shouldRouteRightSidebarModeShortcut(in: window) == true {
-            _ = AppDelegate.shared?.focusRightSidebarInActiveMainWindow(mode: mode, focusFirstItem: true, preferredWindow: window)
+        let appDelegate = AppDelegate.shared
+        if let window,
+           appDelegate?.shouldRouteRightSidebarModeShortcut(in: window) == true,
+           let mode = RightSidebarMode.modeShortcut(for: event) {
+            _ = appDelegate?.focusRightSidebarInActiveMainWindow(mode: mode, focusFirstItem: true, preferredWindow: window)
             return
         }
         if let terminalSurface {
 #if DEBUG
             let dismissNotificationStart = ProcessInfo.processInfo.systemUptime
 #endif
-            AppDelegate.shared?.tabManager?.dismissNotificationOnTerminalInteraction(
+            if appDelegate?.tabManager?.hasDismissibleNotificationOnTerminalInteraction(
                 tabId: terminalSurface.tabId,
                 surfaceId: terminalSurface.id
-            )
+            ) == true {
+                appDelegate?.tabManager?.dismissNotificationOnTerminalInteraction(
+                    tabId: terminalSurface.tabId,
+                    surfaceId: terminalSurface.id
+                )
+            }
 #if DEBUG
             dismissNotificationMs = (ProcessInfo.processInfo.systemUptime - dismissNotificationStart) * 1000.0
 #endif

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -6339,6 +6339,30 @@ class TabManager: ObservableObject {
         dismissNotification(tabId: tabId, surfaceId: surfaceId, context: .terminalInteraction)
     }
 
+    func hasDismissibleNotificationOnTerminalInteraction(tabId: UUID, surfaceId: UUID?) -> Bool {
+        guard selectedTabId == tabId else { return false }
+        guard let notificationStore = AppDelegate.shared?.notificationStore else { return false }
+        let workspace = selectedWorkspace
+        let targetPanelId = surfaceId.flatMap { surfaceOrPanelId in
+            workspace.flatMap { panelId(forSurfaceOrPanelId: surfaceOrPanelId, in: $0) }
+        }
+        var notificationSurfaceIds: [UUID] = []
+        if let surfaceId {
+            notificationSurfaceIds.append(surfaceId)
+        }
+        if let targetPanelId, !notificationSurfaceIds.contains(targetPanelId) {
+            notificationSurfaceIds.append(targetPanelId)
+        }
+        if notificationStore.hasDismissibleActivity(forTabId: tabId, surfaceIds: notificationSurfaceIds) {
+            return true
+        }
+        if let targetPanelId,
+           workspace?.hasDismissibleUnreadIndicator(panelId: targetPanelId) == true {
+            return true
+        }
+        return false
+    }
+
     @discardableResult
     private func dismissNotification(
         tabId: UUID,

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -1136,6 +1136,18 @@ final class TerminalNotificationStore: ObservableObject {
             (focusedReadIndicatorByTabId[tabId].map { $0 == surfaceId } ?? false)
     }
 
+    func hasDismissibleActivity(forTabId tabId: UUID, surfaceIds: [UUID]) -> Bool {
+        if manualUnreadWorkspaceIds.contains(tabId) || restoredUnreadWorkspaceIds.contains(tabId) {
+            return true
+        }
+        if surfaceIds.isEmpty {
+            return hasVisibleNotificationIndicator(forTabId: tabId, surfaceId: nil)
+        }
+        return surfaceIds.contains { surfaceId in
+            hasVisibleNotificationIndicator(forTabId: tabId, surfaceId: surfaceId)
+        }
+    }
+
     func latestNotification(forTabId tabId: UUID) -> TerminalNotification? {
         indexes.latestByTabId[tabId]
     }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -11971,6 +11971,10 @@ final class Workspace: Identifiable, ObservableObject {
         syncUnreadBadgeStateForPanel(panelId)
     }
 
+    func hasDismissibleUnreadIndicator(panelId: UUID) -> Bool {
+        manualUnreadPanelIds.contains(panelId) || restoredUnreadPanelIds.contains(panelId)
+    }
+
     @discardableResult
     func clearAllPanelUnreadIndicatorsForWorkspaceRead() -> Bool {
         let hadLocalUnreadIndicators = !manualUnreadPanelIds.isEmpty || !restoredUnreadPanelIds.isEmpty

--- a/cmuxTests/GhosttyNotificationDispatcherTests.swift
+++ b/cmuxTests/GhosttyNotificationDispatcherTests.swift
@@ -113,3 +113,91 @@ final class GhosttyDefaultBackgroundNotificationDispatcherTests: XCTestCase {
         return -1
     }
 }
+
+final class GhosttyTitleNotificationDispatcherTests: XCTestCase {
+    func testSignalCoalescesBurstToLatestTitle() {
+        let tabId = UUID()
+        let surfaceId = UUID()
+        let expectation = expectation(description: "coalesced title notification")
+        expectation.expectedFulfillmentCount = 1
+        var postedTitles: [String] = []
+        let dispatcher = GhosttyTitleNotificationDispatcher(
+            delay: 0.01,
+            postNotification: { _, userInfo in
+                postedTitles.append(userInfo[GhosttyNotificationKey.title] as? String ?? "")
+                expectation.fulfill()
+            }
+        )
+
+        DispatchQueue.main.async {
+            dispatcher.signal(object: nil, tabId: tabId, surfaceId: surfaceId, title: "vim")
+            dispatcher.signal(object: nil, tabId: tabId, surfaceId: surfaceId, title: "shell")
+        }
+
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(postedTitles, ["shell"])
+    }
+
+    func testSignalPostsLatestTitleForEachSurfaceInBurst() {
+        let tabId = UUID()
+        let firstSurfaceId = UUID()
+        let secondSurfaceId = UUID()
+        let expectation = expectation(description: "coalesced title notifications")
+        expectation.expectedFulfillmentCount = 2
+        var postedTitlesBySurface: [UUID: String] = [:]
+        let dispatcher = GhosttyTitleNotificationDispatcher(
+            delay: 0.01,
+            postNotification: { _, userInfo in
+                guard let surfaceId = userInfo[GhosttyNotificationKey.surfaceId] as? UUID else {
+                    XCTFail("Expected surface id")
+                    return
+                }
+                postedTitlesBySurface[surfaceId] = userInfo[GhosttyNotificationKey.title] as? String ?? ""
+                expectation.fulfill()
+            }
+        )
+
+        DispatchQueue.main.async {
+            dispatcher.signal(object: nil, tabId: tabId, surfaceId: firstSurfaceId, title: "old-1")
+            dispatcher.signal(object: nil, tabId: tabId, surfaceId: secondSurfaceId, title: "old-2")
+            dispatcher.signal(object: nil, tabId: tabId, surfaceId: firstSurfaceId, title: "new-1")
+        }
+
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(postedTitlesBySurface[firstSurfaceId], "new-1")
+        XCTAssertEqual(postedTitlesBySurface[secondSurfaceId], "old-2")
+    }
+
+    func testSignalDropsRepeatedTitleAfterFlush() {
+        let tabId = UUID()
+        let surfaceId = UUID()
+        let firstExpectation = expectation(description: "single repeated title notification")
+        var postedTitles: [String] = []
+        var repeatedExpectation: XCTestExpectation?
+        let dispatcher = GhosttyTitleNotificationDispatcher(
+            delay: 0.01,
+            postNotification: { _, userInfo in
+                postedTitles.append(userInfo[GhosttyNotificationKey.title] as? String ?? "")
+                if postedTitles.count == 1 {
+                    firstExpectation.fulfill()
+                } else {
+                    repeatedExpectation?.fulfill()
+                }
+            }
+        )
+
+        DispatchQueue.main.async {
+            dispatcher.signal(object: nil, tabId: tabId, surfaceId: surfaceId, title: "tmux")
+        }
+        wait(for: [firstExpectation], timeout: 1.0)
+
+        let invertedExpectation = expectation(description: "repeated title not posted")
+        invertedExpectation.isInverted = true
+        repeatedExpectation = invertedExpectation
+        DispatchQueue.main.async {
+            dispatcher.signal(object: nil, tabId: tabId, surfaceId: surfaceId, title: "tmux")
+        }
+        wait(for: [invertedExpectation], timeout: 0.05)
+        XCTAssertEqual(postedTitles, ["tmux"])
+    }
+}

--- a/cmuxTests/WorkspaceManualUnreadTests.swift
+++ b/cmuxTests/WorkspaceManualUnreadTests.swift
@@ -100,6 +100,65 @@ final class WorkspaceManualUnreadTests: XCTestCase {
         XCTAssertEqual(store.unreadCount(forTabId: workspace.id), 0)
     }
 
+    func testTerminalInteractionDismissalHasCheapFalsePathWithoutActivity() {
+        let appDelegate = AppDelegate.shared ?? AppDelegate()
+        let manager = TabManager()
+        let store = TerminalNotificationStore.shared
+
+        let originalTabManager = appDelegate.tabManager
+        let originalNotificationStore = appDelegate.notificationStore
+
+        store.replaceNotificationsForTesting([])
+        appDelegate.tabManager = manager
+        appDelegate.notificationStore = store
+
+        defer {
+            store.replaceNotificationsForTesting([])
+            appDelegate.tabManager = originalTabManager
+            appDelegate.notificationStore = originalNotificationStore
+        }
+
+        guard let workspace = manager.selectedWorkspace,
+              let panelId = workspace.focusedPanelId else {
+            XCTFail("Expected selected workspace with focused panel")
+            return
+        }
+
+        XCTAssertFalse(manager.hasDismissibleNotificationOnTerminalInteraction(tabId: workspace.id, surfaceId: panelId))
+        XCTAssertFalse(manager.dismissNotificationOnTerminalInteraction(tabId: workspace.id, surfaceId: panelId))
+    }
+
+    func testTerminalInteractionDismissalRecognizesFocusedReadIndicator() {
+        let appDelegate = AppDelegate.shared ?? AppDelegate()
+        let manager = TabManager()
+        let store = TerminalNotificationStore.shared
+
+        let originalTabManager = appDelegate.tabManager
+        let originalNotificationStore = appDelegate.notificationStore
+
+        store.replaceNotificationsForTesting([])
+        appDelegate.tabManager = manager
+        appDelegate.notificationStore = store
+
+        defer {
+            store.replaceNotificationsForTesting([])
+            appDelegate.tabManager = originalTabManager
+            appDelegate.notificationStore = originalNotificationStore
+        }
+
+        guard let workspace = manager.selectedWorkspace,
+              let panelId = workspace.focusedPanelId else {
+            XCTFail("Expected selected workspace with focused panel")
+            return
+        }
+
+        store.setFocusedReadIndicator(forTabId: workspace.id, surfaceId: panelId)
+
+        XCTAssertTrue(manager.hasDismissibleNotificationOnTerminalInteraction(tabId: workspace.id, surfaceId: panelId))
+        XCTAssertTrue(manager.dismissNotificationOnTerminalInteraction(tabId: workspace.id, surfaceId: panelId))
+        XCTAssertFalse(store.hasVisibleNotificationIndicator(forTabId: workspace.id, surfaceId: panelId))
+    }
+
     func testRestoredWorkspaceUnreadClearsOnDirectTerminalInteraction() {
         let appDelegate = AppDelegate.shared ?? AppDelegate()
         let manager = TabManager()
@@ -132,6 +191,38 @@ final class WorkspaceManualUnreadTests: XCTestCase {
         XCTAssertTrue(manager.dismissNotificationOnTerminalInteraction(tabId: workspace.id, surfaceId: panelId))
         XCTAssertFalse(store.hasRestoredUnreadIndicator(forTabId: workspace.id))
         XCTAssertEqual(store.unreadCount(forTabId: workspace.id), 0)
+    }
+
+    func testTerminalInteractionDismissalRecognizesRestoredVisualOnlyPanelIndicator() {
+        let appDelegate = AppDelegate.shared ?? AppDelegate()
+        let manager = TabManager()
+        let store = TerminalNotificationStore.shared
+
+        let originalTabManager = appDelegate.tabManager
+        let originalNotificationStore = appDelegate.notificationStore
+
+        store.replaceNotificationsForTesting([])
+        appDelegate.tabManager = manager
+        appDelegate.notificationStore = store
+
+        defer {
+            store.replaceNotificationsForTesting([])
+            appDelegate.tabManager = originalTabManager
+            appDelegate.notificationStore = originalNotificationStore
+        }
+
+        guard let workspace = manager.selectedWorkspace,
+              let panelId = workspace.focusedPanelId else {
+            XCTFail("Expected selected workspace with focused panel")
+            return
+        }
+
+        workspace.restorePanelUnreadIndicator(panelId, contributesToWorkspaceUnread: false)
+
+        XCTAssertFalse(store.hasPanelDerivedUnread(forTabId: workspace.id))
+        XCTAssertTrue(manager.hasDismissibleNotificationOnTerminalInteraction(tabId: workspace.id, surfaceId: panelId))
+        XCTAssertTrue(manager.dismissNotificationOnTerminalInteraction(tabId: workspace.id, surfaceId: panelId))
+        XCTAssertFalse(workspace.hasRestoredUnreadIndicator(panelId: panelId))
     }
 
     func testRestoredPanelUnreadIndicatorMarksWorkspaceUnreadForSidebar() throws {
@@ -397,6 +488,8 @@ final class WorkspaceManualUnreadTests: XCTestCase {
         XCTAssertTrue(store.hasManualUnread(forTabId: workspace.id))
         XCTAssertTrue(store.hasRestoredUnreadIndicator(forTabId: workspace.id))
 
+        XCTAssertTrue(manager.hasDismissibleNotificationOnTerminalInteraction(tabId: workspace.id, surfaceId: panelId))
+
         XCTAssertTrue(manager.dismissNotificationOnDirectInteraction(tabId: workspace.id, surfaceId: panelId))
 
         XCTAssertTrue(workspace.manualUnreadPanelIds.contains(panelId))
@@ -448,6 +541,8 @@ final class WorkspaceManualUnreadTests: XCTestCase {
         XCTAssertTrue(workspace.hasRestoredUnreadIndicator(panelId: panelId))
         XCTAssertTrue(store.hasUnreadNotification(forTabId: workspace.id, surfaceId: liveSurfaceId))
         XCTAssertTrue(store.hasUnreadNotification(forTabId: workspace.id, surfaceId: panelId))
+
+        XCTAssertTrue(manager.hasDismissibleNotificationOnTerminalInteraction(tabId: workspace.id, surfaceId: liveSurfaceId))
 
         XCTAssertTrue(manager.dismissNotificationOnTerminalInteraction(tabId: workspace.id, surfaceId: liveSurfaceId))
 


### PR DESCRIPTION
## Summary

- Reduce terminal typing hot-path work for `cmux ssh`, especially when tmux emits frequent redraw/title updates.
- Gate right-sidebar mode shortcut matching behind `shouldRouteRightSidebarModeShortcut` so normal terminal keypresses skip repeated shortcut/UserDefaults lookups.
- Add a cheap terminal-interaction dismissal predicate so keyDown only runs notification dismissal when there is unread/focused/restored/manual activity to clear.
- Coalesce Ghostty title notifications at the producer before `NotificationCenter` fanout, preserving the latest title per surface and dropping repeated already-posted titles.

Refs #4681.

## Testing

- `swiftc -parse Sources/GhosttyTerminalAppearance.swift Sources/GhosttyTerminalView.swift Sources/TabManager.swift Sources/TerminalNotificationStore.swift Sources/Workspace.swift cmuxTests/GhosttyNotificationDispatcherTests.swift cmuxTests/WorkspaceManualUnreadTests.swift`
- `./scripts/check-pbxproj.sh && ./scripts/lint-pbxproj-test-wiring.sh`
- `git diff --check`

## Demo Video

- Video URL or attachment: n/a (performance/hot-path change)

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally (syntax/project-wiring checks; full Xcode tests deferred to CI)
- [x] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5431"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783223102&installation_id=133855650&pr_number=5431&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5431&signature=c5f478aa8faef43d29a0399146b870f43f4a7ded0f70d87e8f94afdeccc7db53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduces terminal typing lag in `cmux ssh` (especially under tmux) by cutting hot-path work and coalescing noisy title updates. Addresses #4681 by smoothing keystroke handling and preventing NotificationCenter storms.

- **Refactors**
  - Coalesce Ghostty title notifications at the source with `GhosttyTitleNotificationDispatcher`, posting only the latest title per surface and dropping repeats.
  - Gate right-sidebar mode shortcut matching behind `shouldRouteRightSidebarModeShortcut(...)` so normal typing skips shortcut/UserDefaults lookups.
  - Add `hasDismissibleNotificationOnTerminalInteraction(...)` to avoid running dismissal logic unless unread/focused/restored/manual activity exists.
  - Support predicates with lightweight checks in `TerminalNotificationStore` and `Workspace`.

<sup>Written for commit 0a4ef4fa2175e3dd176c268e407d7dc081a7c584. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5431?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification dismissal behavior to only dismiss when dismissible notifications are present, preventing unnecessary automatic dismissals.
  * Enhanced terminal title update handling to efficiently batch rapid consecutive changes.

* **Tests**
  * Added comprehensive test coverage for title notification coalescing behavior.
  * Added tests for notification dismissal eligibility validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->