### PR TITLE
Fix #5321: own the Settings window lifecycle in AppKit so closing keeps it closed

### DIFF
--- a/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Scene/SettingsWindowScene.swift
+++ b/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Scene/SettingsWindowScene.swift
@@ -48,17 +48,20 @@ public struct SettingsWindowRoot: View {
     // because under search the user can click an individual setting
     // hit and we still want the section pane to follow, but two
     // sibling hits inside one section must each be selectable.
-    @SceneStorage("selectedSettingsSection") private var selectedSectionRaw: String = SettingsSectionID.account.rawValue
-    @SceneStorage("selectedSettingsSidebarEntry") private var selectedSidebarEntryID: String = "section:\(SettingsSectionID.account.rawValue)"
-    // Legacy `SettingsRootView` binds `NavigationSplitView`'s
-    // `columnVisibility` so the user can collapse the sidebar via the
-    // toolbar button (or the SidebarCommands menu) and have that state
-    // persist for the lifetime of the window. Without a binding,
-    // `NavigationSplitView` is locked to whatever its initial layout
-    // resolved to, which makes the chevron toggle a no-op in the
-    // package window. Keep this in @State (not @SceneStorage) because
-    // legacy stores it on the transient `SettingsDraftState`, not in
-    // SceneStorage.
+    //
+    // These use @AppStorage, not @SceneStorage: the legacy window kept
+    // them in scene storage, but a cmux-owned AppKit window
+    // (`CmuxHostedWindowController`) is not a SwiftUI scene, so
+    // @SceneStorage would not round-trip — reopening Settings would
+    // always reset to Account. @AppStorage persists the last-viewed
+    // section across reopens (and launches), matching what the scene
+    // window felt like.
+    @AppStorage("selectedSettingsSection") private var selectedSectionRaw: String = SettingsSectionID.account.rawValue
+    @AppStorage("selectedSettingsSidebarEntry") private var selectedSidebarEntryID: String = "section:\(SettingsSectionID.account.rawValue)"
+    // Binds `NavigationSplitView`'s `columnVisibility`. The sidebar
+    // stays open (`.all`): see the `.toolbar(removing:)` note in ``body``
+    // for why the hosted window ships without a collapse toggle. Kept as
+    // bindable @State so a future host-owned toolbar toggle can drive it.
     @State private var columnVisibility: NavigationSplitViewVisibility = .all
     // Mirrors legacy SettingsView.settingsNavigationGeneration. When
     // multiple navigation requests fire in quick succession (e.g. the
@@ -126,6 +129,20 @@ public struct SettingsWindowRoot: View {
             detailScroll
         }
         .navigationSplitViewStyle(.balanced)
+        // Remove the system-provided sidebar toggle: the sidebar stays
+        // open, like macOS System Settings. `NavigationSplitView`'s
+        // built-in toolbar toggle dispatches AppKit's `toggleSidebar:`
+        // through SwiftUI's own handler, which blanks the whole window
+        // when the view is hosted in a cmux-owned AppKit window
+        // (`CmuxHostedWindowController`, for issue #5321) instead of a
+        // `Window` scene. A binding-driven collapse renders fine when
+        // hosted, but a *replacement* SwiftUI `.toolbar` item bridges into
+        // the hosted `NSHostingController` toolbar lazily (it doesn't
+        // appear until the first `columnVisibility` change), so there is
+        // no eager in-toolbar control to drive it. Restoring a collapse
+        // toggle here needs a native `NSToolbarItem` on the host driving a
+        // shared visibility model — tracked as a follow-up.
+        .toolbar(removing: .sidebarToggle)
         // Inject the built search index so each SettingsCardRow can map
         // its declared cmux.json paths to scroll/highlight anchor ids,
         // and publish the active highlight so the matching row pulses.

--- a/Sources/App/CmuxHostedWindowController.swift
+++ b/Sources/App/CmuxHostedWindowController.swift
@@ -67,6 +67,14 @@ final class CmuxHostedWindowController: NSWindowController, NSWindowDelegate {
     }
 
     func windowWillClose(_ notification: Notification) {
+        // `sceneBridgingOptions` makes the NSHostingController reference its
+        // window (to drive the bridged toolbar), and the window references the
+        // hosting controller as its content, a retain cycle that keeps the
+        // window in the window list after close (AltTab could resurrect it,
+        // issue #5321). Break it on close so the window deallocates and leaves
+        // the window list.
+        window?.toolbar = nil
+        window?.contentViewController = nil
         onWindowWillClose()
     }
 }

