### PR TITLE
fix(terminal): forward deleteBackward text input commands

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -10585,9 +10585,11 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         case .deleteBackward:
             let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
             let hasTerminalModifier = !flags.isDisjoint(with: [.control, .option, .command])
-            return !hasTerminalModifier &&
+            let hasEmptyText =
                 (event.characters ?? "").isEmpty &&
                 (event.charactersIgnoringModifiers ?? "").isEmpty
+            return !hasTerminalModifier &&
+                (hasEmptyText || event.keyCode == UInt16(kVK_ANSI_A))
         }
     }
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -10565,7 +10565,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         switch command {
         case .deleteBackward:
             let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-            let hasTerminalModifier = flags.intersection([.control, .option, .command]).isEmpty == false
+            let hasTerminalModifier = !flags.isDisjoint(with: [.control, .option, .command])
             return !hasTerminalModifier &&
                 (event.characters ?? "").isEmpty &&
                 (event.charactersIgnoringModifiers ?? "").isEmpty

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -243,6 +243,7 @@ func cmuxGhosttyModifierActionForFlagsChanged(
     return sidePressed ? GHOSTTY_ACTION_PRESS : GHOSTTY_ACTION_RELEASE
 }
 
+/// AppKit text-input commands that need terminal bytes even when raw key fields are unreliable.
 private enum GhosttyTextInputCommand {
     case deleteBackward
 
@@ -8170,7 +8171,6 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     private var wordPathHoverActive = false
     private var keyboardCopyModeConsumedKeyUps: Set<UInt16> = []
     private var imeConsumedKeyUps: Set<UInt16> = []
-    private var textInputCommandReleaseKeyCodes: [UInt16: UInt32] = [:]
     private var keyboardCopyModeInputState = TerminalKeyboardCopyModeInputState()
     private var keyboardCopyModeCursor: TerminalKeyboardCopyModeCursor?
     private var keyboardCopyModePendingViewportJumpSync = false
@@ -10231,7 +10231,6 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                 keyEvent.consumed_mods = GHOSTTY_MODS_NONE
                 keyEvent.composing = false
                 keyEvent.unshifted_codepoint = command.unshiftedCodepoint
-                textInputCommandReleaseKeyCodes[event.keyCode] = command.keycode
 
 #if DEBUG
                 let ghosttySendStart = ProcessInfo.processInfo.systemUptime
@@ -10417,15 +10416,6 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             return
         }
         if imeConsumedKeyUps.remove(event.keyCode) != nil {
-            return
-        }
-        if let releaseKeyCode = textInputCommandReleaseKeyCodes.removeValue(forKey: event.keyCode) {
-            var keyEvent = ghosttyKeyEvent(for: event, surface: surface)
-            keyEvent.action = GHOSTTY_ACTION_RELEASE
-            keyEvent.keycode = releaseKeyCode
-            keyEvent.text = nil
-            keyEvent.composing = false
-            _ = sendGhosttyKey(surface, keyEvent)
             return
         }
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -10249,6 +10249,25 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                 _ = sendTextInputCommand(command, surface: surface, keyEvent: keyEvent)
 #endif
             }
+        } else if let command = emptyKeyCodeZeroBackspaceFallbackCommand(from: textInputEvent) {
+            keyEvent.keycode = command.keycode
+            keyEvent.consumed_mods = GHOSTTY_MODS_NONE
+            keyEvent.composing = false
+            keyEvent.unshifted_codepoint = command.unshiftedCodepoint
+
+#if DEBUG
+            let ghosttySendStart = ProcessInfo.processInfo.systemUptime
+            _ = sendTextInputCommand(
+                command,
+                surface: surface,
+                keyEvent: keyEvent,
+                path: "terminal.keyDown.emptyKeyCodeZeroBackspaceGhosttySend",
+                event: event
+            )
+            ghosttySendMs += (ProcessInfo.processInfo.systemUptime - ghosttySendStart) * 1000.0
+#else
+            _ = sendTextInputCommand(command, surface: surface, keyEvent: keyEvent)
+#endif
         } else {
             // Get the appropriate text for this key event
             // For control characters, this returns the unmodified character
@@ -10570,6 +10589,18 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                 (event.characters ?? "").isEmpty &&
                 (event.charactersIgnoringModifiers ?? "").isEmpty
         }
