### PR TITLE
Restore window to its display when it reappears after sleep/disconnect

### DIFF
--- a/Sources/App/WindowHomeTracker.swift
+++ b/Sources/App/WindowHomeTracker.swift
@@ -1,0 +1,78 @@
+import AppKit
+import Foundation
+
+/// Tracks the user's intended "home" position for each main window so that a
+/// window relocated off a display by macOS (display sleep, cable disconnect,
+/// system sleep) can be restored to its original display + frame once that
+/// display reappears.
+///
+/// macOS rescues windows off a vanishing display onto the remaining one but
+/// never moves them back when the display returns. ``WindowHomeTracker`` records
+/// the last *user-initiated* placement of each window; ``AppDelegate`` consults
+/// it when the display configuration changes and re-applies the home frame once
+/// the home display is connected again.
+@MainActor
+final class WindowHomeTracker {
+    /// A window's remembered position: the frame it occupied and a snapshot of
+    /// the display it occupied (display id + frame + visible frame).
+    struct Home: Equatable {
+        var frame: CGRect
+        var display: SessionDisplaySnapshot
+    }
+
+    private var homesByWindowId: [UUID: Home] = [:]
+
+    /// Records (or replaces) the home position for the given window.
+    func recordHome(windowId: UUID, frame: CGRect, display: SessionDisplaySnapshot) {
+        homesByWindowId[windowId] = Home(frame: frame, display: display)
+    }
+
+    /// Returns the remembered home for the given window, if any.
+    func home(for windowId: UUID) -> Home? {
+        homesByWindowId[windowId]
+    }
+
+    /// Forgets the home for the given window (e.g. when it closes).
+    func clear(windowId: UUID) {
+        homesByWindowId.removeValue(forKey: windowId)
+    }
+
+    /// Decides whether an observed window move/resize should be recorded as the
+    /// new home.
+    ///
+    /// A move is treated as a genuine user placement — and therefore a home
+    /// update — only when it was an interactive user drag/resize
+    /// (`isUserInitiated`) and none of the suppressing conditions hold. The macOS
+    /// rescue move that relocates a window off a vanishing display arrives
+    /// *without* a preceding `windowWillMove`, so it reports `isUserInitiated ==
+    /// false` and is excluded — this is what prevents the rescue from clobbering
+    /// the remembered home. A real user drag happens with the window in a normal
+    /// (non-fullscreen/zoomed/miniaturized) state on a connected display.
+    ///
+    /// - Parameters:
+    ///   - isUserInitiated: The move/resize came from an interactive user drag.
+    ///   - isReconciling: We are inside a programmatic display-change reconcile.
+    ///   - isApplyingSessionRestore: Startup/session restore is in progress.
+    ///   - isFullScreen: The window is in macOS full screen.
+    ///   - isZoomed: The window is zoomed (green-button maximized).
+    ///   - isMiniaturized: The window is minimized to the Dock.
+    ///   - screenPresent: The window's current display is in the live screen list.
+    /// - Returns: `true` when the move should update the recorded home.
+    static func shouldRecordHome(
+        isUserInitiated: Bool,
+        isReconciling: Bool,
+        isApplyingSessionRestore: Bool,
+        isFullScreen: Bool,
+        isZoomed: Bool,
+        isMiniaturized: Bool,
+        screenPresent: Bool
+    ) -> Bool {
+        isUserInitiated
+            && !isReconciling
+            && !isApplyingSessionRestore
+            && !isFullScreen
+            && !isZoomed
+            && !isMiniaturized
+            && screenPresent
+    }
+}

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -747,6 +747,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private final class MainWindowController: NSWindowController, NSWindowDelegate {
         var onClose: (() -> Void)?
         var shouldClose: (() -> Bool)?
+        /// Invoked when the window finishes moving or live-resizing, so the
+        /// AppDelegate can capture the user's intended "home" position. The
+        /// `userInitiated` flag is true only for an interactive drag/resize the
+        /// user started; a move macOS performs to rescue the window off a
+        /// vanishing display arrives without a preceding `windowWillMove` and is
+        /// reported as `false`, so it never overwrites the remembered home.
+        var onGeometryChanged: ((_ window: NSWindow, _ userInitiated: Bool) -> Void)?
+
+        /// Set between `windowWillMove` (drag start) and the following
+        /// `windowDidMove`, identifying an interactive user move.
+        private var isUserMovingWindow = false
 
         #if DEBUG
         private func logWindowEvent(_ event: String, notification: Notification) {
@@ -760,6 +771,25 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         func windowWillClose(_ notification: Notification) {
             onClose?()
+        }
+
+        func windowWillMove(_ notification: Notification) {
+            isUserMovingWindow = true
+        }
+
+        func windowDidMove(_ notification: Notification) {
+            let userInitiated = isUserMovingWindow
+            isUserMovingWindow = false
+            notifyGeometryChanged(notification, userInitiated: userInitiated)
+        }
+
+        func windowDidEndLiveResize(_ notification: Notification) {
+            notifyGeometryChanged(notification, userInitiated: true)
+        }
+
+        private func notifyGeometryChanged(_ notification: Notification, userInitiated: Bool) {
+            guard let window = notification.object as? NSWindow else { return }
+            onGeometryChanged?(window, userInitiated)
         }
 
         #if DEBUG
@@ -1045,6 +1075,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private var didPrepareStartupSessionSnapshot = false
     var didAttemptStartupSessionRestore = false
     private var isApplyingSessionRestore = false
+    /// Set while we re-apply a window's home frame in response to a display
+    /// configuration change, so the induced move/resize events (and any macOS
+    /// rescue moves in the same burst) are not mistaken for user placements.
+    private var isReconcilingWindowHome = false
+    /// Remembers each main window's user-intended display + frame so it can be
+    /// restored when its display reappears after sleep/disconnect.
+    private let windowHomeTracker = WindowHomeTracker()
     private var sessionAutosaveTimer: DispatchSourceTimer?
     private var sessionAutosaveTickInFlight = false
     private var sessionAutosaveDeferredRetryPending = false
@@ -3554,13 +3591,93 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         guard let window else { return nil }
         let screen = window.screen
             ?? NSScreen.screens.first(where: { $0.frame.intersects(window.frame) })
-        guard let screen else { return nil }
+        return Self.displaySnapshot(for: screen)
+    }
 
+    private nonisolated static func displaySnapshot(for screen: NSScreen?) -> SessionDisplaySnapshot? {
+        guard let screen else { return nil }
         return SessionDisplaySnapshot(
             displayID: screen.cmuxDisplayID,
             frame: SessionRectSnapshot(screen.frame),
             visibleFrame: SessionRectSnapshot(screen.visibleFrame)
         )
+    }
+
+    /// Captures a window's current placement as its "home" when the move is a
+    /// genuine, user-initiated action (an interactive drag/resize — not our own
+    /// reconcile, not session restore, not a macOS rescue off a vanishing
+    /// display, not a fullscreen/zoomed/miniaturized window) and the window sits
+    /// on a connected display. Home lives only in memory; the runtime re-home
+    /// (within a single session) does not need cross-launch persistence, which
+    /// the existing startup restore already handles.
+    private func handleMainWindowGeometryChanged(_ window: NSWindow, userInitiated: Bool) {
+        guard let windowId = mainWindowId(for: window) else { return }
+        let screen = window.screen
+            ?? NSScreen.screens.first(where: { $0.frame.intersects(window.frame) })
+        let screenPresent = screen?.cmuxDisplayID.map { id in
+            NSScreen.screens.contains(where: { $0.cmuxDisplayID == id })
+        } ?? false
+
+        guard WindowHomeTracker.shouldRecordHome(
+            isUserInitiated: userInitiated,
+            isReconciling: isReconcilingWindowHome,
+            isApplyingSessionRestore: isApplyingSessionRestore,
+            isFullScreen: window.styleMask.contains(.fullScreen),
+            isZoomed: window.isZoomed,
+            isMiniaturized: window.isMiniaturized,
+            screenPresent: screenPresent
+        ) else {
+            return
+        }
+
+        guard let snapshot = Self.displaySnapshot(for: screen) else { return }
+        windowHomeTracker.recordHome(windowId: windowId, frame: window.frame, display: snapshot)
+    }
+
+    /// Re-homes the primary main window after a display configuration change.
+    ///
+    /// macOS rescues windows off a vanishing display onto the remaining one and
+    /// leaves them there when the display returns. When the window's remembered
+    /// home display reappears, this re-runs the (pure, idempotent) frame resolver
+    /// against the remembered home and re-applies the result. While the home
+    /// display is absent it does nothing — never fighting a placement the user
+    /// made in the meantime. Idempotent, so a burst of notifications converges
+    /// without a settle delay.
+    private func reconcileWindowHomeForDisplayChange() {
+        guard !isTerminatingApp, !isApplyingSessionRestore else { return }
+        guard !NSScreen.screens.isEmpty else { return }
+        guard let window = preferredRegisteredMainWindowContext()?.window
+            ?? mainWindowContexts.values.first(where: { $0.window != nil })?.window,
+              let windowId = mainWindowId(for: window),
+              let home = windowHomeTracker.home(for: windowId) else {
+            return
+        }
+        guard !window.styleMask.contains(.fullScreen),
+              !window.isZoomed,
+              !window.isMiniaturized else {
+            return
+        }
+
+        // Only restore once the home display is connected again; otherwise leave
+        // the window wherever it currently is.
+        guard let homeDisplayID = home.display.displayID,
+              NSScreen.screens.contains(where: { $0.cmuxDisplayID == homeDisplayID }) else {
+            return
+        }
+
+        let displays = currentDisplayGeometries()
+        guard let resolved = Self.resolvedWindowFrame(
+            from: SessionRectSnapshot(home.frame),
+            display: home.display,
+            availableDisplays: displays.available,
+            fallbackDisplay: displays.fallback
+        ), !Self.rectApproximatelyEqual(resolved, window.frame) else {
+            return
+        }
+
+        isReconcilingWindowHome = true
+        defer { isReconcilingWindowHome = false }
+        window.setFrame(resolved, display: true, animate: false)
     }
 
     private func startSessionAutosaveTimerIfNeeded() {
@@ -3635,6 +3752,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             }
         }
         lifecycleSnapshotObservers.append(didWakeObserver)