--- a/Sources/App/CmuxHostedWindowController.swift
+++ b/Sources/App/CmuxHostedWindowController.swift
@@ -1,0 +1,72 @@
+import AppKit
+import SwiftUI
+
+/// A cmux-owned auxiliary window that hosts SwiftUI content in a plain AppKit
+/// `NSWindow`.
+///
+/// Unlike a SwiftUI `Window` / `WindowGroup` scene (which keeps the backing
+/// window alive on close, ordered out, so a third-party switcher like AltTab can
+/// resurrect a "closed" window, issue #5321), cmux owns the full lifecycle here:
+/// opening creates the window, closing destroys it. When the window closes,
+/// ``windowWillClose(_:)`` tells the owner to drop its reference; with no strong
+/// references left the controller and window deallocate, the window leaves
+/// `NSApp.windows`, and `AXUIElementDestroyed` fires so switchers drop it.
+///
+/// The hosted SwiftUI view (and its animations) render exactly as in a scene,
+/// hosting doesn't change view-internal behavior. `sceneBridgingOptions` bridges
+/// the SwiftUI scene chrome (the `NavigationSplitView` sidebar toggle + title)
+/// into the window's unified toolbar so the window also *looks* like the native
+/// SwiftUI scene.
+@MainActor
+final class CmuxHostedWindowController: NSWindowController, NSWindowDelegate {
+    private let onWindowWillClose: @MainActor () -> Void
+
+    init<Content: View>(
+        identifier: String,
+        title: String,
+        contentSize: NSSize,
+        minSize: NSSize,
+        rootView: Content,
+        onWindowWillClose: @escaping @MainActor () -> Void
+    ) {
+        self.onWindowWillClose = onWindowWillClose
+        let hostingController = NSHostingController(rootView: rootView)
+        // Bridge SwiftUI scene chrome (NavigationSplitView sidebar toggle + title)
+        // into this AppKit window so it matches the native SwiftUI-scene Settings
+        // look (macOS 13+).
+        hostingController.sceneBridgingOptions = [.all]
+        let window = NSWindow(contentViewController: hostingController)
+        window.title = title
+        window.identifier = NSUserInterfaceItemIdentifier(identifier)
+        window.isRestorable = false
+        // Controller-owned destruction: released when the last strong reference
+        // (this controller, held by the presenter) drops on close, not via
+        // `isReleasedWhenClosed` (which a SwiftUI scene self-destructs on).
+        window.isReleasedWhenClosed = false
+        window.styleMask.insert(.fullSizeContentView)
+        // `sceneBridgingOptions` populates the window's toolbar with the hosted
+        // view's toolbar content (the NavigationSplitView sidebar toggle) but
+        // doesn't create the toolbar, so give the window one.
+        let toolbar = NSToolbar()
+        toolbar.showsBaselineSeparator = false
+        window.toolbar = toolbar
+        window.toolbarStyle = .unified
+        window.collectionBehavior.insert(.fullScreenAuxiliary)
+        window.isExcludedFromWindowsMenu = true
+        window.contentMinSize = minSize
+        window.minSize = minSize
+        window.setContentSize(contentSize)
+        AppDelegate.shared?.applyWindowDecorations(to: window)
+        super.init(window: window)
+        window.delegate = self
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) is not supported")
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        onWindowWillClose()
+    }
+}

--- a/Sources/App/SettingsHostedRootView.swift
+++ b/Sources/App/SettingsHostedRootView.swift
@@ -1,0 +1,20 @@
+import CmuxSettingsUI
+import SwiftUI
+
+/// Hosts the Settings UI inside the cmux-owned Settings window
+/// (a ``CmuxHostedWindowController``).
+///
+/// Observes the appearance setting via `@AppStorage` so the window re-tints
+/// live when the user changes the theme, `.cmuxAppearanceColorScheme(_:)` takes
+/// a one-shot value, so the live binding is reproduced here.
+struct SettingsHostedRootView: View {
+    let runtime: SettingsRuntime
+    @AppStorage(AppearanceSettings.appearanceModeKey)
+    private var appearanceMode = AppearanceSettings.defaultMode.rawValue
+
+    var body: some View {
+        SettingsWindowRoot(runtime: runtime)
+            .settingsRuntime(runtime)
+            .cmuxAppearanceColorScheme(appearanceMode)
+    }
+}