+    }
+
+    /// Handles Astropad-style empty Backspace events that never emit `deleteBackward:`.
+    private func emptyKeyCodeZeroBackspaceFallbackCommand(from event: NSEvent) -> GhosttyTextInputCommand? {
+        let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        guard flags.isDisjoint(with: [.control, .option, .command]),
+              (event.characters ?? "").isEmpty,
+              (event.charactersIgnoringModifiers ?? "").isEmpty,
+              event.keyCode == UInt16(kVK_ANSI_A) else {
+            return nil
+        }
+        return .deleteBackward
     }
 
     /// Get the characters for a key event with control character handling.

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -242,6 +242,46 @@ func cmuxGhosttyModifierActionForFlagsChanged(
 
     return sidePressed ? GHOSTTY_ACTION_PRESS : GHOSTTY_ACTION_RELEASE
 }
+
+private enum GhosttyTextInputCommand {
+    case deleteBackward
+
+    init?(selector: Selector) {
+        switch selector {
+        case #selector(NSResponder.deleteBackward(_:)):
+            self = .deleteBackward
+        default:
+            return nil
+        }
+    }
+
+    var keycode: UInt32 {
+        switch self {
+        case .deleteBackward:
+            return UInt32(kVK_Delete)
+        }
+    }
+
+    var text: String? {
+        switch self {
+        case .deleteBackward:
+            return "\u{7F}"
+        }
+    }
+
+    var unshiftedCodepoint: UInt32 {
+        text?.unicodeScalars.first?.value ?? 0
+    }
+
+#if DEBUG
+    var debugName: String {
+        switch self {
+        case .deleteBackward:
+            return "deleteBackward"
+        }
+    }
+#endif
+}
 #endif
 
 private func cmuxRuntimeReadClipboardCallback(
@@ -8130,6 +8170,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     private var wordPathHoverActive = false
     private var keyboardCopyModeConsumedKeyUps: Set<UInt16> = []
     private var imeConsumedKeyUps: Set<UInt16> = []
+    private var textInputCommandReleaseKeyCodes: [UInt16: UInt32] = [:]
     private var keyboardCopyModeInputState = TerminalKeyboardCopyModeInputState()
     private var keyboardCopyModeCursor: TerminalKeyboardCopyModeCursor?
     private var keyboardCopyModePendingViewportJumpSync = false
@@ -9597,6 +9638,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
     // For NSTextInputClient - accumulates text during key events
     private(set) var keyTextAccumulator: [String]? = nil
+    private var keyCommandAccumulator: [GhosttyTextInputCommand]? = nil
     private var markedText = NSMutableAttributedString()
     private var markedSelectedRange = NSRange(location: NSNotFound, length: 0)
     private var lastPerformKeyEvent: TimeInterval?
@@ -9634,7 +9676,12 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
     // Prevents NSBeep for unimplemented actions from interpretKeyEvents
     override func doCommand(by selector: Selector) {
-        // Intentionally empty - prevents system beep on unhandled key commands
+        if let command = GhosttyTextInputCommand(selector: selector),
+           keyCommandAccumulator != nil {
+            keyCommandAccumulator?.append(command)
+            return
+        }
+        // Otherwise intentionally empty - prevents system beep on unhandled key commands
     }
 
     /// Some third-party voice input apps inject committed text by sending the
@@ -10012,9 +10059,13 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             translated: translationEvent
         )
 
-        // Set up text accumulator for interpretKeyEvents
+        // Set up text/command accumulators for interpretKeyEvents
         keyTextAccumulator = []
-        defer { keyTextAccumulator = nil }
+        keyCommandAccumulator = []
+        defer {
+            keyTextAccumulator = nil
+            keyCommandAccumulator = nil
+        }
 
         let markedTextBefore = markedText.length > 0
         let markedStateBefore = (markedText.string, markedSelectedRange)
