### PR TITLE
Add git index polling crash regression guards

### DIFF
--- a/Packages/CmuxGit/Tests/CmuxGitTests/GitMetadataServiceIndexStressTests.swift
+++ b/Packages/CmuxGit/Tests/CmuxGitTests/GitMetadataServiceIndexStressTests.swift
@@ -1,0 +1,265 @@
+import Foundation
+import Testing
+@testable import CmuxGit
+
+@Suite(.serialized) struct GitMetadataServiceIndexStressTests {
+    @Test func malformedPartialAndUnsupportedIndexesReturnNilGracefully() throws {
+        let fixture = try GitRepositoryFixture()
+        try fixture.writeBranch("main")
+        let repository = try #require(GitMetadataService.resolveGitRepository(containing: fixture.root.path))
+        let indexURL = fixture.gitDirectory.appendingPathComponent("index")
+        let validIndex = GitIndexFixture(version: 2, entries: [
+            GitIndexFixture.Entry(path: "tracked.txt"),
+        ]).data()
+        let unsupportedVersionIndex = GitIndexFixture(version: 99, entries: []).data()
+        let truncatedEntryHeader = Data(validIndex.prefix(12 + 20))
+        let missingPathTerminator = Self.indexDataWithMissingPathTerminator()
+        let truncatedV4StripLength = Self.truncatedVersionFourStripLengthIndexData()
+        let extendedFlagsWithoutPayload = Self.extendedFlagsWithoutPayloadIndexData()
+
+        let malformedIndexes = [
+            Data(),
+            Data("not an index".utf8),
+            Data(validIndex.prefix(31)),
+            unsupportedVersionIndex,
+            truncatedEntryHeader,
+            missingPathTerminator,
+            truncatedV4StripLength,
+            extendedFlagsWithoutPayload,
+        ]
+
+        for malformedIndex in malformedIndexes {
+            try malformedIndex.write(to: indexURL)
+            #expect(GitMetadataService.gitIndexSnapshot(indexURL: indexURL) == nil)
+
+            let trackedChanges = GitMetadataService.gitTrackedChangesSnapshot(repository: repository)
+            #expect(!trackedChanges.isDirty)
+            #expect(trackedChanges.indexContentSignature == nil)
+        }
+    }
+
+    @Test func indexLockDoesNotChangePointInTimeIndexParsing() throws {
+        let fixture = try GitRepositoryFixture()
+        try fixture.writeBranch("main")
+        try fixture.writeIndex(GitIndexFixture(version: 2, entries: [
+            GitIndexFixture.Entry(path: "tracked.txt"),
+        ]))
+        let indexURL = fixture.gitDirectory.appendingPathComponent("index")
+        let lockURL = fixture.gitDirectory.appendingPathComponent("index.lock")
+
+        try Data("partial rewrite".utf8).write(to: lockURL)
+        defer {
+            try? FileManager.default.removeItem(at: lockURL)
+        }
+
+        let snapshot = try #require(GitMetadataService.gitIndexSnapshot(indexURL: indexURL))
+        #expect(snapshot.entries.map(\.path) == ["tracked.txt"])
+    }
+
+    @Test(.timeLimit(.seconds(30)))
+    func concurrentParsingSurvivesTornIndexRewritesAcrossLinkedWorktrees() async throws {
+        let fixture = try Self.makeLinkedWorktreeFixture(count: 4)
+        defer {
+            try? FileManager.default.removeItem(at: fixture.baseURL)
+        }
+
+        let variantsByIndexURL = fixture.indexURLs.reduce(into: [URL: [Data]]()) { result, indexURL in
+            let validIndex = fixture.validIndexDataByURL[indexURL] ?? Data()
+            result[indexURL] = Self.indexRewriteVariants(validIndex: validIndex)
+        }
+        for indexURL in fixture.indexURLs {
+            let variants = try #require(variantsByIndexURL[indexURL])
+            try variants[1].write(to: indexURL)
+            #expect(GitMetadataService.gitIndexSnapshot(indexURL: indexURL) == nil)
+            try variants[0].write(to: indexURL)
+            #expect(GitMetadataService.gitIndexSnapshot(indexURL: indexURL) != nil)
+        }
+
+        let observations = try await withThrowingTaskGroup(of: (Int, Int).self) { group in
+            group.addTask {
+                try await Self.rewriteIndexesConcurrently(variantsByIndexURL: variantsByIndexURL, iterations: 240)
+                return (0, 0)
+            }
+
+            for repository in fixture.repositories {
+                group.addTask {
+                    var parsedCount = 0
+                    var nilCount = 0
+                    let indexURL = URL(fileURLWithPath: repository.gitDirectory).appendingPathComponent("index")
+                    for _ in 0..<240 {
+                        if GitMetadataService.gitIndexSnapshot(indexURL: indexURL) == nil {
+                            nilCount += 1
+                        } else {
+                            parsedCount += 1
+                        }
+                        _ = GitMetadataService.gitTrackedChangesSnapshot(repository: repository)
+                        await Task.yield()
+                    }
+                    return (parsedCount, nilCount)
+                }
+            }
+
+            var parsedCount = 0
+            var nilCount = 0
+            for try await result in group {
+                parsedCount += result.0
+                nilCount += result.1
+            }
+            return (parsedCount, nilCount)
+        }
+
+        #expect(observations.0 > 0)
+        #expect(observations.0 + observations.1 == fixture.repositories.count * 240)
+        for indexURL in fixture.indexURLs {
+            #expect(GitMetadataService.gitIndexSnapshot(indexURL: indexURL) != nil)
+        }
+    }
+
+    private static func indexRewriteVariants(validIndex: Data) -> [Data] {
+        [
+            validIndex,
+            Data(validIndex.prefix(8)),
+            Data(validIndex.prefix(31)),
+            Data(validIndex.prefix(max(0, validIndex.count - 7))),
+            GitIndexFixture(version: 99, entries: []).data(),
+            Self.indexDataWithMissingPathTerminator(),
+            Self.truncatedVersionFourStripLengthIndexData(),
+            Self.extendedFlagsWithoutPayloadIndexData(),
+        ]
+    }
+
+    private static func rewriteIndexesConcurrently(
+        variantsByIndexURL: [URL: [Data]],
+        iterations: Int
+    ) async throws {
+        let fileManager = FileManager.default
+        for iteration in 0..<iterations {
+            for (indexURL, variants) in variantsByIndexURL {
+                let lockURL = indexURL.deletingLastPathComponent().appendingPathComponent("index.lock")
+                try? Data("lock-\(iteration)".utf8).write(to: lockURL)
+                try variants[iteration % variants.count].write(to: indexURL)
+                try? fileManager.removeItem(at: lockURL)
+            }
+            await Task.yield()
+        }
+
+        for (indexURL, variants) in variantsByIndexURL {
+            try variants[0].write(to: indexURL)
+        }
+    }
+
+    private static func makeLinkedWorktreeFixture(count: Int) throws -> (
+        baseURL: URL,
+        repositories: [ResolvedGitRepository],
+        indexURLs: [URL],
+        validIndexDataByURL: [URL: Data]
+    ) {
+        let baseURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmuxgit-linked-worktrees-\(UUID().uuidString)", isDirectory: true)
+        let commonGitDirectory = baseURL.appendingPathComponent("main.git", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: commonGitDirectory.appendingPathComponent("refs/heads", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: commonGitDirectory.appendingPathComponent("worktrees", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        try "\(String(repeating: "f", count: 40))\n".write(
+            to: commonGitDirectory.appendingPathComponent("refs/heads/main"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        var repositories: [ResolvedGitRepository] = []
+        var indexURLs: [URL] = []
+        var validIndexDataByURL: [URL: Data] = [:]
+        for index in 0..<count {
+            let worktreeURL = baseURL.appendingPathComponent("worktree-\(index)", isDirectory: true)
+            let gitDirectory = commonGitDirectory
+                .appendingPathComponent("worktrees", isDirectory: true)
+                .appendingPathComponent("worktree-\(index)", isDirectory: true)
+            try FileManager.default.createDirectory(at: worktreeURL, withIntermediateDirectories: true)
+            try FileManager.default.createDirectory(at: gitDirectory, withIntermediateDirectories: true)
+            try "gitdir: \(gitDirectory.path)\n".write(
+                to: worktreeURL.appendingPathComponent(".git"),
+                atomically: true,
+                encoding: .utf8
+            )
+            try "../..".write(
+                to: gitDirectory.appendingPathComponent("commondir"),
+                atomically: true,
+                encoding: .utf8
+            )
+            try "ref: refs/heads/main\n".write(
+                to: gitDirectory.appendingPathComponent("HEAD"),
+                atomically: true,
+                encoding: .utf8
+            )
+
+            let entry = try Self.writeTrackedFile(named: "tracked-\(index).txt", in: worktreeURL)
+            let validIndex = GitIndexFixture(version: 2, entries: [entry]).data()
+            let indexURL = gitDirectory.appendingPathComponent("index")
+            try validIndex.write(to: indexURL)
+            let repository = try #require(GitMetadataService.resolveGitRepository(containing: worktreeURL.path))
+            repositories.append(repository)
+            indexURLs.append(indexURL)
+            validIndexDataByURL[indexURL] = validIndex
+        }
+
+        return (baseURL, repositories, indexURLs, validIndexDataByURL)
+    }
+
+    private static func writeTrackedFile(named name: String, in worktreeURL: URL) throws -> GitIndexFixture.Entry {
+        let fileURL = worktreeURL.appendingPathComponent(name)
+        try "tracked contents for \(name)".write(to: fileURL, atomically: true, encoding: .utf8)
+
+        var statValue = stat()
+        _ = lstat(fileURL.path, &statValue)
+        return GitIndexFixture.Entry(
+            path: name,
+            mode: (statValue.st_mode & S_IXUSR) == 0 ? 0o100644 : 0o100755,
+            mtimeSeconds: UInt32(truncatingIfNeeded: statValue.st_mtimespec.tv_sec),
+            mtimeNanoseconds: UInt32(truncatingIfNeeded: statValue.st_mtimespec.tv_nsec),
+            size: UInt32(truncatingIfNeeded: statValue.st_size)
+        )
+    }
+
+    private static func indexDataWithMissingPathTerminator() -> Data {
+        var bytes: [UInt8] = []
+        bytes.append(contentsOf: Array("DIRC".utf8))
+        bytes.append(contentsOf: GitIndexFixture.bigEndianUInt32(2))
+        bytes.append(contentsOf: GitIndexFixture.bigEndianUInt32(1))
+        bytes.append(contentsOf: Array(repeating: 0, count: 40))
+        bytes.append(contentsOf: GitIndexFixture.hexBytes(String(repeating: "a", count: 40)))
+        bytes.append(contentsOf: GitIndexFixture.bigEndianUInt16(0x0fff))
+        bytes.append(contentsOf: Array("unterminated/path".utf8))
+        bytes.append(contentsOf: Array(repeating: 0xAB, count: 20))
+        return Data(bytes)
+    }
+
+    private static func truncatedVersionFourStripLengthIndexData() -> Data {
+        var bytes: [UInt8] = []
+        bytes.append(contentsOf: Array("DIRC".utf8))
+        bytes.append(contentsOf: GitIndexFixture.bigEndianUInt32(4))
+        bytes.append(contentsOf: GitIndexFixture.bigEndianUInt32(1))
+        bytes.append(contentsOf: Array(repeating: 0, count: 40))
+        bytes.append(contentsOf: GitIndexFixture.hexBytes(String(repeating: "b", count: 40)))
+        bytes.append(contentsOf: GitIndexFixture.bigEndianUInt16(1))
+        bytes.append(0x80)
+        bytes.append(contentsOf: Array(repeating: 0xAB, count: 20))
+        return Data(bytes)
+    }
+
+    private static func extendedFlagsWithoutPayloadIndexData() -> Data {
+        var bytes: [UInt8] = []
+        bytes.append(contentsOf: Array("DIRC".utf8))
+        bytes.append(contentsOf: GitIndexFixture.bigEndianUInt32(3))
+        bytes.append(contentsOf: GitIndexFixture.bigEndianUInt32(1))
+        bytes.append(contentsOf: Array(repeating: 0, count: 40))
+        bytes.append(contentsOf: GitIndexFixture.hexBytes(String(repeating: "c", count: 40)))
+        bytes.append(contentsOf: GitIndexFixture.bigEndianUInt16(0x4001))
+        bytes.append(contentsOf: Array(repeating: 0xAB, count: 20))
+        return Data(bytes)
+    }
+}

--- a/Packages/CmuxGit/Tests/CmuxGitTests/GitMetadataServiceIndexStressTests.swift
+++ b/Packages/CmuxGit/Tests/CmuxGitTests/GitMetadataServiceIndexStressTests.swift
@@ -56,7 +56,7 @@ import Testing
         #expect(snapshot.entries.map(\.path) == ["tracked.txt"])
     }
 
-    @Test(.timeLimit(.seconds(30)))
+    @Test(.timeLimit(.minutes(1)))
     func concurrentParsingSurvivesTornIndexRewritesAcrossLinkedWorktrees() async throws {
         let fixture = try Self.makeLinkedWorktreeFixture(count: 4)
         defer {

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -743,7 +743,7 @@ final class TabManagerPullRequestProbeTests: XCTestCase {
         )
     }
 
-    func testSameDirectoryInitialGitMetadataProbesShareOneSnapshotRead() async throws {
+    func testManySameDirectoryInitialGitMetadataProbesShareOneSnapshotRead() async throws {
         let defaults = UserDefaults.standard
         let previousWatchGitStatus = defaults.object(forKey: SidebarWorkspaceDetailDefaults.watchGitStatusKey)
         defaults.set(false, forKey: SidebarWorkspaceDetailDefaults.watchGitStatusKey)
@@ -789,7 +789,15 @@ final class TabManagerPullRequestProbeTests: XCTestCase {
             return
         }
 
-        let panelIds = [mainPanelId, splitPanel.id, tabPanel.id]
+        var panelIds = [mainPanelId, splitPanel.id, tabPanel.id]
+        for _ in 0..<7 {
+            guard let extraPanel = workspace.newTerminalSurface(inPane: paneId) else {
+                XCTFail("Expected additional terminal panels for coalescing load")
+                return
+            }
+            panelIds.append(extraPanel.id)
+        }
+
         for panelId in panelIds {
             manager.updateSurfaceDirectory(
                 tabId: workspace.id,
@@ -826,7 +834,7 @@ final class TabManagerPullRequestProbeTests: XCTestCase {
             waitForCondition {
                 panelIds.allSatisfy { workspace.panelGitBranches[$0]?.branch == "main" }
             },
-            "One same-directory snapshot should update every queued panel."
+            "One same-directory snapshot should update every queued panel under load."
         )
         let finalObservedCallCount = await reader.observedCallCount
         XCTAssertEqual(finalObservedCallCount, 1)

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -816,13 +816,7 @@ final class TabManagerPullRequestProbeTests: XCTestCase {
         }
         await fulfillment(of: [firstRead], timeout: 1.0)
 
-        let uncoalescedSecondRead = expectation(description: "uncoalesced second git snapshot read")
-        uncoalescedSecondRead.isInverted = true
-        Task {
-            await reader.waitForCallCount(2)
-            uncoalescedSecondRead.fulfill()
-        }
-        await fulfillment(of: [uncoalescedSecondRead], timeout: 0.2)
+        try await Task.sleep(nanoseconds: 200_000_000)
 
         let observedCallCount = await reader.observedCallCount
         let observedMaxActiveCallCount = await reader.observedMaxActiveCallCount

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -76,7 +76,6 @@ private actor BlockingWorkspaceGitMetadataReader: WorkspaceGitMetadataReading {
     private var callCount = 0
     private var maxActiveCallCount = 0
     private var activeCallCount = 0
-    private var callCountWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
     private var releaseContinuations: [CheckedContinuation<Void, Never>] = []
 
     init(metadata: GitWorkspaceMetadata) {
@@ -87,19 +86,11 @@ private actor BlockingWorkspaceGitMetadataReader: WorkspaceGitMetadataReading {
         callCount += 1
         activeCallCount += 1
         maxActiveCallCount = max(maxActiveCallCount, activeCallCount)
-        resumeSatisfiedCallCountWaiters()
         await withCheckedContinuation { continuation in
             releaseContinuations.append(continuation)
         }
         activeCallCount -= 1
         return metadata
-    }
-
-    func waitForCallCount(_ expected: Int) async {
-        guard callCount < expected else { return }
-        await withCheckedContinuation { continuation in
-            callCountWaiters.append((expected, continuation))
-        }
     }
 
     func releaseAll() {
@@ -116,18 +107,6 @@ private actor BlockingWorkspaceGitMetadataReader: WorkspaceGitMetadataReading {
 
     var observedMaxActiveCallCount: Int {
         maxActiveCallCount
-    }
-
-    private func resumeSatisfiedCallCountWaiters() {
-        var remaining: [(Int, CheckedContinuation<Void, Never>)] = []
-        for waiter in callCountWaiters {
-            if callCount >= waiter.0 {
-                waiter.1.resume()
-            } else {
-                remaining.append(waiter)
-            }
-        }
-        callCountWaiters = remaining
     }
 }
 
@@ -809,12 +788,11 @@ final class TabManagerPullRequestProbeTests: XCTestCase {
         defaults.set(true, forKey: SidebarWorkspaceDetailDefaults.watchGitStatusKey)
         manager.sidebarGitMetadataWatchSettingsDidChangeForTesting()
 
-        let firstRead = expectation(description: "first git snapshot read started")
-        Task {
-            await reader.waitForCallCount(1)
-            firstRead.fulfill()
+        let firstReadDeadline = Date().addingTimeInterval(1.0)
+        while await reader.observedCallCount < 1, Date() < firstReadDeadline {
+            try await Task.sleep(nanoseconds: 10_000_000)
         }
-        await fulfillment(of: [firstRead], timeout: 1.0)
+        XCTAssertGreaterThanOrEqual(await reader.observedCallCount, 1)
 
         try await Task.sleep(nanoseconds: 200_000_000)
 

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -792,7 +792,8 @@ final class TabManagerPullRequestProbeTests: XCTestCase {
         while await reader.observedCallCount < 1, Date() < firstReadDeadline {
             try await Task.sleep(nanoseconds: 10_000_000)
         }
-        XCTAssertGreaterThanOrEqual(await reader.observedCallCount, 1)
+        let observedCallCountAfterFirstReadWait = await reader.observedCallCount
+        XCTAssertGreaterThanOrEqual(observedCallCountAfterFirstReadWait, 1)
 
         try await Task.sleep(nanoseconds: 200_000_000)
 


### PR DESCRIPTION
## Summary

Adds behavior-level regression guards for the git-metadata polling crash reported in https://github.com/manaflow-ai/cmux/issues/5477.

Main-branch code audit so far:
- 0.64.13 (`v0.64.13`, `beb0d8f93`) still had the faulting path: `TabManager.gitIndexSnapshot` used per-byte `String(format: "%02x", ...)` and the polling path launched per-panel detached snapshot tasks from `DispatchSourceTimer`s.
- Latest main (`1263d7e19`) has moved git parsing into `Packages/CmuxGit` and no longer has the faulting `String(format:)` allocation site in `gitIndexSnapshot`.
- #5402 / `a23bf2cb7` replaced the git-index hex formatting with byte-table encoding, coalesced same-directory snapshot reads, and added a 2-permit limiter for concurrent polling snapshots.
- #5363 replaced the git/PR `DispatchSourceTimer` paths with cancellable injected-clock tasks.

## Tests Added

- `GitMetadataServiceIndexStressTests` covers malformed, partial, unsupported-version, `index.lock`, and torn-rewrite-style index states.
- Concurrent stress covers multiple linked-worktree-style repositories while index files cycle through valid and malformed bytes, exercising both `gitIndexSnapshot` and `gitTrackedChangesSnapshot` without crashing.
- Strengthens the existing TabManager coalescing regression from 3 same-directory panels to 10 queued panel probes sharing one metadata read.

## Repro / Verification

In progress:
- Cloud macOS latest-main realistic repro with video: https://github.com/manaflow-ai/cmux-loader/actions/runs/27042567520
- CI on this PR.

## Related

- Closes https://github.com/manaflow-ai/cmux/issues/5477 when CI + cloud repro confirm main is safe.
- Cross-links: https://github.com/manaflow-ai/cmux/issues/4603, https://github.com/manaflow-ai/cmux/issues/5392, https://github.com/manaflow-ai/cmux/issues/4639, https://github.com/manaflow-ai/cmux/issues/4705, https://github.com/manaflow-ai/cmux/issues/5130

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5479"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783289189&installation_id=133855650&pr_number=5479&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5479&signature=10f3a549734f50113b73a13161377245bb672a5dcf28d2497e1b30793750f21b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no runtime behavior modifications.
> 
> **Overview**
> Adds **test-only** regression coverage for git index polling crash (#5477); no production code changes.
> 
> **CmuxGit:** New `GitMetadataServiceIndexStressTests` exercises `gitIndexSnapshot` and `gitTrackedChangesSnapshot` under empty/invalid/truncated indexes, unsupported versions, v3/v4 edge cases, presence of `index.lock`, and a concurrent stress run that tears index bytes across four linked-worktree fixtures while parsers run in parallel—expecting `nil` snapshots and non-crashing behavior when parse fails.
> 
> **TabManager:** The same-directory git metadata coalescing test now queues **10** panels (was 3), renames to `testManySameDirectoryInitialGitMetadataProbesShareOneSnapshotRead`, and drops `waitForCallCount` on the blocking test reader in favor of polling `observedCallCount` with a short sleep so coalescing under load is asserted without flaky inverted expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78546bf63525720a2af1f425772b51b4fe3a15b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds test-only regression guards for the git index polling crash and hardens coalescing behavior under load; closes #5477.

- **Bug Fixes**
  - Add `GitMetadataServiceIndexStressTests` in `CmuxGit` to ensure `gitIndexSnapshot` returns nil for malformed/unsupported/truncated indexes, ignores `index.lock`, and survives torn rewrites across linked worktrees; `gitTrackedChangesSnapshot` stays consistent when parsing fails.
  - Strengthen TabManager coalescing test: 10 same-directory panels share one snapshot read; rename to “many” and poll `observedCallCount` with a short sleep (no continuations, no inverted expectation), and assert the count from a local snapshot to avoid races.

<sup>Written for commit bb2d2bddddf3a64e30f7ef9f13d3857e3b13f168. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5479?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added stress tests for Git index parsing that exercise malformed index data, concurrent parsing, and linked-worktree scenarios to ensure snapshot parsing succeeds at least once and tracked-change state remains consistent under load.
  * Expanded unit tests for terminal panel/git-metadata coalescing to validate a single shared snapshot propagates to many same-directory panels under higher concurrent load.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->