### PR TITLE
Fix main window minimum-width ratchet

### DIFF
--- a/Sources/App/CmuxMainWindow.swift
+++ b/Sources/App/CmuxMainWindow.swift
@@ -3,19 +3,13 @@ import SwiftUI
 
 final class MainWindowHostingView<Content: View>: NSHostingView<Content> {
     private let zeroSafeAreaLayoutGuide = NSLayoutGuide()
-    private static var mainWindowMinimumSize: NSSize {
-        NSSize(
-            width: CGFloat(SessionPersistencePolicy.minimumWindowWidth),
-            height: CGFloat(SessionPersistencePolicy.minimumWindowHeight)
-        )
-    }
 
     override var safeAreaInsets: NSEdgeInsets { NSEdgeInsetsZero }
     override var safeAreaRect: NSRect { bounds }
     override var safeAreaLayoutGuide: NSLayoutGuide { zeroSafeAreaLayoutGuide }
     override var mouseDownCanMoveWindow: Bool { false }
-    override var fittingSize: NSSize { Self.mainWindowMinimumSize }
-    override var intrinsicContentSize: NSSize { Self.mainWindowMinimumSize }
+    override var fittingSize: NSSize { CmuxMainWindow.minimumContentSize }
+    override var intrinsicContentSize: NSSize { CmuxMainWindow.minimumContentSize }
 
     /// Lets a click on an interactive titlebar control (the sidebar toggle, the
     /// right-sidebar mode bar, the session-index header controls, etc.) both
@@ -60,6 +54,21 @@ func configureCmuxMainWindowDragBehavior(_ window: NSWindow) {
 
 @MainActor
 final class CmuxMainWindow: NSWindow {
+    static var minimumContentSize: NSSize {
+        NSSize(
+            width: CGFloat(SessionPersistencePolicy.minimumWindowWidth),
+            height: CGFloat(SessionPersistencePolicy.minimumWindowHeight)
+        )
+    }
+
+    static func standardFrame(forDefaultFrame defaultFrame: NSRect) -> NSRect {
+        let minimumSize = minimumContentSize
+        var frame = defaultFrame
+        frame.size.width = max(frame.size.width, minimumSize.width)
+        frame.size.height = max(frame.size.height, minimumSize.height)
+        return frame
+    }
+
     private var isSoftHiddenForVisibilityController = false
 
     func setSoftHiddenForVisibilityController(_ isSoftHidden: Bool) {

--- a/Sources/App/CmuxMainWindow.swift
+++ b/Sources/App/CmuxMainWindow.swift
@@ -3,11 +3,19 @@ import SwiftUI
 
 final class MainWindowHostingView<Content: View>: NSHostingView<Content> {
     private let zeroSafeAreaLayoutGuide = NSLayoutGuide()
+    private static var mainWindowMinimumSize: NSSize {
+        NSSize(
+            width: CGFloat(SessionPersistencePolicy.minimumWindowWidth),
+            height: CGFloat(SessionPersistencePolicy.minimumWindowHeight)
+        )
+    }
 
     override var safeAreaInsets: NSEdgeInsets { NSEdgeInsetsZero }
     override var safeAreaRect: NSRect { bounds }
     override var safeAreaLayoutGuide: NSLayoutGuide { zeroSafeAreaLayoutGuide }
     override var mouseDownCanMoveWindow: Bool { false }
+    override var fittingSize: NSSize { Self.mainWindowMinimumSize }
+    override var intrinsicContentSize: NSSize { Self.mainWindowMinimumSize }
 
     /// Lets a click on an interactive titlebar control (the sidebar toggle, the
     /// right-sidebar mode bar, the session-index header controls, etc.) both

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -8061,6 +8061,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             backing: .buffered,
             defer: false
         )
+        let minimumWindowSize = NSSize(
+            width: CGFloat(SessionPersistencePolicy.minimumWindowWidth),
+            height: CGFloat(SessionPersistencePolicy.minimumWindowHeight)
+        )
+        window.minSize = minimumWindowSize
+        window.contentMinSize = minimumWindowSize
         window.animationBehavior = .none
         // When creating a new window from an existing native fullscreen window,
         // temporarily opt out of fullscreen tiling so AppKit doesn't place the

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -795,6 +795,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             }
             return shouldClose
         }
+
+        func windowWillUseStandardFrame(_ window: NSWindow, defaultFrame newFrame: NSRect) -> NSRect {
+            guard window is CmuxMainWindow else { return newFrame }
+            return CmuxMainWindow.standardFrame(forDefaultFrame: newFrame)
+        }
     }
 
     struct ScriptableMainWindowState {
@@ -8061,10 +8066,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             backing: .buffered,
             defer: false
         )
-        let minimumWindowSize = NSSize(
-            width: CGFloat(SessionPersistencePolicy.minimumWindowWidth),
-            height: CGFloat(SessionPersistencePolicy.minimumWindowHeight)
-        )
+        let minimumWindowSize = CmuxMainWindow.minimumContentSize
         window.minSize = minimumWindowSize
         window.contentMinSize = minimumWindowSize
         window.animationBehavior = .none

--- a/cmuxTests/FileDropOverlayViewTests.swift
+++ b/cmuxTests/FileDropOverlayViewTests.swift
@@ -13,36 +13,6 @@ import CmuxUpdater
 
 @MainActor
 final class FileDropOverlayViewTests: XCTestCase {
-    func testMainWindowHostingViewReportsPolicyMinimumInsteadOfChildMinimum() {
-        _ = NSApplication.shared
-
-        let root = HStack(spacing: 0) {
-            Color.clear
-                .frame(width: 900, height: 240)
-        }
-            .frame(
-                minWidth: CGFloat(SessionPersistencePolicy.minimumWindowWidth),
-                minHeight: CGFloat(SessionPersistencePolicy.minimumWindowHeight)
-            )
-        let hostingView = MainWindowHostingView(rootView: root)
-
-        for width in [520, 1_200] as [CGFloat] {
-            hostingView.frame = NSRect(x: 0, y: 0, width: width, height: 500)
-            hostingView.layoutSubtreeIfNeeded()
-
-            XCTAssertLessThanOrEqual(
-                hostingView.fittingSize.width,
-                CGFloat(SessionPersistencePolicy.minimumWindowWidth),
-                "Main window AppKit fitting width must not inherit child/sidebar width at \(width)pt."
-            )
-            XCTAssertLessThanOrEqual(
-                hostingView.intrinsicContentSize.width,
-                CGFloat(SessionPersistencePolicy.minimumWindowWidth),
-                "Main window AppKit intrinsic width must not inherit child/sidebar width at \(width)pt."
-            )
-        }
-    }
-
     private func makeContentViewWindow(windowId: UUID = UUID()) -> NSWindow {
         _ = NSApplication.shared
 

--- a/cmuxTests/FileDropOverlayViewTests.swift
+++ b/cmuxTests/FileDropOverlayViewTests.swift
@@ -13,6 +13,36 @@ import CmuxUpdater
 
 @MainActor
 final class FileDropOverlayViewTests: XCTestCase {
+    func testMainWindowHostingViewReportsPolicyMinimumInsteadOfChildMinimum() {
+        _ = NSApplication.shared
+
+        let root = HStack(spacing: 0) {
+            Color.clear
+                .frame(width: 900, height: 240)
+        }
+            .frame(
+                minWidth: CGFloat(SessionPersistencePolicy.minimumWindowWidth),
+                minHeight: CGFloat(SessionPersistencePolicy.minimumWindowHeight)
+            )
+        let hostingView = MainWindowHostingView(rootView: root)
+
+        for width in [520, 1_200] as [CGFloat] {
+            hostingView.frame = NSRect(x: 0, y: 0, width: width, height: 500)
+            hostingView.layoutSubtreeIfNeeded()
+
+            XCTAssertLessThanOrEqual(
+                hostingView.fittingSize.width,
+                CGFloat(SessionPersistencePolicy.minimumWindowWidth),
+                "Main window AppKit fitting width must not inherit child/sidebar width at \(width)pt."
+            )
+            XCTAssertLessThanOrEqual(
+                hostingView.intrinsicContentSize.width,
+                CGFloat(SessionPersistencePolicy.minimumWindowWidth),
+                "Main window AppKit intrinsic width must not inherit child/sidebar width at \(width)pt."
+            )
+        }
+    }
+
     private func makeContentViewWindow(windowId: UUID = UUID()) -> NSWindow {
         _ = NSApplication.shared
 

--- a/cmuxTests/WindowAndDragTests.swift
+++ b/cmuxTests/WindowAndDragTests.swift
@@ -1908,8 +1908,8 @@ final class DraggableFolderHitTests: XCTestCase {
 
 
 @MainActor
-final class MainWindowHostingViewTests: XCTestCase {
-    func testReportsPolicyMinimumInsteadOfChildMinimum() {
+@Suite struct MainWindowHostingViewTests {
+    @Test func testReportsPolicyMinimumInsteadOfChildMinimum() {
         _ = NSApplication.shared
 
         let root = HStack(spacing: 0) {
@@ -1921,37 +1921,36 @@ final class MainWindowHostingViewTests: XCTestCase {
                 minHeight: CGFloat(SessionPersistencePolicy.minimumWindowHeight)
             )
         let hostingView = MainWindowHostingView(rootView: root)
+        let expectedMinimumWidth = CGFloat(SessionPersistencePolicy.minimumWindowWidth)
 
         for width in [520, 1_200] as [CGFloat] {
             hostingView.frame = NSRect(x: 0, y: 0, width: width, height: 500)
             hostingView.layoutSubtreeIfNeeded()
 
-            XCTAssertLessThanOrEqual(
-                hostingView.fittingSize.width,
-                CGFloat(SessionPersistencePolicy.minimumWindowWidth),
-                "Main window AppKit fitting width must not inherit child/sidebar width at \(width)pt."
+            #expect(
+                abs(hostingView.fittingSize.width - expectedMinimumWidth) <= 0.001,
+                "Main window AppKit fitting width must equal minimumWindowWidth at \(width)pt."
             )
-            XCTAssertLessThanOrEqual(
-                hostingView.intrinsicContentSize.width,
-                CGFloat(SessionPersistencePolicy.minimumWindowWidth),
-                "Main window AppKit intrinsic width must not inherit child/sidebar width at \(width)pt."
+            #expect(
+                abs(hostingView.intrinsicContentSize.width - expectedMinimumWidth) <= 0.001,
+                "Main window AppKit intrinsic width must equal minimumWindowWidth at \(width)pt."
             )
         }
     }
 
-    func testStandardFrameKeepsAppKitDefaultFrameWhenLargerThanPolicyMinimum() {
+    @Test func testStandardFrameKeepsAppKitDefaultFrameWhenLargerThanPolicyMinimum() {
         let defaultFrame = NSRect(x: 20, y: 40, width: 1_000, height: 700)
 
-        XCTAssertEqual(CmuxMainWindow.standardFrame(forDefaultFrame: defaultFrame), defaultFrame)
+        #expect(CmuxMainWindow.standardFrame(forDefaultFrame: defaultFrame) == defaultFrame)
     }
 
-    func testStandardFrameDoesNotShrinkBelowPolicyMinimum() {
+    @Test func testStandardFrameDoesNotShrinkBelowPolicyMinimum() {
         let tinyDefaultFrame = NSRect(x: 20, y: 40, width: 100, height: 80)
         let standardFrame = CmuxMainWindow.standardFrame(forDefaultFrame: tinyDefaultFrame)
 
-        XCTAssertEqual(standardFrame.origin, tinyDefaultFrame.origin)
-        XCTAssertEqual(standardFrame.width, CGFloat(SessionPersistencePolicy.minimumWindowWidth))
-        XCTAssertEqual(standardFrame.height, CGFloat(SessionPersistencePolicy.minimumWindowHeight))
+        #expect(standardFrame.origin == tinyDefaultFrame.origin)
+        #expect(standardFrame.width == CGFloat(SessionPersistencePolicy.minimumWindowWidth))
+        #expect(standardFrame.height == CGFloat(SessionPersistencePolicy.minimumWindowHeight))
     }
 }
 

--- a/cmuxTests/WindowAndDragTests.swift
+++ b/cmuxTests/WindowAndDragTests.swift
@@ -1908,6 +1908,54 @@ final class DraggableFolderHitTests: XCTestCase {
 
 
 @MainActor
+final class MainWindowHostingViewTests: XCTestCase {
+    func testReportsPolicyMinimumInsteadOfChildMinimum() {
+        _ = NSApplication.shared
+
+        let root = HStack(spacing: 0) {
+            Color.clear
+                .frame(width: 900, height: 240)
+        }
+            .frame(
+                minWidth: CGFloat(SessionPersistencePolicy.minimumWindowWidth),
+                minHeight: CGFloat(SessionPersistencePolicy.minimumWindowHeight)
+            )
+        let hostingView = MainWindowHostingView(rootView: root)
+
+        for width in [520, 1_200] as [CGFloat] {
+            hostingView.frame = NSRect(x: 0, y: 0, width: width, height: 500)
+            hostingView.layoutSubtreeIfNeeded()
+
+            XCTAssertLessThanOrEqual(
+                hostingView.fittingSize.width,
+                CGFloat(SessionPersistencePolicy.minimumWindowWidth),
+                "Main window AppKit fitting width must not inherit child/sidebar width at \(width)pt."
+            )
+            XCTAssertLessThanOrEqual(
+                hostingView.intrinsicContentSize.width,
+                CGFloat(SessionPersistencePolicy.minimumWindowWidth),
+                "Main window AppKit intrinsic width must not inherit child/sidebar width at \(width)pt."
+            )
+        }
+    }
+
+    func testStandardFrameKeepsAppKitDefaultFrameWhenLargerThanPolicyMinimum() {
+        let defaultFrame = NSRect(x: 20, y: 40, width: 1_000, height: 700)
+
+        XCTAssertEqual(CmuxMainWindow.standardFrame(forDefaultFrame: defaultFrame), defaultFrame)
+    }
+
+    func testStandardFrameDoesNotShrinkBelowPolicyMinimum() {
+        let tinyDefaultFrame = NSRect(x: 20, y: 40, width: 100, height: 80)
+        let standardFrame = CmuxMainWindow.standardFrame(forDefaultFrame: tinyDefaultFrame)
+
+        XCTAssertEqual(standardFrame.origin, tinyDefaultFrame.origin)
+        XCTAssertEqual(standardFrame.width, CGFloat(SessionPersistencePolicy.minimumWindowWidth))
+        XCTAssertEqual(standardFrame.height, CGFloat(SessionPersistencePolicy.minimumWindowHeight))
+    }
+}
+
+@MainActor
 final class TitlebarLeadingInsetPassthroughViewTests: XCTestCase {
     func testLeadingInsetViewDoesNotParticipateInHitTesting() {
         let view = TitlebarLeadingInsetPassthroughView(frame: NSRect(x: 0, y: 0, width: 200, height: 40))


### PR DESCRIPTION
Fixes https://github.com/manaflow-ai/cmux/issues/5460

## Summary
- Clamp the main window's AppKit content minimum reporting at `SessionPersistencePolicy.minimumWindowWidth` / `SessionPersistencePolicy.minimumWindowHeight`.
- Set the main `NSWindow` min/content-min size explicitly from the same policy.
- Add a behavior regression test that fails when a wide child/sidebar determines the root hosting view's fitting/intrinsic width.

## Verification
- AWS M4 Pro macOS 15.7.4: first commit focused XCTest failed with fitting/intrinsic width 900 > 300.
- AWS M4 Pro macOS 15.7.4: fix commit focused XCTest passed.
- `./scripts/check-pbxproj.sh`

Note: the AWS focused XCTest was run via direct `/Applications/Xcode.app/Contents/Developer/usr/bin/xctest` after `xcodebuild build-for-testing` because `xcodebuild test` launched the app host and hung under SSH.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized window chrome and sizing behavior with tests; no auth, data, or network changes.
> 
> **Overview**
> Fixes the main window **minimum-size ratchet** (#5460): wide SwiftUI content (e.g. sidebars) could inflate `NSHostingView` **fitting/intrinsic** sizes so AppKit would not let the window shrink below that width.
> 
> **`MainWindowHostingView`** now reports **`fittingSize`** and **`intrinsicContentSize`** as **`CmuxMainWindow.minimumContentSize`**, tied to **`SessionPersistencePolicy.minimumWindowWidth`** / **`minimumWindowHeight`**, instead of inheriting a child’s larger minimum.
> 
> **`CmuxMainWindow`** centralizes that size and adds **`standardFrame(forDefaultFrame:)`** to floor AppKit “standard frame” proposals. New main windows get **`minSize`** / **`contentMinSize`** from the same policy, and the window delegate’s **`windowWillUseStandardFrame`** applies the clamp for **`CmuxMainWindow`** only.
> 
> Regression tests cover hosting-view sizing at varied widths and standard-frame behavior above/below the policy floor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2be4133e272096b0939ed29b4d1bd62c2bea7290. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5474"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783280481&installation_id=133855650&pr_number=5474&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5474&signature=c75be271c5de17fd618830d6f6c898e3a2e2eaa012a2582cdff7c9e5704a0c12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the main window minimum-size ratchet so wide child views or sidebars no longer raise the window’s minimum. Standard frame actions now respect the policy floor. Resolves #5460.

- **Bug Fixes**
  - Clamp `MainWindowHostingView` `fittingSize` and `intrinsicContentSize` to `SessionPersistencePolicy.minimumWindowWidth`/`minimumWindowHeight` via `CmuxMainWindow.minimumContentSize`.
  - Set the main `NSWindow` `minSize` and `contentMinSize` from the same policy; clamp `windowWillUseStandardFrame` using `CmuxMainWindow.standardFrame(...)`.
  - Add tests for hosting-view sizing and standard-frame behavior (keeps larger frames; doesn’t shrink below the policy minimum).

<sup>Written for commit 2be4133e272096b0939ed29b4d1bd62c2bea7290. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Windows now enforce configured minimum content sizes and cannot be resized below those limits; standard frame calculations respect those minimum dimensions.

* **Tests**
  * Added tests covering hosting view and window sizing behavior to verify minimum size enforcement and standard-frame clamping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->