@@ -10073,6 +10124,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 #endif
 
         let accumulatedText = keyTextAccumulator ?? []
+        let accumulatedCommands = keyCommandAccumulator ?? []
         if shouldSuppressGhosttyKeyForwardingAfterIMEHandling(
             before: markedStateBefore,
             after: (markedText.string, markedSelectedRange),
@@ -10173,6 +10225,28 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                 _ = ghostty_surface_key(surface, keyEvent)
 #endif
             }
+        } else if !accumulatedCommands.isEmpty {
+            for command in accumulatedCommands {
+                keyEvent.keycode = command.keycode
+                keyEvent.consumed_mods = GHOSTTY_MODS_NONE
+                keyEvent.composing = false
+                keyEvent.unshifted_codepoint = command.unshiftedCodepoint
+                textInputCommandReleaseKeyCodes[event.keyCode] = command.keycode
+
+#if DEBUG
+                let ghosttySendStart = ProcessInfo.processInfo.systemUptime
+                _ = sendTextInputCommand(
+                    command,
+                    surface: surface,
+                    keyEvent: keyEvent,
+                    path: "terminal.keyDown.commandGhosttySend",
+                    event: event
+                )
+                ghosttySendMs += (ProcessInfo.processInfo.systemUptime - ghosttySendStart) * 1000.0
+#else
+                _ = sendTextInputCommand(command, surface: surface, keyEvent: keyEvent)
+#endif
+            }
         } else {
             // Get the appropriate text for this key event
             // For control characters, this returns the unmodified character
@@ -10263,7 +10337,44 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         return ghostty_surface_key(surface, keyEvent)
     }
 
+    @discardableResult
+    private func sendTextInputCommand(
+        _ command: GhosttyTextInputCommand,
+        surface: ghostty_surface_t,
+        keyEvent: ghostty_input_key_s
+    ) -> Bool {
+        var keyEvent = keyEvent
+        guard let text = command.text else {
+            keyEvent.text = nil
+            return sendGhosttyKey(surface, keyEvent)
+        }
+
+        return text.withCString { ptr in
+            keyEvent.text = ptr
+            return sendGhosttyKey(surface, keyEvent)
+        }
+    }
+
 #if DEBUG
+    @discardableResult
+    private func sendTextInputCommand(
+        _ command: GhosttyTextInputCommand,
+        surface: ghostty_surface_t,
+        keyEvent: ghostty_input_key_s,
+        path: String,
+        event: NSEvent? = nil
+    ) -> Bool {
+        let timingStart = CmuxTypingTiming.start()
+        let handled = sendTextInputCommand(command, surface: surface, keyEvent: keyEvent)
+        CmuxTypingTiming.logDuration(
+            path: path,
+            startedAt: timingStart,
+            event: event,
+            extra: "handled=\(handled ? 1 : 0) command=\(command.debugName)"
+        )
+        return handled
+    }
+
     @discardableResult
     private func sendTimedGhosttyKey(
         _ surface: ghostty_surface_t,
@@ -10306,6 +10417,15 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             return
         }
         if imeConsumedKeyUps.remove(event.keyCode) != nil {
+            return
+        }
+        if let releaseKeyCode = textInputCommandReleaseKeyCodes.removeValue(forKey: event.keyCode) {
+            var keyEvent = ghosttyKeyEvent(for: event, surface: surface)
+            keyEvent.action = GHOSTTY_ACTION_RELEASE
+            keyEvent.keycode = releaseKeyCode
+            keyEvent.text = nil
+            keyEvent.composing = false
+            _ = sendGhosttyKey(surface, keyEvent)
             return
         }
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -10125,6 +10125,9 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
         let accumulatedText = keyTextAccumulator ?? []
         let accumulatedCommands = keyCommandAccumulator ?? []
+        let forwardableCommands = accumulatedCommands.filter {
+            shouldForwardTextInputCommand($0, from: textInputEvent)
+        }
         if shouldSuppressGhosttyKeyForwardingAfterIMEHandling(
             before: markedStateBefore,
             after: (markedText.string, markedSelectedRange),
@@ -10225,8 +10228,8 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                 _ = ghostty_surface_key(surface, keyEvent)
 #endif
             }
