### PR TITLE
Fix notification sound selection playback

### DIFF
--- a/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Bindings/DefaultsValueModel.swift
+++ b/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Bindings/DefaultsValueModel.swift
@@ -75,11 +75,12 @@ public final class DefaultsValueModel<Value: SettingCodable> {
     }
 
     /// Persists the value. The observation stream is the single writer of
-    /// ``current``, so the UI reflects the change once the write lands and
-    /// the stream yields it back (a small storage round-trip). Synchronous
-    /// because SwiftUI `Binding` setters can't `await`; the write itself
-    /// runs in a fire-and-forget `Task`.
+    /// ``current`` for external changes, but direct UI writes update it
+    /// optimistically before the async storage write. Synchronous because
+    /// SwiftUI `Binding` setters can't `await`; the write itself runs in a
+    /// fire-and-forget `Task`.
     public func set(_ value: Value) {
+        current = value
         Task { [store, key] in
             await store.set(value, for: key)
         }
@@ -88,6 +89,7 @@ public final class DefaultsValueModel<Value: SettingCodable> {
     /// Removes the override; ``current`` updates when the stream observes
     /// the reset.
     public func reset() {
+        current = key.defaultValue
         Task { [store, key] in
             await store.reset(key)
         }

--- a/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Environment/SettingsHostActions.swift
+++ b/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Environment/SettingsHostActions.swift
@@ -55,7 +55,7 @@ public protocol SettingsHostActions: AnyObject {
 
     /// Plays the currently configured notification sound so the user
     /// can preview it from the Settings UI.
-    func previewNotificationSound()
+    func previewNotificationSound(value: String, customFilePath: String)
 
     /// Returns the current number of saved browser-history entries, or
     /// `nil` if the host hasn't loaded the history store yet. The
@@ -141,6 +141,8 @@ public final class NoopSettingsHostActions: SettingsHostActions {
     public func openBrowserImportFlow() {}
     public func requestNotificationAuthorization() {}
     public func openTerminalConfigWindow() {}
-    public func previewNotificationSound() {}
+    /// No-op notification sound preview used by tests, previews, and
+    /// package-only settings hosts.
+    public func previewNotificationSound(value: String, customFilePath: String) {}
     public func browserHistoryEntryCount() -> Int? { nil }
 }

--- a/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/AppSection.swift
+++ b/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/AppSection.swift
@@ -680,7 +680,7 @@ public struct AppSection: View {
                     }
                     .labelsHidden()
                     Button {
-                        hostActions.previewNotificationSound()
+                        hostActions.previewNotificationSound(value: model.current, customFilePath: customFile.current)
                     } label: {
                         Image(systemName: "play.fill")
                             .font(.system(size: 9))

--- a/Packages/CmuxSettingsUI/Tests/CmuxSettingsUITests/DefaultsValueModelLifecycleTests.swift
+++ b/Packages/CmuxSettingsUI/Tests/CmuxSettingsUITests/DefaultsValueModelLifecycleTests.swift
@@ -70,4 +70,24 @@ import Testing
         }
         #expect(flag.didTerminate)
     }
+
+    @Test func setUpdatesCurrentBeforeObservationRoundTrip() {
+        let store = UserDefaultsSettingsStore(
+            defaults: UserDefaults(suiteName: "defaults-value-model-optimistic-set")!
+        )
+        let key = SettingCatalog().betaFeatures.extensions
+        let (stream, _) = AsyncStream<Bool>.makeStream()
+        let model = DefaultsValueModel(
+            store: store,
+            key: key,
+            makeStream: { stream }
+        )
+
+        #expect(model.current == false)
+        model.set(true)
+        #expect(model.current == true)
+
+        model.reset()
+        #expect(model.current == false)
+    }
 }

--- a/Sources/HostSettingsActions.swift
+++ b/Sources/HostSettingsActions.swift
@@ -148,8 +148,8 @@ final class HostSettingsActions: SettingsHostActions {
         }
     }
 
-    func previewNotificationSound() {
-        NSSound(named: NSSound.Name("Glass"))?.play()
+    func previewNotificationSound(value: String, customFilePath: String) {
+        NotificationSoundSettings.previewSound(value: value, customFilePath: customFilePath)
     }
 
     func browserHistoryEntryCount() -> Int? {

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -490,7 +490,17 @@ enum NotificationSoundSettings {
             try fileManager.removeItem(at: normalizedDestination)
         }
 
-        try fileManager.copyItem(at: normalizedSource, to: normalizedDestination)
+        do {
+            try fileManager.copyItem(at: normalizedSource, to: normalizedDestination)
+        } catch {
+            let nsError = error as NSError
+            if nsError.domain == NSCocoaErrorDomain,
+               nsError.code == NSFileWriteFileExistsError,
+               fileManager.fileExists(atPath: normalizedDestination.path) {
+                return
+            }
+            throw error
+        }
     }
 
     private static func transcodeStagedSoundIfNeeded(

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -46,6 +46,8 @@ enum NotificationSoundSettings {
         label: "com.cmuxterm.notification-sound-preparation",
         qos: .utility
     )
+    private static let systemSoundBaseName = "cmux-system-notification-sound"
+    private static let systemSoundDirectoryURL = URL(fileURLWithPath: "/System/Library/Sounds", isDirectory: true)
     private static let pendingCustomSoundPreparationLock = NSLock()
     private static var pendingCustomSoundPreparationPaths: Set<String> = []
     private static let activePlaybackSoundsLock = NSLock()
@@ -113,7 +115,10 @@ enum NotificationSoundSettings {
         ("None", "none"),
     ]
 
-    static func sound(defaults: UserDefaults = .standard) -> UNNotificationSound? {
+    static func sound(
+        defaults: UserDefaults = .standard,
+        systemSoundStagingDirectory: URL? = nil
+    ) -> UNNotificationSound? {
         let value = defaults.string(forKey: key) ?? defaultValue
         switch value {
         case "default":
@@ -126,7 +131,14 @@ enum NotificationSoundSettings {
             }
             return UNNotificationSound(named: UNNotificationSoundName(rawValue: customSoundName))
         default:
-            return UNNotificationSound(named: UNNotificationSoundName(rawValue: value))
+            guard let stagedSystemSoundName = stagedSystemSoundName(
+                for: value,
+                stagingDirectory: systemSoundStagingDirectory
+            ) else {
+                NSLog("Notification system sound unavailable, falling back to default: \(value)")
+                return .default
+            }
+            return UNNotificationSound(named: UNNotificationSoundName(rawValue: stagedSystemSoundName))
         }
     }
 
@@ -284,16 +296,70 @@ enum NotificationSoundSettings {
         playSound(value: value, defaults: defaults)
     }
 
-    private static func playSound(value: String, defaults: UserDefaults) {
+    static func previewSound(value: String, customFilePath: String, defaults: UserDefaults = .standard) {
+        playSound(value: value, defaults: defaults, customFilePath: customFilePath)
+    }
+
+    private static func playSound(value: String, defaults: UserDefaults, customFilePath: String? = nil) {
         switch value {
         case "default":
             NSSound.beep()
         case "none":
             break
         case customFileValue:
-            playCustomFileSound(defaults: defaults)
+            if let customFilePath,
+               normalizedCustomFilePath(customFilePath) != nil {
+                playCustomFileSound(path: customFilePath)
+            } else {
+                playCustomFileSound(defaults: defaults)
+            }
         default:
-            NSSound(named: NSSound.Name(value))?.play()
+            playSystemSound(named: value)
+        }
+    }
+
+    static func stagedSystemSoundFileName(for value: String) -> String {
+        "\(systemSoundBaseName)-\(value).aiff"
+    }
+
+    static func stagedSystemSoundName(
+        for value: String,
+        fileManager: FileManager = .default,
+        sourceDirectory: URL = systemSoundDirectoryURL,
+        stagingDirectory: URL? = nil
+    ) -> String? {
+        guard systemSounds.contains(where: { option in
+            option.value == value && value != defaultValue && value != customFileValue && value != "none"
+        }) else {
+            return nil
+        }
+
+        let sourceURL = sourceDirectory.appendingPathComponent("\(value).aiff", isDirectory: false)
+        guard fileManager.fileExists(atPath: sourceURL.path) else {
+            return nil
+        }
+
+        let destinationDirectory = stagedSoundDirectoryURL(stagingDirectory)
+        let destinationFileName = stagedSystemSoundFileName(for: value)
+        let destinationURL = destinationDirectory.appendingPathComponent(destinationFileName, isDirectory: false)
+        do {
+            try fileManager.createDirectory(at: destinationDirectory, withIntermediateDirectories: true)
+            try copyStagedSoundIfNeeded(from: sourceURL, to: destinationURL, fileManager: fileManager)
+            return destinationFileName
+        } catch {
+            NSLog("Failed to stage notification system sound \(value): \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    private static func playSystemSound(named value: String) {
+        guard let sound = NSSound(named: NSSound.Name(value)) else {
+            return
+        }
+        retainActivePlaybackSound(sound)
+        sound.delegate = activePlaybackSoundDelegate
+        if !sound.play() {
+            releaseActivePlaybackSound(sound)
         }
     }
 
@@ -323,8 +389,11 @@ enum NotificationSoundSettings {
         return trimmed
     }
 
-    private static func stagedSoundDirectoryURL() -> URL {
-        URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
+    private static func stagedSoundDirectoryURL(_ override: URL? = nil) -> URL {
+        if let override {
+            return override
+        }
+        return URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
             .appendingPathComponent("Library", isDirectory: true)
             .appendingPathComponent("Sounds", isDirectory: true)
     }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -381,6 +381,7 @@
 		00C3AA443F6DA8D94E28CE17 /* MobileWorkspaceListObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F14137954A34DFFA05C88C /* MobileWorkspaceListObserver.swift */; };
 		B9000015A1B2C3D4E5F60719 /* MultiWindowNotificationsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000016A1B2C3D4E5F60719 /* MultiWindowNotificationsUITests.swift */; };
 		734F49D37E543DD01C2F4FEF /* NotificationAndMenuBarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C075029771815DD5DA1332 /* NotificationAndMenuBarTests.swift */; };
+		4E5F60720000000000000001 /* NotificationSoundSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E5F60720000000000000002 /* NotificationSoundSettingsTests.swift */; };
 		A5001094 /* NotificationsPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001091 /* NotificationsPage.swift */; };
 		D36090020000000000000001 /* NSWindow+CmuxPeerWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36090020000000000000002 /* NSWindow+CmuxPeerWindow.swift */; };
 		4378399A7C0245EF8186F306 /* OmnibarAndToolsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B09C007F42697761B5F1A2AB /* OmnibarAndToolsTests.swift */; };
@@ -1053,6 +1054,7 @@
 		C9F14137954A34DFFA05C88C /* MobileWorkspaceListObserver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileWorkspaceListObserver.swift; sourceTree = "<group>"; };
 		B9000016A1B2C3D4E5F60719 /* MultiWindowNotificationsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiWindowNotificationsUITests.swift; sourceTree = "<group>"; };
 		D2C075029771815DD5DA1332 /* NotificationAndMenuBarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationAndMenuBarTests.swift; sourceTree = "<group>"; };
+		4E5F60720000000000000002 /* NotificationSoundSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSoundSettingsTests.swift; sourceTree = "<group>"; };
 		A5001091 /* NotificationsPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsPage.swift; sourceTree = "<group>"; };
 		D36090020000000000000002 /* NSWindow+CmuxPeerWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "App/NSWindow+CmuxPeerWindow.swift"; sourceTree = "<group>"; };
 		B09C007F42697761B5F1A2AB /* OmnibarAndToolsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OmnibarAndToolsTests.swift; sourceTree = "<group>"; };
@@ -2010,6 +2012,7 @@
 				86544CEFA1CA33CA9225FB6E /* MobileWorkspaceListFidelityTests.swift */,
 				B09C007F42697761B5F1A2AB /* OmnibarAndToolsTests.swift */,
 				D2C075029771815DD5DA1332 /* NotificationAndMenuBarTests.swift */,
+				4E5F60720000000000000002 /* NotificationSoundSettingsTests.swift */,
 				42092CDB2109E250F7F2A76E /* TabManagerUnitTests.swift */,
 				C9A57002C9A57002C9A57002 /* WorkspaceGroupTests.swift */,
 				FEED49850000000000000002 /* FeedEventClassificationTests.swift */,
@@ -2971,6 +2974,7 @@
 				C0DE10510000000000000001 /* MobileHostServiceSettingsTests.swift in Sources */,
 				F6448F377504F33956E7E03B /* MobileWorkspaceListFidelityTests.swift in Sources */,
 				734F49D37E543DD01C2F4FEF /* NotificationAndMenuBarTests.swift in Sources */,
+				4E5F60720000000000000001 /* NotificationSoundSettingsTests.swift in Sources */,
 				4378399A7C0245EF8186F306 /* OmnibarAndToolsTests.swift in Sources */,
 				0A0F00550000000000000001 /* OmpSupportTests.swift in Sources */,
 				A5E01203A1B2C3D4E5F60718 /* OpenCodeHookRegressionTests.swift in Sources */,

--- a/cmuxTests/NotificationAndMenuBarTests.swift
+++ b/cmuxTests/NotificationAndMenuBarTests.swift
@@ -860,6 +860,11 @@ final class NotificationDockBadgeTests: XCTestCase {
             defaults: defaults,
             systemSoundStagingDirectory: stagingDirectory
         ))
