### PR TITLE
Add macOS iOS pairing/onboarding window

### DIFF
--- a/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Environment/SettingsHostActions.swift
+++ b/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Environment/SettingsHostActions.swift
@@ -53,6 +53,11 @@ public protocol SettingsHostActions: AnyObject {
     /// window scene so the package can't open it directly.
     func openTerminalConfigWindow()
 
+    /// Opens the iOS pairing window, which shows a scannable QR code for
+    /// pairing an iPhone with this Mac. The host owns the window so the
+    /// package can't open it directly.
+    func openMobilePairingWindow()
+
     /// Plays the currently configured notification sound so the user
     /// can preview it from the Settings UI.
     func previewNotificationSound(value: String, customFilePath: String)
@@ -101,6 +106,8 @@ public protocol SettingsHostActions: AnyObject {
 }
 
 public extension SettingsHostActions {
+    func openMobilePairingWindow() {}
+
     func browserHistoryEntryCount() -> Int? { nil }
 
     func sidebarFontSize() -> SettingsFontSize {
@@ -141,6 +148,7 @@ public final class NoopSettingsHostActions: SettingsHostActions {
     public func openBrowserImportFlow() {}
     public func requestNotificationAuthorization() {}
     public func openTerminalConfigWindow() {}
+    public func openMobilePairingWindow() {}
     /// No-op notification sound preview used by tests, previews, and
     /// package-only settings hosts.
     public func previewNotificationSound(value: String, customFilePath: String) {}

--- a/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/CuratedSettingEntry+Default.swift
+++ b/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/CuratedSettingEntry+Default.swift
@@ -97,6 +97,7 @@ extension Array where Element == CuratedSettingEntry {
             .init(section: .sidebarAppearance, id: "show-metadata", title: "Show Custom Metadata in Sidebar", synonyms: "sidebar.showCustomMetadata metadata meta report_meta status custom block"),
 
             // Mobile
+            .init(section: .mobile, id: "pairDevice", title: "Pair a Device", synonyms: "pair pairing add device qr qr code scan iphone ipad ios mobile tailscale connect onboarding sign in"),
             .init(section: .mobile, id: "iOSPairingHost", title: "iOS Pairing", synonyms: "ios iphone ipad mobile pairing local network permission sync"),
 
             // Beta

--- a/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Scene/SettingsWindowScene.swift
+++ b/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Scene/SettingsWindowScene.swift
@@ -456,7 +456,7 @@ public struct SettingsWindowRoot: View {
         TextBoxSection(defaultsStore: defaultsStore, catalog: catalog)
             .id(anchorID(for: .textBox))
 
-        MobileSection(defaultsStore: defaultsStore, catalog: catalog)
+        MobileSection(defaultsStore: defaultsStore, catalog: catalog, hostActions: hostActions)
             .id(anchorID(for: .mobile))
 
         SidebarSection(defaultsStore: defaultsStore, catalog: catalog, hostActions: hostActions)

--- a/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/MobileSection.swift
+++ b/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/MobileSection.swift
@@ -6,10 +6,22 @@ import SwiftUI
 @MainActor
 public struct MobileSection: View {
     @State private var iOSPairingHost: DefaultsValueModel<Bool>
+    private let hostActions: SettingsHostActions
 
     /// Creates a Mobile settings section bound to the supplied settings stores.
-    public init(defaultsStore: UserDefaultsSettingsStore, catalog: SettingCatalog) {
+    ///
+    /// - Parameters:
+    ///   - defaultsStore: The user-defaults-backed settings store.
+    ///   - catalog: The settings catalog defining the mobile keys.
+    ///   - hostActions: Host callbacks for actions the package can't perform
+    ///     itself, such as opening the iOS pairing window.
+    public init(
+        defaultsStore: UserDefaultsSettingsStore,
+        catalog: SettingCatalog,
+        hostActions: SettingsHostActions
+    ) {
         _iOSPairingHost = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.mobile.iOSPairingHost))
+        self.hostActions = hostActions
     }
 
     /// The Mobile settings section content.
@@ -17,8 +29,27 @@ public struct MobileSection: View {
         Group {
             SettingsSectionHeader(String(localized: "settings.section.mobile", defaultValue: "Mobile"), section: .mobile)
             SettingsCard {
+                pairDeviceRow
+                SettingsCardDivider()
                 iOSPairingHostRow
             }
+        }
+    }
+
+    @ViewBuilder
+    private var pairDeviceRow: some View {
+        SettingsCardRow(
+            configurationReview: .action,
+            searchAnchorID: "setting:mobile:pairDevice",
+            String(localized: "settings.mobile.pairDevice", defaultValue: "Pair a Device"),
+            subtitle: String(localized: "settings.mobile.pairDevice.subtitle", defaultValue: "Show a QR code to pair your iPhone or iPad with this Mac.")
+        ) {
+            Button(String(localized: "settings.mobile.pairDevice.button", defaultValue: "Pair…")) {
+                hostActions.openMobilePairingWindow()
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+            .accessibilityIdentifier("SettingsMobilePairDeviceButton")
         }
     }
 

--- a/Packages/CmuxSettingsUI/Tests/CmuxSettingsUITests/SettingsRowAnchorResolutionTests.swift
+++ b/Packages/CmuxSettingsUI/Tests/CmuxSettingsUITests/SettingsRowAnchorResolutionTests.swift
@@ -125,6 +125,7 @@ struct SettingsRowAnchorResolutionTests {
         "setting:app:terminal-config",
         "setting:app:desktop-notifications",
         "setting:account:account",
+        "setting:mobile:pairDevice",
         "setting:mobile:iOSPairingHost",
         "setting:betaFeatures:feed",
         "setting:betaFeatures:dock",

--- a/Sources/HostSettingsActions.swift
+++ b/Sources/HostSettingsActions.swift
@@ -139,6 +139,10 @@ final class HostSettingsActions: SettingsHostActions {
         window.orderFrontRegardless()
     }
 
+    func openMobilePairingWindow() {
+        MobilePairingWindowController.shared.show()
+    }
+
     private func existingConfigWindow() -> NSWindow? {
         if let configWindow, configWindow.isVisible || configWindow.isMiniaturized {
             return configWindow

--- a/Sources/Mobile/MobileHostService.swift
+++ b/Sources/Mobile/MobileHostService.swift
@@ -408,6 +408,9 @@ final class MobileHostService {
             }
             lastErrorDescription = String(describing: error)
             mobileHostLog.error("mobile host listener failed to start: \(String(describing: error), privacy: .public)")
+            // No listener was registered, so no state callback will fire to drain
+            // readiness waiters; resolve them now instead of waiting for the deadline.
+            drainReadinessWaiters()
         }
     }
 

--- a/Sources/Mobile/MobileHostService.swift
+++ b/Sources/Mobile/MobileHostService.swift
@@ -259,6 +259,8 @@ final class MobileHostService {
     /// Injected once via `configure(auth:)` at app startup, before the
     /// listener starts accepting connections.
     private var auth: AuthCoordinator?
+    private var readinessWaiters: [CheckedContinuation<MobileHostServiceStatus, Never>] = []
+    private var readinessTimeoutTask: Task<Void, Never>?
     #if DEBUG
     private var debugAcceptedStackAuthToken: String?
     #endif
@@ -435,6 +437,7 @@ final class MobileHostService {
         MobileHostEventSubscriptionTracker.reset()
         MobileHostPublicStatusCache.update(routes: [])
         TerminalController.shared.clearAllMobileViewportReports(reason: "mobile.host.stopped")
+        drainReadinessWaiters()
     }
 
     func statusSnapshot() -> MobileHostServiceStatus {
@@ -446,6 +449,49 @@ final class MobileHostService {
             activeConnectionCount: MobileHostConnectionRegistry.shared.count,
             lastErrorDescription: lastErrorDescription
         )
+    }
+
+    /// Starts the pairing listener (if enabled and not already bound) and
+    /// resolves once it can mint attach tickets, so the in-app pairing window
+    /// can render a QR code without polling the listener state machine.
+    ///
+    /// Resolves immediately when the listener is already ready, or when pairing
+    /// is disabled (the caller then renders an "off" state). Otherwise it awaits
+    /// the next listener-state transition (`ready`, terminal `failed`, or
+    /// `cancelled`) via a continuation, with a bounded safety deadline so the UI
+    /// never hangs on a listener that never settles.
+    func ensureListeningAndReady() async -> MobileHostServiceStatus {
+        start()
+        if listener == nil || listenerPort != nil {
+            return statusSnapshot()
+        }
+        return await withCheckedContinuation { continuation in
+            readinessWaiters.append(continuation)
+            if readinessTimeoutTask == nil {
+                // Bounded, cancellable deadline: a local NWListener normally
+                // reaches `.ready` within milliseconds; this only guards a
+                // never-settling listener. Cancelled on the normal drain path.
+                readinessTimeoutTask = Task { @MainActor [weak self] in
+                    try? await ContinuousClock().sleep(for: .seconds(6))
+                    guard let self, !Task.isCancelled else { return }
+                    self.drainReadinessWaiters()
+                }
+            }
+        }
+    }
+
+    /// Resumes every pending ``ensureListeningAndReady()`` caller with the
+    /// current status and clears the bounded readiness deadline.
+    private func drainReadinessWaiters() {
+        readinessTimeoutTask?.cancel()
+        readinessTimeoutTask = nil
+        guard !readinessWaiters.isEmpty else { return }
+        let snapshot = statusSnapshot()
+        let waiters = readinessWaiters
+        readinessWaiters.removeAll()
+        for waiter in waiters {
+            waiter.resume(returning: snapshot)
+        }
     }
 
     private func publicStatusSnapshot() async -> MobileHostServiceStatus {
@@ -983,6 +1029,7 @@ final class MobileHostService {
                 MobileHostPublicStatusCache.update(routes: [])
             }
             mobileHostLog.info("mobile host listener ready on port \(self.listenerPort ?? 0)")
+            drainReadinessWaiters()
         case let .failed(error):
             lastErrorDescription = String(describing: error)
             MobileHostPublicStatusCache.update(routes: [])
@@ -998,6 +1045,8 @@ final class MobileHostService {
             if shouldRetryWithEphemeralPort {
                 mobileHostLog.info("mobile host preferred port failed after start, falling back to an ephemeral port")
                 startListener(usePreferredPort: false)
+            } else {
+                drainReadinessWaiters()
             }
         case .cancelled:
             listenerGeneration = UUID()
@@ -1005,6 +1054,7 @@ final class MobileHostService {
             listenerUsesEphemeralFallback = false
             listenerPort = nil
             MobileHostPublicStatusCache.update(routes: [])
+            drainReadinessWaiters()
         case .setup, .waiting:
             listenerPort = nil
             MobileHostPublicStatusCache.update(routes: [])

--- a/Sources/Mobile/Pairing/MobilePairingModel.swift
+++ b/Sources/Mobile/Pairing/MobilePairingModel.swift
@@ -1,0 +1,111 @@
+import CMUXMobileCore
+import Foundation
+import Observation
+
+/// Drives the in-app iOS pairing window: turns on the Mac-side pairing host,
+/// mints a short-lived attach ticket, and exposes the QR payload plus a
+/// human-readable fallback (host:port routes) for the view to render.
+///
+/// Opening the window auto-enables the pairing listener (writing the same
+/// `UserDefaults` flag the Settings toggle uses), which is what triggers the
+/// macOS Local Network permission prompt on first use.
+@MainActor
+@Observable
+final class MobilePairingModel {
+    /// The pairing window's render state.
+    enum State: Equatable {
+        /// Bringing the listener up and minting the first ticket.
+        case preparing
+        /// A ticket is ready to display.
+        case ready(Ready)
+        /// The listener could not be started or no ticket could be minted.
+        case failed(String)
+    }
+
+    /// A minted ticket ready for display.
+    struct Ready: Equatable {
+        /// The `cmux-ios://attach?...` URL encoded into the QR code.
+        let attachURL: String
+        /// The Mac's display name, shown above the code.
+        let macName: String
+        /// Reachable `host:port` routes for the manual-entry fallback.
+        let routeLines: [String]
+    }
+
+    /// The current render state, observed by ``MobilePairingView``.
+    private(set) var state: State = .preparing
+
+    private let host: MobileHostService
+    private let ticketTTL: TimeInterval
+
+    /// Creates a pairing model.
+    ///
+    /// - Parameters:
+    ///   - host: The Mac-side pairing host service. Defaults to the shared instance.
+    ///   - ticketTTL: Attach-ticket lifetime in seconds. Defaults to 600.
+    init(host: MobileHostService = .shared, ticketTTL: TimeInterval = 600) {
+        self.host = host
+        self.ticketTTL = ticketTTL
+    }
+
+    /// Enables the pairing host, waits for the listener to be ready, and mints
+    /// a fresh attach ticket. Safe to call repeatedly (e.g. from a Refresh
+    /// button); the latest result wins.
+    func refresh() async {
+        state = .preparing
+        enablePairingHost()
+        let status = await host.ensureListeningAndReady()
+        guard status.isRunning else {
+            state = .failed(
+                status.lastErrorDescription
+                    ?? String(
+                        localized: "mobile.pairing.error.listenerOffline",
+                        defaultValue: "Could not start the pairing listener on this Mac."
+                    )
+            )
+            return
+        }
+        do {
+            let payload = try await host.createAttachTicket(
+                workspaceID: "",
+                terminalID: nil,
+                ttl: ticketTTL
+            )
+            guard let attachURL = payload["attach_url"] as? String, !attachURL.isEmpty else {
+                state = .failed(
+                    String(
+                        localized: "mobile.pairing.error.noTicket",
+                        defaultValue: "Could not generate a pairing code. Try again."
+                    )
+                )
+                return
+            }
+            state = .ready(
+                Ready(
+                    attachURL: attachURL,
+                    macName: Self.macDisplayName,
+                    routeLines: Self.routeLines(status.routes)
+                )
+            )
+        } catch {
+            state = .failed(String(describing: error))
+        }
+    }
+
+    private func enablePairingHost() {
+        UserDefaults.standard.set(true, forKey: MobileHostService.listeningEnabledDefaultsKey)
+    }
+
+    private static var macDisplayName: String {
+        Host.current().localizedName ?? ProcessInfo.processInfo.hostName
+    }
+
+    private static func routeLines(_ routes: [CmxAttachRoute]) -> [String] {
+        routes.compactMap { route in
+            if case let .hostPort(host, port) = route.endpoint {
+                return "\(host):\(port)"
+            }
+            return nil
+        }
+    }
+}

--- a/Sources/Mobile/Pairing/MobilePairingModel.swift
+++ b/Sources/Mobile/Pairing/MobilePairingModel.swift
@@ -1,5 +1,6 @@
 import CMUXAuthCore
 import CMUXMobileCore
+import CmuxAuthRuntime
 import Foundation
 import Observation
 
@@ -8,10 +9,9 @@ import Observation
 /// pairing host, mints a short-lived attach ticket, and exposes the QR payload
 /// plus Tailscale reachability for the view.
 ///
-/// Opening the window does not touch the listener until the user is signed in.
-/// Once signed in, enabling the listener writes the same `UserDefaults` flag the
-/// Settings toggle uses, which is what triggers the macOS Local Network
-/// permission prompt on first use.
+/// Reads auth state from the app's shared ``CmuxAuthRuntime/AuthCoordinator``
+/// (via `AppDelegate`); the browser sign-in is fire-and-forget and completion
+/// is observed by the view through the coordinator's `@Observable` state.
 @MainActor
 @Observable
 final class MobilePairingModel {
@@ -61,17 +61,29 @@ final class MobilePairingModel {
         self.ticketTTL = ticketTTL
     }
 
+    private var coordinator: AuthCoordinator? { AppDelegate.shared?.auth?.coordinator }
+
     /// Re-evaluates sign-in state and, when signed in, brings the listener up
-    /// and mints a fresh attach ticket. Safe to call repeatedly (Refresh button).
+    /// and mints a fresh attach ticket. Safe to call repeatedly (Refresh button,
+    /// or the view re-running it when auth state settles).
     func refresh() async {
         state = .loading
-        await AuthManager.shared.awaitBootstrapped()
-        guard AuthManager.shared.isAuthenticated else {
+        guard let coordinator else {
+            state = .failed(
+                String(
+                    localized: "mobile.pairing.error.listenerOffline",
+                    defaultValue: "Could not start the pairing listener on this Mac."
+                )
+            )
+            return
+        }
+        await coordinator.awaitBootstrapped()
+        guard coordinator.isAuthenticated else {
             signedInEmail = nil
             state = .signedOut
             return
         }
-        signedInEmail = AuthManager.shared.currentUser?.primaryEmail
+        signedInEmail = coordinator.currentUser?.primaryEmail
         state = .preparing
         enablePairingHost()
         let status = await host.ensureListeningAndReady()
@@ -112,16 +124,11 @@ final class MobilePairingModel {
         }
     }
 
-    /// Launches the account sign-in flow and, on success, prepares a code.
-    func signIn() async {
+    /// Launches the Mac browser sign-in flow. Fire-and-forget; the view re-runs
+    /// ``refresh()`` when the coordinator's auth state settles.
+    func signIn() {
         state = .loading
-        let signedIn = await AuthManager.shared.beginSignInAndAwait(timeout: 180)
-        if signedIn {
-            await refresh()
-        } else {
-            signedInEmail = nil
-            state = .signedOut
-        }
+        AppDelegate.shared?.auth?.browserSignIn.beginSignIn()
     }
 
     private func enablePairingHost() {

--- a/Sources/Mobile/Pairing/MobilePairingModel.swift
+++ b/Sources/Mobile/Pairing/MobilePairingModel.swift
@@ -53,6 +53,9 @@ final class MobilePairingModel {
 
     private let host: MobileHostService
     private let ticketTTL: TimeInterval
+    /// Re-mints the ticket shortly before it expires so the displayed QR is
+    /// never stale. Cancelled on every refresh and when the window closes.
+    private var autoRefreshTask: Task<Void, Never>?
 
     /// Creates a pairing model.
     ///
@@ -70,6 +73,7 @@ final class MobilePairingModel {
     /// and mints a fresh attach ticket. Safe to call repeatedly (Refresh button,
     /// or the view re-running it when auth state settles).
     func refresh() async {
+        autoRefreshTask?.cancel()
         state = .loading
         guard let coordinator else {
             state = .failed(
@@ -129,6 +133,7 @@ final class MobilePairingModel {
                     tailscaleLines: Self.tailscaleLines(status.routes)
                 )
             )
+            scheduleExpiryRefresh()
         } catch MobileAttachTicketStoreError.noRoutes, MobileAttachTicketStoreError.routeUnavailable {
             state = .needsTailscale
         } catch {
@@ -146,6 +151,26 @@ final class MobilePairingModel {
     func signIn() {
         state = .loading
         AppDelegate.shared?.auth?.browserSignIn.beginSignIn()
+    }
+
+    /// Cancels the pending expiry re-mint. Call when the window closes.
+    func stopAutoRefresh() {
+        autoRefreshTask?.cancel()
+        autoRefreshTask = nil
+    }
+
+    /// Schedules a re-mint shortly before the current ticket's TTL elapses, so a
+    /// delayed scan never hits an expired code.
+    private func scheduleExpiryRefresh() {
+        autoRefreshTask?.cancel()
+        // Bounded, cancellable, duration-driven deadline (re-mint ~30s before
+        // expiry). Not a poll; cancelled on the next refresh or on window close.
+        let delay = max(1, ticketTTL - 30)
+        autoRefreshTask = Task { [weak self] in
+            try? await ContinuousClock().sleep(for: .seconds(delay))
+            guard let self, !Task.isCancelled else { return }
+            await self.refresh()
+        }
     }
 
     private func enablePairingHost() {

--- a/Sources/Mobile/Pairing/MobilePairingModel.swift
+++ b/Sources/Mobile/Pairing/MobilePairingModel.swift
@@ -56,14 +56,21 @@ final class MobilePairingModel {
     /// Re-mints the ticket shortly before it expires so the displayed QR is
     /// never stale. Cancelled on every refresh and when the window closes.
     private var autoRefreshTask: Task<Void, Never>?
+    /// Bumped on each ``refresh()`` so a slower in-flight run (the UI fires
+    /// refresh from several places) can't overwrite a newer result with a stale
+    /// ticket. Each run captures its value and bails after an `await` if superseded.
+    private var refreshGeneration = 0
 
     /// Creates a pairing model.
     ///
     /// - Parameters:
-    ///   - host: The Mac-side pairing host service. Defaults to the shared instance.
+    ///   - host: The Mac-side pairing host service, or `nil` to use the shared
+    ///     instance. (Resolved in the `@MainActor` init body rather than as a
+    ///     default argument, since default args are evaluated nonisolated and
+    ///     `MobileHostService.shared` is main-actor isolated.)
     ///   - ticketTTL: Attach-ticket lifetime in seconds. Defaults to 600.
-    init(host: MobileHostService = .shared, ticketTTL: TimeInterval = 600) {
-        self.host = host
+    init(host: MobileHostService? = nil, ticketTTL: TimeInterval = 600) {
+        self.host = host ?? .shared
         self.ticketTTL = ticketTTL
     }
 
@@ -74,6 +81,8 @@ final class MobilePairingModel {
     /// or the view re-running it when auth state settles).
     func refresh() async {
         autoRefreshTask?.cancel()
+        refreshGeneration &+= 1
+        let generation = refreshGeneration
         state = .loading
         guard let coordinator else {
             state = .failed(
@@ -85,6 +94,7 @@ final class MobilePairingModel {
             return
         }
         await coordinator.awaitBootstrapped()
+        guard generation == refreshGeneration else { return }
         guard coordinator.isAuthenticated else {
             signedInEmail = nil
             state = .signedOut
@@ -94,13 +104,14 @@ final class MobilePairingModel {
         state = .preparing
         enablePairingHost()
         let status = await host.ensureListeningAndReady()
+        guard generation == refreshGeneration else { return }
         guard status.isRunning else {
+            // Show localized copy, not the raw NWListener error string.
             state = .failed(
-                status.lastErrorDescription
-                    ?? String(
-                        localized: "mobile.pairing.error.listenerOffline",
-                        defaultValue: "Could not start the pairing listener on this Mac."
-                    )
+                String(
+                    localized: "mobile.pairing.error.listenerOffline",
+                    defaultValue: "Could not start the pairing listener on this Mac."
+                )
             )
             return
         }
@@ -117,6 +128,7 @@ final class MobilePairingModel {
                 terminalID: nil,
                 ttl: ticketTTL
             )
+            guard generation == refreshGeneration else { return }
             guard let attachURL = payload["attach_url"] as? String, !attachURL.isEmpty else {
                 state = .failed(
                     String(

--- a/Sources/Mobile/Pairing/MobilePairingModel.swift
+++ b/Sources/Mobile/Pairing/MobilePairingModel.swift
@@ -1,20 +1,27 @@
+import CMUXAuthCore
 import CMUXMobileCore
 import Foundation
 import Observation
 
-/// Drives the in-app iOS pairing window: turns on the Mac-side pairing host,
-/// mints a short-lived attach ticket, and exposes the QR payload plus a
-/// human-readable fallback (host:port routes) for the view to render.
+/// Drives the in-app iOS pairing window. Gates pairing on the Mac being signed
+/// in (authorization is a Stack same-account check), then turns on the
+/// pairing host, mints a short-lived attach ticket, and exposes the QR payload
+/// plus Tailscale reachability for the view.
 ///
-/// Opening the window auto-enables the pairing listener (writing the same
-/// `UserDefaults` flag the Settings toggle uses), which is what triggers the
-/// macOS Local Network permission prompt on first use.
+/// Opening the window does not touch the listener until the user is signed in.
+/// Once signed in, enabling the listener writes the same `UserDefaults` flag the
+/// Settings toggle uses, which is what triggers the macOS Local Network
+/// permission prompt on first use.
 @MainActor
 @Observable
 final class MobilePairingModel {
     /// The pairing window's render state.
     enum State: Equatable {
-        /// Bringing the listener up and minting the first ticket.
+        /// Resolving auth/listener state before anything is shown.
+        case loading
+        /// The Mac is not signed in; pairing can't be authorized yet.
+        case signedOut
+        /// Signed in; bringing the listener up and minting the first ticket.
         case preparing
         /// A ticket is ready to display.
         case ready(Ready)
@@ -28,12 +35,18 @@ final class MobilePairingModel {
         let attachURL: String
         /// The Mac's display name, shown above the code.
         let macName: String
-        /// Reachable `host:port` routes for the manual-entry fallback.
-        let routeLines: [String]
+        /// Reachable Tailscale `host:port` routes. Empty when Tailscale is not
+        /// detected, in which case a real iPhone cannot reach this Mac.
+        let tailscaleLines: [String]
+
+        /// Whether at least one Tailscale route resolved.
+        var reachableViaTailscale: Bool { !tailscaleLines.isEmpty }
     }
 
     /// The current render state, observed by ``MobilePairingView``.
-    private(set) var state: State = .preparing
+    private(set) var state: State = .loading
+    /// The signed-in account email, shown in the checklist. `nil` when signed out.
+    private(set) var signedInEmail: String?
 
     private let host: MobileHostService
     private let ticketTTL: TimeInterval
@@ -48,10 +61,17 @@ final class MobilePairingModel {
         self.ticketTTL = ticketTTL
     }
 
-    /// Enables the pairing host, waits for the listener to be ready, and mints
-    /// a fresh attach ticket. Safe to call repeatedly (e.g. from a Refresh
-    /// button); the latest result wins.
+    /// Re-evaluates sign-in state and, when signed in, brings the listener up
+    /// and mints a fresh attach ticket. Safe to call repeatedly (Refresh button).
     func refresh() async {
+        state = .loading
+        await AuthManager.shared.awaitBootstrapped()
+        guard AuthManager.shared.isAuthenticated else {
+            signedInEmail = nil
+            state = .signedOut
+            return
+        }
+        signedInEmail = AuthManager.shared.currentUser?.primaryEmail
         state = .preparing
         enablePairingHost()
         let status = await host.ensureListeningAndReady()
@@ -84,11 +104,23 @@ final class MobilePairingModel {
                 Ready(
                     attachURL: attachURL,
                     macName: Self.macDisplayName,
-                    routeLines: Self.routeLines(status.routes)
+                    tailscaleLines: Self.tailscaleLines(status.routes)
                 )
             )
         } catch {
             state = .failed(String(describing: error))
+        }
+    }
+
+    /// Launches the account sign-in flow and, on success, prepares a code.
+    func signIn() async {
+        state = .loading
+        let signedIn = await AuthManager.shared.beginSignInAndAwait(timeout: 180)
+        if signedIn {
+            await refresh()
+        } else {
+            signedInEmail = nil
+            state = .signedOut
         }
     }
 
@@ -100,12 +132,13 @@ final class MobilePairingModel {
         Host.current().localizedName ?? ProcessInfo.processInfo.hostName
     }
 
-    private static func routeLines(_ routes: [CmxAttachRoute]) -> [String] {
+    private static func tailscaleLines(_ routes: [CmxAttachRoute]) -> [String] {
         routes.compactMap { route in
-            if case let .hostPort(host, port) = route.endpoint {
-                return "\(host):\(port)"
+            guard route.kind == .tailscale,
+                  case let .hostPort(host, port) = route.endpoint else {
+                return nil
             }
-            return nil
+            return "\(host):\(port)"
         }
     }
 }

--- a/Sources/Mobile/Pairing/MobilePairingModel.swift
+++ b/Sources/Mobile/Pairing/MobilePairingModel.swift
@@ -25,6 +25,9 @@ final class MobilePairingModel {
         case preparing
         /// A ticket is ready to display.
         case ready(Ready)
+        /// The listener is up but there is no route a phone can reach (no
+        /// Tailscale address on this Mac), so no ticket can be minted yet.
+        case needsTailscale
         /// The listener could not be started or no ticket could be minted.
         case failed(String)
     }
@@ -97,6 +100,13 @@ final class MobilePairingModel {
             )
             return
         }
+        // No route a phone can reach (no Tailscale address on this Mac, and no
+        // debug loopback in release): surface the Tailscale-missing guidance
+        // instead of letting `createAttachTicket` throw a raw `noRoutes`.
+        guard !status.routes.isEmpty else {
+            state = .needsTailscale
+            return
+        }
         do {
             let payload = try await host.createAttachTicket(
                 workspaceID: "",
@@ -119,8 +129,15 @@ final class MobilePairingModel {
                     tailscaleLines: Self.tailscaleLines(status.routes)
                 )
             )
+        } catch MobileAttachTicketStoreError.noRoutes, MobileAttachTicketStoreError.routeUnavailable {
+            state = .needsTailscale
         } catch {
-            state = .failed(String(describing: error))
+            state = .failed(
+                String(
+                    localized: "mobile.pairing.error.noTicket",
+                    defaultValue: "Could not generate a pairing code. Try again."
+                )
+            )
         }
     }
 

--- a/Sources/Mobile/Pairing/MobilePairingQRImageView.swift
+++ b/Sources/Mobile/Pairing/MobilePairingQRImageView.swift
@@ -35,6 +35,12 @@ struct MobilePairingQRImageView: View {
                             .font(.system(size: dimension * 0.3))
                             .foregroundStyle(.secondary)
                     )
+                    .accessibilityLabel(
+                        String(
+                            localized: "mobile.pairing.qrUnavailable",
+                            defaultValue: "Pairing code unavailable. Tap Refresh Code."
+                        )
+                    )
             }
         }
     }

--- a/Sources/Mobile/Pairing/MobilePairingQRImageView.swift
+++ b/Sources/Mobile/Pairing/MobilePairingQRImageView.swift
@@ -1,0 +1,59 @@
+import AppKit
+import CoreImage
+import CoreImage.CIFilterBuiltins
+import SwiftUI
+
+/// Renders a payload string as a crisp QR code for the iOS pairing window.
+///
+/// The image is generated with `CIQRCodeGenerator` and scaled with no
+/// interpolation so the modules stay sharp at the requested `dimension`.
+struct MobilePairingQRImageView: View {
+    /// The string encoded into the QR (the `cmux-ios://attach?...` URL).
+    let payload: String
+    /// The rendered side length, in points.
+    let dimension: CGFloat
+
+    var body: some View {
+        Group {
+            if let image = qrImage {
+                Image(nsImage: image)
+                    .interpolation(.none)
+                    .resizable()
+                    .frame(width: dimension, height: dimension)
+                    .accessibilityLabel(
+                        String(
+                            localized: "mobile.pairing.qrAccessibilityLabel",
+                            defaultValue: "Pairing QR code"
+                        )
+                    )
+            } else {
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(Color.secondary.opacity(0.12))
+                    .frame(width: dimension, height: dimension)
+                    .overlay(
+                        Image(systemName: "qrcode")
+                            .font(.system(size: dimension * 0.3))
+                            .foregroundStyle(.secondary)
+                    )
+            }
+        }
+    }
+
+    /// The payload rendered to an `NSImage` via Core Image, or `nil` if the
+    /// generator produced no output for the given string.
+    private var qrImage: NSImage? {
+        let filter = CIFilter.qrCodeGenerator()
+        filter.message = Data(payload.utf8)
+        filter.correctionLevel = "M"
+        guard let output = filter.outputImage, output.extent.width > 0 else {
+            return nil
+        }
+        let scale = dimension / output.extent.width
+        let scaled = output.transformed(by: CGAffineTransform(scaleX: scale, y: scale))
+        let context = CIContext()
+        guard let cgImage = context.createCGImage(scaled, from: scaled.extent) else {
+            return nil
+        }
+        return NSImage(cgImage: cgImage, size: NSSize(width: dimension, height: dimension))
+    }
+}

--- a/Sources/Mobile/Pairing/MobilePairingView.swift
+++ b/Sources/Mobile/Pairing/MobilePairingView.swift
@@ -30,6 +30,7 @@ struct MobilePairingView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
         }
         .task { await model.refresh() }
+        .onDisappear { model.stopAutoRefresh() }
         .onChange(of: coordinator?.isAuthenticated ?? false) { _, _ in
             Task { await model.refresh() }
         }

--- a/Sources/Mobile/Pairing/MobilePairingView.swift
+++ b/Sources/Mobile/Pairing/MobilePairingView.swift
@@ -98,10 +98,11 @@ struct MobilePairingView: View {
 
     /// `true` reachable, `false` not detected, `nil` not yet known.
     private var tailscaleReachable: Bool? {
-        if case let .ready(ready) = model.state {
-            return ready.reachableViaTailscale
+        switch model.state {
+        case let .ready(ready): return ready.reachableViaTailscale
+        case .needsTailscale: return false
+        default: return nil
         }
-        return nil
     }
 
     private func tailscaleSubtitle(reachable: Bool?) -> String {
@@ -157,11 +158,36 @@ struct MobilePairingView: View {
                 Text(String(localized: "mobile.pairing.preparing", defaultValue: "Preparing a pairing code…"))
                     .foregroundStyle(.secondary)
             }
+        case .needsTailscale:
+            needsTailscaleContent
         case let .failed(message):
             failure(message: message)
         case let .ready(ready):
             readyContent(ready)
         }
+    }
+
+    private var needsTailscaleContent: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "network.slash")
+                .font(.system(size: 28))
+                .foregroundStyle(.orange)
+            Text(String(localized: "mobile.pairing.needsTailscale.body", defaultValue: "This Mac has no Tailscale address, so your iPhone can't reach it. Install Tailscale on this Mac and your iPhone (same account), then refresh."))
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            Link(
+                String(localized: "mobile.pairing.req.tailscale.get", defaultValue: "Get Tailscale"),
+                destination: Self.tailscaleDownloadURL
+            )
+            .buttonStyle(.borderedProminent)
+            Button(String(localized: "mobile.pairing.refresh", defaultValue: "Refresh Code")) {
+                Task { await model.refresh() }
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+        }
+        .frame(maxWidth: .infinity, minHeight: 200)
     }
 
     private var signedOut: some View {

--- a/Sources/Mobile/Pairing/MobilePairingView.swift
+++ b/Sources/Mobile/Pairing/MobilePairingView.swift
@@ -2,16 +2,21 @@ import SwiftUI
 
 /// The macOS onboarding window for pairing an iPhone with this Mac.
 ///
-/// Shows a scannable QR code (with a host:port fallback), step-by-step
-/// instructions, and the current pairing-host state. Opening the window
-/// turns the pairing listener on automatically.
+/// Walks the user through the two requirements (signed in to cmux, Tailscale
+/// reachable) and then shows a scannable QR code with step-by-step
+/// instructions. Pairing is gated on sign-in because authorization is a Stack
+/// same-account check; Tailscale is what gives the iPhone a route to this Mac.
 struct MobilePairingView: View {
     @State private var model = MobilePairingModel()
 
+    private static let tailscaleDownloadURL = URL(string: "https://tailscale.com/download")!
+
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 20) {
+            VStack(alignment: .leading, spacing: 18) {
                 header
+                requirements
+                Divider()
                 content
             }
             .padding(24)
@@ -36,11 +41,107 @@ struct MobilePairingView: View {
         }
     }
 
+    // MARK: Requirements checklist
+
+    private var requirements: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            signInRow
+            tailscaleRow
+        }
+    }
+
+    private var signInRow: some View {
+        let signedIn = model.signedInEmail != nil
+        return requirementRow(
+            systemImage: signedIn ? "checkmark.circle.fill" : "person.crop.circle",
+            tint: signedIn ? .green : .secondary,
+            title: String(localized: "mobile.pairing.req.signIn.title", defaultValue: "Signed in to cmux"),
+            subtitle: model.signedInEmail
+                ?? String(localized: "mobile.pairing.req.signIn.subtitle", defaultValue: "Sign in to authorize this Mac for pairing.")
+        ) {
+            EmptyView()
+        }
+    }
+
+    private var tailscaleRow: some View {
+        let reachable = tailscaleReachable
+        return requirementRow(
+            systemImage: reachable == true ? "checkmark.circle.fill" : (reachable == false ? "exclamationmark.triangle.fill" : "network"),
+            tint: reachable == true ? .green : (reachable == false ? .orange : .secondary),
+            title: String(localized: "mobile.pairing.req.tailscale.title", defaultValue: "Tailscale"),
+            subtitle: tailscaleSubtitle(reachable: reachable)
+        ) {
+            if reachable != true {
+                Link(
+                    String(localized: "mobile.pairing.req.tailscale.get", defaultValue: "Get Tailscale"),
+                    destination: Self.tailscaleDownloadURL
+                )
+                .font(.callout)
+            }
+        }
+    }
+
+    /// `true` reachable, `false` not detected, `nil` not yet known.
+    private var tailscaleReachable: Bool? {
+        if case let .ready(ready) = model.state {
+            return ready.reachableViaTailscale
+        }
+        return nil
+    }
+
+    private func tailscaleSubtitle(reachable: Bool?) -> String {
+        switch reachable {
+        case .some(true):
+            return String(localized: "mobile.pairing.req.tailscale.reachable", defaultValue: "Reachable over Tailscale.")
+        case .some(false):
+            return String(localized: "mobile.pairing.req.tailscale.missing", defaultValue: "Not detected. Install Tailscale on this Mac and your iPhone, signed in to the same account.")
+        case .none:
+            return String(localized: "mobile.pairing.req.tailscale.hint", defaultValue: "Your Mac and iPhone both need Tailscale to connect over the internet.")
+        }
+    }
+
+    private func requirementRow<Trailing: View>(
+        systemImage: String,
+        tint: Color,
+        title: String,
+        subtitle: String,
+        @ViewBuilder trailing: () -> Trailing
+    ) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 10) {
+            Image(systemName: systemImage)
+                .foregroundStyle(tint)
+                .frame(width: 18)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title).font(.callout.weight(.medium))
+                Text(subtitle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer(minLength: 8)
+            trailing()
+        }
+    }
+
+    // MARK: Gated content
+
     @ViewBuilder
     private var content: some View {
         switch model.state {
+        case .loading:
+            centered {
+                ProgressView().controlSize(.small)
+                Text(String(localized: "mobile.pairing.checking", defaultValue: "Checking…"))
+                    .foregroundStyle(.secondary)
+            }
+        case .signedOut:
+            signedOut
         case .preparing:
-            preparing
+            centered {
+                ProgressView().controlSize(.small)
+                Text(String(localized: "mobile.pairing.preparing", defaultValue: "Preparing a pairing code…"))
+                    .foregroundStyle(.secondary)
+            }
         case let .failed(message):
             failure(message: message)
         case let .ready(ready):
@@ -48,14 +149,21 @@ struct MobilePairingView: View {
         }
     }
 
-    private var preparing: some View {
-        HStack(spacing: 10) {
-            ProgressView()
-                .controlSize(.small)
-            Text(String(localized: "mobile.pairing.preparing", defaultValue: "Preparing a pairing code…"))
+    private var signedOut: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "person.crop.circle.badge.plus")
+                .font(.system(size: 28))
+                .foregroundStyle(.tint)
+            Text(String(localized: "mobile.pairing.signIn.prompt", defaultValue: "Sign in with your cmux account to pair your iPhone."))
+                .multilineTextAlignment(.center)
                 .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            Button(String(localized: "mobile.pairing.signIn.button", defaultValue: "Sign In")) {
+                Task { await model.signIn() }
+            }
+            .buttonStyle(.borderedProminent)
         }
-        .frame(maxWidth: .infinity, minHeight: 240)
+        .frame(maxWidth: .infinity, minHeight: 200)
     }
 
     private func failure(message: String) -> some View {
@@ -71,7 +179,7 @@ struct MobilePairingView: View {
             }
             .buttonStyle(.borderedProminent)
         }
-        .frame(maxWidth: .infinity, minHeight: 240)
+        .frame(maxWidth: .infinity, minHeight: 200)
     }
 
     @ViewBuilder
@@ -96,7 +204,9 @@ struct MobilePairingView: View {
 
         steps
 
-        manualFallback(ready)
+        if ready.reachableViaTailscale {
+            manualFallback(ready)
+        }
 
         HStack {
             Spacer()
@@ -133,21 +243,24 @@ struct MobilePairingView: View {
 
     @ViewBuilder
     private func manualFallback(_ ready: MobilePairingModel.Ready) -> some View {
-        if !ready.routeLines.isEmpty {
-            VStack(alignment: .leading, spacing: 6) {
-                Text(String(localized: "mobile.pairing.manual.title", defaultValue: "Can't scan? Add this Mac manually:"))
-                    .font(.caption.weight(.semibold))
+        VStack(alignment: .leading, spacing: 6) {
+            Text(String(localized: "mobile.pairing.manual.title", defaultValue: "Can't scan? Add this Mac manually:"))
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+            ForEach(ready.tailscaleLines, id: \.self) { line in
+                Text(line)
+                    .font(.system(.caption, design: .monospaced))
+                    .textSelection(.enabled)
                     .foregroundStyle(.secondary)
-                ForEach(ready.routeLines, id: \.self) { line in
-                    Text(line)
-                        .font(.system(.caption, design: .monospaced))
-                        .textSelection(.enabled)
-                        .foregroundStyle(.secondary)
-                }
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(12)
-            .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 10))
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(12)
+        .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 10))
+    }
+
+    private func centered<C: View>(@ViewBuilder _ content: () -> C) -> some View {
+        HStack(spacing: 10) { content() }
+            .frame(maxWidth: .infinity, minHeight: 200)
     }
 }

--- a/Sources/Mobile/Pairing/MobilePairingView.swift
+++ b/Sources/Mobile/Pairing/MobilePairingView.swift
@@ -1,3 +1,4 @@
+import CmuxAuthRuntime
 import SwiftUI
 
 /// The macOS onboarding window for pairing an iPhone with this Mac.
@@ -9,7 +10,13 @@ import SwiftUI
 struct MobilePairingView: View {
     @State private var model = MobilePairingModel()
 
+    /// The shared auth coordinator, observed so the view re-runs `refresh()`
+    /// when sign-in completes or settles. Captured once; stable post-startup.
+    private let coordinator: AuthCoordinator? = AppDelegate.shared?.auth?.coordinator
+    private let browserSignIn: HostBrowserSignInFlow? = AppDelegate.shared?.auth?.browserSignIn
+
     private static let tailscaleDownloadURL = URL(string: "https://tailscale.com/download")!
+    private static let testFlightURL = URL(string: "https://github.com/manaflow-ai/cmux#founders-edition")!
 
     var body: some View {
         ScrollView {
@@ -23,6 +30,14 @@ struct MobilePairingView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
         }
         .task { await model.refresh() }
+        .onChange(of: coordinator?.isAuthenticated ?? false) { _, _ in
+            Task { await model.refresh() }
+        }
+        .onChange(of: browserSignIn?.isSigningIn ?? false) { _, signingIn in
+            // When the browser flow settles (success or cancel), re-evaluate so a
+            // cancelled sign-in returns to the signed-out state instead of spinning.
+            if !signingIn { Task { await model.refresh() } }
+        }
     }
 
     private var header: some View {
@@ -159,7 +174,7 @@ struct MobilePairingView: View {
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
             Button(String(localized: "mobile.pairing.signIn.button", defaultValue: "Sign In")) {
-                Task { await model.signIn() }
+                model.signIn()
             }
             .buttonStyle(.borderedProminent)
         }
@@ -221,6 +236,18 @@ struct MobilePairingView: View {
     private var steps: some View {
         VStack(alignment: .leading, spacing: 10) {
             step(1, String(localized: "mobile.pairing.step.install", defaultValue: "Install cmux on your iPhone and open it."))
+            HStack(spacing: 4) {
+                Spacer(minLength: 30)
+                Text(String(localized: "mobile.pairing.testflight.prompt", defaultValue: "Don't have it yet?"))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Link(
+                    String(localized: "mobile.pairing.testflight.link", defaultValue: "Download via TestFlight"),
+                    destination: Self.testFlightURL
+                )
+                .font(.caption)
+                Spacer(minLength: 0)
+            }
             step(2, String(localized: "mobile.pairing.step.signIn", defaultValue: "Sign in with the same account you use on this Mac."))
             step(3, String(localized: "mobile.pairing.step.scan", defaultValue: "Tap Add device, then Scan QR Code, and point the camera at the code above."))
         }

--- a/Sources/Mobile/Pairing/MobilePairingView.swift
+++ b/Sources/Mobile/Pairing/MobilePairingView.swift
@@ -1,0 +1,153 @@
+import SwiftUI
+
+/// The macOS onboarding window for pairing an iPhone with this Mac.
+///
+/// Shows a scannable QR code (with a host:port fallback), step-by-step
+/// instructions, and the current pairing-host state. Opening the window
+/// turns the pairing listener on automatically.
+struct MobilePairingView: View {
+    @State private var model = MobilePairingModel()
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                header
+                content
+            }
+            .padding(24)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .task { await model.refresh() }
+    }
+
+    private var header: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "desktopcomputer.and.iphone")
+                .font(.system(size: 28))
+                .foregroundStyle(.tint)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(String(localized: "mobile.pairing.window.heading", defaultValue: "Pair your iPhone"))
+                    .font(.title2.weight(.semibold))
+                Text(String(localized: "mobile.pairing.window.subheading", defaultValue: "Scan this code with the cmux app on your iPhone to sync your terminal workspaces."))
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch model.state {
+        case .preparing:
+            preparing
+        case let .failed(message):
+            failure(message: message)
+        case let .ready(ready):
+            readyContent(ready)
+        }
+    }
+
+    private var preparing: some View {
+        HStack(spacing: 10) {
+            ProgressView()
+                .controlSize(.small)
+            Text(String(localized: "mobile.pairing.preparing", defaultValue: "Preparing a pairing code…"))
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, minHeight: 240)
+    }
+
+    private func failure(message: String) -> some View {
+        VStack(spacing: 12) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 28))
+                .foregroundStyle(.orange)
+            Text(message)
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.secondary)
+            Button(String(localized: "mobile.pairing.retry", defaultValue: "Try Again")) {
+                Task { await model.refresh() }
+            }
+            .buttonStyle(.borderedProminent)
+        }
+        .frame(maxWidth: .infinity, minHeight: 240)
+    }
+
+    @ViewBuilder
+    private func readyContent(_ ready: MobilePairingModel.Ready) -> some View {
+        VStack(alignment: .center, spacing: 14) {
+            MobilePairingQRImageView(payload: ready.attachURL, dimension: 220)
+                .padding(12)
+                .background(.white, in: RoundedRectangle(cornerRadius: 16))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 16)
+                        .strokeBorder(Color.secondary.opacity(0.2))
+                )
+
+            HStack(spacing: 6) {
+                ProgressView().controlSize(.small)
+                Text(String(localized: "mobile.pairing.waiting", defaultValue: "Waiting for your iPhone…"))
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity)
+
+        steps
+
+        manualFallback(ready)
+
+        HStack {
+            Spacer()
+            Button(String(localized: "mobile.pairing.refresh", defaultValue: "Refresh Code")) {
+                Task { await model.refresh() }
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+        }
+    }
+
+    private var steps: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            step(1, String(localized: "mobile.pairing.step.install", defaultValue: "Install cmux on your iPhone and open it."))
+            step(2, String(localized: "mobile.pairing.step.signIn", defaultValue: "Sign in with the same account you use on this Mac."))
+            step(3, String(localized: "mobile.pairing.step.scan", defaultValue: "Tap Add device, then Scan QR Code, and point the camera at the code above."))
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func step(_ number: Int, _ text: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 10) {
+            Text("\(number)")
+                .font(.caption.weight(.bold))
+                .foregroundStyle(.white)
+                .frame(width: 20, height: 20)
+                .background(Color.accentColor, in: Circle())
+            Text(text)
+                .font(.callout)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer(minLength: 0)
+        }
+    }
+
+    @ViewBuilder
+    private func manualFallback(_ ready: MobilePairingModel.Ready) -> some View {
+        if !ready.routeLines.isEmpty {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(String(localized: "mobile.pairing.manual.title", defaultValue: "Can't scan? Add this Mac manually:"))
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                ForEach(ready.routeLines, id: \.self) { line in
+                    Text(line)
+                        .font(.system(.caption, design: .monospaced))
+                        .textSelection(.enabled)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(12)
+            .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 10))
+        }
+    }
+}

--- a/Sources/Mobile/Pairing/MobilePairingWindowController.swift
+++ b/Sources/Mobile/Pairing/MobilePairingWindowController.swift
@@ -23,6 +23,9 @@ final class MobilePairingWindowController {
         NSApp.activate(ignoringOtherApps: true)
 
         if let existing = existingWindow() {
+            if existing.isMiniaturized {
+                existing.deminiaturize(nil)
+            }
             existing.makeKeyAndOrderFront(nil)
             existing.orderFrontRegardless()
             return

--- a/Sources/Mobile/Pairing/MobilePairingWindowController.swift
+++ b/Sources/Mobile/Pairing/MobilePairingWindowController.swift
@@ -1,0 +1,56 @@
+import AppKit
+import SwiftUI
+
+/// Owns the single iOS pairing window and presents it on demand.
+///
+/// Mirrors the host-side config window pattern: it reuses the existing window
+/// when one is already open (so repeated requests focus instead of spawning
+/// duplicates) and hosts ``MobilePairingView`` in an `NSHostingController`.
+@MainActor
+final class MobilePairingWindowController {
+    /// The shared controller. The app target composes window controllers as
+    /// singletons (see the task-manager and debug windows).
+    static let shared = MobilePairingWindowController()
+
+    private static let windowIdentifier = "cmux.mobilePairingWindow"
+
+    private var window: NSWindow?
+
+    private init() {}
+
+    /// Brings the pairing window to the front, creating it if needed.
+    func show() {
+        NSApp.activate(ignoringOtherApps: true)
+
+        if let existing = existingWindow() {
+            existing.makeKeyAndOrderFront(nil)
+            existing.orderFrontRegardless()
+            return
+        }
+
+        let appearanceMode = UserDefaults.standard.string(forKey: AppearanceSettings.appearanceModeKey)
+        let root = MobilePairingView()
+            .cmuxAppearanceColorScheme(appearanceMode)
+        let hostingController = NSHostingController(rootView: root)
+
+        let window = NSWindow(contentViewController: hostingController)
+        window.title = String(localized: "mobile.pairing.window.title", defaultValue: "Pair iPhone")
+        window.identifier = NSUserInterfaceItemIdentifier(Self.windowIdentifier)
+        window.styleMask = [.titled, .closable, .miniaturizable]
+        window.isReleasedWhenClosed = false
+        window.setContentSize(NSSize(width: 460, height: 640))
+        window.center()
+        self.window = window
+        window.makeKeyAndOrderFront(nil)
+        window.orderFrontRegardless()
+    }
+
+    private func existingWindow() -> NSWindow? {
+        if let window, window.isVisible || window.isMiniaturized {
+            return window
+        }
+        return NSApp.windows.first {
+            $0.identifier?.rawValue == Self.windowIdentifier && ($0.isVisible || $0.isMiniaturized)
+        }
+    }
+}

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -375,6 +375,10 @@
 		4E673EDE464BF3AB80E94C1D /* MobileHostRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47BDC06F004C02A52B05E4A0 /* MobileHostRPC.swift */; };
 		F67FBC88671C40AC3A3284CE /* MobileHostService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ACA497A6831165EA879C642 /* MobileHostService.swift */; };
 		C0DE10510000000000000001 /* MobileHostServiceSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE10510000000000000002 /* MobileHostServiceSettingsTests.swift */; };
+		0099C2865D9D468747D14593 /* MobilePairingModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04CE82AE8B39EA0C1395F696 /* MobilePairingModel.swift */; };
+		325AF8814443BDA97AC3CC98 /* MobilePairingQRImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B76EC5E03C345BEAC25828A7 /* MobilePairingQRImageView.swift */; };
+		A2538FE83AE79539E3BF9248 /* MobilePairingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9BC53FA4991A6EBFB930EDF /* MobilePairingView.swift */; };
+		18A8E29E9BD87E184983527C /* MobilePairingWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AE701F43A0B49F08835191C /* MobilePairingWindowController.swift */; };
 		9916B44C7A9914E172D112D4 /* MobileRouteResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A956C76162B79EC74AF9965 /* MobileRouteResolver.swift */; };
 		AB57F0C27BECE8EDFC6B2B97 /* MobileTerminalByteTee.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F05EBBC2FE0D5CB2F662B8A /* MobileTerminalByteTee.swift */; };
 		C9CFB398DF94D6DDEAF42D67 /* MobileTerminalRenderObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = F51B54FAD18160281FC1C2B6 /* MobileTerminalRenderObserver.swift */; };
@@ -1048,6 +1052,10 @@
 		47BDC06F004C02A52B05E4A0 /* MobileHostRPC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileHostRPC.swift; sourceTree = "<group>"; };
 		7ACA497A6831165EA879C642 /* MobileHostService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileHostService.swift; sourceTree = "<group>"; };
 		C0DE10510000000000000002 /* MobileHostServiceSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileHostServiceSettingsTests.swift; sourceTree = "<group>"; };
+		04CE82AE8B39EA0C1395F696 /* MobilePairingModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Pairing/MobilePairingModel.swift"; sourceTree = "<group>"; };
+		B76EC5E03C345BEAC25828A7 /* MobilePairingQRImageView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Pairing/MobilePairingQRImageView.swift"; sourceTree = "<group>"; };
+		F9BC53FA4991A6EBFB930EDF /* MobilePairingView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Pairing/MobilePairingView.swift"; sourceTree = "<group>"; };
+		5AE701F43A0B49F08835191C /* MobilePairingWindowController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Pairing/MobilePairingWindowController.swift"; sourceTree = "<group>"; };
 		7A956C76162B79EC74AF9965 /* MobileRouteResolver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileRouteResolver.swift; sourceTree = "<group>"; };
 		4F05EBBC2FE0D5CB2F662B8A /* MobileTerminalByteTee.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileTerminalByteTee.swift; sourceTree = "<group>"; };
 		F51B54FAD18160281FC1C2B6 /* MobileTerminalRenderObserver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileTerminalRenderObserver.swift; sourceTree = "<group>"; };
@@ -1473,6 +1481,10 @@
 				47BDC06F004C02A52B05E4A0 /* MobileHostRPC.swift */,
 				7ACA497A6831165EA879C642 /* MobileHostService.swift */,
 				7A956C76162B79EC74AF9965 /* MobileRouteResolver.swift */,
+				04CE82AE8B39EA0C1395F696 /* MobilePairingModel.swift */,
+				B76EC5E03C345BEAC25828A7 /* MobilePairingQRImageView.swift */,
+				F9BC53FA4991A6EBFB930EDF /* MobilePairingView.swift */,
+				5AE701F43A0B49F08835191C /* MobilePairingWindowController.swift */,
 				C9F14137954A34DFFA05C88C /* MobileWorkspaceListObserver.swift */,
 				F51B54FAD18160281FC1C2B6 /* MobileTerminalRenderObserver.swift */,
 				4F05EBBC2FE0D5CB2F662B8A /* MobileTerminalByteTee.swift */,
@@ -2631,6 +2643,10 @@
 				284FD21ACF8BD1ED6AEBD7A0 /* MobileAttachTicketStore.swift in Sources */,
 				4E673EDE464BF3AB80E94C1D /* MobileHostRPC.swift in Sources */,
 				F67FBC88671C40AC3A3284CE /* MobileHostService.swift in Sources */,
+				0099C2865D9D468747D14593 /* MobilePairingModel.swift in Sources */,
+				325AF8814443BDA97AC3CC98 /* MobilePairingQRImageView.swift in Sources */,
+				A2538FE83AE79539E3BF9248 /* MobilePairingView.swift in Sources */,
+				18A8E29E9BD87E184983527C /* MobilePairingWindowController.swift in Sources */,
 				9916B44C7A9914E172D112D4 /* MobileRouteResolver.swift in Sources */,
 				AB57F0C27BECE8EDFC6B2B97 /* MobileTerminalByteTee.swift in Sources */,
 				C9CFB398DF94D6DDEAF42D67 /* MobileTerminalRenderObserver.swift in Sources */,


### PR DESCRIPTION
## What

Adds a dedicated Mac-side window for pairing an iPhone, the macOS half of "improve the iOS onboarding experience." Today the only Mac-side surface is a bare on/off toggle in Settings → Mobile, and the only way to actually get a pairing QR is a dev script. This makes pairing a real in-app flow.

The window:
- Auto-enables the pairing listener on open (this is what triggers the macOS Local Network permission prompt on first use).
- Mints a short-lived attach ticket and renders a scannable QR code, with a `host:port` fallback for manual entry.
- Shows numbered steps (install, sign in with the same account, scan) and a "Waiting for your iPhone…" state, plus a Refresh button.

Entry point: a **Pair a Device** button in Settings → Mobile.

## How

- `Sources/Mobile/Pairing/`: `MobilePairingWindowController` (singleton window, reuse-existing pattern like the config window), `MobilePairingView`, `MobilePairingModel` (`@MainActor @Observable`), `MobilePairingQRImageView` (CoreImage QR).
- `MobileHostService.ensureListeningAndReady()`: one async entry that starts the listener and resolves once it can mint tickets, backed by a continuation drained from the existing `handleListenerState` / `stop()` paths (with a bounded, cancellable safety deadline). No polling, and no changes to the security-critical `acceptConnectionOffMain` path.
- `SettingsHostActions.openMobilePairingWindow()` seam + host implementation in `HostSettingsActions`; `MobileSection` gains the new row.
- 17 new strings localized in `en` + `ja`.

## Not included (deferred by design): revoke / device list

The second ask, "revoke access," needs work that isn't UI-only. The Mac mobile host has **no per-device identity** today: authorization is a per-RPC Stack same-account check, attach tickets are in-memory, and there is no authorized-devices registry. There is nothing per-device to revoke against (the only blunt options are toggling the listener off or rotating the Mac's Stack account, both of which kick every phone).

Real per-device revoke needs a stable phone device id (an iOS-side protocol change), an authorized-devices registry on the Mac, an auth-gate extension, and a device list + Revoke UI (which this window becomes the home for). Full design, including the one gating decision (local Mac-only registry vs cloud-backed), is in the cmuxterm-hq control repo at `plans/feat-ios-device-revoke/DESIGN.md`.

## Testing

Pairing end-to-end requires a physical iPhone scanning the code, so it is verified by dogfood, not CI. The QR encoder is a thin CoreImage wrapper; a round-trip decode test was skipped to avoid app-target test-bundle wiring for a single low-risk test. Localization audited: all 21 referenced keys present in en + ja.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5493"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783297457&installation_id=133855650&pr_number=5493&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5493&signature=262134fcf00083c14411c456c44915ff5410d85e1a36344c7f883f3c9a8b80d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches mobile pairing listener startup and auto-enables the pairing host (Local Network permission), but leaves the security-critical connection accept path unchanged; QR tickets still require same-account Stack auth on use.
> 
> **Overview**
> Adds an in-app **Pair iPhone** flow on macOS: Settings → Mobile gets a **Pair a Device** row that opens a dedicated window (host seam `openMobilePairingWindow()`), with search indexing and anchor tests updated.
> 
> The pairing window walks through sign-in and Tailscale checks, turns on the iOS pairing listener when needed, mints short-lived attach tickets, shows a Core Image QR (plus manual `host:port` fallback), onboarding steps, and auto-refreshes the code before TTL expiry.
> 
> `MobileHostService` gains `ensureListeningAndReady()` so the UI can await listener readiness via continuations drained on ready/fail/stop (6s safety timeout) instead of polling; the mobile RPC accept/authorization path is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7b40350430cf361607cc8bda799cb014b20deb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a macOS pairing window for in‑app iOS onboarding from Settings → Mobile, with an auto‑refreshing QR to avoid expired scans. The new “Pair a Device” action is searchable in Settings and covered by a reachability test.

- **New Features**
  - Requirements flow: sign in → Tailscale; shows QR with steps, waiting, Refresh, and a TestFlight link.
  - Listener turns on only after sign‑in; triggers the macOS Local Network prompt on first use. Uses `MobileHostService.ensureListeningAndReady()` with a ~6s safety deadline (no accept‑path changes).
  - Keeps the QR valid by auto‑refreshing the attach ticket ~30s before TTL; cancelled on refresh or when the window closes.

- **Bug Fixes**
  - Serialized refresh with a generation guard to avoid stale ticket overwrites.
  - Drains readiness waiters when the ephemeral‑fallback bind fails, preventing the UI from waiting the full deadline.
  - Reuses and deminiaturizes the existing window when reopening, and shows localized listener‑offline copy instead of raw errors.

<sup>Written for commit c7b40350430cf361607cc8bda799cb014b20deb7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mobile device pairing via QR with a dedicated pairing window, onboarding screens, progress states, manual fallback instructions, and localized strings (en/ja)
  * "Pair a Device" control in settings that opens the pairing UI; QR rendering includes accessibility label, refresh/retry actions, and TestFlight prompts

* **Bug Fixes / Reliability**
  * Improved pairing readiness handling with wait/timeout logic and more reliable listener startup and retries
<!-- end of auto-generated comment: release notes by coderabbit.ai -->