-        } else if !accumulatedCommands.isEmpty {
-            for command in accumulatedCommands {
+        } else if !forwardableCommands.isEmpty {
+            for command in forwardableCommands {
                 keyEvent.keycode = command.keycode
                 keyEvent.consumed_mods = GHOSTTY_MODS_NONE
                 keyEvent.composing = false
@@ -10553,6 +10556,20 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
     private func shouldConsumeSuppressedFindEscape(_ event: NSEvent) -> Bool {
         isFindEscapeSuppressionArmed && cmuxFindEventIsPlainEscape(event)
+    }
+
+    private func shouldForwardTextInputCommand(
+        _ command: GhosttyTextInputCommand,
+        from event: NSEvent
+    ) -> Bool {
+        switch command {
+        case .deleteBackward:
+            let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+            let hasTerminalModifier = flags.intersection([.control, .option, .command]).isEmpty == false
+            return !hasTerminalModifier &&
+                (event.characters ?? "").isEmpty &&
+                (event.charactersIgnoringModifiers ?? "").isEmpty
+        }
     }
 
     /// Get the characters for a key event with control character handling.

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -2896,7 +2896,7 @@ struct GhosttyTextInputCommandForwardingTests {
     }
 
     @Test
-    func deleteBackwardTextInputCommandForwardsCanonicalBackspace() throws {
+    func deleteBackwardTextInputCommandForwardsCanonicalBackspaceWithoutStaleReleaseMapping() throws {
         let window = makeWindow()
         defer { window.orderOut(nil) }
 
@@ -2967,21 +2967,21 @@ struct GhosttyTextInputCommandForwardingTests {
             surfaceView.keyDown(with: event)
         }
 
-        let keyUpEvent = try #require(NSEvent.keyEvent(
+        let laterPhysicalKeyUp = try #require(NSEvent.keyEvent(
             with: .keyUp,
             location: .zero,
             modifierFlags: [],
             timestamp: ProcessInfo.processInfo.systemUptime,
             windowNumber: window.windowNumber,
             context: nil,
-            characters: "",
-            charactersIgnoringModifiers: "",
+            characters: "a",
+            charactersIgnoringModifiers: "a",
             isARepeat: false,
             keyCode: 0
         ))
 
         withExtendedLifetime(surface) {
-            surfaceView.keyUp(with: keyUpEvent)
+            surfaceView.keyUp(with: laterPhysicalKeyUp)
         }
 
         let forwarded = try #require(forwardedKeyEvents.first)
@@ -2989,7 +2989,7 @@ struct GhosttyTextInputCommandForwardingTests {
         #expect(forwarded.keycode == 51)
         #expect(forwarded.unshifted_codepoint == 0x7F)
         #expect(forwardedTexts == ["\u{7F}"])
-        #expect(forwardedReleaseKeyCodes == [51])
+        #expect(forwardedReleaseKeyCodes == [0])
     }
 }
 #endif

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -2871,6 +2871,129 @@ final class TerminalDirectoryOpenTargetAvailabilityTests: XCTestCase {
 }
 
 
+#if DEBUG
+@MainActor
+@Suite(.serialized)
+struct GhosttyTextInputCommandForwardingTests {
+    private func makeWindow() -> NSWindow {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 480, height: 320),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = NSView(frame: window.contentRect(forFrameRect: window.frame))
+        return window
+    }
+
+    private func surfaceView(in hostedView: GhosttySurfaceScrollView) -> NSView? {
+        hostedView.subviews
+            .compactMap { $0 as? NSScrollView }
+            .first?
+            .documentView?
+            .subviews
+            .first
+    }
+
+    @Test
+    func deleteBackwardTextInputCommandForwardsCanonicalBackspace() throws {
+        let window = makeWindow()
+        defer { window.orderOut(nil) }
+
+        let contentView = try #require(window.contentView)
+        let surface = TerminalSurface(
+            tabId: UUID(),
+            context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
+            configTemplate: nil,
+            workingDirectory: nil
+        )
+        let hostedView = surface.hostedView
+        hostedView.frame = contentView.bounds
+        hostedView.autoresizingMask = [.width, .height]
+        contentView.addSubview(hostedView)
+
+        window.makeKeyAndOrderFront(nil)
+        window.displayIfNeeded()
+        contentView.layoutSubtreeIfNeeded()
+        hostedView.layoutSubtreeIfNeeded()
+
+        let surfaceView = try #require(surfaceView(in: hostedView) as? GhosttyNSView)
+        try #require(
+            surface.hasLiveSurface,
+            "Ghostty surface must initialize so key forwarding can be observed."
+        )
+        #expect(window.makeFirstResponder(surfaceView))
+
+        let previousTextInputEventHandler = GhosttyNSView.debugTextInputEventHandler
+        let previousKeyEventObserver = GhosttyNSView.debugGhosttySurfaceKeyEventObserver
+        defer {
+            GhosttyNSView.debugTextInputEventHandler = previousTextInputEventHandler
+            GhosttyNSView.debugGhosttySurfaceKeyEventObserver = previousKeyEventObserver
+            withExtendedLifetime(surface) {}
+        }
+
+        GhosttyNSView.debugTextInputEventHandler = { view, _ in
+            view.doCommand(by: #selector(NSResponder.deleteBackward(_:)))
+            return true
+        }
+
+        var forwardedKeyEvents: [ghostty_input_key_s] = []
+        var forwardedTexts: [String?] = []
+        var forwardedReleaseKeyCodes: [UInt32] = []
+        GhosttyNSView.debugGhosttySurfaceKeyEventObserver = { keyEvent in
+            previousKeyEventObserver?(keyEvent)
+            if keyEvent.action == GHOSTTY_ACTION_PRESS {
+                forwardedKeyEvents.append(keyEvent)
+                forwardedTexts.append(keyEvent.text.map { String(cString: $0) })
+            } else if keyEvent.action == GHOSTTY_ACTION_RELEASE {
+                forwardedReleaseKeyCodes.append(keyEvent.keycode)
+            }
+        }
+
+        let event = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: window.windowNumber,
+            context: nil,
+            characters: "",
+            charactersIgnoringModifiers: "",
+            isARepeat: false,
+            keyCode: 0
+        ))
+
+        withExtendedLifetime(surface) {
+            surfaceView.keyDown(with: event)
+        }
+
+        let keyUpEvent = try #require(NSEvent.keyEvent(
+            with: .keyUp,
+            location: .zero,
+            modifierFlags: [],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: window.windowNumber,
+            context: nil,
+            characters: "",
+            charactersIgnoringModifiers: "",
+            isARepeat: false,
+            keyCode: 0
+        ))
+
+        withExtendedLifetime(surface) {
+            surfaceView.keyUp(with: keyUpEvent)
+        }
+
+        let forwarded = try #require(forwardedKeyEvents.first)
+        #expect(forwardedKeyEvents.count == 1)
+        #expect(forwarded.keycode == 51)
+        #expect(forwarded.unshifted_codepoint == 0x7F)
+        #expect(forwardedTexts == ["\u{7F}"])
+        #expect(forwardedReleaseKeyCodes == [51])
+    }
+}
+#endif
+
 @MainActor
 final class TerminalNotificationDirectInteractionTests: XCTestCase {
     private final class FocusProbeView: NSView {

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -2991,6 +2991,80 @@ struct GhosttyTextInputCommandForwardingTests {
         #expect(forwardedTexts == ["\u{7F}"])
         #expect(forwardedReleaseKeyCodes == [0])
     }
+
+    @Test
+    func modifiedDeleteBackwardCommandStaysOnOriginalKeyPath() throws {
+        let window = makeWindow()
+        defer { window.orderOut(nil) }
+
+        let contentView = try #require(window.contentView)
+        let surface = TerminalSurface(
+            tabId: UUID(),
+            context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
+            configTemplate: nil,
+            workingDirectory: nil
+        )
+        let hostedView = surface.hostedView
+        hostedView.frame = contentView.bounds
+        hostedView.autoresizingMask = [.width, .height]
+        contentView.addSubview(hostedView)
+
+        window.makeKeyAndOrderFront(nil)
+        window.displayIfNeeded()
+        contentView.layoutSubtreeIfNeeded()
+        hostedView.layoutSubtreeIfNeeded()
+
+        let surfaceView = try #require(surfaceView(in: hostedView) as? GhosttyNSView)
+        try #require(
+            surface.hasLiveSurface,
+            "Ghostty surface must initialize so key forwarding can be observed."
+        )
+        #expect(window.makeFirstResponder(surfaceView))
+
+        let previousTextInputEventHandler = GhosttyNSView.debugTextInputEventHandler
+        let previousKeyEventObserver = GhosttyNSView.debugGhosttySurfaceKeyEventObserver
+        defer {
+            GhosttyNSView.debugTextInputEventHandler = previousTextInputEventHandler
+            GhosttyNSView.debugGhosttySurfaceKeyEventObserver = previousKeyEventObserver
+            withExtendedLifetime(surface) {}
+        }
+
+        GhosttyNSView.debugTextInputEventHandler = { view, _ in
+            view.doCommand(by: #selector(NSResponder.deleteBackward(_:)))
+            return true
+        }
+
+        var forwardedPresses: [ghostty_input_key_s] = []
+        GhosttyNSView.debugGhosttySurfaceKeyEventObserver = { keyEvent in
+            previousKeyEventObserver?(keyEvent)
+            guard keyEvent.action == GHOSTTY_ACTION_PRESS else { return }
+            forwardedPresses.append(keyEvent)
+        }
+
+        let event = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.control, .option],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: window.windowNumber,
+            context: nil,
+            characters: "\u{8}",
+            charactersIgnoringModifiers: "h",
+            isARepeat: false,
+            keyCode: UInt16(kVK_ANSI_H)
+        ))
+
+        withExtendedLifetime(surface) {
+            surfaceView.keyDown(with: event)
+        }
+
+        let forwarded = try #require(forwardedPresses.first)
+        #expect(forwardedPresses.count == 1)
+        #expect(forwarded.keycode == UInt32(kVK_ANSI_H))
+        #expect(forwarded.keycode != UInt32(kVK_Delete))
+        #expect(forwarded.mods.rawValue & GHOSTTY_MODS_CTRL.rawValue == GHOSTTY_MODS_CTRL.rawValue)
+        #expect(forwarded.mods.rawValue & GHOSTTY_MODS_ALT.rawValue == GHOSTTY_MODS_ALT.rawValue)
+    }
 }
 #endif
 

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -3067,6 +3067,81 @@ struct GhosttyTextInputCommandForwardingTests {
     }
 
     @Test
