### PR TITLE
ci: harden iOS TestFlight publish (main-only guard + CODEOWNERS)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,18 @@
+# Code owners for publish-critical and secret-touching paths.
+#
+# Every CI workflow can read repository secrets (Apple signing certs, the App
+# Store Connect API key, etc.), and the iOS publish path ships builds to real
+# testers, so a change here is effectively a change to "what can run with our
+# secrets" or "what gets shipped". Require an owner's review on these.
+#
+# NOTE: CODEOWNERS only *enforces* review once branch protection on `main` sets
+# `require_code_owner_review = true` (plus `required_approving_review_count >= 1`).
+# That branch-protection change is the actual gate; this file makes it effective
+# and documents ownership in the meantime.
+
+# All GitHub Actions workflows (all can access secrets).
+/.github/workflows/                     @lawrencecchen
+
+# iOS TestFlight publish path + App Store Connect config.
+/ios/scripts/upload-testflight.sh       @lawrencecchen
+/ios/Config/                            @lawrencecchen

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -105,7 +105,10 @@ jobs:
   upload:
     name: Upload to TestFlight
     needs: decide
-    if: needs.decide.outputs.should_build == 'true'
+    # Only ever publish from main. push/schedule always run on main; this also
+    # blocks publishing arbitrary code by dispatching the workflow against a
+    # feature branch (the ASC secrets are only meant to ship reviewed main).
+    if: needs.decide.outputs.should_build == 'true' && github.ref == 'refs/heads/main'
     runs-on: macos-26
     timeout-minutes: 60
     env:


### PR DESCRIPTION
Defense-in-depth for the iOS TestFlight publish pipeline (follow-up to #5448 / #5453).

**What this does**
- **Main-only publish guard:** the upload job now requires `github.ref == 'refs/heads/main'`. `push`/`schedule` already run on main; this blocks publishing arbitrary code by dispatching the workflow against a feature branch.
- **CODEOWNERS** for secret-touching paths (`/.github/workflows/`, `ios/scripts/upload-testflight.sh`, `ios/Config/`) so changes there require an owner's review.

**Security context (from an audit of the publish path)**
- Confirmed safe: ASC secrets are referenced **only** by `ios-testflight.yml`; **no `pull_request_target`** anywhere; the publish workflow has **no `pull_request` trigger**, so fork/untrusted PRs can't reach the ASC key. Actions are SHA-pinned, permissions are read-only, the `build_number` input is consumed via env (no script injection), and secrets are never logged.
- The real remaining gap is the **merge/publish gate**, which is **pre-existing org posture, not introduced here**: `main` currently requires **0 approving reviews** and `require_code_owner_review=false`, so anyone with write access can merge (and thus auto-publish, or land a workflow change that reads secrets) with no review.

**These two changes are defense-in-depth, not the fix.** They only fully "bite" once branch protection on `main` is set to require ≥1 review + code-owner review (an admin action). Highest-value follow-up: scope the CI App Store Connect key to a dedicated CI-only key with the minimal TestFlight-upload role + rotate it (it's currently the Admin key).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5476"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783287141&installation_id=133855650&pr_number=5476&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5476&signature=1190d09e438f155cc2bc3f76bbf83f3ccdf492037276c909bc5c6d4111179351"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the workflow that uses App Store Connect secrets and TestFlight upload; behavior change is narrow (blocks non-main dispatch) but publish gating is security-sensitive.
> 
> **Overview**
> Adds **defense-in-depth** around the iOS TestFlight publish path so App Store Connect secrets and shipping logic are harder to change or abuse without review.
> 
> The **upload** job in `ios-testflight.yml` now runs only when `github.ref == 'refs/heads/main'`, in addition to the existing `should_build` check. That blocks **manual `workflow_dispatch` runs on feature branches** from publishing with ASC credentials, while normal `push`/`schedule` on `main` are unchanged.
> 
> A new **`.github/CODEOWNERS`** assigns `@lawrencecchen` to `/.github/workflows/`, `ios/scripts/upload-testflight.sh`, and `ios/Config/`. The file documents that **code-owner review only enforces** once branch protection enables `require_code_owner_review` and at least one approving review on `main`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a206f8d61a3cff2df0ee73850e1aa8b9f06e0e1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Locks TestFlight publishing to `main` by adding `github.ref == 'refs/heads/main'` to the upload job, and adds CODEOWNERS for workflows and the iOS publish/config paths. This blocks dispatch-based publishes from feature branches and enables owner review on those paths once branch protection requires code owner reviews.

<sup>Written for commit a206f8d61a3cff2df0ee73850e1aa8b9f06e0e1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5476?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Established code ownership assignments for iOS publishing workflows and critical release scripts to enforce proper review processes.
  * Tightened iOS TestFlight upload conditions to only execute when targeting the main branch, preventing unintended uploads from feature branches and strengthening release control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->