+        let stagedSoundURL = stagingDirectory.appendingPathComponent(
+            NotificationSoundSettings.stagedSystemSoundFileName(for: "Ping"),
+            isDirectory: false
+        )
+        XCTAssertTrue(FileManager.default.fileExists(atPath: stagedSoundURL.path))
     }
 
     func testNotificationSoundDisablesSystemSoundForNoneAndCustomFile() {

--- a/cmuxTests/NotificationAndMenuBarTests.swift
+++ b/cmuxTests/NotificationAndMenuBarTests.swift
@@ -851,7 +851,15 @@ final class NotificationDockBadgeTests: XCTestCase {
 
         defaults.set("Ping", forKey: NotificationSoundSettings.key)
         XCTAssertTrue(NotificationSoundSettings.usesSystemSound(defaults: defaults))
-        XCTAssertNotNil(NotificationSoundSettings.sound(defaults: defaults))
+        let stagingDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-notification-sound-\(UUID().uuidString)", isDirectory: true)
+        defer {
+            try? FileManager.default.removeItem(at: stagingDirectory)
+        }
+        XCTAssertNotNil(NotificationSoundSettings.sound(
+            defaults: defaults,
+            systemSoundStagingDirectory: stagingDirectory
+        ))
     }
 
     func testNotificationSoundDisablesSystemSoundForNoneAndCustomFile() {

--- a/cmuxTests/NotificationSoundSettingsTests.swift
+++ b/cmuxTests/NotificationSoundSettingsTests.swift
@@ -1,0 +1,38 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite struct NotificationSoundSettingsTests {
+    @Test func namedSystemSoundStagesDistinctSoundFile() throws {
+        let fileManager = FileManager.default
+        let stagedName = NotificationSoundSettings.stagedSystemSoundFileName(for: "Bottle")
+        let stagingDirectory = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-notification-sound-\(UUID().uuidString)", isDirectory: true)
+        let stagedURL = stagingDirectory.appendingPathComponent(stagedName, isDirectory: false)
+        defer {
+            try? fileManager.removeItem(at: stagingDirectory)
+        }
+
+        #expect(try #require(NotificationSoundSettings.stagedSystemSoundName(
+            for: "Bottle",
+            stagingDirectory: stagingDirectory
+        )) == stagedName)
+        #expect(fileManager.fileExists(atPath: stagedURL.path))
+
+        let sourceURL = URL(fileURLWithPath: "/System/Library/Sounds/Bottle.aiff", isDirectory: false)
+        let sourceData = try Data(contentsOf: sourceURL)
+        let stagedData = try Data(contentsOf: stagedURL)
+        #expect(stagedData == sourceData)
+    }
+
+    @Test func nonSoundSentinelsDoNotStageSystemSoundFiles() {
+        #expect(NotificationSoundSettings.stagedSystemSoundName(for: "default") == nil)
+        #expect(NotificationSoundSettings.stagedSystemSoundName(for: "none") == nil)
+        #expect(NotificationSoundSettings.stagedSystemSoundName(for: NotificationSoundSettings.customFileValue) == nil)
+    }
+}