+
+        // Re-home the main window when displays come and go. macOS rescues
+        // windows off a vanishing display onto the remaining one but never moves
+        // them back; this observer restores the user's placement once the home
+        // display reappears. The handler is idempotent, so a burst of
+        // notifications during reconfiguration converges without a settle delay.
+        let screenParametersObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.didChangeScreenParametersNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.reconcileWindowHomeForDisplayChange()
+            }
+        }
+        lifecycleSnapshotObservers.append(screenParametersObserver)
     }
 
     private func socketListenerConfigurationIfEnabled() -> (mode: SocketControlMode, path: String)? {
@@ -8107,6 +8240,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 self?.closedWindowHistorySuppressedWindowIds.remove(windowId)
             }
             return shouldClose
+        }
+        controller.onGeometryChanged = { [weak self] movedWindow, userInitiated in
+            self?.handleMainWindowGeometryChanged(movedWindow, userInitiated: userInitiated)
         }
         window.delegate = controller
         mainWindowControllers.append(controller)
@@ -15808,6 +15944,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         guard let removed = unregisterMainWindowContext(for: window) else { return }
         publishCmuxWindowLifecycle(name: "window.closed", windowId: removed.windowId, origin: "appkit_close")
+        windowHomeTracker.clear(windowId: removed.windowId)
         commandPaletteVisibilityByWindowId.removeValue(forKey: removed.windowId)
         commandPalettePendingOpenByWindowId.removeValue(forKey: removed.windowId)
         commandPaletteRecentRequestAtByWindowId.removeValue(forKey: removed.windowId)

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -3157,6 +3157,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private func completeSessionRestoreOperation(isManualReopen: Bool) {
         startupSessionSnapshot = nil
         isApplyingSessionRestore = false
+        seedWindowHomesFromRestoredWindows()
         if Self.shouldSaveSessionSnapshotOnRestoreCompletion(isManualReopen: isManualReopen) {
             // Auto-resume input can be queued before tmux has spawned; preserve
             // restored process-detected bindings until a later live scan.
@@ -3594,7 +3595,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return Self.displaySnapshot(for: screen)
     }
 
-    private nonisolated static func displaySnapshot(for screen: NSScreen?) -> SessionDisplaySnapshot? {
+    private static func displaySnapshot(for screen: NSScreen?) -> SessionDisplaySnapshot? {
         guard let screen else { return nil }
         return SessionDisplaySnapshot(
             displayID: screen.cmuxDisplayID,
@@ -3611,6 +3612,29 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     /// (within a single session) does not need cross-launch persistence, which
     /// the existing startup restore already handles.
     private func handleMainWindowGeometryChanged(_ window: NSWindow, userInitiated: Bool) {
+        recordWindowHome(for: window, isUserInitiated: userInitiated)
+    }
+
+    /// Seeds each restored window's home from its placed frame + display so the
+    /// reconnect path works on the common case: launch the app, session restore
+    /// drops the window on the external monitor, the user steps away without ever
+    /// touching it, the monitor sleeps and wakes. Without this seed the tracker
+    /// would be empty and nothing would restore until the first manual move.
+    /// `isUserInitiated: true` here treats the restored placement as the intended
+    /// home (the user chose it last session); `isApplyingSessionRestore` is
+    /// already cleared by the time this runs.
+    private func seedWindowHomesFromRestoredWindows() {
+        for context in mainWindowContexts.values {
+            guard let window = context.window ?? windowForMainWindowId(context.windowId) else {
+                continue
+            }
+            recordWindowHome(for: window, isUserInitiated: true)
+        }
+    }
+
+    /// Records `window`'s current frame + display as its home when the placement
+    /// should count (see ``WindowHomeTracker/shouldRecordHome(isUserInitiated:isReconciling:isApplyingSessionRestore:isFullScreen:isZoomed:isMiniaturized:screenPresent:)``).
+    private func recordWindowHome(for window: NSWindow, isUserInitiated: Bool) {
         guard let windowId = mainWindowId(for: window) else { return }
         let screen = window.screen
             ?? NSScreen.screens.first(where: { $0.frame.intersects(window.frame) })
@@ -3619,7 +3643,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         } ?? false
 
         guard WindowHomeTracker.shouldRecordHome(
-            isUserInitiated: userInitiated,
+            isUserInitiated: isUserInitiated,
             isReconciling: isReconcilingWindowHome,
             isApplyingSessionRestore: isApplyingSessionRestore,
             isFullScreen: window.styleMask.contains(.fullScreen),

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -193,7 +193,7 @@ struct SessionRectSnapshot: Codable, Equatable, Sendable {
     }
 }
 
-struct SessionDisplaySnapshot: Codable, Sendable {
+struct SessionDisplaySnapshot: Codable, Equatable, Sendable {
     var displayID: UInt32?
     var frame: SessionRectSnapshot?
     var visibleFrame: SessionRectSnapshot?

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -599,6 +599,8 @@
 		A5001240 /* WindowDecorationsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001241 /* WindowDecorationsController.swift */; };
 		B9000018A1B2C3D4E5F60719 /* WindowDragHandleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000017A1B2C3D4E5F60719 /* WindowDragHandleView.swift */; };
 		807E058A23061EFB70A1B7F8 /* WindowGlassEffect.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B54144FA244A0B482D2903D /* WindowGlassEffect.swift */; };
+		F5000020A1B2C3D4E5F60718 /* WindowHomeTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5000021A1B2C3D4E5F60718 /* WindowHomeTracker.swift */; };
+		F5000010A1B2C3D4E5F60718 /* WindowHomeTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5000011A1B2C3D4E5F60718 /* WindowHomeTrackerTests.swift */; };
 		D0B10024A1B2C3D4E5F60001 /* WindowInputRoutingContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B10025A1B2C3D4E5F60001 /* WindowInputRoutingContext.swift */; };
 		A5001209 /* WindowToolbarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001219 /* WindowToolbarController.swift */; };
 		D7AB00000000000000000015 /* Workspace+DetachedSurfaceTransfer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB00000000000000000016 /* Workspace+DetachedSurfaceTransfer.swift */; };
