### PR TITLE
Default Agent Hibernation idle window to 5s when enabled

### DIFF
--- a/Packages/CmuxSettings/Sources/CmuxSettings/Keys/TerminalCatalogSection.swift
+++ b/Packages/CmuxSettings/Sources/CmuxSettings/Keys/TerminalCatalogSection.swift
@@ -28,7 +28,7 @@ public struct TerminalCatalogSection: SettingCatalogSection {
 
     public let agentHibernationIdleSeconds = DefaultsKey<Double>(
         id: "terminal.agentHibernation.idleSeconds",
-        defaultValue: 3600,
+        defaultValue: 5,
         userDefaultsKey: "terminal.agentHibernation.idleSeconds"
     )
 

--- a/Sources/App/WorkspaceRuntimeSettings.swift
+++ b/Sources/App/WorkspaceRuntimeSettings.swift
@@ -266,7 +266,9 @@ enum AgentHibernationSettings {
     static let confirmationSecondsKey = "terminal.agentHibernation.confirmationSeconds"
 
     static let defaultEnabled = false
-    static let defaultIdleSeconds: TimeInterval = 60 * 60
+    // Hibernation is opt-in. Once enabled, reclaim idle background agents quickly:
+    // the maxLiveTerminals cap and the confirmationSeconds settle window keep this safe.
+    static let defaultIdleSeconds: TimeInterval = 5
     static let defaultMaxLiveTerminals = 12
     static let defaultConfirmationSeconds: TimeInterval = 60
     static let didChangeNotification = Notification.Name("cmux.agentHibernationSettingsDidChange")

--- a/cmuxTests/AgentHibernationTests.swift
+++ b/cmuxTests/AgentHibernationTests.swift
@@ -80,7 +80,7 @@ final class AgentHibernationTests: XCTestCase {
         defer { defaults.removePersistentDomain(forName: suiteName) }
 
         XCTAssertFalse(AgentHibernationSettings.isEnabled(defaults: defaults))
-        XCTAssertEqual(AgentHibernationSettings.idleSeconds(defaults: defaults), 3600)
+        XCTAssertEqual(AgentHibernationSettings.idleSeconds(defaults: defaults), 5)
         XCTAssertEqual(AgentHibernationSettings.maxLiveTerminals(defaults: defaults), 12)
 
         let notificationCenter = NotificationCenter()

--- a/docs/agent-hooks.md
+++ b/docs/agent-hooks.md
@@ -50,37 +50,53 @@ Grok uses its `Notification` hook for user-facing completion messages. cmux reco
 
 ## Agent Hibernation
 
-Agent Hibernation is opt-in. It can free old background terminals only when all of these are true:
+Agent Hibernation kills idle background agent processes to free their RAM and CPU, then resumes each one with its saved session when you return to its tab. It is opt-in and off by default. cmux knows which process belongs to which terminal because the agent hooks associate each session ID with its surface (see the session-restore section above), so it can terminate the right process and bring back the right session.
 
-- the terminal has a saved restorable agent session
-- the saved launch data can build a resume command
-- the agent lifecycle is `idle`
-- the terminal has had no output or input for the configured idle window
-- the number of live restorable agent terminals is above the configured limit
-- the panel is not currently visible
+### When a terminal hibernates
 
-cmux double-checks the terminal tail before hibernating. A hibernated terminal stays as a placeholder while it is in the background and automatically resumes when you visit its tab. The Resume button is a fallback for manual retry.
+A live terminal is only ever a candidate when all of these hold:
 
-Enable it from **Settings > Terminal > Agent Hibernation**, or from the CLI:
+- it has a saved restorable agent session, and the saved launch data can build a resume command
+- the agent lifecycle is `idle` (not running, not waiting on input)
+- the terminal is in the background (its panel is not currently visible)
+- you have more live restorable agent terminals than the live-terminal limit (`maxLiveTerminals`, default `12`)
+- the terminal has had no output, input, or lifecycle change for at least the idle window (`idleSeconds`, default `5`)
+
+The live-terminal limit is the first gate. Under the limit, nothing hibernates no matter how long it sits idle. Once you are over the limit, cmux frees only the oldest-idle background terminals, just enough to get back under the limit. Visible terminals are never touched.
+
+Before killing, cmux watches the terminal tail. It samples the last lines of output and a fingerprint of the process, and waits a short confirmation window (`confirmationSeconds`, ~60s) during which the output and process must stay unchanged. Any new output, input, lifecycle change, or PID change cancels the pending hibernation. This is why a small `idleSeconds` is safe: a freshly idle agent that resumes work on its own is never killed mid-task.
+
+So with the defaults, hibernation only affects power users running more than 12 agents at once, and even then only ~1 minute after an agent has gone quiet off-screen.
+
+### What gets killed and how it comes back
+
+cmux sends `SIGTERM` to the agent's process group (scoped to that workspace and surface), then swaps the live terminal for a lightweight placeholder, releasing the terminal's memory and CPU. When you visit the tab again, cmux runs the agent's native resume command with the saved session ID, so the session continues where it left off. The placeholder also shows a Resume button as a manual fallback.
+
+### Enable and configure
+
+Enable from the command palette (`⌘⇧P` -> **Enable Agent Hibernation**), from **Settings > Terminal > Agent Hibernation**, or from the CLI:
 
 ```bash
 cmux agent-hibernation on
 cmux agent-hibernation off
 ```
 
-Configure the idle window and live-terminal limit from Settings, or set them in `~/.config/cmux/cmux.json`:
+Tune the idle window and live-terminal limit from Settings, or set them in `~/.config/cmux/cmux.json`:
 
 ```json
 {
   "terminal": {
     "agentHibernation": {
       "enabled": true,
-      "idleSeconds": 3600,
+      "idleSeconds": 5,
       "maxLiveTerminals": 12
     }
   }
 }
 ```
+
+- `idleSeconds` (default `5`, range `5`-`604800`): how long a background idle agent terminal must be quiet before it can hibernate. Raise it to keep agents alive longer; lower it to reclaim resources sooner. The `confirmationSeconds` settle window still applies on top of this.
+- `maxLiveTerminals` (default `12`, range `1`-`256`): how many live restorable agent terminals to keep before cmux hibernates the oldest idle background ones. Lower it to hibernate more aggressively; raise it to keep more agents live.
 
 ## Custom surface resume commands
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,3 +21,25 @@ Controls what the tab right-click `Fork Conversation` item does. The submenu sti
 Values: `right`, `left`, `top`, `bottom`, `newTab`, `newWorkspace`.
 
 Default: `right`.
+
+## `terminal.agentHibernation`
+
+Opt-in Agent Hibernation. cmux kills idle background agent processes to free RAM and CPU, then resumes each one with its saved session when you visit its tab. See [agent-hooks.md](agent-hooks.md#agent-hibernation) for the full behavior, including the confirmation settle window and how resume works.
+
+```json
+{
+  "terminal": {
+    "agentHibernation": {
+      "enabled": true,
+      "idleSeconds": 5,
+      "maxLiveTerminals": 12
+    }
+  }
+}
+```
+
+- `enabled`: turn Agent Hibernation on. Default: `false`.
+- `idleSeconds`: seconds a background idle agent terminal must be quiet before it can hibernate. A ~60s confirmation settle window still applies on top of this. Default: `5`. Range: `5`-`604800`.
+- `maxLiveTerminals`: how many live restorable agent terminals to keep before cmux hibernates the oldest idle background ones. Nothing hibernates while you are at or under this count. Default: `12`. Range: `1`-`256`.
+
+Enable it from the command palette (`⌘⇧P` -> Enable Agent Hibernation), from **Settings > Terminal > Agent Hibernation**, or with `cmux agent-hibernation on`.

--- a/web/app/[locale]/docs/configuration/page.tsx
+++ b/web/app/[locale]/docs/configuration/page.tsx
@@ -78,7 +78,7 @@ function buildSettingsFileExample(t: ConfigurationTranslation) {
   //   "focusTextBoxOnNewTerminals": false,
   //   "agentHibernation": {
   //     "enabled": false,
-  //     "idleSeconds": 3600,
+  //     "idleSeconds": 5,
   //     "maxLiveTerminals": 12
   //   },
   //   "textBoxMaxLines": 10

--- a/web/data/cmux.schema.json
+++ b/web/data/cmux.schema.json
@@ -413,7 +413,7 @@
         "agentHibernation": {
           "type": "object",
           "additionalProperties": false,
-          "description": "Opt-in Agent Hibernation settings. cmux can suspend old background terminals only when they run a restorable coding agent, the agent lifecycle reports idle, no terminal output has changed for the configured idle window, and the live-terminal limit is exceeded. Hibernated agents resume when their tab is visited; the placeholder Resume button is a manual fallback.",
+          "description": "Opt-in Agent Hibernation settings. cmux kills idle background agent processes to free RAM and CPU, then resumes them with their saved session when their tab is visited. A terminal is only suspended when it runs a restorable coding agent, the agent lifecycle reports idle, the terminal is off-screen, the live-terminal limit is exceeded, and its output has stayed unchanged for the idle window plus a short confirmation settle window. The placeholder Resume button is a manual fallback.",
           "properties": {
             "enabled": {
               "type": "boolean",
@@ -424,8 +424,8 @@
               "type": "integer",
               "minimum": 5,
               "maximum": 604800,
-              "default": 3600,
-              "description": "Minimum seconds with no terminal output or input before an idle restorable agent terminal can hibernate."
+              "default": 5,
+              "description": "Minimum seconds with no terminal output or input before an idle restorable agent terminal can hibernate. A short confirmation settle window (~60s) still applies on top of this before the agent is killed."
             },
             "maxLiveTerminals": {
               "type": "integer",


### PR DESCRIPTION
## What

Lowers the default `terminal.agentHibernation.idleSeconds` from **3600 (1 hour)** to **5 seconds**.

Two parallel default definitions are changed together so the runtime and the Settings UI agree:
- `AgentHibernationSettings.defaultIdleSeconds` (`Sources/App/WorkspaceRuntimeSettings.swift`) — what the controller reads at runtime.
- `agentHibernationIdleSeconds` DefaultsKey (`Packages/CmuxSettings/.../TerminalCatalogSection.swift`) — what the Settings stepper shows when unset.

The `KeyboardShortcutSettingsFileStore` template already derives from the constant, so it follows automatically.

## Why this is safe even at 5s

Agent Hibernation stays **opt-in (off by default)**. Once enabled, an agent terminal is only killed when all of these hold, unchanged by this PR:
- you have more than `maxLiveTerminals` (default 12) live restorable agent terminals
- the terminal is off-screen (not the visible panel)
- the agent lifecycle is `idle`
- it has been quiet for `idleSeconds`
- it then survives a ~60s `confirmationSeconds` settle window with no new output/input/lifecycle/PID change

So with defaults this only affects users running **>12 agents at once**, and even then fires ~1 minute after an agent goes quiet, not 5 seconds. Visible/active agents are never touched.

## Behavior change note

Existing users who already enabled hibernation and never customized `idleSeconds` go from a 1-hour window to 5 seconds. Opt-in, so contained, but not zero. The value sits at the 5s floor (`sanitizedIdleSeconds` minimum).

## Docs

- `docs/agent-hooks.md`: rewrote the Agent Hibernation section to document the kill/resume mechanism, the full gate stack, the confirmation settle window, tuning, and the new default.
- `docs/configuration.md`: added a `terminal.agentHibernation` reference entry.
- `web/data/cmux.schema.json`: `idleSeconds.default` 3600 → 5 and enriched descriptions.
- `web/app/[locale]/docs/configuration/page.tsx`: updated the example.

## Localization

No new user-facing strings. Only a numeric default plus English reference/schema/docs text changed; the existing localized Settings strings are untouched.

## Test

`cmuxTests/AgentHibernationTests.swift` default assertion updated 3600 → 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5449"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783241519&installation_id=133855650&pr_number=5449&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5449&signature=1bd3b2cdf68900606d404bcad34ea2707f760cfc79aacbee72b2ca656143ab11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Opt-in feature, but it changes defaults for users who enabled hibernation without a custom idle window and affects when background agent processes may be terminated (mitigated by maxLiveTerminals and confirmationSeconds).
> 
> **Overview**
> Changes the default **`terminal.agentHibernation.idleSeconds`** from **3600** to **5** in both runtime settings (`AgentHibernationSettings.defaultIdleSeconds`) and the Settings catalog (`agentHibernationIdleSeconds`), with a short comment that hibernation stays opt-in and is bounded by **`maxLiveTerminals`** and **`confirmationSeconds`**.
> 
> **Tests** expect the new default (**5**). **Docs and schema** are updated together: expanded Agent Hibernation behavior (gates, ~60s settle window, SIGTERM/resume), a new `terminal.agentHibernation` section in `configuration.md`, JSON schema default/description tweaks, and the web docs example.
> 
> **Note for reviewers:** Hibernation remains **off by default**. Users who already enabled it and never set `idleSeconds` will pick up **5** on read (not a stored 3600), so eligible background agents can enter the idle gate sooner; actual kills still require exceeding the live-terminal cap and passing the confirmation window.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b2c8551be62c5b6bf88acbff1763e6df00978ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lowered the default `terminal.agentHibernation.idleSeconds` from 3600s to 5s when enabled, updating both runtime (`AgentHibernationSettings.defaultIdleSeconds`) and Settings UI defaults; docs, schema, and tests reflect the new default. Hibernation remains opt-in and gated by `maxLiveTerminals` (12) plus a ~60s confirmation window, so idle off-screen agents are reclaimed after about a minute only when running >12 agents.

- **Migration**
  - Users who enabled hibernation and didn’t customize `idleSeconds` will move from 1 hour to 5s; adjust in Settings or `~/.config/cmux/cmux.json` if needed.

<sup>Written for commit 3b2c8551be62c5b6bf88acbff1763e6df00978ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Agent hibernation default idle timeout reduced from 3600 to 5 seconds, enabling faster hibernation of inactive background terminals.

* **Documentation**
  * Expanded agent hibernation documentation clarifying opt-in behavior, hibernation conditions, and resume mechanics.
  * Updated configuration examples and schema with current defaults and valid ranges for idle timeout and live terminal limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->