### PR TITLE
Fix Claude hibernation for node-backed sessions

### DIFF
--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -1536,10 +1536,36 @@ struct RestorableAgentSessionIndex: Sendable {
               let liveExecutable = process.arguments.first.map(executableBasename) else {
             return pid
         }
-        guard liveExecutable.compare(recordedExecutable, options: [.caseInsensitive, .literal]) == .orderedSame else {
+        guard liveProcessExecutableMatchesRecordedAgent(
+            kind: kind,
+            liveExecutable: liveExecutable,
+            recordedExecutable: recordedExecutable,
+            arguments: process.arguments
+        ) else {
             return nil
         }
         return pid
+    }
+
+    private static func liveProcessExecutableMatchesRecordedAgent(
+        kind: RestorableAgentKind,
+        liveExecutable: String,
+        recordedExecutable: String,
+        arguments: [String]
+    ) -> Bool {
+        if liveExecutable.compare(recordedExecutable, options: [.caseInsensitive, .literal]) == .orderedSame {
+            return true
+        }
+
+        guard kind == .claude else { return false }
+        let liveBase = liveExecutable.lowercased()
+        guard liveBase == "node" || liveBase == "bun" else { return false }
+        return arguments.dropFirst().contains { argument in
+            let lowered = argument.lowercased()
+            return executableBasename(argument).compare("claude", options: [.caseInsensitive, .literal]) == .orderedSame
+                || lowered.contains("/.claude/")
+                || lowered.contains("/claude/versions/")
+        }
     }
 
     private static func recordedExecutableBasename(_ record: RestorableAgentHookSessionRecord) -> String? {

--- a/cmuxTests/AgentHibernationTests.swift
+++ b/cmuxTests/AgentHibernationTests.swift
@@ -377,6 +377,81 @@ final class AgentHibernationTests: XCTestCase {
         XCTAssertTrue(index.hasLiveProcess(workspaceId: workspaceId, panelId: panelId))
     }
 
+    func testSessionIndexAcceptsNodeBackedClaudeProcessAsLiveHookPID() throws {
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-agent-hibernation-claude-node-pid-\(UUID().uuidString)", isDirectory: true)
+        let storeURL = RestorableAgentKind.claude.hookStoreFileURL(homeDirectory: home.path)
+        try FileManager.default.createDirectory(at: storeURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        let workspaceId = UUID()
+        let panelId = UUID()
+        let pid = 23_456
+        let sessionId = "claude-node-live-hook-pid"
+        let transcriptURL = home
+            .appendingPathComponent(".claude/projects/-tmp-repo", isDirectory: true)
+            .appendingPathComponent("\(sessionId).jsonl")
+        try FileManager.default.createDirectory(
+            at: transcriptURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try #"{"type":"summary","summary":"Claude session"}"#.write(
+            to: transcriptURL,
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let jsonObject: [String: Any] = [
+            "version": 1,
+            "sessions": [
+                sessionId: [
+                    "sessionId": sessionId,
+                    "workspaceId": workspaceId.uuidString,
+                    "surfaceId": panelId.uuidString,
+                    "cwd": "/tmp/repo",
+                    "transcriptPath": transcriptURL.path,
+                    "pid": pid,
+                    "agentLifecycle": "idle",
+                    "updatedAt": Date().timeIntervalSince1970,
+                    "launchCommand": [
+                        "launcher": "claude",
+                        "executablePath": "/opt/homebrew/bin/claude",
+                        "arguments": ["/opt/homebrew/bin/claude"],
+                        "workingDirectory": "/tmp/repo",
+                    ],
+                ],
+            ],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: jsonObject, options: [.prettyPrinted])
+        try data.write(to: storeURL, options: .atomic)
+
+        let index = RestorableAgentSessionIndex.load(
+            homeDirectory: home.path,
+            fileManager: .default,
+            registry: CmuxVaultAgentRegistry(registrations: []),
+            detectedSnapshots: [:],
+            processArgumentsProvider: { requestedPID in
+                requestedPID == pid
+                    ? CmuxTopProcessArguments(
+                        arguments: [
+                            "/opt/homebrew/Cellar/node/24.0.0/bin/node",
+                            "/Users/example/.claude/local/node_modules/@anthropic-ai/claude-code/cli.js",
+                        ],
+                        environment: [
+                            "CMUX_WORKSPACE_ID": workspaceId.uuidString,
+                            "CMUX_SURFACE_ID": panelId.uuidString,
+                            "CMUX_AGENT_LAUNCH_KIND": RestorableAgentKind.claude.rawValue,
+                        ]
+                    )
+                    : nil
+            }
+        )
+
+        XCTAssertEqual(index.lifecycle(workspaceId: workspaceId, panelId: panelId), .idle)
+        XCTAssertEqual(index.processIDs(workspaceId: workspaceId, panelId: panelId), [pid])
+        XCTAssertTrue(index.hasLiveProcess(workspaceId: workspaceId, panelId: panelId))
+    }
+
     func testLiveProcessScopeMatchingAcceptsLegacyEnvironmentKeys() throws {
         let workspaceId = UUID()
         let panelId = UUID()


### PR DESCRIPTION
## Summary
- Treat scoped Node/Bun-backed Claude Code processes as live Claude processes for hibernation.
- Add a regression test showing a Claude hook pid with live `node .../.claude/...` argv remains eligible for hibernation.

## Testing
- `./scripts/reload-cloud.sh --tag clhib` passed.

## Issues
- Related: plain-text task, root cause Claude hibernation not working while Codex hibernation does.