### PR TITLE
Restore menu bar icon dropdown menu on click

### DIFF
--- a/Sources/App/MenuBarExtraController.swift
+++ b/Sources/App/MenuBarExtraController.swift
@@ -62,14 +62,12 @@ final class MenuBarExtraController: NSObject, NSMenuDelegate {
         super.init()
 
         buildMenu()
+        statusItem.menu = menu
         if let button = statusItem.button {
             button.imagePosition = .imageOnly
             button.imageScaling = .scaleProportionallyDown
             button.image = MenuBarIconRenderer.makeImage(unreadCount: 0)
             button.toolTip = "cmux"
-            button.target = self
-            button.action = #selector(statusItemButtonAction(_:))
-            button.sendAction(on: [.leftMouseUp, .rightMouseUp])
         }
 
         notificationMenuSnapshotCancellable = notificationStore.$notificationMenuSnapshot
@@ -239,21 +237,6 @@ final class MenuBarExtraController: NSObject, NSMenuDelegate {
     @objc private func openNotificationItemAction(_ sender: NSMenuItem) {
         guard let payload = sender.representedObject as? NotificationMenuItemPayload else { return }
         onOpenNotification(payload.notification)
-    }
-
-    @objc private func statusItemButtonAction(_ sender: NSStatusBarButton) {
-        guard let event = NSApp.currentEvent else {
-            onShowGlobalSearch(sender, nil)
-            return
-        }
-
-        let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-        if event.type == .rightMouseUp || flags.contains(.control) {
-            refreshUI()
-            menu.popUp(positioning: nil, at: NSPoint(x: 0, y: sender.bounds.height), in: sender)
-        } else {
-            onShowGlobalSearch(sender, nil)
-        }
     }
 
     @discardableResult


### PR DESCRIPTION
## Summary
- Restore the cmux menu bar status item to standard behavior: clicking the icon shows the dropdown menu again (No unread / Show cmux / Task Manager / Notifications / Check for Updates / Preferences / Quit).
- Reverts the click change from https://github.com/manaflow-ai/cmux/pull/3908, which made a left-click open the 720×460 global search popover and only showed the menu on right/control-click.
- Global search is unchanged and still reachable via the "Search All Windows…" menu item and its keyboard shortcut. Only the status-item click routing is reverted (re-add `statusItem.menu = menu`, drop the custom button `target`/`action`/`sendAction` and the now-unused `statusItemButtonAction`). Native status-item press highlight is restored as a bonus.

## Testing
- `./scripts/reload-cloud.sh --tag menubar-menu` — builds clean.
- No automated test added: the revert removes the only routing logic worth testing; what remains is pure AppKit menu delegation (`statusItem.menu`). A status-item XCUITest is flaky and high-effort for this, so per the repo's test-quality policy I'm relying on the dogfood build instead.

## Localization
- No user-facing strings added or changed; the "Search All Windows…" item already existed and is untouched. No catalog changes needed.

## Issues
- Task: revert the cmux menu bar extra icon back to the normal dropdown-menu-on-click behavior (regressed by https://github.com/manaflow-ai/cmux/pull/3908).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5451"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783242253&installation_id=133855650&pr_number=5451&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5451&signature=49169884b94bd4d87e3ca0cb82f8d81764ff184c2ffe7a3fd1a85705e8720f8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 682a9ad9fec2f056b8ae982bd29e83c4c969c32c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore the menu bar icon to its normal behavior: clicking the cmux status item now opens the dropdown menu. Global search is unchanged and still available via “Search All Windows…” and its shortcut.

- **Bug Fixes**
  - Re-added `statusItem.menu = menu` to let AppKit handle clicks.
  - Removed custom button target/action and `statusItemButtonAction`.
  - Restores native press highlight on the status item.

<sup>Written for commit 682a9ad9fec2f056b8ae982bd29e83c4c969c32c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Menu bar extra now uses standard macOS menu behavior for improved system integration and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->