### PR TITLE
ci(ios): enforce monotonic TestFlight build numbers against App Store Connect

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -167,40 +167,31 @@ jobs:
           # Write the expanded path ($HOME, not ~) so later steps can read it.
           echo "ASC_API_KEY_PATH=$KEY_PATH" >> "$GITHUB_ENV"
 
-      - name: Resolve build number
-        id: build_number
-        env:
-          INPUT_BUILD_NUMBER: ${{ github.event.inputs.build_number }}
-        run: |
-          set -euo pipefail
-          BN="${INPUT_BUILD_NUMBER:-}"
-          if [ -z "$BN" ]; then
-            # 14-digit UTC stamp (with seconds). CFBundleVersion must increase
-            # monotonically as an integer or TestFlight never offers the build as
-            # an update. Legacy builds used yyyyMMddHHmmss (e.g. 20260520031606
-            # ~2e13); a 12-digit yyyyMMddHHmm (~2e11) is numerically LOWER, so it
-            # would regress below the existing max and never surface. Keep seconds.
-            BN="$(date -u +%Y%m%d%H%M%S)"
-          fi
-          echo "build_number=$BN" >> "$GITHUB_OUTPUT"
-          echo "Using CFBundleVersion: $BN"
-
       - name: Archive, export, and upload to TestFlight
         id: upload
         env:
-          BUILD_NUMBER: ${{ steps.build_number.outputs.build_number }}
+          # Only set for manual workflow_dispatch with an explicit build number.
+          # For push/schedule this is empty and the script generates a monotonic
+          # 14-digit UTC timestamp itself (single source of the numbering scheme,
+          # so the workflow can't drift from it the way it did before). An empty
+          # value here means "let the script decide", which also keeps the guard's
+          # fail-open path (generated timestamps are monotonic by construction;
+          # explicit values fail closed when App Store Connect can't be reached).
+          INPUT_BUILD_NUMBER: ${{ github.event.inputs.build_number }}
           # The script writes the CFBundleVersion that actually shipped here (the
           # monotonic guard may bump it), so the summary reports the real value.
           CMUX_BUILD_NUMBER_OUT_FILE: ${{ runner.temp }}/cmux-final-build-number.txt
         run: |
           set -euo pipefail
-          ./ios/scripts/upload-testflight.sh \
-            --lane beta \
-            --signing automatic \
-            --build-number "$BUILD_NUMBER"
-          FINAL_BN="$BUILD_NUMBER"
+          ARGS=(--lane beta --signing automatic)
+          if [ -n "${INPUT_BUILD_NUMBER:-}" ]; then
+            ARGS+=(--build-number "$INPUT_BUILD_NUMBER")
+          fi
+          ./ios/scripts/upload-testflight.sh "${ARGS[@]}"
           if [ -f "$CMUX_BUILD_NUMBER_OUT_FILE" ]; then
             FINAL_BN="$(cat "$CMUX_BUILD_NUMBER_OUT_FILE")"
+          else
+            FINAL_BN="${INPUT_BUILD_NUMBER:-unknown}"
           fi
           echo "final_build_number=$FINAL_BN" >> "$GITHUB_OUTPUT"
           echo "Shipped CFBundleVersion: $FINAL_BN"
@@ -208,7 +199,7 @@ jobs:
       - name: Summary
         if: always()
         env:
-          BUILD_NUMBER: ${{ steps.upload.outputs.final_build_number || steps.build_number.outputs.build_number }}
+          BUILD_NUMBER: ${{ steps.upload.outputs.final_build_number || github.event.inputs.build_number || 'unknown' }}
         run: |
           {
             echo "### iOS TestFlight upload"

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -147,20 +147,6 @@ jobs:
           ./scripts/install-zig-ci.sh
           ./scripts/ensure-ghosttykit.sh
 
-      - name: Ensure cryptography for the build-number guard
-        # The upload script's monotonic build-number guard (asc_max_build.py)
-        # mints an ES256 JWT with `cryptography`. Install it BEFORE the App Store
-        # Connect private key is written to disk in the next step, so a compromised
-        # install can't read the signing/upload credential. Pinned to a wheel-
-        # satisfiable range. Best-effort + fail-open: if it can't install, the
-        # guard is skipped and the publish still proceeds with the timestamp
-        # build number (which is already correct).
-        run: |
-          python3 -c 'import cryptography' 2>/dev/null && exit 0
-          python3 -m pip install --quiet --disable-pip-version-check 'cryptography>=42,<46' \
-            || python3 -m pip install --quiet --break-system-packages 'cryptography>=42,<46' \
-            || echo "warning: could not install cryptography; build-number guard will be skipped" >&2
-
       - name: Materialize App Store Connect API key
         env:
           ASC_API_KEY_P8_BASE64: ${{ secrets.ASC_API_KEY_P8_BASE64 }}

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -200,19 +200,29 @@ jobs:
           echo "Using CFBundleVersion: $BN"
 
       - name: Archive, export, and upload to TestFlight
+        id: upload
         env:
           BUILD_NUMBER: ${{ steps.build_number.outputs.build_number }}
+          # The script writes the CFBundleVersion that actually shipped here (the
+          # monotonic guard may bump it), so the summary reports the real value.
+          CMUX_BUILD_NUMBER_OUT_FILE: ${{ runner.temp }}/cmux-final-build-number.txt
         run: |
           set -euo pipefail
           ./ios/scripts/upload-testflight.sh \
             --lane beta \
             --signing automatic \
             --build-number "$BUILD_NUMBER"
+          FINAL_BN="$BUILD_NUMBER"
+          if [ -f "$CMUX_BUILD_NUMBER_OUT_FILE" ]; then
+            FINAL_BN="$(cat "$CMUX_BUILD_NUMBER_OUT_FILE")"
+          fi
+          echo "final_build_number=$FINAL_BN" >> "$GITHUB_OUTPUT"
+          echo "Shipped CFBundleVersion: $FINAL_BN"
 
       - name: Summary
         if: always()
         env:
-          BUILD_NUMBER: ${{ steps.build_number.outputs.build_number }}
+          BUILD_NUMBER: ${{ steps.upload.outputs.final_build_number || steps.build_number.outputs.build_number }}
         run: |
           {
             echo "### iOS TestFlight upload"

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -167,6 +167,17 @@ jobs:
           # Write the expanded path ($HOME, not ~) so later steps can read it.
           echo "ASC_API_KEY_PATH=$KEY_PATH" >> "$GITHUB_ENV"
 
+      - name: Ensure cryptography for the build-number guard
+        # The upload script's monotonic build-number guard (asc_max_build.py)
+        # mints an ES256 JWT with `cryptography`. Best-effort install: the guard
+        # is fail-open, so if this can't install, the publish still proceeds with
+        # the timestamp build number (it just skips the ASC monotonic check).
+        run: |
+          python3 -c 'import cryptography' 2>/dev/null && exit 0
+          python3 -m pip install --quiet --disable-pip-version-check cryptography \
+            || python3 -m pip install --quiet --break-system-packages cryptography \
+            || echo "warning: could not install cryptography; build-number guard will be skipped" >&2
+
       - name: Resolve build number
         id: build_number
         env:

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -147,6 +147,20 @@ jobs:
           ./scripts/install-zig-ci.sh
           ./scripts/ensure-ghosttykit.sh
 
+      - name: Ensure cryptography for the build-number guard
+        # The upload script's monotonic build-number guard (asc_max_build.py)
+        # mints an ES256 JWT with `cryptography`. Install it BEFORE the App Store
+        # Connect private key is written to disk in the next step, so a compromised
+        # install can't read the signing/upload credential. Pinned to a wheel-
+        # satisfiable range. Best-effort + fail-open: if it can't install, the
+        # guard is skipped and the publish still proceeds with the timestamp
+        # build number (which is already correct).
+        run: |
+          python3 -c 'import cryptography' 2>/dev/null && exit 0
+          python3 -m pip install --quiet --disable-pip-version-check 'cryptography>=42,<46' \
+            || python3 -m pip install --quiet --break-system-packages 'cryptography>=42,<46' \
+            || echo "warning: could not install cryptography; build-number guard will be skipped" >&2
+
       - name: Materialize App Store Connect API key
         env:
           ASC_API_KEY_P8_BASE64: ${{ secrets.ASC_API_KEY_P8_BASE64 }}
@@ -166,17 +180,6 @@ jobs:
           chmod 600 "$KEY_PATH"
           # Write the expanded path ($HOME, not ~) so later steps can read it.
           echo "ASC_API_KEY_PATH=$KEY_PATH" >> "$GITHUB_ENV"
-
-      - name: Ensure cryptography for the build-number guard
-        # The upload script's monotonic build-number guard (asc_max_build.py)
-        # mints an ES256 JWT with `cryptography`. Best-effort install: the guard
-        # is fail-open, so if this can't install, the publish still proceeds with
-        # the timestamp build number (it just skips the ASC monotonic check).
-        run: |
-          python3 -c 'import cryptography' 2>/dev/null && exit 0
-          python3 -m pip install --quiet --disable-pip-version-check cryptography \
-            || python3 -m pip install --quiet --break-system-packages cryptography \
-            || echo "warning: could not install cryptography; build-number guard will be skipped" >&2
 
       - name: Resolve build number
         id: build_number

--- a/ios/scripts/asc_max_build.py
+++ b/ios/scripts/asc_max_build.py
@@ -9,6 +9,11 @@ from the App Store Connect API key, resolves the app from its bundle id, pages
 through the app's builds, and prints `max(int(version))` to stdout (0 if the app
 has no builds yet).
 
+Dependency-free on purpose: the only third party is `openssl` (preinstalled on
+macOS), invoked via subprocess for the ECDSA signature. The TestFlight upload job
+holds the signing/upload credential, so it must not `pip install` unverified code
+that could persist in site-packages and run once the key is on disk.
+
 Auth comes from the environment (the same vars the upload workflow already sets):
   ASC_API_KEY_ID, ASC_API_ISSUER_ID, and either ASC_API_KEY_PATH (a .p8 file) or
   ASC_API_KEY_P8_BASE64 (the base64-encoded .p8 contents).
@@ -27,13 +32,12 @@ import argparse
 import base64
 import json
 import os
+import subprocess
 import sys
+import tempfile
 import time
 import urllib.error
 import urllib.request
-
-from cryptography.hazmat.primitives import hashes, serialization
-from cryptography.hazmat.primitives.asymmetric import ec, utils as asym_utils
 
 API_BASE = "https://api.appstoreconnect.apple.com"
 
@@ -42,16 +46,43 @@ def _b64u(b):
     return base64.urlsafe_b64encode(b).rstrip(b"=")
 
 
-def _load_private_key():
-    key_path = os.environ.get("ASC_API_KEY_PATH")
-    if key_path:
-        with open(key_path, "rb") as f:
-            pem = f.read()
-    elif os.environ.get("ASC_API_KEY_P8_BASE64"):
-        pem = base64.b64decode(os.environ["ASC_API_KEY_P8_BASE64"])
-    else:
-        raise RuntimeError("set ASC_API_KEY_PATH or ASC_API_KEY_P8_BASE64")
-    return serialization.load_pem_private_key(pem, password=None)
+def _der_ecdsa_to_raw(der):
+    """Convert a DER-encoded ECDSA signature (openssl output) to JOSE raw r||s.
+
+    A P-256 signature is `SEQUENCE { INTEGER r, INTEGER s }` with short-form
+    lengths, so two fixed-width 32-byte integers concatenated give the 64-byte
+    raw form ES256 (RFC 7518) requires.
+    """
+    if not der or der[0] != 0x30:
+        raise RuntimeError("malformed ECDSA signature from openssl")
+    idx = 2
+    if der[1] & 0x80:  # long-form SEQUENCE length (not expected for P-256)
+        idx = 2 + (der[1] & 0x7F)
+    if der[idx] != 0x02:
+        raise RuntimeError("malformed ECDSA signature (r)")
+    rlen = der[idx + 1]
+    idx += 2
+    r = int.from_bytes(der[idx:idx + rlen], "big")
+    idx += rlen
+    if der[idx] != 0x02:
+        raise RuntimeError("malformed ECDSA signature (s)")
+    slen = der[idx + 1]
+    idx += 2
+    s = int.from_bytes(der[idx:idx + slen], "big")
+    return r.to_bytes(32, "big") + s.to_bytes(32, "big")
+
+
+def _sign_es256(signing_input, key_path):
+    """ES256-sign `signing_input` with the .p8 at `key_path` using openssl."""
+    proc = subprocess.run(
+        ["openssl", "dgst", "-sha256", "-sign", key_path],
+        input=signing_input,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError("openssl signing failed")
+    return _der_ecdsa_to_raw(proc.stdout)
 
 
 def _token():
@@ -59,14 +90,25 @@ def _token():
     issuer_id = os.environ.get("ASC_API_ISSUER_ID")
     if not key_id or not issuer_id:
         raise RuntimeError("set ASC_API_KEY_ID and ASC_API_ISSUER_ID")
-    key = _load_private_key()
     hdr = {"alg": "ES256", "kid": key_id, "typ": "JWT"}
     now = int(time.time())
     pld = {"iss": issuer_id, "iat": now, "exp": now + 600, "aud": "appstoreconnect-v1"}
     signing_input = _b64u(json.dumps(hdr).encode()) + b"." + _b64u(json.dumps(pld).encode())
-    der = key.sign(signing_input, ec.ECDSA(hashes.SHA256()))
-    r, s = asym_utils.decode_dss_signature(der)
-    sig = r.to_bytes(32, "big") + s.to_bytes(32, "big")
+
+    key_path = os.environ.get("ASC_API_KEY_PATH")
+    if key_path:
+        sig = _sign_es256(signing_input, key_path)
+    elif os.environ.get("ASC_API_KEY_P8_BASE64"):
+        # Materialize the key to a 0600 temp file only for the openssl call.
+        fd, tmp = tempfile.mkstemp(suffix=".p8")
+        try:
+            os.write(fd, base64.b64decode(os.environ["ASC_API_KEY_P8_BASE64"]))
+            os.close(fd)
+            sig = _sign_es256(signing_input, tmp)
+        finally:
+            os.unlink(tmp)
+    else:
+        raise RuntimeError("set ASC_API_KEY_PATH or ASC_API_KEY_P8_BASE64")
     return (signing_input + b"." + _b64u(sig)).decode()
 
 

--- a/ios/scripts/asc_max_build.py
+++ b/ios/scripts/asc_max_build.py
@@ -104,7 +104,18 @@ def _max_build(token, app_id):
     saw_any = False
     path = f"/v1/builds?filter[app]={app_id}&fields[builds]=version&limit=200"
     pages = 0
-    while path and pages < 20:
+    # Page until App Store Connect stops returning a `next` link. NEVER return a
+    # partial max: a truncated read could be below the true max, which would let
+    # the caller self-heal to a number still <= the real max (the exact
+    # non-updatable build this guard prevents). MAX_PAGES (200 * 50 = 10,000
+    # builds) is only a runaway backstop; hitting it with more pages pending is
+    # an error so the caller fails open instead of trusting an incomplete result.
+    MAX_PAGES = 50
+    while path:
+        if pages >= MAX_PAGES:
+            raise RuntimeError(
+                f"more than {MAX_PAGES} build pages; refusing to return a partial max"
+            )
         status, body = _api(token, path)
         if status != 200:
             raise RuntimeError(f"builds lookup HTTP {status}: {json.dumps(body)[:300]}")

--- a/ios/scripts/asc_max_build.py
+++ b/ios/scripts/asc_max_build.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Print the highest CFBundleVersion already on App Store Connect for an app.
+
+TestFlight only offers a build as an *update* when its CFBundleVersion is the
+highest integer build for the app. This helper lets the upload script enforce
+that invariant directly against the live source of truth (App Store Connect),
+instead of trusting whatever scheme generated the number. It mints an ES256 JWT
+from the App Store Connect API key, resolves the app from its bundle id, pages
+through the app's builds, and prints `max(int(version))` to stdout (0 if the app
+has no builds yet).
+
+Auth comes from the environment (the same vars the upload workflow already sets):
+  ASC_API_KEY_ID, ASC_API_ISSUER_ID, and either ASC_API_KEY_PATH (a .p8 file) or
+  ASC_API_KEY_P8_BASE64 (the base64-encoded .p8 contents).
+
+Usage:
+  asc_max_build.py --bundle-id dev.cmux.app.beta
+
+On success: prints a single integer to stdout and exits 0.
+On any error (missing creds, network, JWT, API shape, no matching app): prints a
+diagnostic to stderr and exits non-zero. Callers MUST treat a non-zero exit as
+"could not determine" and fall back to their own build number (fail-open), so a
+transient App Store Connect hiccup never blocks a publish.
+"""
+
+import argparse
+import base64
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec, utils as asym_utils
+
+API_BASE = "https://api.appstoreconnect.apple.com"
+
+
+def _b64u(b):
+    return base64.urlsafe_b64encode(b).rstrip(b"=")
+
+
+def _load_private_key():
+    key_path = os.environ.get("ASC_API_KEY_PATH")
+    if key_path:
+        with open(key_path, "rb") as f:
+            pem = f.read()
+    elif os.environ.get("ASC_API_KEY_P8_BASE64"):
+        pem = base64.b64decode(os.environ["ASC_API_KEY_P8_BASE64"])
+    else:
+        raise RuntimeError("set ASC_API_KEY_PATH or ASC_API_KEY_P8_BASE64")
+    return serialization.load_pem_private_key(pem, password=None)
+
+
+def _token():
+    key_id = os.environ.get("ASC_API_KEY_ID")
+    issuer_id = os.environ.get("ASC_API_ISSUER_ID")
+    if not key_id or not issuer_id:
+        raise RuntimeError("set ASC_API_KEY_ID and ASC_API_ISSUER_ID")
+    key = _load_private_key()
+    hdr = {"alg": "ES256", "kid": key_id, "typ": "JWT"}
+    now = int(time.time())
+    pld = {"iss": issuer_id, "iat": now, "exp": now + 600, "aud": "appstoreconnect-v1"}
+    signing_input = _b64u(json.dumps(hdr).encode()) + b"." + _b64u(json.dumps(pld).encode())
+    der = key.sign(signing_input, ec.ECDSA(hashes.SHA256()))
+    r, s = asym_utils.decode_dss_signature(der)
+    sig = r.to_bytes(32, "big") + s.to_bytes(32, "big")
+    return (signing_input + b"." + _b64u(sig)).decode()
+
+
+def _api(token, path):
+    req = urllib.request.Request(API_BASE + path, method="GET")
+    req.add_header("Authorization", "Bearer " + token)
+    req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return resp.status, json.loads(resp.read() or b"{}")
+    except urllib.error.HTTPError as e:
+        return e.code, json.loads(e.read() or b"{}")
+
+
+def _resolve_app_id(token, bundle_id):
+    status, body = _api(
+        token, f"/v1/apps?filter[bundleId]={bundle_id}&fields[apps]=bundleId&limit=1"
+    )
+    if status != 200:
+        raise RuntimeError(f"apps lookup HTTP {status}: {json.dumps(body)[:300]}")
+    data = body.get("data", [])
+    if not data:
+        raise RuntimeError(f"no app found for bundle id {bundle_id}")
+    return data[0]["id"]
+
+
+def _max_build(token, app_id):
+    """Page through the app's builds and return the max integer version (0 if none).
+
+    ASC `sort=-version` is a STRING sort, so it cannot be trusted across builds
+    with different digit counts (the exact bug this guard exists to prevent).
+    Fetch pages and compute the max as an integer instead.
+    """
+    highest = 0
+    saw_any = False
+    path = f"/v1/builds?filter[app]={app_id}&fields[builds]=version&limit=200"
+    pages = 0
+    while path and pages < 20:
+        status, body = _api(token, path)
+        if status != 200:
+            raise RuntimeError(f"builds lookup HTTP {status}: {json.dumps(body)[:300]}")
+        for b in body.get("data", []):
+            saw_any = True
+            v = (b.get("attributes") or {}).get("version")
+            try:
+                n = int(str(v).strip())
+            except (TypeError, ValueError):
+                continue  # ignore non-integer historical versions
+            if n > highest:
+                highest = n
+        nxt = (body.get("links") or {}).get("next")
+        # `next` is an absolute URL; strip the base so _api can re-add it.
+        path = nxt[len(API_BASE):] if nxt and nxt.startswith(API_BASE) else None
+        pages += 1
+    if not saw_any:
+        return 0
+    return highest
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bundle-id", required=True, help="app bundle identifier")
+    args = parser.parse_args()
+    token = _token()
+    app_id = _resolve_app_id(token, args.bundle_id)
+    print(_max_build(token, app_id))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as exc:  # fail-open: caller falls back on any error
+        print(f"asc_max_build: {exc}", file=sys.stderr)
+        sys.exit(1)

--- a/ios/scripts/asc_max_build.py
+++ b/ios/scripts/asc_max_build.py
@@ -70,6 +70,18 @@ def _token():
     return (signing_input + b"." + _b64u(sig)).decode()
 
 
+def _asc_error_code(body):
+    """Extract the App Store Connect error code, never the raw payload.
+
+    Error responses can echo request/response detail; surfacing only the status
+    and this scalar code keeps upstream content out of CI logs.
+    """
+    try:
+        return str(((body.get("errors") or [{}])[0]).get("code", "unknown"))
+    except Exception:
+        return "unknown"
+
+
 def _api(token, path):
     req = urllib.request.Request(API_BASE + path, method="GET")
     req.add_header("Authorization", "Bearer " + token)
@@ -86,7 +98,7 @@ def _resolve_app_id(token, bundle_id):
         token, f"/v1/apps?filter[bundleId]={bundle_id}&fields[apps]=bundleId&limit=1"
     )
     if status != 200:
-        raise RuntimeError(f"apps lookup HTTP {status}: {json.dumps(body)[:300]}")
+        raise RuntimeError(f"apps lookup HTTP {status} (code={_asc_error_code(body)})")
     data = body.get("data", [])
     if not data:
         raise RuntimeError(f"no app found for bundle id {bundle_id}")
@@ -101,15 +113,16 @@ def _max_build(token, app_id):
     Fetch pages and compute the max as an integer instead.
     """
     highest = 0
-    saw_any = False
     path = f"/v1/builds?filter[app]={app_id}&fields[builds]=version&limit=200"
     pages = 0
     # Page until App Store Connect stops returning a `next` link. NEVER return a
     # partial max: a truncated read could be below the true max, which would let
     # the caller self-heal to a number still <= the real max (the exact
-    # non-updatable build this guard prevents). MAX_PAGES (200 * 50 = 10,000
-    # builds) is only a runaway backstop; hitting it with more pages pending is
-    # an error so the caller fails open instead of trusting an incomplete result.
+    # non-updatable build this guard prevents). So every way pagination could end
+    # early (page cap, or a `next` URL we can't follow) RAISES instead of
+    # returning what was seen so far; the caller then fails open. MAX_PAGES
+    # (200 * 50 = 10,000 builds) is only a runaway backstop. `highest` is 0 when
+    # the app has no integer builds, which is the correct "no floor" sentinel.
     MAX_PAGES = 50
     while path:
         if pages >= MAX_PAGES:
@@ -118,22 +131,22 @@ def _max_build(token, app_id):
             )
         status, body = _api(token, path)
         if status != 200:
-            raise RuntimeError(f"builds lookup HTTP {status}: {json.dumps(body)[:300]}")
+            raise RuntimeError(f"builds lookup HTTP {status} (code={_asc_error_code(body)})")
         for b in body.get("data", []):
-            saw_any = True
             v = (b.get("attributes") or {}).get("version")
             try:
                 n = int(str(v).strip())
             except (TypeError, ValueError):
                 continue  # ignore non-integer historical versions
-            if n > highest:
-                highest = n
+            highest = max(highest, n)
         nxt = (body.get("links") or {}).get("next")
-        # `next` is an absolute URL; strip the base so _api can re-add it.
-        path = nxt[len(API_BASE):] if nxt and nxt.startswith(API_BASE) else None
+        if not nxt:
+            path = None
+        elif nxt.startswith(API_BASE):
+            path = nxt[len(API_BASE):]  # `next` is absolute; _api re-adds the base
+        else:
+            raise RuntimeError("unexpected App Store Connect pagination URL; refusing to return a partial max")
         pages += 1
-    if not saw_any:
-        return 0
     return highest
 
 

--- a/ios/scripts/upload-testflight.sh
+++ b/ios/scripts/upload-testflight.sh
@@ -180,11 +180,12 @@ fi
 # block a publish (the timestamp scheme is already correct; this is a backstop).
 GUARD_BUILD_NUMBER="$BUILD_NUMBER"
 GUARD_REUSED_ARCHIVE=0