@@ -1256,6 +1258,8 @@
 		A5001241 /* WindowDecorationsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowDecorationsController.swift; sourceTree = "<group>"; };
 		B9000017A1B2C3D4E5F60719 /* WindowDragHandleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowDragHandleView.swift; sourceTree = "<group>"; };
 		0B54144FA244A0B482D2903D /* WindowGlassEffect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Windowing/WindowGlassEffect.swift; sourceTree = "<group>"; };
+		F5000021A1B2C3D4E5F60718 /* WindowHomeTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/WindowHomeTracker.swift; sourceTree = "<group>"; };
+		F5000011A1B2C3D4E5F60718 /* WindowHomeTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowHomeTrackerTests.swift; sourceTree = "<group>"; };
 		D0B10025A1B2C3D4E5F60001 /* WindowInputRoutingContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowInputRoutingContext.swift; sourceTree = "<group>"; };
 		A5001219 /* WindowToolbarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowToolbarController.swift; sourceTree = "<group>"; };
 		D7AB00000000000000000016 /* Workspace+DetachedSurfaceTransfer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+DetachedSurfaceTransfer.swift"; sourceTree = "<group>"; };
@@ -1575,6 +1579,7 @@
 				6B8E2E03F4A64C61B729CF19 /* TerminalDirectoryOpenSupport.swift */,
 				8A4FE96C3F394FC6A6D4B018 /* CmuxCLIPathInstaller.swift */,
 				47D5AA7D29C94F5CA865B2BF /* ScreenIdentity.swift */,
