### PR TITLE
Fix sidebar close button hidden under wrapped workspace titles

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -15468,6 +15468,31 @@ struct TabItemView: View, Equatable {
                     .fixedSize(horizontal: false, vertical: true)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .layoutPriority(1)
+
+                // The close button is a sibling that always reserves its width
+                // when the workspace is closable, so the title wraps/truncates
+                // before this corner instead of flowing under the hover x. Its
+                // visibility toggles via opacity so hover never re-lays-out the
+                // row. (Matches the group-header plus-button pattern.)
+                if canCloseWorkspace {
+                    Button(action: {
+                        #if DEBUG
+                        cmuxDebugLog("sidebar.close workspace=\(tab.id.uuidString.prefix(5)) method=button")
+                        #endif
+                        tabManager.closeWorkspaceWithConfirmation(tab)
+                    }) {
+                        Image(systemName: "xmark")
+                            .font(.system(size: scaledFontSize(9), weight: .medium))
+                            .foregroundColor(activeSecondaryColor(0.7))
+                            .frame(width: scaledCloseButtonWidth, height: scaledCloseButtonHitSize, alignment: .center)
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .safeHelp(closeButtonTooltip)
+                    .opacity(showCloseButton ? 1 : 0)
+                    .allowsHitTesting(showCloseButton)
+                    .accessibilityHidden(!showCloseButton)
+                }
             }
 
             if let description = workspaceSnapshot.customDescription {
@@ -15736,27 +15761,6 @@ struct TabItemView: View, Equatable {
             offsetY: sidebarShortcutHintYOffset,
             fontSize: scaledFontSize(10)
         )
-        .overlay(alignment: .topTrailing) {
-            if showsWorkspaceShortcutHint {
-                EmptyView()
-            } else if showCloseButton {
-                Button(action: {
-                    #if DEBUG
-                    cmuxDebugLog("sidebar.close workspace=\(tab.id.uuidString.prefix(5)) method=button")
-                    #endif
-                    tabManager.closeWorkspaceWithConfirmation(tab)
-                }) {
-                    Image(systemName: "xmark")
-                        .font(.system(size: scaledFontSize(9), weight: .medium))
-                        .foregroundColor(activeSecondaryColor(0.7))
-                }
-                .buttonStyle(.plain)
-                .safeHelp(closeButtonTooltip)
-                .frame(width: scaledCloseButtonWidth, height: scaledCloseButtonHitSize, alignment: .center)
-                .padding(.top, 8)
-                .padding(.trailing, 10)
-            }
-        }
         .shortcutHintVisibilityAnimation(value: showsWorkspaceShortcutHint)
         .padding(.horizontal, 6)
         .background { rowHeightProbe }


### PR DESCRIPTION
## Summary
- The sidebar workspace close (x) button was a floating `overlay(alignment: .topTrailing)` that reserved no layout space. The title used `frame(maxWidth: .infinity)` with no trailing inset, so a name long enough to wrap filled the top-right corner and the semi-transparent x rendered on top of the title glyphs (no background), reading as missing. Short single-line names left that corner empty, which is why they looked fine.
- Moved the close button into the title `HStack` as a trailing sibling that always reserves its width when the workspace is closable, toggling visibility via opacity so hover never re-lays-out the row. The title now wraps/truncates before the button's corner, leaving a clear area where the x always shows. Matches the existing group-header plus-button pattern.

## Testing
- Cloud reload build succeeded (compiles clean).
- Repro on a tagged build with `sidebarWrapWorkspaceTitles` on: before, a wrapped title filled the top-right corner where the x sits; after, the title reserves a trailing gap on every closable row so the x has a clear home. The close-button render/hover logic is unchanged.
- No automated test added: this is a pure visual-overlap layout fix. The x always rendered and was hittable before (just camouflaged over the title), so there is no behavioral or hittability assertion that distinguishes broken from fixed. The `shouldShowCloseButton` unit tests and the Cmd+Shift+W close-dialog UI tests are unaffected.

## Issues
- Reported: multi-line workspace names (with title wrap on) hide the x close button.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5488"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783293433&installation_id=133855650&pr_number=5488&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5488&signature=7fb9118f7a5eb7c9f4b12382459d29e8f6b7779342822c1215d47cf97705eef8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> SwiftUI layout-only change in the sidebar row; close action and hover logic are unchanged.
> 
> **Overview**
> Fixes wrapped sidebar workspace titles drawing under the hover **close** control so the **x** looked missing.
> 
> The close button is no longer a `topTrailing` overlay that ignores layout. It sits in the title **HStack** as a trailing sibling that **always reserves width** when the workspace is closable; **opacity**, hit testing, and accessibility follow existing `showCloseButton` behavior so hover does not reflow the row. The title now wraps/truncates before that reserved corner, matching the group-header plus-button approach.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd37661d08d71325b30b0d12e0e0409f13492e31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the sidebar workspace close (x) button being hidden under wrapped titles by moving it into the title row and reserving space so it always shows.

- **Bug Fixes**
  - Moved the close button from an overlay to a trailing sibling in the title HStack.
  - Reserved button width when closable; toggle visibility with opacity to avoid layout shifts.
  - Title wraps/truncates before the button, keeping the x visible and clickable.

<sup>Written for commit cd37661d08d71325b30b0d12e0e0409f13492e31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed workspace close button layout stability to prevent visual shifts when interacting with the button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->