-# Set to 1 only once a reused archive's embedded version is actually compared
-# against the App Store Connect max. A reused archive that reaches the upload
-# without this set (e.g. the Apple ID upload path, which has no ASC API creds to
-# query) is refused below, since it can't be renumbered or verified.
-REUSED_ARCHIVE_VERIFIED=0
+# Set to 1 only once the build number that will ship is actually compared against
+# the App Store Connect max. Anything that needs verification but reaches the
+# upload without this set (a reused archive, or an explicit --build-number, on a
+# path with no ASC API creds such as the Apple ID upload) is refused below, since
+# it can't be renumbered or trusted.
+GUARD_VERIFIED=0
 RUN_GUARD=1
 if [[ -n "$ARCHIVE_PATH" ]]; then
   # Reused archive: BUILD_NUMBER is never stamped into it, so the only number
@@ -213,9 +214,9 @@ if [[ "$RUN_GUARD" -eq 1 && "$EXPORT_ONLY" -ne 1 && -n "${ASC_API_KEY_ID:-}" && 
   if ASC_MAX="$(ASC_API_KEY_ID="$ASC_API_KEY_ID" ASC_API_ISSUER_ID="$ASC_API_ISSUER_ID" \
       ASC_API_KEY_PATH="${ASC_API_KEY_PATH:-}" ASC_API_KEY_P8_BASE64="${ASC_API_KEY_P8_BASE64:-}" \
       python3 "$SCRIPT_DIR/asc_max_build.py" --bundle-id "$PRODUCT_BUNDLE_IDENTIFIER")"; then
-    # Reached only with a real ASC max in hand: the reused archive is now verified
-    # (it either passes the comparison below or the script exits).
-    REUSED_ARCHIVE_VERIFIED=1
+    # Reached only with a real ASC max in hand: the shipping build number is now
+    # verified (it either passes the comparison below or the script exits).
+    GUARD_VERIFIED=1
     if [[ "$ASC_MAX" =~ ^[0-9]+$ && "$GUARD_BUILD_NUMBER" =~ ^[0-9]+$ ]] && (( 10#$GUARD_BUILD_NUMBER <= 10#$ASC_MAX )); then
       if [[ "$GUARD_REUSED_ARCHIVE" -eq 1 ]]; then
         echo "error: reused archive CFBundleVersion $GUARD_BUILD_NUMBER <= App Store Connect max $ASC_MAX; TestFlight will not offer it as an update. Re-archive with a higher --build-number." >&2
@@ -346,14 +347,21 @@ if [[ "$EXPORT_ONLY" -eq 1 ]]; then
   exit 0
 fi
 
-# Final fail-closed gate for reused archives. A reused --archive-path cannot be
-# renumbered, so it must be verified monotonic against App Store Connect before
-# upload. If the guard above never verified it (e.g. the Apple ID upload path,
-# which has no ASC API creds to query), refuse rather than ship a build that may
-# not be offered as an update.
-if [[ "$GUARD_REUSED_ARCHIVE" -eq 1 && "$REUSED_ARCHIVE_VERIFIED" -ne 1 ]]; then
-  echo "error: refusing to upload a reused --archive-path that was not verified monotonic against App Store Connect (no ASC API credentials available to check). Re-archive with --build-number, or provide ASC_API_KEY_ID/ASC_API_ISSUER_ID/ASC_API_KEY_PATH." >&2
-  exit 1
+# Final fail-closed gate. Any build that needs verification but was not actually
+# checked against the App Store Connect max (e.g. the Apple ID upload path, which
+# has no ASC API creds to query) is refused here rather than shipped as a build
+# that may not be offered as an update. A reused --archive-path can't be
+# renumbered; an explicit --build-number may be stale. The generated UTC
+# timestamp is monotonic by construction, so it is exempt (fail-open).
+if [[ "$GUARD_VERIFIED" -ne 1 ]]; then
+  if [[ "$GUARD_REUSED_ARCHIVE" -eq 1 ]]; then
+    echo "error: refusing to upload a reused --archive-path that was not verified monotonic against App Store Connect (no ASC API credentials available to check). Re-archive with --build-number, or provide ASC_API_KEY_ID/ASC_API_ISSUER_ID/ASC_API_KEY_PATH." >&2
+    exit 1
+  fi
+  if [[ "$BUILD_NUMBER_EXPLICIT" -eq 1 ]]; then
+    echo "error: refusing to upload an explicit --build-number $BUILD_NUMBER that was not verified monotonic against App Store Connect (no ASC API credentials available to check). Omit --build-number to use a monotonic UTC timestamp, or provide ASC_API_KEY_ID/ASC_API_ISSUER_ID/ASC_API_KEY_PATH." >&2
+    exit 1
+  fi
 fi
 
 if [[ -n "${ASC_API_KEY_ID:-}" || -n "${ASC_API_ISSUER_ID:-}" || -n "${ASC_API_KEY_PATH:-}" ]]; then

--- a/ios/scripts/upload-testflight.sh
+++ b/ios/scripts/upload-testflight.sh
@@ -38,7 +38,10 @@ or:
 
 Options:
   --lane <beta>             Distribution lane. Only beta is currently defined.
-  --build-number <number>   CFBundleVersion. Defaults to UTC yyyyMMddHHmm.
+  --build-number <number>   CFBundleVersion. Defaults to UTC yyyyMMddHHmmss.
+                            Self-healed up to (App Store Connect max + 1) if it
+                            would not be the highest build (TestFlight only offers
+                            the highest build as an update).
   --signing <mode>          Export signing mode: manual (default) or automatic.
                             manual uses the "Apple Distribution" certificate and
                             the "cmux Beta Distribution" provisioning profile from
@@ -140,19 +143,47 @@ IOS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 WORKSPACE="$IOS_DIR/cmux.xcworkspace"
 SCHEME="cmux-ios"
 DEVELOPMENT_TEAM="${IOS_DEVELOPMENT_TEAM:-7WLXT3NR37}"
-OUT_DIR="${CMUX_IOS_UPLOAD_DIR:-/tmp/cmux-ios-testflight-$BUILD_NUMBER}"
-DERIVED_DATA="$OUT_DIR/DerivedData"
-EXPORT_PATH="$OUT_DIR/export"
-EXPORT_OPTIONS="$OUT_DIR/ExportOptions.plist"
 
-mkdir -p "$OUT_DIR"
-
+# Resolve App Store Connect API auth (env, else local plist) BEFORE the
+# monotonic guard and output-path computation below: the guard may finalize
+# BUILD_NUMBER, and OUT_DIR is derived from BUILD_NUMBER.
 LOCAL_ASC_CONFIG="$IOS_DIR/Config/AppStoreConnect.local.plist"
 if [[ -f "$LOCAL_ASC_CONFIG" ]]; then
   ASC_API_KEY_ID="${ASC_API_KEY_ID:-$(/usr/libexec/PlistBuddy -c 'Print :ASC_API_KEY_ID' "$LOCAL_ASC_CONFIG" 2>/dev/null || true)}"
   ASC_API_ISSUER_ID="${ASC_API_ISSUER_ID:-$(/usr/libexec/PlistBuddy -c 'Print :ASC_API_ISSUER_ID' "$LOCAL_ASC_CONFIG" 2>/dev/null || true)}"
   ASC_API_KEY_PATH="${ASC_API_KEY_PATH:-$(/usr/libexec/PlistBuddy -c 'Print :ASC_API_KEY_PATH' "$LOCAL_ASC_CONFIG" 2>/dev/null || true)}"
 fi
+
+# Monotonic build-number guard (defense in depth). TestFlight only offers a build
+# as an *update* when its CFBundleVersion is the highest integer build for the
+# app, so a regressed numbering scheme (or a bad manual --build-number) silently
+# produces a build no tester can update to. Ask App Store Connect for the current
+# max and self-heal: never ship a number <= the existing max. This is FAIL-OPEN:
+# any ASC/network/JWT error logs a warning and keeps the timestamp BUILD_NUMBER,
+# because the publish must never be blocked by a transient API hiccup (the
+# timestamp scheme is already correct; this is a backstop, not the primary path).
+if [[ -n "${ASC_API_KEY_ID:-}" && -n "${ASC_API_ISSUER_ID:-}" && ( -n "${ASC_API_KEY_PATH:-}" || -n "${ASC_API_KEY_P8_BASE64:-}" ) ]]; then
+  if ASC_MAX="$(ASC_API_KEY_ID="$ASC_API_KEY_ID" ASC_API_ISSUER_ID="$ASC_API_ISSUER_ID" \
+      ASC_API_KEY_PATH="${ASC_API_KEY_PATH:-}" ASC_API_KEY_P8_BASE64="${ASC_API_KEY_P8_BASE64:-}" \
+      "$SCRIPT_DIR/asc_max_build.py" --bundle-id "$PRODUCT_BUNDLE_IDENTIFIER")"; then
+    if [[ "$ASC_MAX" =~ ^[0-9]+$ && "$BUILD_NUMBER" =~ ^[0-9]+$ ]] && (( 10#$BUILD_NUMBER <= 10#$ASC_MAX )); then
+      NEXT_BUILD=$((10#$ASC_MAX + 1))
+      echo "warning: build number $BUILD_NUMBER <= App Store Connect max $ASC_MAX; bumping to $NEXT_BUILD to keep CFBundleVersion monotonic" >&2
+      BUILD_NUMBER="$NEXT_BUILD"
+    else
+      echo "build-number guard: $BUILD_NUMBER > App Store Connect max ${ASC_MAX:-0}, keeping it" >&2
+    fi
+  else
+    echo "warning: build-number guard skipped (could not read App Store Connect max); using $BUILD_NUMBER" >&2
+  fi
+fi
+
+OUT_DIR="${CMUX_IOS_UPLOAD_DIR:-/tmp/cmux-ios-testflight-$BUILD_NUMBER}"
+DERIVED_DATA="$OUT_DIR/DerivedData"
+EXPORT_PATH="$OUT_DIR/export"
+EXPORT_OPTIONS="$OUT_DIR/ExportOptions.plist"
+
+mkdir -p "$OUT_DIR"
 
 XCODE_AUTH_ARGS=()
 if [[ -n "${ASC_API_KEY_ID:-}" && -n "${ASC_API_ISSUER_ID:-}" && -n "${ASC_API_KEY_PATH:-}" ]]; then

--- a/ios/scripts/upload-testflight.sh
+++ b/ios/scripts/upload-testflight.sh
@@ -173,6 +173,11 @@ fi
 # block a publish (the timestamp scheme is already correct; this is a backstop).
 GUARD_BUILD_NUMBER="$BUILD_NUMBER"
 GUARD_REUSED_ARCHIVE=0
+# Set to 1 only once a reused archive's embedded version is actually compared
+# against the App Store Connect max. A reused archive that reaches the upload
+# without this set (e.g. the Apple ID upload path, which has no ASC API creds to
+# query) is refused below, since it can't be renumbered or verified.
+REUSED_ARCHIVE_VERIFIED=0
 RUN_GUARD=1
 if [[ -n "$ARCHIVE_PATH" ]]; then
   # Reused archive: BUILD_NUMBER is never stamped into it, so the only number
@@ -201,6 +206,9 @@ if [[ "$RUN_GUARD" -eq 1 && "$EXPORT_ONLY" -ne 1 && -n "${ASC_API_KEY_ID:-}" && 
   if ASC_MAX="$(ASC_API_KEY_ID="$ASC_API_KEY_ID" ASC_API_ISSUER_ID="$ASC_API_ISSUER_ID" \
       ASC_API_KEY_PATH="${ASC_API_KEY_PATH:-}" ASC_API_KEY_P8_BASE64="${ASC_API_KEY_P8_BASE64:-}" \
       python3 "$SCRIPT_DIR/asc_max_build.py" --bundle-id "$PRODUCT_BUNDLE_IDENTIFIER")"; then
+    # Reached only with a real ASC max in hand: the reused archive is now verified
+    # (it either passes the comparison below or the script exits).
+    REUSED_ARCHIVE_VERIFIED=1
     if [[ "$ASC_MAX" =~ ^[0-9]+$ && "$GUARD_BUILD_NUMBER" =~ ^[0-9]+$ ]] && (( 10#$GUARD_BUILD_NUMBER <= 10#$ASC_MAX )); then
       if [[ "$GUARD_REUSED_ARCHIVE" -eq 1 ]]; then
         echo "error: reused archive CFBundleVersion $GUARD_BUILD_NUMBER <= App Store Connect max $ASC_MAX; TestFlight will not offer it as an update. Re-archive with a higher --build-number." >&2
@@ -325,6 +333,16 @@ echo "IPA_PATH=$IPA_PATH"
 
 if [[ "$EXPORT_ONLY" -eq 1 ]]; then
   exit 0
+fi
+
+# Final fail-closed gate for reused archives. A reused --archive-path cannot be
+# renumbered, so it must be verified monotonic against App Store Connect before
+# upload. If the guard above never verified it (e.g. the Apple ID upload path,
+# which has no ASC API creds to query), refuse rather than ship a build that may
+# not be offered as an update.
+if [[ "$GUARD_REUSED_ARCHIVE" -eq 1 && "$REUSED_ARCHIVE_VERIFIED" -ne 1 ]]; then
+  echo "error: refusing to upload a reused --archive-path that was not verified monotonic against App Store Connect (no ASC API credentials available to check). Re-archive with --build-number, or provide ASC_API_KEY_ID/ASC_API_ISSUER_ID/ASC_API_KEY_PATH." >&2
+  exit 1
 fi
 
 if [[ -n "${ASC_API_KEY_ID:-}" || -n "${ASC_API_ISSUER_ID:-}" || -n "${ASC_API_KEY_PATH:-}" ]]; then

--- a/ios/scripts/upload-testflight.sh
+++ b/ios/scripts/upload-testflight.sh
@@ -173,18 +173,29 @@ fi
 # block a publish (the timestamp scheme is already correct; this is a backstop).
 GUARD_BUILD_NUMBER="$BUILD_NUMBER"
 GUARD_REUSED_ARCHIVE=0
-if [[ -n "$ARCHIVE_PATH" && -e "$ARCHIVE_PATH/Info.plist" ]]; then
+RUN_GUARD=1
+if [[ -n "$ARCHIVE_PATH" ]]; then
+  # Reused archive: BUILD_NUMBER is never stamped into it, so the only number
+  # that ships is the embedded CFBundleVersion, and it can't be self-healed. If
+  # we can't read it, bumping BUILD_NUMBER would be a no-op that falsely claims a
+  # fix, so skip the guard with a warning instead.
+  GUARD_REUSED_ARCHIVE=1
+  # PlistBuddy prints "File Doesn't Exist..." to stdout (and exits non-zero) when
+  # the archive or key is missing, so require a NUMERIC result rather than just
+  # non-empty output; otherwise the error text would be mistaken for a version.
   ARCHIVE_BUILD_NUMBER="$(/usr/libexec/PlistBuddy -c 'Print :ApplicationProperties:CFBundleVersion' "$ARCHIVE_PATH/Info.plist" 2>/dev/null || true)"
-  if [[ -n "$ARCHIVE_BUILD_NUMBER" ]]; then
+  if [[ "$ARCHIVE_BUILD_NUMBER" =~ ^[0-9]+$ ]]; then
     GUARD_BUILD_NUMBER="$ARCHIVE_BUILD_NUMBER"
-    GUARD_REUSED_ARCHIVE=1
+  else
+    echo "warning: --archive-path given but could not read a numeric CFBundleVersion; skipping monotonic build-number guard" >&2
+    RUN_GUARD=0
   fi
 fi
 
-if [[ "$EXPORT_ONLY" -ne 1 && -n "${ASC_API_KEY_ID:-}" && -n "${ASC_API_ISSUER_ID:-}" && ( -n "${ASC_API_KEY_PATH:-}" || -n "${ASC_API_KEY_P8_BASE64:-}" ) ]]; then
+if [[ "$RUN_GUARD" -eq 1 && "$EXPORT_ONLY" -ne 1 && -n "${ASC_API_KEY_ID:-}" && -n "${ASC_API_ISSUER_ID:-}" && ( -n "${ASC_API_KEY_PATH:-}" || -n "${ASC_API_KEY_P8_BASE64:-}" ) ]]; then
   if ASC_MAX="$(ASC_API_KEY_ID="$ASC_API_KEY_ID" ASC_API_ISSUER_ID="$ASC_API_ISSUER_ID" \
       ASC_API_KEY_PATH="${ASC_API_KEY_PATH:-}" ASC_API_KEY_P8_BASE64="${ASC_API_KEY_P8_BASE64:-}" \
-      "$SCRIPT_DIR/asc_max_build.py" --bundle-id "$PRODUCT_BUNDLE_IDENTIFIER")"; then
+      python3 "$SCRIPT_DIR/asc_max_build.py" --bundle-id "$PRODUCT_BUNDLE_IDENTIFIER")"; then
     if [[ "$ASC_MAX" =~ ^[0-9]+$ && "$GUARD_BUILD_NUMBER" =~ ^[0-9]+$ ]] && (( 10#$GUARD_BUILD_NUMBER <= 10#$ASC_MAX )); then
       if [[ "$GUARD_REUSED_ARCHIVE" -eq 1 ]]; then
         echo "error: reused archive CFBundleVersion $GUARD_BUILD_NUMBER <= App Store Connect max $ASC_MAX; TestFlight will not offer it as an update. Re-archive with a higher --build-number." >&2

--- a/ios/scripts/upload-testflight.sh
+++ b/ios/scripts/upload-testflight.sh
@@ -212,6 +212,18 @@ if [[ "$RUN_GUARD" -eq 1 && "$EXPORT_ONLY" -ne 1 && -n "${ASC_API_KEY_ID:-}" && 
   fi
 fi
 
+# Expose the CFBundleVersion that will actually ship so a CI summary or caller
+# reports the post-guard value (the guard may have bumped a fresh build). For a
+# reused --archive-path the shipping version is the archive's embedded one, not
+# BUILD_NUMBER (which is never applied to it).
+SHIPPED_BUILD_NUMBER="$BUILD_NUMBER"
+if [[ "$GUARD_REUSED_ARCHIVE" -eq 1 && "${ARCHIVE_BUILD_NUMBER:-}" =~ ^[0-9]+$ ]]; then
+  SHIPPED_BUILD_NUMBER="$ARCHIVE_BUILD_NUMBER"
+fi
+if [[ -n "${CMUX_BUILD_NUMBER_OUT_FILE:-}" ]]; then
+  printf '%s\n' "$SHIPPED_BUILD_NUMBER" > "$CMUX_BUILD_NUMBER_OUT_FILE"
+fi
+
 OUT_DIR="${CMUX_IOS_UPLOAD_DIR:-/tmp/cmux-ios-testflight-$BUILD_NUMBER}"
 DERIVED_DATA="$OUT_DIR/DerivedData"
 EXPORT_PATH="$OUT_DIR/export"

--- a/ios/scripts/upload-testflight.sh
+++ b/ios/scripts/upload-testflight.sh
@@ -72,6 +72,12 @@ LANE="beta"
 # is NUMERICALLY LOWER than those (~2.0e13), so it would regress below the
 # existing max and never surface as an update. Keep seconds.
 BUILD_NUMBER="$(date -u +%Y%m%d%H%M%S)"
+# Whether BUILD_NUMBER was supplied by the caller (--build-number) rather than the
+# UTC-timestamp default. The default is monotonic by construction, so it is safe
+# to ship even if the App Store Connect lookup fails (fail-open). An explicit
+# value carries no such guarantee, so if it can't be verified against ASC the
+# guard fails CLOSED instead of shipping a possibly-stale build.
+BUILD_NUMBER_EXPLICIT=0
 ARCHIVE_PATH=""
 EXPORT_ONLY=0
 # Export signing mode. "manual" keeps the original local-keychain behavior;
@@ -89,6 +95,7 @@ while [[ $# -gt 0 ]]; do
     --build-number)
       require_option_value "$1" "${2:-}"
       BUILD_NUMBER="$2"
+      BUILD_NUMBER_EXPLICIT=1
       shift 2
       ;;
     --signing)
@@ -225,7 +232,11 @@ if [[ "$RUN_GUARD" -eq 1 && "$EXPORT_ONLY" -ne 1 && -n "${ASC_API_KEY_ID:-}" && 
       echo "error: reused --archive-path but could not verify its build number against App Store Connect; refusing to upload a possibly non-updatable archive (a reused archive cannot be renumbered). Re-run with App Store Connect access or re-archive." >&2
       exit 1
     fi
-    echo "warning: build-number guard skipped (could not read App Store Connect max); using $GUARD_BUILD_NUMBER" >&2
+    if [[ "$BUILD_NUMBER_EXPLICIT" -eq 1 ]]; then
+      echo "error: explicit --build-number $GUARD_BUILD_NUMBER could not be verified monotonic against App Store Connect; refusing to upload (an explicit value may be stale). Re-run when ASC is reachable, or omit --build-number to use a monotonic UTC timestamp." >&2
+      exit 1
+    fi
+    echo "warning: build-number guard skipped (generated timestamp $GUARD_BUILD_NUMBER is monotonic by construction; could not read App Store Connect max)" >&2
   fi
 fi
 

--- a/ios/scripts/upload-testflight.sh
+++ b/ios/scripts/upload-testflight.sh
@@ -158,23 +158,46 @@ fi
 # as an *update* when its CFBundleVersion is the highest integer build for the
 # app, so a regressed numbering scheme (or a bad manual --build-number) silently
 # produces a build no tester can update to. Ask App Store Connect for the current
-# max and self-heal: never ship a number <= the existing max. This is FAIL-OPEN:
-# any ASC/network/JWT error logs a warning and keeps the timestamp BUILD_NUMBER,
-# because the publish must never be blocked by a transient API hiccup (the
-# timestamp scheme is already correct; this is a backstop, not the primary path).
-if [[ -n "${ASC_API_KEY_ID:-}" && -n "${ASC_API_ISSUER_ID:-}" && ( -n "${ASC_API_KEY_PATH:-}" || -n "${ASC_API_KEY_P8_BASE64:-}" ) ]]; then
+# max and never ship a number <= the existing max.
+#
+# Two cases:
+#  - Fresh archive (the common path): BUILD_NUMBER is stamped at archive time, so
+#    self-heal it up to (max + 1).
+#  - Reused archive (--archive-path): the CFBundleVersion is already baked into
+#    the archive and BUILD_NUMBER is never applied to it, so read the archive's
+#    embedded version and FAIL (re-archive needed) rather than self-heal a value
+#    that won't ship. EXPORT_ONLY exits before upload, so the guard is skipped.
+#
+# FAIL-OPEN on the *generated* path: any ASC/network/JWT error logs a warning and
+# keeps the timestamp BUILD_NUMBER, because a transient API hiccup must never
+# block a publish (the timestamp scheme is already correct; this is a backstop).
+GUARD_BUILD_NUMBER="$BUILD_NUMBER"
+GUARD_REUSED_ARCHIVE=0
+if [[ -n "$ARCHIVE_PATH" && -e "$ARCHIVE_PATH/Info.plist" ]]; then
+  ARCHIVE_BUILD_NUMBER="$(/usr/libexec/PlistBuddy -c 'Print :ApplicationProperties:CFBundleVersion' "$ARCHIVE_PATH/Info.plist" 2>/dev/null || true)"
+  if [[ -n "$ARCHIVE_BUILD_NUMBER" ]]; then
+    GUARD_BUILD_NUMBER="$ARCHIVE_BUILD_NUMBER"
+    GUARD_REUSED_ARCHIVE=1
+  fi
+fi
+
+if [[ "$EXPORT_ONLY" -ne 1 && -n "${ASC_API_KEY_ID:-}" && -n "${ASC_API_ISSUER_ID:-}" && ( -n "${ASC_API_KEY_PATH:-}" || -n "${ASC_API_KEY_P8_BASE64:-}" ) ]]; then
   if ASC_MAX="$(ASC_API_KEY_ID="$ASC_API_KEY_ID" ASC_API_ISSUER_ID="$ASC_API_ISSUER_ID" \
       ASC_API_KEY_PATH="${ASC_API_KEY_PATH:-}" ASC_API_KEY_P8_BASE64="${ASC_API_KEY_P8_BASE64:-}" \
       "$SCRIPT_DIR/asc_max_build.py" --bundle-id "$PRODUCT_BUNDLE_IDENTIFIER")"; then
-    if [[ "$ASC_MAX" =~ ^[0-9]+$ && "$BUILD_NUMBER" =~ ^[0-9]+$ ]] && (( 10#$BUILD_NUMBER <= 10#$ASC_MAX )); then
+    if [[ "$ASC_MAX" =~ ^[0-9]+$ && "$GUARD_BUILD_NUMBER" =~ ^[0-9]+$ ]] && (( 10#$GUARD_BUILD_NUMBER <= 10#$ASC_MAX )); then
+      if [[ "$GUARD_REUSED_ARCHIVE" -eq 1 ]]; then
+        echo "error: reused archive CFBundleVersion $GUARD_BUILD_NUMBER <= App Store Connect max $ASC_MAX; TestFlight will not offer it as an update. Re-archive with a higher --build-number." >&2
+        exit 1
+      fi
       NEXT_BUILD=$((10#$ASC_MAX + 1))
-      echo "warning: build number $BUILD_NUMBER <= App Store Connect max $ASC_MAX; bumping to $NEXT_BUILD to keep CFBundleVersion monotonic" >&2
+      echo "warning: build number $GUARD_BUILD_NUMBER <= App Store Connect max $ASC_MAX; bumping to $NEXT_BUILD to keep CFBundleVersion monotonic" >&2
       BUILD_NUMBER="$NEXT_BUILD"
     else
-      echo "build-number guard: $BUILD_NUMBER > App Store Connect max ${ASC_MAX:-0}, keeping it" >&2
+      echo "build-number guard: $GUARD_BUILD_NUMBER > App Store Connect max ${ASC_MAX:-0}, keeping it" >&2
     fi
   else
-    echo "warning: build-number guard skipped (could not read App Store Connect max); using $BUILD_NUMBER" >&2
+    echo "warning: build-number guard skipped (could not read App Store Connect max); using $GUARD_BUILD_NUMBER" >&2
   fi
 fi
 

--- a/ios/scripts/upload-testflight.sh
+++ b/ios/scripts/upload-testflight.sh
@@ -176,9 +176,11 @@ GUARD_REUSED_ARCHIVE=0
 RUN_GUARD=1
 if [[ -n "$ARCHIVE_PATH" ]]; then
   # Reused archive: BUILD_NUMBER is never stamped into it, so the only number
-  # that ships is the embedded CFBundleVersion, and it can't be self-healed. If
-  # we can't read it, bumping BUILD_NUMBER would be a no-op that falsely claims a
-  # fix, so skip the guard with a warning instead.
+  # that ships is the embedded CFBundleVersion, and it CANNOT be self-healed.
+  # Such an archive must therefore be VERIFIABLE before an upload: if we cannot
+  # read its version (below) or cannot reach App Store Connect (further down), we
+  # fail CLOSED rather than upload a build that may not be offered as an update.
+  # --export-only never uploads, so it only warns and skips.
   GUARD_REUSED_ARCHIVE=1
   # PlistBuddy prints "File Doesn't Exist..." to stdout (and exits non-zero) when
   # the archive or key is missing, so require a NUMERIC result rather than just
@@ -186,9 +188,12 @@ if [[ -n "$ARCHIVE_PATH" ]]; then
   ARCHIVE_BUILD_NUMBER="$(/usr/libexec/PlistBuddy -c 'Print :ApplicationProperties:CFBundleVersion' "$ARCHIVE_PATH/Info.plist" 2>/dev/null || true)"
   if [[ "$ARCHIVE_BUILD_NUMBER" =~ ^[0-9]+$ ]]; then
     GUARD_BUILD_NUMBER="$ARCHIVE_BUILD_NUMBER"
-  else
-    echo "warning: --archive-path given but could not read a numeric CFBundleVersion; skipping monotonic build-number guard" >&2
+  elif [[ "$EXPORT_ONLY" -eq 1 ]]; then
+    echo "warning: --archive-path CFBundleVersion unreadable; skipping guard (--export-only, no upload)" >&2
     RUN_GUARD=0
+  else
+    echo "error: --archive-path given but could not read a numeric CFBundleVersion to verify monotonicity; refusing to upload an unverifiable archive. Re-archive with --build-number." >&2
+    exit 1
   fi
 fi
 
@@ -208,6 +213,10 @@ if [[ "$RUN_GUARD" -eq 1 && "$EXPORT_ONLY" -ne 1 && -n "${ASC_API_KEY_ID:-}" && 
       echo "build-number guard: $GUARD_BUILD_NUMBER > App Store Connect max ${ASC_MAX:-0}, keeping it" >&2
     fi
   else
+    if [[ "$GUARD_REUSED_ARCHIVE" -eq 1 ]]; then
+      echo "error: reused --archive-path but could not verify its build number against App Store Connect; refusing to upload a possibly non-updatable archive (a reused archive cannot be renumbered). Re-run with App Store Connect access or re-archive." >&2
+      exit 1
+    fi
     echo "warning: build-number guard skipped (could not read App Store Connect max); using $GUARD_BUILD_NUMBER" >&2
   fi
 fi

--- a/ios/scripts/upload-testflight.sh
+++ b/ios/scripts/upload-testflight.sh
@@ -214,30 +214,50 @@ if [[ "$RUN_GUARD" -eq 1 && "$EXPORT_ONLY" -ne 1 && -n "${ASC_API_KEY_ID:-}" && 
   if ASC_MAX="$(ASC_API_KEY_ID="$ASC_API_KEY_ID" ASC_API_ISSUER_ID="$ASC_API_ISSUER_ID" \
       ASC_API_KEY_PATH="${ASC_API_KEY_PATH:-}" ASC_API_KEY_P8_BASE64="${ASC_API_KEY_P8_BASE64:-}" \
       python3 "$SCRIPT_DIR/asc_max_build.py" --bundle-id "$PRODUCT_BUNDLE_IDENTIFIER")"; then
-    # Reached only with a real ASC max in hand: the shipping build number is now
-    # verified (it either passes the comparison below or the script exits).
-    GUARD_VERIFIED=1
-    if [[ "$ASC_MAX" =~ ^[0-9]+$ && "$GUARD_BUILD_NUMBER" =~ ^[0-9]+$ ]] && (( 10#$GUARD_BUILD_NUMBER <= 10#$ASC_MAX )); then
-      if [[ "$GUARD_REUSED_ARCHIVE" -eq 1 ]]; then
-        echo "error: reused archive CFBundleVersion $GUARD_BUILD_NUMBER <= App Store Connect max $ASC_MAX; TestFlight will not offer it as an update. Re-archive with a higher --build-number." >&2
-        exit 1
+    if [[ "$ASC_MAX" =~ ^[0-9]+$ && "$GUARD_BUILD_NUMBER" =~ ^[0-9]+$ ]]; then
+      # A real numeric comparison happened: the shipping build number is verified.
+      GUARD_VERIFIED=1
+      if (( 10#$GUARD_BUILD_NUMBER <= 10#$ASC_MAX )); then
+        if [[ "$GUARD_REUSED_ARCHIVE" -eq 1 ]]; then
+          echo "error: reused archive CFBundleVersion $GUARD_BUILD_NUMBER <= App Store Connect max $ASC_MAX; TestFlight will not offer it as an update. Re-archive with a higher --build-number." >&2
+          exit 1
+        fi
+        if [[ "$BUILD_NUMBER_EXPLICIT" -eq 1 ]]; then
+          echo "error: explicit --build-number $GUARD_BUILD_NUMBER <= App Store Connect max $ASC_MAX; TestFlight will not offer it as an update. Use a higher number, or omit --build-number to use a monotonic UTC timestamp." >&2
+          exit 1
+        fi
+        # Generated timestamp below the max (only via clock skew): self-heal it.
+        NEXT_BUILD=$((10#$ASC_MAX + 1))
+        echo "warning: generated build number $GUARD_BUILD_NUMBER <= App Store Connect max $ASC_MAX; bumping to $NEXT_BUILD to keep CFBundleVersion monotonic" >&2
+        BUILD_NUMBER="$NEXT_BUILD"
+      else
+        echo "build-number guard: $GUARD_BUILD_NUMBER > App Store Connect max $ASC_MAX, keeping it" >&2
       fi
-      NEXT_BUILD=$((10#$ASC_MAX + 1))
-      echo "warning: build number $GUARD_BUILD_NUMBER <= App Store Connect max $ASC_MAX; bumping to $NEXT_BUILD to keep CFBundleVersion monotonic" >&2
-      BUILD_NUMBER="$NEXT_BUILD"
     else
-      echo "build-number guard: $GUARD_BUILD_NUMBER > App Store Connect max ${ASC_MAX:-0}, keeping it" >&2
+      # Non-numeric ASC max or build number: no comparison possible. Leave
+      # GUARD_VERIFIED unset; the fail-closed gate below handles reused/explicit.
+      echo "warning: build-number guard could not compare $GUARD_BUILD_NUMBER against App Store Connect max ${ASC_MAX:-?}; leaving it unverified" >&2
     fi
   else
-    if [[ "$GUARD_REUSED_ARCHIVE" -eq 1 ]]; then
-      echo "error: reused --archive-path but could not verify its build number against App Store Connect; refusing to upload a possibly non-updatable archive (a reused archive cannot be renumbered). Re-run with App Store Connect access or re-archive." >&2
-      exit 1
-    fi
-    if [[ "$BUILD_NUMBER_EXPLICIT" -eq 1 ]]; then
-      echo "error: explicit --build-number $GUARD_BUILD_NUMBER could not be verified monotonic against App Store Connect; refusing to upload (an explicit value may be stale). Re-run when ASC is reachable, or omit --build-number to use a monotonic UTC timestamp." >&2
-      exit 1
-    fi
-    echo "warning: build-number guard skipped (generated timestamp $GUARD_BUILD_NUMBER is monotonic by construction; could not read App Store Connect max)" >&2
+    echo "warning: build-number guard could not read the App Store Connect max; leaving $GUARD_BUILD_NUMBER unverified" >&2
+  fi
+fi
+
+# Fail-closed gate, before the (expensive) archive. A build that needs
+# verification but was not actually compared against the App Store Connect max
+# (ASC unreachable, no ASC API creds such as the Apple ID upload path, or a
+# non-numeric value) is refused here. A reused --archive-path can't be
+# renumbered; an explicit --build-number may be stale. The generated UTC
+# timestamp is monotonic by construction, so it is exempt (fail-open).
+# --export-only never uploads, so it is exempt too.
+if [[ "$EXPORT_ONLY" -ne 1 && "$GUARD_VERIFIED" -ne 1 ]]; then
+  if [[ "$GUARD_REUSED_ARCHIVE" -eq 1 ]]; then
+    echo "error: refusing to upload a reused --archive-path that was not verified monotonic against App Store Connect. Re-archive with --build-number, or provide ASC_API_KEY_ID/ASC_API_ISSUER_ID/ASC_API_KEY_PATH so it can be checked." >&2
+    exit 1
+  fi
+  if [[ "$BUILD_NUMBER_EXPLICIT" -eq 1 ]]; then
+    echo "error: refusing to upload an explicit --build-number $BUILD_NUMBER that was not verified monotonic against App Store Connect (it may be stale). Omit --build-number to use a monotonic UTC timestamp, or provide ASC_API_KEY_ID/ASC_API_ISSUER_ID/ASC_API_KEY_PATH so it can be checked." >&2
+    exit 1
   fi
 fi
 
@@ -345,23 +365,6 @@ echo "IPA_PATH=$IPA_PATH"
 
 if [[ "$EXPORT_ONLY" -eq 1 ]]; then
   exit 0
-fi
-
-# Final fail-closed gate. Any build that needs verification but was not actually
-# checked against the App Store Connect max (e.g. the Apple ID upload path, which
-# has no ASC API creds to query) is refused here rather than shipped as a build
-# that may not be offered as an update. A reused --archive-path can't be
-# renumbered; an explicit --build-number may be stale. The generated UTC
-# timestamp is monotonic by construction, so it is exempt (fail-open).
-if [[ "$GUARD_VERIFIED" -ne 1 ]]; then
-  if [[ "$GUARD_REUSED_ARCHIVE" -eq 1 ]]; then
-    echo "error: refusing to upload a reused --archive-path that was not verified monotonic against App Store Connect (no ASC API credentials available to check). Re-archive with --build-number, or provide ASC_API_KEY_ID/ASC_API_ISSUER_ID/ASC_API_KEY_PATH." >&2
-    exit 1
-  fi
-  if [[ "$BUILD_NUMBER_EXPLICIT" -eq 1 ]]; then
-    echo "error: refusing to upload an explicit --build-number $BUILD_NUMBER that was not verified monotonic against App Store Connect (no ASC API credentials available to check). Omit --build-number to use a monotonic UTC timestamp, or provide ASC_API_KEY_ID/ASC_API_ISSUER_ID/ASC_API_KEY_PATH." >&2
-    exit 1
-  fi
 fi
 
 if [[ -n "${ASC_API_KEY_ID:-}" || -n "${ASC_API_ISSUER_ID:-}" || -n "${ASC_API_KEY_PATH:-}" ]]; then


### PR DESCRIPTION
## Why
Follow-up to #5499 / #5503. Those restored the 14-digit build-number scheme, but the regression that broke TestFlight updates (a build number *below* the existing max → no Update button) had **no guard** enforcing the actual invariant. A future scheme drift, timezone change, or a bad manual `--build-number` would silently reproduce it.

## What
A behavioral guard that enforces "CFBundleVersion is strictly the highest build" against the live source of truth (App Store Connect), independent of whatever generates the number:

- **`ios/scripts/asc_max_build.py`** — mints an ES256 JWT from the ASC API key, resolves the app by bundle id, pages its builds and returns `max(int(version))`. (ASC `sort=-version` is a *string* sort, so it can't be trusted across digit counts — exactly this bug. Max as integer instead.)
- **`upload-testflight.sh`** — before archiving, self-heals `BUILD_NUMBER` up to `max+1` when it wouldn't be the highest, with a loud warning. Covers CI, local, and `--build-number`.
- **workflow** — best-effort installs `cryptography` for the guard.

## Fail-open by design
Any ASC / network / JWT error, or missing `cryptography`, logs a warning and keeps the timestamp build number. The publish is **never** blocked by a transient API hiccup — the timestamp scheme is already correct, this is defense-in-depth.

## Verification
- `asc_max_build.py` against live ASC returns `20260606030718` (the current max); bad bundle id / missing creds exit non-zero with a diagnostic (fail-open).
- Guard arithmetic: `202606060220` (regressed) → bumps to `20260606030719`; `99999999999999` → kept.
- `bash -n` + `actionlint` clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5504"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783308510&installation_id=133855650&pr_number=5504&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5504&signature=adee2769ff2a6d333ca9a01e329f841a884831cf18dc9c048caa560f34412d1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release automation and uses ASC API credentials during publish; wrong guard logic could block uploads or ship a non-updatable build, though generated timestamps remain fail-open.
> 
> **Overview**
> Adds a **monotonic CFBundleVersion guard** for TestFlight so builds are never uploaded with a version at or below App Store Connect’s current max (the condition that hides the Update button).
> 
> **`asc_max_build.py`** queries ASC with a stdlib + `openssl` ES256 JWT (no PyPI), pages all builds, and prints the max integer `version`.
> 
> **`upload-testflight.sh`** runs the guard before archive: fresh builds can **bump** to `max+1`; reused `--archive-path` and explicit `--build-number` **fail closed** if ASC can’t verify or the number isn’t strictly higher. Generated UTC `yyyyMMddHHmmss` defaults still **fail open** on API errors. The script writes the final shipped build to **`CMUX_BUILD_NUMBER_OUT_FILE`**.
> 
> **`ios-testflight.yml`** drops the separate “Resolve build number” step; push/schedule no longer pass `--build-number` (script owns the scheme), and the job summary reads the post-guard value from the upload step output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 215d5372bdf114b61674c5d329a6f68be368641c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces monotonic TestFlight build numbers by checking App Store Connect and bumping fresh builds to max+1; reused archives and explicit build numbers now fail closed when unverified or ≤ ASC max. The workflow reports the post-guard value that actually shipped.

- New Features
  - Added `ios/scripts/asc_max_build.py`: mints ES256 JWT via `openssl`, resolves app by bundle id, fully pages builds (no partials), rejects unexpected `next`, logs only HTTP status + ASC error code, prints the max integer version (0 if none).
  - Updated `ios/scripts/upload-testflight.sh`:
    - Fresh archives self-heal to max+1; generated UTC `yyyyMMddHHmmss` timestamps fail open on ASC/JWT/network errors.
    - Reused `--archive-path`: reads a numeric embedded CFBundleVersion and fails if unreadable or ≤ ASC max; cannot be renumbered.
    - Explicit `--build-number`: fails closed if ASC can’t be verified, and also fails when verified but ≤ ASC max (no silent bump).
    - Verification is only marked after a real numeric comparison; a single pre-archive gate refuses any unverified reused archive or explicit build number (including Apple ID uploads).
    - Invokes helper via `python3`; writes the shipped version to `CMUX_BUILD_NUMBER_OUT_FILE`.
  - Workflow: push/schedule no longer pass `--build-number` (script generates the timestamp); `workflow_dispatch` can pass one; summary reads the post-guard value from the out-file.

- Dependencies
  - Removed `cryptography` and all PyPI installs from the signing job; JWT generation uses `openssl` + stdlib only.

<sup>Written for commit 215d5372bdf114b61674c5d329a6f68be368641c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional App Store Connect check that reads the highest existing build and can auto-bump TestFlight build numbers to keep them monotonic.
  * CI now ensures required cryptography tooling is available before iOS publish and reports the actual shipped build number as workflow output.

* **Bug Fixes**
  * Graceful fallbacks and warnings if tooling or ASC checks fail, allowing publish to continue.

* **Documentation**
  * CLI help clarified that a provided build number may be auto-adjusted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->