### PR TITLE
Scale browser chrome with the tab bar font size

### DIFF
--- a/Sources/Panels/BrowserChromeMetrics.swift
+++ b/Sources/Panels/BrowserChromeMetrics.swift
@@ -1,0 +1,62 @@
+import CoreGraphics
+
+/// Derives the browser top-chrome sizes (omnibar text, navigation glyphs,
+/// toolbar icon buttons) from the user's tab bar font size so the whole top
+/// chrome — tabs plus the browser toolbar — renders at one consistent scale.
+///
+/// Every size is a pure multiple of a legacy base constant. At
+/// ``referenceFontSize`` the scale is exactly `1`, so the chrome is
+/// byte-identical to the previously hardcoded layout; larger or smaller tab bar
+/// font sizes scale the chrome proportionally. The derived scale is clamped to
+/// ``minimumScale``...``maximumScale`` so a malformed config value can never
+/// blow the toolbar up or collapse it.
+///
+/// The type is a pure value with no I/O, so the derivation is unit-testable
+/// without launching the app: construct it with a font size and read the
+/// computed sizes.
+struct BrowserChromeMetrics: Equatable {
+    /// The tab bar font size the chrome scales against, in points.
+    let tabBarFontSize: CGFloat
+
+    /// The tab bar font size at which the chrome matches its legacy hardcoded
+    /// sizes (scale `1`). Anchored to the shipped default so "default size looks
+    /// unchanged" holds even if the default is later retuned.
+    static let referenceFontSize: CGFloat = GhosttyConfig.defaultSurfaceTabBarFontSize
+
+    /// Lower bound on the derived scale; guards against a near-zero config value.
+    static let minimumScale: CGFloat = 0.5
+
+    /// Upper bound on the derived scale; guards against an absurd config value.
+    static let maximumScale: CGFloat = 2.0
+
+    /// Multiplier applied to every legacy base size. `1` at ``referenceFontSize``.
+    var scale: CGFloat {
+        guard tabBarFontSize.isFinite, tabBarFontSize > 0 else { return 1 }
+        let raw = tabBarFontSize / Self.referenceFontSize
+        return min(max(raw, Self.minimumScale), Self.maximumScale)
+    }
+
+    /// Point size for the omnibar URL text field. Base `12`.
+    var omnibarFontSize: CGFloat { scaled(12) }
+
+    /// Height of the omnibar text field so taller text is not clipped. Base `18`.
+    var omnibarFieldHeight: CGFloat { scaled(18) }
+
+    /// Point size for the back/forward/reload navigation glyphs. Base `12`.
+    var navigationIconFontSize: CGFloat { scaled(12) }
+
+    /// Point size for the HTTPS lock badge in the omnibar. Base `10`.
+    var secureBadgeFontSize: CGFloat { scaled(10) }
+
+    /// Point size for the right-side accessory glyphs (screenshot, cursor grab,
+    /// profile, theme, developer tools). Base `11`.
+    var accessoryIconFontSize: CGFloat { scaled(11) }
+
+    /// Square edge of the right-side accessory icon buttons. Base `22`.
+    var buttonIconSize: CGFloat { scaled(22) }
+
+    /// Square hit target of the back/forward/reload buttons. Base `26`.
+    var buttonHitSize: CGFloat { scaled(26) }
+
+    private func scaled(_ base: CGFloat) -> CGFloat { base * scale }
+}

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -465,6 +465,11 @@ struct BrowserPanelView: View {
     @State private var isBrowserProfileMenuPresented = false
     @State private var isBrowserThemeMenuPresented = false
     @State private var browserChromeStyle: BrowserChromeStyle
+    // The browser top chrome scales with the tab bar font size so tabs and the
+    // browser toolbar share one consistent scale. Seeded from the cached config
+    // and refreshed live on `.ghosttyConfigDidReload` (same path the tab strip
+    // and terminal panels use). See `BrowserChromeMetrics`.
+    @State private var tabBarFontSize: CGFloat = GhosttyConfig.load().surfaceTabBarFontSize
     // `.onAppear` is not a reliable once-signal for a portal-hosted pane: it can
     // re-fire on every CoreAnimation commit (issue #5303). This guards the first-
     // appearance view-state seed (the empty-state import list) so a spurious appear
@@ -473,10 +478,15 @@ struct BrowserPanelView: View {
     // Keep this below half of the compact omnibar height so it reads as a squircle,
     // not a capsule.
     private let omnibarPillCornerRadius: CGFloat = 10
-    private let addressBarButtonSize: CGFloat = 22
-    private let addressBarButtonHitSize: CGFloat = 26
     private let addressBarVerticalPadding: CGFloat = 4
-    private let devToolsButtonIconSize: CGFloat = 11
+    // Toolbar/omnibar sizes derived from the tab bar font size. Names and call
+    // sites are unchanged; the values now scale via `chromeMetrics`.
+    private var chromeMetrics: BrowserChromeMetrics {
+        BrowserChromeMetrics(tabBarFontSize: tabBarFontSize)
+    }
+    private var addressBarButtonSize: CGFloat { chromeMetrics.buttonIconSize }
+    private var addressBarButtonHitSize: CGFloat { chromeMetrics.buttonHitSize }
+    private var devToolsButtonIconSize: CGFloat { chromeMetrics.accessoryIconFontSize }
 
     init(
         panel: BrowserPanel,
@@ -1138,6 +1148,9 @@ struct BrowserPanelView: View {
         .onReceive(NotificationCenter.default.publisher(for: .webViewDidReceiveClick)) { notification in
             handleBrowserWebViewClickIntent(notification)
         }
+        .onReceive(NotificationCenter.default.publisher(for: .ghosttyConfigDidReload)) { _ in
+            tabBarFontSize = GhosttyConfig.load().surfaceTabBarFontSize
+        }
         .onAppear {
             handleBrowserPanelAppear()
         }
@@ -1252,7 +1265,7 @@ struct BrowserPanelView: View {
                 panel.goBack()
             }) {
                 Image(systemName: "chevron.left")
-                    .font(.system(size: 12, weight: .medium))
+                    .font(.system(size: chromeMetrics.navigationIconFontSize, weight: .medium))
                     .frame(width: addressBarButtonHitSize, height: addressBarButtonHitSize, alignment: .center)
                     .contentShape(Rectangle())
             }
@@ -1268,7 +1281,7 @@ struct BrowserPanelView: View {
                 panel.goForward()
             }) {
                 Image(systemName: "chevron.right")
-                    .font(.system(size: 12, weight: .medium))
+                    .font(.system(size: chromeMetrics.navigationIconFontSize, weight: .medium))
                     .frame(width: addressBarButtonHitSize, height: addressBarButtonHitSize, alignment: .center)
                     .contentShape(Rectangle())
             }
@@ -1279,7 +1292,7 @@ struct BrowserPanelView: View {
 
             Button(action: handleReloadOrStopButtonAction) {
                 Image(systemName: panel.isLoading ? "xmark" : "arrow.clockwise")
-                    .font(.system(size: 12, weight: .medium))
+                    .font(.system(size: chromeMetrics.navigationIconFontSize, weight: .medium))
                     .frame(width: addressBarButtonHitSize, height: addressBarButtonHitSize, alignment: .center)
                     .contentShape(Rectangle())
             }
@@ -1622,12 +1635,13 @@ struct BrowserPanelView: View {
         return HStack(spacing: 4) {
             if showSecureBadge {
                 Image(systemName: "lock.fill")
-                    .font(.system(size: 10))
+                    .font(.system(size: chromeMetrics.secureBadgeFontSize))
                     .foregroundColor(.secondary)
             }
 
             OmnibarTextFieldRepresentable(
                 panelId: panel.id,
+                fontSize: chromeMetrics.omnibarFontSize,
                 text: Binding(
                     get: { omnibarState.buffer },
                     set: { newValue in
@@ -1689,7 +1703,7 @@ struct BrowserPanelView: View {
                     panel.shouldSuppressWebViewFocus()
                 }
             )
-                .frame(height: 18)
+                .frame(height: chromeMetrics.omnibarFieldHeight)
                 .accessibilityIdentifier("BrowserOmnibarTextField")
         }
         .padding(.horizontal, 8)
@@ -4091,6 +4105,7 @@ final class OmnibarNativeTextField: NSTextField {
 
 struct OmnibarTextFieldRepresentable: NSViewRepresentable {
     let panelId: UUID
+    let fontSize: CGFloat
     @Binding var text: String
     @Binding var isFocused: Bool
     let selectAllRequestId: UInt64
@@ -4650,7 +4665,7 @@ struct OmnibarTextFieldRepresentable: NSViewRepresentable {
         field.panelId = panelId
         BrowserOmnibarNativeFieldRegistry.shared.register(field, panelId: panelId)
         field.identifier = browserOmnibarTextFieldIdentifier
-        field.font = .systemFont(ofSize: 12)
+        field.font = .systemFont(ofSize: fontSize)
         field.placeholderString = placeholder
         field.delegate = context.coordinator
         field.target = nil
@@ -4679,6 +4694,9 @@ struct OmnibarTextFieldRepresentable: NSViewRepresentable {
         nsView.panelId = panelId
         BrowserOmnibarNativeFieldRegistry.shared.register(nsView, panelId: panelId)
         nsView.placeholderString = placeholder
+        if nsView.font?.pointSize != fontSize {
+            nsView.font = .systemFont(ofSize: fontSize)
+        }
         context.coordinator.queueSelectAllRequest(selectAllRequestId)
 
         let activeInlineCompletion = omnibarInlineCompletionIfBufferMatchesTypedPrefix(

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -46,6 +46,8 @@
 		AA1B2C3D4E5F60718 /* BonsplitTabDragUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1B2C3D4E5F60719 /* BonsplitTabDragUITests.swift */; };
 		D3622000A1B2C3D4E5F60718 /* BrowserArrowKeyForwardingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3622001A1B2C3D4E5F60718 /* BrowserArrowKeyForwardingTests.swift */; };
 		B3770BA00000000000000001 /* BrowserAutomation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3770BA00000000000000002 /* BrowserAutomation.swift */; };
+		BCBC0A0E0000000000000C01 /* BrowserChromeMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCBC0A0E0000000000000C02 /* BrowserChromeMetrics.swift */; };
+		BCBC0A0E0000000000000D01 /* BrowserChromeMetricsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCBC0A0E0000000000000D02 /* BrowserChromeMetricsTests.swift */; };
 		E12E88F82733EC42F32C36A3 /* BrowserConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 970226F3C99D0D937CD00539 /* BrowserConfigTests.swift */; };
 		A5008373 /* BrowserFindJavaScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5008372 /* BrowserFindJavaScript.swift */; };
 		A5008381 /* BrowserFindJavaScriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5008380 /* BrowserFindJavaScriptTests.swift */; };
@@ -754,6 +756,8 @@
 		AA1B2C3D4E5F60719 /* BonsplitTabDragUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BonsplitTabDragUITests.swift; sourceTree = "<group>"; };
 		D3622001A1B2C3D4E5F60718 /* BrowserArrowKeyForwardingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserArrowKeyForwardingTests.swift; sourceTree = "<group>"; };
 		B3770BA00000000000000002 /* BrowserAutomation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserAutomation.swift; sourceTree = "<group>"; };
+		BCBC0A0E0000000000000C02 /* BrowserChromeMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserChromeMetrics.swift; sourceTree = "<group>"; };
+		BCBC0A0E0000000000000D02 /* BrowserChromeMetricsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserChromeMetricsTests.swift; sourceTree = "<group>"; };
 		970226F3C99D0D937CD00539 /* BrowserConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserConfigTests.swift; sourceTree = "<group>"; };
 		A5008372 /* BrowserFindJavaScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Find/BrowserFindJavaScript.swift; sourceTree = "<group>"; };
 		A5008380 /* BrowserFindJavaScriptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserFindJavaScriptTests.swift; sourceTree = "<group>"; };
@@ -1752,6 +1756,7 @@
 				A500MX00 /* BrowserPanel+MediaPlayback.swift */,
 				A500RG00 /* ReactGrab.swift */,
 				A5001413 /* TerminalPanelView.swift */,
+				BCBC0A0E0000000000000C02 /* BrowserChromeMetrics.swift */,
 				A5001414 /* BrowserPanelView.swift */,
 				B0A501000000000000000002 /* BrowserOmnibarAppKitBridge.swift */,
 				B0A500000000000000000002 /* BrowserOmnibarPerformanceSupport.swift */,
@@ -1904,6 +1909,7 @@
 				1718C0DE1718C0DE17180001 /* GhosttyCommandShiftForwardingTests.swift */,
 				D3284002A1B2C3D4E5F60718 /* TraditionalChineseIMENumpadRegressionTests.swift */,
 				F4000001A1B2C3D4E5F60718 /* GhosttyConfigTests.swift */,
+				BCBC0A0E0000000000000D02 /* BrowserChromeMetricsTests.swift */,
 				A11EB0000000000000000001 /* GhosttyConfigPathResolverTests.swift */,
 				C13519000000000000000004 /* GhosttyTerminalStartupEnvironmentTests.swift */,
 				C13519000000000000000008 /* ClaudeConfigDirectoryPathTests.swift */,
@@ -2458,6 +2464,7 @@
 				D0B10010A1B2C3D4E5F60001 /* BonsplitTabBarDebug.swift in Sources */,
 				D0B10002A1B2C3D4E5F60001 /* BonsplitTabBarPassThrough.swift in Sources */,
 				B3770BA00000000000000001 /* BrowserAutomation.swift in Sources */,
+				BCBC0A0E0000000000000C01 /* BrowserChromeMetrics.swift in Sources */,
 				A5008373 /* BrowserFindJavaScript.swift in Sources */,
 				B42450030000000000000001 /* BrowserHiddenWebViewDiscardManager.swift in Sources */,
 				B42450010000000000000001 /* BrowserHiddenWebViewDiscardPolicy.swift in Sources */,
@@ -2894,6 +2901,7 @@
 				F6000000A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift in Sources */,
 				A11EAA000000000000000000 /* AppearanceSettingsTests.swift in Sources */,
 				D3622000A1B2C3D4E5F60718 /* BrowserArrowKeyForwardingTests.swift in Sources */,
+				BCBC0A0E0000000000000D01 /* BrowserChromeMetricsTests.swift in Sources */,
 				E12E88F82733EC42F32C36A3 /* BrowserConfigTests.swift in Sources */,
 				A5008381 /* BrowserFindJavaScriptTests.swift in Sources */,
 				4E1F28554F1B908F18559390 /* BrowserHistorySuggestionCacheTests.swift in Sources */,

--- a/cmuxTests/BrowserChromeMetricsTests.swift
+++ b/cmuxTests/BrowserChromeMetricsTests.swift
@@ -1,0 +1,84 @@
+import CoreGraphics
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite struct BrowserChromeMetricsTests {
+    /// The legacy hardcoded chrome sizes the layout must reproduce exactly at the
+    /// default tab bar font size, so default appearance stays byte-identical.
+    private static let legacy = (
+        omnibarFontSize: CGFloat(12),
+        omnibarFieldHeight: CGFloat(18),
+        navigationIconFontSize: CGFloat(12),
+        secureBadgeFontSize: CGFloat(10),
+        accessoryIconFontSize: CGFloat(11),
+        buttonIconSize: CGFloat(22),
+        buttonHitSize: CGFloat(26)
+    )
+
+    @Test func defaultFontSizeReproducesLegacySizesByteIdentical() {
+        let metrics = BrowserChromeMetrics(tabBarFontSize: BrowserChromeMetrics.referenceFontSize)
+
+        #expect(metrics.scale == 1)
+        #expect(metrics.omnibarFontSize == Self.legacy.omnibarFontSize)
+        #expect(metrics.omnibarFieldHeight == Self.legacy.omnibarFieldHeight)
+        #expect(metrics.navigationIconFontSize == Self.legacy.navigationIconFontSize)
+        #expect(metrics.secureBadgeFontSize == Self.legacy.secureBadgeFontSize)
+        #expect(metrics.accessoryIconFontSize == Self.legacy.accessoryIconFontSize)
+        #expect(metrics.buttonIconSize == Self.legacy.buttonIconSize)
+        #expect(metrics.buttonHitSize == Self.legacy.buttonHitSize)
+    }
+
+    @Test func referenceFontSizeMatchesShippedDefault() {
+        // The byte-identical anchor must be the actual shipped default (11.0),
+        // not an arbitrary constant.
+        #expect(BrowserChromeMetrics.referenceFontSize == 11)
+    }
+
+    @Test func largerFontScalesEverySizeUpProportionally() {
+        let larger = BrowserChromeMetrics.referenceFontSize + 2 // 13: a valid in-range size
+        let metrics = BrowserChromeMetrics(tabBarFontSize: larger)
+        let expectedScale = larger / BrowserChromeMetrics.referenceFontSize
+
+        #expect(metrics.scale > 1)
+        #expect(metrics.scale == expectedScale)
+        #expect(metrics.omnibarFontSize == Self.legacy.omnibarFontSize * expectedScale)
+        #expect(metrics.buttonIconSize == Self.legacy.buttonIconSize * expectedScale)
+        #expect(metrics.buttonHitSize == Self.legacy.buttonHitSize * expectedScale)
+        #expect(metrics.accessoryIconFontSize == Self.legacy.accessoryIconFontSize * expectedScale)
+    }
+
+    @Test func smallerFontScalesEverySizeDownProportionally() {
+        let smaller = BrowserChromeMetrics.referenceFontSize - 3 // 8: the in-range minimum
+        let metrics = BrowserChromeMetrics(tabBarFontSize: smaller)
+        let expectedScale = smaller / BrowserChromeMetrics.referenceFontSize
+
+        #expect(metrics.scale < 1)
+        #expect(metrics.scale == expectedScale)
+        #expect(metrics.omnibarFontSize == Self.legacy.omnibarFontSize * expectedScale)
+        #expect(metrics.buttonHitSize == Self.legacy.buttonHitSize * expectedScale)
+    }
+
+    @Test func absurdlyLargeFontClampsToMaximumScale() {
+        let metrics = BrowserChromeMetrics(tabBarFontSize: 10_000)
+        #expect(metrics.scale == BrowserChromeMetrics.maximumScale)
+        #expect(metrics.buttonIconSize == Self.legacy.buttonIconSize * BrowserChromeMetrics.maximumScale)
+    }
+
+    @Test func nearZeroFontClampsToMinimumScale() {
+        let metrics = BrowserChromeMetrics(tabBarFontSize: 0.001)
+        #expect(metrics.scale == BrowserChromeMetrics.minimumScale)
+        #expect(metrics.omnibarFontSize == Self.legacy.omnibarFontSize * BrowserChromeMetrics.minimumScale)
+    }
+
+    @Test(arguments: [CGFloat(0), CGFloat(-5), CGFloat.nan, CGFloat.infinity])
+    func nonPositiveOrNonFiniteFontFallsBackToNeutralScale(_ value: CGFloat) {
+        let metrics = BrowserChromeMetrics(tabBarFontSize: value)
+        #expect(metrics.scale == 1)
+        #expect(metrics.buttonIconSize == Self.legacy.buttonIconSize)
+    }
+}

--- a/cmuxTests/BrowserChromeMetricsTests.swift
+++ b/cmuxTests/BrowserChromeMetricsTests.swift
@@ -53,7 +53,7 @@ import Testing
     }
 
     @Test func smallerFontScalesEverySizeDownProportionally() {
-        let smaller = BrowserChromeMetrics.referenceFontSize - 3 // 8: the in-range minimum
+        let smaller = BrowserChromeMetrics.referenceFontSize - 3 // 8: the minimum valid tab bar font size
         let metrics = BrowserChromeMetrics(tabBarFontSize: smaller)
         let expectedScale = smaller / BrowserChromeMetrics.referenceFontSize
 
@@ -75,7 +75,7 @@ import Testing
         #expect(metrics.omnibarFontSize == Self.legacy.omnibarFontSize * BrowserChromeMetrics.minimumScale)
     }
 
-    @Test(arguments: [CGFloat(0), CGFloat(-5), CGFloat.nan, CGFloat.infinity])
+    @Test(arguments: [CGFloat(0), CGFloat(-5), CGFloat.nan, CGFloat.infinity, -CGFloat.infinity])
     func nonPositiveOrNonFiniteFontFallsBackToNeutralScale(_ value: CGFloat) {
         let metrics = BrowserChromeMetrics(tabBarFontSize: value)
         #expect(metrics.scale == 1)

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -3977,6 +3977,7 @@ final class OmnibarNativeTextFieldCaretTests: XCTestCase {
         return OmnibarTextFieldRepresentable.Coordinator(
             parent: OmnibarTextFieldRepresentable(
                 panelId: panelId,
+                fontSize: 12,
                 text: Binding(
                     get: { text },
                     set: { text = $0 }

--- a/cmuxTests/OmnibarAndToolsTests.swift
+++ b/cmuxTests/OmnibarAndToolsTests.swift
@@ -853,6 +853,7 @@ private final class OmnibarInlineDeletionHarness {
         OmnibarTextFieldRepresentable.Coordinator(
             parent: OmnibarTextFieldRepresentable(
                 panelId: UUID(),
+                fontSize: 12,
                 text: Binding(
                     get: { self.state.buffer },
                     set: { self.state.buffer = $0 }


### PR DESCRIPTION
## Summary

The browser omnibar URL text and toolbar icon buttons (back/forward/reload, lock, screenshot, cursor grab, profile, theme, dev tools) were a **fixed** size and ignored the user's font-size settings. They now scale with the existing tab bar font size setting (`surfaceTabBarFontSize`) so the whole top chrome — tabs + browser toolbar — stays at one consistent scale, mirroring how the sidebar font size is already scalable.

Closes #5463. Related context (not closed): #3147, #3862.

## Approach

- New pure value type `BrowserChromeMetrics` (`Sources/Panels/BrowserChromeMetrics.swift`) derives every omnibar/toolbar size from the tab bar font size. The scale is anchored to the shipped default (`11pt`) so at the default font size the scale is exactly `1` and the chrome is **byte-identical** to the previous hardcoded layout. The derived scale is clamped (`0.5…2.0`) so a malformed config value can never blow the toolbar up or collapse it.
- `BrowserPanelView` seeds the size from the cached config and refreshes it **live** on `.ghosttyConfigDidReload` — the exact same observation path the tab strip (`Workspace.applyGhosttyChrome`) and the terminal panel (`TerminalPanelView`) already use — so the chrome re-lays-out the instant the tab bar font size changes.
- The previously hardcoded constants (`addressBarButtonSize` 22, `addressBarButtonHitSize` 26, `devToolsButtonIconSize` 11, omnibar/nav font 12, lock badge 10, omnibar field height 18) are now derived; call sites and names are unchanged.

**Reuses `surfaceTabBarFontSize` — no new setting is introduced**, so no Settings UI / `settings.json` / docs / localization changes are required. No new user-facing strings.

## Tests

`cmuxTests/BrowserChromeMetricsTests.swift` (Swift Testing) unit-tests the pure derivation: the default-size-equals-legacy-constants invariant (byte-identical), proportional scale up/down, min/max scale clamping, and the non-finite/non-positive fallback. Pure SwiftUI layout below the value type is not cleanly unit-testable and is exercised via the metrics seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5464"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783253391&installation_id=133855650&pr_number=5464&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5464&signature=07431418b236d34c5c75ed41aab252e39ad333628aa08480f92e4f701f0d3855"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI layout and font sizing only; no auth, data, or networking changes, with explicit tests and backward-compatible default scale.
> 
> **Overview**
> Browser omnibar and toolbar chrome (navigation icons, lock badge, accessory buttons, omnibar text/height) now **scale with** the existing `surfaceTabBarFontSize` setting instead of fixed point sizes.
> 
> A new **`BrowserChromeMetrics`** value type computes proportional sizes from the tab bar font, anchored at the shipped default (11pt) so **default layout stays identical** to the old hardcoded values; scale is clamped (0.5–2.0) with a safe fallback for invalid inputs. **`BrowserPanelView`** seeds from cached config and refreshes on **`.ghosttyConfigDidReload`**, matching tab strip/terminal behavior. The AppKit **`OmnibarTextFieldRepresentable`** takes a **`fontSize`** and updates the native field when it changes.
> 
> Unit tests cover legacy parity at default size, proportional scaling, clamping, and invalid font sizes; existing omnibar test helpers pass `fontSize: 12`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cb18d21931c58ed4d1c3432985238652172c36f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scale the browser omnibar text and toolbar icons with the tab bar font size so the top chrome stays consistent and respects user settings. Default appearance is unchanged; updates apply instantly on config reload.

- **New Features**
  - Introduced `BrowserChromeMetrics` to derive omnibar/toolbar sizes from `surfaceTabBarFontSize` (anchored to 11pt; clamped 0.5–2.0).
  - `BrowserPanelView` seeds from config and refreshes on `.ghosttyConfigDidReload`; the AppKit omnibar text field now accepts a `fontSize` and updates live.
  - Replaced fixed constants with derived values; no new setting, no UI/docs changes.
  - Added unit tests for default parity, proportional scaling, clamping, and invalid/non-finite input; updated tests to pass `fontSize` to `OmnibarTextFieldRepresentable`.

<sup>Written for commit 4cb18d21931c58ed4d1c3432985238652172c36f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5464?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Address bar and browser chrome now scale dynamically with the configured tab-bar font size; navigation icons, secure badges, omnibar text, field height, and toolbar hit targets update proportionally and refresh when configuration reloads.
* **Tests**
  * Added tests validating baseline sizing, proportional scaling, clamping behavior, and fallback handling for invalid font-size values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->