### PR TITLE
ci: publish iOS TestFlight on iOS-affecting merges to main

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -1,6 +1,22 @@
 name: iOS TestFlight (beta)
 
 on:
+  # Publish to the beta lane on every iOS-affecting merge to main, so testers get
+  # changes immediately instead of waiting for the nightly. Path-filtered to the
+  # inputs that actually change the iOS app (the iOS target, the linked Swift
+  # packages, and GhosttyKit); macOS-only Sources/ changes don't rebuild the iOS
+  # app, so they don't trigger an upload. Push runs always build (the SHA gate is
+  # schedule-only); each merge is a new commit, so there's no duplicate upload.
+  push:
+    branches: [main]
+    paths:
+      - "ios/**"
+      - "Packages/**"
+      - "ghostty"
+      - "scripts/ensure-ghosttykit.sh"
+      - "scripts/install-zig-ci.sh"
+      - "scripts/ghosttykit-checksums.txt"
+      - ".github/workflows/ios-testflight.yml"
   workflow_dispatch:
     inputs:
       build_number:


### PR DESCRIPTION
Follow-up to #5448. Adds a `push: branches:[main]` trigger to the iOS TestFlight workflow so iOS changes merged to main publish to the **beta lane** (`dev.cmux.app.beta`) immediately, rather than waiting for the nightly.

- **Path-filtered** to inputs that actually rebuild the iOS app: `ios/**`, `Packages/**`, `ghostty` (GhosttyKit), the GhosttyKit fetch scripts, and the workflow itself. macOS-only `Sources/**` changes don't change the iOS app, so they don't trigger an upload.
- The **nightly + manual dispatch** stay. Push runs always build (the dedup SHA gate is schedule-only); each merge is a distinct commit so there are no duplicate uploads, and the concurrency group queues (never cancels) so no upload is lost.
- Lane note: the iOS TestFlight lane is **beta** (`dev.cmux.app.beta`, internal). "Nightly" was only the cron cadence; the macOS "nightly" app is unrelated.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5453"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783243674&installation_id=133855650&pr_number=5453&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5453&signature=5d250d81d3529721208237520a8820561a72f52137e8a49551324130d0ff1b44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 515ae2bf362b7138c93b2a51c913a07a66caaf9d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes iOS TestFlight beta (lane `dev.cmux.app.beta`) on merges to `main` that affect the iOS app, so testers get builds immediately instead of waiting for the nightly. The new `push` trigger is path-filtered to `ios/**`, `Packages/**`, `ghostty`, GhosttyKit scripts, and `.github/workflows/ios-testflight.yml`; nightly and manual dispatch remain unchanged.

<sup>Written for commit 515ae2bf362b7138c93b2a51c913a07a66caaf9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5453?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized iOS TestFlight beta release workflow to trigger automatically only on main branch merges when iOS-relevant files or dependencies change, while preserving manual dispatch and scheduled nightly build options for deployment flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->