### PR TITLE
Fix OSC socket input preservation

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7280,6 +7280,13 @@ final class TerminalSurface: Identifiable, ObservableObject {
                 previousWasCR = false
                 index += 1
             case 0x1B:
+                if let osc = oscEscapeSequence(scalars, from: index) {
+                    flushBufferedText()
+                    events.append(.rawBytes(osc.data))
+                    index += osc.length
+                    previousWasCR = false
+                    continue
+                }
                 // A bare ESC is the Escape key. But a full CSI/SS3 navigation
                 // sequence arriving as raw input (the iOS on-screen arrows send
                 // ESC[B, etc.) must stay one key press, or the terminal receives
@@ -7309,6 +7316,42 @@ final class TerminalSurface: Identifiable, ObservableObject {
         }
         flushBufferedText()
         return events
+    }
+
+    private static func oscEscapeSequence(
+        _ scalars: [Unicode.Scalar],
+        from start: Int
+    ) -> (data: Data, length: Int)? {
+        guard start + 1 < scalars.count,
+              scalars[start].value == 0x1B,
+              scalars[start + 1].value == 0x5D else {
+            return nil
+        }
+
+        var index = start + 2
+        while index < scalars.count {
+            switch scalars[index].value {
+            case 0x07:
+                return rawScalarData(scalars[start...index], length: index - start + 1)
+            case 0x1B:
+                if index + 1 < scalars.count, scalars[index + 1].value == 0x5C {
+                    return rawScalarData(scalars[start...(index + 1)], length: index - start + 2)
+                }
+                index += 1
+            default:
+                index += 1
+            }
+        }
+        return nil
+    }
+
+    private static func rawScalarData(
+        _ scalars: ArraySlice<Unicode.Scalar>,
+        length: Int
+    ) -> (data: Data, length: Int) {
+        var sequence = String()
+        sequence.unicodeScalars.append(contentsOf: scalars)
+        return (Data(sequence.utf8), length)
     }
 
     /// Match a CSI (`ESC [ …`) or SS3 (`ESC O …`) cursor/navigation escape

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -1192,6 +1192,28 @@ final class TerminalOffscreenStartupTests: XCTestCase {
         )
     }
 
+    func testColdSocketInputPreservesOSCBackgroundSequenceAsCommittedText() {
+        let panel = TerminalPanel(workspaceId: UUID())
+
+        panel.surface.releaseSurfaceForTesting()
+        let osc11 = "\u{1B}]11;#341c1c\u{1B}\\"
+        XCTAssertTrue(panel.surface.sendInput(osc11))
+
+        let pending = panel.surface.debugPendingSocketInputForTesting()
+        XCTAssertEqual(
+            pending.inputTextItems,
+            1,
+            "Programmatic OSC sequences must stay as one committed-text chunk so Ghostty can parse them."
+        )
+        XCTAssertEqual(
+            pending.keyEvents,
+            0,
+            "Programmatic OSC sequences must not split ESC into synthetic Escape key events."
+        )
+        XCTAssertEqual(pending.pasteTextItems, 0)
+        XCTAssertEqual(pending.bytes, osc11.utf8.count)
+    }
+
     func testColdSocketInputChunksLongCommittedTextInput() {
         let panel = TerminalPanel(workspaceId: UUID())
 


### PR DESCRIPTION
Fixes https://github.com/manaflow-ai/cmux/issues/5478

Summary:
- Preserve complete OSC escape sequences in socket/mobile programmatic terminal input instead of treating the leading ESC as an Escape key.
- Cover OSC 11 preservation in the cold socket input queue so regressions fail before Ghostty starts.

Verification:
- Built tagged dogfood app with `./scripts/reload-cloud.sh --tag osc11`.
- In the tagged app, `printf '\033]11;#341c1c\033\\'` no longer prints `]11;#341c1c\` as terminal text.
- AWS focused unit test attempt was blocked by `xcodebuild` `Trace/BPT trap: 5` during package resolution before tests executed. Hosted checks are the test gate for this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5481"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783289955&installation_id=133855650&pr_number=5481&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5481&signature=59d2f7822ee194efedc0d9bc15f8646914626bcd38e9fe4a01c901dc533f6483"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to socket/mobile input parsing with a regression test; CSI/SS3 Escape handling is unchanged when OSC does not match.
> 
> **Overview**
> Programmatic/socket terminal input now recognizes **OSC sequences** (`ESC ] …` ending in BEL or `ESC \`) and forwards them as a single **raw byte** chunk instead of treating the leading `ESC` as an Escape key.
> 
> In `parsedSocketInputEvents`, OSC handling runs before existing CSI/SS3 navigation and bare-Escape logic, using new helpers `oscEscapeSequence` and `rawScalarData`. A unit test asserts cold-queue OSC 11 input stays one committed-text item with no synthetic key events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d430fc78d8064fdb289866200af0d7c6d644fc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of OSC escape sequences in terminal input parsing to ensure they are properly recognized and processed as complete input chunks

* **Tests**
  * Added regression test to verify OSC escape sequences are correctly preserved during terminal operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->