### PR TITLE
ci(ios): 14-digit build number so TestFlight offers updates

### DIFF
--- a/ios/scripts/upload-testflight.sh
+++ b/ios/scripts/upload-testflight.sh
@@ -63,7 +63,12 @@ require_option_value() {
 }
 
 LANE="beta"
-BUILD_NUMBER="$(date -u +%Y%m%d%H%M)"
+# CFBundleVersion must increase monotonically or TestFlight won't offer the build
+# as an update. Use a 14-digit UTC stamp (with seconds): earlier builds used
+# yyyyMMddHHmmss (e.g. 20260520031606), and a 12-digit yyyyMMddHHmm (~2.0e11)
+# is NUMERICALLY LOWER than those (~2.0e13), so it would regress below the
+# existing max and never surface as an update. Keep seconds.
+BUILD_NUMBER="$(date -u +%Y%m%d%H%M%S)"
 ARCHIVE_PATH=""
 EXPORT_ONLY=0
 # Export signing mode. "manual" keeps the original local-keychain behavior;


### PR DESCRIPTION
**Fixes "no Update button in TestFlight."** The build-number scheme regressed from 14-digit (`yyyyMMddHHmmss`, e.g. `20260520031606`) to 12-digit (`yyyyMMddHHmm`, e.g. `202606060220`). TestFlight picks the highest `CFBundleVersion` as the latest build — and `20,260,520,031,606` (May, 14-digit) **>** `202,606,060,220` (June, 12-digit), so every June build sorted *below* the old May builds and was never offered as an update. Restore seconds so build numbers exceed the legacy max and stay monotonically increasing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5499"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783307543&installation_id=133855650&pr_number=5499&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5499&signature=d9199f69eb219cfb4268b206adae77abe584bf6257e2ac9400f8bfaf0d49fa51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line default build-number change in a release script; no auth or app runtime impact, only upload versioning behavior.
> 
> **Overview**
> Restores the default **CFBundleVersion** in `upload-testflight.sh` from a 12-digit UTC stamp (`yyyyMMddHHmm`) to **14 digits with seconds** (`yyyyMMddHHmm%S`), so new TestFlight uploads sort above legacy builds and show up as updates.
> 
> Comments document that TestFlight treats `CFBundleVersion` as a monotonic integer and that the shorter format was numerically below older 14-digit builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14cb29173d521bb1f4653ea4e98828064887ac64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore 14-digit UTC build numbers (`yyyyMMddHHmmss`) in the iOS TestFlight upload script so `CFBundleVersion` increases monotonically and TestFlight shows updates again.

- **Bug Fixes**
  - Switched `BUILD_NUMBER` from `date -u +%Y%m%d%H%M` to `date -u +%Y%m%d%H%M%S` to avoid numeric regression against older 14-digit builds.

<sup>Written for commit 14cb29173d521bb1f4653ea4e98828064887ac64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TestFlight build number generation to use more precise timestamps, improving build tracking and deployment consistency during rapid release cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->