+				F5000021A1B2C3D4E5F60718 /* WindowHomeTracker.swift */,
 				C1713001C1713001C1713001 /* CommandPaletteShortcutRouting.swift */,
 				B42A82C6AA614E74873D9A5F /* ShortcutRoutingSupport.swift */,
 				AB7F2E9143904957AAA70726 /* ShortcutBareStartRouting.swift */,
@@ -1896,6 +1901,7 @@
 				F4200001A1B2C3D4E5F60718 /* WindowAppearanceSnapshotTests.swift */,
 				F4100001A1B2C3D4E5F60718 /* PortScannerTests.swift */,
 				F5000001A1B2C3D4E5F60718 /* SessionPersistenceTests.swift */,
+				F5000011A1B2C3D4E5F60718 /* WindowHomeTrackerTests.swift */,
 				B35750000000000000000009 /* PiVaultAgentPersistenceTests.swift */,
 				D3610B010000000000000002 /* AgentSessionAutoResumeSettingsTests.swift */,
 				D36A00020000000000000002 /* AgentHibernationTests.swift */,
@@ -2746,6 +2752,7 @@
 				A5001240 /* WindowDecorationsController.swift in Sources */,
 				B9000018A1B2C3D4E5F60719 /* WindowDragHandleView.swift in Sources */,
 				807E058A23061EFB70A1B7F8 /* WindowGlassEffect.swift in Sources */,