### PR DESCRIPTION
## Summary
- Preview the selected notification sound instead of always playing Glass.
- Stage named macOS alert sounds into ~/Library/Sounds so delivered notifications can use distinct files.
- Update settings value models optimistically so picker selection state changes immediately.

## Testing
- swift test --package-path Packages/CmuxSettingsUI
- ./scripts/reload-cloud.sh --tag nsound

## Issues
- Task: user reported every notification sound sounding the same and older macOS selection lag in chat.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5480"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783289241&installation_id=133855650&pr_number=5480&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5480&signature=503b6f0e1885d76c780b4222ae7d67ad7c058ec64af6c57cf1337f1b6c15f217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are localized to notification sound staging/preview and settings UI binding behavior, with tests added; no auth or data-model changes.
> 
> **Overview**
> Fixes notification sound selection so **preview matches the picker** and **delivered notifications can use distinct macOS alert sounds** instead of sounding the same.
> 
> **Notification sounds:** `SettingsHostActions.previewNotificationSound` now takes the selected **sound value** and **custom file path**; the host routes to `NotificationSoundSettings.previewSound` instead of always playing Glass. For named system sounds, delivery copies `/System/Library/Sounds/<name>.aiff` into `~/Library/Sounds` as `cmux-system-notification-sound-<name>.aiff` and references that staged name in `UNNotificationSound` (falls back to `.default` if staging fails). Preview playback retains `NSSound` instances until playback finishes so short clips are audible.
> 
> **Settings UI responsiveness:** `DefaultsValueModel` updates `current` **optimistically** on `set`/`reset` so pickers reflect changes immediately while persistence still runs asynchronously.
> 
> Tests cover optimistic model updates, system-sound staging, and updated notification sound integration checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f8f5bd4fe52dc9b61a9ce6597cc0c2ea383d3be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes notification sound selection so preview and delivered notifications use the sound you choose. Adds safe staging for system sounds, instant picker updates, and reliable custom file previews.

