### PR TITLE
iOS TestFlight CI/CD + fix Release-archive build (DEBUG-gating from #5079)

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -16,8 +16,10 @@ on:
         default: false
         type: boolean
   schedule:
-    # Nightly at 09:10 UTC. The decide job skips the run when main has had no
-    # new commits in the last 24h so we don't re-upload an unchanged build.
+    # Nightly at 09:10 UTC. The decide job skips the run only when the current
+    # main HEAD was already uploaded by a prior successful run (SHA compare, not
+    # a wall-clock window), so a failed or missed nightly retries the
+    # not-yet-uploaded commit instead of permanently stranding it.
     - cron: "10 9 * * *"
 
 concurrency:
@@ -27,6 +29,8 @@ concurrency:
 
 permissions:
   contents: read
+  # decide reads this workflow's prior run history to find the last uploaded SHA.
+  actions: read
 
 jobs:
   decide:
@@ -46,31 +50,37 @@ jobs:
             const { owner, repo } = context.repo;
 
             // workflow_dispatch always builds (the operator asked for it).
-            // Scheduled runs build only when the default branch has had at least
-            // one new commit in the last ~24h, unless force is set.
-            let hasRecentCommits = true;
-            let recentCount = 0;
+            // Scheduled runs build unless the current commit has ALREADY been
+            // uploaded by a prior successful run. We compare HEAD to the head_sha
+            // of the most recent successful run of this workflow, not a wall-clock
+            // window: a failed or missed nightly leaves the last success on an
+            // older SHA, so the next run retries the un-uploaded commit instead of
+            // stranding it. A successful run either uploaded HEAD or correctly
+            // skipped an already-uploaded HEAD, so its head_sha is always an
+            // uploaded commit.
+            let needsBuild = true;
+            let lastUploadedSha = null;
             if (!forceBuild && context.eventName === 'schedule') {
-              const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
-              const commits = await github.rest.repos.listCommits({
+              const runs = await github.rest.actions.listWorkflowRuns({
                 owner,
                 repo,
-                sha: 'main',
-                since,
+                workflow_id: 'ios-testflight.yml',
+                status: 'success',
                 per_page: 1,
               });
-              recentCount = commits.data.length;
-              hasRecentCommits = recentCount > 0;
+              lastUploadedSha = runs.data.workflow_runs[0]?.head_sha ?? null;
+              needsBuild = lastUploadedSha !== context.sha;
             }
 
-            const shouldBuild = forceBuild || context.eventName === 'workflow_dispatch' || hasRecentCommits;
+            const shouldBuild = forceBuild || context.eventName === 'workflow_dispatch' || needsBuild;
             core.setOutput('should_build', shouldBuild ? 'true' : 'false');
             core.summary
               .addHeading('iOS TestFlight upload decision')
               .addTable([
                 [{ data: 'event', header: true }, context.eventName],
                 [{ data: 'force', header: true }, String(forceBuild)],
-                [{ data: 'commits in last 24h (schedule only)', header: true }, String(recentCount)],
+                [{ data: 'head sha', header: true }, context.sha],
+                [{ data: 'last uploaded sha (schedule only)', header: true }, String(lastUploadedSha)],
                 [{ data: 'should build', header: true }, String(shouldBuild)],
               ])
               .write();

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -1,0 +1,173 @@
+name: iOS TestFlight (beta)
+
+on:
+  workflow_dispatch:
+    inputs:
+      build_number:
+        description: CFBundleVersion to stamp (defaults to UTC yyyyMMddHHmm)
+        required: false
+        default: ""
+      force:
+        # Manual (workflow_dispatch) runs always upload, so this only documents
+        # intent. It exists so the no-new-commits skip can be bypassed if the
+        # 24h commit-window check is ever extended to dispatch runs.
+        description: Force an upload (manual runs already always upload)
+        required: false
+        default: false
+        type: boolean
+  schedule:
+    # Nightly at 09:10 UTC. The decide job skips the run when main has had no
+    # new commits in the last 24h so we don't re-upload an unchanged build.
+    - cron: "10 9 * * *"
+
+concurrency:
+  group: ios-testflight-${{ github.ref_name }}
+  # Queue concurrent runs instead of canceling them so no upload is lost.
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  decide:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      should_build: ${{ steps.decide.outputs.should_build }}
+    steps:
+      - name: Decide whether a TestFlight upload is needed
+        id: decide
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          FORCE_BUILD: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.force == 'true' && 'true' || 'false' }}
+        with:
+          script: |
+            const forceBuild = process.env.FORCE_BUILD === 'true';
+            const { owner, repo } = context.repo;
+
+            // workflow_dispatch always builds (the operator asked for it).
+            // Scheduled runs build only when the default branch has had at least
+            // one new commit in the last ~24h, unless force is set.
+            let hasRecentCommits = true;
+            let recentCount = 0;
+            if (!forceBuild && context.eventName === 'schedule') {
+              const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+              const commits = await github.rest.repos.listCommits({
+                owner,
+                repo,
+                sha: 'main',
+                since,
+                per_page: 1,
+              });
+              recentCount = commits.data.length;
+              hasRecentCommits = recentCount > 0;
+            }
+
+            const shouldBuild = forceBuild || context.eventName === 'workflow_dispatch' || hasRecentCommits;
+            core.setOutput('should_build', shouldBuild ? 'true' : 'false');
+            core.summary
+              .addHeading('iOS TestFlight upload decision')
+              .addTable([
+                [{ data: 'event', header: true }, context.eventName],
+                [{ data: 'force', header: true }, String(forceBuild)],
+                [{ data: 'commits in last 24h (schedule only)', header: true }, String(recentCount)],
+                [{ data: 'should build', header: true }, String(shouldBuild)],
+              ])
+              .write();
+
+  upload:
+    needs: decide
+    if: needs.decide.outputs.should_build == 'true'
+    runs-on: macos-26
+    timeout-minutes: 60
+    env:
+      ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
+      ASC_API_ISSUER_ID: ${{ secrets.ASC_API_ISSUER_ID }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          submodules: recursive
+
+      - name: Select Xcode
+        run: |
+          set -euo pipefail
+          if [ -d "/Applications/Xcode.app/Contents/Developer" ]; then
+            XCODE_DIR="/Applications/Xcode.app/Contents/Developer"
+          else
+            XCODE_APP="$(find /Applications -maxdepth 1 -type d -name 'Xcode*.app' -print 2>/dev/null | sort | tail -n 1 || true)"
+            if [ -z "$XCODE_APP" ]; then
+              echo "No Xcode.app found under /Applications" >&2
+              exit 1
+            fi
+            XCODE_DIR="$XCODE_APP/Contents/Developer"
+          fi
+          echo "DEVELOPER_DIR=$XCODE_DIR" >> "$GITHUB_ENV"
+          export DEVELOPER_DIR="$XCODE_DIR"
+          xcodebuild -version
+
+      - name: Provision GhosttyKit
+        run: |
+          # Downloads the prebuilt GhosttyKit.xcframework pinned in
+          # scripts/ghosttykit-checksums.txt for the current ghostty SHA, or
+          # falls back to a from-source build. The iOS app links GhosttyKit via
+          # a local-path binaryTarget, so it must exist before package resolve.
+          ./scripts/install-zig-ci.sh
+          ./scripts/ensure-ghosttykit.sh
+
+      - name: Materialize App Store Connect API key
+        env:
+          ASC_API_KEY_P8_BASE64: ${{ secrets.ASC_API_KEY_P8_BASE64 }}
+        run: |
+          set -euo pipefail
+          if [ -z "${ASC_API_KEY_ID:-}" ] || [ -z "${ASC_API_ISSUER_ID:-}" ] || [ -z "${ASC_API_KEY_P8_BASE64:-}" ]; then
+            echo "Missing one of ASC_API_KEY_ID / ASC_API_ISSUER_ID / ASC_API_KEY_P8_BASE64 secrets" >&2
+            exit 1
+          fi
+          # xcodebuild -allowProvisioningUpdates and altool both look for the key
+          # under ~/.appstoreconnect/private_keys/AuthKey_<KEY_ID>.p8.
+          KEY_DIR="$HOME/.appstoreconnect/private_keys"
+          KEY_PATH="$KEY_DIR/AuthKey_${ASC_API_KEY_ID}.p8"
+          mkdir -p "$KEY_DIR"
+          # Decode without echoing the key contents to the log.
+          printf '%s' "$ASC_API_KEY_P8_BASE64" | base64 --decode > "$KEY_PATH"
+          chmod 600 "$KEY_PATH"
+          # Write the expanded path ($HOME, not ~) so later steps can read it.
+          echo "ASC_API_KEY_PATH=$KEY_PATH" >> "$GITHUB_ENV"
+
+      - name: Resolve build number
+        id: build_number
+        env:
+          INPUT_BUILD_NUMBER: ${{ github.event.inputs.build_number }}
+        run: |
+          set -euo pipefail
+          BN="${INPUT_BUILD_NUMBER:-}"
+          if [ -z "$BN" ]; then
+            BN="$(date -u +%Y%m%d%H%M)"
+          fi
+          echo "build_number=$BN" >> "$GITHUB_OUTPUT"
+          echo "Using CFBundleVersion: $BN"
+
+      - name: Archive, export, and upload to TestFlight
+        env:
+          BUILD_NUMBER: ${{ steps.build_number.outputs.build_number }}
+        run: |
+          set -euo pipefail
+          ./ios/scripts/upload-testflight.sh \
+            --lane beta \
+            --signing automatic \
+            --build-number "$BUILD_NUMBER"
+
+      - name: Summary
+        if: always()
+        env:
+          BUILD_NUMBER: ${{ steps.build_number.outputs.build_number }}
+        run: |
+          {
+            echo "### iOS TestFlight upload"
+            echo
+            echo "- lane: \`beta\` (bundle id \`dev.cmux.app.beta\`)"
+            echo "- signing: automatic (cloud-managed via ASC API key)"
+            echo "- build number (CFBundleVersion): \`${BUILD_NUMBER}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -34,6 +34,7 @@ permissions:
 
 jobs:
   decide:
+    name: Decide whether a TestFlight upload is needed
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -86,6 +87,7 @@ jobs:
               .write();
 
   upload:
+    name: Upload to TestFlight
     needs: decide
     if: needs.decide.outputs.should_build == 'true'
     runs-on: macos-26

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
@@ -26,7 +26,7 @@ struct CMUXMobileRootView: View {
     #endif
 
     private var shouldShowTerminalLayoutPreview: Bool {
-        #if os(iOS)
+        #if os(iOS) && DEBUG
         return UITestConfig.terminalLayoutPreviewEnabled
         #else
         return false
@@ -34,7 +34,7 @@ struct CMUXMobileRootView: View {
     }
 
     @ViewBuilder private var terminalLayoutPreview: some View {
-        #if os(iOS)
+        #if os(iOS) && DEBUG
         TerminalLayoutPreviewView()
         #else
         EmptyView()

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalLayoutPreviewView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalLayoutPreviewView.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+#if canImport(UIKit) && DEBUG
 import CMUXMobileCore
 import CmuxMobileTerminal
 import SwiftUI

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -1562,8 +1562,14 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         return candidates.max { $0.utf8.count < $1.utf8.count }
     }
 
+    #endif
+
     /// Read the surface text for `pointTag` from the raw handle. Pure libghostty
     /// C calls, safe to run off the main actor on the serial output queue.
+    ///
+    /// Intentionally not `#if DEBUG`-gated: the non-DEBUG, release-shipping
+    /// ``visibleTerminalSnapshot()`` (Copy Debug Logs) calls this, so gating it
+    /// out breaks the Release/TestFlight archive while compiling fine in Debug.
     nonisolated static func surfaceText(_ surface: ghostty_surface_t, pointTag: ghostty_point_tag_e) -> String? {
         let topLeft = ghostty_point_s(tag: pointTag, coord: GHOSTTY_POINT_COORD_TOP_LEFT, x: 0, y: 0)
         let bottomRight = ghostty_point_s(tag: pointTag, coord: GHOSTTY_POINT_COORD_BOTTOM_RIGHT, x: 0, y: 0)
@@ -1574,7 +1580,6 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         guard let ptr = text.text, text.text_len > 0 else { return "" }
         return String(decoding: Data(bytes: ptr, count: Int(text.text_len)), as: UTF8.self)
     }
-    #endif
 
     func renderedHTMLForTesting(pointTag: ghostty_point_tag_e = GHOSTTY_POINT_VIEWPORT) -> String? {
         _ = pointTag

--- a/ios/scripts/upload-testflight.sh
+++ b/ios/scripts/upload-testflight.sh
@@ -5,6 +5,7 @@ usage() {
   cat <<'EOF'
 Usage:
   ios/scripts/upload-testflight.sh [--lane beta] [--build-number <number>]
+                                  [--signing manual|automatic]
                                   [--archive-path <path>] [--export-only]
 
 Archives cmux iOS, exports an App Store Connect IPA, and uploads it to
@@ -38,6 +39,13 @@ or:
 Options:
   --lane <beta>             Distribution lane. Only beta is currently defined.
   --build-number <number>   CFBundleVersion. Defaults to UTC yyyyMMddHHmm.
+  --signing <mode>          Export signing mode: manual (default) or automatic.
+                            manual uses the "Apple Distribution" certificate and
+                            the "cmux Beta Distribution" provisioning profile from
+                            the local keychain (for local/dev exports). automatic
+                            uses Xcode cloud-managed signing via the ASC API key
+                            and -allowProvisioningUpdates, so CI does not need an
+                            iOS distribution cert/profile in the keychain.
   --archive-path <path>     Reuse an existing archive instead of archiving.
   --export-only             Stop after exporting the signed IPA.
   -h, --help                Show this help.
@@ -58,6 +66,10 @@ LANE="beta"
 BUILD_NUMBER="$(date -u +%Y%m%d%H%M)"
 ARCHIVE_PATH=""
 EXPORT_ONLY=0
+# Export signing mode. "manual" keeps the original local-keychain behavior;
+# "automatic" switches the export to Xcode cloud-managed signing (used by CI,
+# which has no iOS distribution cert/profile, only the ASC API key).
+SIGNING="manual"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -69,6 +81,11 @@ while [[ $# -gt 0 ]]; do
     --build-number)
       require_option_value "$1" "${2:-}"
       BUILD_NUMBER="$2"
+      shift 2
+      ;;
+    --signing)
+      require_option_value "$1" "${2:-}"
+      SIGNING="$2"
       shift 2
       ;;
     --archive-path)
@@ -99,6 +116,15 @@ case "$LANE" in
     ;;
   *)
     echo "error: unsupported lane '$LANE'" >&2
+    usage >&2
+    exit 2
+    ;;
+esac
+
+case "$SIGNING" in
+  manual|automatic) ;;
+  *)
+    echo "error: unsupported signing mode '$SIGNING' (expected manual or automatic)" >&2
     usage >&2
     exit 2
     ;;
@@ -160,16 +186,28 @@ mkdir -p "$EXPORT_PATH"
 rm -f "$EXPORT_OPTIONS"
 touch "$EXPORT_OPTIONS"
 plutil -create xml1 "$EXPORT_OPTIONS"
+# Keys common to both signing modes.
 plutil -insert method -string app-store-connect "$EXPORT_OPTIONS"
 plutil -insert destination -string export "$EXPORT_OPTIONS"
 plutil -insert teamID -string "$DEVELOPMENT_TEAM" "$EXPORT_OPTIONS"
 plutil -insert manageAppVersionAndBuildNumber -bool NO "$EXPORT_OPTIONS"
 plutil -insert testFlightInternalTestingOnly -bool YES "$EXPORT_OPTIONS"
 plutil -insert uploadSymbols -bool YES "$EXPORT_OPTIONS"
-plutil -insert signingStyle -string manual "$EXPORT_OPTIONS"
-plutil -insert signingCertificate -string "Apple Distribution" "$EXPORT_OPTIONS"
-/usr/libexec/PlistBuddy -c "Add :provisioningProfiles dict" "$EXPORT_OPTIONS"
-/usr/libexec/PlistBuddy -c "Add :provisioningProfiles:$PRODUCT_BUNDLE_IDENTIFIER string $PROVISIONING_PROFILE_NAME" "$EXPORT_OPTIONS"
+if [[ "$SIGNING" == "automatic" ]]; then
+  # Cloud-managed signing: Xcode mints the distribution cert/profile on demand
+  # via the ASC API key + -allowProvisioningUpdates (already passed below), so
+  # the runner needs no iOS distribution cert/profile in its keychain. The
+  # signingCertificate/provisioningProfiles keys must be omitted in this mode;
+  # naming a profile that isn't installed makes -exportArchive fail.
+  plutil -insert signingStyle -string automatic "$EXPORT_OPTIONS"
+else
+  # Manual signing: requires the "Apple Distribution" certificate and the named
+  # provisioning profile to already be present in the local keychain.
+  plutil -insert signingStyle -string manual "$EXPORT_OPTIONS"
+  plutil -insert signingCertificate -string "Apple Distribution" "$EXPORT_OPTIONS"
+  /usr/libexec/PlistBuddy -c "Add :provisioningProfiles dict" "$EXPORT_OPTIONS"
+  /usr/libexec/PlistBuddy -c "Add :provisioningProfiles:$PRODUCT_BUNDLE_IDENTIFIER string $PROVISIONING_PROFILE_NAME" "$EXPORT_OPTIONS"
+fi
 
 xcodebuild -exportArchive \
   -archivePath "$ARCHIVE_PATH" \


### PR DESCRIPTION
Adds GitHub Actions CI/CD that ships the cmux iOS app to TestFlight, and fixes the iOS Release-archive build regression that building it in Release exposed.

## TestFlight workflow (`.github/workflows/ios-testflight.yml`)
- **Triggers:** `workflow_dispatch` (optional `build_number` / `force`) + a nightly cron that skips when `main` has had no new commits in the last 24h (a cheap ubuntu `decide` job), so it doesn't burn build numbers on unchanged code.
- **Build:** `macos-26`, Xcode select + `submodules: recursive` + `install-zig-ci.sh` + `ensure-ghosttykit.sh` (mirrors `test-ios.yml`), then `ios/scripts/upload-testflight.sh --lane beta --signing automatic` (bundle id `dev.cmux.app.beta`, internal TestFlight).
- **Signing:** cloud-managed (automatic) via `-allowProvisioningUpdates` + the App Store Connect API key, so the runner needs **no iOS distribution cert/profile** in its keychain — only the three ASC secrets (`ASC_API_KEY_ID`, `ASC_API_ISSUER_ID`, `ASC_API_KEY_P8_BASE64`). `upload-testflight.sh` gains a `--signing manual|automatic` flag (default `manual`, preserving local-keychain exports).

**Validated end-to-end on the branch** (temp push trigger, since removed): real archive → cloud-signed export → `altool` **UPLOAD SUCCEEDED with no errors**, Delivery UUID `39be114b-d1df-4392-8dcb-32f9708f3f16`, ~3.5 min.

## iOS Release-archive fix (⚠️ this was also breaking main's nightly/release iOS)
`test-ios.yml` only builds Debug/simulator, so two DEBUG-only-used-from-non-DEBUG leaks from the #5079 iOS-mobile merge went unnoticed and broke the Release archive:
- `GhosttySurfaceView.surfaceText` was `#if DEBUG` but the non-DEBUG public `visibleTerminalSnapshot()` (Copy Debug Logs, ships in betas) calls it → **un-gated the helper**.
- `TerminalLayoutPreviewView` (UITest screenshot scaffolding, mounted only when `CMUX_UITEST_TERMINAL_PREVIEW=1`) was gated only by `#if canImport(UIKit)` and called DEBUG-only `debug*ForLayoutPreview` seams → **DEBUG-gated the file + its CMUXMobileRootView mount points**.

`cmux-ios` now compiles in Release (verified `BUILD SUCCEEDED` + the real upload above). Debug behavior is unchanged.

## Notes
- The `ios-testflight` workflow doesn't run on PRs (dispatch + nightly only); it's validated above.
- The Release-archive fix is bundled here because building iOS in Release is exactly what this PR adds, but it independently unbreaks main's nightly/release iOS — worth merging promptly.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5448"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783239419&installation_id=133855650&pr_number=5448&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5448&signature=94cb5d6d87fe0a93b63ddec318bb552101665425d3dd00965968b5fd8c40d9d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches release signing/export and CI secrets for App Store Connect; Swift changes are compile-gating only with no intended runtime behavior change in Release beyond fixing the broken archive.
> 
> **Overview**
> Adds **automated TestFlight delivery** for the iOS beta (`dev.cmux.app.beta`) via a new GitHub Actions workflow: manual dispatch or a nightly cron, with a lightweight `decide` job that skips scheduled uploads when `main` has no commits in the last 24h. The macOS job provisions GhosttyKit, materializes App Store Connect API keys, and runs `upload-testflight.sh` with **`--signing automatic`** so CI can export without a distribution cert in the keychain.
> 
> `upload-testflight.sh` gains **`--signing manual|automatic`** (default manual): automatic export omits manual cert/profile plist entries and relies on cloud-managed signing with `-allowProvisioningUpdates`.
> 
> **Release archive fixes** exposed by shipping Release builds: `GhosttySurfaceView.surfaceText` is no longer `#if DEBUG`-only so release **Copy Debug Logs** / `visibleTerminalSnapshot()` compiles; UITest **terminal layout preview** (`TerminalLayoutPreviewView` and its mount in `CMUXMobileRootView`) is restricted to **DEBUG** so Release does not pull DEBUG-only preview seams.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 458d1001bc1aaaef86039a1c9ff195d352e2951f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automates TestFlight uploads for the cmux iOS beta and fixes Release-archive failures from DEBUG-only code. Manual and nightly uploads use cloud-managed signing; nightly skips only when the current `main` HEAD was already uploaded. Release/TestFlight builds compile again.

- **New Features**
  - Added `iOS TestFlight (beta)` workflow at `.github/workflows/ios-testflight.yml` to archive, export, and upload the `beta` lane (`dev.cmux.app.beta`).
  - Triggers: manual (`workflow_dispatch` with optional `build_number`) and nightly; gate uses the last successful run’s `head_sha` so missed/failed runs retry. Adds `actions: read` to query run history.
  - Uses cloud-managed signing via App Store Connect; requires `ASC_API_KEY_ID`, `ASC_API_ISSUER_ID`, `ASC_API_KEY_P8_BASE64`. No distribution cert/profile on the runner.
  - `ios/scripts/upload-testflight.sh` supports `--signing automatic` (CI) in addition to `manual` (default).
  - Labeled jobs with human-readable names for clearer Actions UI.

- **Bug Fixes**
  - Ungated `GhosttySurfaceView.surfaceText` so `visibleTerminalSnapshot()` works in Release; fixes Release/TestFlight archive failures.
  - DEBUG-gated `TerminalLayoutPreviewView` and its mounts in `CMUXMobileRootView` to avoid DEBUG-only seams in Release.
  - `cmux-ios` now compiles in Release; nightly/release iOS and TestFlight builds succeed.

<sup>Written for commit 171118353693709f3dd703f04a4b3a7262a47a9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an iOS TestFlight CI pipeline to automate conditional beta uploads with manual trigger and nightly scheduling.

* **Improvements**
  * Terminal layout preview is now enabled only in debug iOS builds.
  * Terminal snapshot / “copy logs” functionality remains available in release builds for diagnostics.
  * TestFlight upload tooling now supports selectable signing modes (manual or automatic) for exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->