### PR TITLE
ci(ios): 14-digit build number in the workflow fallback too

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -20,7 +20,7 @@ on:
   workflow_dispatch:
     inputs:
       build_number:
-        description: CFBundleVersion to stamp (defaults to UTC yyyyMMddHHmm)
+        description: CFBundleVersion to stamp (defaults to UTC yyyyMMddHHmmss)
         required: false
         default: ""
       force:
@@ -175,7 +175,12 @@ jobs:
           set -euo pipefail
           BN="${INPUT_BUILD_NUMBER:-}"
           if [ -z "$BN" ]; then
-            BN="$(date -u +%Y%m%d%H%M)"
+            # 14-digit UTC stamp (with seconds). CFBundleVersion must increase
+            # monotonically as an integer or TestFlight never offers the build as
+            # an update. Legacy builds used yyyyMMddHHmmss (e.g. 20260520031606
+            # ~2e13); a 12-digit yyyyMMddHHmm (~2e11) is numerically LOWER, so it
+            # would regress below the existing max and never surface. Keep seconds.
+            BN="$(date -u +%Y%m%d%H%M%S)"
           fi
           echo "build_number=$BN" >> "$GITHUB_OUTPUT"
           echo "Using CFBundleVersion: $BN"


### PR DESCRIPTION
Follow-up to #5499. That PR fixed the script default, but the workflow's **Resolve build number** step *always* passes `--build-number` explicitly, and its no-input fallback was still 12-digit (`date -u +%Y%m%d%H%M`). So every automatic push/schedule build overrode the script's 14-digit default with a 12-digit value, leaving `CFBundleVersion` below the legacy max (`20260520031606`) — and TestFlight never offered it as an update. Match the script: `yyyyMMddHHmmss`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5503"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783307817&installation_id=133855650&pr_number=5503&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5503&signature=2f4bb172e2cc033a13268ca5dd8e0c1157ea403cbf88111a62aea8a19607fdf2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to default build numbering and documentation; no app runtime or signing logic changes.
> 
> **Overview**
> Aligns the **Resolve build number** fallback in `ios-testflight.yml` with the upload script fix from #5499: when no manual `build_number` is provided, CI now stamps `CFBundleVersion` with a **14-digit** UTC time (`yyyyMMddHHmmss`) instead of **12-digit** (`yyyyMMddHHmm`).
> 
> Because the workflow always passes `--build-number` into `upload-testflight.sh`, the script’s 14-digit default never applied on push/schedule runs. The smaller 12-digit values sat **below** legacy builds (e.g. `20260520031606`), so TestFlight treated them as regressions and did not offer updates. The workflow input description and inline comments document the monotonic integer requirement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb7ca9d67bba19d150ce5c9a252dcc73dc0ea9e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use a 14‑digit UTC timestamp (yyyyMMddHHmmss) as the fallback build number in the iOS TestFlight workflow, matching the script and ensuring CFBundleVersion always increases. This fixes auto builds that used a 12‑digit value and didn’t surface as TestFlight updates; the input description now reflects the 14‑digit format.

<sup>Written for commit eb7ca9d67bba19d150ce5c9a252dcc73dc0ea9e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated iOS TestFlight build number generation to ensure consistency and prevent conflicts with earlier build versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->