### PR TITLE
Gate iOS tests on iOS file changes

### DIFF
--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -10,8 +10,6 @@ on:
       - "Packages/CmuxMobile*/**"
       - "Packages/CMUXMobile*/**"
       - "Sources/Mobile/**"
-      - "Sources/GhosttyTerminalView.swift"
-      - "Sources/TerminalController.swift"
       - "vendor/stack-auth-swift-sdk-prerelease/**"
       - "scripts/lint-ios-package-conventions.sh"
       - ".github/workflows/test-ios.yml"
@@ -39,7 +37,42 @@ permissions:
   contents: read
 
 jobs:
+  detect-ios-changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      should_run: ${{ steps.detect.outputs.should_run }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+          fetch-depth: 0
+          persist-credentials: false
+          submodules: false
+
+      - name: Detect iOS changes
+        id: detect
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git diff --name-only "$BASE_SHA" "$HEAD_SHA" > /tmp/changed-files.txt
+          if grep -Eq '^(ios/|Packages/CMUXAuthCore/|Packages/CMUXMobileCore/|Packages/CmuxAuthRuntime/|Packages/CmuxMobile[^/]*/|Packages/CMUXMobile[^/]*/|Sources/Mobile/|vendor/stack-auth-swift-sdk-prerelease/|scripts/lint-ios-package-conventions\.sh$)' /tmp/changed-files.txt; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No iOS-owned files changed; skipping iOS tests."
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+          fi
+
   package-conventions-lint:
+    needs: detect-ios-changes
+    if: ${{ needs.detect-ios-changes.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -59,6 +92,8 @@ jobs:
           ./scripts/lint-ios-package-conventions.sh
 
   mobile-core-package:
+    needs: detect-ios-changes
+    if: ${{ needs.detect-ios-changes.outputs.should_run == 'true' }}
     runs-on: macos-26
     timeout-minutes: 10
     steps:
@@ -91,6 +126,8 @@ jobs:
           swift test --package-path Packages/CMUXMobileCore
 
   ios-simulator:
+    needs: detect-ios-changes
+    if: ${{ needs.detect-ios-changes.outputs.should_run == 'true' }}
     runs-on: macos-26
     timeout-minutes: 35
     strategy:

--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -66,7 +66,7 @@ jobs:
           fi
           BASE_MERGE_BASE="$(git merge-base "$BASE_SHA" "$HEAD_SHA")"
           git diff --name-only "$BASE_MERGE_BASE" "$HEAD_SHA" > /tmp/changed-files.txt
-          if grep -Eq '^(ios/|Packages/CMUXAuthCore/|Packages/CMUXMobileCore/|Packages/CmuxAuthRuntime/|Packages/CmuxMobile[^/]*/|Packages/CMUXMobile[^/]*/|Sources/Mobile/|Sources/GhosttyTerminalView\.swift$|Sources/TerminalController\.swift$|vendor/stack-auth-swift-sdk-prerelease/|scripts/lint-ios-package-conventions\.sh$|\.github/workflows/test-ios\.yml$)' /tmp/changed-files.txt; then
+          if grep -Eq '^(ios/|Packages/CMUXAuthCore/|Packages/CMUXMobileCore/|Packages/CmuxAuthRuntime/|Packages/CmuxMobile[^/]*/|Packages/CMUXMobile[^/]*/|Sources/Mobile/|Sources/GhosttyTerminalView\.swift$|Sources/TerminalController\.swift$|vendor/stack-auth-swift-sdk-prerelease/|scripts/lint-ios-package-conventions\.sh$)' /tmp/changed-files.txt; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"
           else
             echo "No iOS-owned files changed; skipping iOS tests."

--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -10,8 +10,6 @@ on:
       - "Packages/CmuxMobile*/**"
       - "Packages/CMUXMobile*/**"
       - "Sources/Mobile/**"
-      - "Sources/GhosttyTerminalView.swift"
-      - "Sources/TerminalController.swift"
       - "vendor/stack-auth-swift-sdk-prerelease/**"
       - "scripts/lint-ios-package-conventions.sh"
       - ".github/workflows/test-ios.yml"
@@ -66,7 +64,7 @@ jobs:
           fi
           BASE_MERGE_BASE="$(git merge-base "$BASE_SHA" "$HEAD_SHA")"
           git diff --name-only "$BASE_MERGE_BASE" "$HEAD_SHA" > /tmp/changed-files.txt
-          if grep -Eq '^(ios/|Packages/CMUXAuthCore/|Packages/CMUXMobileCore/|Packages/CmuxAuthRuntime/|Packages/CmuxMobile[^/]*/|Packages/CMUXMobile[^/]*/|Sources/Mobile/|Sources/GhosttyTerminalView\.swift$|Sources/TerminalController\.swift$|vendor/stack-auth-swift-sdk-prerelease/|scripts/lint-ios-package-conventions\.sh$)' /tmp/changed-files.txt; then
+          if grep -Eq '^(ios/|Packages/CMUXAuthCore/|Packages/CMUXMobileCore/|Packages/CmuxAuthRuntime/|Packages/CmuxMobile[^/]*/|Packages/CMUXMobile[^/]*/|Sources/Mobile/|vendor/stack-auth-swift-sdk-prerelease/|scripts/lint-ios-package-conventions\.sh$)' /tmp/changed-files.txt; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"
           else
             echo "No iOS-owned files changed; skipping iOS tests."

--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -10,6 +10,8 @@ on:
       - "Packages/CmuxMobile*/**"
       - "Packages/CMUXMobile*/**"
       - "Sources/Mobile/**"
+      - "Sources/GhosttyTerminalView.swift"
+      - "Sources/TerminalController.swift"
       - "vendor/stack-auth-swift-sdk-prerelease/**"
       - "scripts/lint-ios-package-conventions.sh"
       - ".github/workflows/test-ios.yml"
@@ -62,8 +64,9 @@ jobs:
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          git diff --name-only "$BASE_SHA" "$HEAD_SHA" > /tmp/changed-files.txt
-          if grep -Eq '^(ios/|Packages/CMUXAuthCore/|Packages/CMUXMobileCore/|Packages/CmuxAuthRuntime/|Packages/CmuxMobile[^/]*/|Packages/CMUXMobile[^/]*/|Sources/Mobile/|vendor/stack-auth-swift-sdk-prerelease/|scripts/lint-ios-package-conventions\.sh$)' /tmp/changed-files.txt; then
+          BASE_MERGE_BASE="$(git merge-base "$BASE_SHA" "$HEAD_SHA")"
+          git diff --name-only "$BASE_MERGE_BASE" "$HEAD_SHA" > /tmp/changed-files.txt
+          if grep -Eq '^(ios/|Packages/CMUXAuthCore/|Packages/CMUXMobileCore/|Packages/CmuxAuthRuntime/|Packages/CmuxMobile[^/]*/|Packages/CMUXMobile[^/]*/|Sources/Mobile/|Sources/GhosttyTerminalView\.swift$|Sources/TerminalController\.swift$|vendor/stack-auth-swift-sdk-prerelease/|scripts/lint-ios-package-conventions\.sh$|\.github/workflows/test-ios\.yml$)' /tmp/changed-files.txt; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"
           else
             echo "No iOS-owned files changed; skipping iOS tests."


### PR DESCRIPTION
## Summary

- skip expensive iOS CI jobs when a pull request changes no iOS-owned files
- remove shared terminal Swift files from the iOS workflow trigger
- keep workflow_dispatch running iOS tests explicitly

## Verification

- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/test-ios.yml"); puts "yaml ok"'\n- actionlint .github/workflows/test-ios.yml\n\nNo tagged reload, workflow-only change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5443"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783233081&installation_id=133855650&pr_number=5443&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5443&signature=9f9672cb85ab40e1f45bfeeb56947a3d12ee9a368cffde7d102b84278fabad69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only CI gating with no app/runtime changes; the main risk is a path-regex gap skipping iOS tests on a PR that still affects iOS behavior.
> 
> **Overview**
> **Skips expensive iOS CI** on pull requests that touch no iOS-owned code, while **manual `workflow_dispatch` runs still always execute** the full iOS pipeline.
> 
> A new **`detect-ios-changes`** job diffs the PR merge base to head and sets **`should_run`** when changed paths match the iOS package/app/vendor/lint patterns. **`package-conventions-lint`**, **`mobile-core-package`**, and **`ios-simulator`** now **`need`** that job and run only when **`should_run == 'true'`**.
> 
> The **`pull_request` `paths` filter** no longer includes shared **`Sources/GhosttyTerminalView.swift`** and **`Sources/TerminalController.swift`**, and aligns mobile package globs with **`CmuxMobile`** / **`CMUXMobile`** naming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0948d7c5819bc3f011479ed7bcd91a7249328ffb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate iOS CI jobs behind a changed-files check so tests run only when iOS-owned files change, reducing CI time and cost. The gate is now limited to iOS paths and mobile packages; shared terminal Swift files no longer trigger iOS jobs.

- **Refactors**
  - Added a `detect-ios-changes` job that diffs the PR merge base to head and sets `should_run`.
  - Gated `package-conventions-lint`, `mobile-core-package`, and `ios-simulator` with `needs` + `if`.
  - On PRs, run only when `ios/`, `Sources/Mobile/`, mobile package paths, `vendor/stack-auth-swift-sdk-prerelease/`, or `scripts/lint-ios-package-conventions.sh` change; workflow-only edits skip iOS jobs. Non-PR events (including `workflow_dispatch`) always run all iOS jobs.

<sup>Written for commit 0948d7c5819bc3f011479ed7bcd91a7249328ffb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now detects iOS-related file changes and runs iOS test steps only when relevant, reducing unnecessary runs.
  * Linting and mobile package checks are gated to that detection and are skipped unless iOS changes are present.
  * Simulator and mobile test jobs run only when triggered by detected iOS changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->