### PR TITLE
Fix Dock sidebar render after reopen

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -50,7 +50,7 @@
 1001	cmuxTests/SidebarOrderingTests.swift
 987	Sources/CommandPalette/CommandPaletteSearch.swift
 976	cmuxTests/OmnibarAndToolsTests.swift
-923	Sources/DockPanelView.swift
+924	Sources/DockPanelView.swift
 908	cmuxTests/CommandPaletteSearchEngineTests.swift
 829	cmuxUITests/TerminalCmdClickUITests.swift
 820	Sources/RestorableAgentSession.swift

--- a/Sources/DockPanelView.swift
+++ b/Sources/DockPanelView.swift
@@ -254,6 +254,19 @@ final class DockControlsStore: ObservableObject {
 
     fileprivate func terminalAttachment(for controlID: String) -> DockTerminalAttachment? { controls.first { $0.id == controlID }?.terminalAttachment }
 
+    func synchronizeSidebarLifecycle(
+        isRightSidebarVisible: Bool,
+        mode: RightSidebarMode,
+        rootDirectory: String?,
+        workspaceId: UUID?
+    ) {
+        guard isRightSidebarVisible, mode == .dock else {
+            deactivate()
+            return
+        }
+        activate(rootDirectory: rootDirectory, workspaceId: workspaceId)
+    }
+
     func activate(rootDirectory: String?, workspaceId: UUID?) {
         controlsVisibleInUI = true
         if hasLoadedConfiguration, lastRootDirectory == rootDirectory {
@@ -559,18 +572,6 @@ struct DockPanelView: View {
             toolbar
             Divider()
             content
-        }
-        .onAppear {
-            store.activate(rootDirectory: rootDirectory, workspaceId: workspaceId)
-        }
-        .onDisappear {
-            store.deactivate()
-        }
-        .onChange(of: rootDirectory) { _, newValue in
-            store.activate(rootDirectory: newValue, workspaceId: workspaceId)
-        }
-        .onChange(of: workspaceId) { _, newValue in
-            store.activate(rootDirectory: rootDirectory, workspaceId: newValue)
         }
         .background(
             DockKeyboardFocusBridge(store: store)

--- a/Sources/RightSidebarPanelView.swift
+++ b/Sources/RightSidebarPanelView.swift
@@ -238,16 +238,26 @@ struct RightSidebarPanelView: View {
             focusShortcutHintMonitor.start()
             closeShortcutHintMonitor.start()
             fileExplorerState.refreshModeAvailability()
+            synchronizeDockLifecycle()
         }
         .onDisappear {
             modeShortcutHintMonitor.stop()
             focusShortcutHintMonitor.stop()
             closeShortcutHintMonitor.stop()
+            synchronizeDockLifecycle(isRightSidebarVisible: false)
         }
         .onChange(of: fileExplorerState.mode) { _, mode in
-            if mode != .dock { dockStore.deactivate() }
+            synchronizeDockLifecycle(mode: mode)
         }
-        .onChange(of: fileExplorerState.isVisible) { _, visible in if !visible { dockStore.deactivate() } }
+        .onChange(of: fileExplorerState.isVisible) { _, visible in
+            synchronizeDockLifecycle(isRightSidebarVisible: visible)
+        }
+        .onChange(of: dockRootDirectory) { _, newValue in
+            synchronizeDockLifecycle(rootDirectory: newValue, workspaceId: workspaceId)
+        }
+        .onChange(of: workspaceId) { _, newValue in
+            synchronizeDockLifecycle(rootDirectory: dockRootDirectory, workspaceId: newValue)
+        }
         .onChange(of: feedEnabled) { _, _ in refreshModeAvailabilityAndFocusIfNeeded() }
         .onChange(of: dockEnabled) { _, _ in refreshModeAvailabilityAndFocusIfNeeded() }
     }
@@ -447,6 +457,20 @@ struct RightSidebarPanelView: View {
         )
     }
 
+    private func synchronizeDockLifecycle(
+        isRightSidebarVisible: Bool? = nil,
+        mode: RightSidebarMode? = nil,
+        rootDirectory: String? = nil,
+        workspaceId: UUID? = nil
+    ) {
+        dockStore.synchronizeSidebarLifecycle(
+            isRightSidebarVisible: isRightSidebarVisible ?? fileExplorerState.isVisible,
+            mode: mode ?? fileExplorerState.mode,
+            rootDirectory: rootDirectory ?? dockRootDirectory,
+            workspaceId: workspaceId ?? self.workspaceId
+        )
+    }
+
     private func selectMode(_ mode: RightSidebarMode) {
         fileExplorerState.mode = mode
         if fileExplorerState.mode == .sessions {
@@ -460,7 +484,11 @@ struct RightSidebarPanelView: View {
     private func refreshModeAvailabilityAndFocusIfNeeded() {
         let previousMode = fileExplorerState.mode
         fileExplorerState.refreshModeAvailability()
-        guard previousMode != fileExplorerState.mode,
+        let mode = fileExplorerState.mode
+        if previousMode == mode {
+            synchronizeDockLifecycle(mode: mode)
+        }
+        guard previousMode != mode,
               fileExplorerState.isVisible,
               let window = NSApp.keyWindow ?? NSApp.mainWindow
         else { return }

--- a/cmuxUITests/FeedSidebarUITests.swift
+++ b/cmuxUITests/FeedSidebarUITests.swift
@@ -1,4 +1,6 @@
+import CoreGraphics
 import Foundation
+import ImageIO
 import Darwin
 import XCTest
 
@@ -12,6 +14,7 @@ final class FeedSidebarUITests: XCTestCase {
     private var diagnosticsPath = ""
     private var feedResultPath = ""
     private var feedTUIReadyPath = ""
+    private var dockRenderReadyPath = ""
     private var dockConfigPath = ""
     private var requestId = ""
     private let modeKey = "socketControlMode"
@@ -25,6 +28,7 @@ final class FeedSidebarUITests: XCTestCase {
         diagnosticsPath = "/tmp/cmux-feed-sidebar-\(UUID().uuidString).json"
         feedResultPath = "/tmp/cmux-feed-sidebar-result-\(UUID().uuidString).json"
         feedTUIReadyPath = "/tmp/cmux-feed-sidebar-tui-ready-\(UUID().uuidString).json"
+        dockRenderReadyPath = "/tmp/cmux-dock-render-ready-\(UUID().uuidString).json"
         dockConfigPath = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-feed-sidebar-dock-\(UUID().uuidString).json")
             .path
@@ -33,6 +37,7 @@ final class FeedSidebarUITests: XCTestCase {
         try? FileManager.default.removeItem(atPath: diagnosticsPath)
         try? FileManager.default.removeItem(atPath: feedResultPath)
         try? FileManager.default.removeItem(atPath: feedTUIReadyPath)
+        try? FileManager.default.removeItem(atPath: dockRenderReadyPath)
         try? FileManager.default.removeItem(atPath: dockConfigPath)
     }
 
@@ -119,6 +124,77 @@ final class FeedSidebarUITests: XCTestCase {
         app.terminate()
     }
 
+    func testDockTerminalRerendersAfterRightSidebarHideShow() throws {
+        let app = XCUIApplication()
+        app.launchArguments += [
+            "-\(modeKey)", "allowAll",
+            "-\(dockBetaFeatureKey)", "YES",
+            "-AppleLanguages", "(en)",
+            "-AppleLocale", "en_US"
+        ]
+        app.launchEnvironment["CMUX_SOCKET_PATH"] = socketPath
+        app.launchEnvironment["CMUX_SOCKET_ENABLE"] = "1"
+        app.launchEnvironment["CMUX_SOCKET_MODE"] = "allowAll"
+        app.launchEnvironment["CMUX_ALLOW_SOCKET_OVERRIDE"] = "1"
+        app.launchEnvironment["CMUX_TAG"] = launchTag
+        app.launchEnvironment["CMUX_UI_TEST_MODE"] = "1"
+        app.launchEnvironment["CMUX_UI_TEST_SOCKET_SANITY"] = "1"
+        app.launchEnvironment["CMUX_UI_TEST_DIAGNOSTICS_PATH"] = diagnosticsPath
+        app.launchEnvironment["CMUX_UI_TEST_PORTAL_STATS"] = "1"
+        app.launchEnvironment["CMUX_UI_TEST_DOCK_CONFIG_PATH"] = dockConfigPath
+        if let path = ProcessInfo.processInfo.environment["PATH"], !path.isEmpty {
+            app.launchEnvironment["PATH"] = path
+        }
+        try writeDockRenderConfig()
+        launchAndEnsureUsable(app)
+        defer { app.terminate() }
+
+        XCTAssertTrue(
+            waitForInAppSocketReady(timeout: 75),
+            "Expected app-side control socket readiness at \(socketPath). diagnostics=\(loadDiagnostics())"
+        )
+        XCTAssertTrue(
+            revealDockMode(in: app),
+            "Dock mode did not open in the right sidebar. diagnostics=\(loadDiagnostics())"
+        )
+        XCTAssertTrue(
+            waitForDockRenderReady(timeout: 30),
+            "Dock render control did not publish readiness. marker=\(loadDockRenderReadyMarker())"
+        )
+        let renderPID = try XCTUnwrap(
+            dockRenderProcessPID(),
+            "Dock render control did not publish a pid. marker=\(loadDockRenderReadyMarker())"
+        )
+        XCTAssertTrue(
+            waitForDockTerminalBrightPixels(in: app, timeout: 25),
+            "Initial Dock terminal did not render the sentinel. brightPixels=\(dockTerminalBrightPixelCount(in: app)) diagnostics=\(loadDiagnostics())"
+        )
+
+        app.typeKey("b", modifierFlags: [.command, .option])
+        XCTAssertTrue(
+            waitForRightSidebarHidden(in: app, timeout: 8),
+            "Right sidebar did not hide after Opt-Cmd-B"
+        )
+        XCTAssertTrue(
+            dockRenderProcessIsAlive(pid: renderPID),
+            "Dock render process exited after hiding the right sidebar. marker=\(loadDockRenderReadyMarker())"
+        )
+
+        app.typeKey("b", modifierFlags: [.command, .option])
+        XCTAssertTrue(
+            waitForDockModeVisible(in: app, timeout: 8),
+            "Dock mode did not reappear after Opt-Cmd-B. diagnostics=\(loadDiagnostics())"
+        )
+        XCTAssertTrue(
+            dockRenderProcessIsAlive(pid: renderPID),
+            "Dock render process exited after reopening the right sidebar. marker=\(loadDockRenderReadyMarker())"
+        )
+        XCTAssertTrue(
+            waitForDockTerminalBrightPixels(in: app, timeout: 25),
+            "Dock terminal stayed visually blank after right sidebar hide/show. brightPixels=\(dockTerminalBrightPixelCount(in: app)) diagnostics=\(loadDiagnostics())"
+        )
+    }
+
     // MARK: - Socket helpers
 
     private struct FeedPushResult {
@@ -191,10 +267,21 @@ final class FeedSidebarUITests: XCTestCase {
         }
     }
 
+    private func waitForDockRenderReady(timeout: TimeInterval) -> Bool {
+        pollUntil(timeout: timeout, interval: 0.5) {
+            dockRenderProcessPID() != nil
+        }
+    }
+
     private func waitForFeedTUIProcessAlive(timeout: TimeInterval) -> Bool {
         return pollUntil(timeout: timeout, interval: 0.2) {
             feedTUIProcessIsAlive()
         }
+    }
+
+    private func dockRenderProcessIsAlive(pid: Int32) -> Bool {
+        errno = 0
+        return kill(pid, 0) == 0 || errno == EPERM
     }
 
     private func resolvedBunPathForFeedTUI() -> String? {
@@ -279,10 +366,86 @@ final class FeedSidebarUITests: XCTestCase {
     }
 
     private func waitForDockModeVisible(in app: XCUIApplication, timeout: TimeInterval) -> Bool {
+        let dockButton = app.buttons["RightSidebarModeButton.dock"].firstMatch
         let focusButton = app.buttons["Focus Control"].firstMatch
-        let dockPanel = app.otherElements["DockPanel"].firstMatch
         return pollUntil(timeout: timeout, interval: 0.2) {
-            focusButton.exists || dockPanel.exists
+            dockButton.exists && dockButton.isHittable && focusButton.exists && focusButton.isHittable
+        }
+    }
+
+    private func waitForRightSidebarHidden(in app: XCUIApplication, timeout: TimeInterval) -> Bool {
+        let focusButton = app.buttons["Focus Control"].firstMatch
+        let dockButton = app.buttons["RightSidebarModeButton.dock"].firstMatch
+        return pollUntil(timeout: timeout, interval: 0.2) {
+            (!focusButton.exists || !focusButton.isHittable) &&
+                (!dockButton.exists || !dockButton.isHittable)
+        }
+    }
+
+    private func waitForDockTerminalBrightPixels(in app: XCUIApplication, timeout: TimeInterval) -> Bool {
+        pollUntil(timeout: timeout, interval: 0.5) {
+            dockTerminalBrightPixelCount(in: app) >= 600
+        }
+    }
+
+    private func dockTerminalBrightPixelCount(in app: XCUIApplication) -> Int {
+        let window = app.windows.firstMatch
+        guard window.exists else { return 0 }
+        return brightPixelCount(
+            in: window.screenshot(),
+            xFractionStart: 0.88,
+            yFractionStart: 0.18,
+            yFractionEnd: 0.90
+        )
+    }
+
+    private func brightPixelCount(
+        in screenshot: XCUIScreenshot,
+        xFractionStart: Double,
+        yFractionStart: Double,
+        yFractionEnd: Double
+    ) -> Int {
+        guard let source = CGImageSourceCreateWithData(screenshot.pngRepresentation as CFData, nil),
+              let image = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
+            return 0
+        }
+        let width = image.width
+        let height = image.height
+        guard width > 0, height > 0 else { return 0 }
+
+        let bytesPerPixel = 4
+        let bytesPerRow = width * bytesPerPixel
+        var pixels = [UInt8](repeating: 0, count: height * bytesPerRow)
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        return pixels.withUnsafeMutableBytes { buffer in
+            guard let baseAddress = buffer.baseAddress,
+                  let context = CGContext(
+                      data: baseAddress,
+                      width: width,
+                      height: height,
+                      bitsPerComponent: 8,
+                      bytesPerRow: bytesPerRow,
+                      space: colorSpace,
+                      bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+                  ) else {
+                return 0
+            }
+            context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+
+            let startX = min(width, max(0, Int(Double(width) * xFractionStart)))
+            let startY = min(height, max(0, Int(Double(height) * yFractionStart)))
+            let endY = min(height, max(startY, Int(Double(height) * yFractionEnd)))
+            var count = 0
+            let rgba = buffer.bindMemory(to: UInt8.self)
+            for y in startY..<endY {
+                for x in startX..<width {
+                    let index = y * bytesPerRow + x * bytesPerPixel
+                    if rgba[index] > 150, rgba[index + 1] > 150, rgba[index + 2] > 150 {
+                        count += 1
+                    }
+                }
+            }
+            return count
         }
     }
 
@@ -331,12 +494,32 @@ final class FeedSidebarUITests: XCTestCase {
         (try? String(contentsOfFile: feedTUIReadyPath, encoding: .utf8)) ?? ""
     }
 
+    private func loadDockRenderReadyMarker() -> String {
+        (try? String(contentsOfFile: dockRenderReadyPath, encoding: .utf8)) ?? ""
+    }
+
     private func loadFeedTUIReadyPayload() -> [String: String] {
         guard let data = try? Data(contentsOf: URL(fileURLWithPath: feedTUIReadyPath)),
               let object = try? JSONSerialization.jsonObject(with: data) as? [String: String] else {
             return [:]
         }
         return object
+    }
+
+    private func loadDockRenderReadyPayload() -> [String: String] {
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: dockRenderReadyPath)),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: String] else {
+            return [:]
+        }
+        return object
+    }
+
+    private func dockRenderProcessPID() -> Int32? {
+        guard let pidText = loadDockRenderReadyPayload()["pid"],
+              let pidValue = Int32(pidText) else {
+            return nil
+        }
+        return pidValue
     }
 
     private func writeFeedDockConfig(bunPath: String?) throws {
@@ -350,6 +533,32 @@ final class FeedSidebarUITests: XCTestCase {
                 "title": "Feed",
                 "command": "cmux feed tui --opentui",
                 "env": env
+            ]]
+        ]
+        let data = try JSONSerialization.data(withJSONObject: config, options: [.prettyPrinted, .sortedKeys])
+        try data.write(to: URL(fileURLWithPath: dockConfigPath), options: .atomic)
+    }
+
+    private func writeDockRenderConfig() throws {
+        let command = """
+        printf '{"pid":"%s"}\\n' "$$" > "$CMUX_DOCK_RENDER_READY_PATH"; \
+        while true; do \
+          clear; \
+          i=1; \
+          while [ "$i" -le 28 ]; do \
+            printf 'ISSUE5435_DOCK_RENDER_READY %02d ABCDEFGHIJKLMNOPQRSTUVWXYZ 0123456789\\n' "$i"; \
+            i=$((i + 1)); \
+          done; \
+          sleep 0.2; \
+        done
+        """
+        let config: [String: Any] = [
+            "controls": [[
+                "id": "issue5435-render",
+                "title": "Issue 5435 Render",
+                "command": command,
+                "height": 320,
+                "env": ["CMUX_DOCK_RENDER_READY_PATH": dockRenderReadyPath]
             ]]
         ]
         let data = try JSONSerialization.data(withJSONObject: config, options: [.prettyPrinted, .sortedKeys])


### PR DESCRIPTION
## Summary
- add a regression UI test for Dock terminal rendering after right sidebar hide/show
- route right-sidebar Dock visibility through one lifecycle sync so reopening reactivates and redraws the portal-hosted terminal

Fixes https://github.com/manaflow-ai/cmux/issues/5435

## Verification
- CMUX_SKIP_ZIG_BUILD=1 ./scripts/reload.sh --tag issue-5435-dock-blank-reopen
- Manual dogfood: Dock mode with `top -s 1`, hide/reopen right sidebar, confirmed terminal renders after reopen and portal returns to `entryVisible=1 hostedHidden=0`
- GitHub e2e: `FeedSidebarUITests/testDockTerminalRerendersAfterRightSidebarHideShow` via `test-e2e.yml` passed in run https://github.com/manaflow-ai/cmux/actions/runs/26997746067

## Test policy
- Commit `f2a9088c3` adds the failing regression test only
- Commit `e17d0405b` adds the fix
- Commit `405e8257e` updates the Swift file length budget metadata

## Localization
- No user-facing strings changed; only test strings and lifecycle wiring changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5437"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783228671&installation_id=133855650&pr_number=5437&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5437&signature=b82b03004c70963e8f3a0c174e5c6e0dd6731c656f21d6b74b9b0b2c5ca67f17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Dock/right-sidebar lifecycle wiring and UI tests; no auth, data, or user-facing copy changes.
> 
> **Overview**
> Fixes Dock terminals going **blank** after toggling the right sidebar off and on by driving activation from **sidebar state** instead of `DockPanelView` lifecycle hooks.
> 
> `DockControlsStore` gains **`synchronizeSidebarLifecycle`**, which **deactivates** when the sidebar is hidden or not in Dock mode and otherwise **reactivates** with the current root directory and workspace. `RightSidebarPanelView` calls this on appear/disappear and when visibility, mode, `dockRootDirectory`, or `workspaceId` change; **`DockPanelView` no longer** runs its own `onAppear` / `onDisappear` / `onChange` activate logic. A **UI regression test** hides/shows the sidebar (⌥⌘B), keeps the Dock render **PID** alive, and checks the terminal **redraws** via a bright-pixel screenshot crop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 405e8257ea7b35e1d796b6f123fcf2658b4999bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Dock terminal staying blank after hiding and reopening the right sidebar. The Dock lifecycle now reactivates on reopen, keeps the render process alive, and redraws the terminal. Fixes #5435.

- **Bug Fixes**
  - Centralized Dock lifecycle in `RightSidebarPanelView` via `synchronizeDockLifecycle(...)`, which calls `DockControlsStore.synchronizeSidebarLifecycle(...)` on appear/disappear and when sidebar visibility, mode, `rootDirectory`, or `workspaceId` change; deactivates when hidden or not in Dock mode, and re-syncs when mode availability refreshes.
  - Removed local lifecycle hooks from `DockPanelView`; lifecycle is driven by sidebar state so reopen reactivates and redraws.
  - Added a UI regression test that hide/shows the sidebar (⌥⌘B), asserts the render PID stays alive, and verifies redraw via a bright-pixel screenshot check.

- **Refactors**
  - Updated `.github/swift-file-length-budget.tsv` for `Sources/DockPanelView.swift`.

<sup>Written for commit 405e8257ea7b35e1d796b6f123fcf2658b4999bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dock controls now reliably follow the right sidebar’s visibility and mode so the Dock activates and deactivates correctly.
  * Dock terminal reliably re-renders after hiding and showing the right sidebar.

* **Refactor**
  * Sidebar lifecycle handling centralized to improve stability and avoid duplicate lifecycle triggers.

* **Tests**
  * Added end-to-end UI test verifying Dock render readiness, process liveness, and visual re-rendering when toggling the right sidebar.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->