### PR TITLE
iOS: remove dead arrow-nub escapeSequence

### DIFF
--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -2686,14 +2686,6 @@ final class TerminalArrowNubView: UIView {
 
     private enum Direction {
         case up, down, left, right
-        var escapeSequence: Data {
-            switch self {
-            case .up:    return Data([0x1B, 0x5B, 0x41])
-            case .down:  return Data([0x1B, 0x5B, 0x42])
-            case .right: return Data([0x1B, 0x5B, 0x43])
-            case .left:  return Data([0x1B, 0x5B, 0x44])
-            }
-        }
 
         var repeatDirection: TerminalArrowRepeatService.Direction {
             switch self {


### PR DESCRIPTION
Removes dead code surfaced while root-causing the iOS "right on the nub doesn't complete the skill" report.

## What
`TerminalArrowNubView.Direction.escapeSequence` (`Packages/CmuxMobileTerminal/.../GhosttySurfaceView.swift`) hardcoded `ESC [ A/B/C/D` but had zero call sites. The nub drives arrow repeats through `TerminalArrowRepeatService` → `TerminalKeyEncoder`, which is the real source of truth. The stray property just invited drift.

## Why now
The reported nub bug ("right on the nub fails to complete a Claude Code skill") is a separate, already-fixed issue: pre-`7292b2014e` the Mac host split the nub's raw `ESC [ C` into a standalone Escape (which closes Claude Code's slash menu) + literal `[C`. That fix landed via #5079 and is not yet in a release (v0.64.13 lacks it). This PR is just the dead-code cleanup half of that investigation; it does not change behavior.

## Test
No behavioral change (removing an unreferenced computed property). Nub arrow encoding is already covered by `TerminalArrowRepeatServiceTests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5505"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783309951&installation_id=133855650&pr_number=5505&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5505&signature=147330711ca6d8a4fad6caadf09641e474d27a88188e67449889698a6a3f82c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead-code removal only; no call sites and no change to the live arrow repeat/encoding path.
> 
> **Overview**
> Removes the unused **`escapeSequence`** computed property on `TerminalArrowNubView.Direction` in `GhosttySurfaceView.swift`. That property duplicated hardcoded `ESC [ A/B/C/D` bytes but was never referenced.
> 
> The draggable arrow nub still sends keys only through **`TerminalArrowRepeatService`** → **`TerminalKeyEncoder`** via `repeatDirection` and `onArrowKey`. **No runtime behavior change** — cleanup after investigating the nub “right arrow” issue.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d511e8c2e7dc44d3d15ca0b4a8c0e1946f29fdcc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused `escapeSequence` from the iOS arrow nub (`TerminalArrowNubView.Direction`) in `CmuxMobileTerminal`. Arrow repeats still route through `TerminalArrowRepeatService` -> `TerminalKeyEncoder`; cleanup only with no behavior change.

<sup>Written for commit d511e8c2e7dc44d3d15ca0b4a8c0e1946f29fdcc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5505?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal cleanup: removed obsolete internal logic and simplified direction handling.
  * Improves maintainability and reduces implementation complexity.
  * No user-visible changes; UI and behavior remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->