+				F5000020A1B2C3D4E5F60718 /* WindowHomeTracker.swift in Sources */,
 				D0B10024A1B2C3D4E5F60001 /* WindowInputRoutingContext.swift in Sources */,
 				A5001209 /* WindowToolbarController.swift in Sources */,
 				D7AB00000000000000000015 /* Workspace+DetachedSurfaceTransfer.swift in Sources */,
@@ -3000,6 +3007,7 @@
 				C37800000000000000000001 /* VMSSHCommandTests.swift in Sources */,
 				063BC42CEE257D6213A2E30C /* WindowAndDragTests.swift in Sources */,
 				F4200000A1B2C3D4E5F60718 /* WindowAppearanceSnapshotTests.swift in Sources */,
+				F5000010A1B2C3D4E5F60718 /* WindowHomeTrackerTests.swift in Sources */,
 				7F0A0E04A8CADC84BB4F1DF7 /* WorkspaceActionDispatcherTests.swift in Sources */,
 				D7AB00000000000000000011 /* WorkspaceAdjacentPaneMoveTests.swift in Sources */,
 				A11EAE000000000000000000 /* WorkspaceAppearanceConfigResolutionTests.swift in Sources */,

--- a/cmuxTests/WindowHomeTrackerTests.swift
+++ b/cmuxTests/WindowHomeTrackerTests.swift
@@ -1,0 +1,248 @@
+import Testing
+import CoreGraphics
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+@Suite struct WindowHomeTrackerTests {
+    private func makeSnapshot(
+        displayID: UInt32,
+        frame: CGRect = CGRect(x: 0, y: 0, width: 1_000, height: 800)
+    ) -> SessionDisplaySnapshot {
+        SessionDisplaySnapshot(
+            displayID: displayID,
+            frame: SessionRectSnapshot(frame),
+            visibleFrame: SessionRectSnapshot(frame)
+        )
+    }
+
+    @Test func recordsAndRetrievesHome() {
+        let tracker = WindowHomeTracker()
+        let id = UUID()
+        let frame = CGRect(x: 1_200, y: 100, width: 600, height: 400)
+        let display = makeSnapshot(displayID: 2)
+
+        #expect(tracker.home(for: id) == nil)
+        tracker.recordHome(windowId: id, frame: frame, display: display)
+
+        let home = tracker.home(for: id)
+        #expect(home?.frame == frame)
+        #expect(home?.display == display)
+    }
+
+    @Test func recordHomeReplacesPreviousValue() {
+        let tracker = WindowHomeTracker()
+        let id = UUID()
+        tracker.recordHome(
+            windowId: id,
+            frame: CGRect(x: 0, y: 0, width: 100, height: 100),
+            display: makeSnapshot(displayID: 1)
+        )
+        let newFrame = CGRect(x: 1_300, y: 50, width: 700, height: 500)
+        tracker.recordHome(windowId: id, frame: newFrame, display: makeSnapshot(displayID: 2))
+
+        #expect(tracker.home(for: id)?.frame == newFrame)
+        #expect(tracker.home(for: id)?.display.displayID == 2)
+    }
+
+    @Test func clearForgetsHome() {
+        let tracker = WindowHomeTracker()
+        let id = UUID()
+        tracker.recordHome(
+            windowId: id,
+            frame: CGRect(x: 0, y: 0, width: 100, height: 100),
+            display: makeSnapshot(displayID: 1)
+        )
+        tracker.clear(windowId: id)
+        #expect(tracker.home(for: id) == nil)
+    }
+
+    @Test func tracksWindowsIndependently() {
+        let tracker = WindowHomeTracker()
+        let a = UUID()
+        let b = UUID()
+        tracker.recordHome(
+            windowId: a,
+            frame: CGRect(x: 0, y: 0, width: 100, height: 100),
+            display: makeSnapshot(displayID: 1)
+        )
+        tracker.recordHome(
+            windowId: b,
+            frame: CGRect(x: 500, y: 500, width: 200, height: 200),
+            display: makeSnapshot(displayID: 2)
+        )
+        tracker.clear(windowId: a)
+
+        #expect(tracker.home(for: a) == nil)
+        #expect(tracker.home(for: b)?.display.displayID == 2)
+    }
+
+    // MARK: shouldRecordHome decision
+
+    @Test func recordsHomeForStableUserMove() {
+        #expect(WindowHomeTracker.shouldRecordHome(
+            isUserInitiated: true,
+            isReconciling: false,
+            isApplyingSessionRestore: false,
+            isFullScreen: false,
+            isZoomed: false,
+            isMiniaturized: false,
+            screenPresent: true
+        ))
+    }
+
+    /// The crux of the fix: macOS rescues the window off a vanishing display
+    /// onto the laptop, firing `windowDidMove` with NO preceding
+    /// `windowWillMove`, so `isUserInitiated` is false even though the laptop is
+    /// present and the window is in a normal state. This must NOT overwrite the
+    /// remembered home, or the original placement is lost and nothing restores.
+    @Test func doesNotRecordHomeForMacOSRescueMove() {
+        #expect(!WindowHomeTracker.shouldRecordHome(
+            isUserInitiated: false,
+            isReconciling: false,
+            isApplyingSessionRestore: false,
+            isFullScreen: false,
+            isZoomed: false,
+            isMiniaturized: false,
+            screenPresent: true
+        ))
+    }
+
+    @Test(arguments: [
+        // (userInitiated, reconciling, restoring, fullscreen, zoomed, mini, screenPresent)
+        // Each tuple is a user-initiated move with exactly one suppressing condition.
+        (true, true, false, false, false, false, true),   // reconciling (our own restore)
+        (true, false, true, false, false, false, true),    // session restore
+        (true, false, false, true, false, false, true),    // fullscreen
+        (true, false, false, false, true, false, true),    // zoomed
+        (true, false, false, false, false, true, true),    // miniaturized
+        (true, false, false, false, false, false, false),  // window's screen absent
+    ])
+    func doesNotRecordHomeWhenSuppressed(
+        _ args: (Bool, Bool, Bool, Bool, Bool, Bool, Bool)
+    ) {
+        #expect(!WindowHomeTracker.shouldRecordHome(
+            isUserInitiated: args.0,
+            isReconciling: args.1,
+            isApplyingSessionRestore: args.2,
+            isFullScreen: args.3,
+            isZoomed: args.4,
+            isMiniaturized: args.5,
+            screenPresent: args.6
+        ))
+    }
+
+    // MARK: restore resolver flow
+    //
+    // These exercise the exact pipeline `reconcileWindowHomeForDisplayChange`
+    // depends on: resolve the persisted home against the live display list, then
+    // restore only when the resolver reproduced the exact home frame (meaning the
+    // home display is connected again).
+
+    @Test func doesNotRestoreWhileHomeDisplayAbsent() throws {
+        let homeFrame = SessionRectSnapshot(x: 1_200, y: 100, width: 600, height: 400)
+        let homeDisplay = SessionDisplaySnapshot(
+            displayID: 2,
+            frame: SessionRectSnapshot(x: 1_000, y: 0, width: 1_000, height: 800),
+            visibleFrame: SessionRectSnapshot(x: 1_000, y: 0, width: 1_000, height: 800)
+        )
+        // Only the laptop display is present; the external (id 2) is gone.
+        let laptop = AppDelegate.SessionDisplayGeometry(
+            displayID: 1,
+            frame: CGRect(x: 0, y: 0, width: 1_440, height: 900),
+            visibleFrame: CGRect(x: 0, y: 0, width: 1_440, height: 900)
+        )
+
+        let resolved = AppDelegate.resolvedWindowFrame(
+            from: homeFrame,
+            display: homeDisplay,
+            availableDisplays: [laptop],
+            fallbackDisplay: laptop
+        )
+
+        let resolvedFrame = try #require(resolved)
+        // Resolver clamps onto the laptop, so it is NOT the exact home frame.
+        #expect(!rectApproximatelyEqual(resolvedFrame, homeFrame.cgRect))
+    }
+
+    @Test func restoresExactHomeWhenDisplayReturns() throws {
+        let homeFrame = SessionRectSnapshot(x: 1_200, y: 100, width: 600, height: 400)
+        let homeDisplay = SessionDisplaySnapshot(
+            displayID: 2,
+            frame: SessionRectSnapshot(x: 1_000, y: 0, width: 1_000, height: 800),
+            visibleFrame: SessionRectSnapshot(x: 1_000, y: 0, width: 1_000, height: 800)
+        )
+        let laptop = AppDelegate.SessionDisplayGeometry(
+            displayID: 1,
+            frame: CGRect(x: 0, y: 0, width: 1_440, height: 900),
+            visibleFrame: CGRect(x: 0, y: 0, width: 1_440, height: 900)
+        )
+        // External display id 2 is back with identical geometry.
+        let external = AppDelegate.SessionDisplayGeometry(
+            displayID: 2,
+            frame: CGRect(x: 1_000, y: 0, width: 1_000, height: 800),
+            visibleFrame: CGRect(x: 1_000, y: 0, width: 1_000, height: 800)
+        )
+
+        let resolved = AppDelegate.resolvedWindowFrame(
+            from: homeFrame,
+            display: homeDisplay,
+            availableDisplays: [laptop, external],
+            fallbackDisplay: laptop
+        )
+
+        let resolvedFrame = try #require(resolved)
+        // Resolver reproduces the exact home frame, so the reconcile would apply it.
+        #expect(rectApproximatelyEqual(resolvedFrame, homeFrame.cgRect))
+    }
+
+    @Test func restoreIsIdempotentOnceApplied() throws {
+        let homeFrame = SessionRectSnapshot(x: 1_200, y: 100, width: 600, height: 400)
+        let homeDisplay = SessionDisplaySnapshot(
+            displayID: 2,
+            frame: SessionRectSnapshot(x: 1_000, y: 0, width: 1_000, height: 800),
+            visibleFrame: SessionRectSnapshot(x: 1_000, y: 0, width: 1_000, height: 800)
+        )
+        let external = AppDelegate.SessionDisplayGeometry(
+            displayID: 2,
+            frame: CGRect(x: 1_000, y: 0, width: 1_000, height: 800),
+            visibleFrame: CGRect(x: 1_000, y: 0, width: 1_000, height: 800)
+        )
+
+        let first = AppDelegate.resolvedWindowFrame(
+            from: homeFrame,
+            display: homeDisplay,
+            availableDisplays: [external],
+            fallbackDisplay: external
+        )
+        let second = AppDelegate.resolvedWindowFrame(
+            from: homeFrame,
+            display: homeDisplay,
+            availableDisplays: [external],
+            fallbackDisplay: external
+        )
+
+        let firstFrame = try #require(first)
+        let secondFrame = try #require(second)
+        // Re-running the resolver yields the same frame every time, so a burst of
+        // didChangeScreenParameters notifications converges without a settle delay.
+        #expect(firstFrame == secondFrame)
+        #expect(rectApproximatelyEqual(firstFrame, homeFrame.cgRect))
+    }
+
+    /// Local mirror of `AppDelegate.rectApproximatelyEqual` (which is private to
+    /// the app target) so the resolver-flow assertions match the reconcile's own
+    /// comparison semantics.
+    private func rectApproximatelyEqual(_ lhs: CGRect, _ rhs: CGRect, tolerance: CGFloat = 1) -> Bool {
+        let l = lhs.standardized
+        let r = rhs.standardized
+        return abs(l.origin.x - r.origin.x) <= tolerance
+            && abs(l.origin.y - r.origin.y) <= tolerance
+            && abs(l.size.width - r.size.width) <= tolerance
+            && abs(l.size.height - r.size.height) <= tolerance
+    }
+}


### PR DESCRIPTION
## Problem

Window parked on an external monitor jumps to the laptop after a break and never comes back. macOS relocates windows off a sleeping/disconnected display and doesn't move them back on reconnect; cmux only restored frames at startup, with no runtime handler.

## Fix

- New `WindowHomeTracker` — remembers each window's intended frame + display (in memory).
- Seeds home at session restore, so the common case (launch → window on external → walk away → sleep/wake) restores without any manual move.
- On `didChangeScreenParametersNotification`, re-runs the existing frame resolver and re-applies the home frame once that display is back. Idempotent — no settle timer.
- Distinguishes a real user drag (preceded by `windowWillMove`) from a macOS rescue move (none), so the rescue never overwrites home. Honors deliberate moves to the laptop.

## Scope

Single primary window (v1); tracker keyed by `windowId` so multi-window is a clean follow-up.

## Tests

`WindowHomeTrackerTests` (Swift Testing): tracker round-trip, the `shouldRecordHome` decision table incl. the macOS-rescue case, and resolver flow (display absent → no-op, display back → restore, idempotent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)