### PR TITLE
ios: name the TestFlight beta "cmux BETA" on device

### DIFF
--- a/ios/Config/Release.xcconfig
+++ b/ios/Config/Release.xcconfig
@@ -6,3 +6,7 @@
 
 PRODUCT_BUNDLE_IDENTIFIER = dev.cmux.app.beta
 DEVELOPMENT_TEAM = 7WLXT3NR37
+
+// Distinguish the TestFlight beta on-device from a future App Store "cmux"
+// (overrides PRODUCT_DISPLAY_NAME = cmux from Shared.xcconfig). Debug stays "cmux".
+PRODUCT_DISPLAY_NAME = cmux BETA


### PR DESCRIPTION
The TestFlight build ships the beta lane (`dev.cmux.app.beta`) but its on-device name is plain **"cmux"**, indistinguishable from a future App Store "cmux". This sets the Release display name to **"cmux BETA"**.

- One line in `ios/Config/Release.xcconfig`: `PRODUCT_DISPLAY_NAME = cmux BETA` (after the `Shared.xcconfig` include, so it overrides the shared "cmux").
- **Debug builds stay "cmux"** (`dev.cmux.ios`, simulator/dev).
- Matches the macOS variant convention ("cmux NIGHTLY" / "cmux DEV").

Verified deterministically (no GhosttyKit/SPM build needed): the Release config's `baseConfigurationReference` is `Release.xcconfig`, there is no direct `PRODUCT_DISPLAY_NAME` in `project.pbxproj`, and `INFOPLIST_KEY_CFBundleDisplayName = $(PRODUCT_DISPLAY_NAME)` + `Info.plist CFBundleDisplayName = $(PRODUCT_DISPLAY_NAME)`, so the Release app's `CFBundleDisplayName` resolves to "cmux BETA".

Merging triggers the on-merge TestFlight publish (this file is under `ios/`), so the next beta build will install on-device as **"cmux BETA"**. Localization: not applicable — this is the bundle display name (a build setting), not a localized UI string.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5485"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783291192&installation_id=133855650&pr_number=5485&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5485&signature=8321d5f5a202ba2f3413a217add4c4e9173b38ba0d3046f66a41e05b9e1d357f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single build-setting override for the home-screen display name only; no runtime, auth, or data-path changes.
> 
> **Overview**
> Sets the **Release** iOS build’s on-device label to **"cmux BETA"** by overriding `PRODUCT_DISPLAY_NAME` in `ios/Config/Release.xcconfig` (after `Shared.xcconfig`, which keeps `cmux`). That flows through `CFBundleDisplayName` for TestFlight (`dev.cmux.app.beta`) so the beta is visually distinct from a future App Store **cmux** install.
> 
> **Debug** builds are unchanged and still show **cmux** on the home screen.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5a4dc690ae1dc6979ea75f336a658aead4da8e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the iOS TestFlight build’s on-device name to “cmux BETA” to clearly distinguish it from the App Store “cmux”. Implemented by overriding PRODUCT_DISPLAY_NAME in ios/Config/Release.xcconfig; Debug builds remain “cmux”.

<sup>Written for commit b5a4dc690ae1dc6979ea75f336a658aead4da8e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the TestFlight beta app display name to "cmux BETA" to distinguish the beta version from the production app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->