### PR TITLE
Remove mobile host legacy defaults

### DIFF
--- a/Packages/CmuxSettings/Sources/CmuxSettings/Keys/MobileCatalogSection.swift
+++ b/Packages/CmuxSettings/Sources/CmuxSettings/Keys/MobileCatalogSection.swift
@@ -7,11 +7,7 @@ public struct MobileCatalogSection: SettingCatalogSection {
     public let iOSPairingHost = DefaultsKey<Bool>(
         id: "mobile.iOSPairingHost.enabled",
         defaultValue: false,
-        userDefaultsKey: "mobile.iOSPairingHost.enabled",
-        legacyUserDefaultsKeys: [
-            "cmuxMobilePairingHostEnabled",
-            "ios.beta.pairingHost.enabled",
-        ]
+        userDefaultsKey: "mobile.iOSPairingHost.enabled"
     )
 
     /// Creates the Mobile settings catalog section.

--- a/Sources/Mobile/MobileHostService.swift
+++ b/Sources/Mobile/MobileHostService.swift
@@ -295,8 +295,6 @@ final class MobileHostService {
 
     /// User-default key for the opt-in Mac-side iOS pairing listener.
     nonisolated static let listeningEnabledDefaultsKey = SettingCatalog().mobile.iOSPairingHost.userDefaultsKey
-    nonisolated private static let legacyListeningEnabledDefaultsKey = "cmuxMobilePairingHostEnabled"
-    nonisolated private static let legacyBetaListeningEnabledDefaultsKey = "ios.beta.pairingHost.enabled"
 
     /// Whether the mobile pairing host should bind a network listener at all.
     ///
@@ -321,12 +319,6 @@ final class MobileHostService {
     nonisolated static func isListeningEnabled(defaults: UserDefaults) -> Bool {
         if let override = defaults.object(forKey: listeningEnabledDefaultsKey) as? Bool {
             return override
-        }
-        if let legacyOverride = defaults.object(forKey: legacyListeningEnabledDefaultsKey) as? Bool {
-            return legacyOverride
-        }
-        if let legacyBetaOverride = defaults.object(forKey: legacyBetaListeningEnabledDefaultsKey) as? Bool {
-            return legacyBetaOverride
         }
         return SettingCatalog().mobile.iOSPairingHost.defaultValue
     }
@@ -353,8 +345,6 @@ final class MobileHostService {
     nonisolated private static func canPublishRoutesWithoutListenerForXCTest(defaults: UserDefaults) -> Bool {
         guard isRunningUnderXCTest else { return false }
         return defaults.object(forKey: listeningEnabledDefaultsKey) == nil
-            && defaults.object(forKey: legacyListeningEnabledDefaultsKey) == nil
-            && defaults.object(forKey: legacyBetaListeningEnabledDefaultsKey) == nil
     }
 
     private func publishRoutesWithoutListenerForXCTest() {

--- a/cmuxTests/MobileHostServiceSettingsTests.swift
+++ b/cmuxTests/MobileHostServiceSettingsTests.swift
@@ -21,28 +21,4 @@ struct MobileHostServiceSettingsTests {
         defaults.set(false, forKey: MobileHostService.listeningEnabledDefaultsKey)
         #expect(!MobileHostService.isListeningEnabled(defaults: defaults))
     }
-
-    @Test func mobileHostListenerHonorsLegacyExplicitOptIn() throws {
-        let suiteName = "MobileHostServiceSettingsTests.Legacy.\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
-
-        defaults.set(true, forKey: "cmuxMobilePairingHostEnabled")
-        #expect(MobileHostService.isListeningEnabled(defaults: defaults))
-
-        defaults.set(false, forKey: MobileHostService.listeningEnabledDefaultsKey)
-        #expect(!MobileHostService.isListeningEnabled(defaults: defaults))
-    }
-
-    @Test func mobileHostListenerHonorsLegacyBetaExplicitOptIn() throws {
-        let suiteName = "MobileHostServiceSettingsTests.LegacyBeta.\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
-
-        defaults.set(true, forKey: "ios.beta.pairingHost.enabled")
-        #expect(MobileHostService.isListeningEnabled(defaults: defaults))
-
-        defaults.set(false, forKey: MobileHostService.listeningEnabledDefaultsKey)
-        #expect(!MobileHostService.isListeningEnabled(defaults: defaults))
-    }
 }


### PR DESCRIPTION
## Summary
- remove old iOS pairing UserDefaults key fallbacks
- keep only `mobile.iOSPairingHost.enabled` as the Mobile setting key
- delete legacy-key tests

## Verification
- `swift test --package-path Packages/CmuxSettingsUI`
- `git diff --check`

## Note
- `swift test --package-path Packages/CmuxSettings` still fails on the pre-existing `SettingCatalogTests.userDefaultsStorageKeysAreUnique` duplicate-key assertion (`129` keys vs `117` unique).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783290822&installation_id=133855650&pr_number=5484&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5484&signature=cb12e13c672fab26de3c66be8784ef36afc8b2ad1962c46654f0d122a73960e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit dbff725850864585f26d0986ed7bb3d60480a7e8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed legacy iOS pairing host UserDefaults keys and fallbacks, standardizing on the single `mobile.iOSPairingHost.enabled` setting. This simplifies configuration and removes dead paths in the mobile host.

- **Refactors**
  - Removed fallback reads for `cmuxMobilePairingHostEnabled` and `ios.beta.pairingHost.enabled`.
  - Kept only `mobile.iOSPairingHost.enabled`; deleted legacy-key tests and related XCTest checks.

- **Migration**
  - If you used `cmuxMobilePairingHostEnabled` or `ios.beta.pairingHost.enabled`, set `mobile.iOSPairingHost.enabled` instead.
  - When unset, the value defaults to false.

<sup>Written for commit dbff725850864585f26d0986ed7bb3d60480a7e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined mobile device pairing host configuration by consolidating all settings to a single authoritative source, eliminating inconsistencies from multiple configuration methods.
  * Removed support for legacy pairing configuration options; applications currently using these options should migrate to the unified configuration approach.

* **Tests**
  * Updated test suite to verify correct behavior with the consolidated configuration system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->