+    func deleteBackwardTextInputCommandWithAKeyFieldsForwardsCanonicalBackspace() throws {
+        let window = makeWindow()
+        defer { window.orderOut(nil) }
+
+        let contentView = try #require(window.contentView)
+        let surface = TerminalSurface(
+            tabId: UUID(),
+            context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
+            configTemplate: nil,
+            workingDirectory: nil
+        )
+        let hostedView = surface.hostedView
+        hostedView.frame = contentView.bounds
+        hostedView.autoresizingMask = [.width, .height]
+        contentView.addSubview(hostedView)
+
+        window.makeKeyAndOrderFront(nil)
+        window.displayIfNeeded()
+        contentView.layoutSubtreeIfNeeded()
+        hostedView.layoutSubtreeIfNeeded()
+
+        let surfaceView = try #require(surfaceView(in: hostedView) as? GhosttyNSView)
+        try #require(
+            surface.hasLiveSurface,
+            "Ghostty surface must initialize so key forwarding can be observed."
+        )
+        #expect(window.makeFirstResponder(surfaceView))
+
+        let previousTextInputEventHandler = GhosttyNSView.debugTextInputEventHandler
+        let previousKeyEventObserver = GhosttyNSView.debugGhosttySurfaceKeyEventObserver
+        defer {
+            GhosttyNSView.debugTextInputEventHandler = previousTextInputEventHandler
+            GhosttyNSView.debugGhosttySurfaceKeyEventObserver = previousKeyEventObserver
+            withExtendedLifetime(surface) {}
+        }
+
+        GhosttyNSView.debugTextInputEventHandler = { view, _ in
+            view.doCommand(by: #selector(NSResponder.deleteBackward(_:)))
+            return true
+        }
+
+        var forwardedKeyEvents: [ghostty_input_key_s] = []
+        var forwardedTexts: [String?] = []
+        GhosttyNSView.debugGhosttySurfaceKeyEventObserver = { keyEvent in
+            previousKeyEventObserver?(keyEvent)
+            guard keyEvent.action == GHOSTTY_ACTION_PRESS else { return }
+            forwardedKeyEvents.append(keyEvent)
+            forwardedTexts.append(keyEvent.text.map { String(cString: $0) })
+        }
+
+        let event = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: window.windowNumber,
+            context: nil,
+            characters: "a",
+            charactersIgnoringModifiers: "a",
+            isARepeat: false,
+            keyCode: UInt16(kVK_ANSI_A)
+        ))
+
+        withExtendedLifetime(surface) {
+            surfaceView.keyDown(with: event)
+        }
+
+        let forwarded = try #require(forwardedKeyEvents.first)
+        #expect(forwardedKeyEvents.count == 1)
+        #expect(forwarded.keycode == UInt32(kVK_Delete))
+        #expect(forwarded.unshifted_codepoint == 0x7F)
+        #expect(forwardedTexts == ["\u{7F}"])
+    }
+
+    @Test
     func modifiedDeleteBackwardCommandStaysOnOriginalKeyPath() throws {
         let window = makeWindow()
         defer { window.orderOut(nil) }

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -2993,6 +2993,80 @@ struct GhosttyTextInputCommandForwardingTests {
     }
 
     @Test
+    func emptyKeyCodeZeroEventWithoutCommandForwardsCanonicalBackspace() throws {
+        let window = makeWindow()
+        defer { window.orderOut(nil) }
+
+        let contentView = try #require(window.contentView)
+        let surface = TerminalSurface(
+            tabId: UUID(),
+            context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
+            configTemplate: nil,
+            workingDirectory: nil
+        )
+        let hostedView = surface.hostedView
+        hostedView.frame = contentView.bounds
+        hostedView.autoresizingMask = [.width, .height]
+        contentView.addSubview(hostedView)
+
+        window.makeKeyAndOrderFront(nil)
+        window.displayIfNeeded()
+        contentView.layoutSubtreeIfNeeded()
+        hostedView.layoutSubtreeIfNeeded()
+
+        let surfaceView = try #require(surfaceView(in: hostedView) as? GhosttyNSView)
+        try #require(
+            surface.hasLiveSurface,
+            "Ghostty surface must initialize so key forwarding can be observed."
+        )
+        #expect(window.makeFirstResponder(surfaceView))
+
+        let previousTextInputEventHandler = GhosttyNSView.debugTextInputEventHandler
+        let previousKeyEventObserver = GhosttyNSView.debugGhosttySurfaceKeyEventObserver
+        defer {
+            GhosttyNSView.debugTextInputEventHandler = previousTextInputEventHandler
+            GhosttyNSView.debugGhosttySurfaceKeyEventObserver = previousKeyEventObserver
+            withExtendedLifetime(surface) {}
+        }
+
+        GhosttyNSView.debugTextInputEventHandler = { _, _ in
+            true
+        }
+
+        var forwardedKeyEvents: [ghostty_input_key_s] = []
+        var forwardedTexts: [String?] = []
+        GhosttyNSView.debugGhosttySurfaceKeyEventObserver = { keyEvent in
+            previousKeyEventObserver?(keyEvent)
+            guard keyEvent.action == GHOSTTY_ACTION_PRESS else { return }
+            forwardedKeyEvents.append(keyEvent)
+            forwardedTexts.append(keyEvent.text.map { String(cString: $0) })
+        }
+
+        let event = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: window.windowNumber,
+            context: nil,
+            characters: "",
+            charactersIgnoringModifiers: "",
+            isARepeat: false,
+            keyCode: 0
+        ))
+
+        withExtendedLifetime(surface) {
+            surfaceView.keyDown(with: event)
+        }
+
+        let forwarded = try #require(forwardedKeyEvents.first)
+        #expect(forwardedKeyEvents.count == 1)
+        #expect(forwarded.keycode == UInt32(kVK_Delete))
+        #expect(forwarded.unshifted_codepoint == 0x7F)
+        #expect(forwardedTexts == ["\u{7F}"])
+    }
+
+    @Test
     func modifiedDeleteBackwardCommandStaysOnOriginalKeyPath() throws {
         let window = makeWindow()
         defer { window.orderOut(nil) }


### PR DESCRIPTION
## Summary
- Fix Astropad Workbench Backspace input being mis-forwarded in cmux terminal sessions.
- Add Swift Testing regression coverage for a synthetic Backspace event with empty characters and an unreliable keycode.
- Normalize AppKit `deleteBackward:` text-input commands into canonical Ghostty Backspace events.

## Problem
When remote-controlling my Mac from an iPhone with Astropad Workbench, tapping the on-screen Backspace key inside a cmux terminal did not delete text. In my Codex/tmux session, it appeared as bad input and could type `a` instead.

The same Backspace key works correctly outside this path:
- Astropad Workbench -> Ghostty standalone: Backspace sends DEL `0x7f`.
- Physical keyboard -> cmux terminal: Backspace sends DEL `0x7f`.
- Ctrl-H -> cmux terminal: sends BS `0x08`.

That narrows the issue to cmux's embedded Ghostty/AppKit input forwarding path, not tmux, stty, or Ghostty configuration.

## Fix
Synthetic input can arrive as `deleteBackward:` through `interpretKeyEvents` with empty or unreliable raw `NSEvent` fields. cmux previously discarded `doCommand(by:)` commands to suppress system beeps.

This change captures `deleteBackward:` only while processing `interpretKeyEvents` and forwards it to Ghostty as canonical Backspace/DEL: text `0x7f` with `kVK_Delete`.

## Testing
- `git diff --check origin/main..HEAD`
- Built and launched tagged Debug app locally
- Verified Astropad Backspace in terminal input path

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5494"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783299677&installation_id=133855650&pr_number=5494&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5494&signature=832d6a4eee340fc100fec0881e8978d5cd247ebe9e6760e272013972df533af6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Backspace not working in cmux terminals with Astropad Workbench by forwarding AppKit `deleteBackward:` and keyCode-0 “empty” events as canonical Backspace (DEL), even when raw fields look like the `A` key. Also prevents stale key-up mapping and keeps modified key combos on their original path.

- **Bug Fixes**
  - Forward `deleteBackward:` during `interpretKeyEvents` as Backspace/DEL (`0x7F`, `kVK_Delete`), ignoring inconsistent raw fields (e.g., `characters: "a"`, `keyCode: kVK_ANSI_A`); DEBUG tests validate canonical press text.
  - Handle Astropad “empty” Backspace events (no chars, `keyCode == 0`) that don’t emit `deleteBackward:` by sending DEL; gated to plain keys only (no Control/Option/Command), with tests confirming the fallback and that modified commands are untouched.
  - Avoid stale release mapping by not synthesizing a `kVK_Delete` keyUp; the later physical keyUp forwards with its original keycode, with DEBUG tests covering both cases.

- **Refactors**
  - Use a disjoint modifier check for clearer, safer gating of the text-input command fallback.

<sup>Written for commit ce31f5bad03b5ed2ff23c9973a3e7e3b5ef95a98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard handling so responder-chain text-input commands (including IME/compose input and delete/backspace) are consistently converted to terminal key events, suppressing system beeps and ensuring correct press/release pairing and modifier preservation when forwarded.

* **Tests**
  * Added serialized, debug-only tests that validate forwarding behavior and observed key press/release details for text-input commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->