--- a/Sources/App/SettingsWindowPresenter.swift
+++ b/Sources/App/SettingsWindowPresenter.swift
@@ -5,11 +5,21 @@ enum SettingsWindowPresenter {
     static let windowID = "settings"
     static let windowIdentifier = "cmux.settings"
     static let minimumSize = NSSize(width: 820, height: 540)
+    static let defaultContentSize = NSSize(width: 980, height: 680)
     private static let visibleAreaInset: CGFloat = 18
 
-    private static var openWindow: (@MainActor () -> Void)?
+    /// Builds the cmux-owned Settings window. Registered deterministically by the
+    /// app composition root (`AppDelegate.configure`) so the presenter stays
+    /// view-agnostic and is ready before any `settings.open`. The passed
+    /// `onWindowWillClose` is wired to ``didCloseWindow()`` so the presenter drops
+    /// its reference and the window deallocates on close.
+    private static var makeWindowController:
+        (@MainActor (@escaping @MainActor () -> Void) -> CmuxHostedWindowController)?
     private static var parentWindowProvider: (@MainActor () -> NSWindow?)?
-    private static weak var settingsWindow: NSWindow?
+    /// The single live Settings window controller, or `nil` when Settings is
+    /// closed. Closing destroys the controller (and its window), so reopening
+    /// builds a fresh one — there is no hidden window kept alive for reuse.
+    private static var windowController: CmuxHostedWindowController?
     private static var pendingNavigationTarget: SettingsNavigationTarget?
     private static var pendingContentNavigationTarget: SettingsNavigationTarget?
     private static var shouldOpenWhenConfigured = false
@@ -18,31 +28,14 @@ enum SettingsWindowPresenter {
 #endif
 
     static func configure(
-        openWindow: @escaping @MainActor () -> Void,
+        makeWindowController: @escaping @MainActor (@escaping @MainActor () -> Void) -> CmuxHostedWindowController,
         parentWindowProvider: @escaping @MainActor () -> NSWindow? = { nil }
     ) {
-        self.openWindow = openWindow
+        self.makeWindowController = makeWindowController
         self.parentWindowProvider = parentWindowProvider
         if shouldOpenWhenConfigured {
             shouldOpenWhenConfigured = false
-            openWindow()
-        }
-    }
-
-    static func configure(window: NSWindow) {
-        let shouldFocusAfterConfiguration = settingsWindow !== window
-        settingsWindow = window
-        window.identifier = NSUserInterfaceItemIdentifier(windowIdentifier)
-        window.isRestorable = false
-        window.minSize = minimumSize
-        window.contentMinSize = minimumSize
-        window.adoptCmuxPeerWindowLevel()
-        clampToVisibleAreaIfNeeded(window)
-        if shouldFocusAfterConfiguration {
-            Task { @MainActor in
-                guard settingsWindow === window else { return }
-                focus(window)
-            }
+            openNewWindow()
         }
     }
 
@@ -51,7 +44,7 @@ enum SettingsWindowPresenter {
         openWindowOverride: (@MainActor () -> Void)? = nil
     ) {
 #if DEBUG
-        cmuxDebugLog("settings.window.show path=swiftuiWindow")
+        cmuxDebugLog("settings.window.show path=hostedWindow")
         _ = CmuxUITestCapture.mutateJSONObjectIfConfigured(
             envKey: "CMUX_UI_TEST_SETTINGS_OPEN_CAPTURE_PATH"
         ) { payload in
@@ -63,7 +56,7 @@ enum SettingsWindowPresenter {
         pendingNavigationTarget = navigationTarget
         pendingContentNavigationTarget = navigationTarget
 
-        if let window = existingWindow() {
+        if let window = currentWindow() {
             let shouldDeferNavigation = window.isMiniaturized
             if !shouldDeferNavigation {
                 pendingNavigationTarget = nil
@@ -81,11 +74,9 @@ enum SettingsWindowPresenter {
             return
         }
 
-        guard let openWindow else {
-            shouldOpenWhenConfigured = true
-            return
-        }
-        openWindow()
+        // Fresh window: keep the pending navigation target set so the newly
+        // created `SettingsWindowRoot` consumes it on appear.
+        openNewWindow()
     }
 
     static func consumePendingNavigationTarget() -> SettingsNavigationTarget? {
@@ -101,15 +92,19 @@ enum SettingsWindowPresenter {
     }
 
     static func refocusIfVisible() {
-        guard let window = existingWindow() else { return }
+        guard let window = currentWindow() else { return }
         focus(window)
     }
 
 #if DEBUG
+    /// DEBUG-only: the NSWindow the presenter currently tracks as the Settings
+    /// window. `nil` when Settings is closed.
+    static var trackedSettingsWindowForDebug: NSWindow? { windowController?.window }
+
     static func resetForTests() {
-        openWindow = nil
+        makeWindowController = nil
         parentWindowProvider = nil
-        settingsWindow = nil
+        windowController = nil
         pendingNavigationTarget = nil
         pendingContentNavigationTarget = nil
         shouldOpenWhenConfigured = false
@@ -119,23 +114,35 @@ enum SettingsWindowPresenter {
     static func setFocusHandlerForTests(_ handler: @escaping @MainActor (NSWindow) -> Void) {
         focusHandlerForTests = handler
     }
+
+    /// Runs the real focus/clamp/peer-level ordering on a test-provided window so
+    /// the peer-not-child invariant (issue #5081) and visible-area clamping stay
+    /// covered without injecting a full hosted controller.
+    static func performFocusForTests(_ window: NSWindow, parentWindowProvider: @escaping @MainActor () -> NSWindow? = { nil }) {
+        self.parentWindowProvider = parentWindowProvider
+        performFocus(window)
+    }
 #endif
 
-    private static func existingWindow() -> NSWindow? {
-        // Return the settings window whenever it still exists, even if it
-        // is currently ordered out (closed). SwiftUI's single `Window`
-        // scene does not destroy the window on close — it just hides it
-        // (isVisible == false) — and `openWindow(id:)` then no-ops because
-        // the scene still owns that window. So filtering by visibility here
-        // made every reopen-after-close fall through to a dead `openWindow`
-        // call and the window never came back. Reusing the hidden window
-        // lets `show()` re-front it via `makeKeyAndOrderFront`.
-        if let settingsWindow {
-            return settingsWindow
+    private static func openNewWindow() {
+        guard let makeWindowController else {
+            shouldOpenWhenConfigured = true
+            return
         }
-        return NSApp.windows.first {
-            $0.identifier?.rawValue == windowIdentifier
-        }
+        let controller = makeWindowController(didCloseWindow)
+        windowController = controller
+        guard let window = controller.window else { return }
+        focus(window)
+    }
+
+    /// Called from the controller's `windowWillClose`: drop the reference so the
+    /// controller and its window deallocate and leave `NSApp.windows`.
+    private static func didCloseWindow() {
+        windowController = nil
+    }
+
+    private static func currentWindow() -> NSWindow? {
+        windowController?.window
     }
 
     private static func focus(_ window: NSWindow) {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1871,6 +1871,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     func configure(tabManager: TabManager, notificationStore: TerminalNotificationStore, sidebarState: SidebarState, settingsRuntime: SettingsRuntime) {
         self.tabManager = tabManager
         self.settingsRuntime = settingsRuntime
+        // Register the Settings window factory here (deterministic app setup),
+        // not in a SwiftUI `onAppear` (which can fire late or not at all, leaving
+        // `settings.open` to defer forever). Settings is a cmux-owned AppKit
+        // window so closing it destroys it (issue #5321).
+        SettingsWindowPresenter.configure(
+            makeWindowController: { onWindowWillClose in
+                CmuxHostedWindowController(
+                    identifier: SettingsWindowPresenter.windowIdentifier,
+                    title: String(localized: "settings.title", defaultValue: "Settings"),
+                    contentSize: SettingsWindowPresenter.defaultContentSize,
+                    minSize: SettingsWindowPresenter.minimumSize,
+                    rootView: SettingsHostedRootView(runtime: settingsRuntime),
+                    onWindowWillClose: onWindowWillClose
+                )
+            },
+            parentWindowProvider: { AppDelegate.shared?.preferredMainWindowForSettingsPresentation() }
+        )
         self.notificationStore = notificationStore
         self.sidebarState = sidebarState
         scheduleGhosttyCrashBreadcrumbIfNeeded(notificationStore: notificationStore)

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -358,14 +358,9 @@ struct cmuxApp: App {
                 .settingsRuntime(settingsRuntime)
                 .cmuxAppearanceColorScheme(appearanceMode)
                 .onAppear {
-                    SettingsWindowPresenter.configure(
-                        openWindow: {
-                            openWindow(id: SettingsWindowPresenter.windowID)
-                        },
-                        parentWindowProvider: {
-                            AppDelegate.shared?.preferredMainWindowForSettingsPresentation()
-                        }
-                    )
+                    // SettingsWindowPresenter is configured deterministically in
+                    // AppDelegate.configure (off the racy onAppear), so settings.open
+                    // never defers on a missed onAppear.
 #if DEBUG
                     if ProcessInfo.processInfo.environment["CMUX_UI_TEST_MODE"] == "1" {
                         AppDelegate.shared?.updateLog.append("ui test: cmuxApp onAppear")
@@ -800,19 +795,11 @@ struct cmuxApp: App {
             windowAndViewCommands
         }
 
-        Window(String(localized: "settings.title", defaultValue: "Settings"), id: SettingsWindowPresenter.windowID) {
-            SettingsWindowRoot(runtime: settingsRuntime)
-                .settingsRuntime(settingsRuntime)
-                .background(WindowAccessor(dedupeByWindow: false) { window in
-                    SettingsWindowPresenter.configure(window: window)
-                })
-                .cmuxAppearanceColorScheme(appearanceMode)
-        }
-        .defaultSize(width: 980, height: 680)
-        .windowResizability(.contentMinSize)
-        .commands {
-            SidebarCommands()
-        }
+        // Settings is a cmux-owned AppKit window (CmuxHostedWindowController via
+        // SettingsWindowPresenter), not a SwiftUI scene, so closing it destroys
+        // the window and it leaves NSApp.windows instead of lingering for AltTab
+        // to resurrect (issue #5321). The hosted SwiftUI view keeps its native
+        // look + animation; `sceneBridgingOptions` bridges the toolbar/toggle.
 
         Window(String(localized: "settings.config.windowTitle", defaultValue: "Config"), id: ConfigSettingsView.windowID) {
             ConfigSettingsView()

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -149,6 +149,8 @@
 		C617000000000000000000A3 /* CmuxGit in Frameworks */ = {isa = PBXBuildFile; productRef = C617000000000000000000A2 /* CmuxGit */; };
 		C0DE34020000000000000001 /* CmuxHelpCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE34020000000000000003 /* CmuxHelpCommands.swift */; };
 		C0DE34020000000000000002 /* CmuxHelpResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE34020000000000000004 /* CmuxHelpResource.swift */; };
+		BB5321B0C0DE0002FACE0002 /* CmuxHostedWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB5321B0C0DE0001FACE0001 /* CmuxHostedWindowController.swift */; };
+		BB5321C0C0DE0002FACE0002 /* CmuxHostedWindowControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB5321C0C0DE0001FACE0001 /* CmuxHostedWindowControllerTests.swift */; };
 		C0DE46010000000000000001 /* CMUXInstalledExtensionSidebarHostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE46010000000000000002 /* CMUXInstalledExtensionSidebarHostView.swift */; };
 		E7E00000000000000000000B /* CmuxLifecycleEventPublishing.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7E00000000000000000000C /* CmuxLifecycleEventPublishing.swift */; };
 		2F0C07000000000000000002 /* CmuxMainWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0C07000000000000000001 /* CmuxMainWindow.swift */; };
@@ -444,6 +446,7 @@
 		D10000000000000000A00012 /* SettingsAppBehaviorUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000000000000000A00013 /* SettingsAppBehaviorUITests.swift */; };
 		D10000000000000000A00018 /* SettingsAutomationBehaviorUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000000000000000A00019 /* SettingsAutomationBehaviorUITests.swift */; };
 		D10000000000000000A0001A /* SettingsBrowserBehaviorUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000000000000000A0001B /* SettingsBrowserBehaviorUITests.swift */; };
+		BB5321B0C0DE0004FACE0004 /* SettingsHostedRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB5321B0C0DE0003FACE0003 /* SettingsHostedRootView.swift */; };
 		D9CCF002D9CCF002D9CCF002 /* SettingsLazyLoadHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9CCF001D9CCF001D9CCF001 /* SettingsLazyLoadHelpers.swift */; };
 		A50019A0 /* SettingsNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50019A1 /* SettingsNavigation.swift */; };
 		A50019B0 /* SettingsSearchAliases.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50019B1 /* SettingsSearchAliases.swift */; };
@@ -822,6 +825,8 @@
 		E7E000000000000000000002 /* CmuxEventStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxEventStream.swift; sourceTree = "<group>"; };
 		C0DE34020000000000000003 /* CmuxHelpCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/CmuxHelpCommands.swift; sourceTree = "<group>"; };
 		C0DE34020000000000000004 /* CmuxHelpResource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/CmuxHelpResource.swift; sourceTree = "<group>"; };
+		BB5321B0C0DE0001FACE0001 /* CmuxHostedWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/CmuxHostedWindowController.swift; sourceTree = "<group>"; };
+		BB5321C0C0DE0001FACE0001 /* CmuxHostedWindowControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxHostedWindowControllerTests.swift; sourceTree = "<group>"; };
 		C0DE46010000000000000002 /* CMUXInstalledExtensionSidebarHostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMUXInstalledExtensionSidebarHostView.swift; sourceTree = "<group>"; };
 		E7E00000000000000000000C /* CmuxLifecycleEventPublishing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxLifecycleEventPublishing.swift; sourceTree = "<group>"; };
 		2F0C07000000000000000001 /* CmuxMainWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/CmuxMainWindow.swift; sourceTree = "<group>"; };
@@ -1090,6 +1095,7 @@
 		D10000000000000000A00013 /* SettingsAppBehaviorUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsAppBehaviorUITests.swift; sourceTree = "<group>"; };
 		D10000000000000000A00019 /* SettingsAutomationBehaviorUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsAutomationBehaviorUITests.swift; sourceTree = "<group>"; };
 		D10000000000000000A0001B /* SettingsBrowserBehaviorUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsBrowserBehaviorUITests.swift; sourceTree = "<group>"; };
+		BB5321B0C0DE0003FACE0003 /* SettingsHostedRootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/SettingsHostedRootView.swift; sourceTree = "<group>"; };
 		D9CCF001D9CCF001D9CCF001 /* SettingsLazyLoadHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsLazyLoadHelpers.swift; sourceTree = "<group>"; };
 		A50019A1 /* SettingsNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsNavigation.swift; sourceTree = "<group>"; };
 		A50019B1 /* SettingsSearchAliases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSearchAliases.swift; sourceTree = "<group>"; };
@@ -1485,6 +1491,8 @@
 				A50019B1 /* SettingsSearchAliases.swift */,
 				D3610C010000000000000002 /* CmuxSettingsJSONPathSupport.swift */,
 				D36090010000000000000002 /* SettingsWindowPresenter.swift */,
+				BB5321B0C0DE0001FACE0001 /* CmuxHostedWindowController.swift */,
+				BB5321B0C0DE0003FACE0003 /* SettingsHostedRootView.swift */,
 				D36090020000000000000002 /* NSWindow+CmuxPeerWindow.swift */,
 				C0DE35860000000000000002 /* BackgroundWorkspacePrimeCoordinator.swift */,
 				A5001012 /* ContentView.swift */,
@@ -1898,6 +1906,7 @@
 					C0DEC0DE000000000000F203 /* CommandPaletteNucleoFixtures.swift */,
 				A50019B3 /* SettingsSearchIndexTests.swift */,
 				D36090010000000000000004 /* SettingsWindowPresenterTests.swift */,
+				BB5321C0C0DE0001FACE0001 /* CmuxHostedWindowControllerTests.swift */,
 				970226F3C99D0D937CD00539 /* BrowserConfigTests.swift */,
 				C0DE49870000000000000002 /* BrowserWebContentProcessTests.swift */,
 				43F90FAF3FD44F11BF547BE9 /* CmuxWebViewMouseNavigationButtonTests.swift */,
@@ -2413,6 +2422,7 @@
 					E7E000000000000000000001 /* CmuxEventStream.swift in Sources */,
 				C0DE34020000000000000001 /* CmuxHelpCommands.swift in Sources */,
 				C0DE34020000000000000002 /* CmuxHelpResource.swift in Sources */,
+				BB5321B0C0DE0002FACE0002 /* CmuxHostedWindowController.swift in Sources */,
 				C0DE46010000000000000001 /* CMUXInstalledExtensionSidebarHostView.swift in Sources */,
 					E7E00000000000000000000B /* CmuxLifecycleEventPublishing.swift in Sources */,
 				2F0C07000000000000000002 /* CmuxMainWindow.swift in Sources */,
@@ -2588,6 +2598,7 @@
 				A5001670 /* SessionRestoredTerminalCommandStore.swift in Sources */,
 				A50016B1A1B2C3D4E5F60718 /* SessionSnapshotDebugBenchmark.swift in Sources */,
 				F5320002A1B2C3D4E5F60718 /* SessionTranscriptTypes.swift in Sources */,
+				BB5321B0C0DE0004FACE0004 /* SettingsHostedRootView.swift in Sources */,
 				D9CCF002D9CCF002D9CCF002 /* SettingsLazyLoadHelpers.swift in Sources */,
 				A50019A0 /* SettingsNavigation.swift in Sources */,
 				A50019B0 /* SettingsSearchAliases.swift in Sources */,
@@ -2825,6 +2836,7 @@
 				E30750000000000000000006 /* CmuxConfigNamedColorTests.swift in Sources */,
 				C1A2B3C4D5E6F70800000001 /* CmuxConfigTests.swift in Sources */,
 				E7E000000000000000000003 /* CmuxEventBusTests.swift in Sources */,
+				BB5321C0C0DE0002FACE0002 /* CmuxHostedWindowControllerTests.swift in Sources */,
 				C0DE31390000000000000101 /* CMUXOpenCommandTests.swift in Sources */,
 				C3677001000000000000001 /* CmuxSSHURLRequestTests.swift in Sources */,
 				C7A50C000000000000000002 /* CmuxTopProcessCPUTests.swift in Sources */,

--- a/cmuxTests/CmuxHostedWindowControllerTests.swift
+++ b/cmuxTests/CmuxHostedWindowControllerTests.swift
@@ -1,0 +1,83 @@
+import AppKit
+import SwiftUI
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+final class CmuxHostedWindowControllerTests: XCTestCase {
+    private func makeController(
+        identifier: String,
+        onWindowWillClose: @escaping @MainActor () -> Void = {}
+    ) -> CmuxHostedWindowController {
+        CmuxHostedWindowController(
+            identifier: identifier,
+            title: "Test",
+            contentSize: NSSize(width: 400, height: 300),
+            minSize: NSSize(width: 200, height: 150),
+            rootView: Color.clear,
+            onWindowWillClose: onWindowWillClose
+        )
+    }
+
+    func testWindowIsConfiguredAsAuxiliary() {
+        let controller = makeController(identifier: "cmux.settings.test.aux")
+        guard let window = controller.window else { return XCTFail("no window") }
+        defer { window.orderOut(nil) }
+
+        XCTAssertEqual(window.identifier?.rawValue, "cmux.settings.test.aux")
+        XCTAssertTrue(window.isExcludedFromWindowsMenu)
+        XCTAssertTrue(window.collectionBehavior.contains(.fullScreenAuxiliary))
+    }
+
+    func testCloseInvokesCallbackAndBreaksHostingCycle() {
+        var closed = false
+        let controller = makeController(identifier: "cmux.settings.test.close") { closed = true }
+        guard let window = controller.window else { return XCTFail("no window") }
+
+        XCTAssertNotNil(window.contentViewController, "hosting controller is the window's content")
+        window.makeKeyAndOrderFront(nil)
+        window.close()
+
+        XCTAssertTrue(closed, "windowWillClose must invoke onWindowWillClose")
+        // The cycle-break nils the content view controller + toolbar so the
+        // NSHostingController <-> window sceneBridging retain cycle releases and
+        // the window can deallocate (issue #5321).
+        XCTAssertNil(window.contentViewController)
+        XCTAssertNil(window.toolbar)
+    }
+
+    /// #5321 regression: a closed hosted Settings window must actually
+    /// deallocate and leave `NSApp.windows`, otherwise a third-party window
+    /// switcher (AltTab) or the Window menu can resurrect a "closed" window.
+    /// Without the `windowWillClose` cycle-break this fails — the sceneBridging
+    /// retain cycle keeps the window alive and listed.
+    func testClosedHostedWindowDeallocatesAndLeavesWindowList() {
+        let identifier = "cmux.settings.test.dealloc.\(UUID().uuidString)"
+        weak var weakWindow: NSWindow?
+
+        autoreleasepool {
+            var controller: CmuxHostedWindowController? = makeController(identifier: identifier)
+            weakWindow = controller?.window
+            controller?.window?.makeKeyAndOrderFront(nil)
+            XCTAssertTrue(
+                NSApp.windows.contains { $0.identifier?.rawValue == identifier },
+                "window should be listed while open"
+            )
+            controller?.window?.close()
+            // The presenter drops its controller reference in didCloseWindow; do
+            // the same here so nothing keeps the window alive.
+            controller = nil
+        }
+
+        XCTAssertNil(weakWindow, "hosted window should deallocate after close")
+        XCTAssertFalse(
+            NSApp.windows.contains { $0.identifier?.rawValue == identifier },
+            "closed hosted window must leave NSApp.windows (issue #5321)"
+        )
+    }
+}

--- a/cmuxTests/SettingsWindowPresenterTests.swift
+++ b/cmuxTests/SettingsWindowPresenterTests.swift
@@ -15,18 +15,15 @@ final class SettingsWindowPresenterTests: XCTestCase {
         super.tearDown()
     }
 
-    func testConfigureWindowLeavesPendingNavigationForSettingsViews() {
-        let settingsWindow = makeWindow(identifier: SettingsWindowPresenter.windowIdentifier)
+    /// When no Settings window is open and an override is supplied, `show`
+    /// invokes the override and leaves the pending navigation target set so the
+    /// freshly-created `SettingsWindowRoot` consumes it on appear.
+    func testShowWithoutWindowUsesOverrideAndLeavesPendingNavigation() {
         var didOpen = false
-        defer {
-            settingsWindow.orderOut(nil)
-        }
-
         SettingsWindowPresenter.show(
             navigationTarget: .browserImport,
             openWindowOverride: { didOpen = true }
         )
-        SettingsWindowPresenter.configure(window: settingsWindow)
 
         XCTAssertTrue(didOpen)
         XCTAssertEqual(SettingsWindowPresenter.consumePendingNavigationTarget(), .browserImport)
@@ -35,57 +32,11 @@ final class SettingsWindowPresenterTests: XCTestCase {
         XCTAssertNil(SettingsWindowPresenter.consumePendingContentNavigationTarget())
     }
 
-    func testRepeatedConfigureForSameSettingsWindowDoesNotRefocus() async {
-        let settingsWindow = makeWindow(identifier: SettingsWindowPresenter.windowIdentifier)
-        var focusedWindows: [NSWindow] = []
-        defer {
-            settingsWindow.orderOut(nil)
-        }
-
-        SettingsWindowPresenter.setFocusHandlerForTests { window in
-            focusedWindows.append(window)
-        }
-
-        SettingsWindowPresenter.configure(window: settingsWindow)
-        await Task.yield()
-        SettingsWindowPresenter.configure(window: settingsWindow)
-        await Task.yield()
-
-        XCTAssertEqual(focusedWindows.count, 1)
-        XCTAssertTrue(focusedWindows.first === settingsWindow)
-    }
-
-    func testShowPreservesPendingNavigationWhenExistingSettingsWindowIsMiniaturized() async {
-        let settingsWindow = makeWindow(
-            identifier: SettingsWindowPresenter.windowIdentifier,
-            isMiniaturizedForTests: true
-        )
-        var didOpen = false
-        defer {
-            settingsWindow.orderOut(nil)
-        }
-
-        SettingsWindowPresenter.setFocusHandlerForTests { _ in }
-        SettingsWindowPresenter.configure(window: settingsWindow)
-        await Task.yield()
-
-        SettingsWindowPresenter.show(
-            navigationTarget: .browserImport,
-            openWindowOverride: { didOpen = true }
-        )
-
-        XCTAssertFalse(didOpen)
-        XCTAssertEqual(SettingsWindowPresenter.consumePendingNavigationTarget(), .browserImport)
-        XCTAssertEqual(SettingsWindowPresenter.consumePendingContentNavigationTarget(), .browserImport)
-    }
-
     // Settings is a top-level *peer* window, not a child of the main window.
-    // A child window (`addChildWindow`) is pinned above its parent forever and
-    // can never recede when the user clicks the main window — that is the
-    // floating-Settings bug (https://github.com/manaflow-ai/cmux/issues/5081).
-    // These tests pin the peer invariant: configuring/focusing Settings must
-    // never create a parent-child relationship and must leave it at `.normal`.
-    func testDoesNotAttachSettingsAsChildOfPreferredMainWindow() {
+    // Focusing it must never create a parent-child relationship (the floating
+    // Settings bug, https://github.com/manaflow-ai/cmux/issues/5081) and must
+    // leave it at `.normal` level.
+    func testPerformFocusKeepsSettingsAsPeerNotChild() {
         let parentWindow = makeWindow(identifier: "cmux.main.\(UUID().uuidString)")
         let settingsWindow = makeWindow(identifier: SettingsWindowPresenter.windowIdentifier)
         defer {
@@ -93,68 +44,11 @@ final class SettingsWindowPresenterTests: XCTestCase {
             parentWindow.orderOut(nil)
         }
 
-        SettingsWindowPresenter.configure(
-            openWindow: {},
-            parentWindowProvider: { parentWindow }
-        )
-        SettingsWindowPresenter.configure(window: settingsWindow)
+        SettingsWindowPresenter.performFocusForTests(settingsWindow, parentWindowProvider: { parentWindow })
 
         XCTAssertNil(settingsWindow.parent)
         XCTAssertFalse(parentWindow.childWindows?.contains(where: { $0 === settingsWindow }) == true)
         XCTAssertEqual(settingsWindow.level, .normal)
-    }
-
-    func testFocusingSettingsKeepsItAsPeerWhenPreferredMainWindowChanges() {
-        let firstParent = makeWindow(identifier: "cmux.main.\(UUID().uuidString)")
-        let secondParent = makeWindow(identifier: "cmux.main.\(UUID().uuidString)")
-        let settingsWindow = makeWindow(identifier: SettingsWindowPresenter.windowIdentifier)
-        var preferredParent = firstParent
-        defer {
-            settingsWindow.orderOut(nil)
-            firstParent.orderOut(nil)
-            secondParent.orderOut(nil)
-        }
-
-        SettingsWindowPresenter.configure(
-            openWindow: {},
-            parentWindowProvider: { preferredParent }
-        )
-        SettingsWindowPresenter.configure(window: settingsWindow)
-        XCTAssertNil(settingsWindow.parent)
-
-        preferredParent = secondParent
-        settingsWindow.orderFront(nil)
-        // refocusIfVisible() runs the real performFocus ordering path.
-        SettingsWindowPresenter.refocusIfVisible()
-
-        XCTAssertNil(settingsWindow.parent)
-        XCTAssertFalse(firstParent.childWindows?.contains(where: { $0 === settingsWindow }) == true)
-        XCTAssertFalse(secondParent.childWindows?.contains(where: { $0 === settingsWindow }) == true)
-        XCTAssertEqual(settingsWindow.level, .normal)
-    }
-
-    func testSettingsSurvivesPreferredMainWindowCloseAsIndependentPeer() {
-        let parentWindow = makeWindow(identifier: "cmux.main.\(UUID().uuidString)")
-        let settingsWindow = makeWindow(identifier: SettingsWindowPresenter.windowIdentifier)
-        defer {
-            settingsWindow.orderOut(nil)
-            parentWindow.orderOut(nil)
-        }
-
-        SettingsWindowPresenter.configure(
-            openWindow: {},
-            parentWindowProvider: { parentWindow }
-        )
-        SettingsWindowPresenter.configure(window: settingsWindow)
-        settingsWindow.orderFront(nil)
-        XCTAssertNil(settingsWindow.parent)
-
-        // As an independent peer, Settings is unaffected by the main window
-        // closing — there is no child relationship to tear down.
-        NotificationCenter.default.post(name: NSWindow.willCloseNotification, object: parentWindow)
-
-        XCTAssertNil(settingsWindow.parent)
-        XCTAssertTrue(settingsWindow.isVisible)
     }
 
     func testAdoptCmuxPeerWindowLevelBringsFloatingWindowToNormal() {
@@ -169,11 +63,13 @@ final class SettingsWindowPresenterTests: XCTestCase {
         XCTAssertEqual(window.level, .normal)
     }
 
-    func testConfigureClampsOversizedSettingsFrameToVisibleArea() throws {
+    func testPerformFocusClampsOversizedSettingsFrameToVisibleArea() throws {
         guard let screen = NSScreen.main else {
             throw XCTSkip("No screen available for Settings frame clamping")
         }
         let settingsWindow = makeWindow(identifier: SettingsWindowPresenter.windowIdentifier)
+        settingsWindow.minSize = SettingsWindowPresenter.minimumSize
+        settingsWindow.contentMinSize = SettingsWindowPresenter.minimumSize
         let visibleFrame = screen.visibleFrame
         settingsWindow.setFrame(
             NSRect(
@@ -184,56 +80,30 @@ final class SettingsWindowPresenterTests: XCTestCase {
             ),
             display: false
         )
-        defer {
-            settingsWindow.orderOut(nil)
-        }
+        defer { settingsWindow.orderOut(nil) }
 
-        SettingsWindowPresenter.configure(window: settingsWindow)
+        SettingsWindowPresenter.performFocusForTests(settingsWindow)
 
         let inset: CGFloat = 18
-        let availableWidth = max(
-            SettingsWindowPresenter.minimumSize.width,
-            visibleFrame.width - 2 * inset
-        )
-        let availableHeight = max(
-            SettingsWindowPresenter.minimumSize.height,
-            visibleFrame.height - 2 * inset
-        )
+        let availableWidth = max(SettingsWindowPresenter.minimumSize.width, visibleFrame.width - 2 * inset)
+        let availableHeight = max(SettingsWindowPresenter.minimumSize.height, visibleFrame.height - 2 * inset)
         let frame = settingsWindow.frame
         XCTAssertLessThanOrEqual(frame.width, availableWidth)
         XCTAssertLessThanOrEqual(frame.height, availableHeight)
         XCTAssertGreaterThanOrEqual(frame.minX, visibleFrame.minX + inset)
         XCTAssertGreaterThanOrEqual(frame.minY, visibleFrame.minY + inset)
-        if frame.width <= visibleFrame.width - 2 * inset {
-            XCTAssertLessThanOrEqual(frame.maxX, visibleFrame.maxX - inset)
-        }
-        if frame.height <= visibleFrame.height - 2 * inset {
-            XCTAssertLessThanOrEqual(frame.maxY, visibleFrame.maxY - inset)
-        }
     }
 
-    private func makeWindow(
-        identifier: String,
-        isMiniaturizedForTests: Bool? = nil
-    ) -> NSWindow {
-        let window = TestSettingsWindow(
+    private func makeWindow(identifier: String) -> NSWindow {
+        let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 320, height: 220),
             styleMask: [.titled, .closable, .miniaturizable, .resizable],
             backing: .buffered,
             defer: false
         )
-        window.isMiniaturizedForTests = isMiniaturizedForTests
         window.isReleasedWhenClosed = false
         window.identifier = NSUserInterfaceItemIdentifier(identifier)
         return window
-    }
-
-    private final class TestSettingsWindow: NSWindow {
-        var isMiniaturizedForTests: Bool?
-
-        override var isMiniaturized: Bool {
-            isMiniaturizedForTests ?? super.isMiniaturized
-        }
     }
 }
 #endif


### PR DESCRIPTION
Closing the Settings window did not keep it closed. A third-party window switcher (AltTab, bound to Option+Tab) could resurrect it. The SwiftUI `Window(id:)` scene keeps its backing `NSWindow` alive on close (it orders the window out, it does not destroy it), so the window lingers in `NSApp.windows` and the WindowServer list, and AltTab brings it back.

This replaces the SwiftUI Settings scene with a cmux-owned AppKit window, `CmuxHostedWindowController` (`NSWindowController` + `NSHostingController`), that owns the full lifecycle: opening creates the window, closing destroys it and removes it from `NSApp.windows`, so a switcher cannot resurrect a closed window. The presenter registers its window factory from `AppDelegate.configure` (deterministic, ready before any `settings.open`) instead of a view `onAppear` that could fire late or not at all.

`sceneBridgingOptions` bridges the SwiftUI scene chrome into a unified toolbar so the window still looks native, and `windowWillClose` breaks the `NSHostingController` to window sceneBridging retain cycle so the window actually deallocates on close.

Moving the SwiftUI content out of a `Window` scene surfaced two scene-only behaviors that are restored here:

- `@SceneStorage` does not round-trip outside a scene, so the selected section reset to Account on every reopen. It now persists via `@AppStorage`, restoring the last-viewed pane across reopens and launches.
- NavigationSplitView's built-in toolbar sidebar toggle blanks the whole hosted window (it dispatches AppKit's `toggleSidebar:` through SwiftUI's own handler). It is removed with `.toolbar(removing: .sidebarToggle)`; the sidebar now stays open, like macOS System Settings.

Regression test, two-commit red/green: `testClosedHostedWindowDeallocatesAndLeavesWindowList` asserts a closed hosted window deallocates and leaves `NSApp.windows`. Commit 1 adds the AppKit window and the test without the cycle-break (red, the window lingers via the retain cycle); commit 2 adds the cycle-break (green).

Known follow-up: the hosted sidebar is fixed-open. A binding-driven collapse renders fine when hosted, but a replacement SwiftUI `.toolbar` item bridges into the hosted `NSHostingController` toolbar lazily (it does not appear until the first `columnVisibility` change), so an in-toolbar collapse toggle needs a native `NSToolbarItem` on the host driving a shared visibility model.

Dependency: closing destroys and reopening rebuilds the Settings window, which amplifies the settings-observer leak (https://github.com/manaflow-ai/cmux/issues/5329) from once-per-session to once-per-open, so this should land with or after the leak fix in https://github.com/manaflow-ai/cmux/pull/5332.

Replaces https://github.com/manaflow-ai/cmux/pull/5322, which targeted the wrong layer (`collectionBehavior` did not address the scene-keeps-the-window-alive root cause).

Closes https://github.com/manaflow-ai/cmux/issues/5321

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5455"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783243853&installation_id=133855650&pr_number=5455&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5455&signature=3f05aab104287e2a0f0f929e5a5b3758dd33ffaafb78a205cb63a60a7daea1e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk from replacing the Settings window stack (lifecycle, focus/peering, persistence) and known interaction with settings-observer leaks on each reopen; behavior is covered by new unit tests but touches core app chrome.
> 
> **Overview**
> **Settings** moves off the SwiftUI `Window` scene onto a cmux-owned AppKit host (`CmuxHostedWindowController` + `SettingsHostedRootView`). **Closing** now tears down the window and drops it from `NSApp.windows` so switchers like AltTab cannot resurrect a “closed” window (#5321). The factory is registered in **`AppDelegate.configure`** instead of `cmuxApp` `onAppear`, and **`windowWillClose`** breaks the `sceneBridgingOptions` hosting retain cycle so the window actually deallocates.
> 
> **Settings UI** adapts to non-scene hosting: last section/sidebar selection uses **`@AppStorage`** instead of `@SceneStorage`, and the built-in **sidebar toggle is removed** (`.toolbar(removing: .sidebarToggle)`) because it blanks the hosted window; the sidebar stays open like System Settings.
> 
> Tests add **`CmuxHostedWindowControllerTests`** (dealloc / window list) and slim **`SettingsWindowPresenterTests`** around the hosted presenter path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 809e459e4823baf1638e08da0e3c5a76b0629db1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Own the Settings window lifecycle in AppKit so closing destroys the window and removes it from `NSApp.windows`, preventing AltTab and similar switchers from resurrecting it (fixes #5321). Replaces the SwiftUI `Window` scene with a hosted controller while keeping the UI looking native and state persistent.

- **Bug Fixes**
  - Moved Settings to a cmux-owned `CmuxHostedWindowController` (`NSWindowController` + `NSHostingController`); closing now deallocates the window.
  - Broke the `NSHostingController` ↔ window retain cycle in `windowWillClose` by clearing `contentViewController` and `toolbar`.
  - Registered a deterministic window factory in `AppDelegate.configure`, so `settings.open` is always ready.
  - Switched `@SceneStorage` to `@AppStorage` for selected section/sidebar entry to persist across reopens/launches.
  - Removed `NavigationSplitView`’s sidebar toggle toolbar item to avoid a hosted-window blanking bug; sidebar stays open like System Settings.
  - Added tests, including a regression test that asserts a closed hosted window deallocates and leaves the window list.

- **Dependencies**
  - Should land with or after the settings observer leak fix in #5332, since reopening now rebuilds the window each time.

<sup>Written for commit 809e459e4823baf1638e08da0e3c5a76b0629db1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5455?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Settings sidebar now remains permanently visible

* **Bug Fixes**
  * Settings selections now persist when closing and reopening the window
  * Improved Settings window management and stability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->