- Bug Fixes
  - Preview plays the selected sound via `SettingsHostActions.previewNotificationSound(value:customFilePath:)` → `NotificationSoundSettings.previewSound(...)`, retains `NSSound`, and uses the provided custom file path when available (no more hardcoded “Glass”).
  - Delivered notifications stage macOS `.aiff` from `/System/Library/Sounds` into `~/Library/Sounds` as `cmux-system-notification-sound-<name>.aiff`, with a configurable staging directory and idempotent copy; falls back to `.default` if staging fails.
  - Custom files use their stored sound name; `.default` maps to `.default`, and `none` results in `.default` for delivery.
  - `DefaultsValueModel` updates `current` optimistically on set/reset so the picker reflects changes immediately.
  - Tests cover system sound staging (distinct filenames/content, sentinel values not staged, staging directory injection) and optimistic model updates.

<sup>Written for commit e914efb8a63d75c7aa26620fea17422561c7e2e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5480?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Settings now update immediately in the UI (optimistic update) while persistence continues in the background.
  * Notification preview now plays the currently selected sound and accepts a custom file path instead of a fixed default.
  * Improved staging and playback handling for system notification sounds with safer in-memory playback lifetime and fallback behavior.

* **Tests**
  * Added lifecycle tests for immediate set/reset behavior and tests for notification sound staging and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->