### PR TITLE
Fix stale textbox mention rows while refreshing

### DIFF
--- a/Sources/Panels/TerminalPanel.swift
+++ b/Sources/Panels/TerminalPanel.swift
@@ -71,9 +71,11 @@ final class TerminalPanel: Panel, ObservableObject {
         let localURL: URL?
         let beforeText: String
         let afterText: String
+        let completionRootDirectory: String?
     }
 
     private var pendingDebugTextBoxInlineFixture: DebugTextBoxInlineFixture?
+    var debugTextBoxCompletionRootDirectoryOverride: String?
 
     var debugHasPendingTextBoxFocusRequest: Bool {
         shouldFocusTextBoxWhenAvailable || shouldOpenTextBoxFilePickerWhenAvailable
@@ -478,16 +480,19 @@ final class TerminalPanel: Panel, ObservableObject {
     func installDebugTextBoxInlineFixture(
         localURL: URL?,
         beforeText: String,
-        afterText: String
+        afterText: String,
+        completionRootDirectory: String? = nil
     ) -> Bool {
         textBoxInputFocusIntent = .textBox
         isTextBoxActive = true
         shouldFocusTextBoxWhenAvailable = true
+        debugTextBoxCompletionRootDirectoryOverride = completionRootDirectory
 
         let fixture = DebugTextBoxInlineFixture(
             localURL: localURL?.standardizedFileURL,
             beforeText: beforeText,
-            afterText: afterText
+            afterText: afterText,
+            completionRootDirectory: completionRootDirectory
         )
 
         pendingDebugTextBoxInlineFixture = fixture
@@ -514,6 +519,9 @@ final class TerminalPanel: Panel, ObservableObject {
                     localURL: $0,
                     submissionText: TextBoxAttachment.submissionText(forLocalFileURL: $0)
                 )
+        }
+        if let completionRootDirectory = fixture.completionRootDirectory {
+            textBoxInputView.completionRootDirectory = completionRootDirectory
         }
         textBoxContent = fixture.beforeText + fixture.afterText
         textBoxAttachments = attachment.map { [$0] } ?? []

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -15538,6 +15538,8 @@ class TerminalController {
         let hasAttachment = rawPath?.isEmpty == false
         let beforeText = (params["before_text"] as? String) ?? (hasAttachment ? "hello " : "")
         let afterText = (params["after_text"] as? String) ?? (hasAttachment ? "world" : "")
+        let completionRootDirectory = (params["completion_root_directory"] as? String)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
         let rawSurfaceID = params["surface_id"] as? String
         let target = rawSurfaceID?.trimmingCharacters(in: .whitespacesAndNewlines)
         if let rawSurfaceID,
@@ -15562,13 +15564,15 @@ class TerminalController {
             _ = panel.installDebugTextBoxInlineFixture(
                 localURL: url,
                 beforeText: beforeText,
-                afterText: afterText
+                afterText: afterText,
+                completionRootDirectory: completionRootDirectory?.isEmpty == false ? completionRootDirectory : nil
             )
             let textView = panel.textBoxInputView
             result = .ok([
                 "surface_id": panel.id.uuidString,
                 "surface_ref": v2Ref(kind: .surface, uuid: panel.id),
                 "path": url?.path ?? "",
+                "completion_root_directory": completionRootDirectory ?? "",
                 "text_box_active": panel.isTextBoxActive,
                 "has_text_view": textView != nil,
                 "text_view_has_window": textView?.window != nil,

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -22210,14 +22210,9 @@ class TerminalController {
     }
 
     private func mobileTerminalPanels(in workspace: Workspace) -> [TerminalPanel] {
-        let focusedPanelID = workspace.focusedPanelId
-        return workspace.panels.values
-            .compactMap { $0 as? TerminalPanel }
-            .sorted { lhs, rhs in
-                if lhs.id == focusedPanelID { return true }
-                if rhs.id == focusedPanelID { return false }
-                return lhs.id.uuidString < rhs.id.uuidString
-            }
+        // Match the on-screen bonsplit order. The payload's per-terminal
+        // `is_focused` field already carries focus state without reordering.
+        orderedPanels(in: workspace).compactMap { $0 as? TerminalPanel }
     }
 
     private func mobileNonEmpty(_ raw: String?) -> String? {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -15549,12 +15549,7 @@ class TerminalController {
 
         var result: V2CallResult = .err(code: "not_found", message: "Terminal panel not found", data: nil)
         v2MainSync {
-            let panel: TerminalPanel?
-            if let target, !target.isEmpty {
-                panel = resolveTerminalPanel(from: target, tabManager: tabManager)
-            } else {
-                panel = tabManager.selectedTerminalPanel
-            }
+            let panel = v2DebugTextBoxFixturePanel(target: target, tabManager: tabManager)
 
             guard let panel else {
                 return
@@ -15584,6 +15579,56 @@ class TerminalController {
             ])
         }
         return result
+    }
+
+    private func v2DebugTextBoxFixturePanel(target: String?, tabManager: TabManager) -> TerminalPanel? {
+        if let target, !target.isEmpty {
+            return resolveTerminalPanel(from: target, tabManager: tabManager)
+        }
+
+        func terminalPanels(in tab: Workspace) -> [TerminalPanel] {
+            orderedPanels(in: tab).compactMap { $0 as? TerminalPanel }
+        }
+
+        func visibleTerminal(in panels: [TerminalPanel]) -> TerminalPanel? {
+            panels.first { panel in
+                panel.hostedView.window != nil || panel.textBoxInputView?.window != nil
+            }
+        }
+
+        if let selected = tabManager.selectedTerminalPanel,
+           selected.hostedView.window != nil || selected.textBoxInputView?.window != nil {
+            return selected
+        }
+
+        if let selectedTabId = tabManager.selectedTabId,
+           let selectedTab = tabManager.tabs.first(where: { $0.id == selectedTabId }) {
+            let selectedWorkspaceTerminals = terminalPanels(in: selectedTab)
+            if let visible = visibleTerminal(in: selectedWorkspaceTerminals) {
+                return visible
+            }
+            if let selected = tabManager.selectedTerminalPanel {
+                return selected
+            }
+            if let first = selectedWorkspaceTerminals.first {
+                return first
+            }
+        }
+
+        for tab in tabManager.tabs {
+            let panels = terminalPanels(in: tab)
+            if let visible = visibleTerminal(in: panels) {
+                return visible
+            }
+        }
+
+        for tab in tabManager.tabs {
+            if let first = terminalPanels(in: tab).first {
+                return first
+            }
+        }
+
+        return nil
     }
 
     private func v2DebugTextBoxInteract(params: [String: Any]) -> V2CallResult {

--- a/Sources/TextBoxInput.swift
+++ b/Sources/TextBoxInput.swift
@@ -1501,6 +1501,7 @@ private struct TextBoxMentionCompletionPopoverView: View {
     let selectionIndex: Int
     let searchTerm: String
     let isLoading: Bool
+    let renderIdentity: Int
     let onSelect: (TextBoxMentionSuggestion) -> Void
 
     var body: some View {
@@ -1557,6 +1558,7 @@ private struct TextBoxMentionCompletionPopoverView: View {
             }
         }
         .frame(width: 360)
+        .id(renderIdentity)
         .background(.regularMaterial)
         .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
         .transaction { transaction in
@@ -4951,6 +4953,7 @@ final class TextBoxInputTextView: NSTextView {
             selectionIndex: renderState.selectionIndex,
             searchTerm: renderState.searchTerm,
             isLoading: renderState.isLoading,
+            renderIdentity: renderState.identity,
             onSelect: { [weak self] suggestion in
                 self?.window?.makeFirstResponder(self)
                 self?.acceptMentionCompletion(suggestion)

--- a/Sources/TextBoxInput.swift
+++ b/Sources/TextBoxInput.swift
@@ -3662,6 +3662,7 @@ final class TextBoxInputTextView: NSTextView {
         }
         if didChangeTextWasHandled {
             flushAutomaticAttachmentFileCleanup()
+            refreshMentionCompletions()
         } else {
             didChangeText()
         }
@@ -4147,6 +4148,9 @@ final class TextBoxInputTextView: NSTextView {
                 clearAttachmentFocus(dismissPreview: true)
                 refreshInlineAttachmentFocus()
             }
+        case let insertAction where insertAction.hasPrefix("insert_text:"):
+            let insertedText = String(insertAction.dropFirst("insert_text:".count))
+            insertText(insertedText, replacementRange: selectedRange())
         default:
             break
         }
@@ -4452,14 +4456,33 @@ final class TextBoxInputTextView: NSTextView {
     }
 
     func refreshMentionCompletions() {
-        let query = TextBoxMentionCompletionDetector.query(
+        mentionCompletionController.refresh(
+            for: currentMentionCompletionQuery(),
+            rootDirectory: completionRootDirectory
+        )
+    }
+
+    private func currentMentionCompletionQuery() -> TextBoxMentionQuery? {
+        TextBoxMentionCompletionDetector.query(
             in: attributedString().string,
             selectedRange: selectedRange()
         )
+    }
+
+    private func syncMentionCompletionQueryWithTextViewState() -> Bool {
+        guard mentionCompletionController.isActive else { return false }
+        let query = currentMentionCompletionQuery()
+        guard !mentionCompletionController.matchesCurrentInput(
+            query: query,
+            rootDirectory: completionRootDirectory
+        ) else {
+            return false
+        }
         mentionCompletionController.refresh(
             for: query,
             rootDirectory: completionRootDirectory
         )
+        return true
     }
 
     private func warmMentionCompletionIndexesIfNeeded() {
@@ -4672,6 +4695,9 @@ final class TextBoxInputTextView: NSTextView {
     }
 
     private func syncMentionCompletionPopover() {
+        if syncMentionCompletionQueryWithTextViewState() {
+            return
+        }
         guard mentionCompletionController.shouldShowPopover else {
             dismissMentionCompletionPopoverOnly()
             return
@@ -4708,6 +4734,10 @@ final class TextBoxInputTextView: NSTextView {
             mentionCompletionPanelHost = host
         }
         host.frame = NSRect(origin: .zero, size: contentSize)
+        host.needsLayout = true
+        host.needsDisplay = true
+        host.layoutSubtreeIfNeeded()
+        host.displayIfNeeded()
 
         let panel = mentionCompletionPanel ?? makeMentionCompletionPanel(host: host)
         if panel.contentView !== host {
@@ -4729,6 +4759,8 @@ final class TextBoxInputTextView: NSTextView {
         if !panel.isVisible {
             panel.orderFront(nil)
         }
+        panel.contentView?.needsDisplay = true
+        panel.contentView?.displayIfNeeded()
     }
 
     private func makeMentionCompletionPanel(

--- a/Sources/TextBoxInput.swift
+++ b/Sources/TextBoxInput.swift
@@ -1535,6 +1535,7 @@ private struct TextBoxMentionCompletionPopoverView: View {
                             .buttonStyle(.plain)
                             .id(index)
                             .accessibilityIdentifier("TextBoxMentionCompletionPopover.Row.\(index)")
+                            .accessibilityLabel(suggestion.title)
                             .accessibilityValue(
                                 index == selectionIndex
                                     ? "selected \(suggestion.title)"
@@ -4486,20 +4487,19 @@ final class TextBoxInputTextView: NSTextView {
         )
     }
 
-    private func syncMentionCompletionQueryWithTextViewState() -> Bool {
-        guard mentionCompletionController.isActive else { return false }
+    private func syncMentionCompletionQueryWithTextViewState() {
+        guard mentionCompletionController.isActive else { return }
         let query = currentMentionCompletionQuery()
         guard !mentionCompletionController.matchesCurrentInput(
             query: query,
             rootDirectory: completionRootDirectory
         ) else {
-            return false
+            return
         }
         mentionCompletionController.refresh(
             for: query,
             rootDirectory: completionRootDirectory
         )
-        return true
     }
 
     private func warmMentionCompletionIndexesIfNeeded() {
@@ -4712,9 +4712,7 @@ final class TextBoxInputTextView: NSTextView {
     }
 
     private func syncMentionCompletionPopover() {
-        if syncMentionCompletionQueryWithTextViewState() {
-            return
-        }
+        syncMentionCompletionQueryWithTextViewState()
         guard mentionCompletionController.shouldShowPopover else {
             dismissMentionCompletionPopoverOnly()
             return

--- a/Sources/TextBoxInput.swift
+++ b/Sources/TextBoxInput.swift
@@ -1564,6 +1564,16 @@ private struct TextBoxMentionCompletionPopoverView: View {
         }
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier("TextBoxMentionCompletionPopover")
+        .accessibilityValue(Text(verbatim: debugAccessibilityValue))
+    }
+
+    private var debugAccessibilityValue: String {
+#if DEBUG
+        let rowTitles = suggestions.map(\.title).joined(separator: ",")
+        return "query=\(searchTerm);loading=\(isLoading);rows=\(rowTitles)"
+#else
+        return ""
+#endif
     }
 
     private static func highlightedTitle(_ title: String, query: String) -> AttributedString {

--- a/Sources/TextBoxInput.swift
+++ b/Sources/TextBoxInput.swift
@@ -1515,6 +1515,7 @@ private struct TextBoxMentionCompletionPopoverView: View {
                             Spacer(minLength: 0)
                         }
                         .frame(maxWidth: .infinity, minHeight: 28, alignment: .center)
+                        .accessibilityIdentifier("TextBoxMentionCompletionPopover.Loading")
                     } else {
                         ForEach(Array(suggestions.enumerated()), id: \.element.id) { index, suggestion in
                             Button {
@@ -1533,6 +1534,12 @@ private struct TextBoxMentionCompletionPopoverView: View {
                             }
                             .buttonStyle(.plain)
                             .id(index)
+                            .accessibilityIdentifier("TextBoxMentionCompletionPopover.Row.\(index)")
+                            .accessibilityValue(
+                                index == selectionIndex
+                                    ? "selected \(suggestion.title)"
+                                    : suggestion.title
+                            )
                         }
                     }
                 }
@@ -1548,6 +1555,8 @@ private struct TextBoxMentionCompletionPopoverView: View {
         .transaction { transaction in
             transaction.animation = nil
         }
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("TextBoxMentionCompletionPopover")
     }
 
     private static func highlightedTitle(_ title: String, query: String) -> AttributedString {

--- a/Sources/TextBoxInput.swift
+++ b/Sources/TextBoxInput.swift
@@ -4672,11 +4672,11 @@ final class TextBoxInputTextView: NSTextView {
 
     @discardableResult
     private func acceptMentionCompletion(_ explicitSuggestion: TextBoxMentionSuggestion? = nil) -> Bool {
-        guard mentionCompletionController.hasVisibleSuggestions,
+        guard mentionCompletionController.hasAcceptableSuggestions,
               let query = mentionCompletionController.activeQuery,
               let suggestion = explicitSuggestion ?? mentionCompletionController.selectedSuggestion,
               explicitSuggestion == nil ||
-                  mentionCompletionController.visibleSuggestions.contains(where: { $0.id == suggestion.id }),
+                  mentionCompletionController.canAccept(suggestion),
               isValidSelectedRange(query.range),
               shouldChangeText(in: query.range, replacementString: suggestion.insertionText) else {
             return false

--- a/Sources/TextBoxInput.swift
+++ b/Sources/TextBoxInput.swift
@@ -5011,6 +5011,10 @@ final class TextBoxInputTextView: NSTextView {
         mentionCompletionController.debugSuggestionCount
     }
 
+    func debugStoredMentionSuggestionCount() -> Int {
+        mentionCompletionController.debugStoredSuggestionCount
+    }
+
     func debugMentionSuggestionTitles() -> [String] {
         mentionCompletionController.debugSuggestionTitles
     }

--- a/Sources/TextBoxInput.swift
+++ b/Sources/TextBoxInput.swift
@@ -4600,13 +4600,13 @@ final class TextBoxInputTextView: NSTextView {
                 dismissMentionCompletions()
                 return false
             }
-            return acceptMentionCompletion()
+            return acceptMentionCompletionOrConsumeRefreshingRows()
         case kVK_Tab:
             if shouldBypassHiddenMentionCompletionKeyboardInteraction() {
                 dismissMentionCompletions()
                 return false
             }
-            return acceptMentionCompletion()
+            return acceptMentionCompletionOrConsumeRefreshingRows()
         case kVK_Escape:
             if shouldBypassHiddenMentionCompletionKeyboardInteraction() {
                 dismissMentionCompletions()
@@ -4649,13 +4649,13 @@ final class TextBoxInputTextView: NSTextView {
                 dismissMentionCompletions()
                 return false
             }
-            return acceptMentionCompletion()
+            return acceptMentionCompletionOrConsumeRefreshingRows()
         case #selector(NSResponder.insertTab(_:)):
             if shouldBypassHiddenMentionCompletionKeyboardInteraction() {
                 dismissMentionCompletions()
                 return false
             }
-            return acceptMentionCompletion()
+            return acceptMentionCompletionOrConsumeRefreshingRows()
         case #selector(NSResponder.cancelOperation(_:)):
             if shouldBypassHiddenMentionCompletionKeyboardInteraction() {
                 dismissMentionCompletions()
@@ -4717,6 +4717,17 @@ final class TextBoxInputTextView: NSTextView {
         didChangeText()
         scrollRangeToVisible(NSRange(location: insertionLocation, length: 0))
         return true
+    }
+
+    private func acceptMentionCompletionOrConsumeRefreshingRows() -> Bool {
+        if acceptMentionCompletion() {
+            return true
+        }
+
+        // Locally filtered rows are visible while an exact query lookup is loading,
+        // but accepting them is blocked until the current lookup resolves.
+        return mentionCompletionController.hasVisibleSuggestions &&
+            !mentionCompletionController.hasAcceptableSuggestions
     }
 
     private func mentionCompletionReplacementText(

--- a/Sources/TextBoxInput.swift
+++ b/Sources/TextBoxInput.swift
@@ -1538,7 +1538,13 @@ private struct TextBoxMentionCompletionPopoverView: View {
                             .accessibilityLabel(suggestion.title)
                             .accessibilityValue(
                                 index == selectionIndex
-                                    ? "selected \(suggestion.title)"
+                                    ? String(
+                                        format: String(
+                                            localized: "textbox.mentionCompletion.accessibility.selectedValue",
+                                            defaultValue: "selected %@"
+                                        ),
+                                        suggestion.title
+                                    )
                                     : suggestion.title
                             )
                         }

--- a/Sources/TextBoxInput.swift
+++ b/Sources/TextBoxInput.swift
@@ -5011,8 +5011,8 @@ final class TextBoxInputTextView: NSTextView {
         mentionCompletionController.debugSuggestionCount
     }
 
-    func debugStoredMentionSuggestionCount() -> Int {
-        mentionCompletionController.debugStoredSuggestionCount
+    func debugVisibleMentionSuggestionCount() -> Int {
+        mentionCompletionController.debugVisibleSuggestionCount
     }
 
     func debugMentionSuggestionTitles() -> [String] {

--- a/Sources/TextBoxInput.swift
+++ b/Sources/TextBoxInput.swift
@@ -3299,6 +3299,7 @@ struct TextBoxInputView: NSViewRepresentable {
         )
         textView.textContainerInset = TextBoxLayout.textInset
         textView.textContainer?.lineFragmentPadding = 0
+        textView.setAccessibilityIdentifier("TextBoxInput.TextView")
         textView.registerForDraggedTypes([.fileURL])
 
         let scrollView = NSScrollView()

--- a/Sources/TextBoxInput.swift
+++ b/Sources/TextBoxInput.swift
@@ -3350,14 +3350,28 @@ struct TextBoxInputView: NSViewRepresentable {
                 height: CGFloat.greatestFiniteMagnitude
             )
         }
+        let plainText = textView.plainText()
+        let selectedRangeBeforeExternalSync = textView.selectedRange()
         let didSynchronizeExternalText = shouldSynchronizeExternalTextToTextBox(
             inlineAttachmentCount: textView.inlineAttachments().count,
-            plainText: textView.plainText(),
+            plainText: plainText,
             externalText: text,
             hasMarkedText: textView.hasMarkedText()
         )
         if didSynchronizeExternalText {
             textView.string = text
+            let previousLength = (plainText as NSString).length
+            let newLength = (text as NSString).length
+            let selectionWasAtPreviousEnd = selectedRangeBeforeExternalSync.length == 0 &&
+                selectedRangeBeforeExternalSync.location >= previousLength
+            let location: Int
+            if selectionWasAtPreviousEnd {
+                location = newLength
+            } else {
+                location = min(selectedRangeBeforeExternalSync.location, newLength)
+            }
+            let length = min(selectedRangeBeforeExternalSync.length, newLength - location)
+            textView.setSelectedRange(NSRange(location: location, length: length))
         }
         updateTextView(textView, context: context)
         if didSynchronizeExternalText {

--- a/Sources/TextBoxInput.swift
+++ b/Sources/TextBoxInput.swift
@@ -4374,6 +4374,9 @@ final class TextBoxInputTextView: NSTextView {
            let key = controlKey(for: event) {
             if Self.localControlKeys.contains(key) {
                 super.keyDown(with: event)
+                if !hasMarkedText() {
+                    refreshMentionCompletions()
+                }
             } else {
                 onForwardControl(key)
             }
@@ -4396,6 +4399,9 @@ final class TextBoxInputTextView: NSTextView {
         }
 
         super.keyDown(with: event)
+        if !hasMarkedText() {
+            refreshMentionCompletions()
+        }
     }
 
     override func doCommand(by commandSelector: Selector) {
@@ -4720,7 +4726,9 @@ final class TextBoxInputTextView: NSTextView {
 
     private func syncMentionCompletionPopover() {
         syncMentionCompletionQueryWithTextViewState()
-        guard mentionCompletionController.shouldShowPopover else {
+        let renderState = mentionCompletionController.renderState
+        guard mentionCompletionController.isActive,
+              renderState.shouldShowPopover else {
             dismissMentionCompletionPopoverOnly()
             return
         }
@@ -4734,10 +4742,8 @@ final class TextBoxInputTextView: NSTextView {
         }
         updateMentionCompletionWindowObservers(for: parentWindow)
 
-        let visibleSuggestions = mentionCompletionController.visibleSuggestions
-        let showsLoadingRow = visibleSuggestions.isEmpty &&
-            mentionCompletionController.isLoadingSuggestions
-        let rowCount = showsLoadingRow ? 1 : visibleSuggestions.count
+        let showsLoadingRow = renderState.suggestions.isEmpty && renderState.isLoading
+        let rowCount = showsLoadingRow ? 1 : renderState.suggestions.count
         let maxVisibleRows = 12
         let visibleRows = min(rowCount, maxVisibleRows)
         let rowHeight: CGFloat = 25
@@ -4747,10 +4753,10 @@ final class TextBoxInputTextView: NSTextView {
         )
         let host: NSHostingView<TextBoxMentionCompletionPopoverView>
         if let existingHost = mentionCompletionPanelHost {
-            existingHost.rootView = mentionCompletionPopoverView()
+            existingHost.rootView = mentionCompletionPopoverView(renderState: renderState)
             host = existingHost
         } else {
-            host = NSHostingView(rootView: mentionCompletionPopoverView())
+            host = NSHostingView(rootView: mentionCompletionPopoverView(renderState: renderState))
             host.translatesAutoresizingMaskIntoConstraints = true
             host.autoresizingMask = []
             mentionCompletionPanelHost = host
@@ -4927,12 +4933,14 @@ final class TextBoxInputTextView: NSTextView {
         return NSPoint(x: x, y: y)
     }
 
-    private func mentionCompletionPopoverView() -> TextBoxMentionCompletionPopoverView {
+    private func mentionCompletionPopoverView(
+        renderState: TextBoxMentionCompletionRenderState
+    ) -> TextBoxMentionCompletionPopoverView {
         TextBoxMentionCompletionPopoverView(
-            suggestions: mentionCompletionController.visibleSuggestions,
-            selectionIndex: mentionCompletionController.selectionIndex,
-            searchTerm: mentionCompletionController.activeQuery?.query ?? "",
-            isLoading: mentionCompletionController.isLoadingSuggestions,
+            suggestions: renderState.suggestions,
+            selectionIndex: renderState.selectionIndex,
+            searchTerm: renderState.searchTerm,
+            isLoading: renderState.isLoading,
             onSelect: { [weak self] suggestion in
                 self?.window?.makeFirstResponder(self)
                 self?.acceptMentionCompletion(suggestion)

--- a/Sources/TextBoxInput.swift
+++ b/Sources/TextBoxInput.swift
@@ -4757,8 +4757,6 @@ final class TextBoxInputTextView: NSTextView {
         host.frame = NSRect(origin: .zero, size: contentSize)
         host.needsLayout = true
         host.needsDisplay = true
-        host.layoutSubtreeIfNeeded()
-        host.displayIfNeeded()
 
         let panel = mentionCompletionPanel ?? makeMentionCompletionPanel(host: host)
         if panel.contentView !== host {
@@ -4781,7 +4779,6 @@ final class TextBoxInputTextView: NSTextView {
             panel.orderFront(nil)
         }
         panel.contentView?.needsDisplay = true
-        panel.contentView?.displayIfNeeded()
     }
 
     private func makeMentionCompletionPanel(

--- a/Sources/TextBoxInput.swift
+++ b/Sources/TextBoxInput.swift
@@ -3313,15 +3313,19 @@ struct TextBoxInputView: NSViewRepresentable {
                 height: CGFloat.greatestFiniteMagnitude
             )
         }
-        if shouldSynchronizeExternalTextToTextBox(
+        let didSynchronizeExternalText = shouldSynchronizeExternalTextToTextBox(
             inlineAttachmentCount: textView.inlineAttachments().count,
             plainText: textView.plainText(),
             externalText: text,
             hasMarkedText: textView.hasMarkedText()
-        ) {
+        )
+        if didSynchronizeExternalText {
             textView.string = text
         }
         updateTextView(textView, context: context)
+        if didSynchronizeExternalText {
+            textView.refreshMentionCompletions()
+        }
     }
 
     private func updateTextView(_ textView: TextBoxInputTextView, context: Context) {
@@ -4488,7 +4492,7 @@ final class TextBoxInputTextView: NSTextView {
                 // Only claim the navigation keys once there are rows to move through;
                 // otherwise (active query still loading or zero hits) let them fall
                 // through to normal text editing instead of being silently swallowed.
-                guard mentionCompletionController.hasCurrentSuggestions else { return false }
+                guard mentionCompletionController.hasVisibleSuggestions else { return false }
                 mentionCompletionController.moveSelection(delta: -1)
                 return true
             case "n", "j":
@@ -4496,7 +4500,7 @@ final class TextBoxInputTextView: NSTextView {
                     dismissMentionCompletions()
                     return false
                 }
-                guard mentionCompletionController.hasCurrentSuggestions else { return false }
+                guard mentionCompletionController.hasVisibleSuggestions else { return false }
                 mentionCompletionController.moveSelection(delta: 1)
                 return true
             default:
@@ -4510,7 +4514,7 @@ final class TextBoxInputTextView: NSTextView {
                 dismissMentionCompletions()
                 return false
             }
-            guard mentionCompletionController.hasCurrentSuggestions else { return false }
+            guard mentionCompletionController.hasVisibleSuggestions else { return false }
             mentionCompletionController.moveSelection(delta: -1)
             return true
         case kVK_DownArrow:
@@ -4518,7 +4522,7 @@ final class TextBoxInputTextView: NSTextView {
                 dismissMentionCompletions()
                 return false
             }
-            guard mentionCompletionController.hasCurrentSuggestions else { return false }
+            guard mentionCompletionController.hasVisibleSuggestions else { return false }
             mentionCompletionController.moveSelection(delta: 1)
             return true
         case kVK_Return, kVK_ANSI_KeypadEnter:
@@ -4560,7 +4564,7 @@ final class TextBoxInputTextView: NSTextView {
                 dismissMentionCompletions()
                 return false
             }
-            guard mentionCompletionController.hasCurrentSuggestions else { return false }
+            guard mentionCompletionController.hasVisibleSuggestions else { return false }
             mentionCompletionController.moveSelection(delta: -1)
             return true
         case #selector(NSResponder.moveDown(_:)):
@@ -4568,7 +4572,7 @@ final class TextBoxInputTextView: NSTextView {
                 dismissMentionCompletions()
                 return false
             }
-            guard mentionCompletionController.hasCurrentSuggestions else { return false }
+            guard mentionCompletionController.hasVisibleSuggestions else { return false }
             mentionCompletionController.moveSelection(delta: 1)
             return true
         case #selector(NSResponder.insertNewline(_:)):
@@ -4622,11 +4626,11 @@ final class TextBoxInputTextView: NSTextView {
 
     @discardableResult
     private func acceptMentionCompletion(_ explicitSuggestion: TextBoxMentionSuggestion? = nil) -> Bool {
-        guard mentionCompletionController.hasCurrentSuggestions,
+        guard mentionCompletionController.hasVisibleSuggestions,
               let query = mentionCompletionController.activeQuery,
               let suggestion = explicitSuggestion ?? mentionCompletionController.selectedSuggestion,
               explicitSuggestion == nil ||
-                  mentionCompletionController.suggestions.contains(where: { $0.id == suggestion.id }),
+                  mentionCompletionController.visibleSuggestions.contains(where: { $0.id == suggestion.id }),
               isValidSelectedRange(query.range),
               shouldChangeText(in: query.range, replacementString: suggestion.insertionText) else {
             return false
@@ -4682,9 +4686,10 @@ final class TextBoxInputTextView: NSTextView {
         }
         updateMentionCompletionWindowObservers(for: parentWindow)
 
-        let showsLoadingRow = mentionCompletionController.suggestions.isEmpty &&
+        let visibleSuggestions = mentionCompletionController.visibleSuggestions
+        let showsLoadingRow = visibleSuggestions.isEmpty &&
             mentionCompletionController.isLoadingSuggestions
-        let rowCount = showsLoadingRow ? 1 : mentionCompletionController.suggestions.count
+        let rowCount = showsLoadingRow ? 1 : visibleSuggestions.count
         let maxVisibleRows = 12
         let visibleRows = min(rowCount, maxVisibleRows)
         let rowHeight: CGFloat = 25
@@ -4873,7 +4878,7 @@ final class TextBoxInputTextView: NSTextView {
 
     private func mentionCompletionPopoverView() -> TextBoxMentionCompletionPopoverView {
         TextBoxMentionCompletionPopoverView(
-            suggestions: mentionCompletionController.suggestions,
+            suggestions: mentionCompletionController.visibleSuggestions,
             selectionIndex: mentionCompletionController.selectionIndex,
             searchTerm: mentionCompletionController.activeQuery?.query ?? "",
             isLoading: mentionCompletionController.isLoadingSuggestions,

--- a/Sources/TextBoxInput.swift
+++ b/Sources/TextBoxInput.swift
@@ -2690,6 +2690,14 @@ struct TextBoxInputContainer: View {
 
     private var completionRootDirectory: String? {
         guard let workspace = surface.owningWorkspace() else { return nil }
+#if DEBUG
+        if let directory = workspace.terminalPanel(for: surface.id)?
+            .debugTextBoxCompletionRootDirectoryOverride?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+           !directory.isEmpty {
+            return directory
+        }
+#endif
         if let directory = workspace.panelDirectories[surface.id]?.trimmingCharacters(in: .whitespacesAndNewlines),
            !directory.isEmpty {
             return directory

--- a/Sources/TextBoxMentionCompletionController.swift
+++ b/Sources/TextBoxMentionCompletionController.swift
@@ -56,6 +56,13 @@ final class TextBoxMentionCompletionController {
         return visibleSuggestions[selectionIndex]
     }
 
+    func matchesCurrentInput(query: TextBoxMentionQuery?, rootDirectory: String?) -> Bool {
+        guard let query else {
+            return activeQuery == nil
+        }
+        return activeQuery == query && activeRootDirectory == rootDirectory
+    }
+
     func refresh(for query: TextBoxMentionQuery?, rootDirectory: String?) {
         if query == nil {
             guard activeQuery != nil || activeRootDirectory != nil || !suggestions.isEmpty else { return }

--- a/Sources/TextBoxMentionCompletionController.swift
+++ b/Sources/TextBoxMentionCompletionController.swift
@@ -159,8 +159,13 @@ final class TextBoxMentionCompletionController {
                 Self.title(suggestion.title, matchesNormalizedQuery: normalizedQuery)
             }
         }
-        suggestionsQuery = nil
-        suggestionsRootDirectory = nil
+        if suggestions.isEmpty {
+            suggestionsQuery = nil
+            suggestionsRootDirectory = nil
+        } else {
+            suggestionsQuery = activeQuery
+            suggestionsRootDirectory = activeRootDirectory
+        }
         selectionIndex = suggestions.isEmpty ? 0 : min(selectionIndex, suggestions.count - 1)
     }
 

--- a/Sources/TextBoxMentionCompletionController.swift
+++ b/Sources/TextBoxMentionCompletionController.swift
@@ -1,6 +1,24 @@
 import Foundation
 import Observation
 
+struct TextBoxMentionCompletionRenderState: Equatable, Sendable {
+    var suggestions: [TextBoxMentionSuggestion]
+    var selectionIndex: Int
+    var searchTerm: String
+    var isLoading: Bool
+
+    static let hidden = TextBoxMentionCompletionRenderState(
+        suggestions: [],
+        selectionIndex: 0,
+        searchTerm: "",
+        isLoading: false
+    )
+
+    var shouldShowPopover: Bool {
+        !suggestions.isEmpty || isLoading
+    }
+}
+
 @MainActor
 @Observable
 final class TextBoxMentionCompletionController {
@@ -9,6 +27,7 @@ final class TextBoxMentionCompletionController {
     private(set) var suggestions: [TextBoxMentionSuggestion] = []
     private(set) var selectionIndex: Int = 0
     private(set) var isLoadingSuggestions = false
+    private(set) var renderState = TextBoxMentionCompletionRenderState.hidden
 
     @ObservationIgnored
     private(set) var activeQuery: TextBoxMentionQuery?
@@ -32,12 +51,7 @@ final class TextBoxMentionCompletionController {
     }
 
     var visibleSuggestions: [TextBoxMentionSuggestion] {
-        guard hasSuggestions else { return [] }
-        if hasCurrentSuggestions {
-            return suggestions
-        }
-        if isLoadingSuggestions { return locallyFilteredSuggestions ?? [] }
-        return []
+        renderState.suggestions
     }
 
     var hasVisibleSuggestions: Bool {
@@ -53,7 +67,7 @@ final class TextBoxMentionCompletionController {
     }
 
     var shouldShowPopover: Bool {
-        isActive && (hasVisibleSuggestions || isLoadingSuggestions)
+        isActive && renderState.shouldShowPopover
     }
 
     var hasCurrentSuggestions: Bool {
@@ -63,8 +77,8 @@ final class TextBoxMentionCompletionController {
     }
 
     var selectedSuggestion: TextBoxMentionSuggestion? {
-        guard visibleSuggestions.indices.contains(selectionIndex) else { return nil }
-        return visibleSuggestions[selectionIndex]
+        guard visibleSuggestions.indices.contains(renderState.selectionIndex) else { return nil }
+        return visibleSuggestions[renderState.selectionIndex]
     }
 
     func canAccept(_ suggestion: TextBoxMentionSuggestion) -> Bool {
@@ -112,7 +126,7 @@ final class TextBoxMentionCompletionController {
         lookupTask?.cancel()
         lookupGeneration &+= 1
         let generation = lookupGeneration
-        onStateChanged?()
+        publishStateChanged()
 
         lookupTask = Task { [weak self, generation] in
             let suggestions = await TextBoxMentionIndexStore.shared.suggestions(
@@ -133,7 +147,7 @@ final class TextBoxMentionCompletionController {
                 self.locallyFilteredSuggestions = nil
                 self.isLoadingSuggestions = false
                 self.selectionIndex = suggestions.isEmpty ? 0 : min(self.selectionIndex, suggestions.count - 1)
-                self.onStateChanged?()
+                self.publishStateChanged()
             }
         }
     }
@@ -142,7 +156,7 @@ final class TextBoxMentionCompletionController {
         guard hasVisibleSuggestions else { return }
         let count = visibleSuggestions.count
         selectionIndex = (selectionIndex + delta + count) % count
-        onStateChanged?()
+        publishStateChanged()
     }
 
     func clear() {
@@ -157,7 +171,29 @@ final class TextBoxMentionCompletionController {
         lookupTask?.cancel()
         lookupTask = nil
         lookupGeneration &+= 1
+        publishStateChanged()
+    }
+
+    private func publishStateChanged() {
+        updateRenderState()
         onStateChanged?()
+    }
+
+    private func updateRenderState() {
+        let rows: [TextBoxMentionSuggestion]
+        if hasCurrentSuggestions {
+            rows = suggestions
+        } else if isLoadingSuggestions {
+            rows = locallyFilteredSuggestions ?? []
+        } else {
+            rows = []
+        }
+        renderState = TextBoxMentionCompletionRenderState(
+            suggestions: rows,
+            selectionIndex: rows.indices.contains(selectionIndex) ? selectionIndex : 0,
+            searchTerm: activeQuery?.query ?? "",
+            isLoading: isLoadingSuggestions
+        )
     }
 
     private func filterVisibleStaleSuggestions(matching query: String) {
@@ -224,7 +260,7 @@ final class TextBoxMentionCompletionController {
         locallyFilteredSuggestions = nil
         isLoadingSuggestions = isLoading
         selectionIndex = suggestions.isEmpty ? 0 : min(selectionIndex, suggestions.count - 1)
-        onStateChanged?()
+        publishStateChanged()
     }
 
     var debugSuggestionCount: Int {

--- a/Sources/TextBoxMentionCompletionController.swift
+++ b/Sources/TextBoxMentionCompletionController.swift
@@ -23,6 +23,8 @@ final class TextBoxMentionCompletionController {
     @ObservationIgnored
     private var suggestionsRootDirectory: String?
     @ObservationIgnored
+    private var locallyFilteredSuggestions: [TextBoxMentionSuggestion]?
+    @ObservationIgnored
     var onStateChanged: (() -> Void)?
 
     var hasSuggestions: Bool {
@@ -30,11 +32,20 @@ final class TextBoxMentionCompletionController {
     }
 
     var visibleSuggestions: [TextBoxMentionSuggestion] {
-        hasCurrentSuggestions ? suggestions : []
+        guard hasSuggestions else { return [] }
+        if hasCurrentSuggestions {
+            return suggestions
+        }
+        if isLoadingSuggestions { return locallyFilteredSuggestions ?? [] }
+        return []
     }
 
     var hasVisibleSuggestions: Bool {
         !visibleSuggestions.isEmpty
+    }
+
+    var hasAcceptableSuggestions: Bool {
+        hasCurrentSuggestions
     }
 
     var isActive: Bool {
@@ -54,6 +65,10 @@ final class TextBoxMentionCompletionController {
     var selectedSuggestion: TextBoxMentionSuggestion? {
         guard visibleSuggestions.indices.contains(selectionIndex) else { return nil }
         return visibleSuggestions[selectionIndex]
+    }
+
+    func canAccept(_ suggestion: TextBoxMentionSuggestion) -> Bool {
+        hasAcceptableSuggestions && suggestions.contains(where: { $0.id == suggestion.id })
     }
 
     func matchesCurrentInput(query: TextBoxMentionQuery?, rootDirectory: String?) -> Bool {
@@ -78,22 +93,18 @@ final class TextBoxMentionCompletionController {
         activeRootDirectory = rootDirectory
         selectionIndex = 0
         isLoadingSuggestions = true
-        // Moving between a bare trigger and typed query changes the expected
-        // result shape. Show the loading row until that exact query finishes.
         let previousQueryWasEmpty = previousActiveQuery?.query
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .isEmpty ?? true
         let queryIsEmpty = query.query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        let queryChangedToNonEmpty = previousQueryWasEmpty &&
-            !queryIsEmpty
         let queryChangedToEmpty = !previousQueryWasEmpty && queryIsEmpty
         if previousActiveQuery?.trigger != query.trigger ||
             previousRootDirectory != rootDirectory ||
-            queryChangedToNonEmpty ||
             queryChangedToEmpty {
             suggestions = []
             suggestionsQuery = nil
             suggestionsRootDirectory = nil
+            locallyFilteredSuggestions = nil
         } else if previousActiveQuery?.query != query.query,
                   !queryIsEmpty {
             filterVisibleStaleSuggestions(matching: query.query)
@@ -119,6 +130,7 @@ final class TextBoxMentionCompletionController {
                 self.suggestions = suggestions
                 self.suggestionsQuery = query
                 self.suggestionsRootDirectory = rootDirectory
+                self.locallyFilteredSuggestions = nil
                 self.isLoadingSuggestions = false
                 self.selectionIndex = suggestions.isEmpty ? 0 : min(self.selectionIndex, suggestions.count - 1)
                 self.onStateChanged?()
@@ -139,6 +151,7 @@ final class TextBoxMentionCompletionController {
         suggestions = []
         suggestionsQuery = nil
         suggestionsRootDirectory = nil
+        locallyFilteredSuggestions = nil
         isLoadingSuggestions = false
         selectionIndex = 0
         lookupTask?.cancel()
@@ -150,31 +163,20 @@ final class TextBoxMentionCompletionController {
     private func filterVisibleStaleSuggestions(matching query: String) {
         let normalizedQuery = Self.normalizedMentionSearchText(query)
         guard !normalizedQuery.isEmpty, !suggestions.isEmpty else { return }
+        let filteredSuggestions: [TextBoxMentionSuggestion]
         if suggestions.count > Self.maxVisibleStaleSuggestionsToFilter {
             // The index store caps visible rows at this size; oversized injected
             // stale state is safer to clear than filter on the main actor.
-            suggestions = []
+            filteredSuggestions = []
         } else {
-            let filteredSuggestions = suggestions.filter { suggestion in
+            filteredSuggestions = suggestions.filter { suggestion in
                 Self.title(suggestion.title, matchesNormalizedQuery: normalizedQuery)
             }
-            if !filteredSuggestions.isEmpty {
-                suggestions = filteredSuggestions
-            }
         }
-        if suggestions.isEmpty {
-            suggestionsQuery = nil
-            suggestionsRootDirectory = nil
-        } else if suggestions.allSatisfy({ suggestion in
-            Self.title(suggestion.title, matchesNormalizedQuery: normalizedQuery)
-        }) {
-            suggestionsQuery = activeQuery
-            suggestionsRootDirectory = activeRootDirectory
-        } else {
-            suggestionsQuery = nil
-            suggestionsRootDirectory = nil
-        }
-        selectionIndex = suggestions.isEmpty ? 0 : min(selectionIndex, suggestions.count - 1)
+        locallyFilteredSuggestions = filteredSuggestions
+        suggestionsQuery = nil
+        suggestionsRootDirectory = nil
+        selectionIndex = filteredSuggestions.isEmpty ? 0 : min(selectionIndex, filteredSuggestions.count - 1)
     }
 
     private static func title(_ title: String, matchesNormalizedQuery normalizedQuery: String) -> Bool {
@@ -219,6 +221,7 @@ final class TextBoxMentionCompletionController {
         suggestions = debugSuggestions
         suggestionsQuery = query
         suggestionsRootDirectory = rootDirectory
+        locallyFilteredSuggestions = nil
         isLoadingSuggestions = isLoading
         selectionIndex = suggestions.isEmpty ? 0 : min(selectionIndex, suggestions.count - 1)
         onStateChanged?()

--- a/Sources/TextBoxMentionCompletionController.swift
+++ b/Sources/TextBoxMentionCompletionController.swift
@@ -6,7 +6,7 @@ import Observation
 final class TextBoxMentionCompletionController {
     private static let maxVisibleStaleSuggestionsToFilter = 500
 
-    private(set) var suggestions: [TextBoxMentionSuggestion] = []
+    private var suggestions: [TextBoxMentionSuggestion] = []
     private(set) var selectionIndex: Int = 0
     private(set) var isLoadingSuggestions = false
     private(set) var renderState = TextBoxMentionCompletionRenderState.hidden
@@ -28,7 +28,7 @@ final class TextBoxMentionCompletionController {
     @ObservationIgnored
     var onStateChanged: (() -> Void)?
 
-    var hasSuggestions: Bool {
+    private var hasSuggestions: Bool {
         !suggestions.isEmpty
     }
 

--- a/Sources/TextBoxMentionCompletionController.swift
+++ b/Sources/TextBoxMentionCompletionController.swift
@@ -205,11 +205,11 @@ final class TextBoxMentionCompletionController {
     }
 
     var debugSuggestionCount: Int {
-        visibleSuggestions.count
+        suggestions.count
     }
 
-    var debugStoredSuggestionCount: Int {
-        suggestions.count
+    var debugVisibleSuggestionCount: Int {
+        visibleSuggestions.count
     }
 
     var debugHasCurrentSuggestions: Bool {

--- a/Sources/TextBoxMentionCompletionController.swift
+++ b/Sources/TextBoxMentionCompletionController.swift
@@ -29,12 +29,20 @@ final class TextBoxMentionCompletionController {
         !suggestions.isEmpty
     }
 
+    var visibleSuggestions: [TextBoxMentionSuggestion] {
+        hasCurrentSuggestions ? suggestions : []
+    }
+
+    var hasVisibleSuggestions: Bool {
+        !visibleSuggestions.isEmpty
+    }
+
     var isActive: Bool {
         activeQuery != nil
     }
 
     var shouldShowPopover: Bool {
-        isActive && (hasSuggestions || isLoadingSuggestions)
+        isActive && (hasVisibleSuggestions || isLoadingSuggestions)
     }
 
     var hasCurrentSuggestions: Bool {
@@ -44,9 +52,8 @@ final class TextBoxMentionCompletionController {
     }
 
     var selectedSuggestion: TextBoxMentionSuggestion? {
-        guard hasCurrentSuggestions else { return nil }
-        guard suggestions.indices.contains(selectionIndex) else { return nil }
-        return suggestions[selectionIndex]
+        guard visibleSuggestions.indices.contains(selectionIndex) else { return nil }
+        return visibleSuggestions[selectionIndex]
     }
 
     func refresh(for query: TextBoxMentionQuery?, rootDirectory: String?) {
@@ -113,8 +120,8 @@ final class TextBoxMentionCompletionController {
     }
 
     func moveSelection(delta: Int) {
-        guard hasCurrentSuggestions else { return }
-        let count = suggestions.count
+        guard hasVisibleSuggestions else { return }
+        let count = visibleSuggestions.count
         selectionIndex = (selectionIndex + delta + count) % count
         onStateChanged?()
     }
@@ -198,7 +205,7 @@ final class TextBoxMentionCompletionController {
     }
 
     var debugSuggestionCount: Int {
-        suggestions.count
+        visibleSuggestions.count
     }
 
     var debugHasCurrentSuggestions: Bool {
@@ -210,7 +217,7 @@ final class TextBoxMentionCompletionController {
     }
 
     var debugSuggestionTitles: [String] {
-        suggestions.map(\.title)
+        visibleSuggestions.map(\.title)
     }
 #endif
 }

--- a/Sources/TextBoxMentionCompletionController.swift
+++ b/Sources/TextBoxMentionCompletionController.swift
@@ -1,40 +1,6 @@
 import Foundation
 import Observation
 
-struct TextBoxMentionCompletionRenderState: Equatable, Sendable {
-    var suggestions: [TextBoxMentionSuggestion]
-    var selectionIndex: Int
-    var searchTerm: String
-    var isLoading: Bool
-    var identity: Int
-
-    static let hidden = TextBoxMentionCompletionRenderState(suggestions: [])
-
-    init(
-        suggestions: [TextBoxMentionSuggestion],
-        selectionIndex: Int = 0,
-        searchTerm: String = "",
-        isLoading: Bool = false
-    ) {
-        self.suggestions = suggestions
-        self.selectionIndex = selectionIndex
-        self.searchTerm = searchTerm
-        self.isLoading = isLoading
-
-        var hasher = Hasher()
-        hasher.combine(searchTerm)
-        hasher.combine(isLoading)
-        for suggestion in suggestions {
-            hasher.combine(suggestion.id)
-        }
-        identity = hasher.finalize()
-    }
-
-    var shouldShowPopover: Bool {
-        !suggestions.isEmpty || isLoading
-    }
-}
-
 @MainActor
 @Observable
 final class TextBoxMentionCompletionController {

--- a/Sources/TextBoxMentionCompletionController.swift
+++ b/Sources/TextBoxMentionCompletionController.swift
@@ -155,16 +155,24 @@ final class TextBoxMentionCompletionController {
             // stale state is safer to clear than filter on the main actor.
             suggestions = []
         } else {
-            suggestions = suggestions.filter { suggestion in
+            let filteredSuggestions = suggestions.filter { suggestion in
                 Self.title(suggestion.title, matchesNormalizedQuery: normalizedQuery)
+            }
+            if !filteredSuggestions.isEmpty {
+                suggestions = filteredSuggestions
             }
         }
         if suggestions.isEmpty {
             suggestionsQuery = nil
             suggestionsRootDirectory = nil
-        } else {
+        } else if suggestions.allSatisfy({ suggestion in
+            Self.title(suggestion.title, matchesNormalizedQuery: normalizedQuery)
+        }) {
             suggestionsQuery = activeQuery
             suggestionsRootDirectory = activeRootDirectory
+        } else {
+            suggestionsQuery = nil
+            suggestionsRootDirectory = nil
         }
         selectionIndex = suggestions.isEmpty ? 0 : min(selectionIndex, suggestions.count - 1)
     }

--- a/Sources/TextBoxMentionCompletionController.swift
+++ b/Sources/TextBoxMentionCompletionController.swift
@@ -6,13 +6,29 @@ struct TextBoxMentionCompletionRenderState: Equatable, Sendable {
     var selectionIndex: Int
     var searchTerm: String
     var isLoading: Bool
+    var identity: Int
 
-    static let hidden = TextBoxMentionCompletionRenderState(
-        suggestions: [],
-        selectionIndex: 0,
-        searchTerm: "",
-        isLoading: false
-    )
+    static let hidden = TextBoxMentionCompletionRenderState(suggestions: [])
+
+    init(
+        suggestions: [TextBoxMentionSuggestion],
+        selectionIndex: Int = 0,
+        searchTerm: String = "",
+        isLoading: Bool = false
+    ) {
+        self.suggestions = suggestions
+        self.selectionIndex = selectionIndex
+        self.searchTerm = searchTerm
+        self.isLoading = isLoading
+
+        var hasher = Hasher()
+        hasher.combine(searchTerm)
+        hasher.combine(isLoading)
+        for suggestion in suggestions {
+            hasher.combine(suggestion.id)
+        }
+        identity = hasher.finalize()
+    }
 
     var shouldShowPopover: Bool {
         !suggestions.isEmpty || isLoading

--- a/Sources/TextBoxMentionCompletionController.swift
+++ b/Sources/TextBoxMentionCompletionController.swift
@@ -208,6 +208,10 @@ final class TextBoxMentionCompletionController {
         visibleSuggestions.count
     }
 
+    var debugStoredSuggestionCount: Int {
+        suggestions.count
+    }
+
     var debugHasCurrentSuggestions: Bool {
         hasCurrentSuggestions
     }

--- a/Sources/TextBoxMentionCompletionRenderState.swift
+++ b/Sources/TextBoxMentionCompletionRenderState.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+struct TextBoxMentionCompletionRenderState: Equatable, Sendable {
+    var suggestions: [TextBoxMentionSuggestion]
+    var selectionIndex: Int
+    var searchTerm: String
+    var isLoading: Bool
+    var identity: Int
+
+    static let hidden = TextBoxMentionCompletionRenderState(suggestions: [])
+
+    init(
+        suggestions: [TextBoxMentionSuggestion],
+        selectionIndex: Int = 0,
+        searchTerm: String = "",
+        isLoading: Bool = false
+    ) {
+        self.suggestions = suggestions
+        self.selectionIndex = selectionIndex
+        self.searchTerm = searchTerm
+        self.isLoading = isLoading
+
+        var hasher = Hasher()
+        hasher.combine(searchTerm)
+        hasher.combine(isLoading)
+        for suggestion in suggestions {
+            hasher.combine(suggestion.id)
+        }
+        identity = hasher.finalize()
+    }
+
+    var shouldShowPopover: Bool {
+        !suggestions.isEmpty || isLoading
+    }
+}

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -570,6 +570,7 @@
 		C0DE7B260000000000000001 /* TextBoxMentionCandidateIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE7B260000000000000002 /* TextBoxMentionCandidateIndex.swift */; };
 		C0DE7B280000000000000001 /* TextBoxMentionCompletionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE7B280000000000000002 /* TextBoxMentionCompletionController.swift */; };
 		C0DE7B230000000000000001 /* TextBoxMentionCompletionDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE7B230000000000000002 /* TextBoxMentionCompletionDetector.swift */; };
+		C0DE7B330000000000000001 /* TextBoxMentionCompletionRenderState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE7B330000000000000002 /* TextBoxMentionCompletionRenderState.swift */; };
 		C0DE7B300000000000000001 /* TextBoxMentionCompletionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE7B300000000000000002 /* TextBoxMentionCompletionTests.swift */; };
 		C0DE7B320000000000000001 /* TextBoxMentionFileIndexRefreshTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE7B320000000000000002 /* TextBoxMentionFileIndexRefreshTask.swift */; };
 		C0DE7B270000000000000001 /* TextBoxMentionIndexStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE7B270000000000000002 /* TextBoxMentionIndexStore.swift */; };
@@ -1234,6 +1235,7 @@
 		C0DE7B260000000000000002 /* TextBoxMentionCandidateIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextBoxMentionCandidateIndex.swift; sourceTree = "<group>"; };
 		C0DE7B280000000000000002 /* TextBoxMentionCompletionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextBoxMentionCompletionController.swift; sourceTree = "<group>"; };
 		C0DE7B230000000000000002 /* TextBoxMentionCompletionDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextBoxMentionCompletionDetector.swift; sourceTree = "<group>"; };
+		C0DE7B330000000000000002 /* TextBoxMentionCompletionRenderState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextBoxMentionCompletionRenderState.swift; sourceTree = "<group>"; };
 		C0DE7B300000000000000002 /* TextBoxMentionCompletionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextBoxMentionCompletionTests.swift; sourceTree = "<group>"; };
 		C0DE7B320000000000000002 /* TextBoxMentionFileIndexRefreshTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextBoxMentionFileIndexRefreshTask.swift; sourceTree = "<group>"; };
 		C0DE7B270000000000000002 /* TextBoxMentionIndexStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextBoxMentionIndexStore.swift; sourceTree = "<group>"; };
@@ -1609,6 +1611,7 @@
 				C0DE7B260000000000000002 /* TextBoxMentionCandidateIndex.swift */,
 				C0DE7B280000000000000002 /* TextBoxMentionCompletionController.swift */,
 				C0DE7B230000000000000002 /* TextBoxMentionCompletionDetector.swift */,
+				C0DE7B330000000000000002 /* TextBoxMentionCompletionRenderState.swift */,
 				C0DE7B320000000000000002 /* TextBoxMentionFileIndexRefreshTask.swift */,
 				C0DE7B270000000000000002 /* TextBoxMentionIndexStore.swift */,
 				C0DE7B200000000000000002 /* TextBoxMentionKind.swift */,
@@ -2743,6 +2746,7 @@
 				C0DE7B260000000000000001 /* TextBoxMentionCandidateIndex.swift in Sources */,
 				C0DE7B280000000000000001 /* TextBoxMentionCompletionController.swift in Sources */,
 				C0DE7B230000000000000001 /* TextBoxMentionCompletionDetector.swift in Sources */,
+				C0DE7B330000000000000001 /* TextBoxMentionCompletionRenderState.swift in Sources */,
 				C0DE7B320000000000000001 /* TextBoxMentionFileIndexRefreshTask.swift in Sources */,
 				C0DE7B270000000000000001 /* TextBoxMentionIndexStore.swift in Sources */,
 				C0DE7B200000000000000001 /* TextBoxMentionKind.swift in Sources */,

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -7317,7 +7317,7 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         XCTAssertEqual(suggestions.first?.insertionText, "$sample-dollar-skill")
     }
 
-    func testTextBoxMentionRefreshKeepsRowsOnSameTriggerEditButClearsOnTriggerChange() {
+    func testTextBoxMentionRefreshHidesRowsOnSameTriggerMissAndClearsOnTriggerChange() {
         let textView = TextBoxInputTextView(frame: NSRect(x: 0, y: 0, width: 320, height: 30))
         textView.string = "@a"
         textView.setSelectedRange(NSRange(location: 2, length: 0))
@@ -7338,8 +7338,10 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         textView.string = "@z"
         textView.setSelectedRange(NSRange(location: 2, length: 0))
         textView.refreshMentionCompletions()
-        XCTAssertEqual(textView.debugMentionSuggestionCount(), 1)
+        XCTAssertEqual(textView.debugMentionSuggestionCount(), 0)
+        XCTAssertEqual(textView.debugVisibleMentionSuggestionCount(), 0)
         XCTAssertFalse(textView.debugMentionSuggestionsAreCurrent())
+        XCTAssertTrue(textView.debugMentionCompletionsShouldShowPopover())
         XCTAssertFalse(textView.debugAcceptMentionCompletion())
         XCTAssertFalse(textView.debugAcceptMentionCompletion(suggestion: staleSuggestion))
         XCTAssertEqual(textView.string, "@z")

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -7334,11 +7334,13 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
             suggestions: [staleSuggestion]
         )
         XCTAssertEqual(textView.debugMentionSuggestionCount(), 1)
+        XCTAssertEqual(textView.debugStoredMentionSuggestionCount(), 1)
 
         textView.string = "@z"
         textView.setSelectedRange(NSRange(location: 2, length: 0))
         textView.refreshMentionCompletions()
-        XCTAssertEqual(textView.debugMentionSuggestionCount(), 1)
+        XCTAssertEqual(textView.debugMentionSuggestionCount(), 0)
+        XCTAssertEqual(textView.debugStoredMentionSuggestionCount(), 1)
         XCTAssertFalse(textView.debugMentionSuggestionsAreCurrent())
         XCTAssertFalse(textView.debugAcceptMentionCompletion())
         XCTAssertFalse(textView.debugAcceptMentionCompletion(suggestion: staleSuggestion))
@@ -7353,6 +7355,7 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         textView.setSelectedRange(NSRange(location: 2, length: 0))
         textView.refreshMentionCompletions()
         XCTAssertEqual(textView.debugMentionSuggestionCount(), 0)
+        XCTAssertEqual(textView.debugStoredMentionSuggestionCount(), 0)
     }
 
     func testTextBoxSubmitUsesPastePayloadAndSeparateReturn() throws {

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -7334,13 +7334,11 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
             suggestions: [staleSuggestion]
         )
         XCTAssertEqual(textView.debugMentionSuggestionCount(), 1)
-        XCTAssertEqual(textView.debugStoredMentionSuggestionCount(), 1)
 
         textView.string = "@z"
         textView.setSelectedRange(NSRange(location: 2, length: 0))
         textView.refreshMentionCompletions()
-        XCTAssertEqual(textView.debugMentionSuggestionCount(), 0)
-        XCTAssertEqual(textView.debugStoredMentionSuggestionCount(), 1)
+        XCTAssertEqual(textView.debugMentionSuggestionCount(), 1)
         XCTAssertFalse(textView.debugMentionSuggestionsAreCurrent())
         XCTAssertFalse(textView.debugAcceptMentionCompletion())
         XCTAssertFalse(textView.debugAcceptMentionCompletion(suggestion: staleSuggestion))
@@ -7355,7 +7353,6 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         textView.setSelectedRange(NSRange(location: 2, length: 0))
         textView.refreshMentionCompletions()
         XCTAssertEqual(textView.debugMentionSuggestionCount(), 0)
-        XCTAssertEqual(textView.debugStoredMentionSuggestionCount(), 0)
     }
 
     func testTextBoxSubmitUsesPastePayloadAndSeparateReturn() throws {

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -7317,7 +7317,7 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         XCTAssertEqual(suggestions.first?.insertionText, "$sample-dollar-skill")
     }
 
-    func testTextBoxMentionRefreshHidesRowsOnSameTriggerMissAndClearsOnTriggerChange() {
+    func testTextBoxMentionRefreshKeepsRowsOnSameTriggerEditButClearsOnTriggerChange() {
         let textView = TextBoxInputTextView(frame: NSRect(x: 0, y: 0, width: 320, height: 30))
         textView.string = "@a"
         textView.setSelectedRange(NSRange(location: 2, length: 0))
@@ -7338,10 +7338,8 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         textView.string = "@z"
         textView.setSelectedRange(NSRange(location: 2, length: 0))
         textView.refreshMentionCompletions()
-        XCTAssertEqual(textView.debugMentionSuggestionCount(), 0)
-        XCTAssertEqual(textView.debugVisibleMentionSuggestionCount(), 0)
+        XCTAssertEqual(textView.debugMentionSuggestionCount(), 1)
         XCTAssertFalse(textView.debugMentionSuggestionsAreCurrent())
-        XCTAssertTrue(textView.debugMentionCompletionsShouldShowPopover())
         XCTAssertFalse(textView.debugAcceptMentionCompletion())
         XCTAssertFalse(textView.debugAcceptMentionCompletion(suggestion: staleSuggestion))
         XCTAssertEqual(textView.string, "@z")

--- a/cmuxTests/TextBoxMentionCompletionTests.swift
+++ b/cmuxTests/TextBoxMentionCompletionTests.swift
@@ -1212,6 +1212,37 @@ struct TextBoxMentionCompletionTests {
     }
 
     @Test
+    func testTextBoxMentionInsertTextRefreshesRowsAfterBareDollarTrigger() {
+        let textView = TextBoxInputTextView(frame: NSRect(x: 0, y: 0, width: 320, height: 30))
+        textView.string = "$"
+        textView.setSelectedRange(NSRange(location: 1, length: 0))
+        let staleSuggestion = TextBoxMentionSuggestion(
+            id: "$:/tmp/agent-browser/SKILL.md",
+            title: "$agent-browser",
+            subtitle: "/tmp/agent-browser/SKILL.md",
+            insertionText: "$agent-browser",
+            systemImageName: "sparkle.magnifyingglass"
+        )
+
+        textView.debugSetMentionCompletionState(
+            query: TextBoxMentionQuery(
+                kind: .skill,
+                range: NSRange(location: 0, length: 1),
+                query: "",
+                trigger: "$"
+            ),
+            suggestions: [staleSuggestion]
+        )
+
+        textView.insertText("autore", replacementRange: textView.selectedRange())
+
+        #expect(textView.plainText() == "$autore")
+        #expect(textView.debugVisibleMentionSuggestionCount() == 0)
+        #expect(textView.debugMentionCompletionsShouldShowPopover())
+        #expect(!textView.debugAcceptMentionCompletion(suggestion: staleSuggestion))
+    }
+
+    @Test
     func testTextBoxMentionRefreshHidesRowsWhenSameTriggerQueryStaysNonEmpty() {
         let textView = TextBoxInputTextView(frame: NSRect(x: 0, y: 0, width: 320, height: 30))
         textView.string = "$it"

--- a/cmuxTests/TextBoxMentionCompletionTests.swift
+++ b/cmuxTests/TextBoxMentionCompletionTests.swift
@@ -1243,7 +1243,7 @@ struct TextBoxMentionCompletionTests {
     }
 
     @Test
-    func testTextBoxMentionRefreshHidesRowsWhenSameTriggerQueryStaysNonEmpty() {
+    func testTextBoxMentionRefreshKeepsMatchingRowsWhenSameTriggerQueryStaysNonEmpty() {
         let textView = TextBoxInputTextView(frame: NSRect(x: 0, y: 0, width: 320, height: 30))
         textView.string = "$it"
         textView.setSelectedRange(NSRange(location: 3, length: 0))
@@ -1269,14 +1269,13 @@ struct TextBoxMentionCompletionTests {
         textView.string = "$iterate-pr"
         textView.setSelectedRange(NSRange(location: 11, length: 0))
         textView.refreshMentionCompletions()
-        #expect(textView.debugVisibleMentionSuggestionCount() == 0)
-        #expect(!textView.debugMentionSuggestionsAreCurrent())
+        #expect(textView.debugMentionSuggestionTitles() == ["$iterate-pr"])
+        #expect(textView.debugMentionSuggestionsAreCurrent())
         #expect(textView.debugMentionCompletionsShouldShowPopover())
-        #expect(!textView.debugAcceptMentionCompletion())
     }
 
     @Test
-    func testTextBoxMentionVisibleRowsHideNonCurrentMatchesWhileQueryRefreshes() {
+    func testTextBoxMentionVisibleRowsKeepCurrentMatchesWhileQueryRefreshes() {
         let textView = TextBoxInputTextView(frame: NSRect(x: 0, y: 0, width: 320, height: 30))
         textView.string = "$auto"
         textView.setSelectedRange(NSRange(location: 5, length: 0))
@@ -1302,10 +1301,9 @@ struct TextBoxMentionCompletionTests {
         textView.setSelectedRange(NSRange(location: 6, length: 0))
         textView.refreshMentionCompletions()
 
-        #expect(!textView.debugMentionSuggestionsAreCurrent())
-        #expect(textView.debugMentionSuggestionTitles().isEmpty)
+        #expect(textView.debugMentionSuggestionsAreCurrent())
+        #expect(textView.debugMentionSuggestionTitles() == ["$autoreview"])
         #expect(textView.debugMentionCompletionsShouldShowPopover())
-        #expect(!textView.debugAcceptMentionCompletion())
     }
 
     @Test
@@ -1342,14 +1340,14 @@ struct TextBoxMentionCompletionTests {
         textView.setSelectedRange(NSRange(location: 11, length: 0))
         textView.refreshMentionCompletions()
 
-        #expect(textView.debugMentionSuggestionTitles().isEmpty)
-        #expect(!textView.debugMentionSuggestionsAreCurrent())
+        #expect(textView.debugMentionSuggestionTitles() == ["$iterate-pr"])
+        #expect(textView.debugMentionSuggestionsAreCurrent())
         #expect(textView.debugMentionCompletionsShouldShowPopover())
         #expect(!textView.debugAcceptMentionCompletion(suggestion: staleSuggestion))
     }
 
     @Test
-    func testTextBoxMentionFilteredRowsStayNonCurrentWhenQueryReturnsToPreviousValue() {
+    func testTextBoxMentionFilteredRowsStayNarrowWhenQueryReturnsToPreviousValue() {
         let textView = TextBoxInputTextView(frame: NSRect(x: 0, y: 0, width: 320, height: 30))
         textView.string = "$it"
         textView.setSelectedRange(NSRange(location: 3, length: 0))
@@ -1381,15 +1379,14 @@ struct TextBoxMentionCompletionTests {
         textView.string = "$iterate-pr"
         textView.setSelectedRange(NSRange(location: 11, length: 0))
         textView.refreshMentionCompletions()
-        #expect(textView.debugMentionSuggestionTitles().isEmpty)
-        #expect(!textView.debugMentionSuggestionsAreCurrent())
+        #expect(textView.debugMentionSuggestionTitles() == ["$iterate-pr"])
+        #expect(textView.debugMentionSuggestionsAreCurrent())
 
         textView.string = "$it"
         textView.setSelectedRange(NSRange(location: 3, length: 0))
         textView.refreshMentionCompletions()
-        #expect(textView.debugMentionSuggestionTitles().isEmpty)
-        #expect(!textView.debugMentionSuggestionsAreCurrent())
-        #expect(!textView.debugAcceptMentionCompletion())
+        #expect(textView.debugMentionSuggestionTitles() == ["$iterate-pr"])
+        #expect(textView.debugMentionSuggestionsAreCurrent())
     }
 
     @Test
@@ -1425,7 +1422,7 @@ struct TextBoxMentionCompletionTests {
         textView.string = "$iterate-pr"
         textView.setSelectedRange(NSRange(location: 11, length: 0))
         textView.refreshMentionCompletions()
-        #expect(textView.debugMentionSuggestionTitles().isEmpty)
+        #expect(textView.debugMentionSuggestionTitles() == ["$iterate-pr"])
         #expect(textView.debugMentionCompletionsShouldShowPopover())
 
         textView.string = "$"

--- a/cmuxTests/TextBoxMentionCompletionTests.swift
+++ b/cmuxTests/TextBoxMentionCompletionTests.swift
@@ -1016,6 +1016,49 @@ struct TextBoxMentionCompletionTests {
     }
 
     @Test
+    func testTextBoxMentionSkillSuggestionsFilterAutoreQuery() async throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory.appendingPathComponent(
+            "cmux-textbox-skill-autore-filter-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        defer { try? fileManager.removeItem(at: root) }
+
+        let skillsDirectory = root.appendingPathComponent("skills", isDirectory: true)
+        let skillNames = [
+            "agent-browser",
+            "agent-cli-integration",
+            "auto-issue",
+            "auto-merge",
+            "autoreview",
+            "cleanup-dev-builds",
+            "iterate-pr"
+        ] + (0..<40).map { String(format: "zzz-autore-distractor-%02d", $0) }
+        for skillName in skillNames {
+            let skillDirectory = skillsDirectory.appendingPathComponent(skillName, isDirectory: true)
+            try fileManager.createDirectory(at: skillDirectory, withIntermediateDirectories: true)
+            try "name: \(skillName)\n".write(
+                to: skillDirectory.appendingPathComponent("SKILL.md"),
+                atomically: true,
+                encoding: .utf8
+            )
+        }
+
+        let suggestions = await TextBoxMentionIndexStore.shared.suggestions(
+            for: TextBoxMentionQuery(
+                kind: .skill,
+                range: NSRange(location: 0, length: 6),
+                query: "autore",
+                trigger: "$"
+            ),
+            rootDirectory: root.path
+        )
+
+        #expect(suggestions.first?.title == "$autoreview")
+        #expect(!suggestions.contains { $0.title == "$agent-browser" })
+    }
+
+    @Test
     func testTextBoxMentionCandidateIndexDoesNotReturnUnvalidatedNucleoRows() {
         let skillNames = [
             "agent-browser",
@@ -1169,7 +1212,7 @@ struct TextBoxMentionCompletionTests {
     }
 
     @Test
-    func testTextBoxMentionRefreshKeepsRowsWhenSameTriggerQueryStaysNonEmpty() {
+    func testTextBoxMentionRefreshHidesRowsWhenSameTriggerQueryStaysNonEmpty() {
         let textView = TextBoxInputTextView(frame: NSRect(x: 0, y: 0, width: 320, height: 30))
         textView.string = "$it"
         textView.setSelectedRange(NSRange(location: 3, length: 0))
@@ -1195,8 +1238,9 @@ struct TextBoxMentionCompletionTests {
         textView.string = "$iterate-pr"
         textView.setSelectedRange(NSRange(location: 11, length: 0))
         textView.refreshMentionCompletions()
-        #expect(textView.debugMentionSuggestionCount() == 1)
+        #expect(textView.debugMentionSuggestionCount() == 0)
         #expect(!textView.debugMentionSuggestionsAreCurrent())
+        #expect(textView.debugMentionCompletionsShouldShowPopover())
         #expect(!textView.debugAcceptMentionCompletion())
     }
 
@@ -1267,8 +1311,9 @@ struct TextBoxMentionCompletionTests {
         textView.setSelectedRange(NSRange(location: 11, length: 0))
         textView.refreshMentionCompletions()
 
-        #expect(textView.debugMentionSuggestionTitles() == ["$iterate-pr"])
+        #expect(textView.debugMentionSuggestionTitles().isEmpty)
         #expect(!textView.debugMentionSuggestionsAreCurrent())
+        #expect(textView.debugMentionCompletionsShouldShowPopover())
         #expect(!textView.debugAcceptMentionCompletion(suggestion: staleSuggestion))
     }
 
@@ -1305,13 +1350,13 @@ struct TextBoxMentionCompletionTests {
         textView.string = "$iterate-pr"
         textView.setSelectedRange(NSRange(location: 11, length: 0))
         textView.refreshMentionCompletions()
-        #expect(textView.debugMentionSuggestionTitles() == ["$iterate-pr"])
+        #expect(textView.debugMentionSuggestionTitles().isEmpty)
         #expect(!textView.debugMentionSuggestionsAreCurrent())
 
         textView.string = "$it"
         textView.setSelectedRange(NSRange(location: 3, length: 0))
         textView.refreshMentionCompletions()
-        #expect(textView.debugMentionSuggestionTitles() == ["$iterate-pr"])
+        #expect(textView.debugMentionSuggestionTitles().isEmpty)
         #expect(!textView.debugMentionSuggestionsAreCurrent())
         #expect(!textView.debugAcceptMentionCompletion())
     }
@@ -1349,7 +1394,8 @@ struct TextBoxMentionCompletionTests {
         textView.string = "$iterate-pr"
         textView.setSelectedRange(NSRange(location: 11, length: 0))
         textView.refreshMentionCompletions()
-        #expect(textView.debugMentionSuggestionTitles() == ["$iterate-pr"])
+        #expect(textView.debugMentionSuggestionTitles().isEmpty)
+        #expect(textView.debugMentionCompletionsShouldShowPopover())
 
         textView.string = "$"
         textView.setSelectedRange(NSRange(location: 1, length: 0))

--- a/cmuxTests/TextBoxMentionCompletionTests.swift
+++ b/cmuxTests/TextBoxMentionCompletionTests.swift
@@ -1168,12 +1168,12 @@ struct TextBoxMentionCompletionTests {
             ),
             suggestions: [staleSuggestion]
         )
-        #expect(textView.debugMentionSuggestionCount() == 1)
+        #expect(textView.debugVisibleMentionSuggestionCount() == 1)
 
         textView.string = "$iterate-pr"
         textView.setSelectedRange(NSRange(location: 11, length: 0))
         textView.refreshMentionCompletions()
-        #expect(textView.debugMentionSuggestionCount() == 0)
+        #expect(textView.debugVisibleMentionSuggestionCount() == 0)
         #expect(textView.debugMentionCompletionsShouldShowPopover())
         #expect(!(textView.debugAcceptMentionCompletion()))
         #expect(!(textView.debugAcceptMentionCompletion(suggestion: staleSuggestion)))
@@ -1206,7 +1206,7 @@ struct TextBoxMentionCompletionTests {
         textView.setSelectedRange(NSRange(location: 11, length: 0))
         textView.didChangeText()
 
-        #expect(textView.debugMentionSuggestionCount() == 0)
+        #expect(textView.debugVisibleMentionSuggestionCount() == 0)
         #expect(textView.debugMentionCompletionsShouldShowPopover())
         #expect(!textView.debugAcceptMentionCompletion(suggestion: staleSuggestion))
     }
@@ -1233,12 +1233,12 @@ struct TextBoxMentionCompletionTests {
             ),
             suggestions: [currentSuggestion]
         )
-        #expect(textView.debugMentionSuggestionCount() == 1)
+        #expect(textView.debugVisibleMentionSuggestionCount() == 1)
 
         textView.string = "$iterate-pr"
         textView.setSelectedRange(NSRange(location: 11, length: 0))
         textView.refreshMentionCompletions()
-        #expect(textView.debugMentionSuggestionCount() == 0)
+        #expect(textView.debugVisibleMentionSuggestionCount() == 0)
         #expect(!textView.debugMentionSuggestionsAreCurrent())
         #expect(textView.debugMentionCompletionsShouldShowPopover())
         #expect(!textView.debugAcceptMentionCompletion())
@@ -1400,7 +1400,7 @@ struct TextBoxMentionCompletionTests {
         textView.string = "$"
         textView.setSelectedRange(NSRange(location: 1, length: 0))
         textView.refreshMentionCompletions()
-        #expect(textView.debugMentionSuggestionCount() == 0)
+        #expect(textView.debugVisibleMentionSuggestionCount() == 0)
         #expect(textView.debugMentionCompletionsShouldShowPopover())
         #expect(!textView.debugAcceptMentionCompletion())
     }
@@ -1444,7 +1444,7 @@ struct TextBoxMentionCompletionTests {
 
         textView.completionRootDirectory = newRoot.path
 
-        #expect(textView.debugMentionSuggestionCount() == 0)
+        #expect(textView.debugVisibleMentionSuggestionCount() == 0)
         #expect(!(textView.debugAcceptMentionCompletion()))
     }
 
@@ -1472,7 +1472,7 @@ struct TextBoxMentionCompletionTests {
         textView.refreshMentionCompletions()
 
         #expect(textView.debugMentionCompletionsShouldShowPopover())
-        #expect(textView.debugMentionSuggestionCount() == 0)
+        #expect(textView.debugVisibleMentionSuggestionCount() == 0)
     }
 
     @Test
@@ -1564,7 +1564,7 @@ struct TextBoxMentionCompletionTests {
 
             #expect(submitCount == 1)
             #expect(textView.string == scenario.text)
-            #expect(textView.debugMentionSuggestionCount() == 0)
+            #expect(textView.debugVisibleMentionSuggestionCount() == 0)
         }
     }
 
@@ -1612,7 +1612,7 @@ struct TextBoxMentionCompletionTests {
             textView.doCommand(by: #selector(NSResponder.insertTab(_:)))
 
             #expect(textView.string == scenario.expected)
-            #expect(textView.debugMentionSuggestionCount() == 0)
+            #expect(textView.debugVisibleMentionSuggestionCount() == 0)
         }
     }
 

--- a/cmuxTests/TextBoxMentionCompletionTests.swift
+++ b/cmuxTests/TextBoxMentionCompletionTests.swift
@@ -1270,8 +1270,9 @@ struct TextBoxMentionCompletionTests {
         textView.setSelectedRange(NSRange(location: 11, length: 0))
         textView.refreshMentionCompletions()
         #expect(textView.debugMentionSuggestionTitles() == ["$iterate-pr"])
-        #expect(textView.debugMentionSuggestionsAreCurrent())
+        #expect(!textView.debugMentionSuggestionsAreCurrent())
         #expect(textView.debugMentionCompletionsShouldShowPopover())
+        #expect(!textView.debugAcceptMentionCompletion(suggestion: currentSuggestion))
     }
 
     @Test
@@ -1301,9 +1302,10 @@ struct TextBoxMentionCompletionTests {
         textView.setSelectedRange(NSRange(location: 6, length: 0))
         textView.refreshMentionCompletions()
 
-        #expect(textView.debugMentionSuggestionsAreCurrent())
         #expect(textView.debugMentionSuggestionTitles() == ["$autoreview"])
+        #expect(!textView.debugMentionSuggestionsAreCurrent())
         #expect(textView.debugMentionCompletionsShouldShowPopover())
+        #expect(!textView.debugAcceptMentionCompletion(suggestion: previousSuggestion))
     }
 
     @Test
@@ -1341,9 +1343,10 @@ struct TextBoxMentionCompletionTests {
         textView.refreshMentionCompletions()
 
         #expect(textView.debugMentionSuggestionTitles() == ["$iterate-pr"])
-        #expect(textView.debugMentionSuggestionsAreCurrent())
+        #expect(!textView.debugMentionSuggestionsAreCurrent())
         #expect(textView.debugMentionCompletionsShouldShowPopover())
         #expect(!textView.debugAcceptMentionCompletion(suggestion: staleSuggestion))
+        #expect(!textView.debugAcceptMentionCompletion(suggestion: currentSuggestion))
     }
 
     @Test
@@ -1380,13 +1383,13 @@ struct TextBoxMentionCompletionTests {
         textView.setSelectedRange(NSRange(location: 11, length: 0))
         textView.refreshMentionCompletions()
         #expect(textView.debugMentionSuggestionTitles() == ["$iterate-pr"])
-        #expect(textView.debugMentionSuggestionsAreCurrent())
+        #expect(!textView.debugMentionSuggestionsAreCurrent())
 
         textView.string = "$it"
         textView.setSelectedRange(NSRange(location: 3, length: 0))
         textView.refreshMentionCompletions()
         #expect(textView.debugMentionSuggestionTitles() == ["$iterate-pr"])
-        #expect(textView.debugMentionSuggestionsAreCurrent())
+        #expect(!textView.debugMentionSuggestionsAreCurrent())
     }
 
     @Test

--- a/cmuxTests/TextBoxMentionCompletionTests.swift
+++ b/cmuxTests/TextBoxMentionCompletionTests.swift
@@ -1486,6 +1486,55 @@ struct TextBoxMentionCompletionTests {
     }
 
     @Test
+    func testTextBoxMentionAcceptanceKeysDoNotFallThroughWhileFilteredRowsRefresh() {
+        let scenarios: [(key: String, keyCode: UInt16)] = [
+            ("\r", UInt16(kVK_Return)),
+            ("\t", UInt16(kVK_Tab))
+        ]
+
+        for scenario in scenarios {
+            let textView = makeTextViewWithRefreshingAutoreMention()
+            var submitCount = 0
+            textView.onSubmit = { submitCount += 1 }
+            guard let event = makeKeyDownEvent(
+                key: scenario.key,
+                modifiers: [],
+                keyCode: scenario.keyCode,
+                windowNumber: 0
+            ) else {
+                #expect(Bool(false), "Failed to construct mention acceptance event")
+                continue
+            }
+
+            textView.keyDown(with: event)
+
+            #expect(submitCount == 0)
+            #expect(textView.string == "$autore")
+            #expect(textView.debugMentionSuggestionTitles() == ["$autoreview"])
+        }
+    }
+
+    @Test
+    func testTextBoxMentionAcceptanceCommandsDoNotFallThroughWhileFilteredRowsRefresh() {
+        let scenarios: [Selector] = [
+            #selector(NSResponder.insertNewline(_:)),
+            #selector(NSResponder.insertTab(_:))
+        ]
+
+        for commandSelector in scenarios {
+            let textView = makeTextViewWithRefreshingAutoreMention()
+            var submitCount = 0
+            textView.onSubmit = { submitCount += 1 }
+
+            textView.doCommand(by: commandSelector)
+
+            #expect(submitCount == 0)
+            #expect(textView.string == "$autore")
+            #expect(textView.debugMentionSuggestionTitles() == ["$autoreview"])
+        }
+    }
+
+    @Test
     func testTextBoxMentionRootDirectoryChangeClearsActiveFileSuggestions() throws {
         let fileManager = FileManager.default
         let oldRoot = fileManager.temporaryDirectory.appendingPathComponent(
@@ -1694,6 +1743,35 @@ struct TextBoxMentionCompletionTests {
             #expect(textView.string == scenario.expected)
             #expect(textView.debugVisibleMentionSuggestionCount() == 0)
         }
+    }
+
+    private func makeTextViewWithRefreshingAutoreMention() -> TextBoxInputTextView {
+        let textView = TextBoxInputTextView(frame: NSRect(x: 0, y: 0, width: 320, height: 30))
+        textView.string = "$auto"
+        textView.setSelectedRange(NSRange(location: 5, length: 0))
+        textView.debugSetMentionCompletionState(
+            query: TextBoxMentionQuery(
+                kind: .skill,
+                range: NSRange(location: 0, length: 5),
+                query: "auto",
+                trigger: "$"
+            ),
+            suggestions: [
+                TextBoxMentionSuggestion(
+                    id: "$:/tmp/autoreview/SKILL.md",
+                    title: "$autoreview",
+                    subtitle: "/tmp/autoreview/SKILL.md",
+                    insertionText: "$autoreview",
+                    systemImageName: "sparkle.magnifyingglass"
+                )
+            ]
+        )
+        textView.string = "$autore"
+        textView.setSelectedRange(NSRange(location: 6, length: 0))
+        textView.refreshMentionCompletions()
+        #expect(textView.debugMentionSuggestionTitles() == ["$autoreview"])
+        #expect(!textView.debugMentionSuggestionsAreCurrent())
+        return textView
     }
 
     private func makeKeyDownEvent(

--- a/cmuxTests/TextBoxMentionCompletionTests.swift
+++ b/cmuxTests/TextBoxMentionCompletionTests.swift
@@ -1201,6 +1201,39 @@ struct TextBoxMentionCompletionTests {
     }
 
     @Test
+    func testTextBoxMentionVisibleRowsHideNonCurrentMatchesWhileQueryRefreshes() {
+        let textView = TextBoxInputTextView(frame: NSRect(x: 0, y: 0, width: 320, height: 30))
+        textView.string = "$auto"
+        textView.setSelectedRange(NSRange(location: 5, length: 0))
+        let previousSuggestion = TextBoxMentionSuggestion(
+            id: "$:/tmp/autoreview/SKILL.md",
+            title: "$autoreview",
+            subtitle: "/tmp/autoreview/SKILL.md",
+            insertionText: "$autoreview",
+            systemImageName: "sparkle.magnifyingglass"
+        )
+
+        textView.debugSetMentionCompletionState(
+            query: TextBoxMentionQuery(
+                kind: .skill,
+                range: NSRange(location: 0, length: 5),
+                query: "auto",
+                trigger: "$"
+            ),
+            suggestions: [previousSuggestion]
+        )
+
+        textView.string = "$autore"
+        textView.setSelectedRange(NSRange(location: 6, length: 0))
+        textView.refreshMentionCompletions()
+
+        #expect(!textView.debugMentionSuggestionsAreCurrent())
+        #expect(textView.debugMentionSuggestionTitles().isEmpty)
+        #expect(textView.debugMentionCompletionsShouldShowPopover())
+        #expect(!textView.debugAcceptMentionCompletion())
+    }
+
+    @Test
     func testTextBoxMentionRefreshFiltersStaleRowsWhenSameTriggerQueryNarrows() {
         let textView = TextBoxInputTextView(frame: NSRect(x: 0, y: 0, width: 320, height: 30))
         textView.string = "$it"

--- a/cmuxTests/TextBoxMentionCompletionTests.swift
+++ b/cmuxTests/TextBoxMentionCompletionTests.swift
@@ -1147,6 +1147,55 @@ struct TextBoxMentionCompletionTests {
     }
 
     @Test
+    func testTextBoxMentionControllerPublishesFilteredRenderStateBeforeAsyncLookup() {
+        let controller = TextBoxMentionCompletionController()
+        let staleSuggestion = TextBoxMentionSuggestion(
+            id: "$:/tmp/agent-browser/SKILL.md",
+            title: "$agent-browser",
+            subtitle: "/tmp/agent-browser/SKILL.md",
+            insertionText: "$agent-browser",
+            systemImageName: "sparkle.magnifyingglass"
+        )
+        let matchingSuggestion = TextBoxMentionSuggestion(
+            id: "$:/tmp/autoreview/SKILL.md",
+            title: "$autoreview",
+            subtitle: "/tmp/autoreview/SKILL.md",
+            insertionText: "$autoreview",
+            systemImageName: "sparkle.magnifyingglass"
+        )
+
+        controller.debugSetState(
+            query: TextBoxMentionQuery(
+                kind: .skill,
+                range: NSRange(location: 0, length: 1),
+                query: "",
+                trigger: "$"
+            ),
+            suggestions: [staleSuggestion, matchingSuggestion]
+        )
+        var stateChangeCount = 0
+        controller.onStateChanged = {
+            stateChangeCount += 1
+        }
+
+        controller.refresh(
+            for: TextBoxMentionQuery(
+                kind: .skill,
+                range: NSRange(location: 0, length: 6),
+                query: "autore",
+                trigger: "$"
+            ),
+            rootDirectory: nil
+        )
+
+        #expect(stateChangeCount == 1)
+        #expect(controller.renderState.searchTerm == "autore")
+        #expect(controller.renderState.isLoading)
+        #expect(controller.renderState.suggestions.map(\.title) == ["$autoreview"])
+        #expect(!controller.debugHasCurrentSuggestions)
+    }
+
+    @Test
     func testTextBoxMentionRefreshClearsRowsWhenSameTriggerQueryBecomesNonEmpty() {
         let textView = TextBoxInputTextView(frame: NSRect(x: 0, y: 0, width: 320, height: 30))
         textView.string = "$"

--- a/cmuxUITests/AutomationSocketUITests.swift
+++ b/cmuxUITests/AutomationSocketUITests.swift
@@ -115,16 +115,36 @@ final class AutomationSocketUITests: XCTestCase {
             "Expected socket ping at \(socketPath). diagnostics=\(loadDiagnostics())"
         )
 
+        let windowContext = try XCTUnwrap(
+            waitForMainWindowContext(timeout: 12.0),
+            "Expected system.identify to resolve a main window. diagnostics=\(loadDiagnostics())"
+        )
+        let workspace = try XCTUnwrap(
+            socketResult(
+                method: "workspace.create",
+                params: [
+                    "window_id": windowContext.windowID,
+                    "title": "Textbox mention XCUITest",
+                    "working_directory": skillRoot.path,
+                    "focus": true,
+                    "eager_load_terminal": true,
+                    "auto_refresh_metadata": false,
+                ]
+            ),
+            "Expected workspace.create to succeed after main window readiness"
+        )
+        let surfaceID = try XCTUnwrap(workspace["surface_id"] as? String, "Expected created surface id")
+
         let fixture = try XCTUnwrap(
             waitForTextBoxFixture(
-                surfaceID: nil,
+                surfaceID: surfaceID,
                 beforeText: "$",
                 completionRootDirectory: skillRoot.path,
                 timeout: 8.0
             ),
             "Expected text box fixture to mount with a bare $ trigger. last=\(lastTextBoxFixtureResponse) diagnostics=\(loadDiagnostics())"
         )
-        let surfaceID = try XCTUnwrap(fixture["surface_id"] as? String, "Expected fixture surface id")
+        XCTAssertEqual(fixture["surface_id"] as? String, surfaceID)
         _ = try XCTUnwrap(
             socketResult(
                 method: "debug.textbox.interact",
@@ -167,6 +187,16 @@ final class AutomationSocketUITests: XCTestCase {
 
         let typedTitles = typedState["mention_titles"] as? [String] ?? []
         XCTAssertEqual(typedTitles.first, "$autoreview")
+        XCTAssertTrue(
+            waitForMentionPopoverRow(
+                app: app,
+                index: 0,
+                expectedTitle: "$autoreview",
+                forbiddenTitle: "$agent-browser",
+                timeout: 8.0
+            ),
+            "Expected rendered autocomplete row 0 to show $autoreview and not stale $agent-browser"
+        )
     }
 
     private func configuredApp(mode: String) -> XCUIApplication {
@@ -316,6 +346,26 @@ final class AutomationSocketUITests: XCTestCase {
         return envelope["result"] as? [String: Any]
     }
 
+    private func waitForMainWindowContext(timeout: TimeInterval) -> (windowID: String, surfaceID: String?)? {
+        waitForJSON(timeout: timeout) {
+            guard let result = self.socketResult(method: "system.identify", params: [:]),
+                  let focused = result["focused"] as? [String: Any],
+                  let windowID = focused["window_id"] as? String,
+                  !windowID.isEmpty else {
+                return nil
+            }
+            var payload: [String: Any] = ["window_id": windowID]
+            if let surfaceID = focused["surface_id"] as? String, !surfaceID.isEmpty {
+                payload["surface_id"] = surfaceID
+            }
+            return payload
+        }
+        .flatMap { payload in
+            guard let windowID = payload["window_id"] as? String else { return nil }
+            return (windowID, payload["surface_id"] as? String)
+        }
+    }
+
     private func waitForTextBoxFixture(
         surfaceID: String?,
         beforeText: String,
@@ -357,6 +407,35 @@ final class AutomationSocketUITests: XCTestCase {
             return String(describing: value)
         }
         return text
+    }
+
+    private func waitForMentionPopoverRow(
+        app: XCUIApplication,
+        index: Int,
+        expectedTitle: String,
+        forbiddenTitle: String,
+        timeout: TimeInterval
+    ) -> Bool {
+        let row = app.descendants(matching: .any)
+            .matching(identifier: "TextBoxMentionCompletionPopover.Row.\(index)")
+            .firstMatch
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if row.exists {
+                let renderedValue = row.value.map { String(describing: $0) } ?? ""
+                let renderedText = [
+                    row.label,
+                    renderedValue,
+                ]
+                .joined(separator: " ")
+                if renderedText.contains(expectedTitle),
+                   !renderedText.contains(forbiddenTitle) {
+                    return true
+                }
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        }
+        return false
     }
 
     private func waitForMentionState(

--- a/cmuxUITests/AutomationSocketUITests.swift
+++ b/cmuxUITests/AutomationSocketUITests.swift
@@ -511,7 +511,7 @@ final class AutomationSocketUITests: XCTestCase {
     }
 
     private func mentionPopoverRowTitles(in app: XCUIApplication, textBox: XCUIElement? = nil) -> [String] {
-        let indexedRows = (0..<12).compactMap { index in
+        let indexedRows = (0..<12).compactMap { index -> String? in
             let row = app.descendants(matching: .any)
                 .matching(identifier: "TextBoxMentionCompletionPopover.Row.\(index)")
                 .firstMatch

--- a/cmuxUITests/AutomationSocketUITests.swift
+++ b/cmuxUITests/AutomationSocketUITests.swift
@@ -128,7 +128,7 @@ final class AutomationSocketUITests: XCTestCase {
         textBox.click()
         app.typeKey("a", modifierFlags: [.command])
         app.typeKey(XCUIKeyboardKey.delete.rawValue, modifierFlags: [])
-        textBox.typeText("$")
+        app.typeText("$")
 
         _ = try XCTUnwrap(
             waitForMentionRows(
@@ -144,7 +144,7 @@ final class AutomationSocketUITests: XCTestCase {
             """
         )
 
-        textBox.typeText("autore")
+        app.typeText("autore")
 
         let typedRows = try XCTUnwrap(
             waitForMentionRows(
@@ -164,7 +164,7 @@ final class AutomationSocketUITests: XCTestCase {
 
         app.typeKey("a", modifierFlags: [.command])
         app.typeKey(XCUIKeyboardKey.delete.rawValue, modifierFlags: [])
-        textBox.typeText("$iterate")
+        app.typeText("$iterate")
 
         let iterateRows = try XCTUnwrap(
             waitForMentionRows(
@@ -618,6 +618,10 @@ final class AutomationSocketUITests: XCTestCase {
             .matching(identifier: "TextBoxMentionCompletionPopover")
             .firstMatch
             .exists
+        let popoverValue = app.descendants(matching: .any)
+            .matching(identifier: "TextBoxMentionCompletionPopover")
+            .firstMatch
+            .value as? String ?? ""
         let loadingExists = app.descendants(matching: .any)
             .matching(identifier: "TextBoxMentionCompletionPopover.Loading")
             .firstMatch
@@ -634,6 +638,7 @@ final class AutomationSocketUITests: XCTestCase {
         fixtureRoots=
         \(fixtureRootStates)
         popoverExists=\(popoverExists)
+        popoverValue=\(popoverValue)
         loadingExists=\(loadingExists)
         indexedRows=\(indexedRows)
         visibleMentionTexts=\(rows)

--- a/cmuxUITests/AutomationSocketUITests.swift
+++ b/cmuxUITests/AutomationSocketUITests.swift
@@ -112,17 +112,11 @@ final class AutomationSocketUITests: XCTestCase {
             waitForSocketPong(timeout: 12.0),
             "Expected socket ping at \(socketPath). diagnostics=\(loadDiagnostics())"
         )
-        let window = try XCTUnwrap(
-            waitForSocketResult(method: "window.create", params: [:], timeout: 8.0),
-            "Expected window.create to succeed before creating textbox fixture workspace"
-        )
-        let windowID = try XCTUnwrap(window["window_id"] as? String, "Expected created window id")
 
         let workspace = try XCTUnwrap(
             socketResult(
                 method: "workspace.create",
                 params: [
-                    "window_id": windowID,
                     "title": "Textbox mention XCUITest",
                     "working_directory": skillRoot.path,
                     "focus": true,
@@ -155,7 +149,13 @@ final class AutomationSocketUITests: XCTestCase {
         )
         XCTAssertEqual(bareState["plain_text"] as? String, "$")
 
-        app.typeText("autore")
+        _ = try XCTUnwrap(
+            socketResult(
+                method: "debug.textbox.interact",
+                params: ["surface_id": surfaceID, "action": "insert_text:autore"]
+            ),
+            "Expected textbox debug insert to succeed"
+        )
 
         let typedState = try XCTUnwrap(
             waitForMentionState(surfaceID: surfaceID, timeout: 8.0) { state in
@@ -319,16 +319,6 @@ final class AutomationSocketUITests: XCTestCase {
             return nil
         }
         return envelope["result"] as? [String: Any]
-    }
-
-    private func waitForSocketResult(
-        method: String,
-        params: [String: Any],
-        timeout: TimeInterval
-    ) -> [String: Any]? {
-        waitForJSON(timeout: timeout) {
-            self.socketResult(method: method, params: params)
-        }
     }
 
     private func waitForTextBoxFixture(

--- a/cmuxUITests/AutomationSocketUITests.swift
+++ b/cmuxUITests/AutomationSocketUITests.swift
@@ -112,15 +112,17 @@ final class AutomationSocketUITests: XCTestCase {
             waitForSocketPong(timeout: 12.0),
             "Expected socket ping at \(socketPath). diagnostics=\(loadDiagnostics())"
         )
-        _ = try XCTUnwrap(
-            waitForSocketResult(method: "workspace.list", params: [:], timeout: 8.0),
-            "Expected workspace API to be ready before creating textbox fixture workspace"
+        let window = try XCTUnwrap(
+            waitForSocketResult(method: "window.create", params: [:], timeout: 8.0),
+            "Expected window.create to succeed before creating textbox fixture workspace"
         )
+        let windowID = try XCTUnwrap(window["window_id"] as? String, "Expected created window id")
 
         let workspace = try XCTUnwrap(
             socketResult(
                 method: "workspace.create",
                 params: [
+                    "window_id": windowID,
                     "title": "Textbox mention XCUITest",
                     "working_directory": skillRoot.path,
                     "focus": true,

--- a/cmuxUITests/AutomationSocketUITests.swift
+++ b/cmuxUITests/AutomationSocketUITests.swift
@@ -106,10 +106,10 @@ final class AutomationSocketUITests: XCTestCase {
         let app = XCUIApplication()
         configureTextBoxMentionLaunchEnvironment(app)
         defer { app.terminate() }
-        app.launch()
+        launchAllowingBackgroundActivation(app)
 
         XCTAssertTrue(
-            ensureForegroundAfterLaunch(app, timeout: 12.0),
+            waitForRunningApp(app, timeout: 12.0),
             "Expected app to launch for textbox mention test. state=\(app.state.rawValue)"
         )
         XCTAssertTrue(
@@ -244,6 +244,26 @@ final class AutomationSocketUITests: XCTestCase {
         if app.state == .runningBackground {
             app.activate()
             return app.wait(for: .runningForeground, timeout: 6.0)
+        }
+        return false
+    }
+
+    private func launchAllowingBackgroundActivation(_ app: XCUIApplication) {
+        // Headless cloud runners can launch the app but fail WindowServer activation.
+        // The socket and accessibility APIs used below still work in background.
+        let options = XCTExpectedFailure.Options()
+        options.isStrict = false
+        XCTExpectFailure("App activation may fail on headless UI runners", options: options) {
+            app.launch()
+        }
+    }
+
+    private func waitForRunningApp(_ app: XCUIApplication, timeout: TimeInterval) -> Bool {
+        if app.wait(for: .runningForeground, timeout: timeout) {
+            return true
+        }
+        if app.state == .runningBackground {
+            return true
         }
         return false
     }

--- a/cmuxUITests/AutomationSocketUITests.swift
+++ b/cmuxUITests/AutomationSocketUITests.swift
@@ -11,6 +11,7 @@ final class AutomationSocketUITests: XCTestCase {
     private var launchTag = ""
     private var temporaryRoots: [URL] = []
     private var lastTextBoxFixtureResponse = ""
+    private var lastMainWindowContextResponse = ""
 
     override func setUp() {
         super.setUp()
@@ -20,6 +21,7 @@ final class AutomationSocketUITests: XCTestCase {
         launchTag = "ui-tests-automation-\(UUID().uuidString.prefix(8))"
         temporaryRoots = []
         lastTextBoxFixtureResponse = ""
+        lastMainWindowContextResponse = ""
         resetSocketDefaults()
         removeSocketFile()
         try? FileManager.default.removeItem(atPath: diagnosticsPath)
@@ -117,7 +119,7 @@ final class AutomationSocketUITests: XCTestCase {
 
         let windowContext = try XCTUnwrap(
             waitForMainWindowContext(timeout: 12.0),
-            "Expected system.identify to resolve a main window. diagnostics=\(loadDiagnostics())"
+            "Expected main window context. last=\(lastMainWindowContextResponse) diagnostics=\(loadDiagnostics())"
         )
         let workspace = try XCTUnwrap(
             socketResult(
@@ -352,33 +354,62 @@ final class AutomationSocketUITests: XCTestCase {
 
     private func waitForMainWindowContext(timeout: TimeInterval) -> (windowID: String, surfaceID: String?)? {
         waitForJSON(timeout: timeout) {
-            if let result = self.socketResult(method: "system.identify", params: [:]),
-               let focused = result["focused"] as? [String: Any],
-               let windowID = focused["window_id"] as? String,
-               !windowID.isEmpty {
-                var payload: [String: Any] = ["window_id": windowID]
-                if let surfaceID = focused["surface_id"] as? String, !surfaceID.isEmpty {
-                    payload["surface_id"] = surfaceID
+            if let envelope = self.socketJSON(method: "system.identify", params: [:]) {
+                self.lastMainWindowContextResponse = "system.identify \(Self.debugDescription(envelope))"
+                if envelope["ok"] as? Bool == true,
+                   let result = envelope["result"] as? [String: Any],
+                   let focused = result["focused"] as? [String: Any],
+                   let windowID = focused["window_id"] as? String,
+                   !windowID.isEmpty {
+                    var payload: [String: Any] = ["window_id": windowID]
+                    if let surfaceID = focused["surface_id"] as? String, !surfaceID.isEmpty {
+                        payload["surface_id"] = surfaceID
+                    }
+                    return payload
                 }
-                return payload
+            } else {
+                self.lastMainWindowContextResponse = "system.identify nil envelope"
             }
 
-            guard let result = self.socketResult(method: "window.list", params: [:]),
-                  let windows = result["windows"] as? [[String: Any]] else {
-                return nil
+            if let envelope = self.socketJSON(method: "window.list", params: [:]) {
+                self.lastMainWindowContextResponse += " window.list \(Self.debugDescription(envelope))"
+                if envelope["ok"] as? Bool == true,
+                   let result = envelope["result"] as? [String: Any],
+                   let windows = result["windows"] as? [[String: Any]] {
+                    let window = windows.first { item in
+                        item["visible"] as? Bool == true
+                    } ?? windows.first
+                    if let windowID = window?["id"] as? String, !windowID.isEmpty {
+                        return ["window_id": windowID]
+                    }
+                }
+            } else {
+                self.lastMainWindowContextResponse += " window.list nil envelope"
             }
-            let window = windows.first { item in
-                item["visible"] as? Bool == true
-            } ?? windows.first
-            guard let windowID = window?["id"] as? String, !windowID.isEmpty else {
-                return nil
+
+            if let windowID = self.diagnosticMainWindowID() {
+                self.lastMainWindowContextResponse += " diagnostics_window_id \(windowID)"
+                return ["window_id": windowID]
             }
-            return ["window_id": windowID]
+            return nil
         }
         .flatMap { payload in
             guard let windowID = payload["window_id"] as? String else { return nil }
             return (windowID, payload["surface_id"] as? String)
         }
+    }
+
+    private func diagnosticMainWindowID() -> String? {
+        guard let identifiers = loadDiagnostics()["windowIdentifiers"] else { return nil }
+        for rawIdentifier in identifiers.split(separator: ",") {
+            let identifier = String(rawIdentifier).trimmingCharacters(in: .whitespacesAndNewlines)
+            let prefix = "cmux.main."
+            guard identifier.hasPrefix(prefix) else { continue }
+            let windowID = String(identifier.dropFirst(prefix.count))
+            guard UUID(uuidString: windowID) != nil else { continue }
+            return windowID
+        }
+        return nil
     }
 
     private func waitForTextBoxFixture(

--- a/cmuxUITests/AutomationSocketUITests.swift
+++ b/cmuxUITests/AutomationSocketUITests.swift
@@ -95,7 +95,7 @@ final class AutomationSocketUITests: XCTestCase {
     }
 
     func testTextBoxSkillMentionFiltersWhenTypingAfterBareDollarTrigger() throws {
-        let fixtureRoot = try makeSkillFixtureRoot(
+        let fixtureRoots = try makeSkillFixtureRoots(
             skillNames: [
                 "agent-browser",
                 "agent-cli-integration",
@@ -138,7 +138,7 @@ final class AutomationSocketUITests: XCTestCase {
             },
             """
             Expected bare $ popover rows to include $agent-browser.
-            \(mentionPopoverDiagnostics(in: app, textBox: textBox, fixtureRoot: fixtureRoot))
+            \(mentionPopoverDiagnostics(in: app, textBox: textBox, fixtureRoots: fixtureRoots))
             """
         )
 
@@ -155,7 +155,7 @@ final class AutomationSocketUITests: XCTestCase {
             },
             """
             Expected visible popover rows for $autore to hide stale $agent-browser.
-            \(mentionPopoverDiagnostics(in: app, textBox: textBox, fixtureRoot: fixtureRoot))
+            \(mentionPopoverDiagnostics(in: app, textBox: textBox, fixtureRoots: fixtureRoots))
             """
         )
         XCTAssertTrue(typedRows.first?.contains("$autoreview") == true)
@@ -577,7 +577,7 @@ final class AutomationSocketUITests: XCTestCase {
     private func mentionPopoverDiagnostics(
         in app: XCUIApplication,
         textBox: XCUIElement,
-        fixtureRoot: URL
+        fixtureRoots: [URL]
     ) -> String {
         let indexedRows = (0..<12).compactMap { index -> String? in
             let row = app.descendants(matching: .any)
@@ -599,10 +599,13 @@ final class AutomationSocketUITests: XCTestCase {
         let knownTitleStates = knownTitles
             .map { "\($0)=\(mentionElementExists(in: app, title: $0))" }
             .joined(separator: ", ")
+        let fixtureRootStates = fixtureRoots
+            .map { "\($0.path)=\(FileManager.default.fileExists(atPath: $0.path))" }
+            .joined(separator: "\n")
         return """
         textBoxValue=\(String(describing: textBox.value))
-        fixtureRoot=\(fixtureRoot.path)
-        fixtureRootExists=\(FileManager.default.fileExists(atPath: fixtureRoot.path))
+        fixtureRoots=
+        \(fixtureRootStates)
         popoverExists=\(popoverExists)
         loadingExists=\(loadingExists)
         indexedRows=\(indexedRows)
@@ -626,29 +629,60 @@ final class AutomationSocketUITests: XCTestCase {
         return producer()
     }
 
-    private func makeSkillFixtureRoot(skillNames: [String]) throws -> URL {
-        let root = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".codex/skills", isDirectory: true)
-            .appendingPathComponent("cmux-ui-textbox-skills-\(UUID().uuidString)", isDirectory: true)
-        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
-        for skillName in skillNames {
-            let skillDirectory = root.appendingPathComponent(skillName, isDirectory: true)
-            try FileManager.default.createDirectory(at: skillDirectory, withIntermediateDirectories: true)
-            let contents = """
-            ---
-            name: \(skillName)
-            ---
+    private func makeSkillFixtureRoots(skillNames: [String]) throws -> [URL] {
+        let fixtureName = "cmux-ui-textbox-skills-\(UUID().uuidString)"
+        var roots: [URL] = []
 
-            Test skill fixture for \(skillName).
-            """
-            try contents.write(
-                to: skillDirectory.appendingPathComponent("SKILL.md", isDirectory: false),
-                atomically: true,
-                encoding: .utf8
-            )
+        for home in skillFixtureHomeCandidates() {
+            let root = home
+                .appendingPathComponent(".codex/skills", isDirectory: true)
+                .appendingPathComponent(fixtureName, isDirectory: true)
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            for skillName in skillNames {
+                let skillDirectory = root.appendingPathComponent(skillName, isDirectory: true)
+                try FileManager.default.createDirectory(at: skillDirectory, withIntermediateDirectories: true)
+                let contents = """
+                ---
+                name: \(skillName)
+                ---
+
+                Test skill fixture for \(skillName).
+                """
+                try contents.write(
+                    to: skillDirectory.appendingPathComponent("SKILL.md", isDirectory: false),
+                    atomically: true,
+                    encoding: .utf8
+                )
+            }
+            roots.append(root)
+            temporaryRoots.append(root)
         }
-        temporaryRoots.append(root)
-        return root
+        return roots
+    }
+
+    private func skillFixtureHomeCandidates() -> [URL] {
+        var homes: [URL] = [FileManager.default.homeDirectoryForCurrentUser]
+        if let envHome = ProcessInfo.processInfo.environment["HOME"],
+           !envHome.isEmpty {
+            homes.append(URL(fileURLWithPath: envHome, isDirectory: true))
+        }
+        let loginHome = URL(fileURLWithPath: "/Users/\(NSUserName())", isDirectory: true)
+        homes.append(loginHome)
+
+        let runnerContainerSuffix = "/Library/Containers/com.cmuxterm.appuitests.xctrunner/Data"
+        let initialHomes = homes
+        for home in initialHomes {
+            let path = home.standardizedFileURL.path
+            guard path.hasSuffix(runnerContainerSuffix) else { continue }
+            let appHomePath = String(path.dropLast(runnerContainerSuffix.count))
+                + "/Library/Containers/com.cmuxterm.app.debug/Data"
+            homes.append(URL(fileURLWithPath: appHomePath, isDirectory: true))
+        }
+
+        var seen = Set<String>()
+        return homes
+            .map(\.standardizedFileURL)
+            .filter { seen.insert($0.path).inserted }
     }
 
     private func resolveSocketPath(timeout: TimeInterval, allowTmpFallback: Bool = true) -> String? {

--- a/cmuxUITests/AutomationSocketUITests.swift
+++ b/cmuxUITests/AutomationSocketUITests.swift
@@ -133,7 +133,6 @@ final class AutomationSocketUITests: XCTestCase {
         _ = try XCTUnwrap(
             waitForMentionRows(
                 in: app,
-                fallbackTitles: ["$agent-browser"],
                 timeout: 8.0
             ) { rows in
                 rows.contains { $0.contains("$agent-browser") }
@@ -149,7 +148,6 @@ final class AutomationSocketUITests: XCTestCase {
         let typedRows = try XCTUnwrap(
             waitForMentionRows(
                 in: app,
-                fallbackTitles: ["$autoreview", "$agent-browser"],
                 timeout: 8.0
             ) { rows in
                 rows.first?.contains("$autoreview") == true &&
@@ -161,6 +159,12 @@ final class AutomationSocketUITests: XCTestCase {
             """
         )
         XCTAssertTrue(typedRows.first?.contains("$autoreview") == true)
+        assertMentionRowsRemain(
+            in: app,
+            firstTitle: "$autoreview",
+            absentTitle: "$agent-browser",
+            duration: 0.5
+        )
 
         app.typeKey("a", modifierFlags: [.command])
         app.typeKey(XCUIKeyboardKey.delete.rawValue, modifierFlags: [])
@@ -169,7 +173,6 @@ final class AutomationSocketUITests: XCTestCase {
         let iterateRows = try XCTUnwrap(
             waitForMentionRows(
                 in: app,
-                fallbackTitles: ["$iterate-pr", "$agent-browser"],
                 timeout: 8.0
             ) { rows in
                 rows.first?.contains("$iterate-pr") == true &&
@@ -181,6 +184,12 @@ final class AutomationSocketUITests: XCTestCase {
             """
         )
         XCTAssertTrue(iterateRows.first?.contains("$iterate-pr") == true)
+        assertMentionRowsRemain(
+            in: app,
+            firstTitle: "$iterate-pr",
+            absentTitle: "$agent-browser",
+            duration: 0.5
+        )
     }
 
     private func configuredApp(mode: String) -> XCUIApplication {
@@ -548,7 +557,16 @@ final class AutomationSocketUITests: XCTestCase {
         in app: XCUIApplication,
         fallbackTitles: [String] = []
     ) -> [String] {
-        let indexedRows = (0..<12).compactMap { index -> String? in
+        let indexedRows = indexedMentionPopoverRowTitles(in: app)
+        if !indexedRows.isEmpty {
+            return indexedRows
+        }
+
+        return fallbackTitles.filter { mentionElementExists(in: app, title: $0) }
+    }
+
+    private func indexedMentionPopoverRowTitles(in app: XCUIApplication) -> [String] {
+        (0..<12).compactMap { index -> String? in
             let row = app.descendants(matching: .any)
                 .matching(identifier: "TextBoxMentionCompletionPopover.Row.\(index)")
                 .firstMatch
@@ -561,29 +579,50 @@ final class AutomationSocketUITests: XCTestCase {
             }
             return nil
         }
-        if !indexedRows.isEmpty {
-            return indexedRows
-        }
-
-        return fallbackTitles.filter { mentionElementExists(in: app, title: $0) }
     }
 
     private func waitForMentionRows(
         in app: XCUIApplication,
-        fallbackTitles: [String],
         timeout: TimeInterval,
         predicate: @escaping ([String]) -> Bool
     ) -> [String]? {
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
-            let rows = mentionPopoverRowTitles(in: app, fallbackTitles: fallbackTitles)
+            let rows = indexedMentionPopoverRowTitles(in: app)
             if predicate(rows) {
                 return rows
             }
             RunLoop.current.run(until: Date().addingTimeInterval(0.05))
         }
-        let rows = mentionPopoverRowTitles(in: app, fallbackTitles: fallbackTitles)
+        let rows = indexedMentionPopoverRowTitles(in: app)
         return predicate(rows) ? rows : nil
+    }
+
+    private func assertMentionRowsRemain(
+        in app: XCUIApplication,
+        firstTitle: String,
+        absentTitle: String,
+        duration: TimeInterval,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let deadline = Date().addingTimeInterval(duration)
+        var sampleCount = 0
+        while Date() < deadline {
+            let rows = indexedMentionPopoverRowTitles(in: app)
+            sampleCount += 1
+            guard rows.first?.contains(firstTitle) == true,
+                  !rows.contains(where: { $0.contains(absentTitle) }) else {
+                XCTFail(
+                    "Expected popover rows to remain filtered. firstTitle=\(firstTitle) absentTitle=\(absentTitle) rows=\(rows)",
+                    file: file,
+                    line: line
+                )
+                return
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        }
+        XCTAssertGreaterThan(sampleCount, 0, file: file, line: line)
     }
 
     private func mentionElementExists(in app: XCUIApplication, title: String) -> Bool {
@@ -612,7 +651,7 @@ final class AutomationSocketUITests: XCTestCase {
             guard row.exists else { return nil }
             return row.label.isEmpty ? row.value as? String : row.label
         }
-        let knownTitles = ["$agent-browser", "$autoreview"]
+        let knownTitles = ["$agent-browser", "$autoreview", "$iterate-pr"]
         let rows = mentionPopoverRowTitles(in: app, fallbackTitles: knownTitles)
         let popoverExists = app.descendants(matching: .any)
             .matching(identifier: "TextBoxMentionCompletionPopover")

--- a/cmuxUITests/AutomationSocketUITests.swift
+++ b/cmuxUITests/AutomationSocketUITests.swift
@@ -161,6 +161,26 @@ final class AutomationSocketUITests: XCTestCase {
             """
         )
         XCTAssertTrue(typedRows.first?.contains("$autoreview") == true)
+
+        app.typeKey("a", modifierFlags: [.command])
+        app.typeKey(XCUIKeyboardKey.delete.rawValue, modifierFlags: [])
+        textBox.typeText("$iterate")
+
+        let iterateRows = try XCTUnwrap(
+            waitForMentionRows(
+                in: app,
+                fallbackTitles: ["$iterate-pr", "$agent-browser"],
+                timeout: 8.0
+            ) { rows in
+                rows.first?.contains("$iterate-pr") == true &&
+                    !rows.contains { $0.contains("$agent-browser") }
+            },
+            """
+            Expected visible popover rows for $iterate to show $iterate-pr and hide stale $agent-browser.
+            \(mentionPopoverDiagnostics(in: app, textBox: textBox, fixtureRoots: fixtureRoots.skillRoots))
+            """
+        )
+        XCTAssertTrue(iterateRows.first?.contains("$iterate-pr") == true)
     }
 
     private func configuredApp(mode: String) -> XCUIApplication {

--- a/cmuxUITests/AutomationSocketUITests.swift
+++ b/cmuxUITests/AutomationSocketUITests.swift
@@ -352,17 +352,28 @@ final class AutomationSocketUITests: XCTestCase {
 
     private func waitForMainWindowContext(timeout: TimeInterval) -> (windowID: String, surfaceID: String?)? {
         waitForJSON(timeout: timeout) {
-            guard let result = self.socketResult(method: "system.identify", params: [:]),
-                  let focused = result["focused"] as? [String: Any],
-                  let windowID = focused["window_id"] as? String,
-                  !windowID.isEmpty else {
+            if let result = self.socketResult(method: "system.identify", params: [:]),
+               let focused = result["focused"] as? [String: Any],
+               let windowID = focused["window_id"] as? String,
+               !windowID.isEmpty {
+                var payload: [String: Any] = ["window_id": windowID]
+                if let surfaceID = focused["surface_id"] as? String, !surfaceID.isEmpty {
+                    payload["surface_id"] = surfaceID
+                }
+                return payload
+            }
+
+            guard let result = self.socketResult(method: "window.list", params: [:]),
+                  let windows = result["windows"] as? [[String: Any]] else {
                 return nil
             }
-            var payload: [String: Any] = ["window_id": windowID]
-            if let surfaceID = focused["surface_id"] as? String, !surfaceID.isEmpty {
-                payload["surface_id"] = surfaceID
+            let window = windows.first { item in
+                item["visible"] as? Bool == true
+            } ?? windows.first
+            guard let windowID = window?["id"] as? String, !windowID.isEmpty else {
+                return nil
             }
-            return payload
+            return ["window_id": windowID]
         }
         .flatMap { payload in
             guard let windowID = payload["window_id"] as? String else { return nil }

--- a/cmuxUITests/AutomationSocketUITests.swift
+++ b/cmuxUITests/AutomationSocketUITests.swift
@@ -12,6 +12,7 @@ final class AutomationSocketUITests: XCTestCase {
     private var temporaryRoots: [URL] = []
     private var lastTextBoxFixtureResponse = ""
     private var lastMainWindowContextResponse = ""
+    private var lastWorkspaceCreateResponse = ""
 
     override func setUp() {
         super.setUp()
@@ -22,6 +23,7 @@ final class AutomationSocketUITests: XCTestCase {
         temporaryRoots = []
         lastTextBoxFixtureResponse = ""
         lastMainWindowContextResponse = ""
+        lastWorkspaceCreateResponse = ""
         resetSocketDefaults()
         removeSocketFile()
         try? FileManager.default.removeItem(atPath: diagnosticsPath)
@@ -117,36 +119,32 @@ final class AutomationSocketUITests: XCTestCase {
             "Expected socket ping at \(socketPath). diagnostics=\(loadDiagnostics())"
         )
 
-        let windowContext = try XCTUnwrap(
-            waitForMainWindowContext(timeout: 12.0),
-            "Expected main window context. last=\(lastMainWindowContextResponse) diagnostics=\(loadDiagnostics())"
+        let windowContext = waitForMainWindowContext(timeout: 12.0)
+        let workspace = createTextBoxFixtureWorkspace(
+            windowID: windowContext?.windowID,
+            workingDirectory: skillRoot.path
         )
-        let workspace = try XCTUnwrap(
-            socketResult(
-                method: "workspace.create",
-                params: [
-                    "window_id": windowContext.windowID,
-                    "title": "Textbox mention XCUITest",
-                    "working_directory": skillRoot.path,
-                    "focus": true,
-                    "eager_load_terminal": true,
-                    "auto_refresh_metadata": false,
-                ]
-            ),
-            "Expected workspace.create to succeed after main window readiness"
-        )
-        let surfaceID = try XCTUnwrap(workspace["surface_id"] as? String, "Expected created surface id")
+        let createdSurfaceID = workspace?["surface_id"] as? String
 
         let fixture = try XCTUnwrap(
             waitForTextBoxFixture(
-                surfaceID: surfaceID,
+                surfaceID: createdSurfaceID,
                 beforeText: "$",
                 completionRootDirectory: skillRoot.path,
                 timeout: 8.0
             ),
-            "Expected text box fixture to mount with a bare $ trigger. last=\(lastTextBoxFixtureResponse) diagnostics=\(loadDiagnostics())"
+            """
+            Expected text box fixture to mount with a bare $ trigger.
+            window=\(lastMainWindowContextResponse)
+            workspace=\(lastWorkspaceCreateResponse)
+            fixture=\(lastTextBoxFixtureResponse)
+            diagnostics=\(loadDiagnostics())
+            """
         )
-        XCTAssertEqual(fixture["surface_id"] as? String, surfaceID)
+        let surfaceID = try XCTUnwrap(fixture["surface_id"] as? String, "Expected fixture surface id")
+        if let createdSurfaceID {
+            XCTAssertEqual(surfaceID, createdSurfaceID)
+        }
         _ = try XCTUnwrap(
             socketResult(
                 method: "debug.textbox.interact",
@@ -430,6 +428,36 @@ final class AutomationSocketUITests: XCTestCase {
             return windowID
         }
         return nil
+    }
+
+    private func createTextBoxFixtureWorkspace(windowID: String?, workingDirectory: String) -> [String: Any]? {
+        var params: [String: Any] = [
+            "title": "Textbox mention XCUITest",
+            "working_directory": workingDirectory,
+            "focus": true,
+            "eager_load_terminal": true,
+            "auto_refresh_metadata": false,
+        ]
+        if let windowID, !windowID.isEmpty {
+            params["window_id"] = windowID
+            if let result = socketResultCapturingEnvelope(method: "workspace.create", params: params) {
+                return result
+            }
+            params.removeValue(forKey: "window_id")
+        }
+        return socketResultCapturingEnvelope(method: "workspace.create", params: params)
+    }
+
+    private func socketResultCapturingEnvelope(method: String, params: [String: Any]) -> [String: Any]? {
+        guard let envelope = socketJSON(method: method, params: params) else {
+            lastWorkspaceCreateResponse = "\(method) nil envelope"
+            return nil
+        }
+        lastWorkspaceCreateResponse = "\(method) \(Self.debugDescription(envelope))"
+        guard envelope["ok"] as? Bool == true else {
+            return nil
+        }
+        return envelope["result"] as? [String: Any]
     }
 
     private func waitForTextBoxFixture(

--- a/cmuxUITests/AutomationSocketUITests.swift
+++ b/cmuxUITests/AutomationSocketUITests.swift
@@ -10,6 +10,7 @@ final class AutomationSocketUITests: XCTestCase {
     private let legacyKey = "socketControlEnabled"
     private var launchTag = ""
     private var temporaryRoots: [URL] = []
+    private var skillFixtureDiagnostics = ""
     private var lastTextBoxFixtureResponse = ""
     private var lastMainWindowContextResponse = ""
     private var lastWorkspaceCreateResponse = ""
@@ -21,6 +22,7 @@ final class AutomationSocketUITests: XCTestCase {
         diagnosticsPath = "/tmp/cmux-ui-test-automation-socket-\(UUID().uuidString).json"
         launchTag = "ui-tests-automation-\(UUID().uuidString.prefix(8))"
         temporaryRoots = []
+        skillFixtureDiagnostics = ""
         lastTextBoxFixtureResponse = ""
         lastMainWindowContextResponse = ""
         lastWorkspaceCreateResponse = ""
@@ -106,7 +108,7 @@ final class AutomationSocketUITests: XCTestCase {
             ]
         )
         let app = XCUIApplication()
-        configureTextBoxMentionLaunchEnvironment(app)
+        configureTextBoxMentionLaunchEnvironment(app, fixtureHome: fixtureRoots.fixtureHome)
         defer { app.terminate() }
         app.launch()
 
@@ -138,7 +140,7 @@ final class AutomationSocketUITests: XCTestCase {
             },
             """
             Expected bare $ popover rows to include $agent-browser.
-            \(mentionPopoverDiagnostics(in: app, textBox: textBox, fixtureRoots: fixtureRoots))
+            \(mentionPopoverDiagnostics(in: app, textBox: textBox, fixtureRoots: fixtureRoots.skillRoots))
             """
         )
 
@@ -155,7 +157,7 @@ final class AutomationSocketUITests: XCTestCase {
             },
             """
             Expected visible popover rows for $autore to hide stale $agent-browser.
-            \(mentionPopoverDiagnostics(in: app, textBox: textBox, fixtureRoots: fixtureRoots))
+            \(mentionPopoverDiagnostics(in: app, textBox: textBox, fixtureRoots: fixtureRoots.skillRoots))
             """
         )
         XCTAssertTrue(typedRows.first?.contains("$autoreview") == true)
@@ -173,7 +175,7 @@ final class AutomationSocketUITests: XCTestCase {
         return app
     }
 
-    private func configureTextBoxMentionLaunchEnvironment(_ app: XCUIApplication) {
+    private func configureTextBoxMentionLaunchEnvironment(_ app: XCUIApplication, fixtureHome: URL? = nil) {
         app.launchArguments += [
             "-terminal.showTextBoxOnNewTerminals", "1",
             "-terminal.focusTextBoxOnNewTerminals", "1",
@@ -184,6 +186,10 @@ final class AutomationSocketUITests: XCTestCase {
         app.launchEnvironment["CMUX_TAG"] = launchTag
         if let path = ProcessInfo.processInfo.environment["PATH"], !path.isEmpty {
             app.launchEnvironment["PATH"] = path
+        }
+        if let fixtureHome {
+            app.launchEnvironment["CFFIXED_USER_HOME"] = fixtureHome.path
+            app.launchEnvironment["HOME"] = fixtureHome.path
         }
     }
 
@@ -604,6 +610,7 @@ final class AutomationSocketUITests: XCTestCase {
             .joined(separator: "\n")
         return """
         textBoxValue=\(String(describing: textBox.value))
+        \(skillFixtureDiagnostics)
         fixtureRoots=
         \(fixtureRootStates)
         popoverExists=\(popoverExists)
@@ -629,60 +636,33 @@ final class AutomationSocketUITests: XCTestCase {
         return producer()
     }
 
-    private func makeSkillFixtureRoots(skillNames: [String]) throws -> [URL] {
+    private func makeSkillFixtureRoots(skillNames: [String]) throws -> (fixtureHome: URL, skillRoots: [URL]) {
+        let fixtureHome = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("cmux-ui-textbox-home-\(UUID().uuidString)", isDirectory: true)
         let fixtureName = "cmux-ui-textbox-skills-\(UUID().uuidString)"
-        var roots: [URL] = []
+        let root = fixtureHome
+            .appendingPathComponent(".codex/skills", isDirectory: true)
+            .appendingPathComponent(fixtureName, isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        for skillName in skillNames {
+            let skillDirectory = root.appendingPathComponent(skillName, isDirectory: true)
+            try FileManager.default.createDirectory(at: skillDirectory, withIntermediateDirectories: true)
+            let contents = """
+            ---
+            name: \(skillName)
+            ---
 
-        for home in skillFixtureHomeCandidates() {
-            let root = home
-                .appendingPathComponent(".codex/skills", isDirectory: true)
-                .appendingPathComponent(fixtureName, isDirectory: true)
-            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
-            for skillName in skillNames {
-                let skillDirectory = root.appendingPathComponent(skillName, isDirectory: true)
-                try FileManager.default.createDirectory(at: skillDirectory, withIntermediateDirectories: true)
-                let contents = """
-                ---
-                name: \(skillName)
-                ---
-
-                Test skill fixture for \(skillName).
-                """
-                try contents.write(
-                    to: skillDirectory.appendingPathComponent("SKILL.md", isDirectory: false),
-                    atomically: true,
-                    encoding: .utf8
-                )
-            }
-            roots.append(root)
-            temporaryRoots.append(root)
+            Test skill fixture for \(skillName).
+            """
+            try contents.write(
+                to: skillDirectory.appendingPathComponent("SKILL.md", isDirectory: false),
+                atomically: true,
+                encoding: .utf8
+            )
         }
-        return roots
-    }
-
-    private func skillFixtureHomeCandidates() -> [URL] {
-        var homes: [URL] = [FileManager.default.homeDirectoryForCurrentUser]
-        if let envHome = ProcessInfo.processInfo.environment["HOME"],
-           !envHome.isEmpty {
-            homes.append(URL(fileURLWithPath: envHome, isDirectory: true))
-        }
-        let loginHome = URL(fileURLWithPath: "/Users/\(NSUserName())", isDirectory: true)
-        homes.append(loginHome)
-
-        let runnerContainerSuffix = "/Library/Containers/com.cmuxterm.appuitests.xctrunner/Data"
-        let initialHomes = homes
-        for home in initialHomes {
-            let path = home.standardizedFileURL.path
-            guard path.hasSuffix(runnerContainerSuffix) else { continue }
-            let appHomePath = String(path.dropLast(runnerContainerSuffix.count))
-                + "/Library/Containers/com.cmuxterm.app.debug/Data"
-            homes.append(URL(fileURLWithPath: appHomePath, isDirectory: true))
-        }
-
-        var seen = Set<String>()
-        return homes
-            .map(\.standardizedFileURL)
-            .filter { seen.insert($0.path).inserted }
+        temporaryRoots.append(fixtureHome)
+        skillFixtureDiagnostics = "fixtureHome=\(fixtureHome.path)"
+        return (fixtureHome.standardizedFileURL, [root.standardizedFileURL])
     }
 
     private func resolveSocketPath(timeout: TimeInterval, allowTmpFallback: Bool = true) -> String? {

--- a/cmuxUITests/AutomationSocketUITests.swift
+++ b/cmuxUITests/AutomationSocketUITests.swift
@@ -298,7 +298,7 @@ final class AutomationSocketUITests: XCTestCase {
            !expectedPath.isEmpty,
            FileManager.default.fileExists(atPath: expectedPath) {
             socketPath = expectedPath
-            return true
+            return socketCommand("ping") == "PONG"
         }
         return completed
     }
@@ -681,24 +681,29 @@ final class AutomationSocketUITests: XCTestCase {
             guard fd >= 0 else { return nil }
             defer { close(fd) }
 
-            var timeout = timeval(
-                tv_sec: Int(responseTimeout),
-                tv_usec: Int32((responseTimeout - floor(responseTimeout)) * 1_000_000)
-            )
-            withUnsafePointer(to: &timeout) { ptr in
-                _ = setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, ptr, socklen_t(MemoryLayout<timeval>.size))
-                _ = setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, ptr, socklen_t(MemoryLayout<timeval>.size))
+#if os(macOS)
+            var noSigPipe: Int32 = 1
+            _ = withUnsafePointer(to: &noSigPipe) { ptr in
+                setsockopt(
+                    fd,
+                    SOL_SOCKET,
+                    SO_NOSIGPIPE,
+                    ptr,
+                    socklen_t(MemoryLayout<Int32>.size)
+                )
             }
+#endif
 
             var addr = sockaddr_un()
             memset(&addr, 0, MemoryLayout<sockaddr_un>.size)
             addr.sun_family = sa_family_t(AF_UNIX)
 
-            let pathBytes = Array(path.utf8CString)
             let maxLen = MemoryLayout.size(ofValue: addr.sun_path)
+            let pathBytes = Array(path.utf8CString)
             guard pathBytes.count <= maxLen else { return nil }
             withUnsafeMutablePointer(to: &addr.sun_path) { ptr in
                 let raw = UnsafeMutableRawPointer(ptr).assumingMemoryBound(to: CChar.self)
+                memset(raw, 0, maxLen)
                 for index in 0..<pathBytes.count {
                     raw[index] = pathBytes[index]
                 }
@@ -706,33 +711,49 @@ final class AutomationSocketUITests: XCTestCase {
 
             let pathOffset = MemoryLayout<sockaddr_un>.offset(of: \.sun_path) ?? 0
             let addrLen = socklen_t(pathOffset + pathBytes.count)
+#if os(macOS)
+            addr.sun_len = UInt8(min(Int(addrLen), 255))
+#endif
             let connected = withUnsafePointer(to: &addr) { ptr in
-                ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
-                    Darwin.connect(fd, sockaddrPtr, addrLen)
+                ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sa in
+                    Darwin.connect(fd, sa, addrLen)
                 }
             }
             guard connected == 0 else { return nil }
 
-            let payload = Array((line + "\n").utf8)
-            let wrote = payload.withUnsafeBytes { rawBuffer in
-                guard let baseAddress = rawBuffer.baseAddress else { return true }
-                return Darwin.write(fd, baseAddress, rawBuffer.count) == rawBuffer.count
+            let payload = line + "\n"
+            let wrote: Bool = payload.withCString { cString in
+                var remaining = strlen(cString)
+                var pointer = UnsafeRawPointer(cString)
+                while remaining > 0 {
+                    let written = Darwin.write(fd, pointer, remaining)
+                    if written <= 0 { return false }
+                    remaining -= written
+                    pointer = pointer.advanced(by: written)
+                }
+                return true
             }
             guard wrote else { return nil }
 
+            let deadline = Date().addingTimeInterval(responseTimeout)
             var buffer = [UInt8](repeating: 0, count: 4096)
             var accumulator = ""
-            let deadline = Date().addingTimeInterval(responseTimeout)
             while Date() < deadline {
+                var descriptor = pollfd(fd: fd, events: Int16(POLLIN), revents: 0)
+                let ready = Darwin.poll(&descriptor, 1, 100)
+                if ready < 0 {
+                    return nil
+                }
+                if ready == 0 {
+                    continue
+                }
+
                 let count = Darwin.read(fd, &buffer, buffer.count)
-                guard count > 0 else { break }
+                if count <= 0 { break }
                 if let chunk = String(bytes: buffer[0..<count], encoding: .utf8) {
                     accumulator.append(chunk)
                     if let newline = accumulator.firstIndex(of: "\n") {
                         return String(accumulator[..<newline])
-                    }
-                    if count < buffer.count {
-                        break
                     }
                 }
             }

--- a/cmuxUITests/AutomationSocketUITests.swift
+++ b/cmuxUITests/AutomationSocketUITests.swift
@@ -113,23 +113,16 @@ final class AutomationSocketUITests: XCTestCase {
             "Expected socket ping at \(socketPath). diagnostics=\(loadDiagnostics())"
         )
 
-        let workspace = try XCTUnwrap(
-            socketResult(
-                method: "workspace.create",
-                params: [
-                    "title": "Textbox mention XCUITest",
-                    "working_directory": skillRoot.path,
-                    "focus": true,
-                ]
+        let fixture = try XCTUnwrap(
+            waitForTextBoxFixture(
+                surfaceID: nil,
+                beforeText: "$",
+                completionRootDirectory: skillRoot.path,
+                timeout: 8.0
             ),
-            "Expected workspace.create to succeed"
-        )
-        let surfaceID = try XCTUnwrap(workspace["surface_id"] as? String, "Expected created surface id")
-
-        _ = try XCTUnwrap(
-            waitForTextBoxFixture(surfaceID: surfaceID, beforeText: "$", timeout: 8.0),
             "Expected text box fixture to mount with a bare $ trigger"
         )
+        let surfaceID = try XCTUnwrap(fixture["surface_id"] as? String, "Expected fixture surface id")
         _ = try XCTUnwrap(
             socketResult(
                 method: "debug.textbox.interact",
@@ -322,18 +315,25 @@ final class AutomationSocketUITests: XCTestCase {
     }
 
     private func waitForTextBoxFixture(
-        surfaceID: String,
+        surfaceID: String?,
         beforeText: String,
+        completionRootDirectory: String? = nil,
         timeout: TimeInterval
     ) -> [String: Any]? {
         waitForJSON(timeout: timeout) {
+            var params: [String: Any] = [
+                "before_text": beforeText,
+                "after_text": "",
+            ]
+            if let surfaceID {
+                params["surface_id"] = surfaceID
+            }
+            if let completionRootDirectory {
+                params["completion_root_directory"] = completionRootDirectory
+            }
             guard let result = self.socketResult(
                 method: "debug.textbox.inline_fixture",
-                params: [
-                    "surface_id": surfaceID,
-                    "before_text": beforeText,
-                    "after_text": "",
-                ]
+                params: params
             ) else {
                 return nil
             }

--- a/cmuxUITests/AutomationSocketUITests.swift
+++ b/cmuxUITests/AutomationSocketUITests.swift
@@ -10,6 +10,7 @@ final class AutomationSocketUITests: XCTestCase {
     private let legacyKey = "socketControlEnabled"
     private var launchTag = ""
     private var temporaryRoots: [URL] = []
+    private var lastTextBoxFixtureResponse = ""
 
     override func setUp() {
         super.setUp()
@@ -18,6 +19,7 @@ final class AutomationSocketUITests: XCTestCase {
         diagnosticsPath = "/tmp/cmux-ui-test-automation-socket-\(UUID().uuidString).json"
         launchTag = "ui-tests-automation-\(UUID().uuidString.prefix(8))"
         temporaryRoots = []
+        lastTextBoxFixtureResponse = ""
         resetSocketDefaults()
         removeSocketFile()
         try? FileManager.default.removeItem(atPath: diagnosticsPath)
@@ -120,7 +122,7 @@ final class AutomationSocketUITests: XCTestCase {
                 completionRootDirectory: skillRoot.path,
                 timeout: 8.0
             ),
-            "Expected text box fixture to mount with a bare $ trigger"
+            "Expected text box fixture to mount with a bare $ trigger. last=\(lastTextBoxFixtureResponse) diagnostics=\(loadDiagnostics())"
         )
         let surfaceID = try XCTUnwrap(fixture["surface_id"] as? String, "Expected fixture surface id")
         _ = try XCTUnwrap(
@@ -331,10 +333,13 @@ final class AutomationSocketUITests: XCTestCase {
             if let completionRootDirectory {
                 params["completion_root_directory"] = completionRootDirectory
             }
-            guard let result = self.socketResult(
-                method: "debug.textbox.inline_fixture",
-                params: params
-            ) else {
+            guard let envelope = self.socketJSON(method: "debug.textbox.inline_fixture", params: params) else {
+                self.lastTextBoxFixtureResponse = "nil envelope"
+                return nil
+            }
+            self.lastTextBoxFixtureResponse = Self.debugDescription(envelope)
+            guard envelope["ok"] as? Bool == true,
+                  let result = envelope["result"] as? [String: Any] else {
                 return nil
             }
             guard result["text_view_has_window"] as? Bool == true,
@@ -343,6 +348,15 @@ final class AutomationSocketUITests: XCTestCase {
             }
             return result
         }
+    }
+
+    private static func debugDescription(_ value: Any) -> String {
+        guard JSONSerialization.isValidJSONObject(value),
+              let data = try? JSONSerialization.data(withJSONObject: value, options: [.sortedKeys]),
+              let text = String(data: data, encoding: .utf8) else {
+            return String(describing: value)
+        }
+        return text
     }
 
     private func waitForMentionState(

--- a/cmuxUITests/AutomationSocketUITests.swift
+++ b/cmuxUITests/AutomationSocketUITests.swift
@@ -129,7 +129,11 @@ final class AutomationSocketUITests: XCTestCase {
         textBox.typeText("$")
 
         _ = try XCTUnwrap(
-            waitForMentionRows(in: app, textBox: textBox, timeout: 8.0) { rows in
+            waitForMentionRows(
+                in: app,
+                fallbackTitles: ["$agent-browser"],
+                timeout: 8.0
+            ) { rows in
                 rows.contains { $0.contains("$agent-browser") }
             },
             """
@@ -141,7 +145,11 @@ final class AutomationSocketUITests: XCTestCase {
         textBox.typeText("autore")
 
         let typedRows = try XCTUnwrap(
-            waitForMentionRows(in: app, textBox: textBox, timeout: 8.0) { rows in
+            waitForMentionRows(
+                in: app,
+                fallbackTitles: ["$autoreview", "$agent-browser"],
+                timeout: 8.0
+            ) { rows in
                 rows.first?.contains("$autoreview") == true &&
                     !rows.contains { $0.contains("$agent-browser") }
             },
@@ -510,7 +518,10 @@ final class AutomationSocketUITests: XCTestCase {
         }
     }
 
-    private func mentionPopoverRowTitles(in app: XCUIApplication, textBox: XCUIElement? = nil) -> [String] {
+    private func mentionPopoverRowTitles(
+        in app: XCUIApplication,
+        fallbackTitles: [String] = []
+    ) -> [String] {
         let indexedRows = (0..<12).compactMap { index -> String? in
             let row = app.descendants(matching: .any)
                 .matching(identifier: "TextBoxMentionCompletionPopover.Row.\(index)")
@@ -528,45 +539,39 @@ final class AutomationSocketUITests: XCTestCase {
             return indexedRows
         }
 
-        let excludedText = textBox.flatMap { $0.value as? String } ?? ""
-        let predicate = NSPredicate(
-            format: "label BEGINSWITH %@ OR value BEGINSWITH %@",
-            "$",
-            "$"
-        )
-        let visibleMentionTexts = app.descendants(matching: .any)
-            .matching(predicate)
-            .allElementsBoundByIndex
-            .compactMap { element -> String? in
-                guard element.identifier != "TextBoxInput.TextView" else { return nil }
-                let candidates = [element.label, element.value as? String].compactMap { $0 }
-                guard let text = candidates.first(where: { $0.hasPrefix("$") }),
-                      text != excludedText else {
-                    return nil
-                }
-                return text
-            }
-
-        var seen = Set<String>()
-        return visibleMentionTexts.filter { seen.insert($0).inserted }
+        return fallbackTitles.filter { mentionElementExists(in: app, title: $0) }
     }
 
     private func waitForMentionRows(
         in app: XCUIApplication,
-        textBox: XCUIElement,
+        fallbackTitles: [String],
         timeout: TimeInterval,
         predicate: @escaping ([String]) -> Bool
     ) -> [String]? {
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
-            let rows = mentionPopoverRowTitles(in: app, textBox: textBox)
+            let rows = mentionPopoverRowTitles(in: app, fallbackTitles: fallbackTitles)
             if predicate(rows) {
                 return rows
             }
             RunLoop.current.run(until: Date().addingTimeInterval(0.05))
         }
-        let rows = mentionPopoverRowTitles(in: app, textBox: textBox)
+        let rows = mentionPopoverRowTitles(in: app, fallbackTitles: fallbackTitles)
         return predicate(rows) ? rows : nil
+    }
+
+    private func mentionElementExists(in app: XCUIApplication, title: String) -> Bool {
+        if app.staticTexts[title].firstMatch.exists {
+            return true
+        }
+        if app.buttons[title].firstMatch.exists {
+            return true
+        }
+        let predicate = NSPredicate(format: "label == %@ OR value == %@", title, title)
+        return app.descendants(matching: .any)
+            .matching(predicate)
+            .firstMatch
+            .exists
     }
 
     private func mentionPopoverDiagnostics(
@@ -581,7 +586,8 @@ final class AutomationSocketUITests: XCTestCase {
             guard row.exists else { return nil }
             return row.label.isEmpty ? row.value as? String : row.label
         }
-        let rows = mentionPopoverRowTitles(in: app, textBox: textBox)
+        let knownTitles = ["$agent-browser", "$autoreview"]
+        let rows = mentionPopoverRowTitles(in: app, fallbackTitles: knownTitles)
         let popoverExists = app.descendants(matching: .any)
             .matching(identifier: "TextBoxMentionCompletionPopover")
             .firstMatch
@@ -590,11 +596,9 @@ final class AutomationSocketUITests: XCTestCase {
             .matching(identifier: "TextBoxMentionCompletionPopover.Loading")
             .firstMatch
             .exists
-        let mentionDebugLines = app.debugDescription
-            .split(separator: "\n")
-            .filter { $0.contains("TextBoxMentionCompletionPopover") || $0.contains("TextBoxInput.TextView") }
-            .prefix(20)
-            .joined(separator: "\n")
+        let knownTitleStates = knownTitles
+            .map { "\($0)=\(mentionElementExists(in: app, title: $0))" }
+            .joined(separator: ", ")
         return """
         textBoxValue=\(String(describing: textBox.value))
         fixtureRoot=\(fixtureRoot.path)
@@ -603,8 +607,7 @@ final class AutomationSocketUITests: XCTestCase {
         loadingExists=\(loadingExists)
         indexedRows=\(indexedRows)
         visibleMentionTexts=\(rows)
-        axMentions=
-        \(mentionDebugLines)
+        knownTitleStates=\(knownTitleStates)
         """
     }
 

--- a/cmuxUITests/AutomationSocketUITests.swift
+++ b/cmuxUITests/AutomationSocketUITests.swift
@@ -163,6 +163,12 @@ final class AutomationSocketUITests: XCTestCase {
             "Expected bare $ suggestions to include $agent-browser"
         )
         XCTAssertEqual(bareState["plain_text"] as? String, "$")
+        _ = try XCTUnwrap(
+            waitForMentionRows(in: app, timeout: 8.0) { rows in
+                rows.contains { $0.contains("$agent-browser") }
+            },
+            "Expected bare $ popover rows to include $agent-browser. rows=\(mentionPopoverRowTitles(in: app))"
+        )
 
         _ = try XCTUnwrap(
             socketResult(
@@ -187,16 +193,14 @@ final class AutomationSocketUITests: XCTestCase {
 
         let typedTitles = typedState["mention_titles"] as? [String] ?? []
         XCTAssertEqual(typedTitles.first, "$autoreview")
-        XCTAssertTrue(
-            waitForMentionPopoverRow(
-                app: app,
-                index: 0,
-                expectedTitle: "$autoreview",
-                forbiddenTitle: "$agent-browser",
-                timeout: 8.0
-            ),
-            "Expected rendered autocomplete row 0 to show $autoreview and not stale $agent-browser"
+        let typedRows = try XCTUnwrap(
+            waitForMentionRows(in: app, timeout: 8.0) { rows in
+                rows.first?.contains("$autoreview") == true &&
+                    !rows.contains { $0.contains("$agent-browser") }
+            },
+            "Expected visible popover rows for $autore to hide stale $agent-browser. rows=\(mentionPopoverRowTitles(in: app)) state=\(typedState)"
         )
+        XCTAssertTrue(typedRows.first?.contains("$autoreview") == true)
     }
 
     private func configuredApp(mode: String) -> XCUIApplication {
@@ -409,35 +413,6 @@ final class AutomationSocketUITests: XCTestCase {
         return text
     }
 
-    private func waitForMentionPopoverRow(
-        app: XCUIApplication,
-        index: Int,
-        expectedTitle: String,
-        forbiddenTitle: String,
-        timeout: TimeInterval
-    ) -> Bool {
-        let row = app.descendants(matching: .any)
-            .matching(identifier: "TextBoxMentionCompletionPopover.Row.\(index)")
-            .firstMatch
-        let deadline = Date().addingTimeInterval(timeout)
-        while Date() < deadline {
-            if row.exists {
-                let renderedValue = row.value.map { String(describing: $0) } ?? ""
-                let renderedText = [
-                    row.label,
-                    renderedValue,
-                ]
-                .joined(separator: " ")
-                if renderedText.contains(expectedTitle),
-                   !renderedText.contains(forbiddenTitle) {
-                    return true
-                }
-            }
-            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
-        }
-        return false
-    }
-
     private func waitForMentionState(
         surfaceID: String,
         timeout: TimeInterval,
@@ -453,6 +428,39 @@ final class AutomationSocketUITests: XCTestCase {
             }
             return predicate(state) ? state : nil
         }
+    }
+
+    private func mentionPopoverRowTitles(in app: XCUIApplication) -> [String] {
+        (0..<12).compactMap { index in
+            let row = app.descendants(matching: .any)
+                .matching(identifier: "TextBoxMentionCompletionPopover.Row.\(index)")
+                .firstMatch
+            guard row.exists else { return nil }
+            if !row.label.isEmpty {
+                return row.label
+            }
+            if let value = row.value as? String, !value.isEmpty {
+                return value
+            }
+            return nil
+        }
+    }
+
+    private func waitForMentionRows(
+        in app: XCUIApplication,
+        timeout: TimeInterval,
+        predicate: @escaping ([String]) -> Bool
+    ) -> [String]? {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            let rows = mentionPopoverRowTitles(in: app)
+            if predicate(rows) {
+                return rows
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        }
+        let rows = mentionPopoverRowTitles(in: app)
+        return predicate(rows) ? rows : nil
     }
 
     private func waitForJSON(

--- a/cmuxUITests/AutomationSocketUITests.swift
+++ b/cmuxUITests/AutomationSocketUITests.swift
@@ -349,8 +349,11 @@ final class AutomationSocketUITests: XCTestCase {
         return XCTWaiter().wait(for: [expectation], timeout: timeout) == .completed
     }
 
-    private func socketCommand(_ command: String) -> String? {
-        ControlSocketClient(path: socketPath, responseTimeout: 1.0).sendLine(command)
+    private func socketCommand(_ command: String, responseTimeout: TimeInterval = 1.0) -> String? {
+        if let response = ControlSocketClient(path: socketPath, responseTimeout: responseTimeout).sendLine(command) {
+            return response
+        }
+        return socketCommandViaNetcat(command, responseTimeout: responseTimeout)
     }
 
     private func socketJSON(method: String, params: [String: Any]) -> [String: Any]? {
@@ -359,7 +362,49 @@ final class AutomationSocketUITests: XCTestCase {
             "method": method,
             "params": params,
         ]
-        return ControlSocketClient(path: socketPath, responseTimeout: 2.0).sendJSON(request)
+        guard JSONSerialization.isValidJSONObject(request),
+              let data = try? JSONSerialization.data(withJSONObject: request),
+              let line = String(data: data, encoding: .utf8),
+              let response = socketCommand(line, responseTimeout: 2.0),
+              let responseData = response.data(using: .utf8) else {
+            return nil
+        }
+        return (try? JSONSerialization.jsonObject(with: responseData)) as? [String: Any]
+    }
+
+    private func socketCommandViaNetcat(_ command: String, responseTimeout: TimeInterval) -> String? {
+        let nc = "/usr/bin/nc"
+        guard FileManager.default.isExecutableFile(atPath: nc) else { return nil }
+
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/bin/sh")
+        let timeoutSeconds = max(1, Int(ceil(responseTimeout)))
+        let script = "printf '%s\\n' \(shellSingleQuote(command)) | \(nc) -U \(shellSingleQuote(socketPath)) -w \(timeoutSeconds) 2>/dev/null"
+        proc.arguments = ["-lc", script]
+
+        let outPipe = Pipe()
+        proc.standardOutput = outPipe
+
+        do {
+            try proc.run()
+        } catch {
+            return nil
+        }
+
+        proc.waitUntilExit()
+
+        let outData = outPipe.fileHandleForReading.readDataToEndOfFile()
+        guard let outStr = String(data: outData, encoding: .utf8) else { return nil }
+        if let first = outStr.split(separator: "\n", maxSplits: 1).first {
+            return String(first).trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        let trimmed = outStr.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private func shellSingleQuote(_ value: String) -> String {
+        if value.isEmpty { return "''" }
+        return "'" + value.replacingOccurrences(of: "'", with: "'\"'\"'") + "'"
     }
 
     private func socketResult(method: String, params: [String: Any]) -> [String: Any]? {

--- a/cmuxUITests/AutomationSocketUITests.swift
+++ b/cmuxUITests/AutomationSocketUITests.swift
@@ -233,6 +233,18 @@ final class AutomationSocketUITests: XCTestCase {
         if let resolvedPath {
             socketPath = resolvedPath
         }
+        if completed {
+            return true
+        }
+        let diagnostics = loadDiagnostics()
+        if diagnostics["socketReady"] == "1",
+           diagnostics["socketPingResponse"] == "PONG",
+           let expectedPath = diagnostics["socketExpectedPath"],
+           !expectedPath.isEmpty,
+           FileManager.default.fileExists(atPath: expectedPath) {
+            socketPath = expectedPath
+            return true
+        }
         return completed
     }
 

--- a/cmuxUITests/AutomationSocketUITests.swift
+++ b/cmuxUITests/AutomationSocketUITests.swift
@@ -93,6 +93,9 @@ final class AutomationSocketUITests: XCTestCase {
             skillNames: [
                 "agent-browser",
                 "agent-cli-integration",
+                "auto-issue",
+                "auto-merge",
+                "autoreview",
                 "iterate-pr",
             ]
         )
@@ -146,23 +149,23 @@ final class AutomationSocketUITests: XCTestCase {
         )
         XCTAssertEqual(bareState["plain_text"] as? String, "$")
 
-        app.typeText("iterate")
+        app.typeText("autore")
 
         let typedState = try XCTUnwrap(
             waitForMentionState(surfaceID: surfaceID, timeout: 8.0) { state in
                 let titles = state["mention_titles"] as? [String] ?? []
-                return state["plain_text"] as? String == "$iterate" &&
+                return state["plain_text"] as? String == "$autore" &&
                     state["mention_trigger"] as? String == "$" &&
-                    state["mention_query"] as? String == "iterate" &&
+                    state["mention_query"] as? String == "autore" &&
                     state["mention_current"] as? Bool == true &&
-                    titles.contains("$iterate-pr") &&
+                    titles.contains("$autoreview") &&
                     !titles.contains("$agent-browser")
             },
-            "Expected typing iterate after bare $ to filter stale $agent-browser and show $iterate-pr"
+            "Expected typing autore after bare $ to filter stale $agent-browser and show $autoreview"
         )
 
         let typedTitles = typedState["mention_titles"] as? [String] ?? []
-        XCTAssertEqual(typedTitles.first, "$iterate-pr")
+        XCTAssertEqual(typedTitles.first, "$autoreview")
     }
 
     private func configuredApp(mode: String) -> XCUIApplication {

--- a/cmuxUITests/AutomationSocketUITests.swift
+++ b/cmuxUITests/AutomationSocketUITests.swift
@@ -112,6 +112,10 @@ final class AutomationSocketUITests: XCTestCase {
             waitForSocketPong(timeout: 12.0),
             "Expected socket ping at \(socketPath). diagnostics=\(loadDiagnostics())"
         )
+        _ = try XCTUnwrap(
+            waitForSocketResult(method: "workspace.list", params: [:], timeout: 8.0),
+            "Expected workspace API to be ready before creating textbox fixture workspace"
+        )
 
         let workspace = try XCTUnwrap(
             socketResult(
@@ -313,6 +317,16 @@ final class AutomationSocketUITests: XCTestCase {
             return nil
         }
         return envelope["result"] as? [String: Any]
+    }
+
+    private func waitForSocketResult(
+        method: String,
+        params: [String: Any],
+        timeout: TimeInterval
+    ) -> [String: Any]? {
+        waitForJSON(timeout: timeout) {
+            self.socketResult(method: method, params: params)
+        }
     }
 
     private func waitForTextBoxFixture(

--- a/cmuxUITests/AutomationSocketUITests.swift
+++ b/cmuxUITests/AutomationSocketUITests.swift
@@ -95,7 +95,7 @@ final class AutomationSocketUITests: XCTestCase {
     }
 
     func testTextBoxSkillMentionFiltersWhenTypingAfterBareDollarTrigger() throws {
-        let skillRoot = try makeSkillFixtureRoot(
+        _ = try makeSkillFixtureRoot(
             skillNames: [
                 "agent-browser",
                 "agent-cli-integration",
@@ -108,61 +108,26 @@ final class AutomationSocketUITests: XCTestCase {
         let app = XCUIApplication()
         configureTextBoxMentionLaunchEnvironment(app)
         defer { app.terminate() }
-        launchAllowingBackgroundActivation(app)
+        app.launch()
 
         XCTAssertTrue(
-            waitForRunningApp(app, timeout: 12.0),
+            ensureForegroundAfterLaunch(app, timeout: 12.0),
             "Expected app to launch for textbox mention test. state=\(app.state.rawValue)"
         )
-        XCTAssertTrue(
-            waitForSocketPong(timeout: 12.0),
-            "Expected socket ping at \(socketPath). diagnostics=\(loadDiagnostics())"
-        )
 
-        let windowContext = waitForMainWindowContext(timeout: 12.0)
-        let workspace = createTextBoxFixtureWorkspace(
-            windowID: windowContext?.windowID,
-            workingDirectory: skillRoot.path
-        )
-        let createdSurfaceID = workspace?["surface_id"] as? String
-
-        let fixture = try XCTUnwrap(
-            waitForTextBoxFixture(
-                surfaceID: createdSurfaceID,
-                beforeText: "$",
-                completionRootDirectory: skillRoot.path,
-                timeout: 8.0
-            ),
-            """
-            Expected text box fixture to mount with a bare $ trigger.
-            window=\(lastMainWindowContextResponse)
-            workspace=\(lastWorkspaceCreateResponse)
-            fixture=\(lastTextBoxFixtureResponse)
-            diagnostics=\(loadDiagnostics())
-            """
-        )
-        let surfaceID = try XCTUnwrap(fixture["surface_id"] as? String, "Expected fixture surface id")
-        if let createdSurfaceID {
-            XCTAssertEqual(surfaceID, createdSurfaceID)
+        let textBox = app.textViews["TextBoxInput.TextView"].firstMatch
+        if !textBox.waitForExistence(timeout: 6.0) {
+            app.typeKey("n", modifierFlags: [.command])
         }
-        _ = try XCTUnwrap(
-            socketResult(
-                method: "debug.textbox.interact",
-                params: ["surface_id": surfaceID, "action": "focus"]
-            ),
-            "Expected text box focus to succeed"
+        XCTAssertTrue(
+            textBox.waitForExistence(timeout: 12.0),
+            "Expected focused terminal textbox to exist"
         )
+        textBox.click()
+        app.typeKey("a", modifierFlags: [.command])
+        app.typeKey(XCUIKeyboardKey.delete.rawValue, modifierFlags: [])
+        textBox.typeText("$")
 
-        let bareState = try XCTUnwrap(
-            waitForMentionState(surfaceID: surfaceID, timeout: 8.0) { state in
-                let titles = state["mention_titles"] as? [String] ?? []
-                return state["mention_trigger"] as? String == "$" &&
-                    state["mention_query"] as? String == "" &&
-                    titles.contains("$agent-browser")
-            },
-            "Expected bare $ suggestions to include $agent-browser"
-        )
-        XCTAssertEqual(bareState["plain_text"] as? String, "$")
         _ = try XCTUnwrap(
             waitForMentionRows(in: app, timeout: 8.0) { rows in
                 rows.contains { $0.contains("$agent-browser") }
@@ -170,35 +135,14 @@ final class AutomationSocketUITests: XCTestCase {
             "Expected bare $ popover rows to include $agent-browser. rows=\(mentionPopoverRowTitles(in: app))"
         )
 
-        _ = try XCTUnwrap(
-            socketResult(
-                method: "debug.textbox.interact",
-                params: ["surface_id": surfaceID, "action": "insert_text:autore"]
-            ),
-            "Expected textbox debug insert to succeed"
-        )
+        textBox.typeText("autore")
 
-        let typedState = try XCTUnwrap(
-            waitForMentionState(surfaceID: surfaceID, timeout: 8.0) { state in
-                let titles = state["mention_titles"] as? [String] ?? []
-                return state["plain_text"] as? String == "$autore" &&
-                    state["mention_trigger"] as? String == "$" &&
-                    state["mention_query"] as? String == "autore" &&
-                    state["mention_current"] as? Bool == true &&
-                    titles.contains("$autoreview") &&
-                    !titles.contains("$agent-browser")
-            },
-            "Expected typing autore after bare $ to filter stale $agent-browser and show $autoreview"
-        )
-
-        let typedTitles = typedState["mention_titles"] as? [String] ?? []
-        XCTAssertEqual(typedTitles.first, "$autoreview")
         let typedRows = try XCTUnwrap(
             waitForMentionRows(in: app, timeout: 8.0) { rows in
                 rows.first?.contains("$autoreview") == true &&
                     !rows.contains { $0.contains("$agent-browser") }
             },
-            "Expected visible popover rows for $autore to hide stale $agent-browser. rows=\(mentionPopoverRowTitles(in: app)) state=\(typedState)"
+            "Expected visible popover rows for $autore to hide stale $agent-browser. rows=\(mentionPopoverRowTitles(in: app))"
         )
         XCTAssertTrue(typedRows.first?.contains("$autoreview") == true)
     }
@@ -217,17 +161,12 @@ final class AutomationSocketUITests: XCTestCase {
 
     private func configureTextBoxMentionLaunchEnvironment(_ app: XCUIApplication) {
         app.launchArguments += [
-            "-\(modeKey)", "allowAll",
+            "-terminal.showTextBoxOnNewTerminals", "1",
+            "-terminal.focusTextBoxOnNewTerminals", "1",
             "-AppleLanguages", "(en)",
             "-AppleLocale", "en_US",
         ]
         app.launchEnvironment["CMUX_UI_TEST_MODE"] = "1"
-        app.launchEnvironment["CMUX_SOCKET_ENABLE"] = "1"
-        app.launchEnvironment["CMUX_SOCKET_MODE"] = "allowAll"
-        app.launchEnvironment["CMUX_SOCKET_PATH"] = socketPath
-        app.launchEnvironment["CMUX_ALLOW_SOCKET_OVERRIDE"] = "1"
-        app.launchEnvironment["CMUX_UI_TEST_SOCKET_SANITY"] = "1"
-        app.launchEnvironment["CMUX_UI_TEST_DIAGNOSTICS_PATH"] = diagnosticsPath
         app.launchEnvironment["CMUX_TAG"] = launchTag
         if let path = ProcessInfo.processInfo.environment["PATH"], !path.isEmpty {
             app.launchEnvironment["PATH"] = path
@@ -614,12 +553,12 @@ final class AutomationSocketUITests: XCTestCase {
     }
 
     private func makeSkillFixtureRoot(skillNames: [String]) throws -> URL {
-        let root = FileManager.default.temporaryDirectory
+        let root = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".codex/skills", isDirectory: true)
             .appendingPathComponent("cmux-ui-textbox-skills-\(UUID().uuidString)", isDirectory: true)
-        let skills = root.appendingPathComponent("skills", isDirectory: true)
-        try FileManager.default.createDirectory(at: skills, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         for skillName in skillNames {
-            let skillDirectory = skills.appendingPathComponent(skillName, isDirectory: true)
+            let skillDirectory = root.appendingPathComponent(skillName, isDirectory: true)
             try FileManager.default.createDirectory(at: skillDirectory, withIntermediateDirectories: true)
             let contents = """
             ---

--- a/cmuxUITests/AutomationSocketUITests.swift
+++ b/cmuxUITests/AutomationSocketUITests.swift
@@ -95,7 +95,7 @@ final class AutomationSocketUITests: XCTestCase {
     }
 
     func testTextBoxSkillMentionFiltersWhenTypingAfterBareDollarTrigger() throws {
-        _ = try makeSkillFixtureRoot(
+        let fixtureRoot = try makeSkillFixtureRoot(
             skillNames: [
                 "agent-browser",
                 "agent-cli-integration",
@@ -129,20 +129,26 @@ final class AutomationSocketUITests: XCTestCase {
         textBox.typeText("$")
 
         _ = try XCTUnwrap(
-            waitForMentionRows(in: app, timeout: 8.0) { rows in
+            waitForMentionRows(in: app, textBox: textBox, timeout: 8.0) { rows in
                 rows.contains { $0.contains("$agent-browser") }
             },
-            "Expected bare $ popover rows to include $agent-browser. rows=\(mentionPopoverRowTitles(in: app))"
+            """
+            Expected bare $ popover rows to include $agent-browser.
+            \(mentionPopoverDiagnostics(in: app, textBox: textBox, fixtureRoot: fixtureRoot))
+            """
         )
 
         textBox.typeText("autore")
 
         let typedRows = try XCTUnwrap(
-            waitForMentionRows(in: app, timeout: 8.0) { rows in
+            waitForMentionRows(in: app, textBox: textBox, timeout: 8.0) { rows in
                 rows.first?.contains("$autoreview") == true &&
                     !rows.contains { $0.contains("$agent-browser") }
             },
-            "Expected visible popover rows for $autore to hide stale $agent-browser. rows=\(mentionPopoverRowTitles(in: app))"
+            """
+            Expected visible popover rows for $autore to hide stale $agent-browser.
+            \(mentionPopoverDiagnostics(in: app, textBox: textBox, fixtureRoot: fixtureRoot))
+            """
         )
         XCTAssertTrue(typedRows.first?.contains("$autoreview") == true)
     }
@@ -504,8 +510,8 @@ final class AutomationSocketUITests: XCTestCase {
         }
     }
 
-    private func mentionPopoverRowTitles(in app: XCUIApplication) -> [String] {
-        (0..<12).compactMap { index in
+    private func mentionPopoverRowTitles(in app: XCUIApplication, textBox: XCUIElement? = nil) -> [String] {
+        let indexedRows = (0..<12).compactMap { index in
             let row = app.descendants(matching: .any)
                 .matching(identifier: "TextBoxMentionCompletionPopover.Row.\(index)")
                 .firstMatch
@@ -518,23 +524,88 @@ final class AutomationSocketUITests: XCTestCase {
             }
             return nil
         }
+        if !indexedRows.isEmpty {
+            return indexedRows
+        }
+
+        let excludedText = textBox.flatMap { $0.value as? String } ?? ""
+        let predicate = NSPredicate(
+            format: "label BEGINSWITH %@ OR value BEGINSWITH %@",
+            "$",
+            "$"
+        )
+        let visibleMentionTexts = app.descendants(matching: .any)
+            .matching(predicate)
+            .allElementsBoundByIndex
+            .compactMap { element -> String? in
+                guard element.identifier != "TextBoxInput.TextView" else { return nil }
+                let candidates = [element.label, element.value as? String].compactMap { $0 }
+                guard let text = candidates.first(where: { $0.hasPrefix("$") }),
+                      text != excludedText else {
+                    return nil
+                }
+                return text
+            }
+
+        var seen = Set<String>()
+        return visibleMentionTexts.filter { seen.insert($0).inserted }
     }
 
     private func waitForMentionRows(
         in app: XCUIApplication,
+        textBox: XCUIElement,
         timeout: TimeInterval,
         predicate: @escaping ([String]) -> Bool
     ) -> [String]? {
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
-            let rows = mentionPopoverRowTitles(in: app)
+            let rows = mentionPopoverRowTitles(in: app, textBox: textBox)
             if predicate(rows) {
                 return rows
             }
             RunLoop.current.run(until: Date().addingTimeInterval(0.05))
         }
-        let rows = mentionPopoverRowTitles(in: app)
+        let rows = mentionPopoverRowTitles(in: app, textBox: textBox)
         return predicate(rows) ? rows : nil
+    }
+
+    private func mentionPopoverDiagnostics(
+        in app: XCUIApplication,
+        textBox: XCUIElement,
+        fixtureRoot: URL
+    ) -> String {
+        let indexedRows = (0..<12).compactMap { index -> String? in
+            let row = app.descendants(matching: .any)
+                .matching(identifier: "TextBoxMentionCompletionPopover.Row.\(index)")
+                .firstMatch
+            guard row.exists else { return nil }
+            return row.label.isEmpty ? row.value as? String : row.label
+        }
+        let rows = mentionPopoverRowTitles(in: app, textBox: textBox)
+        let popoverExists = app.descendants(matching: .any)
+            .matching(identifier: "TextBoxMentionCompletionPopover")
+            .firstMatch
+            .exists
+        let loadingExists = app.descendants(matching: .any)
+            .matching(identifier: "TextBoxMentionCompletionPopover.Loading")
+            .firstMatch
+            .exists
+        let mentionDebugLines = app.debugDescription
+            .split(separator: "\n")
+            .filter { $0.contains("TextBoxMentionCompletionPopover") || $0.contains("TextBoxInput.TextView") }
+            .prefix(20)
+            .joined(separator: "\n")
+        return """
+        textBoxValue=\(String(describing: textBox.value))
+        fixtureRoot=\(fixtureRoot.path)
+        fixtureRootExists=\(FileManager.default.fileExists(atPath: fixtureRoot.path))
+        popoverExists=\(popoverExists)
+        loadingExists=\(loadingExists)
+        indexedRows=\(indexedRows)
+        visibleMentionTexts=\(rows)
+        axMentions=
+        \(mentionDebugLines)
+        """
     }
 
     private func waitForJSON(


### PR DESCRIPTION
Fixes the stale autocomplete popover rows seen after typing from a bare `$` trigger into a longer skill query like `$autore`.

Changes:
- Hide non-current mention suggestions from the popover and debug socket while the active query is refreshing.
- Refresh mention state after external SwiftUI text synchronization updates the NSTextView string.
- Add regression coverage for non-current visible rows, `$autore` skill filtering, and the focused XCUITest path.

Verification:
- GitHub Actions unit run: https://github.com/manaflow-ai/cmux/actions/runs/27005793197
- GitHub Actions UI run: https://github.com/manaflow-ai/cmux/actions/runs/27005793169
- Tagged reload pending: http://127.0.0.1:17320/tbac

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5450"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783242166&installation_id=133855650&pr_number=5450&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5450&signature=1df0acc0eb02e0ed40b8a72991cd979dd4ed486e4a5efc7b106ce1dfbd27fbda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches TextBox input, mention keyboard handling, and popover rendering—user-visible editing behavior—but changes are scoped to completion UX with broad regression tests rather than auth or data paths.
> 
> **Overview**
> Fixes **stale TextBox mention autocomplete** after typing past a bare `$` trigger (e.g. `$autore` still showing `$agent-browser`).
> 
> The mention controller now drives the popover from **`TextBoxMentionCompletionRenderState`**: only **visible** rows (current index results or locally filtered stale rows while loading) are shown; **acceptance** waits until suggestions match the active query. Return/Tab are **consumed** when visible rows exist but results are still refreshing so they do not submit the text box.
> 
> **`TextBoxInput`** refreshes completions after SwiftUI→AppKit text sync (with caret preservation), `insertText`, and key paths without marked text; syncs query before showing the popover; adds accessibility IDs and localized “selected %@” for popover rows.
> 
> **Debug/UI tests:** `completion_root_directory` on inline fixtures, smarter terminal panel resolution, XCUITest types into the real text field and asserts popover rows via accessibility identifiers; expanded unit coverage for filtered visible rows and blocked acceptance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 498a1100097426ec0794afb66695ba25528e7e52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale TextBox mention autocomplete by showing only rows for the current query, keeping locally filtered matches while results load, and blocking acceptance until results are current. The popover now renders from a single, stable render state with identity to avoid stale reuse, reduce flicker, and improve accessibility.

- **Bug Fixes**
  - Drive popover, keyboard, and selection from visible suggestions; show a loading row; consume Return/Tab while rows refresh; accept only when results are current.
  - Keep mention state in sync after SwiftUI→AppKit text sync, `didChangeText`, `insertText`, key handling without marked text, and a debug `insert_text:` action.
  - Render from a `TextBoxMentionCompletionRenderState` with per-render identity; add accessibility IDs for `TextBoxInput.TextView`, the popover, rows, and loading; localize “selected %@”; add a DEBUG popover accessibility value; ensure host/panel layout and display update.
  - Stabilize debug fixtures: support `completion_root_directory`; choose a visible terminal when no `surface_id`; keep mobile terminals in `orderedPanels` layout order.

- **Tests**
  - UI: type in the real text view; assert popover rows via accessibility identifiers/values; verify rows stay filtered while results load and Return/Tab don’t fall through; allow background launches; place skill fixtures under app container HOME via `CFFIXED_USER_HOME`; socket client uses `poll()` with a `netcat` fallback; narrower popover probes and diagnostics.
  - Units: split visible vs stored counts; prove filtered render state publishes before async lookup; cover `$autore` filtering, insert‑text refresh, keeping matching visible rows while queries refresh, and blocking acceptance until results are current.

<sup>Written for commit 498a1100097426ec0794afb66695ba25528e7e52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Mention popover now refreshes after programmatic text updates, displays only currently relevant suggestions, and prevents accepting stale entries; keyboard navigation and selection respect visible suggestions.

* **Tests**
  * Updated mention-completion and UI automation tests to assert visible-row behavior and a revised mention-filtering scenario; UI tests include a more robust socket readiness check.

* **Chores**
  * Added a DEBUG helper to report visible suggestion counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->