### PR TITLE
Browser omnibar: first focus-gaining click selects whole URL (Chrome parity)

### DIFF
--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -4052,7 +4052,7 @@ final class OmnibarNativeTextField: NSTextField {
         ), let editor = currentEditor() as? NSTextView else {
             return
         }
-        editor.setSelectedRange(NSRange(location: 0, length: (editor.string as NSString).length))
+        editor.setSelectedRange(NSRange(location: 0, length: editor.string.utf16.count))
     }
 
     private func insertionIndex(for event: NSEvent, in editor: NSTextView) -> Int {

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -3899,6 +3899,33 @@ func browserOmnibarShouldSelectAllOnFocusReassertion(
     selectionIntent.shouldSelectAll
 }
 
+/// Whether a completed single click that just moved first responder into the
+/// omnibar should select the field's entire contents (Chrome/Safari/Arc parity),
+/// instead of leaving the caret the field editor placed at the click point.
+///
+/// The first click on an unfocused omnibar showing a URL selects everything so
+/// the user can immediately type a replacement. A subsequent click (the field is
+/// already first responder, so `gainedFocusOnThisClick` is `false`) keeps the
+/// caret placement from https://github.com/manaflow-ai/cmux/issues/5268. A drag
+/// or a Shift-click expresses an explicit range, so select-all defers to it; a
+/// double-click never reaches this path (the field routes multi-clicks straight
+/// to the field editor for word/line selection, and its second click lands after
+/// this click's `mouseUp`, so word selection wins).
+///
+/// - Parameters:
+///   - gainedFocusOnThisClick: `true` when the field had no field editor at
+///     `mouseDown`, i.e. this click is the one that moved focus into the omnibar.
+///   - isShiftClick: `true` when Shift was held, extending an explicit selection.
+///   - didDrag: `true` when the pointer moved far enough to build a drag selection.
+/// - Returns: `true` only for an undragged, unmodified focus-gaining click.
+func browserOmnibarFocusGainingClickShouldSelectAll(
+    gainedFocusOnThisClick: Bool,
+    isShiftClick: Bool,
+    didDrag: Bool
+) -> Bool {
+    gainedFocusOnThisClick && !isShiftClick && !didDrag
+}
+
 final class OmnibarNativeTextField: NSTextField {
     var panelId: UUID?
     var onPointerDown: (() -> Void)?
@@ -3913,6 +3940,12 @@ final class OmnibarNativeTextField: NSTextField {
         let anchor: Int
         let initialWindowLocation: NSPoint
         var didDrag: Bool
+        /// `true` when this click moved first responder into the omnibar, gating
+        /// the Chrome-style select-all-on-focus behavior applied at `mouseUp`.
+        let gainedFocus: Bool
+        /// `true` when Shift was held, so an explicit selection extension overrides
+        /// the focus-gaining select-all.
+        let isShift: Bool
     }
 
     override init(frame frameRect: NSRect) {
@@ -3947,6 +3980,8 @@ final class OmnibarNativeTextField: NSTextField {
             return
         }
 
+        let isShiftClick = event.modifierFlags.contains(.shift)
+
         // Keep multi-click word and line selection in the field editor, while avoiding
         // NSTextField's mouse tracking loop for ordinary clicks.
         if event.clickCount > 1 {
@@ -3958,7 +3993,7 @@ final class OmnibarNativeTextField: NSTextField {
 
         let clickIndex = insertionIndex(for: event, in: editor)
         let anchor: Int
-        if event.modifierFlags.contains(.shift) {
+        if isShiftClick {
             let selected = editor.selectedRange()
             anchor = shiftClickAnchor ?? selected.location
             shiftClickAnchor = anchor
@@ -3972,7 +4007,9 @@ final class OmnibarNativeTextField: NSTextField {
         mouseSelectionState = MouseSelectionState(
             anchor: anchor,
             initialWindowLocation: event.locationInWindow,
-            didDrag: false
+            didDrag: false,
+            gainedFocus: !hadEditor,
+            isShift: isShiftClick
         )
     }
 
@@ -3994,16 +4031,28 @@ final class OmnibarNativeTextField: NSTextField {
     }
 
     override func mouseUp(with event: NSEvent) {
-        guard mouseSelectionState != nil else {
+        guard let state = mouseSelectionState else {
             super.mouseUp(with: event)
             return
         }
-
-        // A single click leaves the caret placed in `mouseDown`; a drag leaves the
-        // range built up in `mouseDragged`. Focus-via-click never selects all — that
-        // is reserved for the keyboard path (Cmd+L), which selects the whole URL via
-        // the `selectAllRequestId` flow, independent of mouse handling.
         mouseSelectionState = nil
+
+        // Chrome/Safari/Arc parity: the click that moves first responder into the
+        // omnibar selects the whole URL so the next keystroke replaces it. A click
+        // while already focused keeps the caret placed in `mouseDown` (issue #5268),
+        // and a drag or Shift-click keeps the explicit range built up during the
+        // gesture. Double-clicks never reach here — `mouseDown` routes multi-clicks
+        // to the field editor for word/line selection and leaves `mouseSelectionState`
+        // nil, and the second click lands after this `mouseUp`, so word selection wins.
+        // The keyboard path (Cmd+L) still selects all via the `selectAllRequestId` flow.
+        guard browserOmnibarFocusGainingClickShouldSelectAll(
+            gainedFocusOnThisClick: state.gainedFocus,
+            isShiftClick: state.isShift,
+            didDrag: state.didDrag
+        ), let editor = currentEditor() as? NSTextView else {
+            return
+        }
+        editor.setSelectedRange(NSRange(location: 0, length: (editor.string as NSString).length))
     }
 
     private func insertionIndex(for event: NSEvent, in editor: NSTextView) -> Int {

--- a/cmuxTests/OmnibarAndToolsTests.swift
+++ b/cmuxTests/OmnibarAndToolsTests.swift
@@ -450,6 +450,49 @@ final class OmnibarStateMachineTests: XCTestCase {
         )
     }
 
+    // State 1 (issue #5459): the single click that moves first responder into the
+    // omnibar selects the whole URL so the next keystroke replaces it (Chrome parity).
+    func testFocusGainingClickSelectsAll() throws {
+        XCTAssertTrue(
+            browserOmnibarFocusGainingClickShouldSelectAll(
+                gainedFocusOnThisClick: true,
+                isShiftClick: false,
+                didDrag: false
+            )
+        )
+    }
+
+    // State 2 (issue #5268 must not regress): a click while the omnibar is already
+    // first responder keeps the caret placed at the click point — no select-all.
+    func testAlreadyFocusedClickPlacesCaret() throws {
+        XCTAssertFalse(
+            browserOmnibarFocusGainingClickShouldSelectAll(
+                gainedFocusOnThisClick: false,
+                isShiftClick: false,
+                didDrag: false
+            )
+        )
+    }
+
+    // A Shift-click or a drag expresses an explicit range, so the focus-gaining
+    // select-all defers to it even on the click that gains focus.
+    func testFocusGainingClickDefersToExplicitSelection() throws {
+        XCTAssertFalse(
+            browserOmnibarFocusGainingClickShouldSelectAll(
+                gainedFocusOnThisClick: true,
+                isShiftClick: true,
+                didDrag: false
+            )
+        )
+        XCTAssertFalse(
+            browserOmnibarFocusGainingClickShouldSelectAll(
+                gainedFocusOnThisClick: true,
+                isShiftClick: false,
+                didDrag: true
+            )
+        )
+    }
+
     func testEscapeRevertsWhenEditingThenBlursOnSecondEscape() throws {
         var state = OmnibarState()
 


### PR DESCRIPTION
Closes #5459

## Problem

Clicking the browser omnibar placed a caret (the fix from #5268), but the **first** focus-gaining click did not select the whole URL. Users had to press Cmd+A / Cmd+L to replace a URL, unlike Chrome/Safari/Arc.

## Behavior — three states, matching Chrome exactly

1. **First click on an unfocused omnibar showing a URL → selects the entire contents.** The user can immediately type a replacement URL.
2. **A subsequent click while the omnibar is already focused → places the caret at the click point and clears the selection.** This preserves the #5268 fix — **no regression**.
3. **Double-click → selects the word under the cursor** (standard, unchanged field-editor behavior).

Drags and Shift-clicks keep their explicit range even on the focus-gaining click.

## Approach

`OmnibarNativeTextField`'s mouse-gesture state machine already owns the mouse selection decision, so the change stays there rather than routing a mouse click through the async, notification-based `requestAddressBarFocus(selectionIntent:)` path — that path is for keyboard/programmatic focus (Cmd+L) and would fight the field editor's caret placement with retry timing.

- `MouseSelectionState` now records `gainedFocus` (the click had no field editor at `mouseDown`, i.e. it moved first responder into the omnibar) and `isShift`.
- `mouseUp` consults a new pure, testable decision function `browserOmnibarFocusGainingClickShouldSelectAll(gainedFocusOnThisClick:isShiftClick:didDrag:)` and selects all **only** on an undragged, unmodified focus-gaining click.
- Double-clicks (`clickCount > 1`) route straight to the field editor and leave `mouseSelectionState` nil, so word selection wins; the second click lands after the first click's `mouseUp`.

No new user-facing strings, so no localization changes.

## Tests

Unit tests for the decision function in `OmnibarStateMachineTests` (alongside the sibling `browserOmnibarShouldSelectAllOnFocusReassertion` tests), covering all three states:
- focus-gaining click → select all
- already-focused click → caret preserved (#5268 guard)
- focus-gaining Shift-click / drag → defers to explicit range

The end-to-end AppKit field-editor click-to-selection is mouse-gesture behavior not cleanly unit-testable without an `NSWindow`/event loop; the pure decision that gates it is fully covered here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5462"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783252295&installation_id=133855650&pr_number=5462&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5462&signature=f4b5ceb58652fb4a9fd201d14c6bd8bc9dbc1c77e81a1a2ea80e7cee1f4c7797"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized AppKit mouse/selection behavior in the omnibar with a pure decision function and unit tests; no auth, data, or API changes.
> 
> **Overview**
> **First click into the omnibar** now selects the full URL so typing replaces it immediately (Chrome/Safari/Arc parity). The logic lives in `OmnibarNativeTextField`’s mouse path via a new pure helper `browserOmnibarFocusGainingClickShouldSelectAll`, applied at `mouseUp` when the click gained focus without Shift or drag.
> 
> **Already-focused clicks** still only place the caret (#5268). Shift-clicks, drags, and multi-clicks keep explicit/word selection; Cmd+L / focus reassertion behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cd85a9c1c6fe3a988b0024747afdf1ff0e077bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The omnibar now selects the whole URL on the first click that moves focus into it, so you can replace the URL immediately. Subsequent clicks keep the caret, and double-click still selects a word, matching Chrome/Safari/Arc.

- **Bug Fixes**
  - Select-all on an undragged, unmodified focus-gaining click; already-focused click places caret (preserves #5268).
  - Shift-click and drag keep explicit ranges; double-click goes to the field editor for word selection.
  - Implemented in `OmnibarNativeTextField` via `browserOmnibarFocusGainingClickShouldSelectAll(...)` with tests in `OmnibarStateMachineTests`; select-all length uses `editor.string.utf16.count` (no `NSString` bridge).

<sup>Written for commit 9cd85a9c1c6fe3a988b0024747afdf1ff0e077bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5462?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved omnibar mouse focus and select-all behavior to match common browsers when a click moves focus; preserves caret/range when appropriate and respects Shift-click and drag.
* **Tests**
  * Added tests covering focus-gaining click selection, non-select behavior when already focused, and Shift/drag interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->