### PR TITLE
Add cmux ssh --here to reuse the current pane instead of creating a new workspace

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -7936,11 +7936,17 @@ struct CMUXCLI {
         let env = ProcessInfo.processInfo.environment
         guard let workspaceId = env["CMUX_WORKSPACE_ID"]?.trimmingCharacters(in: .whitespacesAndNewlines),
               !workspaceId.isEmpty else {
-            throw CLIError(message: "ssh --here: must be run inside a cmux terminal (CMUX_WORKSPACE_ID is not set)")
+            cliDebugLog("cli.ssh.here.guard missing=CMUX_WORKSPACE_ID")
+            throw CLIError(message: "ssh --here must be run from an active cmux terminal pane.")
         }
         guard let surfaceId = env["CMUX_SURFACE_ID"]?.trimmingCharacters(in: .whitespacesAndNewlines),
               !surfaceId.isEmpty else {
-            throw CLIError(message: "ssh --here: must be run inside a cmux terminal (CMUX_SURFACE_ID is not set)")
+            cliDebugLog("cli.ssh.here.guard missing=CMUX_SURFACE_ID")
+            throw CLIError(message: "ssh --here must be run from an active cmux terminal pane.")
+        }
+        // --here always connects in the current pane, so an explicit window target makes no sense.
+        if options.windowRaw != nil {
+            throw CLIError(message: "ssh --here uses the current pane and cannot target another window; drop --window or use `cmux ssh`.")
         }
 
         // Guard: --here connects in the workspace's single terminal. Splits would leave remote
@@ -8033,8 +8039,15 @@ struct CMUXCLI {
         defer { for item in argv { free(item) } }
         argv.append(nil)
         execv("/bin/sh", &argv)
+        // execv only returns on failure — and we have already configured this workspace as remote.
+        // Roll it back to local so the pane isn't stranded in a dangling remote-configured state.
         let code = errno
-        throw CLIError(message: "ssh --here: failed to start ssh session: \(String(cString: strerror(code)))")
+        cliDebugLog("cli.ssh.here.exec.failed errno=\(code) detail=\(String(cString: strerror(code)))")
+        _ = try? client.sendV2(method: "workspace.remote.disconnect", params: [
+            "workspace_id": workspaceId,
+            "clear": true,
+        ])
+        throw CLIError(message: "ssh --here: could not start the ssh session in this pane.")
     }
 
     private func parseSSHCommandOptions(

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -7438,6 +7438,7 @@ struct CMUXCLI {
         let workspaceName: String?
         let windowRaw: String?
         let noFocus: Bool
+        let reuseCurrentPane: Bool
         let sshOptions: [String]
         let extraArguments: [String]
         let agentSocketPath: String?
@@ -7455,6 +7456,7 @@ struct CMUXCLI {
             workspaceName: String?,
             windowRaw: String? = nil,
             noFocus: Bool,
+            reuseCurrentPane: Bool = false,
             sshOptions: [String],
             extraArguments: [String],
             agentSocketPath: String? = nil,
@@ -7469,6 +7471,7 @@ struct CMUXCLI {
             self.workspaceName = workspaceName
             self.windowRaw = windowRaw
             self.noFocus = noFocus
+            self.reuseCurrentPane = reuseCurrentPane
             self.sshOptions = sshOptions
             self.extraArguments = extraArguments
             self.agentSocketPath = agentSocketPath
@@ -7726,6 +7729,24 @@ struct CMUXCLI {
             "extraArgs=\(sshOptions.extraArguments.count)"
         )
 
+        if sshOptions.reuseCurrentPane {
+            // Reuse the pane the CLI is running in instead of creating a new workspace, then exec
+            // the same startup command in place. Never returns normally (execs or throws).
+            try connectRemoteInCurrentPane(
+                options: sshOptions,
+                client: client,
+                relayID: relayID,
+                relayToken: relayToken,
+                remoteSSHOptions: remoteSSHOptions,
+                startupCommand: initialSSHStartupCommand,
+                reusableTerminalStartupCommand: reusableTerminalStartupCommand,
+                autoConnect: deferredRemoteReconnectCommandScript == nil,
+                foregroundAuthToken: configuredForegroundAuthToken,
+                persistentDaemonSlot: persistentDaemonSlot
+            )
+            return
+        }
+
         var workspaceCreateParams: [String: Any] = [
             "initial_command": initialSSHStartupCommand,
         ]
@@ -7896,6 +7917,126 @@ struct CMUXCLI {
         }
     }
 
+    /// `cmux ssh --here`: reuse the workspace/pane the CLI is running in instead of creating a new
+    /// one. The CLI is a child of the current pane's shell, so it configures the current workspace
+    /// as remote and then execs the same SSH startup command in place — the connection runs in the
+    /// pane you typed it in, and the workspace stays in whatever sidebar group it already belongs to.
+    private func connectRemoteInCurrentPane(
+        options: SSHCommandOptions,
+        client: SocketClient,
+        relayID: String,
+        relayToken: String,
+        remoteSSHOptions: [String],
+        startupCommand: String,
+        reusableTerminalStartupCommand: String,
+        autoConnect: Bool,
+        foregroundAuthToken: String?,
+        persistentDaemonSlot: String?
+    ) throws {
+        let env = ProcessInfo.processInfo.environment
+        guard let workspaceId = env["CMUX_WORKSPACE_ID"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !workspaceId.isEmpty else {
+            throw CLIError(message: "ssh --here: must be run inside a cmux terminal (CMUX_WORKSPACE_ID is not set)")
+        }
+        guard let surfaceId = env["CMUX_SURFACE_ID"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !surfaceId.isEmpty else {
+            throw CLIError(message: "ssh --here: must be run inside a cmux terminal (CMUX_SURFACE_ID is not set)")
+        }
+
+        // Guard: --here connects in the workspace's single terminal. Splits would leave remote
+        // tracking ambiguous, so require exactly one terminal surface — and that it is the surface
+        // this command is running in, so the exec'd startup/session-end scripts (which key off
+        // CMUX_SURFACE_ID) bind to the right TTY and the workspace can demote cleanly on exit.
+        let surfaceList = try client.sendV2(method: "surface.list", params: ["workspace_id": workspaceId])
+        let surfaces = (surfaceList["surfaces"] as? [[String: Any]]) ?? []
+        let terminalSurfaceIds = surfaces
+            .filter { ($0["type"] as? String) == "terminal" }
+            .compactMap { $0["id"] as? String }
+        guard terminalSurfaceIds.count == 1 else {
+            throw CLIError(
+                message: "ssh --here: needs a single-terminal workspace (this one has \(terminalSurfaceIds.count)). "
+                    + "Run `cmux ssh` to open a new workspace instead."
+            )
+        }
+        guard terminalSurfaceIds[0].caseInsensitiveCompare(surfaceId) == .orderedSame else {
+            throw CLIError(message: "ssh --here: must be run from the workspace's own terminal surface.")
+        }
+
+        // Guard: don't stack a connection on a workspace that is already remote.
+        let workspaceList = try client.sendV2(method: "workspace.list", params: ["workspace_id": workspaceId])
+        let workspaces = (workspaceList["workspaces"] as? [[String: Any]]) ?? []
+        let currentRemote = workspaces.first { ($0["id"] as? String) == workspaceId }?["remote"] as? [String: Any]
+        if (currentRemote?["enabled"] as? Bool) == true {
+            throw CLIError(
+                message: "ssh --here: this workspace is already a remote session. "
+                    + "Disconnect it first, or run `cmux ssh` for a new one."
+            )
+        }
+
+        cliDebugLog(
+            "cli.ssh.here.start target=\(options.displayDestination) workspace=\(String(workspaceId.prefix(8))) "
+                + "relayPort=\(options.remoteRelayPort) autoConnect=\(autoConnect ? 1 : 0)"
+        )
+
+        if let workspaceName = options.workspaceName?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !workspaceName.isEmpty {
+            _ = try client.sendV2(method: "workspace.rename", params: [
+                "workspace_id": workspaceId,
+                "title": workspaceName,
+            ])
+        }
+
+        var configureParams: [String: Any] = [
+            "workspace_id": workspaceId,
+            "destination": options.displayDestination,
+            "auto_connect": autoConnect,
+            "terminal_startup_command": reusableTerminalStartupCommand,
+        ]
+        if let foregroundAuthToken {
+            configureParams["foreground_auth_token"] = foregroundAuthToken
+        }
+        if let port = options.port {
+            configureParams["port"] = port
+        }
+        if let identityFile = normalizedSSHIdentityPath(options.identityFile) {
+            configureParams["identity_file"] = identityFile
+        }
+        if !remoteSSHOptions.isEmpty {
+            configureParams["ssh_options"] = remoteSSHOptions
+        }
+        if let agentSocketPath = options.agentSocketPath {
+            configureParams["ssh_auth_sock"] = agentSocketPath
+        }
+        if options.remoteRelayPort > 0 {
+            configureParams["relay_port"] = options.remoteRelayPort
+            configureParams["relay_id"] = relayID
+            configureParams["relay_token"] = relayToken
+            configureParams["local_socket_path"] = options.localSocketPath
+        }
+        if options.skipDaemonBootstrap {
+            configureParams["skip_daemon_bootstrap"] = true
+        }
+        if let persistentDaemonSlot {
+            configureParams["preserve_after_terminal_exit"] = true
+            configureParams["persistent_daemon_slot"] = persistentDaemonSlot
+        }
+        _ = try client.sendV2(method: "workspace.remote.configure", params: configureParams)
+
+        cliDebugLog("cli.ssh.here.configured workspace=\(String(workspaceId.prefix(8)))")
+
+        // Hand this pane to ssh. The app would normally run `startupCommand` as the new workspace's
+        // initial command via the shell; we replicate that with `sh -c` so execv replaces this CLI
+        // process (a child of the pane's shell). On exit the startup script's session-end trap fires
+        // and control returns to the shell prompt.
+        let argvStrings = ["/bin/sh", "-c", startupCommand]
+        var argv: [UnsafeMutablePointer<CChar>?] = argvStrings.map { strdup($0) }
+        defer { for item in argv { free(item) } }
+        argv.append(nil)
+        execv("/bin/sh", &argv)
+        let code = errno
+        throw CLIError(message: "ssh --here: failed to start ssh session: \(String(cString: strerror(code)))")
+    }
+
     private func parseSSHCommandOptions(
         _ commandArgs: [String],
         localSocketPath: String = "",
@@ -7908,6 +8049,7 @@ struct CMUXCLI {
         var workspaceName: String?
         var windowRaw: String?
         var noFocus = false
+        var reuseCurrentPane = false
         var sshOptions: [String] = []
         var extraArguments: [String] = []
         var forwardAgentOverride: Bool?
@@ -7956,6 +8098,9 @@ struct CMUXCLI {
             case "--no-focus":
                 noFocus = true
                 index += 1
+            case "--here":
+                reuseCurrentPane = true
+                index += 1
             case "-A", "--forward-agent":
                 forwardAgentOverride = true
                 index += 1
@@ -8003,6 +8148,7 @@ struct CMUXCLI {
             workspaceName: workspaceName,
             windowRaw: windowRaw ?? windowOverride,
             noFocus: noFocus,
+            reuseCurrentPane: reuseCurrentPane,
             sshOptions: agentForwarding.sshOptions,
             extraArguments: extraArguments,
             agentSocketPath: agentForwarding.agentSocketPath,
@@ -13542,9 +13688,13 @@ struct CMUXCLI {
               --ssh-option <opt>      Extra SSH -o option (repeatable)
               --window <id|ref|index> Target window for the managed workspace
               --no-focus              Create workspace without switching to it
+              --here                  Reuse the current pane instead of creating a new workspace.
+                                      Must be run inside a cmux pane; the workspace must have a single
+                                      terminal and not already be remote. Keeps it in its sidebar group.
 
             Example:
               cmux ssh dev@my-host
+              cmux ssh --here dev@my-host
               cmux ssh dev@my-host --name "gpu-box" --port 2222 --identity ~/.ssh/id_ed25519
               cmux ssh dev@my-host --forward-agent
               cmux ssh dev@my-host --ssh-option UserKnownHostsFile=/dev/null --ssh-option StrictHostKeyChecking=no
@@ -31862,7 +32012,7 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
           move-tab-to-new-workspace [--tab <id|ref|index>] [--surface <id|ref|index>] [--workspace <id|ref|index>] [--window <id|ref|index>] [--title <text>] [--focus <true|false>]
           list-workspaces [--window <id|ref|index>]
           new-workspace [--name <title>] [--description <text>] [--cwd <path>] [--command <text>] [--layout <json>] [--window <id|ref|index>] [--focus <true|false>]
-          ssh <destination> [--name <title>] [--port <n>] [--identity <path>] [-A|--forward-agent] [-a|--no-forward-agent] [--ssh-option <opt>] [--window <id|ref|index>] [--no-focus] [-- <remote-command-args>]
+          ssh <destination> [--name <title>] [--port <n>] [--identity <path>] [-A|--forward-agent] [-a|--no-forward-agent] [--ssh-option <opt>] [--window <id|ref|index>] [--no-focus] [--here] [-- <remote-command-args>]
           ssh-session-list [--workspace <id|ref|index> | --all-workspaces]
           ssh-session-attach --session-id <id> [--workspace <id|ref|index>] [--pane <id|ref|index> | --split <left|right|up|down>]
           ssh-session-cleanup [--workspace <id|ref|index> | --all-workspaces] (--session-id <id> | --all)


### PR DESCRIPTION
## Summary

- **What:** A new opt-in `--here` flag on `cmux ssh`. Instead of creating a new workspace, it configures the **current** workspace as the remote SSH session and `exec`s the SSH startup command in the current pane, so the connection runs in the pane you typed it in. Guards: it must run inside a cmux pane (`CMUX_WORKSPACE_ID`/`CMUX_SURFACE_ID`), the workspace must have exactly one terminal and that terminal must be the current surface, and it must not already be remote. It reuses the existing `workspace.remote.configure` + startup-command machinery (including the persistent-PTY path) — **no server-side changes**. English CLI help (`cli.help.ssh`) is updated.
- **Why:** Every `cmux ssh` spawns a new top-level workspace and selects it. With the collapsible workspace groups ("Spaces"), that new workspace lands ungrouped, so remote sessions pop *out* of whatever group you're working in. `--here` connects in the pane you're already in, so the workspace stays in its group. The flag is opt-in and non-breaking — default `cmux ssh` behavior is unchanged.

## Testing

- Built a tagged Debug app from `main` (0.64.13) via `scripts/reload.sh --tag` and tested manually:
  - **Happy path:** `cmux ssh --here <user@host>` from a single-terminal pane connects in place — no new sidebar entry, the workspace stays in its group; exiting ssh returns to the local prompt and demotes the workspace back to local.
  - **Guards error cleanly:** run outside a cmux pane; in a multi-terminal/split workspace; in an already-remote workspace.
  - Plain `cmux ssh <user@host>` is unchanged.
  - Both flag orderings work (`cmux ssh --here <host>` and `cmux ssh <host> --here`).
- Ran a Codex review on the diff and addressed both findings: validate `CMUX_SURFACE_ID` (and that it is the workspace's single terminal) before any mutation; update the English `cli.help.ssh` catalog entry.
- **No automated test added:** the full flow needs a live app plus an SSH target, and per the repo test policy I avoided a shape-only test. Happy to add a CLI-level guard test if maintainers prefer.

**Localization:** only the English (`en`) `cli.help.ssh` entry is updated. The other 19 locales are intentionally left for the separate localization pass (cf. `71f69333` "Localize SSH help for supported locales"). The web docs SSH flags table is left as-is, consistent with `--forward-agent`/`--window` which are also not listed there.

## Demo Video

_To add._

## Checklist

- [x] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed
- [x] I requested bot reviews after my latest commit
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5467"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783256699&installation_id=133855650&pr_number=5467&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5467&signature=c8d53bbbcef15dc8e8f7b432d90fda17769a40002aae3ddef88279a04f511605"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt‑in `--here` flag to `cmux ssh` to run the SSH session in the current pane instead of creating a new workspace, keeping the workspace in its group. Also localizes help text, tightens guard behavior, and adds a rollback if startup fails.

- **New Features**
  - `--here`: configures the current workspace as remote and runs SSH in the same pane; default `cmux ssh` behavior is unchanged.
  - Validations and UX: must run inside a `cmux` pane with a single terminal (the current surface) and not already be remote; rejects `--window` with `--here`; guard errors use product wording.
  - Reliability: reuses `workspace.remote.configure` and the persistent‑PTY flow; rolls the workspace back to local if the `exec` startup fails; no server-side changes.
  - Docs: updated CLI usage and examples; `--here` help is localized across all supported locales.

<sup>Written for commit 08ca9facca5f55151d38e34c12ce152fec241c51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5467?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--here` flag to the `ssh` command to run remote SSH sessions in the current terminal pane.
* **Documentation**
  * Updated help text, usage examples, and localized messages to document the `--here` flag and clarify related behavior and options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->